### PR TITLE
[issue] make p3_maybe_rayon parallel feature non-default

### DIFF
--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -17,6 +17,9 @@ p3-mersenne-31 = { path = "../mersenne-31" }
 criterion = "0.5.1"
 rand = "0.8.5"
 
+[features]
+parallel = ["p3-matrix/parallel", "p3-maybe-rayon/parallel"]
+
 [[bench]]
 name = "fft"
 harness = false

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -4,7 +4,9 @@ use p3_field::{Field, Powers, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;
-use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
+use p3_maybe_rayon::MaybeParChunksMut;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_util::{log2_strict_usize, reverse_bits, reverse_slice_index_bits};
 
 use crate::butterflies::{

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -4,7 +4,9 @@ use p3_field::{Field, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;
-use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
+use p3_maybe_rayon::MaybeParChunksMut;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_util::log2_strict_usize;
 
 use crate::butterflies::{dit_butterfly_on_rows, twiddle_free_butterfly_on_rows};

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -5,6 +5,7 @@ use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;
+#[cfg(feature = "parallel")]
 use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_util::{log2_strict_usize, reverse_bits, reverse_slice_index_bits};
 

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -29,6 +29,9 @@ criterion = "0.5.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 
+[features]
+parallel = ["p3-dft/parallel", "p3-matrix/parallel", "p3-maybe-rayon/parallel", "p3-merkle-tree/parallel"]
+
 [[bench]]
 name = "fold_even_odd"
 harness = false

--- a/fri/src/matrix_reducer.rs
+++ b/fri/src/matrix_reducer.rs
@@ -4,7 +4,9 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use p3_field::{ExtensionField, Field, PackedField};
 use p3_matrix::MatrixRows;
-use p3_maybe_rayon::{IndexedParallelIterator, MaybeIntoParIter, ParallelIterator};
+use p3_maybe_rayon::MaybeIntoParIter;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_util::indices_arr;
 use tracing::instrument;
 

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -13,6 +13,9 @@ rand = "0.8.5"
 [dev-dependencies]
 criterion = "0.5.1"
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [[bench]]
 name = "transpose_benchmark"
 path = "benches/transpose_benchmark.rs"

--- a/matrix/src/mul.rs
+++ b/matrix/src/mul.rs
@@ -1,7 +1,9 @@
 use alloc::vec;
 
 use p3_field::{add_scaled_slice_in_place, Field};
-use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+use p3_maybe_rayon::MaybeIntoParIter;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::ParallelIterator;
 
 use crate::dense::RowMajorMatrix;
 use crate::sparse::CsrMatrix;

--- a/matrix/src/util.rs
+++ b/matrix/src/util.rs
@@ -1,4 +1,6 @@
-use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+use p3_maybe_rayon::MaybeIntoParIter;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::ParallelIterator;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 
 use crate::dense::RowMajorMatrix;

--- a/maybe-rayon/Cargo.toml
+++ b/maybe-rayon/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["parallel"]
+default = []
 parallel = ["rayon"]
 
 [dependencies]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -25,6 +25,9 @@ p3-rescue = { path = "../rescue" }
 criterion = "0.5.1"
 rand = "0.8.5"
 
+[features]
+parallel = ["p3-matrix/parallel", "p3-maybe-rayon/parallel"]
+
 [[bench]]
 name = "merkle_tree"
 harness = false

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -7,7 +7,9 @@ use itertools::Itertools;
 use p3_field::{AbstractField, Field, PackedField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixRowSlices};
-use p3_maybe_rayon::{IndexedParallelIterator, MaybeParChunksMut, ParallelIterator};
+use p3_maybe_rayon::MaybeParChunksMut;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use tracing::instrument;
 

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -31,3 +31,6 @@ rand = "0.8.5"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }
+
+[features]
+parallel = ["p3-maybe-rayon/parallel", "p3-matrix/parallel", "p3-dft/parallel"]

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -4,7 +4,11 @@ use alloc::vec::Vec;
 use itertools::izip;
 use p3_field::{AbstractExtensionField, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_maybe_rayon::{MaybeIntoParIter, ParallelIterator};
+use p3_maybe_rayon::MaybeIntoParIter;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::ParallelIterator;
+#[cfg(not(feature = "parallel"))]
+use p3_maybe_rayon::ParallelIteratorMock;
 use p3_util::log2_strict_usize;
 
 use crate::StarkConfig;

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -11,7 +11,11 @@ use p3_field::{
 };
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixGet, MatrixRows};
-use p3_maybe_rayon::{IndexedParallelIterator, MaybeIntoParIter, ParallelIterator};
+use p3_maybe_rayon::MaybeIntoParIter;
+#[cfg(not(feature = "parallel"))]
+use p3_maybe_rayon::ParallelIteratorMock;
+#[cfg(feature = "parallel")]
+use p3_maybe_rayon::{IndexedParallelIterator, ParallelIterator};
 use p3_util::log2_strict_usize;
 use tracing::{info_span, instrument};
 


### PR DESCRIPTION
Addresses issue #201, to allow `p3_maybe_rayon` parallel feature to be non-default. Also remove `p3_maybe_rayon` dependency from `mersenne-31` crate, as currently it is not needed.