### PR TITLE
`FieldArray`

### DIFF
--- a/baby-bear/benches/root_7.rs
+++ b/baby-bear/benches/root_7.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::Field;
+use p3_field::AbstractField;
 
 type F = BabyBear;
 

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -3,7 +3,8 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    exp_u64, AbstractField, Field, PrimeField, PrimeField32, PrimeField64, TwoAdicField,
+    exp_1725656503, exp_u64_by_squaring, AbstractField, Field, PrimeField, PrimeField32,
+    PrimeField64, TwoAdicField,
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -114,6 +115,16 @@ impl AbstractField for BabyBear {
     fn multiplicative_group_generator() -> Self {
         Self::from_canonical_u32(0x1f)
     }
+
+    // We hard code computing the 7'th root for rescue.
+    fn exp_u64(&self, power: u64) -> Self {
+        // We hard code an addition chain for computing the 5'th root which is 1717986917.
+        // This will be used in rescue.
+        match power {
+            1725656503 => root_7(*self),
+            _ => exp_u64_by_squaring(*self, power),
+        }
+    }
 }
 
 impl Field for BabyBear {
@@ -158,40 +169,10 @@ impl Field for BabyBear {
 
         Some(p1110111111111111111111111111111)
     }
-
-    // We hard code computing the 7'th root for rescue.
-    fn exp_u64(&self, power: u64) -> Self {
-        // We hard code an addition chain for computing the 5'th root which is 1717986917.
-        // This will be used in rescue.
-        match power {
-            1725656503 => root_7(self),
-            _ => exp_u64(self, power),
-        }
-    }
 }
 
-fn root_7(val: &BabyBear) -> BabyBear {
-    // Note that 7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1).
-    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1725656503})^7 = a.
-    // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
-    // This uses 29 Squares + 8 Multiplications => 37 Operations total.
-    // Suspect it's possible to improve this with enough effort.
-    let p1 = *val;
-    let p10 = p1.square();
-    let p11 = p10 * p1;
-    let p110 = p11.square();
-    let p111 = p110 * p1;
-    let p11000 = p110.exp_power_of_2(2);
-    let p11011 = p11000 * p11;
-    let p11000000 = p11000.exp_power_of_2(3);
-    let p11011011 = p11000000 * p11011;
-    let p110011011 = p11011011 * p11000000;
-    let p110011011000000000 = p110011011.exp_power_of_2(9);
-    let p110011011011011011 = p110011011000000000 * p11011011;
-    let p110011011011011011000000000 = p110011011011011011.exp_power_of_2(9);
-    let p110011011011011011011011011 = p110011011011011011000000000 * p11011011;
-    let p1100110110110110110110110110000 = p110011011011011011011011011.exp_power_of_2(4);
-    p1100110110110110110110110110000 * p111
+fn root_7(val: BabyBear) -> BabyBear {
+    exp_1725656503(val)
 }
 
 impl PrimeField for BabyBear {}
