### PR TITLE
Remove the old bit_reversed_zero_pad function

### DIFF
--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -8,7 +8,7 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_bits, reverse_slice_index_bits};
 
 use crate::butterflies::{Butterfly, DifButterfly, DitButterfly, TwiddleFreeButterfly};
-use crate::util::{bit_reversed_zero_pad, divide_by_height};
+use crate::util::divide_by_height;
 use crate::TwoAdicSubgroupDft;
 
 /// The Bowers G FFT algorithm.
@@ -36,7 +36,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {
     fn lde_batch(&self, mut mat: RowMajorMatrix<F>, added_bits: usize) -> RowMajorMatrix<F> {
         bowers_g_t(&mut mat.as_view_mut());
         divide_by_height(&mut mat);
-        bit_reversed_zero_pad(&mut mat, added_bits);
+        mat = mat.bit_reversed_zero_pad(added_bits);
         bowers_g(&mut mat.as_view_mut());
         mat
     }
@@ -65,7 +65,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {
             mat.scale_row(reverse_bits(row, h), weight);
         }
 
-        bit_reversed_zero_pad(&mut mat, added_bits);
+        mat = mat.bit_reversed_zero_pad(added_bits);
 
         bowers_g(&mut mat.as_view_mut());
 

--- a/dft/src/util.rs
+++ b/dft/src/util.rs
@@ -14,33 +14,6 @@ pub fn divide_by_height<F: Field, S: DenseStorage<F> + BorrowMut<[F]>>(
     mat.scale(F::from_canonical_usize(mat.height()).inverse())
 }
 
-/// Append zeros to the "end" of the given matrix, except that the matrix is in bit-reversed order,
-/// so in actuality we're interleaving zero rows.
-#[inline]
-pub fn bit_reversed_zero_pad<F: Field>(mat: &mut RowMajorMatrix<F>, added_bits: usize) {
-    // TODO: This is copypasta from matrix/dense.rs that should be
-    // refactored; it is only used by Radix2Bowers.
-    if added_bits == 0 {
-        return;
-    }
-
-    // This is equivalent to:
-    //     reverse_matrix_index_bits(mat);
-    //     mat
-    //         .values
-    //         .resize(mat.values.len() << added_bits, F::zero());
-    //     reverse_matrix_index_bits(mat);
-    // But rather than implement it with bit reversals, we directly construct the resulting matrix,
-    // whose rows are zero except for rows whose low `added_bits` bits are zero.
-
-    let w = mat.width;
-    let mut values = vec![F::zero(); mat.values.len() << added_bits];
-    for i in (0..mat.values.len()).step_by(w) {
-        values[(i << added_bits)..((i << added_bits) + w)].copy_from_slice(&mat.values[i..i + w]);
-    }
-    *mat = RowMajorMatrix::new(values, w);
-}
-
 /// Multiply each element of row `i` of `mat` by `shift**i`.
 pub(crate) fn coset_shift_cols<F: Field>(mat: &mut RowMajorMatrix<F>, shift: F) {
     mat.rows_mut()

--- a/dft/src/util.rs
+++ b/dft/src/util.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use core::borrow::BorrowMut;
 
 use p3_field::Field;

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -6,6 +6,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 use core::{iter, slice};
 
+use itertools::Itertools;
 use p3_field::{scale_slice_in_place, ExtensionField, Field, PackedValue};
 use p3_maybe_rayon::prelude::*;
 use rand::distributions::{Distribution, Standard};

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -297,7 +297,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         );
         padded
             .par_row_chunks_exact_mut(1 << added_bits)
-            .zip(self.par_row_slices())
+            .zip_eq(self.par_row_slices())
             .for_each(|(mut ch, r)| ch.row_mut(0).copy_from_slice(r));
 
         padded


### PR DESCRIPTION
This older one was single-threaded, although I don't notice the different much (haven't benched them in isolation).