### PR TITLE
Fix Keccak AIR

### DIFF
--- a/keccak-air/src/columns.rs
+++ b/keccak-air/src/columns.rs
@@ -6,6 +6,13 @@ use p3_util::indices_arr;
 use crate::constants::R;
 use crate::{NUM_ROUNDS, RATE_LIMBS, U64_LIMBS};
 
+/// Note: The ordering of each array is based on the input mapping. As the spec says,
+///
+/// > The mapping between the bits of s and those of a is `s[w(5y + x) + z] = a[x][y][z]`.
+///
+/// Thus, for example, `a_prime` is stored in `y, x, z` order. This departs from the more common
+/// convention of `x, y, z` order, but it has the benefit that input lists map to AIR columns in a
+/// nicer way.
 #[repr(C)]
 pub(crate) struct KeccakCols<T> {
     /// The `i`th value is set to 1 if we are in the `i`th round, otherwise 0.

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -78,11 +78,11 @@ fn generate_trace_row_for_round<F: PrimeField64>(row: &mut KeccakCols<F>, round:
         for z in 0..64 {
             let limb = z / BITS_PER_LIMB;
             let bit_in_limb = z % BITS_PER_LIMB;
-            let a = [0, 1, 2, 3, 4].map(|i| {
-                let a_limb = row.a[i][x][limb].as_canonical_u64() as u16;
-                F::from_bool(((a_limb >> bit_in_limb) & 1) != 0)
+            let a = (0..5).map(|y| {
+                let a_limb = row.a[y][x][limb].as_canonical_u64() as u16;
+                ((a_limb >> bit_in_limb) & 1) != 0
             });
-            row.c[x][z] = xor(a);
+            row.c[x][z] = F::from_bool(a.fold(false, |acc, x| acc ^ x));
         }
     }
 
@@ -108,7 +108,7 @@ fn generate_trace_row_for_round<F: PrimeField64>(row: &mut KeccakCols<F>, round:
                 let bit_in_limb = z % BITS_PER_LIMB;
                 let a_limb = row.a[y][x][limb].as_canonical_u64() as u16;
                 let a_bit = F::from_bool(((a_limb >> bit_in_limb) & 1) != 0);
-                row.a_prime[x][y][z] = xor([a_bit, row.c[x][z], row.c_prime[x][z]]);
+                row.a_prime[y][x][z] = xor([a_bit, row.c[x][z], row.c_prime[x][z]]);
             }
         }
     }


### PR DESCRIPTION
There was a bug where an array was treated as having `x, y, z` order rather than `y, x, z` order.

Also made a few other index-related tweaks while I'm here.