### PR TITLE
vectorize `fold_even_odd`

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -115,10 +115,7 @@ pub trait AbstractField:
 
     #[must_use]
     fn powers(&self) -> Powers<Self> {
-        Powers {
-            base: self.clone(),
-            current: Self::ONE,
-        }
+        Self::shifted_powers(&self, Self::ONE)
     }
 
     fn shifted_powers(&self, start: Self) -> Powers<Self> {
@@ -129,16 +126,7 @@ pub trait AbstractField:
     }
 
     fn powers_packed<P: PackedField<Scalar = Self>>(&self) -> PackedPowers<Self, P> {
-        let mut current = P::ONE;
-        let slice = current.as_slice_mut();
-        for i in 1..P::WIDTH {
-            slice[i] = slice[i - 1].clone() * self.clone();
-        }
-
-        PackedPowers {
-            multiplier: P::from(self.clone()).exp_u64(P::WIDTH as u64),
-            current,
-        }
+        self.shifted_powers_packed(Self::ONE)
     }
 
     fn shifted_powers_packed<P: PackedField<Scalar = Self>>(

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -115,7 +115,7 @@ pub trait AbstractField:
 
     #[must_use]
     fn powers(&self) -> Powers<Self> {
-        Self::shifted_powers(&self, Self::ONE)
+        self.shifted_powers(Self::ONE)
     }
 
     fn shifted_powers(&self, start: Self) -> Powers<Self> {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -121,10 +121,16 @@ pub trait AbstractField:
         }
     }
 
-    fn packed_powers<P: PackedField<Scalar = Self>>(&self) -> PackedPowers<Self, P> {
+    fn packed_powers<P: PackedField<Scalar = Self>>(&self, start: Self) -> PackedPowers<Self, P> {
+        let mut current = P::from_fn(|_| start.clone());
+        let slice = current.as_slice_mut();
+        for i in 1..P::WIDTH {
+            slice[i] = slice[i - 1].clone() * self.clone();
+        }
+
         PackedPowers {
-            multiplier: P::from_fn(|_| self.exp_u64(P::WIDTH as u64)),
-            current: P::ONE,
+            multiplier: P::from_fn(|_| self.clone()).exp_u64(P::WIDTH as u64),
+            current
         }
     }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -122,14 +122,14 @@ pub trait AbstractField:
     }
 
     fn packed_powers<P: PackedField<Scalar = Self>>(&self, start: Self) -> PackedPowers<Self, P> {
-        let mut current = P::from_fn(|_| start.clone());
+        let mut current = P::from(start.clone());
         let slice = current.as_slice_mut();
         for i in 1..P::WIDTH {
             slice[i] = slice[i - 1].clone() * self.clone();
         }
 
         PackedPowers {
-            multiplier: P::from_fn(|_| self.clone()).exp_u64(P::WIDTH as u64),
+            multiplier: P::from(self.clone()).exp_u64(P::WIDTH as u64),
             current,
         }
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -121,6 +121,19 @@ pub trait AbstractField:
         }
     }
 
+    #[must_use]
+    fn packed_powers<P: PackedField<Scalar = Self>>(&self) -> Powers<P> {
+        let mut base = P::ZERO;
+        for (dst, pow) in base.as_slice_mut().iter_mut().zip(self.powers()) {
+            *dst = pow;
+        }
+
+        Powers {
+            base,
+            current: P::ONE
+        }
+    }
+
     fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
         u.iter().zip(v).map(|(x, y)| x.clone() * y.clone()).sum()
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -121,7 +121,30 @@ pub trait AbstractField:
         }
     }
 
