### PR TITLE
Generalize the basic Monty trick impl

### DIFF
--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -48,7 +48,7 @@ fn interleave<T: Copy + Default>(arr1: &[T], arr2: &[T], i: usize) -> (Vec<T>, V
 
 fn test_interleave<PF>(i: usize)
 where
-    PF: PackedField + Eq,
+    PF: PackedFieldPow2 + Eq,
     Standard: Distribution<PF::Scalar>,
 {
     assert!(PF::WIDTH % i == 0);
@@ -78,7 +78,7 @@ where
 
 pub fn test_interleaves<PF>()
 where
-    PF: PackedField + Eq,
+    PF: PackedFieldPow2 + Eq,
     Standard: Distribution<PF::Scalar>,
 {
     let mut i = 1;

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -232,6 +232,7 @@ impl<F: Field, const N: usize> MulAssign<F> for FieldArray<F, N> {
 impl<F: Field, const N: usize> Div<F> for FieldArray<F, N> {
     type Output = Self;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     #[inline]
     fn div(self, rhs: F) -> Self::Output {
         let rhs_inv = rhs.inverse();

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -51,9 +51,7 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
     let x_packed = FieldArray::<F, 4>::pack_slice(x);
     let result_packed = FieldArray::<F, 4>::pack_slice_mut(result);
 
-    batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
-        x_packed.inverse()
-    });
+    batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| x_packed.inverse());
 }
 
 /// A simple single-threaded implementation of Montgomery's trick. Since not all `AbstractField`s

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -4,6 +4,7 @@ use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::field::Field;
+use crate::{AbstractField, FieldArray, PackedValue};
 
 /// Batch multiplicative inverses with Montgomery's trick
 /// This is Montgomery's trick. At a high level, we invert the product of the given field
@@ -37,72 +38,31 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
     // Higher WIDTH increases instruction-level parallelism, but too high a value will cause us
     // to run out of registers.
     const WIDTH: usize = 4;
-    // JN note: WIDTH is 4. The code is specialized to this value and will need
-    // modification if it is changed. I tried to make it more generic, but Rust's const
-    // generics are not yet good enough.
 
     let n = x.len();
     assert_eq!(result.len(), n);
-    if n < WIDTH {
-        return batch_multiplicative_inverse_small(x, result);
+    if n % WIDTH != 0 {
+        // There isn't a very clean way to do this with FieldArray; for now just do it in serial.
+        // Another simple (though suboptimal) workaround would be to make two separate calls, one
+        // for the packed part and one for the remainder.
+        return batch_multiplicative_inverse_general(x, result, |x| x.inverse());
     }
 
-    // Buf is reused for a few things to save allocations.
-    // Fill buf with cumulative product of x, only taking every 4th value. Concretely, buf will
-    // be [
-    //   x[0], x[1], x[2], x[3],
-    //   x[0] * x[4], x[1] * x[5], x[2] * x[6], x[3] * x[7],
-    //   x[0] * x[4] * x[8], x[1] * x[5] * x[9], x[2] * x[6] * x[10], x[3] * x[7] * x[11],
-    //   ...
-    // ].
-    // If n is not a multiple of WIDTH, the result is truncated from the end. For example,
-    // for n == 5, we get [x[0], x[1], x[2], x[3], x[0] * x[4]].
-    // let mut buf: Vec<F> = Vec::with_capacity(n);
-    // cumul_prod holds the last WIDTH elements of buf. This is redundant, but it's how we
-    // convince LLVM to keep the values in the registers.
-    let mut cumul_prod: [F; WIDTH] = x[..WIDTH].try_into().unwrap();
-    result[0..WIDTH].copy_from_slice(&cumul_prod);
-    for i in WIDTH..n {
-        cumul_prod[i % WIDTH] *= x[i];
-        result[i] = cumul_prod[i % WIDTH];
-    }
+    let x_packed = FieldArray::<F, 4>::pack_slice(x);
+    let mut result_packed = FieldArray::<F, 4>::pack_slice_mut(result);
 
-    let mut a_inv = {
-        // This is where the four dependency chains meet.
-        // Take the last four elements of buf and invert them all.
-        let c01 = cumul_prod[0] * cumul_prod[1];
-        let c23 = cumul_prod[2] * cumul_prod[3];
-        let c0123 = c01 * c23;
-        let c0123inv = c0123.inverse();
-        let c01inv = c0123inv * c23;
-        let c23inv = c0123inv * c01;
-        [
-            c01inv * cumul_prod[1],
-            c01inv * cumul_prod[0],
-            c23inv * cumul_prod[3],
-            c23inv * cumul_prod[2],
-        ]
-    };
-
-    for i in (WIDTH..n).rev() {
-        // buf[i - WIDTH] has not been written to by this loop, so it equals
-        // x[i % WIDTH] * x[i % WIDTH + WIDTH] * ... * x[i - WIDTH].
-        result[i] = result[i - WIDTH] * a_inv[i % WIDTH];
-        // buf[i] now holds the inverse of x[i].
-        a_inv[i % WIDTH] *= x[i];
-    }
-    for i in (0..WIDTH).rev() {
-        result[i] = a_inv[i];
-    }
-
-    for (&bi, &xi) in result.iter().zip(x) {
-        // Sanity check only.
-        debug_assert_eq!(bi * xi, F::one());
-    }
+    batch_multiplicative_inverse_general(x_packed, &mut result_packed, |x_packed| {
+        x_packed.inverse()
+    });
 }
 
-/// A simple single-threaded implementation of Montgomery's trick, suitable for small n.
-fn batch_multiplicative_inverse_small<F: Field>(x: &[F], result: &mut [F]) {
+/// A simple single-threaded implementation of Montgomery's trick. Since not all `AbstractField`s
+/// support inversion, this takes a custom inversion function.
+pub(crate) fn batch_multiplicative_inverse_general<F, Inv>(x: &[F], result: &mut [F], inv: Inv)
+where
+    F: AbstractField + Copy,
+    Inv: Fn(F) -> F,
+{
     let n = x.len();
     assert_eq!(result.len(), n);
     if n == 0 {
@@ -115,7 +75,7 @@ fn batch_multiplicative_inverse_small<F: Field>(x: &[F], result: &mut [F]) {
     }
 
     let product = result[n - 1] * x[n - 1];
-    let mut inv = product.inverse();
+    let mut inv = inv(product);
 
     for i in (0..n).rev() {
         result[i] *= inv;

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -49,9 +49,9 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
     }
 
     let x_packed = FieldArray::<F, 4>::pack_slice(x);
-    let mut result_packed = FieldArray::<F, 4>::pack_slice_mut(result);
+    let result_packed = FieldArray::<F, 4>::pack_slice_mut(result);
 
-    batch_multiplicative_inverse_general(x_packed, &mut result_packed, |x_packed| {
+    batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
         x_packed.inverse()
     });
 }

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -10,7 +10,6 @@ use crate::AbstractField;
 pub trait Packable: 'static + Default + Copy + Send + Sync + PartialEq + Eq {}
 
 /// # Safety
-/// - `WIDTH` is assumed to be a power of 2.
 /// - If `P` implements `PackedField` then `P` must be castable to/from `[P::Value; P::WIDTH]`
 ///   without UB.
 pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
@@ -121,7 +120,11 @@ pub unsafe trait PackedField: AbstractField<F = Self::Scalar>
     + Div<Self::Scalar, Output = Self>
 {
     type Scalar: Field;
+}
 
+/// # Safety
+/// - `WIDTH` is assumed to be a power of 2.
+pub unsafe trait PackedFieldPow2: PackedField {
     /// Take interpret two vectors as chunks of `block_len` elements. Unpack and interleave those
     /// chunks. This is best seen with an example. If we have:
     /// ```text
@@ -190,7 +193,9 @@ unsafe impl<T: Packable> PackedValue for T {
 
 unsafe impl<F: Field> PackedField for F {
     type Scalar = Self;
+}
 
+unsafe impl<F: Field> PackedFieldPow2 for F {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         match block_len {
             1 => (*self, other),

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -81,10 +81,12 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
     const WIDTH: usize = WIDTH;
 
     fn from_slice(slice: &[Self::Value]) -> &Self {
+        assert_eq!(slice.len(), Self::WIDTH);
         slice.try_into().unwrap()
     }
 
     fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
+        assert_eq!(slice.len(), Self::WIDTH);
         slice.try_into().unwrap()
     }
 
@@ -118,7 +120,7 @@ pub unsafe trait PackedField: AbstractField<F = Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>
 {
-    type Scalar: Field + Add<Self, Output = Self> + Mul<Self, Output = Self> + Sub<Self, Output = Self>;
+    type Scalar: Field;
 
     /// Take interpret two vectors as chunks of `block_len` elements. Unpack and interleave those
     /// chunks. This is best seen with an example. If we have:

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -559,7 +559,9 @@ unsafe impl PackedValue for PackedMersenne31Neon {
 
 unsafe impl PackedField for PackedMersenne31Neon {
     type Scalar = Mersenne31;
+}
 
+unsafe impl PackedFieldPow2 for PackedMersenne31Neon {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -5,7 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -702,7 +702,9 @@ unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31Neon<FP> {
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31Neon<FP> {
     type Scalar = MontyField31<FP>;
+}
 
+unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31Neon<FP> {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());


### PR DESCRIPTION
Optional extension of #482, depending on feedback.

And have the "chunked" implementation (the one with better instruction-level parallelism) call it with a `FieldArray`.

For now, I also changed `FieldArray` to implement `PackedValue`, but I'm not sure about it. There might not be that much benefit (just slightly convenient to have `pack_slice`), and it does fail to enforce `PackedValue`'s power-of-two requirement, though I can't remember why that's needed.