### PR TITLE
feat: parallellize radix2 bowers

### DIFF
--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,8 +1,7 @@
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrixViewMut;
-use p3_matrix::Matrix;
 
-/// DIT butterfly.
+/// DIT butterfly operation on rows.
 #[inline]
 pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
@@ -35,7 +34,7 @@ pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], 
     }
 }
 
-/// DIF butterfly.
+/// DIF butterfly operation on rows.
 #[inline]
 pub(crate) fn dif_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
@@ -65,7 +64,7 @@ pub(crate) fn dif_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], 
     }
 }
 
-/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
+/// Butterfly with twiddle factor 1 on rows (works in either DIT or DIF).
 #[inline]
 pub(crate) fn twiddle_free_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
@@ -124,70 +123,6 @@ pub(crate) fn dit_butterfly<F: Field>(
         let x_2_twiddle = *x_2 * twiddle;
         let sum = *x_1 + x_2_twiddle;
         let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-}
-
-/// DIF butterfly.
-#[inline]
-pub(crate) fn dif_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
-    row_1: usize,
-    row_2: usize,
-    twiddle: F,
-) {
-    debug_assert!(row_1 < mat.height());
-    debug_assert!(row_2 < mat.height());
-
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
-        mat.packing_aligned_rows(row_1, row_2);
-
-    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff * twiddle;
-    }
-    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
-        let sum: F::Packing = *x_1 + *x_2;
-        let diff: F::Packing = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff * twiddle;
-    }
-    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff * twiddle;
-    }
-}
-
-/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
-#[inline]
-pub(crate) fn twiddle_free_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
-    row_1: usize,
-    row_2: usize,
-) {
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
-        mat.packing_aligned_rows(row_1, row_2);
-
-    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
         *x_1 = sum;
         *x_2 = diff;
     }

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,6 +1,6 @@
 use p3_field::Field;
 
-/// DIT butterfly
+/// DIT butterfly.
 #[inline]
 pub(crate) fn dit_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,39 +1,6 @@
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrixViewMut;
 
-/// DIT butterfly operation on rows.
-#[inline]
-pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
-        (
-            row_1.align_to_mut::<F::Packing>(),
-            row_2.align_to_mut::<F::Packing>(),
-        )
-    };
-
-    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-}
-
 /// DIF butterfly operation on rows.
 #[inline]
 pub(crate) fn dif_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
@@ -94,6 +61,20 @@ pub(crate) fn twiddle_free_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &
     }
 }
 
+/// DIT butterfly operation on rows.
+#[inline]
+pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
+        (
+            row_1.align_to_mut::<F::Packing>(),
+            row_2.align_to_mut::<F::Packing>(),
+        )
+    };
+    dit(
+        prefix_1, shorts_1, suffix_1, prefix_2, shorts_2, suffix_2, twiddle,
+    )
+}
+
 /// DIT butterfly.
 #[inline]
 pub(crate) fn dit_butterfly<F: Field>(
@@ -104,7 +85,20 @@ pub(crate) fn dit_butterfly<F: Field>(
 ) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
         mat.packing_aligned_rows(row_1, row_2);
+    dit(
+        prefix_1, shorts_1, suffix_1, prefix_2, shorts_2, suffix_2, twiddle,
+    )
+}
 
+fn dit<F: Field>(
+    prefix_1: &mut [F],
+    shorts_1: &mut [<F as Field>::Packing],
+    suffix_1: &mut [F],
+    prefix_2: &mut [F],
+    shorts_2: &mut [<F as Field>::Packing],
+    suffix_2: &mut [F],
+    twiddle: F,
+) {
     for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
         let x_2_twiddle = *x_2 * twiddle;
         let sum = *x_1 + x_2_twiddle;

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,43 +1,8 @@
 use p3_field::Field;
-use p3_matrix::dense::RowMajorMatrixViewMut;
-use p3_matrix::Matrix;
 
-/// DIT butterfly.
+/// DIT butterfly
 #[inline]
-pub(crate) fn dit_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
-    row_1: usize,
-    row_2: usize,
-    twiddle: F,
-) {
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
-        mat.packing_aligned_rows(row_1, row_2);
-
-    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
-        let x_2_twiddle = *x_2 * twiddle;
-        let sum = *x_1 + x_2_twiddle;
-        let diff = *x_1 - x_2_twiddle;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-}
-
-#[inline]
-pub(crate) fn dit_butterfly_2<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+pub(crate) fn dit_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
         (
             row_1.align_to_mut::<F::Packing>(),
@@ -70,17 +35,13 @@ pub(crate) fn dit_butterfly_2<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddl
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
-    row_1: usize,
-    row_2: usize,
-    twiddle: F,
-) {
-    debug_assert!(row_1 < mat.height());
-    debug_assert!(row_2 < mat.height());
-
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
-        mat.packing_aligned_rows(row_1, row_2);
+pub(crate) fn dif_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
+        (
+            row_1.align_to_mut::<F::Packing>(),
+            row_2.align_to_mut::<F::Packing>(),
+        )
+    };
 
     for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
         let sum = *x_1 + *x_2;
