### PR TITLE
test: adds a simple testing suite to the brakedown crate

### DIFF
--- a/brakedown/src/brakedown_code.rs
+++ b/brakedown/src/brakedown_code.rs
@@ -116,9 +116,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
-
-    use p3_field::AbstractField;
     use p3_matrix::Matrix;
     use p3_mersenne_31::Mersenne31;
     use rand::SeedableRng;
@@ -141,18 +138,6 @@ mod tests {
                 - <BrakedownCode<F, _> as Code<F, Mat>>::message_len(&brakedown.inner_code)
         );
         assert_eq!(brakedown.v_len(), 60);
-    }
-
-    #[test]
-    fn test_brakedown_code_or_family_impl() {
-        let brakedown = brakedown!(1, 1, 1, 1, 1, 1, brakedown_to_rs!(1, 1, 1, 1, 1, 1));
-        let messages = RowMajorMatrix::new(
-            (0..10)
-                .map(|u| F::from_canonical_u16(u))
-                .collect::<Vec<_>>(),
-            10,
-        );
-        <BrakedownCode<F, _> as CodeOrFamily<F, Mat>>::encode_batch(&brakedown, messages);
     }
 
     #[test]

--- a/brakedown/src/brakedown_code.rs
+++ b/brakedown/src/brakedown_code.rs
@@ -113,3 +113,68 @@ where
     In: MatrixRows<F> + Sync,
 {
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use p3_field::AbstractField;
+    use p3_matrix::Matrix;
+    use p3_mersenne_31::Mersenne31;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    use super::*;
+    use crate::macros::{brakedown, brakedown_to_rs};
+
+    type F = Mersenne31;
+    type Mat = RowMajorMatrix<F>;
+
+    #[test]
+    fn test_brakedown_methods() {
+        let brakedown = brakedown!(237, 29, 11, 41, 60, 15, brakedown_to_rs!(29, 4, 0, 5, 7, 0));
+
+        assert_eq!(brakedown.y_len(), 29);
+        assert_eq!(
+            brakedown.z_parity_len(),
+            <BrakedownCode<F, _> as Code<F, Mat>>::codeword_len(&brakedown.inner_code)
+                - <BrakedownCode<F, _> as Code<F, Mat>>::message_len(&brakedown.inner_code)
+        );
+        assert_eq!(brakedown.v_len(), 60);
+    }
+
+    #[test]
+    fn test_brakedown_code_or_family_impl() {
+        let brakedown = brakedown!(1, 1, 1, 1, 1, 1, brakedown_to_rs!(1, 1, 1, 1, 1, 1));
+        let messages = RowMajorMatrix::new(
+            (0..10)
+                .map(|u| F::from_canonical_u16(u))
+                .collect::<Vec<_>>(),
+            10,
+        );
+        <BrakedownCode<F, _> as CodeOrFamily<F, Mat>>::encode_batch(&brakedown, messages);
+    }
+
+    #[test]
+    fn test_brakedown_systematic_code_impl() {
+        let brakedown = brakedown!(237, 29, 11, 41, 60, 15, brakedown_to_rs!(29, 4, 0, 5, 7, 0));
+        assert_eq!(
+            <BrakedownCode<F, _> as SystematicCode<F, Mat>>::parity_len(&brakedown),
+            brakedown.y_len() + brakedown.z_parity_len() + brakedown.v_len()
+        );
+    }
+
+    #[test]
+    fn test_brakedown_code_impl() {
+        let brakedown = brakedown!(237, 29, 11, 41, 60, 15, brakedown_to_rs!(29, 4, 0, 5, 7, 0));
+        assert_eq!(
+            <BrakedownCode<F, _> as Code<F, Mat>>::message_len(&brakedown),
+            brakedown.a.width()
+        );
+        assert_eq!(
+            <BrakedownCode<F, _> as Code<F, Mat>>::codeword_len(&brakedown),
+            <BrakedownCode<F, _> as Code<F, Mat>>::message_len(&brakedown)
+                + <BrakedownCode<F, _> as SystematicCode<F, Mat>>::parity_len(&brakedown)
+        );
+    }
+}


### PR DESCRIPTION
Not an extensive test cover by any means, I was having certain difficulties in coming up with simple enough tests for the `encode_batch` for `brakedown code`'s. Happy to receive any feedback on how to improve the test suite.