### PR TITLE
feat: change commit shifted batches to accept different shifts

### DIFF
--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -88,7 +88,7 @@ where
     fn commit_shifted_batches(
         &self,
         polynomials: Vec<In>,
-        coset_shift: Val,
+        coset_shifts: &[Val],
     ) -> (Self::Commitment, Self::ProverData);
 
     fn commit_shifted_batch(
@@ -96,7 +96,7 @@ where
         polynomials: In,
         coset_shift: Val,
     ) -> (Self::Commitment, Self::ProverData) {
-        self.commit_shifted_batches(vec![polynomials], coset_shift)
+        self.commit_shifted_batches(vec![polynomials], &[coset_shift])
     }
 }
 

--- a/ldt/src/ldt_based_pcs.rs
+++ b/ldt/src/ldt_based_pcs.rs
@@ -73,13 +73,14 @@ where
     fn commit_shifted_batches(
         &self,
         polynomials: Vec<In>,
-        coset_shift: Val,
+        coset_shifts: &[Val],
     ) -> (Self::Commitment, Self::ProverData) {
-        let shift = Val::generator() / coset_shift;
         let ldes = info_span!("compute all coset LDEs").in_scope(|| {
             polynomials
                 .into_iter()
-                .map(|poly| {
+                .zip_eq(coset_shifts.iter())
+                .map(|(poly, coset_shift)| {
+                    let shift = Val::generator() / *coset_shift;
                     let input = poly.to_row_major_matrix();
                     // Commit to the bit-reversed LDE.
                     self.dft
@@ -110,7 +111,10 @@ where
     type Error = L::Error;
 
     fn commit_batches(&self, polynomials: Vec<In>) -> (Self::Commitment, Self::ProverData) {
-        self.commit_shifted_batches(polynomials, Val::one())
+        let shifts = (0..polynomials.len())
+            .map(|_| Val::one())
+            .collect::<Vec<_>>();
+        self.commit_shifted_batches(polynomials, &shifts)
     }
 }
 


### PR DESCRIPTION
In a similar spirit to the API changes introduced in #194, this PR changes `commit_shifted_batches` to support a different shift for each polynomial. 

This is useful when committing to different tables with different max constraint degrees. 