### PR TITLE
[matrix] Add useful row iterator methods to DenseMatrix

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -176,9 +176,9 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         &self,
         chunk_rows: usize,
     ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<T>>
-        where
-            T: Send,
-            S: BorrowMut<[T]>,
+    where
+        T: Send,
+        S: BorrowMut<[T]>,
     {
         self.values
             .borrow()
@@ -190,9 +190,9 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         &self,
         chunk_rows: usize,
     ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<T>>
-        where
-            T: Send,
-            S: BorrowMut<[T]>,
+    where
+        T: Send,
+        S: BorrowMut<[T]>,
     {
         self.values
             .borrow()

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -178,7 +178,6 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
     ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<T>>
     where
         T: Send,
-        S: BorrowMut<[T]>,
     {
         self.values
             .borrow()
@@ -192,7 +191,6 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
     ) -> impl IndexedParallelIterator<Item = RowMajorMatrixView<T>>
     where
         T: Send,
-        S: BorrowMut<[T]>,
     {
         self.values
             .borrow()


### PR DESCRIPTION
`row_slices` is a non-parallel version of `par_row_slices`. Also non-mut analogues of `par_row_chunks_mut` and `par_row_chunks_exact_mut`.