### PR TITLE
feat(AIR): Message AirBuilder

### DIFF
--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -1,4 +1,4 @@
-use p3_air::{Air, AirBuilder, TwoRowMatrixView};
+use p3_air::{Air, AirBuilder, EmptyMessageBuilder, TwoRowMatrixView};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixRowSlices};
@@ -90,3 +90,5 @@ where
         );
     }
 }
+
+impl<'a, F: Field> EmptyMessageBuilder for DebugConstraintBuilder<'a, F> {}

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,4 +1,4 @@
-use p3_air::{AirBuilder, TwoRowMatrixView};
+use p3_air::{AirBuilder, EmptyMessageBuilder, TwoRowMatrixView};
 use p3_field::{AbstractField, Field};
 
 use crate::StarkConfig;
@@ -54,6 +54,8 @@ impl<'a, SC: StarkConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     }
 }
 
+impl<'a, SC: StarkConfig> EmptyMessageBuilder for ProverConstraintFolder<'a, SC> {}
+
 impl<'a, Challenge: Field> AirBuilder for VerifierConstraintFolder<'a, Challenge> {
     type F = Challenge;
     type Expr = Challenge;
@@ -86,3 +88,5 @@ impl<'a, Challenge: Field> AirBuilder for VerifierConstraintFolder<'a, Challenge
         self.accumulator += x;
     }
 }
+
+impl<'a, Challenge: Field> EmptyMessageBuilder for VerifierConstraintFolder<'a, Challenge> {}

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use p3_air::{Air, AirBuilder};
+use p3_air::{Air, AirBuilder, EmptyMessageBuilder};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_ceil_usize;
@@ -105,3 +105,5 @@ impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
         self.constraints.push(x.into());
     }
 }
+
+impl<F: Field> EmptyMessageBuilder for SymbolicAirBuilder<F> {}


### PR DESCRIPTION
This PR adds an additional builder trait called `MessageBuilder`. The motivation for it comes from multi-table STARK constructions. Having the message passing interface allows us to encode the lookup requests as part of the AIR constraints which enables the convenient use of arithmetic expressions over table entries and better readability as all the constraint related interactions are included in the AIR itself. These messages can be used by a specialized builder (similar to a symbolic builder) to translate them into interaction terms used by multi table lookup arguments. 

We also include an `EmptyMessageBuilder` trait that allows for convenient auto-implementation of `MessageBuilder` for which sending and receiving a message is a no-op.

We want to include the message builder API in the main Plonky3 repo as we believe it might be useful for other projects working with cross-table lookup arguments, and also need to provide blanket implementations of `MessageBuilder` for `FilteredAirBuilder`, `SymbolicBuilder`, and other builder types that exist in the uni-stark.