### PR TITLE
refactor: Convert multiple functions to `const` functions

### DIFF
--- a/air/src/two_row_matrix.rs
+++ b/air/src/two_row_matrix.rs
@@ -10,7 +10,7 @@ pub struct TwoRowMatrixView<'a, T> {
 }
 
 impl<'a, T> TwoRowMatrixView<'a, T> {
-    pub fn new(local: &'a [T], next: &'a [T]) -> Self {
+    pub const fn new(local: &'a [T], next: &'a [T]) -> Self {
         Self { local, next }
     }
 }

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -61,7 +61,7 @@ impl<F: Field> VirtualPairCol<F> {
     }
 
     #[must_use]
-    pub fn constant(x: F) -> Self {
+    pub const fn constant(x: F) -> Self {
         Self {
             column_weights: vec![],
             constant: x,

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -446,20 +446,20 @@ pub(crate) const fn to_babybear_array<const N: usize>(input: [u32; N]) -> [BabyB
 
 #[inline]
 #[must_use]
-fn to_monty_64(x: u64) -> u32 {
+const fn to_monty_64(x: u64) -> u32 {
     (((x as u128) << MONTY_BITS) % P as u128) as u32
 }
 
 #[inline]
 #[must_use]
-fn from_monty(x: u32) -> u32 {
+const fn from_monty(x: u32) -> u32 {
     monty_reduce(x as u64)
 }
 
 /// Montgomery reduction of a value in `0..P << MONTY_BITS`.
 #[inline]
 #[must_use]
-fn monty_reduce(x: u64) -> u32 {
+const fn monty_reduce(x: u64) -> u32 {
     let t = x.wrapping_mul(MONTY_MU as u64) & (MONTY_MASK as u64);
     let u = t * (P as u64);
 

--- a/baby-bear/src/mds.rs
+++ b/baby-bear/src/mds.rs
@@ -68,7 +68,7 @@ impl Convolve<BabyBear, i64, i64, i64> for SmallConvolveBabyBear {
 /// x' = x mod 2^10
 /// See Thm 1 (Below function) for a proof that this function is correct.
 #[inline(always)]
-fn barret_red_babybear(input: i128) -> i64 {
+const fn barret_red_babybear(input: i128) -> i64 {
     const N: usize = 40; // beta = 2^N, fixing N = 40 here
     const P: i128 = BabyBear::ORDER_U32 as i128;
     const I: i64 = (((1_i128) << (2 * N)) / P) as i64; // I = 2^80 / P => I < 2**50

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -33,7 +33,7 @@ pub struct Bn254Fr {
 }
 
 impl Bn254Fr {
-    pub(crate) fn new(value: FFBn254Fr) -> Self {
+    pub(crate) const fn new(value: FFBn254Fr) -> Self {
         Self { value }
     }
 }

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -42,7 +42,7 @@ pub struct SerializingChallenger64<F, Inner> {
 }
 
 impl<F: PrimeField32, Inner: CanObserve<u8>> SerializingChallenger32<F, Inner> {
-    pub fn new(inner: Inner) -> Self {
+    pub const fn new(inner: Inner) -> Self {
         Self {
             inner,
             _marker: PhantomData,
@@ -140,7 +140,7 @@ where
 }
 
 impl<F: PrimeField64, Inner: CanObserve<u8>> SerializingChallenger64<F, Inner> {
-    pub fn new(inner: Inner) -> Self {
+    pub const fn new(inner: Inner) -> Self {
         Self {
             inner,
             _marker: PhantomData,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -45,7 +45,7 @@ pub struct CircleDomain<F> {
 }
 
 impl<F: ComplexExtendable> CircleDomain<F> {
-    pub(crate) fn new(log_n: usize, shift: Complex<F>) -> Self {
+    pub(crate) const fn new(log_n: usize, shift: Complex<F>) -> Self {
         Self { log_n, shift }
     }
     pub(crate) fn standard(log_n: usize) -> Self {

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -14,7 +14,7 @@ pub struct ExtensionMmcs<F, EF, InnerMmcs> {
 }
 
 impl<F, EF, InnerMmcs> ExtensionMmcs<F, EF, InnerMmcs> {
-    pub fn new(inner: InnerMmcs) -> Self {
+    pub const fn new(inner: InnerMmcs) -> Self {
         Self {
             inner,
             _phantom: PhantomData,

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -7,7 +7,7 @@ pub struct FriConfig<M> {
 }
 
 impl<M> FriConfig<M> {
-    pub fn blowup(&self) -> usize {
+    pub const fn blowup(&self) -> usize {
         1 << self.log_blowup
     }
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -35,7 +35,7 @@ pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
 }
 
 impl<Val, Dft, InputMmcs, FriMmcs> TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
-    pub fn new(log_n: usize, dft: Dft, mmcs: InputMmcs, fri: FriConfig<FriMmcs>) -> Self {
+    pub const fn new(log_n: usize, dft: Dft, mmcs: InputMmcs, fri: FriConfig<FriMmcs>) -> Self {
         Self {
             log_n,
             dft,

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -392,7 +392,7 @@ pub(crate) fn reduce128(x: u128) -> Goldilocks {
 
 #[inline]
 #[allow(clippy::cast_possible_truncation)]
-fn split(x: u128) -> (u64, u64) {
+const fn split(x: u128) -> (u64, u64) {
     (x as u64, (x >> 64) as u64)
 }
 

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -268,7 +268,10 @@ impl<'a, T> RowMajorMatrixView<'a, T> {
         self.values.par_chunks_exact(self.width)
     }
 
-    pub fn split_rows(&self, r: usize) -> (RowMajorMatrixView<'_, T>, RowMajorMatrixView<'_, T>) {
+    pub const fn split_rows(
+        &self,
+        r: usize,
+    ) -> (RowMajorMatrixView<'_, T>, RowMajorMatrixView<'_, T>) {
         let (upper_values, lower_values) = self.values.split_at(r * self.width);
         let upper = RowMajorMatrixView {
             values: upper_values,

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -27,7 +27,7 @@ pub struct FieldMerkleTreeMmcs<P, PW, H, C, const DIGEST_ELEMS: usize> {
 }
 
 impl<P, PW, H, C, const DIGEST_ELEMS: usize> FieldMerkleTreeMmcs<P, PW, H, C, DIGEST_ELEMS> {
-    pub fn new(hash: H, compress: C) -> Self {
+    pub const fn new(hash: H, compress: C) -> Self {
         Self {
             hash,
             compress,

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -52,7 +52,7 @@ where
         }
     }
 
-    fn s_box(y: u8) -> u8 {
+    const fn s_box(y: u8) -> u8 {
         let tmp = y ^ !y.rotate_left(1) & y.rotate_left(2) & y.rotate_left(3);
         tmp.rotate_left(1)
     }

--- a/reed-solomon/src/lib.rs
+++ b/reed-solomon/src/lib.rs
@@ -31,7 +31,7 @@ where
     L: UndefinedLde<F, In>,
     In: MatrixRows<F>,
 {
-    pub fn new(lde: L, n: usize, k: usize) -> Self {
+    pub const fn new(lde: L, n: usize, k: usize) -> Self {
         Self {
             lde,
             n,

--- a/rescue/src/sbox.rs
+++ b/rescue/src/sbox.rs
@@ -22,7 +22,7 @@ pub struct BasicSboxLayer<F: PrimeField> {
 }
 
 impl<F: PrimeField> BasicSboxLayer<F> {
-    pub fn new(alpha: u64, alpha_inv: u64) -> Self {
+    pub const fn new(alpha: u64, alpha_inv: u64) -> Self {
         Self {
             alpha,
             alpha_inv,

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -21,7 +21,7 @@ pub struct TruncatedPermutation<InnerP, const N: usize, const CHUNK: usize, cons
 impl<InnerP, const N: usize, const CHUNK: usize, const WIDTH: usize>
     TruncatedPermutation<InnerP, N, CHUNK, WIDTH>
 {
-    pub fn new(inner_permutation: InnerP) -> Self {
+    pub const fn new(inner_permutation: InnerP) -> Self {
         Self { inner_permutation }
     }
 }
@@ -58,7 +58,7 @@ where
     T: Clone,
     H: CryptographicHasher<T, [T; CHUNK]>,
 {
-    pub fn new(hasher: H) -> Self {
+    pub const fn new(hasher: H) -> Self {
         Self {
             hasher,
             _phantom: PhantomData,

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -15,13 +15,13 @@ pub struct SerializingHasher64<Inner> {
 }
 
 impl<Inner> SerializingHasher32<Inner> {
-    pub fn new(inner: Inner) -> Self {
+    pub const fn new(inner: Inner) -> Self {
         Self { inner }
     }
 }
 
 impl<Inner> SerializingHasher64<Inner> {
-    pub fn new(inner: Inner) -> Self {
+    pub const fn new(inner: Inner) -> Self {
         Self { inner }
     }
 }

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -18,7 +18,7 @@ pub struct PaddingFreeSponge<P, const WIDTH: usize, const RATE: usize, const OUT
 impl<P, const WIDTH: usize, const RATE: usize, const OUT: usize>
     PaddingFreeSponge<P, WIDTH, RATE, OUT>
 {
-    pub fn new(permutation: P) -> Self {
+    pub const fn new(permutation: P) -> Self {
         Self { permutation }
     }
 }

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -41,7 +41,7 @@ pub struct StarkConfig<Pcs, Challenge, Challenger> {
 }
 
 impl<Pcs, Challenge, Challenger> StarkConfig<Pcs, Challenge, Challenger> {
-    pub fn new(pcs: Pcs) -> Self {
+    pub const fn new(pcs: Pcs) -> Self {
         Self {
             pcs,
             _phantom: PhantomData,

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -38,7 +38,7 @@ pub enum SymbolicExpression<F: Field> {
 
 impl<F: Field> SymbolicExpression<F> {
     /// Returns the multiple of `n` (the trace length) in this expression's degree.
-    pub fn degree_multiple(&self) -> usize {
+    pub const fn degree_multiple(&self) -> usize {
         match self {
             SymbolicExpression::Variable(v) => v.degree_multiple(),
             SymbolicExpression::IsFirstRow => 1,

--- a/uni-stark/src/symbolic_variable.rs
+++ b/uni-stark/src/symbolic_variable.rs
@@ -23,7 +23,7 @@ pub struct SymbolicVariable<F: Field> {
 }
 
 impl<F: Field> SymbolicVariable<F> {
-    pub fn new(entry: Entry, index: usize) -> Self {
+    pub const fn new(entry: Entry, index: usize) -> Self {
         Self {
             entry,
             index,
@@ -31,7 +31,7 @@ impl<F: Field> SymbolicVariable<F> {
         }
     }
 
-    pub fn degree_multiple(&self) -> usize {
+    pub const fn degree_multiple(&self) -> usize {
         match self.entry {
             Entry::Preprocessed { .. } | Entry::Main { .. } | Entry::Permutation { .. } => 1,
             Entry::Public | Entry::Challenge => 0,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -85,7 +85,7 @@ pub struct FibonacciRow<F> {
 }
 
 impl<F> FibonacciRow<F> {
-    fn new(left: F, right: F) -> FibonacciRow<F> {
+    const fn new(left: F, right: F) -> FibonacciRow<F> {
         FibonacciRow { left, right }
     }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -17,7 +17,7 @@ pub const fn ceil_div_usize(a: usize, b: usize) -> usize {
 
 /// Computes `ceil(log_2(n))`.
 #[must_use]
-pub fn log2_ceil_usize(n: usize) -> usize {
+pub const fn log2_ceil_usize(n: usize) -> usize {
     (usize::BITS - n.saturating_sub(1).leading_zeros()) as usize
 }
 


### PR DESCRIPTION
- Transformed a large number of methods and functions across different libraries to constant functions including `new`, `to_monty_64`, `from_monty` and more.
- Enhances performance by utilizing constant functions in Rust, which are evaluated at compile time where possible.