### PR TITLE
Fixing strange AVX2 compilation bug

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,9 +1,12 @@
+use std::any::type_name;
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::AbstractField;
+use p3_field::{AbstractField, Field};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
-    benchmark_sub_latency, benchmark_sub_throughput,
+    benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,
+    benchmark_sub_throughput,
 };
 
 type F = BabyBear;
@@ -33,5 +36,20 @@ fn bench_field(c: &mut Criterion) {
     });
 }
 
-criterion_group!(baby_bear_arithmetic, bench_field);
+fn bench_packedfield(c: &mut Criterion) {
+    let name = type_name::<<F as Field>::Packing>().to_string();
+    // Note that each round of throughput has 10 operations
+    // So we should have 10 * more repetitions for latency tests.
+    const REPS: usize = 100;
+    const L_REPS: usize = 10 * REPS;
+
+    // benchmark_add_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    // benchmark_add_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    // benchmark_sub_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    // benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    benchmark_mul_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_mul_throughput::<<F as Field>::Packing, REPS>(c, &name);
+}
+
+criterion_group!(baby_bear_arithmetic, bench_field, bench_packedfield);
 criterion_main!(baby_bear_arithmetic);

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -43,10 +43,10 @@ fn bench_packedfield(c: &mut Criterion) {
     const REPS: usize = 100;
     const L_REPS: usize = 10 * REPS;
 
-    // benchmark_add_latency::<<F as Field>::Packing, L_REPS>(c, &name);
-    // benchmark_add_throughput::<<F as Field>::Packing, REPS>(c, &name);
-    // benchmark_sub_latency::<<F as Field>::Packing, L_REPS>(c, &name);
-    // benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    benchmark_add_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_add_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    benchmark_sub_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
     benchmark_mul_latency::<<F as Field>::Packing, L_REPS>(c, &name);
     benchmark_mul_throughput::<<F as Field>::Packing, REPS>(c, &name);
 }

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -1,23 +1,32 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
-use p3_field_testing::bench_func::{benchmark_inv, benchmark_mul, benchmark_square};
+use p3_field_testing::bench_func::{
+    benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
+};
 
 type EF4 = BinomialExtensionField<BabyBear, 4>;
 type EF5 = BinomialExtensionField<BabyBear, 5>;
+
+// Note that each round of throughput has 10 operations
+// So we should have 10 * more repetitions for latency tests.
+const REPS: usize = 100;
+const L_REPS: usize = 10 * REPS;
 
 fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
     benchmark_square::<EF4>(c, name);
     benchmark_inv::<EF4>(c, name);
-    benchmark_mul::<EF4>(c, name);
+    benchmark_mul_throughput::<EF4, REPS>(c, name);
+    benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
 fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
     benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
-    benchmark_mul::<EF5>(c, name);
+    benchmark_mul_throughput::<EF5, REPS>(c, name);
+    benchmark_mul_latency::<EF5, L_REPS>(c, name);
 }
 
 criterion_group!(

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use criterion::{black_box, BatchSize, Criterion};
-use p3_field::Field;
+use p3_field::{AbstractField, Field};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -26,18 +26,6 @@ where
     let x = rng.gen::<F>();
     c.bench_function(&format!("{} inv", name), |b| {
         b.iter(|| black_box(black_box(x)).inverse())
-    });
-}
-
-pub fn benchmark_mul<F: Field>(c: &mut Criterion, name: &str)
-where
-    Standard: Distribution<F>,
-{
-    let mut rng = rand::thread_rng();
-    let x = rng.gen::<F>();
-    let y = rng.gen::<F>();
-    c.bench_function(&format!("{} mul", name), |b| {
-        b.iter(|| black_box(black_box(x) * black_box(y)))
     });
 }
 
@@ -65,45 +53,49 @@ pub fn benchmark_iter_sum<F: Field, const N: usize, const REPS: usize>(
     });
 }
 