@@ -418,8 +399,8 @@ mod tests {
         let expected_prod = F::from_canonical_u32(0x1b5c8046);
         assert_eq!(m1 * m2, expected_prod);
 
-        assert_eq!(root_7(&m1).exp_const_u64::<7>(), m1);
-        assert_eq!(root_7(&m2).exp_const_u64::<7>(), m2);
+        assert_eq!(root_7(m1).exp_const_u64::<7>(), m1);
+        assert_eq!(root_7(m2).exp_const_u64::<7>(), m2);
         assert_eq!(f_2.exp_u64(1725656503).exp_const_u64::<7>(), f_2);
     }
 

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -1,0 +1,147 @@
+use core::array;
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::{
+    exp_10540996611094048183, exp_1717986917, exp_1725656503, exp_u64_by_squaring, AbstractField,
+    Field,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FieldArray<F: Field, const N: usize>(pub [F; N]);
+
+impl<F: Field, const N: usize> Default for FieldArray<F, N> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
+    fn from(arr: [F; N]) -> Self {
+        Self(arr)
+    }
+}
+
+impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
+    const ZERO: Self = FieldArray([F::ZERO; N]);
+    const ONE: Self = FieldArray([F::ONE; N]);
+    const TWO: Self = FieldArray([F::TWO; N]);
+    const NEG_ONE: Self = FieldArray([F::NEG_ONE; N]);
+
+    fn from_bool(b: bool) -> Self {
+        [F::from_bool(b); N].into()
+    }
+
+    fn from_canonical_u8(n: u8) -> Self {
+        [F::from_canonical_u8(n); N].into()
+    }
+
+    fn from_canonical_u16(n: u16) -> Self {
+        [F::from_canonical_u16(n); N].into()
+    }
+
+    fn from_canonical_u32(n: u32) -> Self {
+        [F::from_canonical_u32(n); N].into()
+    }
+
+    fn from_canonical_u64(n: u64) -> Self {
+        [F::from_canonical_u64(n); N].into()
+    }
+
+    fn from_canonical_usize(n: usize) -> Self {
+        [F::from_canonical_usize(n); N].into()
+    }
+
+    fn from_wrapped_u32(n: u32) -> Self {
+        [F::from_wrapped_u32(n); N].into()
+    }
+
+    fn from_wrapped_u64(n: u64) -> Self {
+        [F::from_wrapped_u64(n); N].into()
+    }
+
+    fn multiplicative_group_generator() -> Self {
+        [F::multiplicative_group_generator(); N].into()
+    }
+
+    #[inline]
+    fn exp_u64(&self, power: u64) -> Self {
+        match power {
+            1717986917 => exp_1717986917(*self),
+            1725656503 => exp_1725656503(*self),
+            10540996611094048183 => exp_10540996611094048183(*self),
+            _ => exp_u64_by_squaring(*self, power),
+        }
+    }
+}
+
+impl<F: Field, const N: usize> Add for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        array::from_fn(|i| self.0[i] + rhs.0[i]).into()
+    }
+}
+
+impl<F: Field, const N: usize> AddAssign for FieldArray<F, N> {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.0.iter_mut().zip(rhs.0).for_each(|(x, y)| *x += y);
+    }
+}
+
+impl<F: Field, const N: usize> Sub for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        array::from_fn(|i| self.0[i] - rhs.0[i]).into()
+    }
+}
+
+impl<F: Field, const N: usize> SubAssign for FieldArray<F, N> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0.iter_mut().zip(rhs.0).for_each(|(x, y)| *x -= y);
+    }
+}
+
+impl<F: Field, const N: usize> Neg for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        self.0.map(|x| -x).into()
+    }
+}
+
+impl<F: Field, const N: usize> Mul for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        array::from_fn(|i| self.0[i] * rhs.0[i]).into()
+    }
+}
+
+impl<F: Field, const N: usize> MulAssign for FieldArray<F, N> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        self.0.iter_mut().zip(rhs.0).for_each(|(x, y)| *x *= y);
+    }
+}
+
+impl<F: Field, const N: usize> Sum for FieldArray<F, N> {
+    #[inline]
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
+    }
+}
+
+impl<F: Field, const N: usize> Product for FieldArray<F, N> {
+    #[inline]
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
+    }
+}

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -1,0 +1,98 @@
+use crate::AbstractField;
+
+pub fn exp_u64_by_squaring<F: AbstractField>(val: F, power: u64) -> F {
+    let mut current = val;
+    let mut product = F::ONE;
+
+    for j in 0..bits_u64(power) {
+        if (power >> j & 1) != 0 {
+            product *= current.clone();
+        }
+        current = current.square();
+    }
+    product
+}
+
+const fn bits_u64(n: u64) -> usize {
+    (64 - n.leading_zeros()) as usize
+}
+
+pub fn exp_1717986917<F: AbstractField>(val: F) -> F {
+    // Note that 5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1.
+    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1717986917})^5 = a.
+    // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
+    // This uses 30 Squares + 7 Multiplications => 37 Operations total.
+    // Suspect it's possible to improve this with enough effort. For example 1717986918 takes only 4 Multiplications.
+    let p1 = val;
+    let p10 = p1.square();
+    let p11 = p10.clone() * p1;
+    let p101 = p10 * p11.clone();
+    let p110000 = p11.exp_power_of_2(4);
+    let p110011 = p110000 * p11.clone();
+    let p11001100000000 = p110011.exp_power_of_2(8);
+    let p11001100110011 = p11001100000000.clone() * p110011;
+    let p1100110000000000000000 = p11001100000000.exp_power_of_2(8);
+    let p1100110011001100110011 = p1100110000000000000000 * p11001100110011;
+    let p11001100110011001100110000 = p1100110011001100110011.exp_power_of_2(4);
+    let p11001100110011001100110011 = p11001100110011001100110000 * p11;
+    let p1100110011001100110011001100000 = p11001100110011001100110011.exp_power_of_2(5);
+    p1100110011001100110011001100000 * p101
+}
+
+pub fn exp_1725656503<F: AbstractField>(val: F) -> F {
+    // Note that 7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1).
+    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1725656503})^7 = a.
+    // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
+    // This uses 29 Squares + 8 Multiplications => 37 Operations total.
+    // Suspect it's possible to improve this with enough effort.
+    let p1 = val;
+    let p10 = p1.square();
+    let p11 = p10 * p1.clone();
+    let p110 = p11.square();
+    let p111 = p110.clone() * p1;
+    let p11000 = p110.exp_power_of_2(2);
+    let p11011 = p11000.clone() * p11;
+    let p11000000 = p11000.exp_power_of_2(3);
+    let p11011011 = p11000000.clone() * p11011;
+    let p110011011 = p11011011.clone() * p11000000;
+    let p110011011000000000 = p110011011.exp_power_of_2(9);
+    let p110011011011011011 = p110011011000000000 * p11011011.clone();
+    let p110011011011011011000000000 = p110011011011011011.exp_power_of_2(9);
+    let p110011011011011011011011011 = p110011011011011011000000000 * p11011011;
+    let p1100110110110110110110110110000 = p110011011011011011011011011.exp_power_of_2(4);
+    p1100110110110110110110110110000 * p111
+}
+
+pub fn exp_10540996611094048183<F: AbstractField>(val: F) -> F {
+    // Note that 7*10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1).
+    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{10540996611094048183})^7 = a.
+    // Also: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.
+    // This uses 63 Squares + 9 Multiplications => 72 Operations total.
+    // Suspect it's possible to improve this a little with enough effort.
+    let p1 = val;
+    let p10 = p1.square();
+    let p11 = p10.clone() * p1.clone();
+    let p100 = p10.square();
+    let p111 = p100.clone() * p11;
+    let p1000 = p100.square();
+    let p1001 = p1000 * p1;
+    let p1001000000 = p1001.exp_power_of_2(6);
+    let p1001001001 = p1001000000 * p1001.clone();
+    let p1001001001000000 = p1001001001.exp_power_of_2(6);
+    let p1001001001001001 = p1001001001000000.clone() * p1001;
+    let p1001001001000000000000000000 = p1001001001000000.exp_power_of_2(12);
+    let p1001001001001001001001001001 = p1001001001000000000000000000 * p1001001001001001;
+    let p10010010010010010010010010010 = p1001001001001001001001001001.square();
+    let p100100100100100100100100100100000000000000000000000000000000 =
+        p10010010010010010010010010010.exp_power_of_2(31);
+    let p11011011011011011011011011011 =
+        p10010010010010010010010010010 * p1001001001001001001001001001;
+    let p100100100100100100100100100100011011011011011011011011011011 =
+        p100100100100100100100100100100000000000000000000000000000000
+            * p11011011011011011011011011011;
+
+    let p1001001001001001001001001001000110110110110110110110110110110000 =
+        p100100100100100100100100100100011011011011011011011011011011.exp_power_of_2(4);
+
+    p1001001001001001001001001001000110110110110110110110110110110000 * p111
+}

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -54,20 +54,3 @@ where
     // TODO: Use PackedField
     x.iter_mut().zip(y).for_each(|(x_i, y_i)| *x_i += y_i * s);
 }
