### PR TITLE
Round Numbers for Poseidon2

### DIFF
--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-field = { path = "../field" }
+gcd = "2.3.0"
 p3-symmetric = { path = "../symmetric" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -3,7 +3,7 @@ use std::any::type_name;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
 use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
-use p3_field::PrimeField;
+use p3_field::{PrimeField, PrimeField64};
 use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
 use p3_poseidon2::{DiffusionPermutation, Poseidon2};
 use p3_symmetric::Permutation;
@@ -11,18 +11,21 @@ use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 
 fn bench_poseidon2(c: &mut Criterion) {
-    poseidon2::<BabyBear, DiffusionMatrixBabybear, 16, 7>(c);
-    poseidon2::<BabyBear, DiffusionMatrixBabybear, 24, 7>(c);
+    poseidon2_p64::<BabyBear, DiffusionMatrixBabybear, 16, 7>(c);
+    poseidon2_p64::<BabyBear, DiffusionMatrixBabybear, 24, 7>(c);
 
-    poseidon2::<Goldilocks, DiffusionMatrixGoldilocks, 8, 7>(c);
-    poseidon2::<Goldilocks, DiffusionMatrixGoldilocks, 12, 7>(c);
-    poseidon2::<Goldilocks, DiffusionMatrixGoldilocks, 16, 7>(c);
+    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 8, 7>(c);
+    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 12, 7>(c);
+    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 16, 7>(c);
 
-    poseidon2::<Bn254Fr, DiffusionMatrixBN254, 3, 5>(c);
+    poseidon2::<Bn254Fr, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
 }
 
-fn poseidon2<F, Diffusion, const WIDTH: usize, const D: u64>(c: &mut Criterion)
-where
+fn poseidon2<F, Diffusion, const WIDTH: usize, const D: u64>(
+    c: &mut Criterion,
+    rounds_f: usize,
+    rounds_p: usize,
+) where
     F: PrimeField,
     Standard: Distribution<F>,
     Diffusion: DiffusionPermutation<F, WIDTH> + Default,
@@ -30,16 +33,35 @@ where
     let mut rng = thread_rng();
     let internal_mds = Diffusion::default();
 
-    // TODO: Should be calculated for the particular field, width and ALPHA.
-    let rounds_f = 8;
-    let rounds_p = 22;
-
     let poseidon = Poseidon2::<F, Diffusion, WIDTH, D>::new_from_rng(
         rounds_f,
         rounds_p,
         internal_mds,
         &mut rng,
     );
+    let input = [F::zero(); WIDTH];
+    let name = format!(
+        "poseidon2::<{}, {}, {}, {}>",
+        type_name::<F>(),
+        D,
+        rounds_f,
+        rounds_p
+    );
+    let id = BenchmarkId::new(name, WIDTH);
+    c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon.permute(input)));
+}
+
+// For fields implementing PrimeField64 we should benchmark using the optimal round constants.
+fn poseidon2_p64<F, Diffusion, const WIDTH: usize, const D: u64>(c: &mut Criterion)
+where
+    F: PrimeField64,
+    Standard: Distribution<F>,
+    Diffusion: DiffusionPermutation<F, WIDTH> + Default,
+{
+    let mut rng = thread_rng();
+    let internal_mds = Diffusion::default();
+
+    let poseidon = Poseidon2::<F, Diffusion, WIDTH, D>::new_from_rng_128(internal_mds, &mut rng);
     let input = [F::zero(); WIDTH];
     let name = format!("poseidon2::<{}, {}>", type_name::<F>(), D);
     let id = BenchmarkId::new(name, WIDTH);

--- a/poseidon2/src/round_numbers.rs
+++ b/poseidon2/src/round_numbers.rs
@@ -1,24 +1,42 @@
+// As the security analysis of Poseidon2 is identical to that of Poseidon,
+// the relevant constraints regarding the number of full/partial rounds required can be found in
+// the original paper: https://eprint.iacr.org/2019/458.pdf and the associated codebase:
+// https://extgit.iaik.tugraz.at/krypto/hadeshash (See generate_params_poseidon.sage)
+
+// These constraints are broken down into 6 equations:
+// statistical, interpolation, groebner 1, 2, 3 and
+// an extra constraint coming from the paper https://eprint.iacr.org/2023/537.pdf.
+
+// For our parameters (M = 128, p > 2^30, WIDTH = t >= 8, D = alpha < 12),
+// the statistical constraint always simplifies to requiring RF >= 6.
+// Additionally p does not appear in Groebner 3 or the constraint coming from https://eprint.iacr.org/2023/537.pdf.
+// The remaining 3 constraints all can be rearranged into the form:
+// F(RF, RP) >= G(p) where G is a function which is non-decreasing with respect to p.
+
+// Thus, if some tuple (M, p, WIDTH, D, RF, RP) satisfies all constraints, then so will
+// the tuple (M, q, WIDTH, D, RF, RP) for any 2^30 < q < p.
+// Moreover if RF, RP are the "optimal" round numbers (Optimal meaning minimising the number of s-box operations we need to perform)
+// for two tuples (M, p, WIDTH, D) and (M, q, WIDTH, D), then
+// they will also be optimal for (M, r, WIDTH, D) for any q < r < p.
+
 // We compute the optimal required number of external (full) and internal (partial) rounds using:
-// See https://github.com/0xPolygonZero/hash-constants
-// Note the the number of rounds required is the same for fields of approximately the same size.
+// https://github.com/0xPolygonZero/hash-constants
+// Using the above analysis we can conclude that the round numbers are equal
+// for all 31 bit primes and 64 bit primes respectively.
 
+use gcd::Gcd;
 use p3_field::PrimeField64;
-// Mersenne31, KoalaBear and BabyBear fields
-const PRIMES_31_BIT: [u64; 3] = [
-    (1 << 31) - 1,
-    (1 << 31) - (1 << 24) + 1,
-    (1 << 31) - (1 << 27) + 1,
-];
 
-// Goldilocks and Crandall Primes
-const PRIMES_64_BIT: [u64; 2] = [0xFFFFFFFF00000001, 0xFFFFFFFF70000001];
+/// Given a field, a width and an D return the number of full and partial rounds needed to achieve 128 bit security.
+pub fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, d: u64) -> (usize, usize) {
+    // Start by checking that d is a valid permutation.
+    assert!(d.gcd(F::ORDER_U64 - 1) == 1);
 
-/// Given a field, a width and an alpha return the number of full and partial rounds needed to achieve 128 bit security.
-pub fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, alpha: u64) -> (usize, usize) {
-    assert!(PRIMES_31_BIT.contains(&F::ORDER_U64) || PRIMES_64_BIT.contains(&F::ORDER_U64));
+    // Next compute the number of bits in p.
+    let prime_bit_number = (F::ORDER_U64).ilog2() + 1;
 
-    if PRIMES_31_BIT.contains(&F::ORDER_U64) {
-        match (width, alpha) {
+    match prime_bit_number {
+        31 => match (width, d) {
             (16, 3) => (8, 20),
             (16, 5) => (8, 14),
             (16, 7) => (8, 13),
@@ -29,10 +47,9 @@ pub fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, alpha: u64) ->
             (24, 7) => (8, 21),
             (24, 9) => (8, 21),
             (24, 11) => (8, 21),
-            _ => panic!("The given pair of width and alpha has not been checked for these fields"),
-        }
-    } else {
-        match (width, alpha) {
+            _ => panic!("The given pair of width and D has not been checked for these fields"),
+        },
+        64 => match (width, d) {
             (8, 3) => (8, 41),
             (8, 5) => (8, 27),
             (8, 7) => (8, 22),
@@ -48,7 +65,8 @@ pub fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, alpha: u64) ->
             (16, 7) => (8, 22),
             (16, 9) => (8, 20),
             (16, 11) => (8, 18),
-            _ => panic!("The given pair of width and alpha has not been checked for these fields"),
-        }
+            _ => panic!("The given pair of width and D has not been checked for these fields"),
+        },
+        _ => panic!("The optimal parameters for that size of prime have not been computed."),
     }
 }

