### PR TITLE
Possible Poseidon2 refactor for Monty31 fields

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearNeon, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedBabyBearNeon; 16]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 16]) {
-        matmul_internal::<BabyBear, PackedBabyBearNeon, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearNeon, 16> for DiffusionMatrixBabyBear {}
-
-impl Permutation<[PackedBabyBearNeon; 24]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearNeon; 24]) {
-        matmul_internal::<BabyBear, PackedBabyBearNeon, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearNeon, 24> for DiffusionMatrixBabyBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -1,7 +1,10 @@
 //! Implementation of Poseidon2, see: https://eprint.iacr.org/2023/323
 
 use p3_field::PrimeField32;
-use p3_monty_31::{to_monty_array, DiffusionMatrixMontyField31, Poseidon2Monty31, Poseidon2Utils};
+use p3_monty_31::{
+    to_monty_array, DiffusionMatrixMontyField31, DiffusionMatrixParameters,
+    MultipleDiffusionMatrixParameters,
+};
 
 use crate::{BabyBear, BabyBearParameters};
 
@@ -21,12 +24,12 @@ use crate::{BabyBear, BabyBearParameters};
 // such that (1 + D(v)) is the monty form of the matrix. This should allow for some delayed reduction tricks.
 
 pub type DiffusionMatrixBabyBear =
-    DiffusionMatrixMontyField31<BabyBearParameters, BabyBearPoseidon2Utils>;
+    DiffusionMatrixMontyField31<BabyBearParameters, BabyBearDiffusionMatrixParameters>;
 
 #[derive(Debug, Clone, Default)]
-pub struct BabyBearPoseidon2Utils;
+pub struct BabyBearDiffusionMatrixParameters;
 
-impl Poseidon2Utils<BabyBearParameters, 16> for BabyBearPoseidon2Utils {
+impl DiffusionMatrixParameters<BabyBearParameters, 16> for BabyBearDiffusionMatrixParameters {
     type ArrayLike = [u8; 15];
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike =
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
@@ -51,7 +54,7 @@ impl Poseidon2Utils<BabyBearParameters, 16> for BabyBearPoseidon2Utils {
     ]);
 }
 
-impl Poseidon2Utils<BabyBearParameters, 24> for BabyBearPoseidon2Utils {
+impl DiffusionMatrixParameters<BabyBearParameters, 24> for BabyBearDiffusionMatrixParameters {
     type ArrayLike = [u8; 23];
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 23,
@@ -85,7 +88,7 @@ impl Poseidon2Utils<BabyBearParameters, 24> for BabyBearPoseidon2Utils {
     ]);
 }
 
-impl Poseidon2Monty31<BabyBearParameters> for BabyBearPoseidon2Utils {}
+impl MultipleDiffusionMatrixParameters<BabyBearParameters> for BabyBearDiffusionMatrixParameters {}
 
 #[cfg(test)]
 mod tests {

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX2, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedBabyBearAVX2; 16]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 16]) {
-        matmul_internal::<BabyBear, PackedBabyBearAVX2, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearAVX2, 16> for DiffusionMatrixBabyBear {}
-
-impl Permutation<[PackedBabyBearAVX2; 24]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearAVX2; 24]) {
-        matmul_internal::<BabyBear, PackedBabyBearAVX2, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearAVX2, 24> for DiffusionMatrixBabyBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX512, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedBabyBearAVX512; 16]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 16]) {
-        matmul_internal::<BabyBear, PackedBabyBearAVX512, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearAVX512, 16> for DiffusionMatrixBabyBear {}
-
-impl Permutation<[PackedBabyBearAVX512; 24]> for DiffusionMatrixBabyBear {
-    fn permute_mut(&self, state: &mut [PackedBabyBearAVX512; 24]) {
-        matmul_internal::<BabyBear, PackedBabyBearAVX512, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_BABYBEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedBabyBearAVX512, 24> for DiffusionMatrixBabyBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
 

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -31,7 +31,11 @@ type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type MyFriConfig = FriConfig<ChallengeMmcs>;
 
 fn get_ldt_for_testing<R: Rng>(rng: &mut R) -> (Perm, MyFriConfig) {
-    let perm = Perm::new_from_rng_128(Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, rng);
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixBabyBear::default(),
+        rng,
+    );
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress));

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -176,7 +176,7 @@ mod babybear_fri_pcs {
     fn get_pcs(log_blowup: usize) -> (MyPcs, Challenger) {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut seeded_rng(),
         );
         let hash = MyHash::new(perm.clone());

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), VerificationError> {
     type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
 

--- a/koala-bear/src/aarch64_neon/poseidon2.rs
+++ b/koala-bear/src/aarch64_neon/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    DiffusionMatrixKoalaBear, KoalaBear, PackedKoalaBearNeon, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedKoalaBearNeon; 16]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearNeon; 16]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearNeon, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearNeon, 16> for DiffusionMatrixKoalaBear {}
-
-impl Permutation<[PackedKoalaBearNeon; 24]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearNeon; 24]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearNeon, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearNeon, 24> for DiffusionMatrixKoalaBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -1,7 +1,10 @@
 //! Implementation of Poseidon2, see: https://eprint.iacr.org/2023/323
 
 use p3_field::PrimeField32;
