### PR TITLE
AVX2 implementation for Poseidon2 for M31.

### DIFF
--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -11,7 +11,6 @@
 use p3_poseidon2::{
     external_final_permute_state, external_initial_permute_state, internal_permute_state,
     matmul_internal, ExternalLayer, HLMDSMat4, InternalLayer, MDSMat4, NoPackedImplementation,
-    Poseidon2ExternalPackedConstants,
 };
 
 use crate::{to_goldilocks_array, Goldilocks};

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 /// The Mersenne31 prime
-const P: u32 = (1 << 31) - 1;
+pub(crate) const P: u32 = (1 << 31) - 1;
 
 /// The prime field `F_p` where `p = 2^31 - 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -1,7 +1,8 @@
 use p3_field::PrimeField32;
 use p3_poseidon2::{
     external_final_permute_state, external_initial_permute_state, internal_permute_state,
-    ExternalLayer, InternalLayer, MDSMat4, NoPackedImplementation,
+    ExternalLayer, InternalLayer, MDSMat4, Poseidon2ExternalPackedConstants,
+    Poseidon2InternalPackedConstants,
 };
 
 use crate::{from_u62, to_mersenne31_array, Mersenne31};
@@ -87,8 +88,6 @@ fn permute_mut<const N: usize>(state: &mut [Mersenne31; N], shifts: &[u8]) {
 #[derive(Debug, Clone, Default)]
 pub struct Poseidon2InternalLayerMersenne31;
 
-impl NoPackedImplementation for Poseidon2InternalLayerMersenne31 {}
-
 impl InternalLayer<Mersenne31, 16, 5> for Poseidon2InternalLayerMersenne31 {
     type InternalState = [Mersenne31; 16];
 
@@ -96,7 +95,7 @@ impl InternalLayer<Mersenne31, 16, 5> for Poseidon2InternalLayerMersenne31 {
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Mersenne31],
-        _packed_internal_constants: &[()],
+        _packed_internal_constants: &[<Poseidon2InternalLayerMersenne31 as Poseidon2InternalPackedConstants::<Mersenne31>>::ConstantsType],
     ) {
         internal_permute_state::<Mersenne31, 16, 5>(
             state,
@@ -113,7 +112,7 @@ impl InternalLayer<Mersenne31, 24, 5> for Poseidon2InternalLayerMersenne31 {
         &self,
         state: &mut Self::InternalState,
         internal_constants: &[Mersenne31],
-        _packed_internal_constants: &[()],
+        _packed_internal_constants: &[<Poseidon2InternalLayerMersenne31 as Poseidon2InternalPackedConstants::<Mersenne31>>::ConstantsType],
     ) {
         internal_permute_state::<Mersenne31, 24, 5>(
             state,
@@ -126,8 +125,6 @@ impl InternalLayer<Mersenne31, 24, 5> for Poseidon2InternalLayerMersenne31 {
 #[derive(Default, Clone)]
 pub struct Poseidon2ExternalLayerMersenne31;
 
-impl NoPackedImplementation for Poseidon2ExternalLayerMersenne31 {}
-
 impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, 5> for Poseidon2ExternalLayerMersenne31 {
     type InternalState = [Mersenne31; WIDTH];
 
@@ -135,7 +132,7 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, 5> for Poseidon2Extern
         &self,
         mut state: [Mersenne31; WIDTH],
         initial_external_constants: &[[Mersenne31; WIDTH]],
-        _packed_initial_external_constants: &[()],
+        _packed_initial_external_constants: &[<Poseidon2ExternalLayerMersenne31 as Poseidon2ExternalPackedConstants::<Mersenne31, WIDTH>>::ConstantsType],
     ) -> [Mersenne31; WIDTH] {
         external_initial_permute_state::<Mersenne31, MDSMat4, WIDTH, 5>(
             &mut state,
@@ -149,7 +146,7 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, 5> for Poseidon2Extern
         &self,
         mut state: Self::InternalState,
         final_external_constants: &[[Mersenne31; WIDTH]],
-        _packed_final_external_constants: &[()],
+        _packed_final_external_constants: &[<Poseidon2ExternalLayerMersenne31 as Poseidon2ExternalPackedConstants::<Mersenne31, WIDTH>>::ConstantsType],
     ) -> [Mersenne31; WIDTH] {
         external_final_permute_state::<Mersenne31, MDSMat4, WIDTH, 5>(
             &mut state,

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -147,6 +147,8 @@ fn movehdup_epi32(x: __m256i) -> __m256i {
     }
 }
 
+#[inline]
+#[must_use]
 fn moveldup_epi32(x: __m256i) -> __m256i {
     // This instruction is only available in the floating-point flavor; this distinction is only for
     // historical reasons and no longer matters. We cast to floats, duplicate, and cast back.
@@ -299,7 +301,7 @@ fn square_unred(x: __m256i) -> __m256i {
 /// represented as values in {0, ..., P}. If the inputs do not conform
 /// to this representation, the result is undefined.
 #[inline(always)]
-pub(crate) fn sbox(x: __m256i) -> __m256i {
+pub(crate) fn exp5(x: __m256i) -> __m256i {
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
         let input_evn = x;
@@ -462,7 +464,7 @@ impl AbstractField for PackedMersenne31AVX2 {
             4 => self.square().square(),
             5 => unsafe {
                 let val = self.to_vector();
-                Self::from_vector(sbox(val))
+                Self::from_vector(exp5(val))
             },
             6 => self.square().cube(),
             7 => {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -263,7 +263,7 @@ fn sub(lhs: __m256i, rhs: __m256i) -> __m256i {
     }
 }
 
-/// Perform a module reduction to reduce a modulo class representative in {0, ..., P^2}
+/// Reduce a representative in {0, ..., P^2}
 /// to a representative in [-P, P]. If the input is greater than P^2, the output will
 /// still correspond to the same modulo class will instead lie in [-P, 2^34].
 #[inline(always)]

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -265,7 +265,7 @@ fn sub(lhs: __m256i, rhs: __m256i) -> __m256i {
 
 /// Reduce a representative in {0, ..., P^2}
 /// to a representative in [-P, P]. If the input is greater than P^2, the output will
-/// still correspond to the same modulo class will instead lie in [-P, 2^34].
+/// still correspond to the same class but will instead lie in [-P, 2^34].
 #[inline(always)]
 fn partial_reduce_neg(x: __m256i) -> __m256i {
     unsafe {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use crate::Mersenne31;
 
 const WIDTH: usize = 8;
-pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
+pub(crate) const P_AVX2: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
 
 /// Vectorized AVX2 implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -132,7 +132,7 @@ fn add(lhs: __m256i, rhs: __m256i) -> __m256i {
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
         let t = x86_64::_mm256_add_epi32(lhs, rhs);
-        let u = x86_64::_mm256_sub_epi32(t, P);
+        let u = x86_64::_mm256_sub_epi32(t, P_AVX2);
         x86_64::_mm256_min_epu32(t, u)
     }
 }
@@ -211,7 +211,7 @@ fn mul(lhs: __m256i, rhs: __m256i) -> __m256i {
         // the odd values come from prod_odd_dbl.
         let prod_hi = x86_64::_mm256_blend_epi32::<0b10101010>(prod_evn_hi, prod_odd_dbl);
         // Clear the most significant bit.
-        let prod_lo = x86_64::_mm256_and_si256(prod_lo_dirty, P);
+        let prod_lo = x86_64::_mm256_and_si256(prod_lo_dirty, P_AVX2);
 
         // Standard addition of two 31-bit values.
         add(prod_lo, prod_hi)
@@ -232,7 +232,7 @@ fn neg(val: __m256i) -> __m256i {
     // ..., P}.
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
-        x86_64::_mm256_xor_si256(val, P)
+        x86_64::_mm256_xor_si256(val, P_AVX2)
     }
 }
 
@@ -258,7 +258,7 @@ fn sub(lhs: __m256i, rhs: __m256i) -> __m256i {
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
         let t = x86_64::_mm256_sub_epi32(lhs, rhs);
-        let u = x86_64::_mm256_add_epi32(t, P);
+        let u = x86_64::_mm256_add_epi32(t, P_AVX2);
         x86_64::_mm256_min_epu32(t, u)
     }
 }
@@ -320,8 +320,8 @@ pub(crate) fn sbox(x: __m256i) -> __m256i {
 
         let lo_dirty = x86_64::_mm256_blend_epi32::<0b10101010>(evn_5, odd_5_lo_dirty);
         let hi = x86_64::_mm256_blend_epi32::<0b10101010>(evn_5_hi, odd_5_hi);
-        let lo = x86_64::_mm256_and_si256(lo_dirty, P);
-        let corr = x86_64::_mm256_sign_epi32(P, hi);
+        let lo = x86_64::_mm256_and_si256(lo_dirty, P_AVX2);
+        let corr = x86_64::_mm256_sign_epi32(P_AVX2, hi);
         let t = x86_64::_mm256_add_epi32(hi, lo);
         let u = x86_64::_mm256_sub_epi32(t, corr);
 

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -1,48 +1,155 @@
-// use core::arch::x86_64::{self, __m256i};
-// use core::mem::transmute;
+use core::arch::x86_64::{self};
+use p3_poseidon2::DiffusionPermutation;
+use p3_symmetric::Permutation;
 
-use p3_poseidon2::{
-    external_final_permute_state, external_initial_permute_state, internal_permute_state,
-    matmul_internal, ExternalLayer, InternalLayer, MDSMat4,
-};
+use crate::{DiffusionMatrixMersenne31, PackedMersenne31AVX2, P};
 
-use crate::{
-    Mersenne31, PackedMersenne31AVX2, Poseidon2ExternalLayerMersenne31,
-    Poseidon2InternalLayerMersenne31, POSEIDON2_INTERNAL_MATRIX_DIAG_16,
-    POSEIDON2_INTERNAL_MATRIX_DIAG_24,
-};
-
-impl InternalLayer<PackedMersenne31AVX2, 16, 5> for Poseidon2InternalLayerMersenne31 {
-    type InternalState = [PackedMersenne31AVX2; 16];
-
-    fn permute_state(
-        &self,
-        state: &mut Self::InternalState,
-        internal_constants: &[Mersenne31],
-        _packed_internal_constants: &[()],
-    ) {
-        internal_permute_state::<PackedMersenne31AVX2, 16, 5>(
-            state,
-            |x| matmul_internal(x, POSEIDON2_INTERNAL_MATRIX_DIAG_16),
-            internal_constants,
-        )
+// I + I_PRIME must be 31.
+#[inline(always)]
+fn left_shift_single<const I: i32, const I_PRIME: i32>(
+    val: PackedMersenne31AVX2,
+) -> PackedMersenne31AVX2 {
+    // Clearly there would be a nicer way to do this if const generics where better...
+    unsafe {
+        let input = val.to_vector();
+        let hi_bits_dirty = x86_64::_mm256_slli_epi32::<I>(input);
+        let lo_bits = x86_64::_mm256_srli_epi32::<I_PRIME>(input);
+        let hi_bits = x86_64::_mm256_and_si256(hi_bits_dirty, P);
+        let output = x86_64::_mm256_or_si256(lo_bits, hi_bits);
+        PackedMersenne31AVX2::from_vector(output)
     }
 }
 
-impl InternalLayer<PackedMersenne31AVX2, 24, 5> for Poseidon2InternalLayerMersenne31 {
-    type InternalState = [PackedMersenne31AVX2; 24];
+// [-2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16];
+#[inline(always)]
+fn left_shift_16(state: &mut [PackedMersenne31AVX2; 16]) {
+    // A little annoying how this has to be done manually.
+    state[0] = -(state[0] + state[0]);
+    // State 1 shift is a shift by 0 which is free.
+    state[2] = state[2] + state[2];
+    state[3] = left_shift_single::<2, 29>(state[3]);
+    state[4] = left_shift_single::<3, 28>(state[4]);
+    state[5] = left_shift_single::<4, 27>(state[5]);
+    state[6] = left_shift_single::<5, 26>(state[6]);
+    state[7] = left_shift_single::<6, 25>(state[7]);
+    state[8] = left_shift_single::<7, 24>(state[8]);
+    state[9] = left_shift_single::<8, 23>(state[9]);
+    state[10] = left_shift_single::<10, 21>(state[10]);
+    state[11] = left_shift_single::<12, 19>(state[11]);
+    state[12] = left_shift_single::<13, 18>(state[12]);
+    state[13] = left_shift_single::<14, 17>(state[13]);
+    state[14] = left_shift_single::<15, 16>(state[14]);
+    state[15] = left_shift_single::<16, 15>(state[15]);
+}
 
-    fn permute_state(
-        &self,
-        state: &mut Self::InternalState,
-        internal_constants: &[Mersenne31],
-        _packed_internal_constants: &[()],
-    ) {
-        internal_permute_state::<PackedMersenne31AVX2, 24, 5>(
-            state,
-            |x| matmul_internal(x, POSEIDON2_INTERNAL_MATRIX_DIAG_24),
-            internal_constants,
-        )
+// This looks slightly strange but the key idea is that we want to minimize dependency chains.
+// The compiler doesn't realize that add is still associative so we help it out.
+// Note that state[0] is involved in a large s-box immediately before this so we keep it
+// separate for as long as possible.
+#[inline(always)]
+fn sum_16(state: &[PackedMersenne31AVX2; 16]) -> PackedMersenne31AVX2 {
+    let sum23 = state[2] + state[3];
+    let sum45 = state[4] + state[5];
+    let sum67 = state[6] + state[7];
+    let sum89 = state[8] + state[9];
+    let sum1011 = state[10] + state[11];
+    let sum1213 = state[12] + state[13];
+    let sum1415 = state[14] + state[15];
+
+    let sum123 = state[1] + sum23;
+    let sum4567 = sum45 + sum67;
+    let sum891011 = sum89 + sum1011;
+    let sum12131415 = sum1213 + sum1415;
+
+    let sum1234567 = sum123 + sum4567;
+    let sum_top_half = sum891011 + sum12131415;
+
+    let sum_all_but_0 = sum1234567 + sum_top_half;
+
+    sum_all_but_0 + state[0]
+}
+
+// [-2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,];
+#[inline(always)]
+fn left_shift_24(state: &mut [PackedMersenne31AVX2; 24]) {
+    // A little annoying how this has to be done manually.
+    state[0] = -(state[0] + state[0]);
+    // State 1 shift is a shift by 0 which is free.
+    state[2] = state[2] + state[2];
+    state[3] = left_shift_single::<2, 29>(state[3]);
+    state[4] = left_shift_single::<3, 28>(state[4]);
+    state[5] = left_shift_single::<4, 27>(state[5]);
+    state[6] = left_shift_single::<5, 26>(state[6]);
+    state[7] = left_shift_single::<6, 25>(state[7]);
+    state[8] = left_shift_single::<7, 24>(state[8]);
+    state[9] = left_shift_single::<8, 23>(state[9]);
+    state[10] = left_shift_single::<9, 22>(state[10]);
+    state[11] = left_shift_single::<10, 21>(state[11]);
+    state[12] = left_shift_single::<11, 20>(state[12]);
+    state[13] = left_shift_single::<12, 19>(state[13]);
+    state[14] = left_shift_single::<13, 18>(state[14]);
+    state[15] = left_shift_single::<14, 17>(state[15]);
+    state[16] = left_shift_single::<15, 16>(state[16]);
+    state[17] = left_shift_single::<16, 15>(state[17]);
+    state[18] = left_shift_single::<17, 14>(state[18]);
+    state[19] = left_shift_single::<18, 13>(state[19]);
+    state[20] = left_shift_single::<19, 12>(state[20]);
+    state[21] = left_shift_single::<20, 11>(state[21]);
+    state[22] = left_shift_single::<21, 10>(state[22]);
+    state[23] = left_shift_single::<22, 9>(state[23]);
+}
+
+// This looks slightly strange but the key idea is that we want to minimize dependency chains.
+// The compiler doesn't realize that add is still associative so we help it out.
+// Note that state[0] is involved in a large s-box immediately before this so we keep it
+// separate for as long as possible.
+#[inline(always)]
+fn sum_24(state: &[PackedMersenne31AVX2; 24]) -> PackedMersenne31AVX2 {
+    let sum23 = state[2] + state[3];
+    let sum45 = state[4] + state[5];
+    let sum67 = state[6] + state[7];
+    let sum89 = state[8] + state[9];
+    let sum1011 = state[10] + state[11];
+    let sum1213 = state[12] + state[13];
+    let sum1415 = state[14] + state[15];
+    let sum1617 = state[16] + state[17];
+    let sum1819 = state[18] + state[19];
+    let sum2021 = state[20] + state[21];
+    let sum2223 = state[22] + state[23];
+
+    let sum123 = state[1] + sum23;
+    let sum4567 = sum45 + sum67;
+    let sum891011 = sum89 + sum1011;
+    let sum12131415 = sum1213 + sum1415;
+    let sum16171819 = sum1617 + sum1819;
+    let sum20212223 = sum2021 + sum2223;
+
+    let sum1234567 = sum123 + sum4567;
+    let sum_min_third = sum891011 + sum12131415;
+    let sum_top_third = sum16171819 + sum20212223;
+
+    let sum_all_but_0 = sum1234567 + sum_min_third + sum_top_third;
+
+    sum_all_but_0 + state[0]
+}
+
+impl Permutation<[PackedMersenne31AVX2; 16]> for DiffusionMatrixMersenne31 {
+    #[inline(always)]
+    fn permute_mut(&self, state: &mut [PackedMersenne31AVX2; 16]) {
+        let sum = sum_16(state);
+        left_shift_16(state);
+        state.iter_mut().for_each(|val| *val += sum);
+    }
+}
+
+impl DiffusionPermutation<PackedMersenne31AVX2, 16> for DiffusionMatrixMersenne31 {}
+
+impl Permutation<[PackedMersenne31AVX2; 24]> for DiffusionMatrixMersenne31 {
+    #[inline(always)]
+    fn permute_mut(&self, state: &mut [PackedMersenne31AVX2; 24]) {
+        let sum = sum_24(state);
+        left_shift_24(state);
+        state.iter_mut().for_each(|val| *val += sum);
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -127,7 +127,7 @@ fn sum_16(state: &[PackedMersenne31AVX2; 16]) -> PackedMersenne31AVX2 {
 }
 
 /// We hard code multiplication by the diagonal minus 1 of our internal matrix (1 + D)
-/// In the Mersenne31, WIDTH = 16 case, the diagonal minus 1 is:
+/// In the Mersenne31, WIDTH = 24 case, the diagonal minus 1 is:
 /// [-2] + 1 << [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
 /// i.e. The first entry is -2 and all other entires a power of 2.
 #[inline(always)]

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -5,7 +5,7 @@ use p3_poseidon2::{
 };
 
 use crate::{
-    sbox, Mersenne31, PackedMersenne31AVX2, Poseidon2ExternalLayerMersenne31,
+    exp5, Mersenne31, PackedMersenne31AVX2, Poseidon2ExternalLayerMersenne31,
     Poseidon2InternalLayerMersenne31, P, P_AVX2,
 };
 
@@ -47,9 +47,8 @@ impl<const WIDTH: usize> Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>
 /// This requires 2 generic parameters, I and I_PRIME satisfying I + I_PRIME = 31.
 /// If the inputs do not conform to this representations, the result is undefined.
 #[inline(always)]
-fn left_rotation<const I: i32, const I_PRIME: i32>(
-    val: PackedMersenne31AVX2,
-) -> PackedMersenne31AVX2 {
+fn mul_2exp_i<const I: i32, const I_PRIME: i32>(val: PackedMersenne31AVX2) -> PackedMersenne31AVX2 {
+    assert!(I + I_PRIME == 31);
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
         let input = val.to_vector();
@@ -84,19 +83,19 @@ fn diagonal_mul_16(state: &mut [PackedMersenne31AVX2; 16]) {
     state[2] = state[2] + state[2]; // add is 3 instructions whereas shift is 4.
 
     // For the remaining entires we use our fast shift code.
-    state[3] = left_rotation::<2, 29>(state[3]);
-    state[4] = left_rotation::<3, 28>(state[4]);
-    state[5] = left_rotation::<4, 27>(state[5]);
-    state[6] = left_rotation::<5, 26>(state[6]);
-    state[7] = left_rotation::<6, 25>(state[7]);
-    state[8] = left_rotation::<7, 24>(state[8]);
-    state[9] = left_rotation::<8, 23>(state[9]);
-    state[10] = left_rotation::<10, 21>(state[10]);
-    state[11] = left_rotation::<12, 19>(state[11]);
-    state[12] = left_rotation::<13, 18>(state[12]);
-    state[13] = left_rotation::<14, 17>(state[13]);
-    state[14] = left_rotation::<15, 16>(state[14]);
-    state[15] = left_rotation::<16, 15>(state[15]); // TODO: There is a faster method for 15.
+    state[3] = mul_2exp_i::<2, 29>(state[3]);
+    state[4] = mul_2exp_i::<3, 28>(state[4]);
+    state[5] = mul_2exp_i::<4, 27>(state[5]);
+    state[6] = mul_2exp_i::<5, 26>(state[6]);
+    state[7] = mul_2exp_i::<6, 25>(state[7]);
+    state[8] = mul_2exp_i::<7, 24>(state[8]);
+    state[9] = mul_2exp_i::<8, 23>(state[9]);
+    state[10] = mul_2exp_i::<10, 21>(state[10]);
+    state[11] = mul_2exp_i::<12, 19>(state[11]);
+    state[12] = mul_2exp_i::<13, 18>(state[12]);
+    state[13] = mul_2exp_i::<14, 17>(state[13]);
+    state[14] = mul_2exp_i::<15, 16>(state[14]);
+    state[15] = mul_2exp_i::<16, 15>(state[15]); // TODO: There is a faster method for 15.
 }
 
 /// The compiler doesn't realize that add is associative
@@ -137,27 +136,27 @@ fn diagonal_mul_24(state: &mut [PackedMersenne31AVX2; 24]) {
     state[2] = state[2] + state[2]; // add is 3 instructions whereas shift is 4.
 
     // For the remaining entires we use our fast shift code.
-    state[3] = left_rotation::<2, 29>(state[3]);
-    state[4] = left_rotation::<3, 28>(state[4]);
-    state[5] = left_rotation::<4, 27>(state[5]);
-    state[6] = left_rotation::<5, 26>(state[6]);
-    state[7] = left_rotation::<6, 25>(state[7]);
-    state[8] = left_rotation::<7, 24>(state[8]);
-    state[9] = left_rotation::<8, 23>(state[9]);
-    state[10] = left_rotation::<9, 22>(state[10]);
-    state[11] = left_rotation::<10, 21>(state[11]);
-    state[12] = left_rotation::<11, 20>(state[12]);
-    state[13] = left_rotation::<12, 19>(state[13]);
-    state[14] = left_rotation::<13, 18>(state[14]);
-    state[15] = left_rotation::<14, 17>(state[15]); // TODO: There is a faster method for 15.
-    state[16] = left_rotation::<15, 16>(state[16]);
-    state[17] = left_rotation::<16, 15>(state[17]);
-    state[18] = left_rotation::<17, 14>(state[18]);
-    state[19] = left_rotation::<18, 13>(state[19]);
-    state[20] = left_rotation::<19, 12>(state[20]);
-    state[21] = left_rotation::<20, 11>(state[21]);
-    state[22] = left_rotation::<21, 10>(state[22]);
-    state[23] = left_rotation::<22, 9>(state[23]);
+    state[3] = mul_2exp_i::<2, 29>(state[3]);
+    state[4] = mul_2exp_i::<3, 28>(state[4]);
+    state[5] = mul_2exp_i::<4, 27>(state[5]);
+    state[6] = mul_2exp_i::<5, 26>(state[6]);
+    state[7] = mul_2exp_i::<6, 25>(state[7]);
+    state[8] = mul_2exp_i::<7, 24>(state[8]);
+    state[9] = mul_2exp_i::<8, 23>(state[9]);
+    state[10] = mul_2exp_i::<9, 22>(state[10]);
+    state[11] = mul_2exp_i::<10, 21>(state[11]);
+    state[12] = mul_2exp_i::<11, 20>(state[12]);
+    state[13] = mul_2exp_i::<12, 19>(state[13]);
+    state[14] = mul_2exp_i::<13, 18>(state[14]);
+    state[15] = mul_2exp_i::<14, 17>(state[15]); // TODO: There is a faster method for 15.
+    state[16] = mul_2exp_i::<15, 16>(state[16]);
+    state[17] = mul_2exp_i::<16, 15>(state[17]);
+    state[18] = mul_2exp_i::<17, 14>(state[18]);
+    state[19] = mul_2exp_i::<18, 13>(state[19]);
+    state[20] = mul_2exp_i::<19, 12>(state[20]);
+    state[21] = mul_2exp_i::<20, 11>(state[21]);
+    state[22] = mul_2exp_i::<21, 10>(state[22]);
+    state[23] = mul_2exp_i::<22, 9>(state[23]);
 }
 
 /// The compiler doesn't realize that add is associative
@@ -208,7 +207,7 @@ fn add_rc_and_sbox(input: PackedMersenne31AVX2, rc: __m256i) -> PackedMersenne31
 
         // Due to the representations of input and rc, input_plus_rc is in {-P, ..., P}.
         // This is exactly the required bound to apply sbox.
-        let input_post_sbox = sbox(input_plus_rc);
+        let input_post_sbox = exp5(input_plus_rc);
         PackedMersenne31AVX2::from_vector(input_post_sbox)
     }
 }
@@ -263,6 +262,22 @@ impl InternalLayer<PackedMersenne31AVX2, 24, 5> for Poseidon2InternalLayerMersen
     }
 }
 
+/// Compute a collection of Poseidon2 external layers.
+/// One layer for every constant supplied.
+#[inline]
+fn external_rounds<const WIDTH: usize>(
+    state: &mut [PackedMersenne31AVX2; WIDTH],
+    packed_external_constants: &[[__m256i; WIDTH]],
+) {
+    packed_external_constants.iter().for_each(|round_consts| {
+        state
+            .iter_mut()
+            .zip(round_consts.iter())
+            .for_each(|(val, &rc)| *val = add_rc_and_sbox(*val, rc));
+        mds_light_permutation(state, &MDSMat4);
+    });
+}
+
 impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
     for Poseidon2ExternalLayerMersenne31
 {
@@ -276,15 +291,7 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
         packed_initial_external_constants: &[[__m256i; WIDTH]],
     ) -> [PackedMersenne31AVX2; WIDTH] {
         mds_light_permutation(&mut state, &MDSMat4);
-        packed_initial_external_constants
-            .iter()
-            .for_each(|round_consts| {
-                state
-                    .iter_mut()
-                    .zip(round_consts.iter())
-                    .for_each(|(val, &rc)| *val = add_rc_and_sbox(*val, rc));
-                mds_light_permutation(&mut state, &MDSMat4);
-            });
+        external_rounds(&mut state, packed_initial_external_constants);
         state
     }
 
@@ -295,15 +302,7 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
         _final_external_constants: &[[Mersenne31; WIDTH]],
         packed_final_external_constants: &[[__m256i; WIDTH]],
     ) -> [PackedMersenne31AVX2; WIDTH] {
-        packed_final_external_constants
-            .iter()
-            .for_each(|round_consts| {
-                state
-                    .iter_mut()
-                    .zip(round_consts.iter())
-                    .for_each(|(val, &rc)| *val = add_rc_and_sbox(*val, rc));
-                mds_light_permutation(&mut state, &MDSMat4);
-            });
+        external_rounds(&mut state, packed_final_external_constants);
         state
     }
 }

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -48,7 +48,7 @@ impl<const WIDTH: usize> Poseidon2ExternalPackedConstants<Mersenne31, WIDTH>
 /// If the inputs do not conform to this representations, the result is undefined.
 #[inline(always)]
 fn mul_2exp_i<const I: i32, const I_PRIME: i32>(val: PackedMersenne31AVX2) -> PackedMersenne31AVX2 {
-    assert!(I + I_PRIME == 31);
+    assert_eq!(I + I_PRIME, 31);
     unsafe {
         // Safety: If this code got compiled then AVX2 intrinsics are available.
         let input = val.to_vector();

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -13,10 +13,10 @@ rand = { version = "0.8.5", features = ["min_const_gen"] }
 
 [dev-dependencies]
 p3-mersenne-31 = { path = "../mersenne-31" }
-p3-baby-bear = { path = "../baby-bear" }
-p3-koala-bear = { path = "../koala-bear" }
-p3-bn254-fr = { path = "../bn254-fr" }
-p3-goldilocks = { path = "../goldilocks" }
+# p3-baby-bear = { path = "../baby-bear" }
+# p3-koala-bear = { path = "../koala-bear" }
+# p3-bn254-fr = { path = "../bn254-fr" }
+# p3-goldilocks = { path = "../goldilocks" }
 criterion = "0.5.1"
 
 [[bench]]

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -16,7 +16,7 @@ p3-mersenne-31 = { path = "../mersenne-31" }
 # p3-baby-bear = { path = "../baby-bear" }
 # p3-koala-bear = { path = "../koala-bear" }
 # p3-bn254-fr = { path = "../bn254-fr" }
-# p3-goldilocks = { path = "../goldilocks" }
+p3-goldilocks = { path = "../goldilocks" }
 criterion = "0.5.1"
 
 [[bench]]

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,67 +1,73 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
-use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
+// use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
+// use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
 use p3_field::{AbstractField, PrimeField, PrimeField64};
-use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
-use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
-use p3_mersenne_31::{Mersenne31, Poseidon2InternalLayerMersenne31};
+// use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
+// use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
+use p3_mersenne_31::{
+    Mersenne31, Poseidon2ExternalLayerMersenne31, Poseidon2InternalLayerMersenne31,
+};
 use p3_poseidon2::{
-    DiffusionPermutation, MdsLightPermutation, Poseidon2, Poseidon2ExternalMatrixGeneral,
+    ExternalLayer, InternalLayer, Poseidon2, Poseidon2ExternalPackedConstants,
+    Poseidon2InternalPackedConstants,
 };
 use p3_symmetric::Permutation;
 use rand::distributions::{Distribution, Standard};
 use rand::thread_rng;
 
 fn bench_poseidon2(c: &mut Criterion) {
-    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>(c);
-    poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>(c);
+    // poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, 7>(c);
+    // poseidon2_p64::<BabyBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, 7>(c);
 
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 3>(c);
-    poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 3>(c);
+    // poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, 3>(c);
+    // poseidon2_p64::<KoalaBear, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, 3>(c);
 
     poseidon2_p64::<
         Mersenne31,
-        Poseidon2ExternalMatrixGeneral,
+        Poseidon2ExternalLayerMersenne31,
         Poseidon2InternalLayerMersenne31,
         16,
         5,
     >(c);
     poseidon2_p64::<
         Mersenne31,
-        Poseidon2ExternalMatrixGeneral,
+        Poseidon2ExternalLayerMersenne31,
         Poseidon2InternalLayerMersenne31,
         24,
         5,
     >(c);
 
-    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 8, 7>(c);
-    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 12, 7>(
-        c,
-    );
-    poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 16, 7>(
-        c,
-    );
+    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 8, 7>(c);
+    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 12, 7>(
+    //     c,
+    // );
+    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 16, 7>(
+    //     c,
+    // );
 
-    poseidon2::<Bn254Fr, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
+    // poseidon2::<Bn254Fr, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
 }
 
-fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
+fn _poseidon2<F, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>(
     c: &mut Criterion,
     rounds_f: usize,
     rounds_p: usize,
 ) where
     F: PrimeField,
     Standard: Distribution<F>,
-    MdsLight: MdsLightPermutation<F::Packing, WIDTH> + Default,
-    Diffusion: DiffusionPermutation<F::Packing, WIDTH> + Default,
+    ExternalPerm:
+        ExternalLayer<F::Packing, WIDTH, D> + Poseidon2ExternalPackedConstants<F, WIDTH> + Default,
+    InternalPerm: InternalLayer<F::Packing, WIDTH, D, InternalState = ExternalPerm::InternalState>
+        + Poseidon2InternalPackedConstants<F>
+        + Default,
 {
     let mut rng = thread_rng();
-    let external_linear_layer = MdsLight::default();
-    let internal_linear_layer = Diffusion::default();
+    let external_linear_layer = ExternalPerm::default();
+    let internal_linear_layer = InternalPerm::default();
 
-    let poseidon = Poseidon2::<F, MdsLight, Diffusion, WIDTH, D>::new_from_rng(
+    let poseidon = Poseidon2::<F, ExternalPerm, InternalPerm, WIDTH, D>::new_from_rng(
         rounds_f,
         external_linear_layer,
         rounds_p,
@@ -81,18 +87,21 @@ fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
 }
 
 // For fields implementing PrimeField64 we should benchmark using the optimal round constants.
-fn poseidon2_p64<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(c: &mut Criterion)
+fn poseidon2_p64<F, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>(c: &mut Criterion)
 where
     F: PrimeField64,
     Standard: Distribution<F>,
-    MdsLight: MdsLightPermutation<F::Packing, WIDTH> + Default,
-    Diffusion: DiffusionPermutation<F::Packing, WIDTH> + Default,
+    ExternalPerm:
+        ExternalLayer<F::Packing, WIDTH, D> + Poseidon2ExternalPackedConstants<F, WIDTH> + Default,
+    InternalPerm: InternalLayer<F::Packing, WIDTH, D, InternalState = ExternalPerm::InternalState>
+        + Poseidon2InternalPackedConstants<F>
+        + Default,
 {
     let mut rng = thread_rng();
-    let external_linear_layer = MdsLight::default();
-    let internal_linear_layer = Diffusion::default();
+    let external_linear_layer = ExternalPerm::default();
+    let internal_linear_layer = InternalPerm::default();
 
-    let poseidon = Poseidon2::<F, MdsLight, Diffusion, WIDTH, D>::new_from_rng_128(
+    let poseidon = Poseidon2::<F, ExternalPerm, InternalPerm, WIDTH, D>::new_from_rng_128(
         external_linear_layer,
         internal_linear_layer,
         &mut rng,

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -4,7 +4,9 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 // use p3_baby_bear::{BabyBear, DiffusionMatrixBabyBear};
 // use p3_bn254_fr::{Bn254Fr, DiffusionMatrixBN254};
 use p3_field::{AbstractField, PrimeField, PrimeField64};
-// use p3_goldilocks::{DiffusionMatrixGoldilocks, Goldilocks};
+use p3_goldilocks::{
+    Goldilocks, Poseidon2ExternalLayerGoldilocks, Poseidon2InternalLayerGoldilocks,
+};
 // use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
 use p3_mersenne_31::{
     Mersenne31, Poseidon2ExternalLayerMersenne31, Poseidon2InternalLayerMersenne31,
@@ -39,13 +41,27 @@ fn bench_poseidon2(c: &mut Criterion) {
         5,
     >(c);
 
-    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 8, 7>(c);
-    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 12, 7>(
-    //     c,
-    // );
-    // poseidon2_p64::<Goldilocks, Poseidon2ExternalMatrixGeneral, DiffusionMatrixGoldilocks, 16, 7>(
-    //     c,
-    // );
+    poseidon2_p64::<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks,
+        Poseidon2InternalLayerGoldilocks,
+        8,
+        7,
+    >(c);
+    poseidon2_p64::<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks,
+        Poseidon2InternalLayerGoldilocks,
+        12,
+        7,
+    >(c);
+    poseidon2_p64::<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks,
+        Poseidon2InternalLayerGoldilocks,
+        16,
+        7,
+    >(c);
 
     // poseidon2::<Bn254Fr, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBN254, 3, 5>(c, 8, 22);
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -36,6 +36,7 @@ where
 /// [ 1 2 3 1 ]
 /// [ 1 1 2 3 ]
 /// [ 3 1 1 2 ].
+#[inline(always)]
 fn apply_mat4<AF>(x: &mut [AF; 4])
 where
     AF: AbstractField,
@@ -73,19 +74,26 @@ impl<AF: AbstractField> MdsPermutation<AF, 4> for HLMDSMat4 {}
 pub struct MDSMat4;
 
 impl<AF: AbstractField> Permutation<[AF; 4]> for MDSMat4 {
+    #[inline(always)]
     fn permute(&self, input: [AF; 4]) -> [AF; 4] {
         let mut output = input;
         self.permute_mut(&mut output);
         output
     }
 
+    #[inline(always)]
     fn permute_mut(&self, input: &mut [AF; 4]) {
         apply_mat4(input)
     }
 }
 impl<AF: AbstractField> MdsPermutation<AF, 4> for MDSMat4 {}
 
-fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, const WIDTH: usize>(
+#[inline(always)]
+pub fn mds_light_permutation<
+    AF: AbstractField,
+    MdsPerm4: MdsPermutation<AF, 4>,
+    const WIDTH: usize,
+>(
     state: &mut [AF; WIDTH],
     mdsmat: &MdsPerm4,
 ) {


### PR DESCRIPTION
We make a collection of changes to the Poseidon2 implementation for M31. This leads to around a 25%-30% improvement in performance with a slightly higher improvement for the WIDTH=24 case.  A rundown of the changes are as follows:

Custom s-box -- Currently x -> x^5 is being done by repeated multiplication and squaring, we can improve upon this by writing a custom function. In particular note that if we want to compute x^2, it equivalent to start with x in the range {0, ..., P} or {-P, ..., P}. Hence we don't need to fully elements into {0, ..., P} nearly as much. There is a minor drawback later on which is that it is slightly more complicated to reduce something in {-P^2, ..., P^2} but the benefit easily outweighs this negative.

Saving round constants as negatives -- Along the same lines as the above, we save our round constants in the range {-P, ..., 0} instead of {0, ..., P}. This means that x + rc is in {-P, ..., P} allowing for us to immediately plug it into s-box.

Rotations instead of multiplications -- For the internal layer, the diagonal we add to the constant 1 matrix is filled with powers of 2. 2^n x corresponds in M31 to simply a left rotation by n steps. This can be implemented in far fewer instructions than the naive method which just uses multiplication.

Breaking dependency chains -- This simple change has the biggest impact on speed. Addition in PackedMersenne31AVX2 (and more generally all packed additions) is a combination of 3 compiler instructions (add, sub, min) and so the compiler does not realize that this addition is still associative. Hence using .sum() in the internal layer creates a long dependency chain. In addition to the usual drawback, this forces the compiler to wait until it knows s[0] to begin doing any of the additions. But s[0] is also the only element to which we apply an s-box. Hence we manually rewrite the summation to both minimize the length of the longest dependency chain and sum every element other than s[0] before finally adding in s[0].

Finally there are a few changes to the Poseidon2 crate and in particular the benching function. This is just to allow benching to work before I have implemented Poseidon2 for the other fields and will be removed before we merge this into Main.
