### PR TITLE
parallelize polynomial decompose method

### DIFF
--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "parallel")]
 pub mod prelude {
-    pub use rayon::prelude::*;
     pub use rayon::join;
+    pub use rayon::prelude::*;
 }
 
 #[cfg(not(feature = "parallel"))]

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "parallel")]
 pub mod prelude {
     pub use rayon::prelude::*;
+    pub use rayon::join;
 }
 
 #[cfg(not(feature = "parallel"))]

--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -28,6 +28,7 @@ pub trait IntoParallelRefIterator<'data> {
 
     fn par_iter(&'data self) -> Self::Iter;
 }
+
 impl<'data, I: 'data + ?Sized> IntoParallelRefIterator<'data> for I
 where
     &'data I: IntoParallelIterator,
@@ -46,6 +47,7 @@ pub trait IntoParallelRefMutIterator<'data> {
 
     fn par_iter_mut(&'data mut self) -> Self::Iter;
 }
+
 impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
 where
     &'data mut I: IntoParallelIterator,
@@ -162,4 +164,14 @@ impl<T: Iterator> ParIterExt for T {
     {
         self.flat_map(map_op)
     }
+}
+
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA,
+    B: FnOnce() -> RB,
+{
+    let result_a = oper_a();
+    let result_b = oper_b();
+    (result_a, result_b)
 }

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -16,6 +16,7 @@ p3-util = { path = "../util" }
 itertools = "0.12.0"
 tracing = "0.1.37"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+rayon = "1.8.1"
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -16,7 +16,6 @@ p3-util = { path = "../util" }
 itertools = "0.12.0"
 tracing = "0.1.37"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-rayon = "1.8.1"
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -50,7 +50,7 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<
         return vec![poly];
     }
 
-    fft_decompose(poly, log_chunks)
+    fft_decompose(poly, shift, log_chunks)
 }
 
 mod dit_decompose {
@@ -80,7 +80,7 @@ mod dit_decompose {
         let g = F::two_adic_generator(log2_strict_usize(n));
     
         for (i, item) in poly.iter_mut().enumerate() {
-            *item = *item * shift.powers(&g.exp_usize(i));
+            *item = *item * shift.pow(&g.exp_usize(i));
         }
     }    
     

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -50,46 +50,86 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<
         return vec![poly];
     }
 
