### PR TITLE
Separate `Permutation` and `CryptographicPermutation` traits

### DIFF
--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -126,7 +126,7 @@ where
 mod tests {
     use p3_field::AbstractField;
     use p3_goldilocks::Goldilocks;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 
     use super::*;
 
@@ -138,7 +138,7 @@ mod tests {
     #[derive(Clone)]
     struct TestPermutation {}
 
-    impl CryptographicPermutation<TestArray> for TestPermutation {
+    impl Permutation<TestArray> for TestPermutation {
         fn permute(&self, mut input: TestArray) -> TestArray {
             self.permute_mut(&mut input);
             input
@@ -148,6 +148,8 @@ mod tests {
             input.reverse()
         }
     }
+
+    impl CryptographicPermutation<TestArray> for TestPermutation {}
 
     #[test]
     fn test_duplex_challenger() {

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -7,21 +7,23 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use p3_symmetric::hasher::CryptographicHasher;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 use tiny_keccak::{keccakf, Hasher, Keccak};
 
 /// The Keccak-f permutation.
 #[derive(Copy, Clone)]
 pub struct KeccakF;
 
-impl CryptographicPermutation<[u64; 25]> for KeccakF {
+impl Permutation<[u64; 25]> for KeccakF {
     fn permute(&self, mut input: [u64; 25]) -> [u64; 25] {
         keccakf(&mut input);
         input
     }
 }
 
-impl CryptographicPermutation<[u8; 200]> for KeccakF {
+impl CryptographicPermutation<[u64; 25]> for KeccakF {}
+
+impl Permutation<[u8; 200]> for KeccakF {
     fn permute(&self, input_u8s: [u8; 200]) -> [u8; 200] {
         let mut state_u64s: [u64; 25] = core::array::from_fn(|i| {
             u64::from_le_bytes(input_u8s[i * 8..][..8].try_into().unwrap())
@@ -35,6 +37,8 @@ impl CryptographicPermutation<[u8; 200]> for KeccakF {
         })
     }
 }
+
+impl CryptographicPermutation<[u8; 200]> for KeccakF {}
 
 /// The `Keccak` hash functions defined in
 /// [Keccak SHA3 submission](https://keccak.team/files/Keccak-submission-3.pdf).

--- a/mds/src/babybear.rs
+++ b/mds/src/babybear.rs
@@ -6,7 +6,7 @@
 
 use p3_baby_bear::BabyBear;
 use p3_dft::Radix2Bowers;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 use crate::util::{
     apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml, apply_circulant_fft,
@@ -19,14 +19,14 @@ pub struct MdsMatrixBabyBear;
 
 const FFT_ALGO: Radix2Bowers = Radix2Bowers;
 
-impl CryptographicPermutation<[BabyBear; 8]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 8]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 8]) -> [BabyBear; 8] {
         apply_circulant_8_sml(input)
     }
 }
 impl MdsPermutation<BabyBear, 8> for MdsMatrixBabyBear {}
 
-impl CryptographicPermutation<[BabyBear; 12]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 12]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 12]) -> [BabyBear; 12] {
         apply_circulant_12_sml(input)
     }
@@ -41,7 +41,7 @@ const MATRIX_CIRC_MDS_16_BABYBEAR: [u64; 16] = [
     0x2C6D7501, 0x1D110184, 0x0E1F608D, 0x2032F0C6,
 ];
 
-impl CryptographicPermutation<[BabyBear; 16]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 16]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 16]) -> [BabyBear; 16] {
         const ENTRIES: [u64; 16] = first_row_to_first_col(&MATRIX_CIRC_MDS_16_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -59,7 +59,7 @@ const MATRIX_CIRC_MDS_24_BABYBEAR: [u64; 24] = [
     0x0A6E572C, 0x5C7790FA, 0x17E118F6, 0x0878A07F,
 ];
 
-impl CryptographicPermutation<[BabyBear; 24]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 24]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 24]) -> [BabyBear; 24] {
         apply_circulant(&MATRIX_CIRC_MDS_24_BABYBEAR, input)
     }
