### PR TITLE
Add STIR as a PCS type to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Generalized vector commitment schemes
 
 Polynomial commitment schemes
 - [x] FRI-based PCS
+- [ ] STIR-based PCS
 - [ ] tensor PCS
 - [ ] univariate-to-multivariate adapter
 - [ ] multivariate-to-univariate adapter


### PR DESCRIPTION
While I think on a sufficiently long timescale, we just replace most usages of FRI with STIR, in the interrim where STIR isn't commonly implemented I suggest we add it directly to the README.