### PR TITLE
Remove generic const exprs

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -1,8 +1,6 @@
 //! APIs for AIRs, and generalizations like PAIRs.
 
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 

--- a/baby-stark/src/lib.rs
+++ b/baby-stark/src/lib.rs
@@ -88,7 +88,7 @@ mod tests {
     type MDS = MyMds;
     type Perm = Poseidon<F, MDS, 8, 7>;
     type H4 = PaddingFreeSponge<F, Perm, { 4 + 4 }>;
-    type C = TruncatedPermutation<F, Perm, 2, 4>;
+    type C = TruncatedPermutation<F, Perm, 2, 4, { 2 * 4 }>;
     type MMCS = MerkleTreeMMCS<F, [F; 4], H4, C>;
     impl StarkConfig for MyConfig {
         type F = F;

--- a/baby-stark/src/lib.rs
+++ b/baby-stark/src/lib.rs
@@ -87,7 +87,7 @@ mod tests {
 
     type MDS = MyMds;
     type Perm = Poseidon<F, MDS, 8, 7>;
-    type H4 = PaddingFreeSponge<F, Perm, 4, 4>;
+    type H4 = PaddingFreeSponge<F, Perm, { 4 + 4 }>;
     type C = TruncatedPermutation<F, Perm, 2, 4>;
     type MMCS = MerkleTreeMMCS<F, [F; 4], H4, C>;
     impl StarkConfig for MyConfig {

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -1,28 +1,17 @@
 //! Utilities for generating Fiat-Shamir challenges based on an IOP's transcript.
 
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 
 pub mod duplex_challenger;
 pub mod hash_challenger;
 
-use p3_field::field::{Field, FieldExtension};
+use p3_field::field::Field;
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.
 pub trait Challenger<F: Field> {
     fn observe_element(&mut self, element: F);
-
-    fn observe_extension_element<FE: FieldExtension<F>>(&mut self, element: FE)
-    where
-        [(); FE::D]:,
-    {
-        for base in element.to_base_array() {
-            self.observe_element(base);
-        }
-    }
 
     fn random_element(&mut self) -> F;
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -87,23 +87,11 @@ pub trait FieldExtension<Base: Field>:
 {
     const D: usize;
 
-    fn to_base_array(&self) -> [Base; Self::D];
-
-    fn from_base_array(arr: [Base; Self::D]) -> Self;
-
     fn from_base(b: Base) -> Self;
 }
 
 impl<F: Field> FieldExtension<F> for F {
     const D: usize = 1;
-
-    fn to_base_array(&self) -> [F; Self::D] {
-        [*self]
-    }
-
-    fn from_base_array(arr: [F; Self::D]) -> Self {
-        arr[0]
-    }
 
     fn from_base(b: F) -> Self {
         b

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -1,8 +1,6 @@
 //! A framework for finite fields.
 
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -45,9 +45,6 @@ pub unsafe trait PackedField:
     const ZEROS: Self;
     const ONES: Self;
 
-    fn from_arr(arr: [Self::Scalar; Self::WIDTH]) -> Self;
-    fn as_arr(&self) -> [Self::Scalar; Self::WIDTH];
-
     fn from_slice(slice: &[Self::Scalar]) -> &Self;
     fn from_slice_mut(slice: &mut [Self::Scalar]) -> &mut Self;
     fn as_slice(&self) -> &[Self::Scalar];
@@ -106,14 +103,6 @@ unsafe impl<F: Field> PackedField for F {
     const WIDTH: usize = 1;
     const ZEROS: Self = F::ZERO;
     const ONES: Self = F::ONE;
-
-    fn from_arr(arr: [Self::Scalar; Self::WIDTH]) -> Self {
-        arr[0]
-    }
-
-    fn as_arr(&self) -> [Self::Scalar; Self::WIDTH] {
-        [*self]
-    }
 
     fn from_slice(slice: &[Self::Scalar]) -> &Self {
         &slice[0]

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -1,8 +1,6 @@
 //! The Poseidon permutation.
 
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 
@@ -128,10 +126,5 @@ where
 {
 }
 
-pub type PaddingFreePoseidonSponge<
-    F,
-    MDS,
-    const RATE: usize,
-    const CAPACITY: usize,
-    const ALPHA: u64,
-> = PaddingFreeSponge<F, Poseidon<F, MDS, { RATE + CAPACITY }, ALPHA>, RATE, CAPACITY>;
+pub type PaddingFreePoseidonSponge<F, MDS, const WIDTH: usize, const ALPHA: u64> =
+    PaddingFreeSponge<F, Poseidon<F, MDS, WIDTH, ALPHA>, WIDTH>;

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -13,19 +13,19 @@ pub trait PseudoCompressionFunction<T, const N: usize> {
 /// An `n`-to-1 compression function.
 pub trait CompressionFunction<T, const N: usize>: PseudoCompressionFunction<T, N> {}
 
-pub struct TruncatedPermutation<T, InnerP, const N: usize, const CHUNK: usize>
+pub struct TruncatedPermutation<T, InnerP, const N: usize, const CHUNK: usize, const PROD: usize>
 where
-    InnerP: CryptographicPermutation<[T; CHUNK * N]>,
+    InnerP: CryptographicPermutation<[T; PROD]>,
 {
     _phantom_t: PhantomData<T>,
     inner_permutation: InnerP,
 }
 
-impl<T, InnerP, const N: usize, const CHUNK: usize> PseudoCompressionFunction<[T; CHUNK], N>
-    for TruncatedPermutation<T, InnerP, N, CHUNK>
+impl<T, InnerP, const N: usize, const CHUNK: usize, const PROD: usize>
+    PseudoCompressionFunction<[T; CHUNK], N> for TruncatedPermutation<T, InnerP, N, CHUNK, PROD>
 where
     T: Copy,
-    InnerP: CryptographicPermutation<[T; CHUNK * N]>,
+    InnerP: CryptographicPermutation<[T; PROD]>,
 {
     fn compress(&self, input: [[T; CHUNK]; N]) -> [T; CHUNK] {
         let flat_input = input

--- a/symmetric/src/lib.rs
+++ b/symmetric/src/lib.rs
@@ -1,8 +1,6 @@
 //! A framework for symmetric cryptography primitives.
 
 #![no_std]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 
 extern crate alloc;
 

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -5,22 +5,25 @@ use core::marker::PhantomData;
 use itertools::Itertools;
 
 /// A padding-free, overwrite-mode sponge function.
-pub struct PaddingFreeSponge<T, P, const RATE: usize, const CAPACITY: usize>
+///
+/// WIDTH is the sponge's rate + sponge's capacity
+pub struct PaddingFreeSponge<T, P, const WIDTH: usize>
 where
-    P: ArrayPermutation<T, { RATE + CAPACITY }>,
+    P: ArrayPermutation<T, WIDTH>,
 {
     _phantom_f: PhantomData<T>,
     // _phantom_p: PhantomData<P>,
     permutation: P,
 }
 
-impl<T: Default + Copy, P, const RATE: usize, const CAPACITY: usize>
-    CryptographicHasher<Vec<T>, [T; RATE]> for PaddingFreeSponge<T, P, RATE, CAPACITY>
+impl<T: Default + Copy, P, const RATE: usize, const WIDTH: usize>
+    CryptographicHasher<Vec<T>, [T; RATE]> for PaddingFreeSponge<T, P, WIDTH>
 where
-    P: ArrayPermutation<T, { RATE + CAPACITY }>,
+    P: ArrayPermutation<T, WIDTH>,
 {
     fn hash(&self, input: &Vec<T>) -> [T; RATE] {
-        let mut state = [T::default(); RATE + CAPACITY];
+        // static_assert(RATE < WIDTH)
+        let mut state = [T::default(); WIDTH];
         for input_chunk in input.chunks(RATE) {
             state[..input_chunk.len()].copy_from_slice(input_chunk);
             state = self.permutation.permute(state);
@@ -29,16 +32,17 @@ where
     }
 }
 
-impl<T: Default + Copy, P, const RATE: usize, const CAPACITY: usize> IterHasher<T, [T; RATE]>
-    for PaddingFreeSponge<T, P, RATE, CAPACITY>
+impl<T: Default + Copy, P, const RATE: usize, const WIDTH: usize> IterHasher<T, [T; RATE]>
+    for PaddingFreeSponge<T, P, WIDTH>
 where
-    P: ArrayPermutation<T, { RATE + CAPACITY }>,
+    P: ArrayPermutation<T, WIDTH>,
 {
     fn hash_iter<I>(&self, input: I) -> [T; RATE]
     where
         I: IntoIterator<Item = T>,
     {
-        let mut state = [T::default(); RATE + CAPACITY];
+        // static_assert(RATE < WIDTH)
+        let mut state = [T::default(); WIDTH];
         for input_chunk in &input.into_iter().chunks(RATE) {
             state.iter_mut().zip(input_chunk).for_each(|(s, i)| *s = i);
             state = self.permutation.permute(state);


### PR DESCRIPTION
My recent trauma around the `generic_const_expr` prompted me to look at how to remove it in Plonky3. I think the changes here are almost all fine, the only issue being the requirement to manually specify `{ 2 * 4}` in the line ...

I do wonder if there's a simpler way to represent all the sponge, permutation, compression, hashing functions.