### PR TITLE
Simple Renaming

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -2,7 +2,7 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    BabyBear, DiffusionMatrixBabybear, PackedBabyBearNeon, MONTY_INVERSE,
+    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearNeon, MONTY_INVERSE,
     POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
     POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
 };
@@ -11,7 +11,7 @@ use crate::{
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl Permutation<[PackedBabyBearNeon; 16]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearNeon; 16]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 16]) {
         matmul_internal::<BabyBear, PackedBabyBearNeon, 16>(
             state,
@@ -21,9 +21,9 @@ impl Permutation<[PackedBabyBearNeon; 16]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearNeon, 16> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearNeon, 16> for DiffusionMatrixBabyBear {}
 
-impl Permutation<[PackedBabyBearNeon; 24]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearNeon; 24]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 24]) {
         matmul_internal::<BabyBear, PackedBabyBearNeon, 24>(
             state,
@@ -33,7 +33,7 @@ impl Permutation<[PackedBabyBearNeon; 24]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearNeon, 24> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearNeon, 24> for DiffusionMatrixBabyBear {}
 
 #[cfg(test)]
 mod tests {
@@ -42,12 +42,12 @@ mod tests {
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{BabyBear, DiffusionMatrixBabybear, PackedBabyBearNeon};
+    use crate::{BabyBear, DiffusionMatrixBabyBear, PackedBabyBearNeon};
 
     type F = BabyBear;
     const D: u64 = 7;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 24, D>;
+    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, D>;
+    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, D>;
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -57,7 +57,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 
@@ -82,7 +82,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -85,9 +85,9 @@ const POSEIDON2_INTERNAL_MATRIX_DIAG_24_MONTY_SHIFTS: [u8; 23] = [
 ];
 
 #[derive(Debug, Clone, Default)]
-pub struct DiffusionMatrixBabybear;
+pub struct DiffusionMatrixBabyBear;
 
-impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
+impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabyBear {
     #[inline]
     fn permute_mut(&self, state: &mut [BabyBear; 16]) {
         let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
@@ -107,9 +107,9 @@ impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabyBear {}
 
-impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
+impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabyBear {
     #[inline]
     fn permute_mut(&self, state: &mut [BabyBear; 24]) {
         let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
@@ -129,18 +129,18 @@ impl Permutation<[BabyBear; 24]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<BabyBear, 24> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<BabyBear, 24> for DiffusionMatrixBabyBear {}
 
 #[derive(Debug, Clone, Default)]
-pub struct DiffusionMatrixBabybearHL;
+pub struct DiffusionMatrixBabyBearHL;
 
-impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabybearHL {
+impl Permutation<[BabyBear; 16]> for DiffusionMatrixBabyBearHL {
     fn permute_mut(&self, state: &mut [BabyBear; 16]) {
         matmul_internal::<BabyBear, BabyBear, 16>(state, MATRIX_DIAG_16_BABYBEAR_MONTY_HL);
     }
 }
 
-impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabybearHL {}
+impl DiffusionPermutation<BabyBear, 16> for DiffusionMatrixBabyBearHL {}
 
 pub const HL_BABYBEAR_16_EXTERNAL_ROUND_CONSTANTS: [[BabyBear; 16]; 8] = [
     to_babybear_array([
@@ -213,7 +213,7 @@ mod tests {
         let poseidon2: Poseidon2<
             BabyBear,
             Poseidon2ExternalMatrixHL,
-            DiffusionMatrixBabybearHL,
+            DiffusionMatrixBabyBearHL,
             WIDTH,
             D,
         > = Poseidon2::new(
@@ -222,7 +222,7 @@ mod tests {
             Poseidon2ExternalMatrixHL,
             ROUNDS_P,
             HL_BABYBEAR_16_INTERNAL_ROUND_CONSTANTS.to_vec(),
-            DiffusionMatrixBabybearHL,
+            DiffusionMatrixBabyBearHL,
         );
         poseidon2.permute_mut(input);
     }
@@ -247,7 +247,7 @@ mod tests {
         let poseidon2: Poseidon2<
             BabyBear,
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             WIDTH,
             D,
         > = Poseidon2::new(
@@ -256,7 +256,7 @@ mod tests {
             Poseidon2ExternalMatrixGeneral,
             ROUNDS_P,
             internal_round_constants.to_vec(),
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
         );
         poseidon2.permute_mut(input);
     }
@@ -281,7 +281,7 @@ mod tests {
         let poseidon2: Poseidon2<
             BabyBear,
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             WIDTH,
             D,
         > = Poseidon2::new(
@@ -290,7 +290,7 @@ mod tests {
             Poseidon2ExternalMatrixGeneral,
             ROUNDS_P,
             internal_round_constants.to_vec(),
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
         );
         poseidon2.permute_mut(input);
     }

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -2,7 +2,7 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX2, MONTY_INVERSE,
+    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX2, MONTY_INVERSE,
     POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
     POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
 };
@@ -11,7 +11,7 @@ use crate::{
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl Permutation<[PackedBabyBearAVX2; 16]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearAVX2; 16]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 16]) {
         matmul_internal::<BabyBear, PackedBabyBearAVX2, 16>(
             state,
@@ -21,9 +21,9 @@ impl Permutation<[PackedBabyBearAVX2; 16]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearAVX2, 16> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearAVX2, 16> for DiffusionMatrixBabyBear {}
 
-impl Permutation<[PackedBabyBearAVX2; 24]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearAVX2; 24]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 24]) {
         matmul_internal::<BabyBear, PackedBabyBearAVX2, 24>(
             state,
@@ -33,7 +33,7 @@ impl Permutation<[PackedBabyBearAVX2; 24]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearAVX2, 24> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearAVX2, 24> for DiffusionMatrixBabyBear {}
 
 #[cfg(test)]
 mod tests {
@@ -42,12 +42,12 @@ mod tests {
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX2};
+    use crate::{BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX2};
 
     type F = BabyBear;
     const D: u64 = 7;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 24, D>;
+    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, D>;
+    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, D>;
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -57,7 +57,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 
@@ -82,7 +82,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -2,7 +2,7 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX512, MONTY_INVERSE,
+    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX512, MONTY_INVERSE,
     POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
     POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
 };
@@ -11,7 +11,7 @@ use crate::{
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl Permutation<[PackedBabyBearAVX512; 16]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearAVX512; 16]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 16]) {
         matmul_internal::<BabyBear, PackedBabyBearAVX512, 16>(
             state,
@@ -21,9 +21,9 @@ impl Permutation<[PackedBabyBearAVX512; 16]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearAVX512, 16> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearAVX512, 16> for DiffusionMatrixBabyBear {}
 
-impl Permutation<[PackedBabyBearAVX512; 24]> for DiffusionMatrixBabybear {
+impl Permutation<[PackedBabyBearAVX512; 24]> for DiffusionMatrixBabyBear {
     fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 24]) {
         matmul_internal::<BabyBear, PackedBabyBearAVX512, 24>(
             state,
@@ -33,7 +33,7 @@ impl Permutation<[PackedBabyBearAVX512; 24]> for DiffusionMatrixBabybear {
     }
 }
 
-impl DiffusionPermutation<PackedBabyBearAVX512, 24> for DiffusionMatrixBabybear {}
+impl DiffusionPermutation<PackedBabyBearAVX512, 24> for DiffusionMatrixBabyBear {}
 
 #[cfg(test)]
 mod tests {
@@ -42,12 +42,12 @@ mod tests {
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{BabyBear, DiffusionMatrixBabybear, PackedBabyBearAVX512};
+    use crate::{BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX512};
 
     type F = BabyBear;
     const D: u64 = 7;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 24, D>;
+    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, D>;
+    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, D>;
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -57,7 +57,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 
@@ -82,7 +82,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
 

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};
 use p3_commit::ExtensionMmcs;
 use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
@@ -19,7 +19,7 @@ use rand_chacha::ChaCha20Rng;
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 
-type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 type ValMmcs =
@@ -29,7 +29,7 @@ type Challenger = DuplexChallenger<Val, Perm, 16>;
 type MyFriConfig = FriConfig<ChallengeMmcs>;
 
 fn get_ldt_for_testing<R: Rng>(rng: &mut R) -> (Perm, MyFriConfig) {
-    let perm = Perm::new_from_rng_128(Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, rng);
+    let perm = Perm::new_from_rng_128(Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -1,5 +1,5 @@
 use itertools::{izip, Itertools};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::{CanObserve, DuplexChallenger, FieldChallenger};
 use p3_commit::{ExtensionMmcs, Pcs};
 use p3_dft::Radix2DitParallel;
@@ -15,7 +15,7 @@ use rand::thread_rng;
 type Val = BabyBear;
 type Challenge = BinomialExtensionField<Val, 4>;
 
-type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 
@@ -36,7 +36,7 @@ fn make_test_fri_pcs(log_degrees_by_round: &[&[usize]]) {
 
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut rng,
     );
     let hash = MyHash::new(perm.clone());

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -1,4 +1,4 @@
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
@@ -34,10 +34,10 @@ fn main() -> Result<(), VerificationError> {
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
 

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_blake3::Blake3;
 use p3_commit::Mmcs;
 use p3_field::{Field, PackedField, PackedValue};
@@ -31,10 +31,10 @@ fn bench_merkle_trees(criterion: &mut Criterion) {
 fn bench_bb_poseidon2(criterion: &mut Criterion) {
     type F = BabyBear;
 
-    type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -164,7 +164,7 @@ mod tests {
     use alloc::vec;
 
     use itertools::Itertools;
-    use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+    use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
     use p3_commit::Mmcs;
     use p3_field::{AbstractField, Field};
     use p3_matrix::dense::RowMajorMatrix;
@@ -179,7 +179,7 @@ mod tests {
 
     type F = BabyBear;
 
-    type Perm = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
     type MyMmcs =
@@ -189,7 +189,7 @@ mod tests {
     fn commit_single_1x8() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -226,7 +226,7 @@ mod tests {
     fn commit_single_2x2() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -252,7 +252,7 @@ mod tests {
     fn commit_single_2x3() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -286,7 +286,7 @@ mod tests {
     fn commit_mixed() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -351,7 +351,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -372,7 +372,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -394,7 +394,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -433,7 +433,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -488,7 +488,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabybear,
+            DiffusionMatrixBabyBear,
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
 use p3_field::{PrimeField, PrimeField64};
 use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
@@ -14,8 +14,8 @@ use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 
 fn bench_poseidon2(c: &mut Criterion) {
-    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>(c);
-    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 24, 7>(c);
+    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>(c);
+    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>(c);
 
     poseidon2_p64::<Mersenne31, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 16, 5>(
         c,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
@@ -103,7 +103,7 @@ impl<F> Borrow<FibonacciRow<F>> for [F] {
 }
 
 type Val = BabyBear;
-type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
 type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
 type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 type ValMmcs =
@@ -119,7 +119,7 @@ type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 fn test_public_value() {
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
     let hash = MyHash::new(perm.clone());
@@ -153,7 +153,7 @@ fn test_public_value() {
 fn test_incorrect_public_value() {
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
     let hash = MyHash::new(perm.clone());

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use itertools::Itertools;
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabybear};
+use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
 use p3_circle::{Cfft, CirclePcs};
 use p3_commit::testing::TrivialPcs;
@@ -150,10 +150,10 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), VerificationError
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
 
@@ -203,10 +203,10 @@ fn do_test_bb_twoadic(
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabybear, 16, 7>;
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabybear,
+        DiffusionMatrixBabyBear,
         &mut thread_rng(),
     );
 


### PR DESCRIPTION
BabyBear is written with a double capital in all other cases. Just getting DiffusionMatrixBabyBear to follow this convention.