### PR TITLE
Observe the final polynomial in FRI

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use itertools::{izip, Itertools};
-use p3_challenger::{CanObserve, CanSample, GrindingChallenger};
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace};
 use p3_field::extension::{Complex, ComplexExtendable};
 use p3_field::{ExtensionField, Field};
@@ -86,7 +86,7 @@ where
     Challenge: ExtensionField<Val>,
     InputMmcs: Mmcs<Val>,
     FriMmcs: Mmcs<Challenge>,
-    Challenger: CanSample<Challenge> + GrindingChallenger + CanObserve<FriMmcs::Commitment>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<FriMmcs::Commitment>,
 {
     type Domain = CircleDomain<Val>;
     type Commitment = InputMmcs::Commitment;
@@ -155,7 +155,7 @@ where
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample();
+        let alpha: Challenge = challenger.sample_ext_element();
 
         /*
         We are reducing columns ("ro" = reduced opening) with powers of alpha:
@@ -267,7 +267,7 @@ where
         let (first_layer_commitment, first_layer_data) =
             self.fri_config.mmcs.commit(first_layer_mats);
         challenger.observe(first_layer_commitment.clone());
-        let bivariate_beta: Challenge = challenger.sample();
+        let bivariate_beta: Challenge = challenger.sample_ext_element();
 
         // Fold all first layers at bivariate_beta.
 
@@ -354,9 +354,9 @@ where
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample();
+        let alpha: Challenge = challenger.sample_ext_element();
         challenger.observe(proof.first_layer_commitment.clone());
-        let bivariate_beta: Challenge = challenger.sample();
+        let bivariate_beta: Challenge = challenger.sample_ext_element();
 
         // +1 to account for first layer
         let log_global_max_height =

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use itertools::{izip, Itertools};
-use p3_challenger::{CanObserve, CanSample, GrindingChallenger};
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{
@@ -138,7 +138,7 @@ where
     FriMmcs: Mmcs<Challenge>,
     Challenge: TwoAdicField + ExtensionField<Val>,
     Challenger:
-        CanObserve<FriMmcs::Commitment> + CanSample<Challenge> + GrindingChallenger<Witness = Val>,
+        FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
@@ -238,7 +238,7 @@ where
         */
 
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample();
+        let alpha: Challenge = challenger.sample_ext_element();
 
         let mats_and_points = rounds
             .iter()
@@ -361,7 +361,7 @@ where
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample();
+        let alpha: Challenge = challenger.sample_ext_element();
 
         let log_global_max_height = proof.commit_phase_commits.len() + self.fri.log_blowup;
 


### PR DESCRIPTION
There are some challenger related complications here, since the `SerializingChallenger`s don't impl `CanObserve` for extension fields, and doing so creates a theoretical conflict with `Hash`.

The workaround I'm proposing here is to bring back `FieldChallenger` and use its extension field methods. The downside is that the core FRI code now needs to know about the base field `Val`, so we can work with `FieldChallenger<Val>`.