### PR TITLE
Run linters in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,47 @@ jobs:
         # It's necessary to run doc tests separately, until
         # <https://github.com/rust-lang/cargo/issues/6669> is fixed.
         cargo +nightly test --verbose --doc
+
+  lints:
+    name: Formatting and Clippy
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        id: rustc-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-06-30
+          override: true
+          components: rustfmt, clippy
+
+      - name: rust-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rustc-lints-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+        env:
+          CARGO_INCREMENTAL: 1
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets -- -D warnings -A incomplete-features
+        env:
+          CARGO_INCREMENTAL: 1

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,4 +1,5 @@
 use core::ops::{Add, Mul, Sub};
+
 use p3_field::{AbstractExtensionField, AbstractField, AbstractionOf, ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRows;
@@ -209,8 +210,9 @@ impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Air, AirBuilder};
     use p3_matrix::MatrixRows;
+
+    use crate::{Air, AirBuilder};
 
     struct FibonacciAir;
 

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
+
 use p3_field::{AbstractField, Field};
 
 /// An affine function over columns in a PAIR.

--- a/brakedown/benches/encode.rs
+++ b/brakedown/benches/encode.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_brakedown::fast_registry;
 use p3_code::CodeOrFamily;
@@ -6,7 +8,6 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_mersenne_31::Mersenne31;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
-use std::any::type_name;
 
 const BATCH_SIZE: usize = 1 << 12;
 

--- a/brakedown/src/brakedown_code.rs
+++ b/brakedown/src/brakedown_code.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+
 use p3_code::{
     Code, CodeOrFamily, LinearCode, SystematicCode, SystematicCodeOrFamily, SystematicLinearCode,
 };

--- a/brakedown/src/macros.rs
+++ b/brakedown/src/macros.rs
@@ -30,5 +30,4 @@ macro_rules! brakedown_to_rs {
     };
 }
 
-pub(crate) use brakedown;
-pub(crate) use brakedown_to_rs;
+pub(crate) use {brakedown, brakedown_to_rs};

--- a/brakedown/src/standard_fast.rs
+++ b/brakedown/src/standard_fast.rs
@@ -1,7 +1,6 @@
-use crate::macros::{brakedown, brakedown_to_rs};
-use crate::BrakedownCode;
 use alloc::boxed::Box;
 use alloc::vec;
+
 use p3_code::{LinearCodeFamily, SLCodeRegistry};
 use p3_field::Field;
 use p3_matrix::sparse::CsrMatrix;
@@ -9,6 +8,9 @@ use p3_matrix::MatrixRows;
 use rand::distributions::{Distribution, Standard};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+
