### PR TITLE
Define Extension Field for Mersenne 31

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -325,9 +325,7 @@ fn monty_reduce(x: u64) -> u32 {
 #[cfg(test)]
 mod tests {
     use p3_field::PrimeField64;
-    use p3_field_testing::{
-        test_inverse, test_two_adic_coset_zerofier, test_two_adic_subgroup_zerofier,
-    };
+    use p3_field_testing::{test_field, test_two_adic_field};
 
     use super::*;
 
@@ -383,18 +381,6 @@ mod tests {
         assert_eq!(m1 * m2, expected_prod);
     }
 
-    #[test]
-    fn inverse() {
-        test_inverse::<BabyBear>();
-    }
-
-    #[test]
-    fn two_adic_subgroup_zerofier() {
-        test_two_adic_subgroup_zerofier::<BabyBear>();
-    }
-
-    #[test]
-    fn two_adic_coset_zerofier() {
-        test_two_adic_coset_zerofier::<BabyBear>();
-    }
+    test_field!(crate::BabyBear);
+    test_two_adic_field!(crate::BabyBear);
 }

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -11,6 +11,43 @@ use p3_field::{
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
+#[allow(clippy::eq_op)]
+pub fn test_add_neg_sub_mul<F: Field>()
+where
+    Standard: Distribution<F>,
+{
+    let mut rng = rand::thread_rng();
+    let x = rng.gen::<F>();
+    let y = rng.gen::<F>();
+    let z = rng.gen::<F>();
+    assert_eq!(x + (-x), F::ZERO);
+    assert_eq!(-x, F::ZERO - x);
+    assert_eq!(x + x, x * F::TWO);
+    assert_eq!(x * (-x), -x.square());
+    assert_eq!(x + y, y + x);
+    assert_eq!(x * y, y * x);
+    assert_eq!(x * (y * z), (x * y) * z);
+    assert_eq!(x - (y + z), (x - y) - z);
+    assert_eq!((x + y) - z, x + (y - z));
+    assert_eq!(x * (y + z), x * y + x * z);
+}
+
+pub fn test_inv_div<F: Field>()
+where
+    Standard: Distribution<F>,
+{
+    let mut rng = rand::thread_rng();
+    let x = rng.gen::<F>();
+    let y = rng.gen::<F>();
+    let z = rng.gen::<F>();
+    assert_eq!(x * x.inverse(), F::ONE);
+    assert_eq!(x.inverse() * x, F::ONE);
+    assert_eq!(x.square().inverse(), x.inverse().square());
+    assert_eq!((x / y) * y, x);
+    assert_eq!(x / (y * z), (x / y) / z);
+    assert_eq!((x * y) / z, x * (y / z));
+}
+
 pub fn test_inverse<F: Field>()
 where
     Standard: Distribution<F>,
@@ -49,4 +86,40 @@ pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
             assert_eq!(zerofier_eval, F::ZERO);
         }
     }
+}
+
+#[macro_export]
+macro_rules! test_field {
+    ($field:ty) => {
+        mod field_tests {
+            #[test]
+            fn test_add_neg_sub_mul() {
+                $crate::test_add_neg_sub_mul::<$field>();
+            }
+            #[test]
+            fn test_inv_div() {
+                $crate::test_inv_div::<$field>();
+            }
+            #[test]
+            fn test_inverse() {
+                $crate::test_inverse::<$field>();
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! test_two_adic_field {
+    ($field:ty) => {
+        mod two_adic_field_tests {
+            #[test]
+            fn test_two_adic_field_subgroup_zerofier() {
+                $crate::test_two_adic_subgroup_zerofier::<$field>();
+            }
+            #[test]
+            fn test_two_adic_coset_zerofier() {
+                $crate::test_two_adic_coset_zerofier::<$field>();
+            }
+        }
+    };
 }

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -7,7 +7,7 @@ use rand::prelude::Distribution;
 
 use crate::extension::OptimallyExtendable;
 use crate::field::Field;
-use crate::{AbstractExtensionField, AbstractField, ExtensionField};
+use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct CubicOef<F: OptimallyExtendable<3>>(pub [F; 3]);
@@ -109,12 +109,6 @@ impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
             scalar * (a2_w * a2 - a0_a1),
             scalar * (a1_square - a0 * a2),
         ]))
-    }
-}
-
-impl<F: OptimallyExtendable<3>> ExtensionField<F> for CubicOef<F> {
-    fn scalar_mul(&self, scalar: F) -> Self {
-        Self([self.0[0] * scalar, self.0[1] * scalar, self.0[2] * scalar])
     }
 }
 
@@ -242,7 +236,7 @@ impl<F: OptimallyExtendable<3>> Mul<F> for CubicOef<F> {
 
     #[inline]
     fn mul(self, rhs: F) -> Self {
-        self.scalar_mul(rhs)
+        Self([self.0[0] * rhs, self.0[1] * rhs, self.0[2] * rhs])
     }
 }
 
