### PR TITLE
Fix multiplicative generator of KoalaBear

### DIFF
--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -173,7 +173,7 @@ impl AbstractField for KoalaBear {
 
     #[inline]
     fn generator() -> Self {
-        Self::from_canonical_u32(0x1f)
+        Self::from_canonical_u32(3)
     }
 }
 


### PR DESCRIPTION
Somehow missed this initially. 31 is not a generator but 3 is.