### PR TITLE
113 babybear extension fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Fields:
   - [ ] AVX-512
   - [ ] NEON
 - [x] BabyBear
-  - [ ] ~128 bit extension field
+  - [x] ~128 bit extension field
   - [ ] AVX2
   - [ ] AVX-512
   - [x] NEON
 - [x] Goldilocks
-  - [ ] ~128 bit extension field
+  - [x] ~128 bit extension field
 
 Generalized vector commitment schemes
 - [x] generalized Merkle tree

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -18,6 +18,12 @@ pub struct BabyBear {
     value: u32,
 }
 
+impl BabyBear {
+    pub(crate) const fn new(n: u32) -> Self {
+        Self { value: to_monty(n) }
+    }
+}
+
 impl Ord for BabyBear {
     #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
@@ -292,7 +298,7 @@ impl Div for BabyBear {
 
 #[inline]
 #[must_use]
-fn to_monty(x: u32) -> u32 {
+const fn to_monty(x: u32) -> u32 {
     (((x as u64) << 31) % P as u64) as u32
 }
 

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -19,6 +19,7 @@ pub struct BabyBear {
 }
 
 impl BabyBear {
+    /// create a new `BabyBear` from a canonical `u32`.
     pub(crate) const fn new(n: u32) -> Self {
         Self { value: to_monty(n) }
     }

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -1,4 +1,4 @@
-use p3_field::extension::{BinomiallyExtendable, OptimallyExtendable};
+use p3_field::extension::{BinomiallyExtendable, HasFrobenuis};
 use p3_field::AbstractField;
 
 use crate::BabyBear;
@@ -12,7 +12,7 @@ impl BinomiallyExtendable<4> for BabyBear {
         [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO]
     }
 }
-impl OptimallyExtendable<4> for BabyBear {
+impl HasFrobenuis<4> for BabyBear {
     // DTH_ROOT = W^((p - 1)/4)
     const DTH_ROOT: Self = Self::new(1728404513);
 }
@@ -26,7 +26,7 @@ impl BinomiallyExtendable<5> for BabyBear {
         [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO, Self::ZERO]
     }
 }
-impl OptimallyExtendable<5> for BabyBear {
+impl HasFrobenuis<5> for BabyBear {
     // DTH_ROOT = W^((p - 1)/5)
     const DTH_ROOT: Self = Self::new(815036133);
 }
@@ -36,12 +36,12 @@ mod test_tesseractic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::tesseractic::TesseracticOef<crate::BabyBear>);
+    test_field!(p3_field::extension::tesseractic::TesseracticBef<crate::BabyBear>);
 }
 #[cfg(test)]
 mod test_quintic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::quintic::QuinticOef<crate::BabyBear>);
+    test_field!(p3_field::extension::quintic::QuinticBef<crate::BabyBear>);
 }

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -1,0 +1,47 @@
+use p3_field::extension::{BinomiallyExtendable, OptimallyExtendable};
+use p3_field::AbstractField;
+
+use crate::BabyBear;
+
+impl BinomiallyExtendable<4> for BabyBear {
+    // Verifiable in Sage with
+    // `R.<x> = GF(p)[]; assert (x^4 - 11).is_irreducible()`.
+    const W: Self = Self::new(11);
+
+    fn ext_multiplicative_group_generator() -> [Self; 4] {
+        [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO]
+    }
+}
+impl OptimallyExtendable<4> for BabyBear {
+    // DTH_ROOT = W^((p - 1)/4)
+    const DTH_ROOT: Self = Self::new(1728404513);
+}
+
+impl BinomiallyExtendable<5> for BabyBear {
+    // Verifiable in Sage with
+    // `R.<x> = GF(p)[]; assert (x^5 - 2).is_irreducible()`.
+    const W: Self = Self::new(2);
+
+    fn ext_multiplicative_group_generator() -> [Self; 5] {
+        [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO, Self::ZERO]
+    }
+}
+impl OptimallyExtendable<5> for BabyBear {
+    // DTH_ROOT = W^((p - 1)/5)
+    const DTH_ROOT: Self = Self::new(815036133);
+}
+
+#[cfg(test)]
+mod test_tesseractic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::tesseractic::TesseracticOef<crate::BabyBear>);
+}
+#[cfg(test)]
+mod test_quintic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::quintic::QuinticOef<crate::BabyBear>);
+}

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
 mod baby_bear;
+mod extension;
+
 pub use baby_bear::*;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,5 +1,5 @@
 use crate::field::Field;
-use crate::{AbstractExtensionField, PrimeField};
+use crate::AbstractExtensionField;
 
 pub mod cubic;
 pub mod quadratic;
@@ -14,14 +14,15 @@ pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     fn ext_multiplicative_group_generator() -> [Self; D];
 }
 
