### PR TITLE
Simplify parameters to packed test macro

### DIFF
--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -724,17 +724,12 @@ mod tests {
     use super::{BabyBear, PackedBabyBearNeon, WIDTH};
     use crate::to_babybear_array;
 
-    const ZEROS: [BabyBear; WIDTH] = to_babybear_array([0x00000000; WIDTH]);
-
     const SPECIAL_VALS: [BabyBear; WIDTH] =
         to_babybear_array([0x00000000, 0x00000001, 0x00000002, 0x78000000]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::BabyBear,
         crate::PackedBabyBearNeon,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedBabyBearNeon(super::SPECIAL_VALS)
     );
 
     #[test]

--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -729,6 +729,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearNeon,
+        crate::PackedBabyBearNeon::zero(),
         crate::PackedBabyBearNeon(super::SPECIAL_VALS)
     );
 

--- a/baby-bear/src/x86_64_avx2/packing.rs
+++ b/baby-bear/src/x86_64_avx2/packing.rs
@@ -680,6 +680,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearAVX2,
+        crate::PackedBabyBearAVX2::zero(),
         crate::PackedBabyBearAVX2(super::SPECIAL_VALS)
     );
 }

--- a/baby-bear/src/x86_64_avx2/packing.rs
+++ b/baby-bear/src/x86_64_avx2/packing.rs
@@ -673,17 +673,13 @@ mod tests {
     use super::{BabyBear, WIDTH};
     use crate::to_babybear_array;
 
-    const ZEROS: [BabyBear; WIDTH] = to_babybear_array([0x00000000; WIDTH]);
     const SPECIAL_VALS: [BabyBear; WIDTH] = to_babybear_array([
         0x00000000, 0x00000001, 0x78000000, 0x77ffffff, 0x3c000000, 0x0ffffffe, 0x68000003,
         0x70000002,
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::BabyBear,
         crate::PackedBabyBearAVX2,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedBabyBearAVX2(super::SPECIAL_VALS)
     );
 }

--- a/baby-bear/src/x86_64_avx512/packing.rs
+++ b/baby-bear/src/x86_64_avx512/packing.rs
@@ -796,6 +796,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearAVX512,
+        crate::PackedBabyBearAVX512::zero(),
         crate::PackedBabyBearAVX512(super::SPECIAL_VALS)
     );
 }

--- a/baby-bear/src/x86_64_avx512/packing.rs
+++ b/baby-bear/src/x86_64_avx512/packing.rs
@@ -788,7 +788,6 @@ mod tests {
     use super::{BabyBear, WIDTH};
     use crate::to_babybear_array;
 
-    const ZEROS: [BabyBear; WIDTH] = to_babybear_array([0x00000000; WIDTH]);
     const SPECIAL_VALS: [BabyBear; WIDTH] = to_babybear_array([
         0x00000000, 0x00000001, 0x78000000, 0x77ffffff, 0x3c000000, 0x0ffffffe, 0x68000003,
         0x70000002, 0x00000000, 0x00000001, 0x78000000, 0x77ffffff, 0x3c000000, 0x0ffffffe,
@@ -796,10 +795,7 @@ mod tests {
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::BabyBear,
         crate::PackedBabyBearAVX512,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedBabyBearAVX512(super::SPECIAL_VALS)
     );
 }

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -89,7 +89,7 @@ where
 }
 
 #[allow(clippy::eq_op)]
-pub fn test_add_neg<PF>()
+pub fn test_add_neg<PF>(zeros: PF)
 where
     PF: PackedField + Eq,
     Standard: Distribution<PF::Scalar>,
@@ -97,7 +97,6 @@ where
     let vec0 = packed_from_random::<PF>(0x8b078c2b693c893f);
     let vec1 = packed_from_random::<PF>(0x4ff5dec04791e481);
     let vec2 = packed_from_random::<PF>(0x5806c495e9451f8e);
-    let zeros = PF::zero();
 
     assert_eq!(
         (vec0 + vec1) + vec2,
@@ -155,7 +154,7 @@ where
     );
 }
 
-pub fn test_mul<PF>()
+pub fn test_mul<PF>(zeros: PF)
 where
     PF: PackedField + Eq,
     Standard: Distribution<PF::Scalar>,
@@ -163,7 +162,6 @@ where
     let vec0 = packed_from_random::<PF>(0x0b1ee4d7c979d50c);
     let vec1 = packed_from_random::<PF>(0x39faa0844a36e45a);
     let vec2 = packed_from_random::<PF>(0x08fac4ee76260e44);
