### PR TITLE
Default inverse via bezout/euclidean/gcd helper algorithm

### DIFF
--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(specialization)]
 #![no_std]
 
 use core::fmt::{self, Debug, Display, Formatter};

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -152,6 +152,22 @@ pub trait PrimeField64: PrimeField {
     fn as_canonical_u64(&self) -> u64;
 }
 
+default impl<F: PrimeField64> Field for F {
+    default type Packing = F;
+    default fn try_inverse(&self) -> Option<Self> {
+        crate::inverse(self.as_canonical_u64() as i128, Self::ORDER_U64 as i128)
+            .map(|x| Self::from_canonical_u64(x as u64))
+    }
+}
+
+default impl<F: PrimeField32> Field for F {
+    default type Packing = F;
+    default fn try_inverse(&self) -> Option<Self> {
+        crate::inverse(self.as_canonical_u32() as i64, Self::ORDER_U64 as i64)
+            .map(|x| Self::from_canonical_u32(x as u32))
+    }
+}
+
 /// A prime field of order less than `2^32`.
 pub trait PrimeField32: PrimeField64 {
     const ORDER_U32: u32;

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -156,7 +156,7 @@ default impl<F: PrimeField64> Field for F {
     default type Packing = F;
     default fn try_inverse(&self) -> Option<Self> {
         crate::inverse_u::<u64, i64>(self.as_canonical_u64(), Self::ORDER_U64)
-            .map(|x| Self::from_canonical_u64(x as u64))
+            .map(|x| Self::from_canonical_u64(x))
     }
 }
 
@@ -164,7 +164,7 @@ default impl<F: PrimeField32> Field for F {
     default type Packing = F;
     default fn try_inverse(&self) -> Option<Self> {
         crate::inverse_u::<u32, i32>(self.as_canonical_u32(), Self::ORDER_U32)
-            .map(|x| Self::from_canonical_u32(x as u32))
+            .map(|x| Self::from_canonical_u32(x))
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -155,7 +155,7 @@ pub trait PrimeField64: PrimeField {
 default impl<F: PrimeField64> Field for F {
     default type Packing = F;
     default fn try_inverse(&self) -> Option<Self> {
-        crate::inverse(self.as_canonical_u64() as i128, Self::ORDER_U64 as i128)
+        crate::inverse_u::<u64, i64>(self.as_canonical_u64(), Self::ORDER_U64)
             .map(|x| Self::from_canonical_u64(x as u64))
     }
 }
@@ -163,7 +163,7 @@ default impl<F: PrimeField64> Field for F {
 default impl<F: PrimeField32> Field for F {
     default type Packing = F;
     default fn try_inverse(&self) -> Option<Self> {
-        crate::inverse(self.as_canonical_u32() as i64, Self::ORDER_U64 as i64)
+        crate::inverse_u::<u32, i32>(self.as_canonical_u32(), Self::ORDER_U32)
             .map(|x| Self::from_canonical_u32(x as u32))
     }
 }

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -175,7 +175,7 @@ mod tests {
         for _ in 0..1000 {
             let a: i64 = rng.gen::<i32>().abs() as i64;
             let b: i64 = rng.gen::<i32>().abs() as i64;
-            let (g, x, y) = gcd::<i64>(a as i64, b as i64);
+            let (g, x, y) = gcd::<i64>(a, b);
             assert_eq!(g, a * x + b * y);
         }
     }
@@ -200,7 +200,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..1000 {
             let a: i32 = rng.gen();
-            let m: i32 = 1 << 31 - 1;
+            let m: i32 = (((1 << 31) as u32) - 1) as i32;
             if a < m && a > 0 {
                 let inv = inverse(a, m);
                 if let Some(inv) = inv {

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -1,3 +1,5 @@
+use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+
 use crate::field::Field;
 
 /// Computes a multiplicative subgroup whose order is known in advance.
@@ -15,4 +17,136 @@ pub fn cyclic_subgroup_coset_known_order<F: Field>(
     order: usize,
 ) -> impl Iterator<Item = F> + Clone {
     cyclic_subgroup_known_order(generator, order).map(move |x| x * shift)
+}
+
+pub fn bezout<Int>(a: Int, b: Int) -> (Int, Int, Int)
+where
+    Int: Copy
+        + Eq
+        + Rem<Output = Int>
+        + Div<Output = Int>
+        + Sub<Output = Int>
+        + Mul<Output = Int>
+        + Add<Output = Int>
+        + From<u8>,
+{
+    if a == Int::from(0) {
+        return (b, Int::from(0), Int::from(1));
+    }
+    let (q, r) = (b / a, b % a); // hopefully the compiler gets the hint that this is a single division
+    let (g, x, y) = bezout(r, a); // TODO: compare perf vs while loop
+    (g, y - q * x, x)
+}
+
+pub fn inverse<Int>(a: Int, m: Int) -> Option<Int>
+where
+    Int: Copy
+        + Eq
+        + Rem<Output = Int>
+        + Div<Output = Int>
+        + Sub<Output = Int>
+        + Mul<Output = Int>
+        + Add<Output = Int>
+        + From<u8>
+        + PartialOrd,
+{
+    let (g, x, _) = bezout(a, m);
+    // g==1 means a,m relatively prime
+    if g == Int::from(1) {
+        if x < Int::from(0) {
+            Some(x + m)
+        } else {
+            Some(x)
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bezout() {
+        assert_eq!(bezout(240, 46), (2, -9, 47));
+        assert_eq!(bezout(17, 23), (1, -4, 3));
+        assert_eq!(bezout(0, 5), (5, 0, 1));
+        assert_eq!(bezout(5, 0), (5, 1, 0));
+    }
+
+    #[test]
+    fn test_inverse() {
+        assert_eq!(inverse(3, 11), Some(4));
+        assert_eq!(inverse(17, 23), Some(19));
+        assert_eq!(inverse(0, 5), None);
+        assert_eq!(inverse(5, 0), None);
+        assert_eq!(inverse(4, 8), None);
+    }
+    #[test]
+    fn test_inverse_itypes() {
+        //assert_eq!(inverse::<i8>(17, 23), Some(19));
+        assert_eq!(inverse::<i16>(17, 23), Some(19));
+        assert_eq!(inverse::<i32>(17, 23), Some(19));
+        assert_eq!(inverse::<i64>(17, 23), Some(19));
+        assert_eq!(inverse::<i128>(17, 23), Some(19));
+        assert_eq!(inverse::<isize>(17, 23), Some(19));
+    }
+    #[test]
+    fn test_bezout_random() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let a: i64 = rng.gen::<i32>().abs() as i64;
+            let b: i64 = rng.gen::<i32>().abs() as i64;
+            let (g, x, y) = bezout::<i64>(a as i64, b as i64);
+            assert_eq!(g, a * x + b * y);
+        }
+    }
+    #[test]
+    fn test_inverse_random() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let a: i64 = (rng.gen::<i32>().abs() as i64) >> 1;
+            let m: i64 = rng.gen::<i32>().abs() as i64;
+            if m > 0 && a > 0 && a < m {
+                let inv = inverse::<i64>(a, m);
+                if let Some(inv) = inv {
+                    assert_eq!(a * inv % m, 1);
+                }
+            }
+        }
+    }
+    #[test]
+    fn test_inverse_m31_random() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let a: i32 = rng.gen();
+            let m: i32 = 1 << 31 - 1;
+            if a < m && a > 0 {
+                let inv = inverse(a, m);
+                if let Some(inv) = inv {
+                    assert_eq!((a as i64) * (inv as i64) % (m as i64), 1);
+                }
+            }
+        }
+    }
+    #[test]
+    fn test_inverse_goldilocks_random() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let a: i128 = (rng.gen::<u64>() >> 1) as i128;
+            let m: i128 = 0xFFFF_FFFF_0000_0001;
+            if a < m {
+                let inv = inverse(a, m);
+                if let Some(inv) = inv {
+                    assert_eq!((a as u128) * (inv as u128) % (m as u128), 1);
+                    assert!(inv < m);
+                }
+            }
+        }
+    }
 }

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -19,7 +19,7 @@ pub fn cyclic_subgroup_coset_known_order<F: Field>(
     cyclic_subgroup_known_order(generator, order).map(move |x| x * shift)
 }
 
-pub fn bezout<Int>(a: Int, b: Int) -> (Int, Int, Int)
+pub fn gcd<Int>(a: Int, b: Int) -> (Int, Int, Int)
 where
     Int: Copy
         + Eq
@@ -34,7 +34,7 @@ where
         return (b, Int::from(0), Int::from(1));
     }
     let (q, r) = (b / a, b % a); // hopefully the compiler gets the hint that this is a single division
-    let (g, x, y) = bezout(r, a); // TODO: compare perf vs while loop
+    let (g, x, y) = gcd(r, a); // TODO: compare perf vs while loop
     (g, y - q * x, x)
 }
 
