### PR TITLE
`par_row_chunks_mut` -> `par_row_chunks_exact_mut`

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -48,15 +48,16 @@ impl<F: ComplexExtendable> Cfft<F> {
             let half_block_size = block_size >> 1;
             assert_eq!(twiddle.len(), half_block_size);
 
-            mat.par_row_chunks_mut(block_size).for_each(|mut chunk| {
-                for (i, &t) in twiddle.iter().enumerate() {
-                    let (lo, hi) = chunk.row_pair_mut(i, block_size - i - 1);
-                    let (lo_packed, lo_suffix) = F::Packing::pack_slice_with_suffix_mut(lo);
-                    let (hi_packed, hi_suffix) = F::Packing::pack_slice_with_suffix_mut(hi);
-                    dif_butterfly(lo_packed, hi_packed, t.into());
-                    dif_butterfly(lo_suffix, hi_suffix, t);
-                }
-            });
+            mat.par_row_chunks_exact_mut(block_size)
+                .for_each(|mut chunk| {
+                    for (i, &t) in twiddle.iter().enumerate() {
+                        let (lo, hi) = chunk.row_pair_mut(i, block_size - i - 1);
+                        let (lo_packed, lo_suffix) = F::Packing::pack_slice_with_suffix_mut(lo);
+                        let (hi_packed, hi_suffix) = F::Packing::pack_slice_with_suffix_mut(hi);
+                        dif_butterfly(lo_packed, hi_packed, t.into());
+                        dif_butterfly(lo_suffix, hi_suffix, t);
+                    }
+                });
         }
         // TODO: omit this?
         divide_by_height(&mut mat);
@@ -93,15 +94,16 @@ impl<F: ComplexExtendable> Cfft<F> {
             let half_block_size = block_size >> 1;
             assert_eq!(twiddle.len(), half_block_size);
 
-            mat.par_row_chunks_mut(block_size).for_each(|mut chunk| {
-                for (i, &t) in twiddle.iter().enumerate() {
-                    let (lo, hi) = chunk.row_pair_mut(i, block_size - i - 1);
-                    let (lo_packed, lo_suffix) = F::Packing::pack_slice_with_suffix_mut(lo);
-                    let (hi_packed, hi_suffix) = F::Packing::pack_slice_with_suffix_mut(hi);
-                    dit_butterfly(lo_packed, hi_packed, t.into());
-                    dit_butterfly(lo_suffix, hi_suffix, t);
-                }
-            });
+            mat.par_row_chunks_exact_mut(block_size)
+                .for_each(|mut chunk| {
+                    for (i, &t) in twiddle.iter().enumerate() {
+                        let (lo, hi) = chunk.row_pair_mut(i, block_size - i - 1);
+                        let (lo_packed, lo_suffix) = F::Packing::pack_slice_with_suffix_mut(lo);
+                        let (hi_packed, hi_suffix) = F::Packing::pack_slice_with_suffix_mut(hi);
+                        dit_butterfly(lo_packed, hi_packed, t.into());
+                        dit_butterfly(lo_suffix, hi_suffix, t);
+                    }
+                });
         }
 
         mat

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -110,7 +110,7 @@ fn butterfly_layer<F: Field, B: Butterfly<F>>(
     half_block_size: usize,
     twiddles: &[B],
 ) {
-    mat.par_row_chunks_mut(2 * half_block_size)
+    mat.par_row_chunks_exact_mut(2 * half_block_size)
         .enumerate()
         .for_each(|(block, mut chunks)| {
             let (mut hi_chunks, mut lo_chunks) = chunks.split_rows_mut(half_block_size);

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -53,7 +53,7 @@ fn dit_layer<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>, layer: usize, twi
 
     let _width = mat.width();
 
-    mat.par_row_chunks_mut(block_size)
+    mat.par_row_chunks_exact_mut(block_size)
         .for_each(|mut block_chunks| {
             let (mut hi_chunks, mut lo_chunks) = block_chunks.split_rows_mut(half_block_size);
             hi_chunks

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -113,11 +113,12 @@ fn par_dit_layer<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles: &[
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^mid
-    mat.par_row_chunks_mut(1 << mid).for_each(|mut submat| {
-        for layer in 0..mid {
-            dit_layer(&mut submat, log_h, layer, twiddles);
-        }
-    });
+    mat.par_row_chunks_exact_mut(1 << mid)
+        .for_each(|mut submat| {
+            for layer in 0..mid {
+                dit_layer(&mut submat, log_h, layer, twiddles);
+            }
+        });
 }
 
 /// This can be used as the second half of a parallelized butterfly network.
@@ -125,7 +126,7 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^(log_h - mid)
-    mat.par_row_chunks_mut(1 << (log_h - mid))
+    mat.par_row_chunks_exact_mut(1 << (log_h - mid))
         .enumerate()
         .for_each(|(thread, mut submat)| {
             for layer in mid..log_h {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -170,6 +170,20 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
     {
         self.values
             .borrow_mut()
+            .par_chunks_mut(self.width * chunk_rows)
+            .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
+    }
+
+    pub fn par_row_chunks_exact_mut(
+        &mut self,
+        chunk_rows: usize,
+    ) -> impl IndexedParallelIterator<Item = RowMajorMatrixViewMut<T>>
+    where
+        T: Send,
+        S: BorrowMut<[T]>,
+    {
+        self.values
+            .borrow_mut()
             .par_chunks_exact_mut(self.width * chunk_rows)
             .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
     }
@@ -225,7 +239,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
             w,
         );
         padded
-            .par_row_chunks_mut(1 << added_bits)
+            .par_row_chunks_exact_mut(1 << added_bits)
             .zip(self.par_row_slices())
             .for_each(|(mut ch, r)| ch.row_mut(0).copy_from_slice(r));
 


### PR DESCRIPTION
To reflect the current behavior; we could add a non-exact variant later if useful.