### PR TITLE
Pass degree bits to verifier

### DIFF
--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -14,6 +14,7 @@ pub struct Proof<SC: StarkConfig> {
     pub(crate) commitments: Commitments<Com<SC>>,
     pub(crate) opened_values: OpenedValues<SC::Challenge>,
     pub(crate) opening_proof: PcsProof<SC>,
+    pub(crate) degree_bits: usize,
 }
 
 pub struct Commitments<Com> {

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -96,6 +96,7 @@ where
         commitments,
         opened_values,
         opening_proof,
+        degree_bits: log_degree,
     }
 }
 

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -19,15 +19,17 @@ where
     SC: StarkConfig,
     A: for<'a> Air<VerifierConstraintFolder<'a, SC::Challenge>>,
 {
-    let degree_bits = 6; // TODO
+    // let degree_bits = 6; // TODO
     let log_quotient_degree = 1; // TODO
-    let g_subgroup = SC::Val::two_adic_generator(degree_bits);
 
     let Proof {
         commitments,
         opened_values,
         opening_proof,
+        degree_bits,
     } = proof;
+
+    let g_subgroup = SC::Val::two_adic_generator(*degree_bits);
 
     challenger.observe(commitments.trace.clone());
     let alpha: SC::Challenge = challenger.sample_ext_element();
@@ -76,7 +78,7 @@ where
         .map(|(weight, part)| part * weight)
         .sum();
 
-    let z_h = zeta.exp_power_of_2(degree_bits) - SC::Challenge::one();
+    let z_h = zeta.exp_power_of_2(*degree_bits) - SC::Challenge::one();
     let is_first_row = z_h / (zeta - SC::Val::one());
     let is_last_row = z_h / (zeta - g_subgroup.inverse());
     let is_transition = zeta - g_subgroup.inverse();


### PR DESCRIPTION
Currently, the degree bits in uni stark verifier seem to be hardcoded. This hack is to pass them from prover to verifier. Note that such a modification might not be secure as a protocol, and hence is to be removed as plonky3 gets updated