-use p3_monty_31::{to_monty_array, DiffusionMatrixMontyField31, Poseidon2Monty31, Poseidon2Utils};
+use p3_monty_31::{
+    to_monty_array, DiffusionMatrixMontyField31, DiffusionMatrixParameters,
+    MultipleDiffusionMatrixParameters,
+};
 
 use crate::{KoalaBear, KoalaBearParameters};
 
@@ -25,12 +28,12 @@ use crate::{KoalaBear, KoalaBearParameters};
 // They need to be pub and not pub(crate) as otherwise clippy gets annoyed if no vector intrinsics are available.
 
 pub type DiffusionMatrixKoalaBear =
-    DiffusionMatrixMontyField31<KoalaBearParameters, KoalaBearPoseidon2Utils>;
+    DiffusionMatrixMontyField31<KoalaBearParameters, KoalaBearDiffusionMatrixParameters>;
 
 #[derive(Debug, Clone, Default)]
-pub struct KoalaBearPoseidon2Utils;
+pub struct KoalaBearDiffusionMatrixParameters;
 
-impl Poseidon2Utils<KoalaBearParameters, 16> for KoalaBearPoseidon2Utils {
+impl DiffusionMatrixParameters<KoalaBearParameters, 16> for KoalaBearDiffusionMatrixParameters {
     type ArrayLike = [u8; 15];
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike =
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15];
@@ -55,7 +58,7 @@ impl Poseidon2Utils<KoalaBearParameters, 16> for KoalaBearPoseidon2Utils {
     ]);
 }
 
-impl Poseidon2Utils<KoalaBearParameters, 24> for KoalaBearPoseidon2Utils {
+impl DiffusionMatrixParameters<KoalaBearParameters, 24> for KoalaBearDiffusionMatrixParameters {
     type ArrayLike = [u8; 23];
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23,
@@ -89,7 +92,7 @@ impl Poseidon2Utils<KoalaBearParameters, 24> for KoalaBearPoseidon2Utils {
     ]);
 }
 
