### PR TITLE
fix: use abstract field for virtual column

### DIFF
--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -2,11 +2,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
 
-use p3_field::{AbstractField, Field};
+use p3_field::AbstractField;
 
 /// An affine function over columns in a PAIR.
 #[derive(Clone, Debug)]
-pub struct VirtualPairCol<F: Field> {
+pub struct VirtualPairCol<F: AbstractField> {
     column_weights: Vec<(PairCol, F)>,
     constant: F,
 }
@@ -27,7 +27,7 @@ impl PairCol {
     }
 }
 
-impl<F: Field> VirtualPairCol<F> {
+impl<F: AbstractField> VirtualPairCol<F> {
     pub const fn new(column_weights: Vec<(PairCol, F)>, constant: F) -> Self {
         Self {
             column_weights,
@@ -116,9 +116,9 @@ impl<F: Field> VirtualPairCol<F> {
         Expr: AbstractField + Mul<F, Output = Expr>,
         Var: Into<Expr> + Copy,
     {
-        let mut result = self.constant.into();
+        let mut result = self.constant.clone().into();
         for (column, weight) in self.column_weights.iter() {
-            result += column.get(preprocessed, main).into() * *weight;
+            result += column.get(preprocessed, main).into() * weight.clone();
         }
         result
     }


### PR DESCRIPTION
Allow virtual columns to be defined over abstract fields. It doesn't seem like a stricter field restriction is necessary.
I needed this to make virtual columns work properly with symbolic constraints when calculating the degree of a permutation trace