### PR TITLE
Tweak `Display` impl of `BinomialExtensionField`

### DIFF
--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -43,13 +43,20 @@ mod test_quartic_extension {
 
     #[test]
     fn display() {
-        let x = BinomialExtensionField::<BabyBear, 4>::from_base_slice(&[
-            BabyBear::TWO,
-            BabyBear::ONE,
-            BabyBear::ZERO,
-            BabyBear::TWO,
-        ]);
-        assert_eq!(format!("{}", x), "2 + X + 2 X^3");
+        type F = BabyBear;
+        type EF = BinomialExtensionField<F, 4>;
+
+        assert_eq!(format!("{}", EF::ZERO), "0");
+        assert_eq!(format!("{}", EF::ONE), "1");
+        assert_eq!(format!("{}", EF::TWO), "2");
+
+        assert_eq!(
+            format!(
+                "{}",
+                EF::from_base_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
+            ),
+            "2 + X + 2 X^3"
+        );
     }
 }
 

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -30,15 +30,31 @@ impl BinomiallyExtendable<5> for BabyBear {
 }
 
 #[cfg(test)]
-mod test_quatric_extension {
+mod test_quartic_extension {
+    use alloc::format;
 
+    use p3_field::extension::binomial_extension::BinomialExtensionField;
+    use p3_field::{AbstractExtensionField, AbstractField};
     use p3_field_testing::test_field;
 
+    use crate::BabyBear;
+
     test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,4>);
+
+    #[test]
+    fn display() {
+        let x = BinomialExtensionField::<BabyBear, 4>::from_base_slice(&[
+            BabyBear::TWO,
+            BabyBear::ONE,
+            BabyBear::ZERO,
+            BabyBear::TWO,
+        ]);
+        assert_eq!(format!("{}", x), "2 + X + 2 X^3");
+    }
 }
+
 #[cfg(test)]
 mod test_quintic_extension {
-
     use p3_field_testing::test_field;
 
     test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,5>);

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+extern crate alloc;
+
 mod baby_bear;
 mod extension;
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -1,5 +1,3 @@
-use alloc::format;
-use alloc::string::String;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -169,13 +167,11 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Display for BinomialExtensionField<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let linear_part = format!("{} + {}*X", self.value[0], self.value[1]); // ok, since D >= 2
-        let nonlin_part: String = self.value[2..]
-            .iter()
-            .zip(2..)
-            .map(|(x, i)| format!(" + {x}*X^{i}"))
-            .collect();
-        write!(f, "{}", linear_part + &nonlin_part)
+        write!(f, "{}", self.value[0])?;
+        for (i, x) in self.value.iter().enumerate().skip(1) {
+            write!(f, " + {}*X^{}", x, i + 1)?;
+        }
+        Ok(())
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -170,20 +170,24 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Display for BinomialExtensionField<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let str = self
-            .value
-            .iter()
-            .enumerate()
-            .filter(|(_, x)| !x.is_zero())
-            .map(|(i, x)| match (i, x.is_one()) {
-                (0, _) => format!("{x}"),
-                (1, true) => "X".to_string(),
-                (1, false) => format!("{x} X"),
-                (_, true) => format!("X^{i}"),
-                (_, false) => format!("{x} X^{i}"),
-            })
-            .join(" + ");
-        write!(f, "{}", str)
+        if self.is_zero() {
+            write!(f, "0")
+        } else {
+            let str = self
+                .value
+                .iter()
+                .enumerate()
+                .filter(|(_, x)| !x.is_zero())
+                .map(|(i, x)| match (i, x.is_one()) {
+                    (0, _) => format!("{x}"),
+                    (1, true) => "X".to_string(),
+                    (1, false) => format!("{x} X"),
+                    (_, true) => format!("X^{i}"),
+                    (_, false) => format!("{x} X^{i}"),
+                })
+                .join(" + ");
+            write!(f, "{}", str)
+        }
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -1,7 +1,10 @@
+use alloc::format;
+use alloc::string::ToString;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use itertools::Itertools;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
@@ -167,11 +170,20 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Display for BinomialExtensionField<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value[0])?;
-        for (i, x) in self.value.iter().enumerate().skip(1) {
-            write!(f, " + {}*X^{}", x, i + 1)?;
-        }
-        Ok(())
+        let str = self
+            .value
+            .iter()
+            .enumerate()
+            .filter(|(_, x)| !x.is_zero())
+            .map(|(i, x)| match (i, x.is_one()) {
+                (0, _) => format!("{x}"),
+                (1, true) => "X".to_string(),
+                (1, false) => format!("{x} X"),
+                (_, true) => format!("X^{i}"),
+                (_, false) => format!("{x} X^{i}"),
+            })
+            .join(" + ");
+        write!(f, "{}", str)
     }
 }
 


### PR DESCRIPTION
Clippy didn't like the way it was building up a string.