### PR TITLE
Determine the degree of constraints using symbolic evaluation

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -13,6 +13,9 @@ pub trait BaseAir<F>: Sync {
 
 /// An AIR that works with a particular `AirBuilder`.
 pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
+    /// The number of columns (a.k.a. registers) in this AIR.
+    fn width(&self) -> usize;
+
     fn eval(&self, builder: &mut AB);
 }
 
@@ -230,6 +233,10 @@ mod tests {
     impl<F> BaseAir<F> for FibonacciAir {}
 
     impl<AB: AirBuilder> Air<AB> for FibonacciAir {
+        fn width(&self) -> usize {
+            1
+        }
+
         fn eval(&self, builder: &mut AB) {
             let main = builder.main();
 

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -4,7 +4,7 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::AbstractField;
 use p3_matrix::MatrixRowSlices;
 
-use crate::columns::KeccakCols;
+use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
 use crate::constants::rc_value_bit;
 use crate::logic::{andn_gen, xor3_gen, xor_gen};
 use crate::round_flags::eval_round_flags;
@@ -16,6 +16,10 @@ pub struct KeccakAir {}
 impl<F> BaseAir<F> for KeccakAir {}
 
 impl<AB: AirBuilder> Air<AB> for KeccakAir {
+    fn width(&self) -> usize {
+        NUM_KECCAK_COLS
+    }
+
     fn eval(&self, builder: &mut AB) {
         eval_round_flags(builder);
 

--- a/uni-stark/src/degree_builder.rs
+++ b/uni-stark/src/degree_builder.rs
@@ -1,0 +1,235 @@
+use core::iter::{Product, Sum};
+use core::marker::PhantomData;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use p3_air::{Air, AirBuilder};
+use p3_field::{AbstractField, Field};
+use p3_matrix::dense::RowMajorMatrix;
+
+pub fn get_max_constraint_degree<F: Field, A: Air<DegreeBuilder<F>>>(air: &A) -> usize {
+    let mut builder = DegreeBuilder::new(air.width());
+    air.eval(&mut builder);
+    builder.max_degree
+}
+
+/// The degree of a constraint, in the form `x n`, where `n` is a variable representing the trace length.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct ConstraintDegree<F: Field> {
+    degree: usize,
+    _phantom: PhantomData<F>,
+}
+
+impl<F: Field> ConstraintDegree<F> {
+    fn new(degree: usize) -> Self {
+        Self {
+            degree,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn constant() -> Self {
+        Self::new(0)
+    }
+
+    fn linear() -> Self {
+        Self::new(1)
+    }
+}
+
+impl<F: Field> AbstractField for ConstraintDegree<F> {
+    type F = F;
+
+    fn zero() -> Self {
+        Self::constant()
+    }
+
+    fn one() -> Self {
+        Self::constant()
+    }
+
+    fn two() -> Self {
+        Self::constant()
+    }
+
+    fn neg_one() -> Self {
+        Self::constant()
+    }
+
+    fn from_f(_f: Self::F) -> Self {
+        Self::constant()
+    }
+
+    fn from_bool(_b: bool) -> Self {
+        Self::constant()
+    }
+
+    fn from_canonical_u8(_n: u8) -> Self {
+        Self::constant()
+    }
+
+    fn from_canonical_u16(_n: u16) -> Self {
+        Self::constant()
+    }
+
+    fn from_canonical_u32(_n: u32) -> Self {
+        Self::constant()
+    }
+
+    fn from_canonical_u64(_n: u64) -> Self {
+        Self::constant()
+    }
+
+    fn from_canonical_usize(_n: usize) -> Self {
+        Self::constant()
+    }
+
+    fn from_wrapped_u32(_n: u32) -> Self {
+        Self::constant()
+    }
+
+    fn from_wrapped_u64(_n: u64) -> Self {
+        Self::constant()
+    }
+
+    fn generator() -> Self {
+        // TODO: Probably shouldn't be in AbstractField, only Field.
+        todo!()
+    }
+}
+
+impl<F: Field> From<F> for ConstraintDegree<F> {
+    fn from(_value: F) -> Self {
+        Self::constant()
+    }
+}
+
+impl<F: Field> Add for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.degree.max(rhs.degree))
+    }
+}
+
+impl<F: Field> Add<F> for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn add(self, _rhs: F) -> Self::Output {
+        self
+    }
+}
+
+impl<F: Field> AddAssign for ConstraintDegree<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: Field> Sum for ConstraintDegree<F> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|x, y| x + y).unwrap_or(Self::constant())
+    }
+}
+
+impl<F: Field> Sub for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.degree.max(rhs.degree))
+    }
+}
+
+impl<F: Field> Sub<F> for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn sub(self, _rhs: F) -> Self::Output {
+        self
+    }
+}
+
+impl<F: Field> SubAssign for ConstraintDegree<F> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: Field> Neg for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        self
+    }
+}
+
+impl<F: Field> Mul for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        #[allow(clippy::suspicious_arithmetic_impl)]
+        Self::new(self.degree + rhs.degree)
+    }
+}
+
+impl<F: Field> Mul<F> for ConstraintDegree<F> {
+    type Output = Self;
+
+    fn mul(self, _rhs: F) -> Self::Output {
+        self
+    }
+}
+
+impl<F: Field> MulAssign for ConstraintDegree<F> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: Field> Product for ConstraintDegree<F> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|x, y| x * y).unwrap_or(Self::constant())
+    }
+}
+
+pub struct DegreeBuilder<F: Field> {
+    main: RowMajorMatrix<ConstraintDegree<F>>,
+    max_degree: usize,
+}
+
+impl<F: Field> DegreeBuilder<F> {
+    fn new(width: usize) -> Self {
+        let values = (0..2)
+            .flat_map(|_row_offset| (0..width).map(move |_column| ConstraintDegree::linear()))
+            .collect();
+        Self {
+            main: RowMajorMatrix::new(values, width),
+            max_degree: 0,
+        }
+    }
+}
+
+impl<F: Field> AirBuilder for DegreeBuilder<F> {
+    type F = F;
+    type Expr = ConstraintDegree<F>;
+    type Var = ConstraintDegree<F>;
+    type M = RowMajorMatrix<ConstraintDegree<F>>;
+
+    fn main(&self) -> Self::M {
+        self.main.clone()
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        ConstraintDegree::linear()
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        ConstraintDegree::linear()
+    }
+
+    fn is_transition_window(&self, _size: usize) -> Self::Expr {
+        ConstraintDegree::constant()
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        self.max_degree = self.max_degree.max(x.into().degree);
+    }
+}

