### PR TITLE
Coset MDS implementation

### DIFF
--- a/dft/src/lib.rs
+++ b/dft/src/lib.rs
@@ -16,3 +16,4 @@ pub use naive::*;
 pub use radix_2_bowers::*;
 pub use radix_2_dit::*;
 pub use traits::*;
+pub use util::*;

--- a/dft/src/util.rs
+++ b/dft/src/util.rs
@@ -2,7 +2,7 @@ use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
-pub(crate) fn reverse_slice_index_bits<F>(vals: &mut [F]) {
+pub fn reverse_slice_index_bits<F>(vals: &mut [F]) {
     let n = vals.len();
     if n == 0 {
         return;
@@ -28,18 +28,8 @@ pub(crate) fn reverse_matrix_index_bits<F>(vals: &mut RowMajorMatrix<F>) {
     }
 }
 
-/// Assumes `i < j`.
-pub(crate) fn swap_rows<F>(mat: &mut RowMajorMatrix<F>, i: usize, j: usize) {
-    let w = mat.width();
-    let (upper, lower) = mat.values.split_at_mut(j * w);
-    let row_i = &mut upper[i * w..(i + 1) * w];
-    let row_j = &mut lower[..w];
-    row_i.swap_with_slice(row_j);
-}
-
 #[inline]
-pub(crate) fn reverse_bits(x: usize, n: usize) -> usize {
-    debug_assert!(n.is_power_of_two());
+pub const fn reverse_bits(x: usize, n: usize) -> usize {
     // NB: The only reason we need overflowing_shr() here as opposed
     // to plain '>>' is to accommodate the case n == num_bits == 0,
     // which would become `0 >> 64`. Rust thinks that any shift of 64
@@ -47,6 +37,15 @@ pub(crate) fn reverse_bits(x: usize, n: usize) -> usize {
     x.reverse_bits()
         .overflowing_shr(usize::BITS - n.trailing_zeros())
         .0
+}
+
+/// Assumes `i < j`.
+pub(crate) fn swap_rows<F>(mat: &mut RowMajorMatrix<F>, i: usize, j: usize) {
+    let w = mat.width();
+    let (upper, lower) = mat.values.split_at_mut(j * w);
+    let row_i = &mut upper[i * w..(i + 1) * w];
+    let row_j = &mut lower[..w];
+    row_i.swap_with_slice(row_j);
 }
 
 /// Divide each coefficient of the given matrix by its height.

--- a/mds/Cargo.toml
+++ b/mds/Cargo.toml
@@ -12,3 +12,5 @@ p3-goldilocks = { path = "../goldilocks" }
 p3-matrix = { path = "../matrix" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-symmetric = { path = "../symmetric" }
+p3-util = { path = "../util" }
+rand = "0.8.5"

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,0 +1,203 @@
+use p3_dft::reverse_slice_index_bits;
+use p3_field::{Field, Powers, TwoAdicField};
+use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_util::log2_strict_usize;
+
+use crate::MdsPermutation;
+
+/// An MDS permutation which works by interpreting the input as evaluations of a polynomial over a
+/// power-of-two subgroup, and computing evaluations over a coset of that subgroup. This can be
+/// viewed as returning the parity elements of a systematic Reed-Solomon code. Since Reed-Solomon
+/// codes are MDS, this is an MDS permutation.
+#[derive(Copy, Clone, Debug)]
+pub struct CosetMds<F: TwoAdicField, const N: usize> {
+    weights: [F; N],
+}
+
+impl<F: TwoAdicField, const N: usize> Default for CosetMds<F, N> {
+    fn default() -> Self {
+        assert!(N.is_power_of_two());
+        let shift = F::multiplicative_group_generator();
+        let n_inv = F::from_canonical_usize(N).inverse();
+        let mut weights: [F; N] = Powers {
+            base: shift,
+            current: n_inv,
+        }
+        .take(N)
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+        reverse_slice_index_bits(&mut weights);
+        Self { weights }
+    }
+}
+
+impl<F: TwoAdicField, const N: usize> ArrayPermutation<F, N> for CosetMds<F, N> {}
+
+impl<F: TwoAdicField, const N: usize> CryptographicPermutation<[F; N]> for CosetMds<F, N> {
+    fn permute(&self, mut input: [F; N]) -> [F; N] {
+        self.permute_mut(&mut input);
+        input
+    }
+
+    fn permute_mut(&self, values: &mut [F; N]) {
+        // Inverse DFT, except we skip bit reversal and rescaling by 1/N.
+        bowers_g_t(values);
+
+        // Rescale coefficients in two ways:
+        // - divide by N (since we're doing an inverse DFT)
+        // - multiply by powers of the coset shift (see default coset LDE impl for an explanation)
+        for (value, weight) in values.iter_mut().zip(self.weights) {
+            *value *= weight;
+        }
+
+        // DFT, assuming bit-reversed input.
+        bowers_g(values);
+    }
+}
+
+impl<F: TwoAdicField, const N: usize> MdsPermutation<F, N> for CosetMds<F, N> {}
+
+/// Executes the Bowers G network. This is like a DFT, except it assumes the input is in
+/// bit-reversed order.
+fn bowers_g<F: TwoAdicField, const N: usize>(values: &mut [F; N]) {
+    let log_n = log2_strict_usize(N);
+
+    let root = F::primitive_root_of_unity(log_n);
+    let mut twiddles: Vec<F> = root.powers().take(N / 2).collect();
+    reverse_slice_index_bits(&mut twiddles);
+
+    for log_half_block_size in 0..log_n {
+        bowers_g_layer(values, log_half_block_size, &twiddles);
+    }
+}
+
+/// Executes the Bowers G^T network. This is like an inverse DFT, except we skip rescaling by
+/// `1/N`, and the output is bit-reversed.
+fn bowers_g_t<F: TwoAdicField, const N: usize>(values: &mut [F; N]) {
+    let log_n = log2_strict_usize(N);
+
+    let root_inv = F::primitive_root_of_unity(log_n).inverse();
+    let mut twiddles: Vec<F> = root_inv.powers().take(N / 2).collect();
+    reverse_slice_index_bits(&mut twiddles);
+
+    for log_half_block_size in (0..log_n).rev() {
+        bowers_g_t_layer(values, log_half_block_size, &twiddles);
+    }
+}
+
+/// One layer of a Bowers G network. Equivalent to `bowers_g_t_layer` except for the butterfly.
+fn bowers_g_layer<F: Field, const N: usize>(
+    values: &mut [F; N],
+    log_half_block_size: usize,
+    twiddles: &[F],
+) {
+    let log_block_size = log_half_block_size + 1;
+    let half_block_size = 1 << log_half_block_size;
+    let num_blocks = N >> log_block_size;
+
+    // Unroll first iteration with a twiddle factor of 1.
+    for butterfly_hi in 0..half_block_size {
+        let butterfly_lo = butterfly_hi + half_block_size;
+        butterfly_twiddle_one(values, butterfly_hi, butterfly_lo);
+    }
+
+    for (block, &twiddle) in (1..num_blocks).zip(&twiddles[1..]) {
+        let block_start = block << log_block_size;
+        for butterfly_hi in block_start..block_start + half_block_size {
+            let butterfly_lo = butterfly_hi + half_block_size;
+            dif_butterfly(values, butterfly_hi, butterfly_lo, twiddle);
+        }
+    }
+}
+
+/// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
+fn bowers_g_t_layer<F: Field, const N: usize>(
+    values: &mut [F; N],
+    log_half_block_size: usize,
+    twiddles: &[F],
+) {
+    let log_block_size = log_half_block_size + 1;
+    let half_block_size = 1 << log_half_block_size;
+    let num_blocks = N >> log_block_size;
+
+    // Unroll first iteration with a twiddle factor of 1.
+    for butterfly_hi in 0..half_block_size {
+        let butterfly_lo = butterfly_hi + half_block_size;
+        butterfly_twiddle_one(values, butterfly_hi, butterfly_lo);
+    }
+
+    for (block, &twiddle) in (1..num_blocks).zip(&twiddles[1..]) {
+        let block_start = block << log_block_size;
+        for butterfly_hi in block_start..block_start + half_block_size {
+            let butterfly_lo = butterfly_hi + half_block_size;
+            dit_butterfly(values, butterfly_hi, butterfly_lo, twiddle);
+        }
+    }
+}
+
+/// DIT butterfly.
+#[inline]
+pub fn dit_butterfly<F: Field, const N: usize>(
+    values: &mut [F; N],
+    idx_1: usize,
+    idx_2: usize,
+    twiddle: F,
+) {
+    let val_1 = values[idx_1];
+    let val_2 = values[idx_2] * twiddle;
+    values[idx_1] = val_1 + val_2;
+    values[idx_2] = val_1 - val_2;
+}
+
+/// DIF butterfly.
+#[inline]
+pub fn dif_butterfly<F: Field, const N: usize>(
+    values: &mut [F; N],
+    idx_1: usize,
+    idx_2: usize,
+    twiddle: F,
+) {
+    let val_1 = values[idx_1];
+    let val_2 = values[idx_2];
+    values[idx_1] = val_1 + val_2;
+    values[idx_2] = (val_1 - val_2) * twiddle;
+}
+
+/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
+#[inline]
+fn butterfly_twiddle_one<F: Field, const N: usize>(
+    values: &mut [F; N],
+    idx_1: usize,
+    idx_2: usize,
+) {
+    let val_1 = values[idx_1];
+    let val_2 = values[idx_2];
+    values[idx_1] = val_1 + val_2;
+    values[idx_2] = val_1 - val_2;
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::BabyBear;
+    use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
+    use p3_field::AbstractField;
+    use p3_symmetric::permutation::CryptographicPermutation;
+    use rand::{thread_rng, Rng};
+
+    use crate::coset_mds::CosetMds;
+
+    #[test]
+    fn matches_naive() {
+        type F = BabyBear;
+        const N: usize = 8;
+
+        let mut rng = thread_rng();
+        let mut arr: [F; N] = rng.gen();
+
+        let shift = F::multiplicative_group_generator();
+        let coset_lde_naive = NaiveDft.coset_lde(arr.to_vec(), 0, shift);
+        CosetMds::default().permute_mut(&mut arr);
+        assert_eq!(coset_lde_naive, arr);
+    }
+}

--- a/mds/src/lib.rs
+++ b/mds/src/lib.rs
@@ -1,6 +1,7 @@
 use p3_symmetric::permutation::ArrayPermutation;
 
 pub mod babybear;
+pub mod coset_mds;
 pub mod goldilocks;
 pub mod mersenne31;
 pub(crate) mod util;

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -5,6 +5,7 @@ use p3_baby_bear::BabyBear;
 use p3_field::PrimeField64;
 use p3_goldilocks::Goldilocks;
 use p3_mds::babybear::MdsMatrixBabyBear;
+use p3_mds::coset_mds::CosetMds;
 use p3_mds::goldilocks::MdsMatrixGoldilocks;
 use p3_mds::mersenne31::MdsMatrixMersenne31;
 use p3_mds::MdsPermutation;
@@ -17,7 +18,7 @@ use rand::thread_rng;
 fn bench_poseidon(c: &mut Criterion) {
     poseidon::<BabyBear, MdsMatrixBabyBear, 16, 7>(c);
     poseidon::<BabyBear, MdsMatrixBabyBear, 24, 7>(c);
-    poseidon::<BabyBear, MdsMatrixBabyBear, 32, 7>(c);
+    poseidon::<BabyBear, CosetMds<BabyBear, 32>, 32, 7>(c);
 
     poseidon::<Goldilocks, MdsMatrixGoldilocks, 8, 7>(c);
     poseidon::<Goldilocks, MdsMatrixGoldilocks, 12, 7>(c);


### PR DESCRIPTION
This is almost like calling `Radix2Bowers`'s `coset_lde` with `added_bits=0`. I tried to reuse that code, but couldn't get comparable speeds. I haven't dug into the asm but I think there seem to be a couple issues:
- The compiler fails to do constant propagation, even in some cases which seem like they should be easy. This is why I explicitly precomputed `weights`. Ideally we'd compute them in `permute_mut` and constant propagation would make them immediate values, but it wasn't being done.
- I guess there are some range checks, and loops over matrix columns, that the compiler can't eliminate unless it inlines some large methods.

I think we may want the two implementations may diverge anyway, e.g. since `Radix2Bowers` is designed to be applied to matrices, we can vectorize over columns. `CosetMds` is for single polynomials, so we may want to vectorize like we did in Plonky2's FFT code.

Currently this is a lot faster than `apply_circulant_fft`, but I think in principle a similarly optimized convolution impl should be as fast, as the steps are essentially the same. With convolutions we have flexibility about weights (any circulant MDS row), but with `CosetLde` we also have flexibility from the coset choice, and from the fact that e.g. constant scaling doesn't change MDS.