### PR TITLE
refactor: make hidden lifetimes explicit, add missing Debug implementation for public structs

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -55,7 +55,7 @@ pub trait AirBuilder: Sized {
     fn is_transition_window(&self, size: usize) -> Self::Expr;
 
     /// Returns a sub-builder whose constraints are enforced only when `condition` is nonzero.
-    fn when<I: Into<Self::Expr>>(&mut self, condition: I) -> FilteredAirBuilder<Self> {
+    fn when<I: Into<Self::Expr>>(&mut self, condition: I) -> FilteredAirBuilder<'_, Self> {
         FilteredAirBuilder {
             inner: self,
             condition: condition.into(),
@@ -67,27 +67,27 @@ pub trait AirBuilder: Sized {
         &mut self,
         x: I1,
         y: I2,
-    ) -> FilteredAirBuilder<Self> {
+    ) -> FilteredAirBuilder<'_, Self> {
         self.when(x.into() - y.into())
     }
 
     /// Returns a sub-builder whose constraints are enforced only on the first row.
-    fn when_first_row(&mut self) -> FilteredAirBuilder<Self> {
+    fn when_first_row(&mut self) -> FilteredAirBuilder<'_, Self> {
         self.when(self.is_first_row())
     }
 
     /// Returns a sub-builder whose constraints are enforced only on the last row.
-    fn when_last_row(&mut self) -> FilteredAirBuilder<Self> {
+    fn when_last_row(&mut self) -> FilteredAirBuilder<'_, Self> {
         self.when(self.is_last_row())
     }
 
     /// Returns a sub-builder whose constraints are enforced on all rows except the last.
-    fn when_transition(&mut self) -> FilteredAirBuilder<Self> {
+    fn when_transition(&mut self) -> FilteredAirBuilder<'_, Self> {
         self.when(self.is_transition())
     }
 
     /// Returns a sub-builder whose constraints are enforced on all rows except the last `size - 1`.
-    fn when_transition_window(&mut self, size: usize) -> FilteredAirBuilder<Self> {
+    fn when_transition_window(&mut self, size: usize) -> FilteredAirBuilder<'_, Self> {
         self.when(self.is_transition_window(size))
     }
 

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -153,6 +153,7 @@ pub trait PermutationAirBuilder: ExtensionBuilder {
     fn permutation_randomness(&self) -> &[Self::EF];
 }
 
+#[derive(Debug)]
 pub struct FilteredAirBuilder<'a, AB: AirBuilder> {
     pub inner: &'a mut AB,
     condition: AB::Expr,

--- a/air/src/two_row_matrix.rs
+++ b/air/src/two_row_matrix.rs
@@ -3,7 +3,7 @@ use core::slice;
 
 use p3_matrix::{Matrix, MatrixRowSlices, MatrixRows};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TwoRowMatrixView<'a, T> {
     pub local: &'a [T],
     pub next: &'a [T],

--- a/baby-bear/src/mds.rs
+++ b/baby-bear/src/mds.rs
@@ -14,7 +14,7 @@ use p3_symmetric::Permutation;
 
 use crate::BabyBear;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MdsMatrixBabyBear;
 
 /// Instantiate convolution for "small" RHS vectors over BabyBear.

--- a/blake3/src/lib.rs
+++ b/blake3/src/lib.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 use p3_symmetric::CryptographicHasher;
 
 /// The blake3 hash function.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Blake3;
 
 impl CryptographicHasher<u8, [u8; 32]> for Blake3 {

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -45,7 +45,7 @@ mod tests {
     fn bn254_from_ark_ff(input: ark_FpBN256) -> Bn254Fr {
         let bytes = input.into_bigint().to_bytes_le();
 
-        let mut res = <FFBn254Fr as ff::PrimeField>::Repr::default();
+        let mut res = <FFBn254Fr as PrimeField>::Repr::default();
 
         for (i, digit) in res.0.as_mut().iter_mut().enumerate() {
             *digit = bytes[i];

--- a/brakedown/src/brakedown_code.rs
+++ b/brakedown/src/brakedown_code.rs
@@ -11,6 +11,7 @@ use p3_matrix::stack::VerticalPair;
 use p3_matrix::{Matrix, MatrixRows};
 
 /// The Spielman-based code described in the Brakedown paper.
+#[derive(Debug)]
 pub struct BrakedownCode<F, IC>
 where
     F: Field,

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -6,7 +6,7 @@ use p3_symmetric::{CryptographicPermutation, Hash};
 
 use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DuplexChallenger<F, P, const WIDTH: usize>
 where
     F: Clone,

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -5,7 +5,7 @@ use p3_symmetric::CryptographicHasher;
 
 use crate::{CanObserve, CanSample};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HashChallenger<T, H, const OUT_LEN: usize>
 where
     T: Clone,

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -10,7 +10,7 @@ use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
 /// Given a cryptographic permutation that operates on `[Field; WIDTH]`, produces a challenger
 /// that can observe and sample `PrimeField64` elements.  Can also observe values with
 /// `Hash<F, PF, N>` type.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MultiFieldChallenger<F, PF, P, const WIDTH: usize>
 where
     F: PrimeField64,

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 use crate::domain::CircleDomain;
 use crate::twiddles::TwiddleCache;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct Cfft<F>(Rc<RefCell<TwiddleCache<F>>>);
 
 impl<F: ComplexExtendable> Cfft<F> {

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -14,12 +14,14 @@ use crate::cfft::Cfft;
 use crate::domain::CircleDomain;
 use crate::util::{univariate_to_point, v_n};
 
+#[derive(Debug)]
 pub struct CirclePcs<Val, InputMmcs> {
     pub log_blowup: usize,
     pub cfft: Cfft<Val>,
     pub mmcs: InputMmcs,
 }
 
+#[derive(Debug)]
 pub struct ProverData<Val, MmcsData> {
     committed_domains: Vec<CircleDomain<Val>>,
     mmcs_data: MmcsData,

--- a/circle/src/twiddles.rs
+++ b/circle/src/twiddles.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use crate::domain::CircleDomain;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct TwiddleCache<F>(
     // (log_n, shift) -> (twiddles, inverse_twiddles)
     #[allow(clippy::type_complexity)]

--- a/code/src/identity.rs
+++ b/code/src/identity.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 /// The trivial code whose encoder is the identity function.
+#[derive(Debug)]
 pub struct IdentityCode {
     pub len: usize,
 }

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -7,7 +7,7 @@ use p3_matrix::{Dimensions, Matrix, MatrixRows};
 
 use crate::{DirectMmcs, Mmcs};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ExtensionMmcs<F, EF, InnerMmcs> {
     inner: InnerMmcs,
     _phantom: PhantomData<(F, EF)>,
@@ -103,6 +103,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct ExtensionMatrix<F, EF, InnerMat> {
     inner: InnerMat,
     _phantom: PhantomData<(F, EF)>,
@@ -141,6 +142,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct ExtensionRow<F, EF, InnerRowIter> {
     inner: InnerRowIter,
     _phantom: PhantomData<(F, EF)>,

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -9,6 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRows;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 
+#[derive(Debug)]
 pub struct LagrangeSelectors<T> {
     pub is_first_row: T,
     pub is_last_row: T,
@@ -52,7 +53,7 @@ pub trait PolynomialSpace: Copy {
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>>;
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TwoAdicMultiplicativeCoset<Val: TwoAdicField> {
     pub log_n: usize,
     pub shift: Val,

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
 
 /// A trivial PCS: its commitment is simply the coefficients of each poly.
+#[derive(Debug)]
 pub struct TrivialPcs<Val: TwoAdicField, Dft: TwoAdicSubgroupDft<Val>> {
     pub dft: Dft,
     // degree bound

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -78,7 +78,7 @@ pub(crate) fn dit_butterfly_on_rows<F: Field>(row_1: &mut [F], row_2: &mut [F], 
 /// DIT butterfly.
 #[inline]
 pub(crate) fn dit_butterfly<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
+    mat: &mut RowMajorMatrixViewMut<'_, F>,
     row_1: usize,
     row_2: usize,
     twiddle: F,

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -7,7 +7,7 @@ use p3_util::log2_strict_usize;
 
 use crate::TwoAdicSubgroupDft;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct NaiveDft;
 
 impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for NaiveDft {

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -77,7 +77,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {
 
 /// Executes the Bowers G network. This is like a DFT, except it assumes the input is in
 /// bit-reversed order.
-fn bowers_g<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
+fn bowers_g<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<'_, F>) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
 
@@ -93,7 +93,7 @@ fn bowers_g<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
 
 /// Executes the Bowers G^T network. This is like an inverse DFT, except we skip rescaling by
 /// 1/height, and the output is bit-reversed.
-fn bowers_g_t<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
+fn bowers_g_t<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<'_, F>) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
 
@@ -109,7 +109,7 @@ fn bowers_g_t<F: TwoAdicField>(mat: &mut RowMajorMatrixViewMut<F>) {
 
 /// One layer of a Bowers G network. Equivalent to `bowers_g_t_layer` except for the butterfly.
 fn bowers_g_layer<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
+    mat: &mut RowMajorMatrixViewMut<'_, F>,
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
@@ -120,7 +120,7 @@ fn bowers_g_layer<F: Field>(
 
 /// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
 fn bowers_g_t_layer<F: Field>(
-    mat: &mut RowMajorMatrixViewMut<F>,
+    mat: &mut RowMajorMatrixViewMut<'_, F>,
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
@@ -130,7 +130,7 @@ fn bowers_g_t_layer<F: Field>(
 }
 
 fn par_chunks_bowers<F: Field, Fun>(
-    mat: &mut RowMajorMatrixViewMut<F>,
+    mat: &mut RowMajorMatrixViewMut<'_, F>,
     width: usize,
     half_block_size: usize,
     twiddles: &[F],

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -15,7 +15,7 @@ use crate::TwoAdicSubgroupDft;
 
 /// The Bowers G FFT algorithm.
 /// See: "Improved Twiddle Access for Fast Fourier Transforms"
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct Radix2Bowers;
 
 impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -13,7 +13,7 @@ use crate::butterflies::{dit_butterfly_on_rows, twiddle_free_butterfly_on_rows};
 use crate::TwoAdicSubgroupDft;
 
 /// The DIT FFT algorithm.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct Radix2Dit<F: TwoAdicField> {
     /// Memoized twiddle factors for each length log_n.
     twiddles: RefCell<BTreeMap<usize, Vec<F>>>,

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -43,7 +43,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Dit<F> {
 }
 
 /// One layer of a DIT butterfly network.
-fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<F>, layer: usize, twiddles: &[F]) {
+fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>, layer: usize, twiddles: &[F]) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
     let layer_rev = log_h - 1 - layer;

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -138,7 +138,7 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
 
 /// One layer of a DIT butterfly network.
 fn dit_layer<F: Field>(
-    submat: &mut RowMajorMatrixViewMut<F>,
+    submat: &mut RowMajorMatrixViewMut<'_, F>,
     log_h: usize,
     layer: usize,
     twiddles: &[F],
@@ -162,7 +162,7 @@ fn dit_layer<F: Field>(
 /// Like `dit_layer`, except the matrix and twiddles are encoded in bit-reversed order.
 /// This can also be viewed as a layer of the Bowers G^T network.
 fn dit_layer_rev<F: Field>(
-    submat: &mut RowMajorMatrixViewMut<F>,
+    submat: &mut RowMajorMatrixViewMut<'_, F>,
     log_h: usize,
     layer: usize,
     twiddles_rev: &[F],

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -20,7 +20,7 @@ use crate::TwoAdicSubgroupDft;
 /// the same network but in bit-reversed order. This way we're always working with small blocks,
 /// so within each half, we can have a certain amount of parallelism with no cross-thread
 /// communication.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct Radix2DitParallel;
 
 impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -378,7 +378,7 @@ pub trait TwoAdicField: Field {
 }
 
 /// An iterator over the powers of a certain base element `b`: `b^0, b^1, b^2, ...`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Powers<F> {
     pub base: F,
     pub current: F,
@@ -395,7 +395,7 @@ impl<AF: AbstractField> Iterator for Powers<AF> {
 }
 
 /// like `Powers`, but packed into `PackedField` elements
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PackedPowers<F, P: PackedField<Scalar = F>> {
     // base ** P::WIDTH
     pub multiplier: P,

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct FriConfig<M> {
     pub log_blowup: usize,
     pub num_queries: usize,

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -26,7 +26,7 @@ pub struct QueryProof<F: Field, M: Mmcs<F>> {
     pub commit_phase_openings: Vec<CommitPhaseProofStep<F, M>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 // #[serde(bound(serialize = "F: Serialize"))]
 #[serde(bound = "")]
 pub struct CommitPhaseProofStep<F: Field, M: Mmcs<F>> {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -24,6 +24,7 @@ use tracing::{info_span, instrument};
 use crate::verifier::{self, FriError};
 use crate::{prover, FriConfig, FriProof};
 
+#[derive(Debug)]
 pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
     // degree bound
     log_n: usize,

--- a/goldilocks/src/mds.rs
+++ b/goldilocks/src/mds.rs
@@ -14,13 +14,14 @@ use p3_symmetric::Permutation;
 
 use crate::{reduce128, Goldilocks};
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MdsMatrixGoldilocks;
 
 /// Instantiate convolution for "small" RHS vectors over Goldilocks.
 ///
 /// Here "small" means N = len(rhs) <= 16 and sum(r for r in rhs) <
 /// 2^51, though in practice the sum will be less than 2^9.
+#[derive(Debug)]
 pub struct SmallConvolveGoldilocks;
 impl Convolve<Goldilocks, i128, i64, i128> for SmallConvolveGoldilocks {
     /// Return the lift of a Goldilocks element, 0 <= input.value <= P

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -11,6 +11,7 @@ use crate::round_flags::eval_round_flags;
 use crate::{BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
 
 /// Assumes the field size is at least 16 bits.
+#[derive(Debug)]
 pub struct KeccakAir {}
 
 impl<F> BaseAir<F> for KeccakAir {

--- a/keccak-air/src/columns.rs
+++ b/keccak-air/src/columns.rs
@@ -13,6 +13,7 @@ use crate::{NUM_ROUNDS, RATE_LIMBS, U64_LIMBS};
 /// Thus, for example, `a_prime` is stored in `y, x, z` order. This departs from the more common
 /// convention of `x, y, z` order, but it has the benefit that input lists map to AIR columns in a
 /// nicer way.
+#[derive(Debug)]
 #[repr(C)]
 pub struct KeccakCols<T> {
     /// The `i`th value is set to 1 if we are in the `i`th round, otherwise 0.

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -10,7 +10,7 @@ use p3_symmetric::{CryptographicHasher, CryptographicPermutation, Permutation};
 use tiny_keccak::{keccakf, Hasher, Keccak};
 
 /// The Keccak-f permutation.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct KeccakF;
 
 impl Permutation<[u64; 25]> for KeccakF {
@@ -44,7 +44,7 @@ impl CryptographicPermutation<[u8; 200]> for KeccakF {}
 
 /// The `Keccak` hash functions defined in
 /// [Keccak SHA3 submission](https://keccak.team/files/Keccak-submission-3.pdf).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Keccak256Hash;
 
 impl CryptographicHasher<u8, [u8; 32]> for Keccak256Hash {

--- a/lde/src/naive.rs
+++ b/lde/src/naive.rs
@@ -12,12 +12,15 @@ use p3_util::log2_strict_usize;
 use crate::{TwoAdicCosetLde, TwoAdicLde, TwoAdicSubgroupLde, UndefinedLde};
 
 /// A naive quadratic-time implementation of `Lde`, intended for testing.
+#[derive(Debug)]
 pub struct NaiveUndefinedLde;
 
 /// A naive quadratic-time implementation of `TwoAdicSubgroupLde`, intended for testing.
+#[derive(Debug)]
 pub struct NaiveSubgroupLde;
 
 /// A naive quadratic-time implementation of `TwoAdicCosetLde`, intended for testing.
+#[derive(Debug)]
 pub struct NaiveCosetLde;
 
 impl<F, In> UndefinedLde<F, In> for NaiveUndefinedLde

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -60,7 +60,7 @@ impl<T> RowMajorMatrix<T> {
     pub fn par_row_chunks_mut(
         &mut self,
         chunk_rows: usize,
-    ) -> impl IndexedParallelIterator<Item = RowMajorMatrixViewMut<T>>
+    ) -> impl IndexedParallelIterator<Item = RowMajorMatrixViewMut<'_, T>>
     where
         T: Send,
     {
@@ -72,7 +72,7 @@ impl<T> RowMajorMatrix<T> {
     pub fn par_row_chunks(
         &self,
         chunk_rows: usize,
-    ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<T>>
+    ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<'_, T>>
     where
         T: Sync,
     {
@@ -82,14 +82,14 @@ impl<T> RowMajorMatrix<T> {
     }
 
     #[must_use]
-    pub fn as_view(&self) -> RowMajorMatrixView<T> {
+    pub fn as_view(&self) -> RowMajorMatrixView<'_, T> {
         RowMajorMatrixView {
             values: &self.values,
             width: self.width,
         }
     }
 
-    pub fn as_view_mut(&mut self) -> RowMajorMatrixViewMut<T> {
+    pub fn as_view_mut(&mut self) -> RowMajorMatrixViewMut<'_, T> {
         RowMajorMatrixViewMut {
             values: &mut self.values,
             width: self.width,
@@ -268,7 +268,7 @@ impl<'a, T> RowMajorMatrixView<'a, T> {
         self.values.par_chunks_exact(self.width)
     }
 
-    pub fn split_rows(&self, r: usize) -> (RowMajorMatrixView<T>, RowMajorMatrixView<T>) {
+    pub fn split_rows(&self, r: usize) -> (RowMajorMatrixView<'_, T>, RowMajorMatrixView<'_, T>) {
         let (upper_values, lower_values) = self.values.split_at(r * self.width);
         let upper = RowMajorMatrixView {
             values: upper_values,
@@ -364,14 +364,17 @@ impl<'a, T> RowMajorMatrixViewMut<'a, T> {
     }
 
     #[must_use]
-    pub fn as_view(&self) -> RowMajorMatrixView<T> {
+    pub fn as_view(&self) -> RowMajorMatrixView<'_, T> {
         RowMajorMatrixView {
             values: self.values,
             width: self.width,
         }
     }
 
-    pub fn split_rows(&mut self, r: usize) -> (RowMajorMatrixViewMut<T>, RowMajorMatrixViewMut<T>) {
+    pub fn split_rows(
+        &mut self,
+        r: usize,
+    ) -> (RowMajorMatrixViewMut<'_, T>, RowMajorMatrixViewMut<'_, T>) {
         let (upper_values, lower_values) = self.values.split_at_mut(r * self.width);
         let upper = RowMajorMatrixViewMut {
             values: upper_values,

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -244,7 +244,7 @@ impl<T: Clone + Send> MatrixRowChunksMut<T> for RowMajorMatrix<T> {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct RowMajorMatrixView<'a, T> {
     pub values: &'a [T],
     pub width: usize,
@@ -321,6 +321,7 @@ impl<T: Clone> MatrixRowSlices<T> for RowMajorMatrixView<'_, T> {
     }
 }
 
+#[derive(Debug)]
 pub struct RowMajorMatrixViewMut<'a, T> {
     pub values: &'a mut [T],
     pub width: usize,

--- a/matrix/src/sparse.rs
+++ b/matrix/src/sparse.rs
@@ -8,6 +8,7 @@ use rand::Rng;
 use crate::Matrix;
 
 /// A sparse matrix stored in the compressed sparse row format.
+#[derive(Debug)]
 pub struct CsrMatrix<T> {
     width: usize,
 

--- a/matrix/src/stack.rs
+++ b/matrix/src/stack.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use crate::{Matrix, MatrixRows};
 
 /// A combination of two matrices, stacked together vertically.
+#[derive(Debug)]
 pub struct VerticalPair<T, First: Matrix<T>, Second: Matrix<T>> {
     first: First,
     second: Second,
@@ -46,11 +47,13 @@ where
     }
 }
 
+#[derive(Debug)]
 pub enum EitherIterable<L, R> {
     Left(L),
     Right(R),
 }
 
+#[derive(Debug)]
 pub enum EitherIterator<L, R> {
     Left(L),
     Right(R),

--- a/matrix/src/strided.rs
+++ b/matrix/src/strided.rs
@@ -1,5 +1,6 @@
 use crate::{Matrix, MatrixGet, MatrixRows};
 
+#[derive(Debug)]
 pub struct VerticallyStridedMatrixView<Inner> {
     pub(crate) inner: Inner,
     pub(crate) stride: usize,

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 ///
 /// This generally shouldn't be used directly. If you're using a Merkle tree as an MMCS,
 /// see `FieldMerkleTreeMmcs`.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FieldMerkleTree<F, W, const DIGEST_ELEMS: usize> {
     pub(crate) leaves: Vec<RowMajorMatrix<F>>,
     // Enable serialization for this field whenever the underlying array type supports it (len 1-32).

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -19,7 +19,7 @@ use crate::FieldMerkleTree;
 /// - `P`: a leaf value TODO
 /// - `H`: the leaf hasher
 /// - `C`: the digest compression function
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct FieldMerkleTreeMmcs<P, PW, H, C, const DIGEST_ELEMS: usize> {
     hash: H,
     compress: C,

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -153,7 +153,7 @@ fn idft_postprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<F> {
 }
 
 /// The DFT for Mersenne31
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Mersenne31Dft;
 
 impl Mersenne31Dft {

--- a/mersenne-31/src/mds.rs
+++ b/mersenne-31/src/mds.rs
@@ -14,7 +14,7 @@ use p3_symmetric::Permutation;
 
 use crate::Mersenne31;
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MdsMatrixMersenne31;
 
 /// Instantiate convolution for "small" RHS vectors over Mersenne31.

--- a/mersenne-31/src/radix_2_dit.rs
+++ b/mersenne-31/src/radix_2_dit.rs
@@ -13,7 +13,7 @@ use crate::Mersenne31;
 type F = Mersenne31;
 type C = Complex<F>;
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Mersenne31ComplexRadix2Dit;
 
 impl TwoAdicSubgroupDft<C> for Mersenne31ComplexRadix2Dit {

--- a/mersenne-31/src/radix_2_dit.rs
+++ b/mersenne-31/src/radix_2_dit.rs
@@ -40,7 +40,7 @@ impl TwoAdicSubgroupDft<C> for Mersenne31ComplexRadix2Dit {
 // (in `dit_butterfly_inner()` below) into the existing structure.
 
 /// One layer of a DIT butterfly network.
-fn dit_layer(mat: &mut RowMajorMatrixViewMut<C>, layer: usize, twiddles: &[C]) {
+fn dit_layer(mat: &mut RowMajorMatrixViewMut<'_, C>, layer: usize, twiddles: &[C]) {
     let h = mat.height();
     let log_h = log2_strict_usize(h);
     let layer_rev = log_h - 1 - layer;
@@ -64,7 +64,7 @@ fn dit_layer(mat: &mut RowMajorMatrixViewMut<C>, layer: usize, twiddles: &[C]) {
 }
 
 #[inline]
-fn twiddle_free_butterfly(mat: &mut RowMajorMatrixViewMut<C>, row_1: usize, row_2: usize) {
+fn twiddle_free_butterfly(mat: &mut RowMajorMatrixViewMut<'_, C>, row_1: usize, row_2: usize) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
         mat.packing_aligned_rows(row_1, row_2);
 
@@ -83,7 +83,7 @@ fn twiddle_free_butterfly(mat: &mut RowMajorMatrixViewMut<C>, row_1: usize, row_
 }
 
 #[inline]
-fn dit_butterfly(mat: &mut RowMajorMatrixViewMut<C>, row_1: usize, row_2: usize, twiddle: C) {
+fn dit_butterfly(mat: &mut RowMajorMatrixViewMut<'_, C>, row_1: usize, row_2: usize, twiddle: C) {
     let ((prefix_1, shorts_1, suffix_1), (prefix_2, shorts_2, suffix_2)) =
         mat.packing_aligned_rows(row_1, row_2);
 

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -17,6 +17,7 @@ use crate::util::get_random_u32;
 // The Monolith-31 permutation over Mersenne31.
 // NUM_FULL_ROUNDS is the number of rounds - 1
 // (used to avoid const generics because we need an array of length NUM_FULL_ROUNDS)
+#[derive(Debug)]
 pub struct MonolithMersenne31<Mds, const WIDTH: usize, const NUM_FULL_ROUNDS: usize>
 where
     Mds: MdsPermutation<Mersenne31, WIDTH>,

--- a/monolith/src/monolith_mds.rs
+++ b/monolith/src/monolith_mds.rs
@@ -11,7 +11,7 @@ use sha3::{Shake128, Shake128Reader};
 
 use crate::util::get_random_u32;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MonolithMdsMatrixMersenne31<const NUM_ROUNDS: usize>;
 
 const MATRIX_CIRC_MDS_16_MERSENNE31_MONOLITH: [u64; 16] = [

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -14,7 +14,7 @@ use rand::prelude::Distribution;
 use rand::Rng;
 
 /// The Poseidon permutation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Poseidon<F, Mds, const WIDTH: usize, const ALPHA: u64> {
     half_num_full_rounds: usize,
     num_partial_rounds: usize,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -22,7 +22,7 @@ use rand::Rng;
 const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
 
 /// The Poseidon2 permutation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Poseidon2<F, Diffusion, const WIDTH: usize, const D: u64> {
     /// The number of external rounds.
     rounds_f: usize,

--- a/reed-solomon/src/lib.rs
+++ b/reed-solomon/src/lib.rs
@@ -12,6 +12,7 @@ use p3_lde::UndefinedLde;
 use p3_matrix::MatrixRows;
 
 /// A Reed-Solomon code based on an `UndefinedLde`.
+#[derive(Debug)]
 pub struct UndefinedReedSolomonCode<F, L, In>
 where
     F: Field,

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -16,7 +16,7 @@ use crate::sbox::SboxLayers;
 use crate::util::shake256_hash;
 
 /// The Rescue-XLIX permutation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Rescue<F, Mds, Sbox, const WIDTH: usize> {
     num_rounds: usize,
     mds: Mds,

--- a/rescue/src/sbox.rs
+++ b/rescue/src/sbox.rs
@@ -14,7 +14,7 @@ where
     fn inverse_sbox_layer(&self, state: &mut [AF; WIDTH]);
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct BasicSboxLayer<F: PrimeField> {
     alpha: u64,
     alpha_inv: u64,

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -13,7 +13,7 @@ pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
 /// An `N`-to-1 compression function.
 pub trait CompressionFunction<T, const N: usize>: PseudoCompressionFunction<T, N> {}
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TruncatedPermutation<InnerP, const N: usize, const CHUNK: usize, const WIDTH: usize> {
     inner_permutation: InnerP,
 }
@@ -43,7 +43,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CompressionFunctionFromHasher<T, H, const N: usize, const CHUNK: usize>
 where
     T: Clone,

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -3,13 +3,13 @@ use p3_field::{PackedField, PackedValue, PrimeField32, PrimeField64};
 use crate::CryptographicHasher;
 
 /// Maps input field elements to their 4-byte little-endian encodings, outputs `[u8; 32]`.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct SerializingHasher32<Inner> {
     inner: Inner,
 }
 
 /// Maps input field elements to their 8-byte little-endian encodings, outputs `[u8; 32]`.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct SerializingHasher64<Inner> {
     inner: Inner,
 }

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -10,7 +10,7 @@ use crate::permutation::CryptographicPermutation;
 /// A padding-free, overwrite-mode sponge function.
 ///
 /// `WIDTH` is the sponge's rate plus the sponge's capacity.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PaddingFreeSponge<P, const WIDTH: usize, const RATE: usize, const OUT: usize> {
     permutation: P,
 }
@@ -47,7 +47,7 @@ where
 /// using a different `Field` type.
 ///
 /// `WIDTH` is the sponge's rate plus the sponge's capacity.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PaddingFreeSpongeMultiField<
     F,
     PF,

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -39,6 +39,7 @@ where
 
 /// An `AirBuilder` which asserts that each constraint is zero, allowing any failed constraints to
 /// be detected early.
+#[derive(Debug)]
 pub struct DebugConstraintBuilder<'a, F: Field> {
     row_index: usize,
     main: TwoRowMatrixView<'a, F>,

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -34,6 +34,7 @@ pub trait StarkGenericConfig {
     fn pcs(&self) -> &Self::Pcs;
 }
 
+#[derive(Debug)]
 pub struct StarkConfig<Pcs, Challenge, Challenger> {
     pcs: Pcs,
     _phantom: PhantomData<(Challenge, Challenger)>,

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -5,6 +5,7 @@ use p3_field::AbstractField;
 
 use crate::{PackedChallenge, PackedVal, StarkGenericConfig, Val};
 
+#[derive(Debug)]
 pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub main: TwoRowMatrixView<'a, PackedVal<SC>>,
     pub public_values: &'a Vec<Val<SC>>,
@@ -15,6 +16,7 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub accumulator: PackedChallenge<SC>,
 }
 
+#[derive(Debug)]
 pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     pub main: TwoRowMatrixView<'a, SC::Challenge>,
     pub public_values: &'a Vec<Val<SC>>,

--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -23,13 +23,13 @@ pub struct Proof<SC: StarkGenericConfig> {
     pub(crate) degree_bits: usize,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Commitments<Com> {
     pub(crate) trace: Com,
     pub(crate) quotient_chunks: Com,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OpenedValues<Challenge> {
     pub(crate) trace_local: Vec<Challenge>,
     pub(crate) trace_next: Vec<Challenge>,

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -54,6 +54,7 @@ where
 }
 
 /// An `AirBuilder` for evaluating constraints symbolically, and recording them for later use.
+#[derive(Debug)]
 pub struct SymbolicAirBuilder<F: Field> {
     main: RowMajorMatrix<SymbolicVariable<F>>,
     public_values: Vec<F>,

--- a/uni-stark/src/zerofier_coset.rs
+++ b/uni-stark/src/zerofier_coset.rs
@@ -7,6 +7,7 @@ use p3_field::{
 };
 
 /// Precomputations of the evaluation of `Z_H(X) = X^n - 1` on a coset `s K` with `H <= K`.
+#[derive(Debug)]
 pub struct ZerofierOnCoset<F: Field> {
     /// `n = |H|`.
     log_n: usize,

--- a/util/src/array_serialization.rs
+++ b/util/src/array_serialization.rs
@@ -24,7 +24,7 @@ where
 {
     type Value = [T; N];
 
-    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter.write_fmt(format_args!("an array of length {}", N))
     }
 

--- a/util/src/linear_map.rs
+++ b/util/src/linear_map.rs
@@ -6,6 +6,7 @@ use crate::VecExt;
 /// O(n) Vec-backed map for keys that only implement Eq.
 /// Only use this for a very small number of keys, operations
 /// on it can easily become O(n^2).
+#[derive(Debug)]
 pub struct LinearMap<K, V>(Vec<(K, V)>);
 
 impl<K, V> Default for LinearMap<K, V> {


### PR DESCRIPTION
Small issues corrected while reading the code:
- https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetimes-in-paths
- https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations

Opinions on this loosely held, happy to adjust in any way.