### PR TITLE
Remove `ArrayPermutation`

### DIFF
--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use p3_field::PrimeField64;
-use p3_symmetric::permutation::ArrayPermutation;
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
 
@@ -11,7 +11,7 @@ use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
 pub struct DuplexChallenger<F, P, const WIDTH: usize>
 where
     F: Clone,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     sponge_state: [F; WIDTH],
     input_buffer: Vec<F>,
@@ -23,7 +23,7 @@ where
 impl<F, P, const WIDTH: usize> DuplexChallenger<F, P, WIDTH>
 where
     F: Copy,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     pub fn new(permutation: P) -> Self
     where
@@ -57,14 +57,14 @@ where
 impl<F, P, const WIDTH: usize> FieldChallenger<F> for DuplexChallenger<F, P, WIDTH>
 where
     F: PrimeField64,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
 }
 
 impl<F, P, const WIDTH: usize> CanObserve<F> for DuplexChallenger<F, P, WIDTH>
 where
     F: Copy,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn observe(&mut self, value: F) {
         // Any buffered output is now invalid.
@@ -81,7 +81,7 @@ where
 impl<F, P, const N: usize, const WIDTH: usize> CanObserve<[F; N]> for DuplexChallenger<F, P, WIDTH>
 where
     F: Copy,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn observe(&mut self, values: [F; N]) {
         for value in values {
@@ -93,7 +93,7 @@ where
 impl<F, P, const WIDTH: usize> CanSample<F> for DuplexChallenger<F, P, WIDTH>
 where
     F: Copy,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn sample(&mut self) -> F {
         // If we have buffered inputs, we must perform a duplexing so that the challenge will
@@ -111,7 +111,7 @@ where
 impl<F, P, const WIDTH: usize> CanSampleBits<usize> for DuplexChallenger<F, P, WIDTH>
 where
     F: PrimeField64,
-    P: ArrayPermutation<F, WIDTH>,
+    P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
         debug_assert!(bits < (usize::BITS as usize));
@@ -148,8 +148,6 @@ mod tests {
             input.reverse()
         }
     }
-
-    impl ArrayPermutation<F, WIDTH> for TestPermutation {}
 
     #[test]
     fn test_duplex_challenger() {

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use p3_symmetric::hasher::CryptographicHasher;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use tiny_keccak::{keccakf, Hasher, Keccak};
 
 /// The Keccak-f permutation.
@@ -20,8 +20,6 @@ impl CryptographicPermutation<[u64; 25]> for KeccakF {
         input
     }
 }
-
-impl ArrayPermutation<u64, 25> for KeccakF {}
 
 impl CryptographicPermutation<[u8; 200]> for KeccakF {
     fn permute(&self, input_u8s: [u8; 200]) -> [u8; 200] {

--- a/mds/src/babybear.rs
+++ b/mds/src/babybear.rs
@@ -6,7 +6,7 @@
 
 use p3_baby_bear::BabyBear;
 use p3_dft::Radix2Bowers;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::util::{
     apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml, apply_circulant_fft,
@@ -24,7 +24,6 @@ impl CryptographicPermutation<[BabyBear; 8]> for MdsMatrixBabyBear {
         apply_circulant_8_sml(input)
     }
 }
-impl ArrayPermutation<BabyBear, 8> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 8> for MdsMatrixBabyBear {}
 
 impl CryptographicPermutation<[BabyBear; 12]> for MdsMatrixBabyBear {
@@ -32,7 +31,6 @@ impl CryptographicPermutation<[BabyBear; 12]> for MdsMatrixBabyBear {
         apply_circulant_12_sml(input)
     }
 }
-impl ArrayPermutation<BabyBear, 12> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 12> for MdsMatrixBabyBear {}
 
 #[rustfmt::skip]
@@ -49,7 +47,6 @@ impl CryptographicPermutation<[BabyBear; 16]> for MdsMatrixBabyBear {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<BabyBear, 16> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 16> for MdsMatrixBabyBear {}
 
 #[rustfmt::skip]
@@ -67,7 +64,6 @@ impl CryptographicPermutation<[BabyBear; 24]> for MdsMatrixBabyBear {
         apply_circulant(&MATRIX_CIRC_MDS_24_BABYBEAR, input)
     }
 }
-impl ArrayPermutation<BabyBear, 24> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 24> for MdsMatrixBabyBear {}
 
 #[rustfmt::skip]
@@ -88,7 +84,6 @@ impl CryptographicPermutation<[BabyBear; 32]> for MdsMatrixBabyBear {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<BabyBear, 32> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 32> for MdsMatrixBabyBear {}
 
 #[rustfmt::skip]
@@ -117,7 +112,6 @@ impl CryptographicPermutation<[BabyBear; 64]> for MdsMatrixBabyBear {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<BabyBear, 64> for MdsMatrixBabyBear {}
 impl MdsPermutation<BabyBear, 64> for MdsMatrixBabyBear {}
 
 #[cfg(test)]

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,6 +1,6 @@
 use p3_dft::reverse_slice_index_bits;
 use p3_field::{AbstractField, Field, TwoAdicField};
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
@@ -50,13 +50,6 @@ where
             weights,
         }
     }
-}
-
-impl<F, const N: usize> ArrayPermutation<F, N> for CosetMds<F, N>
-where
-    F: AbstractField,
-    F::F: TwoAdicField,
-{
 }
 
 impl<F, const N: usize> CryptographicPermutation<[F; N]> for CosetMds<F, N>

--- a/mds/src/goldilocks.rs
+++ b/mds/src/goldilocks.rs
@@ -6,7 +6,7 @@
 
 use p3_dft::Radix2Bowers;
 use p3_goldilocks::Goldilocks;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::util::{
     apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml, apply_circulant_fft,
@@ -24,7 +24,6 @@ impl CryptographicPermutation<[Goldilocks; 8]> for MdsMatrixGoldilocks {
         apply_circulant_8_sml(input)
     }
 }
-impl ArrayPermutation<Goldilocks, 8> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 8> for MdsMatrixGoldilocks {}
 
 impl CryptographicPermutation<[Goldilocks; 12]> for MdsMatrixGoldilocks {
@@ -32,7 +31,6 @@ impl CryptographicPermutation<[Goldilocks; 12]> for MdsMatrixGoldilocks {
         apply_circulant_12_sml(input)
     }
 }
-impl ArrayPermutation<Goldilocks, 12> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 12> for MdsMatrixGoldilocks {}
 
 #[rustfmt::skip]
@@ -49,7 +47,6 @@ impl CryptographicPermutation<[Goldilocks; 16]> for MdsMatrixGoldilocks {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<Goldilocks, 16> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 16> for MdsMatrixGoldilocks {}
 
 #[rustfmt::skip]
@@ -67,7 +64,6 @@ impl CryptographicPermutation<[Goldilocks; 24]> for MdsMatrixGoldilocks {
         apply_circulant(&MATRIX_CIRC_MDS_24_GOLDILOCKS, input)
     }
 }
-impl ArrayPermutation<Goldilocks, 24> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 24> for MdsMatrixGoldilocks {}
 
 #[rustfmt::skip]
@@ -88,7 +84,6 @@ impl CryptographicPermutation<[Goldilocks; 32]> for MdsMatrixGoldilocks {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<Goldilocks, 32> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 32> for MdsMatrixGoldilocks {}
 
 #[rustfmt::skip]
@@ -117,7 +112,6 @@ impl CryptographicPermutation<[Goldilocks; 64]> for MdsMatrixGoldilocks {
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
 }
-impl ArrayPermutation<Goldilocks, 64> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 64> for MdsMatrixGoldilocks {}
 
 #[rustfmt::skip]
@@ -146,7 +140,6 @@ impl CryptographicPermutation<[Goldilocks; 68]> for MdsMatrixGoldilocks {
         apply_circulant(&MATRIX_CIRC_MDS_68_GOLDILOCKS, input)
     }
 }
-impl ArrayPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use p3_dft::reverse_slice_index_bits;
 use p3_field::{AbstractField, Field, Powers, TwoAdicField};
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
@@ -49,8 +49,6 @@ where
         }
     }
 }
-
-impl<F: AbstractField, const N: usize> ArrayPermutation<F, N> for IntegratedCosetMds<F, N> {}
 
 impl<F: AbstractField, const N: usize> CryptographicPermutation<[F; N]>
     for IntegratedCosetMds<F, N>

--- a/mds/src/lib.rs
+++ b/mds/src/lib.rs
@@ -1,4 +1,4 @@
-use p3_symmetric::permutation::ArrayPermutation;
+use p3_symmetric::permutation::CryptographicPermutation;
 
 pub mod babybear;
 mod butterflies;
@@ -8,4 +8,7 @@ pub mod integrated_coset_mds;
 pub mod mersenne31;
 pub mod util;
 
-pub trait MdsPermutation<T: Clone, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
+pub trait MdsPermutation<T: Clone, const WIDTH: usize>:
+    CryptographicPermutation<[T; WIDTH]>
+{
+}

--- a/mds/src/mersenne31.rs
+++ b/mds/src/mersenne31.rs
@@ -5,7 +5,7 @@
 //! Sizes 8 and 12 are from Plonky2. Other sizes are from Ulrich Haböck's database.
 
 use p3_mersenne_31::Mersenne31;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::util::{apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml};
 use crate::MdsPermutation;
@@ -18,7 +18,6 @@ impl CryptographicPermutation<[Mersenne31; 8]> for MdsMatrixMersenne31 {
         apply_circulant_8_sml(input)
     }
 }
