### PR TITLE
Add random distributions for fields vectorisation

### DIFF
--- a/baby-bear/src/x86_64_avx2.rs
+++ b/baby-bear/src/x86_64_avx2.rs
@@ -2,6 +2,8 @@ use core::arch::x86_64::{self, __m256i};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
 
@@ -497,6 +499,13 @@ impl Sub<PackedBabyBearAVX2> for BabyBear {
     #[inline]
     fn sub(self, rhs: PackedBabyBearAVX2) -> PackedBabyBearAVX2 {
         PackedBabyBearAVX2::from(self) - rhs
+    }
+}
+
+impl Distribution<PackedBabyBearAVX2> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedBabyBearAVX2 {
+        PackedBabyBearAVX2(rng.gen())
     }
 }
 

--- a/baby-bear/src/x86_64_avx2.rs
+++ b/baby-bear/src/x86_64_avx2.rs
@@ -2,10 +2,10 @@ use core::arch::x86_64::{self, __m256i};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use crate::BabyBear;
 

--- a/mersenne-31/src/aarch64_neon.rs
+++ b/mersenne-31/src/aarch64_neon.rs
@@ -2,6 +2,8 @@ use core::arch::aarch64::{self, uint32x4_t};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
 
@@ -467,6 +469,13 @@ impl Sub<PackedMersenne31Neon> for Mersenne31 {
     #[inline]
     fn sub(self, rhs: PackedMersenne31Neon) -> PackedMersenne31Neon {
         PackedMersenne31Neon::from(self) - rhs
+    }
+}
+
+impl Distribution<PackedMersenne31Neon> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedMersenne31Neon {
+        PackedMersenne31Neon(rng.gen())
     }
 }
 

--- a/mersenne-31/src/aarch64_neon.rs
+++ b/mersenne-31/src/aarch64_neon.rs
@@ -2,10 +2,10 @@ use core::arch::aarch64::{self, uint32x4_t};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/x86_64_avx2.rs
+++ b/mersenne-31/src/x86_64_avx2.rs
@@ -2,10 +2,10 @@ use core::arch::x86_64::{self, __m256i};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/x86_64_avx2.rs
+++ b/mersenne-31/src/x86_64_avx2.rs
@@ -2,6 +2,8 @@ use core::arch::x86_64::{self, __m256i};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use p3_field::{AbstractField, Field, PackedField};
 
@@ -471,6 +473,13 @@ impl Sub<PackedMersenne31AVX2> for Mersenne31 {
     #[inline]
     fn sub(self, rhs: PackedMersenne31AVX2) -> PackedMersenne31AVX2 {
         PackedMersenne31AVX2::from(self) - rhs
+    }
+}
+
+impl Distribution<PackedMersenne31AVX2> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> PackedMersenne31AVX2 {
+        PackedMersenne31AVX2(rng.gen())
     }
 }
 


### PR DESCRIPTION
These were missed in the recent AVX PRs #214 and #221 but are used for benchmarking in the `mds` crate. The implementation was just copied from the existing one for BabyBear on Neon.

Aside: As this trait happens to be implemented for all `Field`s, I wonder if it's worth making it mandatory?