### PR TITLE
Fix `cargo test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,8 @@ jobs:
     - name: Build
       run: cargo +nightly build --verbose --all-targets
     - name: Test
-      run: cargo +nightly test --verbose --all-targets
+      run: |
+        cargo +nightly test --verbose --all-targets
+        # It's necessary to run doc tests separately, until
+        # <https://github.com/rust-lang/cargo/issues/6669> is fixed.
+        cargo +nightly test --verbose --doc

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -40,24 +40,31 @@ pub unsafe trait PackedField: AbstractionOf<Self::Scalar>
 
     /// Take interpret two vectors as chunks of `block_len` elements. Unpack and interleave those
     /// chunks. This is best seen with an example. If we have:
-    ///
+    /// ```text
     ///     A = [x0, y0, x1, y1]
     ///     B = [x2, y2, x3, y3]
+    /// ```
     ///
     /// then
     ///
+    /// ```text
     ///     interleave(A, B, 1) = ([x0, x2, x1, x3], [y0, y2, y1, y3])
+    /// ```
     ///
     /// Pairs that were adjacent in the input are at corresponding positions in the output.
     ///
     /// `r` lets us set the size of chunks we're interleaving. If we set `block_len = 2`, then for
     ///
+    /// ```text
     ///     A = [x0, x1, y0, y1]
     ///     B = [x2, x3, y2, y3]
+    /// ```
     ///
     /// we obtain
     ///
+    /// ```text
     ///     interleave(A, B, block_len) = ([x0, x1, x2, x3], [y0, y1, y2, y3])
+    /// ```
     ///
     /// We can also think about this as stacking the vectors, dividing them into 2x2 matrices, and
     /// transposing those matrices.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -36,12 +36,14 @@ pub fn assume(p: bool) {
 
 /// Try to force Rust to emit a branch. Example:
 ///
+/// ```ignore
 ///     if x > 2 {
 ///         y = foo();
 ///         branch_hint();
 ///     } else {
 ///         y = bar();
 ///     }
+/// ```
 ///
 /// This function has no semantics. It is a hint only.
 #[inline(always)]


### PR DESCRIPTION
`cargo test` runs some tests that `cargo test --all-targets` does not run.  See https://github.com/rust-lang/cargo/issues/6669 tracks this issues.  Specifically, doc tests.

This PR adds running the latter to our CI/CD, to ensure that a simple `cargo test` will work.

This PR also marks parts of the documentation that look like tests to cargo, but actually aren't meant to be tests.