-impl Poseidon2Monty31<KoalaBearParameters> for KoalaBearPoseidon2Utils {}
+impl MultipleDiffusionMatrixParameters<KoalaBearParameters> for KoalaBearDiffusionMatrixParameters {}
 
 #[cfg(test)]
 mod tests {

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    DiffusionMatrixKoalaBear, KoalaBear, PackedKoalaBearAVX2, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedKoalaBearAVX2; 16]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearAVX2; 16]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearAVX2, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearAVX2, 16> for DiffusionMatrixKoalaBear {}
-
-impl Permutation<[PackedKoalaBearAVX2; 24]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearAVX2; 24]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearAVX2, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearAVX2, 24> for DiffusionMatrixKoalaBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,40 +1,3 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
-
-use crate::{
-    DiffusionMatrixKoalaBear, KoalaBear, PackedKoalaBearAVX512, MONTY_INVERSE,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-};
-
-// We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
-
-impl Permutation<[PackedKoalaBearAVX512; 16]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearAVX512; 16]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearAVX512, 16>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearAVX512, 16> for DiffusionMatrixKoalaBear {}
-
-impl Permutation<[PackedKoalaBearAVX512; 24]> for DiffusionMatrixKoalaBear {
-    fn permute_mut(&self, state: &mut [PackedKoalaBearAVX512; 24]) {
-        matmul_internal::<KoalaBear, PackedKoalaBearAVX512, 24>(
-            state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24_KOALABEAR_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MONTY_INVERSE);
-    }
-}
-
-impl DiffusionPermutation<PackedKoalaBearAVX512, 24> for DiffusionMatrixKoalaBear {}
-
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
@@ -57,7 +20,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 
@@ -82,7 +45,7 @@ mod tests {
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear,
+            DiffusionMatrixKoalaBear::default(),
             &mut rng,
         );
 

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -34,7 +34,7 @@ fn bench_bb_poseidon2(criterion: &mut Criterion) {
     type Perm = Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -189,7 +189,7 @@ mod tests {
     fn commit_single_1x8() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -226,7 +226,7 @@ mod tests {
     fn commit_single_2x2() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -252,7 +252,7 @@ mod tests {
     fn commit_single_2x3() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -286,7 +286,7 @@ mod tests {
     fn commit_mixed() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut thread_rng(),
         );
         let hash = MyHash::new(perm.clone());
@@ -351,7 +351,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -372,7 +372,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -394,7 +394,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -433,7 +433,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());
@@ -488,7 +488,7 @@ mod tests {
         let mut rng = thread_rng();
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear,
+            DiffusionMatrixBabyBear::default(),
             &mut rng,
         );
         let hash = MyHash::new(perm.clone());

--- a/monty-31/src/aarch64_neon/poseidon2.rs
+++ b/monty-31/src/aarch64_neon/poseidon2.rs
@@ -2,44 +2,31 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    DiffusionMatrixMontyField31, FieldParameters, MontyField31, PackedMontyField31Neon,
-    Poseidon2Monty31,
+    DiffusionMatrixMontyField31, DiffusionMatrixParameters, FieldParameters, MontyField31,
+    MultipleDiffusionMatrixParameters, PackedMontyField31Neon,
 };
 
 // We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31Neon<FP>; 16]>
-    for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[PackedMontyField31Neon<FP>; WIDTH]> for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [PackedMontyField31Neon<FP>; 16]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31Neon<FP>, 16>(
+    fn permute_mut(&self, state: &mut [PackedMontyField31Neon<FP>; WIDTH]) {
+        matmul_internal::<MontyField31<FP>, PackedMontyField31Neon<FP>, WIDTH>(
             state,
-            PU::INTERNAL_DIAG_MONTY,
+            MD::INTERNAL_DIAG_MONTY,
         );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
+        state.iter_mut().for_each(|i| *i *= MD::MONTY_INVERSE);
     }
 }
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31Neon<FP>, 16> for DiffusionMatrixMontyField31<FP, PU>
-{
-}
-
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31Neon<FP>; 24]>
-    for DiffusionMatrixMontyField31<FP, PU>
-{
-    fn permute_mut(&self, state: &mut [PackedMontyField31Neon<FP>; 24]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31Neon<FP>, 24>(
-            state,
-            PU::INTERNAL_DIAG_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
-    }
-}
-
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31Neon<FP>, 24> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<PackedMontyField31Neon<FP>, WIDTH> for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
 }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -45,7 +45,7 @@ impl<FP: FieldParameters> MontyField31<FP> {
 
     // This is `pub(crate)` for tests and delayed reduction strategies. If you're accessing `value` outside of those, you're
     // likely doing something fishy.
-    pub const fn new_monty(value: u32) -> Self {
+    pub(crate) const fn new_monty(value: u32) -> Self {
         Self {
             value,
             _phantom: PhantomData,

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -5,6 +5,8 @@ use p3_symmetric::Permutation;
 
 use crate::{monty_reduce, FieldParameters, MontyField31};
 
+/// Everything needed to compute the internal linear layers.
+/// INTERNAL_DIAG_MONTY is needed currently for Packed Field impls but can be removed long term.
 pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
     type ArrayLike: AsRef<[u8]> + Sized;
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike;
@@ -27,11 +29,12 @@ pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
     }
 }
 
-// Long term we could also do an implementation like the following:
-// Currently this doesn't work due to the orphan rule and the fact that we need to derive
-// Permutation<[_; 16]> for the various field packings. (AVX2, AVX512, NEON)
-// It's also a little ugly due to the need for 2 pieces of PhantomData.
+// Would be good to try and find a way to cut down on PhantomData.
 
+/// MONTY_INVERSE is needed for Packed Field impls.
+/// Will be removed once we have specialised code.
+/// Trait includes data which does not depend on the width of the Poseidon2 permutation.
+/// Long term will likely include some info about external rounds if we end up specialising them.
 pub trait Poseidon2Monty31<FP: FieldParameters>:
     Poseidon2Utils<FP, 16> + Poseidon2Utils<FP, 24> + Clone + Sync
 {

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -5,16 +5,20 @@ use p3_symmetric::Permutation;
 
 use crate::{monty_reduce, FieldParameters, MontyField31};
 
-/// Everything needed to compute the internal linear layers.
-/// INTERNAL_DIAG_MONTY is needed currently for Packed Field impls but can be removed long term.
-pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
+/// Everything needed to compute multiplication by a WIDTH x WIDTH diffusion matrix whose monty form is 1 + D(v).
+pub trait DiffusionMatrixParameters<FP: FieldParameters, const WIDTH: usize> {
+    // Most of the time, ArrayLike will be [u8; WIDTH - 1].
     type ArrayLike: AsRef<[u8]> + Sized;
+
+    // We assume that v[0] = -2 and all other values of v are small powers of 2.
+    // Thus we simply save the powers.
     const INTERNAL_DIAG_SHIFTS: Self::ArrayLike;
 
     // Long term INTERNAL_DIAG_MONTY will be removed.
     // Currently we need it for the naive Packed field implementations.
     const INTERNAL_DIAG_MONTY: [MontyField31<FP>; WIDTH];
 
+    // Implements multiplication by the diffusion matrix 1 + D(v) using a delayed reduction strategy.
     fn permute_state(state: &mut [MontyField31<FP>; WIDTH]) {
         let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
         let full_sum = part_sum + (state[0].value as u64);
@@ -29,38 +33,43 @@ pub trait Poseidon2Utils<FP: FieldParameters, const WIDTH: usize> {
     }
 }
 
-// Would be good to try and find a way to cut down on PhantomData.
-
-/// MONTY_INVERSE is needed for Packed Field impls.
-/// Will be removed once we have specialised code.
-/// Trait includes data which does not depend on the width of the Poseidon2 permutation.
-/// Long term will likely include some info about external rounds if we end up specialising them.
-pub trait Poseidon2Monty31<FP: FieldParameters>:
-    Poseidon2Utils<FP, 16> + Poseidon2Utils<FP, 24> + Clone + Sync
+/// For a given field, we need to implement DiffusionMatrixParameters for several different WIDTHS.
+/// Some code can be shared between the different sizes.
+pub trait MultipleDiffusionMatrixParameters<FP: FieldParameters>:
+    DiffusionMatrixParameters<FP, 16> + DiffusionMatrixParameters<FP, 24> + Clone + Sync
 {
+    // This is currently needed for Packed Field impls.
+    // It can/will be removed once we have vectorized implementations.
     const MONTY_INVERSE: MontyField31<FP> = MontyField31::<FP>::new_monty(1);
 }
 
+// Would be good to try and find a way to cut down on PhantomData.
 #[derive(Debug, Clone, Default)]
-pub struct DiffusionMatrixMontyField31<FP: FieldParameters, PU: Poseidon2Monty31<FP>> {
+pub struct DiffusionMatrixMontyField31<FP, MP>
+where
+    FP: FieldParameters,
+    MP: MultipleDiffusionMatrixParameters<FP>,
+{
     _phantom1: PhantomData<FP>,
-    _phantom2: PhantomData<PU>,
+    _phantom2: PhantomData<MP>,
 }
 
-impl<FP: FieldParameters, const WIDTH: usize, PU: Poseidon2Monty31<FP>>
-    Permutation<[MontyField31<FP>; WIDTH]> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP, const WIDTH: usize, MP: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[MontyField31<FP>; WIDTH]> for DiffusionMatrixMontyField31<FP, MP>
 where
-    PU: Poseidon2Utils<FP, WIDTH>,
+    FP: FieldParameters,
+    MP: DiffusionMatrixParameters<FP, WIDTH>,
 {
     #[inline]
     fn permute_mut(&self, state: &mut [MontyField31<FP>; WIDTH]) {
-        PU::permute_state(state);
+        MP::permute_state(state);
     }
 }
 
-impl<FP: FieldParameters, const WIDTH: usize, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<MontyField31<FP>, WIDTH> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP, const WIDTH: usize, MP: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<MontyField31<FP>, WIDTH> for DiffusionMatrixMontyField31<FP, MP>
 where
-    PU: Poseidon2Utils<FP, WIDTH>,
+    FP: FieldParameters,
+    MP: DiffusionMatrixParameters<FP, WIDTH>,
 {
 }

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -2,19 +2,21 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    DiffusionMatrixMontyField31, FieldParameters, MontyField31, MultipleDiffusionMatrixParameters,
-    PackedMontyField31AVX2,
+    DiffusionMatrixMontyField31, DiffusionMatrixParameters, FieldParameters, MontyField31,
+    MultipleDiffusionMatrixParameters, PackedMontyField31AVX2,
 };
 
 // We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
-    Permutation<[PackedMontyField31AVX2<FP>; 16]> for DiffusionMatrixMontyField31<FP, MD>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[PackedMontyField31AVX2<FP>; WIDTH]> for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [PackedMontyField31AVX2<FP>; 16]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX2<FP>, 16>(
+    fn permute_mut(&self, state: &mut [PackedMontyField31AVX2<FP>; WIDTH]) {
+        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX2<FP>, WIDTH>(
             state,
             MD::INTERNAL_DIAG_MONTY,
         );
@@ -22,24 +24,9 @@ impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
     }
 }
 
-impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
-    DiffusionPermutation<PackedMontyField31AVX2<FP>, 16> for DiffusionMatrixMontyField31<FP, MD>
-{
-}
-
-impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
-    Permutation<[PackedMontyField31AVX2<FP>; 24]> for DiffusionMatrixMontyField31<FP, MD>
-{
-    fn permute_mut(&self, state: &mut [PackedMontyField31AVX2<FP>; 24]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX2<FP>, 24>(
-            state,
-            MD::INTERNAL_DIAG_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MD::MONTY_INVERSE);
-    }
-}
-
-impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
-    DiffusionPermutation<PackedMontyField31AVX2<FP>, 24> for DiffusionMatrixMontyField31<FP, MD>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<PackedMontyField31AVX2<FP>, WIDTH> for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
 }

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -2,44 +2,44 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    DiffusionMatrixMontyField31, FieldParameters, MontyField31, PackedMontyField31AVX2,
-    Poseidon2Monty31,
+    DiffusionMatrixMontyField31, FieldParameters, MontyField31, MultipleDiffusionMatrixParameters,
+    PackedMontyField31AVX2,
 };
 
 // We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31AVX2<FP>; 16]>
-    for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[PackedMontyField31AVX2<FP>; 16]> for DiffusionMatrixMontyField31<FP, MD>
 {
     fn permute_mut(&self, state: &mut [PackedMontyField31AVX2<FP>; 16]) {
         matmul_internal::<MontyField31<FP>, PackedMontyField31AVX2<FP>, 16>(
             state,
-            PU::INTERNAL_DIAG_MONTY,
+            MD::INTERNAL_DIAG_MONTY,
         );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
+        state.iter_mut().for_each(|i| *i *= MD::MONTY_INVERSE);
     }
 }
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31AVX2<FP>, 16> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<PackedMontyField31AVX2<FP>, 16> for DiffusionMatrixMontyField31<FP, MD>
 {
 }
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31AVX2<FP>; 24]>
-    for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[PackedMontyField31AVX2<FP>; 24]> for DiffusionMatrixMontyField31<FP, MD>
 {
     fn permute_mut(&self, state: &mut [PackedMontyField31AVX2<FP>; 24]) {
         matmul_internal::<MontyField31<FP>, PackedMontyField31AVX2<FP>, 24>(
             state,
-            PU::INTERNAL_DIAG_MONTY,
+            MD::INTERNAL_DIAG_MONTY,
         );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
+        state.iter_mut().for_each(|i| *i *= MD::MONTY_INVERSE);
     }
 }
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31AVX2<FP>, 24> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, MD: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<PackedMontyField31AVX2<FP>, 24> for DiffusionMatrixMontyField31<FP, MD>
 {
 }

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -2,44 +2,32 @@ use p3_poseidon2::{matmul_internal, DiffusionPermutation};
 use p3_symmetric::Permutation;
 
 use crate::{
-    DiffusionMatrixMontyField31, FieldParameters, MontyField31, PackedMontyField31AVX512,
-    Poseidon2Monty31,
+    DiffusionMatrixMontyField31, DiffusionMatrixParameters, FieldParameters, MontyField31,
+    MultipleDiffusionMatrixParameters, PackedMontyField31AVX512,
 };
 
 // We need to change from the standard implementation as we are interpreting the matrix (1 + D(v)) as the monty form of the matrix not the raw form.
 // matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
 // These will be removed once we have architecture specific implementations.
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31AVX512<FP>; 16]>
-    for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    Permutation<[PackedMontyField31AVX512<FP>; WIDTH]> for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [PackedMontyField31AVX512<FP>; 16]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX512<FP>, 16>(
+    fn permute_mut(&self, state: &mut [PackedMontyField31AVX512<FP>; WIDTH]) {
+        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX512<FP>, WIDTH>(
             state,
-            PU::INTERNAL_DIAG_MONTY,
+            MD::INTERNAL_DIAG_MONTY,
         );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
+        state.iter_mut().for_each(|i| *i *= MD::MONTY_INVERSE);
     }
 }
 
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31AVX512<FP>, 16> for DiffusionMatrixMontyField31<FP, PU>
-{
-}
-
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>> Permutation<[PackedMontyField31AVX512<FP>; 24]>
-    for DiffusionMatrixMontyField31<FP, PU>
-{
-    fn permute_mut(&self, state: &mut [PackedMontyField31AVX512<FP>; 24]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX512<FP>, 24>(
-            state,
-            PU::INTERNAL_DIAG_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= PU::MONTY_INVERSE);
-    }
-}
-
-impl<FP: FieldParameters, PU: Poseidon2Monty31<FP>>
-    DiffusionPermutation<PackedMontyField31AVX512<FP>, 24> for DiffusionMatrixMontyField31<FP, PU>
+impl<FP: FieldParameters, const WIDTH: usize, MD: MultipleDiffusionMatrixParameters<FP>>
+    DiffusionPermutation<PackedMontyField31AVX512<FP>, WIDTH>
+    for DiffusionMatrixMontyField31<FP, MD>
+where
+    MD: DiffusionMatrixParameters<FP, WIDTH>,
 {
 }

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -118,7 +118,7 @@ type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 fn test_public_value() {
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
     let hash = MyHash::new(perm.clone());
@@ -152,7 +152,7 @@ fn test_public_value() {
 fn test_incorrect_public_value() {
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
     let hash = MyHash::new(perm.clone());

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -153,7 +153,7 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), VerificationError
     type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
 
@@ -206,7 +206,7 @@ fn do_test_bb_twoadic(
     type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixBabyBear,
+        DiffusionMatrixBabyBear::default(),
         &mut thread_rng(),
     );
 


### PR DESCRIPTION
Possible Poseidon2 refactor for Monty31 fields.

It's not 100% clear to me if this is the right approach but this cuts down the amount of code so might be worthwhile.

The main downsides are that it involves a couple of pieces of PhantomData and some rather awkwardly names traits. The upside is that it moves the vast majority of the Poseidon2 field specific code into the Monty-31 crate and lets us make the "new_monty" function pub(crate) instead of pub.