### PR TITLE
(ARM/NEON) faster Baby Bear cube

### DIFF
--- a/baby-bear/src/aarch64_neon.rs
+++ b/baby-bear/src/aarch64_neon.rs
@@ -206,9 +206,7 @@ fn mulby_mu(val: int32x4_t) -> int32x4_t {
     // throughput: .25 cyc/vec (16 els/cyc)
     // latency: 3 cyc
 
-    unsafe {
-        aarch64::vmulq_s32(val, MU)
-    }
+    unsafe { aarch64::vmulq_s32(val, MU) }
 }
 
 #[inline]


### PR DESCRIPTION
A cube for NEON Baby Bear that's a bit faster. It performs the usual `val.square() * val`, but we avoid the final reduction into [0, ..., P) when squaring, saving 2 instructions (so going from 13 to 11).