### PR TITLE
Generalize `CosetMds` to work with an `AbstractField`

### DIFF
--- a/baby-bear/src/aarch64_neon.rs
+++ b/baby-bear/src/aarch64_neon.rs
@@ -6,6 +6,8 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{AbstractField, Field, PackedField};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use crate::BabyBear;
 
@@ -515,6 +517,13 @@ impl Sub<PackedBabyBearNeon> for BabyBear {
     #[inline]
     fn sub(self, rhs: PackedBabyBearNeon) -> PackedBabyBearNeon {
         PackedBabyBearNeon::from(self) - rhs
+    }
+}
+
+impl Distribution<PackedBabyBearNeon> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedBabyBearNeon {
+        PackedBabyBearNeon(rng.gen())
     }
 }
 

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -10,6 +10,7 @@ use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
 #[derive(Clone)]
 pub struct DuplexChallenger<F, P, const WIDTH: usize>
 where
+    F: Clone,
     P: ArrayPermutation<F, WIDTH>,
 {
     sponge_state: [F; WIDTH],

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -79,6 +79,15 @@ impl<F: Field, const N: usize> Add for FieldArray<F, N> {
     }
 }
 
+impl<F: Field, const N: usize> Add<F> for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: F) -> Self::Output {
+        self.0.map(|x| x + rhs).into()
+    }
+}
+
 impl<F: Field, const N: usize> AddAssign for FieldArray<F, N> {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
@@ -92,6 +101,15 @@ impl<F: Field, const N: usize> Sub for FieldArray<F, N> {
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         array::from_fn(|i| self.0[i] - rhs.0[i]).into()
+    }
+}
+
+impl<F: Field, const N: usize> Sub<F> for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: F) -> Self::Output {
+        self.0.map(|x| x - rhs).into()
     }
 }
 
