### PR TITLE
Generalized extension field

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -21,6 +21,13 @@ pub struct BabyBear {
     value: u32,
 }
 
+impl BabyBear {
+    /// create a new `BabyBear` from a canonical `u32`.
+    pub(crate) const fn new(n: u32) -> Self {
+        Self { value: to_monty(n) }
+    }
+}
+
 impl Ord for BabyBear {
     #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
@@ -310,7 +317,7 @@ impl Div for BabyBear {
 
 #[inline]
 #[must_use]
-fn to_monty(x: u32) -> u32 {
+const fn to_monty(x: u32) -> u32 {
     (((x as u64) << 31) % P as u64) as u32
 }
 

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -1,0 +1,45 @@
+use p3_field::extension::BinomiallyExtendable;
+use p3_field::AbstractField;
+
+use crate::BabyBear;
+
+impl BinomiallyExtendable<4> for BabyBear {
+    // Verifiable in Sage with
+    // `R.<x> = GF(p)[]; assert (x^4 - 11).is_irreducible()`.
+    const W: Self = Self::new(11);
+
+    // DTH_ROOT = W^((p - 1)/4)
+    const DTH_ROOT: Self = Self::new(1728404513);
+
+    fn ext_multiplicative_group_generator() -> [Self; 4] {
+        [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO]
+    }
+}
+
+impl BinomiallyExtendable<5> for BabyBear {
+    // Verifiable in Sage with
+    // `R.<x> = GF(p)[]; assert (x^5 - 2).is_irreducible()`.
+    const W: Self = Self::TWO;
+
+    // DTH_ROOT = W^((p - 1)/5)
+    const DTH_ROOT: Self = Self::new(815036133);
+
+    fn ext_multiplicative_group_generator() -> [Self; 5] {
+        [Self::new(8), Self::ONE, Self::ZERO, Self::ZERO, Self::ZERO]
+    }
+}
+
+#[cfg(test)]
+mod test_quatric_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,4>);
+}
+#[cfg(test)]
+mod test_quintic_extension {
+
+    use p3_field_testing::test_field;
+
+    test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,5>);
+}

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
 mod baby_bear;
+mod extension;
+
 pub use baby_bear::*;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -8,7 +8,7 @@ use rand::prelude::Distribution;
 
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
-use crate::{field_to_array, AbstractExtensionField, AbstractField};
+use crate::{field_to_array, AbstractExtensionField, AbstractField, ExtensionField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct BinomialExtensionField<F: BinomiallyExtendable<D>, const D: usize>(pub [F; D]);
@@ -24,6 +24,12 @@ impl<F: BinomiallyExtendable<D>, const D: usize> From<F> for BinomialExtensionFi
         Self(field_to_array::<F, D>(x))
     }
 }
