### PR TITLE
Delayed Reduction for BabyBear Multiplication

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-field = { path = "../field" }
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["min_const_gen"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -25,3 +25,7 @@ harness = false
 [[bench]]
 name = "extension"
 harness = false
+
+[[bench]]
+name = "mul"
+harness = false

--- a/baby-bear/benches/inverse.rs
+++ b/baby-bear/benches/inverse.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
 use p3_field::Field;
 
@@ -8,7 +8,10 @@ fn try_inverse(c: &mut Criterion) {
     c.bench_function("try_inverse", |b| {
         b.iter_batched(
             rand::random::<F>,
-            |x| x.try_inverse(),
+            |x| {
+                black_box(x);
+                x.try_inverse()
+            },
             BatchSize::SmallInput,
         )
     });

--- a/baby-bear/benches/mul.rs
+++ b/baby-bear/benches/mul.rs
@@ -1,11 +1,13 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use p3_baby_bear::{babybear_quad_mul, babybear_triple_mul, BabyBear};
+use p3_baby_bear::{babybear_quad_mul, babybear_triple_mul, fast_exp_7, BabyBear};
 use p3_field::AbstractField;
 use rand::Rng;
 
 type F = BabyBear;
 
 fn bench_mul(c: &mut Criterion) {
+    exp_two(c);
+    exp_three(c);
     mul_three(c);
     mul_three_delayed(c);
     mul_four(c);
@@ -13,52 +15,102 @@ fn bench_mul(c: &mut Criterion) {
     exp_seven(c);
     exp_seven_delayed_1(c);
     exp_seven_delayed_2(c);
+    exp_seven_delayed_3(c);
+}
+
+fn exp_two(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear Exponential", 2);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let mut res = *input;
+            for _ in 0..1000 {
+                res = res.square();
+            }
+            res
+        });
+    });
+}
+
+fn exp_three(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear Exponential", 3);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let mut res = *input;
+            for _ in 0..1000 {
+                res = babybear_triple_mul(res, res, res);
+            }
+            res
+        });
+    });
 }
 
 fn mul_three(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let input = rng.gen::<[F; 3]>();
-    let id = BenchmarkId::new("BabyBear Three MultiMultiplications", 3);
+    let input = rng.gen::<[F; 2001]>();
+    let id = BenchmarkId::new("BabyBear Three Multiplications", 3);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            input[0] * input[1] * input[2]
+            let mut res = input[0];
+            for i in 0..1000 {
+                res = res * input[2*i + 1] * input[2*i + 2];
+            }
+            res
         });
     });
 }
 
 fn mul_three_delayed(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let input = rng.gen::<[F; 3]>();
-    let id = BenchmarkId::new("BabyBear Three MultiMultiplications Delayed", 3);
+    let input = rng.gen::<[F; 2001]>();
+    let id = BenchmarkId::new("BabyBear Three Multiplications Delayed", 3);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            babybear_triple_mul(input[0], input[1], input[2])
+            let mut res = input[0];
+            for i in 0..1000 {
+                res = babybear_triple_mul(res, input[2*i + 1], input[2*i + 2]);
+            }
+            res
+            
         });
     });
 }
 
 fn mul_four(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let input = rng.gen::<[F; 4]>();
-    let id = BenchmarkId::new("BabyBear Four MultiMultiplications", 4);
+    let input = rng.gen::<[F; 3001]>();
+    let id = BenchmarkId::new("BabyBear Four Multiplications", 4);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            input[0] * input[1] * input[2] * input[3]
+            let mut res = input[0];
+            for i in 0..1000 {
+                res = res * input[3*i + 1] * input[3*i + 2] * input[3*i + 3];
+            }
+            res
         });
     });
 }
 
 fn mul_four_delayed(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let input = rng.gen::<[F; 4]>();
-    let id = BenchmarkId::new("BabyBear Four MultiMultiplications Delayed", 4);
+    let input = rng.gen::<[F; 3001]>();
+    let id = BenchmarkId::new("BabyBear Four Multiplications Delayed", 4);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            babybear_quad_mul(input[0], input[1], input[2], input[3])
+            let mut res = input[0];
+            for i in 0..1000 {
+                res = babybear_quad_mul(res, input[3*i + 1], input[3*i + 2], input[3*i + 3]);
+            }
+            res
         });
     });
 }
@@ -66,14 +118,18 @@ fn mul_four_delayed(c: &mut Criterion) {
 fn exp_seven(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let input = rng.gen::<F>();
-    let id = BenchmarkId::new("BabyBear MultiExponential", 7);
+    let id = BenchmarkId::new("BabyBear Exponential", 7);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            let square = input.square();
-            let triple = square * *input;
-            let quad = square.square();
-            triple * quad
+            let mut res = *input;
+            for _ in 0..1000 {
+                let square = res.square();
+                let triple = square * res;
+                let quad = square.square();
+                res = triple * quad
+            }
+            res
         });
     });
 }
