### PR TITLE
Main currently breaks on AVX2 and AVX512

### DIFF
--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -5,7 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{PackedField, PackedValue, PrimeField64};
+use p3_field::{PackedField, PackedFieldPow2, PackedValue, PrimeField64};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -261,7 +261,9 @@ unsafe impl PackedValue for PackedGoldilocksAVX2 {
 
 unsafe impl PackedField for PackedGoldilocksAVX2 {
     type Scalar = Goldilocks;
+}
 
+unsafe impl PackedFieldPow2 for PackedGoldilocksAVX2 {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.get(), other.get());
@@ -584,7 +586,7 @@ unsafe fn interleave2(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
 
 #[cfg(test)]
 mod tests {
-    use p3_field::{AbstractField, PackedField, PackedValue};
+    use p3_field::{AbstractField, PackedFieldPow2, PackedValue};
 
     use crate::x86_64_avx2::packing::WIDTH;
     use crate::{Goldilocks, PackedGoldilocksAVX2};

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -5,7 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{PackedField, PackedValue};
+use p3_field::{PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -260,7 +260,9 @@ unsafe impl PackedValue for PackedGoldilocksAVX512 {
 
 unsafe impl PackedField for PackedGoldilocksAVX512 {
     type Scalar = Goldilocks;
+}
 
+unsafe impl PackedFieldPow2 for PackedGoldilocksAVX512 {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.get(), other.get());
@@ -481,7 +483,7 @@ unsafe fn interleave4(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
 
 #[cfg(test)]
 mod tests {
-    use p3_field::{AbstractField, PackedField, PackedValue};
+    use p3_field::{AbstractField, PackedFieldPow2, PackedValue};
 
     use crate::x86_64_avx512::packing::WIDTH;
     use crate::{Goldilocks, PackedGoldilocksAVX512};

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -623,7 +623,9 @@ unsafe impl PackedValue for PackedMersenne31AVX2 {
 
 unsafe impl PackedField for PackedMersenne31AVX2 {
     type Scalar = Mersenne31;
+}
 
+unsafe impl PackedFieldPow2 for PackedMersenne31AVX2 {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -723,7 +723,9 @@ unsafe impl PackedValue for PackedMersenne31AVX512 {
 
 unsafe impl PackedField for PackedMersenne31AVX512 {
     type Scalar = Mersenne31;
+}
 
+unsafe impl PackedFieldPow2 for PackedMersenne31AVX512 {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -823,7 +823,9 @@ unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX2<FP> {
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX2<FP> {
     type Scalar = MontyField31<FP>;
+}
 
+unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31AVX2<FP> {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedValue};
+use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 
@@ -766,7 +766,9 @@ unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX512<FP> {
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX512<FP> {
     type Scalar = MontyField31<FP>;
+}
 
+unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31AVX512<FP> {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());


### PR DESCRIPTION
When PackedFieldPow2 was spun out of PackedField, this wasn't updated for the AVX2/AVX512 code for various fields (MontyField31, Mersenne31, Goldilocks).