+
+impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
+    for BinomialExtensionField<F, D>
+{
+}
+
 impl<F: BinomiallyExtendable<D>, const D: usize> BinomialExtensionField<F, D> {
     /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
     fn frobenius(&self) -> Self {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
+use super::HasFrobenuis;
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{field_to_array, AbstractExtensionField, AbstractField, ExtensionField};
@@ -30,7 +31,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
 {
 }
 
-impl<F: BinomiallyExtendable<D>, const D: usize> BinomialExtensionField<F, D> {
+impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenuis<F> for BinomialExtensionField<F, D> {
     /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
     fn frobenius(&self) -> Self {
         self.repeated_frobenius(1)

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -155,17 +155,13 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Display for BinomialExtensionField<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut result = String::new();
-        for (i, &x) in self.0.iter().enumerate() {
-            if i == 0 {
-                result.push_str(&(format!("{}", x)));
-            } else if i == 1 {
-                result.push_str(&format!("+{}x", x));
-            } else {
-                result.push_str(&format!("+{}x^{}", x, i));
-            }
-        }
-        write!(f, "{}", result)
+        let linear_part = format!("{} + {}*X", self.0[0], self.0[1]); // ok, since D >= 2
+        let nonlin_part: String = self.0[2..]
+            .iter()
+            .zip(2..)
+            .map(|(x, i)| format!(" + {x}*X^{i}"))
+            .collect();
+        write!(f, "{}", linear_part + &nonlin_part)
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -147,8 +147,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Add for BinomialExtensionField<
     #[inline]
     fn add(self, rhs: Self) -> Self {
         let mut res = self.0;
-        for i in 0..D {
-            res[i] += rhs.0[i];
+        for (r, &rhs_val) in res.iter_mut().zip(&rhs.0) {
+            *r += rhs_val;
         }
         Self(res)
     }
@@ -189,8 +189,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Sub for BinomialExtensionField<
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         let mut res = self.0;
-        for i in 0..D {
-            res[i] -= rhs.0[i];
+        for (r, &rhs_val) in res.iter_mut().zip(&rhs.0) {
+            *r -= rhs_val;
         }
         Self(res)
     }
@@ -202,7 +202,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Sub<F> for BinomialExtensionFie
     #[inline]
     fn sub(self, rhs: F) -> Self {
         let mut res = self.0;
-        res[0] += rhs;
+        res[0] -= rhs;
         Self(res)
     }
 }
@@ -321,8 +321,8 @@ where
 {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BinomialExtensionField<F, D> {
         let mut res = [F::ZERO; D];
-        for i in 0..D {
-            res[i] = Standard.sample(rng);
+        for r in res.iter_mut() {
+            *r = Standard.sample(rng);
         }
         BinomialExtensionField::<F, D>::from_base_slice(&res)
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -101,7 +101,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> AbstractField for BinomialExten
         F::from_wrapped_u64(n).into()
     }
 
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self(F::ext_multiplicative_group_generator())
     }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -1,6 +1,5 @@
 use alloc::format;
 use alloc::string::String;
-use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,4 +1,5 @@
 use crate::field::Field;
+use crate::ExtensionField;
 
 pub mod binomial_extension;
 pub mod cubic;
@@ -16,4 +17,9 @@ pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const DTH_ROOT: Self;
 
     fn ext_multiplicative_group_generator() -> [Self; D];
+}
+
+pub trait HasFrobenuis<F: Field>: ExtensionField<F> {
+    fn frobenius(&self) -> Self;
+    fn repeated_frobenius(&self, count: usize) -> Self;
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,5 +1,4 @@
 use crate::field::Field;
-use crate::AbstractExtensionField;
 
 pub mod binomial_extension;
 pub mod cubic;
@@ -17,41 +16,4 @@ pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const DTH_ROOT: Self;
 
     fn ext_multiplicative_group_generator() -> [Self; D];
-}
-
-pub trait Frobenius<F: BinomiallyExtendable<D>, const D: usize>:
-    Field + Sized + AbstractExtensionField<F>
-{
-    /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
-    fn frobenius(&self) -> Self {
-        self.repeated_frobenius(1)
-    }
-
-    /// Repeated Frobenius automorphisms: x -> x^(n^count).
-    ///
-    /// Follows precomputation suggestion in Section 11.3.3 of the
-    /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
-    fn repeated_frobenius(&self, count: usize) -> Self {
-        if count == 0 {
-            return *self;
-        } else if count >= D {
-            // x |-> x^(n^D) is the identity, so x^(n^count) ==
-            // x^(n^(count % D))
-            return self.repeated_frobenius(count % D);
-        }
-        let arr: &[F] = self.as_base_slice();
-
-        // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
-        let mut z0 = F::DTH_ROOT;
-        for _ in 1..count {
-            z0 *= F::DTH_ROOT;
-        }
-
-        let mut res = [F::ZERO; D];
-        for (i, z) in z0.powers().take(D).enumerate() {
-            res[i] = arr[i] * z;
-        }
-
-        Self::from_base_slice(&res)
-    }
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,6 +1,7 @@
 use crate::field::Field;
 use crate::AbstractExtensionField;
 
+pub mod binomial_extension;
 pub mod cubic;
 pub mod quadratic;
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,4 +1,5 @@
 use crate::field::Field;
+use crate::AbstractExtensionField;
 
 pub mod cubic;
 pub mod quadratic;
@@ -8,5 +9,48 @@ pub mod quadratic;
 /// such that the extension is `F[X]/(X^d-W)`.
 pub trait BinomiallyExtendable<const D: usize>: Field + Sized {
     const W: Self;
+
+    // DTH_ROOT = W^((n - 1)/D).
+    // n is the order of base field.
+    // Only works when exists k such that n = kD + 1.
+    const DTH_ROOT: Self;
+
     fn ext_multiplicative_group_generator() -> [Self; D];
+}
+
+pub trait Frobenius<F: BinomiallyExtendable<D>, const D: usize>:
+    Field + Sized + AbstractExtensionField<F>
+{
+    /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
+    fn frobenius(&self) -> Self {
+        self.repeated_frobenius(1)
+    }
+
+    /// Repeated Frobenius automorphisms: x -> x^(n^count).
+    ///
+    /// Follows precomputation suggestion in Section 11.3.3 of the
+    /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    fn repeated_frobenius(&self, count: usize) -> Self {
+        if count == 0 {
+            return *self;
+        } else if count >= D {
+            // x |-> x^(n^D) is the identity, so x^(n^count) ==
+            // x^(n^(count % D))
+            return self.repeated_frobenius(count % D);
+        }
+        let arr: &[F] = self.as_base_slice();
+
+        // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
+        let mut z0 = F::DTH_ROOT;
+        for _ in 1..count {
+            z0 *= F::DTH_ROOT;
+        }
+
+        let mut res = [F::ZERO; D];
+        for (i, z) in z0.powers().take(D).enumerate() {
+            res[i] = arr[i] * z;
+        }
+
+        Self::from_base_slice(&res)
+    }
 }

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -54,3 +54,11 @@ where
     // TODO: Use PackedField
     x.iter_mut().zip(y).for_each(|(x_i, y_i)| *x_i += y_i * s);
 }
+
+/// Extend a field `F` element `x` to an arry of length `D`
+/// by filling zeros.
+pub const fn field_to_array<F: Field, const D: usize>(x: F) -> [F; D] {
+    let mut arr = [F::ZERO; D];
+    arr[0] = x;
+    arr
+}

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -23,5 +23,12 @@ mod test_quadratic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::quadratic::QuadraticBef<crate::Goldilocks>);
+    // test_field!(p3_field::extension::quadratic::QuadraticBef<crate::Goldilocks>);
+
+    test_field!(
+        p3_field::extension::binomial_extension::BinomialExtensionField<
+            crate::Goldilocks,
+            2,
+        >
+    );
 }

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -7,6 +7,9 @@ impl BinomiallyExtendable<2> for Goldilocks {
     // `R.<x> = GF(p)[]; assert (x^2 - 7).is_irreducible()`.
     const W: Self = Self::new(7);
 
+    // DTH_ROOT = W^((p - 1)/2).
+    const DTH_ROOT: Self = Self::new(18446744069414584320);
+
     fn ext_multiplicative_group_generator() -> [Self; 2] {
         [
             Self::new(18081566051660590251),

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -68,7 +68,14 @@ mod test_cubic_extension {
 
     use p3_field_testing::test_field;
 
-    test_field!(p3_field::extension::cubic::CubicBef<crate::Mersenne31Complex<crate::Mersenne31>>);
+    // test_field!(p3_field::extension::cubic::CubicBef<crate::Mersenne31Complex<crate::Mersenne31>>);
+
+    test_field!(
+        p3_field::extension::binomial_extension::BinomialExtensionField<
+            crate::Mersenne31Complex<crate::Mersenne31>,
+            3,
+        >
+    );
 }
 
 #[cfg(test)]
@@ -76,7 +83,14 @@ mod test_quadratic_extension {
 
     use p3_field_testing::test_field;
 
+    // test_field!(
+    //     p3_field::extension::quadratic::QuadraticBef<crate::Mersenne31Complex<crate::Mersenne31>>
+    // );
+
     test_field!(
-        p3_field::extension::quadratic::QuadraticBef<crate::Mersenne31Complex<crate::Mersenne31>>
+        p3_field::extension::binomial_extension::BinomialExtensionField<
+            crate::Mersenne31Complex<crate::Mersenne31>,
+            2,
+        >
     );
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,4 +1,5 @@
 use p3_field::extension::BinomiallyExtendable;
+use p3_field::AbstractField;
 
 use crate::{Mersenne31, Mersenne31Complex};
 
@@ -13,7 +14,7 @@ impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     // f2 = y^2 - i - 2
     // assert f2.is_irreducible()
     // ```
-    const W: Self = Self::new(Mersenne31::new(2), Mersenne31::new(1));
+    const W: Self = Self::new(Mersenne31::TWO, Mersenne31::ONE);
 
     // Verifiable in Sage with
     // ```sage
@@ -23,11 +24,11 @@ impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     //   assert g^((p^4-1) // f) != 1
     // ```
     fn ext_multiplicative_group_generator() -> [Self; 2] {
-        [
-            Self::new(Mersenne31::new(6), Mersenne31::new(0)),
-            Self::new(Mersenne31::new(1), Mersenne31::new(0)),
-        ]
+        [Self::new_real(Mersenne31::new(6)), Self::ONE]
     }
+
+    // DTH_ROOT = W^((p^2 - 1)/2).
+    const DTH_ROOT: Self = Self::new_real(Mersenne31::new(2147483646));
 }
 
 impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
@@ -41,7 +42,10 @@ impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // f2 = y^3 - 5*i
     // assert f2.is_irreducible()
     // ```
-    const W: Self = Self::new(Mersenne31::new(0), Mersenne31::new(5));
+    const W: Self = Self::new_imag(Mersenne31::new(5));
+
+    // DTH_ROOT = W^((p^2 - 1)/2).
+    const DTH_ROOT: Self = Self::new_real(Mersenne31::new(634005911));
 
     // Verifiable in Sage with
     // ```sage
@@ -52,9 +56,9 @@ impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // ```
     fn ext_multiplicative_group_generator() -> [Self; 3] {
         [
-            Self::new(Mersenne31::new(5), Mersenne31::new(0)),
-            Self::new(Mersenne31::new(1), Mersenne31::new(0)),
-            Self::new(Mersenne31::new(0), Mersenne31::new(0)),
+            Self::new_real(Mersenne31::new(5)),
+            Self::new_real(Mersenne31::ONE),
+            Self::ZERO,
         ]
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/Plonky3/Plonky3/pull/116, implement a general binomial extended field.

For simplification, `Frobenuis` trait is implemented for all `BinomialExtendable`.

Babybear's extension field(https://github.com/Plonky3/Plonky3/issues/113) is also implemented.

QuadraticBef and CubicBef are kept for now until we have a proper benchmark(https://github.com/Plonky3/Plonky3/issues/130) to discuss whether we need those implementations.

https://github.com/Plonky3/Plonky3/pull/116 can be closed if this PR is merged