### PR TITLE
Vectorize columnwise_dot_product

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -319,10 +319,9 @@ where
     type Output = Self;
 
     #[inline]
-    fn add(self, rhs: AF) -> Self {
-        let mut res = self.value;
-        res[0] += rhs;
-        Self { value: res }
+    fn add(mut self, rhs: AF) -> Self {
+        self.value[0] += rhs;
+        self
     }
 }
 
@@ -333,8 +332,8 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        for (val, rhs_val) in self.value.iter_mut().zip(rhs.value) {
-            *val += rhs_val;
+        for i in 0..D {
+            self.value[i] += rhs.value[i].clone();
         }
     }
 }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -333,7 +333,9 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        *self = self.clone() + rhs;
+        for (val, rhs_val) in self.value.iter_mut().zip(rhs.value) {
+            *val += rhs_val;
+        }
     }
 }
 
@@ -344,7 +346,7 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: AF) {
-        *self = self.clone() + rhs;
+        self.value[0] += rhs;
     }
 }
 

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -16,9 +16,16 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 criterion = "0.5.1"
+p3-baby-bear = { path = "../baby-bear" }
 p3-mersenne-31 = { path = "../mersenne-31" }
+rand_chacha = "0.3.1"
 
 [[bench]]
 name = "transpose_benchmark"
 path = "benches/transpose_benchmark.rs"
+harness = false
+
+[[bench]]
+name = "columnwise_dot_product"
+path = "benches/columnwise_dot_product.rs"
 harness = false

--- a/matrix/benches/columnwise_dot_product.rs
+++ b/matrix/benches/columnwise_dot_product.rs
@@ -1,0 +1,32 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+
+fn columnwise_dot_product(c: &mut Criterion) {
+    let mut rng = ChaChaRng::seed_from_u64(0);
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    let log_rows = 16;
+
+    c.benchmark_group("babybear")
+        .sample_size(20)
+        .bench_function("columnwise_dot_product", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        RowMajorMatrix::<F>::rand_nonzero(&mut rng, 1 << log_rows, 1 << 10),
+                        RowMajorMatrix::<EF>::rand_nonzero(&mut rng, 1 << log_rows, 1).values,
+                    )
+                },
+                |(m, v)| m.columnwise_dot_product(&v),
+                BatchSize::PerIteration,
+            );
+        });
+}
+
+criterion_group!(benches, columnwise_dot_product);
+criterion_main!(benches);

--- a/matrix/benches/columnwise_dot_product.rs
+++ b/matrix/benches/columnwise_dot_product.rs
@@ -18,7 +18,7 @@ fn columnwise_dot_product(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     (
-                        RowMajorMatrix::<F>::rand_nonzero(&mut rng, 1 << log_rows, 1 << 10),
+                        RowMajorMatrix::<F>::rand_nonzero(&mut rng, 1 << log_rows, 1 << 12),
                         RowMajorMatrix::<EF>::rand_nonzero(&mut rng, 1 << log_rows, 1).values,
                     )
                 },

--- a/matrix/benches/columnwise_dot_product.rs
+++ b/matrix/benches/columnwise_dot_product.rs
@@ -1,7 +1,8 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
-use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 

