### PR TITLE
as_base_slice

### DIFF
--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 pub mod duplex_challenger;
 pub mod hash_challenger;
 
+use alloc::vec::Vec;
 use p3_field::field::{Field, FieldExtension};
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.
@@ -25,7 +26,16 @@ pub trait Challenger<F: Field> {
 
     fn random_element(&mut self) -> F;
 
+    fn random_ext_element<FE: FieldExtension<F>>(&mut self) {
+        let vec = self.random_vec(FE::D);
+        FE::from_base_slice(&vec);
+    }
+
     fn random_array<const N: usize>(&mut self) -> [F; N] {
         core::array::from_fn(|_| self.random_element())
+    }
+
+    fn random_vec(&mut self, n: usize) -> Vec<F> {
+        (0..n).map(|_| self.random_element()).collect()
     }
 }

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -7,15 +7,25 @@ extern crate alloc;
 pub mod duplex_challenger;
 pub mod hash_challenger;
 
-use p3_field::field::Field;
+use p3_field::field::{Field, FieldExtension, Field32};
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.
 pub trait Challenger<F: Field> {
     fn observe_element(&mut self, element: F);
 
+    fn observe_ext_element<FE: FieldExtension<F>>(&mut self, ext: FE) {
+        for coeff in ext.as_base_slice() {
+            self.observe_element(*coeff);
+        }
+    }
+
     fn random_element(&mut self) -> F;
 
     fn random_array<const N: usize>(&mut self) -> [F; N] {
         core::array::from_fn(|_| self.random_element())
+    }
+
+    fn random_u32(&mut self, bound: u32) -> u32 where F: Field32 {
+        self.random_element().as_canonical_u32() % bound
     }
 }

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -7,25 +7,25 @@ extern crate alloc;
 pub mod duplex_challenger;
 pub mod hash_challenger;
 
-use p3_field::field::{Field, FieldExtension, Field32};
+use p3_field::field::{Field, FieldExtension};
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.
 pub trait Challenger<F: Field> {
     fn observe_element(&mut self, element: F);
 
-    fn observe_ext_element<FE: FieldExtension<F>>(&mut self, ext: FE) {
-        for coeff in ext.as_base_slice() {
-            self.observe_element(*coeff);
+    fn observe_elements(&mut self, elements: &[F]) {
+        for &elt in elements {
+            self.observe_element(elt);
         }
+    }
+
+    fn observe_ext_element<FE: FieldExtension<F>>(&mut self, ext: FE) {
+        self.observe_elements(ext.as_base_slice());
     }
 
     fn random_element(&mut self) -> F;
 
     fn random_array<const N: usize>(&mut self) -> [F; N] {
         core::array::from_fn(|_| self.random_element())
-    }
-
-    fn random_u32(&mut self, bound: u32) -> u32 where F: Field32 {
-        self.random_element().as_canonical_u32() % bound
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -128,6 +128,8 @@ pub trait FieldExtension<Base: Field>:
 
     fn from_base(b: Base) -> Self;
 
+    fn from_base_slice(bs: &[Base]) -> Self;
+
     fn as_base_slice(&self) -> &[Base];
 }
 
@@ -136,6 +138,11 @@ impl<F: Field> FieldExtension<F> for F {
 
     fn from_base(b: F) -> Self {
         b
+    }
+
+    fn from_base_slice(bs: &[F]) -> Self {
+        assert_eq!(bs.len(), 1);
+        bs[0]
     }
 
     fn as_base_slice(&self) -> &[F] {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -2,6 +2,7 @@ use crate::packed::PackedField;
 use core::fmt::{Debug, Display};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::slice;
 use itertools::Itertools;
 
 /// A generalization of `Field` which permits things like
@@ -126,6 +127,8 @@ pub trait FieldExtension<Base: Field>:
     const D: usize;
 
     fn from_base(b: Base) -> Self;
+
+    fn as_base_slice(&self) -> &[Base];
 }
 
 impl<F: Field> FieldExtension<F> for F {
@@ -133,6 +136,10 @@ impl<F: Field> FieldExtension<F> for F {
 
     fn from_base(b: F) -> Self {
         b
+    }
+
+    fn as_base_slice(&self) -> &[F] {
+        slice::from_ref(self)
     }
 }
 


### PR DESCRIPTION
We plan to avoid `generic_const_exprs`, so can't use an array here, but a slice should be fine I think.