### PR TITLE
Cfft perf

### DIFF
--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -68,6 +68,8 @@ impl<F: ComplexExtendable> CircleDomain<F> {
         let shifted_gs = iterate(g, |g| g.double())
             .take(self.log_n - 1)
             .collect_vec();
+        // A pretty naive method of splitting on the MSB. Haven't benched, or looked
+        // into how much rayon likes this.
         par_iter::split((self.shift, self.log_n - 1), move |(p, log_n)| {
             if log_n == 0 {
                 ((p, 0), None)
@@ -351,21 +353,6 @@ mod tests {
             );
         }
     }
-
-    /*
-    fn do_test_par_coset<F: ComplexExtendable>(d: CircleDomain<F>) {
-        let coset0 = d.coset0().collect_vec();
-        let p_coset0 = d.par_coset0().collect::<Vec<_>>();
-        assert_eq!(coset0, p_coset0);
-    }
-
-    #[test]
-    fn par_coset() {
-        type F = Mersenne31;
-        let d = CircleDomain::<F>::standard(8);
-        do_test_par_coset(d);
-    }
-    */
 
     #[test]
     fn selectors() {

--- a/circle/src/lib.rs
+++ b/circle/src/lib.rs
@@ -1,7 +1,7 @@
 //! A framework for operating over the unit circle of a finite field,
 //! following the [Circle STARKs paper](https://eprint.iacr.org/2024/278) by Haböck, Levit and Papini.
 
-#![no_std]
+// #![no_std]
 
 extern crate alloc;
 

--- a/circle/src/lib.rs
+++ b/circle/src/lib.rs
@@ -1,7 +1,7 @@
 //! A framework for operating over the unit circle of a finite field,
 //! following the [Circle STARKs paper](https://eprint.iacr.org/2024/278) by Haböck, Levit and Papini.
 
-// #![no_std]
+#![no_std]
 
 extern crate alloc;
 

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -26,44 +26,6 @@ pub trait Butterfly<F: Field>: Copy + Send + Sync {
     }
 
     #[inline]
-    fn apply_to_rows_from_src(
-        &self,
-        src_row_1: &[F],
-        src_row_2: &[F],
-        dst_row_1: &mut [F],
-        dst_row_2: &mut [F],
-    ) {
-        let (src_shorts_1, src_suffix_1) = F::Packing::pack_slice_with_suffix(src_row_1);
-        let (dst_shorts_1, dst_suffix_1) = F::Packing::pack_slice_with_suffix_mut(dst_row_1);
-
-        let (src_shorts_2, src_suffix_2) = F::Packing::pack_slice_with_suffix(src_row_2);
-        let (dst_shorts_2, dst_suffix_2) = F::Packing::pack_slice_with_suffix_mut(dst_row_2);
-
-        // debug_assert?
-
-        assert!([src_shorts_1, dst_shorts_1, src_shorts_2, dst_shorts_2]
-            .map(|s| s.len())
-            .into_iter()
-            .all_equal());
-
-        assert!([src_suffix_1, dst_suffix_1, src_suffix_2, dst_suffix_2]
-            .map(|s| s.len())
-            .into_iter()
-            .all_equal());
-
-        for (src_x_1, dst_x_1, src_x_2, dst_x_2) in
-            izip!(src_shorts_1, dst_shorts_1, src_shorts_2, dst_shorts_2)
-        {
-            (*dst_x_1, *dst_x_2) = self.apply(*src_x_1, *src_x_2);
-        }
-        for (src_x_1, dst_x_1, src_x_2, dst_x_2) in
-            izip!(src_suffix_1, dst_suffix_1, src_suffix_2, dst_suffix_2)
-        {
-            (*dst_x_1, *dst_x_2) = self.apply(*src_x_1, *src_x_2);
-        }
-    }
-
-    #[inline]
     fn apply_to_uninit_rows_from_src(
         &self,
         src_row_1: &[F],

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,3 +1,4 @@
+use itertools::{izip, Itertools};
 use p3_field::{Field, PackedField, PackedValue};
 
 pub trait Butterfly<F: Field>: Copy + Send + Sync {
@@ -19,6 +20,44 @@ pub trait Butterfly<F: Field>: Copy + Send + Sync {
         }
         for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
             self.apply_in_place(x_1, x_2);
+        }
+    }
+
+    #[inline]
+    fn apply_to_rows_from_src(
+        &self,
+        src_row_1: &[F],
+        src_row_2: &[F],
+        dst_row_1: &mut [F],
+        dst_row_2: &mut [F],
+    ) {
+        let (src_shorts_1, src_suffix_1) = F::Packing::pack_slice_with_suffix(src_row_1);
+        let (dst_shorts_1, dst_suffix_1) = F::Packing::pack_slice_with_suffix_mut(dst_row_1);
+
+        let (src_shorts_2, src_suffix_2) = F::Packing::pack_slice_with_suffix(src_row_2);
+        let (dst_shorts_2, dst_suffix_2) = F::Packing::pack_slice_with_suffix_mut(dst_row_2);
+
+        // debug_assert?
+
+        assert!([src_shorts_1, dst_shorts_1, src_shorts_2, dst_shorts_2]
+            .map(|s| s.len())
+            .into_iter()
+            .all_equal());
+
+        assert!([src_suffix_1, dst_suffix_1, src_suffix_2, dst_suffix_2]
+            .map(|s| s.len())
+            .into_iter()
+            .all_equal());
+
+        for (src_x_1, dst_x_1, src_x_2, dst_x_2) in
+            izip!(src_shorts_1, dst_shorts_1, src_shorts_2, dst_shorts_2)
+        {
+            (*dst_x_1, *dst_x_2) = self.apply(*src_x_1, *src_x_2);
+        }
+        for (src_x_1, dst_x_1, src_x_2, dst_x_2) in
+            izip!(src_suffix_1, dst_suffix_1, src_suffix_2, dst_suffix_2)
+        {
+            (*dst_x_1, *dst_x_2) = self.apply(*src_x_1, *src_x_2);
         }
     }
 }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -538,6 +538,8 @@ where
     /// Panics if D2 != D.
     #[inline]
     fn from_array_trust_me<const D2: usize>(mut arr: [AF; D2]) -> Self {
+        // One is tempted to do something unsafe here, but it seems like LLVM is
+        // fine getting rid of this.
         let mut me = Self::default();
         me.value.swap_with_slice(&mut arr);
         me

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -194,12 +194,7 @@ where
                 res.value[1] = a[0].clone() * a[1].double();
                 res
             }
-            3 => Self {
-                value: cubic_square(&self.value, AF::F::w())
-                    .to_vec()
-                    .try_into()
-                    .unwrap(),
-            },
+            3 => Self::from_array_trust_me(cubic_square(&self.value, AF::F::w())),
             _ => <Self as Mul<Self>>::mul(self.clone(), self.clone()),
         }
     }
