### PR TITLE
impl two-adic trait for BEF

### DIFF
--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -1,5 +1,5 @@
-use p3_field::extension::BinomiallyExtendable;
-use p3_field::AbstractField;
+use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use p3_field::{field_to_array, AbstractField, TwoAdicField};
 
 use crate::BabyBear;
 
@@ -16,6 +16,35 @@ impl BinomiallyExtendable<4> for BabyBear {
     }
 }
 
+impl HasTwoAdicBionmialExtension<4> for BabyBear {
+    const EXT_TWO_ADICITY: usize = 29;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 4] {
+        assert!(bits <= 29);
+
+        match bits {
+            29 => [
+                Self::ZERO,
+                Self::ZERO,
+                Self::ZERO,
+                Self::from_canonical_u32(124907976),
+            ],
+            28 => [
+                Self::ZERO,
+                Self::ZERO,
+                Self::from_canonical_u32(1996171314),
+                Self::ZERO,
+            ],
+            _ => [
+                Self::two_adic_generator(bits),
+                Self::ZERO,
+                Self::ZERO,
+                Self::ZERO,
+            ],
+        }
+    }
+}
+
 impl BinomiallyExtendable<5> for BabyBear {
     // Verifiable in Sage with
     // `R.<x> = GF(p)[]; assert (x^5 - 2).is_irreducible()`.
@@ -29,23 +58,31 @@ impl BinomiallyExtendable<5> for BabyBear {
     }
 }
 
+impl HasTwoAdicBionmialExtension<5> for BabyBear {
+    const EXT_TWO_ADICITY: usize = 27;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 5] {
+        field_to_array::<Self, 5>(Self::two_adic_generator(bits))
+    }
+}
 #[cfg(test)]
 mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::binomial_extension::BinomialExtensionField;
     use p3_field::{AbstractExtensionField, AbstractField};
-    use p3_field_testing::test_field;
+    use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;
 
