### PR TITLE
Faster Baby Bear multiplication on ARM/NEON

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -12,23 +12,10 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 /// The Baby Bear prime
 const P: u32 = 0x78000001;
-
-// We want a different set of parameters on ARM/NEON than elsewhere. In particular, we want ARM to
-// use 31 bits for the limb size, because that lets us use the SQDMULH instruction to do really fast
-// multiplications in NEON. However, other architectures don't have this instruction, so 32-bit
-// limbs are more convenient, being a nice power of 2.
-const MONTY_BITS: u32 = if cfg!(all(target_arch = "aarch64", target_feature = "neon")) {
-    31
-} else {
-    32
-};
+const MONTY_BITS: u32 = 32;
 // We are defining MU = P^-1 (mod 2^MONTY_BITS). This is different from the usual convention
 // (MU = -P^-1 (mod 2^MONTY_BITS)) but it avoids a carry.
-const MONTY_MU: u32 = if cfg!(all(target_arch = "aarch64", target_feature = "neon")) {
-    0x08000001
-} else {
-    0x88000001
-};
+const MONTY_MU: u32 = 0x88000001;
 
 // This is derived from above.
 const MONTY_MASK: u32 = ((1u64 << MONTY_BITS) - 1) as u32;

--- a/baby-bear/src/x86_64_avx2.rs
+++ b/baby-bear/src/x86_64_avx2.rs
@@ -11,7 +11,6 @@ use crate::BabyBear;
 
 const WIDTH: usize = 8;
 const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x78000001; WIDTH]) };
-// On x86 MONTY_BITS is always 32, so MU = P^-1 (mod 2^32) = 0x88000001.
 const MU: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x88000001; WIDTH]) };
 
 /// Vectorized AVX2 implementation of `BabyBear` arithmetic.

--- a/baby-bear/src/x86_64_avx512.rs
+++ b/baby-bear/src/x86_64_avx512.rs
@@ -11,7 +11,6 @@ use crate::BabyBear;
 
 const WIDTH: usize = 16;
 const P: __m512i = unsafe { transmute::<[u32; WIDTH], _>([0x78000001; WIDTH]) };
-// On x86 MONTY_BITS is always 32, so MU = P^-1 (mod 2^32) = 0x88000001.
 const MU: __m512i = unsafe { transmute::<[u32; WIDTH], _>([0x88000001; WIDTH]) };
 const EVENS: __mmask16 = 0b0101010101010101;
 const EVENS4: __mmask16 = 0x0f0f;


### PR DESCRIPTION
I found a way to shave 1 instruction off Baby Bear multiplication in NEON, increasing the throughput by 14%.

As an added bonus, this version uses the 32-bit Montgomery form (that we use everywhere else), instead of the 31-bit form that NEON was previously using, so it avoids the weird fragmentation.

AND the 32-bit Monty form is a bit faster in scalar instructions too, so those should get a lil bit faster.