### PR TITLE
FRI performance fixes

### DIFF
--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -122,7 +122,7 @@ fn commit_phase<FC: FriConfig>(
     commits
 }
 
-#[instrument(name = "fold in matrices", skip_all)]
+#[instrument(name = "fold in matrices", skip(init, matrices, alpha))]
 fn reduce_matrices<F, Challenge, Mat>(
     height: usize,
     init: &[Challenge],


### PR DESCRIPTION
- Avoid allocations in `QuotientMatrix::row`
- Compute `1 / (x - opened_point)` once per row, rather than for each column (we could also do batch inversion, but I think this is good enough for now)