### PR TITLE
Don't run benches on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,7 @@ jobs:
       run: cargo +nightly build --verbose --all-targets
     - name: Test
       run: |
-        cargo +nightly test --verbose --all-targets
-        # It's necessary to run doc tests separately, until
-        # <https://github.com/rust-lang/cargo/issues/6669> is fixed.
-        cargo +nightly test --verbose --doc
+        cargo +nightly test --verbose
 
   lints:
     name: Formatting and Clippy


### PR DESCRIPTION
`--all-targets` seems to include them. And if we don't use `--all-targets`, we don't seem to need `--doc`.