### PR TITLE
Fix extension matrix width

### DIFF
--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -115,7 +115,7 @@ where
     InnerMat: Matrix<F>,
 {
     fn width(&self) -> usize {
-        self.inner.width() * <EF as AbstractExtensionField<F>>::D
+        self.inner.width() / <EF as AbstractExtensionField<F>>::D
     }
 
     fn height(&self) -> usize {


### PR DESCRIPTION
The extension matrix width should be 1/Dth of the inner matrix width