### PR TITLE
Poseidon2 External Linear Layer

### DIFF
--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -102,7 +102,7 @@ mod tests {
     use core::array;
 
     use p3_field::AbstractField;
-    use p3_poseidon2::Poseidon2;
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 
     use super::*;
 
@@ -128,11 +128,18 @@ mod tests {
         const ROUNDS_P: usize = 13;
 
         // Our Poseidon2 implementation.
-        let poseidon2: Poseidon2<BabyBear, DiffusionMatrixBabybear, WIDTH, D> = Poseidon2::new(
+        let poseidon2: Poseidon2<
+            BabyBear,
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            WIDTH,
+            D,
+        > = Poseidon2::new(
             ROUNDS_F,
             HL_BABYBEAR_16_EXTERNAL_ROUND_CONSTANTS
                 .map(to_babybear_array)
                 .to_vec(),
+            Poseidon2ExternalMatrixGeneral,
             ROUNDS_P,
             to_babybear_array(HL_BABYBEAR_16_INTERNAL_ROUND_CONSTANTS).to_vec(),
             DiffusionMatrixBabybear,

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -32,7 +32,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use ff::PrimeField;
-    use p3_poseidon2::Poseidon2;
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use rand::Rng;
     use zkhash::ark_ff::{BigInteger, PrimeField as ark_PrimeField};
     use zkhash::fields::bn256::FpBN256 as ark_FpBN256;
@@ -97,9 +97,16 @@ mod tests {
             .collect::<Vec<_>>();
         let external_round_constants = round_constants;
         // Our Poseidon2 implementation.
-        let poseidon2: Poseidon2<Bn254Fr, DiffusionMatrixBN254, WIDTH, D> = Poseidon2::new(
+        let poseidon2: Poseidon2<
+            Bn254Fr,
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBN254,
+            WIDTH,
+            D,
+        > = Poseidon2::new(
             ROUNDS_F,
             external_round_constants,
+            Poseidon2ExternalMatrixGeneral,
             ROUNDS_P,
             internal_round_constants,
             DiffusionMatrixBN254,

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -10,7 +10,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::{Matrix, MatrixRows};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_util::log2_strict_usize;
 use rand::{Rng, SeedableRng};
@@ -19,7 +19,7 @@ use rand_chacha::ChaCha20Rng;
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 
-type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 type ValMmcs =
@@ -29,7 +29,7 @@ type Challenger = DuplexChallenger<Val, Perm, 16>;
 type MyFriConfig = FriConfig<ChallengeMmcs>;
 
 fn get_ldt_for_testing<R: Rng>(rng: &mut R) -> (Perm, MyFriConfig) {
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, rng);
+    let perm = Perm::new_from_rng_128(Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -8,14 +8,14 @@ use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use rand::thread_rng;
 
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 
-type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 
@@ -34,7 +34,11 @@ fn make_test_fri_pcs(log_degrees_by_round: &[&[usize]]) {
     let num_rounds = log_degrees_by_round.len();
     let mut rng = thread_rng();
 
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut rng,
+    );
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
 

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -237,7 +237,7 @@ pub const HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS: [u64; 22] = [
 mod tests {
     use core::array;
 
-    use p3_poseidon2::Poseidon2;
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 
     use super::*;
 
@@ -267,11 +267,18 @@ mod tests {
         const ROUNDS_P: usize = 22;
 
         // Our Poseidon2 implementation.
-        let poseidon2: Poseidon2<Goldilocks, DiffusionMatrixGoldilocks, WIDTH, D> = Poseidon2::new(
+        let poseidon2: Poseidon2<
+            Goldilocks,
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixGoldilocks,
+            WIDTH,
+            D,
+        > = Poseidon2::new(
             ROUNDS_F,
             HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS
                 .map(to_goldilocks_array)
                 .to_vec(),
+            Poseidon2ExternalMatrixGeneral,
             ROUNDS_P,
             to_goldilocks_array(HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS).to_vec(),
             DiffusionMatrixGoldilocks,

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -8,7 +8,7 @@ use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_matrix::Matrix;
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
 use p3_util::log2_ceil_usize;
@@ -34,8 +34,12 @@ fn main() -> Result<(), VerificationError> {
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
 
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     let hash = MyHash::new(perm.clone());

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -10,7 +10,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_rescue::{BasicSboxLayer, Rescue};
 use p3_symmetric::{
     CompressionFunctionFromHasher, CryptographicHasher, PaddingFreeSponge,
@@ -31,8 +31,12 @@ fn bench_merkle_trees(criterion: &mut Criterion) {
 fn bench_bb_poseidon2(criterion: &mut Criterion) {
     type F = BabyBear;
 
-    type Perm = Poseidon2<BabyBear, DiffusionMatrixBabybear, 16, 7>;
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
 
     type H = PaddingFreeSponge<Perm, 16, 8, 8>;
     let h = H::new(perm.clone());

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -186,7 +186,7 @@ mod tests {
     use p3_field::{AbstractField, Field};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::{Dimensions, Matrix};
-    use p3_poseidon2::Poseidon2;
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
@@ -196,7 +196,7 @@ mod tests {
 
     type F = BabyBear;
 
-    type Perm = Poseidon2<F, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
     type MyMmcs =
@@ -204,7 +204,11 @@ mod tests {
 
     #[test]
     fn commit_single_1x8() {
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut thread_rng(),
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -237,7 +241,11 @@ mod tests {
 
     #[test]
     fn commit_single_2x2() {
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut thread_rng(),
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -259,7 +267,11 @@ mod tests {
 
     #[test]
     fn commit_single_2x3() {
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut thread_rng(),
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -289,7 +301,11 @@ mod tests {
 
     #[test]
     fn commit_mixed() {
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut thread_rng(),
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -350,7 +366,11 @@ mod tests {
     #[test]
     fn commit_either_order() {
         let mut rng = thread_rng();
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut rng,
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
@@ -367,7 +387,11 @@ mod tests {
     #[should_panic]
     fn mismatched_heights() {
         let mut rng = thread_rng();
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut rng,
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
@@ -385,7 +409,11 @@ mod tests {
     #[test]
     fn verify_tampered_proof_fails() {
         let mut rng = thread_rng();
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut rng,
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
@@ -420,7 +448,11 @@ mod tests {
     #[test]
     fn size_gaps() {
         let mut rng = thread_rng();
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut rng,
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
@@ -471,7 +503,11 @@ mod tests {
     #[test]
     fn different_widths() {
         let mut rng = thread_rng();
-        let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut rng);
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabybear,
+            &mut rng,
+        );
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-p3-field = { path = "../field" }
 gcd = "2.3.0"
+p3-field = { path = "../field" }
 p3-symmetric = { path = "../symmetric" }
 p3-mds = { path = "../mds" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -5,38 +5,47 @@ use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
 use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
 use p3_field::{PrimeField, PrimeField64};
 use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
-use p3_poseidon2::{DiffusionPermutation, Poseidon2};
+use p3_poseidon2::{
+    DiffusionPermutation, MdsLightPermutation, Poseidon2, Poseidon2ExternalMatrixGeneral,
+};
 use p3_symmetric::Permutation;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 
 fn bench_poseidon2(c: &mut Criterion) {
-    poseidon2_p64::<BabyBear, DiffusionMatrixBabybear, 16, 7>(c);
-    poseidon2_p64::<BabyBear, DiffusionMatrixBabybear, 24, 7>(c);
+    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>(c);
+    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 24, 7>(c);
 
-    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 8, 7>(c);
-    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 12, 7>(c);
-    poseidon2_p64::<Goldilocks, DiffusionMatrixGoldilocks, 16, 7>(c);
+    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 8, 7>(c);
+    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 12, 7>(
+        c,
+    );
+    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 16, 7>(
+        c,
+    );
 
-    poseidon2::<Bn254Fr, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
+    poseidon2::<Bn254Fr, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
 }
 
-fn poseidon2<F, Diffusion, const WIDTH: usize, const D: u64>(
+fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
     c: &mut Criterion,
     rounds_f: usize,
     rounds_p: usize,
 ) where
     F: PrimeField,
     Standard: Distribution<F>,
+    MdsLight: MdsLightPermutation<F, WIDTH> + Default,
     Diffusion: DiffusionPermutation<F, WIDTH> + Default,
 {
     let mut rng = thread_rng();
-    let internal_mds = Diffusion::default();
+    let external_linear_layer = MdsLight::default();
+    let internal_linear_layer = Diffusion::default();
 
-    let poseidon = Poseidon2::<F, Diffusion, WIDTH, D>::new_from_rng(
+    let poseidon = Poseidon2::<F, MdsLight, Diffusion, WIDTH, D>::new_from_rng(
         rounds_f,
+        external_linear_layer,
         rounds_p,
-        internal_mds,
+        internal_linear_layer,
         &mut rng,
     );
     let input = [F::zero(); WIDTH];
@@ -52,16 +61,22 @@ fn poseidon2<F, Diffusion, const WIDTH: usize, const D: u64>(
 }
 
 // For fields implementing PrimeField64 we should benchmark using the optimal round constants.
-fn poseidon2_p64<F, Diffusion, const WIDTH: usize, const D: u64>(c: &mut Criterion)
+fn poseidon2_p64<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(c: &mut Criterion)
 where
     F: PrimeField64,
     Standard: Distribution<F>,
+    MdsLight: MdsLightPermutation<F, WIDTH> + Default,
     Diffusion: DiffusionPermutation<F, WIDTH> + Default,
 {
     let mut rng = thread_rng();
-    let internal_mds = Diffusion::default();
+    let external_linear_layer = MdsLight::default();
+    let internal_linear_layer = Diffusion::default();
 
-    let poseidon = Poseidon2::<F, Diffusion, WIDTH, D>::new_from_rng_128(internal_mds, &mut rng);
+    let poseidon = Poseidon2::<F, MdsLight, Diffusion, WIDTH, D>::new_from_rng_128(
+        external_linear_layer,
+        internal_linear_layer,
+        &mut rng,
+    );
     let input = [F::zero(); WIDTH];
     let name = format!("poseidon2::<{}, {}>", type_name::<F>(), D);
     let id = BenchmarkId::new(name, WIDTH);

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -6,6 +6,10 @@
 //! > arbitrarily long subspace trails, and ensuring that the polynomial representation
 //! > of the scheme is dense." (Section 5.2)
 //!
+//! > These properties can be ensured by checking the following two conditions:
+//! > Every entry of the Matrix is non 0.
+//! > The characteristic polynomial of the matrix is irreducible.
+//!
 //! This file implements a trait for linear layers that satisfy these three properties.
 
 use p3_field::{AbstractField, Field};

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -14,7 +14,7 @@ mod round_numbers;
 use alloc::vec::Vec;
 
 pub use diffusion::{matmul_internal, DiffusionPermutation};
-use matrix::Poseidon2ExternalMatrixHL;
+pub use matrix::{MdsLightPermutation, Poseidon2ExternalMatrixGeneral};
 use p3_field::{AbstractField, PrimeField, PrimeField64};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};
@@ -25,12 +25,16 @@ const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
 
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
-pub struct Poseidon2<F, Diffusion, const WIDTH: usize, const D: u64> {
+pub struct Poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64> {
     /// The number of external rounds.
     rounds_f: usize,
 
     /// The external round constants.
     external_constants: Vec<[F; WIDTH]>,
+
+    /// The linear layer used in External Rounds. Should be either MDS or a
+    /// circulant matrix based off an MDS matrix of size 4.
+    external_linear_layer: MdsLight,
 
     /// The number of internal rounds.
     rounds_p: usize,
@@ -42,7 +46,8 @@ pub struct Poseidon2<F, Diffusion, const WIDTH: usize, const D: u64> {
     internal_linear_layer: Diffusion,
 }
 
-impl<F, Diffusion, const WIDTH: usize, const D: u64> Poseidon2<F, Diffusion, WIDTH, D>
+impl<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
+    Poseidon2<F, MdsLight, Diffusion, WIDTH, D>
 where
     F: PrimeField,
 {
@@ -50,6 +55,7 @@ where
     pub fn new(
         rounds_f: usize,
         external_constants: Vec<[F; WIDTH]>,
+        external_linear_layer: MdsLight,
         rounds_p: usize,
         internal_constants: Vec<F>,
         internal_linear_layer: Diffusion,
@@ -58,6 +64,7 @@ where
         Self {
             rounds_f,
             external_constants,
+            external_linear_layer,
             rounds_p,
             internal_constants,
             internal_linear_layer,
@@ -67,8 +74,9 @@ where
     /// Create a new Poseidon2 configuration with random parameters.
     pub fn new_from_rng<R: Rng>(
         rounds_f: usize,
+        external_linear_layer: MdsLight,
         rounds_p: usize,
-        internal_mds: Diffusion,
+        internal_linear_layer: Diffusion,
         rng: &mut R,
     ) -> Self
     where
@@ -83,9 +91,10 @@ where
         Self {
             rounds_f,
             external_constants,
+            external_linear_layer,
             rounds_p,
             internal_constants,
-            internal_linear_layer: internal_mds,
+            internal_linear_layer,
         }
     }
 
@@ -117,12 +126,17 @@ where
     }
 }
 
-impl<F, Diffusion, const WIDTH: usize, const D: u64> Poseidon2<F, Diffusion, WIDTH, D>
+impl<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
+    Poseidon2<F, MdsLight, Diffusion, WIDTH, D>
 where
     F: PrimeField64,
 {
     /// Create a new Poseidon2 configuration with 128 bit security and random rounds constants.
-    pub fn new_from_rng_128<R: Rng>(internal_linear_layer: Diffusion, rng: &mut R) -> Self
+    pub fn new_from_rng_128<R: Rng>(
+        external_linear_layer: MdsLight,
+        internal_linear_layer: Diffusion,
+        rng: &mut R,
+    ) -> Self
     where
         Standard: Distribution<F> + Distribution<[F; WIDTH]>,
     {
@@ -137,6 +151,7 @@ where
         Self {
             rounds_f,
             external_constants,
+            external_linear_layer,
             rounds_p,
             internal_constants,
             internal_linear_layer,
@@ -144,25 +159,24 @@ where
     }
 }
 
-impl<AF, Diffusion, const WIDTH: usize, const D: u64> Permutation<[AF; WIDTH]>
-    for Poseidon2<AF::F, Diffusion, WIDTH, D>
+impl<AF, MdsLight, Diffusion, const WIDTH: usize, const D: u64> Permutation<[AF; WIDTH]>
+    for Poseidon2<AF::F, MdsLight, Diffusion, WIDTH, D>
 where
     AF: AbstractField,
     AF::F: PrimeField,
+    MdsLight: MdsLightPermutation<AF, WIDTH>,
     Diffusion: DiffusionPermutation<AF, WIDTH>,
 {
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
-        let external_linear_layer = Poseidon2ExternalMatrixHL;
-
         // The initial linear layer.
-        external_linear_layer.permute_mut(state);
+        self.external_linear_layer.permute_mut(state);
 
         // The first half of the external rounds.
-        let rounds_f_beginning = self.rounds_f / 2;
-        for r in 0..rounds_f_beginning {
+        let rounds_f_half = self.rounds_f / 2;
+        for r in 0..rounds_f_half {
             self.add_rc(state, &self.external_constants[r]);
             self.sbox(state);
-            external_linear_layer.permute_mut(state);
+            self.external_linear_layer.permute_mut(state);
         }
 
         // The internal rounds.
@@ -173,19 +187,20 @@ where
         }
 
         // The second half of the external rounds.
-        for r in rounds_f_beginning..self.rounds_f {
+        for r in rounds_f_half..self.rounds_f {
             self.add_rc(state, &self.external_constants[r]);
             self.sbox(state);
-            external_linear_layer.permute_mut(state);
+            self.external_linear_layer.permute_mut(state);
         }
     }
 }
 
-impl<AF, Diffusion, const WIDTH: usize, const D: u64> CryptographicPermutation<[AF; WIDTH]>
-    for Poseidon2<AF::F, Diffusion, WIDTH, D>
+impl<AF, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
+    CryptographicPermutation<[AF; WIDTH]> for Poseidon2<AF::F, MdsLight, Diffusion, WIDTH, D>
 where
     AF: AbstractField,
     AF::F: PrimeField,
+    MdsLight: MdsLightPermutation<AF, WIDTH>,
     Diffusion: DiffusionPermutation<AF, WIDTH>,
 {
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -15,7 +15,7 @@ pub trait MdsLightPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WID
 // [ 1 1 4 6 ].
 // This uses the formula from the start of Appendix B in the Poseidon2 paper, with multiplications unrolled into additions.
 // It is also the matrix used by the Horizon Labs implementation.
-fn apply_hl_mat4<AF>(x: &mut [AF])
+fn apply_hl_mat4<AF>(x: &mut [AF; 4])
 where
     AF: AbstractField,
 {
@@ -130,9 +130,9 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
 }
 
 #[derive(Default, Clone)]
-pub struct Poseidon2ExternalMatrixHL;
+pub struct Poseidon2ExternalMatrixGeneral;
 
-impl<AF, const WIDTH: usize> Permutation<[AF; WIDTH]> for Poseidon2ExternalMatrixHL
+impl<AF, const WIDTH: usize> Permutation<[AF; WIDTH]> for Poseidon2ExternalMatrixGeneral
 where
     AF: AbstractField,
     AF::F: PrimeField,
@@ -140,4 +140,11 @@ where
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
         mds_light_permutation::<AF, HLMDSMat4, WIDTH>(state, HLMDSMat4)
     }
+}
+
+impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixGeneral
+where
+    AF: AbstractField,
+    AF::F: PrimeField,
+{
 }

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -11,7 +11,7 @@ use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Matrix, MatrixRowSlices};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
 use p3_util::log2_ceil_usize;
@@ -102,7 +102,7 @@ impl<F> Borrow<FibonacciRow<F>> for [F] {
 }
 
 type Val = BabyBear;
-type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 type ValMmcs =
@@ -116,7 +116,11 @@ type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 
 #[test]
 fn test_public_value() {
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);
@@ -145,7 +149,11 @@ fn test_public_value() {
 #[test]
 #[should_panic(expected = "assertion `left == right` failed: constraints had nonzero value")]
 fn test_incorrect_public_value() {
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -16,7 +16,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::MatrixRowSlices;
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_mersenne_31::Mersenne31;
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32, TruncatedPermutation,
 };
@@ -150,8 +150,12 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), VerificationError
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
 
     type Dft = Radix2DitParallel;
     let dft = Dft {};
@@ -199,8 +203,12 @@ fn do_test_bb_twoadic(
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, DiffusionMatrixBabybear, 16, 7>;
-    let perm = Perm::new_from_rng(8, 22, DiffusionMatrixBabybear, &mut thread_rng());
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabybear,
+        &mut thread_rng(),
+    );
 
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     let hash = MyHash::new(perm.clone());


### PR DESCRIPTION
Update Poseidon2 so it accepts as input both an internal_linear_layer and an external_linear_layer.

This lets us optimise the external layers for specific fields and/or architectures.