@@ -412,11 +407,7 @@ where
                 res.value[1] = a[0].clone() * b[1].clone() + a[1].clone() * b[0].clone();
                 res
             }
-            3 => {
-                let mut res = Self::default();
-                res.value.swap_with_slice(&mut cubic_mul(&a, &b, w));
-                res
-            }
+            3 => Self::from_array_trust_me(cubic_mul(&a, &b, w)),
             _ => {
                 let mut res = Self::default();
                 #[allow(clippy::needless_range_loop)]
@@ -523,9 +514,7 @@ where
 
     #[inline]
     fn from_base_slice(bs: &[AF]) -> Self {
-        Self {
-            value: bs.to_vec().try_into().expect("slice has wrong length"),
-        }
+        Self::from_base_fn(|i| bs[i].clone())
     }
 
     #[inline]
@@ -538,6 +527,20 @@ where
     #[inline]
     fn as_base_slice(&self) -> &[AF] {
         &self.value
+    }
+}
+
+impl<AF, const D: usize> BinomialExtensionField<AF, D>
+where
+    AF: AbstractField,
+    AF::F: BinomiallyExtendable<D>,
+{
+    /// Panics if D2 != D.
+    #[inline]
+    fn from_array_trust_me<const D2: usize>(mut arr: [AF; D2]) -> Self {
+        let mut me = Self::default();
+        me.value.swap_with_slice(&mut arr);
+        me
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -412,9 +412,11 @@ where
                 res.value[1] = a[0].clone() * b[1].clone() + a[1].clone() * b[0].clone();
                 res
             }
-            3 => Self {
-                value: cubic_mul(&a, &b, w).to_vec().try_into().unwrap(),
-            },
+            3 => {
+                let mut res = Self::default();
+                res.value.swap_with_slice(&mut cubic_mul(&a, &b, w));
+                res
+            }
             _ => {
                 let mut res = Self::default();
                 #[allow(clippy::needless_range_loop)]

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -23,11 +23,18 @@ pub mod prelude {
             self.fold(&identity, fold_op).reduce(&identity, reduce_op)
         }
     }
+
+    #[macro_export]
+    macro_rules! par_izip {
+        ( $first:expr $( , $rest:expr )+ $(,)* ) => {
+            ($first $( , $rest )+ ).into_par_iter()
+        };
+    }
 }
 
 #[cfg(feature = "parallel")]
 pub mod iter {
-    pub use rayon::iter::repeat;
+    pub use rayon::iter::{repeat, split};
 }
 
 #[cfg(not(feature = "parallel"))]
