### PR TITLE
Finish `MerkleMMCS` Implementation

### DIFF
--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -11,7 +11,7 @@ use p3_matrix::{Dimensions, Matrix, MatrixRows};
 /// When a particular row index is opened, it is interpreted directly as a row index for matrices
 /// with the largest height. For matrices with smaller heights, some bits of the row index are
 /// removed (from the least-significant side) to get the effective row index. These semantics are
-/// useful in the FRI protocol.
+/// useful in the FRI protocol. See the documentation for `open_batch` for more details.
 ///
 /// The `DirectMmcs` sub-trait represents an MMS which can be directly constructed from a set of
 /// matrices. Other MMCSs may be virtual combinations of child MMCSs, or may be constructed in a
@@ -27,7 +27,7 @@ pub trait Mmcs<T>: Clone {
 
     /// Opens a batch of rows from committed matrices
     /// returns (openings, proof)
-    /// where `openings` is a vector whose ith element is the jth row of the ith matrix's `M[i]`,
+    /// where `openings` is a vector whose ith element is the jth row of the ith matrix `M[i]`,
     /// and `j = index >> (log2_ceil(max_height) - log2_ceil(M[i].height))`.
     fn open_batch(
         &self,
@@ -56,7 +56,8 @@ pub trait Mmcs<T>: Clone {
     /// Verify a batch opening.
     /// `index` is the row index we're opening for each matrix, following the same
     /// semantics as `open_batch`.
-    /// `dimensions` is the dimensions of each matrix.
+    /// `dimensions` is a slice whose ith element is the dimensions of the the matrix being opened
+    /// in the ith opening
     fn verify_batch(
         &self,
         commit: &Self::Commitment,

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -25,6 +25,10 @@ pub trait Mmcs<T>: Clone {
     where
         Self: 'a;
 
+    /// Opens a batch of rows from committed matrices
+    /// returns (openings, proof)
+    /// where `openings` is a vector whose ith element is the jth row of the ith matrix's `M[i]`,
+    /// and `j = index >> (log2_ceil(max_height) - log2_ceil(M[i].height))`.
     fn open_batch(
         &self,
         index: usize,
@@ -50,12 +54,15 @@ pub trait Mmcs<T>: Clone {
     }
 
     /// Verify a batch opening.
+    /// `index` is the row index we're opening for each matrix, following the same
+    /// semantics as `open_batch`.
+    /// `dimensions` is the dimensions of each matrix.
     fn verify_batch(
         &self,
         commit: &Self::Commitment,
         dimensions: &[Dimensions],
         index: usize,
-        opened_values: Vec<Vec<T>>,
+        opened_values: &[Vec<T>],
         proof: &Self::Proof,
     ) -> Result<(), Self::Error>;
 }

--- a/ldt/src/quotient.rs
+++ b/ldt/src/quotient.rs
@@ -126,33 +126,31 @@ where
             .max()
             .unwrap();
 
-        let opened_original_values: Vec<Vec<F>> =
-            izip!(opened_quotient_values, &self.openings, dimensions)
-                .map(|(quotient_row, openings, dims)| {
-                    let log_height = log2_strict_usize(dims.height);
-                    let bits_reduced = log_max_height - log_height;
-                    let reduced_index = index >> bits_reduced;
-                    let x = F::two_adic_generator(log_height).exp_u64(reduced_index as u64);
+        let opened_original_values = izip!(opened_quotient_values, &self.openings, dimensions)
+            .map(|(quotient_row, openings, dims)| {
+                let log_height = log2_strict_usize(dims.height);
+                let bits_reduced = log_max_height - log_height;
+                let reduced_index = index >> bits_reduced;
+                let x = F::two_adic_generator(log_height).exp_u64(reduced_index as u64);
 
-                    let original_width = quotient_row.len() / openings.len();
-                    let original_row_repeated: Vec<Vec<EF>> = quotient_row
-                        .chunks(original_width)
-                        .zip(openings)
-                        .map(|(quotient_row_chunk, opening)| {
-                            quotient_row_chunk
-                                .iter()
-                                .zip(&opening.values)
-                                .map(|(&quotient_value, &opened_value)| {
-                                    quotient_value * (EF::from_base(x) - opening.point)
-                                        + opened_value
-                                })
-                                .collect_vec()
-                        })
-                        .collect_vec();
-                    let original_row = get_repeated(original_row_repeated.into_iter());
-                    to_base::<F, EF>(original_row)
-                })
-                .collect();
+                let original_width = quotient_row.len() / openings.len();
+                let original_row_repeated: Vec<Vec<EF>> = quotient_row
+                    .chunks(original_width)
+                    .zip(openings)
+                    .map(|(quotient_row_chunk, opening)| {
+                        quotient_row_chunk
+                            .iter()
+                            .zip(&opening.values)
+                            .map(|(&quotient_value, &opened_value)| {
+                                quotient_value * (EF::from_base(x) - opening.point) + opened_value
+                            })
+                            .collect_vec()
+                    })
+                    .collect_vec();
+                let original_row = get_repeated(original_row_repeated.into_iter());
+                to_base::<F, EF>(original_row)
+            })
+            .collect_vec();
 
         self.inner
             .verify_batch(commit, dimensions, index, &opened_original_values, proof)

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -300,7 +300,8 @@ mod tests {
     use itertools::Itertools;
     use p3_commit::{DirectMmcs, Mmcs};
     use p3_keccak::{Keccak256Hash, KeccakF};
-    use p3_matrix::{dense::RowMajorMatrix, Dimensions, Matrix};
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_matrix::{Dimensions, Matrix};
     use p3_symmetric::compression::TruncatedPermutation;
     use rand::thread_rng;
 

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -40,12 +40,16 @@ impl<L, D> MerkleTree<L, D> {
         assert!(!leaves.is_empty(), "No matrices given?");
 
         // check height property
-        assert!(leaves.iter().map(|m| m.height()).sorted_by_key(|&h| Reverse(h))
-            .tuple_windows()
-            .all(|(curr, next)| curr == next || curr.next_power_of_two() != next.next_power_of_two()),
+        assert!(
+            leaves
+                .iter()
+                .map(|m| m.height())
+                .sorted_by_key(|&h| Reverse(h))
+                .tuple_windows()
+                .all(|(curr, next)| curr == next
+                    || curr.next_power_of_two() != next.next_power_of_two()),
             "matrix heights that round up to the same power of two must be equal"
         );
-
 
         let mut leaves_largest_first = leaves
             .iter()
@@ -390,7 +394,7 @@ mod tests {
         let mmcs = Mmcs::new(Keccak256Hash, compress);
 
         // 4 8x1 matrixes, 4 8x2 matrixes
-        let large_mats = (0..4).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 8, 1)); 
+        let large_mats = (0..4).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 8, 1));
         let large_mat_dims = (0..4).map(|_| Dimensions {
             height: 8,
             width: 1,
@@ -401,24 +405,19 @@ mod tests {
             width: 2,
         });
 
-        let (commit, prover_data) = mmcs.commit(
-            large_mats
-                .chain(small_mats)
-                .collect_vec(),
-        );
+        let (commit, prover_data) = mmcs.commit(large_mats.chain(small_mats).collect_vec());
 
         // open the 3rd row of each matrix, mess with proof, and verify
         let (opened_values, mut proof) = mmcs.open_batch(3, &prover_data);
         proof[0][0] ^= 1;
         mmcs.verify_batch(
             &commit,
-            &large_mat_dims
-                .chain(small_mat_dims)
-                .collect_vec(),
+            &large_mat_dims.chain(small_mat_dims).collect_vec(),
             3,
             &opened_values,
             &proof,
-        ).expect_err("expected verification to fail");
+        )
+        .expect_err("expected verification to fail");
     }
 
     #[test]
@@ -480,7 +479,7 @@ mod tests {
         type Mmcs = MerkleTreeMmcs<u8, [u8; 32], Keccak256Hash, C>;
         let mmcs = Mmcs::new(Keccak256Hash, compress);
 
-        // 10 mats with 32 rows where the ith mat has i + 1 cols 
+        // 10 mats with 32 rows where the ith mat has i + 1 cols
         let mats = (0..10)
             .map(|i| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 32, i + 1))
             .collect_vec();
@@ -488,12 +487,7 @@ mod tests {
 
         let (commit, prover_data) = mmcs.commit(mats);
         let (opened_values, proof) = mmcs.open_batch(17, &prover_data);
-        mmcs.verify_batch(
-            &commit,
-            &dims,
-            17,
-            &opened_values,
-            &proof,
-        ).expect("expected verification to succeed");
+        mmcs.verify_batch(&commit, &dims, 17, &opened_values, &proof)
+            .expect("expected verification to succeed");
     }
 }

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -191,9 +191,7 @@ where
         let max_height = self.get_max_height(prover_data);
         let log_max_height = log2_ceil_usize(max_height);
 
-        // get the the `j`th row of each matrix `M[i]`,
-        // where `j = index >> (log2_ceil(max_height) - log2_ceil(M[i].height))`.
-        let openings: Vec<Vec<L>> = prover_data
+        let openings = prover_data
             .leaves
             .iter()
             .map(|matrix| {
@@ -202,7 +200,7 @@ where
                 let reduced_index = index >> bits_reduced;
                 matrix.row(reduced_index).collect()
             })
-            .collect();
+            .collect_vec();
 
         let proof = (0..log_max_height)
             .map(|i| prover_data.digest_layers[i][(index >> i) ^ 1])
@@ -238,6 +236,7 @@ where
             .1
             .height
             .next_power_of_two();
+
         let mut root = self.hash.hash_iter_slices(
             heights_tallest_first
                 .peeking_take_while(|(_, dims)| {
@@ -245,6 +244,7 @@ where
                 })
                 .map(|(i, _)| opened_values[i].as_slice()),
         );
+
         for &sibling in proof.iter() {
             let (left, right) = if index & 1 == 0 {
                 (root, sibling)
@@ -352,7 +352,7 @@ mod tests {
         type Mmcs = MerkleTreeMmcs<u8, [u8; 32], Keccak256Hash, C>;
         let mmcs = Mmcs::new(Keccak256Hash, compress);
 
-        // attempt to commit to a mat with 8 rows and a mat with 7 rows. this should panic
+        // attempt to commit to a mat with 8 rows and a mat with 7 rows. this should panic.
         let large_mat = RowMajorMatrix::new(vec![1, 2, 3, 4, 5, 6, 7, 8], 1);
         let small_mat = RowMajorMatrix::new(vec![1, 2, 3, 4, 5, 6, 7], 1);
         let _ = mmcs.commit(vec![large_mat, small_mat]);

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -408,7 +408,7 @@ mod tests {
 
         let (commit, prover_data) = mmcs.commit(large_mats.chain(small_mats).collect_vec());
 
-        // open the 3rd row of each matrix, hit proof with a gamma ray, and verify
+        // open the 3rd row of each matrix, mess with proof, and verify
         let (opened_values, mut proof) = mmcs.open_batch(3, &prover_data);
         proof[0][0] ^= 1;
         mmcs.verify_batch(
@@ -429,17 +429,17 @@ mod tests {
         type Mmcs = MerkleTreeMmcs<u8, [u8; 32], Keccak256Hash, C>;
         let mmcs = Mmcs::new(Keccak256Hash, compress);
 
-        // 4 mats with 1024 rows, 8 columns
-        let large_mats = (0..4).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 1024, 8));
+        // 4 mats with 1000 rows, 8 columns
+        let large_mats = (0..4).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 1000, 8));
         let large_mat_dims = (0..4).map(|_| Dimensions {
-            height: 1024,
+            height: 1000,
             width: 8,
         });
 
-        // 5 mats with 64 rows, 8 columns
-        let medium_mats = (0..5).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 64, 8));
+        // 5 mats with 70 rows, 8 columns
+        let medium_mats = (0..5).map(|_| RowMajorMatrix::<u8>::rand(&mut thread_rng(), 70, 8));
         let medium_mat_dims = (0..5).map(|_| Dimensions {
-            height: 64,
+            height: 70,
             width: 8,
         });
 

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 extern crate alloc;
 
 use alloc::vec;
@@ -44,7 +45,7 @@ impl<L, D> MerkleTree<L, D> {
             leaves
                 .iter()
                 .map(|m| m.height())
-                .sorted_by_key(|&h| Reverse(h))
+                .sorted()
                 .tuple_windows()
                 .all(|(curr, next)| curr == next
                     || curr.next_power_of_two() != next.next_power_of_two()),

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -205,7 +205,7 @@ where
             .collect();
 
         let proof = (0..log_max_height)
-            .map(|i| prover_data.digest_layers[i][(index >> i) ^ 1].clone())
+            .map(|i| prover_data.digest_layers[i][(index >> i) ^ 1])
             .collect();
 
         (openings, proof)


### PR DESCRIPTION
Addresses #70.

Summary of changes:
- added doc comments to `MMCS` interface
- changed `verify_batch` function signature to take a slice instead of an owned `Vec` (discussed with @dlubarov offline)
- added `PartialEq` bound for `D` in `MerkleMMCS` (needed to check roots match in `verify_batch`)
- made bounds consistent for `D` between `MerkleMMCS`, `MerkleTree`, and impls
- finished implementation of `open_batch`
- finished implementation of `verify_batch`
- added height property check to `MerkleTree::new`
- added more tests to `MerkleMMCS`