### PR TITLE
Fix the domain we evaluate the quotient over

### DIFF
--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -70,7 +70,7 @@ where
     In: MatrixRows<Val>,
     Challenger: FieldChallenger<Val>,
 {
-    type Lde<'a>: MatrixGet<Val> + Sync
+    type Lde<'a>: MatrixRows<Val> + MatrixGet<Val> + Sync
     where
         Self: 'a;
 

--- a/matrix/src/strided.rs
+++ b/matrix/src/strided.rs
@@ -1,4 +1,4 @@
-use crate::{Matrix, MatrixRows};
+use crate::{Matrix, MatrixGet, MatrixRows};
 
 pub struct VerticallyStridedMatrixView<Inner> {
     pub(crate) inner: Inner,
@@ -17,6 +17,12 @@ impl<T, Inner: Matrix<T>> Matrix<T> for VerticallyStridedMatrixView<Inner> {
         let remainder = h % self.stride;
         let final_stride = self.offset < remainder;
         full_strides + final_stride as usize
+    }
+}
+
+impl<T, Inner: MatrixGet<T>> MatrixGet<T> for VerticallyStridedMatrixView<Inner> {
+    fn get(&self, r: usize, c: usize) -> T {
+        self.inner.get(r * self.stride + self.offset, c)
     }
 }
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -10,7 +10,7 @@ use p3_field::{
     TwoAdicField,
 };
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::{Matrix, MatrixGet};
+use p3_matrix::{Matrix, MatrixGet, MatrixRows};
 use p3_maybe_rayon::{IndexedParallelIterator, MaybeIntoParIter, ParallelIterator};
 use p3_util::log2_strict_usize;
 use tracing::{info_span, instrument};
@@ -50,12 +50,15 @@ where
     assert_eq!(trace_ldes.len(), 1);
     let trace_lde = trace_ldes.pop().unwrap();
 
+    let log_stride_for_quotient = pcs.log_blowup() - log_quotient_degree;
+    let trace_lde_for_quotient = trace_lde.vertically_strided(1 << log_stride_for_quotient, 0);
+
     let quotient_values = quotient_values(
         config,
         air,
         log_degree,
         log_quotient_degree,
-        trace_lde,
+        trace_lde_for_quotient,
         alpha,
     );
 

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -45,10 +45,6 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
             let b = main_local[start + 1];
             let c = main_local[start + 2];
             builder.assert_zero(a * b - c);
-
-            // TODO: Temporarily added this silly degree 3 constraint because we're getting an
-            // OodEvaluationMismatch when log_quotient_degree = 0.
-            builder.assert_zero(a * b * c - c * b * a);
         }
     }
 }


### PR DESCRIPTION
Previously we were evaluating the quotient polynomial over the same domain that trace LDEs were defined over. However, it's valid and sometimes useful to let them diverge, i.e. with a larger blowup factor to minimize FRI queries.

It's also occasionally useful to have the opposite - a quotient whose degree exceeds our (committed) blowup factor. In that case we'd do the larger LDE for quotient evaluation, but Merklize a strided view of it, to speed up the commitment. However, this is a bit more annoying to support, and probably less frequently useful.

Fixes #188.