@@ -276,7 +270,7 @@ impl<F: OptimallyExtendable<3>> MulAssign for CubicOef<F> {
 
 impl<F: OptimallyExtendable<3>> MulAssign<F> for CubicOef<F> {
     fn mul_assign(&mut self, rhs: F) {
-        *self = self.scalar_mul(rhs);
+        *self = *self * rhs;
     }
 }
 impl<F: OptimallyExtendable<3>> AbstractExtensionField<F> for CubicOef<F> {

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -5,7 +5,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use crate::extension::{OptimallyExtendable, OEF};
+use crate::extension::OptimallyExtendable;
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField, ExtensionField};
 
@@ -33,7 +33,7 @@ impl<F: OptimallyExtendable<3>> AbstractField for CubicOef<F> {
     #[inline(always)]
     fn square(&self) -> Self {
         let Self([a0, a1, a2]) = *self;
-        let w = <Self as OEF<F>>::W;
+        let w = F::W;
 
         let w_a2 = w * a2;
 
@@ -91,7 +91,7 @@ impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
             return None;
         }
         let Self([a0, a1, a2]) = *self;
-        let w = <Self as OEF<F>>::W;
+        let w = F::W;
 
         let a0_square = a0.square();
         let a1_square = a1.square();
@@ -221,7 +221,7 @@ impl<F: OptimallyExtendable<3>> Mul for CubicOef<F> {
         let a1_b1 = a1 * b1;
         let a2_b2 = a2 * b2;
 
-        let w = <Self as OEF<F>>::W;
+        let w = F::W;
 
         let c0 = a0_b0 + ((a1 + a2) * (b1 + b2) - a1_b1 - a2_b2) * w;
         let c1 = (a0 + a1) * (b0 + b1) - a0_b0 - a1_b1 + a2_b2 * w;
@@ -288,12 +288,6 @@ impl<F: OptimallyExtendable<3>> AbstractExtensionField<F> for CubicOef<F> {
     fn as_base_slice(&self) -> &[F] {
         self.0.as_ref()
     }
-}
-
-impl<F: OptimallyExtendable<3>> OEF<F> for CubicOef<F> {
-    const W: F = F::W;
-
-    const DTH_ROOT: F = F::DTH_ROOT;
 }
 
 impl<F: OptimallyExtendable<3>> Distribution<CubicOef<F>> for Standard

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -1,0 +1,294 @@
+use core::fmt::{self, Debug, Display, Formatter};
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::extension::{OptimallyExtendable, OEF};
+use crate::field::Field;
+use crate::{AbstractExtensionField, AbstractField, ExtensionField};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct CubicOef<F: OptimallyExtendable<3>>(pub [F; 3]);
+
+impl<F: OptimallyExtendable<3>> Default for CubicOef<F> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: OptimallyExtendable<3>> From<F> for CubicOef<F> {
+    fn from(x: F) -> Self {
+        Self([x, F::ZERO, F::ZERO])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> AbstractField for CubicOef<F> {
+    const ZERO: Self = Self([F::ZERO; 3]);
+    const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO]);
+    const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO]);
+    const NEG_ONE: Self = Self([F::NEG_ONE, F::ZERO, F::ZERO]);
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        let Self([a0, a1, a2]) = *self;
+        let w = <Self as OEF<F>>::W;
+
+        let w_a2 = w * a2;
+
+        let c0 = a0.square() + (a1 * w_a2).double();
+        let c1 = w_a2 * a2 + (a0 * a1).double();
+        let c2 = a1.square() + (a0 * a2).double();
+
+        Self([c0, c1, c2])
+    }
+
+    fn from_bool(b: bool) -> Self {
+        F::from_bool(b).into()
+    }
+
+    fn from_canonical_u8(n: u8) -> Self {
+        F::from_canonical_u8(n).into()
+    }
+
+    fn from_canonical_u16(n: u16) -> Self {
+        F::from_canonical_u16(n).into()
+    }
+
+    fn from_canonical_u32(n: u32) -> Self {
+        F::from_canonical_u32(n).into()
+    }
+
+    /// Convert from `u64`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_u64(n: u64) -> Self {
+        F::from_canonical_u64(n).into()
+    }
+
+    /// Convert from `usize`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_usize(n: usize) -> Self {
+        F::from_canonical_usize(n).into()
+    }
+
+    fn from_wrapped_u32(n: u32) -> Self {
+        F::from_wrapped_u32(n).into()
+    }
+
+    fn from_wrapped_u64(n: u64) -> Self {
+        F::from_wrapped_u64(n).into()
+    }
+
+    fn multiplicative_group_generator() -> Self {
+        Self(F::ext_multiplicate_group_generator())
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
+    type Packing = Self;
+    // Algorithm 11.3.6.b in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn try_inverse(&self) -> Option<Self> {
+        if self.is_zero() {
+            return None;
+        }
+        let Self([a0, a1, a2]) = *self;
+        let w = <Self as OEF<F>>::W;
+
+        let a0_square = a0.square();
+        let a1_square = a1.square();
+        let a2_w = w * a2;
+        let a0_a1 = a0 * a1;
+
+        // scalar = (a0^3+wa1^3+w^2a2^3-3wa0a1a2)^-1
+        let scalar = (a0_square * a0 + w * a1 * a1_square + a2_w.square() * a2
+            - (F::ONE + F::TWO) * a2_w * a0_a1)
+            .inverse();
+
+        //scalar*[a0^2-wa1a2, wa2^2-a0a1, a1^2-a0a2]
+        Some(Self([
+            scalar * (a0_square - a1 * a2_w),
+            scalar * (a2_w * a2 - a0_a1),
+            scalar * (a1_square - a0 * a2),
+        ]))
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Display for CubicOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} + {}*a + {}*a^2", self.0[0], self.0[1], self.0[2])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Debug for CubicOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Neg for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self([-self.0[0], -self.0[1], -self.0[2]])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Add for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] + rhs.0[0],
+            self.0[1] + rhs.0[1],
+            self.0[2] + rhs.0[2],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Add<F> for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: F) -> Self {
+        Self([self.0[0] + rhs, self.0[1], self.0[2]])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> AddAssign for CubicOef<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> AddAssign<F> for CubicOef<F> {
+    fn add_assign(&mut self, rhs: F) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Sum for CubicOef<F> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |acc, x| acc + x)
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Sub for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] - rhs.0[0],
+            self.0[1] - rhs.0[1],
+            self.0[2] - rhs.0[2],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Sub<F> for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: F) -> Self {
+        Self([self.0[0] - rhs, self.0[1], self.0[2]])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> SubAssign for CubicOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> SubAssign<F> for CubicOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Mul for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let Self([a0, a1, a2]) = self;
+        let Self([b0, b1, b2]) = rhs;
+
+        let a0_b0 = a0 * b0;
+        let a1_b1 = a1 * b1;
+        let a2_b2 = a2 * b2;
+
+        let w = <Self as OEF<F>>::W;
+
+        let c0 = a0_b0 + ((a1 + a2) * (b1 + b2) - a1_b1 - a2_b2) * w;
+        let c1 = (a0 + a1) * (b0 + b1) - a0_b0 - a1_b1 + a2_b2 * w;
+        let c2 = (a0 + a2) * (b0 + b2) - a0_b0 - a2_b2 + a1_b1;
+
+        Self([c0, c1, c2])
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Mul<F> for CubicOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: F) -> Self {
+        self.scalar_mul(rhs)
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Product for CubicOef<F> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ONE, |acc, x| acc * x)
+    }
+}
+
+impl<F: OptimallyExtendable<3>> Div for CubicOef<F> {
+    type Output = Self;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self::Output {
+        self * rhs.inverse()
+    }
+}
+
+impl<F: OptimallyExtendable<3>> DivAssign for CubicOef<F> {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> MulAssign for CubicOef<F> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<3>> MulAssign<F> for CubicOef<F> {
+    fn mul_assign(&mut self, rhs: F) {
+        *self = self.scalar_mul(rhs);
+    }
+}
+impl<F: OptimallyExtendable<3>> AbstractExtensionField<F> for CubicOef<F> {
+    const D: usize = F::D;
+
+    fn from_base(b: F) -> Self {
+        Self([b, F::ZERO, F::ZERO])
+    }
+
+    fn from_base_slice(bs: &[F]) -> Self {
+        assert_eq!(bs.len(), 3);
+        Self([bs[0], bs[1], bs[2]])
+    }
+
+    fn as_base_slice(&self) -> &[F] {
+        self.0.as_ref()
+    }
+}
+
+impl<F: OptimallyExtendable<3>> OEF<F> for CubicOef<F> {
+    const W: F = F::W;
+
+    const DTH_ROOT: F = F::DTH_ROOT;
+}

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -79,7 +79,7 @@ impl<F: OptimallyExtendable<3>> AbstractField for CubicOef<F> {
     }
 
     fn multiplicative_group_generator() -> Self {
-        Self(F::ext_multiplicate_group_generator())
+        Self(F::ext_multiplicative_group_generator())
     }
 }
 

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -112,6 +112,12 @@ impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
     }
 }
 