@@ -104,37 +65,7 @@ pub(crate) fn dif_butterfly<F: Field>(
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-pub(crate) fn twiddle_free_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
-    row_1: usize,
-    row_2: usize,
-) {
-    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
-        mat.packing_aligned_rows(row_1, row_2);
-
-    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
-        let sum = *x_1 + *x_2;
-        let diff = *x_1 - *x_2;
-        *x_1 = sum;
-        *x_2 = diff;
-    }
-}
-
-/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
-#[inline]
-pub(crate) fn twiddle_free_butterfly_2<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
+pub(crate) fn twiddle_free_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
         (
             row_1.align_to_mut::<F::Packing>(),

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -36,6 +36,38 @@ pub(crate) fn dit_butterfly<F: Field>(
     }
 }
 
+#[inline]
+pub(crate) fn dit_butterfly_2<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
+        (
+            row_1.align_to_mut::<F::Packing>(),
+            row_2.align_to_mut::<F::Packing>(),
+        )
+    };
+
+    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+}
+
 /// DIF butterfly.
 #[inline]
 pub(crate) fn dif_butterfly<F: Field>(
@@ -79,6 +111,36 @@ pub(crate) fn twiddle_free_butterfly<F: Field>(
 ) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
         mat.packing_aligned_rows(row_1, row_2);
+
+    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+}
+
+/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
+#[inline]
+pub(crate) fn twiddle_free_butterfly_2<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
+        (
+            row_1.align_to_mut::<F::Packing>(),
+            row_2.align_to_mut::<F::Packing>(),
+        )
+    };
 
     for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
         let sum = *x_1 + *x_2;

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,8 +1,10 @@
 use p3_field::Field;
+use p3_matrix::dense::RowMajorMatrixViewMut;
+use p3_matrix::Matrix;
 
 /// DIT butterfly.
 #[inline]
-pub(crate) fn dit_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
         (
             row_1.align_to_mut::<F::Packing>(),
@@ -35,7 +37,7 @@ pub(crate) fn dit_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle:
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
+pub(crate) fn dif_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle: F) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
         (
             row_1.align_to_mut::<F::Packing>(),
@@ -65,13 +67,111 @@ pub(crate) fn dif_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F], twiddle:
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-pub(crate) fn twiddle_free_butterfly<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
+pub(crate) fn twiddle_free_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F]) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) = unsafe {
         (
             row_1.align_to_mut::<F::Packing>(),
             row_2.align_to_mut::<F::Packing>(),
         )
     };