--- a/matrix/benches/columnwise_dot_product.rs
+++ b/matrix/benches/columnwise_dot_product.rs
@@ -13,7 +13,7 @@ fn columnwise_dot_product(c: &mut Criterion) {
     let log_rows = 16;
 
     c.benchmark_group("babybear")
-        .sample_size(20)
+        .sample_size(10)
         .bench_function("columnwise_dot_product", |b| {
             b.iter_batched(
                 || {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -303,9 +303,12 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
 }
 
 impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S> {
+    #[inline]
     fn width(&self) -> usize {
         self.width
     }
+
+    #[inline]
     fn height(&self) -> usize {
         if self.width == 0 {
             0
@@ -313,21 +316,29 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
             self.values.borrow().len() / self.width
         }
     }
+
+    #[inline]
     fn get(&self, r: usize, c: usize) -> T {
         self.values.borrow()[r * self.width + c].clone()
     }
+
     type Row<'a>
         = iter::Cloned<slice::Iter<'a, T>>
     where
         Self: 'a;
+
+    #[inline]
     fn row(&self, r: usize) -> Self::Row<'_> {
         self.values.borrow()[r * self.width..(r + 1) * self.width]
             .iter()
             .cloned()
     }
+
+    #[inline]
     fn row_slice(&self, r: usize) -> impl Deref<Target = [T]> {
         &self.values.borrow()[r * self.width..(r + 1) * self.width]
     }
+
     fn to_row_major_matrix(self) -> RowMajorMatrix<T>
     where
         Self: Sized,
@@ -336,6 +347,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
         RowMajorMatrix::new(self.values.to_vec(), self.width)
     }
 
+    #[inline]
     fn horizontally_packed_row<'a, P>(
         &'a self,
         r: usize,
@@ -352,6 +364,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
         (packed.iter().cloned(), sfx.iter().cloned())
     }
 
+    #[inline]
     fn padded_horizontally_packed_row<'a, P>(
         &'a self,
         r: usize,

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -243,9 +243,8 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use core::marker::PhantomData;
-
     use alloc::vec;
+    use core::marker::PhantomData;
 
     use itertools::izip;
     use p3_baby_bear::BabyBear;
@@ -254,60 +253,6 @@ mod tests {
     use rand::thread_rng;
 
     use super::*;
-
-    struct FakeMatrix<F: Field>(usize, usize, PhantomData<F>);
-
-    impl<F: Field> Matrix<F> for FakeMatrix<F> {
-        fn height(&self) -> usize {
-            self.0
-        }
-        fn width(&self) -> usize {
-            self.1
-        }
-
-        type Row<'a> = vec::IntoIter<F>;
-
-        fn row(&self, r: usize) -> Self::Row<'_> {
-            (0..self.width())
-                .map(|c| F::from_canonical_usize(self.width() * r + c))
-                .collect::<Vec<_>>()
-                .into_iter()
-        }
-    }
-
-    #[test]
-    fn test_matrix_methods() {
-        type F = BabyBear;
-        type P = <F as Field>::Packing;
-        assert_eq!(P::WIDTH, 4);
-        let m: FakeMatrix<F> = FakeMatrix(4, 2, PhantomData);
-        assert_eq!(
-            m.rows().map(|row| row.collect_vec()).collect_vec(),
-            vec![
-                vec![F::from_canonical_usize(0), F::from_canonical_usize(1)],
-                vec![F::from_canonical_usize(2), F::from_canonical_usize(3)],
-                vec![F::from_canonical_usize(4), F::from_canonical_usize(5)],
-                vec![F::from_canonical_usize(6), F::from_canonical_usize(7)],
-            ]
-        );
-
-        let (packed, sfx) = m.horizontally_packed_row::<P>(0);
-        assert_eq!(packed.collect_vec(), vec![]);
-        assert_eq!(
-            sfx.collect_vec(),
-            vec![F::from_canonical_usize(0), F::from_canonical_usize(1)]
-        );
-
-        assert_eq!(
-            m.padded_horizontally_packed_row::<P>(1).collect_vec(),
-            vec![*P::from_slice(&[
-                F::from_canonical_usize(2),
-                F::from_canonical_usize(3),
-                F::zero(),
-                F::zero()
-            ])]
-        );
-    }
 
     #[test]
     fn test_columnwise_dot_product() {

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -127,7 +127,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Clone + Default + 'a,
     {
         let mut row_iter = self.row(r);
-        let num_elems = self.width().next_multiple_of(P::WIDTH);
+        let num_elems = self.width().div_ceil(P::WIDTH);
         // array::from_fn currently always calls in order, but it's not clear whether that's guaranteed.
         (0..num_elems).map(move |_| P::from_fn(|_| row_iter.next().unwrap_or_default()))
     }
@@ -243,6 +243,8 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    use core::marker::PhantomData;
+
     use alloc::vec;
 
     use itertools::izip;
@@ -252,6 +254,60 @@ mod tests {
     use rand::thread_rng;
 
     use super::*;
+
+    struct FakeMatrix<F: Field>(usize, usize, PhantomData<F>);
+
+    impl<F: Field> Matrix<F> for FakeMatrix<F> {
+        fn height(&self) -> usize {
+            self.0
+        }
+        fn width(&self) -> usize {
+            self.1
+        }
+
+        type Row<'a> = vec::IntoIter<F>;
+
+        fn row(&self, r: usize) -> Self::Row<'_> {
+            (0..self.width())
+                .map(|c| F::from_canonical_usize(self.width() * r + c))
+                .collect::<Vec<_>>()
+                .into_iter()
+        }
+    }
+
+    #[test]
+    fn test_matrix_methods() {
+        type F = BabyBear;
+        type P = <F as Field>::Packing;
+        assert_eq!(P::WIDTH, 4);
+        let m: FakeMatrix<F> = FakeMatrix(4, 2, PhantomData);
+        assert_eq!(
+            m.rows().map(|row| row.collect_vec()).collect_vec(),
+            vec![
+                vec![F::from_canonical_usize(0), F::from_canonical_usize(1)],
+                vec![F::from_canonical_usize(2), F::from_canonical_usize(3)],
+                vec![F::from_canonical_usize(4), F::from_canonical_usize(5)],
+                vec![F::from_canonical_usize(6), F::from_canonical_usize(7)],
+            ]
+        );
+
+        let (packed, sfx) = m.horizontally_packed_row::<P>(0);
+        assert_eq!(packed.collect_vec(), vec![]);
+        assert_eq!(
+            sfx.collect_vec(),
+            vec![F::from_canonical_usize(0), F::from_canonical_usize(1)]
+        );
+
+        assert_eq!(
+            m.padded_horizontally_packed_row::<P>(1).collect_vec(),
+            vec![*P::from_slice(&[
+                F::from_canonical_usize(2),
+                F::from_canonical_usize(3),
+                F::zero(),
+                F::zero()
+            ])]
+        );
+    }
 
     #[test]
     fn test_columnwise_dot_product() {

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -243,12 +243,15 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloc::vec;
+
     use itertools::izip;
     use p3_baby_bear::BabyBear;
-    use p3_field::{extension::BinomialExtensionField, AbstractField};
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::AbstractField;
     use rand::thread_rng;
+
+    use super::*;
 
     #[test]
     fn test_columnwise_dot_product() {

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -244,8 +244,6 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    use core::marker::PhantomData;
-
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -244,6 +244,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -185,7 +185,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
-        let packed_width = self.width().next_multiple_of(T::Packing::WIDTH);
+        let packed_width = self.width().div_ceil(T::Packing::WIDTH);
 
         let packed_result = self
             .par_padded_horizontally_packed_rows::<T::Packing>()

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -185,31 +185,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
-        /*
-        let mut acc = EF::zero_vec(self.width());
-        for r in 0..self.height() {
-            for c in 0..self.width() {
-                acc[c] += v[r] * self.get(r, c);
-            }
-        }
-        acc
-        */
-
         let packed_width = self.width().next_multiple_of(T::Packing::WIDTH);
-
-        /*
-        let mut acc = vec![EF::ExtensionPacking::zero(); packed_width];
-        for (r, row) in self
-            .par_padded_horizontally_packed_rows::<T::Packing>()
-            .enumerate()
-        {
-            let scale =
-                EF::ExtensionPacking::from_base_fn(|i| T::Packing::from(v[r].as_base_slice()[i]));
-            for (c, val) in row.enumerate() {
-                acc[c] += scale * val;
-            }
-        }
-        */
 
         let packed_result = self
             .par_padded_horizontally_packed_rows::<T::Packing>()
@@ -237,44 +213,6 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
             })
             .take(self.width())
             .collect()
-
-        /*
-        let packed = self.rows().zip(v).fold(
-            //vec![EF::ExtensionPacking::zero(); self.width()],
-            |mut acc, (row, &scale)| {
-                /*
-                for (l, r) in acc.iter_mut().zip(row) {
-                    *l += scale * r;
-                }
-                */
-                for (i, r) in row.enumerate() {
-                    acc[i] += scale * r;
-                }
-                acc
-            },
-        );
-        packed
-        */
-
-        // let w = self.width();
-
-        /*
-        self.par_rows().zip(v).par_fold_reduce(
-            || EF::zero_vec(self.width()),
-            |mut acc, (row, &scale)| {
-                for (l, r) in acc.iter_mut().zip_eq(row) {
-                    *l += scale * r;
-                }
-                acc
-            },
-            |mut acc_l, acc_r| {
-                for (l, r) in izip!(&mut acc_l, acc_r) {
-                    *l += r;
-                }
-                acc_l
-            },
-        )
-        */
     }
 
     /// Multiply this matrix by the vector of powers of `base`, which is an extension element.

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -13,6 +13,7 @@ pub mod prelude {
     }
 
     impl<I: ParallelIterator> SharedExt for I {
+        #[inline]
         fn par_fold_reduce<Acc, Id, F, R>(self, identity: Id, fold_op: F, reduce_op: R) -> Acc
         where
             Acc: Send,
@@ -51,6 +52,7 @@ pub mod prelude {
     }
 
     impl<I: ParallelIterator> SharedExt for I {
+        #[inline]
         fn par_fold_reduce<Acc, Id, F, R>(self, identity: Id, fold_op: F, _reduce_op: R) -> Acc
         where
             Acc: Send,


### PR DESCRIPTION
75% faster in both serial & parallel.

Still some gains on the table due to iterator chain overhead, I think. The proper solution is to specialize this even further in `DenseMatrix`.

More importantly, though, I need to rewrite `interpolate_coset` to take multiple points, and this should be a matrix-matrix product.