### PR TITLE
Remove some PhantomData from Monty31 MDS stuff

### DIFF
--- a/baby-bear/src/mds.rs
+++ b/baby-bear/src/mds.rs
@@ -7,66 +7,53 @@
 //! database.
 
 use p3_mds::util::first_row_to_first_col;
-use p3_monty_31::{MdsMatrixMontyField31, MDSUtils};
-
-use crate::BabyBearParameters;
+use p3_monty_31::{MDSUtils, MdsMatrixMontyField31};
 
 #[derive(Clone, Default)]
 pub struct MDSBabyBearData;
 
-impl MDSUtils<BabyBearParameters> for MDSBabyBearData {
+impl MDSUtils for MDSBabyBearData {
     const MATRIX_CIRC_MDS_8_COL: [i64; 8] = first_row_to_first_col(&[7, 1, 3, 8, 8, 3, 4, 9]);
-    const MATRIX_CIRC_MDS_12_COL: [i64; 12] = first_row_to_first_col(&[1, 1, 2, 1, 8, 9, 10, 7, 5, 9, 4, 10]);
-    const MATRIX_CIRC_MDS_16_COL: [i64; 16] = first_row_to_first_col(&[1, 1, 51, 1, 11, 17, 2, 1, 101, 63, 15, 2, 67, 22, 13, 3]);
-    const MATRIX_CIRC_MDS_24_COL: [i64; 24] = first_row_to_first_col(
-        &[
-        0x2D0AAAAB, 0x64850517, 0x17F5551D, 0x04ECBEB5,
-        0x6D91A8D5, 0x60703026, 0x18D6F3CA, 0x729601A7,
-        0x77CDA9E2, 0x3C0F5038, 0x26D52A61, 0x0360405D,
-        0x68FC71C8, 0x2495A71D, 0x5D57AFC2, 0x1689DD98,
-        0x3C2C3DBE, 0x0C23DC41, 0x0524C7F2, 0x6BE4DF69,
-        0x0A6E572C, 0x5C7790FA, 0x17E118F6, 0x0878A07F,
-        ]);
-    const MATRIX_CIRC_MDS_32_COL: [i64; 32] = first_row_to_first_col(
-        &[0x0BC00000, 0x2BED8F81, 0x337E0652, 0x4C4535D1,
-        0x4AF2DC32, 0x2DB4050F, 0x676A7CE3, 0x3A06B68E,
-        0x5E95C1B1, 0x2C5F54A0, 0x2332F13D, 0x58E757F1,
-        0x3AA6DCCE, 0x607EE630, 0x4ED57FF0, 0x6E08555B,
-        0x4C155556, 0x587FD0CE, 0x462F1551, 0x032A43CC,
-        0x5E2E43EA, 0x71609B02, 0x0ED97E45, 0x562CA7E9,
-        0x2CB70B1D, 0x4E941E23, 0x174A61C1, 0x117A9426,
+    const MATRIX_CIRC_MDS_12_COL: [i64; 12] =
+        first_row_to_first_col(&[1, 1, 2, 1, 8, 9, 10, 7, 5, 9, 4, 10]);
+    const MATRIX_CIRC_MDS_16_COL: [i64; 16] =
+        first_row_to_first_col(&[1, 1, 51, 1, 11, 17, 2, 1, 101, 63, 15, 2, 67, 22, 13, 3]);
+    const MATRIX_CIRC_MDS_24_COL: [i64; 24] = first_row_to_first_col(&[
+        0x2D0AAAAB, 0x64850517, 0x17F5551D, 0x04ECBEB5, 0x6D91A8D5, 0x60703026, 0x18D6F3CA,
+        0x729601A7, 0x77CDA9E2, 0x3C0F5038, 0x26D52A61, 0x0360405D, 0x68FC71C8, 0x2495A71D,
+        0x5D57AFC2, 0x1689DD98, 0x3C2C3DBE, 0x0C23DC41, 0x0524C7F2, 0x6BE4DF69, 0x0A6E572C,
+        0x5C7790FA, 0x17E118F6, 0x0878A07F,
+    ]);
+    const MATRIX_CIRC_MDS_32_COL: [i64; 32] = first_row_to_first_col(&[
+        0x0BC00000, 0x2BED8F81, 0x337E0652, 0x4C4535D1, 0x4AF2DC32, 0x2DB4050F, 0x676A7CE3,
+        0x3A06B68E, 0x5E95C1B1, 0x2C5F54A0, 0x2332F13D, 0x58E757F1, 0x3AA6DCCE, 0x607EE630,
+        0x4ED57FF0, 0x6E08555B, 0x4C155556, 0x587FD0CE, 0x462F1551, 0x032A43CC, 0x5E2E43EA,
+        0x71609B02, 0x0ED97E45, 0x562CA7E9, 0x2CB70B1D, 0x4E941E23, 0x174A61C1, 0x117A9426,
         0x73562137, 0x54596086, 0x487C560B, 0x68A4ACAB,
-        ]);
-    const MATRIX_CIRC_MDS_64_COL: [i64; 64] = first_row_to_first_col(
-        &[
-        0x39577778, 0x0072F4E1, 0x0B1B8404, 0x041E9C88,
-        0x32D22F9F, 0x4E4BF946, 0x20C7B6D7, 0x0587C267,
-        0x55877229, 0x4D186EC4, 0x4A19FD23, 0x1A64A20F,
-        0x2965CA4D, 0x16D98A5A, 0x471E544A, 0x193D5C8B,
-        0x6E66DF0C, 0x28BF1F16, 0x26DB0BC8, 0x5B06CDDB,
-        0x100DCCA2, 0x65C268AD, 0x199F09E7, 0x36BA04BE,
-        0x06C393F2, 0x51B06DFD, 0x6951B0C4, 0x6683A4C2,
-        0x3B53D11B, 0x26E5134C, 0x45A5F1C5, 0x6F4D2433,
-        0x3CE2D82E, 0x36309A7D, 0x3DD9B459, 0x68051E4C,
-        0x5C3AA720, 0x11640517, 0x0634D995, 0x1B0F6406,
-        0x72A18430, 0x26513CC5, 0x67C0B93C, 0x548AB4A3,
-        0x6395D20D, 0x3E5DBC41, 0x332AF630, 0x3C5DDCB3,
-        0x0AA95792, 0x66EB5492, 0x3F78DDDC, 0x5AC41627,
-        0x16CD5124, 0x3564DA96, 0x461867C9, 0x157B4E11,
-        0x1AA486C8, 0x0C5095A9, 0x3833C0C6, 0x008FEBA5,
-        0x52ECBE2E, 0x1D178A67, 0x58B3C04B, 0x6E95CB51,
-        ]);
+    ]);
+    const MATRIX_CIRC_MDS_64_COL: [i64; 64] = first_row_to_first_col(&[
+        0x39577778, 0x0072F4E1, 0x0B1B8404, 0x041E9C88, 0x32D22F9F, 0x4E4BF946, 0x20C7B6D7,
+        0x0587C267, 0x55877229, 0x4D186EC4, 0x4A19FD23, 0x1A64A20F, 0x2965CA4D, 0x16D98A5A,
+        0x471E544A, 0x193D5C8B, 0x6E66DF0C, 0x28BF1F16, 0x26DB0BC8, 0x5B06CDDB, 0x100DCCA2,
+        0x65C268AD, 0x199F09E7, 0x36BA04BE, 0x06C393F2, 0x51B06DFD, 0x6951B0C4, 0x6683A4C2,
+        0x3B53D11B, 0x26E5134C, 0x45A5F1C5, 0x6F4D2433, 0x3CE2D82E, 0x36309A7D, 0x3DD9B459,
+        0x68051E4C, 0x5C3AA720, 0x11640517, 0x0634D995, 0x1B0F6406, 0x72A18430, 0x26513CC5,
+        0x67C0B93C, 0x548AB4A3, 0x6395D20D, 0x3E5DBC41, 0x332AF630, 0x3C5DDCB3, 0x0AA95792,
+        0x66EB5492, 0x3F78DDDC, 0x5AC41627, 0x16CD5124, 0x3564DA96, 0x461867C9, 0x157B4E11,
+        0x1AA486C8, 0x0C5095A9, 0x3833C0C6, 0x008FEBA5, 0x52ECBE2E, 0x1D178A67, 0x58B3C04B,
+        0x6E95CB51,
+    ]);
 }
 
-pub type MdsMatrixBabyBear = MdsMatrixMontyField31<BabyBearParameters, MDSBabyBearData>;
+pub type MdsMatrixBabyBear = MdsMatrixMontyField31<MDSBabyBearData>;
 
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
     use p3_symmetric::Permutation;
-    use crate::BabyBear;
 
     use super::MdsMatrixBabyBear;
+    use crate::BabyBear;
 
     #[test]
     fn babybear8() {

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -51,7 +51,8 @@ struct Poseidon2BabyBear;
 
 impl Poseidon2Utils<BabyBearParameters, 16> for Poseidon2BabyBear {
     type ArrayLike = [u8; 15];
-    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike =
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
 }
 
 pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY: [BabyBear; 24] =

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -51,7 +51,8 @@ struct Poseidon2KoalaBear {}
 
 impl Poseidon2Utils<KoalaBearParameters, 16> for Poseidon2KoalaBear {
     type ArrayLike = [u8; 15];
-    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
+    const INTERNAL_DIAG_SHIFTS: Self::ArrayLike =
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
 }
 
 pub const POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY: [KoalaBear; 24] =

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -4,13 +4,13 @@
 
 mod data_traits;
 mod extension;
+mod mds;
 mod monty_31;
 mod poseidon2;
 mod utils;
-mod mds;
 
 pub use data_traits::*;
+pub use mds::*;
 pub use monty_31::*;
 pub use poseidon2::*;
 pub use utils::*;
-pub use mds::*;

--- a/monty-31/src/mds.rs
+++ b/monty-31/src/mds.rs
@@ -7,6 +7,7 @@
 //! database.
 
 use core::marker::PhantomData;
+
 use p3_mds::karatsuba_convolution::Convolve;
 use p3_mds::util::dot_product;
 use p3_mds::MdsPermutation;
@@ -34,11 +35,9 @@ pub struct MdsMatrixMontyField31<FP: FieldParameters, MU: MDSUtils<FP>> {
 ///
 /// Here "small" means N = len(rhs) <= 16 and sum(r for r in rhs) <
 /// 2^24 (roughly), though in practice the sum will be less than 2^9.
-struct SmallConvolveMontyField31<FP: FieldParameters> {
-    _phantom1: PhantomData<FP>,
-}
+struct SmallConvolveMontyField31;
 
-impl<FP: FieldParameters> Convolve<MontyField31<FP>, i64, i64, i64> for SmallConvolveMontyField31<FP> {
+impl<FP: FieldParameters> Convolve<MontyField31<FP>, i64, i64, i64> for SmallConvolveMontyField31 {
     /// Return the lift of a BabyBear element, satisfying 0 <=
     /// input.value < P < 2^31. Note that BabyBear elements are
     /// represented in Monty form.
@@ -219,7 +218,9 @@ struct LargeConvolveMontyField31<FP: FieldParameters, MU: MDSUtils<FP>> {
     _phantom2: PhantomData<MU>,
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64, i64> for LargeConvolveMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64, i64>
+    for LargeConvolveMontyField31<FP, MU>
+{
     /// Return the lift of a MontyField31 element, satisfying
     /// 0 <= input.value < P < 2^31.
     /// Note that MontyField31 elements are represented in Monty form.
@@ -279,12 +280,14 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64,
     }
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 8]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 8]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 8]) -> [MontyField31<FP>; 8] {
-            SmallConvolveMontyField31::<FP>::apply(
+        SmallConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_8_COL,
-            SmallConvolveMontyField31::<FP>::conv8,
+            <SmallConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv8,
         )
     }
 
@@ -292,14 +295,19 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 8]> f
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 8> for MdsMatrixMontyField31<FP, MU> {}
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 8>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 12]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 12]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 12]) -> [MontyField31<FP>; 12] {
-            SmallConvolveMontyField31::<FP>::apply(
+        SmallConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_12_COL,
-            SmallConvolveMontyField31::<FP>::conv12,
+            <SmallConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv12,
         )
     }
 
