### PR TITLE
feat: add `CryptographicHasher` implementation for SHA2-256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "poseidon",
     "poseidon2",
     "rescue",
+    "sha256",
     "symmetric",
     "util",
     "uni-stark",

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -25,8 +25,9 @@ p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
-p3-poseidon = {path = "../poseidon"}
+p3-poseidon = { path = "../poseidon" }
 p3-poseidon2 = { path = "../poseidon2" }
+p3-sha256 = { path = "../sha256", features = ["asm"] }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }
 rand = "0.8.5"

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -1,0 +1,75 @@
+use std::fmt::Debug;
+
+use p3_baby_bear::BabyBear;
+use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_sha256::Sha256;
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::random;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 1365;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+
+    type ByteHash = Sha256;
+    type FieldHash = SerializingHasher32<ByteHash>;
+    let byte_hash = ByteHash {};
+    let field_hash = FieldHash::new(Sha256);
+
+    type MyCompress = CompressionFunctionFromHasher<u8, ByteHash, 2, 32>;
+    let compress = MyCompress::new(byte_hash);
+
+    type ValMmcs = FieldMerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
+    let val_mmcs = ValMmcs::new(field_hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Dft = Radix2DitParallel;
+    let dft = Dft {};
+
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+}

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -1,0 +1,75 @@
+use std::fmt::Debug;
+
+use p3_challenger::{HashChallenger, SerializingChallenger64};
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_goldilocks::Goldilocks;
+use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_sha256::Sha256;
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher64};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::random;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 1365;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Goldilocks;
+    type Challenge = BinomialExtensionField<Val, 2>;
+
+    type ByteHash = Sha256;
+    type FieldHash = SerializingHasher64<ByteHash>;
+    let byte_hash = ByteHash {};
+    let field_hash = FieldHash::new(byte_hash);
+
+    type MyCompress = CompressionFunctionFromHasher<u8, ByteHash, 2, 32>;
+    let compress = MyCompress::new(byte_hash);
+
+    type ValMmcs = FieldMerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
+    let val_mmcs = ValMmcs::new(field_hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Dft = Radix2DitParallel;
+    let dft = Dft {};
+
+    type Challenger = SerializingChallenger64<Val, HashChallenger<u8, ByteHash, 32>>;
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+}

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -1,0 +1,78 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_circle::CirclePcs;
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::FriConfig;
+use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_mersenne_31::Mersenne31;
+use p3_sha256::Sha256;
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::random;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 1365;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
+
+    type ByteHash = Sha256;
+    type FieldHash = SerializingHasher32<ByteHash>;
+    let byte_hash = ByteHash {};
+    let field_hash = FieldHash::new(Sha256);
+
+    type MyCompress = CompressionFunctionFromHasher<u8, ByteHash, 2, 32>;
+    let compress = MyCompress::new(byte_hash);
+
+    type ValMmcs = FieldMerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
+    let val_mmcs = ValMmcs::new(field_hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_config,
+        _phantom: PhantomData,
+    };
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+}

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "p3-sha256"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Plonky3 hash trait implementations for the SHA2-256 hash function."
+
+[dependencies]
+p3-symmetric = { path = "../symmetric" }
+sha2 = { version = "0.10.8", default-features = false }
+
+[features]
+default = []
+asm = [
+    "sha2/asm",
+] # Enable either x86 or aarch assembly implementation based on target.
+force-soft = [
+    "sha2/force-soft",
+] # Force software implementation (default if "asm" feature is not enabled).
+
+[dev-dependencies]
+hex-literal = "0.4.1"

--- a/sha256/src/lib.rs
+++ b/sha256/src/lib.rs
@@ -1,0 +1,56 @@
+//! The SHA2-256 hash function.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use p3_symmetric::CryptographicHasher;
+use sha2::Digest;
+
+/// The SHA2-256 hash function.
+#[derive(Copy, Clone, Debug)]
+pub struct Sha256;
+
+impl CryptographicHasher<u8, [u8; 32]> for Sha256 {
+    fn hash_iter<I>(&self, input: I) -> [u8; 32]
+    where
+        I: IntoIterator<Item = u8>,
+    {
+        let input = input.into_iter().collect::<Vec<_>>();
+        self.hash_iter_slices([input.as_slice()])
+    }
+
+    fn hash_iter_slices<'a, I>(&self, input: I) -> [u8; 32]
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+    {
+        let mut hasher = sha2::Sha256::new();
+        for chunk in input.into_iter() {
+            hasher.update(chunk);
+        }
+        hasher.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use p3_symmetric::CryptographicHasher;
+
+    use crate::Sha256;
+
+    #[test]
+    fn test_hello_world() {
+        let input = b"hello world";
+        let expected = hex!(
+            "
+            b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+        "
+        );
+
+        let sha256 = Sha256;
+        assert_eq!(sha256.hash_iter(input.to_vec())[..], expected[..]);
+    }
+}


### PR DESCRIPTION
Adds `CryptographicHasher` implementation for SHA2-256 in a separate `sha256` crate, essentially parallel to the `blake3` crate. I don't think it's possible to implement `CryptographicPermutation` since the internals of the hash are not exposed in the `sha2` crate.

I added some more examples to the `keccak-air` crate using this hasher as `ByteHash`.