### PR TITLE
Stable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,34 +13,43 @@ jobs:
   build_and_test:
     name: Build and Test
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    env:
+      CARGO_INCREMENTAL: 1
 
     steps:
     - uses: actions/checkout@v4
+
     - uses: dtolnay/rust-toolchain@stable
-    - name: Build
-      run: cargo build --verbose --all-targets
-    - name: Test
-      run: cargo test --verbose
-
-  lints:
-    name: Formatting and Clippy
-    runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
+      with:
           components: clippy
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
+      id: rs-stable
 
-      - name: Run cargo fmt
-        run: cargo +nightly fmt --all -- --check 
-        env:
-          CARGO_INCREMENTAL: 1
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt
 
-      - name: Run cargo clippy
-        run: cargo +stable clippy --all-features --all-targets -- -D warnings
-        env:
-          CARGO_INCREMENTAL: 1
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Build
+      run: cargo +stable build --verbose --all-targets
+
+    - name: Check with parallel
+      run: cargo +stable check --verbose --all-targets --features parallel
+
+    - name: Test
+      run: cargo +stable test --verbose
+
+    - name: Clippy
+      run: cargo +stable clippy --all-targets -- -D warnings
+
+    - name: Format
+      run: cargo +nightly fmt --all -- --check 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,56 +15,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build
-      run: cargo +nightly build --verbose --all-targets
+      run: cargo build --verbose --all-targets
     - name: Test
-      run: |
-        cargo +nightly test --verbose
+      run: cargo test --verbose
 
   lints:
     name: Formatting and Clippy
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install nightly toolchain
-        id: rustc-toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: nightly-2023-06-30
-          override: true
-          components: rustfmt, clippy
-
-      - name: rust-cache
-        uses: actions/cache@v3
+          components: clippy
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rustc-lints-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo +nightly fmt --all -- --check 
         env:
           CARGO_INCREMENTAL: 1
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings -A incomplete-features
+        run: cargo +stable clippy --all-features --all-targets -- -D warnings
         env:
           CARGO_INCREMENTAL: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,43 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 1
 
 jobs:
   build_and_test:
     name: Build and Test
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-    env:
-      CARGO_INCREMENTAL: 1
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@stable
+      id: rs-stable
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
+
+    - name: Build
+      run: cargo build --verbose --all-targets
+
+    - name: Check with parallel
+      run: cargo check --verbose --all-targets --features parallel
+
+    - name: Test
+      run: cargo test --verbose
+
+  lint:
+    name: Formatting and Clippy
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
     steps:
     - uses: actions/checkout@v4
@@ -39,17 +68,9 @@ jobs:
           target/
         key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
 
-    - name: Build
-      run: cargo +stable build --verbose --all-targets
-
-    - name: Check with parallel
-      run: cargo +stable check --verbose --all-targets --features parallel
-
-    - name: Test
-      run: cargo +stable test --verbose
-
     - name: Clippy
       run: cargo +stable clippy --all-targets -- -D warnings
 
     - name: Format
       run: cargo +nightly fmt --all -- --check 
+


### PR DESCRIPTION
Seems like `actions-rs` is unmaintained, so switched to `dtolnay/rust-toolchain`. Merged them into one job for more caching, but I'm not sure what the benefits were of two jobs, so I could be wrong. Also added a `check` to make sure it compiles with `--features parallel`.