### PR TITLE
`AbstractField` changes

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{AbstractExtensionField, AbstractField, AbstractionOf, ExtensionField, Field};
+use p3_field::{AbstractExtensionField, AbstractField, ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRowSlices;
 
@@ -19,7 +19,11 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: AbstractionOf<Self::F>
+    type Expr: AbstractField<F = Self::F>
+        + From<Self::F>
+        + Add<Self::F, Output = Self::Expr>
+        + Sub<Self::F, Output = Self::Expr>
+        + Mul<Self::F, Output = Self::Expr>
         + Add<Self::Var, Output = Self::Expr>
         + Sub<Self::Var, Output = Self::Expr>
         + Mul<Self::Var, Output = Self::Expr>;
@@ -140,8 +144,11 @@ pub trait PairBuilder: AirBuilder {
 pub trait PermutationAirBuilder: AirBuilder {
     type EF: ExtensionField<Self::F>;
 
-    type ExprEF: AbstractionOf<Self::EF>
-        + AbstractExtensionField<Self::Expr>
+    type ExprEF: AbstractExtensionField<Self::Expr, F = Self::EF>
+        + From<Self::EF>
+        + Add<Self::EF, Output = Self::ExprEF>
+        + Sub<Self::EF, Output = Self::ExprEF>
+        + Mul<Self::EF, Output = Self::ExprEF>
         + Add<Self::VarEF, Output = Self::ExprEF>
         + Sub<Self::VarEF, Output = Self::ExprEF>
         + Mul<Self::VarEF, Output = Self::ExprEF>;

--- a/baby-bear/src/aarch64_neon.rs
+++ b/baby-bear/src/aarch64_neon.rs
@@ -5,7 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, AbstractionOf, Field, PackedField};
+use p3_field::{AbstractField, Field, PackedField};
 
 use crate::BabyBear;
 
@@ -373,6 +373,8 @@ impl Product for PackedBabyBearNeon {
 }
 
 impl AbstractField for PackedBabyBearNeon {
+    type F = BabyBear;
+
     const ZERO: Self = Self::broadcast(BabyBear::ZERO);
     const ONE: Self = Self::broadcast(BabyBear::ONE);
     const TWO: Self = Self::broadcast(BabyBear::TWO);
@@ -482,8 +484,6 @@ impl Product<BabyBear> for PackedBabyBearNeon {
         iter.product::<BabyBear>().into()
     }
 }
-
-impl AbstractionOf<BabyBear> for PackedBabyBearNeon {}
 
 impl Div<BabyBear> for PackedBabyBearNeon {
     type Output = Self;

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -2,10 +2,7 @@ use core::array;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use crate::{
-    exp_10540996611094048183, exp_1717986917, exp_1725656503, exp_u64_by_squaring, AbstractField,
-    Field,
-};
+use crate::{AbstractField, Field};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FieldArray<F: Field, const N: usize>(pub [F; N]);
@@ -16,6 +13,12 @@ impl<F: Field, const N: usize> Default for FieldArray<F, N> {
     }
 }
 
+impl<F: Field, const N: usize> From<F> for FieldArray<F, N> {
+    fn from(val: F) -> Self {
+        [val; N].into()
+    }
+}
+
 impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
     fn from(arr: [F; N]) -> Self {
         Self(arr)
@@ -23,6 +26,8 @@ impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
 }
 
 impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
+    type F = F;
+
     const ZERO: Self = FieldArray([F::ZERO; N]);
     const ONE: Self = FieldArray([F::ONE; N]);
     const TWO: Self = FieldArray([F::TWO; N]);
@@ -62,16 +67,6 @@ impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
 
     fn multiplicative_group_generator() -> Self {
         [F::multiplicative_group_generator(); N].into()
-    }
-
-    #[inline]
-    fn exp_u64(&self, power: u64) -> Self {
-        match power {
-            1717986917 => exp_1717986917(*self),
-            1725656503 => exp_1725656503(*self),
-            10540996611094048183 => exp_10540996611094048183(*self),
-            _ => exp_u64_by_squaring(*self, power),
-        }
     }
 }
 

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -25,6 +25,8 @@ impl<F: BinomiallyExtendable<3>> From<F> for CubicBef<F> {
 }
 
 impl<F: BinomiallyExtendable<3>> AbstractField for CubicBef<F> {
+    type F = Self;
+
     const ZERO: Self = Self([F::ZERO; 3]);
     const ONE: Self = Self([F::ONE, F::ZERO, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO, F::ZERO]);

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -25,6 +25,8 @@ impl<F: BinomiallyExtendable<2>> From<F> for QuadraticBef<F> {
 }
 
 impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBef<F> {
+    type F = Self;
+
     const ZERO: Self = Self([F::ZERO; 2]);
     const ONE: Self = Self([F::ONE, F::ZERO]);
     const TWO: Self = Self([F::TWO, F::ZERO]);

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -1,16 +1,24 @@
-use core::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
 use core::slice;
 
-use crate::field::{AbstractionOf, Field};
+use crate::field::Field;
+use crate::AbstractField;
 
 /// # Safety
 /// - `WIDTH` is assumed to be a power of 2.
 /// - If `P` implements `PackedField` then `P` must be castable to/from `[P::Scalar; P::WIDTH]`
 ///   without UB.
-pub unsafe trait PackedField: AbstractionOf<Self::Scalar>
+pub unsafe trait PackedField: AbstractField<F = Self::Scalar>
     + 'static
+    + From<Self::Scalar>
     + Copy
     + Default
+    + Add<Self::Scalar, Output = Self>
+    + AddAssign<Self::Scalar>
+    + Sub<Self::Scalar, Output = Self>
+    + SubAssign<Self::Scalar>
+    + Mul<Self::Scalar, Output = Self>
+    + MulAssign<Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>
     + Send

--- a/field/src/symbolic.rs
+++ b/field/src/symbolic.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use crate::field::{AbstractField, AbstractionOf, Field};
+use crate::field::{AbstractField, Field};
 
 #[derive(Clone, Debug)]
 pub enum SymbolicField<F: Field, Var> {
@@ -28,6 +28,8 @@ impl<F: Field, Var> From<F> for SymbolicField<F, Var> {
 }
 
 impl<F: Field, Var: Clone + Debug> AbstractField for SymbolicField<F, Var> {
+    type F = F;
+
     const ZERO: Self = Self::Constant(F::ZERO);
     const ONE: Self = Self::Constant(F::ONE);
     const TWO: Self = Self::Constant(F::TWO);
@@ -69,8 +71,6 @@ impl<F: Field, Var: Clone + Debug> AbstractField for SymbolicField<F, Var> {
         Self::Constant(F::multiplicative_group_generator())
     }
 }
-
-impl<F: Field, Var: Clone + Debug> AbstractionOf<F> for SymbolicField<F, Var> {}
 
 impl<F: Field, Var: Clone + Debug> Add for SymbolicField<F, Var> {
     type Output = Self;

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -8,18 +8,18 @@ use core::fmt::{Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractExtensionField, AbstractField, AbstractionOf, Field, TwoAdicField};
+use p3_field::{AbstractExtensionField, AbstractField, Field, TwoAdicField};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
 use crate::Mersenne31;
 
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug, Default)]
-pub struct Mersenne31Complex<AF: AbstractionOf<Mersenne31>> {
+pub struct Mersenne31Complex<AF: AbstractField<F = Mersenne31>> {
     parts: [AF; 2],
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Mersenne31Complex<AF> {
     pub const fn new(real: AF, imag: AF) -> Self {
         Self {
             parts: [real, imag],
@@ -51,7 +51,7 @@ impl<AF: AbstractionOf<Mersenne31>> Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Add for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Add for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -59,7 +59,7 @@ impl<AF: AbstractionOf<Mersenne31>> Add for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Add<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Add<AF> for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn add(self, rhs: AF) -> Self {
@@ -67,26 +67,26 @@ impl<AF: AbstractionOf<Mersenne31>> Add<AF> for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> AddAssign for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> AddAssign for Mersenne31Complex<AF> {
     fn add_assign(&mut self, rhs: Self) {
         self.parts[0] += rhs.real();
         self.parts[1] += rhs.imag();
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> AddAssign<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> AddAssign<AF> for Mersenne31Complex<AF> {
     fn add_assign(&mut self, rhs: AF) {
         self.parts[0] += rhs;
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Sum for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Sum for Mersenne31Complex<AF> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Sub for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Sub for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -94,7 +94,7 @@ impl<AF: AbstractionOf<Mersenne31>> Sub for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Sub<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Sub<AF> for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn sub(self, rhs: AF) -> Self {
@@ -102,20 +102,20 @@ impl<AF: AbstractionOf<Mersenne31>> Sub<AF> for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> SubAssign for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> SubAssign for Mersenne31Complex<AF> {
     fn sub_assign(&mut self, rhs: Self) {
         self.parts[0] -= rhs.real();
         self.parts[1] -= rhs.imag();
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> SubAssign<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> SubAssign<AF> for Mersenne31Complex<AF> {
     fn sub_assign(&mut self, rhs: AF) {
         self.parts[0] -= rhs;
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Neg for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Neg for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn neg(self) -> Self {
@@ -123,7 +123,7 @@ impl<AF: AbstractionOf<Mersenne31>> Neg for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Mul for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Mul for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
@@ -140,7 +140,7 @@ impl<AF: AbstractionOf<Mersenne31>> Mul for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Mul<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Mul<AF> for Mersenne31Complex<AF> {
     type Output = Self;
 
     fn mul(self, rhs: AF) -> Self {
@@ -148,26 +148,28 @@ impl<AF: AbstractionOf<Mersenne31>> Mul<AF> for Mersenne31Complex<AF> {
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> MulAssign for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> MulAssign for Mersenne31Complex<AF> {
     fn mul_assign(&mut self, rhs: Self) {
         *self = self.clone() * rhs;
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> MulAssign<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> MulAssign<AF> for Mersenne31Complex<AF> {
     fn mul_assign(&mut self, rhs: AF) {
         self.parts[0] *= rhs.clone();
         self.parts[1] *= rhs;
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> Product for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> Product for Mersenne31Complex<AF> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 
-impl<AF: AbstractionOf<Mersenne31>> AbstractField for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> AbstractField for Mersenne31Complex<AF> {
+    type F = Mersenne31Complex<Mersenne31>;
+
     const ZERO: Self = Self::new_real(AF::ZERO);
     const ONE: Self = Self::new_real(AF::ONE);
     const TWO: Self = Self::new_real(AF::TWO);
@@ -212,7 +214,7 @@ impl<AF: AbstractionOf<Mersenne31>> AbstractField for Mersenne31Complex<AF> {
     // sage: F2.multiplicative_generator()
     // u + 12
     fn multiplicative_group_generator() -> Self {
-        Self::new(AF::from(Mersenne31::new(12)), AF::ONE)
+        Self::new(AF::from_canonical_u8(12), AF::ONE)
     }
 }
 
@@ -259,9 +261,7 @@ impl TwoAdicField for Mersenne31Complex<Mersenne31> {
     }
 }
 
-impl<AF: AbstractField + AbstractionOf<Mersenne31>> AbstractExtensionField<AF>
-    for Mersenne31Complex<AF>
-{
+impl<AF: AbstractField<F = Mersenne31>> AbstractExtensionField<AF> for Mersenne31Complex<AF> {
     const D: usize = 2;
 
     fn from_base(b: AF) -> Self {


### PR DESCRIPTION
The main change is to merge `AbstractField` and `AbstractionOf`, simplifying the trait hierarchy.

Previously `AbstractField` didn't know what concrete field it was an abstraction of; now it does via an associated type `F`. This lets us write code like this in `AbstractField`
```rust
fn exp_u64(&self, power: u64) -> Self {
    Self::F::exp_u64_generic(self.clone(), power)
}
```
which was the original motivation for this change. It's a bit of a strange API, but it lets us override `exp_u64_generic` with addition chains that are relevant to a particular field, and have those optimized addition chains used for all abstractions of that field, such as `FieldArray`.