-    test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,4>);
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+
+    test_field!(super::EF);
+    test_two_adic_extension_field!(super::F, super::EF);
 
     #[test]
     fn display() {
-        type F = BabyBear;
-        type EF = BinomialExtensionField<F, 4>;
-
         assert_eq!(format!("{}", EF::ZERO), "0");
         assert_eq!(format!("{}", EF::ONE), "1");
         assert_eq!(format!("{}", EF::TWO), "2");
@@ -62,7 +99,14 @@ mod test_quartic_extension {
 
 #[cfg(test)]
 mod test_quintic_extension {
-    use p3_field_testing::test_field;
+    use p3_field::extension::binomial_extension::BinomialExtensionField;
+    use p3_field_testing::{test_field, test_two_adic_extension_field};
 
-    test_field!(p3_field::extension::binomial_extension::BinomialExtensionField<crate::BabyBear,5>);
+    use crate::BabyBear;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 5>;
+
+    test_field!(super::EF);
+    test_two_adic_extension_field!(super::F, super::EF);
 }

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -94,8 +94,8 @@ pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
 pub fn test_two_adic_generator_consistency<F: TwoAdicField>() {
     let log_n = F::TWO_ADICITY;
     let g = F::two_adic_generator(log_n);
-    for i in 0..log_n {
-        assert_eq!(g.exp_power_of_2(i), F::two_adic_generator(log_n - i));
+    for bits in 0..=log_n {
+        assert_eq!(g.exp_power_of_2(bits), F::two_adic_generator(log_n - bits));
     }
 }
 
@@ -103,13 +103,10 @@ pub fn test_ef_two_adic_generator_consistency<
     F: TwoAdicField,
     EF: TwoAdicField + ExtensionField<F>,
 >() {
-    let log_n = F::TWO_ADICITY;
-    for bits in 1..log_n {
-        assert_eq!(
-            EF::from_base(F::two_adic_generator(bits)),
-            EF::two_adic_generator(bits)
-        );
-    }
+    assert_eq!(
+        EF::from_base(F::two_adic_generator(F::TWO_ADICITY)),
+        EF::two_adic_generator(F::TWO_ADICITY)
+    );
 }
 
 #[macro_export]
@@ -156,6 +153,8 @@ macro_rules! test_two_adic_field {
 macro_rules! test_two_adic_extension_field {
     ($field:ty, $ef:ty) => {
         use $crate::test_two_adic_field;
+
+        test_two_adic_field!($ef);
 
         mod two_adic_extension_field_tests {
 

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -9,7 +9,7 @@ pub mod bench_func;
 pub use bench_func::*;
 use p3_field::{
     cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order, two_adic_coset_zerofier,
-    two_adic_subgroup_zerofier, Field, TwoAdicField,
+    two_adic_subgroup_zerofier, ExtensionField, Field, TwoAdicField,
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -91,6 +91,27 @@ pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
     }
 }
 
+pub fn test_two_adic_generator_consistency<F: TwoAdicField>() {
+    let log_n = F::TWO_ADICITY;
+    let g = F::two_adic_generator(log_n);
+    for i in 0..log_n {
+        assert_eq!(g.exp_power_of_2(i), F::two_adic_generator(log_n - i));
+    }
+}
+
+pub fn test_ef_two_adic_generator_consistency<
+    F: TwoAdicField,
+    EF: TwoAdicField + ExtensionField<F>,
+>() {
+    let log_n = F::TWO_ADICITY;
+    for bits in 1..log_n {
+        assert_eq!(
+            EF::from_base(F::two_adic_generator(bits)),
+            EF::two_adic_generator(bits)
+        );
+    }
+}
+
 #[macro_export]
 macro_rules! test_field {
     ($field:ty) => {
@@ -122,6 +143,25 @@ macro_rules! test_two_adic_field {
             #[test]
             fn test_two_adic_coset_zerofier() {
                 $crate::test_two_adic_coset_zerofier::<$field>();
+            }
+            #[test]
+            fn test_two_adic_consisitency() {
+                $crate::test_two_adic_generator_consistency::<$field>();
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! test_two_adic_extension_field {
+    ($field:ty, $ef:ty) => {
+        use $crate::test_two_adic_field;
+
+        mod two_adic_extension_field_tests {
+
+            #[test]
+            fn test_ef_two_adic_generator_consistency() {
+                $crate::test_ef_two_adic_generator_consistency::<$field, $ef>();
             }
         }
     };

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -8,10 +8,10 @@ use itertools::Itertools;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 
-use super::HasFrobenuis;
+use super::{HasFrobenuis, HasTwoAdicBionmialExtension};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
-use crate::{field_to_array, AbstractExtensionField, AbstractField, ExtensionField};
+use crate::{field_to_array, AbstractExtensionField, AbstractField, ExtensionField, TwoAdicField};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct BinomialExtensionField<F: BinomiallyExtendable<D>, const D: usize> {
@@ -409,6 +409,18 @@ where
             *r = Standard.sample(rng);
         }
         BinomialExtensionField::<F, D>::from_base_slice(&res)
+    }
+}
+
+impl<F: HasTwoAdicBionmialExtension<D>, const D: usize> TwoAdicField
+    for BinomialExtensionField<F, D>
+{
+    const TWO_ADICITY: usize = F::EXT_TWO_ADICITY;
+
+    fn two_adic_generator(bits: usize) -> Self {
+        Self {
+            value: F::ext_two_adic_generator(bits),
+        }
     }
 }
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -22,3 +22,10 @@ pub trait HasFrobenuis<F: Field>: ExtensionField<F> {
     fn repeated_frobenius(&self, count: usize) -> Self;
     fn frobenius_inv(&self) -> Self;
 }
+
+/// Optional trait for implementing Two Adic Binomial Extension Field.
+pub trait HasTwoAdicBionmialExtension<const D: usize>: BinomiallyExtendable<D> {
+    const EXT_TWO_ADICITY: usize;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; D];
+}

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,4 +1,5 @@
-use p3_field::extension::BinomiallyExtendable;
+use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use p3_field::{AbstractField, TwoAdicField};
 
 use crate::Goldilocks;
 
@@ -18,15 +19,32 @@ impl BinomiallyExtendable<2> for Goldilocks {
     }
 }
 
+impl HasTwoAdicBionmialExtension<2> for Goldilocks {
+    const EXT_TWO_ADICITY: usize = 33;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 2] {
+        assert!(bits <= 33);
+
+        if bits == 33 {
+            [Self::ZERO, Self::new(15659105665374529263)]
+        } else {
+            [Self::two_adic_generator(bits), Self::ZERO]
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_quadratic_extension {
 
-    use p3_field_testing::test_field;
+    use p3_field::extension::binomial_extension::BinomialExtensionField;
+    use p3_field_testing::{test_field, test_two_adic_extension_field};
 
-    test_field!(
-        p3_field::extension::binomial_extension::BinomialExtensionField<
-            crate::Goldilocks,
-            2,
-        >
-    );
+    use crate::Goldilocks;
+
+    type F = Goldilocks;
+    type EF = BinomialExtensionField<F, 2>;
+
+    test_field!(super::EF);
+
+    test_two_adic_extension_field!(super::F, super::EF);
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,5 +1,5 @@
-use p3_field::extension::BinomiallyExtendable;
-use p3_field::AbstractField;
+use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use p3_field::{field_to_array, AbstractField, TwoAdicField};
 
 use crate::{Mersenne31, Mersenne31Complex};
 
@@ -29,6 +29,22 @@ impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
 
     // DTH_ROOT = W^((p^2 - 1)/2).
     const DTH_ROOT: Self = Self::new_real(Mersenne31::new(2147483646));
+}
+
+impl HasTwoAdicBionmialExtension<2> for Mersenne31Complex<Mersenne31> {
+    const EXT_TWO_ADICITY: usize = 33;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 2] {
+        assert!(bits <= 33);
+        if bits == 33 {
+            [
+                Self::ZERO,
+                Self::new(Mersenne31::new(1437746044), Mersenne31::new(946469285)),
+            ]
+        } else {
+            [Self::two_adic_generator(bits), Self::ZERO]
+        }
+    }
 }
 
 impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
@@ -63,28 +79,41 @@ impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     }
 }
 
+impl HasTwoAdicBionmialExtension<3> for Mersenne31Complex<Mersenne31> {
+    const EXT_TWO_ADICITY: usize = 32;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 3] {
+        field_to_array::<Self, 3>(Self::two_adic_generator(bits))
+    }
+}
+
 #[cfg(test)]
 mod test_cubic_extension {
 
-    use p3_field_testing::test_field;
+    use p3_field::extension::binomial_extension::BinomialExtensionField;
+    use p3_field_testing::{test_field, test_two_adic_extension_field};
 
-    test_field!(
-        p3_field::extension::binomial_extension::BinomialExtensionField<
-            crate::Mersenne31Complex<crate::Mersenne31>,
-            3,
-        >
-    );
+    use crate::{Mersenne31, Mersenne31Complex};
+    type F = Mersenne31Complex<Mersenne31>;
+    type EF = BinomialExtensionField<F, 3>;
+
+    test_field!(super::EF);
+
+    test_two_adic_extension_field!(super::F, super::EF);
 }
 
 #[cfg(test)]
 mod test_quadratic_extension {
 
-    use p3_field_testing::test_field;
+    use p3_field::extension::binomial_extension::BinomialExtensionField;
+    use p3_field_testing::{test_field, test_two_adic_extension_field};
 
-    test_field!(
-        p3_field::extension::binomial_extension::BinomialExtensionField<
-            crate::Mersenne31Complex<crate::Mersenne31>,
-            2,
-        >
-    );
+    use crate::{Mersenne31, Mersenne31Complex};
+
+    type F = Mersenne31Complex<Mersenne31>;
+    type EF = BinomialExtensionField<F, 2>;
+
+    test_field!(super::EF);
+
+    test_two_adic_extension_field!(super::F, super::EF);
 }


### PR DESCRIPTION
1. Design `HasTwoAdicBinomialExtension<D>` as an extension to `BinomialExtendable`; Implement `TwoAdicField` for `BinomialExtensionField` if base field Implement `HasTwoAdicBinomialExtension<D>`

2. Implement `HasTwoAdicBinomialExtension<D>` for all BinomialExtendable Fields

3. Add tests for two adic extension fields, including self-consistency and base field consistency.