### PR TITLE
Fix slow `degree_multiple()` code

### DIFF
--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -2,7 +2,9 @@ use p3_air::{Air, AirBuilder, TwoRowMatrixView};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixRowSlices};
+use tracing::instrument;
 
+#[instrument(name = "check constraints", skip_all)]
 pub(crate) fn check_constraints<F, A>(air: &A, main: &RowMajorMatrix<F>)
 where
     F: Field,

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -6,10 +6,12 @@ use p3_air::{Air, AirBuilder};
 use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_ceil_usize;
+use tracing::instrument;
 
 use crate::symbolic_expression::SymbolicExpression;
 use crate::symbolic_variable::SymbolicVariable;
 
+#[instrument(name = "infer log of constraint degree", skip_all)]
 pub fn get_log_quotient_degree<F, A>(air: &A) -> usize
 where
     F: Field,
@@ -24,6 +26,7 @@ where
     log2_ceil_usize(constraint_degree - 1)
 }
 
+#[instrument(name = "infer constraint degree", skip_all, level = "debug")]
 pub fn get_max_constraint_degree<F, A>(air: &A) -> usize
 where
     F: Field,
@@ -36,6 +39,7 @@ where
         .unwrap_or(0)
 }
 
+#[instrument(name = "evalute constraints symbolically", skip_all, level = "debug")]
 pub fn get_symbolic_constraints<F, A>(air: &A) -> Vec<SymbolicExpression<F>>
 where
     F: Field,

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -15,10 +15,25 @@ pub enum SymbolicExpression<F: Field> {
     IsLastRow,
     IsTransition,
     Constant(F),
-    Add(Rc<Self>, Rc<Self>),
-    Sub(Rc<Self>, Rc<Self>),
-    Neg(Rc<Self>),
-    Mul(Rc<Self>, Rc<Self>),
+    Add {
+        x: Rc<Self>,
+        y: Rc<Self>,
+        degree_multiple: usize,
+    },
+    Sub {
+        x: Rc<Self>,
+        y: Rc<Self>,
+        degree_multiple: usize,
+    },
+    Neg {
+        x: Rc<Self>,
+        degree_multiple: usize,
+    },
+    Mul {
+        x: Rc<Self>,
+        y: Rc<Self>,
+        degree_multiple: usize,
+    },
 }
 
 impl<F: Field> SymbolicExpression<F> {
@@ -30,10 +45,18 @@ impl<F: Field> SymbolicExpression<F> {
             SymbolicExpression::IsLastRow => 1,
             SymbolicExpression::IsTransition => 0,
             SymbolicExpression::Constant(_) => 0,
-            SymbolicExpression::Add(x, y) => x.degree_multiple().max(y.degree_multiple()),
-            SymbolicExpression::Sub(x, y) => x.degree_multiple().max(y.degree_multiple()),
-            SymbolicExpression::Neg(x) => x.degree_multiple(),
-            SymbolicExpression::Mul(x, y) => x.degree_multiple() + y.degree_multiple(),
+            SymbolicExpression::Add {
+                degree_multiple, ..
+            } => *degree_multiple,
+            SymbolicExpression::Sub {
+                degree_multiple, ..
+            } => *degree_multiple,
+            SymbolicExpression::Neg {
+                degree_multiple, ..
+            } => *degree_multiple,
+            SymbolicExpression::Mul {
+                degree_multiple, ..
+            } => *degree_multiple,
         }
     }
 }
@@ -112,7 +135,12 @@ impl<F: Field> Add for SymbolicExpression<F> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        Self::Add(Rc::new(self), Rc::new(rhs))
+        let degree_multiple = self.degree_multiple().max(rhs.degree_multiple());
+        Self::Add {
+            x: Rc::new(self),
+            y: Rc::new(rhs),
+            degree_multiple,
+        }
     }
 }
 
@@ -152,7 +180,12 @@ impl<F: Field> Sub for SymbolicExpression<F> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        Self::Sub(Rc::new(self), Rc::new(rhs))
+        let degree_multiple = self.degree_multiple().max(rhs.degree_multiple());
+        Self::Sub {
+            x: Rc::new(self),
+            y: Rc::new(rhs),
+            degree_multiple,
+        }
     }
 }
 
@@ -180,7 +213,11 @@ impl<F: Field> Neg for SymbolicExpression<F> {
     type Output = Self;
 
     fn neg(self) -> Self {
-        Self::Neg(Rc::new(self))
+        let degree_multiple = self.degree_multiple();
+        Self::Neg {
+            x: Rc::new(self),
+            degree_multiple,
+        }
     }
 }
 
@@ -188,7 +225,12 @@ impl<F: Field> Mul for SymbolicExpression<F> {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self::Mul(Rc::new(self), Rc::new(rhs))
+        let degree_multiple = self.degree_multiple() + rhs.degree_multiple();
+        Self::Mul {
+            x: Rc::new(self),
+            y: Rc::new(rhs),
+            degree_multiple,
+        }
     }
 }
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -225,6 +225,7 @@ impl<F: Field> Mul for SymbolicExpression<F> {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
+        #[allow(clippy::suspicious_arithmetic_impl)]
         let degree_multiple = self.degree_multiple() + rhs.degree_multiple();
         Self::Mul {
             x: Rc::new(self),

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -1,5 +1,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
+use tracing::instrument;
 
 use p3_air::{Air, BaseAir, TwoRowMatrixView};
 use p3_challenger::{CanObserve, FieldChallenger};
@@ -11,6 +12,7 @@ use p3_util::reverse_slice_index_bits;
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
 use crate::{Proof, StarkConfig, VerifierConstraintFolder};
 
+#[instrument(skip_all)]
 pub fn verify<SC, A>(
     config: &SC,
     air: &A,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -1,6 +1,5 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use tracing::instrument;
 
 use p3_air::{Air, BaseAir, TwoRowMatrixView};
 use p3_challenger::{CanObserve, FieldChallenger};
@@ -8,6 +7,7 @@ use p3_commit::UnivariatePcs;
 use p3_field::{AbstractExtensionField, AbstractField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_util::reverse_slice_index_bits;
+use tracing::instrument;
 
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
 use crate::{Proof, StarkConfig, VerifierConstraintFolder};


### PR DESCRIPTION
It was visiting the same `SymbolicExpression`s repeatedly in some cases. Probably best to just compute it upfront when we construct each `SymbolicExpression`.