--- a/uni-stark/src/lib.rs
+++ b/uni-stark/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 
 mod config;
 mod decompose;
+mod degree_builder;
 mod folder;
 mod proof;
 mod prover;

--- a/uni-stark/src/sym_var.rs
+++ b/uni-stark/src/sym_var.rs
@@ -7,7 +7,7 @@ use p3_field::{Field, SymbolicField};
 pub struct BasicSymVar<F: Field> {
     pub row_offset: usize,
     pub column: usize,
-    _phantom: PhantomData<F>,
+    pub(crate) _phantom: PhantomData<F>,
 }
 
 impl<F: Field> From<BasicSymVar<F>> for SymbolicField<F, BasicSymVar<F>> {

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -31,6 +31,10 @@ struct MulAir;
 impl<F> BaseAir<F> for MulAir {}
 
 impl<AB: AirBuilder> Air<AB> for MulAir {
+    fn width(&self) -> usize {
+        TRACE_WIDTH
+    }
+
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let main_local = main.row_slice(0);
@@ -41,6 +45,10 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
             let b = main_local[start + 1];
             let c = main_local[start + 2];
             builder.assert_zero(a * b - c);
+
+            // TODO: Temporarily added this silly degree 3 constraint because we're getting an
+            // OodEvaluationMismatch when log_quotient_degree = 0.
+            builder.assert_zero(a * b * c - c * b * a);
         }
     }
 }


### PR DESCRIPTION
I had originally planned to write an `AirBuilder` which just captures symbolic constraints (something along the lines of `SymbolicField<BasicSymVar>`); then it could also be used for code generation etc. But I ran into the issue that Rust's coherence rules prevent `SymbolicField` from implementing e.g. `Add<Var>`. I guess we'd need a more specific version of `SymbolicField` (with a specific variable type) for that approach to work.