-/// Optimally extendable field trait.
+/// Trait for defining frobenuis endomorphism of extension field.
 /// An bionomial extension field with a prime base field.
-pub trait OptimallyExtendable<const D: usize>: BinomiallyExtendable<D> + PrimeField {
-    // DTH_ROOT = W^((p - 1)/D)
+pub trait HasFrobenuis<const D: usize>: BinomiallyExtendable<D> {
+    // DTH_ROOT = W^((n - 1)/D)
+    // n is the order of base field.
     const DTH_ROOT: Self;
 }
 
-pub trait Frobenius<F: OptimallyExtendable<D>, const D: usize>:
+pub trait Frobenius<F: HasFrobenuis<D>, const D: usize>:
     Field + Sized + AbstractExtensionField<F>
 {
     /// FrobeniusField automorphisms: x -> x^p, where p is the order of BaseField.

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,7 +1,10 @@
 use crate::field::Field;
+use crate::{AbstractExtensionField, PrimeField};
 
 pub mod cubic;
 pub mod quadratic;
+pub mod quintic;
+pub mod tesseractic;
 
 /// Binomial extension field trait.
 /// A extension field with a irreducible polynomial X^d-W
@@ -9,4 +12,45 @@ pub mod quadratic;
 pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const W: Self;
     fn ext_multiplicative_group_generator() -> [Self; D];
+}
+
+pub trait OptimallyExtendable<const D: usize>: BinomiallyExtendable<D> + PrimeField {
+    const DTH_ROOT: Self;
+}
+
+pub trait Frobenius<F: OptimallyExtendable<D>, const D: usize>:
+    Field + Sized + AbstractExtensionField<F>
+{
+    /// FrobeniusField automorphisms: x -> x^p, where p is the order of BaseField.
+    fn frobenius(&self) -> Self {
+        self.repeated_frobenius(1)
+    }
+
+    /// Repeated Frobenius automorphisms: x -> x^(p^count).
+    ///
+    /// Follows precomputation suggestion in Section 11.3.3 of the
+    /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn repeated_frobenius(&self, count: usize) -> Self {
+        if count == 0 {
+            return *self;
+        } else if count >= D {
+            // x |-> x^(p^D) is the identity, so x^(p^count) ==
+            // x^(p^(count % D))
+            return self.repeated_frobenius(count % D);
+        }
+        let arr: &[F] = self.as_base_slice();
+
+        // z0 = DTH_ROOT^count = W^(k * count) where k = floor((p-1)/D)
+        let mut z0 = F::DTH_ROOT;
+        for _ in 1..count {
+            z0 *= F::DTH_ROOT;
+        }
+
+        let mut res = [F::ZERO; D];
+        for (i, z) in z0.powers().take(D).enumerate() {
+            res[i] = arr[i] * z;
+        }
+
+        Self::from_base_slice(&res)
+    }
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -14,7 +14,10 @@ pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     fn ext_multiplicative_group_generator() -> [Self; D];
 }
 
+/// Optimally extendable field trait.
+/// An bionomial extension field with a prime base field.
 pub trait OptimallyExtendable<const D: usize>: BinomiallyExtendable<D> + PrimeField {
+    // DTH_ROOT = W^((p - 1)/D)
     const DTH_ROOT: Self;
 }
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -17,20 +17,21 @@ pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
 /// Trait for defining frobenuis endomorphism of extension field.
 /// An bionomial extension field with a prime base field.
 pub trait HasFrobenuis<const D: usize>: BinomiallyExtendable<D> {
-    // DTH_ROOT = W^((n - 1)/D)
+    // DTH_ROOT = W^((n - 1)/D).
     // n is the order of base field.
+    // Only works when exists k such that n = kD + 1.
     const DTH_ROOT: Self;
 }
 
 pub trait Frobenius<F: HasFrobenuis<D>, const D: usize>:
     Field + Sized + AbstractExtensionField<F>
 {
-    /// FrobeniusField automorphisms: x -> x^p, where p is the order of BaseField.
+    /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
     fn frobenius(&self) -> Self {
         self.repeated_frobenius(1)
     }
 
-    /// Repeated Frobenius automorphisms: x -> x^(p^count).
+    /// Repeated Frobenius automorphisms: x -> x^(n^count).
     ///
     /// Follows precomputation suggestion in Section 11.3.3 of the
     /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
@@ -38,13 +39,13 @@ pub trait Frobenius<F: HasFrobenuis<D>, const D: usize>:
         if count == 0 {
             return *self;
         } else if count >= D {
-            // x |-> x^(p^D) is the identity, so x^(p^count) ==
-            // x^(p^(count % D))
+            // x |-> x^(n^D) is the identity, so x^(n^count) ==
+            // x^(n^(count % D))
             return self.repeated_frobenius(count % D);
         }
         let arr: &[F] = self.as_base_slice();
 
-        // z0 = DTH_ROOT^count = W^(k * count) where k = floor((p-1)/D)
+        // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
         let mut z0 = F::DTH_ROOT;
         for _ in 1..count {
             z0 *= F::DTH_ROOT;

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -193,10 +193,11 @@ impl<F: BinomiallyExtendable<2>> Mul for QuadraticBef<F> {
         let Self([a0, a1]) = self;
         let Self([b0, b1]) = rhs;
 
-        let c0 = a0 * b0 + F::W * a1 * b1;
-        let c1 = a0 * b1 + a1 * b0;
+        let c0 = a0 * b0;
+        let c2 = a1 * b1;
+        let c1 = (a0 + a1) * (b0 + b1) - c0 - c2;
 
-        Self([c0, c1])
+        Self([c0 + c2 * F::W, c1])
     }
 }
 

--- a/field/src/extension/quintic.rs
+++ b/field/src/extension/quintic.rs
@@ -5,28 +5,28 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use super::{Frobenius, OptimallyExtendable};
+use super::{Frobenius, HasFrobenuis};
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct QuinticOef<F: OptimallyExtendable<5>>(pub [F; 5]);
+pub struct QuinticBef<F: HasFrobenuis<5>>(pub [F; 5]);
 
-impl<F: OptimallyExtendable<5>> Frobenius<F, 5> for QuinticOef<F> {}
+impl<F: HasFrobenuis<5>> Frobenius<F, 5> for QuinticBef<F> {}
 
-impl<F: OptimallyExtendable<5>> Default for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Default for QuinticBef<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: OptimallyExtendable<5>> From<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> From<F> for QuinticBef<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO, F::ZERO, F::ZERO, F::ZERO])
     }
 }
 
