### PR TITLE
Parallelize batch inversion

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -6,10 +6,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 p3-util = { path = "../util" }
+p3-maybe-rayon = { path = "../maybe-rayon" }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.18", default-features = false }
 num-integer = "0.1.46"
 nums = "0.1.0"
+tracing = "0.1.37"
 
 itertools = "0.13.0"
 rand = "0.8.5"

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_maybe_rayon::prelude::*;
@@ -22,7 +21,7 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
     const CHUNK_SIZE: usize = 1024;
 
     let n = x.len();
-    let mut result = vec![F::zero(); n];
+    let mut result = F::zero_vec(n);
 
     x.par_chunks(CHUNK_SIZE)
         .zip(result.par_chunks_mut(CHUNK_SIZE))


### PR DESCRIPTION
This is sort of naive as it involves several separate instances of the batch inversion algorithm, resulting in several `inverse()` calls. It would be more optimal to have one big parallelized instance, with one big partial product tree made up of smaller per-thread trees, but that seems a bit annoying to code. Inversion isn't terribly expensive (especially for 32-bit fields) so the difference doesn't seem that important, but it could be worth revisiting at some point.

Separately, this should ideally be vectorized. I tried doing so with `F::Packing`, but it didn't help much as the most important callers use extension fields with trivial packings. We could use the `ExtensionPacking` approach, there are just some API complications.

This change alone reduces inversion costs from ~6% to ~1%, so pretty good for now.