### PR TITLE
Add a KoalaBear to prove examples

### DIFF
--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -14,6 +14,7 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
+p3-koala-bear = { path = "../koala-bear" }
 p3-challenger = { path = "../challenger" }
 p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit" }

--- a/keccak-air/examples/prove_koala_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_koala_bear_poseidon2.rs
@@ -1,0 +1,87 @@
+use std::fmt::Debug;
+
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
+use p3_merkle_tree::FieldMerkleTreeMmcs;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 1365;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = KoalaBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 3>;
+    let perm = Perm::new_from_rng_128(
+        Poseidon2ExternalMatrixGeneral,
+        DiffusionMatrixKoalaBear::default(),
+        &mut thread_rng(),
+    );
+
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    let hash = MyHash::new(perm.clone());
+
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    let compress = MyCompress::new(perm.clone());
+
+    type ValMmcs = FieldMerkleTreeMmcs<
+        <Val as Field>::Packing,
+        <Val as Field>::Packing,
+        MyHash,
+        MyCompress,
+        8,
+    >;
+    let val_mmcs = ValMmcs::new(hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Dft = Radix2DitParallel;
+    let dft = Dft {};
+
+    type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::new(perm.clone());
+    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::new(perm);
+    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+}


### PR DESCRIPTION
Add a new example using the KoalaBear field.

Currently the timing is pretty similar to BabyBear but this should change after we implement specialized vectorization for Poseidon2.