+impl<F: OptimallyExtendable<3>> ExtensionField<F> for CubicOef<F> {
+    fn scalar_mul(&self, scalar: F) -> Self {
+        Self([self.0[0] * scalar, self.0[1] * scalar, self.0[2] * scalar])
+    }
+}
+
 impl<F: OptimallyExtendable<3>> Display for CubicOef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a + {}*a^2", self.0[0], self.0[1], self.0[2])

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -2,6 +2,9 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+
 use crate::extension::{OptimallyExtendable, OEF};
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField, ExtensionField};
@@ -291,4 +294,17 @@ impl<F: OptimallyExtendable<3>> OEF<F> for CubicOef<F> {
     const W: F = F::W;
 
     const DTH_ROOT: F = F::DTH_ROOT;
+}
+
+impl<F: OptimallyExtendable<3>> Distribution<CubicOef<F>> for Standard
+where
+    Standard: Distribution<F>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicOef<F> {
+        CubicOef::<F>::from_base_slice(&[
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+        ])
+    }
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -4,10 +4,9 @@ use crate::ExtensionField;
 pub mod cubic;
 pub mod quadratic;
 
-/// Optimal extension field trait.
-/// A degree `d` field extension is optimal if there exists a base field element `W`,
+/// Binomial extension field trait.
+/// A extension field with a irreducible polynomial X^d-W
 /// such that the extension is `F[X]/(X^d-W)`.
