### PR TITLE
feat: support multi thread circle

### DIFF
--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -15,6 +15,7 @@ p3-util = { path = "../util" }
 
 tracing = "0.1.37"
 itertools = "0.12.0"
+serde = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 p3-mds = { path = "../mds" }
@@ -25,3 +26,7 @@ p3-symmetric = { path = "../symmetric" }
 
 hashbrown = "0.14.3"
 rand = "0.8.5"
+
+
+[features]
+multi_thread = []

--- a/circle/src/cfft/mod.rs
+++ b/circle/src/cfft/mod.rs
@@ -1,0 +1,52 @@
+//! The Circle FFT and its inverse, as detailed in
+//! Circle STARKs, Section 4.2 (page 14 of the first revision PDF)
+//! This code is based on Angus Gruen's implementation, which uses a slightly
+//! different cfft basis than that of the paper. Basically, it continues using the
+//! same twiddles for the second half of the chunk, which only changes the sign of the
+//! resulting basis. For a full explanation see the comments in `util::circle_basis`.
+//! This alternate basis doesn't cause any change to the code apart from our testing functions.
+
+#[cfg(feature = "multi_thread")]
+pub mod multi_thread {
+    use ::std::sync::{Arc, RwLock};
+
+    include!("cfft.rs");
+}
+
+#[cfg(not(feature = "multi_thread"))]
+pub mod single_thread {
+    mod seal {
+        use ::core::cell::{Ref, RefCell, RefMut};
+
+        #[derive(Default, Debug)]
+        pub struct RwLock<T>(RefCell<T>);
+
+        // Mimic `RwLock`'s API
+        impl<T> RwLock<T> {
+            #[allow(dead_code)]
+            pub fn new(value: T) -> Self {
+                Self(RefCell::new(value))
+            }
+
+            #[allow(dead_code)]
+            #[inline]
+            pub fn read(&self) -> Result<Ref<'_, T>, ::core::convert::Infallible> {
+                Ok(self.0.borrow())
+            }
+
+            #[inline]
+            pub fn write(&self) -> Result<RefMut<'_, T>, ::core::convert::Infallible> {
+                Ok(self.0.borrow_mut())
+            }
+        }
+    }
+    use ::alloc::rc::Rc as Arc;
+    use seal::RwLock;
+
+    include!("cfft.rs");
+}
+
+#[cfg(feature = "multi_thread")]
+pub use multi_thread::*;
+#[cfg(not(feature = "multi_thread"))]
+pub use single_thread::*;

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -1,4 +1,5 @@
 use alloc::vec;
+#[cfg(not(feature = "multi_thread"))]
 use alloc::vec::Vec;
 
 use itertools::Itertools;
@@ -8,6 +9,7 @@ use p3_field::{batch_multiplicative_inverse, AbstractField, ExtensionField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::util::{point_to_univariate, s_p_at_p, univariate_to_point, v_0, v_n};
@@ -37,7 +39,7 @@ use crate::util::{point_to_univariate, s_p_at_p, univariate_to_point, v_0, v_n};
 /// ```
 ///
 /// The full domain is the interleaving of these two cosets
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct CircleDomain<F> {
     // log_n corresponds to the log size of the WHOLE domain
     pub(crate) log_n: usize,

--- a/circle/src/lib.rs
+++ b/circle/src/lib.rs
@@ -1,7 +1,7 @@
 //! A framework for operating over the unit circle of a finite field,
 //! following the [Circle STARKs paper](https://eprint.iacr.org/2024/278) by Haböck, Levit and Papini.
 
-#![no_std]
+#![cfg_attr(not(feature = "multi_thread"), no_std)]
 
 extern crate alloc;
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "multi_thread"))]
 use alloc::vec::Vec;
 
 use itertools::izip;
@@ -7,6 +8,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::cfft::Cfft;
@@ -20,7 +22,7 @@ pub struct CirclePcs<Val: Field, InputMmcs> {
     pub mmcs: InputMmcs,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProverData<Val, MmcsData> {
     committed_domains: Vec<CircleDomain<Val>>,
     mmcs_data: MmcsData,

--- a/circle/src/twiddles.rs
+++ b/circle/src/twiddles.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "multi_thread"))]
 use alloc::vec::Vec;
 use core::mem;
 

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -24,7 +24,7 @@ p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-mds = { path = "../mds" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
-p3-poseidon = {path = "../poseidon"}
+p3-poseidon = { path = "../poseidon" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }


### PR DESCRIPTION
The purpose of this PR is to add multi-thread support in Circle.

Use the `include!` macro to support both `Arc<RwLock>` and `Rc<RefCell>` at the same time without redundant code.

But, we need to warp the API of `RefCell` to be similar to that of `RwLock`.

```rust
 pub struct RwLock<T>(RefCell<T>);
```