### PR TITLE
Remove redundant imports

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -101,7 +101,7 @@ impl BinomialExtensionData<5> for BabyBearParameters {
 mod tests {
     use core::array;
 
-    use p3_field::{AbstractField, Field, PrimeField32, PrimeField64, TwoAdicField};
+    use p3_field::{PrimeField32, PrimeField64, TwoAdicField};
     use p3_field_testing::{test_field, test_two_adic_field};
 
     use super::*;

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -273,7 +273,6 @@ pub fn circle_basis<F: Field>(p: Point<F>, log_n: usize) -> Vec<F> {
 mod tests {
     use itertools::iproduct;
     use p3_field::extension::BinomialExtensionField;
-    use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
     use rand::{random, thread_rng};
 

--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -132,7 +132,6 @@ mod tests {
     use itertools::iproduct;
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
-    use p3_matrix::Matrix;
     use p3_mersenne_31::Mersenne31;
     use rand::{random, thread_rng};
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -468,7 +468,7 @@ where
 #[cfg(test)]
 mod tests {
     use p3_challenger::{HashChallenger, SerializingChallenger32};
-    use p3_commit::{ExtensionMmcs, Pcs};
+    use p3_commit::ExtensionMmcs;
     use p3_field::extension::BinomialExtensionField;
     use p3_keccak::Keccak256Hash;
     use p3_merkle_tree::FieldMerkleTreeMmcs;


### PR DESCRIPTION
Remove redundant imports from `baby-bear` and `circle` crates. These are picked up in `nightly` but not `stable`.