### PR TITLE
`exp_const_u64`

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -55,6 +55,11 @@ pub trait AbstractField:
     }
 
     #[must_use]
+    fn cube(&self) -> Self {
+        self.clone() * self.clone() * self.clone()
+    }
+
+    #[must_use]
     fn powers(&self) -> Powers<Self> {
         Powers {
             base: self.clone(),
@@ -119,6 +124,27 @@ pub trait Field:
     #[must_use]
     fn inverse(&self) -> Self {
         self.try_inverse().expect("Tried to invert zero")
+    }
+
+    #[must_use]
+    #[inline(always)]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        match POWER {
+            0 => Self::ONE,
+            1 => *self,
+            2 => self.square(),
+            3 => self.cube(),
+            4 => self.square().square(),
+            5 => self.square().square() * *self,
+            6 => self.square().cube(),
+            7 => {
+                let x2 = self.square();
+                let x3 = x2 * *self;
+                let x4 = x2.square();
+                x3 * x4
+            }
+            _ => self.exp_u64(POWER),
+        }
     }
 
     #[must_use]

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -56,7 +56,7 @@ pub trait AbstractField:
 
     #[must_use]
     fn cube(&self) -> Self {
-        self.clone() * self.clone() * self.clone()
+        self.square() * self.clone()
     }
 
     #[must_use]

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -95,12 +95,12 @@ where
 
     fn full_sbox_layer(state: &mut [F; WIDTH]) {
         for x in state.iter_mut() {
-            *x = x.exp_u64(ALPHA);
+            *x = x.exp_const_u64::<ALPHA>();
         }
     }
 
     fn partial_sbox_layer(state: &mut [F; WIDTH]) {
-        state[0] = state[0].exp_u64(ALPHA);
+        state[0] = state[0].exp_const_u64::<ALPHA>();
     }
 
     fn constant_layer(&self, state: &mut [F; WIDTH], round: usize) {


### PR DESCRIPTION
This doesn't necessarily feel like the right solution, but in my builds it does seem to speed up Poseidon benchmarks significantly.

OTOH @unzvfu earlier found that the compiler seemed to be specializing the `exp_u64` code for constant arguments as one would hope. So we should probably look into this more. Not sure if it's a compiler difference (I'm using a recent nightly and targeting M1) or due to differences in the call sites.