+
+    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+}
+
+/// DIT butterfly.
+#[inline]
+pub(crate) fn dit_butterfly<F: Field>(
+    mat: &mut RowMajorMatrixViewMut<F>,
+    row_1: usize,
+    row_2: usize,
+    twiddle: F,
+) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
+        mat.packing_aligned_rows(row_1, row_2);
+
+    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
+        let x_2_twiddle = *x_2 * twiddle;
+        let sum = *x_1 + x_2_twiddle;
+        let diff = *x_1 - x_2_twiddle;
+        *x_1 = sum;
+        *x_2 = diff;
+    }
+}
+
+/// DIF butterfly.
+#[inline]
+pub(crate) fn dif_butterfly<F: Field>(
+    mat: &mut RowMajorMatrixViewMut<F>,
+    row_1: usize,
+    row_2: usize,
+    twiddle: F,
+) {
+    debug_assert!(row_1 < mat.height());
+    debug_assert!(row_2 < mat.height());
+
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
+        mat.packing_aligned_rows(row_1, row_2);
+
+    for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff * twiddle;
+    }
+    for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
+        let sum: F::Packing = *x_1 + *x_2;
+        let diff: F::Packing = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff * twiddle;
+    }
+    for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
+        let sum = *x_1 + *x_2;
+        let diff = *x_1 - *x_2;
+        *x_1 = sum;
+        *x_2 = diff * twiddle;
+    }
+}
+
+/// Butterfly with twiddle factor 1 (works in either DIT or DIF).
+#[inline]
+pub(crate) fn twiddle_free_butterfly<F: Field>(
+    mat: &mut RowMajorMatrixViewMut<F>,
+    row_1: usize,
+    row_2: usize,
+) {
+    let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
+        mat.packing_aligned_rows(row_1, row_2);
 
     for (x_1, x_2) in prefix_1.iter_mut().zip(prefix_2) {
         let sum = *x_1 + *x_2;

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -121,22 +121,17 @@ fn bowers_g_layer<F: Field>(
         .enumerate()
         .for_each(|(block, chunks)| {
             let (hi_chunks, lo_chunks) = chunks.split_at_mut(half_block_size * width);
-            if block == 0 {
-                hi_chunks
-                    .par_chunks_exact_mut(width)
-                    .zip(lo_chunks.par_chunks_exact_mut(width))
-                    .for_each(|(hi_chunk, lo_chunk)| {
+            let twiddle = twiddles[block];
+            hi_chunks
+                .par_chunks_exact_mut(width)
+                .zip(lo_chunks.par_chunks_exact_mut(width))
+                .for_each(|(hi_chunk, lo_chunk)| {
+                    if block == 0 {
                         twiddle_free_butterfly_on_rows(hi_chunk, lo_chunk);
-                    });
-            } else {
-                let twiddle = twiddles[block];
-                hi_chunks
-                    .par_chunks_exact_mut(width)
-                    .zip(lo_chunks.par_chunks_exact_mut(width))
-                    .for_each(|(hi_chunk, lo_chunk)| {
-                        dif_butterfly_on_rows(hi_chunk, lo_chunk, twiddle)
-                    });
-            }
+                    } else {
+                        dif_butterfly_on_rows(hi_chunk, lo_chunk, twiddle);
+                    }
+                });
         });
 }
 

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -6,9 +6,7 @@ use p3_matrix::Matrix;
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use p3_util::log2_strict_usize;
 
-use crate::butterflies::{
-    dif_butterfly, dit_butterfly_2, twiddle_free_butterfly, twiddle_free_butterfly_2,
-};
+use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
 use crate::util::{
     bit_reversed_zero_pad, divide_by_height, reverse_bits, reverse_matrix_index_bits,
     reverse_slice_index_bits,
@@ -113,25 +111,31 @@ fn bowers_g_layer<F: Field>(
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
-    let h = mat.height();
-    let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
-    let num_blocks = h >> log_block_size;
+
+    let width = mat.width();
 
     // Unroll first iteration with a twiddle factor of 1.
-    for hi in 0..half_block_size {
-        let lo = hi + half_block_size;
-        twiddle_free_butterfly(mat, hi, lo);
-    }
+    let (hi_chunks, lo_chunks) = mat.values.split_at_mut(half_block_size * width);
+    hi_chunks
+        .par_chunks_exact_mut(width)
+        .zip(lo_chunks[..half_block_size * width].par_chunks_exact_mut(width))
+        .for_each(|(hi_chunk, lo_chunk)| {
+            twiddle_free_butterfly(hi_chunk, lo_chunk);
+        });
 
-    for (block, &twiddle) in (1..num_blocks).zip(&twiddles[1..]) {
-        let block_start = block << log_block_size;
-        for i in 0..half_block_size {
-            let hi = block_start + i;
-            let lo = hi + half_block_size;
-            dif_butterfly(mat, hi, lo, twiddle);
-        }
-    }
+    mat.values
+        .par_chunks_exact_mut(2 * half_block_size * width)
+        .enumerate()
+        .skip(1)
+        .for_each(|(block, chunks)| {
+            let (hi_chunks, lo_chunks) = chunks.split_at_mut(half_block_size * width);
+            let twiddle = twiddles[block];
+            hi_chunks
+                .par_chunks_exact_mut(width)
+                .zip(lo_chunks.par_chunks_exact_mut(width))
+                .for_each(|(hi_chunk, lo_chunk)| dif_butterfly(hi_chunk, lo_chunk, twiddle));
+        });
 }
 
 /// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
@@ -149,7 +153,7 @@ fn bowers_g_t_layer<F: Field>(
         .par_chunks_exact_mut(width)
         .zip(lo_chunks[..half_block_size * width].par_chunks_exact_mut(width))
         .for_each(|(hi_chunk, lo_chunk)| {
-            twiddle_free_butterfly_2(hi_chunk, lo_chunk);
+            twiddle_free_butterfly(hi_chunk, lo_chunk);
         });
 
     mat.values
@@ -162,7 +166,7 @@ fn bowers_g_t_layer<F: Field>(
             hi_chunks
                 .par_chunks_exact_mut(width)
                 .zip(lo_chunks.par_chunks_exact_mut(width))
-                .for_each(|(hi_chunk, lo_chunk)| dit_butterfly_2(hi_chunk, lo_chunk, twiddle));
+                .for_each(|(hi_chunk, lo_chunk)| dit_butterfly(hi_chunk, lo_chunk, twiddle));
         });
 }
 

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -6,7 +6,7 @@ use p3_matrix::Matrix;
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use p3_util::log2_strict_usize;
 
-use crate::butterflies::{dit_butterfly, twiddle_free_butterfly};
+use crate::butterflies::{dit_butterfly_on_rows, twiddle_free_butterfly_on_rows};
 use crate::util::reverse_matrix_index_bits;
 use crate::TwoAdicSubgroupDft;
 
@@ -52,10 +52,10 @@ fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<F>, layer: usize, twiddle
                 .enumerate()
                 .for_each(|(ind, (hi_chunk, lo_chunk))| {
                     if ind == 0 {
-                        twiddle_free_butterfly(hi_chunk, lo_chunk)
+                        twiddle_free_butterfly_on_rows(hi_chunk, lo_chunk)
                     } else {
                         let twiddle = twiddles[ind << layer_rev];
-                        dit_butterfly(hi_chunk, lo_chunk, twiddle)
+                        dit_butterfly_on_rows(hi_chunk, lo_chunk, twiddle)
                     }
                 });
         });

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use p3_field::{Field, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::Matrix;
+use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dit_butterfly, twiddle_free_butterfly};
@@ -39,19 +40,25 @@ fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<F>, layer: usize, twiddle
     let half_block_size = 1 << layer;
     let block_size = half_block_size * 2;
 
