### PR TITLE
Add `condition()` method on `FilteredAirBuilder`

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -163,6 +163,12 @@ pub struct FilteredAirBuilder<'a, AB: AirBuilder> {
     condition: AB::Expr,
 }
 
+impl<'a, AB: AirBuilder> FilteredAirBuilder<'a, AB> {
+    pub fn condition(&self) -> AB::Expr {
+        self.condition.clone()
+    }
+}
+
 impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
     type F = AB::F;
     type Expr = AB::Expr;
@@ -186,7 +192,7 @@ impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
-        self.inner.assert_zero(self.condition.clone() * x.into());
+        self.inner.assert_zero(self.condition() * x.into());
     }
 }
 
@@ -200,7 +206,7 @@ impl<'a, AB: ExtensionBuilder> ExtensionBuilder for FilteredAirBuilder<'a, AB> {
         I: Into<Self::ExprEF>,
     {
         self.inner
-            .assert_zero_ext(x.into() * self.condition.clone());
+            .assert_zero_ext(x.into() * self.condition());
     }
 }
 


### PR DESCRIPTION
Adding this method allows for the following pattern, which would be impossible at the moment since the `condition` field of `FilteredAirBuilder` is private.

```rust
pub trait CustomBuilder: AirBuilder {
    fn assert_custom_when(&mut self, /*operands*/ condition: Option<Self::Expr>);

    fn assert_custom(&mut self /*operands*/) {
        self.assert_custom_when(/*operands*/ None);
    }
}

impl<'a, AB: CustomBuilder> CustomBuilder for FilteredAirBuilder<'a, AB> {
    fn assert_custom_when(&mut self, /*operands*/ outer_condition: Option<Self::Expr>) {
        let condition = if let Some(outer_condition) = outer_condition {
            outer_condition * self.condition()
        } else {
            self.condition()
        };
        self.inner.assert_custom_when(Some(condition))
    }
}

struct ExampleChip {}

impl<AB: CustomBuilder> Air<AB> for ExampleChip {
    fn eval(&self, builder: &mut AB) {
        // `assert_custom` unconditionally
        builder.assert_custom();

        // Only `assert_custom` on the first row
        builder.assert_custom_when(Some(builder.is_first_row()));
        // Equivalent to the more succinct
        builder.when_first_row().assert_custom();
    }
}
```