-    let zeros = PF::zero();
 
     assert_eq!(
         (vec0 * vec1) * vec2,
@@ -325,19 +323,21 @@ where
 
 #[macro_export]
 macro_rules! test_packed_field {
-    ($packedfield:ty, $specials:expr) => {
+    ($packedfield:ty, $zeros:expr, $specials:expr) => {
         mod packed_field_tests {
+            use p3_field::AbstractField;
+
             #[test]
             fn test_interleaves() {
                 $crate::test_interleaves::<$packedfield>();
             }
             #[test]
             fn test_add_neg() {
-                $crate::test_add_neg::<$packedfield>();
+                $crate::test_add_neg::<$packedfield>($zeros);
             }
             #[test]
             fn test_mul() {
-                $crate::test_mul::<$packedfield>();
+                $crate::test_mul::<$packedfield>($zeros);
             }
             #[test]
             fn test_distributivity() {

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -1,55 +1,36 @@
-use core::array;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use p3_field::{Field, PackedField, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
-fn array_from_random<const WIDTH: usize, F>(seed: u64) -> [F; WIDTH]
+fn packed_from_random<PV>(seed: u64) -> PV
 where
-    Standard: Distribution<F>,
+    PV: PackedValue,
+    Standard: Distribution<PV::Value>,
 {
     let mut rng = ChaCha20Rng::seed_from_u64(seed);
-    [(); WIDTH].map(|_| rng.gen())
-}
-
-fn packed_from_random<const WIDTH: usize, F, PF>(seed: u64) -> PF
-where
-    PF: PackedValue<Value = F>,
-    Standard: Distribution<F>,
-{
-    let field_array = array_from_random::<WIDTH, F>(seed);
-    *PF::from_slice(&field_array)
-}
-
-fn packed_from_valid_reps<const WIDTH: usize, F, PF>(vals: [u32; WIDTH]) -> PF
-where
-    F: Field,
-    PF: PackedValue<Value = F>,
-    Standard: Distribution<F>,
-{
-    let field_array = vals.map(F::from_canonical_u32);
-    *PF::from_slice(&field_array)
+    PV::from_fn(|_| rng.gen())
 }
 
 /// Interleave arr1 and arr2 using chuncks of size i.
-fn interleave<const WIDTH: usize>(
-    arr1: [u32; WIDTH],
-    arr2: [u32; WIDTH],
-    i: usize,
-) -> ([u32; WIDTH], [u32; WIDTH]) {
-    assert!(WIDTH % i == 0);
+fn interleave<T: Copy + Default>(arr1: &[T], arr2: &[T], i: usize) -> (Vec<T>, Vec<T>) {
+    let width = arr1.len();
+    assert_eq!(width, arr2.len());
+    assert_eq!(width % i, 0);
 
-    if i == WIDTH {
-        return (arr1, arr2);
+    if i == width {
+        return (arr1.to_vec(), arr2.to_vec());
     }
 
-    let mut outleft = [0_u32; WIDTH];
-    let mut outright = [0_u32; WIDTH];
+    let mut outleft = vec![T::default(); width];
+    let mut outright = vec![T::default(); width];
 
     let mut flag = false;
 
-    for j in 0..WIDTH {
+    for j in 0..width {
         if j % i == 0 {
             flag = !flag;
         }
@@ -65,62 +46,58 @@ fn interleave<const WIDTH: usize>(
     (outleft, outright)
 }
 
-fn test_interleave<const WIDTH: usize, F, PF>(i: usize)
+fn test_interleave<PF>(i: usize)
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    assert!(WIDTH % i == 0);
+    assert!(PF::WIDTH % i == 0);
 
-    let arr1 = array::from_fn(|i| i as u32);
-    let arr2 = array::from_fn(|i| (WIDTH + i) as u32);
+    let vec1 = packed_from_random::<PF>(0x4ff5dec04791e481);
+    let vec2 = packed_from_random::<PF>(0x5806c495e9451f8e);
 
-    let vec0: PF = packed_from_valid_reps::<WIDTH, F, PF>(arr1);
-    let vec1: PF = packed_from_valid_reps::<WIDTH, F, PF>(arr2);
-    let (res0, res1) = vec0.interleave(vec1, i);
+    let arr1 = vec1.as_slice();
+    let arr2 = vec2.as_slice();
 
+    let (res1, res2) = vec1.interleave(vec2, i);
     let (out1, out2) = interleave(arr1, arr2, i);
 
-    let expected0: PF = packed_from_valid_reps::<WIDTH, F, PF>(out1);
-    let expected1: PF = packed_from_valid_reps::<WIDTH, F, PF>(out2);
-
     assert_eq!(
-        res0, expected0,
+        res1.as_slice(),
+        &out1,
         "Error in left output when testing interleave {}.",
         i
     );
     assert_eq!(
-        res1, expected1,
+        res2.as_slice(),
+        &out2,
         "Error in right output when testing interleave {}.",
         i
     );
 }
 
-pub fn test_interleaves<const WIDTH: usize, F, PF>()
+pub fn test_interleaves<PF>()
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
     let mut i = 1;
-    while i <= WIDTH {
-        test_interleave::<WIDTH, F, PF>(i);
+    while i <= PF::WIDTH {
+        test_interleave::<PF>(i);
         i *= 2;
     }
 }
 
 #[allow(clippy::eq_op)]
-pub fn test_add_neg<const WIDTH: usize, F, PF>(zeros_array: [F; WIDTH])
+pub fn test_add_neg<PF>()
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    let vec0 = packed_from_random::<WIDTH, F, PF>(0x8b078c2b693c893f);
-    let vec1 = packed_from_random::<WIDTH, F, PF>(0x4ff5dec04791e481);
-    let vec2 = packed_from_random::<WIDTH, F, PF>(0x5806c495e9451f8e);
-    let zeros = *(PF::from_slice(&zeros_array));
+    let vec0 = packed_from_random::<PF>(0x8b078c2b693c893f);
+    let vec1 = packed_from_random::<PF>(0x4ff5dec04791e481);
+    let vec2 = packed_from_random::<PF>(0x5806c495e9451f8e);
+    let zeros = PF::zero();
 
     assert_eq!(
         (vec0 + vec1) + vec2,
@@ -178,17 +155,15 @@ where
     );
 }
 
-#[allow(clippy::eq_op)]
-pub fn test_mul<const WIDTH: usize, F, PF>(zeros_array: [F; WIDTH])
+pub fn test_mul<PF>()
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    let vec0 = packed_from_random::<WIDTH, F, PF>(0x0b1ee4d7c979d50c);
-    let vec1 = packed_from_random::<WIDTH, F, PF>(0x39faa0844a36e45a);
-    let vec2 = packed_from_random::<WIDTH, F, PF>(0x08fac4ee76260e44);
-    let zeros = *(PF::from_slice(&zeros_array));
+    let vec0 = packed_from_random::<PF>(0x0b1ee4d7c979d50c);
+    let vec1 = packed_from_random::<PF>(0x39faa0844a36e45a);
+    let vec2 = packed_from_random::<PF>(0x08fac4ee76260e44);
+    let zeros = PF::zero();
 
     assert_eq!(
         (vec0 * vec1) * vec2,
@@ -237,16 +212,14 @@ where
     );
 }
 
-#[allow(clippy::eq_op)]
-pub fn test_distributivity<const WIDTH: usize, F, PF>()
+pub fn test_distributivity<PF>()
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    let vec0 = packed_from_random::<WIDTH, F, PF>(0x278d9e202925a1d1);
-    let vec1 = packed_from_random::<WIDTH, F, PF>(0xf04cbac0cbad419f);
-    let vec2 = packed_from_random::<WIDTH, F, PF>(0x76976e2abdc5a056);
+    let vec0 = packed_from_random::<PF>(0x278d9e202925a1d1);
+    let vec1 = packed_from_random::<PF>(0xf04cbac0cbad419f);
+    let vec2 = packed_from_random::<PF>(0x76976e2abdc5a056);
 
     assert_eq!(
         vec0 * (-vec1),
@@ -281,19 +254,17 @@ where
     );
 }
 
-#[allow(clippy::eq_op)]
-pub fn test_vs_scalar<const WIDTH: usize, F, PF>(special_vals: [F; WIDTH])
+pub fn test_vs_scalar<PF>(special_vals: PF)
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    let arr0 = array_from_random::<WIDTH, F>(0x278d9e202925a1d1);
-    let arr1 = array_from_random::<WIDTH, F>(0xf04cbac0cbad419f);
+    let vec0: PF = packed_from_random(0x278d9e202925a1d1);
+    let vec1: PF = packed_from_random(0xf04cbac0cbad419f);
+    let vec_special = special_vals;
 
-    let vec0 = *(PF::from_slice(&arr0));
-    let vec1 = *(PF::from_slice(&arr1));
-    let vec_special = *(PF::from_slice(&special_vals));
+    let arr0 = vec0.as_slice();
+    let arr1 = vec1.as_slice();
 
     let vec_sum = vec0 + vec1;
     let arr_sum = vec_sum.as_slice();
@@ -321,7 +292,8 @@ where
     let vec_special_neg = -vec_special;
     let arr_special_neg = vec_special_neg.as_slice();
 
-    for i in 0..WIDTH {
+    let special_vals = special_vals.as_slice();
+    for i in 0..PF::WIDTH {
         assert_eq!(arr_sum[i], arr0[i] + arr1[i]);
         assert_eq!(arr_special_sum_left[i], special_vals[i] + arr0[i]);
         assert_eq!(arr_special_sum_right[i], arr1[i] + special_vals[i]);
@@ -339,49 +311,45 @@ where
     }
 }
 
-pub fn test_multiplicative_inverse<const WIDTH: usize, F, PF>()
+pub fn test_multiplicative_inverse<PF>()
 where
-    F: Field,
-    PF: PackedField<Scalar = F> + PackedValue + Eq,
-    Standard: Distribution<F>,
+    PF: PackedField + Eq,
+    Standard: Distribution<PF::Scalar>,
 {
-    let arr = array_from_random::<WIDTH, F>(0xb0c7a5153103c5a8);
-    let arr_inv = arr.map(|x| x.inverse());
-
-    let vec = *(PF::from_slice(&arr));
-    let vec_inv = *(PF::from_slice(&arr_inv));
-
+    let vec: PF = packed_from_random(0xb0c7a5153103c5a8);
+    let arr = vec.as_slice();
+    let vec_inv = PF::from_fn(|i| arr[i].inverse());
     let res = vec * vec_inv;
     assert_eq!(res, PF::one());
 }
 
 #[macro_export]
 macro_rules! test_packed_field {
-    ($width:expr, $field:ty, $packedfield:ty, $zeros:expr, $specials:expr) => {
+    ($packedfield:ty, $specials:expr) => {
         mod packed_field_tests {
             #[test]
             fn test_interleaves() {
-                $crate::test_interleaves::<$width, $field, $packedfield>();
+                $crate::test_interleaves::<$packedfield>();
             }
             #[test]
             fn test_add_neg() {
-                $crate::test_add_neg::<$width, $field, $packedfield>($zeros);
+                $crate::test_add_neg::<$packedfield>();
             }
             #[test]
             fn test_mul() {
-                $crate::test_mul::<$width, $field, $packedfield>($zeros);
+                $crate::test_mul::<$packedfield>();
             }
             #[test]
             fn test_distributivity() {
-                $crate::test_distributivity::<$width, $field, $packedfield>();
+                $crate::test_distributivity::<$packedfield>();
             }
             #[test]
             fn test_vs_scalar() {
-                $crate::test_vs_scalar::<$width, $field, $packedfield>($specials);
+                $crate::test_vs_scalar::<$packedfield>($specials);
             }
             #[test]
             fn test_multiplicative_inverse() {
-                $crate::test_multiplicative_inverse::<$width, $field, $packedfield>();
+                $crate::test_multiplicative_inverse::<$packedfield>();
             }
         }
     };

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -724,17 +724,12 @@ mod tests {
     use super::{KoalaBear, PackedKoalaBearNeon, WIDTH};
     use crate::to_koalabear_array;
 
-    const ZEROS: [KoalaBear; WIDTH] = to_koalabear_array([0x00000000; WIDTH]);
-
     const SPECIAL_VALS: [KoalaBear; WIDTH] =
         to_koalabear_array([0x00000000, 0x00000001, 0x00000002, 0x7f000000]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::KoalaBear,
         crate::PackedKoalaBearNeon,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedKoalaBearNeon(super::SPECIAL_VALS)
     );
 
     #[test]

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -729,6 +729,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearNeon,
+        crate::PackedKoalaBearNeon::zero(),
         crate::PackedKoalaBearNeon(super::SPECIAL_VALS)
     );
 

--- a/koala-bear/src/x86_64_avx2/packing.rs
+++ b/koala-bear/src/x86_64_avx2/packing.rs
@@ -673,18 +673,13 @@ mod tests {
     use super::{KoalaBear, WIDTH};
     use crate::to_koalabear_array;
 
-    const ZEROS: [KoalaBear; WIDTH] = to_koalabear_array([0x00000000; WIDTH]);
-
     const SPECIAL_VALS: [KoalaBear; WIDTH] = to_koalabear_array([
         0x00000000, 0x00000001, 0x7f000000, 0x7effffff, 0x3f800000, 0x0ffffffe, 0x68000003,
         0x70000002,
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::KoalaBear,
         crate::PackedKoalaBearAVX2,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedKoalaBearAVX2(super::SPECIAL_VALS)
     );
 }

--- a/koala-bear/src/x86_64_avx2/packing.rs
+++ b/koala-bear/src/x86_64_avx2/packing.rs
@@ -680,6 +680,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearAVX2,
+        crate::PackedKoalaBearAVX2::zero(),
         crate::PackedKoalaBearAVX2(super::SPECIAL_VALS)
     );
 }

--- a/koala-bear/src/x86_64_avx512/packing.rs
+++ b/koala-bear/src/x86_64_avx512/packing.rs
@@ -788,8 +788,6 @@ mod tests {
     use super::{KoalaBear, WIDTH};
     use crate::to_koalabear_array;
 
-    const ZEROS: [KoalaBear; WIDTH] = to_koalabear_array([0x00000000; WIDTH]);
-
     const SPECIAL_VALS: [KoalaBear; WIDTH] = to_koalabear_array([
         0x00000000, 0x00000001, 0x78000000, 0x77ffffff, 0x3c000000, 0x0ffffffe, 0x68000003,
         0x70000002, 0x00000000, 0x00000001, 0x78000000, 0x77ffffff, 0x3c000000, 0x0ffffffe,
@@ -797,10 +795,7 @@ mod tests {
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::KoalaBear,
         crate::PackedKoalaBearAVX512,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedKoalaBearAVX512(super::SPECIAL_VALS)
     );
 }

--- a/koala-bear/src/x86_64_avx512/packing.rs
+++ b/koala-bear/src/x86_64_avx512/packing.rs
@@ -796,6 +796,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearAVX512,
+        crate::PackedKoalaBearAVX512::zero(),
         crate::PackedKoalaBearAVX512(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -583,18 +583,11 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
-    /// Zero has a redundant representation, so let's test both.
-    const ZEROS: [Mersenne31; WIDTH] =
-        to_mersenne31_array([0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff]);
-
     const SPECIAL_VALS: [Mersenne31; WIDTH] =
         to_mersenne31_array([0x00000000, 0x00000001, 0x00000002, 0x7ffffffe]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::Mersenne31,
         crate::PackedMersenne31Neon,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedMersenne31Neon(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -583,11 +583,16 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
+    /// Zero has a redundant representation, so let's test both.
+    const ZEROS: [Mersenne31; WIDTH] =
+        to_mersenne31_array([0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff]);
+
     const SPECIAL_VALS: [Mersenne31; WIDTH] =
         to_mersenne31_array([0x00000000, 0x00000001, 0x00000002, 0x7ffffffe]);
 
     test_packed_field!(
         crate::PackedMersenne31Neon,
+        crate::PackedMersenne31Neon(super::ZEROS),
         crate::PackedMersenne31Neon(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -648,6 +648,12 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
+    /// Zero has a redundant representation, so let's test both.
+    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
+        0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
+        0x7fffffff,
+    ]);
+
     const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff,
@@ -655,6 +661,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedMersenne31AVX2,
+        crate::PackedMersenne31AVX2(super::ZEROS),
         crate::PackedMersenne31AVX2(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -648,22 +648,13 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
-    /// Zero has a redundant representation, so let's test both.
-    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
-        0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
-        0x7fffffff,
-    ]);
-
     const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff,
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::Mersenne31,
         crate::PackedMersenne31AVX2,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedMersenne31AVX2(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -749,6 +749,13 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
+    /// Zero has a redundant representation, so let's test both.
+    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
+        0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
+        0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff,
+        0x00000000, 0x7fffffff,
+    ]);
+
     const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff, 0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd,
@@ -757,6 +764,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedMersenne31AVX512,
+        crate::PackedMersenne31AVX512(super::ZEROS),
         crate::PackedMersenne31AVX512(super::SPECIAL_VALS)
     );
 }

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -749,13 +749,6 @@ mod tests {
     use super::{Mersenne31, WIDTH};
     use crate::to_mersenne31_array;
 
-    /// Zero has a redundant representation, so let's test both.
-    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
-        0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
-        0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff,
-        0x00000000, 0x7fffffff,
-    ]);
-
     const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff, 0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd,
@@ -763,10 +756,7 @@ mod tests {
     ]);
 
     test_packed_field!(
-        { super::WIDTH },
-        crate::Mersenne31,
         crate::PackedMersenne31AVX512,
-        super::ZEROS,
-        super::SPECIAL_VALS
+        crate::PackedMersenne31AVX512(super::SPECIAL_VALS)
     );
 }


### PR DESCRIPTION
I think these simplifications resolve all the outstanding issues with #381 and tidy the code still further.

I have put the code with the `zeros` parameter in a second commit. I'm not convinced it should be part of the test suite, since it is only used by the `mersenne-31` crate. Might be better to do those specific tests just in that crate.