### PR TITLE
Better External Linear Layer

### DIFF
--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -102,7 +102,7 @@ mod tests {
     use core::array;
 
     use p3_field::AbstractField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixHL};
 
     use super::*;
 
@@ -130,7 +130,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2: Poseidon2<
             BabyBear,
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             DiffusionMatrixBabybear,
             WIDTH,
             D,
@@ -139,7 +139,7 @@ mod tests {
             HL_BABYBEAR_16_EXTERNAL_ROUND_CONSTANTS
                 .map(to_babybear_array)
                 .to_vec(),
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             ROUNDS_P,
             to_babybear_array(HL_BABYBEAR_16_INTERNAL_ROUND_CONSTANTS).to_vec(),
             DiffusionMatrixBabybear,

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -32,7 +32,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use ff::PrimeField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixHL};
     use rand::Rng;
     use zkhash::ark_ff::{BigInteger, PrimeField as ark_PrimeField};
     use zkhash::fields::bn256::FpBN256 as ark_FpBN256;
@@ -99,14 +99,14 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2: Poseidon2<
             Bn254Fr,
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             DiffusionMatrixBN254,
             WIDTH,
             D,
         > = Poseidon2::new(
             ROUNDS_F,
             external_round_constants,
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             ROUNDS_P,
             internal_round_constants,
             DiffusionMatrixBN254,

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -237,7 +237,7 @@ pub const HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS: [u64; 22] = [
 mod tests {
     use core::array;
 
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixHL};
 
     use super::*;
 
@@ -269,7 +269,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2: Poseidon2<
             Goldilocks,
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             DiffusionMatrixGoldilocks,
             WIDTH,
             D,
@@ -278,7 +278,7 @@ mod tests {
             HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS
                 .map(to_goldilocks_array)
                 .to_vec(),
-            Poseidon2ExternalMatrixGeneral,
+            Poseidon2ExternalMatrixHL,
             ROUNDS_P,
             to_goldilocks_array(HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS).to_vec(),
             DiffusionMatrixGoldilocks,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -14,7 +14,7 @@ mod round_numbers;
 use alloc::vec::Vec;
 
 pub use diffusion::{matmul_internal, DiffusionPermutation};
-pub use matrix::{MdsLightPermutation, Poseidon2ExternalMatrixGeneral};
+pub use matrix::*;
 use p3_field::{AbstractField, PrimeField, PrimeField64};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -23,8 +23,8 @@ where
     let t1 = x[2].clone() + x[3].clone();
     let t2 = x[1].clone() + x[1].clone() + t1.clone();
     let t3 = x[3].clone() + x[3].clone() + t0.clone();
-    let t4 = t1.clone() + t1.clone() + t1.clone() + t1 + t3.clone();
-    let t5 = t0.clone() + t0.clone() + t0.clone() + t0 + t2.clone();
+    let t4 = t1.double().double() + t3.clone();
+    let t5 = t0.double().double() + t2.clone();
     let t6 = t3 + t5.clone();
     let t7 = t2 + t4.clone();
     x[0] = t6;
@@ -33,29 +33,27 @@ where
     x[3] = t4;
 }
 
-// At some point we should switch this matrix to:
+// Multiply a 4-element vector x by:
 // [ 2 3 1 1 ]
 // [ 1 2 3 1 ]
 // [ 1 1 2 3 ]
 // [ 3 1 1 2 ].
-// This is more efficient than the one above (11 additions vs 16 additions) and leads to a ~5% speed up.
-// Unfortunately it breaks all the tests as we are testing against the implementation from zkhash.
-// Hence will leave this as a comment for now and implement later.
-// fn apply_m_4<AF>(x: &mut [AF])
-// where
-//     AF: AbstractField,
-//     AF::F: PrimeField,
-// {
-//     let t01 = x[0].clone() + x[1].clone();
-//     let t23 = x[2].clone() + x[3].clone();
-//     let t0123 = t01.clone() + t23.clone();
-//     let t01123 = t0123.clone() + x[1].clone();
-//     let t01233 = t0123.clone() + x[3].clone();
-//     x[3] = t01233.clone() + x[0].clone() + x[0].clone(); // 3*x[0] + x[1] + x[2] + 2*x[3]
-//     x[1] = t01123.clone() + x[2].clone() + x[2].clone(); // x[0] + 2*x[1] + 3*x[2] + x[3]
-//     x[0] = t01123 + t01; // 2*x[0] + 3*x[1] + x[2] + x[3]
-//     x[2] = t01233 + t23; // x[0] + x[1] + 2*x[2] + 3*x[3]
-// }
+// This is more efficient than the previous matrix.
+fn apply_mat4<AF>(x: &mut [AF; 4])
+where
+    AF: AbstractField,
+{
+    let t01 = x[0].clone() + x[1].clone();
+    let t23 = x[2].clone() + x[3].clone();
+    let t0123 = t01.clone() + t23.clone();
+    let t01123 = t0123.clone() + x[1].clone();
+    let t01233 = t0123.clone() + x[3].clone();
+    // The order here is important. Need to overwrite x[0] and x[2] after x[1] and x[3].
+    x[3] = t01233.clone() + x[0].double(); // 3*x[0] + x[1] + x[2] + 2*x[3]
+    x[1] = t01123.clone() + x[2].double(); // x[0] + 2*x[1] + 3*x[2] + x[3]
+    x[0] = t01123 + t01; // 2*x[0] + 3*x[1] + x[2] + x[3]
+    x[2] = t01233 + t23; // x[0] + x[1] + 2*x[2] + 3*x[3]
+}
 
 // The 4x4 MDS matrix used by the Horizon Labs implementation of Poseidon2.
 #[derive(Clone, Default)]
@@ -73,6 +71,22 @@ impl<AF: AbstractField> Permutation<[AF; 4]> for HLMDSMat4 {
     }
 }
 impl<AF: AbstractField> MdsPermutation<AF, 4> for HLMDSMat4 {}
+
+#[derive(Clone, Default)]
+pub struct MDSMat4;
+
+impl<AF: AbstractField> Permutation<[AF; 4]> for MDSMat4 {
+    fn permute(&self, input: [AF; 4]) -> [AF; 4] {
+        let mut output = input.clone();
+        self.permute_mut(&mut output);
+        output
+    }
+
+    fn permute_mut(&self, input: &mut [AF; 4]) {
+        apply_mat4(input)
+    }
+}
+impl<AF: AbstractField> MdsPermutation<AF, 4> for MDSMat4 {}
 
 fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, const WIDTH: usize>(
     state: &mut [AF; WIDTH],
@@ -138,11 +152,31 @@ where
     AF::F: PrimeField,
 {
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
-        mds_light_permutation::<AF, HLMDSMat4, WIDTH>(state, HLMDSMat4)
+        mds_light_permutation::<AF, MDSMat4, WIDTH>(state, MDSMat4)
     }
 }
 
 impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixGeneral
+where
+    AF: AbstractField,
+    AF::F: PrimeField,
+{
+}
+
+#[derive(Default, Clone)]
+pub struct Poseidon2ExternalMatrixHL;
+
+impl<AF, const WIDTH: usize> Permutation<[AF; WIDTH]> for Poseidon2ExternalMatrixHL
+where
+    AF: AbstractField,
+    AF::F: PrimeField,
+{
+    fn permute_mut(&self, state: &mut [AF; WIDTH]) {
+        mds_light_permutation::<AF, HLMDSMat4, WIDTH>(state, HLMDSMat4)
+    }
+}
+
+impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixHL
 where
     AF: AbstractField,
     AF::F: PrimeField,


### PR DESCRIPTION
We can improve the External Linear layer to require only 9 additions and 2 doubles as opposed to 10 additions and 4 doubles.

Only a small speed up (Roughly 2-5%) but no point leaving simple improvements on the table.

Currently still supporting both options to give the option to match our implementation with the Horizon Labs implementation.