### PR TITLE
Modify `Radix2DitParallel` to treat a coset LDE...

### DIFF
--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -2,18 +2,18 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
-use itertools::{izip, Itertools};
-use p3_field::{scale_slice_in_place, Field, Powers, TwoAdicField};
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
+use itertools::izip;
+use p3_field::{Field, Powers, TwoAdicField};
+use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
-use p3_util::{log2_strict_usize, reverse_slice_index_bits};
-use tracing::instrument;
+use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
+use tracing::{debug_span, info_span, instrument};
 
 use crate::butterflies::{Butterfly, DitButterfly};
-use crate::TwoAdicSubgroupDft;
+use crate::{divide_by_height, TwoAdicSubgroupDft};
 
 /// A parallel FFT algorithm which divides a butterfly network's layers into two halves.
 ///
@@ -27,11 +27,11 @@ pub struct Radix2DitParallel<F> {
     /// Twiddles based on roots of unity, used in the forward DFT.
     twiddles: RefCell<BTreeMap<usize, VectorPair<F>>>,
 
+    /// A map from `(log_h, shift)` to forward DFT twiddles with that coset shift baked in.
+    coset_twiddles: RefCell<BTreeMap<(usize, F), Vec<Vec<F>>>>,
+
     /// Twiddles based on inverse roots of unity, used in the inverse DFT.
     inverse_twiddles: RefCell<BTreeMap<usize, VectorPair<F>>>,
-
-    /// A map from (log_h, shift) to the weights used in the middle of the coset LDE.
-    coset_lde_weights: RefCell<BTreeMap<(usize, F), Vec<F>>>,
 }
 
 /// A pair of vectors, one with twiddle factors in their natural order, the other bit-reversed.
@@ -55,6 +55,29 @@ fn compute_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F> {
 }
 
 #[instrument(level = "debug", skip_all)]
+fn compute_coset_twiddles<F: TwoAdicField + Ord>(log_h: usize, shift: F) -> Vec<Vec<F>> {
+    let mid = log_h / 2;
+    let h = 1 << log_h;
+    let root = F::two_adic_generator(log_h);
+
+    (0..log_h)
+        .map(|layer| {
+            let shift_power = shift.exp_power_of_2(layer);
+            let powers = Powers {
+                base: root.exp_power_of_2(layer),
+                current: shift_power,
+            };
+            let mut twiddles: Vec<_> = powers.take(h >> (layer + 1)).collect();
+            let layer_rev = log_h - 1 - layer;
+            if layer_rev >= mid {
+                reverse_slice_index_bits(&mut twiddles);
+            }
+            twiddles
+        })
+        .collect()
+}
+
+#[instrument(level = "debug", skip_all)]
 fn compute_inverse_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F> {
     let half_h = (1 << log_h) >> 1;
     let root_inv = F::two_adic_generator(log_h).inverse();
@@ -68,21 +91,6 @@ fn compute_inverse_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F
         twiddles,
         bit_reversed_twiddles,
     }
-}
-
-/// weights used in the middle of the coset LDE.
-#[instrument(level = "debug", skip_all)]
-fn compute_coset_lde_weighs<F: TwoAdicField>(log_h: usize, shift: F) -> Vec<F> {
-    let h = 1 << log_h;
-    let h_inv = F::from_canonical_usize(h).inverse();
-    let mut weights = Powers {
-        base: shift,
-        current: h_inv,
-    }
-    .take(h)
-    .collect_vec();
-    reverse_slice_index_bits(&mut weights);
-    weights
 }
 
 impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
@@ -111,13 +119,14 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
         mat.bit_reverse_rows()
     }
 
