### PR TITLE
Include degree in the transcript

### DIFF
--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -51,6 +51,10 @@ where
     let (trace_commit, trace_data) =
         info_span!("commit to trace data").in_scope(|| pcs.commit(vec![(trace_domain, trace)]));
 
+    // Observe the instance.
+    challenger.observe(Val::<SC>::from_canonical_usize(log_degree));
+    // TODO: Might be best practice to include other instance data here; see verifier comment.
+
     challenger.observe(trace_commit.clone());
     challenger.observe_slice(public_values);
     let alpha: SC::Challenge = challenger.sample_ext_element();

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -54,6 +54,14 @@ where
         return Err(VerificationError::InvalidProofShape);
     }
 
+    // Observe the instance.
+    challenger.observe(Val::<SC>::from_canonical_usize(proof.degree_bits));
+    // TODO: Might be best practice to include other instance data here in the transcript, like some
+    // encoding of the AIR. This protects against transcript collisions between distinct instances.
+    // Practically speaking though, the only related known attack is from failing to include public
+    // values. It's not clear if failing to include other instance data could enable a transcript
+    // collision, since most such changes would completely change the set of satisfying witnesses.
+
     challenger.observe(commitments.trace.clone());
     challenger.observe_slice(public_values);
     let alpha: SC::Challenge = challenger.sample_ext_element();


### PR DESCRIPTION
Per the audit. And add a note about potentially including other witness data later.