@@ -61,9 +68,23 @@ pub mod prelude {
             self.fold(identity(), fold_op)
         }
     }
+
+    #[macro_export]
+    macro_rules! par_izip {
+        ( $first:expr $( , $rest:expr )+ $(,)* ) => {
+            itertools::izip!($first $(, $rest)+ )
+        };
+    }
 }
 
 #[cfg(not(feature = "parallel"))]
 pub mod iter {
     pub use core::iter::repeat;
+
+    pub fn split<D, S>(data: D, _splitter: S) -> core::iter::Once<D>
+    where
+        S: Fn(D) -> (D, Option<D>),
+    {
+        core::iter::once(data)
+    }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -8,6 +8,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::type_name;
 use core::hint::unreachable_unchecked;
+use core::mem::MaybeUninit;
+use core::slice;
 
 pub mod array_serialization;
 pub mod linear_map;
@@ -132,6 +134,8 @@ pub trait VecExt<T> {
     fn pushed_ref(&mut self, elem: T) -> &T;
     /// Push `elem` and return a mutable reference to it.
     fn pushed_mut(&mut self, elem: T) -> &mut T;
+
+    unsafe fn split_at_spare_ref_mut(&mut self) -> (&[T], &mut [MaybeUninit<T>]);
 }
 
 impl<T> VecExt<T> for alloc::vec::Vec<T> {
@@ -142,6 +146,15 @@ impl<T> VecExt<T> for alloc::vec::Vec<T> {
     fn pushed_mut(&mut self, elem: T) -> &mut T {
         self.push(elem);
         self.last_mut().unwrap()
+    }
+    unsafe fn split_at_spare_ref_mut(&mut self) -> (&[T], &mut [MaybeUninit<T>]) {
+        let ptr = self.as_mut_ptr();
+        let len = self.len();
+        let spare_len = self.capacity() - len;
+        (
+            slice::from_raw_parts(ptr, len),
+            slice::from_raw_parts_mut(ptr.add(len) as *mut MaybeUninit<T>, spare_len),
+        )
     }
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -135,7 +135,9 @@ pub trait VecExt<T> {
     /// Push `elem` and return a mutable reference to it.
     fn pushed_mut(&mut self, elem: T) -> &mut T;
 
-    unsafe fn split_at_spare_ref_mut(&mut self) -> (&[T], &mut [MaybeUninit<T>]);
+    /// Same as alloc::vec::Vec::split_at_spare_mut, which is nightly-only.
+    /// The "v" stands for "vendored".
+    unsafe fn v_split_at_spare_mut(&mut self) -> (&mut [T], &mut [MaybeUninit<T>]);
 }
 
 impl<T> VecExt<T> for alloc::vec::Vec<T> {
@@ -147,12 +149,12 @@ impl<T> VecExt<T> for alloc::vec::Vec<T> {
         self.push(elem);
         self.last_mut().unwrap()
     }
-    unsafe fn split_at_spare_ref_mut(&mut self) -> (&[T], &mut [MaybeUninit<T>]) {
+    unsafe fn v_split_at_spare_mut(&mut self) -> (&mut [T], &mut [MaybeUninit<T>]) {
         let ptr = self.as_mut_ptr();
         let len = self.len();
         let spare_len = self.capacity() - len;
         (
-            slice::from_raw_parts(ptr, len),
+            slice::from_raw_parts_mut(ptr, len),
             slice::from_raw_parts_mut(ptr.add(len) as *mut MaybeUninit<T>, spare_len),
         )
     }


### PR DESCRIPTION
- Avoid large resize in LDE by writing to uninit
- Parallelize `CircleDomain::points()` and `CircleDomain::selectors_on_coset()`
- Avoid `to_vec()` in generic cubic extension mul