### PR TITLE
Tweak generator methods in field APIs

### DIFF
--- a/baby-bear/src/aarch64_neon.rs
+++ b/baby-bear/src/aarch64_neon.rs
@@ -417,8 +417,8 @@ impl AbstractField for PackedBabyBearNeon {
     }
 
     #[inline]
-    fn multiplicative_group_generator() -> Self {
-        BabyBear::multiplicative_group_generator().into()
+    fn generator() -> Self {
+        BabyBear::generator().into()
     }
 }
 

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -114,7 +114,7 @@ impl AbstractField for BabyBear {
     }
 
     #[inline]
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self::from_canonical_u32(0x1f)
     }
 }
@@ -208,9 +208,11 @@ impl PrimeField32 for BabyBear {
 impl TwoAdicField for BabyBear {
     const TWO_ADICITY: usize = 27;
 
-    #[inline]
-    fn power_of_two_generator() -> Self {
-        Self::from_canonical_u32(0x1a427a41)
+    fn two_adic_generator(bits: usize) -> Self {
+        // TODO: Consider a `match` which may speed this up.
+        assert!(bits <= Self::TWO_ADICITY);
+        let base = Self::from_canonical_u32(0x1a427a41); // generates the whole 2^TWO_ADICITY group
+        base.exp_power_of_2(Self::TWO_ADICITY - bits)
     }
 }
 

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -115,7 +115,7 @@ where
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
             b.iter(|| {
-                dft.coset_lde_batch(messages.clone(), 1, F::multiplicative_group_generator());
+                dft.coset_lde_batch(messages.clone(), 1, F::generator());
             });
         });
     }

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -15,7 +15,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for NaiveDft {
         let w = mat.width();
         let h = mat.height();
         let log_h = log2_strict_usize(h);
-        let g = F::primitive_root_of_unity(log_h);
+        let g = F::two_adic_generator(log_h);
 
         let mut res = RowMajorMatrix::new(vec![F::ZERO; w * h], w);
         for (res_r, point) in g.powers().take(h).enumerate() {

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -78,7 +78,7 @@ fn bowers_g<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
 
-    let root = F::primitive_root_of_unity(log_h);
+    let root = F::two_adic_generator(log_h);
     let mut twiddles: Vec<F> = root.powers().take(h / 2).collect();
     reverse_slice_index_bits(&mut twiddles);
 
@@ -94,7 +94,7 @@ fn bowers_g_t<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
 
-    let root_inv = F::primitive_root_of_unity(log_h).inverse();
+    let root_inv = F::two_adic_generator(log_h).inverse();
     let mut twiddles: Vec<F> = root_inv.powers().take(h / 2).collect();
     reverse_slice_index_bits(&mut twiddles);
 

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -18,7 +18,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Dit {
         let h = mat.height();
         let log_h = log2_strict_usize(h);
 
-        let root = F::primitive_root_of_unity(log_h);
+        let root = F::two_adic_generator(log_h);
         let twiddles: Vec<F> = root.powers().take(h / 2).collect();
 
         // DIT butterfly

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -25,7 +25,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
         let h = mat.height();
         let log_h = log2_strict_usize(h);
 
-        let root = F::primitive_root_of_unity(log_h);
+        let root = F::two_adic_generator(log_h);
         let mut twiddles: Vec<F> = root.powers().take(h / 2).collect();
 
         let mid = log_h / 2;
@@ -54,7 +54,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
         let mid = log_h / 2;
         let h_inv = F::from_canonical_usize(h).inverse();
 
-        let root = F::primitive_root_of_unity(log_h);
+        let root = F::two_adic_generator(log_h);
         let root_inv = root.inverse();
 
         let mut twiddles_inv: Vec<F> = root_inv.powers().take(h / 2).collect();
@@ -88,7 +88,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
         let log_h = log2_strict_usize(h);
         let mid = log_h / 2;
 
-        let root = F::primitive_root_of_unity(log_h);
+        let root = F::two_adic_generator(log_h);
 
         let mut twiddles: Vec<F> = root.powers().take(h / 2).collect();
 

--- a/dft/src/testing.rs
+++ b/dft/src/testing.rs
@@ -33,7 +33,7 @@ where
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
-        let shift = F::multiplicative_group_generator();
+        let shift = F::generator();
         let coset_dft_naive = NaiveDft.coset_dft_batch(mat.clone(), shift);
         let coset_dft_result = dft.coset_dft_batch(mat, shift);
         assert_eq!(coset_dft_naive, coset_dft_result);
@@ -85,7 +85,7 @@ where
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
-        let shift = F::multiplicative_group_generator();
+        let shift = F::generator();
         let coset_lde_naive = NaiveDft.coset_lde_batch(mat.clone(), 1, shift);
         let coset_lde_result = dft.coset_lde_batch(mat, 1, shift);
         assert_eq!(coset_lde_naive, coset_lde_result);

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -69,7 +69,7 @@ where
 
 pub fn test_two_adic_subgroup_zerofier<F: TwoAdicField>() {
     for log_n in 0..5 {
-        let g = F::primitive_root_of_unity(log_n);
+        let g = F::two_adic_generator(log_n);
         for x in cyclic_subgroup_known_order(g, 1 << log_n) {
             let zerofier_eval = two_adic_subgroup_zerofier(log_n, x);
             assert_eq!(zerofier_eval, F::ZERO);
@@ -79,8 +79,8 @@ pub fn test_two_adic_subgroup_zerofier<F: TwoAdicField>() {
 
 pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
     for log_n in 0..5 {
-        let g = F::primitive_root_of_unity(log_n);
-        let shift = F::multiplicative_group_generator();
+        let g = F::two_adic_generator(log_n);
+        let shift = F::generator();
         for x in cyclic_subgroup_coset_known_order(g, shift, 1 << log_n) {
             let zerofier_eval = two_adic_coset_zerofier(log_n, shift, x);
             assert_eq!(zerofier_eval, F::ZERO);

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -65,8 +65,8 @@ impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
         [F::from_wrapped_u64(n); N].into()
     }
 
-    fn multiplicative_group_generator() -> Self {
-        [F::multiplicative_group_generator(); N].into()
+    fn generator() -> Self {
+        [F::generator(); N].into()
     }
 }
 

--- a/field/src/extension/cubic.rs
+++ b/field/src/extension/cubic.rs
@@ -66,7 +66,7 @@ impl<F: BinomiallyExtendable<3>> AbstractField for CubicBef<F> {
         F::from_wrapped_u64(n).into()
     }
 
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self(F::ext_multiplicative_group_generator())
     }
 

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -66,7 +66,7 @@ impl<F: BinomiallyExtendable<2>> AbstractField for QuadraticBef<F> {
         F::from_wrapped_u64(n).into()
     }
 
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self(F::ext_multiplicative_group_generator())
     }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -53,7 +53,8 @@ pub trait AbstractField:
     fn from_wrapped_u32(n: u32) -> Self;
     fn from_wrapped_u64(n: u64) -> Self;
 
-    fn multiplicative_group_generator() -> Self;
+    /// A generator of this field's entire multiplicative group.
+    fn generator() -> Self;
 
     #[must_use]
     fn double(&self) -> Self {
@@ -288,21 +289,15 @@ impl<F: AbstractField> AbstractExtensionField<F> for F {
 }
 
 /// A field which supplies information like the two-adicity of its multiplicative group, and methods
-/// for obtaining two-adic roots of unity.
+/// for obtaining two-adic generators.
 pub trait TwoAdicField: Field {
     /// The number of factors of two in this field's multiplicative group.
     const TWO_ADICITY: usize;
 
-    /// Generator of a multiplicative subgroup of order `2^TWO_ADICITY`.
-    fn power_of_two_generator() -> Self;
-
-    /// Returns a primitive root of order `2^bits`.
+    /// Returns a generator of the multiplicative group of order `2^bits`.
+    /// Assumes `bits < TWO_ADICITY`, otherwise the result is undefined.
     #[must_use]
-    fn primitive_root_of_unity(bits: usize) -> Self {
-        assert!(bits <= Self::TWO_ADICITY);
-        let base = Self::power_of_two_generator();
-        base.exp_power_of_2(Self::TWO_ADICITY - bits)
-    }
+    fn two_adic_generator(bits: usize) -> Self;
 }
 
 /// An iterator over the powers of a certain base element `b`: `b^0, b^1, b^2, ...`.

--- a/field/src/symbolic.rs
+++ b/field/src/symbolic.rs
@@ -67,8 +67,8 @@ impl<F: Field, Var: Clone + Debug> AbstractField for SymbolicField<F, Var> {
         Self::Constant(F::from_wrapped_u64(n))
     }
 
-    fn multiplicative_group_generator() -> Self {
-        Self::Constant(F::multiplicative_group_generator())
+    fn generator() -> Self {
+        Self::Constant(F::generator())
     }
 }
 

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -30,7 +30,7 @@ pub(crate) fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     debug_assert!(n > 1);
     let log_n = log2_strict_usize(n);
 
-    let g_inv = F::primitive_root_of_unity(log_n).inverse();
+    let g_inv = F::two_adic_generator(log_n).inverse();
     let one_half = F::TWO.inverse();
     let half_beta = beta * one_half;
 

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -129,7 +129,7 @@ impl AbstractField for Goldilocks {
     }
 
     // Sage: GF(2^64 - 2^32 + 1).multiplicative_generator()
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self::new(7)
     }
 }
@@ -228,8 +228,11 @@ impl PrimeField64 for Goldilocks {
 impl TwoAdicField for Goldilocks {
     const TWO_ADICITY: usize = 32;
 
-    fn power_of_two_generator() -> Self {
-        Self::new(1_753_635_133_440_165_772)
+    fn two_adic_generator(bits: usize) -> Self {
+        // TODO: Consider a `match` which may speed this up.
+        assert!(bits <= Self::TWO_ADICITY);
+        let base = Self::new(1_753_635_133_440_165_772); // generates the whole 2^TWO_ADICITY group
+        base.exp_power_of_2(Self::TWO_ADICITY - bits)
     }
 }
 
@@ -434,10 +437,7 @@ mod tests {
         let f = F::from_canonical_u64(F::ORDER_U64);
         assert!(f.is_zero());
 
-        assert_eq!(
-            F::multiplicative_group_generator().as_canonical_u64(),
-            7_u64
-        );
+        assert_eq!(F::generator().as_canonical_u64(), 7_u64);
 
         let f_1 = F::new(1);
         let f_1_copy = F::new(1);
@@ -477,10 +477,7 @@ mod tests {
 
         // Generator check
         let expected_multiplicative_group_generator = F::new(7);
-        assert_eq!(
-            F::multiplicative_group_generator(),
-            expected_multiplicative_group_generator
-        );
+        assert_eq!(F::generator(), expected_multiplicative_group_generator);
 
         // Check on `reduce_u128`
         let x = u128::MAX;

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -38,7 +38,7 @@ where
     let width = coset_evals.width();
     let height = coset_evals.height();
     let log_height = log2_strict_usize(height);
-    let g = F::primitive_root_of_unity(log_height);
+    let g = F::two_adic_generator(log_height);
 
     let diffs: Vec<EF> = cyclic_subgroup_coset_known_order(g, shift, height)
         .map(|subgroup_i| point - subgroup_i)
@@ -84,7 +84,7 @@ mod tests {
     fn test_interpolate_coset() {
         // x^2 + 2 x + 3
         type F = BabyBear;
-        let shift = F::multiplicative_group_generator();
+        let shift = F::generator();
         let evals = [
             1026, 129027310, 457985035, 994890337, 902, 1988942953, 1555278970, 913671254,
         ]

--- a/lde/src/naive.rs
+++ b/lde/src/naive.rs
@@ -50,7 +50,7 @@ where
 {
     fn lde_batch(&self, polys: RowMajorMatrix<Val>, added_bits: usize) -> RowMajorMatrix<Domain> {
         let bits = log2_strict_usize(polys.height());
-        let g = Domain::primitive_root_of_unity(bits);
+        let g = Domain::two_adic_generator(bits);
         let subgroup = cyclic_subgroup_known_order::<Domain>(g, 1 << bits).collect::<Vec<_>>();
         let weights = barycentric_weights(&subgroup);
 
@@ -72,7 +72,7 @@ where
 {
     fn lde_batch(&self, polys: RowMajorMatrix<Val>, added_bits: usize) -> RowMajorMatrix<Domain> {
         let bits = log2_strict_usize(polys.height());
-        let g = Domain::primitive_root_of_unity(bits);
+        let g = Domain::two_adic_generator(bits);
         let subgroup = cyclic_subgroup_known_order::<Domain>(g, 1 << bits).collect::<Vec<_>>();
         let weights = barycentric_weights(&subgroup);
 
@@ -101,7 +101,7 @@ where
     Domain: ExtensionField<Val> + TwoAdicField,
 {
     fn shift(&self, _lde_bits: usize) -> Domain {
-        Domain::multiplicative_group_generator()
+        Domain::generator()
     }
 }
 

--- a/ldt/src/ldt_based_pcs.rs
+++ b/ldt/src/ldt_based_pcs.rs
@@ -62,7 +62,7 @@ where
     type Error = L::Error;
 
     fn commit_batches(&self, polynomials: Vec<In>) -> (Self::Commitment, Self::ProverData) {
-        let shift = Domain::multiplicative_group_generator();
+        let shift = Domain::generator();
         let ldes = info_span!("compute all coset LDEs").in_scope(|| {
             polynomials
                 .into_iter()
@@ -105,7 +105,7 @@ where
                             .into_iter()
                             .map(|mat| {
                                 let low_coset = mat.vertically_strided(1 << self.added_bits, 0);
-                                let shift = Domain::multiplicative_group_generator();
+                                let shift = Domain::generator();
                                 interpolate_coset(&low_coset, shift, point)
                             })
                             .collect::<OpenedValuesForPoint<EF>>()
@@ -174,7 +174,7 @@ where
     Challenger: FieldChallenger<Val>,
 {
     fn coset_shift(&self) -> Domain {
-        Domain::multiplicative_group_generator()
+        Domain::generator()
     }
 
     fn get_ldes<'a, 'b>(

--- a/ldt/src/quotient.rs
+++ b/ldt/src/quotient.rs
@@ -59,7 +59,7 @@ where
                 let log2_height = log2_strict_usize(height);
                 let bits_reduced = log_max_height - log2_height;
                 let reduced_index = index >> bits_reduced;
-                let x = F::primitive_root_of_unity(log2_height).exp_u64(reduced_index as u64);
+                let x = F::two_adic_generator(log2_height).exp_u64(reduced_index as u64);
                 openings_for_mat
                     .iter()
                     .flat_map(|Opening { point, values }| {
@@ -86,7 +86,7 @@ where
             .map(|(inner, openings)| {
                 let height = inner.height();
                 let log2_height = log2_strict_usize(height);
-                let g = F::primitive_root_of_unity(log2_height);
+                let g = F::two_adic_generator(log2_height);
                 let subgroup = g.powers().take(height).collect_vec();
 
                 let denominators: Vec<EF> = subgroup
@@ -131,7 +131,7 @@ where
                 let log_height = log2_strict_usize(dims.height);
                 let bits_reduced = log_max_height - log_height;
                 let reduced_index = index >> bits_reduced;
-                let x = F::primitive_root_of_unity(log_height).exp_u64(reduced_index as u64);
+                let x = F::two_adic_generator(log_height).exp_u64(reduced_index as u64);
 
                 let original_width = quotient_row.len() / openings.len();
                 let original_row_repeated: Vec<Vec<EF>> = quotient_row

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -29,14 +29,14 @@ where
     fn default() -> Self {
         let log_n = log2_strict_usize(N);
 
-        let root = F::F::primitive_root_of_unity(log_n);
+        let root = F::F::two_adic_generator(log_n);
         let root_inv = root.inverse();
         let mut fft_twiddles: Vec<F::F> = root.powers().take(N / 2).collect();
         let mut ifft_twiddles: Vec<F::F> = root_inv.powers().take(N / 2).collect();
         reverse_slice_index_bits(&mut fft_twiddles);
         reverse_slice_index_bits(&mut ifft_twiddles);
 
-        let shift = F::F::multiplicative_group_generator();
+        let shift = F::F::generator();
         let mut weights: [F::F; N] = shift
             .powers()
             .take(N)
@@ -173,7 +173,7 @@ mod tests {
         let mut rng = thread_rng();
         let mut arr: [F; N] = rng.gen();
 
-        let shift = F::multiplicative_group_generator();
+        let shift = F::generator();
         let mut coset_lde_naive = NaiveDft.coset_lde(arr.to_vec(), 0, shift);
         coset_lde_naive
             .iter_mut()

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -23,9 +23,9 @@ where
 {
     fn default() -> Self {
         let log_n = log2_strict_usize(N);
-        let root = F::F::primitive_root_of_unity(log_n);
+        let root = F::F::two_adic_generator(log_n);
         let root_inv = root.inverse();
-        let coset_shift = F::F::multiplicative_group_generator();
+        let coset_shift = F::F::generator();
 
         let mut ifft_twiddles: Vec<F::F> = root_inv.powers().take(N / 2).collect();
         reverse_slice_index_bits(&mut ifft_twiddles);
@@ -138,7 +138,7 @@ mod tests {
         let mut arr_rev = arr.to_vec();
         reverse_slice_index_bits(&mut arr_rev);
 
-        let shift = F::multiplicative_group_generator();
+        let shift = F::generator();
         let mut coset_lde_naive = NaiveDft.coset_lde(arr_rev, 0, shift);
         reverse_slice_index_bits(&mut coset_lde_naive);
         coset_lde_naive

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -223,7 +223,7 @@ where
     // sage: F2.<u> = F.extension(x^2 + 1)
     // sage: F2.multiplicative_generator()
     // u + 12
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self::new(AF::from_canonical_u8(12), AF::ONE)
     }
 }
@@ -270,18 +270,22 @@ impl Field for Mersenne31Complex<Mersenne31> {
 impl TwoAdicField for Mersenne31Complex<Mersenne31> {
     const TWO_ADICITY: usize = 32;
 
-    // sage: p = 2^31 - 1
-    // sage: F = GF(p)
-    // sage: R.<x> = F[]
-    // sage: F2.<u> = F.extension(x^2 + 1)
-    // sage: g = F2.multiplicative_generator()^((p^2 - 1) / 2^32); g
-    // 1117296306*u + 1166849849
-    // sage: assert(g.multiplicative_order() == 2^32)
-    fn power_of_two_generator() -> Self {
-        Self::new(
+    fn two_adic_generator(bits: usize) -> Self {
+        // TODO: Consider a `match` which may speed this up.
+        assert!(bits <= Self::TWO_ADICITY);
+        // Generator of the whole 2^TWO_ADICITY group
+        // sage: p = 2^31 - 1
+        // sage: F = GF(p)
+        // sage: R.<x> = F[]
+        // sage: F2.<u> = F.extension(x^2 + 1)
+        // sage: g = F2.multiplicative_generator()^((p^2 - 1) / 2^32); g
+        // 1117296306*u + 1166849849
+        // sage: assert(g.multiplicative_order() == 2^32)
+        let base = Self::new(
             Mersenne31::new(1_166_849_849),
             Mersenne31::new(1_117_296_306),
-        )
+        );
+        base.exp_power_of_2(Self::TWO_ADICITY - bits)
     }
 }
 

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -69,7 +69,7 @@ fn dft_postprocess(
 
     // NB: The original real matrix had height 2h, hence log2(2h) = log2(h) + 1.
     // omega is a 2h-th root of unity
-    let omega = Mersenne31Complex::primitive_root_of_unity(log2_h + 1);
+    let omega = Mersenne31Complex::two_adic_generator(log2_h + 1);
     let mut omega_j = omega;
 
     let mut output = Vec::with_capacity((h + 1) * input.width());
@@ -116,7 +116,7 @@ fn idft_preprocess(
 
     // NB: The original real matrix had length 2h, hence log2(2h) = log2(h) + 1.
     // omega is a 2n-th root of unity
-    let omega = Mersenne31Complex::primitive_root_of_unity(log2_h + 1).inverse();
+    let omega = Mersenne31Complex::two_adic_generator(log2_h + 1).inverse();
     let mut omega_j = Mersenne31Complex::ONE;
 
     let mut output = Vec::with_capacity(h * input.width());

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -152,7 +152,7 @@ impl AbstractField for Mersenne31 {
     }
 
     // Sage: GF(2^31 - 1).multiplicative_generator()
-    fn multiplicative_group_generator() -> Self {
+    fn generator() -> Self {
         Self::new(7)
     }
 }

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -47,7 +47,7 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, log_chunks: usize) -> Vec<Vec<F>> {
     debug_assert!(n > 1);
     let log_n = log2_strict_usize(n);
     let half_n = poly.len() / 2;
-    let g_inv = F::primitive_root_of_unity(log_n).inverse();
+    let g_inv = F::two_adic_generator(log_n).inverse();
 
     let mut even = Vec::with_capacity(half_n);
     let mut odd = Vec::with_capacity(half_n);

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -32,7 +32,7 @@ where
     let log_degree = log2_strict_usize(degree);
     let log_quotient_degree = 1; // TODO
 
-    let g_subgroup = SC::Domain::primitive_root_of_unity(log_degree);
+    let g_subgroup = SC::Domain::two_adic_generator(log_degree);
 
     let pcs = config.pcs();
     let (trace_commit, trace_data) =
@@ -104,8 +104,8 @@ where
     let degree = 1 << degree_bits;
     let quotient_size_bits = degree_bits + quotient_degree_bits;
     let quotient_size = 1 << quotient_size_bits;
-    let g_subgroup = SC::Domain::primitive_root_of_unity(degree_bits);
-    let g_extended = SC::Domain::primitive_root_of_unity(quotient_size_bits);
+    let g_subgroup = SC::Domain::two_adic_generator(degree_bits);
+    let g_extended = SC::Domain::two_adic_generator(quotient_size_bits);
     let subgroup_last = g_subgroup.inverse();
     let coset_shift = config.pcs().coset_shift();
     let next_step = 1 << quotient_degree_bits;

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -20,7 +20,7 @@ where
 {
     let degree_bits = 6; // TODO
     let log_quotient_degree = 1; // TODO
-    let g_subgroup = SC::Domain::primitive_root_of_unity(degree_bits);
+    let g_subgroup = SC::Domain::two_adic_generator(degree_bits);
 
     let Proof {
         commitments,
@@ -68,7 +68,7 @@ where
         })
         .collect();
     // Then we reconstruct the larger quotient polynomial from its degree-n parts.
-    let g_quotient_parts = SC::Domain::primitive_root_of_unity(log_quotient_degree);
+    let g_quotient_parts = SC::Domain::two_adic_generator(log_quotient_degree);
     let quotient: SC::Challenge = g_quotient_parts
         .powers()
         .zip(quotient_parts)

--- a/uni-stark/src/zerofier_coset.rs
+++ b/uni-stark/src/zerofier_coset.rs
@@ -23,7 +23,7 @@ pub struct ZerofierOnCoset<F: Field> {
 impl<F: TwoAdicField> ZerofierOnCoset<F> {
     pub fn new(log_n: usize, rate_bits: usize, coset_shift: F) -> Self {
         let s_pow_n = coset_shift.exp_power_of_2(log_n);
-        let evals = F::primitive_root_of_unity(rate_bits)
+        let evals = F::two_adic_generator(rate_bits)
             .powers()
             .take(1 << rate_bits)
             .map(|x| s_pow_n * x - F::ONE)
@@ -65,8 +65,8 @@ impl<F: TwoAdicField> ZerofierOnCoset<F> {
     pub(crate) fn lagrange_basis_unnormalized(&self, i: usize) -> Vec<F> {
         let log_coset_size = self.log_n + self.rate_bits;
         let coset_size = 1 << log_coset_size;
-        let g_h = F::primitive_root_of_unity(self.log_n);
-        let g_k = F::primitive_root_of_unity(log_coset_size);
+        let g_h = F::two_adic_generator(self.log_n);
+        let g_k = F::two_adic_generator(log_coset_size);
 
         let target_point = g_h.exp_u64(i as u64);
         let denominators = cyclic_subgroup_coset_known_order(g_k, self.coset_shift, coset_size)


### PR DESCRIPTION
- `multiplicative_group_generator()` -> `generator()` - it's less clear but "multiplicative group" just seems rather long, particularly if we include it in other methods (`power_of_two_multiplicative_group_generator()`?).

- Remove `power_of_two_generator()` (the one that generates the entire group) - it wasn't used except by the default impl.

- Rename `primitive_root_of_unity()` -> `two_adic_generator()` for consistent terminology.