### PR TITLE
rename MultivariatePCS to MultilinearPCS

### DIFF
--- a/commit/src/adapters/multi_from_uni_pcs.rs
+++ b/commit/src/adapters/multi_from_uni_pcs.rs
@@ -6,7 +6,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::MatrixRows;
 
 use crate::pcs::{UnivariatePCS, PCS};
-use crate::MultivariatePCS;
+use crate::MultilinearPCS;
 
 pub struct MultiFromUniPCS<F, In, U>
 where
@@ -35,7 +35,7 @@ where
     }
 }
 
-impl<F, In, U> MultivariatePCS<F, In> for MultiFromUniPCS<F, In, U>
+impl<F, In, U> MultilinearPCS<F, In> for MultiFromUniPCS<F, In, U>
 where
     F: Field,
     In: for<'a> MatrixRows<'a, F>,

--- a/commit/src/adapters/uni_from_multi_pcs.rs
+++ b/commit/src/adapters/uni_from_multi_pcs.rs
@@ -3,17 +3,17 @@ use core::marker::PhantomData;
 use p3_field::Field;
 use p3_matrix::MatrixRows;
 
-use crate::pcs::MultivariatePCS;
+use crate::pcs::MultilinearPCS;
 
 pub struct UniFromMultiPCS<F, In, M>
 where
     F: Field,
     In: for<'a> MatrixRows<'a, F>,
-    M: MultivariatePCS<F, In>,
+    M: MultilinearPCS<F, In>,
 {
     _multi: M,
     _phantom_f: PhantomData<F>,
     _phantom_in: PhantomData<In>,
 }
 
-// impl<F: Field, M: MultivariatePCS<F>> UnivariatePCS<F> for UniFromMultiPCS<F> {}
+// impl<F: Field, M: MultilinearPCS<F>> UnivariatePCS<F> for UniFromMultiPCS<F> {}

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -11,7 +11,7 @@ use p3_matrix::MatrixRows;
 /// polynomials defined over the field `F`.
 ///
 /// This high-level trait is agnostic with respect to the structure of a point; see `UnivariatePCS`
-/// and `MultivariatePCS` for more specific subtraits.
+/// and `MultilinearPCS` for more specific subtraits.
 // TODO: Should we have a super-trait for weakly-binding PCSs, like FRI outside unique decoding radius?
 pub trait PCS<F: Field, In: for<'a> MatrixRows<'a, F>> {
     /// The commitment that's sent to the verifier.
@@ -55,7 +55,7 @@ pub trait UnivariatePCS<F: Field, In: for<'a> MatrixRows<'a, F>>: PCS<F, In> {
         Chal: Challenger<F>;
 }
 
-pub trait MultivariatePCS<F: Field, In: for<'a> MatrixRows<'a, F>>: PCS<F, In> {
+pub trait MultilinearPCS<F: Field, In: for<'a> MatrixRows<'a, F>>: PCS<F, In> {
     fn open_multi_batches<EF, Chal>(
         &self,
         prover_data: &[&Self::ProverData],

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use p3_commit::MultivariatePCS;
+use p3_commit::MultilinearPCS;
 use p3_field::{AbstractExtensionField, ExtensionField, Field, PackedField};
 use p3_matrix::dense::RowMajorMatrixView;
 
@@ -15,7 +15,7 @@ pub trait StarkConfig {
         + AbstractExtensionField<<Self::Val as Field>::Packing>;
 
     /// The PCS used to commit to trace polynomials.
-    type PCS: for<'a> MultivariatePCS<Self::Val, RowMajorMatrixView<'a, Self::Val>>;
+    type PCS: for<'a> MultilinearPCS<Self::Val, RowMajorMatrixView<'a, Self::Val>>;
 
     fn pcs(&self) -> &Self::PCS;
 }
@@ -44,7 +44,7 @@ where
     Val: Field,
     Challenge: ExtensionField<Val>,
     PackedChallenge: PackedField<Scalar = Challenge> + AbstractExtensionField<Val::Packing>,
-    PCS: for<'a> MultivariatePCS<Val, RowMajorMatrixView<'a, Val>>,
+    PCS: for<'a> MultilinearPCS<Val, RowMajorMatrixView<'a, Val>>,
 {
     type Val = Val;
     type Challenge = Challenge;

--- a/tensor-pcs/src/tensor_pcs.rs
+++ b/tensor-pcs/src/tensor_pcs.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 
 use p3_challenger::Challenger;
 use p3_code::LinearCodeFamily;
-use p3_commit::{DirectMMCS, MultivariatePCS, PCS};
+use p3_commit::{DirectMMCS, MultilinearPCS, PCS};
 use p3_field::{ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRows;
@@ -64,7 +64,7 @@ where
     }
 }
 
-impl<F, In, C, M> MultivariatePCS<F, In> for TensorPCS<F, C, M>
+impl<F, In, C, M> MultilinearPCS<F, In> for TensorPCS<F, C, M>
 where
     F: Field,
     In: for<'a> MatrixRows<'a, F>,


### PR DESCRIPTION
The name `MultivariatePCS` seems a bit misleading because most of the relevant "multivariate" PCSs (e.g. tensor PCS aka BCG20, Orion, Brakedown, etc) are for multilinear polys specifically.

I propose we rename `MultivariatePCS` to `MultilinearPCS`. In the event that there is a more general PCS that supports more than just multilinear polynomials, we can create a subtrait.