### PR TITLE
FRI PCS adjust indices based on the "global" max height

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -324,7 +324,8 @@ where
             verifier::verify_shape_and_sample_challenges(&self.fri, &proof.fri_proof, challenger)
                 .map_err(VerificationError::FriError)?;
 
-        let log_max_height = proof.fri_proof.commit_phase_commits.len() + self.fri.log_blowup;
+        let log_global_max_height =
+            proof.fri_proof.commit_phase_commits.len() + self.fri.log_blowup;
 
         let reduced_openings: Vec<[Challenge; 32]> = proof
             .query_openings
@@ -333,19 +334,27 @@ where
             .map(|(query_opening, &index)| {
                 let mut ro = [Challenge::zero(); 32];
                 let mut alpha_pow = [Challenge::one(); 32];
+
                 for (batch_opening, (batch_commit, mats)) in izip!(query_opening, &rounds) {
-                    let batch_dims: Vec<Dimensions> = mats
+                    let batch_heights = mats
                         .iter()
-                        .map(|(domain, _)| Dimensions {
-                            // todo: mmcs doesn't really need width
-                            width: 0,
-                            height: domain.size(),
-                        })
+                        .map(|(domain, _)| domain.size() << self.fri.log_blowup)
                         .collect_vec();
+                    let batch_dims = batch_heights
+                        .iter()
+                        // TODO: MMCS doesn't really need width; we put 0 for now.
+                        .map(|&height| Dimensions { width: 0, height })
+                        .collect_vec();
+
+                    let batch_max_height = batch_heights.iter().max().expect("Empty batch?");
+                    let log_batch_max_height = log2_strict_usize(*batch_max_height);
+                    let bits_reduced = log_global_max_height - log_batch_max_height;
+                    let reduced_index = index >> bits_reduced;
+
                     self.mmcs.verify_batch(
                         batch_commit,
                         &batch_dims,
-                        index,
+                        reduced_index,
                         &batch_opening.opened_values,
                         &batch_opening.opening_proof,
                     )?;
@@ -354,7 +363,7 @@ where
                     {
                         let log_height = log2_strict_usize(mat_domain.size()) + self.fri.log_blowup;
 
-                        let bits_reduced = log_max_height - log_height;
+                        let bits_reduced = log_global_max_height - log_height;
                         let rev_reduced_index = reverse_bits_len(index >> bits_reduced, log_height);
 
                         let x = Val::generator()

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -30,7 +30,7 @@ type Challenger = DuplexChallenger<Val, Perm, 16>;
 
 type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 
-fn single_round_fri_test(log_degrees_by_round: &[&[usize]]) {
+fn make_test_fri_pcs(log_degrees_by_round: &[&[usize]]) {
     let num_rounds = log_degrees_by_round.len();
     let mut rng = thread_rng();
 
@@ -122,13 +122,13 @@ fn single_round_fri_test(log_degrees_by_round: &[&[usize]]) {
 
 #[test]
 fn test_fri_pcs_single() {
-    single_round_fri_test(&[&[3]]);
+    make_test_fri_pcs(&[&[3]]);
 }
 
 #[test]
 fn test_fri_pcs_many_equal() {
     for i in 1..4 {
-        single_round_fri_test(&[&[i; 5]]);
+        make_test_fri_pcs(&[&[i; 5]]);
     }
 }
 
@@ -136,7 +136,7 @@ fn test_fri_pcs_many_equal() {
 fn test_fri_pcs_many_different() {
     for i in 2..4 {
         let degrees = (3..3 + i).collect::<Vec<_>>();
-        single_round_fri_test(&[&degrees]);
+        make_test_fri_pcs(&[&degrees]);
     }
 }
 
@@ -144,19 +144,19 @@ fn test_fri_pcs_many_different() {
 fn test_fri_pcs_many_different_rev() {
     for i in 2..4 {
         let degrees = (3..3 + i).rev().collect::<Vec<_>>();
-        single_round_fri_test(&[&degrees]);
+        make_test_fri_pcs(&[&degrees]);
     }
 }
 
 #[test]
 fn test_fri_pcs_multiple_rounds() {
-    single_round_fri_test(&[&[3]]);
-    single_round_fri_test(&[&[3], &[3]]);
-    single_round_fri_test(&[&[3], &[2]]);
-    single_round_fri_test(&[&[2], &[3]]);
-    single_round_fri_test(&[&[3, 4], &[3, 4]]);
-    single_round_fri_test(&[&[4, 2], &[4, 2]]);
-    single_round_fri_test(&[&[2, 2], &[3, 3]]);
-    single_round_fri_test(&[&[3, 3], &[2, 2]]);
-    single_round_fri_test(&[&[2], &[3, 3]]);
+    make_test_fri_pcs(&[&[3]]);
+    make_test_fri_pcs(&[&[3], &[3]]);
+    make_test_fri_pcs(&[&[3], &[2]]);
+    make_test_fri_pcs(&[&[2], &[3]]);
+    make_test_fri_pcs(&[&[3, 4], &[3, 4]]);
+    make_test_fri_pcs(&[&[4, 2], &[4, 2]]);
+    make_test_fri_pcs(&[&[2, 2], &[3, 3]]);
+    make_test_fri_pcs(&[&[3, 3], &[2, 2]]);
+    make_test_fri_pcs(&[&[2], &[3, 3]]);
 }

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -1,3 +1,4 @@
+use itertools::{izip, Itertools};
 use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
 use p3_challenger::{CanObserve, DuplexChallenger, FieldChallenger};
 use p3_commit::{ExtensionMmcs, Pcs};
@@ -11,36 +12,34 @@ use p3_poseidon2::Poseidon2;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use rand::thread_rng;
 
-fn make_test_fri_pcs(log_degrees: &[usize]) {
+type Val = BabyBear;
+type Challenge = BinomialExtensionField<Val, 4>;
+
+type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+
+type ValMmcs =
+    FieldMerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+
+type Dft = Radix2DitParallel;
+
+type Challenger = DuplexChallenger<Val, Perm, 16>;
+
+type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+
+fn single_round_fri_test(log_degrees_by_round: &[&[usize]]) {
+    let num_rounds = log_degrees_by_round.len();
     let mut rng = thread_rng();
-    type Val = BabyBear;
-    type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
     let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
-
-    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     let hash = MyHash::new(perm.clone());
-
-    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
     let compress = MyCompress::new(perm.clone());
 
-    type ValMmcs = FieldMerkleTreeMmcs<
-        <Val as Field>::Packing,
-        <Val as Field>::Packing,
-        MyHash,
-        MyCompress,
-        8,
-    >;
     let val_mmcs = ValMmcs::new(hash, compress);
-
-    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-
-    type Dft = Radix2DitParallel;
-    let dft = Dft {};
-
-    type Challenger = DuplexChallenger<Val, Perm, 16>;
 
     let fri_config = FriConfig {
         log_blowup: 1,
@@ -48,59 +47,88 @@ fn make_test_fri_pcs(log_degrees: &[usize]) {
         proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
-    type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-    let max_log_n = log_degrees.iter().copied().max().unwrap();
-    let pcs: MyPcs = MyPcs::new(max_log_n, dft, val_mmcs, fri_config);
+    let max_log_n = log_degrees_by_round
+        .iter()
+        .copied()
+        .flatten()
+        .copied()
+        .max()
+        .unwrap();
+    let pcs = MyPcs::new(max_log_n, Dft {}, val_mmcs, fri_config);
 
     let mut challenger = Challenger::new(perm.clone());
 
-    let domains_and_polys = log_degrees
+    let domains_and_polys_by_round = log_degrees_by_round
         .iter()
-        .map(|&d| {
-            (
-                <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << d),
-                RowMajorMatrix::<Val>::rand(&mut rng, 1 << d, 10),
-            )
+        .map(|log_degrees| {
+            log_degrees
+                .iter()
+                .map(|&log_degree| {
+                    let d = 1 << log_degree;
+                    (
+                        <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                        RowMajorMatrix::<Val>::rand(&mut rng, d, 10),
+                    )
+                })
+                .collect_vec()
         })
-        .collect::<Vec<_>>();
+        .collect_vec();
 
-    let (commit, data) =
-        <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.clone());
-
-    challenger.observe(commit);
-
-    let zeta = challenger.sample_ext_element::<Challenge>();
-
-    let points = domains_and_polys
+    let (commits_by_round, data_by_round): (Vec<_>, Vec<_>) = domains_and_polys_by_round
         .iter()
-        .map(|_| vec![zeta])
-        .collect::<Vec<_>>();
+        .map(|domains_and_polys| {
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.clone())
+        })
+        .unzip();
+    assert_eq!(commits_by_round.len(), num_rounds);
+    assert_eq!(data_by_round.len(), num_rounds);
+    challenger.observe_slice(&commits_by_round);
 
-    let (opening, proof) = pcs.open(vec![(&data, points)], &mut challenger);
+    let zeta: Challenge = challenger.sample_ext_element();
 
-    // verify the proof.
+    let points_by_round = log_degrees_by_round
+        .iter()
+        .map(|log_degrees| vec![vec![zeta]; log_degrees.len()])
+        .collect_vec();
+    let data_and_points = data_by_round.iter().zip(points_by_round).collect();
+    let (opening_by_round, proof) = pcs.open(data_and_points, &mut challenger);
+    assert_eq!(opening_by_round.len(), num_rounds);
+
+    // Verify the proof.
     let mut challenger = Challenger::new(perm);
-    challenger.observe(commit);
-    let _ = challenger.sample_ext_element::<Challenge>();
+    challenger.observe_slice(&commits_by_round);
+    let verifier_zeta: Challenge = challenger.sample_ext_element();
+    assert_eq!(verifier_zeta, zeta);
 
-    let os = domains_and_polys
-        .iter()
-        .zip(&opening[0])
-        .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
-        .collect();
-    pcs.verify(vec![(commit, os)], &proof, &mut challenger)
+    let commits_and_claims_by_round = izip!(
+        commits_by_round,
+        domains_and_polys_by_round,
+        opening_by_round
+    )
+    .map(|(commit, domains_and_polys, openings)| {
+        let claims = domains_and_polys
+            .iter()
+            .zip(openings)
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect_vec();
+        (commit, claims)
+    })
+    .collect_vec();
+    assert_eq!(commits_and_claims_by_round.len(), num_rounds);
+
+    pcs.verify(commits_and_claims_by_round, &proof, &mut challenger)
         .unwrap()
 }
 
 #[test]
 fn test_fri_pcs_single() {
-    make_test_fri_pcs(&[3]);
+    single_round_fri_test(&[&[3]]);
 }
 
 #[test]
 fn test_fri_pcs_many_equal() {
     for i in 1..4 {
-        make_test_fri_pcs(&[i; 5]);
+        single_round_fri_test(&[&[i; 5]]);
     }
 }
 
@@ -108,7 +136,7 @@ fn test_fri_pcs_many_equal() {
 fn test_fri_pcs_many_different() {
     for i in 2..4 {
         let degrees = (3..3 + i).collect::<Vec<_>>();
-        make_test_fri_pcs(&degrees);
+        single_round_fri_test(&[&degrees]);
     }
 }
 
@@ -116,6 +144,19 @@ fn test_fri_pcs_many_different() {
 fn test_fri_pcs_many_different_rev() {
     for i in 2..4 {
         let degrees = (3..3 + i).rev().collect::<Vec<_>>();
-        make_test_fri_pcs(&degrees);
+        single_round_fri_test(&[&degrees]);
     }
+}
+
+#[test]
+fn test_fri_pcs_multiple_rounds() {
+    single_round_fri_test(&[&[3]]);
+    single_round_fri_test(&[&[3], &[3]]);
+    single_round_fri_test(&[&[3], &[2]]);
+    single_round_fri_test(&[&[2], &[3]]);
+    single_round_fri_test(&[&[3, 4], &[3, 4]]);
+    single_round_fri_test(&[&[4, 2], &[4, 2]]);
+    single_round_fri_test(&[&[2, 2], &[3, 3]]);
+    single_round_fri_test(&[&[3, 3], &[2, 2]]);
+    single_round_fri_test(&[&[2], &[3, 3]]);
 }


### PR DESCRIPTION
"Global" in the sense that it's the max for all FRI inputs, not just for all matrices under a certain commitment.

Fixes #250.