@@ -50,13 +50,89 @@ where
         + From<u8>
         + PartialOrd,
 {
-    let (g, x, _) = bezout(a, m);
-    // g==1 means a,m relatively prime
+    let (g, x, _) = gcd(a, m);
+
     if g == Int::from(1) {
+        // a,m relatively prime
         if x < Int::from(0) {
             Some(x + m)
         } else {
             Some(x)
+        }
+    } else {
+        None
+    }
+}
+
+pub fn gcd_u<UInt, IInt>(a: UInt, b: UInt) -> (UInt, IInt, IInt)
+where
+    UInt: Copy
+        + Eq
+        + Rem<Output = UInt>
+        + Div<Output = UInt>
+        + Mul<Output = UInt>
+        + Add<Output = UInt>
+        + From<u8>
+        + TryFrom<IInt>,
+    IInt: Copy
+        + Eq
+        + Rem<Output = IInt>
+        + Div<Output = IInt>
+        + Sub<Output = IInt>
+        + Mul<Output = IInt>
+        + Add<Output = IInt>
+        + From<u8>
+        + TryFrom<UInt>,
+{
+    if a == UInt::from(0) {
+        return (b, IInt::from(0), IInt::from(1));
+    }
+    if a == UInt::from(1) {
+        return (UInt::from(1), IInt::from(1), IInt::from(0));
+    }
+    let (q, r) = (b / a, b % a); // hopefully the compiler gets the hint that this is a single division
+    let (g, x, y) = gcd_u::<UInt, IInt>(r, a); // TODO: compare perf vs while loop
+    let z = IInt::try_from(q).unwrap_or_else(|_| panic!("Failed to convert q to IInt"));
+    (g, y - z * x, x)
+}
+
+pub fn inverse_u<UInt, IInt>(a: UInt, m: UInt) -> Option<UInt>
+where
+    UInt: Copy
+        + Eq
+        + Rem<Output = UInt>
+        + Div<Output = UInt>
+        + Mul<Output = UInt>
+        + Add<Output = UInt>
+        + Sub<Output = UInt>
+        + From<u8>
+        + TryFrom<IInt>,
+    IInt: Copy
+        + Eq
+        + Rem<Output = IInt>
+        + Div<Output = IInt>
+        + Sub<Output = IInt>
+        + Mul<Output = IInt>
+        + Add<Output = IInt>
+        + From<u8>
+        + TryFrom<UInt>
+        + PartialOrd<IInt>
+        + Neg<Output = IInt>,
+{
+    let (g, x, _) = gcd_u::<UInt, IInt>(a, m);
+    // g==1 means a,m relatively prime
+    if g == UInt::from(1) {
+        if x < IInt::from(0) {
+            Some(
+                m - (-x)
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("Failed to convert q to UInt")),
+            )
+        } else {
+            Some(
+                x.try_into()
+                    .unwrap_or_else(|_| panic!("Failed to convert q to UInt")),
+            )
         }
     } else {
         None
@@ -68,11 +144,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bezout() {
-        assert_eq!(bezout(240, 46), (2, -9, 47));
-        assert_eq!(bezout(17, 23), (1, -4, 3));
-        assert_eq!(bezout(0, 5), (5, 0, 1));
-        assert_eq!(bezout(5, 0), (5, 1, 0));
+    fn test_gcd() {
+        assert_eq!(gcd(240, 46), (2, -9, 47));
+        assert_eq!(gcd(17, 23), (1, -4, 3));
+        assert_eq!(gcd(0, 5), (5, 0, 1));
+        assert_eq!(gcd(5, 0), (5, 1, 0));
     }
 
     #[test]
@@ -99,7 +175,7 @@ mod tests {
         for _ in 0..1000 {
             let a: i64 = rng.gen::<i32>().abs() as i64;
             let b: i64 = rng.gen::<i32>().abs() as i64;
-            let (g, x, y) = bezout::<i64>(a as i64, b as i64);
+            let (g, x, y) = gcd::<i64>(a as i64, b as i64);
             assert_eq!(g, a * x + b * y);
         }
     }
@@ -142,6 +218,23 @@ mod tests {
             let m: i128 = 0xFFFF_FFFF_0000_0001;
             if a < m {
                 let inv = inverse(a, m);
+                if let Some(inv) = inv {
+                    assert_eq!((a as u128) * (inv as u128) % (m as u128), 1);
+                    assert!(inv < m);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_inverse_goldilocks_random_u() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let a: u64 = rng.gen::<u64>();
+            let m: u64 = 0xFFFF_FFFF_0000_0001;
+            if a < m {
+                let inv = inverse_u::<u64, i64>(a, m);
                 if let Some(inv) = inv {
                     assert_eq!((a as u128) * (inv as u128) % (m as u128), 1);
                     assert!(inv < m);

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -1,5 +1,5 @@
 //! A framework for finite fields.
-
+#![feature(specialization)]
 #![no_std]
 
 extern crate alloc;

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -1,5 +1,5 @@
 //! The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
-
+#![feature(specialization)]
 #![no_std]
 
 use core::fmt;

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -1,5 +1,5 @@
 //! The prime field `F_p` where `p = 2^31 - 1`.
-
+#![feature(specialization)]
 #![no_std]
 
 mod complex;


### PR DESCRIPTION
includes default implementations through specialization of PrimeField64/32 and removes the old goldilocks try_inverse() todo()

the new goldilocks try_inverse() #40 can get merged in to override the default euclidean inverse if desired

Usage:
```
bezout::<i16>(240, 46)== (2, -9, 47)
inverse::<i16>(17, 23)==Some(19)
```

The math must be done in a signed type, so the default implementation for a u32 field is i64. 
This can probably be solved in a small number of steps of the bezout recursion.