+use crate::macros::{brakedown, brakedown_to_rs};
+use crate::BrakedownCode;
 
 pub fn fast_registry<F, In>() -> impl LinearCodeFamily<F, In>
 where

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -86,10 +86,9 @@ mod tests {
     struct TestPermutation {}
 
     impl CryptographicPermutation<TestArray> for TestPermutation {
-        fn permute(&self, input: TestArray) -> TestArray {
-            let mut output = input.clone();
-            output.reverse();
-            output.try_into().unwrap()
+        fn permute(&self, mut input: TestArray) -> TestArray {
+            self.permute_mut(&mut input);
+            input
         }
 
         fn permute_mut(&self, input: &mut TestArray) {
@@ -124,7 +123,7 @@ mod tests {
 
         let should_be_output_buffer: [F; WIDTH] = (0..WIDTH as u8)
             .rev()
-            .map(|i| F::from_canonical_u8(i))
+            .map(F::from_canonical_u8)
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
@@ -139,8 +138,7 @@ mod tests {
 
         // Test functionality when observing additional elements
         duplex_challenger.duplexing();
-        let mut should_be_output_buffer =
-            (0..31).map(|i| F::from_canonical_u8(i)).collect::<Vec<_>>();
+        let mut should_be_output_buffer = (0..31).map(F::from_canonical_u8).collect::<Vec<_>>();
         should_be_output_buffer.push(F::from_canonical_u8(255));
         assert_eq!(duplex_challenger.input_buffer, vec![]);
         assert_eq!(duplex_challenger.output_buffer, should_be_output_buffer);
@@ -162,7 +160,7 @@ mod tests {
             vec![F::ZERO; WIDTH / 2],
             (0..WIDTH / 2)
                 .rev()
-                .map(|i| F::from_canonical_usize(i))
+                .map(F::from_canonical_usize)
                 .collect::<Vec<_>>(),
         ]
         .concat()

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_field::Field;
 use p3_symmetric::permutation::ArrayPermutation;
 

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -1,9 +1,11 @@
-use crate::Challenger;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_field::Field;
 use p3_symmetric::hasher::CryptographicHasher;
+
+use crate::Challenger;
 
 #[derive(Clone)]
 pub struct HashChallenger<F: Field, H: CryptographicHasher<F, [F; OUT_LEN]>, const OUT_LEN: usize> {

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -7,10 +7,10 @@ extern crate alloc;
 mod duplex_challenger;
 mod hash_challenger;
 
+use alloc::vec::Vec;
+
 pub use duplex_challenger::*;
 pub use hash_challenger::*;
-
-use alloc::vec::Vec;
 use p3_field::{AbstractExtensionField, Field};
 
 /// Observes prover messages during an IOP, and generates Fiat-Shamir challenges in response.

--- a/code/src/identity.rs
+++ b/code/src/identity.rs
@@ -1,8 +1,9 @@
+use p3_field::Field;
+use p3_matrix::MatrixRows;
+
 use crate::{
     Code, CodeOrFamily, LinearCode, SystematicCode, SystematicCodeOrFamily, SystematicLinearCode,
 };
-use p3_field::Field;
-use p3_matrix::MatrixRows;
 
 /// The trivial code whose encoder is the identity function.
 pub struct IdentityCode {

--- a/code/src/registry.rs
+++ b/code/src/registry.rs
@@ -1,11 +1,13 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use p3_field::Field;
+use p3_matrix::{Matrix, MatrixRows};
+
 use crate::{
     CodeFamily, CodeOrFamily, LinearCodeFamily, SystematicCodeFamily, SystematicCodeOrFamily,
     SystematicLinearCode,
 };
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use p3_field::Field;
-use p3_matrix::{Matrix, MatrixRows};
 
 /// A registry of systematic, linear codes for various message sizes.
 pub struct SLCodeRegistry<F: Field, In: Matrix<F>, Out: Matrix<F>> {

--- a/code/src/systematic.rs
+++ b/code/src/systematic.rs
@@ -1,6 +1,7 @@
-use crate::{Code, CodeFamily, CodeOrFamily, LinearCode};
 use p3_field::Field;
 use p3_matrix::MatrixRows;
+
+use crate::{Code, CodeFamily, CodeOrFamily, LinearCode};
 
 /// A systematic code, or a family thereof.
 // TODO: Remove? Not really used.

--- a/commit/src/adapters/multi_from_uni_pcs.rs
+++ b/commit/src/adapters/multi_from_uni_pcs.rs
@@ -1,10 +1,12 @@
-use crate::pcs::{UnivariatePCS, PCS};
-use crate::MultivariatePCS;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_challenger::Challenger;
 use p3_field::{ExtensionField, Field};
 use p3_matrix::MatrixRows;
+
+use crate::pcs::{UnivariatePCS, PCS};
+use crate::MultivariatePCS;
 
 pub struct MultiFromUniPCS<F, In, U>
 where

--- a/commit/src/adapters/uni_from_multi_pcs.rs
+++ b/commit/src/adapters/uni_from_multi_pcs.rs
@@ -1,7 +1,9 @@
-use crate::pcs::MultivariatePCS;
 use core::marker::PhantomData;
+
 use p3_field::Field;
 use p3_matrix::MatrixRows;
+
+use crate::pcs::MultivariatePCS;
 
 pub struct UniFromMultiPCS<F, In, M>
 where

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+
 use p3_matrix::MatrixRows;
 
 /// A "Mixed Matrix Commitment Scheme" (MMCS) is a bit like a vector commitment scheme, but it

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -1,10 +1,10 @@
 //! Traits for polynomial commitment schemes.
 
 use alloc::vec;
-use p3_field::{ExtensionField, Field};
-
 use alloc::vec::Vec;
+
 use p3_challenger::Challenger;
+use p3_field::{ExtensionField, Field};
 use p3_matrix::MatrixRows;
 
 /// A (not necessarily hiding) polynomial commitment scheme, for committing to (batches of)

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -1,6 +1,7 @@
-use crate::field::Field;
 use alloc::vec;
 use alloc::vec::Vec;
+
+use crate::field::Field;
 
 /// Batch multiplicative inverses with Montgomery's trick
 /// This is Montgomery's trick. At a high level, we invert the product of the given field

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1,4 +1,3 @@
-use crate::packed::PackedField;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::iter::{Product, Sum};
@@ -6,6 +5,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::slice;
 
 use p3_util::log2_ceil_u64;
+
+use crate::packed::PackedField;
 
 /// A generalization of `Field` which permits things like
 /// - an actual field element

--- a/field/src/symbolic.rs
+++ b/field/src/symbolic.rs
@@ -1,8 +1,9 @@
-use crate::field::{AbstractField, AbstractionOf, Field};
 use alloc::rc::Rc;
 use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::field::{AbstractField, AbstractionOf, Field};
 
 #[derive(Clone, Debug)]
 pub enum SymbolicField<F: Field, Var> {

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -11,7 +11,7 @@ use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{ExtensionField, Field};
 use p3_ldt::{LDTBasedPCS, LDT};
 
-use crate::proof::FriProof;
+pub use crate::proof::FriProof;
 use crate::prover::prove;
 use crate::verifier::verify;
 

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -4,14 +4,16 @@
 
 extern crate alloc;
 
-use crate::proof::FriProof;
-use crate::prover::prove;
-use crate::verifier::verify;
 use core::marker::PhantomData;
+
 use p3_challenger::Challenger;
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{ExtensionField, Field};
 use p3_ldt::{LDTBasedPCS, LDT};
+
+use crate::proof::FriProof;
+use crate::prover::prove;
+use crate::verifier::verify;
 
 mod config;
 mod proof;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{ExtensionField, Field};
 

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -1,14 +1,15 @@
-use crate::{FriConfig, FriProof};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Reverse;
+
 use itertools::Itertools;
 use p3_challenger::Challenger;
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{AbstractField, ExtensionField, Field};
 use p3_matrix::{Matrix, MatrixRows};
-use p3_maybe_rayon::MaybeIntoParIter;
-use p3_maybe_rayon::ParallelIterator;
+use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+
+use crate::{FriConfig, FriProof};
 
 pub(crate) fn prove<F, Challenge, M, MC, Chal>(
     codewords: &[M::ProverData],

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,7 +1,8 @@
-use crate::FriProof;
 use p3_challenger::Challenger;
 use p3_commit::{DirectMMCS, MMCS};
 use p3_field::{ExtensionField, Field};
+
+use crate::FriProof;
 
 pub(crate) fn verify<F, EF, M, MC, Chal>(
     _proof: &FriProof<F, EF, M, MC>,

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -7,6 +7,7 @@ use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+
 use p3_field::{AbstractField, Field, PrimeField, PrimeField64, TwoAdicField};
 use p3_util::{assume, branch_hint};
 use rand::distributions::{Distribution, Standard};

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+
 use p3_symmetric::hasher::CryptographicHasher;
 use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
 use tiny_keccak::{keccakf, Hasher, Keccak};

--- a/lde/src/naive.rs
+++ b/lde/src/naive.rs
@@ -1,13 +1,15 @@
-use crate::{TwoAdicCosetLDE, TwoAdicLDE, TwoAdicSubgroupLDE, UndefinedLDE};
 use alloc::vec::Vec;
+
 use p3_field::{
     batch_multiplicative_inverse, cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order,
+    ExtensionField, Field, TwoAdicField,
 };
-use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::VerticalPair;
 use p3_matrix::{Matrix, MatrixRows};
 use p3_util::log2_strict_usize;
+
+use crate::{TwoAdicCosetLDE, TwoAdicLDE, TwoAdicSubgroupLDE, UndefinedLDE};
 
 /// A naive quadratic-time implementation of `LDE`, intended for testing.
 pub struct NaiveUndefinedLDE;

--- a/ldt/src/lib.rs
+++ b/ldt/src/lib.rs
@@ -6,9 +6,9 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_challenger::Challenger;
-use p3_commit::{DirectMMCS, MMCS};
-use p3_commit::{UnivariatePCS, PCS};
+use p3_commit::{DirectMMCS, UnivariatePCS, MMCS, PCS};
 use p3_field::{AbstractExtensionField, ExtensionField, Field, TwoAdicField};
 use p3_lde::TwoAdicLDE;
 use p3_matrix::dense::RowMajorMatrix;

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -1,8 +1,10 @@
-use crate::{Matrix, MatrixGet, MatrixRows};
 use alloc::vec::Vec;
+
 use p3_field::Field;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
+
+use crate::{Matrix, MatrixGet, MatrixRows};
 
 /// A dense matrix stored in row-major form.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -4,8 +4,9 @@
 
 extern crate alloc;
 
-use crate::dense::RowMajorMatrix;
 use alloc::boxed::Box;
+
+use crate::dense::RowMajorMatrix;
 
 pub mod dense;
 pub mod mul;

--- a/matrix/src/mul.rs
+++ b/matrix/src/mul.rs
@@ -1,9 +1,11 @@
+use alloc::vec;
+
+use p3_field::Field;
+use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+
 use crate::dense::RowMajorMatrix;
 use crate::sparse::CsrMatrix;
 use crate::{Matrix, MatrixRows};
-use alloc::vec;
-use p3_field::Field;
-use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
 
 /// Compute `C = A * B`, where `A` in a CSR matrix and `B` is a dense matrix.
 ///

--- a/matrix/src/sparse.rs
+++ b/matrix/src/sparse.rs
@@ -1,9 +1,11 @@
-use crate::Matrix;
 use alloc::vec::Vec;
 use core::iter;
 use core::ops::Range;
+
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
+
+use crate::Matrix;
 
 /// A sparse matrix stored in the compressed sparse row format.
 pub struct CsrMatrix<T> {

--- a/matrix/src/stack.rs
+++ b/matrix/src/stack.rs
@@ -1,5 +1,6 @@
-use crate::{Matrix, MatrixRows};
 use core::marker::PhantomData;
+
+use crate::{Matrix, MatrixRows};
 
 /// A combination of two matrices, stacked together vertically.
 pub struct VerticalPair<T, First: Matrix<T>, Second: Matrix<T>> {

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 use core::cmp::Reverse;
 use core::iter;
 use core::marker::PhantomData;
+
 use itertools::Itertools;
 use p3_commit::{Dimensions, DirectMMCS, MMCS};
 use p3_matrix::{Matrix, MatrixRows};
@@ -235,13 +236,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::MerkleTreeMMCS;
     use alloc::vec;
+
     use p3_commit::DirectMMCS;
     use p3_keccak::Keccak256Hash;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_symmetric::compression::TruncatedPermutation;
     use rand::thread_rng;
+
+    use crate::MerkleTreeMMCS;
 
     #[test]
     fn commit() {

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -61,8 +61,7 @@ where
                 h.hash_iter(
                     tallest_matrices
                         .iter()
-                        .map(|m| m.row(i).into_iter().copied())
-                        .flatten(),
+                        .flat_map(|m| m.row(i).into_iter().copied()),
                 )
             })
             .chain(iter::repeat(D::default()))
@@ -137,8 +136,7 @@ where
         let tallest_digest = h.hash_iter(
             tallest_matrices
                 .iter()
-                .map(|m| m.row(i).into_iter().copied())
-                .flatten(),
+                .flat_map(|m| m.row(i).into_iter().copied()),
         );
         digest = c.compress([digest, tallest_digest]);
         next_digests.push(digest);

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -1,8 +1,10 @@
-use crate::Mersenne31;
 use core::fmt::{Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+
 use p3_field::{AbstractExtensionField, AbstractField, AbstractionOf, Field, TwoAdicField};
+
+use crate::Mersenne31;
 
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug, Default)]
 pub struct Mersenne31Complex<AF: AbstractionOf<Mersenne31>> {

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -172,7 +172,7 @@ impl Field for Mersenne31 {
         loop {
             // Shift off trailing zeros
             let e = u.trailing_zeros() as u64;
-            u = u >> e;
+            u >>= e;
 
             // Circular shift
             a = a.mul_2exp_u64(31 - e);

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -4,13 +4,13 @@
 
 mod complex;
 
-pub use complex::*;
-
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, BitXorAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+
+pub use complex::*;
 use p3_field::{AbstractField, Field, PrimeField, PrimeField32};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -288,8 +288,9 @@ impl Div for Mersenne31 {
 
 #[cfg(test)]
 mod tests {
-    use crate::Mersenne31;
     use p3_field::{AbstractField, Field, PrimeField32};
+
+    use crate::Mersenne31;
 
     type F = Mersenne31;
 

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use p3_commit::MultivariatePCS;
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField};
 use p3_matrix::dense::RowMajorMatrixView;

--- a/multi-stark/src/folder.rs
+++ b/multi-stark/src/folder.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use p3_air::{AirBuilder, TwoRowMatrixView};
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField};
 

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -1,8 +1,9 @@
-use crate::{ConstraintFolder, StarkConfig};
 use p3_air::Air;
 use p3_challenger::Challenger;
 use p3_commit::PCS;
 use p3_matrix::dense::RowMajorMatrix;
+
+use crate::{ConstraintFolder, StarkConfig};
 
 pub fn prove<SC, A, Chal>(
     config: &SC,

--- a/multi-stark/src/sym_var.rs
+++ b/multi-stark/src/sym_var.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Sub};
-use p3_field::Field;
-use p3_field::SymbolicField;
+
+use p3_field::{Field, SymbolicField};
 
 #[derive(Copy, Clone, Debug)]
 pub struct BasicSymVar<F: Field> {

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+
 use p3_field::Field;
 use p3_symmetric::mds::MDSPermutation;
 use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};

--- a/reed-solomon/src/lib.rs
+++ b/reed-solomon/src/lib.rs
@@ -1,12 +1,13 @@
 //! Reed-Solomon codes.
 
+use std::marker::PhantomData;
+
 use p3_code::{
     Code, CodeOrFamily, LinearCode, SystematicCode, SystematicCodeOrFamily, SystematicLinearCode,
 };
 use p3_field::Field;
 use p3_lde::UndefinedLDE;
 use p3_matrix::MatrixRows;
-use std::marker::PhantomData;
 
 /// A Reed-Solomon code based on an `UndefinedLDE`.
 pub struct UndefinedReedSolomonCode<F, L, In>

--- a/rescue/src/inverse_sbox.rs
+++ b/rescue/src/inverse_sbox.rs
@@ -1,6 +1,6 @@
-use crate::util::get_inverse;
-
 use p3_field::{PrimeField, PrimeField64};
+
+use crate::util::get_inverse;
 
 pub trait InverseSboxLayer<F: PrimeField, const WIDTH: usize, const ALPHA: u64> {
     fn inverse_sbox_layer(&self, state: &mut [F; WIDTH]);

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -134,8 +134,11 @@ where
             self.mds.permute_mut(&mut state);
 
             // Constants
-            for j in 0..WIDTH {
-                state[j] += self.round_constants[round * WIDTH * 2 + j];
+            for (state_item, &round_constant) in itertools::izip!(
+                state.iter_mut(),
+                self.round_constants[round * WIDTH * 2..].iter()
+            ) {
+                *state_item += round_constant;
             }
 
             // Inverse S-box
@@ -145,8 +148,11 @@ where
             self.mds.permute_mut(&mut state);
 
             // Constants
-            for j in 0..WIDTH {
-                state[j] += self.round_constants[round * WIDTH * 2 + WIDTH + j];
+            for (state_item, &round_constant) in itertools::izip!(
+                state.iter_mut(),
+                self.round_constants[round * WIDTH * 2 + WIDTH..].iter()
+            ) {
+                *state_item += round_constant;
             }
         }
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -1,6 +1,3 @@
-use crate::inverse_sbox::InverseSboxLayer;
-use crate::util::shake256_hash;
-
 use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
@@ -11,6 +8,9 @@ use p3_util::ceil_div_usize;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
+
+use crate::inverse_sbox::InverseSboxLayer;
+use crate::util::shake256_hash;
 
 #[derive(Clone)]
 pub struct Rescue<F, MDS, ISL, const WIDTH: usize, const ALPHA: u64>

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -1,11 +1,8 @@
 use gcd::Gcd;
 use modinverse::modinverse;
-
 use p3_field::PrimeField64;
-use sha3::{
-    digest::{ExtendableOutput, Update, XofReader},
-    Shake256,
-};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::Shake256;
 
 /// Generate alpha, the smallest integer relatively prime to `p − 1`.
 pub(crate) fn get_alpha<F: PrimeField64>() -> u64 {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+unstable_features = true

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -1,6 +1,7 @@
+use core::marker::PhantomData;
+
 use crate::hasher::CryptographicHasher;
 use crate::permutation::CryptographicPermutation;
-use core::marker::PhantomData;
 
 /// An `n`-to-1 compression function, like `CompressionFunction`, except that it need only be
 /// collision-resistant in a hash tree setting, where the preimage of a non-leaf node must consist

--- a/symmetric/src/mds.rs
+++ b/symmetric/src/mds.rs
@@ -1,5 +1,6 @@
-use crate::permutation::{ArrayPermutation, CryptographicPermutation};
 use p3_field::PrimeField;
+
+use crate::permutation::{ArrayPermutation, CryptographicPermutation};
 
 pub trait MDSPermutation<T, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
 

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -1,7 +1,9 @@
+use core::marker::PhantomData;
+
+use itertools::Itertools;
+
 use crate::hasher::CryptographicHasher;
 use crate::permutation::ArrayPermutation;
-use core::marker::PhantomData;
-use itertools::Itertools;
 
 /// A padding-free, overwrite-mode sponge function.
 ///

--- a/tensor-pcs/src/reshape.rs
+++ b/tensor-pcs/src/reshape.rs
@@ -3,10 +3,7 @@ use p3_util::log2_strict_usize;
 pub(crate) fn optimal_wraps(width: usize, height: usize) -> usize {
     let height_bits = log2_strict_usize(height);
     (0..height_bits)
-        .min_by_key(|&wrap_bits| {
-            let cost = estimate_cost(width << wrap_bits, height >> wrap_bits);
-            cost
-        })
+        .min_by_key(|&wrap_bits| estimate_cost(width << wrap_bits, height >> wrap_bits))
         .unwrap()
 }
 

--- a/tensor-pcs/src/tensor_pcs.rs
+++ b/tensor-pcs/src/tensor_pcs.rs
@@ -1,13 +1,15 @@
-use crate::reshape::optimal_wraps;
-use crate::wrapped_matrix::WrappedMatrix;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_challenger::Challenger;
 use p3_code::LinearCodeFamily;
 use p3_commit::{DirectMMCS, MultivariatePCS, PCS};
 use p3_field::{ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRows;
+
+use crate::reshape::optimal_wraps;
+use crate::wrapped_matrix::WrappedMatrix;
 
 pub struct TensorPCS<F, C, M>
 where

--- a/tensor-pcs/src/wrapped_matrix.rs
+++ b/tensor-pcs/src/wrapped_matrix.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use p3_matrix::{Matrix, MatrixRows};
 
 pub struct WrappedMatrix<T, M> {

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use p3_commit::UnivariatePCS;
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField, TwoAdicField};
 use p3_lde::TwoAdicCosetLDE;

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use p3_air::{AirBuilder, TwoRowMatrixView};
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField};
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -1,6 +1,6 @@
-use crate::{ConstraintFolder, StarkConfig};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+
 use p3_air::{Air, TwoRowMatrixView};
 use p3_challenger::Challenger;
 use p3_commit::PCS;
@@ -12,6 +12,8 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixGet};
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeIntoParIter, ParallelIterator};
 use p3_util::log2_strict_usize;
+
+use crate::{ConstraintFolder, StarkConfig};
 
 pub fn prove<SC, A, Chal>(
     air: &A,

--- a/uni-stark/src/sym_var.rs
+++ b/uni-stark/src/sym_var.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Sub};
-use p3_field::Field;
-use p3_field::SymbolicField;
+
+use p3_field::{Field, SymbolicField};
 
 #[derive(Copy, Clone, Debug)]
 pub struct BasicSymVar<F: Field> {


### PR DESCRIPTION
We import the linter settings from plonky2.

This PR has three steps as three commits:

* Run `cargo fmt` with the settings from plonky2
* Minor changes to make clippy happy
* Actually enforce these things in the CI from now on