### PR TITLE
Optimize Baby Bear arithmetic

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -201,9 +201,9 @@ impl Add for BabyBear {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         let mut sum = self.value + rhs.value;
-        let (sum_minus_P, over) = sum.overflowing_sub(P);
+        let (corr_sum, over) = sum.overflowing_sub(P);
         if !over {
-            sum = sum_minus_P;
+            sum = corr_sum;
         }
         Self { value: sum }
     }


### PR DESCRIPTION
A few optimizations for Baby Bear arithmetic. Tbh the biggest thing here is `#[inline]`s