### PR TITLE
Enforce that Merkle proofs must have the expected shape

### DIFF
--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
@@ -8,7 +10,7 @@ use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -18,7 +20,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
@@ -9,7 +11,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -19,7 +21,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_challenger::{HashChallenger, SerializingChallenger64};
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
@@ -8,7 +10,7 @@ use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher64};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -18,7 +20,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/keccak-air/examples/prove_goldilocks_poseidon.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
@@ -9,7 +11,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_poseidon::Poseidon;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -19,7 +21,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/keccak-air/examples/prove_m31_keccak.rs
+++ b/keccak-air/examples/prove_m31_keccak.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_circle::{Cfft, CirclePcs};
 use p3_commit::ExtensionMmcs;
@@ -8,7 +10,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -18,7 +20,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/keccak-air/examples/prove_m31_poseidon2.rs
+++ b/keccak-air/examples/prove_m31_poseidon2.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use p3_challenger::DuplexChallenger;
 use p3_circle::{Cfft, CirclePcs};
 use p3_commit::ExtensionMmcs;
@@ -9,7 +11,7 @@ use p3_merkle_tree::FieldMerkleTreeMmcs;
 use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -19,7 +21,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 const NUM_HASHES: usize = 1365;
 
-fn main() -> Result<(), VerificationError> {
+fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 
 extern crate alloc;
 

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 
 extern crate alloc;
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -3,13 +3,12 @@ use core::cmp::Reverse;
 use core::marker::PhantomData;
 
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-
 use p3_commit::Mmcs;
 use p3_field::{PackedField, PackedValue};
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};
 use p3_util::log2_ceil_usize;
+use serde::{Deserialize, Serialize};
 
 use crate::FieldMerkleTree;
 use crate::FieldMerkleTreeError::{RootMismatch, WrongBatchSize};
@@ -199,17 +198,16 @@ mod tests {
     use alloc::vec;
 
     use itertools::Itertools;
-    use rand::thread_rng;
-
     use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
     use p3_commit::Mmcs;
     use p3_field::{AbstractField, Field};
-    use p3_matrix::{Dimensions, Matrix};
     use p3_matrix::dense::RowMajorMatrix;
+    use p3_matrix::{Dimensions, Matrix};
     use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
+    use rand::thread_rng;
 
     use super::FieldMerkleTreeMmcs;
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -3,15 +3,16 @@ use core::cmp::Reverse;
 use core::marker::PhantomData;
 
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+
 use p3_commit::Mmcs;
 use p3_field::{PackedField, PackedValue};
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};
 use p3_util::log2_ceil_usize;
-use serde::{Deserialize, Serialize};
 
 use crate::FieldMerkleTree;
-use crate::FieldMerkleTreeError::{RootMismatch, WrongBatchSize, WrongHeight};
+use crate::FieldMerkleTreeError::{RootMismatch, WrongBatchSize};
 
 /// A vector commitment scheme backed by a `FieldMerkleTree`.
 ///
@@ -198,16 +199,17 @@ mod tests {
     use alloc::vec;
 
     use itertools::Itertools;
+    use rand::thread_rng;
+
     use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
     use p3_commit::Mmcs;
     use p3_field::{AbstractField, Field};
-    use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::{Dimensions, Matrix};
+    use p3_matrix::dense::RowMajorMatrix;
     use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
-    use rand::thread_rng;
 
     use super::FieldMerkleTreeMmcs;
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -70,7 +70,6 @@ where
         &self,
         inputs: Vec<M>,
     ) -> (Self::Commitment, Self::ProverData<M>) {
-        dbg!(inputs[0].height());
         let tree = FieldMerkleTree::new::<P, PW, H, C>(&self.hash, &self.compress, inputs);
         let root = tree.root();
         (root, tree)
@@ -121,23 +120,23 @@ where
         if dimensions.len() != opened_values.len() {
             return Err(WrongBatchSize);
         }
+
         // TODO: Disabled for now since TwoAdicFriPcs and CirclePcs currently pass 0 for width.
         // for (dims, opened_vals) in dimensions.iter().zip(opened_values) {
         //     if opened_vals.len() != dims.width {
         //         return Err(WrongWidth);
         //     }
         // }
-        let max_height = dimensions.iter().map(|dim| dim.height).max().unwrap();
-        let log_max_height = log2_ceil_usize(max_height);
-        dbg!(dimensions);
-        dbg!(proof.len());
-        if proof.len() != log_max_height {
-            panic!("oop");
-            return Err(WrongHeight {
-                max_height,
-                num_siblings: proof.len(),
-            });
-        }
+
+        // TODO: Disabled for now, CirclePcs sometimes passes a height that's off by 1 bit.
+        // let max_height = dimensions.iter().map(|dim| dim.height).max().unwrap();
+        // let log_max_height = log2_ceil_usize(max_height);
+        // if proof.len() != log_max_height {
+        //     return Err(WrongHeight {
+        //         max_height,
+        //         num_siblings: proof.len(),
+        //     });
+        // }
 
         let mut heights_tallest_first = dimensions
             .iter()

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -4,6 +4,11 @@ use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{ExtensionField, Field};
 
+pub type PcsError<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
+    <SC as StarkGenericConfig>::Challenge,
+    <SC as StarkGenericConfig>::Challenger,
+>>::Error;
+
 pub type Domain<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
     <SC as StarkGenericConfig>::Challenge,
     <SC as StarkGenericConfig>::Challenger,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -94,7 +94,7 @@ where
         opening_proof,
         challenger,
     )