-    for j in (0..h).step_by(block_size) {
-        // Unroll i=0 case
-        let butterfly_hi = j;
-        let butterfly_lo = butterfly_hi + half_block_size;
-        twiddle_free_butterfly(mat, butterfly_hi, butterfly_lo);
+    let width = mat.width();
 
-        for i in 1..half_block_size {
-            let butterfly_hi = j + i;
-            let butterfly_lo = butterfly_hi + half_block_size;
-            let twiddle = twiddles[i << layer_rev];
-            dit_butterfly(mat, butterfly_hi, butterfly_lo, twiddle);
-        }
-    }
+    mat.values
+        .par_chunks_exact_mut(block_size * width)
+        .for_each(|block_chunks| {
+            let (hi_chunks, lo_chunks) = block_chunks.split_at_mut(half_block_size * width);
+            hi_chunks
+                .par_chunks_exact_mut(width)
+                .zip(lo_chunks.par_chunks_exact_mut(width))
+                .enumerate()
+                .for_each(|(ind, (hi_chunk, lo_chunk))| {
+                    if ind == 0 {
+                        twiddle_free_butterfly(hi_chunk, lo_chunk)
+                    } else {
+                        let twiddle = twiddles[ind << layer_rev];
+                        dit_butterfly(hi_chunk, lo_chunk, twiddle)
+                    }
+                });
+        });
 }
 
 #[cfg(test)]

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -42,8 +42,7 @@ fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<F>, layer: usize, twiddle
 
     let width = mat.width();
 
