### PR TITLE
Proposal for lazy matrix view API

### DIFF
--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -2,7 +2,8 @@ use alloc::vec::Vec;
 
 use p3_field::{Field, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
-use p3_matrix::Matrix;
+use p3_matrix::view::{MatrixView, RowPermutation};
+use p3_matrix::{Matrix, MatrixRows};
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
 use p3_util::log2_strict_usize;
 
@@ -15,7 +16,7 @@ use crate::TwoAdicSubgroupDft;
 pub struct Radix2Dit;
 
 impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Dit {
-    fn dft_batch(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+    fn dft_batch(&self, mat: impl MatrixRows<F>) -> MatrixView<F, RowMajorMatrix<F>> {
         let h = mat.height();
         let log_h = log2_strict_usize(h);
 
@@ -23,11 +24,13 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Dit {
         let twiddles: Vec<F> = root.powers().take(h / 2).collect();
 
         // DIT butterfly
-        reverse_matrix_index_bits(&mut mat);
+        let mut mat = mat
+            .permute_rows(RowPermutation::BitReversed)
+            .to_row_major_matrix();
         for layer in 0..log_h {
             dit_layer(&mut mat.as_view_mut(), layer, &twiddles);
         }
-        mat
+        MatrixView::identity(mat)
     }
 }
 

--- a/dft/src/testing.rs
+++ b/dft/src/testing.rs
@@ -1,5 +1,6 @@
 use p3_field::TwoAdicField;
 use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::MatrixRows;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 
@@ -105,6 +106,6 @@ where
         let original = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
         let dft_output = dft.dft_batch(original.clone());
         let idft_output = dft.idft_batch(dft_output);
-        assert_eq!(original, idft_output);
+        assert_eq!(original, idft_output.to_row_major_matrix());
     }
 }

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -1,35 +1,44 @@
 use alloc::vec::Vec;
 
 use p3_field::TwoAdicField;
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::view::MatrixView;
 use p3_matrix::Matrix;
+use p3_matrix::{dense::RowMajorMatrix, MatrixRows};
 
 use crate::util::{divide_by_height, swap_rows};
 
 pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft(&self, vec: Vec<F>) -> Vec<F> {
-        self.dft_batch(RowMajorMatrix::new(vec, 1)).values
+        self.dft_batch(RowMajorMatrix::new(vec, 1))
+            .to_row_major_matrix()
+            .values
     }
 
     /// Compute the discrete Fourier transform (DFT) of each column in `mat`.
-    fn dft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F>;
+    fn dft_batch(&self, mat: impl MatrixRows<F>) -> MatrixView<F, RowMajorMatrix<F>>;
 
     /// Compute the "coset DFT" of `vec`. This can be viewed as interpolation onto a coset of a
     /// multiplicative subgroup, rather than the subgroup itself.
     fn coset_dft(&self, vec: Vec<F>, shift: F) -> Vec<F> {
         self.coset_dft_batch(RowMajorMatrix::new(vec, 1), shift)
+            .to_row_major_matrix()
             .values
     }
 
     /// Compute the "coset DFT" of each column in `mat`. This can be viewed as interpolation onto a
     /// coset of a multiplicative subgroup, rather than the subgroup itself.
-    fn coset_dft_batch(&self, mut mat: RowMajorMatrix<F>, shift: F) -> RowMajorMatrix<F> {
+    fn coset_dft_batch(
+        &self,
+        mat: impl MatrixRows<F>,
+        shift: F,
+    ) -> MatrixView<F, RowMajorMatrix<F>> {
         // Observe that
         //     y_i = \sum_j c_j (s g^i)^j
         //         = \sum_j (c_j s^j) (g^i)^j
         // which has the structure of an ordinary DFT, except each coefficient c_j is first replaced
         // by c_j s^j.
+        let mut mat = mat.to_row_major_matrix();
         mat.rows_mut()
             .zip(shift.powers())
             .for_each(|(row, weight)| {
@@ -42,12 +51,14 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
 
     /// Compute the inverse DFT of `vec`.
     fn idft(&self, vec: Vec<F>) -> Vec<F> {
-        self.idft_batch(RowMajorMatrix::new(vec, 1)).values
+        self.idft_batch(RowMajorMatrix::new(vec, 1))
+            .to_row_major_matrix()
+            .values
     }
 
     /// Compute the inverse DFT of each column in `mat`.
-    fn idft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
-        let mut dft = self.dft_batch(mat);
+    fn idft_batch(&self, mat: impl MatrixRows<F>) -> MatrixView<F, RowMajorMatrix<F>> {
+        let mut dft = self.dft_batch(mat).to_row_major_matrix();
         let h = dft.height();
 
         divide_by_height(&mut dft);
@@ -56,18 +67,23 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             swap_rows(&mut dft, row, h - row);
         }
 
-        dft
+        MatrixView::identity(dft)
     }
 
     /// Compute the low-degree extension of `vec` onto a larger subgroup.
     fn lde(&self, vec: Vec<F>, added_bits: usize) -> Vec<F> {
         self.lde_batch(RowMajorMatrix::new(vec, 1), added_bits)
+            .to_row_major_matrix()
             .values
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a larger subgroup.
-    fn lde_batch(&self, mat: RowMajorMatrix<F>, added_bits: usize) -> RowMajorMatrix<F> {
-        let mut coeffs = self.idft_batch(mat);
+    fn lde_batch(
+        &self,
+        mat: impl MatrixRows<F>,
+        added_bits: usize,
+    ) -> MatrixView<F, RowMajorMatrix<F>> {
+        let mut coeffs = self.idft_batch(mat).to_row_major_matrix();
         coeffs
             .values
             .resize(coeffs.values.len() << added_bits, F::zero());
@@ -77,17 +93,18 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
     fn coset_lde(&self, vec: Vec<F>, added_bits: usize, shift: F) -> Vec<F> {
         self.coset_lde_batch(RowMajorMatrix::new(vec, 1), added_bits, shift)
+            .to_row_major_matrix()
             .values
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
     fn coset_lde_batch(
         &self,
-        mat: RowMajorMatrix<F>,
+        mat: impl MatrixRows<F>,
         added_bits: usize,
         shift: F,
-    ) -> RowMajorMatrix<F> {
-        let mut coeffs = self.idft_batch(mat);
+    ) -> MatrixView<F, RowMajorMatrix<F>> {
+        let mut coeffs = self.idft_batch(mat).to_row_major_matrix();
         coeffs
             .values
             .resize(coeffs.values.len() << added_bits, F::zero());

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 p3-field = { path = "../field" }
 p3-maybe-rayon = { path = "../maybe-rayon" }
+p3-util = { path = "../util" }
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -8,6 +8,7 @@ use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterato
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
+use crate::view::{MatrixView, RowPermutation};
 use crate::{Matrix, MatrixGet, MatrixRowSlices, MatrixRowSlicesMut, MatrixRows, MatrixTranspose};
 
 /// A default constant for block size matrix transposition. The value was chosen with 32-byte type, in mind.
@@ -200,9 +201,18 @@ impl<T: Clone> MatrixRows<T> for RowMajorMatrix<T> {
     {
         self
     }
+
+    type Permuted = MatrixView<T, Self>;
+    fn permute_rows(self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        MatrixView::new(self, perm)
+    }
 }
 
 impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrix<T> {
+    type PermutedSlices = MatrixView<T, Self>;
     fn row_slice(&self, r: usize) -> &[T] {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
@@ -210,6 +220,7 @@ impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrix<T> {
 }
 
 impl<T: Clone> MatrixRowSlicesMut<T> for RowMajorMatrix<T> {
+    type PermutedSlicesMut = MatrixView<T, Self>;
     fn row_slice_mut(&mut self, r: usize) -> &mut [T] {
         debug_assert!(r < self.height());
         &mut self.values[r * self.width..(r + 1) * self.width]
@@ -277,9 +288,18 @@ impl<T: Clone> MatrixRows<T> for RowMajorMatrixView<'_, T> {
     {
         RowMajorMatrix::new(self.values.to_vec(), self.width)
     }
+
+    type Permuted = MatrixView<T, Self>;
+    fn permute_rows(self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        MatrixView::new(self, perm)
+    }
 }
 
 impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrixView<'_, T> {
+    type PermutedSlices = MatrixView<T, Self>;
     fn row_slice(&self, r: usize) -> &[T] {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
@@ -408,9 +428,18 @@ impl<T: Clone> MatrixRows<T> for RowMajorMatrixViewMut<'_, T> {
     {
         RowMajorMatrix::new(self.values.to_vec(), self.width)
     }
+
+    type Permuted = MatrixView<T, Self>;
+    fn permute_rows(self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        MatrixView::new(self, perm)
+    }
 }
 
 impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrixViewMut<'_, T> {
+    type PermutedSlices = MatrixView<T, Self>;
     fn row_slice(&self, r: usize) -> &[T] {
         debug_assert!(r < self.height());
         &self.values[r * self.width..(r + 1) * self.width]
@@ -418,6 +447,7 @@ impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrixViewMut<'_, T> {
 }
 
 impl<T: Clone> MatrixRowSlicesMut<T> for RowMajorMatrixViewMut<'_, T> {
+    type PermutedSlicesMut = MatrixView<T, Self>;
     fn row_slice_mut(&mut self, r: usize) -> &mut [T] {
         debug_assert!(r < self.height());
         &mut self.values[r * self.width..(r + 1) * self.width]

--- a/matrix/src/stack.rs
+++ b/matrix/src/stack.rs
@@ -1,6 +1,9 @@
 use core::marker::PhantomData;
 
-use crate::{Matrix, MatrixRows};
+use crate::{
+    view::{MatrixView, RowPermutation},
+    Matrix, MatrixRows,
+};
 
 /// A combination of two matrices, stacked together vertically.
 pub struct VerticalPair<T, First: Matrix<T>, Second: Matrix<T>> {
@@ -43,6 +46,14 @@ where
         } else {
             EitherIterable::Right(self.second.row(r - self.first.height()))
         }
+    }
+
+    type Permuted = MatrixView<T, Self>;
+    fn permute_rows(self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        MatrixView::new(self, perm)
     }
 }
 

--- a/matrix/src/strided.rs
+++ b/matrix/src/strided.rs
@@ -1,4 +1,7 @@
-use crate::{Matrix, MatrixRows};
+use crate::{
+    view::{MatrixView, RowPermutation},
+    Matrix, MatrixRows,
+};
 
 pub struct VerticallyStridedMatrixView<Inner> {
     pub(crate) inner: Inner,
@@ -25,5 +28,13 @@ impl<T, Inner: MatrixRows<T>> MatrixRows<T> for VerticallyStridedMatrixView<Inne
 
     fn row(&self, r: usize) -> Self::Row<'_> {
         self.inner.row(r * self.stride + self.offset)
+    }
+
+    type Permuted = MatrixView<T, Self>;
+    fn permute_rows(self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        MatrixView::new(self, perm)
     }
 }

--- a/matrix/src/view.rs
+++ b/matrix/src/view.rs
@@ -1,0 +1,187 @@
+use core::marker::PhantomData;
+
+use alloc::vec;
+use alloc::{boxed::Box, vec::Vec};
+use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+use p3_util::{log2_strict_usize, reverse_bits, reverse_bits_len};
+
+use crate::dense::RowMajorMatrix;
+use crate::{Matrix, MatrixRowSlices, MatrixRowSlicesMut, MatrixRows};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RowPermutation {
+    BitReversed,
+    // Opaque(Box<dyn Fn(/*height*/ usize, /*index*/ usize) -> usize>),
+}
+
+impl RowPermutation {
+    fn apply(&self, height: usize, index: usize) -> usize {
+        match self {
+            RowPermutation::BitReversed => reverse_bits(index, height),
+            // RowPermutation::Opaque(f) => f(height, index),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MatrixView<T, Inner> {
+    inner: Inner,
+    perms: Vec<RowPermutation>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: PartialEq, Inner: MatrixRows<T>> PartialEq for MatrixView<T, Inner> {
+    fn eq(&self, other: &Self) -> bool {
+        (0..self.height()).all(|r| {
+            self.row(r)
+                .into_iter()
+                .zip(other.row(r))
+                .all(|(x, y)| x == y)
+        })
+    }
+}
+impl<T: Eq, Inner: MatrixRows<T>> Eq for MatrixView<T, Inner> {}
+
+impl<T, Inner> MatrixView<T, Inner> {
+    pub fn identity(inner: Inner) -> Self {
+        Self {
+            inner,
+            perms: vec![],
+            _phantom: PhantomData,
+        }
+    }
+    pub fn new(inner: Inner, perm: RowPermutation) -> Self {
+        Self {
+            inner,
+            perms: vec![perm],
+            _phantom: PhantomData,
+        }
+    }
+
+    fn permute_row_index(&self, index: usize) -> usize
+    where
+        Inner: Matrix<T>,
+    {
+        if self.perms.is_empty() {
+            index
+        } else {
+            // Apply permutations right-to-left.
+            self.perms
+                .iter()
+                .rfold(index, |index, perm| perm.apply(self.inner.height(), index))
+        }
+    }
+}
+
+impl<T, Inner: Matrix<T>> Matrix<T> for MatrixView<T, Inner> {
+    fn width(&self) -> usize {
+        self.inner.width()
+    }
+    fn height(&self) -> usize {
+        self.inner.height()
+    }
+}
+
+impl<T, Inner: MatrixRows<T>> MatrixRows<T> for MatrixView<T, Inner> {
+    type Row<'a> = Inner::Row<'a> where Self: 'a;
+
+    fn row(&self, r: usize) -> Self::Row<'_> {
+        self.inner.row(self.permute_row_index(r))
+    }
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+        T: Clone,
+    {
+        if self.perms.is_empty() {
+            // Fast path for realizing the identity transform
+            self.inner.to_row_major_matrix()
+        } else if &self.perms == &[RowPermutation::BitReversed] {
+            // Fast path for a single bit-reversal
+            let mut mat = self.inner.to_row_major_matrix();
+            reverse_matrix_index_bits(&mut mat);
+            mat
+        } else {
+            RowMajorMatrix::new(
+                (0..self.height()).flat_map(|r| self.row(r)).collect(),
+                self.width(),
+            )
+        }
+    }
+
+    type Permuted = Self;
+    fn permute_rows(mut self, perm: RowPermutation) -> Self::Permuted
+    where
+        Self: Sized,
+    {
+        use RowPermutation::*;
+        match (perm, self.perms.last()) {
+            (BitReversed, Some(BitReversed)) => {
+                self.perms.pop();
+            }
+            (perm, _) => self.perms.push(perm),
+        }
+        self
+    }
+}
+
+impl<T, Inner: MatrixRowSlices<T>> MatrixRowSlices<T> for MatrixView<T, Inner> {
+    type PermutedSlices = Self;
+    fn row_slice(&self, r: usize) -> &[T] {
+        self.inner.row_slice(self.permute_row_index(r))
+    }
+}
+
+impl<T, Inner: MatrixRowSlicesMut<T>> MatrixRowSlicesMut<T> for MatrixView<T, Inner> {
+    type PermutedSlicesMut = Self;
+    fn row_slice_mut(&mut self, r: usize) -> &mut [T] {
+        self.inner.row_slice_mut(self.permute_row_index(r))
+    }
+}
+
+fn reverse_matrix_index_bits<F>(mat: &mut RowMajorMatrix<F>) {
+    let w = mat.width();
+    let h = mat.height();
+    let log_h = log2_strict_usize(h);
+    let values = mat.values.as_mut_ptr() as usize;
+
+    (0..h).into_par_iter().for_each(|i| {
+        let values = values as *mut F;
+        let j = reverse_bits_len(i, log_h);
+        if i < j {
+            unsafe { swap_rows_raw(values, w, i, j) };
+        }
+    });
+}
+
+unsafe fn swap_rows_raw<F>(mat: *mut F, w: usize, i: usize, j: usize) {
+    let row_i = core::slice::from_raw_parts_mut(mat.add(i * w), w);
+    let row_j = core::slice::from_raw_parts_mut(mat.add(j * w), w);
+    row_i.swap_with_slice(row_j);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dense::RowMajorMatrix;
+
+    #[test]
+    fn test_bit_reversal() {
+        let x = RowMajorMatrix::<usize>::new((0..8).collect(), 2);
+
+        let x_br = x.permute_rows(RowPermutation::BitReversed);
+        assert_eq!(x_br.row_slice(0), &[0, 1]);
+        assert_eq!(x_br.row_slice(1), &[4, 5]);
+        assert_eq!(x_br.row_slice(2), &[2, 3]);
+        assert_eq!(x_br.row_slice(3), &[6, 7]);
+
+        let x_br_br = x_br.permute_rows(RowPermutation::BitReversed);
+        assert_eq!(x_br_br.row_slice(0), &[0, 1]);
+        assert_eq!(x_br_br.row_slice(1), &[2, 3]);
+        assert_eq!(x_br_br.row_slice(2), &[4, 5]);
+        assert_eq!(x_br_br.row_slice(3), &[6, 7]);
+
+        assert!(x_br_br.perms.is_empty(), "bit-reversing twice is a no-op");
+    }
+}

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -170,7 +170,7 @@ impl Mersenne31Dft {
         mat: RowMajorMatrix<Base>,
     ) -> RowMajorMatrix<Ext> {
         let dft = Dft::default();
-        dft_postprocess(dft.dft_batch(dft_preprocess(mat)))
+        dft_postprocess(dft.dft_batch(dft_preprocess(mat)).to_row_major_matrix())
     }
 
     /// Compute the inverse DFT of each column of `mat`.
@@ -180,7 +180,7 @@ impl Mersenne31Dft {
         mat: RowMajorMatrix<Ext>,
     ) -> RowMajorMatrix<Base> {
         let dft = Dft::default();
-        idft_postprocess(dft.idft_batch(idft_preprocess(mat)))
+        idft_postprocess(dft.idft_batch(idft_preprocess(mat)).to_row_major_matrix())
     }
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -45,6 +45,37 @@ pub const fn indices_arr<const N: usize>() -> [usize; N] {
     indices_arr
 }
 
+#[inline]
+pub const fn reverse_bits(x: usize, n: usize) -> usize {
+    reverse_bits_len(x, n.trailing_zeros() as usize)
+}
+
+#[inline]
+pub const fn reverse_bits_len(x: usize, bit_len: usize) -> usize {
+    // NB: The only reason we need overflowing_shr() here as opposed
+    // to plain '>>' is to accommodate the case n == num_bits == 0,
+    // which would become `0 >> 64`. Rust thinks that any shift of 64
+    // bits causes overflow, even when the argument is zero.
+    x.reverse_bits()
+        .overflowing_shr(usize::BITS - bit_len as u32)
+        .0
+}
+
+pub fn reverse_slice_index_bits<F>(vals: &mut [F]) {
+    let n = vals.len();
+    if n == 0 {
+        return;
+    }
+    let log_n = log2_strict_usize(n);
+
+    for i in 0..n {
+        let j = reverse_bits_len(i, log_n);
+        if i < j {
+            vals.swap(i, j);
+        }
+    }
+}
+
 #[inline(always)]
 pub fn assume(p: bool) {
     debug_assert!(p);


### PR DESCRIPTION
A `MatrixView` is defined which wraps an inner `MatrixRows`. The `MatrixView` stores a list of row permutations to be applied to any index before indexing into the underlying `MatrixRows`.

Disadvantages:
- Row permutation is not known statically
- Very slight performance loss when indexing into an identity wrapper (checks if `self.perms.is_empty()`)
- Small boilerplate for any new `MatrixRows` implementer
- Can't permute columns (lazy transpose), this could be possible with some more machinery but will pollute API (it would need a separate `MatrixColView` so that `MatrixView` can still implement `MatrixRowSlices`)

Advantages:
- Can "JIT" known patterns of permutations (bitrev . bitrev, possible others)
- Equal performance in DFT benches

Short term work remaining: let the permutation also redefine height & width so we can absorb VerticallyStridedView

Long term:
- investigate `Rc` and/or `Cow` setups. For instance, `MerkleMmcs` only needs a readonly copy of its leaves, but currently takes ownership, necessitating copies.
- make `MatrixView` general enough to absorb `RowMajorMatrixView{,Mut}`.

I guess the main concern is that this is adding enough complexity that it could be difficult to do the `Rc/Cow` optimizations later, like it could just be wasting time if it's all going to be rewritten anyways.