### PR TITLE
Default impl of `permute` rather than `permute_mut`

### DIFF
--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -15,9 +15,8 @@ use tiny_keccak::{keccakf, Hasher, Keccak};
 pub struct KeccakF;
 
 impl Permutation<[u64; 25]> for KeccakF {
-    fn permute(&self, mut input: [u64; 25]) -> [u64; 25] {
-        keccakf(&mut input);
-        input
+    fn permute_mut(&self, input: &mut [u64; 25]) {
+        keccakf(input);
     }
 }
 
@@ -35,6 +34,10 @@ impl Permutation<[u8; 200]> for KeccakF {
             let u64_limb = state_u64s[i / 8];
             u64_limb.to_le_bytes()[i % 8]
         })
+    }
+
+    fn permute_mut(&self, input: &mut [u8; 200]) {
+        *input = self.permute(*input);
     }
 }
 

--- a/mds/src/babybear.rs
+++ b/mds/src/babybear.rs
@@ -23,12 +23,20 @@ impl Permutation<[BabyBear; 8]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 8]) -> [BabyBear; 8] {
         apply_circulant_8_sml(input)
     }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 8]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<BabyBear, 8> for MdsMatrixBabyBear {}
 
 impl Permutation<[BabyBear; 12]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 12]) -> [BabyBear; 12] {
         apply_circulant_12_sml(input)
+    }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 12]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<BabyBear, 12> for MdsMatrixBabyBear {}
@@ -46,6 +54,10 @@ impl Permutation<[BabyBear; 16]> for MdsMatrixBabyBear {
         const ENTRIES: [u64; 16] = first_row_to_first_col(&MATRIX_CIRC_MDS_16_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 16]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<BabyBear, 16> for MdsMatrixBabyBear {}
 
@@ -62,6 +74,10 @@ const MATRIX_CIRC_MDS_24_BABYBEAR: [u64; 24] = [
 impl Permutation<[BabyBear; 24]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 24]) -> [BabyBear; 24] {
         apply_circulant(&MATRIX_CIRC_MDS_24_BABYBEAR, input)
+    }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 24]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<BabyBear, 24> for MdsMatrixBabyBear {}
@@ -82,6 +98,10 @@ impl Permutation<[BabyBear; 32]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 32]) -> [BabyBear; 32] {
         const ENTRIES: [u64; 32] = first_row_to_first_col(&MATRIX_CIRC_MDS_32_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
+    }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 32]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<BabyBear, 32> for MdsMatrixBabyBear {}
@@ -110,6 +130,10 @@ impl Permutation<[BabyBear; 64]> for MdsMatrixBabyBear {
     fn permute(&self, input: [BabyBear; 64]) -> [BabyBear; 64] {
         const ENTRIES: [u64; 64] = first_row_to_first_col(&MATRIX_CIRC_MDS_64_BABYBEAR);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
+    }
+
+    fn permute_mut(&self, input: &mut [BabyBear; 64]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<BabyBear, 64> for MdsMatrixBabyBear {}

--- a/mds/src/goldilocks.rs
+++ b/mds/src/goldilocks.rs
@@ -23,12 +23,20 @@ impl Permutation<[Goldilocks; 8]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 8]) -> [Goldilocks; 8] {
         apply_circulant_8_sml(input)
     }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 8]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<Goldilocks, 8> for MdsMatrixGoldilocks {}
 
 impl Permutation<[Goldilocks; 12]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 12]) -> [Goldilocks; 12] {
         apply_circulant_12_sml(input)
+    }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 12]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Goldilocks, 12> for MdsMatrixGoldilocks {}
@@ -46,6 +54,10 @@ impl Permutation<[Goldilocks; 16]> for MdsMatrixGoldilocks {
         const ENTRIES: [u64; 16] = first_row_to_first_col(&MATRIX_CIRC_MDS_16_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 16]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<Goldilocks, 16> for MdsMatrixGoldilocks {}
 
@@ -62,6 +74,10 @@ const MATRIX_CIRC_MDS_24_GOLDILOCKS: [u64; 24] = [
 impl Permutation<[Goldilocks; 24]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 24]) -> [Goldilocks; 24] {
         apply_circulant(&MATRIX_CIRC_MDS_24_GOLDILOCKS, input)
+    }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 24]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Goldilocks, 24> for MdsMatrixGoldilocks {}
@@ -82,6 +98,10 @@ impl Permutation<[Goldilocks; 32]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 32]) -> [Goldilocks; 32] {
         const ENTRIES: [u64; 32] = first_row_to_first_col(&MATRIX_CIRC_MDS_32_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
+    }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 32]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Goldilocks, 32> for MdsMatrixGoldilocks {}
@@ -111,6 +131,10 @@ impl Permutation<[Goldilocks; 64]> for MdsMatrixGoldilocks {
         const ENTRIES: [u64; 64] = first_row_to_first_col(&MATRIX_CIRC_MDS_64_GOLDILOCKS);
         apply_circulant_fft(FFT_ALGO, ENTRIES, &input)
     }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 64]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<Goldilocks, 64> for MdsMatrixGoldilocks {}
 
