### PR TITLE
Minor change to avoid sorting the same iterator twice.

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -50,22 +50,21 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
 
         assert_eq!(P::WIDTH, PW::WIDTH, "Packing widths must match");
 
+        let mut leaves_largest_first = leaves
+            .iter()
+            .sorted_by_key(|l| Reverse(l.height()))
+            .peekable();
+
         // check height property
         assert!(
-            leaves
-                .iter()
+            leaves_largest_first
+                .clone()
                 .map(|m| m.height())
-                .sorted()
                 .tuple_windows()
                 .all(|(curr, next)| curr == next
                     || curr.next_power_of_two() != next.next_power_of_two()),
             "matrix heights that round up to the same power of two must be equal"
         );
-
-        let mut leaves_largest_first = leaves
-            .iter()
-            .sorted_by_key(|l| Reverse(l.height()))
-            .peekable();
 
         let max_height = leaves_largest_first.peek().unwrap().height();
         let tallest_matrices = leaves_largest_first


### PR DESCRIPTION
Shouldn't have any real performance implications as these iterators are all small but seems morally better to only sort the iterator once.