### PR TITLE
Convert `VirtualPairCol` internal to a `Cow` pointer instead of `Vec`

### DIFF
--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
@@ -5,19 +6,21 @@ use core::ops::Mul;
 use p3_field::{AbstractField, Field};
 
 /// An affine function over columns in a PAIR.
-pub struct VirtualPairCol<F: Field> {
-    column_weights: Vec<(PairCol, F)>,
+#[derive(Clone, Debug)]
+pub struct VirtualPairCol<'a, F: Field> {
+    column_weights: Cow<'a, [(PairCol, F)]>,
     constant: F,
 }
 
 /// A column in a PAIR, i.e. either a preprocessed column or a main trace column.
+#[derive(Clone, Copy, Debug)]
 pub enum PairCol {
     Preprocessed(usize),
     Main(usize),
 }
 
 impl PairCol {
-    fn get<T: Copy>(&self, preprocessed: &[T], main: &[T]) -> T {
+    pub const fn get<T: Copy>(&self, preprocessed: &[T], main: &[T]) -> T {
         match self {
             PairCol::Preprocessed(i) => preprocessed[*i],
             PairCol::Main(i) => main[*i],
@@ -25,10 +28,24 @@ impl PairCol {
     }
 }
 
-impl<F: Field> VirtualPairCol<F> {
-    pub fn new(column_weights: Vec<(PairCol, F)>, constant: F) -> Self {
+impl<'a, F: Field> VirtualPairCol<'a, F> {
+    pub const fn new(column_weights: Cow<'a, [(PairCol, F)]>, constant: F) -> Self {
         Self {
-            column_weights,
+            column_weights: column_weights,
+            constant,
+        }
+    }
+
+    pub const fn new_owned(column_weights: Vec<(PairCol, F)>, constant: F) -> Self {
+        Self {
+            column_weights: Cow::Owned(column_weights),
+            constant,
+        }
+    }
+
+    pub const fn new_borrowed(column_weights: &'a [(PairCol, F)], constant: F) -> Self {
+        Self {
+            column_weights: Cow::Borrowed(column_weights),
             constant,
         }
     }
@@ -61,7 +78,7 @@ impl<F: Field> VirtualPairCol<F> {
     #[must_use]
     pub fn constant(x: F) -> Self {
         Self {
-            column_weights: vec![],
+            column_weights: Cow::Owned(vec![]),
             constant: x,
         }
     }
@@ -69,7 +86,7 @@ impl<F: Field> VirtualPairCol<F> {
     #[must_use]
     pub fn single(column: PairCol) -> Self {
         Self {
-            column_weights: vec![(column, F::one())],
+            column_weights: Cow::Owned(vec![(column, F::one())]),
             constant: F::zero(),
         }
     }
@@ -115,7 +132,7 @@ impl<F: Field> VirtualPairCol<F> {
         Var: Into<Expr> + Copy,
     {
         let mut result = self.constant.into();
-        for (column, weight) in &self.column_weights {
+        for (column, weight) in self.column_weights.iter() {
             result += column.get(preprocessed, main).into() * *weight;
         }
         result

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -31,7 +31,7 @@ impl PairCol {
 impl<'a, F: Field> VirtualPairCol<'a, F> {
     pub const fn new(column_weights: Cow<'a, [(PairCol, F)]>, constant: F) -> Self {
         Self {
-            column_weights: column_weights,
+            column_weights,
             constant,
         }
     }


### PR DESCRIPTION
This PR replaces the `Vec<(PairCol, F)>` of column weights in the virtual column struct to a clone-on-write smart pointer `Cow<'a, [(PairCol, F)]>`. This allows us to have both vector instances and static slice instances of the virtual column struct.  