-    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits))]
+    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits = added_bits))]
     fn coset_lde_batch(
         &self,
         mut mat: RowMajorMatrix<F>,
         added_bits: usize,
         shift: F,
     ) -> Self::Evaluations {
+        let w = mat.width;
         let h = mat.height();
         let log_h = log2_strict_usize(h);
         let mid = log_h / 2;
@@ -136,38 +145,83 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
         par_dit_layer_rev(&mut mat, mid, &twiddles.bit_reversed_twiddles);
         // We skip the final bit-reversal, since the next FFT expects bit-reversed input.
 
-        // Rescale coefficients in two ways:
-        // - divide by height (since we're doing an inverse DFT)
-        // - multiply by powers of the coset shift (see default coset LDE impl for an explanation)
-        let mut weights_ref_mut = self.coset_lde_weights.borrow_mut();
-        let weights = weights_ref_mut
-            .entry((log_h, shift))
-            .or_insert_with(|| compute_coset_lde_weighs(log_h, shift));
+        divide_by_height(&mut mat);
 
-        mat.par_rows_mut().enumerate().for_each(|(r, row)| {
-            scale_slice_in_place(weights[r], row);
-        });
+        // mat.values.resize(w * (h << added_bits), F::zero());
+        let target_capacity = w * (h << added_bits);
+        let to_reserve = target_capacity.saturating_sub(mat.values.capacity());
+        debug_span!("reserve_exact").in_scope(|| mat.values.reserve_exact(to_reserve));
+        unsafe {
+            mat.values.set_len(w * (h << added_bits));
+        }
 
-        mat = mat.bit_reversed_zero_pad(added_bits);
+        let g_big = F::two_adic_generator(log_h + added_bits);
 
-        let h = mat.height();
-        let log_h = log2_strict_usize(h);
-        let mid = log_h / 2;
+        // mat.values.spare_capacity_mut();
 
-        let mut twiddles_ref_mut = self.twiddles.borrow_mut();
-        let twiddles = twiddles_ref_mut
-            .entry(log_h)
-            .or_insert_with(|| compute_twiddles(log_h));
+        let mut coset_mats: Vec<RowMajorMatrixViewMut<F>> = mat.row_chunks_exact_mut(h).collect();
+        let mut first_coset_mat = coset_mats.remove(0);
 
-        // The first half looks like a normal DIT.
-        par_dit_layer(&mut mat, mid, &twiddles.twiddles);
+        for coset_idx in 1..(1 << added_bits) {
+            let total_shift = g_big.exp_u64(coset_idx as u64) * shift;
+            let coset_idx = reverse_bits_len(coset_idx, added_bits);
+            let dest = &mut coset_mats[coset_idx - 1]; // - 1 because we removed the first matrix.
+            dest.copy_from(&first_coset_mat); // todo
+            coset_dft(self, dest, total_shift);
+        }
 
-        // For the second half, we flip the DIT, working in bit-reversed order.
-        reverse_matrix_index_bits(&mut mat);
-        par_dit_layer_rev(&mut mat, mid, &twiddles.bit_reversed_twiddles);
+        // Now run a forward DFT on the very first coset, this time in-place.
+        coset_dft(self, &mut first_coset_mat.as_view_mut(), shift);
 
-        mat.bit_reverse_rows()
+        BitReversalPerm::new_view(mat)
     }
+}
+
+fn coset_dft<F: TwoAdicField + Ord>(
+    dft: &Radix2DitParallel<F>,
+    mut mat: &mut RowMajorMatrixViewMut<F>,
+    shift: F,
+) {
+    let log_h = log2_strict_usize(mat.height());
+    let mid = log_h / 2;
+
+    let mut twiddles_ref_mut = dft.coset_twiddles.borrow_mut();
+    let twiddles = twiddles_ref_mut
+        .entry((log_h, shift))
+        .or_insert_with(|| compute_coset_twiddles(log_h, shift));
+
+    // The first half looks like a normal DIT.
+    // par_dit_layer(&mut mat, mid, &old_twiddles.twiddles);
+    info_span!("modified par_dit_layer").in_scope(|| {
+        mat.par_row_chunks_exact_mut(1 << mid)
+            .for_each(|mut submat| {
+                for layer in 0..mid {
+                    let layer_rev = log_h - 1 - layer;
+                    dit_layer(&mut submat, layer, twiddles[layer_rev].iter().copied());
+                }
+            });
+    });
+
+    // For the second half, we flip the DIT, working in bit-reversed order.
+    reverse_matrix_index_bits(&mut mat);
+
+    // par_dit_layer_rev(&mut mat, mid, &old_twiddles.bit_reversed_twiddles);
+    info_span!("modified par_dit_layer_rev").in_scope(|| {
+        mat.par_row_chunks_exact_mut(1 << (log_h - mid))
+            .enumerate()
+            .for_each(|(thread, mut submat)| {
+                for layer in mid..log_h {
+                    let layer_rev = log_h - 1 - layer;
+                    let first_block = thread << (layer - mid);
+                    dit_layer_rev(
+                        &mut submat,
+                        log_h,
+                        layer,
+                        twiddles[layer_rev][first_block..].iter().copied(),
+                    );
+                }
+            });
+    });
 }
 
 /// This can be used as the first half of a parallelized butterfly network.
