### PR TITLE
fix: goldilocks Poseidon example to match new merkle tree api

### DIFF
--- a/keccak-air/examples/prove_goldilocks_poseidon.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon.rs
@@ -42,7 +42,13 @@ fn main() -> Result<(), VerificationError> {
     type MyCompress = TruncatedPermutation<Perm, 2, 4, 8>;
     let compress = MyCompress::new(perm.clone());
 
-    type ValMmcs = FieldMerkleTreeMmcs<<Val as Field>::Packing, MyHash, MyCompress, 4>;
+    type ValMmcs = FieldMerkleTreeMmcs<
+        <Val as Field>::Packing,
+        <Val as Field>::Packing,
+        MyHash,
+        MyCompress,
+        4,
+    >;
     let val_mmcs = ValMmcs::new(hash, compress);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;


### PR DESCRIPTION
A quick follow up to fix #263 (which now fails to build) to match the new tree api introduced in #264 