### PR TITLE
Remove example config

### DIFF
--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -32,18 +32,6 @@ rand = "0.8.5"
 tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 
-[[example]]
-name = "prove_baby_bear_keccak"
-
-[[example]]
-name = "prove_baby_bear_poseidon2"
-
-[[example]]
-name = "prove_goldilocks_keccak"
-
-[[example]]
-name = "prove_goldilocks_poseidon"
-
 [features]
 # TODO: Consider removing, at least when this gets split off into another repository.
 # We should be able to enable p3-maybe-rayon/parallel directly; this just doesn't


### PR DESCRIPTION
Since we don't actually need any config beyond the default; this shouldn't change anything.