-    fn packed_powers<P: PackedField<Scalar = Self>>(&self, start: Self) -> PackedPowers<Self, P> {
+    fn shifted_powers(&self, start: Self) -> Powers<Self> {
+        Powers {
+            base: self.clone(),
+            current: start,
+        }
+    }
+
+    fn powers_packed<P: PackedField<Scalar = Self>>(&self) -> PackedPowers<Self, P> {
+        let mut current = P::ONE;
+        let slice = current.as_slice_mut();
+        for i in 1..P::WIDTH {
+            slice[i] = slice[i - 1].clone() * self.clone();
+        }
+
+        PackedPowers {
+            multiplier: P::from(self.clone()).exp_u64(P::WIDTH as u64),
+            current,
+        }
+    }
+
+    fn shifted_powers_packed<P: PackedField<Scalar = Self>>(
+        &self,
+        start: Self,
+    ) -> PackedPowers<Self, P> {
         let mut current = P::from(start);
         let slice = current.as_slice_mut();
         for i in 1..P::WIDTH {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -122,7 +122,7 @@ pub trait AbstractField:
     }
 
     fn packed_powers<P: PackedField<Scalar = Self>>(&self, start: Self) -> PackedPowers<Self, P> {
-        let mut current = P::from(start.clone());
+        let mut current = P::from(start);
         let slice = current.as_slice_mut();
         for i in 1..P::WIDTH {
             slice[i] = slice[i - 1].clone() * self.clone();

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -130,7 +130,7 @@ pub trait AbstractField:
 
         PackedPowers {
             multiplier: P::from_fn(|_| self.clone()).exp_u64(P::WIDTH as u64),
-            current
+            current,
         }
     }
 
@@ -345,7 +345,7 @@ impl<AF: AbstractField, P: PackedField<Scalar = AF>> Iterator for PackedPowers<A
     type Item = P;
 
     fn next(&mut self) -> Option<P> {
-        let result = self.current.clone();
+        let result = self.current;
         self.current *= self.multiplier;
         Some(result)
     }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1.37"
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-mersenne-31 = { path = "../mersenne-31" }
+p3-dft = { path = "../dft" }
 criterion = "0.5.1"
 rand = "0.8.5"
 

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::izip;
-use p3_field::{PackedField, Powers, TwoAdicField};
+use p3_field::{PackedField, TwoAdicField};
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
@@ -30,49 +30,6 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     let n = poly.len();
     debug_assert!(n > 1);
 
-    if n < F::Packing::WIDTH {
-        let mut res = vec![F::ZERO; n / 2];
-        let (first, second) = poly.split_at(n / 2);
-        fold_even_odd_packed::<F, F>(res.iter_mut(), first.iter(), second.iter(), n, beta);
-        res
-    } else {
-        let half_n = n / 2;
-        let nearest_mutliple_of_packing_width = (half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH;
-        let cutoff = (half_n / F::Packing::WIDTH) * F::Packing::WIDTH;
-
-        let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width * F::Packing::WIDTH];
-        let res_packed = F::Packing::pack_slice_mut(&mut res);
-
-        let (first, second) = poly.split_at(n / 2);
-        let first_leftover =
-            F::Packing::from_fn(|i| if cutoff + i < first.len() { first[i] } else { F::ZERO });
-        let second_leftover = F::Packing::from_fn(|i| {
-            if cutoff + i < second.len() {
-                second[cutoff + i]
-            } else {
-                F::ZERO
-            }
-        });
-        let first = F::Packing::pack_slice(&first[..cutoff])
-            .iter()
-            .chain(core::iter::once(&first_leftover));
-        let second = F::Packing::pack_slice(&second[..cutoff])
-            .iter()
-            .chain(core::iter::once(&second_leftover));
-
-        fold_even_odd_packed::<F, F::Packing>(res_packed.iter_mut(), first, second, n, beta);
-        res.truncate(half_n);
-        res
-    }
-}
-
-fn fold_even_odd_packed<'a, F: TwoAdicField, P: PackedField<Scalar = F>>(
-    dst: impl Iterator<Item = &'a mut P>,
-    first: impl Iterator<Item = &'a P>,
-    second: impl Iterator<Item = &'a P>,
-    n: usize,
-    beta: F,
-) {
     let log_n = log2_strict_usize(n);
 
     let g_inv = F::two_adic_generator(log_n).inverse();
@@ -80,16 +37,42 @@ fn fold_even_odd_packed<'a, F: TwoAdicField, P: PackedField<Scalar = F>>(
     let half_beta = beta * one_half;
 
     // beta/2 times successive powers of g_inv
-    let powers = Powers {
-        base: P::from_fn(|_| g_inv),
-        current: P::from_fn(|_| half_beta),
-    };
+    let powers = g_inv.packed_powers::<F::Packing>(half_beta);
 
-    let one_half = P::from_fn(|_| one_half);
+    // pack first / second polys, rounding up to the nearest multiple of packing width
+    let half_n = n / 2;
+    let cutoff = (half_n / F::Packing::WIDTH) * F::Packing::WIDTH;
+
+    let (first, second) = poly.split_at(n / 2);
+    let first_leftover =
+        F::Packing::from_fn(|i| if cutoff + i < first.len() { first[i] } else { F::ZERO });
+    let second_leftover = F::Packing::from_fn(|i| {
+        if cutoff + i < second.len() {
+            second[cutoff + i]
+        } else {
+            F::ZERO
+        }
+    });
+    let first = F::Packing::pack_slice(&first[..cutoff])
+        .iter()
+        .chain(core::iter::once(&first_leftover));
+    let second = F::Packing::pack_slice(&second[..cutoff])
+        .iter()
+        .chain(core::iter::once(&second_leftover));
+
+    // allocate and pack result, rounding up to the nearest multiple of packing width
+    let nearest_mutliple_of_packing_width = F::Packing::WIDTH * ((half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH);
+    let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width];
+    let res_packed = F::Packing::pack_slice_mut(&mut res);
+
+    let one_half = F::Packing::from_fn(|_| one_half);
     for (src, dst) in izip!(powers, first, second)
         .map(|(power, &a, &b)| (one_half + power) * a + (one_half - power) * b)
-        .zip(dst)
+        .zip(res_packed.iter_mut())
     {
         *dst = src;
     }
+
+    res.truncate(half_n);
+    res
 }

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -44,8 +44,13 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     let cutoff = (half_n / F::Packing::WIDTH) * F::Packing::WIDTH;
 
     let (first, second) = poly.split_at(n / 2);
-    let first_leftover =
-        F::Packing::from_fn(|i| if cutoff + i < first.len() { first[i] } else { F::ZERO });
+    let first_leftover = F::Packing::from_fn(|i| {
+        if cutoff + i < first.len() {
+            first[i]
+        } else {
+            F::ZERO
+        }
+    });
     let second_leftover = F::Packing::from_fn(|i| {
         if cutoff + i < second.len() {
             second[cutoff + i]
@@ -61,7 +66,8 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
         .chain(core::iter::once(&second_leftover));
 
     // allocate and pack result, rounding up to the nearest multiple of packing width
-    let nearest_mutliple_of_packing_width = F::Packing::WIDTH * ((half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH);
+    let nearest_mutliple_of_packing_width =
+        F::Packing::WIDTH * ((half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH);
     let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width];
     let res_packed = F::Packing::pack_slice_mut(&mut res);
 
@@ -76,7 +82,6 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     res.truncate(half_n);
     res
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -99,12 +104,19 @@ mod tests {
         let dft = Radix2Dit::default();
         let evals = dft.dft(coeffs.clone());
 
-        let (even_coeffs, odd_coeffs): (Vec<_>, Vec<_>) = coeffs.iter().cloned().step_by(2).zip(coeffs.iter().cloned().skip(1).step_by(2)).unzip();
+        let (even_coeffs, odd_coeffs): (Vec<_>, Vec<_>) = coeffs
+            .iter()
+            .cloned()
+            .step_by(2)
+            .zip(coeffs.iter().cloned().skip(1).step_by(2))
+            .unzip();
         let even_evals = dft.dft(even_coeffs);
         let odd_evals = dft.dft(odd_coeffs);
 
         let beta = rng.gen::<F>();
-        let expected = izip!(even_evals, odd_evals).map(|(even, odd)| even + beta * odd).collect::<Vec<_>>();
+        let expected = izip!(even_evals, odd_evals)
+            .map(|(even, odd)| even + beta * odd)
+            .collect::<Vec<_>>();
         let got = fold_even_odd(&evals, beta);
         assert_eq!(expected, got);
     }

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -85,6 +85,7 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use p3_baby_bear::BabyBear;
     use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
     use rand::{thread_rng, Rng};
@@ -104,13 +105,10 @@ mod tests {
         let dft = Radix2Dit::default();
         let evals = dft.dft(coeffs.clone());
 
-        let (even_coeffs, odd_coeffs): (Vec<_>, Vec<_>) = coeffs
-            .iter()
-            .cloned()
-            .step_by(2)
-            .zip(coeffs.iter().cloned().skip(1).step_by(2))
-            .unzip();
+        let even_coeffs = coeffs.iter().cloned().step_by(2).collect_vec();
         let even_evals = dft.dft(even_coeffs);
+
+        let odd_coeffs = coeffs.iter().cloned().skip(1).step_by(2).collect_vec();
         let odd_evals = dft.dft(odd_coeffs);
 
         let beta = rng.gen::<F>();

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::izip;
 use p3_field::{PackedField, TwoAdicField};
-use p3_util::log2_strict_usize;
+use p3_util::{log2_strict_usize, ceil_div_usize};
 use tracing::instrument;
 
 /// Fold a polynomial
@@ -67,7 +67,7 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
 
     // allocate and pack result, rounding up to the nearest multiple of packing width
     let nearest_mutliple_of_packing_width =
-        F::Packing::WIDTH * ((half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH);
+        F::Packing::WIDTH * ceil_div_usize(half_n, F::Packing::WIDTH);
     let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width];
     let res_packed = F::Packing::pack_slice_mut(&mut res);
 

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -37,27 +37,15 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
     let half_beta = beta * one_half;
 
     // beta/2 times successive powers of g_inv
-    let powers = g_inv.packed_powers::<F::Packing>(half_beta);
+    let powers = g_inv.shifted_powers_packed::<F::Packing>(half_beta);
 
     // pack first / second polys, rounding up to the nearest multiple of packing width
     let half_n = n / 2;
     let cutoff = (half_n / F::Packing::WIDTH) * F::Packing::WIDTH;
 
     let (first, second) = poly.split_at(n / 2);
-    let first_leftover = F::Packing::from_fn(|i| {
-        if cutoff + i < first.len() {
-            first[i]
-        } else {
-            F::ZERO
-        }
-    });
-    let second_leftover = F::Packing::from_fn(|i| {
-        if cutoff + i < second.len() {
-            second[cutoff + i]
-        } else {
-            F::ZERO
-        }
-    });
+    let first_leftover = first.get(cutoff + i).copied().unwrap_or_default();
+    let second_leftover = second.get(cutoff + i).copied().unwrap_or_default();
     let first = F::Packing::pack_slice(&first[..cutoff])
         .iter()
         .chain(core::iter::once(&first_leftover));

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::izip;
 use p3_field::{PackedField, TwoAdicField};
-use p3_util::{log2_strict_usize, ceil_div_usize};
+use p3_util::{ceil_div_usize, log2_strict_usize};
 use tracing::instrument;
 
 /// Fold a polynomial

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -40,7 +40,7 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: &[F], beta: F) -> Vec<F> {
         let nearest_mutliple_of_packing_width = (half_n + F::Packing::WIDTH - 1) / F::Packing::WIDTH;
         let cutoff = (half_n / F::Packing::WIDTH) * F::Packing::WIDTH;
 
-        let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width];
+        let mut res = vec![F::ZERO; nearest_mutliple_of_packing_width * F::Packing::WIDTH];
         let res_packed = F::Packing::pack_slice_mut(&mut res);
 
         let (first, second) = poly.split_at(n / 2);

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -102,7 +102,7 @@ mod tests {
         let n = 1 << log_n;
         let coeffs = (0..n).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
 
-        let dft = Radix2Dit::default();
+        let dft = Radix2Dit;
         let evals = dft.dft(coeffs.clone());
 
         let even_coeffs = coeffs.iter().cloned().step_by(2).collect_vec();


### PR DESCRIPTION
Summary of changes:
- use `F::Packing` in `fold_even_odd`, padding to the nearest multiple of `F::Packing::WIDTH` and truncating the result if necessary.
- add `PackedPowers`, a version of `Powers` that's more or less a "chunked" version of `Powers`, where the chunks are packed field elements.
- add a very basic test for `fold_even_odd`


Resulted in a significant (~3.5-4x) speedup for`BabyBear`, and small changes for other fields (which don't yet have vectorized impls)

For instance, on my M1 MBP, I get the following results for `fold_even_odd` size 2^16:

| field               | before (mean) | after (mean) | change           |
|---------------------|---------------|--------------|------------------|
| `BabyBear`          | 193.02 µs     | 45.240 µs    | -76.552% (~4.2x) |
| `Goldilocks`        | 61.270 µs     | 65.994 µs    | +7.6771%         |
| `Mersenne31Complex` | 666.26 µs     | 631.55 µs    | -5.0013%         |