### PR TITLE
Fix uni-stark quotient

### DIFF
--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -82,6 +82,21 @@ where
     ) -> Vec<RowMajorMatrixView<'b, Domain>>
     where
         'a: 'b;
+
+    // Commit to polys that are already defined over a coset.
+    fn commit_shifted_batches(
+        &self,
+        polynomials: Vec<In>,
+        coset_shift: Domain,
+    ) -> (Self::Commitment, Self::ProverData);
+
+    fn commit_shifted_batch(
+        &self,
+        polynomials: In,
+        coset_shift: Domain,
+    ) -> (Self::Commitment, Self::ProverData) {
+        self.commit_shifted_batches(vec![polynomials], coset_shift)
+    }
 }
 
 pub trait MultivariatePcs<Val, Domain, EF, In, Challenger>: Pcs<Val, In>

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -155,9 +155,9 @@ fn commit_phase<FC: FriConfig>(
     assert_eq!(current.len(), config.blowup());
     let final_poly = current[0];
     // TODO: Re-enable after fixing the interleaving TODO above.
-    // for x in current {
-    //     assert_eq!(x, final_poly);
-    // }
+    for x in current {
+        assert_eq!(x, final_poly);
+    }
 
     CommitPhaseResult {
         commits,

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -154,7 +154,6 @@ fn commit_phase<FC: FriConfig>(
     // We should be left with `blowup` evaluations of a constant polynomial.
     assert_eq!(current.len(), config.blowup());
     let final_poly = current[0];
-    // TODO: Re-enable after fixing the interleaving TODO above.
     for x in current {
         assert_eq!(x, final_poly);
     }

--- a/ldt/src/ldt_based_pcs.rs
+++ b/ldt/src/ldt_based_pcs.rs
@@ -116,6 +116,9 @@ where
         let (prover_data, all_points): (Vec<_>, Vec<_>) =
             prover_data_and_points.iter().copied().unzip();
 
+        let coset_shift: Domain =
+            <Self as UnivariatePcsWithLde<Val, Domain, EF, In, Challenger>>::coset_shift(self);
+
         let quotient_mmcs = all_points
             .into_iter()
             .zip(&all_opened_values)
@@ -139,7 +142,7 @@ where
                 QuotientMmcs::<Domain, EF, _> {
                     inner: self.mmcs.clone(),
                     openings,
-                    _phantom: PhantomData,
+                    coset_shift,
                 }
             })
             .collect_vec();

--- a/ldt/src/quotient.rs
+++ b/ldt/src/quotient.rs
@@ -63,7 +63,8 @@ where
                 let log2_height = log2_strict_usize(height);
                 let bits_reduced = log_max_height - log2_height;
                 let reduced_index = index >> bits_reduced;
-                let x = F::two_adic_generator(log2_height).exp_u64(reduced_index as u64);
+                let x = self.coset_shift
+                    * F::two_adic_generator(log2_height).exp_u64(reduced_index as u64);
                 openings_for_mat
                     .iter()
                     .flat_map(|Opening { point, values }| {
@@ -134,7 +135,8 @@ where
                 let log_height = log2_strict_usize(dims.height);
                 let bits_reduced = log_max_height - log_height;
                 let reduced_index = index >> bits_reduced;
-                let x = F::two_adic_generator(log_height).exp_u64(reduced_index as u64);
+                let x = self.coset_shift
+                    * F::two_adic_generator(log_height).exp_u64(reduced_index as u64);
 
                 let original_width = quotient_row.len() / openings.len();
                 let original_row_repeated: Vec<Vec<EF>> = quotient_row

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -98,7 +98,7 @@ mod tests {
         let chunks = 1 << log_chunks;
         let shift = F::generator();
 
-        let mut coeffs = (0..n).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
+        let coeffs = (0..n).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
 
         let coset_evals = dft.coset_dft(coeffs.clone(), shift);
         let mut decomp = decompose(coset_evals, shift, log_chunks);

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -14,9 +14,10 @@ use crate::StarkConfig;
 /// becomes `D` columns of the resulting matrix, where `D` is the field extension degree.
 pub fn decompose_and_flatten<SC: StarkConfig>(
     quotient_poly: Vec<SC::Challenge>,
+    shift: SC::Challenge,
     log_chunks: usize,
 ) -> RowMajorMatrix<SC::Val> {
-    let chunks: Vec<Vec<SC::Challenge>> = decompose(quotient_poly, log_chunks);
+    let chunks: Vec<Vec<SC::Challenge>> = decompose(quotient_poly, shift, log_chunks);
     let degree = chunks[0].len();
     let quotient_chunks_flattened: Vec<SC::Val> = (0..degree)
         .into_par_iter()
@@ -34,7 +35,7 @@ pub fn decompose_and_flatten<SC: StarkConfig>(
 }
 
 /// A generalization of even-odd decomposition.
-fn decompose<F: TwoAdicField>(poly: Vec<F>, log_chunks: usize) -> Vec<Vec<F>> {
+fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<Vec<F>> {
     // For now, we use a naive recursive method.
     // A more optimized method might look similar to a decimation-in-time FFT,
     // but only the first `log_chunks` layers. It should also be parallelized.
@@ -54,20 +55,62 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, log_chunks: usize) -> Vec<Vec<F>> {
 
     // Note that
     //     p_e(g^(2i)) = (p(g^i) + p(g^(n/2 + i))) / 2
-    //     p_o(g^(2i)) = (p(g^i) - p(g^(n/2 + i))) / (2 g^i)
+    //     p_o(g^(2i)) = (p(g^i) - p(g^(n/2 + i))) / (2 s g^i)
 
     //     p_e(g^(2i)) = (a + b) / 2
-    //     p_o(g^(2i)) = (a - b) / (2 g^i)
+    //     p_o(g^(2i)) = (a - b) / (2 s g^i)
     let one_half = F::two().inverse();
     let (first, second) = poly.split_at(half_n);
-    for (g_inv_power, &a, &b) in izip!(g_inv.powers(), first, second) {
+    for (g_inv_power, &a, &b) in izip!(g_inv.shifted_powers(shift.inverse()), first, second) {
         let sum = a + b;
         let diff = a - b;
         even.push(sum * one_half);
         odd.push(diff * one_half * g_inv_power);
     }
 
-    let mut combined = decompose(even, log_chunks - 1);
-    combined.extend(decompose(odd, log_chunks - 1));
+    let mut combined = decompose(even, shift.square(), log_chunks - 1);
+    combined.extend(decompose(odd, shift.square(), log_chunks - 1));
     combined
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use p3_baby_bear::BabyBear;
+    use p3_dft::{reverse_slice_index_bits, Radix2Dit, TwoAdicSubgroupDft};
+    use p3_field::AbstractField;
+    use rand::{thread_rng, Rng};
+
+    use super::*;
+
+    // If we decompose evaluations over a coset s*g^i, we should get
+    // evaluations over s^log_chunks * g^(log_chunks*i).
+    #[test]
+    fn test_decompose_coset() {
+        type F = BabyBear;
+
+        let mut rng = thread_rng();
+        let dft = Radix2Dit;
+
+        let log_n = 5;
+        let n = 1 << log_n;
+        let log_chunks = 3;
+        let chunks = 1 << log_chunks;
+        let shift = F::generator();
+
+        let mut coeffs = (0..n).map(|_| rng.gen::<F>()).collect::<Vec<_>>();
+
+        let coset_evals = dft.coset_dft(coeffs.clone(), shift);
+        let mut decomp = decompose(coset_evals, shift, log_chunks);
+
+        reverse_slice_index_bits(&mut decomp);
+
+        for (i, e) in decomp.into_iter().enumerate() {
+            let chunk_coeffs = coeffs.iter().cloned().skip(i).step_by(chunks).collect_vec();
+            assert_eq!(
+                dft.coset_dft(chunk_coeffs, shift.exp_power_of_2(log_chunks)),
+                e
+            );
+        }
+    }
 }

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -35,7 +35,6 @@ where
     let log_quotient_degree = 1; // TODO
 
     let g_subgroup = SC::Domain::two_adic_generator(log_degree);
-    let shift_inv = config.pcs().coset_shift().inverse();
 
     let pcs = config.pcs();
     let (trace_commit, trace_data) =
@@ -56,10 +55,20 @@ where
         alpha,
     );
 
-    let quotient_chunks_flattened = info_span!("decompose quotient polynomial")
-        .in_scope(|| decompose_and_flatten::<SC>(quotient_values, log_quotient_degree));
-    let (quotient_commit, quotient_data) = info_span!("commit to quotient poly chunks")
-        .in_scope(|| pcs.commit_batch(quotient_chunks_flattened));
+    let quotient_chunks_flattened = info_span!("decompose quotient polynomial").in_scope(|| {
+        decompose_and_flatten::<SC>(
+            quotient_values,
+            SC::Challenge::from_base(pcs.coset_shift()),
+            log_quotient_degree,
+        )
+    });
+    let (quotient_commit, quotient_data) =
+        info_span!("commit to quotient poly chunks").in_scope(|| {
+            pcs.commit_shifted_batch(
+                quotient_chunks_flattened,
+                pcs.coset_shift().exp_power_of_2(log_quotient_degree),
+            )
+        });
     challenger.observe(quotient_commit.clone());
 
     let commitments = Commitments {
@@ -71,12 +80,7 @@ where
     let (opened_values, opening_proof) = pcs.open_multi_batches(
         &[
             (&trace_data, &[zeta, zeta * g_subgroup]),
-            (
-                &quotient_data,
-                // Since the quotient is computed from the shifted trace LDE,
-                // we need to correct for the extra shift.
-                &[(zeta * shift_inv).exp_power_of_2(log_quotient_degree)],
-            ),
+            (&quotient_data, &[zeta.exp_power_of_2(log_quotient_degree)]),
         ],
         challenger,
     );

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use p3_air::{Air, TwoRowMatrixView};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, UnivariatePcs, UnivariatePcsWithLde};
+use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
 use p3_field::{
     cyclic_subgroup_coset_known_order, AbstractExtensionField, AbstractField, Field, PackedField,
     TwoAdicField,
@@ -53,6 +54,13 @@ where
         log_quotient_degree,
         trace_lde,
         alpha,
+    );
+
+    // TODO: don't do this.
+    let quotient_poly = NaiveDft.idft(quotient_values);
+    let quotient_values = NaiveDft.coset_dft(
+        quotient_poly,
+        SC::Challenge::from_base(config.pcs().coset_shift()).inverse(),
     );
 
     let quotient_chunks_flattened = info_span!("decompose quotient polynomial")

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -68,8 +68,7 @@ where
         })
         .collect();
     // Then we reconstruct the larger quotient polynomial from its degree-n parts.
-    let g_quotient_parts = SC::Domain::two_adic_generator(log_quotient_degree);
-    let quotient: SC::Challenge = g_quotient_parts
+    let quotient: SC::Challenge = zeta
         .powers()
         .zip(quotient_parts)
         .map(|(weight, part)| part * weight)
@@ -96,8 +95,7 @@ where
     // Finally, check that
     //     folded_constraints(zeta) = Z_H(zeta) * quotient(zeta)
     if folded_constraints != z_h * quotient {
-        // TODO: Re-enable when it's passing.
-        // return Err(VerificationError::OodEvaluationMismatch);
+        return Err(VerificationError::OodEvaluationMismatch);
     }
 
     Ok(())

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use p3_air::{Air, TwoRowMatrixView};
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_commit::{UnivariatePcs, UnivariatePcsWithLde};
+use p3_commit::UnivariatePcs;
 use p3_dft::reverse_slice_index_bits;
 use p3_field::{AbstractExtensionField, AbstractField, Field, TwoAdicField};
 


### PR DESCRIPTION
The quotient poly is computed from the trace's LDE over the *coset*, but `commit_batch` does not expect its input to be shifted. Also, the quotient parts need to be reduced with zeta instead of the root of unity.

As a proof of concept, I put a DFT -> unshift -> IDFT into the prover. This gets the test passing, is obviously not very efficient. I tried opening quotient_chunks at `(zeta * shift.inverse())^quotient_bits` instead of `zeta^quotient_bits`, but I couldn't get it to work. Maybe `commit_batch` can take a parameter for the shift to apply?

Not intended to merge, just for discussion!