### PR TITLE
Speeding up Vertically_Packed_Row

### DIFF
--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -1,6 +1,8 @@
 use core::iter;
 use core::marker::PhantomData;
+use core::ops::Deref;
 
+use alloc::vec::Vec;
 use p3_field::{ExtensionField, Field};
 
 use crate::Matrix;
@@ -44,6 +46,17 @@ where
             idx: 0,
             _phantom: PhantomData,
         }
+    }
+
+    fn row_slice(&self, r: usize) -> impl Deref<Target = [F]> {
+        let ef_row: Vec<F> = self
+            .0
+            .row_slice(r)
+            .iter()
+            .flat_map(|val| val.as_base_slice())
+            .copied()
+            .collect();
+        ef_row
     }
 }
 

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -1,8 +1,8 @@
+use alloc::vec::Vec;
 use core::iter;
 use core::marker::PhantomData;
 use core::ops::Deref;
 
-use alloc::vec::Vec;
 use p3_field::{ExtensionField, Field};
 
 use crate::Matrix;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -185,12 +185,13 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     /// height of the matrix, wrap around and include initial rows.
     ///
     /// We assume P::WIDTH > step which lets us batch together getting the relevant matrix rows.
+    /// If a larger step size is needed, we should instead run vertically_packed_row twice.
     fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
     where
         T: Copy,
         P: PackedValue<Value = T>,
     {
-        debug_assert!(P::WIDTH > step);
+        debug_assert!((P::WIDTH == 1) || (P::WIDTH >= step));
         let rows = (0..(P::WIDTH + step))
             .map(|c| self.row_slice((r + c) % self.height()))
             .collect_vec();

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -191,6 +191,8 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Copy,
         P: PackedValue<Value = T>,
     {
+        // We include the P::WIDTH == 1 option so we can pass tests.
+        // This should always be run with vectorization in practice.
         debug_assert!((P::WIDTH == 1) || (P::WIDTH >= step));
         let rows = (0..(P::WIDTH + step))
             .map(|c| self.row_slice((r + c) % self.height()))

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -162,10 +162,10 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
 
     /// Pack together a collection of adjacent rows from the matrix.
     ///
-    /// Returns a vector whose i'th element is packing of the i'th element of the
+    /// Returns an iterator whose i'th element is packing of the i'th element of the
     /// rows r through r + P::WIDTH - 1. If we exceed the height of the matrix,
     /// wrap around and include initial rows.
-    fn vertically_packed_row<P>(&self, r: usize) -> Vec<P>
+    fn vertically_packed_row<P>(&self, r: usize) -> impl Iterator<Item = P>
     where
         T: Copy,
         P: PackedValue<Value = T>,
@@ -173,9 +173,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         let rows = (0..(P::WIDTH))
             .map(|c| self.row_slice((r + c) % self.height()))
             .collect_vec();
-        (0..self.width())
-            .map(|c| P::from_fn(|i| rows[i][c]))
-            .collect_vec()
+        (0..self.width()).map(move |c| P::from_fn(|i| rows[i][c]))
     }
 
     /// Pack together a collection of rows and "next" rows from the matrix.

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -170,13 +170,27 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     }
 
     /// Wraps at the end.
