### PR TITLE
feat: add public, preprocessed, and permutation to uni-stark symbolic

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -109,7 +109,9 @@ pub trait AirBuilder: Sized {
 }
 
 pub trait AirBuilderWithPublicValues: AirBuilder {
-    fn public_values(&self) -> &[Self::F];
+    type PublicVar: Into<Self::Expr> + Copy;
+
+    fn public_values(&self) -> &[Self::PublicVar];
 }
 
 pub trait PairBuilder: AirBuilder {

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -98,6 +98,8 @@ where
 }
 
 impl<'a, F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, F> {
+    type PublicVar = Self::F;
+
     fn public_values(&self) -> &[Self::F] {
         self.public_values
     }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -59,6 +59,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
 }
 
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'a, SC> {
+    type PublicVar = Self::F;
+
     fn public_values(&self) -> &[Self::F] {
         self.public_values
     }
@@ -97,6 +99,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     }
 }
 impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, SC> {
+    type PublicVar = Self::F;
+
     fn public_values(&self) -> &[Self::F] {
         self.public_values
     }

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::symbolic_expression::SymbolicExpression;
 use crate::symbolic_variable::SymbolicVariable;
-use crate::{Entry, Row};
+use crate::Entry;
 
 #[instrument(name = "infer log of constraint degree", skip_all)]
 pub fn get_log_quotient_degree<F, A>(air: &A, num_public_values: usize) -> usize
@@ -62,10 +62,10 @@ pub struct SymbolicAirBuilder<F: Field> {
 
 impl<F: Field> SymbolicAirBuilder<F> {
     pub(crate) fn new(width: usize, num_public_values: usize) -> Self {
-        let main_values = [Row::Local, Row::Next]
+        let main_values = [0, 1]
             .into_iter()
-            .flat_map(|row| {
-                (0..width).map(move |index| SymbolicVariable::new(Entry::Main(row), index))
+            .flat_map(|offset| {
+                (0..width).map(move |index| SymbolicVariable::new(Entry::Main { offset }, index))
             })
             .collect();
         let public_values = (0..num_public_values)

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -1,6 +1,5 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues};
 use p3_field::Field;
@@ -57,26 +56,25 @@ where
 /// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.
 pub struct SymbolicAirBuilder<F: Field> {
     main: RowMajorMatrix<SymbolicVariable<F>>,
-    public_values: Vec<F>,
+    public_values: Vec<SymbolicVariable<F>>,
     constraints: Vec<SymbolicExpression<F>>,
 }
 
 impl<F: Field> SymbolicAirBuilder<F> {
     pub(crate) fn new(width: usize, num_public_values: usize) -> Self {
-        let values = [Row::Local, Row::Next]
+        let main_values = [Row::Local, Row::Next]
             .into_iter()
             .flat_map(|row| {
-                (0..width).map(move |index| SymbolicVariable {
-                    entry: Entry::Main(row),
-                    index,
-                    _phantom: PhantomData,
-                })
+                (0..width).map(move |index| SymbolicVariable::new(Entry::Main(row), index))
             })
             .collect();
+        let public_values = (0..num_public_values)
+            .map(move |index| SymbolicVariable::new(Entry::Public, index))
+            .collect();
         Self {
-            main: RowMajorMatrix::new(values, width),
+            main: RowMajorMatrix::new(main_values, width),
             // TODO replace zeros once we have SymbolicExpression::PublicValue
-            public_values: vec![F::zero(); num_public_values],
+            public_values: public_values,
             constraints: vec![],
         }
     }
@@ -118,7 +116,8 @@ impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
 }
 
 impl<F: Field> AirBuilderWithPublicValues for SymbolicAirBuilder<F> {
-    fn public_values(&self) -> &[Self::F] {
-        self.public_values.as_slice()
+    type PublicVar = SymbolicVariable<F>;
+    fn public_values(&self) -> &[Self::PublicVar] {
+        &self.public_values
     }
 }

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -74,7 +74,7 @@ impl<F: Field> SymbolicAirBuilder<F> {
         Self {
             main: RowMajorMatrix::new(main_values, width),
             // TODO replace zeros once we have SymbolicExpression::PublicValue
-            public_values: public_values,
+            public_values,
             constraints: vec![],
         }
     }

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -10,6 +10,7 @@ use tracing::instrument;
 
 use crate::symbolic_expression::SymbolicExpression;
 use crate::symbolic_variable::SymbolicVariable;
+use crate::{Entry, Row};
 
 #[instrument(name = "infer log of constraint degree", skip_all)]
 pub fn get_log_quotient_degree<F, A>(air: &A, num_public_values: usize) -> usize
@@ -62,12 +63,12 @@ pub struct SymbolicAirBuilder<F: Field> {
 
 impl<F: Field> SymbolicAirBuilder<F> {
     pub(crate) fn new(width: usize, num_public_values: usize) -> Self {
-        let values = [false, true]
+        let values = [Row::Local, Row::Next]
             .into_iter()
-            .flat_map(|is_next| {
-                (0..width).map(move |column| SymbolicVariable {
-                    is_next,
-                    column,
+            .flat_map(|row| {
+                (0..width).map(move |index| SymbolicVariable {
+                    entry: Entry::Main(row),
+                    index,
                     _phantom: PhantomData,
                 })
             })

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -40,7 +40,7 @@ impl<F: Field> SymbolicExpression<F> {
     /// Returns the multiple of `n` (the trace length) in this expression's degree.
     pub fn degree_multiple(&self) -> usize {
         match self {
-            SymbolicExpression::Variable(_) => 1,
+            SymbolicExpression::Variable(v) => v.degree_multiple(),
             SymbolicExpression::IsFirstRow => 1,
             SymbolicExpression::IsLastRow => 1,
             SymbolicExpression::IsTransition => 0,

--- a/uni-stark/src/symbolic_variable.rs
+++ b/uni-stark/src/symbolic_variable.rs
@@ -5,20 +5,42 @@ use p3_field::Field;
 
 use crate::symbolic_expression::SymbolicExpression;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Row {
+    Local,
+    Next,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Entry {
+    Preprocessed(Row),
+    Main(Row),
+    Permutation(Row),
+    Public,
+    Challenge,
+}
+
 /// A variable within the evaluation window, i.e. a column in either the local or next row.
 #[derive(Copy, Clone, Debug)]
 pub struct SymbolicVariable<F: Field> {
-    pub is_next: bool,
-    pub column: usize,
+    pub entry: Entry,
+    pub index: usize,
     pub(crate) _phantom: PhantomData<F>,
 }
 
 impl<F: Field> SymbolicVariable<F> {
-    pub fn new(is_next: bool, column: usize) -> Self {
+    pub fn new(entry: Entry, index: usize) -> Self {
         Self {
-            is_next,
-            column,
+            entry,
+            index,
             _phantom: PhantomData,
+        }
+    }
+
+    pub fn degree_multiple(&self) -> usize {
+        match self.entry {
+            Entry::Preprocessed(_) | Entry::Main(_) | Entry::Permutation(_) => 1,
+            Entry::Public | Entry::Challenge => 0,
         }
     }
 }

--- a/uni-stark/src/symbolic_variable.rs
+++ b/uni-stark/src/symbolic_variable.rs
@@ -6,16 +6,10 @@ use p3_field::Field;
 use crate::symbolic_expression::SymbolicExpression;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Row {
-    Local,
-    Next,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Entry {
-    Preprocessed(Row),
-    Main(Row),
-    Permutation(Row),
+    Preprocessed { offset: usize },
+    Main { offset: usize },
+    Permutation { offset: usize },
     Public,
     Challenge,
 }
@@ -39,7 +33,7 @@ impl<F: Field> SymbolicVariable<F> {
 
     pub fn degree_multiple(&self) -> usize {
         match self.entry {
-            Entry::Preprocessed(_) | Entry::Main(_) | Entry::Permutation(_) => 1,
+            Entry::Preprocessed { .. } | Entry::Main { .. } | Entry::Permutation { .. } => 1,
             Entry::Public | Entry::Challenge => 0,
         }
     }


### PR DESCRIPTION
It has been mentioned that uni-stark may support permutation traces. If this is the case, I think the symbolic variables and expressions could be shared between uni-stark, sp1, and Valida. 

Add an enum `Entry` to describe whether the variable is a public input, preprocessed trace,  main trace, permutation trace, public values, or challenges.