### PR TITLE
Remove blanket `OptimallyExtendable` impl

### DIFF
--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,5 +1,4 @@
 use crate::field::Field;
-use crate::ExtensionField;
 
 pub mod cubic;
 pub mod quadratic;
@@ -12,13 +11,4 @@ pub trait OptimallyExtendable<const D: usize>: Field + Sized {
     const DTH_ROOT: Self;
 
     fn ext_multiplicative_group_generator() -> [Self; D];
-}
-
-impl<F: Field + ExtensionField<F>> OptimallyExtendable<1> for F {
-    const W: Self = F::ONE;
-    const DTH_ROOT: Self = F::ONE;
-
-    fn ext_multiplicative_group_generator() -> [Self; 1] {
-        [F::multiplicative_group_generator()]
-    }
 }


### PR DESCRIPTION
It seems like this may have been intended for defining trivial extension fields? But we also have a blanket impl declaring each field a trivial extension of itself, which seems more direct (there's no irreducible polynomial involved).