### PR TITLE
feat: SHA-256 pseudo-compression 2-to-1 function

### DIFF
--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -8,8 +8,8 @@ use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_sha256::Sha256;
-use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
+use p3_sha256::{Sha256, Sha256Compress};
+use p3_symmetric::SerializingHasher32;
 use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
@@ -36,16 +36,16 @@ fn main() -> Result<(), impl Debug> {
     type ByteHash = Sha256;
     type FieldHash = SerializingHasher32<ByteHash>;
     let byte_hash = ByteHash {};
-    let field_hash = FieldHash::new(Sha256);
+    let field_hash = FieldHash::new(byte_hash);
 
-    type MyCompress = CompressionFunctionFromHasher<u8, ByteHash, 2, 32>;
-    let compress = MyCompress::new(byte_hash);
+    type MyCompress = Sha256Compress;
+    let compress = MyCompress {};
 
     type ValMmcs = FieldMerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
     let val_mmcs = ValMmcs::new(field_hash, compress);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
-    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs);
 
     type Dft = Radix2DitParallel;
     let dft = Dft {};

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -7,7 +7,7 @@ description = "Plonky3 hash trait implementations for the SHA2-256 hash function
 
 [dependencies]
 p3-symmetric = { path = "../symmetric" }
-sha2 = { version = "0.10.8", default-features = false }
+sha2 = { version = "0.10.8", default-features = false, features = ["compress"] }
 
 [features]
 default = []

--- a/sha256/src/lib.rs
+++ b/sha256/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
+use p3_symmetric::{CompressionFunction, CryptographicHasher, PseudoCompressionFunction};
 use sha2::digest::generic_array::GenericArray;
 use sha2::digest::typenum::U64;
 use sha2::Digest;
@@ -59,6 +59,8 @@ impl PseudoCompressionFunction<[u8; 32], 2> for Sha256Compress {
         output
     }
 }
+
+impl CompressionFunction<[u8; 32], 2> for Sha256Compress {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Since the SHA256 block size is 64 bytes, in a binary Merkle tree the 2-to-1 hashing would require 2 blocks due to padding. However if we treat SHA256 without padding as a pseudo-compression function, then the 2-to-1 compression would use only 1 block.

I added another example in `keccak-air` where `MyCompress = Sha256Compress` to show the usage. Unfortunately when I ran it locally there was essentially no difference in the prover speed, which was surprising to me.