-
-pub fn exp_u64<F: Field>(val: &F, power: u64) -> F {
-    let mut current = *val;
-    let mut product = F::ONE;
-
-    for j in 0..bits_u64(power) {
-        if (power >> j & 1) != 0 {
-            product *= current;
-        }
-        current = current.square();
-    }
-    product
-}
-
-const fn bits_u64(n: u64) -> usize {
-    (64 - n.leading_zeros()) as usize
-}

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -4,14 +4,18 @@
 
 extern crate alloc;
 
+mod array;
 mod batch_inverse;
+mod exponentiation;
 pub mod extension;
 mod field;
 mod helpers;
 mod packed;
 mod symbolic;
 
+pub use array::*;
 pub use batch_inverse::*;
+pub use exponentiation::*;
 pub use field::*;
 pub use helpers::*;
 pub use packed::*;

--- a/goldilocks/benches/root_7.rs
+++ b/goldilocks/benches/root_7.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::Field;
+use p3_field::AbstractField;
 use p3_goldilocks::Goldilocks;
 
 type F = Goldilocks;

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -10,7 +10,10 @@ use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{exp_u64, AbstractField, Field, PrimeField, PrimeField64, TwoAdicField};
+use p3_field::{
+    exp_10540996611094048183, exp_u64_by_squaring, AbstractField, Field, PrimeField, PrimeField64,
+    TwoAdicField,
+};
 use p3_util::{assume, branch_hint};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -127,6 +130,14 @@ impl AbstractField for Goldilocks {
     fn multiplicative_group_generator() -> Self {
         Self::new(7)
     }
+
+    // We hard code computing the 7'th root for rescue.
+    fn exp_u64(&self, power: u64) -> Self {
+        match power {
+            10540996611094048183 => root_7(*self),
+            _ => exp_u64_by_squaring(*self, power),
+        }
+    }
 }
 
 impl Field for Goldilocks {
@@ -181,48 +192,10 @@ impl Field for Goldilocks {
         // compute base^1111111111111111111111111111111011111111111111111111111111111111
         Some(t63.square() * *self)
     }
-
-    // We hard code computing the 7'th root for rescue.
-    fn exp_u64(&self, power: u64) -> Self {
-        match power {
-            10540996611094048183 => root_7(self),
-            _ => exp_u64(self, power),
-        }
-    }
 }
 