@@ -117,6 +135,15 @@ impl<F: Field, const N: usize> Mul for FieldArray<F, N> {
     #[inline]
     fn mul(self, rhs: Self) -> Self::Output {
         array::from_fn(|i| self.0[i] * rhs.0[i]).into()
+    }
+}
+
+impl<F: Field, const N: usize> Mul<F> for FieldArray<F, N> {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: F) -> Self::Output {
+        self.0.map(|x| x * rhs).into()
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -15,22 +15,24 @@ use crate::packed::PackedField;
 /// - a vector of field elements
 pub trait AbstractField:
     Sized
+    + From<Self::F>
     + Default
     + Clone
     + Add<Output = Self>
+    + Add<Self::F, Output = Self>
     + AddAssign
     + Sub<Output = Self>
+    + Sub<Self::F, Output = Self>
     + SubAssign
     + Neg<Output = Self>
     + Mul<Output = Self>
+    + Mul<Self::F, Output = Self>
     + MulAssign
     + Sum
     + Product
     + Debug
 {
     type F: Field;
-
-    // fn from_f(f: Self::F) -> Self;
 
     const ZERO: Self;
     const ONE: Self;

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::PrimeField64;
+use p3_field::{AbstractField, Field};
 use p3_goldilocks::Goldilocks;
 use p3_mds::babybear::MdsMatrixBabyBear;
 use p3_mds::coset_mds::CosetMds;
@@ -17,6 +17,7 @@ use rand::{thread_rng, Rng};
 fn bench_all_mds(c: &mut Criterion) {
     bench_mds::<BabyBear, IntegratedCosetMds<BabyBear, 16>, 16>(c);
     bench_mds::<BabyBear, CosetMds<BabyBear, 16>, 16>(c);
+    bench_mds::<<BabyBear as Field>::Packing, CosetMds<<BabyBear as Field>::Packing, 16>, 16>(c);
     bench_mds::<BabyBear, MdsMatrixBabyBear, 12>(c);
     bench_mds::<BabyBear, MdsMatrixBabyBear, 24>(c);
 
@@ -30,7 +31,7 @@ fn bench_all_mds(c: &mut Criterion) {
 
 fn bench_mds<F, Mds, const WIDTH: usize>(c: &mut Criterion)
 where
-    F: PrimeField64,
+    F: AbstractField,
     Standard: Distribution<F>,
     Mds: MdsPermutation<F, WIDTH> + Default,
 {
@@ -39,7 +40,7 @@ where
     let mut rng = thread_rng();
     let input = rng.gen::<[F; WIDTH]>();
     let id = BenchmarkId::new(type_name::<Mds>(), WIDTH);
-    c.bench_with_input(id, &input, |b, &input| b.iter(|| mds.permute(input)));
+    c.bench_with_input(id, &input, |b, input| b.iter(|| mds.permute(input.clone())));
 }
 
 criterion_group!(benches, bench_all_mds);

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,5 +1,5 @@
 use p3_dft::reverse_slice_index_bits;
-use p3_field::{Field, TwoAdicField};
+use p3_field::{AbstractField, Field, TwoAdicField};
 use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
 use p3_util::log2_strict_usize;
 
@@ -10,25 +10,33 @@ use crate::MdsPermutation;
 /// viewed as returning the parity elements of a systematic Reed-Solomon code. Since Reed-Solomon
 /// codes are MDS, this is an MDS permutation.
 #[derive(Clone, Debug)]
-pub struct CosetMds<F: TwoAdicField, const N: usize> {
-    fft_twiddles: Vec<F>,
-    ifft_twiddles: Vec<F>,
-    weights: [F; N],
+pub struct CosetMds<F, const N: usize>
+where
+    F: AbstractField,
+    F::F: TwoAdicField,
+{
+    fft_twiddles: Vec<F::F>,
+    ifft_twiddles: Vec<F::F>,
+    weights: [F::F; N],
 }
 
-impl<F: TwoAdicField, const N: usize> Default for CosetMds<F, N> {
+impl<F, const N: usize> Default for CosetMds<F, N>
+where
+    F: AbstractField,
+    F::F: TwoAdicField,
+{
     fn default() -> Self {
         let log_n = log2_strict_usize(N);
 
-        let root = F::primitive_root_of_unity(log_n);
+        let root = F::F::primitive_root_of_unity(log_n);
         let root_inv = root.inverse();
-        let mut fft_twiddles: Vec<F> = root.powers().take(N / 2).collect();
-        let mut ifft_twiddles: Vec<F> = root_inv.powers().take(N / 2).collect();
+        let mut fft_twiddles: Vec<F::F> = root.powers().take(N / 2).collect();
+        let mut ifft_twiddles: Vec<F::F> = root_inv.powers().take(N / 2).collect();
         reverse_slice_index_bits(&mut fft_twiddles);
         reverse_slice_index_bits(&mut ifft_twiddles);
 
-        let shift = F::multiplicative_group_generator();
-        let mut weights: [F; N] = shift
+        let shift = F::F::multiplicative_group_generator();
+        let mut weights: [F::F; N] = shift
             .powers()
             .take(N)
             .collect::<Vec<_>>()
@@ -43,9 +51,18 @@ impl<F: TwoAdicField, const N: usize> Default for CosetMds<F, N> {
     }
 }
 
-impl<F: TwoAdicField, const N: usize> ArrayPermutation<F, N> for CosetMds<F, N> {}
+impl<F, const N: usize> ArrayPermutation<F, N> for CosetMds<F, N>
+where
+    F: AbstractField,
+    F::F: TwoAdicField,
+{
+}
 
-impl<F: TwoAdicField, const N: usize> CryptographicPermutation<[F; N]> for CosetMds<F, N> {
+impl<F, const N: usize> CryptographicPermutation<[F; N]> for CosetMds<F, N>
+where
+    F: AbstractField,
+    F::F: TwoAdicField,
+{
     fn permute(&self, mut input: [F; N]) -> [F; N] {
         self.permute_mut(&mut input);
         input
@@ -57,7 +74,7 @@ impl<F: TwoAdicField, const N: usize> CryptographicPermutation<[F; N]> for Coset
 
         // Multiply by powers of the coset shift (see default coset LDE impl for an explanation)
         for (value, weight) in values.iter_mut().zip(self.weights) {
-            *value *= weight;
+            *value = value.clone() * weight;
         }
 
         // DFT, assuming bit-reversed input.
@@ -65,12 +82,17 @@ impl<F: TwoAdicField, const N: usize> CryptographicPermutation<[F; N]> for Coset
     }
 }
 
-impl<F: TwoAdicField, const N: usize> MdsPermutation<F, N> for CosetMds<F, N> {}
+impl<F, const N: usize> MdsPermutation<F, N> for CosetMds<F, N>
+where
+    F: AbstractField,
+    F::F: TwoAdicField,
+{
+}
 
 /// Executes the Bowers G network. This is like a DFT, except it assumes the input is in
 /// bit-reversed order.
 #[inline]
-fn bowers_g<F: TwoAdicField, const N: usize>(values: &mut [F; N], twiddles: &[F]) {
+fn bowers_g<F: AbstractField, const N: usize>(values: &mut [F; N], twiddles: &[F::F]) {
     let log_n = log2_strict_usize(N);
     for log_half_block_size in 0..log_n {
         bowers_g_layer(values, log_half_block_size, twiddles);
@@ -80,7 +102,7 @@ fn bowers_g<F: TwoAdicField, const N: usize>(values: &mut [F; N], twiddles: &[F]
 /// Executes the Bowers G^T network. This is like an inverse DFT, except we skip rescaling by
 /// `1/N`, and the output is bit-reversed.
 #[inline]
-fn bowers_g_t<F: TwoAdicField, const N: usize>(values: &mut [F; N], twiddles: &[F]) {
+fn bowers_g_t<F: AbstractField, const N: usize>(values: &mut [F; N], twiddles: &[F::F]) {
     let log_n = log2_strict_usize(N);
     for log_half_block_size in (0..log_n).rev() {
         bowers_g_t_layer(values, log_half_block_size, twiddles);
@@ -89,10 +111,10 @@ fn bowers_g_t<F: TwoAdicField, const N: usize>(values: &mut [F; N], twiddles: &[
 
 /// One layer of a Bowers G network. Equivalent to `bowers_g_t_layer` except for the butterfly.
 #[inline]
-fn bowers_g_layer<F: Field, const N: usize>(
+fn bowers_g_layer<F: AbstractField, const N: usize>(
     values: &mut [F; N],
     log_half_block_size: usize,
-    twiddles: &[F],
+    twiddles: &[F::F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -115,10 +137,10 @@ fn bowers_g_layer<F: Field, const N: usize>(
 
 /// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
 #[inline]
-fn bowers_g_t_layer<F: Field, const N: usize>(
+fn bowers_g_t_layer<F: AbstractField, const N: usize>(
     values: &mut [F; N],
     log_half_block_size: usize,
-    twiddles: &[F],
+    twiddles: &[F::F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -141,42 +163,42 @@ fn bowers_g_t_layer<F: Field, const N: usize>(
 
 /// DIT butterfly.
 #[inline]
-pub fn dit_butterfly<F: Field, const N: usize>(
+pub fn dit_butterfly<F: AbstractField, const N: usize>(
     values: &mut [F; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: F,
+    twiddle: F::F,
 ) {
-    let val_1 = values[idx_1];
-    let val_2 = values[idx_2] * twiddle;
-    values[idx_1] = val_1 + val_2;
+    let val_1 = values[idx_1].clone();
+    let val_2 = values[idx_2].clone() * twiddle;
+    values[idx_1] = val_1.clone() + val_2.clone();
     values[idx_2] = val_1 - val_2;
 }
 
 /// DIF butterfly.
 #[inline]
-pub fn dif_butterfly<F: Field, const N: usize>(
+pub fn dif_butterfly<F: AbstractField, const N: usize>(
     values: &mut [F; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: F,
+    twiddle: F::F,
 ) {
-    let val_1 = values[idx_1];
-    let val_2 = values[idx_2];
-    values[idx_1] = val_1 + val_2;
+    let val_1 = values[idx_1].clone();
+    let val_2 = values[idx_2].clone();
+    values[idx_1] = val_1.clone() + val_2.clone();
     values[idx_2] = (val_1 - val_2) * twiddle;
 }
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-fn twiddle_free_butterfly<F: Field, const N: usize>(
+fn twiddle_free_butterfly<F: AbstractField, const N: usize>(
     values: &mut [F; N],
     idx_1: usize,
     idx_2: usize,
 ) {
-    let val_1 = values[idx_1];
-    let val_2 = values[idx_2];
-    values[idx_1] = val_1 + val_2;
+    let val_1 = values[idx_1].clone();
+    let val_2 = values[idx_2].clone();
+    values[idx_1] = val_1.clone() + val_2.clone();
     values[idx_2] = val_1 - val_2;
 }
 

--- a/mds/src/lib.rs
+++ b/mds/src/lib.rs
@@ -7,4 +7,4 @@ pub mod integrated_coset_mds;
 pub mod mersenne31;
 pub mod util;
 
-pub trait MdsPermutation<T, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
+pub trait MdsPermutation<T: Clone, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -4,7 +4,7 @@
 //! Note that X^2 + 1 is irreducible over p = Mersenne31 field because
 //! kronecker(-1, p) = -1, that is, -1 is not square in F_p.
 
-use core::fmt::{Display, Formatter};
+use core::fmt::{Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -82,7 +82,8 @@ impl<AF: AbstractField<F = Mersenne31>> AddAssign<AF> for Mersenne31Complex<AF> 
 
 impl<AF: AbstractField<F = Mersenne31>> Sum for Mersenne31Complex<AF> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
+        iter.reduce(|x, y| x + y)
+            .unwrap_or(Self::new_real(AF::ZERO))
     }
 }
 
@@ -163,11 +164,17 @@ impl<AF: AbstractField<F = Mersenne31>> MulAssign<AF> for Mersenne31Complex<AF> 
 
 impl<AF: AbstractField<F = Mersenne31>> Product for Mersenne31Complex<AF> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
+        iter.reduce(|x, y| x * y).unwrap_or(Self::new_real(AF::ONE))
     }
 }
 
-impl<AF: AbstractField<F = Mersenne31>> AbstractField for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> AbstractField for Mersenne31Complex<AF>
+where
+    Self: From<Mersenne31Complex<Mersenne31>>,
+    Self: Add<Mersenne31Complex<Mersenne31>, Output = Self>,
+    Self: Sub<Mersenne31Complex<Mersenne31>, Output = Self>,
+    Self: Mul<Mersenne31Complex<Mersenne31>, Output = Self>,
+{
     type F = Mersenne31Complex<Mersenne31>;
 
     const ZERO: Self = Self::new_real(AF::ZERO);
@@ -261,7 +268,13 @@ impl TwoAdicField for Mersenne31Complex<Mersenne31> {
     }
 }
 
-impl<AF: AbstractField<F = Mersenne31>> AbstractExtensionField<AF> for Mersenne31Complex<AF> {
+impl<AF: AbstractField<F = Mersenne31>> AbstractExtensionField<AF> for Mersenne31Complex<AF>
+where
+    Self: From<Mersenne31Complex<Mersenne31>>,
+    Self: Add<Mersenne31Complex<Mersenne31>, Output = Self>,
+    Self: Sub<Mersenne31Complex<Mersenne31>, Output = Self>,
+    Self: Mul<Mersenne31Complex<Mersenne31>, Output = Self>,
+{
     const D: usize = 2;
 
     fn from_base(b: AF) -> Self {

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -11,7 +11,7 @@
 use p3_field::Field;
 use p3_symmetric::permutation::ArrayPermutation;
 
-pub trait DiffusionPermutation<T, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
+pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
 
 pub fn matmul_internal<F: Field, const WIDTH: usize>(
     state: &mut [F; WIDTH],

--- a/symmetric/src/permutation.rs
+++ b/symmetric/src/permutation.rs
@@ -1,12 +1,12 @@
-pub trait CryptographicPermutation<T>: Clone {
+pub trait CryptographicPermutation<T: Clone>: Clone {
     fn permute(&self, input: T) -> T;
 
-    fn permute_mut(&self, input: &mut T)
-    where
-        T: Copy,
-    {
-        *input = self.permute(*input);
+    fn permute_mut(&self, input: &mut T) {
+        *input = self.permute(input.clone());
     }
 }
 
-pub trait ArrayPermutation<T, const WIDTH: usize>: CryptographicPermutation<[T; WIDTH]> {}
+pub trait ArrayPermutation<T: Clone, const WIDTH: usize>:
+    CryptographicPermutation<[T; WIDTH]>
+{
+}


### PR DESCRIPTION
So it can be used with `PackedField`s, and/or possibly `FieldArray` (which could use `F::Packing` later) if we need more instruction-level parallelism.

If there are no concerns, I'll make similar changes to other MDS impls, arithmetic hash impls, etc.

`IntegratedCosetMds` seems to take ~100ns with `BabyBear` and ~120ns with `PackedBabyBearNeon` (on M1), so seems promising in terms of potential throughput increases.