### PR TITLE
Mersenne31 Fourier transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Interpolation
 - [x] radix-2 DIT FFT
 - [x] radix-2 Bowers FFT
 - [ ] four-step FFT
-- [ ] Mersenne circle group FFT
+- [x] Mersenne circle group FFT
 
 Hashes
 - [x] Rescue

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -13,6 +13,7 @@ p3-util = { path = "../util" }
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
+p3-mersenne-31 = { path = "../mersenne-31" }
 criterion = "0.5.1"
 rand = "0.8.5"
 

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -27,7 +27,7 @@ fn bench_fft(c: &mut Criterion) {
 fn fft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion)
 where
     F: TwoAdicField,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
     Standard: Distribution<F>,
 {
     let mut group = c.benchmark_group(&format!(
@@ -56,7 +56,7 @@ where
 fn ifft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion)
 where
     F: TwoAdicField,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
     Standard: Distribution<F>,
 {
     let mut group = c.benchmark_group(&format!(
@@ -85,7 +85,7 @@ where
 fn coset_lde<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion)
 where
     F: TwoAdicField,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
     Standard: Distribution<F>,
 {
     let mut group = c.benchmark_group(&format!(

--- a/dft/src/testing.rs
+++ b/dft/src/testing.rs
@@ -9,7 +9,7 @@ pub(crate) fn test_dft_matches_naive<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();
@@ -26,7 +26,7 @@ pub(crate) fn test_coset_dft_matches_naive<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();
@@ -44,7 +44,7 @@ pub(crate) fn test_idft_matches_naive<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();
@@ -61,7 +61,7 @@ pub(crate) fn test_lde_matches_naive<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();
@@ -78,7 +78,7 @@ pub(crate) fn test_coset_lde_matches_naive<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();
@@ -96,7 +96,7 @@ pub(crate) fn test_dft_idft_consistency<F, Dft>()
 where
     F: TwoAdicField,
     Standard: Distribution<F>,
-    Dft: TwoAdicSubgroupDft<F> + Default,
+    Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
     let mut rng = thread_rng();

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -6,7 +6,7 @@ use p3_matrix::Matrix;
 
 use crate::util::{divide_by_height, swap_rows};
 
-pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone {
+pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft(&self, vec: Vec<F>) -> Vec<F> {
         self.dft_batch(RowMajorMatrix::new(vec, 1)).values

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -6,8 +6,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 criterion = "0.5"
+itertools = "0.11.0"
 p3-dft = { path = "../dft" }
 p3-field = { path = "../field" }
+p3-matrix = { path = "../matrix" }
+p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-util = { path = "../util" }
 rand = "0.8.5"
 

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -6,7 +6,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 criterion = "0.5"
+p3-dft = { path = "../dft" }
 p3-field = { path = "../field" }
+p3-util = { path = "../util" }
 rand = "0.8.5"
 
 [[bench]]

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -239,6 +239,20 @@ impl Field for Mersenne31Complex<Mersenne31> {
             .try_inverse()
             .map(|x| self.conjugate() * x)
     }
+
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        Self::new(
+            self.parts[0].mul_2exp_u64(exp),
+            self.parts[1].mul_2exp_u64(exp),
+        )
+    }
+
+    fn div_2exp_u64(&self, exp: u64) -> Self {
+        Self::new(
+            self.parts[0].div_2exp_u64(exp),
+            self.parts[1].div_2exp_u64(exp),
+        )
+    }
 }
 
 impl TwoAdicField for Mersenne31Complex<Mersenne31> {

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -33,7 +33,7 @@ fn dft_preprocess(
         input
             .rows()
             .tuples()
-            .map(|(row_0, row_1)| {
+            .flat_map(|(row_0, row_1)| {
                 // For each pair of rows in input, convert each
                 // two-element column into a Mersenne31Complex
                 // treating the first row as the real part and the
@@ -43,7 +43,6 @@ fn dft_preprocess(
                     .zip(row_1)
                     .map(|(&x, &y)| Mersenne31Complex::new(x, y))
             })
-            .flatten()
             .collect(),
         input.width(),
     )
@@ -144,15 +143,14 @@ fn idft_postprocess(
     RowMajorMatrix::new(
         input
             .rows()
-            .map(|row| {
+            .flat_map(|row| {
                 // Convert each row of input into two rows, the first row
                 // having the real parts of the input, the second row
                 // having the imaginary parts.
                 let (reals, imags): (Vec<_>, Vec<_>) =
                     row.iter().map(|x| (x.real(), x.imag())).unzip();
-                reals.into_iter().chain(imags.into_iter())
+                reals.into_iter().chain(imags)
             })
-            .flatten()
             .collect(),
         input.width(),
     )

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -4,6 +4,11 @@
 //! In short, fold a Mersenne31 DFT of length n into a Mersenne31Complex DFT
 //! of length n/2. Some pre/post-processing is necessary so that the result
 //! of the transform behaves as expected wrt the convolution theorem etc.
+//!
+//! Note that we don't return the final n/2 - 1 elements since we know that
+//! the "complex conjugate" of the (n-k)th element equals the kth element.
+//! The convolution theorem maintains this relationship and so these final
+//! n/2 - 1 elements are essentially redundant.
 
 use alloc::vec::Vec;
 
@@ -102,7 +107,7 @@ fn dft_postprocess(
 ///
 /// Source: https://www.robinscheibler.org/2013/02/13/real-fft.html
 ///
-/// NB: This function and `dft_preprocess()` are inverses.
+/// NB: This function and `dft_postprocess()` are inverses.
 fn idft_preprocess(
     input: RowMajorMatrix<Mersenne31Complex<Mersenne31>>,
 ) -> RowMajorMatrix<Mersenne31Complex<Mersenne31>> {

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -132,19 +132,17 @@ fn idft_postprocess(
 pub struct Mersenne31Dft;
 
 impl Mersenne31Dft {
-    // FIXME: Shouldn't need to require Default here
-    pub fn dft_batch<DFT: TwoAdicSubgroupDft<Mersenne31Complex<Mersenne31>> + Default>(
+    pub fn dft_batch<Dft: TwoAdicSubgroupDft<Mersenne31Complex<Mersenne31>>>(
         mat: RowMajorMatrix<Mersenne31>,
     ) -> RowMajorMatrix<Mersenne31Complex<Mersenne31>> {
-        let dft = DFT::default();
+        let dft = Dft::default();
         dft_postprocess(dft.dft_batch(dft_preprocess(mat)))
     }
 
-    // FIXME: Shouldn't need to require Default here
-    pub fn idft_batch<DFT: TwoAdicSubgroupDft<Mersenne31Complex<Mersenne31>> + Default>(
+    pub fn idft_batch<Dft: TwoAdicSubgroupDft<Mersenne31Complex<Mersenne31>>>(
         mat: RowMajorMatrix<Mersenne31Complex<Mersenne31>>,
     ) -> RowMajorMatrix<Mersenne31> {
-        let dft = DFT::default();
+        let dft = Dft::default();
         idft_postprocess(dft.idft_batch(idft_preprocess(mat)))
     }
 }

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -1,0 +1,160 @@
+use crate::{Mersenne31, Mersenne31Complex};
+use p3_field::{AbstractField, Field, TwoAdicField};
+use p3_util::log2_strict_usize;
+
+use alloc::vec::Vec;
+
+// TODO: Redo this in terms of RowMajorMatrix{,View{,Mut}}
+
+/// Given a vector u = (u_0, ..., u_{n-1}), where n is even, return a
+/// vector U = (U_0, ..., U_{N/2 - 1}) whose jth entry is
+/// Mersenne31Complex(u_{2j}, u_{2j + 1}); i.e. the even elements
+/// become the real parts and the odd elements become the imaginary
+/// parts.
+///
+/// This packing is suitable as input to a Fourier Transform over the
+/// domain Mersenne31Complex.
+pub fn dft_preprocess(input: Vec<Mersenne31>) -> Vec<Mersenne31Complex<Mersenne31>> {
+    assert!(input.len() % 2 == 0, "input vector length must be even");
+    input
+        .chunks_exact(2)
+        .map(|pair| Mersenne31Complex::new(pair[0], pair[1]))
+        .collect()
+}
+
+pub fn dft_postprocess(
+    input: Vec<Mersenne31Complex<Mersenne31>>,
+) -> Vec<Mersenne31Complex<Mersenne31>> {
+    let n = input.len();
+    let log2_n = log2_strict_usize(n); // checks that n is a power of two
+
+    // NB: The original vector was length 2n, hence log2(2n) = log2(n) + 1.
+    // omega is a 2n-th root of unity
+    let omega = Mersenne31Complex::primitive_root_of_unity(log2_n + 1);
+    let mut omega_j = omega;
+
+    let mut output = Vec::with_capacity(n + 1);
+    output.push(Mersenne31Complex::new_real(
+        input[0].real() + input[0].imag(),
+    ));
+    for j in 1..n {
+        let even = input[j] + input[n - j].conjugate();
+        let odd = input[j] - input[n - j].conjugate();
+        // TODO: pull apart components and integrate the multiplication-by-i
+        let odd = Mersenne31Complex::new(odd.imag(), -odd.real()); // odd *= -i
+        output.push((even + odd * omega_j).div_2exp_u64(1));
+        omega_j *= omega;
+    }
+    output.push(Mersenne31Complex::new_real(
+        input[0].real() - input[0].imag(),
+    ));
+    output
+}
+
+pub fn idft_preprocess(
+    input: Vec<Mersenne31Complex<Mersenne31>>,
+) -> Vec<Mersenne31Complex<Mersenne31>> {
+    let n = input.len() - 1;
+    let log2_n = log2_strict_usize(n); // checks that n is a power of two
+
+    // NB: The original vector was length 2n, hence log2(2n) = log2(n) + 1.
+    // omega is a 2n-th root of unity
+    let omega = Mersenne31Complex::primitive_root_of_unity(log2_n + 1).inverse();
+    let mut omega_j = Mersenne31Complex::ONE;
+
+    let mut output = Vec::with_capacity(n);
+    // TODO: Specialise j = 0 and j = n (which we know must be real)?
+    for j in 0..n {
+        let even = input[j] + input[n - j].conjugate();
+        let odd = input[j] - input[n - j].conjugate();
+        // TODO: pull apart components and integrate the multiplication-by-i
+        let odd = Mersenne31Complex::new(-odd.imag(), odd.real());
+        output.push((even + odd * omega_j).div_2exp_u64(1));
+        omega_j *= omega;
+    }
+    output
+}
+
+pub fn idft_postprocess(input: Vec<Mersenne31Complex<Mersenne31>>) -> Vec<Mersenne31> {
+    // TODO: The memory layout of input and output are identical; find a way
+    // to just do a memcpy.
+    let mut output = Vec::with_capacity(2 * input.len());
+    for x in input {
+        output.push(x.real());
+        output.push(x.imag());
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Mersenne31;
+    use p3_dft::{NaiveDft, Radix2Dit, TwoAdicSubgroupDft};
+    use rand::distributions::{Distribution, Standard};
+    use rand::{thread_rng, Rng};
+
+    #[test]
+    fn consistency()
+    where
+        Standard: Distribution<Mersenne31>,
+    {
+        const N: usize = 1 << 12;
+        let a = thread_rng()
+            .sample_iter(Standard)
+            .take(32)
+            .collect::<Vec<Mersenne31>>();
+        let b = dft_preprocess(a.clone());
+        let c = Radix2Dit.dft(b.clone());
+        let d = dft_postprocess(c);
+        let e = idft_preprocess(d);
+        let f = Radix2Dit.idft(e);
+        let g = idft_postprocess(f);
+
+        assert!(a == g);
+    }
+
+    #[test]
+    fn convolution()
+    where
+        Standard: Distribution<Mersenne31>,
+    {
+        const N: usize = 1 << 12;
+        let a = thread_rng()
+            .sample_iter(Standard)
+            .take(N)
+            .collect::<Vec<Mersenne31>>();
+        let b = thread_rng()
+            .sample_iter(Standard)
+            .take(N)
+            .collect::<Vec<Mersenne31>>();
+
+        let fft_a = dft_preprocess(a.clone());
+        let fft_a = Radix2Dit.dft(fft_a);
+        let fft_a = dft_postprocess(fft_a);
+
+        let fft_b = dft_preprocess(b.clone());
+        let fft_b = Radix2Dit.dft(fft_b);
+        let fft_b = dft_postprocess(fft_b);
+
+        let fft_c = fft_a
+            .iter()
+            .zip(fft_b.iter())
+            .map(|(&xi, &yi)| xi * yi)
+            .collect();
+        let c = idft_preprocess(fft_c);
+        let c = Radix2Dit.idft(c);
+        let c = idft_postprocess(c);
+
+        let mut conv = Vec::with_capacity(N);
+        for i in 0..N {
+            let mut t = Mersenne31::ZERO;
+            for j in 0..N {
+                t += a[j] * b[(N + i - j) % N];
+            }
+            conv.push(t);
+        }
+
+        assert!(c == conv);
+    }
+}

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -5,14 +5,16 @@
 //! of length n/2. Some pre/post-processing is necessary so that the result
 //! of the transform behaves as expected wrt the convolution theorem etc.
 
-use crate::{Mersenne31, Mersenne31Complex};
+use alloc::vec::Vec;
+
+use itertools::Itertools;
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{AbstractField, Field, TwoAdicField};
-use p3_matrix::{dense::RowMajorMatrix, Matrix, MatrixRowSlices, MatrixRows};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::{Matrix, MatrixRowSlices, MatrixRows};
 use p3_util::log2_strict_usize;
 
-use alloc::vec::Vec;
-use itertools::Itertools;
+use crate::{Mersenne31, Mersenne31Complex};
 
 /// Given an hxw matrix M = (m_{ij}) where h is even, return an
 /// (h/2)xw matrix N whose (k,l) entry is
@@ -187,11 +189,12 @@ impl Mersenne31Dft {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::Mersenne31;
     use p3_dft::Radix2Dit;
     use rand::distributions::{Distribution, Standard};
     use rand::{thread_rng, Rng};
+
+    use super::*;
+    use crate::Mersenne31;
 
     #[test]
     fn consistency()

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -15,6 +15,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, BitXorAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use complex::*;
+pub use dft::Mersenne31Dft;
 pub use extension::*;
 use p3_field::{AbstractField, Field, PrimeField, PrimeField32, PrimeField64};
 use rand::distributions::{Distribution, Standard};

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -1,8 +1,11 @@
 //! The prime field `F_p` where `p = 2^31 - 1`.
 
-#![no_std]
+//#![no_std]
+
+extern crate alloc;
 
 mod complex;
+mod dft;
 mod extension;
 
 use core::fmt;

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -1,6 +1,6 @@
 //! The prime field `F_p` where `p = 2^31 - 1`.
 
-//#![no_std]
+#![no_std]
 
 extern crate alloc;
 


### PR DESCRIPTION
This PR implements the discrete Fourier transform over `Mersenne31`. It does so by packing a `Mersenne31` DFT of length `n` into a `Mersenne31Complex` DFT of length `n/2`. Some pre/post-processing is necessary so that the result of the transform behaves as expected wrt the convolution theorem etc. For the maths behind this I followed [this blog post](https://www.robinscheibler.org/2013/02/13/real-fft.html).

Notes:
- This is currently quite slow, even compared to what we might have expected. For example, this DFT is, respectively, about 5.5x, 4x, and 2.5x slower on vectors of length 2^14, 2^16, and 2^18, than the same sized DFT on `BabyBear`. Without thinking about it deeply I would have expected a 2x slowdown across the board (since multiplication is about 4x more expensive but the DFT length is halved (note that on my machine, the 3mul 2add 3sub algo for complex multiplication resulted in a slowdown of about 10% compared with the 4mul 2add algo)). In any case, there are some performance questions to unpack.
- Anyway, the purpose of this PR is just to have a working version; performance improvements will appear in forthcoming PRs.
- The code is implemented in the `Mersenne31Dft` struct, and is not integrated with the existing DFT traits. A forthcoming PR will propose a way to do this, however it may well be preferable to keep it separate and treat it specially.

Closes #58.