-fn root_7(val: &Goldilocks) -> Goldilocks {
-    // Note that 7*10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1).
-    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{10540996611094048183})^7 = a.
-    // Also: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.
-    // This uses 63 Squares + 9 Multiplications => 72 Operations total.
-    // Suspect it's possible to improve this a little with enough effort.
-    let p1 = *val;
-    let p10 = p1.square();
-    let p11 = p10 * p1;
-    let p100 = p10.square();
-    let p111 = p100 * p11;
-    let p1000 = p100.square();
-    let p1001 = p1000 * p1;
-    let p1001000000 = p1001.exp_power_of_2(6);
-    let p1001001001 = p1001000000 * p1001;
-    let p1001001001000000 = p1001001001.exp_power_of_2(6);
-    let p1001001001001001 = p1001001001000000 * p1001;
-    let p1001001001000000000000000000 = p1001001001000000.exp_power_of_2(12);
-    let p1001001001001001001001001001 = p1001001001000000000000000000 * p1001001001001001;
-    let p10010010010010010010010010010 = p1001001001001001001001001001.square();
-    let p100100100100100100100100100100000000000000000000000000000000 =
-        p10010010010010010010010010010.exp_power_of_2(31);
-    let p11011011011011011011011011011 =
-        p10010010010010010010010010010 * p1001001001001001001001001001;
-    let p100100100100100100100100100100011011011011011011011011011011 =
-        p100100100100100100100100100100000000000000000000000000000000
-            * p11011011011011011011011011011;
-
-    let p1001001001001001001001001001000110110110110110110110110110110000 =
-        p100100100100100100100100100100011011011011011011011011011011.exp_power_of_2(4);
-
-    p1001001001001001001001001001000110110110110110110110110110110000 * p111
+fn root_7(val: Goldilocks) -> Goldilocks {
+    exp_10540996611094048183(val)
 }
 
 impl PrimeField for Goldilocks {}
@@ -525,8 +498,8 @@ mod tests {
         let expected_result = -F::new(2_u64.pow(32)) - F::new(1);
         assert_eq!(y, expected_result);
 
-        assert_eq!(root_7(&f).exp_const_u64::<7>(), f);
-        assert_eq!(root_7(&y).exp_const_u64::<7>(), y);
+        assert_eq!(root_7(f).exp_const_u64::<7>(), f);
+        assert_eq!(root_7(y).exp_const_u64::<7>(), y);
         assert_eq!(f_2.exp_u64(10540996611094048183).exp_const_u64::<7>(), f_2);
     }
 

