### PR TITLE
perf: Avoid hashing together default digests (zeros) in MT construction

### DIFF
--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -86,7 +86,7 @@ fn bench_bb_blake3(criterion: &mut Criterion) {
     let b = Blake3 {};
     let c = C::new(b);
 
-    bench_mmcs::<F, u8, H, C, 32>(criterion, h.clone(), c.clone());
+    bench_mmcs::<F, u8, H, C, 32>(criterion, h, c.clone());
     bench_merkle_tree::<F, u8, H, C, 32>(criterion, h, c);
 }
 
@@ -100,7 +100,7 @@ fn bench_bb_keccak(criterion: &mut Criterion) {
     type C = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
     let c = C::new(k);
 
-    bench_mmcs::<F, u8, H, C, 32>(criterion, h.clone(), c.clone());
+    bench_mmcs::<F, u8, H, C, 32>(criterion, h, c.clone());
     bench_merkle_tree::<F, u8, H, C, 32>(criterion, h, c);
 }
 

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -80,7 +80,7 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
             if prev_layer.len() == 1 {
                 break;
             }
-            let next_layer_len = prev_layer.len().next_power_of_two() / 2;
+            let next_layer_len = (prev_layer.len() / 2).next_power_of_two();
 
             // The matrices that get injected at this layer.
             let matrices_to_inject = leaves_largest_first

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -211,7 +211,7 @@ where
     // for the last bit.
     for i in (next_len / width * width)..next_len {
         let left = prev_layer[2 * i];
-        let right = *prev_layer.get(2 * i + 1).unwrap_or(&default_digest);
+        let right = prev_layer[2 * i + 1];
         let digest = c.compress([left, right]);
         let rows_digest = h.hash_iter(matrices_to_inject.iter().flat_map(|m| m.row(i)));
         next_digests[i] = c.compress([digest, rows_digest]);
@@ -221,7 +221,7 @@ where
     // process above except with default_digest in place of an input digest.
     for i in next_len..next_len_padded {
         let left = prev_layer[2 * i];
-        let right = *prev_layer.get(2 * i + 1).unwrap_or(&default_digest);
+        let right = prev_layer[2 * i + 1];
         let digest = c.compress([left, right]);
         next_digests[i] = c.compress([digest, default_digest]);
     }

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -420,10 +420,7 @@ mod tests {
                     compress.compress([mat_1_leaf_hashes[4], default_digest]),
                     mat_2_leaf_hashes[2],
                 ]),
-                compress.compress([
-                    compress.compress([default_digest, default_digest]),
-                    default_digest,
-                ]),
+                default_digest,
             ]),
         ]);
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -351,17 +351,41 @@ mod tests {
         //   0 1
         //   2 1
         //   2 2
+        //   2 1
+        //   2 2
         // ]
         let mat_1 = RowMajorMatrix::new(
-            vec![F::zero(), F::one(), F::two(), F::one(), F::two(), F::two()],
+            vec![
+                F::zero(),
+                F::one(),
+                F::two(),
+                F::one(),
+                F::two(),
+                F::two(),
+                F::two(),
+                F::one(),
+                F::two(),
+                F::two(),
+            ],
             2,
         );
         // mat_2 = [
         //   1 2 1
         //   0 2 2
+        //   1 2 1
         // ]
         let mat_2 = RowMajorMatrix::new(
-            vec![F::one(), F::two(), F::one(), F::zero(), F::two(), F::two()],
+            vec![
+                F::one(),
+                F::two(),
+                F::one(),
+                F::zero(),
+                F::two(),
+                F::two(),
+                F::one(),
+                F::two(),
+                F::one(),
+            ],
             3,
         );
 
@@ -371,22 +395,38 @@ mod tests {
             hash.hash_slice(&[F::zero(), F::one()]),
             hash.hash_slice(&[F::two(), F::one()]),
             hash.hash_slice(&[F::two(), F::two()]),
+            hash.hash_slice(&[F::two(), F::one()]),
+            hash.hash_slice(&[F::two(), F::two()]),
         ];
         let mat_2_leaf_hashes = [
             hash.hash_slice(&[F::one(), F::two(), F::one()]),
             hash.hash_slice(&[F::zero(), F::two(), F::two()]),
+            hash.hash_slice(&[F::one(), F::two(), F::one()]),
         ];
 
         let expected_result = compress.compress([
             compress.compress([
-                compress.compress([mat_1_leaf_hashes[0], mat_1_leaf_hashes[1]]),
-                mat_2_leaf_hashes[0],
+                compress.compress([
+                    compress.compress([mat_1_leaf_hashes[0], mat_1_leaf_hashes[1]]),
+                    mat_2_leaf_hashes[0],
+                ]),
+                compress.compress([
+                    compress.compress([mat_1_leaf_hashes[2], mat_1_leaf_hashes[3]]),
+                    mat_2_leaf_hashes[1],
+                ]),
             ]),
             compress.compress([
-                compress.compress([mat_1_leaf_hashes[2], default_digest]),
-                mat_2_leaf_hashes[1],
+                compress.compress([
+                    compress.compress([mat_1_leaf_hashes[4], default_digest]),
+                    mat_2_leaf_hashes[2],
+                ]),
+                compress.compress([
+                    compress.compress([default_digest, default_digest]),
+                    default_digest,
+                ]),
             ]),
         ]);
+
         assert_eq!(commit, expected_result);
 
         let (opened_values, _proof) = mmcs.open_batch(2, &prover_data);

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -496,10 +496,18 @@ mod tests {
             width: 8,
         });
 
