### PR TITLE
Found a better addition chain for M31 too!

### DIFF
--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -179,14 +179,13 @@ impl Field for Mersenne31 {
             return None;
         }
         let p1 = *self;
-        let p2 = p1.square() * p1;
-        let p4 = p2.exp_power_of_2(2) * p2;
+        let p1_1 = p1.exp_power_of_2(2) * p1;
+        let p4 = p1_1.square() * p1_1;
         let p8 = p4.exp_power_of_2(4) * p4;
         let p16 = p8.exp_power_of_2(8) * p8;
         let p24 = p16.exp_power_of_2(8) * p8;
         let p28 = p24.exp_power_of_2(4) * p4;
-        let p29 = p28.exp_power_of_2(1) * p1;
-        let p29_1 = p29.exp_power_of_2(2) * p1;
+        let p29_1 = p28.exp_power_of_2(3) * p1_1;
         Some(p29_1)
     }
 }


### PR DESCRIPTION
Today seems to be a good day. Improved the addition chain for inversion in M31. Saves 1 operation again.

For some reason running the benchmark on my computer for this (minor) improvement is giving a 25% speed increase but that seem ridiculous. I'd expect roughly a 5% improvement again.