-    mat.values
-        .par_chunks_exact_mut(block_size * width)
+    mat.row_chunks_exact_mut(block_size)
         .for_each(|block_chunks| {
             let (hi_chunks, lo_chunks) = block_chunks.split_at_mut(half_block_size * width);
             hi_chunks

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -110,7 +110,7 @@ fn par_dit_layer<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles: &[
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^mid
-    mat.row_chunks_mut(1 << mid).for_each(|mut submat| {
+    mat.par_row_chunks_mut(1 << mid).for_each(|mut submat| {
         for layer in 0..mid {
             dit_layer(&mut submat, log_h, layer, twiddles);
         }
@@ -122,7 +122,7 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^(log_h - mid)
-    mat.row_chunks_mut(1 << (log_h - mid))
+    mat.par_row_chunks_mut(1 << (log_h - mid))
         .enumerate()
         .for_each(|(thread, mut submat)| {
             for layer in mid..log_h {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -293,7 +293,7 @@ impl<'a, T> RowMajorMatrixViewMut<'a, T> {
         self.values.chunks_exact_mut(self.width)
     }
 
-    pub fn par_rows_mut(&mut self) -> impl ParallelIterator<Item = &mut [T]>
+    pub fn par_rows_mut(&mut self) -> p3_maybe_rayon::rayon::slice::ChunksExactMut<'_, T>
     where
         T: Send,
     {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -4,7 +4,6 @@ use core::iter::Cloned;
 use core::slice;
 
 use p3_field::{ExtensionField, Field, PackedField};
-use p3_maybe_rayon::rayon::slice::ChunksExactMut;
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -54,7 +53,7 @@ impl<T> RowMajorMatrix<T> {
         self.values.chunks_exact_mut(self.width)
     }
 
-    pub fn row_chunks_mut(
+    pub fn par_row_chunks_mut(
         &mut self,
         chunk_rows: usize,
     ) -> impl IndexedParallelIterator<Item = RowMajorMatrixViewMut<T>>
@@ -294,14 +293,17 @@ impl<'a, T> RowMajorMatrixViewMut<'a, T> {
         self.values.chunks_exact_mut(self.width)
     }
 
-    pub fn par_rows_mut(&mut self) -> impl ParallelIterator<Item = &mut [T]>
+    pub fn par_rows_mut(&mut self) -> impl IndexedParallelIterator<Item = &mut [T]>
     where
         T: Send,
     {
         self.values.par_chunks_exact_mut(self.width)
     }
 
-    pub fn row_chunks_exact_mut(&mut self, size: usize) -> ChunksExactMut<T>
+    pub fn par_row_chunks_mut(
+        &mut self,
+        size: usize,
+    ) -> impl IndexedParallelIterator<Item = &mut [T]>
     where
         T: Send,
     {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -4,6 +4,7 @@ use core::iter::Cloned;
 use core::slice;
 
 use p3_field::{ExtensionField, Field, PackedField};
+use p3_maybe_rayon::rayon::slice::ChunksExactMut;
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -293,11 +294,18 @@ impl<'a, T> RowMajorMatrixViewMut<'a, T> {
         self.values.chunks_exact_mut(self.width)
     }
 
-    pub fn par_rows_mut(&mut self) -> p3_maybe_rayon::rayon::slice::ChunksExactMut<'_, T>
+    pub fn par_rows_mut(&mut self) -> impl ParallelIterator<Item = &mut [T]>
     where
         T: Send,
     {
         self.values.par_chunks_exact_mut(self.width)
+    }
+
+    pub fn row_chunks_exact_mut(&mut self, size: usize) -> ChunksExactMut<T>
+    where
+        T: Send,
+    {
+        self.values.par_chunks_exact_mut(size * self.width)
     }
 
     pub fn rows(&self) -> impl Iterator<Item = &[T]> {


### PR DESCRIPTION
This PR enhances the performance of DFT radix2 bowers by parallelizing the dit and dif butterfly methods across matrix rows in row-major form. Benchmarks indicate above 3x speed improvements. For instance, 

| Bench Name | Previous Execution Time (ms) | New Execution Time (ms) | Improvement Factor |
|------------|------------------------------|-------------------------|--------------------|
| `fft::<p3_goldilocks::Goldilocks, p3_dft::radix_2_dit::Radix2Dit, 100>/65536` | ~168 | 50.986 | ~3.3x |
| `fft::<p3_baby_bear::baby_bear::BabyBear, p3_dft::radix_2_dit::Radix2Dit, 100>/262144` | ~101 | 50.808 | ~2 |
| `m31_fft::<p3_dft::radix_2_dit::Radix2Dit, 100>/262144` | ~800 | 259.91 | ~3.13 |


However, our methods applied to the logic in `radix_2_dit_parallel.rs` exhibited increased execution times, likely due to parallelization overheads; thus, no refactoring was applied to it.