+    fn one_vertically_packed_row<P>(&self, r: usize) -> Vec<P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        let rows = (0..(P::WIDTH))
+            .map(move |c| self.row_slice((r + c) % self.height()))
+            .collect_vec();
+        iter::empty()
+            .chain((0..self.width()).map(|c| P::from_fn(|i| rows[i][c])))
+            .collect_vec()
+    }
+
+    /// Wraps at the end.
     fn two_vertically_packed_rows<P>(&self, r: usize, step: usize) -> Vec<P>
     where
         T: Copy,
         P: PackedValue<Value = T>,
     {
         let rows = (0..(P::WIDTH + step))
-            .map(move |c| self.row((r + c) % self.height()).collect_vec())
+            .map(move |c| self.row_slice((r + c) % self.height()))
             .collect_vec();
         iter::empty()
             .chain((0..self.width()).map(|c| P::from_fn(|i| rows[i][c])))

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -183,11 +183,14 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     /// The i'th element of the second row contains the packing of the i'th element of the
     /// rows r + step through r + step + P::WIDTH - 1. If at some point we exceed the
     /// height of the matrix, wrap around and include initial rows.
+    ///
+    /// We assume P::WIDTH > step which lets us batch together getting the relevant matrix rows.
     fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
     where
         T: Copy,
         P: PackedValue<Value = T>,
     {
+        debug_assert!(P::WIDTH > step);
         let rows = (0..(P::WIDTH + step))
             .map(|c| self.row_slice((r + c) % self.height()))
             .collect_vec();

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -33,7 +33,7 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
 {
     /// Matrix heights need not be powers of two. However, if the heights of two given matrices
     /// round up to the same power of two, they must be equal.
-    #[instrument(name = "build merkle tree", level = "debug", skip_all,
+    #[instrument(name = "build merkle tree", level = "info", skip_all,
                  fields(dimensions = alloc::format!("{:?}", leaves.iter().map(|l| l.dimensions()).collect::<Vec<_>>())))]
     pub fn new<P, PW, H, C>(h: &H, c: &C, leaves: Vec<M>) -> Self
     where
@@ -140,7 +140,7 @@ where
             let packed_digest: [PW; DIGEST_ELEMS] = h.hash_iter(
                 tallest_matrices
                     .iter()
-                    .flat_map(|m| m.vertically_packed_row(first_row)),
+                    .flat_map(|m| m.one_vertically_packed_row(first_row)),
             );
             for (dst, src) in digests_chunk.iter_mut().zip(unpack_array(packed_digest)) {
                 *dst = src;
@@ -199,7 +199,7 @@ where
             let tallest_digest = h.hash_iter(
                 matrices_to_inject
                     .iter()
-                    .flat_map(|m| m.vertically_packed_row(first_row)),
+                    .flat_map(|m| m.one_vertically_packed_row(first_row)),
             );
             packed_digest = c.compress([packed_digest, tallest_digest]);
             for (dst, src) in digests_chunk.iter_mut().zip(unpack_array(packed_digest)) {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -140,7 +140,7 @@ where
             let packed_digest: [PW; DIGEST_ELEMS] = h.hash_iter(
                 tallest_matrices
                     .iter()
-                    .flat_map(|m| m.one_vertically_packed_row(first_row)),
+                    .flat_map(|m| m.vertically_packed_row(first_row)),
             );
             for (dst, src) in digests_chunk.iter_mut().zip(unpack_array(packed_digest)) {
                 *dst = src;
@@ -199,7 +199,7 @@ where
             let tallest_digest = h.hash_iter(
                 matrices_to_inject
                     .iter()
-                    .flat_map(|m| m.one_vertically_packed_row(first_row)),
+                    .flat_map(|m| m.vertically_packed_row(first_row)),
             );
             packed_digest = c.compress([packed_digest, tallest_digest]);
             for (dst, src) in digests_chunk.iter_mut().zip(unpack_array(packed_digest)) {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -33,7 +33,7 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const DIGEST_ELEMS: usize>
 {
     /// Matrix heights need not be powers of two. However, if the heights of two given matrices
     /// round up to the same power of two, they must be equal.
-    #[instrument(name = "build merkle tree", level = "info", skip_all,
+    #[instrument(name = "build merkle tree", level = "debug", skip_all,
                  fields(dimensions = alloc::format!("{:?}", leaves.iter().map(|l| l.dimensions()).collect::<Vec<_>>())))]
     pub fn new<P, PW, H, C>(h: &H, c: &C, leaves: Vec<M>) -> Self
     where

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -169,7 +169,7 @@ where
             let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
 
             let main = RowMajorMatrix::new(
-                trace_on_quotient_domain.two_vertically_packed_rows(i_start, next_step),
+                trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
                 width,
             );
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -169,8 +169,6 @@ where
             let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
 
             let main = RowMajorMatrix::new(
-                // vertically_packed_row_pair should only be used if next_step = 1, 2, 4.
-                // Potentially want to add an if branch here or something similar.
                 trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
                 width,
             );

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -169,6 +169,8 @@ where
             let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
 
             let main = RowMajorMatrix::new(
+                // vertically_packed_row_pair should only be used if next_step = 1, 2, 4.
+                // Potentially want to add an if branch here or something similar.
                 trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
                 width,
             );

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -1,6 +1,5 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use core::iter;
 
 use itertools::{izip, Itertools};
 use p3_air::Air;
@@ -170,10 +169,7 @@ where
             let inv_zeroifier = *PackedVal::<SC>::from_slice(&sels.inv_zeroifier[i_range.clone()]);
 
             let main = RowMajorMatrix::new(
-                iter::empty()
-                    .chain(trace_on_quotient_domain.vertically_packed_row(i_start))
-                    .chain(trace_on_quotient_domain.vertically_packed_row(i_start + next_step))
-                    .collect_vec(),
+                trace_on_quotient_domain.two_vertically_packed_rows(i_start, next_step),
                 width,
             );
 


### PR DESCRIPTION
Currently vertically_packed_row is creating an expensive iterator which may repeatably run through rows of a given matrix.

We split vertically_packed_row into 2 entities. One which returns a single packed row and one which returns a pair of a packed row and a pack "next" row.

This gives around a 5-10% speed-up  to the examples prove_poseidon2_koala_bear_keccak and prove_poseidon2_m31_keccak. In particular "compute quotient polynomial" drops from ~16% to around 9%.