### PR TITLE
feat: make lagrange_basis_unnormalized + folders in uni-stark pub

### DIFF
--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -4,21 +4,21 @@ use p3_field::{AbstractField, Field};
 use crate::StarkConfig;
 
 pub struct ProverConstraintFolder<'a, SC: StarkConfig> {
-    pub(crate) main: TwoRowMatrixView<'a, SC::PackedVal>,
-    pub(crate) is_first_row: SC::PackedVal,
-    pub(crate) is_last_row: SC::PackedVal,
-    pub(crate) is_transition: SC::PackedVal,
-    pub(crate) alpha: SC::Challenge,
-    pub(crate) accumulator: SC::PackedChallenge,
+    pub main: TwoRowMatrixView<'a, SC::PackedVal>,
+    pub is_first_row: SC::PackedVal,
+    pub is_last_row: SC::PackedVal,
+    pub is_transition: SC::PackedVal,
+    pub alpha: SC::Challenge,
+    pub accumulator: SC::PackedChallenge,
 }
 
 pub struct VerifierConstraintFolder<'a, Challenge> {
-    pub(crate) main: TwoRowMatrixView<'a, Challenge>,
-    pub(crate) is_first_row: Challenge,
-    pub(crate) is_last_row: Challenge,
-    pub(crate) is_transition: Challenge,
-    pub(crate) alpha: Challenge,
-    pub(crate) accumulator: Challenge,
+    pub main: TwoRowMatrixView<'a, Challenge>,
+    pub is_first_row: Challenge,
+    pub is_last_row: Challenge,
+    pub is_transition: Challenge,
+    pub alpha: Challenge,
+    pub accumulator: Challenge,
 }
 
 impl<'a, SC: StarkConfig> AirBuilder for ProverConstraintFolder<'a, SC> {

--- a/uni-stark/src/zerofier_coset.rs
+++ b/uni-stark/src/zerofier_coset.rs
@@ -62,7 +62,7 @@ impl<F: TwoAdicField> ZerofierOnCoset<F> {
     /// Evaluate the Langrange basis polynomial, `L_i(x) = Z_H(x) / (x - g_H^i)`, on our coset `s K`.
     /// Here `L_i(x)` is unnormalized in the sense that it evaluates to some nonzero value at `g_H^i`,
     /// not necessarily 1.
-    pub(crate) fn lagrange_basis_unnormalized(&self, i: usize) -> Vec<F> {
+    pub fn lagrange_basis_unnormalized(&self, i: usize) -> Vec<F> {
         let log_coset_size = self.log_n + self.rate_bits;
         let coset_size = 1 << log_coset_size;
         let g_h = F::two_adic_generator(self.log_n);


### PR DESCRIPTION
Making these methods public makes it easier for projects trying to use individual components in `uni-stark`.