### PR TITLE
feat: batch_multiplicative_inverse_inplace

### DIFF
--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -98,7 +98,8 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
     buf
 }
 
-/// An implementation of `batch_multiplicative_inverse` that operates in place.
+/// An implementation of `batch_multiplicative_inverse` that operates in place. Zero values are left
+/// unchanged.
 pub fn batch_multiplicative_inverse_inplace<F: Field>(values: &mut [F]) {
     // Check if values are zero and construct a new vector with only nonzero values.
     let mut nonzero_values = Vec::with_capacity(values.len());

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -97,3 +97,25 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
 
     buf
 }
+
+/// An implementation of `batch_multiplicative_inverse` that operates in place.
+pub fn batch_multiplicative_inverse_inplace<F: Field>(values: &mut [F]) {
+    // Check if values are zero and construct a new vector with only nonzero values.
+    let mut nonzero_values = Vec::with_capacity(values.len());
+    let mut indices = Vec::with_capacity(values.len());
+    for (i, value) in values.iter().cloned().enumerate() {
+        if value.is_zero() {
+            continue;
+        }
+        nonzero_values.push(value);
+        indices.push(i);
+    }
+
+    // Compute the multiplicative inverse of nonzero values.
+    let inverse_nonzero_values = batch_multiplicative_inverse(&nonzero_values);
+
+    // Reconstruct the original vector.
+    for (i, index) in indices.into_iter().enumerate() {
+        values[index] = inverse_nonzero_values[i];
+    }
+}


### PR DESCRIPTION
Adds an inplace version of `batch_multiplicative_inverse`, which we use in [sp1](https://github.com/succinctlabs/sp1/blob/449764168dea9ec5b75886836130020d698d5f24/core/src/stark/permutation.rs#L139)