@@ -307,14 +315,19 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 12]> 
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 12> for MdsMatrixMontyField31<FP, MU> {}
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 12>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 16]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 16]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 16]) -> [MontyField31<FP>; 16] {
-            SmallConvolveMontyField31::<FP>::apply(
+        SmallConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_16_COL,
-            SmallConvolveMontyField31::<FP>::conv16,
+            <SmallConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv16,
         )
     }
 
@@ -322,11 +335,16 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 16]> 
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 16> for MdsMatrixMontyField31<FP, MU> {}
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 16>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 24]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 24]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 24]) -> [MontyField31<FP>; 24] {
-            LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::<FP, MU>::apply(
             input,
             MU::MATRIX_CIRC_MDS_24_COL,
             LargeConvolveMontyField31::<FP, MU>::conv24,
@@ -337,11 +355,16 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 24]> 
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 24> for MdsMatrixMontyField31<FP, MU> {}
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 24>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 32]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 32]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 32]) -> [MontyField31<FP>; 32] {
-            LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::<FP, MU>::apply(
             input,
             MU::MATRIX_CIRC_MDS_32_COL,
             LargeConvolveMontyField31::<FP, MU>::conv32,
@@ -352,11 +375,16 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 32]> 
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 32> for MdsMatrixMontyField31<FP, MU> {}
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 32>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 64]> for MdsMatrixMontyField31<FP, MU> {
+impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 64]>
+    for MdsMatrixMontyField31<FP, MU>
+{
     fn permute(&self, input: [MontyField31<FP>; 64]) -> [MontyField31<FP>; 64] {
-            LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::<FP, MU>::apply(
             input,
             MU::MATRIX_CIRC_MDS_64_COL,
             LargeConvolveMontyField31::<FP, MU>::conv64,
@@ -367,5 +395,7 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 64]> 
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 64> for MdsMatrixMontyField31<FP, MU> {}
-
+impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 64>
+    for MdsMatrixMontyField31<FP, MU>
+{
+}

--- a/monty-31/src/mds.rs
+++ b/monty-31/src/mds.rs
@@ -15,7 +15,6 @@ use p3_symmetric::Permutation;
 use crate::{FieldParameters, MontyField31};
 /// A collection of constants related to convolutions.
 /// The MDS matrices are saved using their left most column.
-/// The remaining constants are needed for the Barret Reduction algorithm.
 pub trait MDSUtils<FP: FieldParameters>: Clone + Sync {
     const MATRIX_CIRC_MDS_8_COL: [i64; 8];
     const MATRIX_CIRC_MDS_12_COL: [i64; 12];
@@ -23,11 +22,6 @@ pub trait MDSUtils<FP: FieldParameters>: Clone + Sync {
     const MATRIX_CIRC_MDS_24_COL: [i64; 24];
     const MATRIX_CIRC_MDS_32_COL: [i64; 32];
     const MATRIX_CIRC_MDS_64_COL: [i64; 64];
-
-    const N: usize = 40; // beta = 2^N, fixing N = 40 here
-    const PRIME_I128: i128 = FP::PRIME as i128;
-    const I: i64 = (((1_i128) << (2 * Self::N)) / Self::PRIME_I128) as i64; // I = 2^80 / P => I < 2**50
-    const MASK: i64 = !((1 << 10) - 1); // Lets us 0 out the bottom 10 digits of an i64.
 }
 
 #[derive(Clone, Debug, Default)]
@@ -89,20 +83,25 @@ impl<FP: FieldParameters> Convolve<MontyField31<FP>, i64, i64, i64> for SmallCon
 /// x' = x mod 2^10
 /// See Thm 1 (Below function) for a proof that this function is correct.
 #[inline(always)]
-const fn barret_red_monty31<FP: FieldParameters, MU: MDSUtils<FP>>(input: i128) -> i64 {
+fn barret_red_monty31(input: i128, prime: u32) -> i64 {
+    const N: usize = 40; // beta = 2^N, fixing N = 40 here
+    let prime: i128 = prime as i128;
+    let pseudo_inv: i64 = (((1_i128) << (2 * N)) / prime) as i64; // I = 2^80 / P => I < 2**50
+    const MASK: i64 = !((1 << 10) - 1); // Lets us 0 out the bottom 10 digits of an i64.
+
     // input = input_low + beta*input_high
     // So input_high < 2**63 and fits in an i64.
-    let input_high = (input >> MU::N) as i64; // input_high < input / beta < 2**{80 - N}
+    let input_high = (input >> N) as i64; // input_high < input / beta < 2**{80 - N}
 
     // I, input_high are i64's so this multiplication can't overflow.
-    let quot = (((input_high as i128) * (MU::I as i128)) >> MU::N) as i64;
+    let quot = (((input_high as i128) * (pseudo_inv as i128)) >> N) as i64;
 
     // Replace quot by a close value which is divisible by 2^10.
-    let quot_2adic = quot & MU::MASK;
+    let quot_2adic = quot & MASK;
 
     // quot_2adic, P are i64's so this can't overflow.
     // sub is by construction divisible by both P and 2^10.
-    let sub = (quot_2adic as i128) * MU::PRIME_I128;
+    let sub = (quot_2adic as i128) * prime;
 
     (input - sub) as i64
 }
@@ -240,7 +239,7 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64,
         for i in 0..N {
             dp += u[i] as i128 * v[i] as i128;
         }
-        barret_red_monty31::<FP, MU>(dp)
+        barret_red_monty31(dp, FP::PRIME)
     }
 
     #[inline(always)]

--- a/monty-31/src/mds.rs
+++ b/monty-31/src/mds.rs
@@ -16,7 +16,7 @@ use p3_symmetric::Permutation;
 use crate::{FieldParameters, MontyField31};
 /// A collection of constants related to convolutions.
 /// The MDS matrices are saved using their left most column.
-pub trait MDSUtils<FP: FieldParameters>: Clone + Sync {
+pub trait MDSUtils: Clone + Sync {
     const MATRIX_CIRC_MDS_8_COL: [i64; 8];
     const MATRIX_CIRC_MDS_12_COL: [i64; 12];
     const MATRIX_CIRC_MDS_16_COL: [i64; 16];
@@ -26,8 +26,7 @@ pub trait MDSUtils<FP: FieldParameters>: Clone + Sync {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct MdsMatrixMontyField31<FP: FieldParameters, MU: MDSUtils<FP>> {
-    _phantom1: PhantomData<FP>,
+pub struct MdsMatrixMontyField31<MU: MDSUtils> {
     _phantom2: PhantomData<MU>,
 }
 
@@ -213,14 +212,9 @@ fn barret_red_monty31(input: i128, prime: u32) -> i64 {
 /// Here "large" means the elements can be as big as the field
 /// characteristic, and the size N of the RHS is <= 64.
 #[derive(Debug, Clone, Default)]
-struct LargeConvolveMontyField31<FP: FieldParameters, MU: MDSUtils<FP>> {
-    _phantom1: PhantomData<FP>,
-    _phantom2: PhantomData<MU>,
-}
+struct LargeConvolveMontyField31;
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64, i64>
-    for LargeConvolveMontyField31<FP, MU>
-{
+impl<FP: FieldParameters> Convolve<MontyField31<FP>, i64, i64, i64> for LargeConvolveMontyField31 {
     /// Return the lift of a MontyField31 element, satisfying
     /// 0 <= input.value < P < 2^31.
     /// Note that MontyField31 elements are represented in Monty form.
@@ -280,8 +274,8 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Convolve<MontyField31<FP>, i64, i64,
     }
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 8]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 8]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 8]) -> [MontyField31<FP>; 8] {
         SmallConvolveMontyField31::apply(
@@ -295,13 +289,13 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 8]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 8>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 8>
+    for MdsMatrixMontyField31<MU>
 {
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 12]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 12]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 12]) -> [MontyField31<FP>; 12] {
         SmallConvolveMontyField31::apply(
@@ -315,13 +309,13 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 12]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 12>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 12>
+    for MdsMatrixMontyField31<MU>
 {
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 16]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 16]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 16]) -> [MontyField31<FP>; 16] {
         SmallConvolveMontyField31::apply(
@@ -335,19 +329,19 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 16]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 16>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 16>
+    for MdsMatrixMontyField31<MU>
 {
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 24]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 24]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 24]) -> [MontyField31<FP>; 24] {
-        LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_24_COL,
-            LargeConvolveMontyField31::<FP, MU>::conv24,
+            <LargeConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv24,
         )
     }
 