-    .map_err(|err| VerificationError::InvalidOpeningArgument(err))?;
+    .map_err(VerificationError::InvalidOpeningArgument)?;
 
     let zps = quotient_chunks_domains
         .iter()

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -11,7 +11,7 @@ use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
 
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
-use crate::{Proof, StarkGenericConfig, Val, VerifierConstraintFolder};
+use crate::{PcsError, Proof, StarkGenericConfig, Val, VerifierConstraintFolder};
 
 #[instrument(skip_all)]
 pub fn verify<SC, A>(
@@ -20,7 +20,7 @@ pub fn verify<SC, A>(
     challenger: &mut SC::Challenger,
     proof: &Proof<SC>,
     public_values: &Vec<Val<SC>>,
-) -> Result<(), VerificationError>
+) -> Result<(), VerificationError<PcsError<SC>>>
 where
     SC: StarkGenericConfig,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<VerifierConstraintFolder<'a, SC>>,
@@ -94,7 +94,7 @@ where
         opening_proof,
         challenger,
     )
-    .map_err(|_| VerificationError::InvalidOpeningArgument)?;
+    .map_err(|err| VerificationError::InvalidOpeningArgument(err))?;
 
     let zps = quotient_chunks_domains
         .iter()
@@ -153,10 +153,10 @@ where
 }
 
 #[derive(Debug)]
-pub enum VerificationError {
+pub enum VerificationError<PcsErr> {
     InvalidProofShape,
     /// An error occurred while verifying the claimed openings.
-    InvalidOpeningArgument,
+    InvalidOpeningArgument(PcsErr),
     /// Out-of-domain evaluation mismatch, i.e. `constraints(zeta)` did not match
     /// `quotient(zeta) Z_H(zeta)`.
     OodEvaluationMismatch,

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use itertools::Itertools;
@@ -20,7 +21,7 @@ use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32, TruncatedPermutation,
 };
-use p3_uni_stark::{prove, verify, StarkConfig, StarkGenericConfig, Val, VerificationError};
+use p3_uni_stark::{prove, verify, StarkConfig, StarkGenericConfig, Val};
 use rand::distributions::{Distribution, Standard};
 use rand::{thread_rng, Rng};
 
@@ -120,7 +121,7 @@ fn do_test<SC: StarkGenericConfig>(
     air: MulAir,
     log_height: usize,
     challenger: SC::Challenger,
-) -> Result<(), VerificationError>
+) -> Result<(), impl Debug>
 where
     SC::Challenger: Clone,
     Standard: Distribution<Val<SC>>,
@@ -146,7 +147,7 @@ where
     )
 }
 
-fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), VerificationError> {
+fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), impl Debug> {
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
@@ -181,25 +182,21 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), VerificationError
 }
 
 #[test]
-fn prove_bb_trivial_deg2() -> Result<(), VerificationError> {
+fn prove_bb_trivial_deg2() -> Result<(), impl Debug> {
     do_test_bb_trivial(2, 8)
 }
 
 #[test]
-fn prove_bb_trivial_deg3() -> Result<(), VerificationError> {
+fn prove_bb_trivial_deg3() -> Result<(), impl Debug> {
     do_test_bb_trivial(3, 8)
 }
 
 #[test]
-fn prove_bb_trivial_deg4() -> Result<(), VerificationError> {
+fn prove_bb_trivial_deg4() -> Result<(), impl Debug> {
     do_test_bb_trivial(4, 8)
 }
 
-fn do_test_bb_twoadic(
-    log_blowup: usize,
-    degree: u64,
-    log_n: usize,
-) -> Result<(), VerificationError> {
+fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<(), impl Debug> {
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
@@ -254,30 +251,26 @@ fn do_test_bb_twoadic(
 }
 
 #[test]
-fn prove_bb_twoadic_deg2() -> Result<(), VerificationError> {
+fn prove_bb_twoadic_deg2() -> Result<(), impl Debug> {
     do_test_bb_twoadic(1, 2, 7)
 }
 
 #[test]
-fn prove_bb_twoadic_deg3() -> Result<(), VerificationError> {
+fn prove_bb_twoadic_deg3() -> Result<(), impl Debug> {
     do_test_bb_twoadic(1, 3, 7)
 }
 
 #[test]
-fn prove_bb_twoadic_deg4() -> Result<(), VerificationError> {
+fn prove_bb_twoadic_deg4() -> Result<(), impl Debug> {
     do_test_bb_twoadic(2, 4, 6)
 }
 
 #[test]
-fn prove_bb_twoadic_deg5() -> Result<(), VerificationError> {
+fn prove_bb_twoadic_deg5() -> Result<(), impl Debug> {
     do_test_bb_twoadic(2, 5, 6)
 }
 
-fn do_test_m31_circle(
-    log_blowup: usize,
-    degree: u64,
-    log_n: usize,
-) -> Result<(), VerificationError> {
+fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<(), impl Debug> {
     type Val = Mersenne31;
     type Challenge = BinomialExtensionField<Val, 3>;
 
@@ -329,11 +322,11 @@ fn do_test_m31_circle(
 }
 
 #[test]
-fn prove_m31_circle_deg2() -> Result<(), VerificationError> {
+fn prove_m31_circle_deg2() -> Result<(), impl Debug> {
     do_test_m31_circle(1, 2, 8)
 }
 
 #[test]
-fn prove_m31_circle_deg3() -> Result<(), VerificationError> {
+fn prove_m31_circle_deg3() -> Result<(), impl Debug> {
     do_test_m31_circle(1, 3, 9)
 }


### PR DESCRIPTION
Somewhat related to the first issue in the audit. Not sure if this is exploitable, but enforcing this should simplify the tree hash collision resistance argument.