### PR TITLE
Add a `zero_vec` method in `Field`

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -249,6 +249,18 @@ pub trait Field:
     fn bits() -> usize {
         Self::order().bits() as usize
     }
+
+    /// Allocates a vector of zero elements of length `len`. Many operating systems zero pages
+    /// before assigning them to a userspace process. In that case, our process should not need to
+    /// write zeros, which would be redundant. However, the compiler may not always recognize this.
+    ///
+    /// In particular, `vec![Self::zero(); len]` appears to result in redundant userspace zeroing.
+    /// This is the default implementation, but implementors may wish to provide their own
+    /// implementation which transmutes something like `vec![0u32; len]`.
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        vec![Self::zero(); len]
+    }
 }
 
 pub trait PrimeField: Field + Ord {

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 
 extern crate alloc;
+
 mod extension;
 mod mds;
 mod poseidon2;
@@ -21,6 +22,9 @@ mod poseidon2;
     not(all(feature = "nightly-features", target_feature = "avx512f"))
 ))]
 mod x86_64_avx2;
+
+use alloc::vec;
+use alloc::vec::Vec;
 
 #[cfg(all(
     target_arch = "x86_64",
@@ -39,6 +43,7 @@ mod x86_64_avx512;
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
+use core::intrinsics::transmute;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -65,6 +70,7 @@ const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[repr(transparent)] // Packed field implementations rely on this!
 pub struct Goldilocks {
     /// Not necessarily canonical.
     value: u64,
@@ -290,6 +296,12 @@ impl Field for Goldilocks {
     #[inline]
     fn order() -> BigUint {
         P.into()
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        // SAFETY: repr(transparent) ensures transmutation safety.
+        unsafe { transmute(vec![0u64; len]) }
     }
 }
 

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_field::PrimeField64;
@@ -16,8 +15,7 @@ use crate::{BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
 #[instrument(name = "generate Keccak trace", skip_all)]
 pub fn generate_trace_rows<F: PrimeField64>(inputs: Vec<[u64; 25]>) -> RowMajorMatrix<F> {
     let num_rows = (inputs.len() * NUM_ROUNDS).next_power_of_two();
-    let mut trace =
-        RowMajorMatrix::new(vec![F::zero(); num_rows * NUM_KECCAK_COLS], NUM_KECCAK_COLS);
+    let mut trace = RowMajorMatrix::new(F::zero_vec(num_rows * NUM_KECCAK_COLS), NUM_KECCAK_COLS);
     let (prefix, rows, suffix) = unsafe { trace.values.align_to_mut::<KeccakCols<F>>() };
     assert!(prefix.is_empty(), "Alignment should match");
     assert!(suffix.is_empty(), "Alignment should match");

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -275,7 +275,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
     #[instrument(level = "debug", skip_all)]
     pub fn bit_reversed_zero_pad(self, added_bits: usize) -> RowMajorMatrix<T>
     where
-        T: Copy + Default + Send + Sync,
+        T: Field,
     {
         if added_bits == 0 {
             return self.to_row_major_matrix();
@@ -291,10 +291,8 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         // whose rows are zero except for rows whose low `added_bits` bits are zero.
 
         let w = self.width;
-        let mut padded = RowMajorMatrix::new(
-            vec![T::default(); self.values.borrow().len() << added_bits],
-            w,
-        );
+        let mut padded =
+            RowMajorMatrix::new(T::zero_vec(self.values.borrow().len() << added_bits), w);
         padded
             .par_row_chunks_exact_mut(1 << added_bits)
             .zip(self.par_row_slices())

--- a/matrix/src/mul.rs
+++ b/matrix/src/mul.rs
@@ -1,5 +1,3 @@
-use alloc::vec;
-
 use p3_field::{add_scaled_slice_in_place, Field};
 use p3_maybe_rayon::prelude::*;
 
@@ -22,7 +20,7 @@ where
     let c_values = (0..a.height())
         .into_par_iter()
         .flat_map(|a_row_idx| {
-            let mut c_row = vec![F::zero(); c_width];
+            let mut c_row = F::zero_vec(c_width);
             for &(a_col_idx, a_val) in a.sparse_row(a_row_idx) {
                 add_scaled_slice_in_place(&mut c_row, b.row(a_col_idx), a_val);
             }

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -1,7 +1,10 @@
+use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
+use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use num_bigint::BigUint;
@@ -18,6 +21,7 @@ const P: u32 = (1 << 31) - 1;
 
 /// The prime field `F_p` where `p = 2^31 - 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+#[repr(transparent)] // Packed field implementations rely on this!
 pub struct Mersenne31 {
     /// Not necessarily canonical, but must fit in 31 bits.
     pub(crate) value: u32,
@@ -262,6 +266,12 @@ impl Field for Mersenne31 {
     #[inline]
     fn order() -> BigUint {
         P.into()
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        // SAFETY: repr(transparent) ensures transmutation safety.
+        unsafe { transmute(vec![0u32; len]) }
     }
 }
 

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -1,10 +1,8 @@
 //! An implementation of the FFT for `MontyField31`
 extern crate alloc;
 
-use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
-use core::mem::transmute;
 
 use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
@@ -249,13 +247,10 @@ impl<MP: MontyParameters + FieldParameters + TwoAdicData> TwoAdicSubgroupDft<Mon
         let mat = mat.bit_reverse_rows().to_row_major_matrix();
 
         // Allocate space for the output and the intermediate state.
-        // NB: The unsafe version below takes well under 1ms, whereas doing
-        //   vec![MontyField31::zero(); output_size])
-        // takes 100s of ms. Safety is expensive.
-        let (mut output, mut padded) = debug_span!("allocate scratch space").in_scope(|| unsafe {
+        let (mut output, mut padded) = debug_span!("allocate scratch space").in_scope(|| {
             // Safety: These are pretty dodgy, but work because MontyField31 is #[repr(transparent)]
-            let output = transmute::<Vec<u32>, Vec<MontyField31<MP>>>(vec![0u32; output_size]);
-            let padded = transmute::<Vec<u32>, Vec<MontyField31<MP>>>(vec![0u32; output_size]);
+            let output = MontyField31::<MP>::zero_vec(output_size);
+            let padded = MontyField31::<MP>::zero_vec(output_size);
             (output, padded)
         });
 

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -8,6 +8,8 @@
     feature(stdarch_x86_avx512)
 )]
 
+extern crate alloc;
+
 mod data_traits;
 pub mod dft;
 mod extension;

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -1,7 +1,10 @@
 //! An abstraction of 31-bit fields which use a MONTY approach for faster multiplication.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::Hash;
+use core::intrinsics::transmute;
 use core::iter::{Product, Sum};
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -267,6 +270,12 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
     #[inline]
     fn order() -> BigUint {
         FP::PRIME.into()
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        // SAFETY: repr(transparent) ensures transmutation safety.
+        unsafe { transmute(vec![0u32; len]) }
     }
 }
 

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_field::PrimeField;
@@ -36,7 +35,7 @@ pub fn generate_vectorized_trace_rows<
     let nrows = n.div_ceil(VECTOR_LEN);
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
-    let mut trace = RowMajorMatrix::new(vec![F::zero(); nrows * ncols], ncols);
+    let mut trace = RowMajorMatrix::new(F::zero_vec(nrows * ncols), ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
@@ -89,7 +88,7 @@ pub fn generate_trace_rows<
     );
 
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>();
-    let mut trace = RowMajorMatrix::new(vec![F::zero(); n * ncols], ncols);
+    let mut trace = RowMajorMatrix::new(F::zero_vec(n * ncols), ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -59,8 +59,7 @@ impl<AB: AirBuilderWithPublicValues> Air<AB> for FibonacciAir {
 pub fn generate_trace_rows<F: PrimeField64>(a: u64, b: u64, n: usize) -> RowMajorMatrix<F> {
     assert!(n.is_power_of_two());
 
-    let mut trace =
-        RowMajorMatrix::new(vec![F::zero(); n * NUM_FIBONACCI_COLS], NUM_FIBONACCI_COLS);
+    let mut trace = RowMajorMatrix::new(F::zero_vec(n * NUM_FIBONACCI_COLS), NUM_FIBONACCI_COLS);
 
     let (prefix, rows, suffix) = unsafe { trace.values.align_to_mut::<FibonacciRow<F>>() };
     assert!(prefix.is_empty(), "Alignment should match");

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -58,7 +58,7 @@ impl MulAir {
         Standard: Distribution<F>,
     {
         let mut rng = thread_rng();
-        let mut trace_values = vec![F::default(); rows * TRACE_WIDTH];
+        let mut trace_values = F::zero_vec(rows * TRACE_WIDTH);
         for (i, (a, b, c)) in trace_values.iter_mut().tuples().enumerate() {
             let row = i / REPETITIONS;
 


### PR DESCRIPTION
This follows the transmutation approach @unzvfu used in #440, and applies it more broadly to some other places where we allocate zero vectors.