### PR TITLE
Separating arch specific poseidon2 for Babybear

### DIFF
--- a/baby-bear/src/aarch64_neon/mod.rs
+++ b/baby-bear/src/aarch64_neon/mod.rs
@@ -1,3 +1,4 @@
 mod packing;
+mod poseidon2;
 
 pub use packing::*;

--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -1,0 +1,23 @@
+use p3_poseidon2::{matmul_internal, DiffusionPermutation};
+use p3_symmetric::Permutation;
+
+use crate::{
+    BabyBear, DiffusionMatrixBabybear, PackedBabyBearNeon, MATRIX_DIAG_16_BABYBEAR_MONTY,
+    MATRIX_DIAG_24_BABYBEAR_MONTY,
+};
+
+impl Permutation<[PackedBabyBearNeon; 16]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 16]) {
+        matmul_internal::<BabyBear, PackedBabyBearNeon, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearNeon, 16> for DiffusionMatrixBabybear {}
+
+impl Permutation<[PackedBabyBearNeon; 24]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 24]) {
+        matmul_internal::<BabyBear, PackedBabyBearNeon, 24>(state, MATRIX_DIAG_24_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearNeon, 24> for DiffusionMatrixBabybear {}

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -8,7 +8,6 @@
 
 //! Long term we will use more optimised internal and external linear layers.
 
-use p3_field::AbstractField;
 use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
@@ -26,29 +25,29 @@ const MATRIX_DIAG_24_BABYBEAR_U32: [u32; 24] = [
 ];
 
 // Convert the above arrays of u32's into arrays of BabyBear field elements saved in MONTY form.
-const MATRIX_DIAG_16_BABYBEAR_MONTY: [BabyBear; 16] =
+pub(crate) const MATRIX_DIAG_16_BABYBEAR_MONTY: [BabyBear; 16] =
     to_babybear_array(MATRIX_DIAG_16_BABYBEAR_U32);
-const MATRIX_DIAG_24_BABYBEAR_MONTY: [BabyBear; 24] =
+pub(crate) const MATRIX_DIAG_24_BABYBEAR_MONTY: [BabyBear; 24] =
     to_babybear_array(MATRIX_DIAG_24_BABYBEAR_U32);
 
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixBabybear;
 
-impl<AF: AbstractField<F = BabyBear>> Permutation<[AF; 16]> for DiffusionMatrixBabybear {
-    fn permute_mut(&self, state: &mut [AF; 16]) {
-        matmul_internal::<BabyBear, AF, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY);
+impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [BabyBear; 16]) {
+        matmul_internal::<BabyBear, BabyBear, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY);
     }
 }
 
-impl<AF: AbstractField<F = BabyBear>> DiffusionPermutation<AF, 16> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
 
-impl<AF: AbstractField<F = BabyBear>> Permutation<[AF; 24]> for DiffusionMatrixBabybear {
-    fn permute_mut(&self, state: &mut [AF; 24]) {
-        matmul_internal::<BabyBear, AF, 24>(state, MATRIX_DIAG_24_BABYBEAR_MONTY);
+impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [BabyBear; 24]) {
+        matmul_internal::<BabyBear, BabyBear, 24>(state, MATRIX_DIAG_24_BABYBEAR_MONTY);
     }
 }
 
-impl<AF: AbstractField<F = BabyBear>> DiffusionPermutation<AF, 24> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<BabyBear, 24> for DiffusionMatrixBabybear {}
 
 pub const HL_BABYBEAR_16_EXTERNAL_ROUND_CONSTANTS: [[u32; 16]; 8] = [
     [

--- a/baby-bear/src/x86_64_avx2/mod.rs
+++ b/baby-bear/src/x86_64_avx2/mod.rs
@@ -1,3 +1,4 @@
 mod packing;
+mod poseidon2;
 
 pub use packing::*;

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -1,0 +1,23 @@
+use p3_poseidon2::{matmul_internal, DiffusionPermutation};
+use p3_symmetric::Permutation;
+
+use crate::{
+    BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX2, MATRIX_DIAG_16_BABYBEAR_MONTY,
+    MATRIX_DIAG_24_BABYBEAR_MONTY,
+};
+
+impl Permutation<[PackedBabyBearAVX2; 16]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 16]) {
+        matmul_internal::<BabyBear, PackedBabyBearAVX2, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearAVX2, 16> for DiffusionMatrixBabybear {}
+
+impl Permutation<[PackedBabyBearAVX2; 24]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 24]) {
+        matmul_internal::<BabyBear, PackedBabyBearAVX2, 24>(state, MATRIX_DIAG_24_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearAVX2, 24> for DiffusionMatrixBabybear {}

--- a/baby-bear/src/x86_64_avx512/mod.rs
+++ b/baby-bear/src/x86_64_avx512/mod.rs
@@ -1,3 +1,4 @@
 mod packing;
+mod poseidon2;
 
 pub use packing::*;

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,0 +1,23 @@
+use p3_poseidon2::{matmul_internal, DiffusionPermutation};
+use p3_symmetric::Permutation;
+
+use crate::{
+    BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX512, MATRIX_DIAG_16_BABYBEAR_MONTY,
+    MATRIX_DIAG_24_BABYBEAR_MONTY,
+};
+
+impl Permutation<[PackedBabyBearAVX512; 16]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 16]) {
+        matmul_internal::<BabyBear, PackedBabyBearAVX512, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearAVX512, 16> for DiffusionMatrixBabybear {}
+
+impl Permutation<[PackedBabyBearAVX512; 24]> for DiffusionMatrixBabybear {
+    fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 24]) {
+        matmul_internal::<BabyBear, PackedBabyBearAVX512, 24>(state, MATRIX_DIAG_24_BABYBEAR_MONTY);
+    }
+}
+
+impl DiffusionPermutation<PackedBabyBearAVX512, 24> for DiffusionMatrixBabybear {}


### PR DESCRIPTION
As opposed to defining DiffusionMatrixBabyBear for any abstract field over BabyBear, we split it out. This will allow for architecture specific implementations.