-impl ArrayPermutation<Mersenne31, 8> for MdsMatrixMersenne31 {}
 impl MdsPermutation<Mersenne31, 8> for MdsMatrixMersenne31 {}
 
 impl CryptographicPermutation<[Mersenne31; 12]> for MdsMatrixMersenne31 {
@@ -26,7 +25,6 @@ impl CryptographicPermutation<[Mersenne31; 12]> for MdsMatrixMersenne31 {
         apply_circulant_12_sml(input)
     }
 }
-impl ArrayPermutation<Mersenne31, 12> for MdsMatrixMersenne31 {}
 impl MdsPermutation<Mersenne31, 12> for MdsMatrixMersenne31 {}
 
 #[rustfmt::skip]
@@ -42,7 +40,6 @@ impl CryptographicPermutation<[Mersenne31; 16]> for MdsMatrixMersenne31 {
         apply_circulant(&MATRIX_CIRC_MDS_16_MERSENNE31, input)
     }
 }
-impl ArrayPermutation<Mersenne31, 16> for MdsMatrixMersenne31 {}
 impl MdsPermutation<Mersenne31, 16> for MdsMatrixMersenne31 {}
 
 #[rustfmt::skip]
@@ -62,7 +59,6 @@ impl CryptographicPermutation<[Mersenne31; 32]> for MdsMatrixMersenne31 {
         apply_circulant(&MATRIX_CIRC_MDS_32_MERSENNE31, input)
     }
 }