-
 pub trait OptimallyExtendable<const D: usize>: Field + Sized {
     const W: Self;
     const DTH_ROOT: Self;

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -15,7 +15,7 @@ pub trait OptimallyExtendable<const D: usize>: Field + Sized {
 
     const DTH_ROOT: Self;
 
-    fn ext_multiplicate_group_generator() -> [Self; D];
+    fn ext_multiplicative_group_generator() -> [Self; D];
 }
 
 impl<F: Field + ExtensionField<F>> OptimallyExtendable<1> for F {
@@ -23,7 +23,7 @@ impl<F: Field + ExtensionField<F>> OptimallyExtendable<1> for F {
     const W: Self = F::ONE;
     const DTH_ROOT: Self = F::ONE;
 
-    fn ext_multiplicate_group_generator() -> [Self; 1] {
+    fn ext_multiplicative_group_generator() -> [Self; 1] {
         [F::multiplicative_group_generator()]
     }
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -9,17 +9,13 @@ pub mod quadratic;
 /// such that the extension is `F[X]/(X^d-W)`.
 
 pub trait OptimallyExtendable<const D: usize>: Field + Sized {
-    type Extension: Field + From<Self>;
-
     const W: Self;
-
     const DTH_ROOT: Self;
 
     fn ext_multiplicative_group_generator() -> [Self; D];
 }
 
 impl<F: Field + ExtensionField<F>> OptimallyExtendable<1> for F {
-    type Extension = F;
     const W: Self = F::ONE;
     const DTH_ROOT: Self = F::ONE;
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -7,25 +7,9 @@ pub mod quadratic;
 /// Optimal extension field trait.
 /// A degree `d` field extension is optimal if there exists a base field element `W`,
 /// such that the extension is `F[X]/(X^d-W)`.
-#[allow(clippy::upper_case_acronyms)]
-
-pub trait OEF<Base: Field>: ExtensionField<Base> {
-    // Element W of BaseField, such that `X^d - W` is irreducible over BaseField.
-    const W: Base;
-
-    // Element of BaseField such that DTH_ROOT^D == 1. Implementors
-    // should set this to W^((p - 1)/D), where W is as above and p is
-    // the order of the BaseField.
-    const DTH_ROOT: Base;
-}
-
-impl<F: Field> OEF<F> for F {
-    const W: F = F::ONE;
-    const DTH_ROOT: F = F::ONE;
-}
 
 pub trait OptimallyExtendable<const D: usize>: Field + Sized {
-    type Extension: Field + OEF<Self> + From<Self>;
+    type Extension: Field + From<Self>;
 
     const W: Self;
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,0 +1,45 @@
+use crate::field::Field;
+use crate::ExtensionField;
+
+pub mod cubic;
+pub mod quadratic;
+
+/// Optimal extension field trait.
+/// A degree `d` field extension is optimal if there exists a base field element `W`,
+/// such that the extension is `F[X]/(X^d-W)`.
+#[allow(clippy::upper_case_acronyms)]
+
+pub trait OEF<Base: Field>: ExtensionField<Base> {
+    // Element W of BaseField, such that `X^d - W` is irreducible over BaseField.
+    const W: Base;
+
+    // Element of BaseField such that DTH_ROOT^D == 1. Implementors
+    // should set this to W^((p - 1)/D), where W is as above and p is
+    // the order of the BaseField.
+    const DTH_ROOT: Base;
+}
+
+impl<F: Field> OEF<F> for F {
+    const W: F = F::ONE;
+    const DTH_ROOT: F = F::ONE;
+}
+
+pub trait OptimallyExtendable<const D: usize>: Field + Sized {
+    type Extension: Field + OEF<Self> + From<Self>;
+
+    const W: Self;
+
+    const DTH_ROOT: Self;
+
+    fn ext_multiplicate_group_generator() -> [Self; D];
+}
+
+impl<F: Field + ExtensionField<F>> OptimallyExtendable<1> for F {
+    type Extension = F;
+    const W: Self = F::ONE;
+    const DTH_ROOT: Self = F::ONE;
+
+    fn ext_multiplicate_group_generator() -> [Self; 1] {
+        [F::multiplicative_group_generator()]
+    }
+}

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -1,0 +1,262 @@
+use core::fmt::{self, Debug, Display, Formatter};
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::extension::{OptimallyExtendable, OEF};
+use crate::field::Field;
+use crate::{AbstractExtensionField, AbstractField, ExtensionField};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct QuadraticOef<F: OptimallyExtendable<2>>(pub [F; 2]);
+
+impl<F: OptimallyExtendable<2>> Default for QuadraticOef<F> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: OptimallyExtendable<2>> From<F> for QuadraticOef<F> {
+    fn from(x: F) -> Self {
+        Self([x, F::ZERO])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> AbstractField for QuadraticOef<F> {
+    const ZERO: Self = Self([F::ZERO; 2]);
+    const ONE: Self = Self([F::ONE, F::ZERO]);
+    const TWO: Self = Self([F::TWO, F::ZERO]);
+    const NEG_ONE: Self = Self([F::NEG_ONE, F::ZERO]);
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        // Specialising mul reduces the computation of c1 from 2 muls
+        // and one add to one mul and a shift
+
+        let Self([a0, a1]) = *self;
+
+        let c0 = a0.square() + <Self as OEF<F>>::W * a1.square();
+        let c1 = a0 * a1.double();
+
+        Self([c0, c1])
+    }
+
+    fn from_bool(b: bool) -> Self {
+        F::from_bool(b).into()
+    }
+
+    fn from_canonical_u8(n: u8) -> Self {
+        F::from_canonical_u8(n).into()
+    }
+
+    fn from_canonical_u16(n: u16) -> Self {
+        F::from_canonical_u16(n).into()
+    }
+
+    fn from_canonical_u32(n: u32) -> Self {
+        F::from_canonical_u32(n).into()
+    }
+
+    /// Convert from `u64`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_u64(n: u64) -> Self {
+        F::from_canonical_u64(n).into()
+    }
+
+    /// Convert from `usize`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_usize(n: usize) -> Self {
+        F::from_canonical_usize(n).into()
+    }
+
+    fn from_wrapped_u32(n: u32) -> Self {
+        F::from_wrapped_u32(n).into()
+    }
+
+    fn from_wrapped_u64(n: u64) -> Self {
+        F::from_wrapped_u64(n).into()
+    }
+
+    fn multiplicative_group_generator() -> Self {
+        Self(F::ext_multiplicate_group_generator())
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
+    type Packing = Self;
+    // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn try_inverse(&self) -> Option<Self> {
+        if self.is_zero() {
+            return None;
+        }
+        let Self([a0, a1]) = *self;
+        let base = Self([a0, -a1]);
+        let scalar = (a0.square() - <Self as OEF<F>>::W * a1.square()).inverse();
+        Some(ExtensionField::scalar_mul(&base, scalar))
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Display for QuadraticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} + {}*a", self.0[0], self.0[1])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Debug for QuadraticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Neg for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self([-self.0[0], -self.0[1]])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Add for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self([self.0[0] + rhs.0[0], self.0[1] + rhs.0[1]])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Add<F> for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: F) -> Self {
+        Self([self.0[0] + rhs, self.0[1]])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> AddAssign for QuadraticOef<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> AddAssign<F> for QuadraticOef<F> {
+    fn add_assign(&mut self, rhs: F) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Sum for QuadraticOef<F> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |acc, x| acc + x)
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Sub for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self([self.0[0] - rhs.0[0], self.0[1] - rhs.0[1]])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Sub<F> for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: F) -> Self {
+        Self([self.0[0] - rhs, self.0[1]])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> SubAssign for QuadraticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> SubAssign<F> for QuadraticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Mul for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let Self([a0, a1]) = self;
+        let Self([b0, b1]) = rhs;
+
+        let c0 = a0 * b0 + <Self as OEF<F>>::W * a1 * b1;
+        let c1 = a0 * b1 + a1 * b0;
+
+        Self([c0, c1])
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Mul<F> for QuadraticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: F) -> Self {
+        self.scalar_mul(rhs)
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Product for QuadraticOef<F> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ONE, |acc, x| acc * x)
+    }
+}
+
+impl<F: OptimallyExtendable<2>> Div for QuadraticOef<F> {
+    type Output = Self;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self::Output {
+        self * rhs.inverse()
+    }
+}
+
+impl<F: OptimallyExtendable<2>> DivAssign for QuadraticOef<F> {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> MulAssign for QuadraticOef<F> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<2>> MulAssign<F> for QuadraticOef<F> {
+    fn mul_assign(&mut self, rhs: F) {
+        *self = self.scalar_mul(rhs);
+    }
+}
+impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
+    const D: usize = F::D;
+
+    fn from_base(b: F) -> Self {
+        Self([b, F::ZERO])
+    }
+
+    fn from_base_slice(bs: &[F]) -> Self {
+        Self([bs[0], bs[1]])
+    }
+
+    fn as_base_slice(&self) -> &[F] {
+        self.0.as_ref()
+    }
+}
+
+impl<F: OptimallyExtendable<2>> OEF<F> for QuadraticOef<F> {
+    const W: F = F::W;
+
+    const DTH_ROOT: F = F::DTH_ROOT;
+}

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -2,6 +2,9 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+
 use crate::extension::{OptimallyExtendable, OEF};
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField, ExtensionField};
@@ -259,4 +262,13 @@ impl<F: OptimallyExtendable<2>> OEF<F> for QuadraticOef<F> {
     const W: F = F::W;
 
     const DTH_ROOT: F = F::DTH_ROOT;
+}
+
+impl<F: OptimallyExtendable<2>> Distribution<QuadraticOef<F>> for Standard
+where
+    Standard: Distribution<F>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadraticOef<F> {
+        QuadraticOef::<F>::from_base_slice(&[Standard.sample(rng), Standard.sample(rng)])
+    }
 }

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -251,6 +251,7 @@ impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
     }
 
     fn from_base_slice(bs: &[F]) -> Self {
+        assert_eq!(bs.len(), 2);
         Self([bs[0], bs[1]])
     }
 

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -96,6 +96,12 @@ impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
     }
 }
 
