### PR TITLE
BabyBear - KoalaBear Refactor. Combining Poseidon2

### DIFF
--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -48,8 +48,9 @@ pub const POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY: [BabyBear; 16] =
 
 struct Poseidon2BabyBear {}
 
-impl Poseidon2Utils<BabyBearParameters, 16, 15> for Poseidon2BabyBear {
-    const INTERNAL_DIAG_SHIFTS: [u8; 15] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
+impl Poseidon2Utils<BabyBearParameters, 16> for Poseidon2BabyBear {
+    type ArrayLike = [u8; 15];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
 }
 
 pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY: [BabyBear; 24] =
@@ -80,8 +81,9 @@ pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY: [BabyBear; 24] =
         1 << 23,
     ]);
 
-impl Poseidon2Utils<BabyBearParameters, 24, 23> for Poseidon2BabyBear {
-    const INTERNAL_DIAG_SHIFTS: [u8; 23] = [
+impl Poseidon2Utils<BabyBearParameters, 24> for Poseidon2BabyBear {
+    type ArrayLike = [u8; 23];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 23,
     ];
 }

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -56,8 +56,9 @@ pub const POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY: [KoalaBear; 16] =
 
 struct Poseidon2KoalaBear {}
 
-impl Poseidon2Utils<KoalaBearParameters, 16, 15> for Poseidon2KoalaBear {
-    const INTERNAL_DIAG_SHIFTS: [u8; 15] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
+impl Poseidon2Utils<KoalaBearParameters, 16> for Poseidon2KoalaBear {
+    type ArrayLike = [u8; 15];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
 }
 
 pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY: [KoalaBear; 24] =
@@ -88,8 +89,9 @@ pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY: [KoalaBear; 24] =
         1 << 23,
     ]);
 
-impl Poseidon2Utils<KoalaBearParameters, 24, 23> for Poseidon2KoalaBear {
-    const INTERNAL_DIAG_SHIFTS: [u8; 23] = [
+impl Poseidon2Utils<KoalaBearParameters, 24> for Poseidon2KoalaBear {
+    type ArrayLike = [u8; 23];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23,
     ];
 }

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-field = { path = "../field" }
+p3-poseidon2 = { path = "../poseidon2" }
+p3-symmetric = { path = "../symmetric" }
 num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -5,8 +5,10 @@
 mod data_traits;
 mod extension;
 mod monty_31;
+mod poseidon2;
 mod utils;
 
 pub use data_traits::*;
 pub use monty_31::*;
+pub use poseidon2::*;
 pub use utils::*;

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -1,0 +1,66 @@
+use core::marker::PhantomData;
+
+use p3_poseidon2::DiffusionPermutation;
+use p3_symmetric::Permutation;
+
+use crate::{monty_reduce, FieldParameters, MontyField31};
+
+pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize, const WIDTH_MINUS_ONE: usize> {
+    const INTERNAL_DIAG_SHIFTS: [u8; WIDTH_MINUS_ONE];
+
+    fn permute_state(state: &mut [MontyField31<FP>; WIDTH]) {
+        let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
+        let full_sum = part_sum + (state[0].value as u64);
+        let s0 = part_sum + (-state[0]).value as u64;
+        state[0] = MontyField31::new_monty(monty_reduce::<FP>(s0));
+
+        for i in 0..WIDTH_MINUS_ONE {
+            let si = full_sum + ((state[i + 1].value as u64) << Self::INTERNAL_DIAG_SHIFTS[i]);
+            state[i + 1] = MontyField31::new_monty(monty_reduce::<FP>(si));
+        }
+    }
+}
+
+// Long term we could also do an implementation like the following:
+// Currently this doesn't work due to the orphan rule and the fact that we need to derive
+// Permutation<[_; 16]> for the various field packings. (AVX2, AVX512, NEON)
+// It's also a little ugly due to the need for 2 pieces of PhantomData.
+
+#[derive(Debug, Clone, Default)]
+struct DiffusionMatrixMontyField31<FP: FieldParameters, PU: Poseidon2Monty31<FP>> {
+    _phantom1: PhantomData<FP>,
+    _phantom2: PhantomData<PU>,
+}
+
+impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[MontyField31<FP>; 16]>
+    for DiffusionMatrixMontyField31<FP, PU>
+{
+    #[inline]
+    fn permute_mut(&self, state: &mut [MontyField31<FP>; 16]) {
+        PU::permute_state(state)
+    }
+}
+
+impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> DiffusionPermutation<MontyField31<FP>, 16>
+    for DiffusionMatrixMontyField31<FP, PU>
+{
+}
+
+impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[MontyField31<FP>; 24]>
+    for DiffusionMatrixMontyField31<FP, PU>
+{
+    #[inline]
+    fn permute_mut(&self, state: &mut [MontyField31<FP>; 24]) {
+        PU::permute_state(state)
+    }
+}
+
+impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> DiffusionPermutation<MontyField31<FP>, 24>
+    for DiffusionMatrixMontyField31<FP, PU>
+{
+}
+
+pub trait Poseidon2Monty31<FP: FieldParameters>:
+    Poseidon2Utils<FP, 16, 15> + Poseidon2Utils<FP, 24, 23> + Clone + Sync
+{
+}

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -5,8 +5,9 @@ use p3_symmetric::Permutation;
 
 use crate::{monty_reduce, FieldParameters, MontyField31};
 
-pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize, const WIDTH_MINUS_ONE: usize> {
-    const INTERNAL_DIAG_SHIFTS: [u8; WIDTH_MINUS_ONE];
+pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
+    type ArrayLike: AsRef<[u8]> + Sized;
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike;
 
     fn permute_state(state: &mut [MontyField31<FP>; WIDTH]) {
         let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
@@ -14,8 +15,8 @@ pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize, const WIDTH_MI
         let s0 = part_sum + (-state[0]).value as u64;
         state[0] = MontyField31::new_monty(monty_reduce::<FP>(s0));
 
-        for i in 0..WIDTH_MINUS_ONE {
-            let si = full_sum + ((state[i + 1].value as u64) << Self::INTERNAL_DIAG_SHIFTS[i]);
+        for i in 0..Self::INTERNAL_DIAG_SHIFTS.as_ref().len() {
+            let si = full_sum + ((state[i + 1].value as u64) << Self::INTERNAL_DIAG_SHIFTS.as_ref()[i]);
             state[i + 1] = MontyField31::new_monty(monty_reduce::<FP>(si));
         }
     }
@@ -61,6 +62,6 @@ impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> DiffusionPermutation<MontyFi
 }
 
 pub trait Poseidon2Monty31<FP: FieldParameters>:
-    Poseidon2Utils<FP, 16, 15> + Poseidon2Utils<FP, 24, 23> + Clone + Sync
+    Poseidon2Utils<FP, 16> + Poseidon2Utils<FP, 24> + Clone + Sync
 {
 }


### PR DESCRIPTION
Stage 2 of slowly building the refactor. Note we are not merging with main, will do that in the far future.

Moving the poseidon2 implementation across to generic Monty-Field.

Currently there are 2 ways of going about it, either just providing methods or defining DiffusionMatrixMontyField31. This second way doesn't work yet due to the orphan rule but will work after we have moved the vector implementations across. (See the bottom of monty-31/src/poseidon2.rs.

Can decide later which method to keep later.