### PR TITLE
Use link-time-optimization to increase performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ members = [
     "util",
     "uni-stark",
 ]
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
When I run `cargo bench` times drop between 0 to 50% in the different benchmarks with `lto = "fat"` on my computer at the cost of longer build times.

As a compromise, you can also try `lto = "thin"` for almost the same speedup at neglible increase in build times.