### PR TITLE
better tracing info message

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -15,7 +15,7 @@ use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use serde::{Deserialize, Serialize};
-use tracing::{info_span, instrument};
+use tracing::info_span;
 
 use crate::deep_quotient::{deep_quotient_reduce_row, extract_lambda};
 use crate::domain::CircleDomain;

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -131,7 +131,6 @@ where
         }
     }
 
-    #[instrument(skip_all)]
     fn open(
         &self,
         // For each round,

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -88,17 +88,19 @@ where
     let zeta: SC::Challenge = challenger.sample();
     let zeta_next = trace_domain.next_point(zeta).unwrap();
 
-    let (opened_values, opening_proof) = pcs.open(
-        vec![
-            (&trace_data, vec![vec![zeta, zeta_next]]),
-            (
-                &quotient_data,
-                // open every chunk at zeta
-                (0..quotient_degree).map(|_| vec![zeta]).collect_vec(),
-            ),
-        ],
-        challenger,
-    );
+    let (opened_values, opening_proof) = info_span!("open").in_scope(|| {
+        pcs.open(
+            vec![
+                (&trace_data, vec![vec![zeta, zeta_next]]),
+                (
+                    &quotient_data,
+                    // open every chunk at zeta
+                    (0..quotient_degree).map(|_| vec![zeta]).collect_vec(),
+                ),
+            ],
+            challenger,
+        )
+    });
     let trace_local = opened_values[0][0][0].clone();
     let trace_next = opened_values[0][0][1].clone();
     let quotient_chunks = opened_values[1].iter().map(|v| v[0].clone()).collect_vec();


### PR DESCRIPTION
PCS should have unified tracing info message.
## Before
circle pcs print `open`, while two_adic_pcs does not print
```
RUST_LOG=info cargo run --example prove_baby_bear_keccak --release --features parallel
INFO     prove [ 1.04s | 0.86% / 100.00% ]
INFO     ┝━ infer log of constraint degree [ 5.64ms | 0.54% ]
INFO     ┝━ commit to trace data [ 519ms | 29.22% / 50.13% ]
INFO     │  ┕━ coset_lde_batch [ 216ms | 20.91% ] dims: 2633x32768
INFO     ┝━ compute quotient polynomial [ 306ms | 29.60% ]
INFO     ┝━ commit to quotient poly chunks [ 16.8ms | 0.80% / 1.62% ]
INFO     │  ┝━ coset_lde_batch [ 6.71ms | 0.65% ] dims: 4x32768
INFO     │  ┕━ coset_lde_batch [ 1.76ms | 0.17% ] dims: 4x32768
INFO     ┝━ compute_inverse_denominators [ 7.92ms | 0.77% ]
INFO     ┝━ reduce matrix quotient [ 65.4ms | 0.01% / 6.32% ] dims: 2633x65536
INFO     │  ┝━ compute opened values with Lagrange interpolation [ 46.6ms | 4.50% ]
INFO     │  ┕━ reduce rows [ 18.7ms | 1.81% ]
INFO     ┝━ reduce matrix quotient [ 65.9ms | 0.01% / 6.36% ] dims: 2633x65536
INFO     │  ┝━ compute opened values with Lagrange interpolation [ 48.3ms | 4.67% ]
INFO     │  ┕━ reduce rows [ 17.5ms | 1.69% ]
INFO     ┝━ reduce matrix quotient [ 3.11ms | 0.00% / 0.30% ] dims: 4x65536
INFO     │  ┝━ compute opened values with Lagrange interpolation [ 2.54ms | 0.25% ]
INFO     │  ┕━ reduce rows [ 569µs | 0.05% ]
INFO     ┝━ reduce matrix quotient [ 3.09ms | 0.00% / 0.30% ] dims: 4x65536
INFO     │  ┝━ compute opened values with Lagrange interpolation [ 2.49ms | 0.24% ]
INFO     │  ┕━ reduce rows [ 595µs | 0.06% ]
INFO     ┕━ FRI prover [ 33.1ms | 0.01% / 3.20% ]
INFO        ┝━ commit phase [ 14.2ms | 1.37% ]
INFO        ┝━ grind for proof-of-work witness [ 17.5ms | 1.69% ]
INFO        ┕━ query phase [ 1.35ms | 0.13% ]
```

```
RUST_LOG=info cargo run --example prove_m31_keccak --release --features parallel
INFO     prove [ 1.44s | 0.55% / 100.00% ]
INFO     ┝━ infer log of constraint degree [ 5.39ms | 0.37% ]
INFO     ┝━ commit to trace data [ 642ms | 21.28% / 44.53% ]
INFO     │  ┕━ extrapolate [ 335ms | 0.00% / 23.25% ] dims: 2633x32768
INFO     │     ┝━ interpolate [ 99.2ms | 5.81% / 6.88% ] dims: 2633x32768
INFO     │     │  ┕━ divide_by_height [ 15.4ms | 1.07% ] dims: 2633x32768
INFO     │     ┕━ evaluate [ 236ms | 16.37% ] dims: 2633x32768
INFO     ┝━ compute quotient polynomial [ 435ms | 24.62% / 30.18% ]
INFO     │  ┕━ selectors_on_coset [ 80.2ms | 5.56% ] log_n: 16
INFO     ┝━ commit to quotient poly chunks [ 56.0ms | 1.31% / 3.89% ]
INFO     │  ┝━ extrapolate [ 19.0ms | 0.00% / 1.32% ] dims: 3x32768
INFO     │  │  ┝━ interpolate [ 9.73ms | 0.67% / 0.68% ] dims: 3x32768
INFO     │  │  │  ┕━ divide_by_height [ 18.5µs | 0.00% ] dims: 3x32768
INFO     │  │  ┕━ evaluate [ 9.31ms | 0.65% ] dims: 3x32768
INFO     │  ┕━ extrapolate [ 18.1ms | 0.00% / 1.25% ] dims: 3x32768
INFO     │     ┝━ interpolate [ 8.80ms | 0.61% / 0.61% ] dims: 3x32768
INFO     │     │  ┕━ divide_by_height [ 15.5µs | 0.00% ] dims: 3x32768
INFO     │     ┕━ evaluate [ 9.28ms | 0.64% ] dims: 3x32768
INFO     ┕━ open [ 295ms | 0.46% / 20.48% ]
INFO        ┝━ compute opened values with Lagrange interpolation [ 72.7ms | 5.05% ]
INFO        ┝━ deep_quotient_reduce [ 20.6ms | 1.43% ] dims: 2633x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 76.1ms | 5.28% ]
INFO        ┝━ deep_quotient_reduce [ 20.4ms | 1.42% ] dims: 2633x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 32.6ms | 2.27% ]
INFO        ┝━ deep_quotient_reduce [ 9.41ms | 0.65% ] dims: 3x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 32.6ms | 2.26% ]
INFO        ┝━ deep_quotient_reduce [ 9.45ms | 0.66% ] dims: 3x65536
INFO        ┝━ extract_lambda [ 467µs | 0.03% ] bits: 16
INFO        ┕━ FRI prover [ 14.1ms | 0.00% / 0.98% ]
INFO           ┝━ commit phase [ 8.79ms | 0.61% ]
INFO           ┝━ grind for proof-of-work witness [ 4.32ms | 0.30% ]
INFO           ┕━ query phase [ 1.00ms | 0.07% ]
```

## After
```
RUST_LOG=info cargo run --example prove_baby_bear_keccak --release --features parallel
INFO     generate Keccak trace [ 166ms | 100.00% ]
INFO     prove [ 1.20s | 0.94% / 100.00% ]
INFO     ┝━ infer log of constraint degree [ 5.64ms | 0.47% ]
INFO     ┝━ commit to trace data [ 550ms | 27.08% / 45.93% ]
INFO     │  ┕━ coset_lde_batch [ 225ms | 18.85% ] dims: 2633x32768
INFO     ┝━ compute quotient polynomial [ 434ms | 36.26% ]
INFO     ┝━ commit to quotient poly chunks [ 29.4ms | 1.63% / 2.46% ]
INFO     │  ┝━ coset_lde_batch [ 4.96ms | 0.41% ] dims: 4x32768
INFO     │  ┕━ coset_lde_batch [ 4.95ms | 0.41% ] dims: 4x32768
INFO     ┕━ open [ 167ms | 0.01% / 13.95% ]
INFO        ┝━ compute_inverse_denominators [ 8.13ms | 0.68% ]
INFO        ┝━ reduce matrix quotient [ 70.9ms | 0.01% / 5.92% ] dims: 2633x65536
INFO        │  ┝━ compute opened values with Lagrange interpolation [ 53.6ms | 4.48% ]
INFO        │  ┕━ reduce rows [ 17.1ms | 1.43% ]
INFO        ┝━ reduce matrix quotient [ 65.2ms | 0.01% / 5.45% ] dims: 2633x65536
INFO        │  ┝━ compute opened values with Lagrange interpolation [ 47.3ms | 3.96% ]
INFO        │  ┕━ reduce rows [ 17.8ms | 1.49% ]
INFO        ┝━ reduce matrix quotient [ 3.41ms | 0.00% / 0.28% ] dims: 4x65536
INFO        │  ┝━ compute opened values with Lagrange interpolation [ 2.59ms | 0.22% ]
INFO        │  ┕━ reduce rows [ 820µs | 0.07% ]
INFO        ┝━ reduce matrix quotient [ 3.32ms | 0.00% / 0.28% ] dims: 4x65536
INFO        │  ┝━ compute opened values with Lagrange interpolation [ 2.68ms | 0.22% ]
INFO        │  ┕━ reduce rows [ 638µs | 0.05% ]
INFO        ┕━ FRI prover [ 15.8ms | 0.01% / 1.32% ]
INFO           ┝━ commit phase [ 13.7ms | 1.14% ]
INFO           ┝━ grind for proof-of-work witness [ 903µs | 0.08% ]
INFO           ┕━ query phase [ 1.14ms | 0.10% ]
INFO     verify [ 183ms | 97.00% / 100.00% ]
INFO     ┕━ infer log of constraint degree [ 5.51ms | 3.00% ]
```

```
RUST_LOG=info cargo run --example prove_m31_keccak --release --features parallel
INFO     generate Keccak trace [ 67.5ms | 100.00% ]
INFO     prove [ 1.45s | 0.53% / 100.00% ]
INFO     ┝━ infer log of constraint degree [ 5.75ms | 0.40% ]
INFO     ┝━ commit to trace data [ 632ms | 21.10% / 43.67% ]
INFO     │  ┕━ extrapolate [ 327ms | 0.00% / 22.57% ] dims: 2633x32768
INFO     │     ┝━ interpolate [ 96.5ms | 5.60% / 6.66% ] dims: 2633x32768
INFO     │     │  ┕━ divide_by_height [ 15.3ms | 1.06% ] dims: 2633x32768
INFO     │     ┕━ evaluate [ 230ms | 15.91% ] dims: 2633x32768
INFO     ┝━ compute quotient polynomial [ 455ms | 25.87% / 31.43% ]
INFO     │  ┕━ selectors_on_coset [ 80.5ms | 5.56% ] log_n: 16
INFO     ┝━ commit to quotient poly chunks [ 44.1ms | 0.52% / 3.04% ]
INFO     │  ┝━ extrapolate [ 17.8ms | 0.00% / 1.23% ] dims: 3x32768
INFO     │  │  ┝━ interpolate [ 8.06ms | 0.56% / 0.56% ] dims: 3x32768
INFO     │  │  │  ┕━ divide_by_height [ 14.1µs | 0.00% ] dims: 3x32768
INFO     │  │  ┕━ evaluate [ 9.75ms | 0.67% ] dims: 3x32768
INFO     │  ┕━ extrapolate [ 18.8ms | 0.00% / 1.30% ] dims: 3x32768
INFO     │     ┝━ interpolate [ 9.26ms | 0.64% / 0.64% ] dims: 3x32768
INFO     │     │  ┕━ divide_by_height [ 17.7µs | 0.00% ] dims: 3x32768
INFO     │     ┕━ evaluate [ 9.53ms | 0.66% ] dims: 3x32768
INFO     ┕━ open [ 303ms | 0.46% / 20.92% ]
INFO        ┝━ compute opened values with Lagrange interpolation [ 79.2ms | 5.47% ]
INFO        ┝━ deep_quotient_reduce [ 22.5ms | 1.55% ] dims: 2633x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 76.3ms | 5.27% ]
INFO        ┝━ deep_quotient_reduce [ 21.0ms | 1.45% ] dims: 2633x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 32.8ms | 2.26% ]
INFO        ┝━ deep_quotient_reduce [ 9.96ms | 0.69% ] dims: 3x65536
INFO        ┝━ compute opened values with Lagrange interpolation [ 32.8ms | 2.27% ]
INFO        ┝━ deep_quotient_reduce [ 9.68ms | 0.67% ] dims: 3x65536
INFO        ┝━ extract_lambda [ 549µs | 0.04% ] bits: 16
INFO        ┕━ FRI prover [ 11.6ms | 0.00% / 0.80% ]
INFO           ┝━ commit phase [ 7.92ms | 0.55% ]
INFO           ┝━ grind for proof-of-work witness [ 2.22ms | 0.15% ]
INFO           ┕━ query phase [ 1.39ms | 0.10% ]
INFO     verify [ 44.9ms | 88.31% / 100.00% ]
INFO     ┕━ infer log of constraint degree [ 5.25ms | 11.69% ]
```