@@ -355,19 +349,19 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 24]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 24>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 24>
+    for MdsMatrixMontyField31<MU>
 {
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 32]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 32]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 32]) -> [MontyField31<FP>; 32] {
-        LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_32_COL,
-            LargeConvolveMontyField31::<FP, MU>::conv32,
+            <LargeConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv32,
         )
     }
 
@@ -375,19 +369,19 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 32]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 32>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 32>
+    for MdsMatrixMontyField31<MU>
 {
 }
 
-impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 64]>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> Permutation<[MontyField31<FP>; 64]>
+    for MdsMatrixMontyField31<MU>
 {
     fn permute(&self, input: [MontyField31<FP>; 64]) -> [MontyField31<FP>; 64] {
-        LargeConvolveMontyField31::<FP, MU>::apply(
+        LargeConvolveMontyField31::apply(
             input,
             MU::MATRIX_CIRC_MDS_64_COL,
-            LargeConvolveMontyField31::<FP, MU>::conv64,
+            <LargeConvolveMontyField31 as Convolve<MontyField31<FP>, i64, i64, i64>>::conv64,
         )
     }
 
@@ -395,7 +389,7 @@ impl<FP: FieldParameters, MU: MDSUtils<FP>> Permutation<[MontyField31<FP>; 64]>
         *input = self.permute(*input);
     }
 }
-impl<FP: FieldParameters, MU: MDSUtils<FP>> MdsPermutation<MontyField31<FP>, 64>
-    for MdsMatrixMontyField31<FP, MU>
+impl<FP: FieldParameters, MU: MDSUtils> MdsPermutation<MontyField31<FP>, 64>
+    for MdsMatrixMontyField31<MU>
 {
 }

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -16,7 +16,8 @@ pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
         state[0] = MontyField31::new_monty(monty_reduce::<FP>(s0));
 
         for i in 0..Self::INTERNAL_DIAG_SHIFTS.as_ref().len() {
-            let si = full_sum + ((state[i + 1].value as u64) << Self::INTERNAL_DIAG_SHIFTS.as_ref()[i]);
+            let si =
+                full_sum + ((state[i + 1].value as u64) << Self::INTERNAL_DIAG_SHIFTS.as_ref()[i]);
             state[i + 1] = MontyField31::new_monty(monty_reduce::<FP>(si));
         }
     }


### PR DESCRIPTION
_For consideration._

This removes some of the `PhantomData` that's been proliferating. Unfortunately some lines become quite ugly, though they might be fixable.

Note that many of the changes are just because `cargo fmt` wasn't run on the source branch.