-pub fn benchmark_add_latency<F: Field, const N: usize>(c: &mut Criterion, name: &str)
-where
-    Standard: Distribution<F>,
+pub fn benchmark_add_latency<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
 {
-    c.bench_function(&format!("{} add-latency/{}", name, N), |b| {
+    c.bench_function(&format!("add-latency/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<F>())
+                    vec.push(rng.gen::<AF>())
                 }
                 vec
             },
-            |x| x.iter().fold(F::zero(), |x, y| x + *y),
+            |x| x.iter().fold(AF::zero(), |x, y| x + *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_add_throughput<F: Field, const N: usize>(c: &mut Criterion, name: &str)
-where
-    Standard: Distribution<F>,
+pub fn benchmark_add_throughput<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
 {
-    c.bench_function(&format!("{} add-throughput/{}", name, N), |b| {
+    c.bench_function(&format!("add-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -128,45 +120,49 @@ where
     });
 }
 
-pub fn benchmark_sub_latency<F: Field, const N: usize>(c: &mut Criterion, name: &str)
-where
-    Standard: Distribution<F>,
+pub fn benchmark_sub_latency<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
 {
-    c.bench_function(&format!("{} sub-latency/{}", name, N), |b| {
+    c.bench_function(&format!("sub-latency/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<F>())
+                    vec.push(rng.gen::<AF>())
                 }
                 vec
             },
-            |x| x.iter().fold(F::zero(), |x, y| x - *y),
+            |x| x.iter().fold(AF::zero(), |x, y| x - *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_sub_throughput<F: Field, const N: usize>(c: &mut Criterion, name: &str)
-where
-    Standard: Distribution<F>,
+pub fn benchmark_sub_throughput<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
 {
-    c.bench_function(&format!("{} sub-throughput/{}", name, N), |b| {
+    c.bench_function(&format!("sub-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
-                    rng.gen::<F>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -182,6 +178,73 @@ where
                         h - i,
                         i - j,
                         j - a,
+                    );
+                }
+                (a, b, c, d, e, f, g, h, i, j)
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn benchmark_mul_latency<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
+{
+    c.bench_function(&format!("mul-latency/{} {}", N, name), |b| {
+        b.iter_batched(
+            || {
+                let mut rng = rand::thread_rng();
+                let mut vec = Vec::new();
+                for _ in 0..N {
+                    vec.push(rng.gen::<AF>())
+                }
+                vec
+            },
+            |x| x.iter().fold(AF::zero(), |x, y| x * *y),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn benchmark_mul_throughput<AF: AbstractField + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    Standard: Distribution<AF>,
+{
+    c.bench_function(&format!("mul-throughput/{} {}", N, name), |b| {
+        b.iter_batched(
+            || {
+                let mut rng = rand::thread_rng();
+                (
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                    rng.gen::<AF>(),
+                )
+            },
+            |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
+                for _ in 0..N {
+                    (a, b, c, d, e, f, g, h, i, j) = (
+                        a * b,
+                        b * c,
+                        c * d,
+                        d * e,
+                        e * f,
+                        f * g,
+                        g * h,
+                        h * i,
+                        i * j,
+                        j * a,
                     );
                 }
                 (a, b, c, d, e, f, g, h, i, j)

--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -1,15 +1,23 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use p3_field::extension::BinomialExtensionField;
-use p3_field_testing::bench_func::{benchmark_inv, benchmark_mul, benchmark_square};
+use p3_field_testing::bench_func::{
+    benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
+};
 use p3_goldilocks::Goldilocks;
 
 type EF2 = BinomialExtensionField<Goldilocks, 2>;
+
+// Note that each round of throughput has 10 operations
+// So we should have 10 * more repetitions for latency tests.
+const REPS: usize = 50;
+const L_REPS: usize = 10 * REPS;
 
 fn bench_qudratic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Goldilocks, 2>";
     benchmark_square::<EF2>(c, name);
     benchmark_inv::<EF2>(c, name);
-    benchmark_mul::<EF2>(c, name);
+    benchmark_mul_throughput::<EF2, REPS>(c, name);
+    benchmark_mul_latency::<EF2, L_REPS>(c, name);
 }
 
 criterion_group!(bench_goldilocks_ef2, bench_qudratic_extension);

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -1,8 +1,11 @@
+use std::any::type_name;
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::AbstractField;
+use p3_field::{AbstractField, Field};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
-    benchmark_sub_latency, benchmark_sub_throughput,
+    benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,
+    benchmark_sub_throughput,
 };
 use p3_koala_bear::KoalaBear;
 
@@ -33,5 +36,20 @@ fn bench_field(c: &mut Criterion) {
     });
 }
 
-criterion_group!(koala_bear_arithmetic, bench_field);
+fn bench_packedfield(c: &mut Criterion) {
+    let name = type_name::<<F as Field>::Packing>().to_string();
+    // Note that each round of throughput has 10 operations
+    // So we should have 10 * more repetitions for latency tests.
+    const REPS: usize = 100;
+    const L_REPS: usize = 10 * REPS;
+
+    benchmark_add_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_add_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    benchmark_sub_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
+    benchmark_mul_latency::<<F as Field>::Packing, L_REPS>(c, &name);
+    benchmark_mul_throughput::<<F as Field>::Packing, REPS>(c, &name);
+}
+
+criterion_group!(koala_bear_arithmetic, bench_field, bench_packedfield);
 criterion_main!(koala_bear_arithmetic);

--- a/mersenne-31/benches/extension.rs
+++ b/mersenne-31/benches/extension.rs
@@ -1,23 +1,30 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use p3_field::extension::{BinomialExtensionField, Complex};
-use p3_field_testing::bench_func::{benchmark_inv, benchmark_mul, benchmark_square};
+use p3_field_testing::bench_func::{
+    benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
+};
 use p3_mersenne_31::Mersenne31;
 
 type EF2 = BinomialExtensionField<Complex<Mersenne31>, 2>;
 type EF3 = BinomialExtensionField<Complex<Mersenne31>, 3>;
 
+const REPS: usize = 100;
+const L_REPS: usize = 10 * REPS;
+
 fn bench_qudratic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Mersenne31Complex<Mersenne31>, 2>";
     benchmark_square::<EF2>(c, name);
     benchmark_inv::<EF2>(c, name);
-    benchmark_mul::<EF2>(c, name);
+    benchmark_mul_throughput::<EF2, REPS>(c, name);
+    benchmark_mul_latency::<EF2, L_REPS>(c, name);
 }
 
 fn bench_cubic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Mersenne31Complex<Mersenne31>, 3>";
     benchmark_square::<EF3>(c, name);
     benchmark_inv::<EF3>(c, name);
-    benchmark_mul::<EF3>(c, name);
+    benchmark_mul_throughput::<EF3, REPS>(c, name);
+    benchmark_mul_latency::<EF3, L_REPS>(c, name);
 }
 
 criterion_group!(bench_mersennecomplex_ef2, bench_qudratic_extension);

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -174,7 +174,7 @@ fn monty_d<MPAVX2: MontyParametersAVX2>(lhs: __m256i, rhs: __m256i) -> __m256i {
         let prod = x86_64::_mm256_mul_epu32(lhs, rhs);
         let q = x86_64::_mm256_mul_epu32(prod, MPAVX2::PACKED_MU);
         let q_P = x86_64::_mm256_mul_epu32(q, MPAVX2::PACKED_P);
-        x86_64::_mm256_sub_epi64(prod, q_P)
+        x86_64::_mm256_sub_epi32(prod, q_P)
     }
 }
 


### PR DESCRIPTION
This PR contains 2 things. Most of the changes are simply modifying the benchmark code to be able to bench the packed field implementations and adding in benchmarks for mul latency and throughput.

These benchmarks are then used to show the improvement that the 2 character change to monty-31/src/x86_64_avx2/packing.rs produces. Note that this change is valid as the bottom 32 bits of the things being subtracted are always identical (This is broadly the entire point of Monty multiplication). Despite being mathematically identical, there is a large difference in the code produced by the 2 almost identical implementations of Monty multiplication. (See https://godbolt.org/z/3W8M7Tv84 for the compiled code produced).

For such a small change, the output is somewhat dramatic. We get roughly a 30% improvement for mul-latency and a somewhat crazy 55% improvement for mul-throughput.

These translate to around a 30% improvement to the proving speed of the examples `prove_baby_bear_poseidon2` and `prove_koala_bear_poseidon2`.




