### PR TITLE
Suggestion for expressing field/extension parameter information

### DIFF
--- a/baby-stark/tests/mul_air.rs
+++ b/baby-stark/tests/mul_air.rs
@@ -33,7 +33,7 @@ impl StarkConfig for MyConfig {
     type F = F;
     type Domain = Mersenne31Complex<F>;
     type Challenge = Self::F; // TODO: Use an extension.
-    type PCS = FRIBasedPCS<Self::F, Self::Challenge, MMCS, MMCS>;
+    type PCS = FRIBasedPCS<Self::Challenge, MMCS, MMCS>;
     type LDE = NaiveLDE;
 }
 

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -19,34 +19,31 @@ mod verifier;
 
 pub use proof::*;
 
-pub struct FriLDT<F, FE, M, MC>
+pub struct FriLDT<F, M, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
 {
     _phantom_f: PhantomData<F>,
-    _phantom_fe: PhantomData<FE>,
     _phantom_m: PhantomData<M>,
     _phantom_mc: PhantomData<MC>,
 }
 
-impl<F, FE, M, MC> LDT<F, M> for FriLDT<F, FE, M, MC>
+impl<F, M, MC> LDT<F::Base, M> for FriLDT<F, M, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
 {
-    type Proof = FriProof<F, FE, M, MC>;
+    type Proof = FriProof<F, M, MC>;
     type Error = ();
 
     fn prove<Chal>(codewords: &[M::ProverData], challenger: &mut Chal) -> Self::Proof
     where
-        Chal: Challenger<F>,
+        Chal: Challenger<F::Base>,
     {
-        prove::<F, FE, M, MC, Chal>(codewords, challenger)
+        prove::<F, M, MC, Chal>(codewords, challenger)
     }
 
     fn verify<Chal>(
@@ -55,10 +52,10 @@ where
         challenger: &mut Chal,
     ) -> Result<(), Self::Error>
     where
-        Chal: Challenger<F>,
+        Chal: Challenger<F::Base>,
     {
-        verify::<F, FE, M, MC, Chal>(proof, challenger)
+        verify::<F, M, MC, Chal>(proof, challenger)
     }
 }
 
-pub type FRIBasedPCS<F, FE, M, MC> = LDTBasedPCS<F, M, FriLDT<F, FE, M, MC>>;
+pub type FRIBasedPCS<F, M, MC> = LDTBasedPCS<<F as Field>::Base, M, FriLDT<F, M, MC>>;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -2,36 +2,33 @@ use alloc::vec::Vec;
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::Field;
 
-pub struct FriProof<F, FE, M, MC>
+pub struct FriProof<F, M, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
 {
-    queries: Vec<QueryProof<F, FE, M, MC>>,
+    queries: Vec<QueryProof<F, M, MC>>,
 }
 
-pub struct QueryProof<F, FE, M, MC>
+pub struct QueryProof<F, M, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
 {
     /// An opened row of each matrix that was part of this batch-FRI proof.
-    leaves: Vec<Vec<F>>,
+    leaves: Vec<Vec<F::Base>>,
     leaf_opening_proofs: Vec<M::Proof>,
-    steps: Vec<QueryStepProof<F, FE, MC>>,
+    steps: Vec<QueryStepProof<F, MC>>,
 }
 