+        // 7 tiny mat with 1 row, 8 columns
+        let tiny_mats = (0..7).map(|_| RowMajorMatrix::<F>::rand(&mut thread_rng(), 1, 8));
+        let tiny_mat_dims = (0..7).map(|_| Dimensions {
+            height: 1,
+            width: 8,
+        });
+
         let (commit, prover_data) = mmcs.commit(
             large_mats
                 .chain(medium_mats)
                 .chain(small_mats)
+                .chain(tiny_mats)
                 .collect_vec(),
         );
 
@@ -510,6 +518,7 @@ mod tests {
             &large_mat_dims
                 .chain(medium_mat_dims)
                 .chain(small_mat_dims)
+                .chain(tiny_mat_dims)
                 .collect_vec(),
             6,
             &opened_values,

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -258,6 +258,24 @@ mod tests {
     }
 
     #[test]
+    fn commit_single_8x1() {
+        let perm = Perm::new_from_rng_128(
+            Poseidon2ExternalMatrixGeneral,
+            DiffusionMatrixBabyBear::default(),
+            &mut thread_rng(),
+        );
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash.clone(), compress.clone());
+
+        let mat = RowMajorMatrix::<F>::rand(&mut thread_rng(), 1, 8);
+        let (commit, _) = mmcs.commit(vec![mat.clone()]);
+
+        let expected_result = hash.hash_iter(mat.clone().vertically_packed_row(0));
+        assert_eq!(commit, expected_result);
+    }
+
+    #[test]
     fn commit_single_2x2() {
         let perm = Perm::new_from_rng_128(
             Poseidon2ExternalMatrixGeneral,


### PR DESCRIPTION
When matrices have #rows != pow-of-two, there is no reason we should be padding to the next power of two and hashing all the zeros together. We can save prover time by avoiding hashing the trailing zeros.

These changes affect the root computation (the digest changes).
The API for opening & verification stay the same.
The changes make the code a bit less elegant.
Also note that if higher arity trees are ever introduced, the `_padded` lengths would need to change from even, to divisible by the arity (ariteven?).

The change is best illustrated with these two matrices: this exact test is included, see commit 62d02bcc373c016f2ec716fd98e9ac69b8cf6cfd which adds the test case for current construction (initially broken) and a59d70663c0e0580d79f5a3731785d7984b6e7e3 which fixes it to adapt to this PR.
mat1: 5 rows
mat2: 3 rows

**Previous MT construction**
```
let expected_result = compress.compress([
    compress.compress([
        compress.compress([
            compress.compress([mat_1_leaf_hashes[0], mat_1_leaf_hashes[1]]),
            mat_2_leaf_hashes[0],
        ]),
        compress.compress([
            compress.compress([mat_1_leaf_hashes[2], mat_1_leaf_hashes[3]]),
            mat_2_leaf_hashes[1],
        ]),
    ]),
    compress.compress([
        compress.compress([
            compress.compress([mat_1_leaf_hashes[4], default_digest]),
            mat_2_leaf_hashes[2],
        ]),
        compress.compress([
            compress.compress([default_digest, default_digest]),
            default_digest,
        ]),
    ]),
]);
```

**Improved MT construction**
```
let expected_result = compress.compress([
    compress.compress([
        compress.compress([
            compress.compress([mat_1_leaf_hashes[0], mat_1_leaf_hashes[1]]),
            mat_2_leaf_hashes[0],
        ]),
        compress.compress([
            compress.compress([mat_1_leaf_hashes[2], mat_1_leaf_hashes[3]]),
            mat_2_leaf_hashes[1],
        ]),
    ]),
    compress.compress([
        compress.compress([
            compress.compress([mat_1_leaf_hashes[4], default_digest]),
            mat_2_leaf_hashes[2],
        ]),
        default_digest,
    ]),
]);
```


# Bench results
All single threaded

### current, Blake3
```
MerkleTreeMmcs::<p3_symmetric::serializing_hasher::SerializingHasher32<p3_blake3::Blake3>, p3_symmet...
                        time:   [128.64 ms 128.73 ms 128.81 ms]
```

### improved, Blake3
```
MerkleTreeMmcs::<p3_symmetric::serializing_hasher::SerializingHasher32<p3_blake3::Blake3>, p3_symmet...
                        time:   [119.55 ms 119.87 ms 120.17 ms]
                        change: [-7.1368% -6.9825% -6.8059%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### current, Poseidon2
```
MerkleTreeMmcs::<p3_symmetric::sponge::PaddingFreeSponge<p3_poseidon2::Poseidon2<p3_monty_31::monty_...
                        time:   [351.35 ms 351.40 ms 351.45 ms]
```

### improved, Poseidon2
```
MerkleTreeMmcs::<p3_symmetric::sponge::PaddingFreeSponge<p3_poseidon2::Poseidon2<p3_monty_31::monty_...
                        time:   [317.10 ms 317.15 ms 317.19 ms]
                        change: [-9.7650% -9.7472% -9.7289%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### Parallel
-29.180% for Blake3
-45.842% for Poseidon2

https://github.com/NP-Eng/Plonky3/tree/mmagician/hash-zeroes-par/
vs. 
https://github.com/NP-Eng/Plonky3/tree/mmagician/skip-hashing-zeroes-par