-impl ArrayPermutation<Mersenne31, 32> for MdsMatrixMersenne31 {}
 impl MdsPermutation<Mersenne31, 32> for MdsMatrixMersenne31 {}
 
 #[rustfmt::skip]
@@ -90,7 +86,6 @@ impl CryptographicPermutation<[Mersenne31; 64]> for MdsMatrixMersenne31 {
         apply_circulant(&MATRIX_CIRC_MDS_64_MERSENNE31, input)
     }
 }
-impl ArrayPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 
 #[cfg(test)]

--- a/monolith/src/monolith_mds.rs
+++ b/monolith/src/monolith_mds.rs
@@ -5,7 +5,7 @@ use p3_field::PrimeField32;
 use p3_mds::util::apply_circulant;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use sha3::digest::{ExtendableOutput, Update};
 use sha3::{Shake128, Shake128Reader};
 
@@ -41,10 +41,6 @@ impl<const WIDTH: usize, const NUM_ROUNDS: usize> CryptographicPermutation<[Mers
     }
 }
 
-impl<const WIDTH: usize, const NUM_ROUNDS: usize> ArrayPermutation<Mersenne31, WIDTH>
-    for MonolithMdsMatrixMersenne31<NUM_ROUNDS>
-{
-}
 impl<const WIDTH: usize, const NUM_ROUNDS: usize> MdsPermutation<Mersenne31, WIDTH>
     for MonolithMdsMatrixMersenne31<NUM_ROUNDS>
 {

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use p3_field::Field;
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -122,12 +122,4 @@ where
         self.half_full_rounds(&mut state, &mut round_ctr);
         state
     }