@@ -81,12 +137,16 @@ fn exp_seven(c: &mut Criterion) {
 fn exp_seven_delayed_1(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let input = rng.gen::<F>();
-    let id = BenchmarkId::new("BabyBear MultiExponential Delayed 1", 7);
+    let id = BenchmarkId::new("BabyBear Exponential Delayed 1", 7);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            let square = input.square();
-            babybear_quad_mul(square, square, square, *input)
+            let mut res = *input;
+            for _ in 0..1000 {
+                let square = res.square();
+                res = babybear_quad_mul(square, square, square, res);
+            }
+            res
         });
     });
 }
@@ -94,12 +154,32 @@ fn exp_seven_delayed_1(c: &mut Criterion) {
 fn exp_seven_delayed_2(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
     let input = rng.gen::<F>();
-    let id = BenchmarkId::new("BabyBear MultiExponential Delayed 2", 7);
+    let id = BenchmarkId::new("BabyBear Exponential Delayed 2", 7);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| {
             black_box(input);
-            let cube = babybear_triple_mul(*input, *input, *input);
-            babybear_triple_mul(cube, cube, *input)
+            let mut res = *input;
+            for _ in 0..1000 {
+                let cube = babybear_triple_mul(res, res, res);
+                res = babybear_triple_mul(cube, cube, res);
+            }
+            res
+        });
+    });
+}
+
+fn exp_seven_delayed_3(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear Exponential Delayed 3", 7);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let mut res = *input;
+            for _ in 0..1000 {
+                res = fast_exp_7(res);
+            }
+            res
         });
     });
 }

--- a/baby-bear/benches/mul.rs
+++ b/baby-bear/benches/mul.rs
@@ -1,0 +1,108 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use p3_baby_bear::{babybear_quad_mul, babybear_triple_mul, BabyBear};
+use p3_field::AbstractField;
+use rand::Rng;
+
+type F = BabyBear;
+
+fn bench_mul(c: &mut Criterion) {
+    mul_three(c);
+    mul_three_delayed(c);
+    mul_four(c);
+    mul_four_delayed(c);
+    exp_seven(c);
+    exp_seven_delayed_1(c);
+    exp_seven_delayed_2(c);
+}
+
+fn mul_three(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<[F; 3]>();
+    let id = BenchmarkId::new("BabyBear Three MultiMultiplications", 3);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            input[0] * input[1] * input[2]
+        });
+    });
+}
+
+fn mul_three_delayed(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<[F; 3]>();
+    let id = BenchmarkId::new("BabyBear Three MultiMultiplications Delayed", 3);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            babybear_triple_mul(input[0], input[1], input[2])
+        });
+    });
+}
+
+fn mul_four(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<[F; 4]>();
+    let id = BenchmarkId::new("BabyBear Four MultiMultiplications", 4);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            input[0] * input[1] * input[2] * input[3]
+        });
+    });
+}
+
+fn mul_four_delayed(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<[F; 4]>();
+    let id = BenchmarkId::new("BabyBear Four MultiMultiplications Delayed", 4);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            babybear_quad_mul(input[0], input[1], input[2], input[3])
+        });
+    });
+}
+
+fn exp_seven(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear MultiExponential", 7);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let square = input.square();
+            let triple = square * *input;
+            let quad = square.square();
+            triple * quad
+        });
+    });
+}
+
+fn exp_seven_delayed_1(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear MultiExponential Delayed 1", 7);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let square = input.square();
+            babybear_quad_mul(square, square, square, *input)
+        });
+    });
+}
+
+fn exp_seven_delayed_2(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let input = rng.gen::<F>();
+    let id = BenchmarkId::new("BabyBear MultiExponential Delayed 2", 7);
+    c.bench_with_input(id, &input, |b, input| {
+        b.iter(|| {
+            black_box(input);
+            let cube = babybear_triple_mul(*input, *input, *input);
+            babybear_triple_mul(cube, cube, *input)
+        });
+    });
+}
+
+criterion_group!(baby_bear_arithmetic, bench_mul);
+criterion_main!(baby_bear_arithmetic);

--- a/baby-bear/benches/mul.rs
+++ b/baby-bear/benches/mul.rs
@@ -59,7 +59,7 @@ fn mul_three(c: &mut Criterion) {
             black_box(input);
             let mut res = input[0];
             for i in 0..1000 {
-                res = res * input[2*i + 1] * input[2*i + 2];
+                res = res * input[2 * i + 1] * input[2 * i + 2];
             }
             res
         });
