### PR TITLE
Let PCS take any `MatrixRows`

### DIFF
--- a/commit/src/adapters/multi_from_uni_pcs.rs
+++ b/commit/src/adapters/multi_from_uni_pcs.rs
@@ -1,46 +1,47 @@
-use crate::pcs::{MultivariatePCS, UnivariatePCS, PCS};
+use crate::pcs::{UnivariatePCS, PCS};
+use crate::MultivariatePCS;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use p3_challenger::Challenger;
 use p3_field::{ExtensionField, Field};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::MatrixRows;
 
-pub struct MultiFromUniPCS<F: Field, U: UnivariatePCS<F>> {
+pub struct MultiFromUniPCS<F, In, U>
+where
+    F: Field,
+    In: for<'a> MatrixRows<'a, F>,
+    U: UnivariatePCS<F, In>,
+{
     _uni: U,
     _phantom_f: PhantomData<F>,
+    _phantom_in: PhantomData<In>,
 }
 
-impl<F: Field, U: UnivariatePCS<F>> PCS<F> for MultiFromUniPCS<F, U> {
+impl<F, In, U> PCS<F, In> for MultiFromUniPCS<F, In, U>
+where
+    F: Field,
+    In: for<'a> MatrixRows<'a, F>,
+    U: UnivariatePCS<F, In>,
+{
     type Commitment = ();
     type ProverData = U::ProverData;
     type Proof = ();
     type Error = ();
 
-    fn commit_batches(
-        &self,
-        _polynomials: Vec<RowMajorMatrix<F>>,
-    ) -> (Self::Commitment, Self::ProverData) {
-        todo!()
-    }
-
-    fn get_committed_height(&self, _prover_data: &Self::ProverData, _matrix: usize) -> usize {
-        todo!()
-    }
-
-    fn get_committed_row(
-        &self,
-        _prover_data: &Self::ProverData,
-        _matrix: usize,
-        _row: usize,
-    ) -> &[F] {
+    fn commit_batches(&self, _polynomials: Vec<In>) -> (Self::Commitment, Self::ProverData) {
         todo!()
     }
 }
 
-impl<F: Field, U: UnivariatePCS<F>> MultivariatePCS<F> for MultiFromUniPCS<F, U> {
+impl<F, In, U> MultivariatePCS<F, In> for MultiFromUniPCS<F, In, U>
+where
+    F: Field,
+    In: for<'a> MatrixRows<'a, F>,
+    U: UnivariatePCS<F, In>,
+{
     fn open_multi_batches<EF, Chal>(
         &self,
-        _prover_data: &[Self::ProverData],
+        _prover_data: &[&Self::ProverData],
         _points: &[Vec<EF>],
         _challenger: &mut Chal,
     ) -> (Vec<Vec<Vec<EF>>>, Self::Proof)

--- a/commit/src/adapters/uni_from_multi_pcs.rs
+++ b/commit/src/adapters/uni_from_multi_pcs.rs
@@ -1,10 +1,17 @@
 use crate::pcs::MultivariatePCS;
 use core::marker::PhantomData;
 use p3_field::Field;
+use p3_matrix::MatrixRows;
 
-pub struct UniFromMultiPCS<F: Field, M: MultivariatePCS<F>> {
+pub struct UniFromMultiPCS<F, In, M>
+where
+    F: Field,
+    In: for<'a> MatrixRows<'a, F>,
+    M: MultivariatePCS<F, In>,
+{
     _multi: M,
     _phantom_f: PhantomData<F>,
+    _phantom_in: PhantomData<In>,
 }
 
 // impl<F: Field, M: MultivariatePCS<F>> UnivariatePCS<F> for UniFromMultiPCS<F> {}

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -1,12 +1,12 @@
 use alloc::vec::Vec;
 use p3_commit::{DirectMMCS, MMCS};
-use p3_field::{AbstractExtensionField, Field};
+use p3_field::{ExtensionField, Field};
 
 #[allow(dead_code)] // TODO: fields should be used soon
 pub struct FriProof<F, EF, M, MC>
 where
     F: Field,
-    EF: AbstractExtensionField<F>,
+    EF: ExtensionField<F>,
     M: MMCS<F>,
     MC: DirectMMCS<F>,
 {
@@ -17,7 +17,7 @@ where
 pub struct QueryProof<F, EF, M, MC>
 where
     F: Field,
-    EF: AbstractExtensionField<F>,
+    EF: ExtensionField<F>,
     M: MMCS<F>,
     MC: DirectMMCS<F>,
 {
@@ -31,7 +31,7 @@ where
 pub struct QueryStepProof<F, EF, MC>
 where
     F: Field,
-    EF: AbstractExtensionField<F>,
+    EF: ExtensionField<F>,
     MC: DirectMMCS<F>,
 {
     /// An opened row of each matrix that was part of this batch-FRI proof.

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,7 +1,7 @@
 use crate::FriProof;
 use p3_challenger::Challenger;
 use p3_commit::{DirectMMCS, MMCS};
-use p3_field::{AbstractExtensionField, Field};
+use p3_field::{ExtensionField, Field};
 
 pub(crate) fn verify<F, EF, M, MC, Chal>(
     _proof: &FriProof<F, EF, M, MC>,
@@ -9,7 +9,7 @@ pub(crate) fn verify<F, EF, M, MC, Chal>(
 ) -> Result<(), ()>
 where
     F: Field,
-    EF: AbstractExtensionField<F>,
+    EF: ExtensionField<F>,
     M: MMCS<F>,
     MC: DirectMMCS<F>,
     Chal: Challenger<F>,

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -114,6 +114,13 @@ impl<'a, T: 'a> MatrixRows<'a, T> for RowMajorMatrix<T> {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
     }
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+    {
+        self
+    }
 }
 
 #[derive(Copy, Clone)]
@@ -144,6 +151,14 @@ impl<'a, T: 'a> MatrixRows<'a, T> for RowMajorMatrixView<'_, T> {
     fn row(&'a self, r: usize) -> &'a [T] {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
+    }
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+        T: Clone,
+    {
+        RowMajorMatrix::new(self.values.to_vec(), self.width)
     }
 }
 
@@ -204,5 +219,13 @@ impl<'a, T: 'a> MatrixRows<'a, T> for RowMajorMatrixViewMut<'_, T> {
     fn row(&'a self, r: usize) -> &'a [T] {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
+    }
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+        T: Clone,
+    {
+        RowMajorMatrix::new(self.values.to_vec(), self.width)
     }
 }

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 
+use crate::dense::RowMajorMatrix;
 use alloc::boxed::Box;
 
 pub mod dense;
@@ -27,6 +28,14 @@ pub trait MatrixRows<'a, T: 'a>: Matrix<T> {
     type Row: IntoIterator<Item = &'a T>;
 
     fn row(&'a self, r: usize) -> Self::Row;
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+        T: Clone,
+    {
+        todo!()
+    }
 }
 
 impl<T> Matrix<T> for Box<dyn Matrix<T>> {

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -182,7 +182,7 @@ impl<L, D, H, C, Mat> MerkleTreeMMCS<L, D, H, C, Mat> {
 
 impl<L, D, H, C, Mat> MMCS<L> for MerkleTreeMMCS<L, D, H, C, Mat>
 where
-    L: 'static + Clone,
+    L: Clone,
     H: CryptographicHasher<L, D>,
     C: PseudoCompressionFunction<D, 2>,
     Mat: for<'a> MatrixRows<'a, L>,
@@ -220,7 +220,7 @@ where
 
 impl<L, D, H, C, Mat> DirectMMCS<L> for MerkleTreeMMCS<L, D, H, C, Mat>
 where
-    L: 'static + Copy,
+    L: Copy,
     D: Copy + Default,
     H: CryptographicHasher<L, D>,
     C: PseudoCompressionFunction<D, 2>,

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 use p3_commit::MultivariatePCS;
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField};
+use p3_matrix::dense::RowMajorMatrixView;
 
 pub trait StarkConfig {
     /// A value of the trace.
@@ -13,7 +14,7 @@ pub trait StarkConfig {
         + AbstractExtensionField<<Self::Val as Field>::Packing>;
 
     /// The PCS used to commit to trace polynomials.
-    type PCS: MultivariatePCS<Self::Val>;
+    type PCS: for<'a> MultivariatePCS<Self::Val, RowMajorMatrixView<'a, Self::Val>>;
 
     fn pcs(&self) -> &Self::PCS;
 }
@@ -42,7 +43,7 @@ where
     Val: Field,
     Challenge: ExtensionField<Val>,
     PackedChallenge: PackedField<Scalar = Challenge> + AbstractExtensionField<Val::Packing>,
-    PCS: MultivariatePCS<Val>,
+    PCS: for<'a> MultivariatePCS<Val, RowMajorMatrixView<'a, Val>>,
 {
     type Val = Val;
     type Challenge = Challenge;

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -14,7 +14,7 @@ pub fn prove<SC, A, Chal>(
     A: for<'a> Air<ConstraintFolder<'a, SC::Val, SC::Challenge, SC::PackedChallenge>>,
     Chal: Challenger<SC::Val>,
 {
-    let (_trace_commit, _trace_data) = config.pcs().commit_batch(trace);
+    let (_trace_commit, _trace_data) = config.pcs().commit_batch(trace.as_view());
 
     // challenger.observe_ext_element(trace_commit); // TODO
 }

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 use p3_commit::UnivariatePCS;
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField, TwoAdicField};
 use p3_lde::TwoAdicCosetLDE;
+use p3_matrix::dense::RowMajorMatrixView;
 
 pub trait StarkConfig {
     /// A value of the trace.
@@ -17,7 +18,7 @@ pub trait StarkConfig {
         + AbstractExtensionField<<Self::Domain as Field>::Packing>;
 
     /// The PCS used to commit to trace polynomials.
-    type PCS: UnivariatePCS<Self::Val>;
+    type PCS: for<'a> UnivariatePCS<Self::Val, RowMajorMatrixView<'a, Self::Val>>;
 
     type LDE: TwoAdicCosetLDE<Self::Val, Self::Domain>;
 
@@ -57,7 +58,7 @@ where
     Domain: ExtensionField<Val> + TwoAdicField,
     Challenge: ExtensionField<Domain>,
     PackedChallenge: PackedField<Scalar = Challenge> + AbstractExtensionField<Domain::Packing>,
-    PCS: UnivariatePCS<Val>,
+    PCS: for<'a> UnivariatePCS<Val, RowMajorMatrixView<'a, Val>>,
     LDE: TwoAdicCosetLDE<Val, Domain>,
 {
     type Val = Val;

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -66,7 +66,7 @@ pub fn prove<SC, A, Chal>(
 
     let trace_lde = config.lde().lde_batch(trace.clone(), quotient_degree_bits);
 
-    let (_trace_commit, _trace_data) = config.pcs().commit_batch(trace);
+    let (_trace_commit, _trace_data) = config.pcs().commit_batch(trace.as_view());
 
     // challenger.observe_ext_element(trace_commit); // TODO
     let alpha = challenger.random_ext_element::<SC::Challenge>();


### PR DESCRIPTION
And remove the methods for reading committed data. I think in the future we can pass borrowed matrix types instead.