--- a/mersenne-31/benches/root_5.rs
+++ b/mersenne-31/benches/root_5.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::Field;
+use p3_field::AbstractField;
 use p3_mersenne_31::Mersenne31;
 
 type F = Mersenne31;

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -13,7 +13,10 @@ use core::ops::{Add, AddAssign, BitXorAssign, Div, Mul, MulAssign, Neg, Sub, Sub
 
 pub use complex::*;
 pub use extension::*;
-use p3_field::{exp_u64, AbstractField, Field, PrimeField, PrimeField32, PrimeField64};
+use p3_field::{
+    exp_1717986917, exp_u64_by_squaring, AbstractField, Field, PrimeField, PrimeField32,
+    PrimeField64,
+};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -146,6 +149,14 @@ impl AbstractField for Mersenne31 {
     fn multiplicative_group_generator() -> Self {
         Self::new(7)
     }
+
+    // We hard code computing the 5'th root for rescue.
+    fn exp_u64(&self, power: u64) -> Self {
+        match power {
+            1717986917 => root_5(*self),
+            _ => exp_u64_by_squaring(*self, power),
+        }
+    }
 }
 
 impl Field for Mersenne31 {
@@ -195,36 +206,10 @@ impl Field for Mersenne31 {
             p1111111111111111111111111111.exp_power_of_2(3) * p101;
         Some(p1111111111111111111111111111101)
     }
-
-    // We hard code computing the 5'th root for rescue.
-    fn exp_u64(&self, power: u64) -> Self {
-        match power {
-            1717986917 => root_5(self),
-            _ => exp_u64(self, power),
-        }
-    }
 }
 
-fn root_5(val: &Mersenne31) -> Mersenne31 {
-    // Note that 5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1.
-    // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1717986917})^5 = a.
-    // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
-    // This uses 30 Squares + 7 Multiplications => 37 Operations total.
-    // Suspect it's possible to improve this with enough effort. For example 1717986918 takes only 4 Multiplications.
-    let p1 = *val;
-    let p10 = p1.square();
-    let p11 = p10 * p1;
-    let p101 = p10 * p11;
-    let p110000 = p11.exp_power_of_2(4);
-    let p110011 = p110000 * p11;
-    let p11001100000000 = p110011.exp_power_of_2(8);
-    let p11001100110011 = p11001100000000 * p110011;
-    let p1100110000000000000000 = p11001100000000.exp_power_of_2(8);
-    let p1100110011001100110011 = p1100110000000000000000 * p11001100110011;
-    let p11001100110011001100110000 = p1100110011001100110011.exp_power_of_2(4);
-    let p11001100110011001100110011 = p11001100110011001100110000 * p11;
-    let p1100110011001100110011001100000 = p11001100110011001100110011.exp_power_of_2(5);
-    p1100110011001100110011001100000 * p101
+fn root_5(val: Mersenne31) -> Mersenne31 {
+    exp_1717986917(val)
 }
 
 impl PrimeField for Mersenne31 {}
@@ -400,8 +385,8 @@ mod tests {
         let m1 = F::from_canonical_u32(0x34167c58);
         let m2 = F::from_canonical_u32(0x61f3207b);
 
-        assert_eq!(root_5(&m1).exp_const_u64::<5>(), m1);
-        assert_eq!(root_5(&m2).exp_const_u64::<5>(), m2);
+        assert_eq!(root_5(m1).exp_const_u64::<5>(), m1);
+        assert_eq!(root_5(m2).exp_const_u64::<5>(), m2);
         assert_eq!(F::TWO.exp_u64(1717986917).exp_const_u64::<5>(), F::TWO);
     }
 

--- a/rescue/src/inverse_sbox.rs
+++ b/rescue/src/inverse_sbox.rs
@@ -1,9 +1,7 @@
-use p3_field::{PrimeField, PrimeField64};
-
-// use crate::util::get_inverse;
+use p3_field::{AbstractField, FieldArray, PrimeField, PrimeField64};
 
 pub trait InverseSboxLayer<F: PrimeField, const WIDTH: usize, const ALPHA: u64>: Clone {
-    fn inverse_sbox_layer(&self, state: &mut [F; WIDTH], alpha_inv: &u64);
+    fn inverse_sbox_layer(&self, state: &mut [F; WIDTH], alpha_inv: u64);
 }
 
 #[derive(Copy, Clone, Default)]
@@ -12,9 +10,7 @@ pub struct BasicInverseSboxLayer;
 impl<F: PrimeField64, const WIDTH: usize, const ALPHA: u64> InverseSboxLayer<F, WIDTH, ALPHA>
     for BasicInverseSboxLayer
 {
-    fn inverse_sbox_layer(&self, state: &mut [F; WIDTH], alpha_inv: &u64) {
-        for x in state {
-            *x = x.exp_u64(*alpha_inv);
-        }
+    fn inverse_sbox_layer(&self, state: &mut [F; WIDTH], alpha_inv: u64) {
+        *state = FieldArray(*state).exp_u64(alpha_inv).0;
     }
 }

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -145,7 +145,7 @@ where
             }
 
             // Inverse S-box
-            self.isl.inverse_sbox_layer(&mut state, &alpha_inv);
+            self.isl.inverse_sbox_layer(&mut state, alpha_inv);
 
             // MDS
             self.mds.permute_mut(&mut state);


### PR DESCRIPTION
Doing operations like exponentiation on `FieldArray` lets us do the same computation to be done in a different order (assuming the compiler preserves it), potentially enabling better instruction-level parallelism.

Results seem mixed but better overall. E.g. `BabyBear` width 16 gets ~6% slower, width 24 gets ~40% faster. Probably crossing some inlining or unrolling threshold in LLVM?