@@ -78,7 +78,7 @@ const MATRIX_CIRC_MDS_32_BABYBEAR: [u64; 32] = [
     0x73562137, 0x54596086, 0x487C560B, 0x68A4ACAB,
 ];
 
-impl CryptographicPermutation<[BabyBear; 32]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 32]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 32]) -> [BabyBear; 32] {
         const ENTRIES: [u64; 32] = first_row_to_first_col(&MATRIX_CIRC_MDS_32_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -106,7 +106,7 @@ const MATRIX_CIRC_MDS_64_BABYBEAR: [u64; 64] = [
     0x52ECBE2E, 0x1D178A67, 0x58B3C04B, 0x6E95CB51,
 ];
 
-impl CryptographicPermutation<[BabyBear; 64]> for MdsMatrixBabyBear {
+impl Permutation<[BabyBear; 64]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 64]) -> [BabyBear; 64] {
         const ENTRIES: [u64; 64] = first_row_to_first_col(&MATRIX_CIRC_MDS_64_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -118,7 +118,7 @@ impl MdsPermutation<BabyBear, 64> for MdsMatrixBabyBear {}
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::AbstractField;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
 
     use super::MdsMatrixBabyBear;
 

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,6 +1,6 @@
 use p3_dft::reverse_slice_index_bits;
 use p3_field::{AbstractField, Field, TwoAdicField};
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
@@ -52,7 +52,7 @@ where
     }
 }
 
-impl<F, const N: usize> CryptographicPermutation<[F; N]> for CosetMds<F, N>
+impl<F, const N: usize> Permutation<[F; N]> for CosetMds<F, N>
 where
     F: AbstractField,
     F::F: TwoAdicField,
@@ -160,7 +160,7 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
     use p3_field::AbstractField;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
     use rand::{thread_rng, Rng};
 
     use crate::coset_mds::CosetMds;

--- a/mds/src/goldilocks.rs
+++ b/mds/src/goldilocks.rs
@@ -6,7 +6,7 @@
 
 use p3_dft::Radix2Bowers;
 use p3_goldilocks::Goldilocks;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 use crate::util::{
     apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml, apply_circulant_fft,
@@ -19,14 +19,14 @@ pub struct MdsMatrixGoldilocks;
 
 const FFT_ALGO: Radix2Bowers = Radix2Bowers;
 
-impl CryptographicPermutation<[Goldilocks; 8]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 8]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 8]) -> [Goldilocks; 8] {
         apply_circulant_8_sml(input)
     }
 }
 impl MdsPermutation<Goldilocks, 8> for MdsMatrixGoldilocks {}
 
-impl CryptographicPermutation<[Goldilocks; 12]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 12]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 12]) -> [Goldilocks; 12] {
         apply_circulant_12_sml(input)
     }
@@ -41,7 +41,7 @@ const MATRIX_CIRC_MDS_16_GOLDILOCKS: [u64; 16] = [
     0x36665FFFCFFFFCCD, 0x8F7CFBE74FC1FE11, 0xF3C1DE178881E0F0, 0x511EC2B933D84731,
 ];
 
-impl CryptographicPermutation<[Goldilocks; 16]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 16]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 16]) -> [Goldilocks; 16] {
         const ENTRIES: [u64; 16] = first_row_to_first_col(&MATRIX_CIRC_MDS_16_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -59,7 +59,7 @@ const MATRIX_CIRC_MDS_24_GOLDILOCKS: [u64; 24] = [
     0x1FF8E38E20038E39, 0x214139BD5C40A09D, 0x3065B7CCF3B3B621, 0x23B6F4622485CEDC,
 ];
 
-impl CryptographicPermutation<[Goldilocks; 24]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 24]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 24]) -> [Goldilocks; 24] {
         apply_circulant(&MATRIX_CIRC_MDS_24_GOLDILOCKS, input)
     }
