### PR TITLE
Minor Changes to make Clippy happy

### DIFF
--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 /// A "Mixed Matrix Commitment Scheme" (MMCS) is a generalization of a vector commitment scheme.
-/// 
+///
 /// It supports committing to matrices and then opening rows. It is also batch-oriented; one can commit
 /// to a batch of matrices at once even if their widths and heights differ.
 ///

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -7,8 +7,9 @@ use p3_matrix::{Dimensions, Matrix};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-/// A "Mixed Matrix Commitment Scheme" (MMCS) is a generalization of a vector commitment scheme; it
-/// supports committing to matrices and then opening rows. It is also batch-oriented; one can commit
+/// A "Mixed Matrix Commitment Scheme" (MMCS) is a generalization of a vector commitment scheme.
+/// 
+/// It supports committing to matrices and then opening rows. It is also batch-oriented; one can commit
 /// to a batch of matrices at once even if their widths and heights differ.
 ///
 /// When a particular row index is opened, it is interpreted directly as a row index for matrices

--- a/keccak/src/avx2.rs
+++ b/keccak/src/avx2.rs
@@ -306,7 +306,7 @@ fn keccak_perm(buf: &mut [[u64; VECTOR_LEN]; 25]) {
     for i in 0..24 {
         state = round(i, state);
     }
-    *buf = unsafe { transmute(state) };
+    *buf = unsafe { transmute::<[__m256i; 25], [[u64; VECTOR_LEN]; 25]>(state) };
 }
 
 impl Permutation<[[u64; VECTOR_LEN]; 25]> for KeccakF {
@@ -436,18 +436,18 @@ mod tests {
 
     fn our_res() -> [[u64; 25]; 4] {
         let mut packed_result = [[0; 4]; 25];
-        for i in 0..25 {
-            packed_result[i] = [STATES[0][i], STATES[1][i], STATES[2][i], STATES[3][i]];
+        for (i, packed_res) in packed_result.iter_mut().enumerate() {
+            *packed_res = [STATES[0][i], STATES[1][i], STATES[2][i], STATES[3][i]];
         }
 
         keccak_perm(&mut packed_result);
 
         let mut result = [[0; 25]; 4];
-        for i in 0..25 {
-            result[0][i] = packed_result[i][0];
-            result[1][i] = packed_result[i][1];
-            result[2][i] = packed_result[i][2];
-            result[3][i] = packed_result[i][3];
+        for (i, packed_res) in packed_result.iter_mut().enumerate() {
+            result[0][i] = packed_res[0];
+            result[1][i] = packed_res[1];
+            result[2][i] = packed_res[2];
+            result[3][i] = packed_res[3];
         }
         result
     }

--- a/keccak/src/avx512.rs
+++ b/keccak/src/avx512.rs
@@ -353,7 +353,7 @@ fn keccak_perm(buf: &mut [[u64; VECTOR_LEN]; 25]) {
     for i in 0..24 {
         state = round(i, state);
     }
-    *buf = unsafe { transmute(state) };
+    *buf = unsafe { transmute::<[__m512i; 25], [[u64; VECTOR_LEN]; 25]>(state) };
 }
 
 impl Permutation<[[u64; VECTOR_LEN]; 25]> for KeccakF {
@@ -591,8 +591,8 @@ mod tests {
 
     fn our_res() -> [[u64; 25]; 8] {
         let mut packed_result = [[0; 8]; 25];
-        for i in 0..25 {
-            packed_result[i] = [
+        for (i, packed_res) in packed_result.iter_mut().enumerate() {
+            *packed_res = [
                 STATES[0][i],
                 STATES[1][i],
                 STATES[2][i],
@@ -607,15 +607,15 @@ mod tests {
         keccak_perm(&mut packed_result);
 
         let mut result = [[0; 25]; 8];
-        for i in 0..25 {
-            result[0][i] = packed_result[i][0];
-            result[1][i] = packed_result[i][1];
-            result[2][i] = packed_result[i][2];
-            result[3][i] = packed_result[i][3];
-            result[4][i] = packed_result[i][4];
-            result[5][i] = packed_result[i][5];
-            result[6][i] = packed_result[i][6];
-            result[7][i] = packed_result[i][7];
+        for (i, packed_res) in packed_result.iter_mut().enumerate() {
+            result[0][i] = packed_res[0];
+            result[1][i] = packed_res[1];
+            result[2][i] = packed_res[2];
+            result[3][i] = packed_res[3];
+            result[4][i] = packed_res[4];
+            result[5][i] = packed_res[5];
+            result[6][i] = packed_res[6];
+            result[7][i] = packed_res[7];
         }
         result
     }

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -7,8 +7,8 @@ use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
 use crate::MdsPermutation;
 
-/// An Reed-Solomon based MDS permutation.
-/// 
+/// A Reed-Solomon based MDS permutation.
+///
 /// An MDS permutation which works by interpreting the input as evaluations of a polynomial over a
 /// power-of-two subgroup, and computing evaluations over a coset of that subgroup. This can be
 /// viewed as returning the parity elements of a systematic Reed-Solomon code. Since Reed-Solomon

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -7,6 +7,8 @@ use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 use crate::butterflies::{dif_butterfly, dit_butterfly, twiddle_free_butterfly};
 use crate::MdsPermutation;
 
+/// An Reed-Solomon based MDS permutation.
+/// 
 /// An MDS permutation which works by interpreting the input as evaluations of a polynomial over a
 /// power-of-two subgroup, and computing evaluations over a coset of that subgroup. This can be
 /// viewed as returning the parity elements of a systematic Reed-Solomon code. Since Reed-Solomon

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -57,8 +57,8 @@ pub fn apply_circulant<AF: AbstractField, const N: usize>(
 }
 
 /// Given the first row of a circulant matrix, return the first column.
-/// 
-/// For example if, `v = [0, 1, 2, 3, 4, 5]` then `output = [0, 5, 4, 3, 2, 1]`, 
+///
+/// For example if, `v = [0, 1, 2, 3, 4, 5]` then `output = [0, 5, 4, 3, 2, 1]`,
 /// i.e. the first element is the same and the other elements are reversed.
 ///
 /// This is useful to prepare a circulant matrix for input to an FFT
@@ -84,7 +84,7 @@ pub const fn first_row_to_first_col<const N: usize, T: Copy>(v: &[T; N]) -> [T; 
 
 /// Use the convolution theorem to calculate the product of the given
 /// circulant matrix and the given vector.
-/// 
+///
 /// The circulant matrix must be specified by its first *column*, not its first row. If you have
 /// the row as an array, you can obtain the column with `first_row_to_first_col()`.
 #[inline]

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -56,10 +56,10 @@ pub fn apply_circulant<AF: AbstractField, const N: usize>(
     output
 }
 
-/// Given the first row of a circulant matrix, return the first column
-/// of that circulant matrix. For example, v = [0, 1, 2, 3, 4, 5],
-/// then output = [0, 5, 4, 3, 2, 1], i.e. the first element is the
-/// same and the other elements are reversed.
+/// Given the first row of a circulant matrix, return the first column.
+/// 
+/// For example if, `v = [0, 1, 2, 3, 4, 5]` then `output = [0, 5, 4, 3, 2, 1]`, 
+/// i.e. the first element is the same and the other elements are reversed.
 ///
 /// This is useful to prepare a circulant matrix for input to an FFT
 /// algorithm, which expects the first column of the matrix rather
@@ -83,8 +83,9 @@ pub const fn first_row_to_first_col<const N: usize, T: Copy>(v: &[T; N]) -> [T; 
 }
 
 /// Use the convolution theorem to calculate the product of the given
-/// circulant matrix and the given vector. The circulant matrix must
-/// be specified by its first *column*, not its first row. If you have
+/// circulant matrix and the given vector.
+/// 
+/// The circulant matrix must be specified by its first *column*, not its first row. If you have
 /// the row as an array, you can obtain the column with `first_row_to_first_col()`.
 #[inline]
 pub fn apply_circulant_fft<F: TwoAdicField, const N: usize, FFT: TwoAdicSubgroupDft<F>>(

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -8,9 +8,9 @@ use p3_symmetric::Permutation;
 use crate::{monty_reduce, FieldParameters, MontyField31, MontyParameters};
 
 /// Trait implementing the internal linear layer for Poseidon2.
-/// 
-/// This contains everything needed to compute multiplication by a WIDTH x WIDTH 
-/// diffusion matrix whose monty form is `1 + Diag(vec)`. `vec` is assumed to be of 
+///
+/// This contains everything needed to compute multiplication by a WIDTH x WIDTH
+/// diffusion matrix whose monty form is `1 + Diag(vec)`. `vec` is assumed to be of
 /// the form `[-2, ...]` with all entries after the first being small powers of 2.
 pub trait DiffusionMatrixParameters<FP: FieldParameters, const WIDTH: usize>: Clone + Sync {
     // Most of the time, ArrayLike will be [u8; WIDTH - 1].

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -7,8 +7,11 @@ use p3_symmetric::Permutation;
 
 use crate::{monty_reduce, FieldParameters, MontyField31, MontyParameters};
 
-/// Everything needed to compute multiplication by a WIDTH x WIDTH diffusion matrix whose monty form is 1 + Diag(vec).
-/// vec is assumed to be of the form [-2, ...] with all entries after the first being small powers of 2.
+/// Trait implementing the internal linear layer for Poseidon2.
+/// 
+/// This contains everything needed to compute multiplication by a WIDTH x WIDTH 
+/// diffusion matrix whose monty form is `1 + Diag(vec)`. `vec` is assumed to be of 
+/// the form `[-2, ...]` with all entries after the first being small powers of 2.
 pub trait DiffusionMatrixParameters<FP: FieldParameters, const WIDTH: usize>: Clone + Sync {
     // Most of the time, ArrayLike will be [u8; WIDTH - 1].
     type ArrayLike: AsRef<[u8]> + Sized;

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -1,9 +1,11 @@
 use crate::hasher::CryptographicHasher;
 use crate::permutation::CryptographicPermutation;
 
-/// An `n`-to-1 compression function, like `CompressionFunction`, except that it need only be
-/// collision-resistant in a hash tree setting, where the preimage of a non-leaf node must consist
-/// of compression outputs.
+/// An `N`-to-1 compression function collision-resistant in a hash tree setting.
+/// 
+/// Unlike `CompressionFunction`, it may not be collision-resistant in general.
+/// Instead it is only collision-resistant in hash-tree like settings where 
+/// the preimage of a non-leaf node must consist of compression outputs.
 pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
     fn compress(&self, input: [T; N]) -> T;
 }

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -2,9 +2,9 @@ use crate::hasher::CryptographicHasher;
 use crate::permutation::CryptographicPermutation;
 
 /// An `N`-to-1 compression function collision-resistant in a hash tree setting.
-/// 
+///
 /// Unlike `CompressionFunction`, it may not be collision-resistant in general.
-/// Instead it is only collision-resistant in hash-tree like settings where 
+/// Instead it is only collision-resistant in hash-tree like settings where
 /// the preimage of a non-leaf node must consist of compression outputs.
 pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
     fn compress(&self, input: [T; N]) -> T;

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -17,7 +17,6 @@ use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::thread_rng;
 
 /// For testing the public values feature
-
 pub struct FibonacciAir {}
 
 impl<F> BaseAir<F> for FibonacciAir {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -202,6 +202,8 @@ where
     (buf, i)
 }
 
+/// Split an interator into small arrays and apply `func` to each.
+/// 
 /// Repeatedly read `BUFLEN` elements from `input` into an array and
 /// pass the array to `func` as a slice. If less than `BUFLEN`
 /// elements are remaining, that smaller slice is passed to `func` (if
@@ -222,9 +224,11 @@ where
     }
 }
 
-/// Converts a vector of one type to one of another type. This is useful to convert between things
-/// like `Vec<u32>` and `Vec<[u32; 10]>`, for example. This is roughly like a transmutation, except
-/// that we also adjust the vector's length and capacity based on the sizes of the two types.
+/// Converts a vector of one type to one of another type.
+/// 
+/// This is useful to convert between things like `Vec<u32>` and `Vec<[u32; 10]>`, for example.
+/// This is roughly like a transmutation, except that we also adjust the vector's length
+/// and capacity based on the sizes of the two types.
 ///
 /// # Safety
 /// In addition to the usual safety considerations around transmutation, the caller must ensure that

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -203,7 +203,7 @@ where
 }
 
 /// Split an interator into small arrays and apply `func` to each.
-/// 
+///
 /// Repeatedly read `BUFLEN` elements from `input` into an array and
 /// pass the array to `func` as a slice. If less than `BUFLEN`
 /// elements are remaining, that smaller slice is passed to `func` (if
@@ -225,7 +225,7 @@ where
 }
 
 /// Converts a vector of one type to one of another type.
-/// 
+///
 /// This is useful to convert between things like `Vec<u32>` and `Vec<[u32; 10]>`, for example.
 /// This is roughly like a transmutation, except that we also adjust the vector's length
 /// and capacity based on the sizes of the two types.


### PR DESCRIPTION
My Clippy seems to be a slightly newer version than the one in our CI and so gives me a couple of silly errors.

None of these changes should have any effect on timing or anything. Most of them are fixing: [too_long_first_doc_paragraph ](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph) which basically wants the first line of doc strings to be short. There are also a couple of [missing_transmute_annotations](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_transmute_annotations) and [needless_range_loop](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_range_loop).

I've tried where possible to rewrite the doc comments with minimal changes to meaning. Let me know if I've messed one up.