+impl<F: OptimallyExtendable<2>> ExtensionField<F> for QuadraticOef<F> {
+    fn scalar_mul(&self, scalar: F) -> Self {
+        Self([self.0[0] * scalar, self.0[1] * scalar])
+    }
+}
+
 impl<F: OptimallyExtendable<2>> Display for QuadraticOef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a", self.0[0], self.0[1])

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -7,7 +7,7 @@ use rand::prelude::Distribution;
 
 use crate::extension::OptimallyExtendable;
 use crate::field::Field;
-use crate::{AbstractExtensionField, AbstractField, ExtensionField};
+use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct QuadraticOef<F: OptimallyExtendable<2>>(pub [F; 2]);
@@ -92,13 +92,7 @@ impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
         let Self([a0, a1]) = *self;
         let base = Self([a0, -a1]);
         let scalar = (a0.square() - F::W * a1.square()).inverse();
-        Some(ExtensionField::scalar_mul(&base, scalar))
-    }
-}
-
-impl<F: OptimallyExtendable<2>> ExtensionField<F> for QuadraticOef<F> {
-    fn scalar_mul(&self, scalar: F) -> Self {
-        Self([self.0[0] * scalar, self.0[1] * scalar])
+        Some(base * scalar)
     }
 }
 
@@ -211,7 +205,7 @@ impl<F: OptimallyExtendable<2>> Mul<F> for QuadraticOef<F> {
 
     #[inline]
     fn mul(self, rhs: F) -> Self {
-        self.scalar_mul(rhs)
+        Self([self.0[0] * rhs, self.0[1] * rhs])
     }
 }
 