-}
-
-impl<F: Field, Mds, const WIDTH: usize, const ALPHA: u64> ArrayPermutation<F, WIDTH>
-    for Poseidon<F, Mds, WIDTH, ALPHA>
-where
-    F: Field,
-    Mds: MdsPermutation<F, WIDTH>,
-{
 }

--- a/poseidon2/src/babybear.rs
+++ b/poseidon2/src/babybear.rs
@@ -3,7 +3,7 @@
 //! Reference: https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_babybear.rs
 
 use p3_baby_bear::BabyBear;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::diffusion::matmul_internal;
 use crate::DiffusionPermutation;
@@ -29,7 +29,6 @@ impl CryptographicPermutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
         input
     }
 }
-impl ArrayPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
 impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
 
 impl CryptographicPermutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
@@ -39,5 +38,4 @@ impl CryptographicPermutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
         input
     }
 }
-impl ArrayPermutation<BabyBear, 24> for DiffusionMatrixBabybear {}
 impl DiffusionPermutation<BabyBear, 24> for DiffusionMatrixBabybear {}

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -9,9 +9,12 @@
 //! This file implements a trait for linear layers that satisfy these three properties.
 
 use p3_field::Field;
-use p3_symmetric::permutation::ArrayPermutation;
+use p3_symmetric::permutation::CryptographicPermutation;
 
-pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: ArrayPermutation<T, WIDTH> {}
+pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>:
+    CryptographicPermutation<[T; WIDTH]>
+{
+}
 
 pub fn matmul_internal<F: Field, const WIDTH: usize>(
     state: &mut [F; WIDTH],

--- a/poseidon2/src/goldilocks.rs
+++ b/poseidon2/src/goldilocks.rs
@@ -3,7 +3,7 @@
 //! Reference: https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_goldilocks.rs
 
 use p3_goldilocks::Goldilocks;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 
 use crate::diffusion::matmul_internal;
 use crate::DiffusionPermutation;
@@ -86,7 +86,6 @@ impl CryptographicPermutation<[Goldilocks; 8]> for DiffusionMatrixGoldilocks {
         input
     }
 }
-impl ArrayPermutation<Goldilocks, 8> for DiffusionMatrixGoldilocks {}
 impl DiffusionPermutation<Goldilocks, 8> for DiffusionMatrixGoldilocks {}
 
 impl CryptographicPermutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
@@ -96,7 +95,6 @@ impl CryptographicPermutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
         input
     }
 }
-impl ArrayPermutation<Goldilocks, 12> for DiffusionMatrixGoldilocks {}
 impl DiffusionPermutation<Goldilocks, 12> for DiffusionMatrixGoldilocks {}
 
 impl CryptographicPermutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
@@ -106,7 +104,6 @@ impl CryptographicPermutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
         input
     }
 }
