### PR TITLE
AVX512 implementation for Koala/BabyBear, Poseidon2

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [features]
-nightly-features = []
+nightly-features = ["p3-monty-31/nightly-features"]
 
 [dependencies]
 p3-field = { path = "../field" }

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -24,9 +24,17 @@ mod aarch64_neon;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use aarch64_neon::*;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 mod x86_64_avx2;
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -8,9 +8,6 @@ use p3_monty_31::{
 
 use crate::{BabyBearInternalLayerParameters, BabyBearParameters};
 
-// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
-// https://godbolt.org/z/xK91MKsdd
-
 impl InternalLayerParametersAVX2<16> for BabyBearInternalLayerParameters {
     type ArrayLike = [__m256i; 15];
 

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -103,7 +103,7 @@ impl InternalLayerParametersAVX512<16> for BabyBearInternalLayerParameters {
         input[8] = sub::<BabyBearParameters>(sum, input[8]);
         input[9] = add::<BabyBearParameters>(sum, input[9]);
         input[10] = sub::<BabyBearParameters>(sum, input[10]);
-        input[11] = add::<BabyBearParameters>(sum, input[11]);
+        input[11] = sub::<BabyBearParameters>(sum, input[11]);
         input[12] = add::<BabyBearParameters>(sum, input[12]);
         input[13] = sub::<BabyBearParameters>(sum, input[13]);
         input[14] = add::<BabyBearParameters>(sum, input[14]);
@@ -206,7 +206,7 @@ impl InternalLayerParametersAVX512<24> for BabyBearInternalLayerParameters {
         // This outputs the negative of what we want. This will be handled in add_sum.
         input[20] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 9, 18>(input[20]);
 
-        // input[21] -> sum - input[21]/2**27
+        // input[21] -> sum + input[21]/2**27
         // This outputs the negative of what we want. This will be handled in add_sum.
         input[21] = mul_neg_2_exp_neg_two_adicity_avx512::<BabyBearParameters, 27, 4>(input[21]);
 
@@ -233,16 +233,16 @@ impl InternalLayerParametersAVX512<24> for BabyBearInternalLayerParameters {
         input[8] = sub::<BabyBearParameters>(sum, input[8]);
         input[9] = add::<BabyBearParameters>(sum, input[9]);
         input[10] = sub::<BabyBearParameters>(sum, input[10]);
-        input[11] = sub::<BabyBearParameters>(sum, input[11]);
-        input[12] = add::<BabyBearParameters>(sum, input[12]);
-        input[13] = sub::<BabyBearParameters>(sum, input[13]);
-        input[14] = add::<BabyBearParameters>(sum, input[14]);
-        input[15] = sub::<BabyBearParameters>(sum, input[15]);
+        input[11] = add::<BabyBearParameters>(sum, input[11]);
+        input[12] = sub::<BabyBearParameters>(sum, input[12]);
+        input[13] = add::<BabyBearParameters>(sum, input[13]);
+        input[14] = sub::<BabyBearParameters>(sum, input[14]);
+        input[15] = add::<BabyBearParameters>(sum, input[15]);
         input[16] = add::<BabyBearParameters>(sum, input[16]);
-        input[17] = sub::<BabyBearParameters>(sum, input[17]);
-        input[18] = add::<BabyBearParameters>(sum, input[18]);
+        input[17] = add::<BabyBearParameters>(sum, input[17]);
+        input[18] = sub::<BabyBearParameters>(sum, input[18]);
         input[19] = add::<BabyBearParameters>(sum, input[19]);
-        input[20] = add::<BabyBearParameters>(sum, input[20]);
+        input[20] = sub::<BabyBearParameters>(sum, input[20]);
         input[21] = sub::<BabyBearParameters>(sum, input[21]);
         input[22] = add::<BabyBearParameters>(sum, input[22]);
     }

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -7,9 +7,6 @@ use p3_monty_31::{
 
 use crate::{BabyBearInternalLayerParameters, BabyBearParameters};
 
-// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
-// https://godbolt.org/z/xK91MKsdd
-
 impl InternalLayerParametersAVX512<16> for BabyBearInternalLayerParameters {
     type ArrayLike = [__m512i; 15];
 

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,8 +1,8 @@
 use core::arch::x86_64::__m512i;
 
 use p3_monty_31::{
-    add, halve_avx512,
-    mul_neg_2_exp_neg_8_avx512, mul_neg_2_exp_neg_n_avx512, mul_neg_2_exp_neg_two_adicity_avx512, sub, InternalLayerParametersAVX512,
+    add, halve_avx512, mul_neg_2_exp_neg_8_avx512, mul_neg_2_exp_neg_n_avx512,
+    mul_neg_2_exp_neg_two_adicity_avx512, sub, InternalLayerParametersAVX512,
 };
 
 use crate::{BabyBearInternalLayerParameters, BabyBearParameters};

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -100,13 +100,9 @@ impl InternalLayerParametersAVX512<16> for BabyBearInternalLayerParameters {
             .iter_mut()
             .for_each(|x| *x = sub::<BabyBearParameters>(sum, *x));
 
-        // We similarly need to eitehr add or subtract sum depending on if diagonal mul returned the positive or negative.
-        // Note additionally that we are using sub/add for something not completely intended.
-        // We are breaking the canonical assumption as input lies in [0, P] and not [0, P).
-        // Luckily for us however, the functions still work identically if we relax this assumption slightly.
-        // add is symmetric in inputs and will output the correct value in [0, P) provided only one input lies in
-        // [0, P] instead of [0, P).
-        // sub computes x - y and will output the correct value in [0, P) if x lies in [0, P) and y lies in [0, P].
+        // We either add sum or subtract from sum depending on if diagonal mul returned the positive or negative.
+        // We are breaking the canonical assumption as input lies in [0, P] and not [0, P) but we are doing it
+        // in a way allowed by the add and sum specifications.
         input[8] = sub::<BabyBearParameters>(sum, input[8]);
         input[9] = add::<BabyBearParameters>(sum, input[9]);
         input[10] = sub::<BabyBearParameters>(sum, input[10]);
@@ -235,12 +231,8 @@ impl InternalLayerParametersAVX512<24> for BabyBearInternalLayerParameters {
             .for_each(|x| *x = sub::<BabyBearParameters>(sum, *x));
 
         // We either add sum or subtract from sum depending on if diagonal mul returned the positive or negative.
-        // Note additionally that we are using sub/add for something not completely intended.
-        // We are breaking the canonical assumption as input lies in [0, P] and not [0, P).
-        // Luckily for us however, the functions still work identically if we relax this assumption slightly.
-        // add is symmetric in inputs and will output the correct value in [0, P) provided only one input lies in
-        // [0, P] instead of [0, P).
-        // sub computes x - y and will output the correct value in [0, P) if x lies in [0, P) and y lies in [0, P].
+        // We are breaking the canonical assumption as input lies in [0, P] and not [0, P) but we are doing it
+        // in a way allowed by the add and sum specifications.
         input[8] = sub::<BabyBearParameters>(sum, input[8]);
         input[9] = add::<BabyBearParameters>(sum, input[9]);
         input[10] = sub::<BabyBearParameters>(sum, input[10]);

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,16 +1,239 @@
+use core::arch::x86_64::__m512i;
+
+use p3_monty_31::{
+    add, halve_avx512, mul_2_exp_neg_8_avx512, mul_2_exp_neg_n_avx512, mul_2_exp_neg_two_adicity_avx512,
+    mul_neg_2_exp_neg_8_avx512, mul_neg_2_exp_neg_n_avx512, mul_neg_2_exp_neg_two_adicity_avx512,
+    signed_add_avx512, sub, InternalLayerParametersAVX512,
+};
+
+use crate::{BabyBearInternalLayerParameters, BabyBearParameters};
+
+// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
+// https://godbolt.org/z/xK91MKsdd
+
+impl InternalLayerParametersAVX512<16> for BabyBearInternalLayerParameters {
+    type ArrayLike = [__m512i; 15];
+
+    /// For the BabyBear field and width 16 we multiply by the diagonal matrix:
+    /// D = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, -1/2^8, 1/4, 1/8, -1/16, 1/2^27, -1/2^27].
+    /// The inputs must be in canonical form, otherwise the result is undefined.
+    /// Even when the inputs are in canonical form, we make no guarantees on the output except that, provided
+    /// the output is piped directly into add_sum the vector will be modified such that x[i] = D[i]*x[i] + sum.
+    #[inline(always)]
+    unsafe fn diagonal_mul(input: &mut [__m512i; 15]) {
+        // As far as we know this is optimal in that it need the fewest instructions to perform all of these
+        // multiplications. (Note that -1, 0 are not allowed on the diagonal for technical reasons).
+        // If there exist other numbers b for which x*b mod P can be computed quickly this diagonal can be updated.
+
+        // The strategy is very simple. 2, 3, 4, -3, -4 are implemented using addition.
+        //                              1/2, -1/2 using the custom half function.
+        //                              and the remainder utilizing the custom functions for multiplication by 2^{-n}.
+
+        // Note that for -3, -4, -1/2 we actually output 3x, 4x, x/2 and the negative is dealt with in add_sum by subtracting
+        // this from the summation instead of adding it.
+
+        // Note that input only contains the last 15 elements of the state.
+        // The first element is handled separately as we need to apply the s-box to it.
+
+        // input[0] is being multiplied by 1 so we can also ignore it.
+
+        // input[1] -> sum + 2*input[1]
+        input[1] = add::<BabyBearParameters>(input[1], input[1]);
+
+        // input[2] -> sum + input[2]/2
+        input[2] = halve_avx512::<BabyBearParameters>(input[2]);
+
+        // input[3] -> sum + 3*input[3]
+        let acc3 = add::<BabyBearParameters>(input[3], input[3]);
+        input[3] = add::<BabyBearParameters>(acc3, input[3]);
+
+        // input[4]-> sum + 4*input[4]
+        let acc4 = add::<BabyBearParameters>(input[4], input[4]);
+        input[4] = add::<BabyBearParameters>(acc4, acc4);
+
+        // input[5] -> sum - input[5]/2
+        input[5] = halve_avx512::<BabyBearParameters>(input[5]);
+
+        // input[6] -> sum - 3*input[6]
+        let acc6 = add::<BabyBearParameters>(input[6], input[6]);
+        input[6] = add::<BabyBearParameters>(acc6, input[6]);
+
+        // input[7] -> sum - 4*input[7]
+        let acc7 = add::<BabyBearParameters>(input[7], input[7]);
+        input[7] = add::<BabyBearParameters>(acc7, acc7);
+
+        // input[8] -> sum + input[8]/2**8
+        input[8] = mul_2_exp_neg_8_avx512::<BabyBearParameters, 19>(input[8]);
+
+        // input[9] -> sum - input[9]/2**8
+        input[9] = mul_neg_2_exp_neg_8_avx512::<BabyBearParameters, 19>(input[9]);
+
+        // input[10] -> sum + input[10]/2**2
+        input[10] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 2, 25>(input[10]);
+
+        // input[11] -> sum + input[11]/2**3
+        input[11] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 3, 24>(input[11]);
+
+        // input[12] -> sum - input[12]/2**4
+        input[12] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 4, 23>(input[12]);
+
+        // input[13] -> sum + input[13]/2**27
+        input[13] = mul_2_exp_neg_two_adicity_avx512::<BabyBearParameters, 27, 4>(input[13]);
+
+        // input[14] -> sum - input[14]/2**27
+        input[14] = mul_neg_2_exp_neg_two_adicity_avx512::<BabyBearParameters, 27, 4>(input[14]);
+    }
+
+    /// Add sum to every element of input.
+    /// Sum must be in canonical form and input must be exactly the output of diagonal mul.
+    /// If either of these does not hold, the result is undefined.
+    unsafe fn add_sum(input: &mut [__m512i; 15], sum: __m512i) {
+        input[..5]
+            .iter_mut()
+            .for_each(|x| *x = add::<BabyBearParameters>(sum, *x));
+
+        // Diagonal mul multiplied these by 1/2, 3, 4 instead of -1/2, -3, -4 so we need to subtract instead of adding.
+        input[5..8]
+            .iter_mut()
+            .for_each(|x| *x = sub::<BabyBearParameters>(sum, *x));
+
+        // Diagonal mul output a signed value in (-P, P) so we need to do a signed add.
+        // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
+        input[8..]
+            .iter_mut()
+            .for_each(|x| *x = signed_add_avx512::<BabyBearParameters>(sum, *x));
+    }
+}
+
+impl InternalLayerParametersAVX512<24> for BabyBearInternalLayerParameters {
+    type ArrayLike = [__m512i; 23];
+
+    /// For the BabyBear field and width 16 we multiply by the diagonal matrix:
+    /// D = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, -1/2^8, 1/4, -1/4, 1/8, -1/8, 1/16, -1/16, -1/32, -1/64, 1/2^7, -1/2^7, 1/2^9, 1/2^27, -1/2^27]
+    /// The inputs must be in canonical form, otherwise the result is undefined.
+    /// Even when the inputs are in canonical form, we make no guarantees on the output except that, provided
+    /// the output is piped directly into add_sum, the vector will be modified such that x[i] = D[i]*x[i] + sum.
+    #[inline(always)]
+    unsafe fn diagonal_mul(input: &mut [__m512i; 23]) {
+        // As far as we know this is optimal in that it need the fewest instructions to perform all of these
+        // multiplications. (Note that -1, 0 are not allowed on the diagonal for technical reasons).
+        // If there exist other number b for which x*b mod P can be computed quickly this diagonal can be updated.
+
+        // The strategy is very simple. 2, 3, 4, -3, -4 are implemented using addition.
+        //                              1/2, -1/2 using the custom half function.
+        //                              and the remainder utilizing the custom functions for multiplication by 2^{-n}.
+
+        // Note that for -3, -4, -1/2 we actually output 3x, 4x, x/2 and the negative is dealt with in add_sum by subtracting
+        // this from the summation instead of adding it.
+
+        // Note that input only contains the last 23 elements of the state.
+        // The first element is handled separately as we need to apply the s-box to it.
+
+        // input[0] is being multiplied by 1 so we can also ignore it.
+
+        // input[1] -> sum + 2*input[1]
+        input[1] = add::<BabyBearParameters>(input[1], input[1]);
+
+        // input[2] -> sum + input[2]/2
+        input[2] = halve_avx512::<BabyBearParameters>(input[2]);
+
+        // input[3] -> sum + 3*input[3]
+        let acc3 = add::<BabyBearParameters>(input[3], input[3]);
+        input[3] = add::<BabyBearParameters>(acc3, input[3]);
+
+        // input[4] -> sum + 4*input[4]
+        let acc4 = add::<BabyBearParameters>(input[4], input[4]);
+        input[4] = add::<BabyBearParameters>(acc4, acc4);
+
+        // input[5] -> sum - input[5]/2
+        input[5] = halve_avx512::<BabyBearParameters>(input[5]);
+
+        // input[6] -> sum - 3*input[6]
+        let acc6 = add::<BabyBearParameters>(input[6], input[6]);
+        input[6] = add::<BabyBearParameters>(acc6, input[6]);
+
+        // input[7] -> sum - 4*input[7]
+        let acc7 = add::<BabyBearParameters>(input[7], input[7]);
+        input[7] = add::<BabyBearParameters>(acc7, acc7);
+
+        // input[8] -> sum + input[8]/2**8
+        input[8] = mul_2_exp_neg_8_avx512::<BabyBearParameters, 19>(input[8]);
+
+        // input[9] -> sum - input[9]/2**8
+        input[9] = mul_neg_2_exp_neg_8_avx512::<BabyBearParameters, 19>(input[9]);
+
+        // input[10] -> sum + input[10]/2**2
+        input[10] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 2, 25>(input[10]);
+
+        // input[11] -> sum - input[11]/2**2
+        input[11] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 2, 25>(input[11]);
+
+        // input[12] -> sum + input[12]/2**3
+        input[12] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 3, 24>(input[12]);
+
+        // input[13] -> sum - input[13]/2**3
+        input[13] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 3, 24>(input[13]);
+
+        // input[14] -> sum + input[14]/2**4
+        input[14] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 4, 23>(input[14]);
+
+        // input[15] -> sum - input[15]/2**4
+        input[15] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 4, 23>(input[15]);
+
+        // input[16] -> sum - input[16]/2**5
+        input[16] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 5, 22>(input[16]);
+
+        // input[17] -> sum - input[17]/2**6
+        input[17] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 6, 21>(input[17]);
+
+        // input[18] -> sum + input[18]/2**7
+        input[18] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 7, 20>(input[18]);
+
+        // input[19] -> sum - input[19]/2**7
+        input[19] = mul_neg_2_exp_neg_n_avx512::<BabyBearParameters, 7, 20>(input[19]);
+
+        // input[20] -> sum + input[20]/2**9
+        input[20] = mul_2_exp_neg_n_avx512::<BabyBearParameters, 9, 18>(input[20]);
+
+        // input[21] -> sum - input[21]/2**27
+        input[21] = mul_2_exp_neg_two_adicity_avx512::<BabyBearParameters, 27, 4>(input[21]);
+
+        // input[22] -> sum - input[22]/2**27
+        input[22] = mul_neg_2_exp_neg_two_adicity_avx512::<BabyBearParameters, 27, 4>(input[22]);
+    }
+
+    /// Add sum to every element of input.
+    /// Sum must be in canonical form and input must be exactly the output of diagonal mul.
+    /// If either of these does not hold, the result is undefined.
+    unsafe fn add_sum(input: &mut [__m512i; 23], sum: __m512i) {
+        input[..5]
+            .iter_mut()
+            .for_each(|x| *x = add::<BabyBearParameters>(sum, *x));
+
+        // Diagonal mul multiplied these by 1/2, 3, 4 instead of -1/2, -3, -4 so we need to subtract instead of adding.
+        input[5..8]
+            .iter_mut()
+            .for_each(|x| *x = sub::<BabyBearParameters>(sum, *x));
+
+        // Diagonal mul output a signed value in (-P, P) so we need to do a signed add.
+        // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
+        input[8..]
+            .iter_mut()
+            .for_each(|x| *x = signed_add_avx512::<BabyBearParameters>(sum, *x));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{BabyBear, DiffusionMatrixBabyBear, PackedBabyBearAVX512};
+    use crate::{BabyBear, PackedBabyBearAVX512, Poseidon2BabyBear};
 
     type F = BabyBear;
-    const D: u64 = 7;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixBabyBear, 24, D>;
+    type Perm16 = Poseidon2BabyBear<16>;
+    type Perm24 = Poseidon2BabyBear<24>;
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -18,11 +241,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Our Poseidon2 implementation.
-        let poseidon2 = Perm16::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear::default(),
-            &mut rng,
-        );
+        let poseidon2 = Perm16::new_from_rng_128(&mut rng);
 
         let input: [F; 16] = rng.gen();
 
@@ -43,11 +262,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Our Poseidon2 implementation.
-        let poseidon2 = Perm24::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixBabyBear::default(),
-            &mut rng,
-        );
+        let poseidon2 = Perm24::new_from_rng_128(&mut rng);
 
         let input: [F; 24] = rng.gen();
 

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [features]
-nightly-features = []
+nightly-features = ["p3-monty-31/nightly-features"]
 
 [dependencies]
 p3-field = { path = "../field" }

--- a/koala-bear/src/lib.rs
+++ b/koala-bear/src/lib.rs
@@ -22,9 +22,17 @@ mod aarch64_neon;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use aarch64_neon::*;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 mod x86_64_avx2;
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -55,7 +55,7 @@ unsafe fn mul_2_exp_neg_8(input: __m256i) -> __m256i {
 
 /// Multiply a vector of Monty31 field elements in canonical form by 2**{-8}.
 /// This is specialised to the KoalaBear prime which allows us to replace a
-/// shifts by a twiddle.
+/// shift by a twiddle.
 /// # Safety
 ///
 /// Input must be given in canonical form.

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -274,7 +274,7 @@ impl InternalLayerParametersAVX2<24> for KoalaBearInternalLayerParameters {
         // input[20] -> sum - input[20]/2^9
         input[20] = mul_neg_2_exp_neg_n_avx2::<KoalaBearParameters, 9, 15>(input[20]);
 
-        // input[21] -> sum - input[21]/2^24
+        // input[21] -> sum + input[21]/2^24
         input[21] = mul_2_exp_neg_two_adicity_avx2::<KoalaBearParameters, 24, 7>(input[21]);
 
         // input[22] -> sum - input[22]/2^24

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,9 +1,8 @@
 use core::arch::x86_64::__m512i;
 
 use p3_monty_31::{
-    add, halve_avx512,
-    mul_neg_2_exp_neg_n_avx512, mul_neg_2_exp_neg_two_adicity_avx512, mul_neg_2_exp_neg_8_avx512, sub,
-    InternalLayerParametersAVX512
+    add, halve_avx512, mul_neg_2_exp_neg_8_avx512, mul_neg_2_exp_neg_n_avx512,
+    mul_neg_2_exp_neg_two_adicity_avx512, sub, InternalLayerParametersAVX512,
 };
 
 use crate::{KoalaBearInternalLayerParameters, KoalaBearParameters};

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -7,9 +7,6 @@ use p3_monty_31::{
 
 use crate::{KoalaBearInternalLayerParameters, KoalaBearParameters};
 
-// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
-// https://godbolt.org/z/xK91MKsdd
-
 impl InternalLayerParametersAVX512<16> for KoalaBearInternalLayerParameters {
     type ArrayLike = [__m512i; 15];
 

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -1,16 +1,318 @@
+use core::arch::x86_64::{self, __m512i};
+use core::mem::transmute;
+
+use p3_monty_31::{
+    add, halve_avx512, mul_2_exp_neg_n_avx512, mul_2_exp_neg_two_adicity_avx512,
+    mul_neg_2_exp_neg_n_avx512, mul_neg_2_exp_neg_two_adicity_avx512, signed_add_avx512, sub,
+    InternalLayerParametersAVX512,
+};
+
+use crate::{KoalaBearInternalLayerParameters, KoalaBearParameters};
+
+// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
+// https://godbolt.org/z/xK91MKsdd
+
+// We reimplement multiplication by +/- 2^{-8} here as there is an extra trick we can do specifically in the KoalaBear case.
+// This lets us replace a left shift by _mm512_bslli_epi128 which can be performed on Port 5. This takes a small amount
+// of pressure off Ports 0, 1.
+
+/// Multiply a vector of Monty31 field elements in canonical form by 2**{-8}.
+/// This is specialised to the KoalaBear prime which allows us to replace a
+/// shifts by a twiddle.
+/// # Safety
+///
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+unsafe fn mul_2_exp_neg_8(input: __m512i) -> __m512i {
+    // We want this to compile to:
+    //      vpsrld      hi, val, 8
+    //      vpmaddubsw  lo, val, [r; 8]
+    //      vpslldq     lo, lo, 2
+    //      vpsubd      t, hi, lo
+    // throughput: 1.333
+    // latency: 7
+    unsafe {
+        const ONE_TWENTY_SEVEN: __m512i = unsafe { transmute([127; 16]) }; // P = r*2^j + 1 = 127 * 2^24 + 1
+        let hi = x86_64::_mm512_srli_epi32::<8>(input);
+
+        // Whilst it generically does something else, provided
+        // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
+        // performs an element wise multiplication of odd_factor with
+        // the bottom 8 bits of input interpreted as an unsigned integer
+        // Thus lo contains r*x_lo.
+        let lo = x86_64::_mm512_maddubs_epi16(input, ONE_TWENTY_SEVEN);
+
+        // As the high 16 bits of each 32 bit word are all 0
+        // we don't need to worry about shifting the high bits of one
+        // word into the low bits of another. Thus we can use
+        // _mm512_bslli_epi128 which can run on Port 5 as it is classed as
+        // a swizzle operation.
+        let lo_shft = x86_64::_mm512_bslli_epi128::<2>(lo);
+        x86_64::_mm512_sub_epi32(hi, lo_shft)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by 2**{-8}.
+/// This is specialised to the KoalaBear prime which allows us to replace a
+/// shifts by a twiddle.
+/// # Safety
+///
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+unsafe fn mul_neg_2_exp_neg_8(input: __m512i) -> __m512i {
+    // We want this to compile to:
+    //      vpsrld      hi, val, 8
+    //      vpmaddubsw  lo, val, [r; 8]
+    //      vpslldq     lo, lo, 2
+    //      vpsubd      t, lo, hi
+    // throughput: 1.333
+    // latency: 7
+    unsafe {
+        const ONE_TWENTY_SEVEN: __m512i = unsafe { transmute([127; 16]) }; // P = r*2^j + 1 = 127 * 2^24 + 1
+        let hi = x86_64::_mm512_srli_epi32::<8>(input);
+
+        // Whilst it generically does something else, provided
+        // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
+        // performs an element wise multiplication of odd_factor with
+        // the bottom 8 bits of input interpreted as an unsigned integer
+        // Thus lo contains r*x_lo.
+        let lo = x86_64::_mm512_maddubs_epi16(input, ONE_TWENTY_SEVEN);
+
+        // As the high 16 bits of each 32 bit word are all 0
+        // we don't need to worry about shifting the high bits of one
+        // word into the low bits of another. Thus we can use
+        // _mm512_bslli_epi128 which can run on Port 5 as it is classed as
+        // a swizzle operation.
+        let lo_shft = x86_64::_mm512_bslli_epi128::<2>(lo);
+        x86_64::_mm512_sub_epi32(lo_shft, hi)
+    }
+}
+
+impl InternalLayerParametersAVX512<16> for KoalaBearInternalLayerParameters {
+    type ArrayLike = [__m512i; 15];
+
+    /// For the KoalaBear field and width 16 we multiply by the diagonal matrix:
+    /// D = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, -1/2^8, 1/8, -1/8, -1/16, 1/2^24, -1/2^24].
+    /// The inputs must be in canonical form, otherwise the result is undefined.
+    /// Even when the inputs are in canonical form, we make no guarantees on the output except that, provided
+    /// the output is piped directly into add_sum the vector will be modified such that x[i] = D[i]*x[i] + sum.
+    #[inline(always)]
+    unsafe fn diagonal_mul(input: &mut [__m512i; 15]) {
+        // As far as we know this is optimal in that it need the fewest instructions to perform all of these
+        // multiplications. (Note that -1, 0 are not allowed on the diagonal for technical reasons).
+        // If there exist other number b for which x*b mod P can be computed quickly this diagonal can be updated.
+
+        // The strategy is very simple. 2, 3, 4, -3, -4 are implemented using addition.
+        //                              1/2, -1/2 using the custom half function.
+        //                              and the remainder utilizing the custom functions for multiplication by 2^{-n}.
+
+        // Note that for -3, -4, -1/2 we actually output 3x, 4x, x/2 and the negative is dealt with in add_sum by subtracting
+        // this from the summation instead of adding it.
+
+        // Note that input only contains the last 15 elements of the state.
+        // The first element is handled separately as we need to apply the s-box to it.
+
+        // input[0] is being multiplied by 1 so we can also ignore it.
+
+        // input[1]-> sum + 2*input[1]
+        input[1] = add::<KoalaBearParameters>(input[1], input[1]);
+
+        // input[2]-> sum + input[2]/2
+        input[2] = halve_avx512::<KoalaBearParameters>(input[2]);
+
+        // input[3]-> sum + 3*input[3]
+        let acc3 = add::<KoalaBearParameters>(input[3], input[3]);
+        input[3] = add::<KoalaBearParameters>(acc3, input[3]);
+
+        // input[4]-> sum + 4*input[4]
+        let acc4 = add::<KoalaBearParameters>(input[4], input[4]);
+        input[4] = add::<KoalaBearParameters>(acc4, acc4);
+
+        // input[5]-> sum - input[5]/2
+        input[5] = halve_avx512::<KoalaBearParameters>(input[5]);
+
+        // input[6]-> sum - 3*input[6]
+        let acc6 = add::<KoalaBearParameters>(input[6], input[6]);
+        input[6] = add::<KoalaBearParameters>(acc6, input[6]);
+
+        // input[7]-> sum - 4*input[7]
+        let acc7 = add::<KoalaBearParameters>(input[7], input[7]);
+        input[7] = add::<KoalaBearParameters>(acc7, acc7);
+
+        // input[8]-> sum + input[8]/2^8
+        input[8] = mul_2_exp_neg_8(input[8]);
+
+        // input[9] -> sum - input[9]/2^8
+        input[9] = mul_neg_2_exp_neg_8(input[9]);
+
+        // input[10] -> sum + input[10]/2^3
+        input[10] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 3, 21>(input[10]);
+
+        // input[11] -> sum - input[11]/2^3
+        input[11] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 3, 21>(input[11]);
+
+        // input[12] -> sum - input[12]/2^4
+        input[12] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 4, 20>(input[12]);
+
+        // input[13] -> sum + input[13]/2^24
+        input[13] = mul_2_exp_neg_two_adicity_avx512::<KoalaBearParameters, 24, 7>(input[13]);
+
+        // input[14] -> sum - input[14]/2^24
+        input[14] = mul_neg_2_exp_neg_two_adicity_avx512::<KoalaBearParameters, 24, 7>(input[14]);
+    }
+
+    /// Add sum to every element of input.
+    /// Sum must be in canonical form and input must be exactly the output of diagonal mul.
+    /// If either of these does not hold, the result is undefined.
+    unsafe fn add_sum(input: &mut [__m512i; 15], sum: __m512i) {
+        input[..5]
+            .iter_mut()
+            .for_each(|x| *x = add::<KoalaBearParameters>(sum, *x));
+
+        // Diagonal mul multiplied these by 1/2, 3, 4 instead of -1/2, -3, -4 so we need to subtract instead of adding.
+        input[5..8]
+            .iter_mut()
+            .for_each(|x| *x = sub::<KoalaBearParameters>(sum, *x));
+
+        // Diagonal mul output a signed value in (-P, P) so we need to do a signed add.
+        // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
+        input[8..]
+            .iter_mut()
+            .for_each(|x| *x = signed_add_avx512::<KoalaBearParameters>(sum, *x));
+    }
+}
+
+impl InternalLayerParametersAVX512<24> for KoalaBearInternalLayerParameters {
+    type ArrayLike = [__m512i; 23];
+
+    /// For the KoalaBear field and width 16 we multiply by the diagonal matrix:
+    /// D = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, -1/2^8, 1/4, 1/8, -1/8, 1/16, -1/16, 1/32, -1/32, 1/64, -1/64, -1/2^7, -1/2^9, 1/2**24, -1/2**24]
+    /// The inputs must be in canonical form, otherwise the result is undefined.
+    /// Even when the inputs are in canonical form, we make no guarantees on the output except that, provided
+    /// the output is piped directly into add_sum, the vector will be modified such that x[i] = D[i]*x[i] + sum.
+    #[inline(always)]
+    unsafe fn diagonal_mul(input: &mut [__m512i; 23]) {
+        // As far as we know this is optimal in that it need the fewest instructions to perform all of these
+        // multiplications. (Note that -1, 0 are not allowed on the diagonal for technical reasons).
+        // If there exist other number b for which x*b mod P can be computed quickly this diagonal can be updated.
+
+        // The strategy is very simple. 2, 3, 4, -3, -4 are implemented using addition.
+        //                              1/2, -1/2 using the custom half function.
+        //                              and the remainder utilizing the custom functions for multiplication by 2^{-n}.
+
+        // Note that for -3, -4, -1/2 we actually output 3x, 4x, x/2 and the negative is dealt with in add_sum by subtracting
+        // this from the summation instead of adding it.
+
+        // Note that input only contains the last 23 elements of the state.
+        // The first element is handled separately as we need to apply the s-box to it.
+
+        // input[0] is being multiplied by 1 so we can also ignore it.
+
+        // input[1] -> sum + 2*input[1]
+        input[1] = add::<KoalaBearParameters>(input[1], input[1]);
+
+        // input[2] -> sum + input[2]/2
+        input[2] = halve_avx512::<KoalaBearParameters>(input[2]);
+
+        // input[3] -> sum + 3*input[3]
+        let acc3 = add::<KoalaBearParameters>(input[3], input[3]);
+        input[3] = add::<KoalaBearParameters>(acc3, input[3]);
+
+        // input[4] -> sum + 4*input[4]
+        let acc4 = add::<KoalaBearParameters>(input[4], input[4]);
+        input[4] = add::<KoalaBearParameters>(acc4, acc4);
+
+        // input[5] -> sum - input[5]/2
+        input[5] = halve_avx512::<KoalaBearParameters>(input[5]);
+
+        // input[6] -> sum - 3*input[6]
+        let acc6 = add::<KoalaBearParameters>(input[6], input[6]);
+        input[6] = add::<KoalaBearParameters>(acc6, input[6]);
+
+        // input[7] -> sum - 4*input[7]
+        let acc7 = add::<KoalaBearParameters>(input[7], input[7]);
+        input[7] = add::<KoalaBearParameters>(acc7, acc7);
+
+        // input[8] -> sum + input[8]/2^8
+        input[8] = mul_2_exp_neg_8(input[8]);
+
+        // input[9] -> sum - input[9]/2^8
+        input[9] = mul_neg_2_exp_neg_8(input[9]);
+
+        // input[10] -> sum + input[10]/2^2
+        input[10] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 2, 22>(input[10]);
+
+        // input[11] -> sum + input[11]/2^3
+        input[11] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 3, 21>(input[11]);
+
+        // input[12] -> sum - input[12]/2^3
+        input[12] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 3, 21>(input[12]);
+
+        // input[13] -> sum + input[13]/2^4
+        input[13] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 4, 20>(input[13]);
+
+        // input[14] -> sum - input[14]/2^4
+        input[14] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 4, 20>(input[14]);
+
+        // input[15] -> sum + input[15]/2^5
+        input[15] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 5, 19>(input[15]);
+
+        // input[16] -> sum - input[16]/2^5
+        input[16] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 5, 19>(input[16]);
+
+        // input[17] -> sum + input[17]/2^6
+        input[17] = mul_2_exp_neg_n_avx512::<KoalaBearParameters, 6, 18>(input[17]);
+
+        // input[18] -> sum - input[18]/2^6
+        input[18] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 6, 18>(input[18]);
+
+        // input[19] -> sum - input[19]/2^7
+        input[19] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 7, 17>(input[19]);
+
+        // input[20] -> sum - input[20]/2^9
+        input[20] = mul_neg_2_exp_neg_n_avx512::<KoalaBearParameters, 9, 15>(input[20]);
+
+        // input[21] -> sum - input[21]/2^24
+        input[21] = mul_2_exp_neg_two_adicity_avx512::<KoalaBearParameters, 24, 7>(input[21]);
+
+        // input[22] -> sum - input[22]/2^24
+        input[22] = mul_neg_2_exp_neg_two_adicity_avx512::<KoalaBearParameters, 24, 7>(input[22]);
+    }
+
+    /// Add sum to every element of input.
+    /// Sum must be in canonical form and input must be exactly the output of diagonal mul.
+    /// If either of these does not hold, the result is undefined.
+    unsafe fn add_sum(input: &mut [__m512i; 23], sum: __m512i) {
+        input[..5]
+            .iter_mut()
+            .for_each(|x| *x = add::<KoalaBearParameters>(sum, *x));
+
+        // Diagonal mul multiplied these by 1/2, 3, 4 instead of -1/2, -3, -4 so we need to subtract instead of adding.
+        input[5..8]
+            .iter_mut()
+            .for_each(|x| *x = sub::<KoalaBearParameters>(sum, *x));
+
+        // Diagonal mul output a signed value in (-P, P) so we need to do a signed add.
+        // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
+        input[8..]
+            .iter_mut()
+            .for_each(|x| *x = signed_add_avx512::<KoalaBearParameters>(sum, *x));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use p3_field::AbstractField;
-    use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
     use p3_symmetric::Permutation;
     use rand::Rng;
 
-    use crate::{DiffusionMatrixKoalaBear, KoalaBear, PackedKoalaBearAVX512};
+    use crate::{KoalaBear, PackedKoalaBearAVX512, Poseidon2KoalaBear};
 
     type F = KoalaBear;
-    const D: u64 = 7;
-    type Perm16 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 16, D>;
-    type Perm24 = Poseidon2<F, Poseidon2ExternalMatrixGeneral, DiffusionMatrixKoalaBear, 24, D>;
+    type Perm16 = Poseidon2KoalaBear<16>;
+    type Perm24 = Poseidon2KoalaBear<24>;
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -18,11 +320,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Our Poseidon2 implementation.
-        let poseidon2 = Perm16::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear::default(),
-            &mut rng,
-        );
+        let poseidon2 = Perm16::new_from_rng_128(&mut rng);
 
         let input: [F; 16] = rng.gen();
 
@@ -43,11 +341,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         // Our Poseidon2 implementation.
-        let poseidon2 = Perm24::new_from_rng_128(
-            Poseidon2ExternalMatrixGeneral,
-            DiffusionMatrixKoalaBear::default(),
-            &mut rng,
-        );
+        let poseidon2 = Perm24::new_from_rng_128(&mut rng);
 
         let input: [F; 24] = rng.gen();
 

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -40,7 +40,7 @@ pub trait PackedMontyParameters: crate::MontyParametersAVX2 + MontyParameters {}
 ))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
 pub trait PackedMontyParameters:
-    crate::MontyParametersAVX2 + crate::MontyParametersAVX512 + MontyParameters
+    crate::MontyParametersAVX512 + MontyParameters
 {
 }
 #[cfg(not(any(

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -39,10 +39,7 @@ pub trait PackedMontyParameters: crate::MontyParametersAVX2 + MontyParameters {}
     target_feature = "avx512f"
 ))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
-pub trait PackedMontyParameters:
-    crate::MontyParametersAVX512 + MontyParameters
-{
-}
+pub trait PackedMontyParameters: crate::MontyParametersAVX512 + MontyParameters {}
 #[cfg(not(any(
     all(target_arch = "aarch64", target_feature = "neon"),
     all(

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -28,9 +28,17 @@ mod aarch64_neon;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use aarch64_neon::*;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 mod x86_64_avx2;
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(

--- a/monty-31/src/no_packing/poseidon2.rs
+++ b/monty-31/src/no_packing/poseidon2.rs
@@ -7,7 +7,7 @@ use p3_poseidon2::{ExternalLayerConstants, ExternalLayerConstructor, InternalLay
 
 use crate::{FieldParameters, InternalLayerBaseParameters, MontyField31, MontyParameters};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Poseidon2InternalLayerMonty31<
     MP: MontyParameters,
     const WIDTH: usize,
@@ -17,10 +17,9 @@ pub struct Poseidon2InternalLayerMonty31<
     _phantom: PhantomData<ILP>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Poseidon2ExternalLayerMonty31<MP: MontyParameters, const WIDTH: usize> {
-    pub(crate) initial_external_constants: Vec<[MontyField31<MP>; WIDTH]>,
-    pub(crate) terminal_external_constants: Vec<[MontyField31<MP>; WIDTH]>,
+    pub(crate) external_constants: ExternalLayerConstants<MontyField31<MP>, WIDTH>,
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<FP, WIDTH>>
@@ -40,12 +39,8 @@ impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyFiel
     fn new_from_constants(
         external_constants: ExternalLayerConstants<MontyField31<FP>, WIDTH>,
     ) -> Self {
-        let initial_external_constants = external_constants.get_initial_constants().clone();
-        let terminal_external_constants = external_constants.get_terminal_constants().clone();
-
         Self {
-            initial_external_constants,
-            terminal_external_constants,
+            external_constants
         }
     }
 }

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -43,7 +43,6 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
 ))]
 pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     InternalLayerBaseParameters<FP, WIDTH>
-    + crate::InternalLayerParametersAVX2<WIDTH>
     + crate::InternalLayerParametersAVX512<WIDTH>
 {
 }

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -96,7 +96,7 @@ where
     fn permute_state_initial(&self, mut state: [MontyField31<FP>; WIDTH]) -> Self::InternalState {
         external_initial_permute_state::<MontyField31<FP>, MDSMat4, WIDTH, D>(
             &mut state,
-            &self.initial_external_constants,
+            self.external_constants.get_initial_constants(),
             &MDSMat4,
         );
         state
@@ -106,7 +106,7 @@ where
     fn permute_state_terminal(&self, mut state: Self::InternalState) -> [MontyField31<FP>; WIDTH] {
         external_terminal_permute_state::<MontyField31<FP>, MDSMat4, WIDTH, D>(
             &mut state,
-            &self.terminal_external_constants,
+            self.external_constants.get_terminal_constants(),
             &MDSMat4,
         );
         state

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -42,8 +42,7 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     target_feature = "avx512f"
 ))]
 pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
-    InternalLayerBaseParameters<FP, WIDTH>
-    + crate::InternalLayerParametersAVX512<WIDTH>
+    InternalLayerBaseParameters<FP, WIDTH> + crate::InternalLayerParametersAVX512<WIDTH>
 {
 }
 #[cfg(not(any(

--- a/monty-31/src/x86_64_avx2/utils.rs
+++ b/monty-31/src/x86_64_avx2/utils.rs
@@ -224,7 +224,7 @@ pub unsafe fn mul_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: i32>(
         // Thus lo_x_r contains lo * r.
         let lo_x_r = x86_64::_mm256_maddubs_epi16(input, odd_factor);
 
-        let lo_shft = x86_64::_mm256_slli_epi32::<N_PRIME>(lo);
+        let lo_shft = x86_64::_mm256_slli_epi32::<N_PRIME>(lo_x_r);
         x86_64::_mm256_sub_epi32(hi, lo_shft)
     }
 }

--- a/monty-31/src/x86_64_avx2/utils.rs
+++ b/monty-31/src/x86_64_avx2/utils.rs
@@ -123,7 +123,7 @@ pub unsafe fn mul_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: i32, const N_PRIME
 ) -> __m256i {
     /*
         We want this to compile to:
-            vpslld      val_hi,     val,        N
+            vpsrld      val_hi,     val,        N
             vpand       val_lo,     val,        2^{N} - 1
             vpmaddwd    lo_x_r,     val_lo,     [r; 8]
             vpslld      lo,         lo_x_r,     j - N
@@ -163,7 +163,7 @@ pub unsafe fn mul_neg_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: i32, const N_P
 ) -> __m256i {
     /*
         We want this to compile to:
-            vpslld      val_hi,     val,        N
+            vpsrld      val_hi,     val,        N
             vpand       val_lo,     val,        2^N - 1
             vpmaddwd    lo_x_r,     val_lo,     [r; 8]
             vpslld      lo,         lo_x_r,     j - N
@@ -276,7 +276,7 @@ pub unsafe fn mul_2_exp_neg_two_adicity_avx2<TAD: TwoAdicData, const N: i32, con
 ) -> __m256i {
     /*
         We want this to compile to:
-            vpslld  val_hi, 	 	val,            N
+            vpsrld  val_hi, 	 	val,            N
             vpand   val_lo, 	 	val,     	    2^{N} - 1
             vpslrd  val_lo_hi,   	val_lo,         31 - N
             vpaddd  val_hi_plus_lo, val_lo,         val_hi
@@ -316,7 +316,7 @@ pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx2<
 ) -> __m256i {
     /*
         We want this to compile to:
-            vpslld  val_hi, 	 	val,        N
+            vpsrld  val_hi, 	 	val,        N
             vpand   val_lo, 	 	val,        2^{N} - 1
             vpslrd  val_lo_hi,   	val_lo,     31 - N
             vpaddd  val_hi_plus_lo, val_lo,     val_hi

--- a/monty-31/src/x86_64_avx512/mod.rs
+++ b/monty-31/src/x86_64_avx512/mod.rs
@@ -1,4 +1,7 @@
 mod packing;
 mod poseidon2;
+mod utils;
 
 pub use packing::*;
+pub use poseidon2::*;
+pub use utils::*;

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -123,7 +123,7 @@ impl<PMP: PackedMontyParameters> Sub for PackedMontyField31AVX512<PMP> {
 /// If the inputs are not in canonical form, the result is undefined.
 #[inline]
 #[must_use]
-fn add<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
+pub fn add<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
     // We want this to compile to:
     //      vpaddd   t, lhs, rhs
     //      vpsubd   u, t, P
@@ -416,7 +416,7 @@ fn neg<MPAVX512: MontyParametersAVX512>(val: __m512i) -> __m512i {
 /// If the inputs are not in canonical form, the result is undefined.
 #[inline]
 #[must_use]
-fn sub<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
+pub fn sub<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
     // We want this to compile to:
     //      vpsubd   t, lhs, rhs
     //      vpaddd   u, t, P

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -28,7 +28,7 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {
     #[inline]
     #[must_use]
     /// Get an arch-specific vector representing the packed values.
-    fn to_vector(self) -> __m512i {
+    pub(crate) fn to_vector(self) -> __m512i {
         unsafe {
             // Safety: `MontyField31` is `repr(transparent)` so it can be transmuted to `u32`. It
             // follows that `[MontyField31; WIDTH]` can be transmuted to `[u32; WIDTH]`, which can be
@@ -45,7 +45,7 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid
     /// `MontyField31`. In particular, each element of vector must be in `0..=P`.
-    unsafe fn from_vector(vector: __m512i) -> Self {
+    pub(crate) unsafe fn from_vector(vector: __m512i) -> Self {
         // Safety: It is up to the user to ensure that elements of `vector` represent valid
         // `MontyField31` values. We must only reason about memory representations. `__m512i` can be
         // transmuted to `[u32; WIDTH]` (since arrays elements are contiguous in memory), which can

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -1,5 +1,5 @@
-use core::arch::x86_64::{self, __m512i, __mmask16, __mmask8};
 use core::arch::asm;
+use core::arch::x86_64::{self, __m512i, __mmask16, __mmask8};
 use core::hint::unreachable_unchecked;
 use core::iter::{Product, Sum};
 use core::mem::transmute;
@@ -148,7 +148,7 @@ fn confuse_compiler(x: __m512i) -> __m512i {
 }
 
 /// Add two vectors of MontyField31 elements in canonical form.
-/// 
+///
 /// We allow a slight loosening of the canonical form requirement. One of this inputs
 /// must be in canonical form [0, P) but the other is also allowed to equal P.
 /// If the inputs do not conform to this representation, the result is undefined.
@@ -178,7 +178,7 @@ pub fn add<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m51
 }
 
 /// Subtract vectors of MontyField31 elements in canonical form.
-/// 
+///
 /// We allow a slight loosening of the canonical form requirement. The
 /// rhs input is additionally allowed to be P.
 /// If the inputs do not conform to this representation, the result is undefined.
@@ -234,7 +234,9 @@ pub fn sub<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m51
 /// The output will lie in {-P, ..., P} and be stored in the upper 32 bits.
 #[inline]
 #[must_use]
-fn partial_monty_red_unsigned_to_signed<MPAVX512: MontyParametersAVX512>(input: __m512i) -> __m512i {
+fn partial_monty_red_unsigned_to_signed<MPAVX512: MontyParametersAVX512>(
+    input: __m512i,
+) -> __m512i {
     unsafe {
         let q = confuse_compiler(x86_64::_mm512_mul_epu32(input, MPAVX512::PACKED_MU));
         let q_p = confuse_compiler(x86_64::_mm512_mul_epu32(q, MPAVX512::PACKED_P));

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -136,9 +136,8 @@ impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX512
 /// A struct containing the constants and methods needed to perform the external layers of the Poseidon2 permutation.
 #[derive(Debug, Clone)]
 pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH: usize> {
-    pub(crate) initial_external_constants: Vec<[MontyField31<PMP>; WIDTH]>,
+    pub(crate) external_constants: ExternalLayerConstants<MontyField31<PMP>, WIDTH>,
     packed_initial_external_constants: Vec<[__m512i; WIDTH]>,
-    pub(crate) terminal_external_constants: Vec<[MontyField31<PMP>; WIDTH]>,
     packed_terminal_external_constants: Vec<[__m512i; WIDTH]>,
 }
 
@@ -152,20 +151,17 @@ impl<FP: FieldParameters, const WIDTH: usize>
     fn new_from_constants(
         external_constants: ExternalLayerConstants<MontyField31<FP>, WIDTH>,
     ) -> Self {
-        let initial_external_constants = external_constants.get_initial_constants().clone();
-        let terminal_external_constants = external_constants.get_terminal_constants().clone();
-        let packed_initial_external_constants = initial_external_constants
+        let packed_initial_external_constants = external_constants.get_initial_constants()
             .iter()
             .map(|array| array.map(|constant| convert_to_vec_neg_form::<FP>(constant.value as i32)))
             .collect();
-        let packed_terminal_external_constants = terminal_external_constants
+        let packed_terminal_external_constants = external_constants.get_terminal_constants()
             .iter()
             .map(|array| array.map(|constant| convert_to_vec_neg_form::<FP>(constant.value as i32)))
             .collect();
         Self {
-            initial_external_constants,
+            external_constants,
             packed_initial_external_constants,
-            terminal_external_constants,
             packed_terminal_external_constants,
         }
     }
@@ -387,15 +383,15 @@ where
     }
 
     /// Compute the second half of the Poseidon2 external layers.
-    /// SAFETY: The caller must ensure that each element of `state` represents a valid `MontyField31<PMP>`.
-    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
     fn permute_state_terminal(
         &self,
         state: Self::InternalState,
     ) -> [PackedMontyField31AVX512<FP>; 16] {
-        // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
-        // Thus to_packed_field_array is safe to use.
-        let mut output_state = unsafe { state.to_packed_field_array() };
+        let mut output_state = unsafe { 
+            // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
+            // Thus to_packed_field_array is safe to use.
+            state.to_packed_field_array() 
+        };
 
         external_rounds::<FP, 16, D>(&mut output_state, &self.packed_terminal_external_constants);
         output_state
@@ -422,15 +418,15 @@ where
     }
 
     /// Compute the second half of the Poseidon2 external layers.
-    /// SAFETY: The caller must ensure that each element of `state` represents a valid `MontyField31<PMP>`.
-    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
     fn permute_state_terminal(
         &self,
         state: Self::InternalState,
     ) -> [PackedMontyField31AVX512<FP>; 24] {
-        // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
-        // Thus to_packed_field_array is safe to use.
-        let mut output_state = unsafe { state.to_packed_field_array() };
+        let mut output_state = unsafe { 
+            // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
+            // Thus to_packed_field_array is safe to use.
+            state.to_packed_field_array() 
+        };
 
         external_rounds::<FP, 24, D>(&mut output_state, &self.packed_terminal_external_constants);
         output_state

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -1,34 +1,436 @@
-use p3_poseidon2::{matmul_internal, DiffusionPermutation};
-use p3_symmetric::Permutation;
+//! Vectorized AVX512 implementation of Poseidon2 for MontyField31
 
-use crate::{
-    DiffusionMatrixMontyField31, DiffusionMatrixParameters, FieldParameters, MontyField31,
-    PackedFieldPoseidon2Helpers, PackedMontyField31AVX512,
+use alloc::vec::Vec;
+use core::arch::x86_64::{self, __m512i};
+use core::marker::PhantomData;
+use core::mem::transmute;
+
+use p3_poseidon2::{
+    mds_light_permutation, sum_15, sum_23, ExternalLayer, ExternalLayerConstants,
+    ExternalLayerConstructor, InternalLayer, InternalLayerConstructor, MDSMat4,
 };
 
-// We need to change from the standard implementation as we are interpreting the matrix (1 + Diag(vec)) as the monty form of the matrix not the raw form.
-// matmul_internal internal performs a standard matrix multiplication so we need to additional rescale by the inverse monty constant.
-// These will be removed once we have architecture specific implementations.
+use crate::{
+    apply_func_to_even_odd, packed_exp_3, packed_exp_5, packed_exp_7, FieldParameters,
+    MontyField31, MontyParameters, PackedMontyField31AVX512, PackedMontyParameters,
+};
 
-impl<FP, const WIDTH: usize, MP> Permutation<[PackedMontyField31AVX512<FP>; WIDTH]>
-    for DiffusionMatrixMontyField31<MP>
-where
-    FP: FieldParameters,
-    MP: DiffusionMatrixParameters<FP, WIDTH> + PackedFieldPoseidon2Helpers<FP>,
-{
-    fn permute_mut(&self, state: &mut [PackedMontyField31AVX512<FP>; WIDTH]) {
-        matmul_internal::<MontyField31<FP>, PackedMontyField31AVX512<FP>, WIDTH>(
-            state,
-            MP::INTERNAL_DIAG_MONTY,
-        );
-        state.iter_mut().for_each(|i| *i *= MP::MONTY_INVERSE);
+// In the internal layers, it is valuable to treat the first entry of the state differently
+// as it is the only entry to which we apply s-box.
+// It seems to help the compiler if we introduce a different data structure for these layers.
+// Note that we use this structure instead of a tuple so we can force the memory layout to align for transmutes.
+#[derive(Clone, Copy)]
+#[repr(C)] // This is needed to make `transmute`s safe.
+pub struct InternalLayer16<PMP: PackedMontyParameters> {
+    s0: PackedMontyField31AVX512<PMP>,
+    s_hi: [__m512i; 15],
+}
+
+impl<PMP: PackedMontyParameters> InternalLayer16<PMP> {
+    #[inline]
+    #[must_use]
+    /// Convert from `InternalLayer16<PMP>` to `[PackedMontyField31AVX512<PMP>; 16]`
+    ///
+    /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.
+    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
+    unsafe fn to_packed_field_array(self) -> [PackedMontyField31AVX512<PMP>; 16] {
+        // Safety: It is up to the user to ensure that elements of `s_hi` represent valid
+        // `MontyField31<PMP>` values. We must only reason about memory representations.
+        // As described in packing.rs, PackedMontyField31AVX512<PMP> can be transmuted to and from `__m512i`.
+
+        // `InternalLayer16` is `repr(C)` so its memory layout looks like:
+        // `[PackedMontyField31AVX512<PMP>, __m512i, ..., __m512i]`
+        // Thus as `__m512i` can be can be transmuted to `PackedMontyField31AVX512<FP>`,
+        // `InternalLayer16` can be transmuted to `[PackedMontyField31AVX512<FP>; 16]`.
+        transmute(self)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Convert from `[PackedMontyField31AVX512<PMP>; 16]` to `InternalLayer16<PMP>`
+    fn from_packed_field_array(vector: [PackedMontyField31AVX512<PMP>; 16]) -> Self {
+        unsafe {
+            // Safety: As described in packing.rs, PackedMontyField31AVX512<PMP> can be transmuted to and from `__m512i`.
+
+            // `InternalLayer16` is `repr(C)` so its memory layout looks like:
+            // `[PackedMontyField31AVX512<PMP>, __m512i, ..., __m512i]`
+            // Thus as `PackedMontyField31AVX512<FP>` can be can be transmuted to `__m512i`,
+            // `[PackedMontyField31AVX512<FP>; 16]` can be transmuted to `InternalLayer16`.
+            transmute(vector)
+        }
     }
 }
 
-impl<FP, const WIDTH: usize, MP> DiffusionPermutation<PackedMontyField31AVX512<FP>, WIDTH>
-    for DiffusionMatrixMontyField31<MP>
+#[derive(Clone, Copy)]
+#[repr(C)] // This is needed to make `transmute`s safe.
+pub struct InternalLayer24<PMP: PackedMontyParameters> {
+    s0: PackedMontyField31AVX512<PMP>,
+    s_hi: [__m512i; 23],
+}
+
+impl<PMP: PackedMontyParameters> InternalLayer24<PMP> {
+    #[inline]
+    #[must_use]
+    /// Convert from `InternalLayer24<PMP>` to `[PackedMontyField31AVX512<PMP>; 24]`
+    ///
+    /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.
+    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
+    unsafe fn to_packed_field_array(self) -> [PackedMontyField31AVX512<PMP>; 24] {
+        // Safety: As described in packing.rs, PackedMontyField31AVX512<PMP> can be transmuted to and from `__m512i`.
+
+        // `InternalLayer24` is `repr(C)` so its memory layout looks like:
+        // `[PackedMontyField31AVX512<PMP>, __m512i, ..., __m512i]`
+        // Thus as `__m512i` can be can be transmuted to `PackedMontyField31AVX512<FP>`,
+        // `InternalLayer24` can be transmuted to `[PackedMontyField31AVX512<FP>; 24]`.
+        transmute(self)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Convert from `[PackedMontyField31AVX512<PMP>; 24]` to `InternalLayer24<PMP>`
+    fn from_packed_field_array(vector: [PackedMontyField31AVX512<PMP>; 24]) -> Self {
+        unsafe {
+            // Safety: As described in packing.rs, PackedMontyField31AVX512<PMP> can be transmuted to and from `__m512i`.
+
+            // `InternalLayer24` is `repr(C)` so its memory layout looks like:
+            // `[PackedMontyField31AVX512<PMP>, __m512i, ..., __m512i]`
+            // Thus as `PackedMontyField31AVX512<FP>` can be can be transmuted to `__m512i`,
+            // `[PackedMontyField31AVX512<FP>; 24]` can be transmuted to `InternalLayer24`.
+            transmute(vector)
+        }
+    }
+}
+
+/// A struct containing the constants and methods needed to perform the internal layers of the Poseidon2 permutation.
+#[derive(Debug, Clone)]
+pub struct Poseidon2InternalLayerMonty31<
+    PMP: PackedMontyParameters,
+    const WIDTH: usize,
+    ILP: InternalLayerParametersAVX512<WIDTH>,
+> {
+    pub(crate) internal_constants: Vec<MontyField31<PMP>>,
+    packed_internal_constants: Vec<__m512i>,
+    _phantom: PhantomData<ILP>,
+}
+
+impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX512<WIDTH>>
+    InternalLayerConstructor<PackedMontyField31AVX512<FP>>
+    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+{
+    /// Construct an instance of Poseidon2InternalLayerMersenne31AVX2 from a vector containing
+    /// the constants for each round. Internally, the constants are transformed into the
+    /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
+    fn new_from_constants(internal_constants: Vec<MontyField31<FP>>) -> Self {
+        let packed_internal_constants = internal_constants
+            .iter()
+            .map(|constant| convert_to_vec_neg_form::<FP>(constant.value as i32))
+            .collect();
+        Self {
+            internal_constants,
+            packed_internal_constants,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// A struct containing the constants and methods needed to perform the external layers of the Poseidon2 permutation.
+#[derive(Debug, Clone)]
+pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH: usize> {
+    pub(crate) initial_external_constants: Vec<[MontyField31<PMP>; WIDTH]>,
+    packed_initial_external_constants: Vec<[__m512i; WIDTH]>,
+    pub(crate) terminal_external_constants: Vec<[MontyField31<PMP>; WIDTH]>,
+    packed_terminal_external_constants: Vec<[__m512i; WIDTH]>,
+}
+
+impl<FP: FieldParameters, const WIDTH: usize>
+    ExternalLayerConstructor<PackedMontyField31AVX512<FP>, WIDTH>
+    for Poseidon2ExternalLayerMonty31<FP, WIDTH>
+{
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of
+    /// vectors containing the constants for each round. Internally, the constants
+    ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
+    fn new_from_constants(
+        external_constants: ExternalLayerConstants<MontyField31<FP>, WIDTH>,
+    ) -> Self {
+        let initial_external_constants = external_constants.get_initial_constants().clone();
+        let terminal_external_constants = external_constants.get_terminal_constants().clone();
+        let packed_initial_external_constants = initial_external_constants
+            .iter()
+            .map(|array| array.map(|constant| convert_to_vec_neg_form::<FP>(constant.value as i32)))
+            .collect();
+        let packed_terminal_external_constants = terminal_external_constants
+            .iter()
+            .map(|array| array.map(|constant| convert_to_vec_neg_form::<FP>(constant.value as i32)))
+            .collect();
+        Self {
+            initial_external_constants,
+            packed_initial_external_constants,
+            terminal_external_constants,
+            packed_terminal_external_constants,
+        }
+    }
+}
+
+/// Use hard coded methods to compute x -> x^d for the even index entries and small d.
+/// Inputs should be signed 32-bit integers in [-P, ..., P].
+/// Outputs will also be signed integers in (-P, ..., P) stored in the odd indices.
+#[inline(always)]
+#[must_use]
+fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m512i) -> __m512i {
+    match D {
+        3 => packed_exp_3::<PMP>(val),
+        5 => packed_exp_5::<PMP>(val),
+        7 => packed_exp_7::<PMP>(val),
+        _ => panic!("No exp function for given D"),
+    }
+}
+
+/// Compute val -> (val + rc)^D. Each entry of val should be represented in canonical form.
+/// Each entry of rc should be represented by an element in in [-P, 0].
+/// Each entry of the output will be represented by an element in canonical form.
+/// If the inputs do not conform to this representation, the result is undefined.
+#[inline(always)]
+#[must_use]
+fn add_rc_and_sbox<PMP: PackedMontyParameters, const D: u64>(
+    val: PackedMontyField31AVX512<PMP>,
+    rc: __m512i,
+) -> PackedMontyField31AVX512<PMP> {
+    unsafe {
+        // As our exponential functions simply assume that
+        // the input lies in [-P, P] we do not need to perform a reduction provided
+        // rc is represented by an element in [-P, 0]
+        let vec_val = val.to_vector();
+        let val_plus_rc = x86_64::_mm512_add_epi32(vec_val, rc);
+        let output = apply_func_to_even_odd::<PMP>(val_plus_rc, exp_small::<PMP, D>);
+
+        PackedMontyField31AVX512::<PMP>::from_vector(output)
+    }
+}
+
+/// A trait containing the specific information needed to
+/// implement the Poseidon2 Permutation for Monty31 Fields.
+pub trait InternalLayerParametersAVX512<const WIDTH: usize>: Clone + Sync {
+    type ArrayLike;
+
+    // diagonal_mul and add_sum morally should be one function but are split because diagonal_mul can happen simultaneously to
+    // the sbox being applied to the first element of the state which is advantageous as this s-box has very high latency.
+    // However these functions should only ever be used together and we only make safety guarantees about the output
+    // of the combined function add_sum(diagonal_mul(state), sum) which will output field elements in canonical form provided inputs are in canonical form.
+
+    // Diagonal_mul will not output field elements in canonical form and indeed may even output incorrect values in places where
+    // it is efficient to pipe computation to add_sum. E.g. it might output 3*x instead of -3*x and then add_sum does sum - x.
+    // Similarly add_sum assumes its input has been piped directly from diagonal_mul so might assume that some inputs
+    // are the negative of the correct value or in some form other than canonical.
+
+    // For these reason we mark both functions as unsafe.
+
+    /// # Safety
+    ///
+    /// This function assumes its output is piped directly into add_sum.
+    unsafe fn diagonal_mul(input: &mut Self::ArrayLike);
+
+    /// # Safety
+    ///
+    /// This function assumes its input is taken directly from diagonal_mul.
+    unsafe fn add_sum(input: &mut Self::ArrayLike, sum: __m512i);
+}
+
+/// Convert elements from canonical form [0, P) to a negative form in [-P, ..., 0) and copy into a vector.
+#[inline(always)]
+fn convert_to_vec_neg_form<MP: MontyParameters>(input: i32) -> __m512i {
+    let input_sub_p = input - (MP::PRIME as i32);
+    unsafe {
+        // Safety: If this code got compiled then AVX512-F intrinsics are available.
+        x86_64::_mm512_set1_epi32(input_sub_p)
+    }
+}
+
+impl<FP, ILP, const D: u64> InternalLayer<PackedMontyField31AVX512<FP>, 16, D>
+    for Poseidon2InternalLayerMonty31<FP, 16, ILP>
 where
     FP: FieldParameters,
-    MP: DiffusionMatrixParameters<FP, WIDTH> + PackedFieldPoseidon2Helpers<FP>,
+    ILP: InternalLayerParametersAVX512<16, ArrayLike = [__m512i; 15]>,
 {
+    type InternalState = InternalLayer16<FP>;
+
+    /// Compute a collection of Poseidon2 internal layers.
+    /// One layer for every constant supplied.
+    fn permute_state(&self, state: &mut Self::InternalState) {
+        unsafe {
+            /*
+                Fix a vector v and let Diag(v) denote the diagonal matrix with diagonal given by v.
+                Additionally, let 1 denote the matrix with all elements equal to 1.
+                The internal layer consists of an sbox operation then a matrix multiplication by 1 + Diag(v).
+                Explicitly the internal layer consists of the following 2 operations:
+
+                s0 -> (s0 + rc)^d
+                s -> (1 + Diag(v))s
+
+                Note that this matrix multiplication can be implemented as:
+                sum = sum_i s_i
+                s_i -> sum + s_iv_i
+
+                which is essentially how we implement it.
+            */
+            self.packed_internal_constants.iter().for_each(|&rc| {
+                state.s0 = add_rc_and_sbox::<FP, D>(state.s0, rc); // s0 -> (s0 + rc)^D
+                let sum_non_0 = sum_15(
+                    &transmute::<[__m512i; 15], [PackedMontyField31AVX512<FP>; 15]>(state.s_hi),
+                ); // Get the sum of all elements other than s0.
+                ILP::diagonal_mul(&mut state.s_hi); // si -> vi * si for all i > 0.
+                let sum = sum_non_0 + state.s0; // Get the full sum.
+                state.s0 = sum_non_0 - state.s0; // s0 -> sum - 2*s0 = sum_non_0 - s0.
+                ILP::add_sum(
+                    &mut state.s_hi,
+                    transmute::<PackedMontyField31AVX512<FP>, __m512i>(sum),
+                ); // si -> si + sum for all i > 0.
+            })
+        }
+    }
+}
+
+impl<FP, ILP, const D: u64> InternalLayer<PackedMontyField31AVX512<FP>, 24, D>
+    for Poseidon2InternalLayerMonty31<FP, 24, ILP>
+where
+    FP: FieldParameters,
+    ILP: InternalLayerParametersAVX512<24, ArrayLike = [__m512i; 23]>,
+{
+    type InternalState = InternalLayer24<FP>;
+
+    /// Compute a collection of Poseidon2 internal layers.
+    /// One layer for every constant supplied.
+    fn permute_state(&self, state: &mut Self::InternalState) {
+        unsafe {
+            /*
+                Fix a vector v and let Diag(v) denote the diagonal matrix with diagonal given by v.
+                Additionally, let 1 denote the matrix with all elements equal to 1.
+                The internal layer consists of an sbox operation then a matrix multiplication by 1 + Diag(v).
+                Explicitly the internal layer consists of the following 2 operations:
+
+                s0 -> (s0 + rc)^d
+                s -> (1 + Diag(v))s
+
+                Note that this matrix multiplication can be implemented as:
+                sum = sum_i s_i
+                s_i -> sum + s_iv_i
+
+                which is essentially how we implement it.
+            */
+
+            self.packed_internal_constants.iter().for_each(|&rc| {
+                state.s0 = add_rc_and_sbox::<FP, D>(state.s0, rc); // s0 -> (s0 + rc)^D
+                let sum_non_0 = sum_23(
+                    &transmute::<[__m512i; 23], [PackedMontyField31AVX512<FP>; 23]>(state.s_hi),
+                ); // Get the sum of all elements other than s0.
+                ILP::diagonal_mul(&mut state.s_hi); // si -> vi * si for all i > 0.
+                let sum = sum_non_0 + state.s0; // Get the full sum.
+                state.s0 = sum_non_0 - state.s0; // s0 -> sum - 2*s0 = sum_non_0 - s0.
+                ILP::add_sum(
+                    &mut state.s_hi,
+                    transmute::<PackedMontyField31AVX512<FP>, __m512i>(sum),
+                ); // si -> si + sum for all i > 0.
+            })
+        }
+    }
+}
+
+/// Compute a collection of Poseidon2 external layers.
+/// One layer for every constant supplied.
+#[inline]
+fn external_rounds<FP, const WIDTH: usize, const D: u64>(
+    state: &mut [PackedMontyField31AVX512<FP>; WIDTH],
+    packed_external_constants: &[[__m512i; WIDTH]],
+) where
+    FP: FieldParameters,
+{
+    /*
+        The external layer consists of the following 2 operations:
+
+        s -> s + rc
+        s -> s^d
+        s -> Ms
+
+        Where by s^d we mean to apply this power function element wise.
+
+        Multiplication by M is implemented efficiently in p3_poseidon2/matrix.
+    */
+    packed_external_constants.iter().for_each(|round_consts| {
+        state
+            .iter_mut()
+            .zip(round_consts.iter())
+            .for_each(|(val, &rc)| {
+                *val = add_rc_and_sbox::<FP, D>(*val, rc);
+            });
+        mds_light_permutation(state, &MDSMat4);
+    });
+}
+
+impl<FP, const D: u64> ExternalLayer<PackedMontyField31AVX512<FP>, 16, D>
+    for Poseidon2ExternalLayerMonty31<FP, 16>
+where
+    FP: FieldParameters,
+{
+    type InternalState = InternalLayer16<FP>;
+
+    /// Compute the first half of the Poseidon2 external layers.
+    fn permute_state_initial(
+        &self,
+        mut state: [PackedMontyField31AVX512<FP>; 16],
+    ) -> Self::InternalState {
+        mds_light_permutation(&mut state, &MDSMat4);
+
+        external_rounds::<FP, 16, D>(&mut state, &self.packed_initial_external_constants);
+
+        InternalLayer16::from_packed_field_array(state)
+    }
+
+    /// Compute the second half of the Poseidon2 external layers.
+    /// SAFETY: The caller must ensure that each element of `state` represents a valid `MontyField31<PMP>`.
+    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
+    fn permute_state_terminal(
+        &self,
+        state: Self::InternalState,
+    ) -> [PackedMontyField31AVX512<FP>; 16] {
+        // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
+        // Thus to_packed_field_array is safe to use.
+        let mut output_state = unsafe { state.to_packed_field_array() };
+
+        external_rounds::<FP, 16, D>(&mut output_state, &self.packed_terminal_external_constants);
+        output_state
+    }
+}
+
+impl<FP, const D: u64> ExternalLayer<PackedMontyField31AVX512<FP>, 24, D>
+    for Poseidon2ExternalLayerMonty31<FP, 24>
+where
+    FP: FieldParameters,
+{
+    type InternalState = InternalLayer24<FP>;
+
+    /// Compute the first half of the Poseidon2 external layers.
+    fn permute_state_initial(
+        &self,
+        mut state: [PackedMontyField31AVX512<FP>; 24],
+    ) -> Self::InternalState {
+        mds_light_permutation(&mut state, &MDSMat4);
+
+        external_rounds::<FP, 24, D>(&mut state, &self.packed_initial_external_constants);
+
+        InternalLayer24::from_packed_field_array(state)
+    }
+
+    /// Compute the second half of the Poseidon2 external layers.
+    /// SAFETY: The caller must ensure that each element of `state` represents a valid `MontyField31<PMP>`.
+    /// In particular, each element of each vector must be in `[0, P)` (canonical form).
+    fn permute_state_terminal(
+        &self,
+        state: Self::InternalState,
+    ) -> [PackedMontyField31AVX512<FP>; 24] {
+        // SAFETY: The internal layer outputs elements in canonical form when given elements in canonical form.
+        // Thus to_packed_field_array is safe to use.
+        let mut output_state = unsafe { state.to_packed_field_array() };
+
+        external_rounds::<FP, 24, D>(&mut output_state, &self.packed_terminal_external_constants);
+        output_state
+    }
 }

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -274,9 +274,10 @@ where
             */
             self.packed_internal_constants.iter().for_each(|&rc| {
                 state.s0 = add_rc_and_sbox::<FP, D>(state.s0, rc); // s0 -> (s0 + rc)^D
-                let sum_non_0 = sum_15(
-                    &transmute::<[__m512i; 15], [PackedMontyField31AVX512<FP>; 15]>(state.s_hi),
-                ); // Get the sum of all elements other than s0.
+                let sum_non_0 = sum_15(&transmute::<
+                    [__m512i; 15],
+                    [PackedMontyField31AVX512<FP>; 15],
+                >(state.s_hi)); // Get the sum of all elements other than s0.
                 ILP::diagonal_mul(&mut state.s_hi); // si -> vi * si for all i > 0.
                 let sum = sum_non_0 + state.s0; // Get the full sum.
                 state.s0 = sum_non_0 - state.s0; // s0 -> sum - 2*s0 = sum_non_0 - s0.
@@ -319,9 +320,10 @@ where
 
             self.packed_internal_constants.iter().for_each(|&rc| {
                 state.s0 = add_rc_and_sbox::<FP, D>(state.s0, rc); // s0 -> (s0 + rc)^D
-                let sum_non_0 = sum_23(
-                    &transmute::<[__m512i; 23], [PackedMontyField31AVX512<FP>; 23]>(state.s_hi),
-                ); // Get the sum of all elements other than s0.
+                let sum_non_0 = sum_23(&transmute::<
+                    [__m512i; 23],
+                    [PackedMontyField31AVX512<FP>; 23],
+                >(state.s_hi)); // Get the sum of all elements other than s0.
                 ILP::diagonal_mul(&mut state.s_hi); // si -> vi * si for all i > 0.
                 let sum = sum_non_0 + state.s0; // Get the full sum.
                 state.s0 = sum_non_0 - state.s0; // s0 -> sum - 2*s0 = sum_non_0 - s0.

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -9,7 +9,7 @@ use crate::{MontyParameters, PackedMontyParameters, TwoAdicData};
 /// Halve a vector of Monty31 field elements in canonical form.
 /// If the inputs are not in canonical form, the result is undefined.
 #[inline(always)]
-pub fn halve_avx2<MP: MontyParameters>(input: __m512i) -> __m512i {
+pub fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
     /*
         We want this to compile to:
             vpand    least_bit, val, ONE
@@ -43,7 +43,7 @@ pub fn halve_avx2<MP: MontyParameters>(input: __m512i) -> __m512i {
 /// conform to the expected representation. Each element of lhs must lie in [0, P) and
 /// each element of rhs in (-P, P).
 #[inline(always)]
-pub unsafe fn signed_add_avx2<PMP: PackedMontyParameters>(lhs: __m512i, rhs: __m512i) -> __m512i {
+pub unsafe fn signed_add_avx512<PMP: PackedMontyParameters>(lhs: __m512i, rhs: __m512i) -> __m512i {
     /*
         We want this to compile to:
             vpsignd  pos_neg_P,  P,     rhs
@@ -117,7 +117,7 @@ pub unsafe fn signed_add_avx2<PMP: PackedMontyParameters>(lhs: __m512i, rhs: __m
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+pub unsafe fn mul_2_exp_neg_n_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -157,7 +157,7 @@ pub unsafe fn mul_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -196,7 +196,7 @@ pub unsafe fn mul_neg_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_P
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
+pub unsafe fn mul_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -233,7 +233,7 @@ pub unsafe fn mul_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -270,7 +270,7 @@ pub unsafe fn mul_neg_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_2_exp_neg_two_adicity_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+pub unsafe fn mul_2_exp_neg_two_adicity_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -306,7 +306,7 @@ pub unsafe fn mul_2_exp_neg_two_adicity_avx2<TAD: TwoAdicData, const N: u32, con
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx2<
+pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx512<
     TAD: TwoAdicData,
     const N: u32,
     const N_PRIME: u32,

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -4,7 +4,7 @@ use core::mem::transmute;
 use crate::{MontyParameters, PackedMontyParameters, TwoAdicData};
 
 // Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
-// https://godbolt.org/z/xK91MKsdd
+// https://godbolt.org/z/WW3GYjsTn
 
 /// Halve a vector of Monty31 field elements in canonical form.
 /// If the inputs are not in canonical form, the result is undefined.

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -1,0 +1,340 @@
+use core::arch::x86_64::{self, __m512i};
+use core::mem::transmute;
+
+use crate::{MontyParameters, PackedMontyParameters, TwoAdicData};
+
+// Godbolt file showing that these all compile to the expected instructions. (Potentially plus a few memory ops):
+// https://godbolt.org/z/xK91MKsdd
+
+/// Halve a vector of Monty31 field elements in canonical form.
+/// If the inputs are not in canonical form, the result is undefined.
+#[inline(always)]
+pub fn halve_avx2<MP: MontyParameters>(input: __m512i) -> __m512i {
+    /*
+        We want this to compile to:
+            vpand    least_bit, val, ONE
+            vpsrld   t, val, 1
+            vpsignd  maybe_half, HALF, least_bit
+            vpaddd   res, t, maybe_half
+        throughput: 1.33 cyc/vec
+        latency: 3 cyc
+
+        Given an element val in [0, P), we want to compute val/2 mod P.
+        If val is even: val/2 mod P = val/2 = val >> 1.
+        If val is odd: val/2 mod P = (val + P)/2 = (val >> 1) + (P + 1)/2
+    */
+    unsafe {
+        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        const ONE: __m512i = unsafe { transmute([1; 16]) };
+        let half: __m512i = transmute([(MP::PRIME + 1) / 2; 16]); // Compiler realises this is constant.
+
+        let least_bit = x86_64::_mm512_test_epi32_mask(input, ONE); // Determine the parity of val.
+        let t = x86_64::_mm512_srli_epi32::<1>(input);
+        // This does nothing when least_bit = 1 and sets the corresponding entry to 0 when least_bit = 0
+        x86_64::_mm512_mask_add_epi32(t, least_bit, t, half)
+    }
+}
+
+/// Add two vectors of Monty31 field elements with lhs in canonical form and rhs in (-P, P).
+///
+/// # Safety
+///
+/// This function is not symmetric in the inputs. The caller must ensure that inputs
+/// conform to the expected representation. Each element of lhs must lie in [0, P) and
+/// each element of rhs in (-P, P).
+#[inline(always)]
+pub unsafe fn signed_add_avx2<PMP: PackedMontyParameters>(lhs: __m512i, rhs: __m512i) -> __m512i {
+    /*
+        We want this to compile to:
+            vpsignd  pos_neg_P,  P,     rhs
+            vpaddd   sum,        lhs,   rhs
+            vpsubd   sum_corr,   sum,   pos_neg_P
+            vpminud  res,        sum,   sum_corr
+        throughput: 1.33 cyc/vec
+        latency: 3 cyc
+
+        While this is more expensive than an add, it is cheaper than reducing the rhs to a canonical value and then adding.
+
+        We give a short proof that the output is correct:
+
+        Let t = lhs + rhs mod 2^32, we want to return t mod P while correcting for any possible wraparound.
+        We make use of the fact wrapping addition acts identically on signed and unsigned inputs.
+
+        If rhs is positive, lhs + rhs < 2P < 2^32 and so we interpret t as a unsigned 32 bit integer.
+            In this case, t mod P = min_{u32}(t, t - P) where min_{u32} takes the min treating both inputs as unsigned 32 bit integers.
+            This works as if t >= P then t - P < t and if t < P then, due to wraparound, t - P outputs t - P + 2^32 > t.
+        If rhs is negative, -2^31 < -P < lhs + rhs < P < 2^31 so we interpret t as a signed 32 bit integer.
+            In this case t mod P = min_{u32}(t, t + P)
+            This works as if t > 0 then t < t + P and if t < 0 then due to wraparound when we interpret t as an unsigned integer it becomes
+            2^32 + t > t + P.
+        if rhs = 0 then we can just return t = lhs as it is already in the desired range.
+    */
+    unsafe {
+        // If rhs > 0 set the value to P, if rhs < 0 set it to -P and if rhs = 0 set it to 0.
+        let pos_neg_p = x86_64::_mm512_sign_epi32(PMP::PACKED_P, rhs);
+
+        // Compute t = lhs + rhs
+        let sum = x86_64::_mm512_add_epi32(lhs, rhs);
+
+        // sum_corr = (t - P) if rhs > 0, t + P if rhs < 0 and t if rhs = 0 as desired.
+        let sum_corr = x86_64::_mm512_sub_epi32(sum, pos_neg_p);
+
+        x86_64::_mm512_min_epu32(sum, sum_corr)
+    }
+}
+
+/*
+    Write our prime P as r * 2^j + 1 for odd r.
+    The following functions implement x -> +/- 2^{-N} x for varying N and output a value in (-P, P).
+    There is one approach which works provided N < 15 and r < 2^15.
+    Similarly, there is another approach which works when N = j and when r = 2^i - 1.
+
+    Both approaches rely on the same basic observation about multiplication by +/- 2^{-N} which we present here.
+    We will focus on the -2^{-N} case but note that the case of 2^{-N} is essentially identical.
+    The strategy for these products is to observe that -2^{-N} = r2^{j - N} mod P.
+    Hence given a field element x write it as x = x_lo + 2^N x_hi where x_lo < 2^N.
+    Then -2^{-N} x = -x_hi + r2^{j - N} x_lo.
+    Clearly x_hi < P and, as x_lo < 2^N, r2^{j - N} x_lo < r2^j < P so
+    -P < r2^{j - N} x_lo - x_hi < P
+
+    It remains to understand how to efficiently compute r2^{j - N} x_lo. This splits into several cases:
+
+    When r < 2^16, N < 15, r2^{j - N} x_lo can be computed efficiently using _mm512_madd_epi16.
+    This avoids having to split the input in two and doing multiple multiplications and/or monty reductions.
+
+    There is a further improvement possible when if r < 2^7 and N = 8 using _mm512_maddubs_epi16.
+    This lets us avoid a mask and an and so we implement a specialised version for this.
+
+    When n = j and r = 2^i - 1, rx_lo can also be computed efficiently using a shift and subtraction.
+*/
+
+/// Multiply a vector of Monty31 field elements in canonical form by 2**{-N}.
+///
+/// # Safety
+///
+/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^15.
+/// N must be between 0 and 15.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpslld      val_hi,     val,        N
+            vpand       val_lo,     val,        2^{N} - 1
+            vpmaddwd    lo_x_r,     val_lo,     [r; 16]
+            vpslld      lo,         lo_x_r,     j - N
+            vpsubd      res,        val_hi,     lo
+        throughput: 1.67
+        latency: 8
+    */
+    unsafe {
+        assert_eq!(N + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
+
+        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
+        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
+
+        let hi = x86_64::_mm512_srli_epi32::<N>(input);
+        let val_lo = x86_64::_mm512_and_si512(input, mask);
+
+        // Whilst it generically does something else, provided
+        // each entry of val_lo, odd_factor are < 2^15, _mm512_madd_epi16
+        // performs an element wise multiplication.
+        // Thus lo_x_r contains r*x_lo.
+        let lo_x_r = x86_64::_mm512_madd_epi16(val_lo, odd_factor);
+        let lo = x86_64::_mm512_slli_epi32::<N_PRIME>(lo_x_r);
+        x86_64::_mm512_sub_epi32(hi, lo)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by -2**{-N}.
+/// # Safety
+///
+/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^15.
+/// N must be between 0 and 15.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_neg_2_exp_neg_n_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpslld      val_hi,     val,        N
+            vpand       val_lo,     val,        2^N - 1
+            vpmaddwd    lo_x_r,     val_lo,     [r; 16]
+            vpslld      lo,         lo_x_r,     j - N
+            vpsubd      res,        lo,         val_hi
+        throughput: 1.67
+        latency: 8
+    */
+    unsafe {
+        assert_eq!(N + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
+
+        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
+        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
+
+        let hi = x86_64::_mm512_srli_epi32::<N>(input);
+        let val_lo = x86_64::_mm512_and_si512(input, mask);
+
+        // Whilst it generically does something else, provided
+        // each entry of val_lo, odd_factor are < 2^15, _mm512_madd_epi16
+        // performs an element wise multiplication.
+        // Thus lo_x_r contains r*x_lo.
+        let lo_x_r = x86_64::_mm512_madd_epi16(val_lo, odd_factor);
+        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo_x_r);
+        x86_64::_mm512_sub_epi32(lo_shft, hi)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by 2**{-8}.
+/// # Safety
+///
+/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^7.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpsrld      hi, val, 8
+            vpmaddubsw  lo, val, [r; 16]
+            vpslldq     lo, lo, j - 8
+            vpsubd      t, hi, lo
+        throughput: 1.33
+        latency: 7
+    */
+    unsafe {
+        assert_eq!(8 + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
+
+        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
+        let hi = x86_64::_mm512_srli_epi32::<8>(input);
+
+        // Whilst it generically does something else, provided
+        // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
+        // performs an element wise multiplication of odd_factor with
+        // the bottom 8 bits of input interpreted as an unsigned integer
+        // Thus lo contains r*x_lo.
+        let lo = x86_64::_mm512_maddubs_epi16(input, odd_factor);
+
+        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+        x86_64::_mm512_sub_epi32(hi, lo_shft)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by -2**{-8}.
+/// # Safety
+///
+/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^7.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_neg_2_exp_neg_8_avx2<TAD: TwoAdicData, const N_PRIME: u32>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpsrld      hi, val, 8
+            vpmaddubsw  lo, val, [r; 16]
+            vpslldq     lo, lo, j - 8
+            vpsubd      t, lo, hi
+        throughput: 1.33
+        latency: 7
+    */
+    unsafe {
+        assert_eq!(8 + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
+
+        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
+        let hi = x86_64::_mm512_srli_epi32::<8>(input);
+
+        // Whilst it generically does something else, provided
+        // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
+        // performs an element wise multiplication of odd_factor with
+        // the bottom 8 bits of input interpreted as an unsigned integer
+        // Thus lo contains r*x_lo.
+        let lo = x86_64::_mm512_maddubs_epi16(input, odd_factor);
+
+        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+        x86_64::_mm512_sub_epi32(lo_shft, hi)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by 2**{-N} where P = 2^31 - 2^N + 1.
+/// # Safety
+///
+/// The prime P must have the form P = 2^31 - 2^N + 1.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_2_exp_neg_two_adicity_avx2<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpslld  val_hi, 	 	val,            N
+            vpand   val_lo, 	 	val,     	    2^{N} - 1
+            vpslrd  val_lo_hi,   	val_lo,         31 - N
+            vpaddd  val_hi_plus_lo, val_lo,         val_hi
+            vpsubd  res 		 	val_hi_plus_lo, val_lo_hi,
+        throughput: 1.67
+        latency: 3
+    */
+    unsafe {
+        assert_eq!(N, (TAD::TWO_ADICITY as u32)); // Compiler removes this provided it is satisfied.
+        assert_eq!(N + N_PRIME, 31); // Compiler removes this provided it is satisfied.
+
+        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
+        let hi = x86_64::_mm512_srli_epi32::<N>(input);
+
+        // Provided overflow does not occur, (2^{31 - N} - 1)*x = (x << {31 - N}) - 1.
+        // lo < 2^N => (lo << {31 - N}) < 2^31 and (lo << {31 - N}) - lo < P.
+        let lo = x86_64::_mm512_and_si512(input, mask);
+        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+        let lo_plus_hi = x86_64::_mm512_add_epi32(lo, hi);
+        x86_64::_mm512_sub_epi32(lo_plus_hi, lo_shft)
+    }
+}
+
+/// Multiply a vector of Monty31 field elements in canonical form by -2**{-N} where P = 2^31 - 2^N + 1.
+/// # Safety
+///
+/// The prime P must have the form P = 2^31 - 2^N + 1.
+/// Input must be given in canonical form.
+/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+#[inline(always)]
+pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx2<
+    TAD: TwoAdicData,
+    const N: u32,
+    const N_PRIME: u32,
+>(
+    input: __m512i,
+) -> __m512i {
+    /*
+        We want this to compile to:
+            vpslld  val_hi, 	 	val,        N
+            vpand   val_lo, 	 	val,        2^{N} - 1
+            vpslrd  val_lo_hi,   	val_lo,     31 - N
+            vpaddd  val_hi_plus_lo, val_lo,     val_hi
+            vpsubd  res 		 	val_lo_hi,  val_hi_plus_lo
+        throughput: 1.67
+        latency: 3
+    */
+    unsafe {
+        assert_eq!(N, (TAD::TWO_ADICITY as u32)); // Compiler removes this provided it is satisfied.
+        assert_eq!(N + N_PRIME, 31); // Compiler removes this provided it is satisfied.
+
+        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
+        let hi = x86_64::_mm512_srli_epi32::<N>(input);
+
+        // Provided overflow does not occur, (2^{31 - N} - 1)*x = (x << {31 - N}) - 1.
+        // lo < 2^N => (lo << {31 - N}) < 2^31 and (lo << {31 - N}) - lo < P.
+        let lo = x86_64::_mm512_and_si512(input, mask);
+        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+        let lo_plus_hi = x86_64::_mm512_add_epi32(lo, hi);
+        x86_64::_mm512_sub_epi32(lo_shft, lo_plus_hi)
+    }
+}

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -46,8 +46,8 @@ pub fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
     Then -2^{-N} x = -x_hi + r2^{j - N} x_lo.
 
     Observe that if x_lo > 0, then x_hi < r2^{j - N}x_lo < P and so r2^{j - N} x_lo - x_hi is canonical.
-    On the other hand, if x_lo = 0 then the canonical result should be P - x_hi if x_hi > 0 and 0 otherwise. 
-    
+    On the other hand, if x_lo = 0 then the canonical result should be P - x_hi if x_hi > 0 and 0 otherwise.
+
     Using intrinsics we can efficiently output r2^{j - N} x_lo - x_hi if x_lo > 0 and P - x_hi if x_lo = 0.
     Whilst this means the output will not be canonical and instead will lie in [0, P] this will be handled by
     a seperate function.
@@ -71,7 +71,11 @@ pub fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
 /// Input must be given in canonical form.
 /// Output may not be in canonical form but will lie in [0, P].
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData + PackedMontyParameters, const N: u32, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_n_avx512<
+    TAD: TwoAdicData + PackedMontyParameters,
+    const N: u32,
+    const N_PRIME: u32,
+>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -120,7 +124,10 @@ pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData + PackedMontyParameter
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData + PackedMontyParameters, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_8_avx512<
+    TAD: TwoAdicData + PackedMontyParameters,
+    const N_PRIME: u32,
+>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -139,7 +146,7 @@ pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData + PackedMontyParameter
 
         let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
         let hi = x86_64::_mm512_srli_epi32::<8>(input);
-        
+
         let mask: __m512i = transmute([(1 << 8) - 1; 16]); // Compiler realises this is a constant.
 
         // Determine the non 0 values of lo.

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -12,12 +12,11 @@ use crate::{MontyParameters, PackedMontyParameters, TwoAdicData};
 pub fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
     /*
         We want this to compile to:
-            vpand    least_bit, val, ONE
+            vptestmd least_bit, val, ONE
             vpsrld   t, val, 1
-            vpsignd  maybe_half, HALF, least_bit
-            vpaddd   res, t, maybe_half
-        throughput: 1.33 cyc/vec
-        latency: 3 cyc
+            vpaddd   res, least_bit, t, maybe_half
+        throughput: 2 cyc/vec
+        latency: 4 cyc
 
         Given an element val in [0, P), we want to compute val/2 mod P.
         If val is even: val/2 mod P = val/2 = val >> 1.
@@ -35,70 +34,23 @@ pub fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
     }
 }
 
-/// Add two vectors of Monty31 field elements with lhs in canonical form and rhs in (-P, P).
-///
-/// # Safety
-///
-/// This function is not symmetric in the inputs. The caller must ensure that inputs
-/// conform to the expected representation. Each element of lhs must lie in [0, P) and
-/// each element of rhs in (-P, P).
-#[inline(always)]
-pub unsafe fn signed_add_avx512<PMP: PackedMontyParameters>(lhs: __m512i, rhs: __m512i) -> __m512i {
-    /*
-        We want this to compile to:
-            vpsignd  pos_neg_P,  P,     rhs
-            vpaddd   sum,        lhs,   rhs
-            vpsubd   sum_corr,   sum,   pos_neg_P
-            vpminud  res,        sum,   sum_corr
-        throughput: 1.33 cyc/vec
-        latency: 3 cyc
-
-        While this is more expensive than an add, it is cheaper than reducing the rhs to a canonical value and then adding.
-
-        We give a short proof that the output is correct:
-
-        Let t = lhs + rhs mod 2^32, we want to return t mod P while correcting for any possible wraparound.
-        We make use of the fact wrapping addition acts identically on signed and unsigned inputs.
-
-        If rhs is positive, lhs + rhs < 2P < 2^32 and so we interpret t as a unsigned 32 bit integer.
-            In this case, t mod P = min_{u32}(t, t - P) where min_{u32} takes the min treating both inputs as unsigned 32 bit integers.
-            This works as if t >= P then t - P < t and if t < P then, due to wraparound, t - P outputs t - P + 2^32 > t.
-        If rhs is negative, -2^31 < -P < lhs + rhs < P < 2^31 so we interpret t as a signed 32 bit integer.
-            In this case t mod P = min_{u32}(t, t + P)
-            This works as if t > 0 then t < t + P and if t < 0 then due to wraparound when we interpret t as an unsigned integer it becomes
-            2^32 + t > t + P.
-        if rhs = 0 then we can just return t = lhs as it is already in the desired range.
-    */
-    unsafe {
-        // Currently can't come up with anything better than just correcting rhs to lie in [0, P).
-        // This is rather annoying. I strongly suspect there should be a way to save an operation here.
-        // Unfortunately the natural extension of the AVX2 method doesn't work as _mm512_sign_epi32 doesn't exist.
-        let pos_rhs = x86_64::_mm512_add_epi32(PMP::PACKED_P, rhs);
-        let rhs_canonical = x86_64::_mm512_min_epu32(rhs, pos_rhs);
-        
-        // Compute t = lhs + rhs
-        let sum = x86_64::_mm512_add_epi32(lhs, rhs_canonical);
-
-        // sum_corr = (t - P) if rhs > 0, t + P if rhs < 0 and t if rhs = 0 as desired.
-        let sum_corr = x86_64::_mm512_sub_epi32(sum, PMP::PACKED_P);
-
-        x86_64::_mm512_min_epu32(sum, sum_corr)
-    }
-}
-
 /*
     Write our prime P as r * 2^j + 1 for odd r.
-    The following functions implement x -> +/- 2^{-N} x for varying N and output a value in (-P, P).
+    The following functions implement x -> -2^{-N} x for varying N and output a value in (-P, P).
     There is one approach which works provided N < 15 and r < 2^15.
     Similarly, there is another approach which works when N = j and when r = 2^i - 1.
 
-    Both approaches rely on the same basic observation about multiplication by +/- 2^{-N} which we present here.
-    We will focus on the -2^{-N} case but note that the case of 2^{-N} is essentially identical.
+    These approaches rely on the same basic observation about multiplication by -2^{-N} which we present here.
     The strategy for these products is to observe that -2^{-N} = r2^{j - N} mod P.
-    Hence given a field element x write it as x = x_lo + 2^N x_hi where x_lo < 2^N.
+    Hence given a field element x write it as x = x_lo + 2^N x_hi where x_lo < 2^N and x_hi <= r2^{j - N}.
     Then -2^{-N} x = -x_hi + r2^{j - N} x_lo.
-    Clearly x_hi < P and, as x_lo < 2^N, r2^{j - N} x_lo < r2^j < P so
-    -P < r2^{j - N} x_lo - x_hi < P
+
+    Observe that if x_lo > 0, then x_hi < r2^{j - N}x_lo < P and so r2^{j - N} x_lo - x_hi is canonical.
+    On the other hand, if x_lo = 0 then the canonical result should be P - x_hi if x_hi > 0 and 0 otherwise. 
+    
+    Using intrinsics we can efficiently output r2^{j - N} x_lo - x_hi if x_lo > 0 and P - x_hi if x_lo = 0.
+    Whilst this means the output will not be canonical and instead will lie in [0, P] this will be handled by
+    a seperate function.
 
     It remains to understand how to efficiently compute r2^{j - N} x_lo. This splits into several cases:
 
@@ -111,64 +63,24 @@ pub unsafe fn signed_add_avx512<PMP: PackedMontyParameters>(lhs: __m512i, rhs: _
     When n = j and r = 2^i - 1, rx_lo can also be computed efficiently using a shift and subtraction.
 */
 
-/// Multiply a vector of Monty31 field elements in canonical form by 2**{-N}.
-///
-/// # Safety
-///
-/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^15.
-/// N must be between 0 and 15.
-/// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
-#[inline(always)]
-pub unsafe fn mul_2_exp_neg_n_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
-    input: __m512i,
-) -> __m512i {
-    /*
-        We want this to compile to:
-            vpslld      val_hi,     val,        N
-            vpand       val_lo,     val,        2^{N} - 1
-            vpmaddwd    lo_x_r,     val_lo,     [r; 16]
-            vpslld      lo,         lo_x_r,     j - N
-            vpsubd      res,        val_hi,     lo
-        throughput: 1.67
-        latency: 8
-    */
-    unsafe {
-        assert_eq!(N + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
-
-        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
-        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
-
-        let hi = x86_64::_mm512_srli_epi32::<N>(input);
-        let val_lo = x86_64::_mm512_and_si512(input, mask);
-
-        // Whilst it generically does something else, provided
-        // each entry of val_lo, odd_factor are < 2^15, _mm512_madd_epi16
-        // performs an element wise multiplication.
-        // Thus lo_x_r contains r*x_lo.
-        let lo_x_r = x86_64::_mm512_madd_epi16(val_lo, odd_factor);
-        let lo = x86_64::_mm512_slli_epi32::<N_PRIME>(lo_x_r);
-        x86_64::_mm512_sub_epi32(hi, lo)
-    }
-}
-
 /// Multiply a vector of Monty31 field elements in canonical form by -2**{-N}.
 /// # Safety
 ///
 /// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^15.
 /// N must be between 0 and 15.
 /// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+/// Output may not be in canonical form but will lie in [0, P].
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData + PackedMontyParameters, const N: u32, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
         We want this to compile to:
-            vpslld      val_hi,     val,        N
-            vpand       val_lo,     val,        2^N - 1
+            vpsrld      val_hi,     val,        N
+            vpandd      val_lo,     val,        2^N - 1
+            vptestmd    lo_MASK,    val,        2^N - 1
             vpmaddwd    lo_x_r,     val_lo,     [r; 16]
-            vpslld      lo,         lo_x_r,     j - N
+            vpslld      P,          lo_MASK,    lo_x_r,     j - N
             vpsubd      res,        lo,         val_hi
         throughput: 1.67
         latency: 8
@@ -182,50 +94,21 @@ pub unsafe fn mul_neg_2_exp_neg_n_avx512<TAD: TwoAdicData, const N: u32, const N
         let hi = x86_64::_mm512_srli_epi32::<N>(input);
         let val_lo = x86_64::_mm512_and_si512(input, mask);
 
+        // Determine the non 0 values of lo.
+        let lo_mask = x86_64::_mm512_test_epi32_mask(input, mask);
+
         // Whilst it generically does something else, provided
         // each entry of val_lo, odd_factor are < 2^15, _mm512_madd_epi16
         // performs an element wise multiplication.
         // Thus lo_x_r contains r*x_lo.
         let lo_x_r = x86_64::_mm512_madd_epi16(val_lo, odd_factor);
-        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo_x_r);
+
+        // When lo = 0, lo_shft = P
+        // When lo > 0, lo_shft = r2^{j - N} x_lo
+        let lo_shft = x86_64::_mm512_mask_slli_epi32::<N_PRIME>(TAD::PACKED_P, lo_mask, lo_x_r);
+
+        // As hi < r2^{j - N} < P, the output is always in [0, P]. It is equal to P only when input t = 0.
         x86_64::_mm512_sub_epi32(lo_shft, hi)
-    }
-}
-
-/// Multiply a vector of Monty31 field elements in canonical form by 2**{-8}.
-/// # Safety
-///
-/// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^7.
-/// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
-#[inline(always)]
-pub unsafe fn mul_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
-    input: __m512i,
-) -> __m512i {
-    /*
-        We want this to compile to:
-            vpsrld      hi, val, 8
-            vpmaddubsw  lo, val, [r; 16]
-            vpslldq     lo, lo, j - 8
-            vpsubd      t, hi, lo
-        throughput: 1.33
-        latency: 7
-    */
-    unsafe {
-        assert_eq!(8 + N_PRIME, TAD::TWO_ADICITY as u32); // Compiler removes this provided it is satisfied.
-
-        let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
-        let hi = x86_64::_mm512_srli_epi32::<8>(input);
-
-        // Whilst it generically does something else, provided
-        // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
-        // performs an element wise multiplication of odd_factor with
-        // the bottom 8 bits of input interpreted as an unsigned integer
-        // Thus lo contains r*x_lo.
-        let lo = x86_64::_mm512_maddubs_epi16(input, odd_factor);
-
-        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
-        x86_64::_mm512_sub_epi32(hi, lo_shft)
     }
 }
 
@@ -236,7 +119,7 @@ pub unsafe fn mul_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
 /// Input must be given in canonical form.
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
-pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
+pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData + PackedMontyParameters, const N_PRIME: u32>(
     input: __m512i,
 ) -> __m512i {
     /*
@@ -253,52 +136,21 @@ pub unsafe fn mul_neg_2_exp_neg_8_avx512<TAD: TwoAdicData, const N_PRIME: u32>(
 
         let odd_factor: __m512i = transmute([TAD::ODD_FACTOR; 16]); // This is [r; 16]. Compiler realises this is a constant.
         let hi = x86_64::_mm512_srli_epi32::<8>(input);
+        
+        let mask: __m512i = transmute([(1 << 8) - 1; 16]); // Compiler realises this is a constant.
 
         // Whilst it generically does something else, provided
         // each entry of odd_factor is < 2^7, _mm512_maddubs_epi16
         // performs an element wise multiplication of odd_factor with
         // the bottom 8 bits of input interpreted as an unsigned integer
         // Thus lo contains r*x_lo.
-        let lo = x86_64::_mm512_maddubs_epi16(input, odd_factor);
+        let lo_x_r = x86_64::_mm512_maddubs_epi16(input, odd_factor);
 
-        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+        // Determine the non 0 values of lo.
+        let lo_mask = x86_64::_mm512_test_epi32_mask(input, mask);
+
+        let lo_shft = x86_64::_mm512_mask_slli_epi32::<N_PRIME>(TAD::PACKED_P, lo_mask, lo_x_r);
         x86_64::_mm512_sub_epi32(lo_shft, hi)
-    }
-}
-
-/// Multiply a vector of Monty31 field elements in canonical form by 2**{-N} where P = 2^31 - 2^N + 1.
-/// # Safety
-///
-/// The prime P must have the form P = 2^31 - 2^N + 1.
-/// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
-#[inline(always)]
-pub unsafe fn mul_2_exp_neg_two_adicity_avx512<TAD: TwoAdicData, const N: u32, const N_PRIME: u32>(
-    input: __m512i,
-) -> __m512i {
-    /*
-        We want this to compile to:
-            vpslld  val_hi, 	 	val,            N
-            vpand   val_lo, 	 	val,     	    2^{N} - 1
-            vpslrd  val_lo_hi,   	val_lo,         31 - N
-            vpaddd  val_hi_plus_lo, val_lo,         val_hi
-            vpsubd  res 		 	val_hi_plus_lo, val_lo_hi,
-        throughput: 1.67
-        latency: 3
-    */
-    unsafe {
-        assert_eq!(N, (TAD::TWO_ADICITY as u32)); // Compiler removes this provided it is satisfied.
-        assert_eq!(N + N_PRIME, 31); // Compiler removes this provided it is satisfied.
-
-        let mask: __m512i = transmute([(1 << N) - 1; 16]); // Compiler realises this is a constant.
-        let hi = x86_64::_mm512_srli_epi32::<N>(input);
-
-        // Provided overflow does not occur, (2^{31 - N} - 1)*x = (x << {31 - N}) - 1.
-        // lo < 2^N => (lo << {31 - N}) < 2^31 and (lo << {31 - N}) - lo < P.
-        let lo = x86_64::_mm512_and_si512(input, mask);
-        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
-        let lo_plus_hi = x86_64::_mm512_add_epi32(lo, hi);
-        x86_64::_mm512_sub_epi32(lo_plus_hi, lo_shft)
     }
 }
 
@@ -310,7 +162,7 @@ pub unsafe fn mul_2_exp_neg_two_adicity_avx512<TAD: TwoAdicData, const N: u32, c
 /// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
 #[inline(always)]
 pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx512<
-    TAD: TwoAdicData,
+    TAD: TwoAdicData + PackedMontyParameters,
     const N: u32,
     const N_PRIME: u32,
 >(
@@ -336,7 +188,12 @@ pub unsafe fn mul_neg_2_exp_neg_two_adicity_avx512<
         // Provided overflow does not occur, (2^{31 - N} - 1)*x = (x << {31 - N}) - 1.
         // lo < 2^N => (lo << {31 - N}) < 2^31 and (lo << {31 - N}) - lo < P.
         let lo = x86_64::_mm512_and_si512(input, mask);
-        let lo_shft = x86_64::_mm512_slli_epi32::<N_PRIME>(lo);
+
+        // Determine the non 0 values of lo.
+        let lo_mask = x86_64::_mm512_test_epi32_mask(input, mask);
+
+        let lo_shft = x86_64::_mm512_mask_slli_epi32::<N_PRIME>(TAD::PACKED_P, lo_mask, lo);
+
         let lo_plus_hi = x86_64::_mm512_add_epi32(lo, hi);
         x86_64::_mm512_sub_epi32(lo_shft, lo_plus_hi)
     }

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+nightly-features = ["p3-baby-bear/nightly-features", "p3-koala-bear/nightly-features"]
+
 [dependencies]
 gcd = "2.3.0"
 p3-field = { path = "../field" }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -147,7 +147,7 @@ pub fn mds_light_permutation<
 }
 
 /// A simple struct which holds the constants for the external layer.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ExternalLayerConstants<T, const WIDTH: usize> {
     // Once initialised, these constants should be immutable.
     initial: Vec<[T; WIDTH]>,


### PR DESCRIPTION
NOTE: This is not merging into main (for now). Will wait until all specialized impls (AVX2/AVX512/NEON, M31/MONTY31) are done before doing that.

Initial try was to basically copy/paste the AVX2 implementation but this ended up being a little complicated due to missing a few missing intrinsic. Hence I needed to rebuild the custom `-2^{-N}` multipliers in [monty-31/src/x86_64_avx512/utils.rs] and ended up getting rid of the `2^{-N}` multipliers, instead handling that change later by replacing an add by a sub. This had a side effect of forcing me to slightly update the specifications for add/sub and show that they can handle one input being equal to `P`.

When looking into Goldbolt I also noticed that some of the current AVX512 functions are not compiling correctly. To fix this I introduced a new "confuse_compiler" function similarly to the one in Neon and messed around a little with some of those functions.

Timing data:
                    MAIN:               WIDTH 16        WIDTH 24         THIS BRANCH:       WIDTH 16        WIDTH 24         
BabyBear:                                 2.4µ                   4.4µ                                                1.4µ                  2.4µ        
KoalaBear:                                2.2µ                   3.5µ                                                1.2µ                  1.8µ

