### PR TITLE
Clean up Poseidon2 Benching

### DIFF
--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -3,7 +3,7 @@ use std::any::type_name;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
-use p3_field::{PrimeField, PrimeField64};
+use p3_field::{AbstractField, PrimeField, PrimeField64};
 use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
 use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
 use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
@@ -19,11 +19,7 @@ fn bench_poseidon2(c: &mut Criterion) {
     poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>(c);
 
     poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 3>(c);
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 5>(c);
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 7>(c);
     poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 3>(c);
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 5>(c);
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 7>(c);
 
     poseidon2_p64::<Mersenne31, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 16, 5>(
         c,
@@ -50,8 +46,8 @@ fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
 ) where
     F: PrimeField,
     Standard: Distribution<F>,
-    MdsLight: MdsLightPermutation<F, WIDTH> + Default,
-    Diffusion: DiffusionPermutation<F, WIDTH> + Default,
+    MdsLight: MdsLightPermutation<F::Packing, WIDTH> + Default,
+    Diffusion: DiffusionPermutation<F::Packing, WIDTH> + Default,
 {
     let mut rng = thread_rng();
     let external_linear_layer = MdsLight::default();
@@ -64,10 +60,10 @@ fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
         internal_linear_layer,
         &mut rng,
     );
-    let input = [F::zero(); WIDTH];
+    let input = [F::Packing::zero(); WIDTH];
     let name = format!(
         "poseidon2::<{}, {}, {}, {}>",
-        type_name::<F>(),
+        type_name::<F::Packing>(),
         D,
         rounds_f,
         rounds_p
@@ -81,8 +77,8 @@ fn poseidon2_p64<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(c: &m
 where
     F: PrimeField64,
     Standard: Distribution<F>,
-    MdsLight: MdsLightPermutation<F, WIDTH> + Default,
-    Diffusion: DiffusionPermutation<F, WIDTH> + Default,
+    MdsLight: MdsLightPermutation<F::Packing, WIDTH> + Default,
+    Diffusion: DiffusionPermutation<F::Packing, WIDTH> + Default,
 {
     let mut rng = thread_rng();
     let external_linear_layer = MdsLight::default();
@@ -93,8 +89,13 @@ where
         internal_linear_layer,
         &mut rng,
     );
-    let input = [F::zero(); WIDTH];
-    let name = format!("poseidon2::<{}, {}>", type_name::<F>(), D);
+    let input = [F::Packing::zero(); WIDTH];
+    let name = format!(
+        "poseidon2::<{}, {}, {}>",
+        type_name::<F::Packing>(),
+        D,
+        WIDTH
+    );
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon.permute(input)));
 }


### PR DESCRIPTION
Slightly modifying the Poseidon2 benching functions to use the associated packed fields (if available).

I'm going to start pushing some Neon/AVX2/AVX512 specialized code for poseidon2 and in production we should always be hashing packed fields so it makes sense to focus the benchmarking just on the packed field case. You can still benchmark the non packed case simply by compiling without target-cpu=native or with target-cpu=something which doesn't support Neon/AVX2/AVX512.

I've also removed the benchmarks for KoalaBear with D = 5, 7. The D = 3 is the fastest (particularly after we write specialized code) and so there isn't really a good reason to leave the default as benching all three options. (It's also easy to modify the file anyway if we want to bench the D = 5, 7 cases for some specific reason).

