### PR TITLE
Add M31 and BabyBear examples for prove Poseidon2

### DIFF
--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -1,4 +1,6 @@
-use p3_field::PrimeField32;
+use core::ops::Mul;
+
+use p3_field::{AbstractField, PrimeField32};
 use p3_poseidon2::DiffusionPermutation;
 use p3_symmetric::Permutation;
 
@@ -107,6 +109,57 @@ impl Permutation<[Mersenne31; 24]> for DiffusionMatrixMersenne31 {
 }
 
 impl DiffusionPermutation<Mersenne31, 24> for DiffusionMatrixMersenne31 {}
+
+/// Like `DiffusionMatrixMontyField31`, but generalized to any `AbstractField`, and less efficient
+/// for the concrete Monty fields.
+#[derive(Debug, Clone, Default)]
+pub struct GenericDiffusionMatrixMersenne31 {}
+
+impl<AF> Permutation<[AF; 16]>
+    for GenericDiffusionMatrixMersenne31
+where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+{
+    fn permute_mut(&self, state: &mut [AF; 16]) {
+        let part_sum: AF = state.iter().skip(1).cloned().sum();
+        let full_sum = part_sum.clone() + state[0].clone();
+        state[0] = part_sum - state[0].clone();
+
+        for (state_i, const_i) in state.iter_mut().zip(POSEIDON2_INTERNAL_MATRIX_DIAG_16).skip(1) {
+            *state_i = full_sum.clone() + state_i.clone() * const_i;
+        }
+    }
+}
+
+impl<AF> DiffusionPermutation<AF, 16>
+    for GenericDiffusionMatrixMersenne31
+where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+{
+}
+
+impl<AF> Permutation<[AF; 24]>
+    for GenericDiffusionMatrixMersenne31
+where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+{
+    fn permute_mut(&self, state: &mut [AF; 24]) {
+        let part_sum: AF = state.iter().skip(1).cloned().sum();
+        let full_sum = part_sum.clone() + state[0].clone();
+        state[0] = part_sum - state[0].clone();
+
+        for (state_i, const_i) in state.iter_mut().zip(POSEIDON2_INTERNAL_MATRIX_DIAG_24).skip(1) {
+            *state_i = full_sum.clone() + state_i.clone() * const_i;
+        }
+    }
+}
+
+impl<AF> DiffusionPermutation<AF, 24>
+    for GenericDiffusionMatrixMersenne31
+where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+{
+}
 
 #[cfg(test)]
 mod tests {

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -115,8 +115,7 @@ impl DiffusionPermutation<Mersenne31, 24> for DiffusionMatrixMersenne31 {}
 #[derive(Debug, Clone, Default)]
 pub struct GenericDiffusionMatrixMersenne31 {}
 
-impl<AF> Permutation<[AF; 16]>
-    for GenericDiffusionMatrixMersenne31
+impl<AF> Permutation<[AF; 16]> for GenericDiffusionMatrixMersenne31
 where
     AF: AbstractField + Mul<Mersenne31, Output = AF>,
 {
@@ -125,21 +124,22 @@ where
         let full_sum = part_sum.clone() + state[0].clone();
         state[0] = part_sum - state[0].clone();
 
-        for (state_i, const_i) in state.iter_mut().zip(POSEIDON2_INTERNAL_MATRIX_DIAG_16).skip(1) {
+        for (state_i, const_i) in state
+            .iter_mut()
+            .zip(POSEIDON2_INTERNAL_MATRIX_DIAG_16)
+            .skip(1)
+        {
             *state_i = full_sum.clone() + state_i.clone() * const_i;
         }
     }
 }
 
-impl<AF> DiffusionPermutation<AF, 16>
-    for GenericDiffusionMatrixMersenne31
-where
-    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+impl<AF> DiffusionPermutation<AF, 16> for GenericDiffusionMatrixMersenne31 where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>
 {
 }
 
-impl<AF> Permutation<[AF; 24]>
-    for GenericDiffusionMatrixMersenne31
+impl<AF> Permutation<[AF; 24]> for GenericDiffusionMatrixMersenne31
 where
     AF: AbstractField + Mul<Mersenne31, Output = AF>,
 {
@@ -148,16 +148,18 @@ where
         let full_sum = part_sum.clone() + state[0].clone();
         state[0] = part_sum - state[0].clone();
 
-        for (state_i, const_i) in state.iter_mut().zip(POSEIDON2_INTERNAL_MATRIX_DIAG_24).skip(1) {
+        for (state_i, const_i) in state
+            .iter_mut()
+            .zip(POSEIDON2_INTERNAL_MATRIX_DIAG_24)
+            .skip(1)
+        {
             *state_i = full_sum.clone() + state_i.clone() * const_i;
         }
     }
 }
 
-impl<AF> DiffusionPermutation<AF, 24>
-    for GenericDiffusionMatrixMersenne31
-where
-    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+impl<AF> DiffusionPermutation<AF, 24> for GenericDiffusionMatrixMersenne31 where
+    AF: AbstractField + Mul<Mersenne31, Output = AF>
 {
 }
 

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -15,7 +15,9 @@ rand = "0.8.5"
 tracing = "0.1.37"
 
 [dev-dependencies]
+p3-baby-bear = { path = "../baby-bear" }
 p3-challenger = { path = "../challenger" }
+p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -1,0 +1,139 @@
+use std::fmt::Debug;
+
+use p3_baby_bear::{BabyBear, BabyBearDiffusionMatrixParameters, BabyBearParameters};
+use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_keccak::{Keccak256Hash, KeccakF};
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_monty_31::GenericDiffusionMatrixMontyField31;
+use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
+use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
+use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+const WIDTH: usize = 16;
+const SBOX_DEGREE: usize = 7;
+const SBOX_REGISTERS: usize = 1;
+const HALF_FULL_ROUNDS: usize = 4;
+const PARTIAL_ROUNDS: usize = 20;
+
+const NUM_ROWS: usize = 1 << 15;
+const VECTOR_LEN: usize = 1 << 3;
+const NUM_PERMUTATIONS: usize = NUM_ROWS * VECTOR_LEN;
+
+#[cfg(feature = "parallel")]
+type Dft = p3_dft::Radix2DitParallel;
+#[cfg(not(feature = "parallel"))]
+type Dft = p3_dft::Radix2Bowers;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+
+    type ByteHash = Keccak256Hash;
+    let byte_hash = ByteHash {};
+
+    type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
+    let u64_hash = U64Hash::new(KeccakF {});
+
+    type FieldHash = SerializingHasher32To64<U64Hash>;
+    let field_hash = FieldHash::new(u64_hash);
+
+    type MyCompress = CompressionFunctionFromHasher<U64Hash, 2, 4>;
+    let compress = MyCompress::new(u64_hash);
+
+    type ValMmcs = MerkleTreeMmcs<
+        [Val; p3_keccak::VECTOR_LEN],
+        [u64; p3_keccak::VECTOR_LEN],
+        FieldHash,
+        MyCompress,
+        4,
+    >;
+    let val_mmcs = ValMmcs::new(field_hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+
+    type MdsLight = Poseidon2ExternalMatrixGeneral;
+    let external_linear_layer = MdsLight {};
+
+    type Diffusion =
+        GenericDiffusionMatrixMontyField31<BabyBearParameters, BabyBearDiffusionMatrixParameters>;
+    let internal_linear_layer = Diffusion::new();
+
+    let constants = RoundConstants::from_rng(&mut thread_rng());
+    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_vectorized_trace_rows::<
+        Val,
+        MdsLight,
+        Diffusion,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    >(
+        inputs,
+        &constants,
+        &external_linear_layer,
+        &internal_linear_layer,
+    );
+
+    let air: VectorizedPoseidon2Air<
+        Val,
+        MdsLight,
+        Diffusion,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    > = VectorizedPoseidon2Air::new(constants, external_linear_layer, internal_linear_layer);
+
+    let dft = Dft {};
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    verify(&config, &air, &mut challenger, &proof, &vec![])
+}

--- a/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
@@ -1,0 +1,136 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_circle::CirclePcs;
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::FriConfig;
+use p3_keccak::{Keccak256Hash, KeccakF};
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_mersenne_31::{GenericDiffusionMatrixMersenne31, Mersenne31};
+use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
+use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
+use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+const WIDTH: usize = 16;
+const SBOX_DEGREE: usize = 5;
+const SBOX_REGISTERS: usize = 1;
+const HALF_FULL_ROUNDS: usize = 4;
+const PARTIAL_ROUNDS: usize = 14;
+
+const NUM_ROWS: usize = 1 << 15;
+const VECTOR_LEN: usize = 1 << 3;
+const NUM_PERMUTATIONS: usize = NUM_ROWS * VECTOR_LEN;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
+
+    type ByteHash = Keccak256Hash;
+    let byte_hash = ByteHash {};
+
+    type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
+    let u64_hash = U64Hash::new(KeccakF {});
+
+    type FieldHash = SerializingHasher32To64<U64Hash>;
+    let field_hash = FieldHash::new(u64_hash);
+
+    type MyCompress = CompressionFunctionFromHasher<U64Hash, 2, 4>;
+    let compress = MyCompress::new(u64_hash);
+
+    type ValMmcs = MerkleTreeMmcs<
+        [Val; p3_keccak::VECTOR_LEN],
+        [u64; p3_keccak::VECTOR_LEN],
+        FieldHash,
+        MyCompress,
+        4,
+    >;
+    let val_mmcs = ValMmcs::new(field_hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+
+    type MdsLight = Poseidon2ExternalMatrixGeneral;
+    let external_linear_layer = MdsLight {};
+
+    type Diffusion = GenericDiffusionMatrixMersenne31;
+    let internal_linear_layer = Diffusion::default();
+
+    let constants = RoundConstants::from_rng(&mut thread_rng());
+    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_vectorized_trace_rows::<
+        Val,
+        MdsLight,
+        Diffusion,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    >(
+        inputs,
+        &constants,
+        &external_linear_layer,
+        &internal_linear_layer,
+    );
+
+    let air: VectorizedPoseidon2Air<
+        Val,
+        MdsLight,
+        Diffusion,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    > = VectorizedPoseidon2Air::new(constants, external_linear_layer, internal_linear_layer);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_config,
+        _phantom: PhantomData,
+    };
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    verify(&config, &air, &mut challenger, &proof, &vec![])
+}


### PR DESCRIPTION
Adding a pair of examples to prove Poseidon2 which use M31 and BabyBear respectively to allow a better comparison between different fields.

The BabyBear example is identical to the KoalaBear one except for the fact that we need an extra register for each s-box. This doubles the width of the trace and so BabyBear takes about 2x times as long as the equivalent KoalaBear example.

For M31 this means we switch to using the Circle stark instead of the standard stark as well as needing an extra register for each s-box. For now as the circle stark is less optimized, this example is 3x slower than the KoalaBear/