### PR TITLE
chore: add serde/clone derives

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -20,7 +20,7 @@ pub struct CirclePcs<Val: Field, InputMmcs> {
     pub mmcs: InputMmcs,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProverData<Val, MmcsData> {
     committed_domains: Vec<CircleDomain<Val>>,
     mmcs_data: MmcsData,
@@ -31,6 +31,7 @@ where
     Val: ComplexExtendable,
     Challenge: ExtensionField<Val>,
     InputMmcs: Mmcs<Val>,
+    <InputMmcs as Mmcs<Val>>::ProverData<RowMajorMatrix<Val>>: Clone,
 {
     type Domain = CircleDomain<Val>;
     type Commitment = InputMmcs::Commitment;

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -8,6 +8,8 @@ use p3_field::{
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub struct LagrangeSelectors<T> {
@@ -53,7 +55,9 @@ pub trait PolynomialSpace: Copy {
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>>;
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "Val: Serialize"))]
+#[serde(bound(deserialize = "Val: DeserializeOwned"))]
 pub struct TwoAdicMultiplicativeCoset<Val: TwoAdicField> {
     pub log_n: usize,
     pub shift: Val,

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -25,7 +25,7 @@ where
     type Commitment: Clone + Serialize + DeserializeOwned;
 
     /// Data that the prover stores for committed polynomials, to help the prover with opening.
-    type ProverData;
+    type ProverData: Clone;
 
     /// The opening argument.
     type Proof: Clone + Serialize + DeserializeOwned;

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -86,6 +86,7 @@ where
     Challenge: TwoAdicField + ExtensionField<Val>,
     Challenger:
         CanObserve<FriMmcs::Commitment> + CanSample<Challenge> + GrindingChallenger<Witness = Val>,
+    <InputMmcs as Mmcs<Val>>::ProverData<RowMajorMatrix<Val>>: Clone,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -12,6 +12,7 @@ use core::ops::Deref;
 use itertools::{izip, Itertools};
 use p3_field::{ExtensionField, Field, PackedValue};
 use p3_maybe_rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
 
 use crate::dense::RowMajorMatrix;
@@ -26,7 +27,7 @@ pub mod stack;
 pub mod strided;
 pub mod util;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct Dimensions {
     pub width: usize,
     pub height: usize,

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 ///
 /// This generally shouldn't be used directly. If you're using a Merkle tree as an MMCS,
 /// see `FieldMerkleTreeMmcs`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FieldMerkleTree<F, W, M, const DIGEST_ELEMS: usize> {
     pub(crate) leaves: Vec<M>,
     // Enable serialization for this field whenever the underlying array type supports it (len 1-32).


### PR DESCRIPTION
serde / Clone changes necessary to make vkey/pkeys in SP1 Clone/serde

* make `ProverData` struct Clone
* make `TwoAdicMultiplicativeCoset` struct serde
* make `Pcs::ProverData` Clone
* make `Dimensions` struct Clone