### PR TITLE
rename symbols for extension field.

### DIFF
--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -10,21 +10,21 @@ use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct CubicBEF<F: BinomiallyExtendable<3>>(pub [F; 3]);
+pub struct CubicBef<F: BinomiallyExtendable<3>>(pub [F; 3]);
 
-impl<F: BinomiallyExtendable<3>> Default for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Default for CubicBef<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: BinomiallyExtendable<3>> From<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> From<F> for CubicBef<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO, F::ZERO])
     }
 }
 
-impl<F: BinomiallyExtendable<3>> AbstractField for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> AbstractField for CubicBef<F> {
     const ZERO: Self = Self([F::ZERO; 3]);
     const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO]);
@@ -83,7 +83,7 @@ impl<F: BinomiallyExtendable<3>> AbstractField for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Field for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Field for CubicBef<F> {
     type Packing = Self;
     // Algorithm 11.3.6.b in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -112,19 +112,19 @@ impl<F: BinomiallyExtendable<3>> Field for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Display for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Display for CubicBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a + {}*a^2", self.0[0], self.0[1], self.0[2])
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Debug for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Debug for CubicBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Neg for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Neg for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -133,7 +133,7 @@ impl<F: BinomiallyExtendable<3>> Neg for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Add for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Add for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -146,7 +146,7 @@ impl<F: BinomiallyExtendable<3>> Add for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Add<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Add<F> for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -155,25 +155,25 @@ impl<F: BinomiallyExtendable<3>> Add<F> for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> AddAssign for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> AddAssign for CubicBef<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> AddAssign<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> AddAssign<F> for CubicBef<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Sum for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Sum for CubicBef<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Sub for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Sub for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -186,7 +186,7 @@ impl<F: BinomiallyExtendable<3>> Sub for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Sub<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Sub<F> for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -195,21 +195,21 @@ impl<F: BinomiallyExtendable<3>> Sub<F> for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> SubAssign for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> SubAssign for CubicBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> SubAssign<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> SubAssign<F> for CubicBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Mul for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Mul for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -231,7 +231,7 @@ impl<F: BinomiallyExtendable<3>> Mul for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Mul<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Mul<F> for CubicBef<F> {
     type Output = Self;
 
     #[inline]
@@ -240,13 +240,13 @@ impl<F: BinomiallyExtendable<3>> Mul<F> for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Product for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Product for CubicBef<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Div for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> Div for CubicBef<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -255,25 +255,25 @@ impl<F: BinomiallyExtendable<3>> Div for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> DivAssign for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> DivAssign for CubicBef<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> MulAssign for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> MulAssign for CubicBef<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<3>> MulAssign<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> MulAssign<F> for CubicBef<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
-impl<F: BinomiallyExtendable<3>> AbstractExtensionField<F> for CubicBEF<F> {
+impl<F: BinomiallyExtendable<3>> AbstractExtensionField<F> for CubicBef<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -290,12 +290,12 @@ impl<F: BinomiallyExtendable<3>> AbstractExtensionField<F> for CubicBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<3>> Distribution<CubicBEF<F>> for Standard
+impl<F: BinomiallyExtendable<3>> Distribution<CubicBef<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicBEF<F> {
-        CubicBEF::<F>::from_base_slice(&[
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicBef<F> {
+        CubicBef::<F>::from_base_slice(&[
             Standard.sample(rng),
             Standard.sample(rng),
             Standard.sample(rng),

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -5,26 +5,26 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use crate::extension::OptimallyExtendable;
+use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct CubicOef<F: OptimallyExtendable<3>>(pub [F; 3]);
+pub struct CubicBEF<F: BinomiallyExtendable<3>>(pub [F; 3]);
 
-impl<F: OptimallyExtendable<3>> Default for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Default for CubicBEF<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: OptimallyExtendable<3>> From<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> From<F> for CubicBEF<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO, F::ZERO])
     }
 }
 
-impl<F: OptimallyExtendable<3>> AbstractField for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> AbstractField for CubicBEF<F> {
     const ZERO: Self = Self([F::ZERO; 3]);
     const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO]);
@@ -83,7 +83,7 @@ impl<F: OptimallyExtendable<3>> AbstractField for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Field for CubicBEF<F> {
     type Packing = Self;
     // Algorithm 11.3.6.b in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -112,19 +112,19 @@ impl<F: OptimallyExtendable<3>> Field for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Display for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Display for CubicBEF<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a + {}*a^2", self.0[0], self.0[1], self.0[2])
     }
 }
 
-impl<F: OptimallyExtendable<3>> Debug for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Debug for CubicBEF<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: OptimallyExtendable<3>> Neg for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Neg for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -133,7 +133,7 @@ impl<F: OptimallyExtendable<3>> Neg for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Add for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Add for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -146,7 +146,7 @@ impl<F: OptimallyExtendable<3>> Add for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Add<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Add<F> for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -155,25 +155,25 @@ impl<F: OptimallyExtendable<3>> Add<F> for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> AddAssign for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> AddAssign for CubicBEF<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> AddAssign<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> AddAssign<F> for CubicBEF<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> Sum for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Sum for CubicBEF<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: OptimallyExtendable<3>> Sub for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Sub for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -186,7 +186,7 @@ impl<F: OptimallyExtendable<3>> Sub for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Sub<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Sub<F> for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -195,21 +195,21 @@ impl<F: OptimallyExtendable<3>> Sub<F> for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> SubAssign for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> SubAssign for CubicBEF<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> SubAssign<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> SubAssign<F> for CubicBEF<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> Mul for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Mul for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -231,7 +231,7 @@ impl<F: OptimallyExtendable<3>> Mul for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Mul<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Mul<F> for CubicBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -240,13 +240,13 @@ impl<F: OptimallyExtendable<3>> Mul<F> for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Product for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Product for CubicBEF<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: OptimallyExtendable<3>> Div for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> Div for CubicBEF<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -255,25 +255,25 @@ impl<F: OptimallyExtendable<3>> Div for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> DivAssign for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> DivAssign for CubicBEF<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> MulAssign for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> MulAssign for CubicBEF<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<3>> MulAssign<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> MulAssign<F> for CubicBEF<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
-impl<F: OptimallyExtendable<3>> AbstractExtensionField<F> for CubicOef<F> {
+impl<F: BinomiallyExtendable<3>> AbstractExtensionField<F> for CubicBEF<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -290,12 +290,12 @@ impl<F: OptimallyExtendable<3>> AbstractExtensionField<F> for CubicOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<3>> Distribution<CubicOef<F>> for Standard
+impl<F: BinomiallyExtendable<3>> Distribution<CubicBEF<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicOef<F> {
-        CubicOef::<F>::from_base_slice(&[
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicBEF<F> {
+        CubicBEF::<F>::from_base_slice(&[
             Standard.sample(rng),
             Standard.sample(rng),
             Standard.sample(rng),

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -6,7 +6,7 @@ pub mod quadratic;
 /// Binomial extension field trait.
 /// A extension field with a irreducible polynomial X^d-W
 /// such that the extension is `F[X]/(X^d-W)`.
-pub trait OptimallyExtendable<const D: usize>: Field + Sized {
+pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const W: Self;
     const DTH_ROOT: Self;
 

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -5,26 +5,26 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use crate::extension::OptimallyExtendable;
+use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct QuadraticOef<F: OptimallyExtendable<2>>(pub [F; 2]);
+pub struct QuadraticBEF<F: BinomiallyExtendable<2>>(pub [F; 2]);
 
-impl<F: OptimallyExtendable<2>> Default for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Default for QuadraticBEF<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: OptimallyExtendable<2>> From<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> From<F> for QuadraticBEF<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO])
     }
 }
 
-impl<F: OptimallyExtendable<2>> AbstractField for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBEF<F> {
     const ZERO: Self = Self([F::ZERO; 2]);
     const ONE: Self = Self([F::ONE, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO]);
@@ -82,7 +82,7 @@ impl<F: OptimallyExtendable<2>> AbstractField for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Field for QuadraticBEF<F> {
     type Packing = Self;
     // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -96,19 +96,19 @@ impl<F: OptimallyExtendable<2>> Field for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Display for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Display for QuadraticBEF<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a", self.0[0], self.0[1])
     }
 }
 
-impl<F: OptimallyExtendable<2>> Debug for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Debug for QuadraticBEF<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: OptimallyExtendable<2>> Neg for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Neg for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -117,7 +117,7 @@ impl<F: OptimallyExtendable<2>> Neg for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Add for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Add for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -126,7 +126,7 @@ impl<F: OptimallyExtendable<2>> Add for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Add<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Add<F> for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -135,25 +135,25 @@ impl<F: OptimallyExtendable<2>> Add<F> for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> AddAssign for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> AddAssign for QuadraticBEF<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> AddAssign<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> AddAssign<F> for QuadraticBEF<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> Sum for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Sum for QuadraticBEF<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: OptimallyExtendable<2>> Sub for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Sub for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -162,7 +162,7 @@ impl<F: OptimallyExtendable<2>> Sub for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Sub<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Sub<F> for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -171,21 +171,21 @@ impl<F: OptimallyExtendable<2>> Sub<F> for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> SubAssign for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> SubAssign for QuadraticBEF<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> SubAssign<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> SubAssign<F> for QuadraticBEF<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> Mul for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Mul for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -200,7 +200,7 @@ impl<F: OptimallyExtendable<2>> Mul for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Mul<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Mul<F> for QuadraticBEF<F> {
     type Output = Self;
 
     #[inline]
@@ -209,13 +209,13 @@ impl<F: OptimallyExtendable<2>> Mul<F> for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Product for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Product for QuadraticBEF<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: OptimallyExtendable<2>> Div for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> Div for QuadraticBEF<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -224,26 +224,26 @@ impl<F: OptimallyExtendable<2>> Div for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> DivAssign for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> DivAssign for QuadraticBEF<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> MulAssign for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> MulAssign for QuadraticBEF<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> MulAssign<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> MulAssign<F> for QuadraticBEF<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
+impl<F: BinomiallyExtendable<2>> AbstractExtensionField<F> for QuadraticBEF<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -260,11 +260,11 @@ impl<F: OptimallyExtendable<2>> AbstractExtensionField<F> for QuadraticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<2>> Distribution<QuadraticOef<F>> for Standard
+impl<F: BinomiallyExtendable<2>> Distribution<QuadraticBEF<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadraticOef<F> {
-        QuadraticOef::<F>::from_base_slice(&[Standard.sample(rng), Standard.sample(rng)])
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadraticBEF<F> {
+        QuadraticBEF::<F>::from_base_slice(&[Standard.sample(rng), Standard.sample(rng)])
     }
 }

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -10,21 +10,21 @@ use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct QuadraticBEF<F: BinomiallyExtendable<2>>(pub [F; 2]);
+pub struct QuadraticBef<F: BinomiallyExtendable<2>>(pub [F; 2]);
 
-impl<F: BinomiallyExtendable<2>> Default for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Default for QuadraticBef<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: BinomiallyExtendable<2>> From<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> From<F> for QuadraticBef<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO])
     }
 }
 
-impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBef<F> {
     const ZERO: Self = Self([F::ZERO; 2]);
     const ONE: Self = Self([F::ONE, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO]);
@@ -82,7 +82,7 @@ impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Field for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Field for QuadraticBef<F> {
     type Packing = Self;
     // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -96,19 +96,19 @@ impl<F: BinomiallyExtendable<2>> Field for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Display for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Display for QuadraticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a", self.0[0], self.0[1])
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Debug for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Debug for QuadraticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Neg for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Neg for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -117,7 +117,7 @@ impl<F: BinomiallyExtendable<2>> Neg for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Add for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Add for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -126,7 +126,7 @@ impl<F: BinomiallyExtendable<2>> Add for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Add<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Add<F> for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -135,25 +135,25 @@ impl<F: BinomiallyExtendable<2>> Add<F> for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> AddAssign for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> AddAssign for QuadraticBef<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> AddAssign<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> AddAssign<F> for QuadraticBef<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Sum for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Sum for QuadraticBef<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Sub for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Sub for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -162,7 +162,7 @@ impl<F: BinomiallyExtendable<2>> Sub for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Sub<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Sub<F> for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -171,21 +171,21 @@ impl<F: BinomiallyExtendable<2>> Sub<F> for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> SubAssign for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> SubAssign for QuadraticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> SubAssign<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> SubAssign<F> for QuadraticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Mul for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Mul for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -200,7 +200,7 @@ impl<F: BinomiallyExtendable<2>> Mul for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Mul<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Mul<F> for QuadraticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -209,13 +209,13 @@ impl<F: BinomiallyExtendable<2>> Mul<F> for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Product for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Product for QuadraticBef<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Div for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> Div for QuadraticBef<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -224,26 +224,26 @@ impl<F: BinomiallyExtendable<2>> Div for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> DivAssign for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> DivAssign for QuadraticBef<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> MulAssign for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> MulAssign for QuadraticBef<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> MulAssign<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> MulAssign<F> for QuadraticBef<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
 
-impl<F: BinomiallyExtendable<2>> AbstractExtensionField<F> for QuadraticBEF<F> {
+impl<F: BinomiallyExtendable<2>> AbstractExtensionField<F> for QuadraticBef<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -260,11 +260,11 @@ impl<F: BinomiallyExtendable<2>> AbstractExtensionField<F> for QuadraticBEF<F> {
     }
 }
 
-impl<F: BinomiallyExtendable<2>> Distribution<QuadraticBEF<F>> for Standard
+impl<F: BinomiallyExtendable<2>> Distribution<QuadraticBef<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadraticBEF<F> {
-        QuadraticBEF::<F>::from_base_slice(&[Standard.sample(rng), Standard.sample(rng)])
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuadraticBef<F> {
+        QuadraticBef::<F>::from_base_slice(&[Standard.sample(rng), Standard.sample(rng)])
     }
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -70,7 +70,7 @@ mod test_cubic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::cubic::CubicBEF<crate::Mersenne31Complex<crate::Mersenne31>>);
+    test_field!(p3_field::extension::cubic::CubicBef<crate::Mersenne31Complex<crate::Mersenne31>>);
 }
 
 #[cfg(test)]
@@ -79,6 +79,6 @@ mod test_quadratic_extension {
     use p3_field_testing::test_field;
 
     test_field!(
-        p3_field::extension::quadratic::QuadraticBEF<crate::Mersenne31Complex<crate::Mersenne31>>
+        p3_field::extension::quadratic::QuadraticBef<crate::Mersenne31Complex<crate::Mersenne31>>
     );
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,8 +1,8 @@
-use p3_field::extension::OptimallyExtendable;
+use p3_field::extension::BinomiallyExtendable;
 
 use crate::{Mersenne31, Mersenne31Complex};
 
-impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
+impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     // Verifiable in Sage with
     // ```sage
     // p = 2**31 - 1  # Mersenne31
@@ -33,7 +33,7 @@ impl OptimallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     }
 }
 
-impl OptimallyExtendable<3> for Mersenne31Complex<Mersenne31> {
+impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // Verifiable in Sage with
     // ```sage
     // p = 2**31 - 1  # Mersenne31
@@ -70,7 +70,7 @@ mod test_cubic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::cubic::CubicOef<crate::Mersenne31Complex<crate::Mersenne31>>);
+    test_field!(p3_field::extension::cubic::CubicBEF<crate::Mersenne31Complex<crate::Mersenne31>>);
 }
 
 #[cfg(test)]
@@ -79,6 +79,6 @@ mod test_quadratic_extension {
     use p3_field_testing::test_field;
 
     test_field!(
-        p3_field::extension::quadratic::QuadraticOef<crate::Mersenne31Complex<crate::Mersenne31>>
+        p3_field::extension::quadratic::QuadraticBEF<crate::Mersenne31Complex<crate::Mersenne31>>
     );
 }


### PR DESCRIPTION
Rename symbols before we define other extension fields.
OptimallyExtendable ->BinomialExtendable
XXXOef -> XXXBEF.

Note: We can still define OEF for QuinticExtension and TesseracticExtension of baby bear
in https://github.com/Plonky3/Plonky3/issues/52 for faster computing of the inverse.