-pub struct QueryStepProof<F, FE, MC>
+pub struct QueryStepProof<F, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    MC: DirectMMCS<F>,
+    MC: DirectMMCS<F::Base>,
 {
     /// An opened row of each matrix that was part of this batch-FRI proof.
-    leaves: FE,
+    leaves: F,
     leaf_opening_proofs: MC::Proof,
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -8,34 +8,32 @@ use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{AbstractField, Field};
 use p3_matrix::Matrix;
 
-pub(crate) fn prove<F, FE, M, MC, Chal>(
+pub(crate) fn prove<F, M, MC, Chal>(
     codewords: &[M::ProverData],
     challenger: &mut Chal,
-) -> FriProof<F, FE, M, MC>
+) -> FriProof<F, M, MC>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
-    Chal: Challenger<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
+    Chal: Challenger<F::Base>,
 {
-    let commit_phase_commits = commit_phase::<F, FE, M, MC, Chal>(codewords, challenger);
+    let commit_phase_commits = commit_phase::<F, M, MC, Chal>(codewords, challenger);
     let queries = todo!();
     todo!()
 }
 
-pub(crate) fn commit_phase<F, FE, M, MC, Chal>(
+pub(crate) fn commit_phase<F, M, MC, Chal>(
     codewords: &[M::ProverData],
     challenger: &mut Chal,
 ) -> Vec<MC::ProverData>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
-    Chal: Challenger<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
+    Chal: Challenger<F::Base>,
 {
-    let alpha: FE = <FE as AbstractField>::ZERO; // TODO challenger.random_ext_element();
+    let alpha: F = <F as AbstractField>::ZERO; // TODO challenger.random_ext_element();
     let matrices_by_desc_height = codewords
         .iter()
         .flat_map(|data| M::get_matrices(data))
@@ -45,18 +43,17 @@ where
 
     let (max_height, largest_matrices_iter) = matrices_by_desc_height.next().expect("No matrices?");
     let largest_matrices = largest_matrices_iter.collect_vec();
-    let zero_vec = vec![<FE as AbstractField>::ZERO; max_height];
+    let zero_vec = vec![<F as AbstractField>::ZERO; max_height];
     let mut current = reduce_matrices(max_height, zero_vec, largest_matrices, alpha);
     let mut committed = vec![current.clone()];
 
     for (height, matrices) in matrices_by_desc_height {
         while current.len() < height {
-            let beta = <FE as AbstractField>::ZERO; // TODO
+            let beta = <F as AbstractField>::ZERO; // TODO
             current = fold_even_odd(&current, beta);
         }
         committed.push(current.clone());
-        current =
-            reduce_matrices::<F, FE, M::Mat>(height, current.clone(), matrices.collect(), alpha);
+        current = reduce_matrices::<F, M::Mat>(height, current.clone(), matrices.collect(), alpha);
     }
     todo!()
 }
@@ -66,16 +63,10 @@ fn fold_even_odd<F: Field>(poly: &[F], beta: F) -> Vec<F> {
     todo!()
 }
 
-fn reduce_matrices<F, FE, Mat>(
-    height: usize,
-    init: Vec<FE>,
-    matrices: Vec<&Mat>,
-    alpha: FE,
-) -> Vec<FE>
+fn reduce_matrices<F, Mat>(height: usize, init: Vec<F>, matrices: Vec<&Mat>, alpha: F) -> Vec<F>
 where
     F: Field,
-    FE: Field<Base = F>,
-    Mat: Matrix<F>,
+    Mat: Matrix<F::Base>,
 {
     (0..height)
         .map(|r| {

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -3,16 +3,15 @@ use p3_challenger::Challenger;
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::Field;
 
-pub(crate) fn verify<F, FE, M, MC, Chal>(
-    _proof: &FriProof<F, FE, M, MC>,
+pub(crate) fn verify<F, M, MC, Chal>(
+    _proof: &FriProof<F, M, MC>,
     _challenger: &mut Chal,
 ) -> Result<(), ()>
 where
     F: Field,
-    FE: Field<Base = F>,
-    M: MMCS<F>,
-    MC: DirectMMCS<F>,
-    Chal: Challenger<F>,
+    M: MMCS<F::Base>,
+    MC: DirectMMCS<F::Base>,
+    Chal: Challenger<F::Base>,
 {
     todo!()
 }


### PR DESCRIPTION
Removed the base field parameter `F`; renamed `FE` to `F` throughout, and specified `F::Base` when base field is needed.