@@ -245,9 +239,10 @@ impl<F: OptimallyExtendable<2>> MulAssign for QuadraticOef<F> {
 
 impl<F: OptimallyExtendable<2>> MulAssign<F> for QuadraticOef<F> {
     fn mul_assign(&mut self, rhs: F) {
-        *self = self.scalar_mul(rhs);
+        *self = *self * rhs;
     }
 }
+
 impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
     const D: usize = F::D;
 

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -5,7 +5,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use crate::extension::{OptimallyExtendable, OEF};
+use crate::extension::OptimallyExtendable;
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField, ExtensionField};
 
@@ -37,7 +37,7 @@ impl<F: OptimallyExtendable<2>> AbstractField for QuadraticOef<F> {
 
         let Self([a0, a1]) = *self;
 
-        let c0 = a0.square() + <Self as OEF<F>>::W * a1.square();
+        let c0 = a0.square() + F::W * a1.square();
         let c1 = a0 * a1.double();
 
         Self([c0, c1])
@@ -91,7 +91,7 @@ impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
         }
         let Self([a0, a1]) = *self;
         let base = Self([a0, -a1]);
-        let scalar = (a0.square() - <Self as OEF<F>>::W * a1.square()).inverse();
+        let scalar = (a0.square() - F::W * a1.square()).inverse();
         Some(ExtensionField::scalar_mul(&base, scalar))
     }
 }
@@ -193,7 +193,7 @@ impl<F: OptimallyExtendable<2>> Mul for QuadraticOef<F> {
         let Self([a0, a1]) = self;
         let Self([b0, b1]) = rhs;
 
-        let c0 = a0 * b0 + <Self as OEF<F>>::W * a1 * b1;
+        let c0 = a0 * b0 + F::W * a1 * b1;
         let c1 = a0 * b1 + a1 * b0;
 
         Self([c0, c1])
@@ -256,12 +256,6 @@ impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
     fn as_base_slice(&self) -> &[F] {
         self.0.as_ref()
     }
-}
-
-impl<F: OptimallyExtendable<2>> OEF<F> for QuadraticOef<F> {
-    const W: F = F::W;
-
-    const DTH_ROOT: F = F::DTH_ROOT;
 }
 
 impl<F: OptimallyExtendable<2>> Distribution<QuadraticOef<F>> for Standard

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -78,7 +78,7 @@ impl<F: OptimallyExtendable<2>> AbstractField for QuadraticOef<F> {
     }
 
     fn multiplicative_group_generator() -> Self {
-        Self(F::ext_multiplicate_group_generator())
+        Self(F::ext_multiplicative_group_generator())
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -199,15 +199,9 @@ pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
     fn is_in_basefield(&self) -> bool {
         self.as_base_slice()[1..].iter().all(|x| x.is_zero())
     }
-
-    fn scalar_mul(&self, scalar: Base) -> Self;
 }
 