@@ -179,7 +233,13 @@ fn par_dit_layer<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles: &[
     mat.par_row_chunks_exact_mut(1 << mid)
         .for_each(|mut submat| {
             for layer in 0..mid {
-                dit_layer(&mut submat, log_h, layer, twiddles);
+                let layer_rev = log_h - 1 - layer;
+                let layer_pow = 1 << layer_rev;
+                dit_layer(
+                    &mut submat,
+                    layer,
+                    twiddles.iter().copied().step_by(layer_pow),
+                );
             }
         });
 }
@@ -195,7 +255,12 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
         .for_each(|(thread, mut submat)| {
             for layer in mid..log_h {
                 let first_block = thread << (layer - mid);
-                dit_layer_rev(&mut submat, log_h, layer, &twiddles_rev[first_block..]);
+                dit_layer_rev(
+                    &mut submat,
+                    log_h,
+                    layer,
+                    twiddles_rev[first_block..].iter().copied(),
+                );
             }
         });
 }
@@ -203,13 +268,9 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
 /// One layer of a DIT butterfly network.
 fn dit_layer<F: Field>(
     submat: &mut RowMajorMatrixViewMut<'_, F>,
-    log_h: usize,
     layer: usize,
-    twiddles: &[F],
+    twiddles: impl Iterator<Item = F> + Clone,
 ) {
-    let layer_rev = log_h - 1 - layer;
-    let layer_pow = 1 << layer_rev;
-
     let half_block_size = 1 << layer;
     let block_size = half_block_size * 2;
     let width = submat.width();
@@ -218,10 +279,10 @@ fn dit_layer<F: Field>(
     for block in submat.values.chunks_mut(block_size * width) {
         let (lows, highs) = block.split_at_mut(half_block_size * width);
 
-        for (lo, hi, &twiddle) in izip!(
+        for (lo, hi, twiddle) in izip!(
             lows.chunks_mut(width),
             highs.chunks_mut(width),
-            twiddles.iter().step_by(layer_pow)
+            twiddles.clone()
         ) {
             DitButterfly(twiddle).apply_to_rows(lo, hi);
         }
@@ -234,7 +295,7 @@ fn dit_layer_rev<F: Field>(
     submat: &mut RowMajorMatrixViewMut<'_, F>,
     log_h: usize,
     layer: usize,
-    twiddles_rev: &[F],
+    twiddles_rev: impl Iterator<Item = F>,
 ) {
     let layer_rev = log_h - 1 - layer;
 
@@ -243,7 +304,7 @@ fn dit_layer_rev<F: Field>(
     let width = submat.width();
     debug_assert!(submat.height() >= block_size);
 
-    for (block, &twiddle) in submat
+    for (block, twiddle) in submat
         .values
         .chunks_mut(block_size * width)
         .zip(twiddles_rev)

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -5,6 +5,7 @@ use core::iter::Sum;
 use core::ops::Mul;
 
 use num_bigint::BigUint;
+use p3_maybe_rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::field::Field;
 use crate::{AbstractField, PackedValue, PrimeField, PrimeField32, TwoAdicField};
@@ -55,7 +56,7 @@ pub fn scale_vec<F: Field>(s: F, vec: Vec<F>) -> Vec<F> {
 pub fn scale_slice_in_place<F: Field>(s: F, slice: &mut [F]) {
     let (packed, sfx) = F::Packing::pack_slice_with_suffix_mut(slice);
     let packed_s: F::Packing = s.into();
-    packed.iter_mut().for_each(|x| *x *= packed_s);
+    packed.par_iter_mut().for_each(|x| *x *= packed_s);
     sfx.iter_mut().for_each(|x| *x *= s);
 }
 

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -95,6 +95,22 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         RowMajorMatrixViewMut::new(self.values.borrow_mut(), self.width)
     }
 
+    pub fn copy_from<S2>(&mut self, source: &DenseMatrix<T, S2>)
+    where
+        T: Copy,
+        S: BorrowMut<[T]>,
+        S2: DenseStorage<T>,
+    {
+        assert_eq!(self.dimensions(), source.dimensions());
+        // Equivalent to:
+        // self.values.borrow_mut().copy_from_slice(source.values.borrow());
+        self.par_rows_mut()
+            .zip(source.par_row_slices())
+            .for_each(|(dst, src)| {
+                dst.copy_from_slice(src);
+            });
+    }
+
     pub fn flatten_to_base<F: Field>(&self) -> RowMajorMatrix<F>
     where
         T: ExtensionField<F>,
@@ -225,6 +241,20 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         self.values
             .borrow_mut()
             .par_chunks_mut(self.width * chunk_rows)
+            .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
+    }
+
+    pub fn row_chunks_exact_mut(
+        &mut self,
+        chunk_rows: usize,
+    ) -> impl Iterator<Item = RowMajorMatrixViewMut<T>>
+    where
+        T: Send,
+        S: BorrowMut<[T]>,
+    {
+        self.values
+            .borrow_mut()
+            .chunks_exact_mut(self.width * chunk_rows)
             .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
     }
 

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -28,7 +28,7 @@ pub mod stack;
 pub mod strided;
 pub mod util;
 
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Dimensions {
     pub width: usize,
     pub height: usize,

--- a/matrix/src/util.rs
+++ b/matrix/src/util.rs
@@ -1,16 +1,22 @@
+use core::borrow::BorrowMut;
+
 use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 use tracing::instrument;
 
-use crate::dense::RowMajorMatrix;
+use crate::dense::{DenseMatrix, DenseStorage, RowMajorMatrix};
 use crate::Matrix;
 
 #[instrument(level = "debug", skip_all)]
-pub fn reverse_matrix_index_bits<F: Clone + Send + Sync>(mat: &mut RowMajorMatrix<F>) {
+pub fn reverse_matrix_index_bits<'a, F, S>(mat: &mut DenseMatrix<F, S>)
+where
+    F: Clone + Send + Sync + 'a,
+    S: DenseStorage<F> + BorrowMut<[F]>,
+{
     let w = mat.width();
     let h = mat.height();
     let log_h = log2_strict_usize(h);
-    let values = mat.values.as_mut_ptr() as usize;
+    let values = mat.values.borrow_mut().as_mut_ptr() as usize;
 
     (0..h).into_par_iter().for_each(|i| {
         let values = values as *mut F;

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -120,7 +120,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     let fri_config = FriConfig {
-        log_blowup: 1,
+        log_blowup: 1, // TODO: Should this be 3? Why is it working?
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 use p3_field::PrimeField;
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_maybe_rayon::prelude::*;
 use p3_poseidon2::{DiffusionPermutation, MdsLightPermutation};
 use tracing::instrument;
@@ -36,16 +37,12 @@ pub fn generate_vectorized_trace_rows<
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
     let mut vec = Vec::with_capacity(nrows * ncols * 2);
-    unsafe {
-        vec.set_len(nrows * ncols); // TODO unsafe
-    }
-    // vec.resize(nrows * ncols, F::zero());
-    // let vec = F::zero_vec(nrows * ncols);
-    let mut trace = RowMajorMatrix::new(vec, ncols);
+    let trace: &mut [MaybeUninit<F>] = &mut vec.spare_capacity_mut()[..nrows * ncols];
+    let trace: RowMajorMatrixViewMut<MaybeUninit<F>> = RowMajorMatrixViewMut::new(trace, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
-            F,
+            MaybeUninit<F>,
             WIDTH,
             SBOX_DEGREE,
             SBOX_REGISTERS,
@@ -67,7 +64,10 @@ pub fn generate_vectorized_trace_rows<
         );
     });
 
-    trace
+    unsafe {
+        vec.set_len(nrows * ncols);
+    }
+    RowMajorMatrix::new(vec, ncols)
 }
 
 // TODO: Take generic iterable
@@ -95,16 +95,12 @@ pub fn generate_trace_rows<
 
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>();
     let mut vec = Vec::with_capacity(n * ncols * 2);
-    unsafe {
-        vec.set_len(n * ncols); // TODO unsafe
-    }
-    // vec.resize(n * ncols, F::zero());
-    // let vec = F::zero_vec(n * ncols);
-    let mut trace = RowMajorMatrix::new(vec, ncols);
+    let trace: &mut [MaybeUninit<F>] = &mut vec.spare_capacity_mut()[..n * ncols];
+    let trace: RowMajorMatrixViewMut<MaybeUninit<F>> = RowMajorMatrixViewMut::new(trace, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
-            F,
+            MaybeUninit<F>,
             WIDTH,
             SBOX_DEGREE,
             SBOX_REGISTERS,
@@ -126,7 +122,10 @@ pub fn generate_trace_rows<
         );
     });
 
-    trace
+    unsafe {
+        vec.set_len(n * ncols);
+    }
+    RowMajorMatrix::new(vec, ncols)
 }
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
@@ -141,7 +140,7 @@ fn generate_trace_rows_for_perm<
     const PARTIAL_ROUNDS: usize,
 >(
     perm: &mut Poseidon2Cols<
-        F,
+        MaybeUninit<F>,
         WIDTH,
         SBOX_DEGREE,
         SBOX_REGISTERS,
@@ -153,8 +152,13 @@ fn generate_trace_rows_for_perm<
     external_linear_layer: &MdsLight,
     internal_linear_layer: &Diffusion,
 ) {
-    perm.export = F::one();
-    perm.inputs = state;
+    perm.export.write(F::one());
+    perm.inputs
+        .iter_mut()
+        .zip(state.iter())
+        .for_each(|(input, &x)| {
+            input.write(x);
+        });
 
     external_linear_layer.permute_mut(&mut state);
 
@@ -207,7 +211,7 @@ fn generate_full_round<
     const SBOX_REGISTERS: usize,
 >(
     state: &mut [F; WIDTH],
-    full_round: &mut FullRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
+    full_round: &mut FullRound<MaybeUninit<F>, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constants: &[F; WIDTH],
     external_linear_layer: &MdsLight,
 ) {
@@ -218,7 +222,13 @@ fn generate_full_round<
         generate_sbox(sbox_i, state_i);
     }
     external_linear_layer.permute_mut(state);
-    full_round.post = *state;
+    full_round
+        .post
+        .iter_mut()
+        .zip(*state)
+        .for_each(|(post, x)| {
+            post.write(x);
+        });
 }
 
 #[inline]
@@ -230,19 +240,19 @@ fn generate_partial_round<
     const SBOX_REGISTERS: usize,
 >(
     state: &mut [F; WIDTH],
-    partial_round: &mut PartialRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
+    partial_round: &mut PartialRound<MaybeUninit<F>, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constant: F,
     internal_linear_layer: &Diffusion,
 ) {
     state[0] += round_constant;
     generate_sbox(&mut partial_round.sbox, &mut state[0]);
-    partial_round.post_sbox = state[0];
+    partial_round.post_sbox.write(state[0]);
     internal_linear_layer.permute_mut(state);
 }
 
 #[inline]
 fn generate_sbox<F: PrimeField, const DEGREE: usize, const REGISTERS: usize>(
-    sbox: &mut SBox<F, DEGREE, REGISTERS>,
+    sbox: &mut SBox<MaybeUninit<F>, DEGREE, REGISTERS>,
     x: &mut F,
 ) {
     *x = match (DEGREE, REGISTERS) {
@@ -252,20 +262,20 @@ fn generate_sbox<F: PrimeField, const DEGREE: usize, const REGISTERS: usize>(
         (5, 1) => {
             let x2 = x.square();
             let x3 = x2 * *x;
-            sbox.0[0] = x3;
+            sbox.0[0].write(x3);
             x3 * x2
         }
         (7, 1) => {
             let x3 = x.cube();
-            sbox.0[0] = x3;
+            sbox.0[0].write(x3);
             x3 * x3 * *x
         }
         (11, 2) => {
             let x2 = x.square();
             let x3 = x2 * *x;
             let x9 = x3.cube();
-            sbox.0[0] = x3;
-            sbox.0[1] = x9;
+            sbox.0[0].write(x3);
+            sbox.0[1].write(x9);
             x9 * x2
         }
         _ => panic!(

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -35,7 +35,13 @@ pub fn generate_vectorized_trace_rows<
     let nrows = n.div_ceil(VECTOR_LEN);
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
-    let mut trace = RowMajorMatrix::new(F::zero_vec(nrows * ncols), ncols);
+    let mut vec = Vec::with_capacity(nrows * ncols * 2);
+    unsafe {
+        vec.set_len(nrows * ncols); // TODO unsafe
+    }
+    // vec.resize(nrows * ncols, F::zero());
+    // let vec = F::zero_vec(nrows * ncols);
+    let mut trace = RowMajorMatrix::new(vec, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
@@ -88,7 +94,13 @@ pub fn generate_trace_rows<
     );
 
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>();
-    let mut trace = RowMajorMatrix::new(F::zero_vec(n * ncols), ncols);
+    let mut vec = Vec::with_capacity(n * ncols * 2);
+    unsafe {
+        vec.set_len(n * ncols); // TODO unsafe
+    }
+    // vec.resize(n * ncols, F::zero());
+    // let vec = F::zero_vec(n * ncols);
+    let mut trace = RowMajorMatrix::new(vec, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<


### PR DESCRIPTION
... as the union of several DFTs onto several smaller cosets.

Also change it to resize the input vector rather than allocating a separate vector for the result. This works well iff the input vector was already allocated with extra capacity.