--- a/poseidon2/src/round_numbers.rs
+++ b/poseidon2/src/round_numbers.rs
@@ -20,7 +20,7 @@
 // they will also be optimal for (M, r, WIDTH, D) for any q < r < p.
 
 // We compute the optimal required number of external (full) and internal (partial) rounds using:
-// https://github.com/0xPolygonZero/hash-constants
+// https://github.com/0xPolygonZero/hash-constants/blob/master/calc_round_numbers.py
 // Using the above analysis we can conclude that the round numbers are equal
 // for all 31 bit primes and 64 bit primes respectively.
 

--- a/poseidon2/src/round_numbers.rs
+++ b/poseidon2/src/round_numbers.rs
@@ -1,28 +1,28 @@
-// As the security analysis of Poseidon2 is identical to that of Poseidon,
-// the relevant constraints regarding the number of full/partial rounds required can be found in
-// the original paper: https://eprint.iacr.org/2019/458.pdf and the associated codebase:
-// https://extgit.iaik.tugraz.at/krypto/hadeshash (See generate_params_poseidon.sage)
-
-// These constraints are broken down into 6 equations:
-// statistical, interpolation, groebner 1, 2, 3 and
-// an extra constraint coming from the paper https://eprint.iacr.org/2023/537.pdf.
-
-// For our parameters (M = 128, p > 2^30, WIDTH = t >= 8, D = alpha < 12),
-// the statistical constraint always simplifies to requiring RF >= 6.
-// Additionally p does not appear in Groebner 3 or the constraint coming from https://eprint.iacr.org/2023/537.pdf.
-// The remaining 3 constraints all can be rearranged into the form:
-// F(RF, RP) >= G(p) where G is a function which is non-decreasing with respect to p.
-
-// Thus, if some tuple (M, p, WIDTH, D, RF, RP) satisfies all constraints, then so will
-// the tuple (M, q, WIDTH, D, RF, RP) for any 2^30 < q < p.
-// Moreover if RF, RP are the "optimal" round numbers (Optimal meaning minimising the number of s-box operations we need to perform)
-// for two tuples (M, p, WIDTH, D) and (M, q, WIDTH, D), then
-// they will also be optimal for (M, r, WIDTH, D) for any q < r < p.
-
-// We compute the optimal required number of external (full) and internal (partial) rounds using:
-// https://github.com/0xPolygonZero/hash-constants/blob/master/calc_round_numbers.py
-// Using the above analysis we can conclude that the round numbers are equal
-// for all 31 bit primes and 64 bit primes respectively.
+//! As the security analysis of Poseidon2 is identical to that of Poseidon,
+//! the relevant constraints regarding the number of full/partial rounds required can be found in
+//! the original paper: https://eprint.iacr.org/2019/458.pdf and the associated codebase:
+//! https://extgit.iaik.tugraz.at/krypto/hadeshash (See generate_params_poseidon.sage)
+//!
+//! These constraints are broken down into 6 equations:
+//! statistical, interpolation, groebner 1, 2, 3 and
+//! an extra constraint coming from the paper https://eprint.iacr.org/2023/537.pdf.
+//!
+//! For our parameters (M = 128, p > 2^30, WIDTH = t >= 8, D = alpha < 12),
+//! the statistical constraint always simplifies to requiring RF >= 6.
+//! Additionally p does not appear in Groebner 3 or the constraint coming from https://eprint.iacr.org/2023/537.pdf.
+//! The remaining 3 constraints all can be rearranged into the form:
+//! F(RF, RP) >= G(p) where G is a function which is non-decreasing with respect to p.
+//!
+//! Thus, if some tuple (M, p, WIDTH, D, RF, RP) satisfies all constraints, then so will
+//! the tuple (M, q, WIDTH, D, RF, RP) for any 2^30 < q < p.
+//! Moreover if RF, RP are the "optimal" round numbers (Optimal meaning minimising the number of s-box operations we need to perform)
+//! for two tuples (M, p, WIDTH, D) and (M, q, WIDTH, D), then
+//! they will also be optimal for (M, r, WIDTH, D) for any q < r < p.
+//!
+//! We compute the optimal required number of external (full) and internal (partial) rounds using:
+//! https://github.com/0xPolygonZero/hash-constants/blob/master/calc_round_numbers.py
+//! Using the above analysis we can conclude that the round numbers are equal
+//! for all 31 bit primes and 64 bit primes respectively.
 
 use gcd::Gcd;
 use p3_field::PrimeField64;

