### PR TITLE
Added square root and power functions

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -60,6 +60,65 @@ where
     assert_eq!((x * y) / z, x * (y / z));
 }
 
+pub fn test_sqrt<F: Field>()
+where
+    Standard: Distribution<F>,
+{
+    let mut rng = rand::thread_rng();
+    let (x, y) = {
+        let t = rng.gen::<F>();
+        let gt = t*F::generator();
+        assert!(t.is_square() ^ gt.is_square());
+        if t.is_square() {
+            (t, gt)
+        } else {
+            (gt, t)
+        }
+    };
+    let x_sqrt = x.sqrt();
+    let y_sqrt = y.sqrt();
+
+    assert_eq!(x_sqrt.unwrap().square(), x);
+    assert_eq!(y_sqrt, None);
+
+    assert_eq!(x.legendre(), F::one());
+    assert_eq!(y.legendre(), F::neg_one());
+}
+
+pub fn test_pow<F: Field>()
+where
+    Standard: Distribution<F>,
+{
+    let mut rng = rand::thread_rng();
+    let x = rng.gen::<F>();
+    let x2 = x.square();
+    let x4 = x2.square();
+    let x8 = x4.square();
+    let x16 = x8.square();
+
+    let x23 = x16*x4*x2*x;
+
+    assert_eq!(x.pow(&BigUint::from(2u8)), x2);
+    assert_eq!(x.pow(&BigUint::from(4u8)), x4);
+    assert_eq!(x.pow(&BigUint::from(8u8)), x8);
+    assert_eq!(x.pow(&BigUint::from(16u8)), x16);
+    assert_eq!(x.pow(&BigUint::from(23u8)), x23);
+
+
+    let mut x_2_289 = x;
+    for _ in 0..289 {
+        x_2_289 = x_2_289.square();
+    }
+
+    let power_2_289  = BigUint::from(2u8).pow(289);
+    assert_eq!(x_2_289, x.pow(&power_2_289));
+
+    let x_2_289_plus_23 = x_2_289*x23;
+    let power_2_289_plus_23 = power_2_289+BigUint::from(23u8);
+    assert_eq!(x_2_289_plus_23, x.pow(&power_2_289_plus_23));
+
+}
+
 pub fn test_inverse<F: Field>()
 where
     Standard: Distribution<F>,
@@ -145,6 +204,16 @@ macro_rules! test_field {
             #[test]
             fn test_multiplicative_group_factors() {
                 $crate::test_multiplicative_group_factors::<$field>();
+            }
+
+            #[test]
+            fn test_sqrt() {
+                $crate::test_sqrt::<$field>();
+            }
+
+            #[test]
+            fn test_pow() {
+                $crate::test_pow::<$field>();
             }
         }
     };

--- a/field/src/cipolla_sqrt.rs
+++ b/field/src/cipolla_sqrt.rs
@@ -1,0 +1,80 @@
+use core::fmt::Debug;
+use num_bigint::BigUint;
+use num_traits::One;
+use num_integer::Integer;
+
+use crate::Field;
+
+#[derive(Clone, Copy, Debug)]
+struct ChipollaExtension<F: Field> {
+    real: F,
+    imag: F,
+}
+
+impl <F: Field> ChipollaExtension<F> {
+    fn new(real: F, imag: F) -> Self {
+        Self { real, imag }
+    }
+
+    fn one() -> Self {
+        Self::new(F::one(), F::zero())
+    }  
+
+
+    fn mul(&self, other: Self, nonresidue: F) -> Self {
+        Self::new(self.real * other.real + nonresidue * self.imag * other.imag, self.real * other.imag + self.imag * other.real)
+    }
+
+    fn pow(&self, exp: BigUint, nonresidue: F) -> Self {
+        let mut result = Self::one();
+        let mut base = *self;
+        let bits = exp.bits();
+
+        for i in 0..bits{
+            if exp.bit(i) {
+                result = result.mul(base, nonresidue);
+            }
+            base = base.mul(base, nonresidue);
+        }
+        result
+    }
+}
+
+
+pub (crate) fn cipolla_sqrt<F: Field>(n: F) -> Option<F> {
+    if n.is_zero() || n.is_one() {
+        return Some(n);
+    }
+
+    if !n.is_square() {
+        return None;
+    }
+
+    let order = F::order();
+
+    {
+        let (d, m) = order.div_mod_floor(&BigUint::from(4u8));
+        if m == BigUint::from(3u8) {
+            return Some(n.pow(&(d + BigUint::one())));
+        }
+    }
+
+    let g = F::generator();
+
+    let mut a = F::one();
+    let mut nonresidue = F::one() - n;
+
+    while nonresidue.is_square() {
+        a *= g;
+        nonresidue = a.square() - n;
+    }
+        
+
+    let chipolla_power = (&order+BigUint::one())/BigUint::from(2u8);
+    let mut x = ChipollaExtension::new(a, F::one());
+
+    x = x.pow(chipolla_power, nonresidue);
+
+    Some(x.real)
+    
+}

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use crate::exponentiation::exp_u64_by_squaring;
 use crate::packed::{PackedField, PackedValue};
 use crate::Packable;
+use crate::cipolla_sqrt::cipolla_sqrt;
 
 /// A generalization of `Field` which permits things like
 /// - an actual field element
@@ -182,6 +183,34 @@ pub trait Field:
 
     fn is_one(&self) -> bool {
         *self == Self::one()
+    }
+
+    fn is_square(&self) -> bool {
+        self.legendre().is_one()
+    }
+
+    fn sqrt(&self) -> Option<Self> {
+        cipolla_sqrt(*self)
+    }
+
+    fn legendre(&self) -> Self {
+        let power = (Self::order() - BigUint::one()) / BigUint::from(2u8);
+        self.pow(&power)
+    }
+
+    fn pow(&self, power: &BigUint) -> Self {
+        let mut result = Self::one();
+        let mut base = *self;
+        let bits = power.bits();
+
+        for i in 0..bits {
+            if power.bit(i) {
+                result = result * base;
+            }
+            base = base * base;
+        }
+
+        result
     }
 
     /// self * 2^exp

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -11,6 +11,8 @@ pub mod extension;
 mod field;
 mod helpers;
 mod packed;
+mod cipolla_sqrt;
+
 
 pub use array::*;
 pub use batch_inverse::*;


### PR DESCRIPTION
Adding support for square root computations over prime fields in Plonky3 would be highly beneficial for several reasons. Firstly, it would enable efficient implementation of elliptic curve cryptography (ECC) algorithms, which rely heavily on square root operations for point arithmetic. Secondly, it would facilitate the development and verification of certain Verifiable Delay Functions (VDFs), particularly those based on the assumption of the hardness of finding modular square roots. 

The Field trait has also been extended with several new methods: `is_square`, `sqrt`, `legendre`, and `pow`. These methods provide additional functionality related to square roots and powers of elements in a field.

In addition, a new module named `cipolla_sqrt` has been created in the field library. This module implements Cipolla's algorithm for finding square roots in finite fields.

Two new test functions have been added to the field-testing library: `test_sqrt` and `test_pow`. These functions generate random values, perform operations (square root or power), and assert the results.