### PR TITLE
Rename ext_multiplicative_group_generator -> ext_generator

### DIFF
--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -15,7 +15,7 @@ impl BinomiallyExtendable<4> for BabyBear {
         Self::new(1728404513)
     }
 
-    fn ext_multiplicative_group_generator() -> [Self; 4] {
+    fn ext_generator() -> [Self; 4] {
         [Self::new(8), Self::one(), Self::zero(), Self::zero()]
     }
 }
@@ -61,7 +61,7 @@ impl BinomiallyExtendable<5> for BabyBear {
         Self::new(815036133)
     }
 
-    fn ext_multiplicative_group_generator() -> [Self; 5] {
+    fn ext_generator() -> [Self; 5] {
         [
             Self::new(8),
             Self::one(),

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -169,7 +169,7 @@ where
 
     fn generator() -> Self {
         Self {
-            value: AF::F::ext_multiplicative_group_generator().map(AF::from_f),
+            value: AF::F::ext_generator().map(AF::from_f),
         }
     }
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -14,7 +14,7 @@ pub trait BinomiallyExtendable<const D: usize>: Field {
     // Only works when exists k such that n = kD + 1.
     fn dth_root() -> Self;
 
-    fn ext_multiplicative_group_generator() -> [Self; D];
+    fn ext_generator() -> [Self; D];
 }
 
 pub trait HasFrobenuis<F: Field>: ExtensionField<F> {

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -15,7 +15,7 @@ impl BinomiallyExtendable<2> for Goldilocks {
         Self::new(18446744069414584320)
     }
 
-    fn ext_multiplicative_group_generator() -> [Self; 2] {
+    fn ext_generator() -> [Self; 2] {
         [
             Self::new(18081566051660590251),
             Self::new(16121475356294670766),

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -25,7 +25,7 @@ impl BinomiallyExtendable<2> for Mersenne31Complex<Mersenne31> {
     // for f in factor(p^4 - 1):
     //   assert g^((p^4-1) // f) != 1
     // ```
-    fn ext_multiplicative_group_generator() -> [Self; 2] {
+    fn ext_generator() -> [Self; 2] {
         [Self::new_real(Mersenne31::new(6)), Self::one()]
     }
 
@@ -78,7 +78,7 @@ impl BinomiallyExtendable<3> for Mersenne31Complex<Mersenne31> {
     // for f in factor(p^6 - 1):
     //   assert g^((p^6-1) // f) != 1
     // ```
-    fn ext_multiplicative_group_generator() -> [Self; 3] {
+    fn ext_generator() -> [Self; 3] {
         [
             Self::new_real(Mersenne31::new(5)),
             Self::new_real(Mersenne31::one()),


### PR DESCRIPTION
To match `AbstractField::generator()` (it was renamed somewhat recently).