### PR TITLE
Removing our custom impl of div_ceil.

### DIFF
--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -5,7 +5,6 @@ use p3_field::PrimeField64;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::iter::repeat;
 use p3_maybe_rayon::prelude::*;
-use p3_util::ceil_div_usize;
 use tracing::instrument;
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
@@ -24,7 +23,7 @@ pub fn generate_trace_rows<F: PrimeField64>(inputs: Vec<[u64; 25]>) -> RowMajorM
     assert!(suffix.is_empty(), "Alignment should match");
     assert_eq!(rows.len(), num_rows);
 
-    let num_padding_inputs = ceil_div_usize(num_rows, NUM_ROUNDS) - inputs.len();
+    let num_padding_inputs = num_rows.div_ceil(NUM_ROUNDS) - inputs.len();
     let padded_inputs = inputs
         .into_par_iter()
         .chain(repeat([0; 25]).take(num_padding_inputs));

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -5,7 +5,6 @@ use p3_field::PrimeField;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_poseidon2::{DiffusionPermutation, MdsLightPermutation};
-use p3_util::ceil_div_usize;
 use tracing::instrument;
 
 use crate::columns::{num_cols, Poseidon2Cols};
@@ -34,7 +33,7 @@ pub fn generate_vectorized_trace_rows<
         "Callers expected to pad inputs to VECTOR_LEN times a power of two"
     );
 
-    let nrows = ceil_div_usize(n, VECTOR_LEN);
+    let nrows = n.div_ceil(VECTOR_LEN);
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
     let mut trace = RowMajorMatrix::new(vec![F::zero(); nrows * ncols], ncols);

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -7,7 +7,6 @@ use num_integer::binomial;
 use p3_field::{AbstractField, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
-use p3_util::ceil_div_usize;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -73,7 +72,7 @@ where
         F: PrimeField64,
     {
         let num_constants = 2 * WIDTH * num_rounds;
-        let bytes_per_constant = ceil_div_usize(F::bits(), 8) + 1;
+        let bytes_per_constant = F::bits().div_ceil(8) + 1;
         let num_bytes = bytes_per_constant * num_constants;
 
         let seed_string = format!(

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -13,12 +13,6 @@ use core::mem::MaybeUninit;
 pub mod array_serialization;
 pub mod linear_map;
 
-/// Computes `ceil(a / b)`. Assumes `a + b` does not overflow.
-#[must_use]
-pub const fn ceil_div_usize(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 /// Computes `ceil(log_2(n))`.
 #[must_use]
 pub const fn log2_ceil_usize(n: usize) -> usize {


### PR DESCRIPTION
div_ceil is now stabilized so we no longer need our own version in utils.

See: https://doc.rust-lang.org/std/primitive.u32.html#method.div_ceil

At some point we should similarly remove log2_ceil_u64/log2_ceil_usize as ilog2 is also standardized but this is slightly more annoying as the rounding is different (ilog2 rounds down instead of up).