@@ -78,7 +78,7 @@ const MATRIX_CIRC_MDS_32_GOLDILOCKS: [u64; 32] = [
     0x68ED2D2DB4B87697, 0x8B264C98A74E9D3B, 0x09EC23D83D847B09, 0x2C9A4D26669349A5,
 ];
 
-impl CryptographicPermutation<[Goldilocks; 32]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 32]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 32]) -> [Goldilocks; 32] {
         const ENTRIES: [u64; 32] = first_row_to_first_col(&MATRIX_CIRC_MDS_32_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -106,7 +106,7 @@ const MATRIX_CIRC_MDS_64_GOLDILOCKS: [u64; 64] = [
     0xA8AE615C19CC2B99, 0xBC44444388444445, 0xDFE3F1F81CFC7E40, 0xDA4924916D24924A,
 ];
 
-impl CryptographicPermutation<[Goldilocks; 64]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 64]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 64]) -> [Goldilocks; 64] {
         const ENTRIES: [u64; 64] = first_row_to_first_col(&MATRIX_CIRC_MDS_64_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
@@ -135,7 +135,7 @@ const MATRIX_CIRC_MDS_68_GOLDILOCKS: [u64; 68] = [
     0xCB158EF40BC75CAC, 0xA97E818DBC152B4C, 0x9FC8339D415C3999, 0x006A88C0A0D8201C,
 ];
 
-impl CryptographicPermutation<[Goldilocks; 68]> for MdsMatrixGoldilocks {
+impl Permutation<[Goldilocks; 68]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 68]) -> [Goldilocks; 68] {
         apply_circulant(&MATRIX_CIRC_MDS_68_GOLDILOCKS, input)
     }
@@ -146,7 +146,7 @@ impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 mod tests {
     use p3_field::AbstractField;
     use p3_goldilocks::Goldilocks;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
 
     use super::MdsMatrixGoldilocks;
 

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use p3_dft::reverse_slice_index_bits;
 use p3_field::{AbstractField, Field, Powers, TwoAdicField};
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
@@ -50,9 +50,7 @@ where
     }
 }
 
-impl<F: AbstractField, const N: usize> CryptographicPermutation<[F; N]>
-    for IntegratedCosetMds<F, N>
-{
+impl<F: AbstractField, const N: usize> Permutation<[F; N]> for IntegratedCosetMds<F, N> {
     fn permute(&self, mut input: [F; N]) -> [F; N] {
         self.permute_mut(&mut input);
         input
@@ -124,7 +122,7 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{reverse_slice_index_bits, NaiveDft, TwoAdicSubgroupDft};
     use p3_field::AbstractField;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
     use rand::{thread_rng, Rng};
 
     use crate::integrated_coset_mds::IntegratedCosetMds;

--- a/mds/src/lib.rs
+++ b/mds/src/lib.rs
@@ -1,4 +1,4 @@
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 pub mod babybear;
 mod butterflies;
@@ -8,7 +8,4 @@ pub mod integrated_coset_mds;
 pub mod mersenne31;
 pub mod util;
 
-pub trait MdsPermutation<T: Clone, const WIDTH: usize>:
-    CryptographicPermutation<[T; WIDTH]>
-{
-}
+pub trait MdsPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WIDTH]> {}

--- a/mds/src/mersenne31.rs
+++ b/mds/src/mersenne31.rs
@@ -5,7 +5,7 @@
 //! Sizes 8 and 12 are from Plonky2. Other sizes are from Ulrich Haböck's database.
 
 use p3_mersenne_31::Mersenne31;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 use crate::util::{apply_circulant, apply_circulant_12_sml, apply_circulant_8_sml};
 use crate::MdsPermutation;
@@ -13,14 +13,14 @@ use crate::MdsPermutation;
 #[derive(Clone, Default)]
 pub struct MdsMatrixMersenne31;
 
-impl CryptographicPermutation<[Mersenne31; 8]> for MdsMatrixMersenne31 {
+impl Permutation<[Mersenne31; 8]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 8]) -> [Mersenne31; 8] {
         apply_circulant_8_sml(input)
     }
 }
 impl MdsPermutation<Mersenne31, 8> for MdsMatrixMersenne31 {}
 
