### PR TITLE
Vectorizing Poseidon2: Initial API Changes

### DIFF
--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -8,13 +8,11 @@
 
 //! Long term we will use more optimised internal and external linear layers.
 
-use p3_field::AbstractField;
 use p3_poseidon2::{
     external_final_permute_state, external_initial_permute_state, internal_permute_state,
     matmul_internal, ExternalLayer, HLMDSMat4, InternalLayer, MDSMat4, NoPackedImplementation,
-    Poseidon2ExternalPackedConstants, Poseidon2InternalPackedConstants,
+    Poseidon2ExternalPackedConstants,
 };
-use p3_symmetric::Permutation;
 
 use crate::{to_goldilocks_array, Goldilocks};
 
@@ -96,7 +94,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 8, 7> for Poseidon2Intern
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Goldilocks],
-        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Goldilocks>>::InternalConstantsType],
+        _packed_internal_constants: &[()],
     ) {
         internal_permute_state::<Goldilocks, 8, 7>(
             state,
@@ -113,7 +111,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 12, 7> for Poseidon2Inter
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Goldilocks],
-        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Goldilocks>>::InternalConstantsType],
+        _packed_internal_constants: &[()],
     ) {
         internal_permute_state::<Goldilocks, 12, 7>(
             state,
@@ -130,7 +128,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 16, 7> for Poseidon2Inter
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Goldilocks],
-        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Goldilocks>>::InternalConstantsType],
+        _packed_internal_constants: &[()],
     ) {
         internal_permute_state::<Goldilocks, 16, 7>(
             state,
@@ -147,7 +145,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 20, 7> for Poseidon2Inter
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Goldilocks],
-        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Goldilocks>>::InternalConstantsType],
+        _packed_internal_constants: &[()],
     ) {
         internal_permute_state::<Goldilocks, 20, 7>(
             state,
@@ -163,7 +161,8 @@ pub struct Poseidon2ExternalLayerGoldilocks;
 impl<const WIDTH: usize> ExternalLayer<Goldilocks, NoPackedImplementation, WIDTH, 7>
     for Poseidon2ExternalLayerGoldilocks
 where
-    NoPackedImplementation: Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>,
+    NoPackedImplementation:
+        Poseidon2ExternalPackedConstants<Goldilocks, WIDTH, ExternalConstantsType = ()>,
 {
     type InternalState = [Goldilocks; WIDTH];
     type ArrayState = [[Goldilocks; WIDTH]; 1];
@@ -180,7 +179,7 @@ where
         &self,
         state: &mut [Goldilocks; WIDTH],
         initial_external_constants: &[[Goldilocks; WIDTH]],
-        _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>>::ExternalConstantsType],
+        _packed_initial_external_constants: &[()],
     ) {
         external_initial_permute_state::<_, _, WIDTH, 7>(
             state,
@@ -193,7 +192,7 @@ where
         &self,
         state: &mut Self::InternalState,
         final_external_constants: &[[Goldilocks; WIDTH]],
-        _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>>::ExternalConstantsType],
+        _packed_final_external_constants: &[()],
     ) {
         external_final_permute_state::<_, _, WIDTH, 7>(state, final_external_constants, &MDSMat4);
     }
@@ -356,7 +355,9 @@ pub const HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS: [u64; 22] = [
 mod tests {
     use core::array;
 
+    use p3_field::AbstractField;
     use p3_poseidon2::Poseidon2;
+    use p3_symmetric::Permutation;
 
     use super::*;
 

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -87,7 +87,9 @@ pub const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] = to_goldilocks_array([
 #[derive(Debug, Clone, Default)]
 pub struct Poseidon2InternalLayerGoldilocks;
 
-impl InternalLayer<Goldilocks, NoPackedImplementation, 8, 7> for Poseidon2InternalLayerGoldilocks {
+impl NoPackedImplementation for Poseidon2InternalLayerGoldilocks {}
+
+impl InternalLayer<Goldilocks, 8, 7> for Poseidon2InternalLayerGoldilocks {
     type InternalState = [Goldilocks; 8];
 
     fn permute_state(
@@ -104,7 +106,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 8, 7> for Poseidon2Intern
     }
 }
 
-impl InternalLayer<Goldilocks, NoPackedImplementation, 12, 7> for Poseidon2InternalLayerGoldilocks {
+impl InternalLayer<Goldilocks, 12, 7> for Poseidon2InternalLayerGoldilocks {
     type InternalState = [Goldilocks; 12];
 
     fn permute_state(
@@ -121,7 +123,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 12, 7> for Poseidon2Inter
     }
 }
 
-impl InternalLayer<Goldilocks, NoPackedImplementation, 16, 7> for Poseidon2InternalLayerGoldilocks {
+impl InternalLayer<Goldilocks, 16, 7> for Poseidon2InternalLayerGoldilocks {
     type InternalState = [Goldilocks; 16];
 
     fn permute_state(
@@ -138,7 +140,7 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 16, 7> for Poseidon2Inter
     }
 }
 
-impl InternalLayer<Goldilocks, NoPackedImplementation, 20, 7> for Poseidon2InternalLayerGoldilocks {
+impl InternalLayer<Goldilocks, 20, 7> for Poseidon2InternalLayerGoldilocks {
     type InternalState = [Goldilocks; 20];
 
     fn permute_state(
@@ -158,85 +160,76 @@ impl InternalLayer<Goldilocks, NoPackedImplementation, 20, 7> for Poseidon2Inter
 #[derive(Default, Clone)]
 pub struct Poseidon2ExternalLayerGoldilocks;
 
-impl<const WIDTH: usize> ExternalLayer<Goldilocks, NoPackedImplementation, WIDTH, 7>
-    for Poseidon2ExternalLayerGoldilocks
-where
-    NoPackedImplementation:
-        Poseidon2ExternalPackedConstants<Goldilocks, WIDTH, ExternalConstantsType = ()>,
-{
+impl NoPackedImplementation for Poseidon2ExternalLayerGoldilocks {}
+
+impl<const WIDTH: usize> ExternalLayer<Goldilocks, WIDTH, 7> for Poseidon2ExternalLayerGoldilocks {
     type InternalState = [Goldilocks; WIDTH];
-    type ArrayState = [[Goldilocks; WIDTH]; 1];
-
-    fn to_internal_rep(&self, state: [Goldilocks; WIDTH]) -> Self::ArrayState {
-        [state]
-    }
-
-    fn to_output_rep(&self, state: Self::ArrayState) -> [Goldilocks; WIDTH] {
-        state[0]
-    }
 
     fn permute_state_initial(
         &self,
-        state: &mut [Goldilocks; WIDTH],
+        mut state: [Goldilocks; WIDTH],
         initial_external_constants: &[[Goldilocks; WIDTH]],
         _packed_initial_external_constants: &[()],
-    ) {
+    ) -> [Goldilocks; WIDTH] {
         external_initial_permute_state::<_, _, WIDTH, 7>(
-            state,
+            &mut state,
             initial_external_constants,
             &MDSMat4,
         );
+        state
     }
 
     fn permute_state_final(
         &self,
-        state: &mut Self::InternalState,
+        mut state: [Goldilocks; WIDTH],
         final_external_constants: &[[Goldilocks; WIDTH]],
         _packed_final_external_constants: &[()],
-    ) {
-        external_final_permute_state::<_, _, WIDTH, 7>(state, final_external_constants, &MDSMat4);
+    ) -> [Goldilocks; WIDTH] {
+        external_final_permute_state::<_, _, WIDTH, 7>(
+            &mut state,
+            final_external_constants,
+            &MDSMat4,
+        );
+        state
     }
 }
 
 #[derive(Default, Clone)]
 pub struct Poseidon2ExternalLayerGoldilocksHL;
 
-impl<const WIDTH: usize> ExternalLayer<Goldilocks, NoPackedImplementation, WIDTH, 7>
+impl NoPackedImplementation for Poseidon2ExternalLayerGoldilocksHL {}
+
+impl<const WIDTH: usize> ExternalLayer<Goldilocks, WIDTH, 7>
     for Poseidon2ExternalLayerGoldilocksHL
-where
-    NoPackedImplementation: Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>,
 {
     type InternalState = [Goldilocks; WIDTH];
-    type ArrayState = [[Goldilocks; WIDTH]; 1];
-
-    fn to_internal_rep(&self, state: [Goldilocks; WIDTH]) -> Self::ArrayState {
-        [state]
-    }
-
-    fn to_output_rep(&self, state: Self::ArrayState) -> [Goldilocks; WIDTH] {
-        state[0]
-    }
 
     fn permute_state_initial(
         &self,
-        state: &mut [Goldilocks; WIDTH],
+        mut state: [Goldilocks; WIDTH],
         initial_external_constants: &[[Goldilocks; WIDTH]],
-        _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>>::ExternalConstantsType],
-    ) {
+        _packed_initial_external_constants: &[()],
+    ) -> [Goldilocks; WIDTH] {
         external_initial_permute_state::<_, _, WIDTH, 7>(
-            state,
+            &mut state,
             initial_external_constants,
             &HLMDSMat4,
         );
+        state
     }
 
     fn permute_state_final(
         &self,
-        state: &mut Self::InternalState,
+        mut state: Self::InternalState,
         final_external_constants: &[[Goldilocks; WIDTH]],
-        _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Goldilocks, WIDTH>>::ExternalConstantsType],
-    ) {
-        external_final_permute_state::<_, _, WIDTH, 7>(state, final_external_constants, &HLMDSMat4);
+        _packed_final_external_constants: &[()],
+    ) -> [Goldilocks; WIDTH] {
+        external_final_permute_state::<_, _, WIDTH, 7>(
+            &mut state,
+            final_external_constants,
+            &HLMDSMat4,
+        );
+        state
     }
 }
 
@@ -374,7 +367,6 @@ mod tests {
             Goldilocks,
             Poseidon2ExternalLayerGoldilocksHL,
             Poseidon2InternalLayerGoldilocks,
-            NoPackedImplementation,
             WIDTH,
             D,
         > = Poseidon2::new(

--- a/keccak-air/examples/prove_m31_poseidon2.rs
+++ b/keccak-air/examples/prove_m31_poseidon2.rs
@@ -9,7 +9,7 @@ use p3_field::Field;
 use p3_fri::FriConfig;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
+use p3_mersenne_31::{Poseidon2InternalLayerMersenne31, Mersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
@@ -35,10 +35,10 @@ fn main() -> Result<(), impl Debug> {
     type Val = Mersenne31;
     type Challenge = BinomialExtensionField<Val, 3>;
 
-    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 16, 5>;
+    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, Poseidon2InternalLayerMersenne31, 16, 5>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
-        DiffusionMatrixMersenne31,
+        Poseidon2InternalLayerMersenne31,
         &mut thread_rng(),
     );
 

--- a/keccak-air/examples/prove_m31_poseidon2.rs
+++ b/keccak-air/examples/prove_m31_poseidon2.rs
@@ -9,7 +9,7 @@ use p3_field::Field;
 use p3_fri::FriConfig;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::FieldMerkleTreeMmcs;
-use p3_mersenne_31::{Poseidon2InternalLayerMersenne31, Mersenne31};
+use p3_mersenne_31::{Mersenne31, Poseidon2InternalLayerMersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
@@ -35,7 +35,8 @@ fn main() -> Result<(), impl Debug> {
     type Val = Mersenne31;
     type Challenge = BinomialExtensionField<Val, 3>;
 
-    type Perm = Poseidon2<Val, Poseidon2ExternalMatrixGeneral, Poseidon2InternalLayerMersenne31, 16, 5>;
+    type Perm =
+        Poseidon2<Val, Poseidon2ExternalMatrixGeneral, Poseidon2InternalLayerMersenne31, 16, 5>;
     let perm = Perm::new_from_rng_128(
         Poseidon2ExternalMatrixGeneral,
         Poseidon2InternalLayerMersenne31,

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -1,6 +1,9 @@
 use p3_field::PrimeField32;
-use p3_poseidon2::DiffusionPermutation;
-use p3_symmetric::Permutation;
+use p3_poseidon2::{
+    external_final_permute_state, external_initial_permute_state, internal_permute_state,
+    ExternalLayer, InternalLayer, NoPackedImplementation, Poseidon2ExternalPackedConstants,
+    Poseidon2InternalPackedConstants,
+};
 
 use crate::{from_u62, to_mersenne31_array, Mersenne31};
 
@@ -71,47 +74,97 @@ const POSEIDON2_INTERNAL_MATRIX_DIAG_24_SHIFTS: [u8; 23] = [
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
 ];
 
+fn permute_mut<const N: usize>(state: &mut [Mersenne31; N], shifts: &[u8]) {
+    let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
+    let full_sum = part_sum + (state[0].value as u64);
+    let s0 = part_sum + (-state[0]).value as u64;
+    state[0] = from_u62(s0);
+    for i in 1..N {
+        let si = full_sum + ((state[i].value as u64) << shifts[i - 1]);
+        state[i] = from_u62(si);
+    }
+}
+
 #[derive(Debug, Clone, Default)]
-pub struct DiffusionMatrixMersenne31;
+pub struct Poseidon2InternalLayerMersenne31;
 
-impl Permutation<[Mersenne31; 16]> for DiffusionMatrixMersenne31 {
-    #[inline]
-    fn permute_mut(&self, state: &mut [Mersenne31; 16]) {
-        let part_sum: u64 = state.iter().skip(1).map(|x| x.value as u64).sum();
-        let full_sum = part_sum + (state[0].value as u64);
-        let s0 = part_sum + (-state[0]).value as u64;
-        state[0] = from_u62(s0);
-        for i in 1..16 {
-            let si = full_sum
-                + ((state[i].value as u64) << POSEIDON2_INTERNAL_MATRIX_DIAG_16_SHIFTS[i - 1]);
-            state[i] = from_u62(si);
-        }
+impl InternalLayer<Mersenne31, NoPackedImplementation, 16, 5> for Poseidon2InternalLayerMersenne31 {
+    type InternalState = [Mersenne31; 16];
+
+    fn permute_state(
+        &self,
+        state: &mut Self::InternalState,
+        internal_constants: &[Mersenne31],
+        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Mersenne31>>::InternalConstantsType],
+    ) {
+        internal_permute_state::<Mersenne31, 16, 5>(
+            state,
+            |x| permute_mut(x, &POSEIDON2_INTERNAL_MATRIX_DIAG_16_SHIFTS),
+            internal_constants,
+        )
     }
 }
 
-impl DiffusionPermutation<Mersenne31, 16> for DiffusionMatrixMersenne31 {}
+impl InternalLayer<Mersenne31, NoPackedImplementation, 24, 5> for Poseidon2InternalLayerMersenne31 {
+    type InternalState = [Mersenne31; 24];
 
-impl Permutation<[Mersenne31; 24]> for DiffusionMatrixMersenne31 {
-    #[inline]
-    fn permute_mut(&self, state: &mut [Mersenne31; 24]) {
-        let part_sum: u64 = state[1..].iter().map(|x| x.value as u64).sum();
-        let full_sum = part_sum + (state[0].value as u64);
-        let s0 = part_sum + (-state[0]).value as u64;
-        state[0] = from_u62(s0);
-        for i in 1..24 {
-            let si = full_sum
-                + ((state[i].value as u64) << POSEIDON2_INTERNAL_MATRIX_DIAG_24_SHIFTS[i - 1]);
-            state[i] = from_u62(si);
-        }
+    fn permute_state(
+        &self,
+        state: &mut Self::InternalState,
+        internal_constants: &[Mersenne31],
+        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Mersenne31>>::InternalConstantsType],
+    ) {
+        internal_permute_state::<Mersenne31, 24, 5>(
+            state,
+            |x| permute_mut(x, &POSEIDON2_INTERNAL_MATRIX_DIAG_24_SHIFTS),
+            internal_constants,
+        )
     }
 }
 
-impl DiffusionPermutation<Mersenne31, 24> for DiffusionMatrixMersenne31 {}
+#[derive(Default, Clone)]
+pub struct Poseidon2ExternalLayerMersenne31;
+
+impl<const WIDTH: usize> ExternalLayer<Mersenne31, NoPackedImplementation, WIDTH, 5>
+    for Poseidon2ExternalLayerMersenne31
+where
+    NoPackedImplementation: Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>,
+{
+    type InternalState = [Mersenne31; WIDTH];
+    type ArrayState = [[Mersenne31; WIDTH]; 1];
+
+    fn to_internal_rep(&self, state: [Mersenne31; WIDTH]) -> Self::ArrayState {
+        [state]
+    }
+
+    fn to_output_rep(&self, state: Self::ArrayState) -> [Mersenne31; WIDTH] {
+        state[0]
+    }
+
+    fn permute_state_initial(
+        &self,
+        state: &mut [Mersenne31; WIDTH],
+        initial_external_constants: &[[Mersenne31; WIDTH]],
+        _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
+    ) {
+        external_initial_permute_state::<Mersenne31, WIDTH, 5>(state, initial_external_constants);
+    }
+
+    fn permute_state_final(
+        &self,
+        state: &mut Self::InternalState,
+        final_external_constants: &[[Mersenne31; WIDTH]],
+        _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
+    ) {
+        external_final_permute_state::<Mersenne31, WIDTH, 5>(state, final_external_constants);
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+    use p3_poseidon2::Poseidon2;
+    use p3_symmetric::Permutation;
     use rand::SeedableRng;
     use rand_xoshiro::Xoroshiro128Plus;
 
@@ -123,17 +176,40 @@ mod tests {
     // See: https://github.com/0xPolygonZero/hash-constants for the sage code used to create all these tests.
 
     // Our Poseidon2 Implementation for Mersenne31
-    fn poseidon2_mersenne31<const WIDTH: usize, const D: u64, DiffusionMatrix>(
-        input: &mut [F; WIDTH],
-        diffusion_matrix: DiffusionMatrix,
-    ) where
-        DiffusionMatrix: DiffusionPermutation<F, WIDTH>,
+    fn poseidon2_mersenne31<const WIDTH: usize, const D: u64>(input: &mut [F; WIDTH])
+    where
+        NoPackedImplementation: Poseidon2InternalPackedConstants<Mersenne31>
+            + Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>,
+        Poseidon2ExternalLayerMersenne31:
+            ExternalLayer<Mersenne31, NoPackedImplementation, WIDTH, D>,
+        Poseidon2InternalLayerMersenne31: InternalLayer<
+            Mersenne31,
+            NoPackedImplementation,
+            WIDTH,
+            D,
+            InternalState = <Poseidon2ExternalLayerMersenne31 as ExternalLayer<
+                Mersenne31,
+                NoPackedImplementation,
+                WIDTH,
+                D,
+            >>::InternalState,
+        >,
     {
         let mut rng = Xoroshiro128Plus::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
-        let poseidon2: Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrix, WIDTH, D> =
-            Poseidon2::new_from_rng_128(Poseidon2ExternalMatrixGeneral, diffusion_matrix, &mut rng);
+        let poseidon2: Poseidon2<
+            F,
+            Poseidon2ExternalLayerMersenne31,
+            Poseidon2InternalLayerMersenne31,
+            NoPackedImplementation,
+            WIDTH,
+            D,
+        > = Poseidon2::new_from_rng_128(
+            Poseidon2ExternalLayerMersenne31,
+            Poseidon2InternalLayerMersenne31,
+            &mut rng,
+        );
 
         poseidon2.permute_mut(input);
     }
@@ -158,7 +234,7 @@ mod tests {
         ]
         .map(F::from_canonical_u32);
 
-        poseidon2_mersenne31::<16, 5, _>(&mut input, DiffusionMatrixMersenne31);
+        poseidon2_mersenne31::<16, 5>(&mut input);
         assert_eq!(input, expected);
     }
 
@@ -184,7 +260,7 @@ mod tests {
         ]
         .map(F::from_canonical_u32);
 
-        poseidon2_mersenne31::<24, 5, _>(&mut input, DiffusionMatrixMersenne31);
+        poseidon2_mersenne31::<24, 5>(&mut input);
         assert_eq!(input, expected);
     }
 }

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -1,8 +1,8 @@
 use p3_field::PrimeField32;
 use p3_poseidon2::{
     external_final_permute_state, external_initial_permute_state, internal_permute_state,
-    ExternalLayer, InternalLayer, NoPackedImplementation, Poseidon2ExternalPackedConstants,
-    Poseidon2InternalPackedConstants,
+    ExternalLayer, InternalLayer, MDSMat4, NoPackedImplementation,
+    Poseidon2ExternalPackedConstants, Poseidon2InternalPackedConstants,
 };
 
 use crate::{from_u62, to_mersenne31_array, Mersenne31};
@@ -147,7 +147,11 @@ where
         initial_external_constants: &[[Mersenne31; WIDTH]],
         _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
     ) {
-        external_initial_permute_state::<Mersenne31, WIDTH, 5>(state, initial_external_constants);
+        external_initial_permute_state::<Mersenne31, MDSMat4, WIDTH, 5>(
+            state,
+            initial_external_constants,
+            &MDSMat4,
+        );
     }
 
     fn permute_state_final(
@@ -156,7 +160,11 @@ where
         final_external_constants: &[[Mersenne31; WIDTH]],
         _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
     ) {
-        external_final_permute_state::<Mersenne31, WIDTH, 5>(state, final_external_constants);
+        external_final_permute_state::<Mersenne31, MDSMat4, WIDTH, 5>(
+            state,
+            final_external_constants,
+            &MDSMat4,
+        );
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -1,46 +1,119 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
+// use core::arch::x86_64::{self, __m256i};
+// use core::mem::transmute;
+
+use p3_poseidon2::{
+    external_final_permute_state, external_initial_permute_state, internal_permute_state,
+    matmul_internal, ExternalLayer, InternalLayer, NoPackedImplementation,
+    Poseidon2ExternalPackedConstants, Poseidon2InternalPackedConstants,
+};
+
 
 use crate::{
-    DiffusionMatrixMersenne31, Mersenne31, PackedMersenne31AVX2, POSEIDON2_INTERNAL_MATRIX_DIAG_16,
+    Mersenne31, PackedMersenne31AVX2, Poseidon2ExternalLayerMersenne31,
+    Poseidon2InternalLayerMersenne31, POSEIDON2_INTERNAL_MATRIX_DIAG_16,
     POSEIDON2_INTERNAL_MATRIX_DIAG_24,
 };
 
-impl Permutation<[PackedMersenne31AVX2; 16]> for DiffusionMatrixMersenne31 {
-    fn permute_mut(&self, state: &mut [PackedMersenne31AVX2; 16]) {
-        matmul_internal::<Mersenne31, PackedMersenne31AVX2, 16>(
+impl InternalLayer<PackedMersenne31AVX2, NoPackedImplementation, 16, 5>
+    for Poseidon2InternalLayerMersenne31
+{
+    type InternalState = [PackedMersenne31AVX2; 16];
+
+    fn permute_state(
+        &self,
+        state: &mut Self::InternalState,
+        internal_constants: &[Mersenne31],
+        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Mersenne31>>::InternalConstantsType],
+    ) {
+        internal_permute_state::<PackedMersenne31AVX2, 16, 5>(
             state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_16,
-        );
+            |x| matmul_internal(x, POSEIDON2_INTERNAL_MATRIX_DIAG_16),
+            internal_constants,
+        )
     }
 }
 
-impl DiffusionPermutation<PackedMersenne31AVX2, 16> for DiffusionMatrixMersenne31 {}
+impl InternalLayer<PackedMersenne31AVX2, NoPackedImplementation, 24, 5>
+    for Poseidon2InternalLayerMersenne31
+{
+    type InternalState = [PackedMersenne31AVX2; 24];
 
-impl Permutation<[PackedMersenne31AVX2; 24]> for DiffusionMatrixMersenne31 {
-    fn permute_mut(&self, state: &mut [PackedMersenne31AVX2; 24]) {
-        matmul_internal::<Mersenne31, PackedMersenne31AVX2, 24>(
+    fn permute_state(
+        &self,
+        state: &mut Self::InternalState,
+        internal_constants: &[Mersenne31],
+        _packed_internal_constants: &[<NoPackedImplementation as Poseidon2InternalPackedConstants<Mersenne31>>::InternalConstantsType],
+    ) {
+        internal_permute_state::<PackedMersenne31AVX2, 24, 5>(
             state,
-            POSEIDON2_INTERNAL_MATRIX_DIAG_24,
-        );
+            |x| matmul_internal(x, POSEIDON2_INTERNAL_MATRIX_DIAG_24),
+            internal_constants,
+        )
     }
 }
 
-impl DiffusionPermutation<PackedMersenne31AVX2, 24> for DiffusionMatrixMersenne31 {}
+impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, NoPackedImplementation, WIDTH, 5>
+    for Poseidon2ExternalLayerMersenne31
+where
+    NoPackedImplementation: Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>,
+{
+    type InternalState = [PackedMersenne31AVX2; WIDTH];
+    type ArrayState = [[PackedMersenne31AVX2; WIDTH]; 1];
+
+    fn to_internal_rep(&self, state: [PackedMersenne31AVX2; WIDTH]) -> Self::ArrayState {
+        [state]
+    }
+
+    fn to_output_rep(&self, state: Self::ArrayState) -> [PackedMersenne31AVX2; WIDTH] {
+        state[0]
+    }
+
+    fn permute_state_initial(
+        &self,
+        state: &mut Self::InternalState,
+        initial_external_constants: &[[Mersenne31; WIDTH]],
+        _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
+    ) {
+        external_initial_permute_state::<_, WIDTH, 5>(state, initial_external_constants);
+    }
+
+    fn permute_state_final(
+        &self,
+        state: &mut Self::InternalState,
+        final_external_constants: &[[Mersenne31; WIDTH]],
+        _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
+    ) {
+        external_final_permute_state::<_, WIDTH, 5>(state, final_external_constants);
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+    use p3_poseidon2::Poseidon2;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{DiffusionMatrixMersenne31, Mersenne31, PackedMersenne31AVX2};
+    use super::*;
 
     type F = Mersenne31;
     const D: u64 = 5;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 24, D>;
+    type Perm16 = Poseidon2<
+        F,
+        Poseidon2ExternalLayerMersenne31,
+        Poseidon2InternalLayerMersenne31,
+        NoPackedImplementation,
+        16,
+        D,
+    >;
+    type Perm24 = Poseidon2<
+        F,
+        Poseidon2ExternalLayerMersenne31,
+        Poseidon2InternalLayerMersenne31,
+        NoPackedImplementation,
+        24,
+        D,
+    >;
 
     /// Test that the output is the same as the scalar version on a random input of length 16.
     #[test]
@@ -49,8 +122,8 @@ mod tests {
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixMersenne31,
+            Poseidon2ExternalLayerMersenne31,
+            Poseidon2InternalLayerMersenne31,
             &mut rng,
         );
 
@@ -74,8 +147,8 @@ mod tests {
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixMersenne31,
+            Poseidon2ExternalLayerMersenne31,
+            Poseidon2InternalLayerMersenne31,
             &mut rng,
         );
 

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -3,10 +3,9 @@
 
 use p3_poseidon2::{
     external_final_permute_state, external_initial_permute_state, internal_permute_state,
-    matmul_internal, ExternalLayer, InternalLayer, NoPackedImplementation,
+    matmul_internal, ExternalLayer, InternalLayer, MDSMat4, NoPackedImplementation,
     Poseidon2ExternalPackedConstants, Poseidon2InternalPackedConstants,
 };
-
 
 use crate::{
     Mersenne31, PackedMersenne31AVX2, Poseidon2ExternalLayerMersenne31,
@@ -74,7 +73,11 @@ where
         initial_external_constants: &[[Mersenne31; WIDTH]],
         _packed_initial_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
     ) {
-        external_initial_permute_state::<_, WIDTH, 5>(state, initial_external_constants);
+        external_initial_permute_state::<_, _, WIDTH, 5>(
+            state,
+            initial_external_constants,
+            &MDSMat4,
+        );
     }
 
     fn permute_state_final(
@@ -83,7 +86,7 @@ where
         final_external_constants: &[[Mersenne31; WIDTH]],
         _packed_final_external_constants: &[<NoPackedImplementation as Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>>::ExternalConstantsType],
     ) {
-        external_final_permute_state::<_, WIDTH, 5>(state, final_external_constants);
+        external_final_permute_state::<_, _, WIDTH, 5>(state, final_external_constants, &MDSMat4);
     }
 }
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -6,7 +6,7 @@ use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
 use p3_field::{AbstractField, PrimeField, PrimeField64};
 use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
 use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
-use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
+use p3_mersenne_31::{Mersenne31, Poseidon2InternalLayerMersenne31};
 use p3_poseidon2::{
     DiffusionPermutation, MdsLightPermutation, Poseidon2, Poseidon2ExternalMatrixGeneral,
 };
@@ -21,12 +21,20 @@ fn bench_poseidon2(c: &mut Criterion) {
     poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 3>(c);
     poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 3>(c);
 
-    poseidon2_p64::<Mersenne31, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 16, 5>(
-        c,
-    );
-    poseidon2_p64::<Mersenne31, Poseidon2ExternalMatrixGeneral, DiffusionMatrixMersenne31, 24, 5>(
-        c,
-    );
+    poseidon2_p64::<
+        Mersenne31,
+        Poseidon2ExternalMatrixGeneral,
+        Poseidon2InternalLayerMersenne31,
+        16,
+        5,
+    >(c);
+    poseidon2_p64::<
+        Mersenne31,
+        Poseidon2ExternalMatrixGeneral,
+        Poseidon2InternalLayerMersenne31,
+        24,
+        5,
+    >(c);
 
     poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 8, 7>(c);
     poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 12, 7>(

--- a/poseidon2/src/constants.rs
+++ b/poseidon2/src/constants.rs
@@ -1,0 +1,40 @@
+// We split the internal and external constant traits as the external constant method depends on the WIDTH
+// but the internal one does not.
+
+/// Data needed to generate constants for the internal rounds of the Poseidon2 permutation.
+pub trait Poseidon2InternalPackedConstants<F>: Sync + Clone {
+    // In the scalar case this is AF::F but it may be different for PackedFields.
+    type InternalConstantsType: Clone + core::fmt::Debug + Sync;
+
+    fn manipulate_internal_constants(internal_constants: &F) -> Self::InternalConstantsType;
+}
+
+/// Data needed to generate constants for the external rounds of the Poseidon2 permutation.
+pub trait Poseidon2ExternalPackedConstants<F, const WIDTH: usize>: Sync + Clone {
+    // In the scalar case, ExternalConstantsType = [AF::F; WIDTH] but it may be different for PackedFields.
+    type ExternalConstantsType: Clone + core::fmt::Debug + Sync;
+
+    fn manipulate_external_constants(
+        external_constants: &[F; WIDTH],
+    ) -> Self::ExternalConstantsType;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NoPackedImplementation;
+
+impl<F> Poseidon2InternalPackedConstants<F> for NoPackedImplementation {
+    // In the scalar case this is AF::F but it may be different for PackedFields.
+    type InternalConstantsType = ();
+
+    fn manipulate_internal_constants(_internal_constants: &F) -> Self::InternalConstantsType {}
+}
+
+impl<F, const WIDTH: usize> Poseidon2ExternalPackedConstants<F, WIDTH> for NoPackedImplementation {
+    // In the scalar case this is AF::F but it may be different for PackedFields.
+    type ExternalConstantsType = ();
+
+    fn manipulate_external_constants(
+        _external_constants: &[F; WIDTH],
+    ) -> Self::ExternalConstantsType {
+    }
+}

--- a/poseidon2/src/constants.rs
+++ b/poseidon2/src/constants.rs
@@ -19,6 +19,7 @@ pub trait Poseidon2ExternalPackedConstants<F, const WIDTH: usize>: Sync + Clone 
     ) -> Self::ExternalConstantsType;
 }
 
+/// We prove a simple default option for fields which do not have a specialised Poseidon2 Packed implementation.
 #[derive(Debug, Clone, Default)]
 pub struct NoPackedImplementation;
 

--- a/poseidon2/src/constants.rs
+++ b/poseidon2/src/constants.rs
@@ -24,14 +24,16 @@ pub trait Poseidon2ExternalPackedConstants<F, const WIDTH: usize>: Sync + Clone 
 pub struct NoPackedImplementation;
 
 impl<F> Poseidon2InternalPackedConstants<F> for NoPackedImplementation {
-    // In the scalar case this is AF::F but it may be different for PackedFields.
+    // If there is no specialised implementation, the Internal Packed Constants will never be read.
+    // So we set it to the empty type.
     type InternalConstantsType = ();
 
     fn manipulate_internal_constants(_internal_constants: &F) -> Self::InternalConstantsType {}
 }
 
 impl<F, const WIDTH: usize> Poseidon2ExternalPackedConstants<F, WIDTH> for NoPackedImplementation {
-    // In the scalar case this is AF::F but it may be different for PackedFields.
+    // If there is no specialised implementation, the External Packed Constants will never be read.
+    // So we set it to the empty type.
     type ExternalConstantsType = ();
 
     fn manipulate_external_constants(

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -55,6 +55,7 @@ where
     type InternalState;
 
     /// Compute the internal part of the Poseidon2 permutation.
+    /// Implementations will usually not use both constants fields.
     fn permute_state(
         &self,
         state: &mut Self::InternalState,
@@ -63,8 +64,8 @@ where
     );
 }
 
-// A helper method which allows any field to easily implement Internal Layer.
-// This should be used in places where performance is not critical.
+/// A helper method which allows any field to easily implement Internal Layer.
+/// This should only be used in places where performance is not critical.
 #[inline]
 pub fn internal_permute_state<AF: AbstractField, const WIDTH: usize, const D: u64>(
     state: &mut [AF; WIDTH],

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -43,11 +43,10 @@ pub fn matmul_internal<F: Field, AF: AbstractField<F = F>, const WIDTH: usize>(
     }
 }
 
-pub trait InternalLayer<AF, PackedConstants, const WIDTH: usize, const D: u64>:
-    Sync + Clone
+pub trait InternalLayer<AF, const WIDTH: usize, const D: u64>:
+    Poseidon2InternalPackedConstants<AF::F>
 where
     AF: AbstractField,
-    PackedConstants: Poseidon2InternalPackedConstants<AF::F>,
 {
     /// The type used internally by the Poseidon2 implementation.
     /// In the scalar case, InternalState = [AF; WIDTH] but for PackedFields it's faster to use packed vectors.
@@ -60,7 +59,7 @@ where
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[AF::F],
-        internal_packed_constants: &[PackedConstants::InternalConstantsType],
+        internal_packed_constants: &[Self::ConstantsType],
     );
 }
 

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -1,4 +1,4 @@
-//! Inside the Posedion paper, they describe that the internal layers of the hash
+//! Inside the Poseidon2 paper, they describe that the internal layers of the hash
 //! function do not require the full properties of MDS matrices.
 //!
 //! > For the partial rounds, the MDS property is not required anymore, and
@@ -28,9 +28,8 @@
 //      assert ((const_mat + diag_mat)^i).characteristic_polynomial().is_irreducible()
 
 use p3_field::{AbstractField, Field};
-use p3_symmetric::Permutation;
 
-pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WIDTH]> {}
+use crate::Poseidon2InternalPackedConstants;
 
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
 pub fn matmul_internal<F: Field, AF: AbstractField<F = F>, const WIDTH: usize>(
@@ -41,5 +40,40 @@ pub fn matmul_internal<F: Field, AF: AbstractField<F = F>, const WIDTH: usize>(
     for i in 0..WIDTH {
         state[i] *= AF::from_f(mat_internal_diag_m_1[i]);
         state[i] += sum.clone();
+    }
+}
+
+pub trait InternalLayer<AF, PackedConstants, const WIDTH: usize, const D: u64>:
+    Sync + Clone
+where
+    AF: AbstractField,
+    PackedConstants: Poseidon2InternalPackedConstants<AF::F>,
+{
+    /// The type used internally by the Poseidon2 implementation.
+    /// In the scalar case, InternalState = [AF; WIDTH] but for PackedFields it's faster to use packed vectors.
+    /// This must be the same as the InternalState field used in the corresponding External Layer.
+    type InternalState;
+
+    /// Compute the internal part of the Poseidon2 permutation.
+    fn permute_state(
+        &self,
+        state: &mut Self::InternalState,
+        internal_constants: &[AF::F],
+        internal_packed_constants: &[PackedConstants::InternalConstantsType],
+    );
+}
+
+// A helper method which allows any field to easily implement Internal Layer.
+// This should be used in places where performance is not critical.
+#[inline]
+pub fn internal_permute_state<AF: AbstractField, const WIDTH: usize, const D: u64>(
+    state: &mut [AF; WIDTH],
+    diffusion_mat: fn(&mut [AF; WIDTH]),
+    internal_constants: &[AF::F],
+) {
+    for elem in internal_constants.iter() {
+        state[0] += AF::from_f(*elem);
+        state[0] = state[0].exp_const_u64::<D>();
+        diffusion_mat(state);
     }
 }

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -8,14 +8,16 @@
 
 extern crate alloc;
 
+mod constants;
 mod diffusion;
 mod matrix;
 mod round_numbers;
 use alloc::vec::Vec;
 
-pub use diffusion::{matmul_internal, DiffusionPermutation};
+pub use constants::*;
+pub use diffusion::*;
 pub use matrix::*;
-use p3_field::{AbstractField, PrimeField, PrimeField64};
+use p3_field::{AbstractField, Field, PrimeField, PrimeField64};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -25,182 +27,183 @@ const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
 
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
-pub struct Poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64> {
-    /// The number of external rounds.
-    rounds_f: usize,
-
+pub struct Poseidon2<
+    F,
+    ExternalPerm,
+    InternalPerm,
+    PackedConstants,
+    const WIDTH: usize,
+    const D: u64,
+> where
+    F: Field,
+    PackedConstants:
+        Poseidon2ExternalPackedConstants<F, WIDTH> + Poseidon2InternalPackedConstants<F>,
+{
     /// The external round constants.
-    external_constants: Vec<[F; WIDTH]>,
+    external_constants: [Vec<[F; WIDTH]>; 2],
 
-    /// The linear layer used in External Rounds. Should be either MDS or a
-    /// circulant matrix based off an MDS matrix of size 4.
-    external_linear_layer: MdsLight,
+    /// The external round constants converted for optimal use with PackedFields.
+    external_packed_constants: [Vec<PackedConstants::ExternalConstantsType>; 2],
 
-    /// The number of internal rounds.
-    rounds_p: usize,
+    /// The permutations used in External Rounds.
+    external_layer: ExternalPerm,
 
     /// The internal round constants.
     internal_constants: Vec<F>,
 
-    /// The linear layer used in internal rounds (only needs diffusion property, not MDS).
-    internal_linear_layer: Diffusion,
+    /// The internal round constants converted for optimal use with PackedFields.
+    internal_packed_constants: Vec<PackedConstants::InternalConstantsType>,
+
+    /// The permutation used in Internal Rounds.
+    internal_layer: InternalPerm,
 }
 
-impl<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
-    Poseidon2<F, MdsLight, Diffusion, WIDTH, D>
+impl<F, ExternalPerm, InternalPerm, PackedConstants, const WIDTH: usize, const D: u64>
+    Poseidon2<F, ExternalPerm, InternalPerm, PackedConstants, WIDTH, D>
 where
     F: PrimeField,
+    PackedConstants:
+        Poseidon2ExternalPackedConstants<F, WIDTH> + Poseidon2InternalPackedConstants<F>,
 {
     /// Create a new Poseidon2 configuration.
+    /// This internally converts the given constants to the relevant packed versions.
     pub fn new(
-        rounds_f: usize,
-        external_constants: Vec<[F; WIDTH]>,
-        external_linear_layer: MdsLight,
-        rounds_p: usize,
+        external_constants: [Vec<[F; WIDTH]>; 2],
+        external_layer: ExternalPerm,
         internal_constants: Vec<F>,
-        internal_linear_layer: Diffusion,
+        internal_layer: InternalPerm,
     ) -> Self {
         assert!(SUPPORTED_WIDTHS.contains(&WIDTH));
+        let external_packed_constants: [Vec<_>; 2] =
+            external_constants.clone().map(|constant_list| {
+                constant_list
+                    .iter()
+                    .map(|constants| PackedConstants::manipulate_external_constants(constants))
+                    .collect()
+            });
+        let internal_packed_constants: Vec<_> = internal_constants
+            .iter()
+            .map(|val| PackedConstants::manipulate_internal_constants(val))
+            .collect();
+
         Self {
-            rounds_f,
             external_constants,
-            external_linear_layer,
-            rounds_p,
+            external_packed_constants,
+            external_layer,
             internal_constants,
-            internal_linear_layer,
+            internal_packed_constants,
+            internal_layer,
         }
     }
 
     /// Create a new Poseidon2 configuration with random parameters.
     pub fn new_from_rng<R: Rng>(
         rounds_f: usize,
-        external_linear_layer: MdsLight,
+        external_layer: ExternalPerm,
         rounds_p: usize,
-        internal_linear_layer: Diffusion,
+        internal_layer: InternalPerm,
         rng: &mut R,
     ) -> Self
     where
         Standard: Distribution<F> + Distribution<[F; WIDTH]>,
     {
-        let external_constants = rng
-            .sample_iter(Standard)
-            .take(rounds_f)
-            .collect::<Vec<[F; WIDTH]>>();
+        let half_f = rounds_f / 2;
+        assert_eq!(
+            2 * half_f,
+            rounds_f,
+            "The total number of external rounds should be even"
+        );
+        let init_external_constants = rng.sample_iter(Standard).take(half_f).collect();
+        let final_external_constants = rng.sample_iter(Standard).take(half_f).collect();
+        let external_constants = [init_external_constants, final_external_constants];
         let internal_constants = rng.sample_iter(Standard).take(rounds_p).collect::<Vec<F>>();
 
-        Self {
-            rounds_f,
+        Self::new(
             external_constants,
-            external_linear_layer,
-            rounds_p,
+            external_layer,
             internal_constants,
-            internal_linear_layer,
-        }
-    }
-
-    #[inline]
-    fn add_rc<AF>(&self, state: &mut [AF; WIDTH], rc: &[AF::F; WIDTH])
-    where
-        AF: AbstractField<F = F>,
-    {
-        state
-            .iter_mut()
-            .zip(rc)
-            .for_each(|(a, b)| *a += AF::from_f(*b));
-    }
-
-    #[inline]
-    fn sbox_p<AF>(&self, input: &AF) -> AF
-    where
-        AF: AbstractField<F = F>,
-    {
-        input.exp_const_u64::<D>()
-    }
-
-    #[inline]
-    fn sbox<AF>(&self, state: &mut [AF; WIDTH])
-    where
-        AF: AbstractField<F = F>,
-    {
-        state.iter_mut().for_each(|a| *a = self.sbox_p(a));
+            internal_layer,
+        )
     }
 }
 
-impl<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
-    Poseidon2<F, MdsLight, Diffusion, WIDTH, D>
+impl<F, ExternalPerm, InternalPerm, PackedConstants, const WIDTH: usize, const D: u64>
+    Poseidon2<F, ExternalPerm, InternalPerm, PackedConstants, WIDTH, D>
 where
     F: PrimeField64,
+    PackedConstants:
+        Poseidon2ExternalPackedConstants<F, WIDTH> + Poseidon2InternalPackedConstants<F>,
 {
     /// Create a new Poseidon2 configuration with 128 bit security and random rounds constants.
     pub fn new_from_rng_128<R: Rng>(
-        external_linear_layer: MdsLight,
-        internal_linear_layer: Diffusion,
+        external_layer: ExternalPerm,
+        internal_layer: InternalPerm,
         rng: &mut R,
     ) -> Self
     where
         Standard: Distribution<F> + Distribution<[F; WIDTH]>,
     {
         let (rounds_f, rounds_p) = poseidon2_round_numbers_128::<F>(WIDTH, D);
-
-        let external_constants = rng
-            .sample_iter(Standard)
-            .take(rounds_f)
-            .collect::<Vec<[F; WIDTH]>>();
-        let internal_constants = rng.sample_iter(Standard).take(rounds_p).collect::<Vec<F>>();
-
-        Self {
-            rounds_f,
-            external_constants,
-            external_linear_layer,
-            rounds_p,
-            internal_constants,
-            internal_linear_layer,
-        }
+        Self::new_from_rng(rounds_f, external_layer, rounds_p, internal_layer, rng)
     }
 }
 
-impl<AF, MdsLight, Diffusion, const WIDTH: usize, const D: u64> Permutation<[AF; WIDTH]>
-    for Poseidon2<AF::F, MdsLight, Diffusion, WIDTH, D>
+impl<AF, ExternalPerm, InternalPerm, PackedConstants, const WIDTH: usize, const D: u64>
+    Permutation<[AF; WIDTH]>
+    for Poseidon2<AF::F, ExternalPerm, InternalPerm, PackedConstants, WIDTH, D>
 where
     AF: AbstractField,
     AF::F: PrimeField,
-    MdsLight: MdsLightPermutation<AF, WIDTH>,
-    Diffusion: DiffusionPermutation<AF, WIDTH>,
+    PackedConstants:
+        Poseidon2ExternalPackedConstants<AF::F, WIDTH> + Poseidon2InternalPackedConstants<AF::F>,
+    ExternalPerm: ExternalLayer<AF, PackedConstants, WIDTH, D>,
+    InternalPerm:
+        InternalLayer<AF, PackedConstants, WIDTH, D, InternalState = ExternalPerm::InternalState>,
 {
+    fn permute(&self, state: [AF; WIDTH]) -> [AF; WIDTH] {
+        let mut internal_state = self.external_layer.to_internal_rep(state);
+
+        for sub_state in internal_state.as_mut() {
+            // The first half of the external rounds.
+            self.external_layer.permute_state_initial(
+                sub_state,
+                &self.external_constants[0],
+                &self.external_packed_constants[0],
+            );
+
+            // The internal rounds.
+            self.internal_layer.permute_state(
+                sub_state,
+                &self.internal_constants,
+                &self.internal_packed_constants,
+            );
+
+            // The second half of the external rounds.
+            self.external_layer.permute_state_final(
+                sub_state,
+                &self.external_constants[1],
+                &self.external_packed_constants[1],
+            );
+        }
+
+        self.external_layer.to_output_rep(internal_state)
+    }
+
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
-        // The initial linear layer.
-        self.external_linear_layer.permute_mut(state);
-
-        // The first half of the external rounds.
-        let rounds_f_half = self.rounds_f / 2;
-        for r in 0..rounds_f_half {
-            self.add_rc(state, &self.external_constants[r]);
-            self.sbox(state);
-            self.external_linear_layer.permute_mut(state);
-        }
-
-        // The internal rounds.
-        for r in 0..self.rounds_p {
-            state[0] += AF::from_f(self.internal_constants[r]);
-            state[0] = self.sbox_p(&state[0]);
-            self.internal_linear_layer.permute_mut(state);
-        }
-
-        // The second half of the external rounds.
-        for r in rounds_f_half..self.rounds_f {
-            self.add_rc(state, &self.external_constants[r]);
-            self.sbox(state);
-            self.external_linear_layer.permute_mut(state);
-        }
+        *state = self.permute((*state).clone())
     }
 }
 
-impl<AF, MdsLight, Diffusion, const WIDTH: usize, const D: u64>
-    CryptographicPermutation<[AF; WIDTH]> for Poseidon2<AF::F, MdsLight, Diffusion, WIDTH, D>
+impl<AF, ExternalPerm, InternalPerm, PackedConstants, const WIDTH: usize, const D: u64>
+    CryptographicPermutation<[AF; WIDTH]>
+    for Poseidon2<AF::F, ExternalPerm, InternalPerm, PackedConstants, WIDTH, D>
 where
     AF: AbstractField,
     AF::F: PrimeField,
-    MdsLight: MdsLightPermutation<AF, WIDTH>,
-    Diffusion: DiffusionPermutation<AF, WIDTH>,
+    PackedConstants:
+        Poseidon2ExternalPackedConstants<AF::F, WIDTH> + Poseidon2InternalPackedConstants<AF::F>,
+    ExternalPerm: ExternalLayer<AF, PackedConstants, WIDTH, D>,
+    InternalPerm:
+        InternalLayer<AF, PackedConstants, WIDTH, D, InternalState = ExternalPerm::InternalState>,
 {
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -161,6 +161,7 @@ where
     // with the initial rounds involving an extra matrix multiplication.
 
     /// Compute the initial external permutation.
+    /// Implementations will usually not use both constants fields.
     fn permute_state_initial(
         &self,
         state: &mut Self::InternalState,
@@ -169,6 +170,7 @@ where
     );
 
     /// Compute the final external permutation.
+    /// Implementations will usually not use both constants fields.
     fn permute_state_final(
         &self,
         state: &mut Self::InternalState,
@@ -180,8 +182,8 @@ where
     fn to_output_rep(&self, state: Self::ArrayState) -> [AF; WIDTH];
 }
 
-// A pair of helper methods which allow any field to easily implement External Layer.
-// These should be used in places where performance is not critical.
+/// A helper method which allow any field to easily implement the final External Layer.
+/// This should only be used in places where performance is not critical.
 #[inline]
 pub fn external_final_permute_state<
     AF: AbstractField,
@@ -203,6 +205,8 @@ pub fn external_final_permute_state<
     }
 }
 
+/// A helper method which allow any field to easily implement the initial External Layer.
+/// This should only be used in places where performance is not critical.
 #[inline]
 pub fn external_initial_permute_state<
     AF: AbstractField,


### PR DESCRIPTION
We should be able to make Poseidon2 quite a bit faster (~10-20% for M31, 30-50% for BabyBear/KoalaBear) by making use of vectorization. Unfortunately, this will lead to some necessarily breaking API changes.

This PR introduces the suggested API changes and re-writes the Goldilocks and M31 Poseidon2 implementations using the new API but without any vectorization for now.

Plan is to do a similar thing to when developing the MONTY-31 field we do a bunch of PR requests onto a branch to help with the eventual large PR on main. This also lets us leave the branch slightly broken (e.g. it currently won't compile) as we slowly build things.

The broad goal of the API changes are to facilitate fast vectorized implementations.

There are 2 major problems with the current API which this PR seeks to address.

1: For both the internal and external layers, currently we are only able to externally edit the linear layer with the method of performing the s-box and adding the round constants fixed. For a more optimized implementation it's faster to combine these three parts of each layer to minimize the number of modulo reductions.

2: We would like to be able to have finer control on the internal formatting of the inputs and outputs of the layers. E.g. even though the input may be gives as a vector of packed field elements, usually internally we want to work with some type of architecture specific vector form.

3: Similarly to the above point, it's also important to be able to save the round constants in the correct format to speed up loading and applying them. The specific form will depend on the architecture used and so we introduce a new trait and Poseidon2 parameter to handle this. We leave the old implementation to allow for Poseidon2 to work mostly unchanged for fields which have less architecture specific support.

Some minor comments:

1: Most of the external/internal layers now take 3 inputs, state, constants, packed_constants the intention is that non packed implementations will ignore the third input and similarly packed implementation will ignore the second.

2: I've added a couple of functions which basically recreate the old functionality to make it easy for fields to implement a basic (non optimized) version. See what's been done in the Goldilocks crate for an example of how this is used.