### PR TITLE
Split FRI proof objects & logic

### DIFF
--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -11,7 +11,7 @@ use p3_matrix::Matrix;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 
 use crate::domain::CircleDomain;
-use crate::{InputError, InputProof};
+use crate::{CircleInputProof, InputError};
 
 pub(crate) struct CircleFriGenericConfig<F, InputProof, InputError>(
     pub(crate) PhantomData<(F, InputProof, InputError)>,
@@ -19,7 +19,7 @@ pub(crate) struct CircleFriGenericConfig<F, InputProof, InputError>(
 
 pub(crate) type CircleFriConfig<Val, Challenge, InputMmcs, FriMmcs> = CircleFriGenericConfig<
     Val,
-    InputProof<Val, Challenge, InputMmcs, FriMmcs>,
+    CircleInputProof<Val, Challenge, InputMmcs, FriMmcs>,
     InputError<<InputMmcs as Mmcs<Val>>::Error, <FriMmcs as Mmcs<Challenge>>::Error>,
 >;
 

--- a/circle/src/lib.rs
+++ b/circle/src/lib.rs
@@ -12,8 +12,12 @@ mod folding;
 mod ordering;
 mod pcs;
 mod point;
+mod proof;
+mod prover;
+mod verifier;
 
 pub use cfft::*;
 pub use domain::*;
 pub use ordering::*;
 pub use pcs::*;
+pub use proof::*;

--- a/circle/src/proof.rs
+++ b/circle/src/proof.rs
@@ -1,0 +1,42 @@
+use alloc::vec::Vec;
+
+use p3_commit::Mmcs;
+use p3_field::Field;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(bound(
+    serialize = "Witness: Serialize, InputProof: Serialize",
+    deserialize = "Witness: Deserialize<'de>, InputProof: Deserialize<'de>"
+))]
+pub struct CircleFriProof<F: Field, M: Mmcs<F>, Witness, InputProof> {
+    pub commit_phase_commits: Vec<M::Commitment>,
+    pub query_proofs: Vec<CircleQueryProof<F, M, InputProof>>,
+    // This could become Vec<FC::Challenge> if this library was generalized to support non-constant
+    // final polynomials.
+    pub final_poly: F,
+    pub pow_witness: Witness,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(bound(
+    serialize = "InputProof: Serialize",
+    deserialize = "InputProof: Deserialize<'de>",
+))]
+pub struct CircleQueryProof<F: Field, M: Mmcs<F>, InputProof> {
+    pub input_proof: InputProof,
+    /// For each commit phase commitment, this contains openings of a commit phase codeword at the
+    /// queried location, along with an opening proof.
+    pub commit_phase_openings: Vec<CircleCommitPhaseProofStep<F, M>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(bound = "")]
+pub struct CircleCommitPhaseProofStep<F: Field, M: Mmcs<F>> {
+    /// The opening of the commit phase codeword at the sibling location.
+    // This may change to Vec<FC::Challenge> if the library is generalized to support other FRI
+    // folding arities besides 2, meaning that there can be multiple siblings.
+    pub sibling_value: F,
+
+    pub opening_proof: M::Proof,
+}

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -1,0 +1,152 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter;
+
+use itertools::{izip, Itertools};
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_commit::Mmcs;
+use p3_field::{ExtensionField, Field};
+use p3_fri::{FriConfig, FriGenericConfig};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_util::log2_strict_usize;
+use tracing::{info_span, instrument};
+
+use crate::{CircleCommitPhaseProofStep, CircleFriProof, CircleQueryProof};
+
+#[instrument(name = "FRI prover", skip_all)]
+pub fn prove<G, Val, Challenge, M, Challenger>(
+    g: &G,
+    config: &FriConfig<M>,
+    inputs: Vec<Vec<Challenge>>,
+    challenger: &mut Challenger,
+    open_input: impl Fn(usize) -> G::InputProof,
+) -> CircleFriProof<Challenge, M, Challenger::Witness, G::InputProof>
+where
+    Val: Field,
+    Challenge: ExtensionField<Val>,
+    M: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
+    G: FriGenericConfig<Challenge>,
+{
+    // check sorted descending
+    assert!(inputs
+        .iter()
+        .tuple_windows()
+        .all(|(l, r)| l.len() >= r.len()));
+
+    let log_max_height = log2_strict_usize(inputs[0].len());
+
+    let commit_phase_result = commit_phase(g, config, inputs, challenger);
+
+    let pow_witness = challenger.grind(config.proof_of_work_bits);
+
+    let query_proofs = info_span!("query phase").in_scope(|| {
+        iter::repeat_with(|| challenger.sample_bits(log_max_height + g.extra_query_index_bits()))
+            .take(config.num_queries)
+            .map(|index| CircleQueryProof {
+                input_proof: open_input(index),
+                commit_phase_openings: answer_query(
+                    config,
+                    &commit_phase_result.data,
+                    index >> g.extra_query_index_bits(),
+                ),
+            })
+            .collect()
+    });
+
+    CircleFriProof {
+        commit_phase_commits: commit_phase_result.commits,
+        query_proofs,
+        final_poly: commit_phase_result.final_poly,
+        pow_witness,
+    }
+}
+
+struct CommitPhaseResult<F: Field, M: Mmcs<F>> {
+    commits: Vec<M::Commitment>,
+    data: Vec<M::ProverData<RowMajorMatrix<F>>>,
+    final_poly: F,
+}
+
+#[instrument(name = "commit phase", skip_all)]
+fn commit_phase<G, Val, Challenge, M, Challenger>(
+    g: &G,
+    config: &FriConfig<M>,
+    inputs: Vec<Vec<Challenge>>,
+    challenger: &mut Challenger,
+) -> CommitPhaseResult<Challenge, M>
+where
+    Val: Field,
+    Challenge: ExtensionField<Val>,
+    M: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + CanObserve<M::Commitment>,
+    G: FriGenericConfig<Challenge>,
+{
+    let mut inputs_iter = inputs.into_iter().peekable();
+    let mut folded = inputs_iter.next().unwrap();
+    let mut commits = vec![];
+    let mut data = vec![];
+
+    while folded.len() > config.blowup() {
+        let leaves = RowMajorMatrix::new(folded, 2);
+        let (commit, prover_data) = config.mmcs.commit_matrix(leaves);
+        challenger.observe(commit.clone());
+
+        let beta: Challenge = challenger.sample_ext_element();
+        // We passed ownership of `current` to the MMCS, so get a reference to it
+        let leaves = config.mmcs.get_matrices(&prover_data).pop().unwrap();
+        folded = g.fold_matrix(beta, leaves.as_view());
+
+        commits.push(commit);
+        data.push(prover_data);
+
+        if let Some(v) = inputs_iter.next_if(|v| v.len() == folded.len()) {
+            izip!(&mut folded, v).for_each(|(c, x)| *c += x);
+        }
+    }
+
+    // We should be left with `blowup` evaluations of a constant polynomial.
+    assert_eq!(folded.len(), config.blowup());
+    let final_poly = folded[0];
+    for x in folded {
+        assert_eq!(x, final_poly);
+    }
+    challenger.observe_ext_element(final_poly);
+
+    CommitPhaseResult {
+        commits,
+        data,
+        final_poly,
+    }
+}
+
+fn answer_query<F, M>(
+    config: &FriConfig<M>,
+    commit_phase_commits: &[M::ProverData<RowMajorMatrix<F>>],
+    index: usize,
+) -> Vec<CircleCommitPhaseProofStep<F, M>>
+where
+    F: Field,
+    M: Mmcs<F>,
+{
+    commit_phase_commits
+        .iter()
+        .enumerate()
+        .map(|(i, commit)| {
+            let index_i = index >> i;
+            let index_i_sibling = index_i ^ 1;
+            let index_pair = index_i >> 1;
+
+            let (mut opened_rows, opening_proof) = config.mmcs.open_batch(index_pair, commit);
+            assert_eq!(opened_rows.len(), 1);
+            let opened_row = opened_rows.pop().unwrap();
+            assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");
+            let sibling_value = opened_row[index_i_sibling % 2];
+
+            CircleCommitPhaseProofStep {
+                sibling_value,
+                opening_proof,
+            }
+        })
+        .collect()
+}

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -1,0 +1,139 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use itertools::{izip, Itertools};
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_commit::Mmcs;
+use p3_field::{ExtensionField, Field};
+use p3_fri::verifier::FriError;
+use p3_fri::{FriConfig, FriGenericConfig};
+use p3_matrix::Dimensions;
+
+use crate::{CircleCommitPhaseProofStep, CircleFriProof};
+
+pub fn verify<G, Val, Challenge, M, Challenger>(
+    g: &G,
+    config: &FriConfig<M>,
+    proof: &CircleFriProof<Challenge, M, Challenger::Witness, G::InputProof>,
+    challenger: &mut Challenger,
+    open_input: impl Fn(usize, &G::InputProof) -> Result<Vec<(usize, Challenge)>, G::InputError>,
+) -> Result<(), FriError<M::Error, G::InputError>>
+where
+    Val: Field,
+    Challenge: ExtensionField<Val>,
+    M: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
+    G: FriGenericConfig<Challenge>,
+{
+    let betas: Vec<Challenge> = proof
+        .commit_phase_commits
+        .iter()
+        .map(|comm| {
+            challenger.observe(comm.clone());
+            challenger.sample_ext_element()
+        })
+        .collect();
+    challenger.observe_ext_element(proof.final_poly);
+
+    if proof.query_proofs.len() != config.num_queries {
+        return Err(FriError::InvalidProofShape);
+    }
+
+    // Check PoW.
+    if !challenger.check_witness(config.proof_of_work_bits, proof.pow_witness) {
+        return Err(FriError::InvalidPowWitness);
+    }
+
+    let log_max_height = proof.commit_phase_commits.len() + config.log_blowup;
+
+    for qp in &proof.query_proofs {
+        let index = challenger.sample_bits(log_max_height + g.extra_query_index_bits());
+        let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
+
+        debug_assert!(
+            ro.iter().tuple_windows().all(|((l, _), (r, _))| l > r),
+            "reduced openings sorted by height descending"
+        );
+
+        let folded_eval = verify_query(
+            g,
+            config,
+            index >> g.extra_query_index_bits(),
+            izip!(
+                &betas,
+                &proof.commit_phase_commits,
+                &qp.commit_phase_openings
+            ),
+            ro,
+            log_max_height,
+        )?;
+
+        if folded_eval != proof.final_poly {
+            return Err(FriError::FinalPolyMismatch);
+        }
+    }
+
+    Ok(())
+}
+
+type CommitStep<'a, F, M> = (
+    &'a F,
+    &'a <M as Mmcs<F>>::Commitment,
+    &'a CircleCommitPhaseProofStep<F, M>,
+);
+
+fn verify_query<'a, G, F, M>(
+    g: &G,
+    config: &FriConfig<M>,
+    mut index: usize,
+    steps: impl Iterator<Item = CommitStep<'a, F, M>>,
+    reduced_openings: Vec<(usize, F)>,
+    log_max_height: usize,
+) -> Result<F, FriError<M::Error, G::InputError>>
+where
+    F: Field,
+    M: Mmcs<F> + 'a,
+    G: FriGenericConfig<F>,
+{
+    let mut folded_eval = F::zero();
+    let mut ro_iter = reduced_openings.into_iter().peekable();
+
+    for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {
+        if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height + 1) {
+            folded_eval += ro;
+        }
+
+        let index_sibling = index ^ 1;
+        let index_pair = index >> 1;
+
+        let mut evals = vec![folded_eval; 2];
+        evals[index_sibling % 2] = opening.sibling_value;
+
+        let dims = &[Dimensions {
+            width: 2,
+            height: 1 << log_folded_height,
+        }];
+        config
+            .mmcs
+            .verify_batch(
+                comm,
+                dims,
+                index_pair,
+                &[evals.clone()],
+                &opening.opening_proof,
+            )
+            .map_err(FriError::CommitPhaseMmcsError)?;
+
+        index = index_pair;
+
+        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+    }
+
+    debug_assert!(index < config.blowup(), "index was {}", index);
+    debug_assert!(
+        ro_iter.next().is_none(),
+        "verifier reduced_openings were not in descending order?"
+    );
+
+    Ok(folded_eval)
+}


### PR DESCRIPTION
Such that regular FRI and circle FRI no longer share that code. Keeping `FriConfig`, `FriGenericConfig`, `FriError` shared for now; not sure if they'll diverge later.