-impl<F: Field> ExtensionField<F> for F {
-    fn scalar_mul(&self, scalar: F) -> Self {
-        *self * scalar
-    }
-}
+impl<F: Field> ExtensionField<F> for F {}
 
 impl<F: Field> AbstractExtensionField<F> for F {
     const D: usize = 1;

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::iter::{Product, Sum};
@@ -195,7 +196,22 @@ pub trait AbstractExtensionField<Base>:
     fn as_base_slice(&self) -> &[Base];
 }
 
-pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {}
+pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
+    fn is_in_basefield(&self) -> bool {
+        self.as_base_slice()[1..].iter().all(|x| x.is_zero())
+    }
+
+    fn scalar_mul(&self, scalar: Base) -> Self {
+        let value: &[Base] = self.as_base_slice();
+        Self::from_base_slice(
+            value
+                .iter()
+                .map(|&x| x * scalar)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+    }
+}
 
 impl<Base: Field, Ext: Field + AbstractExtensionField<Base>> ExtensionField<Base> for Ext {}
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::iter::{Product, Sum};
@@ -201,19 +200,14 @@ pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
         self.as_base_slice()[1..].iter().all(|x| x.is_zero())
     }
 
-    fn scalar_mul(&self, scalar: Base) -> Self {
-        let value: &[Base] = self.as_base_slice();
-        Self::from_base_slice(
-            value
-                .iter()
-                .map(|&x| x * scalar)
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-    }
+    fn scalar_mul(&self, scalar: Base) -> Self;
 }
 
