### PR TITLE
Example of removal of FieldExtension

### DIFF
--- a/baby-stark/src/lib.rs
+++ b/baby-stark/src/lib.rs
@@ -7,13 +7,13 @@ use p3_air::symbolic::Symbolic;
 use p3_air::window::{BasicAirWindow, TwoRowMatrixView};
 use p3_air::Air;
 use p3_commit::pcs::PCS;
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
 pub trait StarkConfig {
     type F: Field;
-    type Challenge: FieldExtension<Self::F>;
+    type Challenge: Field<DistinguishedSubfield = Self::F>;
     type PCS: PCS<Self::F>;
 }
 
@@ -93,7 +93,7 @@ mod tests {
     impl StarkConfig for MyConfig {
         type F = F;
         type Challenge = Self::F; // TODO: Use an extension.
-        type PCS = FRIBasedPCS<Self::F, Self::Challenge, MMCS>;
+        type PCS = FRIBasedPCS<Self::Challenge, MMCS>;
     }
 
     struct MulAir;

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -2,27 +2,21 @@
 
 #![no_std]
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 
 pub mod duplex_challenger;
 pub mod hash_challenger;
 
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.
 pub trait Challenger<F: Field> {
+    // Could use Field::map_components() to get functionality similar
+    // to observe_extension_element(), though as mentioned there, it's
+    // better to avoid depending on the individual components of the
+    // representation of a field element.
     fn observe_element(&mut self, element: F);
-
-    fn observe_extension_element<FE: FieldExtension<F>>(&mut self, element: FE)
-    where
-        [(); FE::D]:,
-    {
-        for base in element.to_base_array() {
-            self.observe_element(base);
-        }
-    }
 
     fn random_element(&mut self) -> F;
 

--- a/commit/src/adapters/multi_from_uni_pcs.rs
+++ b/commit/src/adapters/multi_from_uni_pcs.rs
@@ -1,7 +1,7 @@
 use crate::pcs::{MultivariatePCS, UnivariatePCS, PCS};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 
 pub struct MultiFromUniPCS<F: Field, U: UnivariatePCS<F>> {
@@ -27,14 +27,14 @@ impl<F: Field, U: UnivariatePCS<F>> PCS<F> for MultiFromUniPCS<F, U> {
 }
 
 impl<F: Field, U: UnivariatePCS<F>> MultivariatePCS<F> for MultiFromUniPCS<F, U> {
-    fn open_multi_batches<FE: FieldExtension<F>>(
+    fn open_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         _points: &[FE],
         _prover_data: &[Self::ProverData],
     ) -> (Vec<Vec<Vec<FE>>>, Self::Proof) {
         todo!()
     }
 
-    fn verify_multi_batches<FE: FieldExtension<F>>(
+    fn verify_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         _commits: &[Self::Commitment],
         _points: &[FE],
         _values: &[Vec<Vec<FE>>],

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -1,7 +1,7 @@
 //! Traits for polynomial commitment schemes.
 
 use alloc::vec;
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 
 use alloc::vec::Vec;
@@ -34,12 +34,12 @@ pub trait PCS<F: Field> {
 }
 
 pub trait UnivariatePCS<F: Field>: PCS<F> {
-    fn open_multi_batches<FE: FieldExtension<F>>(
+    fn open_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         prover_data: &[Self::ProverData],
         points: &[FE],
     ) -> (Vec<Vec<Vec<FE>>>, Self::Proof);
 
-    fn verify_multi_batches<FE: FieldExtension<F>>(
+    fn verify_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         commits: &[Self::Commitment],
         points: &[FE],
         values: &[Vec<Vec<FE>>],
@@ -48,12 +48,12 @@ pub trait UnivariatePCS<F: Field>: PCS<F> {
 }
 
 pub trait MultivariatePCS<F: Field>: PCS<F> {
-    fn open_multi_batches<FE: FieldExtension<F>>(
+    fn open_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         points: &[FE],
         prover_data: &[Self::ProverData],
     ) -> (Vec<Vec<Vec<FE>>>, Self::Proof);
 
-    fn verify_multi_batches<FE: FieldExtension<F>>(
+    fn verify_multi_batches<FE: Field<DistinguishedSubfield = F>>(
         commits: &[Self::Commitment],
         points: &[FE],
         values: &[Vec<Vec<FE>>],

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -45,8 +45,10 @@ pub unsafe trait PackedField:
     const ZEROS: Self;
     const ONES: Self;
 
+    /* These are not actually used anywhere but in the test suite.
     fn from_arr(arr: [Self::Scalar; Self::WIDTH]) -> Self;
     fn as_arr(&self) -> [Self::Scalar; Self::WIDTH];
+    */
 
     fn from_slice(slice: &[Self::Scalar]) -> &Self;
     fn from_slice_mut(slice: &mut [Self::Scalar]) -> &mut Self;
@@ -107,6 +109,7 @@ unsafe impl<F: Field> PackedField for F {
     const ZEROS: Self = F::ZERO;
     const ONES: Self = F::ONE;
 
+    /*
     fn from_arr(arr: [Self::Scalar; Self::WIDTH]) -> Self {
         arr[0]
     }
@@ -114,6 +117,7 @@ unsafe impl<F: Field> PackedField for F {
     fn as_arr(&self) -> [Self::Scalar; Self::WIDTH] {
         [*self]
     }
+    */
 
     fn from_slice(slice: &[Self::Scalar]) -> &Self {
         &slice[0]

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -8,30 +8,27 @@ use crate::proof::FriProof;
 use crate::prover::prove;
 use core::marker::PhantomData;
 use p3_commit::mmcs::MMCS;
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 use p3_ldt::{LDTBasedPCS, LDT};
 
 pub mod proof;
 pub mod prover;
 
-pub struct FriLDT<F, FE, M>
+pub struct FriLDT<F, M>
 where
     F: Field,
-    FE: FieldExtension<F>,
     M: MMCS<F>,
 {
     _phantom_f: PhantomData<F>,
-    _phantom_fe: PhantomData<FE>,
     _phantom_o: PhantomData<M>,
 }
 
-impl<F, FE, M> LDT<F, M> for FriLDT<F, FE, M>
+impl<F, M> LDT<F, M> for FriLDT<F, M>
 where
     F: Field,
-    FE: FieldExtension<F>,
     M: MMCS<F>,
 {
-    type Proof = FriProof<F, FE, M>;
+    type Proof = FriProof<F, M>;
     type Error = ();
 
     fn prove(codewords: &[M::ProverData]) -> Self::Proof {
@@ -43,4 +40,4 @@ where
     }
 }
 
-pub type FRIBasedPCS<F, FE, M> = LDTBasedPCS<F, M, FriLDT<F, FE, M>>;
+pub type FRIBasedPCS<F, M> = LDTBasedPCS<F, M, FriLDT<F, M>>;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -1,11 +1,9 @@
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 
-pub struct FriProof<F, FE, O>
+pub struct FriProof<F, O>
 where
     F: Field,
-    FE: FieldExtension<F>,
 {
     _todo_f: F,
-    _todo_fe: FE,
     _todo_o: O,
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -1,11 +1,10 @@
 use crate::FriProof;
 use p3_commit::mmcs::MMCS;
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 
-pub(crate) fn prove<F, FE, O>(_codewords: &[O::ProverData]) -> FriProof<F, FE, O>
+pub(crate) fn prove<F, O>(_codewords: &[O::ProverData]) -> FriProof<F, O>
 where
     F: Field,
-    FE: FieldExtension<F>,
     O: MMCS<F>,
 {
     todo!()

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -7,7 +7,7 @@ use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use p3_field::field::{Field, PrimeField};
+use p3_field::field::Field;
 use p3_util::{assume, branch_hint};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -77,6 +77,17 @@ impl Field for Goldilocks {
     // TODO: Add cfg-guarded Packing for AVX2, NEON, etc.
     type Packing = Self;
 
+    type DistinguishedSubfield = Self;
+    const EXT_DEGREE: usize = 1;
+
+    fn lift(x: Self::DistinguishedSubfield) -> Self {
+        x
+    }
+
+    fn try_lower(&self) -> Option<Self::DistinguishedSubfield> {
+        Some(*self)
+    }
+
     const ZERO: Self = Self { value: 0 };
     const ONE: Self = Self { value: 1 };
     const TWO: Self = Self { value: 2 };
@@ -94,8 +105,6 @@ impl Field for Goldilocks {
         todo!()
     }
 }
-
-impl PrimeField for Goldilocks {}
 
 impl Add<Self> for Goldilocks {
     type Output = Self;

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -7,7 +7,7 @@ use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, BitXorAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use p3_field::field::{Field, PrimeField};
+use p3_field::field::Field;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -98,6 +98,17 @@ impl Field for Mersenne31 {
     // TODO: Add cfg-guarded Packing for AVX2, NEON, etc.
     type Packing = Self;
 
+    type DistinguishedSubfield = Self;
+    const EXT_DEGREE: usize = 1;
+
+    fn lift(x: Self::DistinguishedSubfield) -> Self {
+        x
+    }
+
+    fn try_lower(&self) -> Option<Self::DistinguishedSubfield> {
+        Some(*self)
+    }
+
     const ZERO: Self = Self { value: 0 };
     const ONE: Self = Self { value: 1 };
     const TWO: Self = Self { value: 2 };
@@ -133,8 +144,6 @@ impl Field for Mersenne31 {
         todo!()
     }
 }
-
-impl PrimeField for Mersenne31 {}
 
 impl Add<Self> for Mersenne31 {
     type Output = Self;


### PR DESCRIPTION
**Not intended to be merged**

This PR is just an example of how the interface might look if we remove the `FieldExtension` trait. Discussion welcome, in particular, it would be good to identify under what circumstances this approach might limit us in the future, compared to using the parameterised trait `FieldExtension<F: Field>`.