### PR TITLE
De-dup itertools versions

### DIFF
--- a/mds/Cargo.toml
+++ b/mds/Cargo.toml
@@ -11,7 +11,7 @@ p3-matrix = { path = "../matrix" }
 p3-symmetric = { path = "../symmetric" }
 p3-util = { path = "../util" }
 rand = { version = "0.8.5", features = ["min_const_gen"] }
-itertools = "0.12.0"
+itertools = "0.13.0"
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
Everywhere else uses version 0.13.0, but the `mds` package used 0.12.0 for no particular reason. This caused `itertools` was imported and compiled twice. Fixed by updating the `mds` import to use 0.13.0 too.