### PR TITLE
refactor: Simplify implementation of symbolic arithmetic operations

### DIFF
--- a/uni-stark/src/symbolic_variable.rs
+++ b/uni-stark/src/symbolic_variable.rs
@@ -1,9 +1,7 @@
+use crate::symbolic_expression::SymbolicExpression;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Sub};
-
 use p3_field::Field;
-
-use crate::symbolic_expression::SymbolicExpression;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Entry {
@@ -16,13 +14,13 @@ pub enum Entry {
 
 /// A variable within the evaluation window, i.e. a column in either the local or next row.
 #[derive(Copy, Clone, Debug)]
-pub struct SymbolicVariable<F: Field> {
+pub struct SymbolicVariable<F> {
     pub entry: Entry,
     pub index: usize,
     pub(crate) _phantom: PhantomData<F>,
 }
 
-impl<F: Field> SymbolicVariable<F> {
+impl<F> SymbolicVariable<F> {
     pub const fn new(entry: Entry, index: usize) -> Self {
         Self {
             entry,
@@ -45,98 +43,35 @@ impl<F: Field> From<SymbolicVariable<F>> for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> Add for SymbolicVariable<F> {
+impl<F: Field, T> Add<T> for SymbolicVariable<F>
+where
+    T: Into<SymbolicExpression<F>>,
+{
     type Output = SymbolicExpression<F>;
 
-    fn add(self, rhs: Self) -> Self::Output {
-        SymbolicExpression::from(self) + SymbolicExpression::from(rhs)
+    fn add(self, rhs: T) -> Self::Output {
+        SymbolicExpression::from(self) + rhs.into()
     }
 }
 
-impl<F: Field> Add<F> for SymbolicVariable<F> {
+impl<F: Field, T> Sub<T> for SymbolicVariable<F>
+where
+    T: Into<SymbolicExpression<F>>,
+{
     type Output = SymbolicExpression<F>;
 
-    fn add(self, rhs: F) -> Self::Output {
-        SymbolicExpression::from(self) + SymbolicExpression::from(rhs)
+    fn sub(self, rhs: T) -> Self::Output {
+        SymbolicExpression::from(self) - rhs.into()
     }
 }
 
-impl<F: Field> Add<SymbolicExpression<F>> for SymbolicVariable<F> {
+impl<F: Field, T> Mul<T> for SymbolicVariable<F>
+where
+    T: Into<SymbolicExpression<F>>,
+{
     type Output = SymbolicExpression<F>;
 
-    fn add(self, rhs: SymbolicExpression<F>) -> Self::Output {
-        SymbolicExpression::from(self) + rhs
-    }
-}
-
-impl<F: Field> Add<SymbolicVariable<F>> for SymbolicExpression<F> {
-    type Output = Self;
-
-    fn add(self, rhs: SymbolicVariable<F>) -> Self::Output {
-        self + Self::from(rhs)
-    }
-}
-
-impl<F: Field> Sub for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        SymbolicExpression::from(self) - SymbolicExpression::from(rhs)
-    }
-}
-
-impl<F: Field> Sub<F> for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn sub(self, rhs: F) -> Self::Output {
-        SymbolicExpression::from(self) - SymbolicExpression::from(rhs)
-    }
-}
-
-impl<F: Field> Sub<SymbolicExpression<F>> for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn sub(self, rhs: SymbolicExpression<F>) -> Self::Output {
-        SymbolicExpression::from(self) - rhs
-    }
-}
-
-impl<F: Field> Sub<SymbolicVariable<F>> for SymbolicExpression<F> {
-    type Output = Self;
-
-    fn sub(self, rhs: SymbolicVariable<F>) -> Self::Output {
-        self - Self::from(rhs)
-    }
-}
-
-impl<F: Field> Mul for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        SymbolicExpression::from(self) * SymbolicExpression::from(rhs)
-    }
-}
-
-impl<F: Field> Mul<F> for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn mul(self, rhs: F) -> Self::Output {
-        SymbolicExpression::from(self) * SymbolicExpression::from(rhs)
-    }
-}
-
-impl<F: Field> Mul<SymbolicExpression<F>> for SymbolicVariable<F> {
-    type Output = SymbolicExpression<F>;
-
-    fn mul(self, rhs: SymbolicExpression<F>) -> Self::Output {
-        SymbolicExpression::from(self) * rhs
-    }
-}
-
-impl<F: Field> Mul<SymbolicVariable<F>> for SymbolicExpression<F> {
-    type Output = Self;
-
-    fn mul(self, rhs: SymbolicVariable<F>) -> Self::Output {
-        self * Self::from(rhs)
+    fn mul(self, rhs: T) -> Self::Output {
+        SymbolicExpression::from(self) * rhs.into()
     }
 }

--- a/uni-stark/src/symbolic_variable.rs
+++ b/uni-stark/src/symbolic_variable.rs
@@ -1,7 +1,9 @@
-use crate::symbolic_expression::SymbolicExpression;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Sub};
+
 use p3_field::Field;
+
+use crate::symbolic_expression::SymbolicExpression;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Entry {


### PR DESCRIPTION
Small refactor to combine different arithmetic operations over `SymbolicExpression` and `SymbolicVariable`. In particular, for each `Op = Add, Sub, Mul`, we replace the 8 implementations

```rust 
// expr * f
impl<F> Op<F> for SymbolicExpression<F> {}
// expr * var
impl<F> Op<SymbolicVariable<F>> for SymbolicExpression<F> {}
// expr * expr
impl<F> Op for SymbolicExpression<F> {}

// expr += f
impl<F> OpAssign<F> for SymbolicExpression<F> {}
// expr += expr
impl<F> OpAssign for SymbolicExpression<F> {}

// var + f
impl<F> Op<F> for SymbolicVariable<F> {}
// var + var
impl<F> Op for SymbolicVariable<F> {}
// var + expr
impl<F> Op<SymbolicExpression<F>> for SymbolicVariable<F> {}
```

with 3 generic ones that take advantage of `Into<SymbolicExpression<F>>`.

```rust 
// expr + {f, var, expr}
impl<F, T: Into<Self>> Op<T> for SymbolicExpression<F> {}
// expr += {f, var, expr}
impl<F, T: Into<Self>> OpAssign<T> for SymbolicExpression<F> {}
// var + {f, var, expr}
impl<F, T: Into<SymbolicExpression<F>> Op<T> for SymbolicVariable<F> {}
```

In addition, when two expression operands are constants, we compute the expression directly rather than creating new nodes in the tree.