### PR TITLE
Adding repr(transparent) to M31 and Goldilocks 

### DIFF
--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -65,6 +65,7 @@ const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[repr(transparent)] // Packed field implementations rely on this!
 pub struct Goldilocks {
     /// Not necessarily canonical.
     value: u64,

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -18,6 +18,7 @@ const P: u32 = (1 << 31) - 1;
 
 /// The prime field `F_p` where `p = 2^31 - 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[repr(transparent)] // Packed field implementations rely on this!
 pub struct Mersenne31 {
     /// Not necessarily canonical, but must fit in 31 bits.
     pub(crate) value: u32,


### PR DESCRIPTION
Somehow the base M31 and Goldilocks fields were missing `#[repr(transparent)]`!

Luckily this has had no effect so far but in principle this could break all the transmutes used in pack field code.