### PR TITLE
Minor: Fixing alpha in sbox for BabyBear and Goldilocks in Poseidon2

### DIFF
--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -21,7 +21,7 @@ type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 
 type MyMds = CosetMds<Val, 16>;
-type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 5>;
+type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 type ValMmcs = FieldMerkleTreeMmcs<<Val as Field>::Packing, MyHash, MyCompress, 8>;

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), VerificationError> {
     type MyMds = CosetMds<Val, 16>;
     let mds = MyMds::default();
 
-    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 5>;
+    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 7>;
     let perm = Perm::new_from_rng(8, 22, mds, DiffusionMatrixBabybear, &mut thread_rng());
 
     type MyHash = SerializingHasher32<Keccak256Hash>;

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), VerificationError> {
     type MyMds = CosetMds<Val, 16>;
     let mds = MyMds::default();
 
-    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 5>;
+    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 7>;
     let perm = Perm::new_from_rng(8, 22, mds, DiffusionMatrixBabybear, &mut thread_rng());
 
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), VerificationError> {
     type MyMds = CosetMds<Val, 8>;
     let mds = MyMds::default();
 
-    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixGoldilocks, 8, 5>;
+    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixGoldilocks, 8, 7>;
     let perm = Perm::new_from_rng(8, 22, mds, DiffusionMatrixGoldilocks, &mut thread_rng());
 
     type MyHash = SerializingHasher64<Keccak256Hash>;

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -80,7 +80,7 @@ fn test_prove_baby_bear() -> Result<(), VerificationError> {
     type MyMds = CosetMds<Val, 16>;
     let mds = MyMds::default();
 
-    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 5>;
+    type Perm = Poseidon2<Val, MyMds, DiffusionMatrixBabybear, 16, 7>;
     let perm = Perm::new_from_rng(8, 22, mds, DiffusionMatrixBabybear, &mut thread_rng());
 
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;


### PR DESCRIPTION
Hi folks, I was reading the code lately, and I noticed some minor typos in testing related to Poseidon2, on SBox alpha, which should be the smallest positive integer satisfying gcd(p - 1, alpha) = 1. I believe this setting should derive from https://eprint.iacr.org/2019/458.pdf under section 2.3, s-box layer.

I went through the codebase and fixed alphas for Poseidon2 permutation instantiations over Goldilocks or BabyBear fields, in both cases the minimum alpha should be 7 rather than 5, if I calculated correctly.

Please let me know your thoughts on this minor PR, thanks.