### PR TITLE
Remove some unused dependencies

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -13,7 +13,6 @@ p3-mds = { path = "../mds" }
 p3-monty-31 = { path = "../monty-31" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
-num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -24,7 +24,6 @@ p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-merkle-tree = { path = "../merkle-tree" }
-p3-poseidon = { path = "../poseidon" }
 p3-symmetric = { path = "../symmetric" }
 
 hashbrown = "0.14.3"

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -20,6 +20,5 @@ serde = { version = "1.0", default-features = false }
 p3-dft = { path = "../dft", optional = true }
 
 [dev-dependencies]
-p3-baby-bear = { path = "../baby-bear" }
 p3-dft = { path = "../dft" }
 rand = "0.8.5"

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -13,7 +13,6 @@ p3-mds = { path = "../mds" }
 p3-monty-31 = { path = "../monty-31" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
-num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -19,8 +19,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }
-ark-ff = { version = "^0.4.0", default-features = false }
-zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }
 criterion = "0.5.1"
 rand_chacha = "0.3.1"

--- a/monolith/Cargo.toml
+++ b/monolith/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 generic-array = "1.0"
 p3-field = { path = "../field" }
-p3-goldilocks = { path = "../goldilocks" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-mds = { path = "../mds" }
 p3-symmetric = { path = "../symmetric" }

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -25,11 +25,8 @@ p3-fri = { path = "../fri" }
 p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-merkle-tree = { path = "../merkle-tree" }
-p3-goldilocks = { path = "../goldilocks" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
 rand = "0.8.5"
-tracing-subscriber = { version = "0.3.17", features = ["std", "env-filter"] }
-tracing-forest = { version = "0.1.6", features = ["ansi", "smallvec"] }
 postcard = { version = "1.0.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Just some tidying; used the output of `cargo +nightly udeps`.

(I left in the unused dependencies in `keccak-air` and `poseidon2-air`, since the examples in those crates are meant for experimenting with different parameters, and it would be annoying to adjust the dependencies each the time.)