@@ -75,10 +75,9 @@ fn mul_three_delayed(c: &mut Criterion) {
             black_box(input);
             let mut res = input[0];
             for i in 0..1000 {
-                res = babybear_triple_mul(res, input[2*i + 1], input[2*i + 2]);
+                res = babybear_triple_mul(res, input[2 * i + 1], input[2 * i + 2]);
             }
             res
-            
         });
     });
 }
@@ -92,7 +91,7 @@ fn mul_four(c: &mut Criterion) {
             black_box(input);
             let mut res = input[0];
             for i in 0..1000 {
-                res = res * input[3*i + 1] * input[3*i + 2] * input[3*i + 3];
+                res = res * input[3 * i + 1] * input[3 * i + 2] * input[3 * i + 3];
             }
             res
         });
@@ -108,7 +107,7 @@ fn mul_four_delayed(c: &mut Criterion) {
             black_box(input);
             let mut res = input[0];
             for i in 0..1000 {
-                res = babybear_quad_mul(res, input[3*i + 1], input[3*i + 2], input[3*i + 3]);
+                res = babybear_quad_mul(res, input[3 * i + 1], input[3 * i + 2], input[3 * i + 3]);
             }
             res
         });

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -166,6 +166,28 @@ impl AbstractField for BabyBear {
     fn generator() -> Self {
         Self::from_canonical_u32(0x1f)
     }
+
+    #[must_use]
+    #[inline(always)]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        match POWER {
+            0 => Self::one(),
+            1 => self.clone(),
+            2 => self.square(),
+            3 => self.cube(),
+            4 => self.square().square(),
+            5 => self.square().square() * self.clone(),
+            6 => self.square().cube(),
+            // 7 => {
+            //     let x2 = self.square();
+            //     let x3 = x2.clone() * self.clone();
+            //     let x4 = x2.square();
+            //     x3 * x4
+            // }
+            7 => fast_exp_7(*self),
+            _ => self.exp_u64(POWER),
+        }
+    }
 }
 
 impl Field for BabyBear {
@@ -421,10 +443,80 @@ fn monty_reduce(x: u64) -> u32 {
     x_sub_u_hi.wrapping_add(corr)
 }
 
+#[inline]
+pub fn sum_u64(vec: &[BabyBear]) -> BabyBear {
+    BabyBear {
+        value: (vec.iter().map(|x| (x.value as u64)).sum::<u64>() % (P as u64)) as u32,
+    }
+}
+
+const MONTY_SQUARE_BITS: u32 = 2 * MONTY_BITS;
+const MONTY_SQUARE_MU: u64 = 0x383fffff88000001;
+// (225 << 54) - (1 << 31) + (1 << 27) - 1
+const MONTY_SQUARE_MASK: u64 = ((1u128 << MONTY_SQUARE_BITS) - 1) as u64;
+
+/// Montgomery reduction of a value in `0..P << MONTY_BITS^2`.
+/// Given x, the output is in 0..P and equal to x (1 << MONTY_BITS)^{-2} mod P
+#[inline]
+#[must_use]
+fn monty_square_reduce(x: u128) -> u32 {
+    let t = (x as u64).wrapping_mul(MONTY_SQUARE_MU) & MONTY_SQUARE_MASK;
+    let u = (t as u128) * (P as u128);
+
+    let (x_sub_u, over) = x.overflowing_sub(u);
+    let x_sub_u_hi = (x_sub_u >> MONTY_SQUARE_BITS) as u32;
+    let corr = if over { P } else { 0 };
+    x_sub_u_hi.wrapping_add(corr)
+}
+
+#[inline]
+pub fn babybear_triple_mul(x0: BabyBear, x1: BabyBear, x2: BabyBear) -> BabyBear {
+    let x01 = x0.value as u64 * x1.value as u64;
+    BabyBear {
+        value: monty_square_reduce(x01 as u128 * x2.value as u128),
+    }
+}
+
+const MONTY_CUBE_TERM: u128 = 0x1a5dffffc7c0000077ffffff;
+// (225 << 85) - (225 << 81) - (225 << 54) + (1 << 31) - (1 << 27) - 1;
+const MONTY_CUBE_BITS: u32 = 3 * MONTY_BITS;
+const MONTY_CUBE_MU: u128 = (1u128 << MONTY_CUBE_BITS) - MONTY_CUBE_TERM;
+const MONTY_CUBE_MASK: u128 = (1u128 << MONTY_CUBE_BITS) - 1;
+
+/// Montgomery reduction of a value in `0..P << MONTY_BITS^3`.
+/// Given x, the output is in 0..P and equal to x (1 << MONTY_BITS)^{-3} mod P
+#[inline]
+#[must_use]
+fn monty_cube_reduce(x: u128) -> u32 {
+    let t = x.wrapping_mul(MONTY_CUBE_MU) & MONTY_CUBE_MASK;
+    let u = t * (P as u128);
+
+    let (x_sub_u, over) = x.overflowing_sub(u);
+    let x_sub_u_hi = (x_sub_u >> MONTY_CUBE_BITS) as u32;
+    let corr = if over { P } else { 0 };
+    x_sub_u_hi.wrapping_add(corr)
+}
+
+#[inline]
+pub fn babybear_quad_mul(x0: BabyBear, x1: BabyBear, x2: BabyBear, x3: BabyBear) -> BabyBear {
+    let x01 = x0.value as u64 * x1.value as u64;
+    let x23 = x2.value as u64 * x3.value as u64;
+    BabyBear {
+        value: monty_cube_reduce(x01 as u128 * x23 as u128),
+    }
+}
+
+#[inline]
+pub fn fast_exp_7(x1: BabyBear) -> BabyBear {
+    let x11 = babybear_triple_mul(x1, x1, x1);
+    babybear_triple_mul(x11, x11, x1)
+}
+
 #[cfg(test)]
 mod tests {
     use p3_field::PrimeField64;
     use p3_field_testing::{test_field, test_two_adic_field};
+    use rand::Rng;
 
     use super::*;
 
@@ -493,6 +585,34 @@ mod tests {
         assert_eq!(m1.exp_u64(1725656503).exp_const_u64::<7>(), m1);
         assert_eq!(m2.exp_u64(1725656503).exp_const_u64::<7>(), m2);
         assert_eq!(f_2.exp_u64(1725656503).exp_const_u64::<7>(), f_2);
+    }
+
+    #[test]
+    fn test_triple_mul() {
+        // Picked 4 numbers roughly at random.
+        let mut rng = rand::thread_rng();
+        for _ in 0..100 {
+            let input = rng.gen::<[F; 3]>();
+
+            let mul_1 = input[0] * input[1] * input[2];
+            let mul_2 = babybear_triple_mul(input[0], input[1], input[2]);
+
+            assert_eq!(mul_1, mul_2);
+        }
+    }
+
+    #[test]
+    fn test_quad_mul() {
+        // Picked 4 numbers roughly at random.
+        let mut rng = rand::thread_rng();
+        for _ in 0..100 {
+            let input = rng.gen::<[F; 4]>();
+
+            let mul_1 = input[0] * input[1] * input[2] * input[3];
+            let mul_2 = babybear_quad_mul(input[0], input[1], input[2], input[3]);
+
+            assert_eq!(mul_1, mul_2);
+        }
     }
 
     test_field!(crate::BabyBear);

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -549,7 +549,9 @@ pub fn fast_exp_7(x1: BabyBear) -> BabyBear {
     let x10 = x1u64 * x1u64;
     let x11 = monty_half_square_reduce(x10 as u128 * x1u128);
     let x110 = x11 as i64 * x11 as i64; // Always Positive
-    BabyBear { value: monty_square_reduce(x110 as u128 * x1u128)}
+    BabyBear {
+        value: monty_square_reduce(x110 as u128 * x1u128),
+    }
 }
 
 #[cfg(test)]

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -172,18 +172,12 @@ impl AbstractField for BabyBear {
     fn exp_const_u64<const POWER: u64>(&self) -> Self {
         match POWER {
             0 => Self::one(),
-            1 => self.clone(),
+            1 => *self,
             2 => self.square(),
             3 => self.cube(),
             4 => self.square().square(),
-            5 => self.square().square() * self.clone(),
+            5 => self.square().square() * *self,
             6 => self.square().cube(),
-            // 7 => {
-            //     let x2 = self.square();
-            //     let x3 = x2.clone() * self.clone();
-            //     let x4 = x2.square();
-            //     x3 * x4
-            // }
             7 => fast_exp_7(*self),
             _ => self.exp_u64(POWER),
         }

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -501,7 +501,7 @@ pub fn monty_half_square_reduce(x: u128) -> i32 {
     let t = (x as u64).wrapping_mul(MONTY_SQUARE_MU) & MONTY_SQUARE_MASK;
     let u = (t as u128) * (P as u128);
 
-    ((x as i128 - u as i128) >> MONTY_SQUARE_BITS) as i32
+    (x >> MONTY_SQUARE_BITS) as i32 - (u >> MONTY_SQUARE_BITS) as i32
 }
 
 #[inline]


### PR DESCRIPTION
It is possible to speed up 3 and 4 way multiplications in BabyBear using delayed reduction.

In particular this can be used to speed up the `x -> x^7` map by roughly `30%`.

As this map is used in Poseidon2 it gives roughly a `10%` speed up for the Poseidon2 hash.

It should also apply to the rescue hash but that will require rewriting the current way that the rescue hash sbox layer works to use exp_const_u64 not exp_u64.