-    fft_decompose(poly, shift, log_chunks)
+    let n = poly.len();
+    debug_assert!(n > 1);
+    let log_n = log2_strict_usize(n);
+    let half_n = poly.len() / 2;
+    let g_inv = F::two_adic_generator(log_n).inverse();
+
+    let one_half = F::two().inverse();
+    let (first, second) = poly.split_at(half_n);
+
+    // Note that
+    //     p_e(g^(2i)) = (p(g^i) + p(g^(n/2 + i))) / 2
+    //     p_o(g^(2i)) = (p(g^i) - p(g^(n/2 + i))) / (2 s g^i)
+
+    //     p_e(g^(2i)) = (a + b) / 2
+    //     p_o(g^(2i)) = (a - b) / (2 s g^i)
+    let (even, odd): (Vec<_>, Vec<_>) = first
+        .par_iter()
+        .zip(second.par_iter())
+        .zip(g_inv.shifted_powers(shift.inverse()))
+        .map(|((&a, &b), g_inv_power)| {
+            let sum = a + b;
+            let diff = a - b;
+            (sum * one_half, diff * one_half * g_inv_power)
+        })
+        .unzip();
+
+    let (even_decomp, odd_decomp) = rayon::join(
+        || decompose(even, shift.square(), log_chunks - 1),
+        || decompose(odd, shift.square(), log_chunks - 1),
+    );
+
+    let mut combined = even_decomp;
+    combined.extend(odd_decomp);
+    combined
 }
 
 mod dit_decompose {
     use alloc::vec::Vec;
+
     use p3_field::TwoAdicField;
     use p3_util::log2_strict_usize;
 
-    pub fn fft_decompose<F: TwoAdicField>(mut poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<Vec<F>> {
+    pub fn fft_decompose<F: TwoAdicField>(
+        mut poly: Vec<F>,
+        shift: F,
+        log_chunks: usize,
+    ) -> Vec<Vec<F>> {
         let n = poly.len();
         let log_n = log2_strict_usize(n);
-    
+
         // Ensure the poly length is a power of 2
         assert!(n.is_power_of_two());
-    
+
         // Apply the shift for coset FFT
-        apply_shift(&mut poly, &shift);
-    
+        // apply_shift(&mut poly, &shift);
+
         // Transform the polynomial using a partial FFT (only up to log_chunks layers)
         partial_fft(&mut poly, log_n, log_chunks);
-    
+
         // Split the transformed polynomial into chunks
-        poly.chunks(1 << log_chunks).map(|chunk| chunk.to_vec()).collect()
+        poly.chunks(1 << log_chunks)
+            .map(|chunk| chunk.to_vec())
+            .collect()
     }
-    
-    fn apply_shift<F: TwoAdicField>(poly: &mut [F], shift: &F) {
-        let n = poly.len();
-        let g = F::two_adic_generator(log2_strict_usize(n));
-    
-        for (i, item) in poly.iter_mut().enumerate() {
-            *item = *item * shift.pow(&g.exp_usize(i));
-        }
-    }    
-    
+
+    // fn apply_shift<F: TwoAdicField>(poly: &mut [F], shift: &F) {
+    //     let n = poly.len();
+    //     let g = F::two_adic_generator(log2_strict_usize(n));
+
+    //     for (i, item) in poly.iter_mut().enumerate() {
+    //         *item = *item * shift.pow(&g.exp_usize(i));
+    //     }
+    // }
+
     fn partial_fft<F: TwoAdicField>(poly: &mut [F], log_n: usize, log_chunks: usize) {
         let n = poly.len();
         if n <= 1 || log_chunks == 0 {
             return;
         }
-    
+
         // Bit-reverse the order of the coefficients
         for i in 0..n {
             let rev = bit_reverse(i, log_n);
@@ -97,7 +137,7 @@ mod dit_decompose {
                 poly.swap(i, rev);
             }
         }
-    
+
         // Perform the butterfly operations only up to log_chunks layers
         let mut m = 1;
         for _ in 0..log_chunks {
@@ -117,7 +157,7 @@ mod dit_decompose {
             m *= 2;
         }
     }
-    
+
     fn bit_reverse(mut x: usize, log_n: usize) -> usize {
         let mut result = 0;
         for _ in 0..log_n {
@@ -125,7 +165,7 @@ mod dit_decompose {
             x >>= 1;
         }
         result
-    }    
+    }
 }
 
 #[cfg(test)]

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -62,14 +62,14 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<
 
     //     p_e(g^(2i)) = (a + b) / 2
     //     p_o(g^(2i)) = (a - b) / (2 s g^i)
-    let mut g_powers = g_inv.shifted_powers(shift.inverse());
-    let g_powers = (0..first.len())
-        .map(|_| g_powers.next().unwrap())
+    let mut g_inv_powers = g_inv.shifted_powers(shift.inverse());
+    let g_inv_powers = (0..first.len())
+        .map(|_| g_inv_powers.next().unwrap())
         .collect::<Vec<_>>();
     let (even, odd): (Vec<_>, Vec<_>) = first
         .par_iter()
         .zip(second.par_iter())
-        .zip(g_powers.par_iter())
+        .zip(g_inv_powers.par_iter())
         .map(|((&a, &b), g_inv_power)| {
             let sum = a + b;
             let diff = a - b;

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -77,7 +77,7 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<
         })
         .unzip();
 
-    let (even_decomp, odd_decomp) = rayon::join(
+    let (even_decomp, odd_decomp) = join(
         || decompose(even, shift.square(), log_chunks - 1),
         || decompose(odd, shift.square(), log_chunks - 1),
     );

--- a/uni-stark/src/decompose.rs
+++ b/uni-stark/src/decompose.rs
@@ -8,6 +8,8 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
+use self::dit_decompose::fft_decompose;
+
 /// Decompose the quotient polynomial into chunks using a generalization of even-odd decomposition.
 /// Then, arrange the results in a row-major matrix, so that each chunk of the decomposed polynomial
 /// becomes `D` columns of the resulting matrix, where `D` is the field extension degree.
@@ -48,33 +50,82 @@ fn decompose<F: TwoAdicField>(poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<
         return vec![poly];
     }
 
-    let n = poly.len();
-    debug_assert!(n > 1);
-    let log_n = log2_strict_usize(n);
-    let half_n = poly.len() / 2;
-    let g_inv = F::two_adic_generator(log_n).inverse();
+    fft_decompose(poly, log_chunks)
+}
 
-    let mut even = Vec::with_capacity(half_n);
-    let mut odd = Vec::with_capacity(half_n);
+mod dit_decompose {
+    use alloc::vec::Vec;
+    use p3_field::TwoAdicField;
+    use p3_util::log2_strict_usize;
 
-    // Note that
-    //     p_e(g^(2i)) = (p(g^i) + p(g^(n/2 + i))) / 2
-    //     p_o(g^(2i)) = (p(g^i) - p(g^(n/2 + i))) / (2 s g^i)
-
-    //     p_e(g^(2i)) = (a + b) / 2
-    //     p_o(g^(2i)) = (a - b) / (2 s g^i)
-    let one_half = F::two().inverse();
-    let (first, second) = poly.split_at(half_n);
-    for (g_inv_power, &a, &b) in izip!(g_inv.shifted_powers(shift.inverse()), first, second) {
-        let sum = a + b;
-        let diff = a - b;
-        even.push(sum * one_half);
-        odd.push(diff * one_half * g_inv_power);
+    pub fn fft_decompose<F: TwoAdicField>(mut poly: Vec<F>, shift: F, log_chunks: usize) -> Vec<Vec<F>> {
+        let n = poly.len();
+        let log_n = log2_strict_usize(n);
+    
+        // Ensure the poly length is a power of 2
+        assert!(n.is_power_of_two());
+    
+        // Apply the shift for coset FFT
+        apply_shift(&mut poly, &shift);
+    
+        // Transform the polynomial using a partial FFT (only up to log_chunks layers)
+        partial_fft(&mut poly, log_n, log_chunks);
+    
+        // Split the transformed polynomial into chunks
+        poly.chunks(1 << log_chunks).map(|chunk| chunk.to_vec()).collect()
     }
-
-    let mut combined = decompose(even, shift.square(), log_chunks - 1);
-    combined.extend(decompose(odd, shift.square(), log_chunks - 1));
-    combined
+    
+    fn apply_shift<F: TwoAdicField>(poly: &mut [F], shift: &F) {
+        let n = poly.len();
+        let g = F::two_adic_generator(log2_strict_usize(n));
+    
+        for (i, item) in poly.iter_mut().enumerate() {
+            *item = *item * shift.powers(&g.exp_usize(i));
+        }
+    }    
+    
+    fn partial_fft<F: TwoAdicField>(poly: &mut [F], log_n: usize, log_chunks: usize) {
+        let n = poly.len();
+        if n <= 1 || log_chunks == 0 {
+            return;
+        }
+    
+        // Bit-reverse the order of the coefficients
+        for i in 0..n {
+            let rev = bit_reverse(i, log_n);
+            if i < rev {
+                poly.swap(i, rev);
+            }
+        }
+    
+        // Perform the butterfly operations only up to log_chunks layers
+        let mut m = 1;
+        for _ in 0..log_chunks {
+            let w_m = F::two_adic_generator(m * 2);
+            let mut k = 0;
+            while k < n {
+                let mut w = F::one();
+                for j in 0..m {
+                    let t = w * poly[k + j + m];
+                    let u = poly[k + j];
+                    poly[k + j] = u + t;
+                    poly[k + j + m] = u - t;
+                    w = w * w_m;
+                }
+                k += m * 2;
+            }
+            m *= 2;
+        }
+    }
+    
+    fn bit_reverse(mut x: usize, log_n: usize) -> usize {
+        let mut result = 0;
+        for _ in 0..log_n {
+            result = (result << 1) | (x & 1);
+            x >>= 1;
+        }
+        result
+    }    
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR introduces parallel processing logic for computing a generalized form of the even-odd decomposition for polynomials.

To evaluate the performance gains we run the proving `prove_baby_bear_keccak` example. With parallelization we obtain

```
INFO     generate Keccak trace [ 389ms | 100.00% ]
INFO     prove [ 1.67s | 50.05% / 100.00% ]
INFO     ┝━ commit to trace data [ 350ms | 8.88% / 21.01% ]
INFO     │  ┕━ compute all coset LDEs [ 202ms | 12.13% ]
INFO     ┝━ compute quotient polynomial [ 83.6ms | 5.02% ]
INFO     ┝━ decompose and flatten quotient [ 827µs | 0.05% ]
INFO     ┝━ commit to quotient poly chunks [ 4.55ms | 0.20% / 0.27% ]
INFO     │  ┕━ compute all coset LDEs [ 1.18ms | 0.07% ]
INFO     ┕━ prove batch opening [ 393ms | 0.16% / 23.59% ]
INFO        ┝━ compute opened values with Lagrange interpolation [ 258ms | 15.51% ]
INFO        ┕━ FRI prover [ 132ms | 0.09% / 7.93% ]
INFO           ┝━ commit phase [ 112ms | 6.71% ]
INFO           ┝━ grind for proof-of-work witness [ 17.5ms | 1.05% ]
INFO           ┕━ query phase [ 1.25ms | 0.08% ]
```

Whereas, running the same program in the current branch yields:

```
INFO     generate Keccak trace [ 382ms | 100.00% ]
INFO     prove [ 1.62s | 50.81% / 100.00% ]
INFO     ┝━ commit to trace data [ 325ms | 9.50% / 20.10% ]
INFO     │  ┕━ compute all coset LDEs [ 171ms | 10.60% ]
INFO     ┝━ compute quotient polynomial [ 83.8ms | 5.18% ]
INFO     ┝━ decompose and flatten quotient [ 1.27ms | 0.08% ]
INFO     ┝━ commit to quotient poly chunks [ 5.02ms | 0.24% / 0.31% ]
INFO     │  ┕━ compute all coset LDEs [ 1.18ms | 0.07% ]
INFO     ┕━ prove batch opening [ 380ms | 0.15% / 23.52% ]
INFO        ┝━ compute opened values with Lagrange interpolation [ 248ms | 15.36% ]
INFO        ┕━ FRI prover [ 129ms | 0.09% / 8.01% ]
INFO           ┝━ commit phase [ 107ms | 6.65% ]
INFO           ┝━ grind for proof-of-work witness [ 19.5ms | 1.21% ]
INFO           ┕━ query phase [ 1.11ms | 0.07% ]
```

Interpreting these results, we conclude that parallelization to the decompose methods pertains to 0.05% of the total compute time, whereas with the current sequential approach (on main branch) it accounts for 0.08%. The performance gains noticed were a reduction from 1.27ms for the sequential case to 827µs for the parallel case (that is, the parallel approach time accounts for roughly 65% of the total sequential time approach).