-impl<F: OptimallyExtendable<5>> AbstractField for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> AbstractField for QuinticBef<F> {
     const ZERO: Self = Self([F::ZERO; 5]);
     const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
@@ -88,7 +88,7 @@ impl<F: OptimallyExtendable<5>> AbstractField for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Field for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Field for QuinticBef<F> {
     type Packing = Self;
     // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -113,19 +113,19 @@ impl<F: OptimallyExtendable<5>> Field for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Display for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Display for QuinticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a", self.0[0], self.0[1])
     }
 }
 
-impl<F: OptimallyExtendable<5>> Debug for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Debug for QuinticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: OptimallyExtendable<5>> Neg for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Neg for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -134,7 +134,7 @@ impl<F: OptimallyExtendable<5>> Neg for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Add for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Add for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -149,7 +149,7 @@ impl<F: OptimallyExtendable<5>> Add for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Add<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Add<F> for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -158,25 +158,25 @@ impl<F: OptimallyExtendable<5>> Add<F> for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> AddAssign for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> AddAssign for QuinticBef<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> AddAssign<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> AddAssign<F> for QuinticBef<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> Sum for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Sum for QuinticBef<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: OptimallyExtendable<5>> Sub for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Sub for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -191,7 +191,7 @@ impl<F: OptimallyExtendable<5>> Sub for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Sub<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Sub<F> for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -200,21 +200,21 @@ impl<F: OptimallyExtendable<5>> Sub<F> for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> SubAssign for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> SubAssign for QuinticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> SubAssign<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> SubAssign<F> for QuinticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> Mul for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Mul for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -269,7 +269,7 @@ impl<F: OptimallyExtendable<5>> Mul for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Mul<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Mul<F> for QuinticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -284,13 +284,13 @@ impl<F: OptimallyExtendable<5>> Mul<F> for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Product for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Product for QuinticBef<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: OptimallyExtendable<5>> Div for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> Div for QuinticBef<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -299,26 +299,26 @@ impl<F: OptimallyExtendable<5>> Div for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> DivAssign for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> DivAssign for QuinticBef<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> MulAssign for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> MulAssign for QuinticBef<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> MulAssign<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> MulAssign<F> for QuinticBef<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<5>> AbstractExtensionField<F> for QuinticOef<F> {
+impl<F: HasFrobenuis<5>> AbstractExtensionField<F> for QuinticBef<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -335,12 +335,12 @@ impl<F: OptimallyExtendable<5>> AbstractExtensionField<F> for QuinticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<5>> Distribution<QuinticOef<F>> for Standard
+impl<F: HasFrobenuis<5>> Distribution<QuinticBef<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuinticOef<F> {
-        QuinticOef::<F>::from_base_slice(&[
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuinticBef<F> {
+        QuinticBef::<F>::from_base_slice(&[
             Standard.sample(rng),
             Standard.sample(rng),
             Standard.sample(rng),

--- a/field/src/extension/quintic.rs
+++ b/field/src/extension/quintic.rs
@@ -1,0 +1,315 @@
+use core::fmt::{self, Debug, Display, Formatter};
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+
+use super::{Frobenius, OptimallyExtendable};
+use crate::field::Field;
+use crate::{AbstractExtensionField, AbstractField};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct QuinticOef<F: OptimallyExtendable<5>>(pub [F; 5]);
+
+impl<F: OptimallyExtendable<5>> Frobenius<F, 5> for QuinticOef<F> {}
+
+impl<F: OptimallyExtendable<5>> Default for QuinticOef<F> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: OptimallyExtendable<5>> From<F> for QuinticOef<F> {
+    fn from(x: F) -> Self {
+        Self([x, F::ZERO, F::ZERO, F::ZERO, F::ZERO])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> AbstractField for QuinticOef<F> {
+    const ZERO: Self = Self([F::ZERO; 5]);
+    const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+    const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+    const NEG_ONE: Self = Self([F::NEG_ONE, F::ZERO, F::ZERO, F::ZERO, F::ZERO]);
+
+    fn from_bool(b: bool) -> Self {
+        F::from_bool(b).into()
+    }
+
+    fn from_canonical_u8(n: u8) -> Self {
+        F::from_canonical_u8(n).into()
+    }
+
+    fn from_canonical_u16(n: u16) -> Self {
+        F::from_canonical_u16(n).into()
+    }
+
+    fn from_canonical_u32(n: u32) -> Self {
+        F::from_canonical_u32(n).into()
+    }
+
+    /// Convert from `u64`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_u64(n: u64) -> Self {
+        F::from_canonical_u64(n).into()
+    }
+
+    /// Convert from `usize`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_usize(n: usize) -> Self {
+        F::from_canonical_usize(n).into()
+    }
+
+    fn from_wrapped_u32(n: u32) -> Self {
+        F::from_wrapped_u32(n).into()
+    }
+
+    fn from_wrapped_u64(n: u64) -> Self {
+        F::from_wrapped_u64(n).into()
+    }
+
+    fn multiplicative_group_generator() -> Self {
+        Self(F::ext_multiplicative_group_generator())
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        let Self([a0, a1, a2, a3, a4]) = *self;
+        let w = F::W;
+        let double_w = w.double();
+
+        let c0 = a0.square() + double_w * (a1 * a4 + a2 * a3);
+        let double_a0 = a0.double();
+        let c1 = double_a0 * a1 + double_w * a2 * a4 + w * a3 * a3;
+        let c2 = double_a0 * a2 + a1 * a1 + double_w * a4 * a3;
+        let double_a1 = a1.double();
+        let c3 = double_a0 * a3 + double_a1 * a2 + w * a4 * a4;
+        let c4 = double_a0 * a4 + double_a1 * a3 + a2 * a2;
+
+        Self([c0, c1, c2, c3, c4])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Field for QuinticOef<F> {
+    type Packing = Self;
+    // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn try_inverse(&self) -> Option<Self> {
+        if self.is_zero() {
+            return None;
+        }
+
+        // Writing 'a' for self:
+        let d = self.frobenius(); // d = a^p
+        let e = d * d.frobenius(); // e = a^(p + p^2)
+        let f = e * e.repeated_frobenius(2); // f = a^(p + p^2 + p^3 + p^4)
+
+        // g = a^r is in the base field, so only compute that
+        // coefficient rather than the full product.
+        let Self([a0, a1, a2, a3, a4]) = *self;
+        let Self([b0, b1, b2, b3, b4]) = f;
+        let g = a0 * b0 + F::W * (a1 * b4 + a2 * b3 + a3 * b2 + a4 * b1);
+
+        debug_assert_eq!(Self::from(g), *self * f);
+
+        Some(f * g.inverse())
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Display for QuinticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} + {}*a", self.0[0], self.0[1])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Debug for QuinticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Neg for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self([-self.0[0], -self.0[1], -self.0[2], -self.0[3], -self.0[4]])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Add for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] + rhs.0[0],
+            self.0[1] + rhs.0[1],
+            self.0[2] + rhs.0[2],
+            self.0[3] + rhs.0[3],
+            self.0[4] + rhs.0[4],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Add<F> for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: F) -> Self {
+        Self([self.0[0] + rhs, self.0[1], self.0[2], self.0[3], self.0[4]])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> AddAssign for QuinticOef<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> AddAssign<F> for QuinticOef<F> {
+    fn add_assign(&mut self, rhs: F) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Sum for QuinticOef<F> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |acc, x| acc + x)
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Sub for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] - rhs.0[0],
+            self.0[1] - rhs.0[1],
+            self.0[2] - rhs.0[2],
+            self.0[3] - rhs.0[3],
+            self.0[4] - rhs.0[4],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Sub<F> for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: F) -> Self {
+        Self([self.0[0] - rhs, self.0[1], self.0[2], self.0[3], self.0[4]])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> SubAssign for QuinticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> SubAssign<F> for QuinticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Mul for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let Self([a0, a1, a2, a3, a4]) = self;
+        let Self([b0, b1, b2, b3, b4]) = rhs;
+        let w = F::W;
+
+        let c0 = a0 * b0 + w * (a1 * b4 + a2 * b3 + a3 * b2 + a4 * b1);
+        let c1 = a0 * b1 + a1 * b0 + w * (a2 * b4 + a3 * b3 + a4 * b2);
+        let c2 = a0 * b2 + a1 * b1 + a2 * b0 + w * (a3 * b4 + a4 * b3);
+        let c3 = a0 * b3 + a1 * b2 + a2 * b1 + a3 * b0 + w * a4 * b4;
+        let c4 = a0 * b4 + a1 * b3 + a2 * b2 + a3 * b1 + a4 * b0;
+
+        Self([c0, c1, c2, c3, c4])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Mul<F> for QuinticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: F) -> Self {
+        Self([
+            self.0[0] * rhs,
+            self.0[1] * rhs,
+            self.0[2] * rhs,
+            self.0[3] * rhs,
+            self.0[4] * rhs,
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Product for QuinticOef<F> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ONE, |acc, x| acc * x)
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Div for QuinticOef<F> {
+    type Output = Self;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self::Output {
+        self * rhs.inverse()
+    }
+}
+
+impl<F: OptimallyExtendable<5>> DivAssign for QuinticOef<F> {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> MulAssign for QuinticOef<F> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> MulAssign<F> for QuinticOef<F> {
+    fn mul_assign(&mut self, rhs: F) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<5>> AbstractExtensionField<F> for QuinticOef<F> {
+    const D: usize = F::D;
+
+    fn from_base(b: F) -> Self {
+        Self([b, F::ZERO, F::ZERO, F::ZERO, F::ZERO])
+    }
+
+    fn from_base_slice(bs: &[F]) -> Self {
+        assert_eq!(bs.len(), 5);
+        Self([bs[0], bs[1], bs[2], bs[3], bs[4]])
+    }
+
+    fn as_base_slice(&self) -> &[F] {
+        self.0.as_ref()
+    }
+}
+
+impl<F: OptimallyExtendable<5>> Distribution<QuinticOef<F>> for Standard
+where
+    Standard: Distribution<F>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuinticOef<F> {
+        QuinticOef::<F>::from_base_slice(&[
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+        ])
+    }
+}

--- a/field/src/extension/tesseractic.rs
+++ b/field/src/extension/tesseractic.rs
@@ -5,28 +5,28 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use super::{Frobenius, OptimallyExtendable};
+use super::{Frobenius, HasFrobenuis};
 use crate::field::Field;
 use crate::{AbstractExtensionField, AbstractField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct TesseracticOef<F: OptimallyExtendable<4>>(pub [F; 4]);
+pub struct TesseracticBef<F: HasFrobenuis<4>>(pub [F; 4]);
 
-impl<F: OptimallyExtendable<4>> Frobenius<F, 4> for TesseracticOef<F> {}
+impl<F: HasFrobenuis<4>> Frobenius<F, 4> for TesseracticBef<F> {}
 
-impl<F: OptimallyExtendable<4>> Default for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Default for TesseracticBef<F> {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
-impl<F: OptimallyExtendable<4>> From<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> From<F> for TesseracticBef<F> {
     fn from(x: F) -> Self {
         Self([x, F::ZERO, F::ZERO, F::ZERO])
     }
 }
 
-impl<F: OptimallyExtendable<4>> AbstractField for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> AbstractField for TesseracticBef<F> {
     const ZERO: Self = Self([F::ZERO; 4]);
     const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO, F::ZERO]);
@@ -85,7 +85,7 @@ impl<F: OptimallyExtendable<4>> AbstractField for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Field for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Field for TesseracticBef<F> {
     type Packing = Self;
     // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn try_inverse(&self) -> Option<Self> {
@@ -110,19 +110,19 @@ impl<F: OptimallyExtendable<4>> Field for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Display for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Display for TesseracticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} + {}*a", self.0[0], self.0[1])
     }
 }
 
-impl<F: OptimallyExtendable<4>> Debug for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Debug for TesseracticBef<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<F: OptimallyExtendable<4>> Neg for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Neg for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -131,7 +131,7 @@ impl<F: OptimallyExtendable<4>> Neg for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Add for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Add for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -145,7 +145,7 @@ impl<F: OptimallyExtendable<4>> Add for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Add<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Add<F> for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -154,25 +154,25 @@ impl<F: OptimallyExtendable<4>> Add<F> for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> AddAssign for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> AddAssign for TesseracticBef<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> AddAssign<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> AddAssign<F> for TesseracticBef<F> {
     fn add_assign(&mut self, rhs: F) {
         *self = *self + rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> Sum for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Sum for TesseracticBef<F> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F: OptimallyExtendable<4>> Sub for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Sub for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -186,7 +186,7 @@ impl<F: OptimallyExtendable<4>> Sub for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Sub<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Sub<F> for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -195,21 +195,21 @@ impl<F: OptimallyExtendable<4>> Sub<F> for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> SubAssign for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> SubAssign for TesseracticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> SubAssign<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> SubAssign<F> for TesseracticBef<F> {
     #[inline]
     fn sub_assign(&mut self, rhs: F) {
         *self = *self - rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Mul for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -253,7 +253,7 @@ impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Mul<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Mul<F> for TesseracticBef<F> {
     type Output = Self;
 
     #[inline]
@@ -267,13 +267,13 @@ impl<F: OptimallyExtendable<4>> Mul<F> for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> Product for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Product for TesseracticBef<F> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 
-impl<F: OptimallyExtendable<4>> Div for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> Div for TesseracticBef<F> {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -282,26 +282,26 @@ impl<F: OptimallyExtendable<4>> Div for TesseracticOef<F> {
     }
 }
 
-impl<F: OptimallyExtendable<4>> DivAssign for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> DivAssign for TesseracticBef<F> {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> MulAssign for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> MulAssign for TesseracticBef<F> {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> MulAssign<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> MulAssign<F> for TesseracticBef<F> {
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
 }
 
-impl<F: OptimallyExtendable<4>> AbstractExtensionField<F> for TesseracticOef<F> {
+impl<F: HasFrobenuis<4>> AbstractExtensionField<F> for TesseracticBef<F> {
     const D: usize = F::D;
 
     fn from_base(b: F) -> Self {
@@ -318,12 +318,12 @@ impl<F: OptimallyExtendable<4>> AbstractExtensionField<F> for TesseracticOef<F> 
     }
 }
 
-impl<F: OptimallyExtendable<4>> Distribution<TesseracticOef<F>> for Standard
+impl<F: HasFrobenuis<4>> Distribution<TesseracticBef<F>> for Standard
 where
     Standard: Distribution<F>,
 {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> TesseracticOef<F> {
-        TesseracticOef::<F>::from_base_slice(&[
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> TesseracticBef<F> {
+        TesseracticBef::<F>::from_base_slice(&[
             Standard.sample(rng),
             Standard.sample(rng),
             Standard.sample(rng),

--- a/field/src/extension/tesseractic.rs
+++ b/field/src/extension/tesseractic.rs
@@ -223,18 +223,16 @@ impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
         // low = A0B0, mid = (A0+A1)(B0+B1)-A0B0-A1B1, high = A1B1
         // result = low + (mid-low-high)*X^2+ high*X^4
 
-        let a0_b0 = a0 * b0;
-        let a1_b1 = a1 * b1;
-        let a2_b2 = a2 * b2;
-        let a3_b3 = a3 * b3;
-
         // compute low degree terms
-        // low0 = a0_b0 , low2= a1b1
-        let low1 = (a0 + a1) * (b0 + b1) - a0_b0 - a1_b1;
+        let low0 = a0 * b0;
+        let low2 = a1 * b1;
+        let low1 = (a0 + a1) * (b0 + b1) - low0 - low2;
 
         // compute high degree terms
         // high0 = a2_b2, high2 = a3_b3
-        let high1 = (a2 + a3) * (b2 + b3) - a2_b2 - a3_b3;
+        let high0 = a2 * b2;
+        let high2 = a3 * b3;
+        let high1 = (a2 + a3) * (b2 + b3) - high0 - high2;
 
         // compute mid degree terms
         let c0 = a0 + a2;
@@ -244,13 +242,13 @@ impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
 
         let mid0 = c0 * d0;
         let mid2 = c1 * d1;
-        let mid1 = (c0 + c1) * (d0 + d1) - mid0 - mid2 - low1 - high1;
+        let mid1 = (c0 + c1) * (d0 + d1) - mid0 - mid2;
 
         Self([
-            a0_b0 + (mid2 - a1_b1 - a3_b3 + a2_b2) * w,
+            low0 + (mid2 - low2 - high2 + high0) * w,
             low1 + high1 * w,
-            a1_b1 + mid0 - a0_b0 - a2_b2 + a3_b3 * w,
-            mid1,
+            low2 + mid0 - low0 - high0 + high2 * w,
+            mid1 - low1 - high1,
         ])
     }
 }

--- a/field/src/extension/tesseractic.rs
+++ b/field/src/extension/tesseractic.rs
@@ -218,12 +218,40 @@ impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
         let Self([b0, b1, b2, b3]) = rhs;
         let w = F::W;
 
-        let c0 = a0 * b0 + w * (a1 * b3 + a2 * b2 + a3 * b1);
-        let c1 = a0 * b1 + a1 * b0 + w * (a2 * b3 + a3 * b2);
-        let c2 = a0 * b2 + a1 * b1 + a2 * b0 + w * (a3 * b3);
-        let c3 = a0 * b3 + a1 * b2 + a2 * b1 + a3 * b0;
+        // use karatsuba's method to reduce the multiplications
+        // let self = A0+A1X^2; rhs = B0+B1X^2
+        // low = A0B0, mid = (A0+A1)(B0+B1)-A0B0-A1B1, high = A1B1
+        // result = low + (mid-low-high)*X^2+ high*X^4
 
-        Self([c0, c1, c2, c3])
+        let a0_b0 = a0 * b0;
+        let a1_b1 = a1 * b1;
+        let a2_b2 = a2 * b2;
+        let a3_b3 = a3 * b3;
+
+        // compute low degree terms
+        // low0 = a0_b0 , low2= a1b1
+        let low1 = (a0 + a1) * (b0 + b1) - a0_b0 - a1_b1;
+
+        // compute high degree terms
+        // high0 = a2_b2, high2 = a3_b3
+        let high1 = (a2 + a3) * (b2 + b3) - a2_b2 - a3_b3;
+
+        // compute mid degree terms
+        let c0 = a0 + a2;
+        let d0 = b0 + b2;
+        let c1 = a1 + a3;
+        let d1 = b1 + b3;
+
+        let mid0 = c0 * d0;
+        let mid2 = c1 * d1;
+        let mid1 = (c0 + c1) * (d0 + d1) - mid0 - mid2 - low1 - high1;
+
+        Self([
+            a0_b0 + (mid2 - a1_b1 - a3_b3 + a2_b2) * w,
+            low1 + high1 * w,
+            a1_b1 + mid0 - a0_b0 - a2_b2 + a3_b3 * w,
+            mid1,
+        ])
     }
 }
 

--- a/field/src/extension/tesseractic.rs
+++ b/field/src/extension/tesseractic.rs
@@ -1,0 +1,307 @@
+use core::fmt::{self, Debug, Display, Formatter};
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+
+use super::{Frobenius, OptimallyExtendable};
+use crate::field::Field;
+use crate::{AbstractExtensionField, AbstractField};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct TesseracticOef<F: OptimallyExtendable<4>>(pub [F; 4]);
+
+impl<F: OptimallyExtendable<4>> Frobenius<F, 4> for TesseracticOef<F> {}
+
+impl<F: OptimallyExtendable<4>> Default for TesseracticOef<F> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: OptimallyExtendable<4>> From<F> for TesseracticOef<F> {
+    fn from(x: F) -> Self {
+        Self([x, F::ZERO, F::ZERO, F::ZERO])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> AbstractField for TesseracticOef<F> {
+    const ZERO: Self = Self([F::ZERO; 4]);
+    const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO, F::ZERO]);
+    const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO, F::ZERO]);
+    const NEG_ONE: Self = Self([F::NEG_ONE, F::ZERO, F::ZERO, F::ZERO]);
+
+    fn from_bool(b: bool) -> Self {
+        F::from_bool(b).into()
+    }
+
+    fn from_canonical_u8(n: u8) -> Self {
+        F::from_canonical_u8(n).into()
+    }
+
+    fn from_canonical_u16(n: u16) -> Self {
+        F::from_canonical_u16(n).into()
+    }
+
+    fn from_canonical_u32(n: u32) -> Self {
+        F::from_canonical_u32(n).into()
+    }
+
+    /// Convert from `u64`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_u64(n: u64) -> Self {
+        F::from_canonical_u64(n).into()
+    }
+
+    /// Convert from `usize`. Undefined behavior if the input is outside the canonical range.
+    fn from_canonical_usize(n: usize) -> Self {
+        F::from_canonical_usize(n).into()
+    }
+
+    fn from_wrapped_u32(n: u32) -> Self {
+        F::from_wrapped_u32(n).into()
+    }
+
+    fn from_wrapped_u64(n: u64) -> Self {
+        F::from_wrapped_u64(n).into()
+    }
+
+    fn multiplicative_group_generator() -> Self {
+        Self(F::ext_multiplicative_group_generator())
+    }
+
+    #[inline(always)]
+    fn square(&self) -> Self {
+        let Self([a0, a1, a2, a3]) = *self;
+        let w = F::W;
+        let double_a3 = a3.double();
+        let double_a1 = a1.double();
+
+        let c0 = a0.square() + w * (double_a3 * a1 + a2.square());
+        let c1 = double_a1 * a0 + double_a3 * a2 * w;
+        let c2 = a1.square() + a3.square() * w + (a0 * a2).double();
+        let c3 = a2 * double_a1 + a0 * double_a3;
+        Self([c0, c1, c2, c3])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Field for TesseracticOef<F> {
+    type Packing = Self;
+    // Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn try_inverse(&self) -> Option<Self> {
+        if self.is_zero() {
+            return None;
+        }
+
+        // Writing 'a' for self:
+        let d = self.frobenius(); // d = a^p
+        let e = d * d.frobenius(); // e = a^(p + p^2)
+        let f = d * e.frobenius(); // f = a^(p + p^2 + p^3)
+
+        // g = a^r is in the base field, so only compute that
+        // coefficient rather than the full product.
+
+        let Self([a0, a1, a2, a3]) = *self;
+        let Self([b0, b1, b2, b3]) = f;
+        let g = a0 * b0 + F::W * (a1 * b3 + a2 * b2 + a3 * b1);
+        debug_assert_eq!(Self::from(g), *self * f);
+
+        Some(f * g.inverse())
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Display for TesseracticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} + {}*a", self.0[0], self.0[1])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Debug for TesseracticOef<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Neg for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self([-self.0[0], -self.0[1], -self.0[2], -self.0[3]])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Add for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] + rhs.0[0],
+            self.0[1] + rhs.0[1],
+            self.0[2] + rhs.0[2],
+            self.0[3] + rhs.0[3],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Add<F> for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: F) -> Self {
+        Self([self.0[0] + rhs, self.0[1], self.0[2], self.0[3]])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> AddAssign for TesseracticOef<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> AddAssign<F> for TesseracticOef<F> {
+    fn add_assign(&mut self, rhs: F) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Sum for TesseracticOef<F> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |acc, x| acc + x)
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Sub for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self([
+            self.0[0] - rhs.0[0],
+            self.0[1] - rhs.0[1],
+            self.0[2] - rhs.0[2],
+            self.0[3] - rhs.0[3],
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Sub<F> for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: F) -> Self {
+        Self([self.0[0] - rhs, self.0[1], self.0[2], self.0[3]])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> SubAssign for TesseracticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> SubAssign<F> for TesseracticOef<F> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Mul for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let Self([a0, a1, a2, a3]) = self;
+        let Self([b0, b1, b2, b3]) = rhs;
+        let w = F::W;
+
+        let c0 = a0 * b0 + w * (a1 * b3 + a2 * b2 + a3 * b1);
+        let c1 = a0 * b1 + a1 * b0 + w * (a2 * b3 + a3 * b2);
+        let c2 = a0 * b2 + a1 * b1 + a2 * b0 + w * (a3 * b3);
+        let c3 = a0 * b3 + a1 * b2 + a2 * b1 + a3 * b0;
+
+        Self([c0, c1, c2, c3])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Mul<F> for TesseracticOef<F> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: F) -> Self {
+        Self([
+            self.0[0] * rhs,
+            self.0[1] * rhs,
+            self.0[2] * rhs,
+            self.0[3] * rhs,
+        ])
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Product for TesseracticOef<F> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ONE, |acc, x| acc * x)
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Div for TesseracticOef<F> {
+    type Output = Self;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self::Output {
+        self * rhs.inverse()
+    }
+}
+
+impl<F: OptimallyExtendable<4>> DivAssign for TesseracticOef<F> {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> MulAssign for TesseracticOef<F> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> MulAssign<F> for TesseracticOef<F> {
+    fn mul_assign(&mut self, rhs: F) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: OptimallyExtendable<4>> AbstractExtensionField<F> for TesseracticOef<F> {
+    const D: usize = F::D;
+
+    fn from_base(b: F) -> Self {
+        Self([b, F::ZERO, F::ZERO, F::ZERO])
+    }
+
+    fn from_base_slice(bs: &[F]) -> Self {
+        assert_eq!(bs.len(), 4);
+        Self([bs[0], bs[1], bs[2], bs[3]])
+    }
+
+    fn as_base_slice(&self) -> &[F] {
+        self.0.as_ref()
+    }
+}
+
+impl<F: OptimallyExtendable<4>> Distribution<TesseracticOef<F>> for Standard
+where
+    Standard: Distribution<F>,
+{
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> TesseracticOef<F> {
+        TesseracticOef::<F>::from_base_slice(&[
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+            Standard.sample(rng),
+        ])
+    }
+}


### PR DESCRIPTION
Implement OEF for baby bear extension:

1. OptimallyExtendable Add Dth-root for BinomiallyExtendable prime field.
2. Define Tesseratic and quintic OEF, which require the underlying field to be OptimallyExtendable
3. Frobenuis is defined as an independent trait for extension fields that has an OptimallyExtendable base field for the given degree.
4. Mul used Karatsuba's algorithm, which minimizes the computation of multiplication
5. I haven't found a proper const constructor for Babybear, so I created a new function to construct babybear like other fields.
6. `X^4-11` and `X^5-2` are used as irreducible poly for babybear.