### PR TITLE
Add missing constraint for Keccak preimage matching A (round input)

### DIFF
--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -30,12 +30,25 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         let local: &KeccakCols<AB::Var> = (*local).borrow();
         let next: &KeccakCols<AB::Var> = (*next).borrow();
 
+        let first_step = local.step_flags[0];
+        let final_step = local.step_flags[NUM_ROUNDS - 1];
+        let not_final_step = AB::Expr::one() - final_step;
+
+        // If this is the first step, the input A must match the preimage.
+        for y in 0..5 {
+            for x in 0..5 {
+                for limb in 0..U64_LIMBS {
+                    builder
+                        .when(first_step)
+                        .assert_eq(local.preimage[y][x][limb], local.a[y][x][limb]);
+                }
+            }
+        }
+
         // The export flag must be 0 or 1.
         builder.assert_bool(local.export);
 
         // If this is not the final step, the export flag must be off.
-        let final_step = local.step_flags[NUM_ROUNDS - 1];
-        let not_final_step = AB::Expr::one() - final_step;
         builder
             .when(not_final_step.clone())
             .assert_zero(local.export);
@@ -45,8 +58,8 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             for x in 0..5 {
                 for limb in 0..U64_LIMBS {
                     builder
-                        .when_transition()
                         .when(not_final_step.clone())
+                        .when_transition()
                         .assert_eq(local.preimage[y][x][limb], next.preimage[y][x][limb]);
                 }
             }
@@ -162,7 +175,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for x in 0..5 {
             for y in 0..5 {
                 for limb in 0..U64_LIMBS {
-                    let output = local.a_prime_prime_prime(x, y, limb);
+                    let output = local.a_prime_prime_prime(y, x, limb);
                     let input = next.a[y][x][limb];
                     builder
                         .when_transition()

--- a/keccak-air/src/columns.rs
+++ b/keccak-air/src/columns.rs
@@ -27,9 +27,6 @@ pub struct KeccakCols<T> {
     /// Permutation inputs, stored in y-major order.
     pub preimage: [[[T; U64_LIMBS]; 5]; 5],
 
-    /// Permutation outputs, stored in y-major order.
-    pub postimage: [[[T; U64_LIMBS]; 5]; 5],
-
     pub a: [[[T; U64_LIMBS]; 5]; 5],
 
     /// ```ignore
@@ -81,12 +78,12 @@ impl<T: Copy> KeccakCols<T> {
         self.a_prime[b][a][(z + 64 - rot) % 64]
     }
 
-    pub fn a_prime_prime_prime(&self, x: usize, y: usize, limb: usize) -> T {
-        debug_assert!(x < 5);
+    pub fn a_prime_prime_prime(&self, y: usize, x: usize, limb: usize) -> T {
         debug_assert!(y < 5);
+        debug_assert!(x < 5);
         debug_assert!(limb < U64_LIMBS);
 
-        if x == 0 && y == 0 {
+        if y == 0 && x == 0 {
             self.a_prime_prime_prime_0_0_limbs[limb]
         } else {
             self.a_prime_prime[y][x][limb]
@@ -117,7 +114,7 @@ pub fn output_limb(i: usize) -> usize {
     let y = i_u64 / 5;
     let x = i_u64 % 5;
 
-    KECCAK_COL_MAP.postimage[y][x][limb_index]
+    KECCAK_COL_MAP.a_prime_prime_prime(y, x, limb_index)
 }
 
 pub const NUM_KECCAK_COLS: usize = size_of::<KeccakCols<u8>>();

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -70,7 +70,7 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], inp
         for y in 0..5 {
             for x in 0..5 {
                 for limb in 0..U64_LIMBS {
-                    rows[round].a[y][x][limb] = rows[round - 1].a_prime_prime_prime(x, y, limb);
+                    rows[round].a[y][x][limb] = rows[round - 1].a_prime_prime_prime(y, x, limb);
                 }
             }
         }


### PR DESCRIPTION
Also remove postimage, which isn't needed; we can use the usual row/step state since we don't need to copy it from one row to the next (since only final rows are exported)