--- a/poseidon2/src/round_numbers.rs
+++ b/poseidon2/src/round_numbers.rs
@@ -1,0 +1,54 @@
+// We compute the optimal required number of external (full) and internal (partial) rounds using:
+// See https://github.com/0xPolygonZero/hash-constants
+// Note the the number of rounds required is the same for fields of approximately the same size.
+
+use p3_field::PrimeField64;
+// Mersenne31, KoalaBear and BabyBear fields
+const PRIMES_31_BIT: [u64; 3] = [
+    (1 << 31) - 1,
+    (1 << 31) - (1 << 24) + 1,
+    (1 << 31) - (1 << 27) + 1,
+];
+
+// Goldilocks and Crandall Primes
+const PRIMES_64_BIT: [u64; 2] = [0xFFFFFFFF00000001, 0xFFFFFFFF70000001];
+
+/// Given a field, a width and an alpha return the number of full and partial rounds needed to achieve 128 bit security.
+pub fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, alpha: u64) -> (usize, usize) {
+    assert!(PRIMES_31_BIT.contains(&F::ORDER_U64) || PRIMES_64_BIT.contains(&F::ORDER_U64));
+
+    if PRIMES_31_BIT.contains(&F::ORDER_U64) {
+        match (width, alpha) {
+            (16, 3) => (8, 20),
+            (16, 5) => (8, 14),
+            (16, 7) => (8, 13),
+            (16, 9) => (8, 13),
+            (16, 11) => (8, 13),
+            (24, 3) => (8, 23),
+            (24, 5) => (8, 22),
+            (24, 7) => (8, 21),
+            (24, 9) => (8, 21),
+            (24, 11) => (8, 21),
+            _ => panic!("The given pair of width and alpha has not been checked for these fields"),
+        }
+    } else {
+        match (width, alpha) {
+            (8, 3) => (8, 41),
+            (8, 5) => (8, 27),
+            (8, 7) => (8, 22),
+            (8, 9) => (8, 19),
+            (8, 11) => (8, 17),
+            (12, 3) => (8, 42),
+            (12, 5) => (8, 27),
+            (12, 7) => (8, 22),
+            (12, 9) => (8, 20),
+            (12, 11) => (8, 18),
+            (16, 3) => (8, 42),
+            (16, 5) => (8, 27),
+            (16, 7) => (8, 22),
+            (16, 9) => (8, 20),
+            (16, 11) => (8, 18),
+            _ => panic!("The given pair of width and alpha has not been checked for these fields"),
+        }
+    }
+}


### PR DESCRIPTION
Adding in round numbers so that new instances of poseidon2 can be created which automatically use the optimal round numbers for the prime, width, D triple.

Currently this is unused outside of the benchmarks but in a future PR we will start to propagate this throughout the code.