-impl<Base: Field, Ext: Field + AbstractExtensionField<Base>> ExtensionField<Base> for Ext {}
+impl<F: Field> ExtensionField<F> for F {
+    fn scalar_mul(&self, scalar: F) -> Self {
+        *self * scalar
+    }
+}
 
 impl<F: Field> AbstractExtensionField<F> for F {
     const D: usize = 1;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate alloc;
 
 mod batch_inverse;
+pub mod extension;
 mod field;
 mod helpers;
 mod packed;

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -391,9 +391,7 @@ unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::{
-        test_inverse, test_two_adic_coset_zerofier, test_two_adic_subgroup_zerofier,
-    };
+    use p3_field_testing::{test_field, test_two_adic_field};
 
     use super::*;
 
@@ -483,18 +481,6 @@ mod tests {
         assert_eq!(y, expected_result);
     }
 
-    #[test]
-    fn inverse() {
-        test_inverse::<Goldilocks>();
-    }
-
-    #[test]
-    fn two_adic_subgroup_zerofier() {
-        test_two_adic_subgroup_zerofier::<Goldilocks>();
-    }
-
-    #[test]
-    fn two_adic_coset_zerofier() {
-        test_two_adic_coset_zerofier::<Goldilocks>();
-    }
+    test_field!(crate::Goldilocks);
+    test_two_adic_field!(crate::Goldilocks);
 }

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -281,7 +281,7 @@ impl Distribution<Mersenne31Complex<Mersenne31>> for Standard {
 #[cfg(test)]
 mod tests {
     use p3_field::PrimeField32;
-    use p3_field_testing::test_inverse;
+    use p3_field_testing::{test_field, test_two_adic_field};
 
     use super::*;
 
@@ -396,8 +396,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn inverse() {
-        test_inverse::<Mersenne31Complex<Mersenne31>>();
-    }
+    test_field!(crate::Mersenne31Complex<crate::Mersenne31>);
+    test_two_adic_field!(crate::Mersenne31Complex<crate::Mersenne31>);
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -29,7 +29,7 @@ impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     // for f in factor(p^4 - 1):
     //   assert g^((p^4-1) // f) != 1
     // ```
-    fn ext_multiplicate_group_generator() -> [Self; 2] {
+    fn ext_multiplicative_group_generator() -> [Self; 2] {
         [
             Self::new(Mersenne31::new(6), Mersenne31::new(0)),
             Self::new(Mersenne31::new(1), Mersenne31::new(0)),
@@ -62,7 +62,7 @@ impl OptimallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // for f in factor(p^6 - 1):
     //   assert g^((p^6-1) // f) != 1
     // ```
-    fn ext_multiplicate_group_generator() -> [Self; 3] {
+    fn ext_multiplicative_group_generator() -> [Self; 3] {
         [
             Self::new(Mersenne31::new(5), Mersenne31::new(0)),
             Self::new(Mersenne31::new(1), Mersenne31::new(0)),

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,0 +1,72 @@
+use p3_field::extension::cubic::CubicOef;
+use p3_field::extension::quadratic::QuadraticOef;
+use p3_field::extension::OptimallyExtendable;
+
+use crate::{Mersenne31, Mersenne31Complex};
+
+impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
+    type Extension = QuadraticOef<Self>;
+
+    // Verifiable in Sage with
+    // ```sage
+    // p = 2**31 - 1  # Mersenne31
+    // F = GF(p)  # The base field GF(p)
+    // R.<x> = F[]  # The polynomial ring over F
+    // K.<i> = F.extension(x^2 + 1)  # The complex extension field
+    // R2.<y> = K[]
+    // f2 = y^2 - i - 2
+    // assert f2.is_irreducible()
+    // ```
+    const W: Self = Self::new(Mersenne31::new(2), Mersenne31::new(1));
+
+    // DTH_ROOT = W^((p - 1)/2)
+    const DTH_ROOT: Self = Self::new(Mersenne31::new(21189756), Mersenne31::new(42379512));
+
+    // Verifiable in Sage with
+    // ```sage
+    // K2.<j> = K.extension(f2)
+    //  g = j + 6
+    // for f in factor(p^4 - 1):
+    //   assert g^((p^4-1) // f) != 1
+    // ```
+    fn ext_multiplicate_group_generator() -> [Self; 2] {
+        [
+            Self::new(Mersenne31::new(6), Mersenne31::new(0)),
+            Self::new(Mersenne31::new(1), Mersenne31::new(0)),
+        ]
+    }
+}
+
+impl OptimallyExtendable<3> for Mersenne31Complex<Mersenne31> {
+    type Extension = CubicOef<Self>;
+
+    // Verifiable in Sage with
+    // ```sage
+    // p = 2**31 - 1  # Mersenne31
+    // F = GF(p)  # The base field GF(p)
+    // R.<x> = F[]  # The polynomial ring over F
+    // K.<i> = F.extension(x^2 + 1)  # The complex extension field
+    // R2.<y> = K[]
+    // f2 = y^3 - 5*i
+    // assert f2.is_irreducible()
+    // ```
+    const W: Self = Self::new(Mersenne31::new(0), Mersenne31::new(5));
+
+    // DTH_ROOT = W^((p - 1)/3)
+    const DTH_ROOT: Self = Self::new(Mersenne31::new(634005912), Mersenne31::new(0));
+
+    // Verifiable in Sage with
+    // ```sage
+    // K2.<j> = K.extension(f2)
+    //  g = j + 5
+    // for f in factor(p^6 - 1):
+    //   assert g^((p^6-1) // f) != 1
+    // ```
+    fn ext_multiplicate_group_generator() -> [Self; 3] {
+        [
+            Self::new(Mersenne31::new(5), Mersenne31::new(0)),
+            Self::new(Mersenne31::new(1), Mersenne31::new(0)),
+            Self::new(Mersenne31::new(0), Mersenne31::new(0)),
+        ]
+    }
+}

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,12 +1,8 @@
-use p3_field::extension::cubic::CubicOef;
-use p3_field::extension::quadratic::QuadraticOef;
 use p3_field::extension::OptimallyExtendable;
 
 use crate::{Mersenne31, Mersenne31Complex};
 
 impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
-    type Extension = QuadraticOef<Self>;
-
     // Verifiable in Sage with
     // ```sage
     // p = 2**31 - 1  # Mersenne31
@@ -38,8 +34,6 @@ impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
 }
 
 impl OptimallyExtendable<3> for Mersenne31Complex<Mersenne31> {
-    type Extension = CubicOef<Self>;
-
     // Verifiable in Sage with
     // ```sage
     // p = 2**31 - 1  # Mersenne31

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -70,3 +70,21 @@ impl OptimallyExtendable<3> for Mersenne31Complex<Mersenne31> {
         ]
     }
 }
+
+#[cfg(test)]
+mod test_cubic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::cubic::CubicOef<crate::Mersenne31Complex<crate::Mersenne31>>);
+}
+
+#[cfg(test)]
+mod test_quadratic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(
+        p3_field::extension::quadratic::QuadraticOef<crate::Mersenne31Complex<crate::Mersenne31>>
+    );
+}

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -313,7 +313,7 @@ impl Div for Mersenne31 {
 #[cfg(test)]
 mod tests {
     use p3_field::{AbstractField, Field, PrimeField32};
-    use p3_field_testing::test_inverse;
+    use p3_field_testing::test_field;
 
     use crate::Mersenne31;
 
@@ -356,8 +356,5 @@ mod tests {
         assert_eq!(F::new(32).div_2exp_u64(5), F::new(1));
     }
 
-    #[test]
-    fn inverse() {
-        test_inverse::<Mersenne31>();
-    }
+    test_field!(crate::Mersenne31);
 }

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 
 mod complex;
+mod extension;
 
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
@@ -11,6 +12,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, BitXorAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use complex::*;
+pub use extension::*;
 use p3_field::{AbstractField, Field, PrimeField, PrimeField32, PrimeField64};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;


### PR DESCRIPTION
- [x] Define General API of Extension Field
- [x] Define extension field for Mersenne 31
- [x] Tests

What has been Added:
1. Define trait Frobenius, OEF, and OptimalExtendable according to Plonky2 (mod.rs)
2. Define QuadraticOef and CubicOef with default implementation and distribution trait (quadratic.rs, cubic.rs)
3. Define quadratic and cubic extension for Mersenne31Complex (For simplicity, I used w=(i+2) for quadratic extension and w=5i for cubic extension) (extension.rs)
4. Copy two tests from Plonky2 and synthesis them in field_testing and update tests for all defined fields

Question:
Do we need another optional trait for Frobenuis? Created a new issue https://github.com/Plonky3/Plonky3/issues/90
