### PR TITLE
quadratic extension field for goldlilocks

### DIFF
--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -8,7 +8,5 @@ pub mod quadratic;
 /// such that the extension is `F[X]/(X^d-W)`.
 pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const W: Self;
-    const DTH_ROOT: Self;
-
     fn ext_multiplicative_group_generator() -> [Self; D];
 }

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -7,9 +7,6 @@ impl BinomiallyExtendable<2> for Goldilocks {
     // `R.<x> = GF(p)[]; assert (x^2 - 7).is_irreducible()`.
     const W: Self = Self::new(7);
 
-    // DTH_ROOT = W^((ORDER - 1)/2)
-    const DTH_ROOT: Self = Self::new(18446744069414584320);
-
     fn ext_multiplicative_group_generator() -> [Self; 2] {
         [
             Self::new(18081566051660590251),

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,0 +1,27 @@
+use p3_field::extension::BinomiallyExtendable;
+
+use crate::Goldilocks;
+
+impl BinomiallyExtendable<2> for Goldilocks {
+    // Verifiable in Sage with
+    // `R.<x> = GF(p)[]; assert (x^2 - 7).is_irreducible()`.
+    const W: Self = Self::new(7);
+
+    // DTH_ROOT = W^((ORDER - 1)/2)
+    const DTH_ROOT: Self = Self::new(18446744069414584320);
+
+    fn ext_multiplicative_group_generator() -> [Self; 2] {
+        [
+            Self::new(18081566051660590251),
+            Self::new(16121475356294670766),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod test_quadratic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::quadratic::QuadraticBef<crate::Goldilocks>);
+}

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![no_std]
 
+mod extension;
+
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -15,9 +15,6 @@ impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     // ```
     const W: Self = Self::new(Mersenne31::new(2), Mersenne31::new(1));
 
-    // DTH_ROOT = W^((p - 1)/2)
-    const DTH_ROOT: Self = Self::new(Mersenne31::new(21189756), Mersenne31::new(42379512));
-
     // Verifiable in Sage with
     // ```sage
     // K2.<j> = K.extension(f2)
@@ -45,9 +42,6 @@ impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // assert f2.is_irreducible()
     // ```
     const W: Self = Self::new(Mersenne31::new(0), Mersenne31::new(5));
-
-    // DTH_ROOT = W^((p - 1)/3)
-    const DTH_ROOT: Self = Self::new(Mersenne31::new(634005912), Mersenne31::new(0));
 
     // Verifiable in Sage with
     // ```sage


### PR DESCRIPTION
extension field for goldilocks with binomial irreducible poly x^2-7

parameters come from plonky2.

Remove the DTH root from BinomialExtendable since this is not well defined for Bef (e.g., it seems it should be w^(p^2-1/ord) for the extension field of mersenne31complex). Since it is not used in the current implementation, I quickly removed it in this PR. I will reintroduce it when defining OEF(https://github.com/Plonky3/Plonky3/issues/113), which uses the Dth_root in the frobenuis function.