### PR TITLE
add prove_goldilocks_poseidon example in keccak-air

### DIFF
--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -22,6 +22,7 @@ p3-keccak = { path = "../keccak" }
 p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-mds = { path = "../mds" }
 p3-merkle-tree = { path = "../merkle-tree" }
+p3-poseidon = {path = "../poseidon"}
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }
@@ -37,6 +38,9 @@ name = "prove_baby_bear_poseidon2"
 
 [[example]]
 name = "prove_goldilocks_keccak"
+
+[[example]]
+name = "prove_goldilocks_poseidon"
 
 [features]
 # TODO: Consider removing, at least when this gets split off into another repository.

--- a/keccak-air/examples/prove_goldilocks_poseidon.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon.rs
@@ -1,0 +1,83 @@
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriConfig, TwoAdicFriPcs, TwoAdicFriPcsConfig};
+use p3_goldilocks::Goldilocks;
+use p3_field::Field;
+use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+//use p3_poseidon2::{DiffusionMatrixGoldilocks, Poseidon2};
+use p3_mds::goldilocks::MdsMatrixGoldilocks;
+use p3_poseidon::Poseidon;
+use p3_symmetric::TruncatedPermutation;
+use p3_symmetric::PaddingFreeSponge;
+use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use rand::{random, thread_rng};
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 680;
+
+fn main() -> Result<(), VerificationError> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Goldilocks;
+    type Challenge = BinomialExtensionField<Val, 2>; 
+
+    type Perm = Poseidon<Val, MdsMatrixGoldilocks, 8, 7>;
+    let perm = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut thread_rng());
+
+    type MyHash = PaddingFreeSponge<Perm, 8, 4, 4>;
+    let hash = MyHash::new(perm.clone());
+
+    type MyCompress = TruncatedPermutation<Perm, 2, 4, 8>;
+    let compress = MyCompress::new(perm.clone());
+
+    // ?? valmmcs digest element size ne olmalıdır?
+    // 8 yapmışlar poseidon2 için
+    // Buradan öncesi poseidon permutation, buradan sonrası ise vector commitment
+    type ValMmcs = FieldMerkleTreeMmcs<<Val as Field>::Packing, MyHash, MyCompress, 4>;
+    let val_mmcs = ValMmcs::new(hash, compress);
+
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Dft = Radix2DitParallel;
+    let dft = Dft {};
+
+    type Challenger = DuplexChallenger<Val, Perm, 8>;
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs =
+        TwoAdicFriPcs<TwoAdicFriPcsConfig<Val, Challenge, Challenger, Dft, ValMmcs, ChallengeMmcs>>;
+    let pcs = Pcs::new(fri_config, dft, val_mmcs);
+
+    type MyConfig = StarkConfig<Val, Challenge, Pcs, Challenger>;
+    let config = StarkConfig::new(pcs);
+
+    let mut challenger = Challenger::new(perm.clone());
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+    let proof = prove::<MyConfig, _>(&config, &KeccakAir {}, &mut challenger, trace);
+
+    let mut challenger = Challenger::new(perm);
+    verify(&config, &KeccakAir {}, &mut challenger, &proof)
+}


### PR DESCRIPTION
Benchmark for Poseidon hash in Goldilocks field is added.

You can test it using `RUST_LOG=info cargo run --example prove_goldilocks_poseidon --release --features parallel`