### PR TITLE
Disable test that only makes sense in debug builds

### DIFF
--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -142,6 +142,7 @@ fn test_public_value() {
     verify(&config, &FibonacciAir {}, &mut challenger, &proof, &pis).expect("verification failed");
 }
 
+#[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "assertion `left == right` failed: constraints had nonzero value")]
 fn test_incorrect_public_value() {


### PR DESCRIPTION
The test `fib_air.rs::test_incorrect_public_values()` in the `uni-stark` crate fails in release builds because relies on being run in a debug build to return the expected result; however this was not enforced in its metadata. This PR adds the missing directive.

@dlubarov Please confirm that this is the intended behaviour of the test; in particular that the code is not supposed to panic in release builds. Thanks!