-impl CryptographicPermutation<[Mersenne31; 12]> for MdsMatrixMersenne31 {
+impl Permutation<[Mersenne31; 12]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 12]) -> [Mersenne31; 12] {
         apply_circulant_12_sml(input)
     }
@@ -35,7 +35,7 @@ const MATRIX_CIRC_MDS_16_MERSENNE31: [u64; 16] = [
     0x7AEDC4EC, 0x653B794A, 0x47366EC7, 0x6D85346D
 ];
 
-impl CryptographicPermutation<[Mersenne31; 16]> for MdsMatrixMersenne31 {
+impl Permutation<[Mersenne31; 16]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 16]) -> [Mersenne31; 16] {
         apply_circulant(&MATRIX_CIRC_MDS_16_MERSENNE31, input)
     }
@@ -54,7 +54,7 @@ const MATRIX_CIRC_MDS_32_MERSENNE31: [u64; 32] = [
     0x500BB628, 0x0B1428CE, 0x3A62E1D6, 0x77692387
 ];
 
-impl CryptographicPermutation<[Mersenne31; 32]> for MdsMatrixMersenne31 {
+impl Permutation<[Mersenne31; 32]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 32]) -> [Mersenne31; 32] {
         apply_circulant(&MATRIX_CIRC_MDS_32_MERSENNE31, input)
     }
@@ -81,7 +81,7 @@ const MATRIX_CIRC_MDS_64_MERSENNE31: [u64; 64] = [
     0x130EC21C, 0x3C84C4F5, 0x50FD67C0, 0x30FDD85A,
 ];
 
-impl CryptographicPermutation<[Mersenne31; 64]> for MdsMatrixMersenne31 {
+impl Permutation<[Mersenne31; 64]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 64]) -> [Mersenne31; 64] {
         apply_circulant(&MATRIX_CIRC_MDS_64_MERSENNE31, input)
     }
