### PR TITLE
pass degree bits to verifier

### DIFF
--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -14,6 +14,9 @@ pub struct Proof<SC: StarkConfig> {
     pub(crate) commitments: Commitments<Com<SC>>,
     pub(crate) opened_values: OpenedValues<SC::Challenge>,
     pub(crate) opening_proof: PcsProof<SC>,
+    /// Hack to pass degree bits to verifier so that it doesn't have to be hardcoded.
+    /// To be removed later according to plonky3 updates
+    pub(crate) degree_bits: usize,
 }
 
 pub struct Commitments<Com> {

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -96,6 +96,7 @@ where
         commitments,
         opened_values,
         opening_proof,
+        degree_bits: log_degree,
     }
 }
 

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -19,15 +19,18 @@ where
     SC: StarkConfig,
     A: for<'a> Air<VerifierConstraintFolder<'a, SC::Challenge>>,
 {
-    let degree_bits = 6; // TODO
+    // let degree_bits = 6; // TODO
     let log_quotient_degree = 1; // TODO
-    let g_subgroup = SC::Val::two_adic_generator(degree_bits);
+                                 // let g_subgroup = SC::Val::two_adic_generator(degree_bits);
 
     let Proof {
         commitments,
         opened_values,
         opening_proof,
+        degree_bits,
     } = proof;
+
+    let g_subgroup = SC::Val::two_adic_generator(*degree_bits);
 
     challenger.observe(commitments.trace.clone());
     let alpha: SC::Challenge = challenger.sample_ext_element();
@@ -76,7 +79,7 @@ where
         .map(|(weight, part)| part * weight)
         .sum();
 
-    let z_h = zeta.exp_power_of_2(degree_bits) - SC::Challenge::one();
+    let z_h = zeta.exp_power_of_2(*degree_bits) - SC::Challenge::one();
     let is_first_row = z_h / (zeta - SC::Val::one());
     let is_last_row = z_h / (zeta - g_subgroup.inverse());
     let is_transition = zeta - g_subgroup.inverse();


### PR DESCRIPTION
Currently, verifer seems to store degree of trace as hardcoded value. The hack is to pass this value from prover to verifer as part of proof. Note that such practice might be unsecure with malicious prover, so it has to be removed in future