@@ -138,6 +162,10 @@ const MATRIX_CIRC_MDS_68_GOLDILOCKS: [u64; 68] = [
 impl Permutation<[Goldilocks; 68]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 68]) -> [Goldilocks; 68] {
         apply_circulant(&MATRIX_CIRC_MDS_68_GOLDILOCKS, input)
+    }
+
+    fn permute_mut(&self, input: &mut [Goldilocks; 68]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}

--- a/mds/src/mersenne31.rs
+++ b/mds/src/mersenne31.rs
@@ -17,12 +17,20 @@ impl Permutation<[Mersenne31; 8]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 8]) -> [Mersenne31; 8] {
         apply_circulant_8_sml(input)
     }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; 8]) {
+        *input = self.permute(*input);
+    }
 }
 impl MdsPermutation<Mersenne31, 8> for MdsMatrixMersenne31 {}
 
 impl Permutation<[Mersenne31; 12]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 12]) -> [Mersenne31; 12] {
         apply_circulant_12_sml(input)
+    }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; 12]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Mersenne31, 12> for MdsMatrixMersenne31 {}
@@ -38,6 +46,10 @@ const MATRIX_CIRC_MDS_16_MERSENNE31: [u64; 16] = [
 impl Permutation<[Mersenne31; 16]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 16]) -> [Mersenne31; 16] {
         apply_circulant(&MATRIX_CIRC_MDS_16_MERSENNE31, input)
+    }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; 16]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Mersenne31, 16> for MdsMatrixMersenne31 {}
@@ -57,6 +69,10 @@ const MATRIX_CIRC_MDS_32_MERSENNE31: [u64; 32] = [
 impl Permutation<[Mersenne31; 32]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 32]) -> [Mersenne31; 32] {
         apply_circulant(&MATRIX_CIRC_MDS_32_MERSENNE31, input)
+    }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; 32]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Mersenne31, 32> for MdsMatrixMersenne31 {}
@@ -84,6 +100,10 @@ const MATRIX_CIRC_MDS_64_MERSENNE31: [u64; 64] = [
 impl Permutation<[Mersenne31; 64]> for MdsMatrixMersenne31 {
     fn permute(&self, input: [Mersenne31; 64]) -> [Mersenne31; 64] {
         apply_circulant(&MATRIX_CIRC_MDS_64_MERSENNE31, input)
+    }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; 64]) {
+        *input = self.permute(*input);
     }
 }
 impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}

--- a/monolith/src/monolith_mds.rs
+++ b/monolith/src/monolith_mds.rs
@@ -39,6 +39,10 @@ impl<const WIDTH: usize, const NUM_ROUNDS: usize> Permutation<[Mersenne31; WIDTH
             apply_cauchy_mds_matrix(&mut shake_finalized, input)
         }
     }