@@ -92,7 +92,7 @@ impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 mod tests {
     use p3_field::AbstractField;
     use p3_mersenne_31::Mersenne31;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
 
     use super::MdsMatrixMersenne31;
 

--- a/monolith/src/monolith_mds.rs
+++ b/monolith/src/monolith_mds.rs
@@ -5,7 +5,7 @@ use p3_field::PrimeField32;
 use p3_mds::util::apply_circulant;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use sha3::digest::{ExtendableOutput, Update};
 use sha3::{Shake128, Shake128Reader};
 
@@ -19,7 +19,7 @@ const MATRIX_CIRC_MDS_16_MERSENNE31_MONOLITH: [u64; 16] = [
     33823, 28750, 1108,
 ];
 
-impl<const WIDTH: usize, const NUM_ROUNDS: usize> CryptographicPermutation<[Mersenne31; WIDTH]>
+impl<const WIDTH: usize, const NUM_ROUNDS: usize> Permutation<[Mersenne31; WIDTH]>
     for MonolithMdsMatrixMersenne31<NUM_ROUNDS>
 {
     fn permute(&self, input: [Mersenne31; WIDTH]) -> [Mersenne31; WIDTH] {

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -11,7 +11,7 @@ use p3_mds::mersenne31::MdsMatrixMersenne31;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
 use p3_poseidon::Poseidon;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use p3_field::{AbstractField, PrimeField};
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<F, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[F; WIDTH]>
+impl<F, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[F; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: AbstractField,
@@ -123,4 +123,13 @@ where
         self.half_full_rounds(&mut state, &mut round_ctr);
         state
     }
+}
+
+impl<F, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[F; WIDTH]>
+    for Poseidon<F, Mds, WIDTH, ALPHA>
+where
+    F: AbstractField,
+    F::F: PrimeField,
+    Mds: MdsPermutation<F, WIDTH>,
+{
 }

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -10,7 +10,7 @@ use p3_mds::MdsPermutation;
 use p3_poseidon2::{
     DiffusionMatrixBabybear, DiffusionMatrixGoldilocks, DiffusionPermutation, Poseidon2,
 };
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 

--- a/poseidon2/src/babybear.rs
+++ b/poseidon2/src/babybear.rs
@@ -3,7 +3,7 @@
 //! Reference: https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_babybear.rs
 
 use p3_baby_bear::BabyBear;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 use crate::diffusion::matmul_internal;
 use crate::DiffusionPermutation;
@@ -22,7 +22,7 @@ pub const MATRIX_DIAG_24_BABYBEAR: [u64; 24] = [
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixBabybear;
 
-impl CryptographicPermutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
+impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
     fn permute(&self, input: [BabyBear; 16]) -> [BabyBear; 16] {
         let mut input = input;
         matmul_internal::<BabyBear, 16>(&mut input, MATRIX_DIAG_16_BABYBEAR);
@@ -31,7 +31,7 @@ impl CryptographicPermutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
 }
 impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
 
-impl CryptographicPermutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
+impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
     fn permute(&self, input: [BabyBear; 24]) -> [BabyBear; 24] {
         let mut input = input;
         matmul_internal::<BabyBear, 24>(&mut input, MATRIX_DIAG_24_BABYBEAR);

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -9,12 +9,9 @@
 //! This file implements a trait for linear layers that satisfy these three properties.
 
 use p3_field::Field;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
-pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>:
-    CryptographicPermutation<[T; WIDTH]>
-{
-}
+pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WIDTH]> {}
 
 pub fn matmul_internal<F: Field, const WIDTH: usize>(
     state: &mut [F; WIDTH],

--- a/poseidon2/src/goldilocks.rs
+++ b/poseidon2/src/goldilocks.rs
@@ -3,7 +3,7 @@
 //! Reference: https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_goldilocks.rs
 
 use p3_goldilocks::Goldilocks;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 
 use crate::diffusion::matmul_internal;
 use crate::DiffusionPermutation;
@@ -79,7 +79,7 @@ pub const MATRIX_DIAG_20_GOLDILOCKS: [u64; 20] = [
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixGoldilocks;
 
-impl CryptographicPermutation<[Goldilocks; 8]> for DiffusionMatrixGoldilocks {
+impl Permutation<[Goldilocks; 8]> for DiffusionMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 8]) -> [Goldilocks; 8] {
         let mut input = input;
         matmul_internal::<Goldilocks, 8>(&mut input, MATRIX_DIAG_8_GOLDILOCKS);
@@ -88,7 +88,7 @@ impl CryptographicPermutation<[Goldilocks; 8]> for DiffusionMatrixGoldilocks {
 }
 impl DiffusionPermutation<Goldilocks, 8> for DiffusionMatrixGoldilocks {}
 
-impl CryptographicPermutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
+impl Permutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 12]) -> [Goldilocks; 12] {
         let mut input = input;
         matmul_internal::<Goldilocks, 12>(&mut input, MATRIX_DIAG_12_GOLDILOCKS);
@@ -97,7 +97,7 @@ impl CryptographicPermutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
 }
 impl DiffusionPermutation<Goldilocks, 12> for DiffusionMatrixGoldilocks {}
 
-impl CryptographicPermutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
+impl Permutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 16]) -> [Goldilocks; 16] {
         let mut input = input;
         matmul_internal::<Goldilocks, 16>(&mut input, MATRIX_DIAG_16_GOLDILOCKS);
@@ -106,7 +106,7 @@ impl CryptographicPermutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
 }
 impl DiffusionPermutation<Goldilocks, 16> for DiffusionMatrixGoldilocks {}
 
-impl CryptographicPermutation<[Goldilocks; 20]> for DiffusionMatrixGoldilocks {
+impl Permutation<[Goldilocks; 20]> for DiffusionMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 20]) -> [Goldilocks; 20] {
         let mut input = input;
         matmul_internal::<Goldilocks, 20>(&mut input, MATRIX_DIAG_20_GOLDILOCKS);

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -18,7 +18,7 @@ pub use diffusion::DiffusionPermutation;
 pub use goldilocks::DiffusionMatrixGoldilocks;
 use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -120,7 +120,7 @@ where
     }
 }
 
