### PR TITLE
Further generalize permutations

### DIFF
--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -43,7 +43,7 @@ where
     let half_num_full_rounds = 4;
     let num_partial_rounds = 22;
 
-    let poseidon = Poseidon::<AF, Mds, WIDTH, ALPHA>::new_from_rng(
+    let poseidon = Poseidon::<AF::F, Mds, WIDTH, ALPHA>::new_from_rng(
         half_num_full_rounds,
         num_partial_rounds,
         mds,

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -15,21 +15,16 @@ use rand::Rng;
 
 /// The Poseidon permutation.
 #[derive(Clone)]
-pub struct Poseidon<AF, Mds, const WIDTH: usize, const ALPHA: u64>
-where
-    AF: AbstractField,
-    Mds: MdsPermutation<AF, WIDTH>,
-{
+pub struct Poseidon<F, Mds, const WIDTH: usize, const ALPHA: u64> {
     half_num_full_rounds: usize,
     num_partial_rounds: usize,
-    constants: Vec<AF::F>,
+    constants: Vec<F>,
     mds: Mds,
 }
 
-impl<AF, Mds, const WIDTH: usize, const ALPHA: u64> Poseidon<AF, Mds, WIDTH, ALPHA>
+impl<F, Mds, const WIDTH: usize, const ALPHA: u64> Poseidon<F, Mds, WIDTH, ALPHA>
 where
-    AF: AbstractField,
-    Mds: MdsPermutation<AF, WIDTH>,
+    F: PrimeField,
 {
     /// Create a new Poseidon configuration.
     ///
@@ -38,7 +33,7 @@ where
     pub fn new(
         half_num_full_rounds: usize,
         num_partial_rounds: usize,
-        constants: Vec<AF::F>,
+        constants: Vec<F>,
         mds: Mds,
     ) -> Self {
         let num_rounds = 2 * half_num_full_rounds + num_partial_rounds;
@@ -58,7 +53,7 @@ where
         rng: &mut R,
     ) -> Self
     where
-        Standard: Distribution<AF::F>,
+        Standard: Distribution<F>,
     {
         let num_rounds = 2 * half_num_full_rounds + num_partial_rounds;
         let num_constants = WIDTH * num_rounds;
@@ -74,7 +69,11 @@ where
         }
     }
 
-    fn half_full_rounds(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize) {
+    fn half_full_rounds<AF>(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize)
+    where
+        AF: AbstractField<F = F>,
+        Mds: MdsPermutation<AF, WIDTH>,
+    {
         for _ in 0..self.half_num_full_rounds {
             self.constant_layer(state, *round_ctr);
             Self::full_sbox_layer(state);
@@ -83,7 +82,11 @@ where
         }
     }
 
-    fn partial_rounds(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize) {
+    fn partial_rounds<AF>(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize)
+    where
+        AF: AbstractField<F = F>,
+        Mds: MdsPermutation<AF, WIDTH>,
+    {
         for _ in 0..self.num_partial_rounds {
             self.constant_layer(state, *round_ctr);
             Self::partial_sbox_layer(state);
@@ -92,17 +95,26 @@ where
         }
     }
 
-    fn full_sbox_layer(state: &mut [AF; WIDTH]) {
+    fn full_sbox_layer<AF>(state: &mut [AF; WIDTH])
+    where
+        AF: AbstractField<F = F>,
+    {
         for x in state.iter_mut() {
             *x = x.exp_const_u64::<ALPHA>();
         }
     }
 
-    fn partial_sbox_layer(state: &mut [AF; WIDTH]) {
+    fn partial_sbox_layer<AF>(state: &mut [AF; WIDTH])
+    where
+        AF: AbstractField<F = F>,
+    {
         state[0] = state[0].exp_const_u64::<ALPHA>();
     }
 
-    fn constant_layer(&self, state: &mut [AF; WIDTH], round: usize) {
+    fn constant_layer<AF>(&self, state: &mut [AF; WIDTH], round: usize)
+    where
+        AF: AbstractField<F = F>,
+    {
         for (i, x) in state.iter_mut().enumerate() {
             *x += self.constants[round * WIDTH + i];
         }
@@ -110,7 +122,7 @@ where
 }
 
 impl<AF, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[AF; WIDTH]>
-    for Poseidon<AF, Mds, WIDTH, ALPHA>
+    for Poseidon<AF::F, Mds, WIDTH, ALPHA>
 where
     AF: AbstractField,
     AF::F: PrimeField,
@@ -125,7 +137,7 @@ where
 }
 
 impl<AF, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[AF; WIDTH]>
-    for Poseidon<AF, Mds, WIDTH, ALPHA>
+    for Poseidon<AF::F, Mds, WIDTH, ALPHA>
 where
     AF: AbstractField,
     AF::F: PrimeField,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -16,7 +16,7 @@ use alloc::vec::Vec;
 pub use babybear::DiffusionMatrixBabybear;
 pub use diffusion::DiffusionPermutation;
 pub use goldilocks::DiffusionMatrixGoldilocks;
-use p3_field::AbstractField;
+use p3_field::{AbstractField, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::permutation::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -27,12 +27,7 @@ const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
 
 /// The Poseidon2 permutation.
 #[derive(Clone)]
-pub struct Poseidon2<AF, Mds, Diffusion, const WIDTH: usize, const D: u64>
-where
-    AF: AbstractField,
-    Mds: MdsPermutation<AF, WIDTH>,
-    Diffusion: DiffusionPermutation<AF, WIDTH>,
-{
+pub struct Poseidon2<F, Mds, Diffusion, const WIDTH: usize, const D: u64> {
     /// The number of external rounds.
     rounds_f: usize,
 
@@ -40,7 +35,7 @@ where
     rounds_p: usize,
 
     /// The round constants.
-    constants: Vec<[AF::F; WIDTH]>,
+    constants: Vec<[F; WIDTH]>,
 
     /// The linear layer used in external rounds.
     external_linear_layer: Mds,
@@ -49,17 +44,18 @@ where
     internal_linear_layer: Diffusion,
 }
 
-impl<AF, Mds, Diffusion, const WIDTH: usize, const D: u64> Poseidon2<AF, Mds, Diffusion, WIDTH, D>
+impl<F, Mds, Diffusion, const WIDTH: usize, const D: u64> Poseidon2<F, Mds, Diffusion, WIDTH, D>
 where
-    AF: AbstractField,
-    Mds: MdsPermutation<AF, WIDTH>,
-    Diffusion: DiffusionPermutation<AF, WIDTH>,
+    F: PrimeField,
+    // AF: AbstractField,
+    // Mds: MdsPermutation<AF, WIDTH>,
+    // Diffusion: DiffusionPermutation<AF, WIDTH>,
 {
     /// Create a new Poseidon2 configuration.
     pub fn new(
         rounds_f: usize,
         rounds_p: usize,
-        constants: Vec<[AF::F; WIDTH]>,
+        constants: Vec<[F; WIDTH]>,
         external_linear_layer: Mds,
         internal_linear_layer: Diffusion,
     ) -> Self {
@@ -82,12 +78,12 @@ where
         rng: &mut R,
     ) -> Self
     where
-        Standard: Distribution<AF::F>,
+        Standard: Distribution<F>,
     {
         let mut constants = Vec::new();
         let rounds = rounds_f + rounds_p;
         for _ in 0..rounds {
-            constants.push(rng.gen::<[AF::F; WIDTH]>());
+            constants.push(rng.gen::<[F; WIDTH]>());
         }
 
         Self {
@@ -100,25 +96,35 @@ where
     }
 
     #[inline]
-    fn add_rc(&self, state: &mut [AF; WIDTH], rc: &[AF::F; WIDTH]) {
+    fn add_rc<AF>(&self, state: &mut [AF; WIDTH], rc: &[AF::F; WIDTH])
+    where
+        AF: AbstractField<F = F>,
+    {
         state.iter_mut().zip(rc).for_each(|(a, b)| *a += *b);
     }
 
     #[inline]
-    fn sbox_p(&self, input: &AF) -> AF {
+    fn sbox_p<AF>(&self, input: &AF) -> AF
+    where
+        AF: AbstractField<F = F>,
+    {
         input.exp_const_u64::<D>()
     }
 
     #[inline]
-    fn sbox(&self, state: &mut [AF; WIDTH]) {
+    fn sbox<AF>(&self, state: &mut [AF; WIDTH])
+    where
+        AF: AbstractField<F = F>,
+    {
         state.iter_mut().for_each(|a| *a = self.sbox_p(a));
     }
 }
 
 impl<AF, Mds, Diffusion, const WIDTH: usize, const D: u64> Permutation<[AF; WIDTH]>
-    for Poseidon2<AF, Mds, Diffusion, WIDTH, D>
+    for Poseidon2<AF::F, Mds, Diffusion, WIDTH, D>
 where
     AF: AbstractField,
+    AF::F: PrimeField,
     Mds: MdsPermutation<AF, WIDTH>,
     Diffusion: DiffusionPermutation<AF, WIDTH>,
 {
@@ -153,9 +159,10 @@ where
 }
 
 impl<AF, Mds, Diffusion, const WIDTH: usize, const D: u64> CryptographicPermutation<[AF; WIDTH]>
-    for Poseidon2<AF, Mds, Diffusion, WIDTH, D>
+    for Poseidon2<AF::F, Mds, Diffusion, WIDTH, D>
 where
     AF: AbstractField,
+    AF::F: PrimeField,
     Mds: MdsPermutation<AF, WIDTH>,
     Diffusion: DiffusionPermutation<AF, WIDTH>,
 {

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -46,7 +46,7 @@ where
     let round_constants = rng.sample_iter(Standard).take(num_constants).collect();
     let mds = Mds::default();
     let isl = Sbox::default();
-    let rescue = Rescue::<AF, Mds, Sbox, WIDTH>::new(NUM_ROUNDS, round_constants, mds, isl);
+    let rescue = Rescue::<AF::F, Mds, Sbox, WIDTH>::new(NUM_ROUNDS, round_constants, mds, isl);
     let input = [AF::ZERO; WIDTH];
     let name = format!("rescue::<{}, {}>", type_name::<AF>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);


### PR DESCRIPTION
So a particular permutation struct type is not tied to a particular `AbstractField`, only the underlying concrete field. This lets a single permutation object impl e.g. `CryptographicPermutation<F::Packing>` as well as `CryptographicPermutation<F>` simultaneously.