### PR TITLE
Remove vector allocations in `hash_iter()` implementations

### DIFF
--- a/blake3/Cargo.toml
+++ b/blake3/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-symmetric = { path = "../symmetric" }
+p3-util = { path = "../util" }
 blake3 = "1.5"
 
 [features]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-symmetric = { path = "../symmetric" }
+p3-util = { path = "../util" }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -7,6 +7,7 @@ description = "Plonky3 hash trait implementations for the SHA2-256 hash function
 
 [dependencies]
 p3-symmetric = { path = "../symmetric" }
+p3-util = { path = "../util" }
 sha2 = { version = "0.10.8", default-features = false, features = ["compress"] }
 
 [features]

--- a/sha256/src/lib.rs
+++ b/sha256/src/lib.rs
@@ -2,10 +2,6 @@
 
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use p3_symmetric::{CompressionFunction, CryptographicHasher, PseudoCompressionFunction};
 use sha2::digest::generic_array::GenericArray;
 use sha2::digest::typenum::U64;
@@ -24,8 +20,10 @@ impl CryptographicHasher<u8, [u8; 32]> for Sha256 {
     where
         I: IntoIterator<Item = u8>,
     {
-        let input = input.into_iter().collect::<Vec<_>>();
-        self.hash_iter_slices([input.as_slice()])
+        const BUFLEN: usize = 512; // Tweakable parameter; determined by experiment
+        let mut hasher = sha2::Sha256::new();
+        p3_util::apply_to_chunks::<BUFLEN, _, _>(input, |buf| hasher.update(buf));
+        hasher.finalize().into()
     }
 
     fn hash_iter_slices<'a, I>(&self, input: I) -> [u8; 32]

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -183,15 +183,16 @@ unsafe fn iter_next_chunk<const BUFLEN: usize, I: Iterator>(
 where
     I::Item: Copy,
 {
-    // Read BUFLEN values from `iter` into `buf` at a time.
     let mut buf = unsafe {
         let t = [const { MaybeUninit::<I::Item>::uninit() }; BUFLEN];
         // We are forced to use `transmute_copy` here instead of
         // `transmute` because `BUFLEN` is a const generic parameter.
+        // The compiler *should* be smart enough not to emit a copy though.
         core::mem::transmute_copy::<_, [I::Item; BUFLEN]>(&t)
     };
     let mut i = 0;
 
+    // Read BUFLEN values from `iter` into `buf` at a time.
     for c in iter {
         // Copy the next Item into `buf`.
         unsafe {
@@ -216,7 +217,6 @@ where
     I: IntoIterator<Item = u8>,
     H: FnMut(&[I::Item]),
 {
-    // Read BUFLEN values from `iter` into `buf` at a time.
     let mut iter = input.into_iter();
     loop {
         let (buf, n) = unsafe { iter_next_chunk::<BUFLEN, _>(&mut iter) };


### PR DESCRIPTION
Most `hash_iter()` implementations are copypasta that includes an avoidable vector allocation. This PR introduces a "buffered iterator" that repeatedly calls the underlying hash update function with chunks of bytes from the input iterator. Improves performance of most `hash_iter()` calls by 10-20%.