+
+    fn permute_mut(&self, input: &mut [Mersenne31; WIDTH]) {
+        *input = self.permute(*input);
+    }
 }
 
 impl<const WIDTH: usize, const NUM_ROUNDS: usize> MdsPermutation<Mersenne31, WIDTH>

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -116,12 +116,11 @@ where
     F::F: PrimeField,
     Mds: MdsPermutation<F, WIDTH>,
 {
-    fn permute(&self, mut state: [F; WIDTH]) -> [F; WIDTH] {
+    fn permute_mut(&self, state: &mut [F; WIDTH]) {
         let mut round_ctr = 0;
-        self.half_full_rounds(&mut state, &mut round_ctr);
-        self.partial_rounds(&mut state, &mut round_ctr);
-        self.half_full_rounds(&mut state, &mut round_ctr);
-        state
+        self.half_full_rounds(state, &mut round_ctr);
+        self.partial_rounds(state, &mut round_ctr);
+        self.half_full_rounds(state, &mut round_ctr);
     }
 }
 

--- a/poseidon2/src/babybear.rs
+++ b/poseidon2/src/babybear.rs
@@ -23,19 +23,17 @@ pub const MATRIX_DIAG_24_BABYBEAR: [u64; 24] = [
 pub struct DiffusionMatrixBabybear;
 
 impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
-    fn permute(&self, input: [BabyBear; 16]) -> [BabyBear; 16] {
-        let mut input = input;
-        matmul_internal::<BabyBear, 16>(&mut input, MATRIX_DIAG_16_BABYBEAR);
-        input
+    fn permute_mut(&self, state: &mut [BabyBear; 16]) {
+        matmul_internal::<BabyBear, 16>(state, MATRIX_DIAG_16_BABYBEAR);
     }
 }
+
 impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
 
 impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
-    fn permute(&self, input: [BabyBear; 24]) -> [BabyBear; 24] {
-        let mut input = input;
-        matmul_internal::<BabyBear, 24>(&mut input, MATRIX_DIAG_24_BABYBEAR);
-        input
+    fn permute_mut(&self, state: &mut [BabyBear; 24]) {
+        matmul_internal::<BabyBear, 24>(state, MATRIX_DIAG_24_BABYBEAR);
     }
 }
+
 impl DiffusionPermutation<BabyBear, 24> for DiffusionMatrixBabybear {}

--- a/poseidon2/src/goldilocks.rs
+++ b/poseidon2/src/goldilocks.rs
@@ -80,37 +80,33 @@ pub const MATRIX_DIAG_20_GOLDILOCKS: [u64; 20] = [
 pub struct DiffusionMatrixGoldilocks;
 
 impl Permutation<[Goldilocks; 8]> for DiffusionMatrixGoldilocks {
-    fn permute(&self, input: [Goldilocks; 8]) -> [Goldilocks; 8] {
-        let mut input = input;
-        matmul_internal::<Goldilocks, 8>(&mut input, MATRIX_DIAG_8_GOLDILOCKS);
-        input
+    fn permute_mut(&self, state: &mut [Goldilocks; 8]) {
+        matmul_internal::<Goldilocks, 8>(state, MATRIX_DIAG_8_GOLDILOCKS);
     }
 }
+
 impl DiffusionPermutation<Goldilocks, 8> for DiffusionMatrixGoldilocks {}
 
 impl Permutation<[Goldilocks; 12]> for DiffusionMatrixGoldilocks {
-    fn permute(&self, input: [Goldilocks; 12]) -> [Goldilocks; 12] {
-        let mut input = input;
-        matmul_internal::<Goldilocks, 12>(&mut input, MATRIX_DIAG_12_GOLDILOCKS);
-        input
+    fn permute_mut(&self, state: &mut [Goldilocks; 12]) {
+        matmul_internal::<Goldilocks, 12>(state, MATRIX_DIAG_12_GOLDILOCKS);
     }
 }
+
 impl DiffusionPermutation<Goldilocks, 12> for DiffusionMatrixGoldilocks {}
 
 impl Permutation<[Goldilocks; 16]> for DiffusionMatrixGoldilocks {
-    fn permute(&self, input: [Goldilocks; 16]) -> [Goldilocks; 16] {
-        let mut input = input;
-        matmul_internal::<Goldilocks, 16>(&mut input, MATRIX_DIAG_16_GOLDILOCKS);
-        input
+    fn permute_mut(&self, state: &mut [Goldilocks; 16]) {
+        matmul_internal::<Goldilocks, 16>(state, MATRIX_DIAG_16_GOLDILOCKS);
     }
 }
+
 impl DiffusionPermutation<Goldilocks, 16> for DiffusionMatrixGoldilocks {}
 
 impl Permutation<[Goldilocks; 20]> for DiffusionMatrixGoldilocks {
-    fn permute(&self, input: [Goldilocks; 20]) -> [Goldilocks; 20] {
-        let mut input = input;
-        matmul_internal::<Goldilocks, 20>(&mut input, MATRIX_DIAG_20_GOLDILOCKS);
-        input
+    fn permute_mut(&self, state: &mut [Goldilocks; 20]) {
+        matmul_internal::<Goldilocks, 20>(state, MATRIX_DIAG_20_GOLDILOCKS);
     }
 }
+
 impl DiffusionPermutation<Goldilocks, 20> for DiffusionMatrixGoldilocks {}

--- a/symmetric/src/permutation.rs
+++ b/symmetric/src/permutation.rs
@@ -1,10 +1,11 @@
 /// A permutation in the mathematical sense.
 pub trait Permutation<T: Clone>: Clone {
-    fn permute(&self, input: T) -> T;
-
-    fn permute_mut(&self, input: &mut T) {
-        *input = self.permute(input.clone());
+    fn permute(&self, mut input: T) -> T {
+        self.permute_mut(&mut input);
+        input
     }
+
+    fn permute_mut(&self, input: &mut T);
 }
 
 /// A permutation thought to be cryptographically secure, in the sense that it is thought to be


### PR DESCRIPTION
To encourage direct impls of the latter. If compilers were smarter, it wouldn't matter, but in practice this seems to speed up things like Poseidon2 a nontrivial amount.