-impl ArrayPermutation<Goldilocks, 16> for DiffusionMatrixGoldilocks {}
 impl DiffusionPermutation<Goldilocks, 16> for DiffusionMatrixGoldilocks {}
 
 impl CryptographicPermutation<[Goldilocks; 20]> for DiffusionMatrixGoldilocks {
@@ -116,5 +113,4 @@ impl CryptographicPermutation<[Goldilocks; 20]> for DiffusionMatrixGoldilocks {
         input
     }
 }
-impl ArrayPermutation<Goldilocks, 20> for DiffusionMatrixGoldilocks {}
 impl DiffusionPermutation<Goldilocks, 20> for DiffusionMatrixGoldilocks {}

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -19,7 +19,7 @@ pub use diffusion::DiffusionPermutation;
 pub use goldilocks::DiffusionMatrixGoldilocks;
 use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -160,13 +160,4 @@ where
 
         state
     }
-}
-
-impl<F, Mds, Diffusion, const T: usize, const D: u64> ArrayPermutation<F, T>
-    for Poseidon2<F, Mds, Diffusion, T, D>
-where
-    F: AbstractField,
-    Mds: MdsPermutation<F, T>,
-    Diffusion: DiffusionPermutation<F, T>,
-{
 }

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -11,7 +11,6 @@ extern crate alloc;
 mod babybear;
 mod diffusion;
 mod goldilocks;
-use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
 pub use babybear::DiffusionMatrixBabybear;
@@ -128,9 +127,7 @@ where
     Mds: MdsPermutation<F, WIDTH>,
     Diffusion: DiffusionPermutation<F, WIDTH>,
 {
-    fn permute(&self, state: [F; WIDTH]) -> [F; WIDTH] {
-        let mut state = state.to_owned();
-
+    fn permute(&self, mut state: [F; WIDTH]) -> [F; WIDTH] {
         // The initial linear layer.
         self.external_linear_layer.permute_mut(&mut state);
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -3,7 +3,7 @@ use num::{BigUint, One};
 use num_integer::binomial;
 use p3_field::{PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::{ArrayPermutation, CryptographicPermutation};
+use p3_symmetric::permutation::CryptographicPermutation;
 use p3_util::ceil_div_usize;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
@@ -161,15 +161,6 @@ where
 
         state
     }
-}
-
-impl<F, Mds, Isl, const WIDTH: usize, const ALPHA: u64> ArrayPermutation<F, WIDTH>
-    for Rescue<F, Mds, Isl, WIDTH, ALPHA>
-where
-    F: PrimeField64,
-    Mds: MdsPermutation<F, WIDTH>,
-    Isl: InverseSboxLayer<F, WIDTH, ALPHA>,
-{
 }
 
 #[cfg(test)]

--- a/symmetric/src/permutation.rs
+++ b/symmetric/src/permutation.rs
@@ -5,8 +5,3 @@ pub trait CryptographicPermutation<T: Clone>: Clone {
         *input = self.permute(input.clone());
     }
 }
-
-pub trait ArrayPermutation<T: Clone, const WIDTH: usize>:
-    CryptographicPermutation<[T; WIDTH]>
-{
-}

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use itertools::Itertools;
 
 use crate::hasher::CryptographicHasher;
-use crate::permutation::ArrayPermutation;
+use crate::permutation::CryptographicPermutation;
 
 /// A padding-free, overwrite-mode sponge function.
 ///
@@ -29,7 +29,7 @@ impl<T, P, const WIDTH: usize, const RATE: usize, const OUT: usize> Cryptographi
     for PaddingFreeSponge<T, P, WIDTH, RATE, OUT>
 where
     T: Default + Copy,
-    P: ArrayPermutation<T, WIDTH>,
+    P: CryptographicPermutation<[T; WIDTH]>,
 {
     fn hash_iter<I>(&self, input: I) -> [T; OUT]
     where


### PR DESCRIPTION
`CryptographicPermutation<[T; N]>` works fine; `ArrayPermutation` was adding boilerplate without much benefit.