### PR TITLE
chore: use `halo2curves` for BN254 `Fr` and implement `TwoAdicField`

### DIFF
--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -13,11 +13,7 @@ ff = { version = "0.13", features = ["derive", "derive_bits"] }
 num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-halo2curves = { version = "0.6.1", features = [
-    "bits",
-    "bn256-table",
-    "derive_serde",
-] }
+halo2curves = { version = "0.6.1", features = ["bits", "derive_serde"] }
 
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }
@@ -29,6 +25,9 @@ zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
 
 [features]
 default = []
+table = [
+    "halo2curves/bn256-table",
+] # Generate cached table of [0, 2^16) in Bn254Fr at compile time
 asm = ["halo2curves/asm"]
 
 [[bench]]

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -13,6 +13,11 @@ ff = { version = "0.13", features = ["derive", "derive_bits"] }
 num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+halo2curves = { version = "0.6.1", features = [
+    "bits",
+    "bn256-table",
+    "derive_serde",
+] }
 
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }
@@ -21,6 +26,10 @@ criterion = "0.5.1"
 num-traits = "0.2.16"
 serde_json = "1.0.113"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
+
+[features]
+default = []
+asm = ["halo2curves/asm"]
 
 [[bench]]
 name = "bench_field"

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -9,10 +9,10 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use ff::{Field as FFField, PrimeField as FFPrimeField};
-use halo2curves::bn256::Fr as FFBn254Fr;
+pub use halo2curves::bn256::Fr as FFBn254Fr;
 use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
-use p3_field::{AbstractField, Field, Packable, PrimeField};
+use p3_field::{AbstractField, Field, Packable, PrimeField, TwoAdicField};
 pub use poseidon2::DiffusionMatrixBN254;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -266,6 +266,18 @@ impl Distribution<Bn254Fr> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Bn254Fr {
         Bn254Fr::new(FFBn254Fr::random(rng))
+    }
+}
+
+impl TwoAdicField for Bn254Fr {
+    const TWO_ADICITY: usize = FFBn254Fr::S as usize;
+
+    fn two_adic_generator(bits: usize) -> Self {
+        let mut omega = FFBn254Fr::ROOT_OF_UNITY;
+        for _ in bits..Self::TWO_ADICITY {
+            omega = omega.square();
+        }
+        Self::new(omega)
     }
 }
 

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -8,7 +8,7 @@ use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use ff::{Field as FFField, PrimeField as FFPrimeField, PrimeFieldBits};
+use ff::{Field as FFField, PrimeField as FFPrimeField};
 use halo2curves::bn256::Fr as FFBn254Fr;
 use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
@@ -43,13 +43,9 @@ impl<'de> Deserialize<'de> for Bn254Fr {
 
         let value = FFBn254Fr::from_raw_bytes(&bytes);
 
-        if value.is_some().into() {
-            Ok(Self {
-                value: value.unwrap(),
-            })
-        } else {
-            Err(serde::de::Error::custom("Invalid field element"))
-        }
+        value
+            .map(Self::new)
+            .ok_or(serde::de::Error::custom("Invalid field element"))
     }
 }
 

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -31,6 +31,8 @@ impl Bn254Fr {
 }
 
 impl Serialize for Bn254Fr {
+    /// Serializes to raw bytes, which are typically of the Montgomery representation of the field element.
+    // See https://github.com/privacy-scaling-explorations/halo2curves/blob/d34e9e46f7daacd194739455de3b356ca6c03206/derive/src/field/mod.rs#L493
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let bytes = self.value.to_raw_bytes();
         serializer.serialize_bytes(&bytes)
@@ -38,6 +40,10 @@ impl Serialize for Bn254Fr {
 }
 
 impl<'de> Deserialize<'de> for Bn254Fr {
+    /// Deserializes from raw bytes, which are typically of the Montgomery representation of the field element.
+    /// Performs a check that the deserialized field element corresponds to a value less than the field modulus, and
+    /// returns error otherwise.
+    // See https://github.com/privacy-scaling-explorations/halo2curves/blob/d34e9e46f7daacd194739455de3b356ca6c03206/derive/src/field/mod.rs#L485
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let bytes: Vec<u8> = Deserialize::deserialize(d)?;
 

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -45,7 +45,7 @@ mod tests {
 
         let mut res = <FFBn254Fr as PrimeField>::Repr::default();
 
-        for (i, digit) in res.0.as_mut().iter_mut().enumerate() {
+        for (i, digit) in res.as_mut().iter_mut().enumerate() {
             *digit = bytes[i];
         }
 

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -20,6 +20,7 @@ p3-commit = { path = "../commit" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }
+p3-blake3 = { path = "../blake3" }
 p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-merkle-tree = { path = "../merkle-tree" }

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -68,8 +68,8 @@ fn main() -> Result<(), impl Debug> {
     let trace = generate_trace_rows::<Val>(inputs);
 
     let fri_config = FriConfig {
-        log_blowup: 1,
-        num_queries: 100,
+        log_blowup: 3,
+        num_queries: 33,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -68,8 +68,8 @@ fn main() -> Result<(), impl Debug> {
     let trace = generate_trace_rows::<Val>(inputs);
 
     let fri_config = FriConfig {
-        log_blowup: 3,
-        num_queries: 33,
+        log_blowup: 1,
+        num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -14,10 +14,7 @@ pub type Domain<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
     <SC as StarkGenericConfig>::Challenger,
 >>::Domain;
 
-pub type Val<SC> = <<<SC as StarkGenericConfig>::Pcs as Pcs<
-    <SC as StarkGenericConfig>::Challenge,
-    <SC as StarkGenericConfig>::Challenger,
->>::Domain as PolynomialSpace>::Val;
+pub type Val<SC> = <Domain<SC> as PolynomialSpace>::Val;
 
 pub type PackedVal<SC> = <Val<SC> as Field>::Packing;
 


### PR DESCRIPTION
Switches the `Bn254Fr` field to internally use the [halo2curves](https://crates.io/crates/halo2curves) implementation of `Fr`, which still implements the `ff` trait but has more optimized [implementations](https://github.com/privacy-scaling-explorations/halo2curves/blob/main/derive/src/field/arith.rs) of field arithmetic, which I believe are now fairly mature and well-used. There is also a feature "asm" for x86 assembly optimized implementations of field arithmetic.

Also implements `TwoAdicField` for `Bn254Fr` so it can be used as the `Val` (base field) for uni-stark if desired.

A note on serialization:
- I assume that plonky3 prefers serializations that are more optimized for speed, so I switched the serialization to serialize the raw internal bytes format of the field elements, which is `[u8;32]` in **Montgomery form**. This skips doing Montgomery reduction when serializing. If human-readable form is preferred, it can be switched back.
- When de-serializing, a safety check that the deserialized value is less than the prime modulus is done. This could be removed if performance is more important.