### PR TITLE
Fix naive LDE

### DIFF
--- a/brakedown/src/standard_fast.rs
+++ b/brakedown/src/standard_fast.rs
@@ -12,6 +12,7 @@ use rand_chacha::ChaCha20Rng;
 use crate::macros::{brakedown, brakedown_to_rs};
 use crate::BrakedownCode;
 
+#[allow(deprecated)] // TODO: Remove when UndefinedLDE is gone.
 pub fn fast_registry<F, In>() -> impl LinearCodeFamily<F, In>
 where
     F: Field,

--- a/lde/src/lib.rs
+++ b/lde/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate contains a framework for low-degree tests (LDTs).
 
 #![no_std]
+#![deprecated]
 
 mod naive;
 

--- a/lde/src/naive.rs
+++ b/lde/src/naive.rs
@@ -55,7 +55,8 @@ where
         let weights = barycentric_weights(&subgroup);
 
         let lde_bits = bits + added_bits;
-        let lde_subgroup = cyclic_subgroup_known_order::<Domain>(g, 1 << lde_bits);
+        let g_lde = Domain::two_adic_generator(lde_bits);
+        let lde_subgroup = cyclic_subgroup_known_order::<Domain>(g_lde, 1 << lde_bits);
 
         let polys_fe = polys.map(|x| Domain::from_base(x));
         let values = lde_subgroup
@@ -77,8 +78,9 @@ where
         let weights = barycentric_weights(&subgroup);
 
         let lde_bits = bits + added_bits;
+        let g_lde = Domain::two_adic_generator(lde_bits);
         let lde_subgroup =
-            cyclic_subgroup_coset_known_order(g, self.shift(lde_bits), 1 << lde_bits);
+            cyclic_subgroup_coset_known_order(g_lde, self.shift(lde_bits), 1 << lde_bits);
 
         let polys_fe = polys.map(|x| Domain::from_base(x));
         let values = lde_subgroup

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -17,7 +17,6 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use complex::*;
 pub use dft::Mersenne31Dft;
-pub use extension::*;
 use p3_field::{
     exp_1717986917, exp_u64_by_squaring, AbstractField, Field, PrimeField, PrimeField32,
     PrimeField64,

--- a/reed-solomon/src/lib.rs
+++ b/reed-solomon/src/lib.rs
@@ -1,5 +1,7 @@
 //! Reed-Solomon codes.
 
+#![allow(deprecated)] // TODO: Remove when UndefinedLDE is gone.
+
 use std::marker::PhantomData;
 
 use p3_code::{


### PR DESCRIPTION
Fix the issue pointed out by @LKY-stephen in https://github.com/Plonky3/Plonky3/issues/159#issuecomment-1783743133

Also mark the LDE crate deprecated, I think it should be replaced by the `dft` APIs.