### PR TITLE
Multiplicative group orders using naive trial division

### DIFF
--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -184,6 +184,21 @@ impl Field for Bn254Fr {
         let bytes = FFBn254Fr::char_le_bits();
         BigUint::from_bytes_le(bytes.as_raw_slice())
     }
+
+    fn multiplicative_group_factors() -> Vec<(BigUint, usize)> {
+        vec![
+            (BigUint::from(2u8), 28),
+            (BigUint::from(3u8), 2),
+            (BigUint::from(13u8), 1),
+            (BigUint::from(29u8), 1),
+            (BigUint::from(983u16), 1),
+            (BigUint::from(11003u16), 1),
+            (BigUint::from(237073u32), 1),
+            (BigUint::from(405928799u32), 1),
+            (BigUint::from(1670836401704629u64), 1),
+            (BigUint::from(13818364434197438864469338081u128), 1),
+        ]
+    }
 }
 
 impl PrimeField for Bn254Fr {

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT OR Apache-2.0"
 p3-field = { path = "../field" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 criterion = "0.5.1"
+num-bigint = { version = "0.4.3", default-features = false }
+num-traits = "0.2.19"
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -7,6 +7,8 @@ extern crate alloc;
 pub mod bench_func;
 
 pub use bench_func::*;
+use num_bigint::BigUint;
+use num_traits::identities::One;
 use p3_field::{
     cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order, two_adic_coset_zerofier,
     two_adic_subgroup_zerofier, ExtensionField, Field, TwoAdicField,
@@ -75,6 +77,14 @@ where
     }
 }
 
+pub fn test_multiplicative_group_factors<F: Field>() {
+    let product: BigUint = F::multiplicative_group_factors()
+        .into_iter()
+        .map(|(factor, exponent)| factor.pow(exponent as u32))
+        .product();
+    assert_eq!(product + BigUint::one(), F::order());
+}
+
 pub fn test_two_adic_subgroup_zerofier<F: TwoAdicField>() {
     for log_n in 0..5 {
         let g = F::two_adic_generator(log_n);
@@ -129,6 +139,10 @@ macro_rules! test_field {
             #[test]
             fn test_inverse() {
                 $crate::test_inverse::<$field>();
+            }
+            #[test]
+            fn test_multiplicative_group_factors() {
+                $crate::test_multiplicative_group_factors::<$field>();
             }
         }
     };

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 p3-util = { path = "../util" }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.18", default_features = false }
+num-integer = "0.1.46"
 
 itertools = "0.12.0"
 rand = "0.8.5"

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -9,6 +9,7 @@ p3-util = { path = "../util" }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.18", default_features = false }
 num-integer = "0.1.46"
+nums = "0.1.0"
 
 itertools = "0.12.0"
 rand = "0.8.5"

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -9,11 +9,11 @@ use core::slice;
 use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::One;
+use nums::{Factorizer, FactorizerFromSplitter, MillerRabin, PollardRho};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::exponentiation::exp_u64_by_squaring;
-use crate::helpers::factor;
 use crate::packed::{PackedField, PackedValue};
 use crate::Packable;
 
@@ -235,7 +235,11 @@ pub trait Field:
 
     /// A list of (factor, exponent) pairs.
     fn multiplicative_group_factors() -> Vec<(BigUint, usize)> {
-        factor(Self::order() - BigUint::one())
+        let primality_test = MillerRabin { error_bits: 128 };
+        let composite_splitter = PollardRho;
+        let factorizer = FactorizerFromSplitter { primality_test, composite_splitter };
+        let n = Self::order() - BigUint::one();
+        factorizer.factor_counts(&n)
     }
 
     #[inline]

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1,4 +1,5 @@
 use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::iter::{Product, Sum};
@@ -7,10 +8,12 @@ use core::slice;
 
 use itertools::Itertools;
 use num_bigint::BigUint;
+use num_traits::One;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::exponentiation::exp_u64_by_squaring;
+use crate::helpers::factor;
 use crate::packed::{PackedField, PackedValue};
 use crate::Packable;
 
@@ -229,6 +232,11 @@ pub trait Field:
     }
 
     fn order() -> BigUint;
+
+    /// A list of (factor, exponent) pairs.
+    fn multiplicative_group_factors() -> Vec<(BigUint, usize)> {
+        factor(Self::order() - BigUint::one())
+    }
 
     #[inline]
     fn bits() -> usize {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -237,7 +237,10 @@ pub trait Field:
     fn multiplicative_group_factors() -> Vec<(BigUint, usize)> {
         let primality_test = MillerRabin { error_bits: 128 };
         let composite_splitter = PollardRho;
-        let factorizer = FactorizerFromSplitter { primality_test, composite_splitter };
+        let factorizer = FactorizerFromSplitter {
+            primality_test,
+            composite_splitter,
+        };
         let n = Self::order() - BigUint::one();
         factorizer.factor_counts(&n)
     }

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -5,8 +5,6 @@ use core::iter::Sum;
 use core::ops::Mul;
 
 use num_bigint::BigUint;
-use num_integer::Integer;
-use num_traits::{One, Zero};
 
 use crate::field::Field;
 use crate::{AbstractField, PrimeField, PrimeField32, TwoAdicField};
@@ -175,75 +173,4 @@ where
     S: Sum<<LI::Item as Mul<RI::Item>>::Output>,
 {
     li.zip(ri).map(|(l, r)| l * r).sum()
-}
-
-pub fn factor(mut n: BigUint) -> Vec<(BigUint, usize)> {
-    // Naive trial division for now.
-    let mut factors = vec![];
-    let mut divisor = BigUint::from(2u8);
-    while &divisor * &divisor <= n {
-        let (quotient, count) = division_loop(n.clone(), &divisor);
-        if count > 0 {
-            factors.push((divisor.clone(), count));
-        }
-        n = quotient;
-        divisor += BigUint::one();
-    }
-    if !n.is_one() {
-        factors.push((n, 1));
-    }
-    factors
-}
-
-/// Divide n by d repeatedly for as long as it's divisible; return the quotient and the number of divisions.
-fn division_loop(mut n: BigUint, d: &BigUint) -> (BigUint, usize) {
-    let mut count = 0;
-    loop {
-        let (quotient, remainder) = n.div_rem(d);
-        if remainder.is_zero() {
-            n = quotient;
-            count += 1;
-        } else {
-            return (n, count);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use alloc::vec;
-
-    use num_bigint::BigUint;
-
-    use crate::factor;
-
-    #[test]
-    fn test_factor() {
-        assert_eq!(factor(BigUint::from(1u8)), vec![]);
-        assert_eq!(factor(BigUint::from(2u8)), vec![(BigUint::from(2u8), 1)]);
-        assert_eq!(factor(BigUint::from(8u8)), vec![(BigUint::from(2u8), 3)]);
-        assert_eq!(
-            factor(BigUint::from((1u32 << 31) - 2)), // M31 multiplicative group
-            vec![
-                (BigUint::from(2u8), 1),
-                (BigUint::from(3u8), 2),
-                (BigUint::from(7u8), 1),
-                (BigUint::from(11u8), 1),
-                (BigUint::from(31u8), 1),
-                (BigUint::from(151u8), 1),
-                (BigUint::from(331u16), 1)
-            ]
-        );
-        assert_eq!(
-            factor(BigUint::from(0xFFFF_FFFF_0000_0000u64)), // Goldilocks multiplicative group
-            vec![
-                (BigUint::from(2u8), 32),
-                (BigUint::from(3u8), 1),
-                (BigUint::from(5u8), 1),
-                (BigUint::from(17u8), 1),
-                (BigUint::from(257u16), 1),
-                (BigUint::from(65537u32), 1)
-            ]
-        );
-    }
 }

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -5,6 +5,8 @@ use core::iter::Sum;
 use core::ops::Mul;
 
 use num_bigint::BigUint;
+use num_integer::Integer;
+use num_traits::{One, Zero};
 
 use crate::field::Field;
 use crate::{AbstractField, PrimeField, PrimeField32, TwoAdicField};
@@ -173,4 +175,75 @@ where
     S: Sum<<LI::Item as Mul<RI::Item>>::Output>,
 {
     li.zip(ri).map(|(l, r)| l * r).sum()
+}
+
+pub fn factor(mut n: BigUint) -> Vec<(BigUint, usize)> {
+    // Naive trial division for now.
+    let mut factors = vec![];
+    let mut divisor = BigUint::from(2u8);
+    while &divisor * &divisor <= n {
+        let (quotient, count) = division_loop(n.clone(), &divisor);
+        if count > 0 {
+            factors.push((divisor.clone(), count));
+        }
+        n = quotient;
+        divisor += BigUint::one();
+    }
+    if !n.is_one() {
+        factors.push((n, 1));
+    }
+    factors
+}
+
+/// Divide n by d repeatedly for as long as it's divisible; return the quotient and the number of divisions.
+fn division_loop(mut n: BigUint, d: &BigUint) -> (BigUint, usize) {
+    let mut count = 0;
+    loop {
+        let (quotient, remainder) = n.div_rem(d);
+        if remainder.is_zero() {
+            n = quotient;
+            count += 1;
+        } else {
+            return (n, count);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use num_bigint::BigUint;
+
+    use crate::factor;
+
+    #[test]
+    fn test_factor() {
+        assert_eq!(factor(BigUint::from(1u8)), vec![]);
+        assert_eq!(factor(BigUint::from(2u8)), vec![(BigUint::from(2u8), 1)]);
+        assert_eq!(factor(BigUint::from(8u8)), vec![(BigUint::from(2u8), 3)]);
+        assert_eq!(
+            factor(BigUint::from((1u32 << 31) - 2)), // M31 multiplicative group
+            vec![
+                (BigUint::from(2u8), 1),
+                (BigUint::from(3u8), 2),
+                (BigUint::from(7u8), 1),
+                (BigUint::from(11u8), 1),
+                (BigUint::from(31u8), 1),
+                (BigUint::from(151u8), 1),
+                (BigUint::from(331u16), 1)
+            ]
+        );
+        assert_eq!(
+            factor(BigUint::from(0xFFFF_FFFF_0000_0000u64)), // Goldilocks multiplicative group
+            vec![
+                (BigUint::from(2u8), 32),
+                (BigUint::from(3u8), 1),
+                (BigUint::from(5u8), 1),
+                (BigUint::from(17u8), 1),
+                (BigUint::from(257u16), 1),
+                (BigUint::from(65537u32), 1)
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Only `Bn254Fr` has a nontrivial `sqrt(largest_factor)`, so I hardcoded its factorization for now. It could be quickly inferred using other algorithms, but might be overkill.