### PR TITLE
Make clippy even happier

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -192,6 +192,8 @@ pub trait PrimeField64: PrimeField {
     const ORDER_U64: u64;
 
     // TODO: Move to Field itself? Limiting it to `PrimeField64` seems unusual.
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     fn bits() -> usize {
         log2_ceil_u64(Self::ORDER_U64) as usize
     }
@@ -266,7 +268,7 @@ pub trait AbstractExtensionField<Base: AbstractField>:
 
 pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base, F = Self> {
     fn is_in_basefield(&self) -> bool {
-        self.as_base_slice()[1..].iter().all(|x| x.is_zero())
+        self.as_base_slice()[1..].iter().all(Field::is_zero)
     }
 }
 

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -31,6 +31,7 @@ pub fn cyclic_subgroup_coset_known_order<F: Field>(
     cyclic_subgroup_known_order(generator, order).map(move |x| x * shift)
 }
 
+#[must_use]
 pub fn add_vecs<F: Field>(v: Vec<F>, w: Vec<F>) -> Vec<F> {
     assert_eq!(v.len(), w.len());
     v.into_iter().zip(w).map(|(x, y)| x + y).collect()

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -16,8 +16,9 @@ pub fn log2_ceil_usize(n: usize) -> usize {
     (usize::BITS - n.saturating_sub(1).leading_zeros()) as usize
 }
 
+#[must_use]
 pub fn log2_ceil_u64(n: u64) -> u64 {
-    (u64::BITS - n.saturating_sub(1).leading_zeros()) as u64
+    (u64::BITS - n.saturating_sub(1).leading_zeros()).into()
 }
 
 /// Computes `log_2(n)`
@@ -33,6 +34,7 @@ pub fn log2_strict_usize(n: usize) -> usize {
 }
 
 /// Returns `[0, ..., N - 1]`.
+#[must_use]
 pub const fn indices_arr<const N: usize>() -> [usize; N] {
     let mut indices_arr = [0; N];
     let mut i = 0;


### PR DESCRIPTION
Some simple fixes to some of clippy's more stringent demands (not currently enforced by CI, but still a good idea).

I wanted to add those to https://github.com/Plonky3/Plonky3/pull/145 but you were faster than me.

I'm using the following command to get some more hints from clippy:

```bash
cargo clippy --all-features --all-targets -- \
    -D warnings \
    -D clippy::pedantic \
    -A clippy::inline-always \
    -A clippy::similar-names \
    -A clippy::module-name-repetitions \
    -A clippy::missing-errors-doc \
    -A clippy::missing-panics-doc
```