-impl<F, Mds, Diffusion, const WIDTH: usize, const D: u64> CryptographicPermutation<[F; WIDTH]>
+impl<F, Mds, Diffusion, const WIDTH: usize, const D: u64> Permutation<[F; WIDTH]>
     for Poseidon2<F, Mds, Diffusion, WIDTH, D>
 where
     F: AbstractField,
@@ -157,4 +157,13 @@ where
 
         state
     }
+}
+
+impl<F, Mds, Diffusion, const WIDTH: usize, const D: u64> CryptographicPermutation<[F; WIDTH]>
+    for Poseidon2<F, Mds, Diffusion, WIDTH, D>
+where
+    F: AbstractField,
+    Mds: MdsPermutation<F, WIDTH>,
+    Diffusion: DiffusionPermutation<F, WIDTH>,
+{
 }

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -10,7 +10,7 @@ use p3_mds::mersenne31::MdsMatrixMersenne31;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
 use p3_rescue::{BasicInverseSboxLayer, InverseSboxLayer, Rescue};
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::Permutation;
 use rand::distributions::{Distribution, Standard};
 use rand::{thread_rng, Rng};
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -3,7 +3,7 @@ use num::{BigUint, One};
 use num_integer::binomial;
 use p3_field::{PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
-use p3_symmetric::permutation::CryptographicPermutation;
+use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 use p3_util::ceil_div_usize;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
@@ -114,7 +114,7 @@ where
     }
 }
 
-impl<F, Mds, Isl, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[F; WIDTH]>
+impl<F, Mds, Isl, const WIDTH: usize, const ALPHA: u64> Permutation<[F; WIDTH]>
     for Rescue<F, Mds, Isl, WIDTH, ALPHA>
 where
     F: PrimeField64,
@@ -163,13 +163,22 @@ where
     }
 }
 
+impl<F, Mds, Isl, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[F; WIDTH]>
+    for Rescue<F, Mds, Isl, WIDTH, ALPHA>
+where
+    F: PrimeField64,
+    Mds: MdsPermutation<F, WIDTH>,
+    Isl: InverseSboxLayer<F, WIDTH, ALPHA>,
+{
+}
+
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
     use p3_mds::mersenne31::MdsMatrixMersenne31;
     use p3_mersenne_31::Mersenne31;
     use p3_symmetric::hasher::CryptographicHasher;
-    use p3_symmetric::permutation::CryptographicPermutation;
+    use p3_symmetric::permutation::Permutation;
     use p3_symmetric::sponge::PaddingFreeSponge;
 
     use crate::inverse_sbox::BasicInverseSboxLayer;

--- a/symmetric/src/permutation.rs
+++ b/symmetric/src/permutation.rs
@@ -1,7 +1,12 @@
-pub trait CryptographicPermutation<T: Clone>: Clone {
+/// A permutation in the mathematical sense.
+pub trait Permutation<T: Clone>: Clone {
     fn permute(&self, input: T) -> T;
 
     fn permute_mut(&self, input: &mut T) {
         *input = self.permute(input.clone());
     }
 }
+
+/// A permutation thought to be cryptographically secure, in the sense that it is thought to be
+/// difficult to distinguish (in a nontrivial way) from a random permutation.
+pub trait CryptographicPermutation<T: Clone>: Permutation<T> {}


### PR DESCRIPTION
So that e.g. (simple, linear) MDS permutations can't be used in constructions like `PaddingFreeSponge`; the type checker will now prevent it.