### PR TITLE
Change how `bit_reversed_zero_pad` allocates and fills its buffer

### DIFF
--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "parallel")]
 pub mod prelude {
     pub use rayon::prelude::*;
-    pub use rayon::{current_num_threads, join};
+    pub use rayon::{current_num_threads, join, ThreadPoolBuilder};
 
     pub trait SharedExt: ParallelIterator {
         fn par_fold_reduce<Acc, Id, F, R>(self, identity: Id, fold_op: F, reduce_op: R) -> Acc

--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -179,3 +179,34 @@ where
 pub fn current_num_threads() -> usize {
     1
 }
+
+pub struct ThreadPool;
+
+impl ThreadPool {
+    pub fn install<OP, R>(&self, op: OP) -> R
+    where
+        OP: FnOnce() -> R + Send,
+        R: Send,
+    {
+        op()
+    }
+}
+
+pub struct ThreadPoolBuilder;
+
+impl ThreadPoolBuilder {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn num_threads(self, _num_threads: usize) -> Self {
+        self
+    }
+
+    pub fn build(self) -> Result<ThreadPool, ThreadPoolBuildError> {
+        Ok(ThreadPool)
+    }
+}
+
+#[derive(Debug)]
+pub struct ThreadPoolBuildError;


### PR DESCRIPTION
This method interleaves rows of the original matrix with some blocks of zeros. A couple changes:

- Rather than starting with a zeroed buffer, start with an uninitialized buffer and manually zero the appropriate parts. In theory starting with a zeroed buffer should be faster, at least on some systems, since the OS may have already zeroed out the pages it's giving us. However, `vec![T::default(); m]` appears to trigger userspace zeroing. (I'm guessing based on benches, haven't checked generated code.) It seems like we'd need to do something like `vec![0u32; m]` to get the compiler to handle that as desired. We could allocate like that and then transmute, but it seems a bit messier (need to think about alignment), and the resulting performance seems about the same.
- Use a smaller thread pool (3 threads) to do the copying and zeroing. On my system 3 seems ideal; my understanding is around 3 cores will usually saturate memory bandwidth at least on most single-socket systems.