### PR TITLE
add benchmark for `fold_even_odd`

### DIFF
--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -14,3 +14,14 @@ p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-util = { path = "../util" }
 itertools = "0.11.0"
 tracing = "0.1.37"
+
+[dev-dependencies]
+p3-baby-bear = { path = "../baby-bear" }
+p3-goldilocks = { path = "../goldilocks" }
+p3-mersenne-31 = { path = "../mersenne-31" }
+criterion = "0.5.1"
+rand = "0.8.5"
+
+[[bench]]
+name = "fold_even_odd"
+harness = false

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use itertools::Itertools;
 use p3_baby_bear::BabyBear;
@@ -5,11 +7,8 @@ use p3_field::TwoAdicField;
 use p3_fri::fold_even_odd;
 use p3_goldilocks::Goldilocks;
 use p3_mersenne_31::{Mersenne31, Mersenne31Complex};
-use rand::{
-    distributions::{Distribution, Standard},
-    thread_rng, Rng,
-};
-use std::any::type_name;
+use rand::distributions::{Distribution, Standard};
+use rand::{thread_rng, Rng};
 
 fn bench<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize])
 where

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -1,0 +1,46 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use itertools::Itertools;
+use p3_baby_bear::BabyBear;
+use p3_field::TwoAdicField;
+use p3_fri::fold_even_odd;
+use p3_goldilocks::Goldilocks;
+use p3_mersenne_31::{Mersenne31, Mersenne31Complex};
+use rand::{
+    distributions::{Distribution, Standard},
+    thread_rng, Rng,
+};
+use std::any::type_name;
+
+fn bench<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize])
+where
+    Standard: Distribution<F>,
+{
+    let name = format!("fold_even_odd::<{}>", type_name::<F>(),);
+    let mut group = c.benchmark_group(&name);
+    group.sample_size(10);
+
+    for log_size in log_sizes {
+        let n = 1 << log_size;
+
+        let mut rng = thread_rng();
+        let beta = rng.sample(Standard);
+        let poly = rng.sample_iter(Standard).take(n).collect_vec();
+
+        group.bench_function(BenchmarkId::from_parameter(n), |b| {
+            b.iter(|| {
+                fold_even_odd(&poly, beta);
+            })
+        });
+    }
+}
+
+fn bench_fold_even_odd(c: &mut Criterion) {
+    let log_sizes = [12, 14, 16, 18, 20, 22];
+
+    bench::<BabyBear>(c, &log_sizes);
+    bench::<Goldilocks>(c, &log_sizes);
+    bench::<Mersenne31Complex<Mersenne31>>(c, &log_sizes);
+}
+
+criterion_group!(benches, bench_fold_even_odd);
+criterion_main!(benches);

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 /// p_even(x) + beta p_odd(x)
 /// ```
 #[instrument(skip_all, level = "debug")]
-pub(crate) fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
+pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     // We use the fact that
     //     p_e(x^2) = (p(x) + p(-x)) / 2
     //     p_o(x^2) = (p(x) - p(-x)) / (2 x)

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -17,7 +17,7 @@ mod prover;
 mod verifier;
 
 pub use config::*;
-pub use fold_even_odd::fold_even_odd;
+pub use fold_even_odd::*;
 pub use proof::*;
 
 pub struct FriLdt<FC: FriConfig> {

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -17,6 +17,7 @@ mod prover;
 mod verifier;
 
 pub use config::*;
+pub use fold_even_odd::fold_even_odd;
 pub use proof::*;
 
 pub struct FriLdt<FC: FriConfig> {


### PR DESCRIPTION
addresses #140

summary of changes:
- make `fold_even_odd` `pub` (needed for bench)
- added benchmark for `fold_even_odd`.