### PR TITLE
Change a collection of trait functions into constants

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -96,7 +96,7 @@ pub trait AirBuilder: Sized {
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I);
 
     fn assert_one<I: Into<Self::Expr>>(&mut self, x: I) {
-        self.assert_zero(x.into() - Self::Expr::one());
+        self.assert_zero(x.into() - Self::Expr::ONE);
     }
 
     fn assert_eq<I1: Into<Self::Expr>, I2: Into<Self::Expr>>(&mut self, x: I1, y: I2) {
@@ -106,7 +106,7 @@ pub trait AirBuilder: Sized {
     /// Assert that `x` is a boolean, i.e. either 0 or 1.
     fn assert_bool<I: Into<Self::Expr>>(&mut self, x: I) {
         let x = x.into();
-        self.assert_zero(x.clone() * (x - Self::Expr::one()));
+        self.assert_zero(x.clone() * (x - Self::Expr::ONE));
     }
 }
 
@@ -143,7 +143,7 @@ pub trait ExtensionBuilder: AirBuilder {
     where
         I: Into<Self::ExprEF>,
     {
-        self.assert_eq_ext(x, Self::ExprEF::one())
+        self.assert_eq_ext(x, Self::ExprEF::ONE)
     }
 }
 

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -98,13 +98,13 @@ impl<F: Field> VirtualPairCol<F> {
     /// `a - b`, where `a` and `b` are columns in the preprocessed trace.
     #[must_use]
     pub fn diff_preprocessed(a_col: usize, b_col: usize) -> Self {
-        Self::new_preprocessed(vec![(a_col, F::ONE), (b_col, F::neg_one())], F::ZERO)
+        Self::new_preprocessed(vec![(a_col, F::ONE), (b_col, F::NEG_ONE)], F::ZERO)
     }
 
     /// `a - b`, where `a` and `b` are columns in the main trace.
     #[must_use]
     pub fn diff_main(a_col: usize, b_col: usize) -> Self {
-        Self::new_main(vec![(a_col, F::ONE), (b_col, F::neg_one())], F::ZERO)
+        Self::new_main(vec![(a_col, F::ONE), (b_col, F::NEG_ONE)], F::ZERO)
     }
 
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -55,10 +55,7 @@ impl<F: Field> VirtualPairCol<F> {
         )
     }
 
-    #[must_use]
-    pub fn one() -> Self {
-        Self::constant(F::one())
-    }
+    pub const ONE: Self = Self::constant(F::ONE);
 
     #[must_use]
     pub const fn constant(x: F) -> Self {
@@ -71,7 +68,7 @@ impl<F: Field> VirtualPairCol<F> {
     #[must_use]
     pub fn single(column: PairCol) -> Self {
         Self {
-            column_weights: vec![(column, F::one())],
+            column_weights: vec![(column, F::ONE)],
             constant: F::ZERO,
         }
     }
@@ -88,26 +85,26 @@ impl<F: Field> VirtualPairCol<F> {
 
     #[must_use]
     pub fn sum_main(columns: Vec<usize>) -> Self {
-        let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
+        let column_weights = columns.into_iter().map(|col| (col, F::ONE)).collect();
         Self::new_main(column_weights, F::ZERO)
     }
 
     #[must_use]
     pub fn sum_preprocessed(columns: Vec<usize>) -> Self {
-        let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
+        let column_weights = columns.into_iter().map(|col| (col, F::ONE)).collect();
         Self::new_preprocessed(column_weights, F::ZERO)
     }
 
     /// `a - b`, where `a` and `b` are columns in the preprocessed trace.
     #[must_use]
     pub fn diff_preprocessed(a_col: usize, b_col: usize) -> Self {
-        Self::new_preprocessed(vec![(a_col, F::one()), (b_col, F::neg_one())], F::ZERO)
+        Self::new_preprocessed(vec![(a_col, F::ONE), (b_col, F::neg_one())], F::ZERO)
     }
 
     /// `a - b`, where `a` and `b` are columns in the main trace.
     #[must_use]
     pub fn diff_main(a_col: usize, b_col: usize) -> Self {
-        Self::new_main(vec![(a_col, F::one()), (b_col, F::neg_one())], F::ZERO)
+        Self::new_main(vec![(a_col, F::ONE), (b_col, F::neg_one())], F::ZERO)
     }
 
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -72,7 +72,7 @@ impl<F: Field> VirtualPairCol<F> {
     pub fn single(column: PairCol) -> Self {
         Self {
             column_weights: vec![(column, F::one())],
-            constant: F::zero(),
+            constant: F::ZERO,
         }
     }
 
@@ -89,25 +89,25 @@ impl<F: Field> VirtualPairCol<F> {
     #[must_use]
     pub fn sum_main(columns: Vec<usize>) -> Self {
         let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
-        Self::new_main(column_weights, F::zero())
+        Self::new_main(column_weights, F::ZERO)
     }
 
     #[must_use]
     pub fn sum_preprocessed(columns: Vec<usize>) -> Self {
         let column_weights = columns.into_iter().map(|col| (col, F::one())).collect();
-        Self::new_preprocessed(column_weights, F::zero())
+        Self::new_preprocessed(column_weights, F::ZERO)
     }
 
     /// `a - b`, where `a` and `b` are columns in the preprocessed trace.
     #[must_use]
     pub fn diff_preprocessed(a_col: usize, b_col: usize) -> Self {
-        Self::new_preprocessed(vec![(a_col, F::one()), (b_col, F::neg_one())], F::zero())
+        Self::new_preprocessed(vec![(a_col, F::one()), (b_col, F::neg_one())], F::ZERO)
     }
 
     /// `a - b`, where `a` and `b` are columns in the main trace.
     #[must_use]
     pub fn diff_main(a_col: usize, b_col: usize) -> Self {
-        Self::new_main(vec![(a_col, F::one()), (b_col, F::neg_one())], F::zero())
+        Self::new_main(vec![(a_col, F::one()), (b_col, F::neg_one())], F::ZERO)
     }
 
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr

--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -27,7 +27,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearNeon,
-        crate::PackedBabyBearNeon::zero(),
+        crate::PackedBabyBearNeon::ZERO,
         p3_monty_31::PackedMontyField31Neon::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -152,7 +152,7 @@ mod tests {
         let f_1 = F::one();
         let f_1_copy = F::from_canonical_u32(1);
 
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
         let expected_result = F::two();
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(f_1 + f_2 * f_2, expected_result);
 
         let f_p_minus_1 = F::from_canonical_u32(F::ORDER_U32 - 1);
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 + f_p_minus_1, expected_result);
 
         let f_p_minus_2 = F::from_canonical_u32(F::ORDER_U32 - 2);

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -149,7 +149,7 @@ mod tests {
         let f = F::from_wrapped_u32(F::ORDER_U32);
         assert!(f.is_zero());
 
-        let f_1 = F::one();
+        let f_1 = F::ONE;
         let f_1_copy = F::from_canonical_u32(1);
 
         let expected_result = F::ZERO;

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -155,7 +155,7 @@ mod tests {
         let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
-        let expected_result = F::two();
+        let expected_result = F::TWO;
         assert_eq!(f_1 + f_1_copy, expected_result);
 
         let f_2 = F::from_canonical_u32(2);

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -18,12 +18,12 @@ mod test_quartic_extension {
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");
         assert_eq!(format!("{}", EF::ONE), "1");
-        assert_eq!(format!("{}", EF::two()), "2");
+        assert_eq!(format!("{}", EF::TWO), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::ONE, F::ZERO, F::two()])
+                EF::from_base_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
             ),
             "2 + X + 2 X^3"
         );

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -17,13 +17,13 @@ mod test_quartic_extension {
     #[test]
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");
-        assert_eq!(format!("{}", EF::one()), "1");
+        assert_eq!(format!("{}", EF::ONE), "1");
         assert_eq!(format!("{}", EF::two()), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::one(), F::ZERO, F::two()])
+                EF::from_base_slice(&[F::two(), F::ONE, F::ZERO, F::two()])
             ),
             "2 + X + 2 X^3"
         );

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -16,14 +16,14 @@ mod test_quartic_extension {
 
     #[test]
     fn display() {
-        assert_eq!(format!("{}", EF::zero()), "0");
+        assert_eq!(format!("{}", EF::ZERO), "0");
         assert_eq!(format!("{}", EF::one()), "1");
         assert_eq!(format!("{}", EF::two()), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::one(), F::zero(), F::two()])
+                EF::from_base_slice(&[F::two(), F::one(), F::ZERO, F::two()])
             ),
             "2 + X + 2 X^3"
         );

--- a/baby-bear/src/x86_64_avx2/packing.rs
+++ b/baby-bear/src/x86_64_avx2/packing.rs
@@ -28,7 +28,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearAVX2,
-        crate::PackedBabyBearAVX2::zero(),
+        crate::PackedBabyBearAVX2::ZERO,
         p3_monty_31::PackedMontyField31AVX2::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/baby-bear/src/x86_64_avx512/packing.rs
+++ b/baby-bear/src/x86_64_avx512/packing.rs
@@ -29,7 +29,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedBabyBearAVX512,
-        crate::PackedBabyBearAVX512::zero(),
+        crate::PackedBabyBearAVX512::ZERO,
         p3_monty_31::PackedMontyField31AVX512::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -145,6 +145,7 @@ impl AbstractField for Bn254Fr {
 impl Field for Bn254Fr {
     type Packing = Self;
 
+    // generator is 5
     const GENERATOR: Self = Self::new(FFBn254Fr::from_raw([5u64, 0, 0, 0]));
 
     fn is_zero(&self) -> bool {

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -92,9 +92,8 @@ impl Debug for Bn254Fr {
 impl AbstractField for Bn254Fr {
     type F = Self;
 
-    fn zero() -> Self {
-        Self::new(FFBn254Fr::ZERO)
-    }
+    const ZERO: Self = Self::new(FFBn254Fr::ZERO);
+
     fn one() -> Self {
         Self::new(FFBn254Fr::ONE)
     }
@@ -213,7 +212,7 @@ impl AddAssign for Bn254Fr {
 
 impl Sum for Bn254Fr {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x + y).unwrap_or(Self::zero())
+        iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
     }
 }
 
@@ -312,7 +311,7 @@ mod tests {
         let f_1 = F::new(FFBn254Fr::from_u128(1));
         let f_1_copy = F::new(FFBn254Fr::from_u128(1));
 
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
         let expected_result = F::new(FFBn254Fr::from_u128(2));
@@ -328,7 +327,7 @@ mod tests {
         let f_r_minus_1 = F::new(
             FFBn254Fr::from_str_vartime(&(F::order() - BigUint::one()).to_str_radix(10)).unwrap(),
         );
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 + f_r_minus_1, expected_result);
 
         let f_r_minus_2 = F::new(

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -95,6 +95,8 @@ impl AbstractField for Bn254Fr {
     const ZERO: Self = Self::new(FFBn254Fr::ZERO);
     const ONE: Self = Self::new(FFBn254Fr::ONE);
     const TWO: Self = Self::new(FFBn254Fr::from_raw([2u64, 0, 0, 0]));
+
+    // r - 1 = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000
     const NEG_ONE: Self = Self::new(FFBn254Fr::from_raw([
         0x43e1f593f0000000,
         0x2833e84879b97091,

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -93,10 +93,8 @@ impl AbstractField for Bn254Fr {
     type F = Self;
 
     const ZERO: Self = Self::new(FFBn254Fr::ZERO);
+    const ONE: Self = Self::new(FFBn254Fr::ONE);
 
-    fn one() -> Self {
-        Self::new(FFBn254Fr::ONE)
-    }
     fn two() -> Self {
         Self::new(FFBn254Fr::from(2u64))
     }
@@ -254,7 +252,7 @@ impl MulAssign for Bn254Fr {
 
 impl Product for Bn254Fr {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -94,14 +94,13 @@ impl AbstractField for Bn254Fr {
 
     const ZERO: Self = Self::new(FFBn254Fr::ZERO);
     const ONE: Self = Self::new(FFBn254Fr::ONE);
-
-    fn two() -> Self {
-        Self::new(FFBn254Fr::from(2u64))
-    }
-
-    fn neg_one() -> Self {
-        Self::new(-FFBn254Fr::ONE)
-    }
+    const TWO: Self = Self::new(FFBn254Fr::from_raw([2u64, 0, 0, 0]));
+    const NEG_ONE: Self = Self::new(FFBn254Fr::from_raw([
+        0x43e1f593f0000000,
+        0x2833e84879b97091,
+        0xb85045b68181585d,
+        0x30644e72e131a029,
+    ]));
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -139,14 +138,12 @@ impl AbstractField for Bn254Fr {
     fn from_wrapped_u64(n: u64) -> Self {
         Self::new(FFBn254Fr::from(n))
     }
-
-    fn generator() -> Self {
-        Self::new(FFBn254Fr::from(5u64))
-    }
 }
 
 impl Field for Bn254Fr {
     type Packing = Self;
+
+    const GENERATOR: Self = Self::new(FFBn254Fr::from_raw([5u64, 0, 0, 0]));
 
     fn is_zero(&self) -> bool {
         self.value.is_zero().into()
@@ -232,7 +229,7 @@ impl Neg for Bn254Fr {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        self * Self::neg_one()
+        self * Self::NEG_ONE
     }
 }
 
@@ -304,7 +301,7 @@ mod tests {
         let f = F::new(FFBn254Fr::from_str_vartime(&F::order().to_str_radix(10)).unwrap());
         assert!(f.is_zero());
 
-        assert_eq!(F::generator().as_canonical_biguint(), BigUint::new(vec![5]));
+        assert_eq!(F::GENERATOR.as_canonical_biguint(), BigUint::new(vec![5]));
 
         let f_1 = F::new(FFBn254Fr::from_u128(1));
         let f_1_copy = F::new(FFBn254Fr::from_u128(1));
@@ -352,7 +349,7 @@ mod tests {
 
         // Generator check
         let expected_multiplicative_group_generator = F::new(FFBn254Fr::from_u128(5));
-        assert_eq!(F::generator(), expected_multiplicative_group_generator);
+        assert_eq!(F::GENERATOR, expected_multiplicative_group_generator);
 
         let f_serialized = serde_json::to_string(&f).unwrap();
         let f_deserialized: F = serde_json::from_str(&f_serialized).unwrap();

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -13,7 +13,7 @@ use crate::Bn254Fr;
 #[inline]
 fn get_diffusion_matrix_3() -> &'static [Bn254Fr; 3] {
     static MAT_DIAG3_M_1: OnceLock<[Bn254Fr; 3]> = OnceLock::new();
-    MAT_DIAG3_M_1.get_or_init(|| [Bn254Fr::one(), Bn254Fr::one(), Bn254Fr::two()])
+    MAT_DIAG3_M_1.get_or_init(|| [Bn254Fr::ONE, Bn254Fr::ONE, Bn254Fr::two()])
 }
 
 #[derive(Debug, Clone, Default)]

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -13,7 +13,7 @@ use crate::Bn254Fr;
 #[inline]
 fn get_diffusion_matrix_3() -> &'static [Bn254Fr; 3] {
     static MAT_DIAG3_M_1: OnceLock<[Bn254Fr; 3]> = OnceLock::new();
-    MAT_DIAG3_M_1.get_or_init(|| [Bn254Fr::ONE, Bn254Fr::ONE, Bn254Fr::two()])
+    MAT_DIAG3_M_1.get_or_init(|| [Bn254Fr::ONE, Bn254Fr::ONE, Bn254Fr::TWO])
 }
 
 #[derive(Debug, Clone, Default)]

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -191,7 +191,7 @@ mod tests {
             .for_each(|element| duplex_challenger.observe(F::from_canonical_u8(element as u8)));
 
         let should_be_sponge_state: [F; WIDTH] = [
-            vec![F::zero(); WIDTH / 2],
+            vec![F::ZERO; WIDTH / 2],
             (0..WIDTH / 2)
                 .rev()
                 .map(F::from_canonical_usize)
@@ -225,7 +225,7 @@ mod tests {
             assert_eq!(duplex_challenger.input_buffer, vec![]);
             assert_eq!(
                 duplex_challenger.output_buffer,
-                vec![F::zero(); WIDTH / 2 - i - 1]
+                vec![F::ZERO; WIDTH / 2 - i - 1]
             );
             assert_eq!(duplex_challenger.sponge_state, should_be_sponge_state)
         })

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -116,15 +116,14 @@ mod tests {
             I: IntoIterator<Item = &'a [F]>,
             F: 'a,
         {
-            let (sum, len) =
-                input
-                    .into_iter()
-                    .fold((F::ZERO, 0_usize), |(acc_sum, acc_len), n| {
-                        (
-                            acc_sum + n.iter().fold(F::ZERO, |acc, f| acc + *f),
-                            acc_len + n.len(),
-                        )
-                    });
+            let (sum, len) = input
+                .into_iter()
+                .fold((F::ZERO, 0_usize), |(acc_sum, acc_len), n| {
+                    (
+                        acc_sum + n.iter().fold(F::ZERO, |acc, f| acc + *f),
+                        acc_len + n.len(),
+                    )
+                });
             [sum, F::from_canonical_usize(len)]
         }
     }

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -103,7 +103,7 @@ mod tests {
         {
             let (sum, len) = input
                 .into_iter()
-                .fold((F::zero(), 0_usize), |(acc_sum, acc_len), f| {
+                .fold((F::ZERO, 0_usize), |(acc_sum, acc_len), f| {
                     (acc_sum + f, acc_len + 1)
                 });
             [sum, F::from_canonical_usize(len)]
@@ -119,9 +119,9 @@ mod tests {
             let (sum, len) =
                 input
                     .into_iter()
-                    .fold((F::zero(), 0_usize), |(acc_sum, acc_len), n| {
+                    .fold((F::ZERO, 0_usize), |(acc_sum, acc_len), n| {
                         (
-                            acc_sum + n.iter().fold(F::zero(), |acc, f| acc + *f),
+                            acc_sum + n.iter().fold(F::ZERO, |acc, f| acc + *f),
                             acc_len + n.len(),
                         )
                     });

--- a/circle/benches/cfft.rs
+++ b/circle/benches/cfft.rs
@@ -60,7 +60,7 @@ fn lde_twoadic<F: TwoAdicField, Dft: TwoAdicSubgroupDft<F>, M: Measurement>(
         |b, (dft, m)| {
             b.iter_batched(
                 || (dft.clone(), m.clone()),
-                |(dft, m)| dft.coset_lde_batch(m, 1, F::generator()),
+                |(dft, m)| dft.coset_lde_batch(m, 1, F::GENERATOR),
                 criterion::BatchSize::LargeInput,
             )
         },

--- a/circle/examples/lde.rs
+++ b/circle/examples/lde.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use p3_baby_bear::BabyBear;
 use p3_circle::{CircleDomain, CircleEvaluations};
 use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
-use p3_field::AbstractField;
+use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_mersenne_31::Mersenne31;
@@ -48,5 +48,5 @@ fn main() {
     black_box(go(black_box(evals), log_n + 1));
 
     let m = RowMajorMatrix::<BabyBear>::rand(&mut thread_rng(), 1 << log_n, 1 << log_w);
-    black_box(Radix2DitParallel::default().coset_lde_batch(black_box(m), 1, BabyBear::generator()));
+    black_box(Radix2DitParallel::default().coset_lde_batch(black_box(m), 1, BabyBear::GENERATOR));
 }

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -141,7 +141,7 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
 
         if log_n < domain.log_n {
             // We could simply pad coeffs like this:
-            // coeffs.pad_to_height(target_domain.size(), F::zero());
+            // coeffs.pad_to_height(target_domain.size(), F::ZERO);
             // But the first `added_bits` layers will simply fill out the zeros
             // with the lower order values. (In `DitButterfly`, `x_2` is 0, so
             // both `x_1` and `x_2` are set to `x_1`).

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -254,7 +254,7 @@ fn compute_twiddles<F: ComplexExtendable>(domain: CircleDomain<F>) -> Vec<Vec<F>
             let cur = prev
                 .iter()
                 .step_by(2)
-                .map(|x| x.square().double() - F::one())
+                .map(|x| x.square().double() - F::ONE)
                 .collect_vec();
             twiddles.push(cur);
         }
@@ -263,13 +263,13 @@ fn compute_twiddles<F: ComplexExtendable>(domain: CircleDomain<F>) -> Vec<Vec<F>
 }
 
 pub fn circle_basis<F: Field>(p: Point<F>, log_n: usize) -> Vec<F> {
-    let mut b = vec![F::one(), p.y];
+    let mut b = vec![F::ONE, p.y];
     let mut x = p.x;
     for _ in 0..(log_n - 1) {
         for i in 0..b.len() {
             b.push(b[i] * x);
         }
-        x = x.square().double() - F::one();
+        x = x.square().double() - F::ONE;
     }
     assert_eq!(b.len(), 1 << log_n);
     b

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -104,7 +104,7 @@ pub fn extract_lambda<F: ComplexExtendable, EF: ExtensionField<F>>(
 
     // < v_d, v_d >
     // This formula was determined experimentally...
-    let v_d_2 = F::two().exp_u64(log_lde_size as u64 - 1);
+    let v_d_2 = F::TWO.exp_u64(log_lde_size as u64 - 1);
 
     let v_d = v_d.take(lde.len()).collect_vec();
     let v_d = cfft_permute_slice(&v_d);

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -199,7 +199,7 @@ mod tests {
         let alpha: EF = random();
         let zeta: Point<EF> = Point::from_projective_line(random());
 
-        let mut alpha_offset = EF::one();
+        let mut alpha_offset = EF::ONE;
         let mut ros = vec![EF::ZERO; 1 << lde_domain.log_n];
 
         for _ in 0..4 {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -200,7 +200,7 @@ mod tests {
         let zeta: Point<EF> = Point::from_projective_line(random());
 
         let mut alpha_offset = EF::one();
-        let mut ros = vec![EF::zero(); 1 << lde_domain.log_n];
+        let mut ros = vec![EF::ZERO; 1 << lde_domain.log_n];
 
         for _ in 0..4 {
             let evals = CircleEvaluations::from_cfft_order(
@@ -229,7 +229,7 @@ mod tests {
         let log_n = 5;
         for log_blowup in [1, 2, 3] {
             let mut coeffs = RowMajorMatrix::<F>::rand(&mut thread_rng(), (1 << log_n) + 1, 1);
-            coeffs.pad_to_height(1 << (log_n + log_blowup), F::zero());
+            coeffs.pad_to_height(1 << (log_n + log_blowup), F::ZERO);
 
             let domain = CircleDomain::standard(log_n + log_blowup);
             let mut lde = CircleEvaluations::evaluate(domain, coeffs.clone()).values;
@@ -243,7 +243,7 @@ mod tests {
                     .values;
             assert_eq!(&coeffs2[..(1 << log_n)], &coeffs.values[..(1 << log_n)]);
             assert_eq!(lambda, coeffs.values[1 << log_n]);
-            assert_eq!(coeffs2[1 << log_n], F::zero());
+            assert_eq!(coeffs2[1 << log_n], F::ZERO);
             assert_eq!(
                 &coeffs2[(1 << log_n) + 1..],
                 &coeffs.values[(1 << log_n) + 1..]

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -179,7 +179,7 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
         LagrangeSelectors {
             is_first_row: self.s_p(self.shift, point),
             is_last_row: self.s_p(-self.shift, point),
-            is_transition: Ext::one() - self.s_p_normalized(-self.shift, point),
+            is_transition: Ext::ONE - self.s_p_normalized(-self.shift, point),
             inv_zeroifier: self.zeroifier(point).inverse(),
         }
     }
@@ -390,7 +390,7 @@ mod tests {
             z_coeffs,
             iter::empty()
                 .chain(iter::repeat(F::ZERO).take(n))
-                .chain(iter::once(F::one()))
+                .chain(iter::once(F::ONE))
                 .chain(iter::repeat(F::ZERO).take(n - 1))
                 .collect_vec()
         );

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -284,7 +284,7 @@ mod tests {
 
         // zp is zero
         for p in d.points() {
-            assert_eq!(d.zp_at_point(p.to_projective_line().unwrap()), F::zero());
+            assert_eq!(d.zp_at_point(p.to_projective_line().unwrap()), F::ZERO);
         }
 
         // split domains
@@ -356,7 +356,7 @@ mod tests {
             );
             let coeffs = evals.interpolate().to_row_major_matrix();
             let (lo, hi) = coeffs.split_rows(n);
-            assert_eq!(hi.values, vec![F::zero(); n]);
+            assert_eq!(hi.values, vec![F::ZERO; n]);
             CircleEvaluations::evaluate(d, lo.to_row_major_matrix())
                 .to_natural_order()
                 .to_row_major_matrix()
@@ -365,18 +365,18 @@ mod tests {
 
         // Nonzero at first point, zero everywhere else on domain
         let is_first_row = coset_to_d(&sels.is_first_row);
-        assert_ne!(is_first_row[0], F::zero());
-        assert_eq!(&is_first_row[1..], &vec![F::zero(); n - 1]);
+        assert_ne!(is_first_row[0], F::ZERO);
+        assert_eq!(&is_first_row[1..], &vec![F::ZERO; n - 1]);
 
         // Nonzero at last point, zero everywhere else on domain
         let is_last_row = coset_to_d(&sels.is_last_row);
-        assert_eq!(&is_last_row[..n - 1], &vec![F::zero(); n - 1]);
-        assert_ne!(is_last_row[n - 1], F::zero());
+        assert_eq!(&is_last_row[..n - 1], &vec![F::ZERO; n - 1]);
+        assert_ne!(is_last_row[n - 1], F::ZERO);
 
         // Nonzero everywhere on domain but last point
         let is_transition = coset_to_d(&sels.is_transition);
-        assert_ne!(&is_transition[..n - 1], &vec![F::zero(); n - 1]);
-        assert_eq!(is_transition[n - 1], F::zero());
+        assert_ne!(&is_transition[..n - 1], &vec![F::ZERO; n - 1]);
+        assert_eq!(is_transition[n - 1], F::ZERO);
 
         // Zeroifier coefficients look like [0.. (n times), 1, 0.. (n-1 times)]
         let z_coeffs = CircleEvaluations::from_natural_order(
@@ -389,9 +389,9 @@ mod tests {
         assert_eq!(
             z_coeffs,
             iter::empty()
-                .chain(iter::repeat(F::zero()).take(n))
+                .chain(iter::repeat(F::ZERO).take(n))
                 .chain(iter::once(F::one()))
-                .chain(iter::repeat(F::zero()).take(n - 1))
+                .chain(iter::repeat(F::ZERO).take(n - 1))
                 .collect_vec()
         );
     }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -185,7 +185,7 @@ where
 
                         let (alpha_offset, reduced_opening_for_log_height) =
                             reduced_openings.entry(log_height).or_insert_with(|| {
-                                (Challenge::one(), vec![Challenge::ZERO; 1 << log_height])
+                                (Challenge::ONE, vec![Challenge::ZERO; 1 << log_height])
                             });
 
                         points_for_mat
@@ -397,7 +397,7 @@ where
 
                         let (alpha_offset, ro) = reduced_openings
                             .entry(log_height)
-                            .or_insert((Challenge::one(), Challenge::ZERO));
+                            .or_insert((Challenge::ONE, Challenge::ZERO));
                         let alpha_pow_width_2 = alpha.exp_u64(ps_at_x.len() as u64).square();
 
                         for (zeta_uni, ps_at_zeta) in mat_points_and_values {

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -185,7 +185,7 @@ where
 
                         let (alpha_offset, reduced_opening_for_log_height) =
                             reduced_openings.entry(log_height).or_insert_with(|| {
-                                (Challenge::one(), vec![Challenge::zero(); 1 << log_height])
+                                (Challenge::one(), vec![Challenge::ZERO; 1 << log_height])
                             });
 
                         points_for_mat
@@ -397,7 +397,7 @@ where
 
                         let (alpha_offset, ro) = reduced_openings
                             .entry(log_height)
-                            .or_insert((Challenge::one(), Challenge::zero()));
+                            .or_insert((Challenge::one(), Challenge::ZERO));
                         let alpha_pow_width_2 = alpha.exp_u64(ps_at_x.len() as u64).square();
 
                         for (zeta_uni, ps_at_zeta) in mat_points_and_values {

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -18,12 +18,12 @@ pub struct Point<F> {
 impl<F: Field> Point<F> {
     #[inline]
     pub fn new(x: F, y: F) -> Point<F> {
-        debug_assert_eq!(x.square() + y.square(), F::one());
+        debug_assert_eq!(x.square() + y.square(), F::ONE);
         Point { x, y, _private: () }
     }
 
     pub fn zero() -> Self {
-        Self::new(F::one(), F::ZERO)
+        Self::new(F::ONE, F::ZERO)
     }
 
     /// Circle STARKs, Section 3, Lemma 1: (page 4 of the first revision PDF)
@@ -34,8 +34,8 @@ impl<F: Field> Point<F> {
     /// (on the projective *circle*) (1 : ±i : 0)
     pub fn from_projective_line(t: F) -> Self {
         let t2 = t.square();
-        let inv_denom = (F::one() + t2).try_inverse().expect("t^2 = -1");
-        Self::new((F::one() - t2) * inv_denom, t.double() * inv_denom)
+        let inv_denom = (F::ONE + t2).try_inverse().expect("t^2 = -1");
+        Self::new((F::ONE - t2) * inv_denom, t.double() * inv_denom)
     }
 
     /// Circle STARKs, Section 3, Lemma 1: (page 4 of the first revision PDF)
@@ -48,14 +48,14 @@ impl<F: Field> Point<F> {
     /// and a simple pole at (-1,0), which in the paper is called v_0
     /// Circle STARKs, Section 5.1, Lemma 11 (page 21 of the first revision PDF)
     pub fn to_projective_line(self) -> Option<F> {
-        self.y.try_div(self.x + F::one())
+        self.y.try_div(self.x + F::ONE)
     }
 
     /// The "squaring map", or doubling in additive notation, denoted π(x,y)
     /// Circle STARKs, Section 3.1, Equation 1: (page 5 of the first revision PDF)
     pub fn double(self) -> Self {
         Self::new(
-            self.x.square().double() - F::one(),
+            self.x.square().double() - F::ONE,
             self.x.double() * self.y,
         )
     }
@@ -65,7 +65,7 @@ impl<F: Field> Point<F> {
     /// Circle STARKs, Section 3.3, Equation 8 (page 10 of the first revision PDF)
     pub fn v_n(mut self, log_n: usize) -> F {
         for _ in 0..(log_n - 1) {
-            self.x = self.x.square().double() - F::one(); // TODO: replace this by a custom field impl.
+            self.x = self.x.square().double() - F::ONE; // TODO: replace this by a custom field impl.
         }
         self.x
     }
@@ -73,11 +73,11 @@ impl<F: Field> Point<F> {
     /// Compute a product of successive `v_n`'s.
     ///
     /// More explicitely this computes `(1..log_n).map(|i| self.v_n(i)).product()`
-    /// but uses far fewer `self.x.square().double() - F::one()` steps compared to the naive implementation.
+    /// but uses far fewer `self.x.square().double() - F::ONE` steps compared to the naive implementation.
     pub fn v_n_prod(mut self, log_n: usize) -> F {
         let mut output = self.x;
         for _ in 0..(log_n - 2) {
-            self.x = self.x.square().double() - F::one(); // TODO: replace this by a custom field impl.
+            self.x = self.x.square().double() - F::ONE; // TODO: replace this by a custom field impl.
             output *= self.x;
         }
         output
@@ -103,7 +103,7 @@ impl<F: Field> Point<F> {
     /// Circle STARKs, Section 3.3, Equation 11 (page 11 of the first edition PDF).
     pub fn v_p<EF: ExtensionField<F>>(self, at: Point<EF>) -> (EF, EF) {
         let diff = -at + self;
-        (EF::one() - diff.x, -diff.y)
+        (EF::ONE - diff.x, -diff.y)
     }
 }
 
@@ -121,7 +121,7 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
         .iter()
         .map(|&pt| {
             let diff = at - pt;
-            let numer = diff.x + F::one();
+            let numer = diff.x + F::ONE;
             let denom = diff.y * pt.s_p_at_p(log_n);
             (numer, denom)
         })

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -22,9 +22,11 @@ impl<F: Field> Point<F> {
         Point { x, y, _private: () }
     }
 
-    pub fn zero() -> Self {
-        Self::new(F::ONE, F::ZERO)
-    }
+    const ZERO: Self = Self {
+        x: F::ONE,
+        y: F::ZERO,
+        _private: (),
+    };
 
     /// Circle STARKs, Section 3, Lemma 1: (page 4 of the first revision PDF)
     /// ```ignore
@@ -179,7 +181,7 @@ impl<F: Field, EF: ExtensionField<F>> Sub<Point<F>> for Point<EF> {
 impl<F: Field> Mul<usize> for Point<F> {
     type Output = Self;
     fn mul(mut self, mut rhs: usize) -> Self::Output {
-        let mut res = Self::zero();
+        let mut res = Self::ZERO;
         while rhs != 0 {
             if rhs & 1 == 1 {
                 res += self;
@@ -203,11 +205,11 @@ mod tests {
     #[test]
     fn test_arithmetic() {
         let one = Pt::generator(3);
-        assert_eq!(one - one, Pt::zero());
+        assert_eq!(one - one, Pt::ZERO);
         assert_eq!(one + one, one * 2);
         assert_eq!(one + one + one, one * 3);
         assert_eq!(one * 7, -one);
-        assert_eq!(one * 8, Pt::zero());
+        assert_eq!(one * 8, Pt::ZERO);
 
         let gen = Pt::generator(10);
         let log_n = 10;

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -21,8 +21,9 @@ impl<F: Field> Point<F> {
         debug_assert_eq!(x.square() + y.square(), F::one());
         Point { x, y, _private: () }
     }
+
     pub fn zero() -> Self {
-        Self::new(F::one(), F::zero())
+        Self::new(F::one(), F::ZERO)
     }
 
     /// Circle STARKs, Section 3, Lemma 1: (page 4 of the first revision PDF)

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -54,10 +54,7 @@ impl<F: Field> Point<F> {
     /// The "squaring map", or doubling in additive notation, denoted π(x,y)
     /// Circle STARKs, Section 3.1, Equation 1: (page 5 of the first revision PDF)
     pub fn double(self) -> Self {
-        Self::new(
-            self.x.square().double() - F::ONE,
-            self.x.double() * self.y,
-        )
+        Self::new(self.x.square().double() - F::ONE, self.x.double() * self.y)
     }
 
     /// Evaluate the vanishing polynomial for the standard position coset of size 2^log_n

--- a/circle/src/twiddles.rs
+++ b/circle/src/twiddles.rs
@@ -68,7 +68,7 @@ fn compute_twiddles<F: ComplexExtendable>(log_n: usize, shift: Complex<F>) -> Ve
                     .iter()
                     .take(size / 2)
                     // When we square a point, the real part changes as x -> 2x^2 - 1.
-                    .map(|x| x.square().double() - F::one())
+                    .map(|x| x.square().double() - F::ONE)
                     .collect();
                 mem::replace(&mut working_domain, new_working_domain)
             };

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -95,7 +95,7 @@ where
     M: Mmcs<F> + 'a,
     G: FriGenericConfig<F>,
 {
-    let mut folded_eval = F::zero();
+    let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
     for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -83,7 +83,7 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
     fn create_disjoint_domain(&self, min_size: usize) -> Self {
         Self {
             log_n: log2_ceil_usize(min_size),
-            shift: self.shift * Val::generator(),
+            shift: self.shift * Val::GENERATOR,
         }
     }
     fn split_domains(&self, num_chunks: usize) -> Vec<Self> {

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -112,14 +112,14 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
             .collect()
     }
     fn zp_at_point<Ext: ExtensionField<Val>>(&self, point: Ext) -> Ext {
-        (point * self.shift.inverse()).exp_power_of_2(self.log_n) - Ext::one()
+        (point * self.shift.inverse()).exp_power_of_2(self.log_n) - Ext::ONE
     }
 
     fn selectors_at_point<Ext: ExtensionField<Val>>(&self, point: Ext) -> LagrangeSelectors<Ext> {
         let unshifted_point = point * self.shift.inverse();
-        let z_h = unshifted_point.exp_power_of_2(self.log_n) - Ext::one();
+        let z_h = unshifted_point.exp_power_of_2(self.log_n) - Ext::ONE;
         LagrangeSelectors {
-            is_first_row: z_h / (unshifted_point - Ext::one()),
+            is_first_row: z_h / (unshifted_point - Ext::ONE),
             is_last_row: z_h / (unshifted_point - self.gen().inverse()),
             is_transition: unshifted_point - self.gen().inverse(),
             inv_zeroifier: z_h.inverse(),
@@ -127,8 +127,8 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
     }
 
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Val>> {
-        assert_eq!(self.shift, Val::one());
-        assert_ne!(coset.shift, Val::one());
+        assert_eq!(self.shift, Val::ONE);
+        assert_ne!(coset.shift, Val::ONE);
         assert!(coset.log_n >= self.log_n);
         let rate_bits = coset.log_n - self.log_n;
 
@@ -137,7 +137,7 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
         let evals = Val::two_adic_generator(rate_bits)
             .powers()
             .take(1 << rate_bits)
-            .map(|x| s_pow_n * x - Val::one())
+            .map(|x| s_pow_n * x - Val::ONE)
             .collect_vec();
 
         let xs = cyclic_subgroup_coset_known_order(coset.gen(), coset.shift, 1 << coset.log_n)

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -25,7 +25,7 @@ pub fn eval_coeffs_at_pt<F: Field, EF: ExtensionField<F>>(
     coeffs: &RowMajorMatrix<F>,
     x: EF,
 ) -> Vec<EF> {
-    let mut acc = vec![EF::zero(); coeffs.width()];
+    let mut acc = vec![EF::ZERO; coeffs.width()];
     for r in (0..coeffs.height()).rev() {
         let row = coeffs.row_slice(r);
         for (acc_c, row_c) in acc.iter_mut().zip(row.as_ref().iter()) {
@@ -99,7 +99,7 @@ where
         assert!(domain.log_n >= self.log_n);
         coeffs.values.resize(
             coeffs.values.len() << (domain.log_n - self.log_n),
-            Val::zero(),
+            Val::ZERO,
         );
         self.dft.coset_dft_batch(coeffs, domain.shift)
     }

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -55,7 +55,7 @@ where
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         TwoAdicMultiplicativeCoset {
             log_n: log2_strict_usize(degree),
-            shift: Val::one(),
+            shift: Val::ONE,
         }
     }
 

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -151,7 +151,7 @@ where
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
             b.iter(|| {
-                dft.coset_lde_batch(messages.clone(), 1, F::generator());
+                dft.coset_lde_batch(messages.clone(), 1, F::GENERATOR);
             });
         });
     }

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -75,7 +75,7 @@ mod tests {
                     F::from_canonical_u8(9),
                     F::from_canonical_u8(5),
                     F::ZERO,
-                    F::one(),
+                    F::ONE,
                     F::neg_one(),
                     F::ZERO,
                 ],

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -18,7 +18,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for NaiveDft {
         let log_h = log2_strict_usize(h);
         let g = F::two_adic_generator(log_h);
 
-        let mut res = RowMajorMatrix::new(vec![F::zero(); w * h], w);
+        let mut res = RowMajorMatrix::new(vec![F::ZERO; w * h], w);
         for (res_r, point) in g.powers().take(h).enumerate() {
             for (src_r, point_power) in point.powers().take(h).enumerate() {
                 for c in 0..w {
@@ -55,10 +55,10 @@ mod tests {
             vec![
                 F::from_canonical_u8(5),
                 F::from_canonical_u8(2),
-                F::zero(),
+                F::ZERO,
                 F::from_canonical_u8(4),
                 F::from_canonical_u8(3),
-                F::zero(),
+                F::ZERO,
             ],
             3,
         );
@@ -74,10 +74,10 @@ mod tests {
                 vec![
                     F::from_canonical_u8(9),
                     F::from_canonical_u8(5),
-                    F::zero(),
+                    F::ZERO,
                     F::one(),
                     F::neg_one(),
-                    F::zero(),
+                    F::ZERO,
                 ],
                 3,
             )

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -36,7 +36,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::{AbstractField, Field};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::dense::RowMajorMatrix;
     use rand::thread_rng;
@@ -76,7 +76,7 @@ mod tests {
                     F::from_canonical_u8(5),
                     F::ZERO,
                     F::ONE,
-                    F::neg_one(),
+                    F::NEG_ONE,
                     F::ZERO,
                 ],
                 3,
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn coset_dft_idft_consistency() {
         type F = Goldilocks;
-        let generator = F::generator();
+        let generator = F::GENERATOR;
         let mut rng = thread_rng();
         let original = RowMajorMatrix::<F>::rand(&mut rng, 8, 3);
         let dft = NaiveDft.coset_dft_batch(original.clone(), generator);

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -93,7 +93,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         let mut coeffs = self.idft_batch(mat);
         coeffs
             .values
-            .resize(coeffs.values.len() << added_bits, F::zero());
+            .resize(coeffs.values.len() << added_bits, F::ZERO);
         self.dft_batch(coeffs)
     }
 
@@ -119,7 +119,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
                 .len()
                 .checked_shl(added_bits.try_into().unwrap())
                 .unwrap(),
-            F::zero(),
+            F::ZERO,
         );
         self.coset_dft_batch(coeffs, shift)
     }

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -42,7 +42,7 @@ pub fn benchmark_iter_sum<F: Field, const N: usize, const REPS: usize>(
     for _ in 0..REPS {
         input.push(rng.gen::<[F; N]>())
     }
-    let mut output = [F::zero(); REPS];
+    let mut output = [F::ZERO; REPS];
     c.bench_function(&format!("{} sum/{}, {}", name, REPS, N), |b| {
         b.iter(|| {
             for i in 0..REPS {
@@ -69,7 +69,7 @@ pub fn benchmark_add_latency<AF: AbstractField + Copy, const N: usize>(
                 }
                 vec
             },
-            |x| x.iter().fold(AF::zero(), |x, y| x + *y),
+            |x| x.iter().fold(AF::ZERO, |x, y| x + *y),
             BatchSize::SmallInput,
         )
     });
@@ -136,7 +136,7 @@ pub fn benchmark_sub_latency<AF: AbstractField + Copy, const N: usize>(
                 }
                 vec
             },
-            |x| x.iter().fold(AF::zero(), |x, y| x - *y),
+            |x| x.iter().fold(AF::ZERO, |x, y| x - *y),
             BatchSize::SmallInput,
         )
     });
@@ -203,7 +203,7 @@ pub fn benchmark_mul_latency<AF: AbstractField + Copy, const N: usize>(
                 }
                 vec
             },
-            |x| x.iter().fold(AF::zero(), |x, y| x * *y),
+            |x| x.iter().fold(AF::ZERO, |x, y| x * *y),
             BatchSize::SmallInput,
         )
     });

--- a/field-testing/src/dft_testing.rs
+++ b/field-testing/src/dft_testing.rs
@@ -33,7 +33,7 @@ where
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let coset_dft_naive = NaiveDft.coset_dft_batch(mat.clone(), shift);
         let coset_dft_result = dft.coset_dft_batch(mat, shift);
         assert_eq!(coset_dft_naive, coset_dft_result.to_row_major_matrix());
@@ -68,7 +68,7 @@ where
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let idft_naive = NaiveDft.coset_idft_batch(mat.clone(), shift);
         let idft_result = dft.coset_idft_batch(mat, shift);
         assert_eq!(idft_naive, idft_result.to_row_major_matrix());
@@ -103,7 +103,7 @@ where
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let coset_lde_naive = NaiveDft.coset_lde_batch(mat.clone(), 1, shift);
         let coset_lde_result = dft.coset_lde_batch(mat, 1, shift);
         assert_eq!(coset_lde_naive, coset_lde_result.to_row_major_matrix());

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -29,12 +29,17 @@ where
     let x = rng.gen::<F>();
     let y = rng.gen::<F>();
     let z = rng.gen::<F>();
+    assert_eq!(F::ONE + F::NEG_ONE, F::ZERO);
     assert_eq!(x + (-x), F::ZERO);
+    assert_eq!(F::ONE + F::ONE, F::TWO);
     assert_eq!(-x, F::ZERO - x);
-    assert_eq!(x + x, x * F::two());
-    assert_eq!(x, x.halve() * F::two());
+    assert_eq!(x + x, x * F::TWO);
+    assert_eq!(x * F::TWO, x.double());
+    assert_eq!(x, x.halve() * F::TWO);
     assert_eq!(x * (-x), -x.square());
     assert_eq!(x + y, y + x);
+    assert_eq!(x * F::ZERO, F::ZERO);
+    assert_eq!(x * F::ONE, x);
     assert_eq!(x * y, y * x);
     assert_eq!(x * (y * z), (x * y) * z);
     assert_eq!(x - (y + z), (x - y) - z);
@@ -102,7 +107,7 @@ pub fn test_two_adic_subgroup_zerofier<F: TwoAdicField>() {
 pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
     for log_n in 0..5 {
         let g = F::two_adic_generator(log_n);
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         for x in cyclic_subgroup_coset_known_order(g, shift, 1 << log_n) {
             let zerofier_eval = two_adic_coset_zerofier(log_n, shift, x);
             assert_eq!(zerofier_eval, F::ZERO);
@@ -217,8 +222,8 @@ mod tests {
         type F = BabyBear;
         // (x - 1)(x - 2) = x^2 - 3x + 2
         assert_eq!(
-            binomial_expand(&[F::ONE, F::two()]),
-            vec![F::two(), -F::from_canonical_usize(3), F::ONE]
+            binomial_expand(&[F::ONE, F::TWO]),
+            vec![F::TWO, -F::from_canonical_usize(3), F::ONE]
         );
     }
 }

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -29,8 +29,8 @@ where
     let x = rng.gen::<F>();
     let y = rng.gen::<F>();
     let z = rng.gen::<F>();
-    assert_eq!(x + (-x), F::zero());
-    assert_eq!(-x, F::zero() - x);
+    assert_eq!(x + (-x), F::ZERO);
+    assert_eq!(-x, F::ZERO - x);
     assert_eq!(x + x, x * F::two());
     assert_eq!(x, x.halve() * F::two());
     assert_eq!(x * (-x), -x.square());
@@ -66,7 +66,7 @@ pub fn test_inverse<F: Field>()
 where
     Standard: Distribution<F>,
 {
-    assert_eq!(None, F::zero().try_inverse());
+    assert_eq!(None, F::ZERO.try_inverse());
 
     assert_eq!(Some(F::one()), F::one().try_inverse());
 
@@ -94,7 +94,7 @@ pub fn test_two_adic_subgroup_zerofier<F: TwoAdicField>() {
         let g = F::two_adic_generator(log_n);
         for x in cyclic_subgroup_known_order(g, 1 << log_n) {
             let zerofier_eval = two_adic_subgroup_zerofier(log_n, x);
-            assert_eq!(zerofier_eval, F::zero());
+            assert_eq!(zerofier_eval, F::ZERO);
         }
     }
 }
@@ -105,7 +105,7 @@ pub fn test_two_adic_coset_zerofier<F: TwoAdicField>() {
         let shift = F::generator();
         for x in cyclic_subgroup_coset_known_order(g, shift, 1 << log_n) {
             let zerofier_eval = two_adic_coset_zerofier(log_n, shift, x);
-            assert_eq!(zerofier_eval, F::zero());
+            assert_eq!(zerofier_eval, F::ZERO);
         }
     }
 }

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -54,8 +54,8 @@ where
     let x = rng.gen::<F>();
     let y = rng.gen::<F>();
     let z = rng.gen::<F>();
-    assert_eq!(x * x.inverse(), F::one());
-    assert_eq!(x.inverse() * x, F::one());
+    assert_eq!(x * x.inverse(), F::ONE);
+    assert_eq!(x.inverse() * x, F::ONE);
     assert_eq!(x.square().inverse(), x.inverse().square());
     assert_eq!((x / y) * y, x);
     assert_eq!(x / (y * z), (x / y) / z);
@@ -68,7 +68,7 @@ where
 {
     assert_eq!(None, F::ZERO.try_inverse());
 
-    assert_eq!(Some(F::one()), F::one().try_inverse());
+    assert_eq!(Some(F::ONE), F::ONE.try_inverse());
 
     let mut rng = rand::thread_rng();
     for _ in 0..1000 {
@@ -76,7 +76,7 @@ where
         if !x.is_zero() && !x.is_one() {
             let z = x.inverse();
             assert_ne!(x, z);
-            assert_eq!(x * z, F::one());
+            assert_eq!(x * z, F::ONE);
         }
     }
 }
@@ -217,8 +217,8 @@ mod tests {
         type F = BabyBear;
         // (x - 1)(x - 2) = x^2 - 3x + 2
         assert_eq!(
-            binomial_expand(&[F::one(), F::two()]),
-            vec![F::two(), -F::from_canonical_usize(3), F::one()]
+            binomial_expand(&[F::ONE, F::two()]),
+            vec![F::two(), -F::from_canonical_usize(3), F::ONE]
         );
     }
 }

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -120,12 +120,12 @@ where
     );
     assert_eq!(
         vec0 + (-vec0),
-        PF::zero(),
+        PF::ZERO,
         "Error when testing additive inverse."
     );
     assert_eq!(
         vec0 - vec0,
-        PF::zero(),
+        PF::ZERO,
         "Error when testing subtracting of self."
     );
     assert_eq!(
@@ -185,12 +185,12 @@ where
     );
     assert_eq!(
         vec0 * zeros,
-        PF::zero(),
+        PF::ZERO,
         "Error when testing right multiplication by 0."
     );
     assert_eq!(
         zeros * vec0,
-        PF::zero(),
+        PF::ZERO,
         "Error when testing left multiplication by 0."
     );
     assert_eq!(

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -145,8 +145,8 @@ where
         vec0 + (-vec1),
         "Error when testing addition of negation"
     );
-    assert_eq!(PF::ONE + PF::ONE, PF::two(), "Error 1 + 1 =/= 2");
-    assert_eq!(PF::neg_one() + PF::two(), PF::ONE, "Error -1 + 2 =/= 1");
+    assert_eq!(PF::ONE + PF::ONE, PF::TWO, "Error 1 + 1 =/= 2");
+    assert_eq!(PF::NEG_ONE + PF::TWO, PF::ONE, "Error -1 + 2 =/= 1");
     assert_eq!(
         vec0.double(),
         vec0 + vec0,
@@ -194,18 +194,18 @@ where
         "Error when testing left multiplication by 0."
     );
     assert_eq!(
-        vec0 * PF::neg_one(),
+        vec0 * PF::NEG_ONE,
         -(vec0),
         "Error when testing right multiplication by -1."
     );
     assert_eq!(
-        PF::neg_one() * vec0,
+        PF::NEG_ONE * vec0,
         -(vec0),
         "Error when testing left multiplication by -1."
     );
     assert_eq!(
         vec0.double(),
-        PF::two() * vec0,
+        PF::TWO * vec0,
         "Error when comparing x.double() to 2 * x."
     );
     assert_eq!(

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -145,8 +145,8 @@ where
         vec0 + (-vec1),
         "Error when testing addition of negation"
     );
-    assert_eq!(PF::one() + PF::one(), PF::two(), "Error 1 + 1 =/= 2");
-    assert_eq!(PF::neg_one() + PF::two(), PF::one(), "Error -1 + 2 =/= 1");
+    assert_eq!(PF::ONE + PF::ONE, PF::two(), "Error 1 + 1 =/= 2");
+    assert_eq!(PF::neg_one() + PF::two(), PF::ONE, "Error -1 + 2 =/= 1");
     assert_eq!(
         vec0.double(),
         vec0 + vec0,
@@ -175,12 +175,12 @@ where
     );
     assert_eq!(
         vec0,
-        vec0 * PF::one(),
+        vec0 * PF::ONE,
         "Error when testing multiplicative identity right."
     );
     assert_eq!(
         vec0,
-        PF::one() * vec0,
+        PF::ONE * vec0,
         "Error when testing multiplicative identity left."
     );
     assert_eq!(
@@ -429,7 +429,7 @@ where
     let res = vec * vec_inv;
     assert_eq!(
         res,
-        PF::one(),
+        PF::ONE,
         "Error when testing multiplication by inverse."
     );
 }

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -39,10 +39,8 @@ impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
     type F = F;
 
     const ZERO: Self = FieldArray([F::ZERO; N]);
+    const ONE: Self = FieldArray([F::ONE; N]);
 
-    fn one() -> Self {
-        FieldArray([F::one(); N])
-    }
     fn two() -> Self {
         FieldArray([F::two(); N])
     }
@@ -249,6 +247,6 @@ impl<F: Field, const N: usize> Sum for FieldArray<F, N> {
 impl<F: Field, const N: usize> Product for FieldArray<F, N> {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -40,13 +40,8 @@ impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
 
     const ZERO: Self = FieldArray([F::ZERO; N]);
     const ONE: Self = FieldArray([F::ONE; N]);
-
-    fn two() -> Self {
-        FieldArray([F::two(); N])
-    }
-    fn neg_one() -> Self {
-        FieldArray([F::neg_one(); N])
-    }
+    const TWO: Self = FieldArray([F::TWO; N]);
+    const NEG_ONE: Self = FieldArray([F::NEG_ONE; N]);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -83,10 +78,6 @@ impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
 
     fn from_wrapped_u64(n: u64) -> Self {
         [F::from_wrapped_u64(n); N].into()
-    }
-
-    fn generator() -> Self {
-        [F::generator(); N].into()
     }
 }
 

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -19,7 +19,7 @@ impl<F: Field, const N: usize> FieldArray<F, N> {
 
 impl<F: Field, const N: usize> Default for FieldArray<F, N> {
     fn default() -> Self {
-        Self::zero()
+        Self::ZERO
     }
 }
 
@@ -38,9 +38,8 @@ impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
 impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
     type F = F;
 
-    fn zero() -> Self {
-        FieldArray([F::zero(); N])
-    }
+    const ZERO: Self = FieldArray([F::ZERO; N]);
+
     fn one() -> Self {
         FieldArray([F::one(); N])
     }
@@ -243,7 +242,7 @@ impl<F: Field, const N: usize> Div<F> for FieldArray<F, N> {
 impl<F: Field, const N: usize> Sum for FieldArray<F, N> {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -67,7 +67,7 @@ where
         return;
     }
 
-    result[0] = F::one();
+    result[0] = F::ONE;
     for i in 1..n {
         result[i] = result[i - 1] * x[i - 1];
     }

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -2,7 +2,7 @@ use crate::AbstractField;
 
 pub fn exp_u64_by_squaring<AF: AbstractField>(val: AF, power: u64) -> AF {
     let mut current = val;
-    let mut product = AF::one();
+    let mut product = AF::ONE;
 
     for j in 0..bits_u64(power) {
         if (power >> j & 1) != 0 {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -33,7 +33,7 @@ pub struct BinomialExtensionField<AF, const D: usize> {
 impl<AF: AbstractField, const D: usize> Default for BinomialExtensionField<AF, D> {
     fn default() -> Self {
         Self {
-            value: array::from_fn(|_| AF::zero()),
+            value: array::from_fn(|_| AF::ZERO),
         }
     }
 }
@@ -80,7 +80,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
             z0 *= F::dth_root();
         }
 
-        let mut res = [F::zero(); D];
+        let mut res = [F::ZERO; D];
         for (i, z) in z0.powers().take(D).enumerate() {
             res[i] = arr[i] * z;
         }
@@ -101,7 +101,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
         // coefficient rather than the full product.
         let a = self.value;
         let b = f.value;
-        let mut g = F::zero();
+        let mut g = F::ZERO;
         for i in 1..D {
             g += a[i] * b[D - i];
         }
@@ -120,12 +120,9 @@ where
 {
     type F = BinomialExtensionField<AF::F, D>;
 
-    #[inline]
-    fn zero() -> Self {
-        Self {
-            value: array::from_fn(|_| AF::zero()),
-        }
-    }
+    const ZERO: Self = Self {
+        value: [AF::ZERO; D],
+    };
 
     #[inline]
     fn one() -> Self {
@@ -356,7 +353,7 @@ where
 {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         let zero = Self {
-            value: field_to_array::<AF, D>(AF::zero()),
+            value: field_to_array::<AF, D>(AF::ZERO),
         };
         iter.fold(zero, |acc, x| acc + x)
     }
@@ -575,7 +572,7 @@ where
     Standard: Distribution<F>,
 {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BinomialExtensionField<F, D> {
-        let mut res = [F::zero(); D];
+        let mut res = [F::ZERO; D];
         for r in res.iter_mut() {
             *r = Standard.sample(rng);
         }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -92,7 +92,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
     fn frobenius_inv(&self) -> Self {
         // Writing 'a' for self, we need to compute a^(r-1):
         // r = n^D-1/n-1 = n^(D-1)+n^(D-2)+...+n
-        let mut f = Self::one();
+        let mut f = Self::ONE;
         for _ in 1..D {
             f = (f * *self).frobenius();
         }
@@ -124,12 +124,9 @@ where
         value: [AF::ZERO; D],
     };
 
-    #[inline]
-    fn one() -> Self {
-        Self {
-            value: field_to_array::<AF, D>(AF::one()),
-        }
-    }
+    const ONE: Self = Self {
+        value: field_to_array::<AF, D>(AF::ONE),
+    };
 
     #[inline]
     fn two() -> Self {
@@ -474,7 +471,7 @@ where
 {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         let one = Self {
-            value: field_to_array::<AF, D>(AF::one()),
+            value: field_to_array::<AF, D>(AF::ONE),
         };
         iter.fold(one, |acc, x| acc * x)
     }
@@ -610,7 +607,7 @@ fn cubic_inv<F: Field>(a: &[F], w: F) -> [F; 3] {
 
     // scalar = (a0^3+wa1^3+w^2a2^3-3wa0a1a2)^-1
     let scalar = (a0_square * a[0] + w * a[1] * a1_square + a2_w.square() * a[2]
-        - (F::one() + F::two()) * a2_w * a0_a1)
+        - (F::ONE + F::two()) * a2_w * a0_a1)
         .inverse();
 
     //scalar*[a0^2-wa1a2, wa2^2-a0a1, a1^2-a0a2]

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -349,10 +349,7 @@ where
     AF::F: BinomiallyExtendable<D>,
 {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        let zero = Self {
-            value: field_to_array::<AF, D>(AF::ZERO),
-        };
-        iter.fold(zero, |acc, x| acc + x)
+        iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
@@ -470,10 +467,7 @@ where
     AF::F: BinomiallyExtendable<D>,
 {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        let one = Self {
-            value: field_to_array::<AF, D>(AF::ONE),
-        };
-        iter.fold(one, |acc, x| acc * x)
+        iter.fold(Self::ONE, |acc, x| acc * x)
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -75,9 +75,9 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
         let arr: &[F] = self.as_base_slice();
 
         // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
-        let mut z0 = F::dth_root();
+        let mut z0 = F::DTH_ROOT;
         for _ in 1..count {
-            z0 *= F::dth_root();
+            z0 *= F::DTH_ROOT;
         }
 
         let mut res = [F::ZERO; D];
@@ -105,7 +105,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
         for i in 1..D {
             g += a[i] * b[D - i];
         }
-        g *= F::w();
+        g *= F::W;
         g += a[0] * b[0];
         debug_assert_eq!(Self::from(g), *self * f);
 
@@ -189,13 +189,13 @@ where
             2 => {
                 let a = self.value.clone();
                 let mut res = Self::default();
-                res.value[0] = a[0].square() + a[1].square() * AF::from_f(AF::F::w());
+                res.value[0] = a[0].square() + a[1].square() * AF::from_f(AF::F::W);
                 res.value[1] = a[0].clone() * a[1].double();
                 res
             }
             3 => {
                 let mut res = Self::default();
-                cubic_square(&self.value, &mut res.value, AF::F::w());
+                cubic_square(&self.value, &mut res.value, AF::F::W);
                 res
             }
             _ => <Self as Mul<Self>>::mul(self.clone(), self.clone()),
@@ -222,8 +222,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
         }
 
         match D {
-            2 => Some(Self::from_base_slice(&qudratic_inv(&self.value, F::w()))),
-            3 => Some(Self::from_base_slice(&cubic_inv(&self.value, F::w()))),
+            2 => Some(Self::from_base_slice(&qudratic_inv(&self.value, F::W))),
+            3 => Some(Self::from_base_slice(&cubic_inv(&self.value, F::W))),
             _ => Some(self.frobenius_inv()),
         }
     }
@@ -411,7 +411,7 @@ where
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
-        let w = AF::F::w();
+        let w = AF::F::W;
         let w_af = AF::from_f(w);
 
         match D {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -128,19 +128,13 @@ where
         value: field_to_array::<AF, D>(AF::ONE),
     };
 
-    #[inline]
-    fn two() -> Self {
-        Self {
-            value: field_to_array::<AF, D>(AF::two()),
-        }
-    }
+    const TWO: Self = Self {
+        value: field_to_array::<AF, D>(AF::TWO),
+    };
 
-    #[inline]
-    fn neg_one() -> Self {
-        Self {
-            value: field_to_array::<AF, D>(AF::neg_one()),
-        }
-    }
+    const NEG_ONE: Self = Self {
+        value: field_to_array::<AF, D>(AF::NEG_ONE),
+    };
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -189,12 +183,6 @@ where
         AF::from_wrapped_u64(n).into()
     }
 
-    fn generator() -> Self {
-        Self {
-            value: AF::F::ext_generator().map(AF::from_f),
-        }
-    }
-
     #[inline(always)]
     fn square(&self) -> Self {
         match D {
@@ -223,6 +211,10 @@ where
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionField<F, D> {
     type Packing = Self;
+
+    const GENERATOR: Self = Self {
+        value: F::EXT_GENERATOR,
+    };
 
     fn try_inverse(&self) -> Option<Self> {
         if self.is_zero() {
@@ -601,7 +593,7 @@ fn cubic_inv<F: Field>(a: &[F], w: F) -> [F; 3] {
 
     // scalar = (a0^3+wa1^3+w^2a2^3-3wa0a1a2)^-1
     let scalar = (a0_square * a[0] + w * a[1] * a1_square + a2_w.square() * a[2]
-        - (F::ONE + F::two()) * a2_w * a0_a1)
+        - (F::ONE + F::TWO) * a2_w * a0_a1)
         .inverse();
 
     //scalar*[a0^2-wa1a2, wa2^2-a0a1, a1^2-a0a2]

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -4,7 +4,7 @@ use crate::{AbstractExtensionField, AbstractField, Field};
 pub type Complex<AF> = BinomialExtensionField<AF, 2>;
 
 /// A field for which `p = 3 (mod 4)`. Equivalently, `-1` is not a square,
-/// so the complex extension can be defined `F[X]/(X^2+1)`.
+/// so the complex extension can be defined `F[i] = F[X]/(X^2+1)`.
 pub trait ComplexExtendable: Field {
     /// The two-adicity of `p+1`, the order of the circle group.
     const CIRCLE_TWO_ADICITY: usize;
@@ -15,17 +15,11 @@ pub trait ComplexExtendable: Field {
 }
 
 impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
-    #[inline(always)]
-    fn w() -> Self {
-        F::NEG_ONE
-    }
+    const W: Self = F::NEG_ONE;
 
-    #[inline(always)]
-    fn dth_root() -> Self {
-        // since `p = 3 (mod 4)`, `(p-1)/2` is always odd,
-        // so `(-1)^((p-1)/2) = -1`
-        F::NEG_ONE
-    }
+    // since `p = 3 (mod 4)`, `(p-1)/2` is always odd,
+    // so `(-1)^((p-1)/2) = -1`
+    const DTH_ROOT: Self = F::NEG_ONE;
 
     const EXT_GENERATOR: [Self; 2] = F::COMPLEX_GENERATOR.value;
 }
@@ -85,10 +79,16 @@ impl<AF: AbstractField> Complex<AF> {
 }
 
 /// The complex extension of this field has a binomial extension.
+///
+/// This exists if the polynomial ring `F[i][X]` has an irreducible polynomial `X^d-W`
+/// allowing us to define the binomial extension field `F[i][X]/(X^d-W)`.
 pub trait HasComplexBinomialExtension<const D: usize>: ComplexExtendable {
-    fn w() -> Complex<Self>;
+    const W: Complex<Self>;
 
-    fn dth_root() -> Complex<Self>;
+    // DTH_ROOT = W^((n - 1)/D).
+    // n is the order of base field.
+    // Only works when exists k such that n = kD + 1.
+    const DTH_ROOT: Complex<Self>;
 
     const EXT_GENERATOR: [Complex<Self>; D];
 }
@@ -97,15 +97,9 @@ impl<F, const D: usize> BinomiallyExtendable<D> for Complex<F>
 where
     F: HasComplexBinomialExtension<D>,
 {
-    #[inline(always)]
-    fn w() -> Self {
-        <F as HasComplexBinomialExtension<D>>::w()
-    }
+    const W: Self = <F as HasComplexBinomialExtension<D>>::W;
 
-    #[inline(always)]
-    fn dth_root() -> Self {
-        <F as HasComplexBinomialExtension<D>>::dth_root()
-    }
+    const DTH_ROOT: Self = <F as HasComplexBinomialExtension<D>>::DTH_ROOT;
 
     const EXT_GENERATOR: [Self; D] = F::EXT_GENERATOR;
 }

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -9,7 +9,7 @@ pub trait ComplexExtendable: Field {
     /// The two-adicity of `p+1`, the order of the circle group.
     const CIRCLE_TWO_ADICITY: usize;
 
-    fn complex_generator() -> Complex<Self>;
+    const COMPLEX_GENERATOR: Complex<Self>;
 
     fn circle_two_adic_generator(bits: usize) -> Complex<Self>;
 }
@@ -17,20 +17,17 @@ pub trait ComplexExtendable: Field {
 impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
     #[inline(always)]
     fn w() -> Self {
-        F::neg_one()
+        F::NEG_ONE
     }
 
     #[inline(always)]
     fn dth_root() -> Self {
         // since `p = 3 (mod 4)`, `(p-1)/2` is always odd,
         // so `(-1)^((p-1)/2) = -1`
-        F::neg_one()
+        F::NEG_ONE
     }
 
-    #[inline(always)]
-    fn ext_generator() -> [Self; 2] {
-        F::complex_generator().value
-    }
+    const EXT_GENERATOR: [Self; 2] = F::COMPLEX_GENERATOR.value;
 }
 
 /// Convenience methods for complex extensions
@@ -43,12 +40,12 @@ impl<AF: AbstractField> Complex<AF> {
     }
 
     #[inline(always)]
-    pub fn new_real(real: AF) -> Self {
+    pub const fn new_real(real: AF) -> Self {
         Self::new(real, AF::ZERO)
     }
 
     #[inline(always)]
-    pub fn new_imag(imag: AF) -> Self {
+    pub const fn new_imag(imag: AF) -> Self {
         Self::new(AF::ZERO, imag)
     }
 
@@ -93,7 +90,7 @@ pub trait HasComplexBinomialExtension<const D: usize>: ComplexExtendable {
 
     fn dth_root() -> Complex<Self>;
 
-    fn ext_generator() -> [Complex<Self>; D];
+    const EXT_GENERATOR: [Complex<Self>; D];
 }
 
 impl<F, const D: usize> BinomiallyExtendable<D> for Complex<F>
@@ -110,10 +107,7 @@ where
         <F as HasComplexBinomialExtension<D>>::dth_root()
     }
 
-    #[inline(always)]
-    fn ext_generator() -> [Self; D] {
-        <F as HasComplexBinomialExtension<D>>::ext_generator()
-    }
+    const EXT_GENERATOR: [Self; D] = F::EXT_GENERATOR;
 }
 
 /// The complex extension of this field has a two-adic binomial extension.

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -44,12 +44,12 @@ impl<AF: AbstractField> Complex<AF> {
 
     #[inline(always)]
     pub fn new_real(real: AF) -> Self {
-        Self::new(real, AF::zero())
+        Self::new(real, AF::ZERO)
     }
 
     #[inline(always)]
     pub fn new_imag(imag: AF) -> Self {
-        Self::new(AF::zero(), imag)
+        Self::new(AF::ZERO, imag)
     }
 
     #[inline(always)]

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -32,9 +32,9 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
     fn frobenius_inv(&self) -> Self;
 
     fn minimal_poly(mut self) -> Vec<F> {
-        let mut m = vec![Self::one()];
+        let mut m = vec![Self::ONE];
         for _ in 0..Self::D {
-            m = naive_poly_mul(&m, &[-self, Self::one()]);
+            m = naive_poly_mul(&m, &[-self, Self::ONE]);
             self = self.frobenius();
         }
         let mut m_iter = m
@@ -42,7 +42,7 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
             .map(|c| c.as_base().expect("Extension is not algebraic?"));
         let m: Vec<F> = m_iter.by_ref().take(Self::D + 1).collect();
         debug_assert_eq!(m.len(), Self::D + 1);
-        debug_assert_eq!(m.last(), Some(&F::one()));
+        debug_assert_eq!(m.last(), Some(&F::ONE));
         debug_assert!(m_iter.all(|c| c.is_zero()));
         m
     }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -13,15 +13,16 @@ pub use binomial_extension::*;
 pub use complex::*;
 
 /// Binomial extension field trait.
-/// A extension field with a irreducible polynomial X^d-W
-/// such that the extension is `F[X]/(X^d-W)`.
+///
+/// This exists if the polynomial ring `F[X]` has an irreducible polynomial `X^d-W`
+/// allowing us to define the binomial extension field `F[X]/(X^d-W)`.
 pub trait BinomiallyExtendable<const D: usize>: Field {
-    fn w() -> Self;
+    const W: Self;
 
     // DTH_ROOT = W^((n - 1)/D).
     // n is the order of base field.
     // Only works when exists k such that n = kD + 1.
-    fn dth_root() -> Self;
+    const DTH_ROOT: Self;
 
     const EXT_GENERATOR: [Self; D];
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -23,7 +23,7 @@ pub trait BinomiallyExtendable<const D: usize>: Field {
     // Only works when exists k such that n = kD + 1.
     fn dth_root() -> Self;
 
-    fn ext_generator() -> [Self; D];
+    const EXT_GENERATOR: [Self; D];
 }
 
 pub trait HasFrobenius<F: Field>: ExtensionField<F> {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -39,7 +39,7 @@ pub trait AbstractField:
     type F: Field;
 
     const ZERO: Self;
-    fn one() -> Self;
+    const ONE: Self;
     fn two() -> Self;
     fn neg_one() -> Self;
 
@@ -115,7 +115,7 @@ pub trait AbstractField:
     #[inline(always)]
     fn exp_const_u64<const POWER: u64>(&self) -> Self {
         match POWER {
-            0 => Self::one(),
+            0 => Self::ONE,
             1 => self.clone(),
             2 => self.square(),
             3 => self.cube(),
@@ -143,7 +143,7 @@ pub trait AbstractField:
 
     #[must_use]
     fn powers(&self) -> Powers<Self> {
-        self.shifted_powers(Self::one())
+        self.shifted_powers(Self::ONE)
     }
 
     fn shifted_powers(&self, start: Self) -> Powers<Self> {
@@ -154,7 +154,7 @@ pub trait AbstractField:
     }
 
     fn powers_packed<P: PackedField<Scalar = Self>>(&self) -> PackedPowers<Self, P> {
-        self.shifted_powers_packed(Self::one())
+        self.shifted_powers_packed(Self::ONE)
     }
 
     fn shifted_powers_packed<P: PackedField<Scalar = Self>>(
@@ -220,7 +220,7 @@ pub trait Field:
     }
 
     fn is_one(&self) -> bool {
-        *self == Self::one()
+        *self == Self::ONE
     }
 
     /// self * 2^exp
@@ -372,7 +372,7 @@ pub trait AbstractExtensionField<Base: AbstractField>:
     fn monomial(exponent: usize) -> Self {
         assert!(exponent < Self::D, "requested monomial of too high degree");
         let mut vec = vec![Base::ZERO; Self::D];
-        vec[exponent] = Base::one();
+        vec[exponent] = Base::ONE;
         Self::from_base_slice(&vec)
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -20,7 +20,7 @@ use crate::Packable;
 /// A generalization of `Field` which permits things like
 /// - an actual field element
 /// - a symbolic expression which would evaluate to a field element
-/// - a vector of field elements
+/// - a array of field elements
 pub trait AbstractField:
     Sized
     + Default
@@ -40,8 +40,8 @@ pub trait AbstractField:
 
     const ZERO: Self;
     const ONE: Self;
-    fn two() -> Self;
-    fn neg_one() -> Self;
+    const TWO: Self;
+    const NEG_ONE: Self;
 
     fn from_f(f: Self::F) -> Self;
 
@@ -80,9 +80,6 @@ pub trait AbstractField:
 
     fn from_wrapped_u32(n: u32) -> Self;
     fn from_wrapped_u64(n: u64) -> Self;
-
-    /// A generator of this field's entire multiplicative group.
-    fn generator() -> Self;
 
     #[must_use]
     fn double(&self) -> Self {
@@ -215,6 +212,9 @@ pub trait Field:
 {
     type Packing: PackedField<Scalar = Self>;
 
+    /// A generator of this field's entire multiplicative group.
+    const GENERATOR: Self;
+
     fn is_zero(&self) -> bool {
         *self == Self::ZERO
     }
@@ -227,14 +227,14 @@ pub trait Field:
     #[must_use]
     #[inline]
     fn mul_2exp_u64(&self, exp: u64) -> Self {
-        *self * Self::two().exp_u64(exp)
+        *self * Self::TWO.exp_u64(exp)
     }
 
     /// self / 2^exp
     #[must_use]
     #[inline]
     fn div_2exp_u64(&self, exp: u64) -> Self {
-        *self / Self::two().exp_u64(exp)
+        *self / Self::TWO.exp_u64(exp)
     }
 
     /// Exponentiation by a `u64` power. This is similar to `exp_u64`, but more general in that it
@@ -264,7 +264,7 @@ pub trait Field:
     /// Will error if the field characteristic is 2.
     #[must_use]
     fn halve(&self) -> Self {
-        let half = Self::two()
+        let half = Self::TWO
             .try_inverse()
             .expect("Cannot divide by 2 in fields with characteristic 2");
         *self * half

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -38,7 +38,7 @@ pub trait AbstractField:
 {
     type F: Field;
 
-    fn zero() -> Self;
+    const ZERO: Self;
     fn one() -> Self;
     fn two() -> Self;
     fn neg_one() -> Self;
@@ -189,12 +189,12 @@ pub trait AbstractField:
     /// before assigning them to a userspace process. In that case, our process should not need to
     /// write zeros, which would be redundant. However, the compiler may not always recognize this.
     ///
-    /// In particular, `vec![Self::zero(); len]` appears to result in redundant userspace zeroing.
+    /// In particular, `vec![Self::ZERO; len]` appears to result in redundant userspace zeroing.
     /// This is the default implementation, but implementors may wish to provide their own
     /// implementation which transmutes something like `vec![0u32; len]`.
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
-        vec![Self::zero(); len]
+        vec![Self::ZERO; len]
     }
 }
 
@@ -216,7 +216,7 @@ pub trait Field:
     type Packing: PackedField<Scalar = Self>;
 
     fn is_zero(&self) -> bool {
-        *self == Self::zero()
+        *self == Self::ZERO
     }
 
     fn is_one(&self) -> bool {
@@ -371,7 +371,7 @@ pub trait AbstractExtensionField<Base: AbstractField>:
     /// different f might have been used.
     fn monomial(exponent: usize) -> Self {
         assert!(exponent < Self::D, "requested monomial of too high degree");
-        let mut vec = vec![Base::zero(); Self::D];
+        let mut vec = vec![Base::ZERO; Self::D];
         vec[exponent] = Base::one();
         Self::from_base_slice(&vec)
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -20,7 +20,7 @@ use crate::Packable;
 /// A generalization of `Field` which permits things like
 /// - an actual field element
 /// - a symbolic expression which would evaluate to a field element
-/// - a array of field elements
+/// - an array of field elements
 pub trait AbstractField:
     Sized
     + Default

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -73,7 +73,7 @@ where
 /// by filling zeros.
 #[inline]
 pub fn field_to_array<AF: AbstractField, const D: usize>(x: AF) -> [AF; D] {
-    let mut arr = array::from_fn(|_| AF::zero());
+    let mut arr = array::from_fn(|_| AF::ZERO);
     arr[0] = x;
     arr
 }
@@ -81,7 +81,7 @@ pub fn field_to_array<AF: AbstractField, const D: usize>(x: AF) -> [AF; D] {
 /// Naive polynomial multiplication.
 pub fn naive_poly_mul<AF: AbstractField>(a: &[AF], b: &[AF]) -> Vec<AF> {
     // Grade school algorithm
-    let mut product = vec![AF::zero(); a.len() + b.len() - 1];
+    let mut product = vec![AF::ZERO; a.len() + b.len() - 1];
     for (i, c1) in a.iter().enumerate() {
         for (j, c2) in b.iter().enumerate() {
             product[i + j] += c1.clone() * c2.clone();
@@ -92,7 +92,7 @@ pub fn naive_poly_mul<AF: AbstractField>(a: &[AF], b: &[AF]) -> Vec<AF> {
 
 /// Expand a product of binomials (x - roots[0])(x - roots[1]).. into polynomial coefficients.
 pub fn binomial_expand<AF: AbstractField>(roots: &[AF]) -> Vec<AF> {
-    let mut coeffs = vec![AF::zero(); roots.len() + 1];
+    let mut coeffs = vec![AF::ZERO; roots.len() + 1];
     coeffs[0] = AF::one();
     for (i, x) in roots.iter().enumerate() {
         for j in (1..i + 2).rev() {
@@ -104,7 +104,7 @@ pub fn binomial_expand<AF: AbstractField>(roots: &[AF]) -> Vec<AF> {
 }
 
 pub fn eval_poly<AF: AbstractField>(poly: &[AF], x: AF) -> AF {
-    let mut acc = AF::zero();
+    let mut acc = AF::ZERO;
     for coeff in poly.iter().rev() {
         acc *= x.clone();
         acc += coeff.clone();
@@ -143,7 +143,7 @@ pub fn halve_u64<const P: u64>(input: u64) -> u64 {
 /// Given a slice of SF elements, reduce them to a TF element using a 2^32-base decomposition.
 pub fn reduce_32<SF: PrimeField32, TF: PrimeField>(vals: &[SF]) -> TF {
     let po2 = TF::from_canonical_u64(1u64 << 32);
-    let mut result = TF::zero();
+    let mut result = TF::ZERO;
     for val in vals.iter().rev() {
         result = result * po2 + TF::from_canonical_u32(val.as_canonical_u32());
     }
@@ -165,7 +165,7 @@ pub fn split_32<SF: PrimeField, TF: PrimeField32>(val: SF, n: usize) -> Vec<TF> 
         if !digit_u64s.is_empty() {
             result.push(TF::from_wrapped_u64(digit_u64s[0]));
         } else {
-            result.push(TF::zero())
+            result.push(TF::ZERO)
         }
         val /= po2.clone();
     }

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -31,7 +31,7 @@ pub fn fold_even_odd<F: TwoAdicField>(poly: Vec<F>, beta: F) -> Vec<F> {
     //                    + (1/2 - beta/2 g_inv^i) p(g^(n/2 + i))
     let m = RowMajorMatrix::new(poly, 2);
     let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + 1).inverse();
-    let one_half = F::two().inverse();
+    let one_half = F::TWO.inverse();
     let half_beta = beta * one_half;
 
     // TODO: vectorize this (after we have packed extension fields)

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -275,7 +275,7 @@ where
             for (mat, points_for_mat) in izip!(mats, points) {
                 let log_height = log2_strict_usize(mat.height());
                 let reduced_opening_for_log_height = reduced_openings[log_height]
-                    .get_or_insert_with(|| vec![Challenge::zero(); mat.height()]);
+                    .get_or_insert_with(|| vec![Challenge::ZERO; mat.height()]);
                 debug_assert_eq!(reduced_opening_for_log_height.len(), mat.height());
 
                 let opened_values_for_mat = opened_values_for_round.pushed_mut(vec![]);
@@ -412,7 +412,7 @@ where
 
                     let (alpha_pow, ro) = reduced_openings
                         .entry(log_height)
-                        .or_insert((Challenge::one(), Challenge::zero()));
+                        .or_insert((Challenge::one(), Challenge::ZERO));
 
                     for (z, ps_at_z) in mat_points_and_values {
                         for (&p_at_x, &p_at_z) in izip!(mat_opening, ps_at_z) {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -107,7 +107,7 @@ impl<F: TwoAdicField, InputProof, InputError: Debug> FriGenericConfig<F>
         //                    = (1/2 + beta/2 g_inv^i) p(g^i)
         //                    + (1/2 - beta/2 g_inv^i) p(g^(n/2 + i))
         let g_inv = F::two_adic_generator(log2_strict_usize(m.height()) + 1).inverse();
-        let one_half = F::one().halve();
+        let one_half = F::ONE.halve();
         let half_beta = beta * one_half;
 
         // TODO: vectorize this (after we have packed extension fields)
@@ -150,7 +150,7 @@ where
         let log_n = log2_strict_usize(degree);
         TwoAdicMultiplicativeCoset {
             log_n,
-            shift: Val::one(),
+            shift: Val::ONE,
         }
     }
 
@@ -412,7 +412,7 @@ where
 
                     let (alpha_pow, ro) = reduced_openings
                         .entry(log_height)
-                        .or_insert((Challenge::one(), Challenge::ZERO));
+                        .or_insert((Challenge::ONE, Challenge::ZERO));
 
                     for (z, ps_at_z) in mat_points_and_values {
                         for (&p_at_x, &p_at_z) in izip!(mat_opening, ps_at_z) {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -162,7 +162,7 @@ where
             .into_iter()
             .map(|(domain, evals)| {
                 assert_eq!(domain.size(), evals.height());
-                let shift = Val::generator() / domain.shift;
+                let shift = Val::GENERATOR / domain.shift;
                 // Commit to the bit-reversed LDE.
                 self.dft
                     .coset_lde_batch(evals, self.fri.log_blowup, shift)
@@ -181,7 +181,7 @@ where
         domain: Self::Domain,
     ) -> impl Matrix<Val> + 'a {
         // todo: handle extrapolation for LDEs we don't have
-        assert_eq!(domain.shift, Val::generator());
+        assert_eq!(domain.shift, Val::GENERATOR);
         let lde = self.mmcs.get_matrices(prover_data)[idx];
         assert!(lde.height() >= domain.size());
         lde.split_rows(domain.size()).0.bit_reverse_rows()
@@ -263,7 +263,7 @@ where
 
         // For each unique opening point z, we will find the largest degree bound
         // for that point, and precompute 1/(X - z) for the largest subgroup (in bitrev order).
-        let inv_denoms = compute_inverse_denominators(&mats_and_points, Val::generator());
+        let inv_denoms = compute_inverse_denominators(&mats_and_points, Val::GENERATOR);
 
         let mut all_opened_values: OpenedValues<Challenge> = vec![];
 
@@ -290,7 +290,7 @@ where
                                 mat.split_rows(mat.height() >> self.fri.log_blowup);
                             interpolate_coset(
                                 &BitReversalPerm::new_view(low_coset),
-                                Val::generator(),
+                                Val::GENERATOR,
                                 point,
                             )
                         });
@@ -407,7 +407,7 @@ where
 
                     // todo: this can be nicer with domain methods?
 
-                    let x = Val::generator()
+                    let x = Val::GENERATOR
                         * Val::two_adic_generator(log_height).exp_u64(rev_reduced_index as u64);
 
                     let (alpha_pow, ro) = reduced_openings

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -102,7 +102,7 @@ where
     M: Mmcs<F> + 'a,
     G: FriGenericConfig<F>,
 {
-    let mut folded_eval = F::zero();
+    let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
     for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -52,7 +52,7 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
     let (perm, fc) = get_ldt_for_testing(rng);
     let dft = Radix2Dit::default();
 
-    let shift = Val::generator();
+    let shift = Val::GENERATOR;
 
     let ldes: Vec<RowMajorMatrix<Val>> = (3..10)
         .map(|deg_bits| {

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -30,9 +30,9 @@ impl HasTwoAdicBionmialExtension<2> for Goldilocks {
         assert!(bits <= 33);
 
         if bits == 33 {
-            [Self::zero(), Self::new(15659105665374529263)]
+            [Self::ZERO, Self::new(15659105665374529263)]
         } else {
-            [Self::two_adic_generator(bits), Self::zero()]
+            [Self::two_adic_generator(bits), Self::ZERO]
         }
     }
 }

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -6,14 +6,10 @@ use crate::Goldilocks;
 impl BinomiallyExtendable<2> for Goldilocks {
     // Verifiable in Sage with
     // `R.<x> = GF(p)[]; assert (x^2 - 7).is_irreducible()`.
-    fn w() -> Self {
-        Self::new(7)
-    }
+    const W: Self = Self::new(7);
 
     // DTH_ROOT = W^((p - 1)/2).
-    fn dth_root() -> Self {
-        Self::new(18446744069414584320)
-    }
+    const DTH_ROOT: Self = Self::new(18446744069414584320);
 
     const EXT_GENERATOR: [Self; 2] = [
         Self::new(18081566051660590251),

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -15,12 +15,10 @@ impl BinomiallyExtendable<2> for Goldilocks {
         Self::new(18446744069414584320)
     }
 
-    fn ext_generator() -> [Self; 2] {
-        [
-            Self::new(18081566051660590251),
-            Self::new(16121475356294670766),
-        ]
-    }
+    const EXT_GENERATOR: [Self; 2] = [
+        Self::new(18081566051660590251),
+        Self::new(16121475356294670766),
+    ];
 }
 
 impl HasTwoAdicBionmialExtension<2> for Goldilocks {

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -93,10 +93,8 @@ impl AbstractField for Goldilocks {
     type F = Self;
 
     const ZERO: Self = Self::new(0);
+    const ONE: Self = Self::new(1);
 
-    fn one() -> Self {
-        Self::new(1)
-    }
     fn two() -> Self {
         Self::new(2)
     }
@@ -383,7 +381,7 @@ impl MulAssign for Goldilocks {
 
 impl Product for Goldilocks {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -94,13 +94,8 @@ impl AbstractField for Goldilocks {
 
     const ZERO: Self = Self::new(0);
     const ONE: Self = Self::new(1);
-
-    fn two() -> Self {
-        Self::new(2)
-    }
-    fn neg_one() -> Self {
-        Self::new(Self::ORDER_U64 - 1)
-    }
+    const TWO: Self = Self::new(2);
+    const NEG_ONE: Self = Self::new(Self::ORDER_U64 - 1);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -144,11 +139,6 @@ impl AbstractField for Goldilocks {
         Self::new(n)
     }
 
-    // Sage: GF(2^64 - 2^32 + 1).multiplicative_generator()
-    fn generator() -> Self {
-        Self::new(7)
-    }
-
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: repr(transparent) ensures transmutation safety.
@@ -185,6 +175,9 @@ impl Field for Goldilocks {
         ),
     )))]
     type Packing = Self;
+
+    // Sage: GF(2^64 - 2^32 + 1).multiplicative_generator()
+    const GENERATOR: Self = Self::new(7);
 
     fn is_zero(&self) -> bool {
         self.value == 0 || self.value == Self::ORDER_U64
@@ -509,7 +502,7 @@ mod tests {
         let f = F::from_canonical_u64(F::ORDER_U64);
         assert!(f.is_zero());
 
-        assert_eq!(F::generator().as_canonical_u64(), 7_u64);
+        assert_eq!(F::GENERATOR.as_canonical_u64(), 7_u64);
 
         let f_1 = F::new(1);
         let f_1_copy = F::new(1);
@@ -549,7 +542,7 @@ mod tests {
 
         // Generator check
         let expected_multiplicative_group_generator = F::new(7);
-        assert_eq!(F::generator(), expected_multiplicative_group_generator);
+        assert_eq!(F::GENERATOR, expected_multiplicative_group_generator);
 
         // Check on `reduce_u128`
         let x = u128::MAX;

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -92,9 +92,8 @@ impl Distribution<Goldilocks> for Standard {
 impl AbstractField for Goldilocks {
     type F = Self;
 
-    fn zero() -> Self {
-        Self::new(0)
-    }
+    const ZERO: Self = Self::new(0);
+
     fn one() -> Self {
         Self::new(1)
     }
@@ -319,7 +318,7 @@ impl AddAssign for Goldilocks {
 
 impl Sum for Goldilocks {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::zero()) for iterators of length > 2.
+        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO) for iterators of length > 2.
 
         // This sum will not overflow so long as iter.len() < 2^64.
         let sum = iter.map(|x| x.value as u128).sum::<u128>();
@@ -517,7 +516,7 @@ mod tests {
         let f_1 = F::new(1);
         let f_1_copy = F::new(1);
 
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
         let expected_result = F::new(2);
@@ -531,7 +530,7 @@ mod tests {
         assert_eq!(f_1 + f_2 * f_2, expected_result);
 
         let f_p_minus_1 = F::from_canonical_u64(F::ORDER_U64 - 1);
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 + f_p_minus_1, expected_result);
 
         let f_p_minus_2 = F::from_canonical_u64(F::ORDER_U64 - 2);

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -152,7 +152,7 @@ impl Neg for PackedGoldilocksAVX2 {
 impl Product for PackedGoldilocksAVX2 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 
@@ -160,11 +160,7 @@ impl AbstractField for PackedGoldilocksAVX2 {
     type F = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
-
-    #[inline]
-    fn one() -> Self {
-        Goldilocks::one().into()
-    }
+    const ONE: Self = Self([Goldilocks::ONE; WIDTH]);
 
     #[inline]
     fn two() -> Self {

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -81,7 +81,7 @@ impl Debug for PackedGoldilocksAVX2 {
 impl Default for PackedGoldilocksAVX2 {
     #[inline]
     fn default() -> Self {
-        Self::zero()
+        Self::ZERO
     }
 }
 
@@ -159,10 +159,7 @@ impl Product for PackedGoldilocksAVX2 {
 impl AbstractField for PackedGoldilocksAVX2 {
     type F = Goldilocks;
 
-    #[inline]
-    fn zero() -> Self {
-        Goldilocks::zero().into()
-    }
+    const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
 
     #[inline]
     fn one() -> Self {
@@ -322,7 +319,7 @@ impl SubAssign<Goldilocks> for PackedGoldilocksAVX2 {
 impl Sum for PackedGoldilocksAVX2 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x + y).unwrap_or(Self::zero())
+        iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
     }
 }
 
@@ -608,7 +605,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedGoldilocksAVX2,
-        crate::PackedGoldilocksAVX2::zero(),
+        crate::PackedGoldilocksAVX2::ZERO,
         crate::PackedGoldilocksAVX2(super::SPECIAL_VALS)
     );
 }

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -161,16 +161,8 @@ impl AbstractField for PackedGoldilocksAVX2 {
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
     const ONE: Self = Self([Goldilocks::ONE; WIDTH]);
-
-    #[inline]
-    fn two() -> Self {
-        Goldilocks::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        Goldilocks::neg_one().into()
-    }
+    const TWO: Self = Self([Goldilocks::TWO; WIDTH]);
+    const NEG_ONE: Self = Self([Goldilocks::NEG_ONE; WIDTH]);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -209,11 +201,6 @@ impl AbstractField for PackedGoldilocksAVX2 {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         Goldilocks::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        Goldilocks::generator().into()
     }
 
     #[inline]

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -80,7 +80,7 @@ impl Debug for PackedGoldilocksAVX512 {
 impl Default for PackedGoldilocksAVX512 {
     #[inline]
     fn default() -> Self {
-        Self::zero()
+        Self::ZERO
     }
 }
 
@@ -160,7 +160,7 @@ impl AbstractField for PackedGoldilocksAVX512 {
 
     #[inline]
     fn zero() -> Self {
-        Goldilocks::zero().into()
+        Goldilocks::ZERO.into()
     }
 
     #[inline]
@@ -322,7 +322,7 @@ impl SubAssign<Goldilocks> for PackedGoldilocksAVX512 {
 impl Sum for PackedGoldilocksAVX512 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x + y).unwrap_or(Self::zero())
+        iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
     }
 }
 
@@ -509,7 +509,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedGoldilocksAVX512,
-        crate::PackedGoldilocksAVX512::zero(),
+        crate::PackedGoldilocksAVX512::ZERO,
         crate::PackedGoldilocksAVX512(super::SPECIAL_VALS)
     );
 }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -158,10 +158,7 @@ impl Product for PackedGoldilocksAVX512 {
 impl AbstractField for PackedGoldilocksAVX512 {
     type F = Goldilocks;
 
-    #[inline]
-    fn zero() -> Self {
-        Goldilocks::ZERO.into()
-    }
+    const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
 
     #[inline]
     fn one() -> Self {

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -160,16 +160,8 @@ impl AbstractField for PackedGoldilocksAVX512 {
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
     const ONE: Self = Self([Goldilocks::ONE; WIDTH]);
-
-    #[inline]
-    fn two() -> Self {
-        Goldilocks::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        Goldilocks::neg_one().into()
-    }
+    const TWO: Self = Self([Goldilocks::TWO; WIDTH]);
+    const NEG_ONE: Self = Self([Goldilocks::NEG_ONE; WIDTH]);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -208,11 +200,6 @@ impl AbstractField for PackedGoldilocksAVX512 {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         Goldilocks::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        Goldilocks::generator().into()
     }
 
     #[inline]

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -151,7 +151,7 @@ impl Neg for PackedGoldilocksAVX512 {
 impl Product for PackedGoldilocksAVX512 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 
@@ -159,11 +159,7 @@ impl AbstractField for PackedGoldilocksAVX512 {
     type F = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
-
-    #[inline]
-    fn one() -> Self {
-        Goldilocks::one().into()
-    }
+    const ONE: Self = Self([Goldilocks::ONE; WIDTH]);
 
     #[inline]
     fn two() -> Self {

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::AbstractField;
+    use p3_field::{AbstractField, Field};
     use p3_matrix::dense::RowMajorMatrix;
 
     use crate::{interpolate_coset, interpolate_subgroup};
@@ -101,7 +101,7 @@ mod tests {
     fn test_interpolate_coset() {
         // x^2 + 2 x + 3
         type F = BabyBear;
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let evals = [
             1026, 129027310, 457985035, 994890337, 902, 1988942953, 1555278970, 913671254,
         ]

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -23,7 +23,7 @@ where
     EF: ExtensionField<F> + TwoAdicField,
     Mat: Matrix<F>,
 {
-    interpolate_coset(subgroup_evals, F::one(), point)
+    interpolate_coset(subgroup_evals, F::ONE, point)
 }
 
 /// Given evaluations of a batch of polynomials over the given coset of the canonical power-of-two

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -116,7 +116,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 let diff = sum - local.c_prime[x][z];
                 let four = AB::Expr::from_canonical_u8(4);
                 builder
-                    .assert_zero(diff.clone() * (diff.clone() - AB::Expr::two()) * (diff - four));
+                    .assert_zero(diff.clone() * (diff.clone() - AB::Expr::TWO) * (diff - four));
             }
         }
 

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -115,8 +115,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 let sum: AB::Expr = (0..5).map(|y| local.a_prime[y][x][z].into()).sum();
                 let diff = sum - local.c_prime[x][z];
                 let four = AB::Expr::from_canonical_u8(4);
-                builder
-                    .assert_zero(diff.clone() * (diff.clone() - AB::Expr::TWO) * (diff - four));
+                builder.assert_zero(diff.clone() * (diff.clone() - AB::Expr::TWO) * (diff - four));
             }
         }
 

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -32,7 +32,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
 
         let first_step = local.step_flags[0];
         let final_step = local.step_flags[NUM_ROUNDS - 1];
-        let not_final_step = AB::Expr::one() - final_step;
+        let not_final_step = AB::Expr::ONE - final_step;
 
         // If this is the first step, the input A must match the preimage.
         for y in 0..5 {

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -98,7 +98,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                     let a_limb = local.a[y][x][limb];
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                         .rev()
-                        .fold(AB::Expr::zero(), |acc, z| {
+                        .fold(AB::Expr::ZERO, |acc, z| {
                             builder.assert_bool(local.a_prime[y][x][z]);
                             acc.double() + get_bit(z)
                         });
@@ -134,7 +134,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 for limb in 0..U64_LIMBS {
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                         .rev()
-                        .fold(AB::Expr::zero(), |acc, z| acc.double() + get_bit(z));
+                        .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_bit(z));
                     builder.assert_eq(computed_limb, local.a_prime_prime[y][x][limb]);
                 }
             }
@@ -145,7 +145,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             let computed_a_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
-                .fold(AB::Expr::zero(), |acc, z| {
+                .fold(AB::Expr::ZERO, |acc, z| {
                     builder.assert_bool(local.a_prime_prime_0_0_bits[z]);
                     acc.double() + local.a_prime_prime_0_0_bits[z]
                 });
@@ -154,7 +154,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         }
 
         let get_xored_bit = |i| {
-            let mut rc_bit_i = AB::Expr::zero();
+            let mut rc_bit_i = AB::Expr::ZERO;
             for r in 0..NUM_ROUNDS {
                 let this_round = local.step_flags[r];
                 let this_round_constant = AB::Expr::from_canonical_u8(rc_value_bit(r, i));
@@ -169,7 +169,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             let computed_a_prime_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
-                .fold(AB::Expr::zero(), |acc, z| acc.double() + get_xored_bit(z));
+                .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_xored_bit(z));
             builder.assert_eq(
                 computed_a_prime_prime_prime_0_0_limb,
                 a_prime_prime_prime_0_0_limb,

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -77,7 +77,7 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], inp
 }
 
 fn generate_trace_row_for_round<F: PrimeField64>(row: &mut KeccakCols<F>, round: usize) {
-    row.step_flags[round] = F::one();
+    row.step_flags[round] = F::ONE;
 
     // Populate C[x] = xor(A[x, 0], A[x, 1], A[x, 2], A[x, 3], A[x, 4]).
     for x in 0..5 {

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -126,7 +126,7 @@ fn generate_trace_row_for_round<F: PrimeField64>(row: &mut KeccakCols<F>, round:
             for limb in 0..U64_LIMBS {
                 row.a_prime_prime[y][x][limb] = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                     .rev()
-                    .fold(F::zero(), |acc, z| {
+                    .fold(F::ZERO, |acc, z| {
                         let bit = xor([
                             row.b(x, y, z),
                             andn(row.b((x + 1) % 5, y, z), row.b((x + 2) % 5, y, z)),

--- a/keccak-air/src/logic.rs
+++ b/keccak-air/src/logic.rs
@@ -1,7 +1,7 @@
 use p3_field::{AbstractField, PrimeField64};
 
 pub(crate) fn xor<F: PrimeField64, const N: usize>(xs: [F; N]) -> F {
-    xs.into_iter().fold(F::zero(), |acc, x| {
+    xs.into_iter().fold(F::ZERO, |acc, x| {
         debug_assert!(x.is_zero() || x.is_one());
         F::from_canonical_u64(acc.as_canonical_u64() ^ x.as_canonical_u64())
     })

--- a/keccak-air/src/logic.rs
+++ b/keccak-air/src/logic.rs
@@ -26,5 +26,5 @@ pub(crate) fn andn<F: PrimeField64>(x: F, y: F) -> F {
 }
 
 pub(crate) fn andn_gen<AF: AbstractField>(x: AF, y: AF) -> AF {
-    (AF::one() - x) * y
+    (AF::ONE - x) * y
 }

--- a/keccak/benches/bench_keccak.rs
+++ b/keccak/benches/bench_keccak.rs
@@ -47,7 +47,7 @@ pub fn keccak_field_32_hash(c: &mut Criterion) {
     type P = [F; VECTOR_LEN];
     const PACKED_ELEMS_PER_HASH: usize = 100;
     const BYTES_PER_HASH: usize = size_of::<P>() * PACKED_ELEMS_PER_HASH;
-    let input = vec![[F::zero(); VECTOR_LEN]; PACKED_ELEMS_PER_HASH];
+    let input = vec![[F::ZERO; VECTOR_LEN]; PACKED_ELEMS_PER_HASH];
 
     type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
     let u64_hash = U64Hash::new(KeccakF {});

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -27,7 +27,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearNeon,
-        crate::PackedKoalaBearNeon::zero(),
+        crate::PackedKoalaBearNeon::ZERO,
         p3_monty_31::PackedMontyField31Neon::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -18,12 +18,12 @@ mod test_quartic_extension {
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");
         assert_eq!(format!("{}", EF::ONE), "1");
-        assert_eq!(format!("{}", EF::two()), "2");
+        assert_eq!(format!("{}", EF::TWO), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::ONE, F::ZERO, F::two()])
+                EF::from_base_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
             ),
             "2 + X + 2 X^3"
         );

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -17,13 +17,13 @@ mod test_quartic_extension {
     #[test]
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");
-        assert_eq!(format!("{}", EF::one()), "1");
+        assert_eq!(format!("{}", EF::ONE), "1");
         assert_eq!(format!("{}", EF::two()), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::one(), F::ZERO, F::two()])
+                EF::from_base_slice(&[F::two(), F::ONE, F::ZERO, F::two()])
             ),
             "2 + X + 2 X^3"
         );

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -16,14 +16,14 @@ mod test_quartic_extension {
 
     #[test]
     fn display() {
-        assert_eq!(format!("{}", EF::zero()), "0");
+        assert_eq!(format!("{}", EF::ZERO), "0");
         assert_eq!(format!("{}", EF::one()), "1");
         assert_eq!(format!("{}", EF::two()), "2");
 
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::two(), F::one(), F::zero(), F::two()])
+                EF::from_base_slice(&[F::two(), F::one(), F::ZERO, F::two()])
             ),
             "2 + X + 2 X^3"
         );

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -135,7 +135,7 @@ mod tests {
         let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
-        let expected_result = F::two();
+        let expected_result = F::TWO;
         assert_eq!(f_1 + f_1_copy, expected_result);
 
         let f_2 = F::from_canonical_u32(2);

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -129,7 +129,7 @@ mod tests {
         let f = F::from_wrapped_u32(F::ORDER_U32);
         assert!(f.is_zero());
 
-        let f_1 = F::one();
+        let f_1 = F::ONE;
         let f_1_copy = F::from_canonical_u32(1);
 
         let expected_result = F::ZERO;

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -132,7 +132,7 @@ mod tests {
         let f_1 = F::one();
         let f_1_copy = F::from_canonical_u32(1);
 
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 - f_1_copy, expected_result);
 
         let expected_result = F::two();
@@ -146,7 +146,7 @@ mod tests {
         assert_eq!(f_1 + f_2 * f_2, expected_result);
 
         let f_p_minus_1 = F::from_canonical_u32(F::ORDER_U32 - 1);
-        let expected_result = F::zero();
+        let expected_result = F::ZERO;
         assert_eq!(f_1 + f_p_minus_1, expected_result);
 
         let f_p_minus_2 = F::from_canonical_u32(F::ORDER_U32 - 2);

--- a/koala-bear/src/x86_64_avx2/packing.rs
+++ b/koala-bear/src/x86_64_avx2/packing.rs
@@ -28,7 +28,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearAVX2,
-        crate::PackedKoalaBearAVX2::zero(),
+        crate::PackedKoalaBearAVX2::ZERO,
         p3_monty_31::PackedMontyField31AVX2::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/koala-bear/src/x86_64_avx512/packing.rs
+++ b/koala-bear/src/x86_64_avx512/packing.rs
@@ -29,7 +29,7 @@ mod tests {
 
     test_packed_field!(
         crate::PackedKoalaBearAVX512,
-        crate::PackedKoalaBearAVX512::zero(),
+        crate::PackedKoalaBearAVX512::ZERO,
         p3_monty_31::PackedMontyField31AVX512::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
 }

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -285,7 +285,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         //     reverse_matrix_index_bits(mat);
         //     mat
         //         .values
-        //         .resize(mat.values.len() << added_bits, F::zero());
+        //         .resize(mat.values.len() << added_bits, F::ZERO);
         //     reverse_matrix_index_bits(mat);
         // But rather than implement it with bit reversals, we directly construct the resulting matrix,
         // whose rows are zero except for rows whose low `added_bits` bits are zero.

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -300,7 +300,7 @@ mod tests {
         let m = RowMajorMatrix::<F>::rand(&mut thread_rng(), 1 << 8, 1 << 4);
         let v = RowMajorMatrix::<EF>::rand(&mut thread_rng(), 1 << 8, 1).values;
 
-        let mut expected = vec![EF::zero(); m.width()];
+        let mut expected = vec![EF::ZERO; m.width()];
         for (row, &scale) in izip!(m.rows(), &v) {
             for (l, r) in izip!(&mut expected, row) {
                 *l += scale * r;

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -34,7 +34,7 @@ where
         reverse_slice_index_bits(&mut fft_twiddles);
         reverse_slice_index_bits(&mut ifft_twiddles);
 
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let mut weights: [F; N] = shift
             .powers()
             .take(N)
@@ -157,7 +157,7 @@ fn bowers_g_t_layer<AF: AbstractField, const N: usize>(
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-    use p3_field::AbstractField;
+    use p3_field::{AbstractField, Field};
     use p3_symmetric::Permutation;
     use rand::{thread_rng, Rng};
 
@@ -171,7 +171,7 @@ mod tests {
         let mut rng = thread_rng();
         let mut arr: [F; N] = rng.gen();
 
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let mut coset_lde_naive = NaiveDft.coset_lde(arr.to_vec(), 0, shift);
         coset_lde_naive
             .iter_mut()

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -23,7 +23,7 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
         let log_n = log2_strict_usize(N);
         let root = F::two_adic_generator(log_n);
         let root_inv = root.inverse();
-        let coset_shift = F::generator();
+        let coset_shift = F::GENERATOR;
 
         let mut ifft_twiddles: Vec<F> = root_inv.powers().take(N / 2).collect();
         reverse_slice_index_bits(&mut ifft_twiddles);
@@ -119,7 +119,7 @@ fn bowers_g_t_layer<AF: AbstractField, const N: usize>(
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-    use p3_field::AbstractField;
+    use p3_field::{AbstractField, Field};
     use p3_symmetric::Permutation;
     use p3_util::reverse_slice_index_bits;
     use rand::{thread_rng, Rng};
@@ -137,7 +137,7 @@ mod tests {
         let mut arr_rev = arr.to_vec();
         reverse_slice_index_bits(&mut arr_rev);
 
-        let shift = F::generator();
+        let shift = F::GENERATOR;
         let mut coset_lde_naive = NaiveDft.coset_lde(arr_rev, 0, shift);
         reverse_slice_index_bits(&mut coset_lde_naive);
         coset_lde_naive

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -47,7 +47,7 @@ pub fn apply_circulant<AF: AbstractField, const N: usize>(
 ) -> [AF; N] {
     let mut matrix: [AF; N] = circ_matrix.map(AF::from_canonical_u64);
 
-    let mut output = array::from_fn(|_| AF::zero());
+    let mut output = array::from_fn(|_| AF::ZERO);
     for out_i in output.iter_mut().take(N - 1) {
         *out_i = AF::dot_product(&matrix, &input);
         matrix.rotate_right(1);

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -233,10 +233,10 @@ mod tests {
 
         // v = [2, 1, 2, 2, 0, 0, 1, 0]
         let v = vec![
-            F::two(),
+            F::TWO,
             F::ONE,
-            F::two(),
-            F::two(),
+            F::TWO,
+            F::TWO,
             F::ZERO,
             F::ZERO,
             F::ONE,
@@ -272,13 +272,13 @@ mod tests {
         //   0 1
         //   2 1
         // ]
-        let mat = RowMajorMatrix::new(vec![F::ZERO, F::ONE, F::two(), F::ONE], 2);
+        let mat = RowMajorMatrix::new(vec![F::ZERO, F::ONE, F::TWO, F::ONE], 2);
 
         let (commit, _) = mmcs.commit(vec![mat]);
 
         let expected_result = compress.compress([
             hash.hash_slice(&[F::ZERO, F::ONE]),
-            hash.hash_slice(&[F::two(), F::ONE]),
+            hash.hash_slice(&[F::TWO, F::ONE]),
         ]);
         assert_eq!(commit, expected_result);
     }
@@ -301,7 +301,7 @@ mod tests {
         //   2 2
         // ]
         let mat = RowMajorMatrix::new(
-            vec![F::ZERO, F::ONE, F::two(), F::ONE, F::two(), F::two()],
+            vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO],
             2,
         );
 
@@ -310,9 +310,9 @@ mod tests {
         let expected_result = compress.compress([
             compress.compress([
                 hash.hash_slice(&[F::ZERO, F::ONE]),
-                hash.hash_slice(&[F::two(), F::ONE]),
+                hash.hash_slice(&[F::TWO, F::ONE]),
             ]),
-            compress.compress([hash.hash_slice(&[F::two(), F::two()]), default_digest]),
+            compress.compress([hash.hash_slice(&[F::TWO, F::TWO]), default_digest]),
         ]);
         assert_eq!(commit, expected_result);
     }
@@ -335,7 +335,7 @@ mod tests {
         //   2 2
         // ]
         let mat_1 = RowMajorMatrix::new(
-            vec![F::ZERO, F::ONE, F::two(), F::ONE, F::two(), F::two()],
+            vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO],
             2,
         );
         // mat_2 = [
@@ -343,7 +343,7 @@ mod tests {
         //   0 2 2
         // ]
         let mat_2 = RowMajorMatrix::new(
-            vec![F::ONE, F::two(), F::ONE, F::ZERO, F::two(), F::two()],
+            vec![F::ONE, F::TWO, F::ONE, F::ZERO, F::TWO, F::TWO],
             3,
         );
 
@@ -351,12 +351,12 @@ mod tests {
 
         let mat_1_leaf_hashes = [
             hash.hash_slice(&[F::ZERO, F::ONE]),
-            hash.hash_slice(&[F::two(), F::ONE]),
-            hash.hash_slice(&[F::two(), F::two()]),
+            hash.hash_slice(&[F::TWO, F::ONE]),
+            hash.hash_slice(&[F::TWO, F::TWO]),
         ];
         let mat_2_leaf_hashes = [
-            hash.hash_slice(&[F::ONE, F::two(), F::ONE]),
-            hash.hash_slice(&[F::ZERO, F::two(), F::two()]),
+            hash.hash_slice(&[F::ONE, F::TWO, F::ONE]),
+            hash.hash_slice(&[F::ZERO, F::TWO, F::TWO]),
         ];
 
         let expected_result = compress.compress([
@@ -374,7 +374,7 @@ mod tests {
         let (opened_values, _proof) = mmcs.open_batch(2, &prover_data);
         assert_eq!(
             opened_values,
-            vec![vec![F::two(), F::two()], vec![F::ZERO, F::two(), F::two()]]
+            vec![vec![F::TWO, F::TWO], vec![F::ZERO, F::TWO, F::TWO]]
         );
     }
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -234,12 +234,12 @@ mod tests {
         // v = [2, 1, 2, 2, 0, 0, 1, 0]
         let v = vec![
             F::two(),
-            F::one(),
+            F::ONE,
             F::two(),
             F::two(),
             F::ZERO,
             F::ZERO,
-            F::one(),
+            F::ONE,
             F::ZERO,
         ];
         let (commit, _) = mmcs.commit_vec(v.clone());
@@ -272,13 +272,13 @@ mod tests {
         //   0 1
         //   2 1
         // ]
-        let mat = RowMajorMatrix::new(vec![F::ZERO, F::one(), F::two(), F::one()], 2);
+        let mat = RowMajorMatrix::new(vec![F::ZERO, F::ONE, F::two(), F::ONE], 2);
 
         let (commit, _) = mmcs.commit(vec![mat]);
 
         let expected_result = compress.compress([
-            hash.hash_slice(&[F::ZERO, F::one()]),
-            hash.hash_slice(&[F::two(), F::one()]),
+            hash.hash_slice(&[F::ZERO, F::ONE]),
+            hash.hash_slice(&[F::two(), F::ONE]),
         ]);
         assert_eq!(commit, expected_result);
     }
@@ -301,7 +301,7 @@ mod tests {
         //   2 2
         // ]
         let mat = RowMajorMatrix::new(
-            vec![F::ZERO, F::one(), F::two(), F::one(), F::two(), F::two()],
+            vec![F::ZERO, F::ONE, F::two(), F::ONE, F::two(), F::two()],
             2,
         );
 
@@ -309,8 +309,8 @@ mod tests {
 
         let expected_result = compress.compress([
             compress.compress([
-                hash.hash_slice(&[F::ZERO, F::one()]),
-                hash.hash_slice(&[F::two(), F::one()]),
+                hash.hash_slice(&[F::ZERO, F::ONE]),
+                hash.hash_slice(&[F::two(), F::ONE]),
             ]),
             compress.compress([hash.hash_slice(&[F::two(), F::two()]), default_digest]),
         ]);
@@ -335,7 +335,7 @@ mod tests {
         //   2 2
         // ]
         let mat_1 = RowMajorMatrix::new(
-            vec![F::ZERO, F::one(), F::two(), F::one(), F::two(), F::two()],
+            vec![F::ZERO, F::ONE, F::two(), F::ONE, F::two(), F::two()],
             2,
         );
         // mat_2 = [
@@ -343,19 +343,19 @@ mod tests {
         //   0 2 2
         // ]
         let mat_2 = RowMajorMatrix::new(
-            vec![F::one(), F::two(), F::one(), F::ZERO, F::two(), F::two()],
+            vec![F::ONE, F::two(), F::ONE, F::ZERO, F::two(), F::two()],
             3,
         );
 
         let (commit, prover_data) = mmcs.commit(vec![mat_1, mat_2]);
 
         let mat_1_leaf_hashes = [
-            hash.hash_slice(&[F::ZERO, F::one()]),
-            hash.hash_slice(&[F::two(), F::one()]),
+            hash.hash_slice(&[F::ZERO, F::ONE]),
+            hash.hash_slice(&[F::two(), F::ONE]),
             hash.hash_slice(&[F::two(), F::two()]),
         ];
         let mat_2_leaf_hashes = [
-            hash.hash_slice(&[F::one(), F::two(), F::one()]),
+            hash.hash_slice(&[F::ONE, F::two(), F::ONE]),
             hash.hash_slice(&[F::ZERO, F::two(), F::two()]),
         ];
 
@@ -449,7 +449,7 @@ mod tests {
 
         // open the 3rd row of each matrix, mess with proof, and verify
         let (opened_values, mut proof) = mmcs.open_batch(3, &prover_data);
-        proof[0][0] += F::one();
+        proof[0][0] += F::ONE;
         mmcs.verify_batch(
             &commit,
             &large_mat_dims.chain(small_mat_dims).collect_vec(),

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -237,10 +237,10 @@ mod tests {
             F::one(),
             F::two(),
             F::two(),
-            F::zero(),
-            F::zero(),
+            F::ZERO,
+            F::ZERO,
             F::one(),
-            F::zero(),
+            F::ZERO,
         ];
         let (commit, _) = mmcs.commit_vec(v.clone());
 
@@ -272,12 +272,12 @@ mod tests {
         //   0 1
         //   2 1
         // ]
-        let mat = RowMajorMatrix::new(vec![F::zero(), F::one(), F::two(), F::one()], 2);
+        let mat = RowMajorMatrix::new(vec![F::ZERO, F::one(), F::two(), F::one()], 2);
 
         let (commit, _) = mmcs.commit(vec![mat]);
 
         let expected_result = compress.compress([
-            hash.hash_slice(&[F::zero(), F::one()]),
+            hash.hash_slice(&[F::ZERO, F::one()]),
             hash.hash_slice(&[F::two(), F::one()]),
         ]);
         assert_eq!(commit, expected_result);
@@ -293,7 +293,7 @@ mod tests {
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
-        let default_digest = [F::zero(); 8];
+        let default_digest = [F::ZERO; 8];
 
         // mat = [
         //   0 1
@@ -301,7 +301,7 @@ mod tests {
         //   2 2
         // ]
         let mat = RowMajorMatrix::new(
-            vec![F::zero(), F::one(), F::two(), F::one(), F::two(), F::two()],
+            vec![F::ZERO, F::one(), F::two(), F::one(), F::two(), F::two()],
             2,
         );
 
@@ -309,7 +309,7 @@ mod tests {
 
         let expected_result = compress.compress([
             compress.compress([
-                hash.hash_slice(&[F::zero(), F::one()]),
+                hash.hash_slice(&[F::ZERO, F::one()]),
                 hash.hash_slice(&[F::two(), F::one()]),
             ]),
             compress.compress([hash.hash_slice(&[F::two(), F::two()]), default_digest]),
@@ -327,7 +327,7 @@ mod tests {
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
-        let default_digest = [F::zero(); 8];
+        let default_digest = [F::ZERO; 8];
 
         // mat_1 = [
         //   0 1
@@ -335,7 +335,7 @@ mod tests {
         //   2 2
         // ]
         let mat_1 = RowMajorMatrix::new(
-            vec![F::zero(), F::one(), F::two(), F::one(), F::two(), F::two()],
+            vec![F::ZERO, F::one(), F::two(), F::one(), F::two(), F::two()],
             2,
         );
         // mat_2 = [
@@ -343,20 +343,20 @@ mod tests {
         //   0 2 2
         // ]
         let mat_2 = RowMajorMatrix::new(
-            vec![F::one(), F::two(), F::one(), F::zero(), F::two(), F::two()],
+            vec![F::one(), F::two(), F::one(), F::ZERO, F::two(), F::two()],
             3,
         );
 
         let (commit, prover_data) = mmcs.commit(vec![mat_1, mat_2]);
 
         let mat_1_leaf_hashes = [
-            hash.hash_slice(&[F::zero(), F::one()]),
+            hash.hash_slice(&[F::ZERO, F::one()]),
             hash.hash_slice(&[F::two(), F::one()]),
             hash.hash_slice(&[F::two(), F::two()]),
         ];
         let mat_2_leaf_hashes = [
             hash.hash_slice(&[F::one(), F::two(), F::one()]),
-            hash.hash_slice(&[F::zero(), F::two(), F::two()]),
+            hash.hash_slice(&[F::ZERO, F::two(), F::two()]),
         ];
 
         let expected_result = compress.compress([
@@ -374,10 +374,7 @@ mod tests {
         let (opened_values, _proof) = mmcs.open_batch(2, &prover_data);
         assert_eq!(
             opened_values,
-            vec![
-                vec![F::two(), F::two()],
-                vec![F::zero(), F::two(), F::two()]
-            ]
+            vec![vec![F::two(), F::two()], vec![F::ZERO, F::two(), F::two()]]
         );
     }
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -300,10 +300,7 @@ mod tests {
         //   2 1
         //   2 2
         // ]
-        let mat = RowMajorMatrix::new(
-            vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO],
-            2,
-        );
+        let mat = RowMajorMatrix::new(vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO], 2);
 
         let (commit, _) = mmcs.commit(vec![mat]);
 
@@ -334,18 +331,12 @@ mod tests {
         //   2 1
         //   2 2
         // ]
-        let mat_1 = RowMajorMatrix::new(
-            vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO],
-            2,
-        );
+        let mat_1 = RowMajorMatrix::new(vec![F::ZERO, F::ONE, F::TWO, F::ONE, F::TWO, F::TWO], 2);
         // mat_2 = [
         //   1 2 1
         //   0 2 2
         // ]
-        let mat_2 = RowMajorMatrix::new(
-            vec![F::ONE, F::TWO, F::ONE, F::ZERO, F::TWO, F::TWO],
-            3,
-        );
+        let mat_2 = RowMajorMatrix::new(vec![F::ONE, F::TWO, F::ONE, F::ZERO, F::TWO, F::TWO], 3);
 
         let (commit, prover_data) = mmcs.commit(vec![mat_1, mat_2]);
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -313,16 +313,8 @@ impl AbstractField for PackedMersenne31Neon {
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
     const ONE: Self = Self::broadcast(Mersenne31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        Mersenne31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        Mersenne31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(Mersenne31::TWO);
+    const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -361,11 +353,6 @@ impl AbstractField for PackedMersenne31Neon {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         Mersenne31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        Mersenne31::generator().into()
     }
 
     #[inline(always)]

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -311,10 +311,7 @@ impl Product for PackedMersenne31Neon {
 impl AbstractField for PackedMersenne31Neon {
     type F = Mersenne31;
 
-    #[inline]
-    fn zero() -> Self {
-        Mersenne31::ZERO.into()
-    }
+    const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -294,7 +294,7 @@ impl Sum for PackedMersenne31Neon {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -313,7 +313,7 @@ impl AbstractField for PackedMersenne31Neon {
 
     #[inline]
     fn zero() -> Self {
-        Mersenne31::zero().into()
+        Mersenne31::ZERO.into()
     }
 
     #[inline]

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -304,7 +304,7 @@ impl Product for PackedMersenne31Neon {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -312,11 +312,7 @@ impl AbstractField for PackedMersenne31Neon {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        Mersenne31::one().into()
-    }
+    const ONE: Self = Self::broadcast(Mersenne31::ONE);
 
     #[inline]
     fn two() -> Self {

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -20,7 +20,7 @@ impl ComplexExtendable for Mersenne31 {
     // u + 12
     #[inline(always)]
     fn complex_generator() -> Complex<Self> {
-        Complex::new(Mersenne31::new(12), Mersenne31::one())
+        Complex::new(Mersenne31::new(12), Mersenne31::ONE)
     }
 
     fn circle_two_adic_generator(bits: usize) -> Complex<Self> {
@@ -73,9 +73,9 @@ mod tests {
     #[test]
     fn add() {
         // real part
-        assert_eq!(Fi::one() + Fi::one(), Fi::two());
-        assert_eq!(Fi::neg_one() + Fi::one(), Fi::ZERO);
-        assert_eq!(Fi::neg_one() + Fi::two(), Fi::one());
+        assert_eq!(Fi::ONE + Fi::ONE, Fi::two());
+        assert_eq!(Fi::neg_one() + Fi::ONE, Fi::ZERO);
+        assert_eq!(Fi::neg_one() + Fi::two(), Fi::ONE);
         assert_eq!(
             (Fi::neg_one() + Fi::neg_one()).real(),
             F::new(F::ORDER_U32 - 2)
@@ -83,16 +83,16 @@ mod tests {
 
         // complex part
         assert_eq!(
-            Fi::new_imag(F::one()) + Fi::new_imag(F::one()),
+            Fi::new_imag(F::ONE) + Fi::new_imag(F::ONE),
             Fi::new_imag(F::two())
         );
         assert_eq!(
-            Fi::new_imag(F::neg_one()) + Fi::new_imag(F::one()),
+            Fi::new_imag(F::neg_one()) + Fi::new_imag(F::ONE),
             Fi::new_imag(F::ZERO)
         );
         assert_eq!(
             Fi::new_imag(F::neg_one()) + Fi::new_imag(F::two()),
-            Fi::new_imag(F::one())
+            Fi::new_imag(F::ONE)
         );
         assert_eq!(
             (Fi::new_imag(F::neg_one()) + Fi::new_imag(F::neg_one())).imag(),
@@ -101,38 +101,38 @@ mod tests {
 
         // further tests
         assert_eq!(
-            Fi::new(F::one(), F::two()) + Fi::new(F::one(), F::one()),
+            Fi::new(F::ONE, F::two()) + Fi::new(F::ONE, F::ONE),
             Fi::new(F::two(), F::new(3))
         );
         assert_eq!(
-            Fi::new(F::neg_one(), F::neg_one()) + Fi::new(F::one(), F::one()),
+            Fi::new(F::neg_one(), F::neg_one()) + Fi::new(F::ONE, F::ONE),
             Fi::ZERO
         );
         assert_eq!(
-            Fi::new(F::neg_one(), F::one()) + Fi::new(F::two(), F::new(F::ORDER_U32 - 2)),
-            Fi::new(F::one(), F::neg_one())
+            Fi::new(F::neg_one(), F::ONE) + Fi::new(F::two(), F::new(F::ORDER_U32 - 2)),
+            Fi::new(F::ONE, F::neg_one())
         );
     }
 
     #[test]
     fn sub() {
         // real part
-        assert_eq!(Fi::one() - Fi::one(), Fi::ZERO);
+        assert_eq!(Fi::ONE - Fi::ONE, Fi::ZERO);
         assert_eq!(Fi::two() - Fi::two(), Fi::ZERO);
         assert_eq!(Fi::neg_one() - Fi::neg_one(), Fi::ZERO);
-        assert_eq!(Fi::two() - Fi::one(), Fi::one());
+        assert_eq!(Fi::two() - Fi::ONE, Fi::ONE);
         assert_eq!(Fi::neg_one() - Fi::ZERO, Fi::neg_one());
 
         // complex part
-        assert_eq!(Fi::new_imag(F::one()) - Fi::new_imag(F::one()), Fi::ZERO);
+        assert_eq!(Fi::new_imag(F::ONE) - Fi::new_imag(F::ONE), Fi::ZERO);
         assert_eq!(Fi::new_imag(F::two()) - Fi::new_imag(F::two()), Fi::ZERO);
         assert_eq!(
             Fi::new_imag(F::neg_one()) - Fi::new_imag(F::neg_one()),
             Fi::ZERO
         );
         assert_eq!(
-            Fi::new_imag(F::two()) - Fi::new_imag(F::one()),
-            Fi::new_imag(F::one())
+            Fi::new_imag(F::two()) - Fi::new_imag(F::ONE),
+            Fi::new_imag(F::ONE)
         );
         assert_eq!(
             Fi::new_imag(F::neg_one()) - Fi::ZERO,
@@ -152,9 +152,9 @@ mod tests {
     fn mul_2exp_u64() {
         // real part
         // 1 * 2^0 = 1.
-        assert_eq!(Fi::one().mul_2exp_u64(0), Fi::one());
+        assert_eq!(Fi::ONE.mul_2exp_u64(0), Fi::ONE);
         // 2 * 2^30 = 2^31 = 1.
-        assert_eq!(Fi::two().mul_2exp_u64(30), Fi::one());
+        assert_eq!(Fi::two().mul_2exp_u64(30), Fi::ONE);
         // 5 * 2^2 = 20.
         assert_eq!(
             Fi::new_real(F::new(5)).mul_2exp_u64(2),
@@ -164,13 +164,13 @@ mod tests {
         // complex part
         // i * 2^0 = i.
         assert_eq!(
-            Fi::new_imag(F::one()).mul_2exp_u64(0),
-            Fi::new_imag(F::one())
+            Fi::new_imag(F::ONE).mul_2exp_u64(0),
+            Fi::new_imag(F::ONE)
         );
         // (2i) * 2^30 = (2^31) * i = i.
         assert_eq!(
             Fi::new_imag(F::two()).mul_2exp_u64(30),
-            Fi::new_imag(F::one())
+            Fi::new_imag(F::ONE)
         );
         // 5i * 2^2 = 20i.
         assert_eq!(

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -18,10 +18,7 @@ impl ComplexExtendable for Mersenne31 {
     // sage: F2.<u> = F.extension(x^2 + 1)
     // sage: F2.multiplicative_generator()
     // u + 12
-    #[inline(always)]
-    fn complex_generator() -> Complex<Self> {
-        Complex::new(Mersenne31::new(12), Mersenne31::ONE)
-    }
+    const COMPLEX_GENERATOR: Complex<Self> = Complex::new(Mersenne31::new(12), Mersenne31::ONE);
 
     fn circle_two_adic_generator(bits: usize) -> Complex<Self> {
         // Generator of the whole 2^TWO_ADICITY group
@@ -73,44 +70,41 @@ mod tests {
     #[test]
     fn add() {
         // real part
-        assert_eq!(Fi::ONE + Fi::ONE, Fi::two());
-        assert_eq!(Fi::neg_one() + Fi::ONE, Fi::ZERO);
-        assert_eq!(Fi::neg_one() + Fi::two(), Fi::ONE);
-        assert_eq!(
-            (Fi::neg_one() + Fi::neg_one()).real(),
-            F::new(F::ORDER_U32 - 2)
-        );
+        assert_eq!(Fi::ONE + Fi::ONE, Fi::TWO);
+        assert_eq!(Fi::NEG_ONE + Fi::ONE, Fi::ZERO);
+        assert_eq!(Fi::NEG_ONE + Fi::TWO, Fi::ONE);
+        assert_eq!((Fi::NEG_ONE + Fi::NEG_ONE).real(), F::new(F::ORDER_U32 - 2));
 
         // complex part
         assert_eq!(
             Fi::new_imag(F::ONE) + Fi::new_imag(F::ONE),
-            Fi::new_imag(F::two())
+            Fi::new_imag(F::TWO)
         );
         assert_eq!(
-            Fi::new_imag(F::neg_one()) + Fi::new_imag(F::ONE),
+            Fi::new_imag(F::NEG_ONE) + Fi::new_imag(F::ONE),
             Fi::new_imag(F::ZERO)
         );
         assert_eq!(
-            Fi::new_imag(F::neg_one()) + Fi::new_imag(F::two()),
+            Fi::new_imag(F::NEG_ONE) + Fi::new_imag(F::TWO),
             Fi::new_imag(F::ONE)
         );
         assert_eq!(
-            (Fi::new_imag(F::neg_one()) + Fi::new_imag(F::neg_one())).imag(),
+            (Fi::new_imag(F::NEG_ONE) + Fi::new_imag(F::NEG_ONE)).imag(),
             F::new(F::ORDER_U32 - 2)
         );
 
         // further tests
         assert_eq!(
-            Fi::new(F::ONE, F::two()) + Fi::new(F::ONE, F::ONE),
-            Fi::new(F::two(), F::new(3))
+            Fi::new(F::ONE, F::TWO) + Fi::new(F::ONE, F::ONE),
+            Fi::new(F::TWO, F::new(3))
         );
         assert_eq!(
-            Fi::new(F::neg_one(), F::neg_one()) + Fi::new(F::ONE, F::ONE),
+            Fi::new(F::NEG_ONE, F::NEG_ONE) + Fi::new(F::ONE, F::ONE),
             Fi::ZERO
         );
         assert_eq!(
-            Fi::new(F::neg_one(), F::ONE) + Fi::new(F::two(), F::new(F::ORDER_U32 - 2)),
-            Fi::new(F::ONE, F::neg_one())
+            Fi::new(F::NEG_ONE, F::ONE) + Fi::new(F::TWO, F::new(F::ORDER_U32 - 2)),
+            Fi::new(F::ONE, F::NEG_ONE)
         );
     }
 
@@ -118,33 +112,33 @@ mod tests {
     fn sub() {
         // real part
         assert_eq!(Fi::ONE - Fi::ONE, Fi::ZERO);
-        assert_eq!(Fi::two() - Fi::two(), Fi::ZERO);
-        assert_eq!(Fi::neg_one() - Fi::neg_one(), Fi::ZERO);
-        assert_eq!(Fi::two() - Fi::ONE, Fi::ONE);
-        assert_eq!(Fi::neg_one() - Fi::ZERO, Fi::neg_one());
+        assert_eq!(Fi::TWO - Fi::TWO, Fi::ZERO);
+        assert_eq!(Fi::NEG_ONE - Fi::NEG_ONE, Fi::ZERO);
+        assert_eq!(Fi::TWO - Fi::ONE, Fi::ONE);
+        assert_eq!(Fi::NEG_ONE - Fi::ZERO, Fi::NEG_ONE);
 
         // complex part
         assert_eq!(Fi::new_imag(F::ONE) - Fi::new_imag(F::ONE), Fi::ZERO);
-        assert_eq!(Fi::new_imag(F::two()) - Fi::new_imag(F::two()), Fi::ZERO);
+        assert_eq!(Fi::new_imag(F::TWO) - Fi::new_imag(F::TWO), Fi::ZERO);
         assert_eq!(
-            Fi::new_imag(F::neg_one()) - Fi::new_imag(F::neg_one()),
+            Fi::new_imag(F::NEG_ONE) - Fi::new_imag(F::NEG_ONE),
             Fi::ZERO
         );
         assert_eq!(
-            Fi::new_imag(F::two()) - Fi::new_imag(F::ONE),
+            Fi::new_imag(F::TWO) - Fi::new_imag(F::ONE),
             Fi::new_imag(F::ONE)
         );
         assert_eq!(
-            Fi::new_imag(F::neg_one()) - Fi::ZERO,
-            Fi::new_imag(F::neg_one())
+            Fi::new_imag(F::NEG_ONE) - Fi::ZERO,
+            Fi::new_imag(F::NEG_ONE)
         );
     }
 
     #[test]
     fn mul() {
         assert_eq!(
-            Fi::new(F::two(), F::two()) * Fi::new(F::new(4), F::new(5)),
-            Fi::new(-F::two(), F::new(18))
+            Fi::new(F::TWO, F::TWO) * Fi::new(F::new(4), F::new(5)),
+            Fi::new(-F::TWO, F::new(18))
         );
     }
 
@@ -154,7 +148,7 @@ mod tests {
         // 1 * 2^0 = 1.
         assert_eq!(Fi::ONE.mul_2exp_u64(0), Fi::ONE);
         // 2 * 2^30 = 2^31 = 1.
-        assert_eq!(Fi::two().mul_2exp_u64(30), Fi::ONE);
+        assert_eq!(Fi::TWO.mul_2exp_u64(30), Fi::ONE);
         // 5 * 2^2 = 20.
         assert_eq!(
             Fi::new_real(F::new(5)).mul_2exp_u64(2),
@@ -165,10 +159,7 @@ mod tests {
         // i * 2^0 = i.
         assert_eq!(Fi::new_imag(F::ONE).mul_2exp_u64(0), Fi::new_imag(F::ONE));
         // (2i) * 2^30 = (2^31) * i = i.
-        assert_eq!(
-            Fi::new_imag(F::two()).mul_2exp_u64(30),
-            Fi::new_imag(F::ONE)
-        );
+        assert_eq!(Fi::new_imag(F::TWO).mul_2exp_u64(30), Fi::new_imag(F::ONE));
         // 5i * 2^2 = 20i.
         assert_eq!(
             Fi::new_imag(F::new(5)).mul_2exp_u64(2),

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -74,7 +74,7 @@ mod tests {
     fn add() {
         // real part
         assert_eq!(Fi::one() + Fi::one(), Fi::two());
-        assert_eq!(Fi::neg_one() + Fi::one(), Fi::zero());
+        assert_eq!(Fi::neg_one() + Fi::one(), Fi::ZERO);
         assert_eq!(Fi::neg_one() + Fi::two(), Fi::one());
         assert_eq!(
             (Fi::neg_one() + Fi::neg_one()).real(),
@@ -88,7 +88,7 @@ mod tests {
         );
         assert_eq!(
             Fi::new_imag(F::neg_one()) + Fi::new_imag(F::one()),
-            Fi::new_imag(F::zero())
+            Fi::new_imag(F::ZERO)
         );
         assert_eq!(
             Fi::new_imag(F::neg_one()) + Fi::new_imag(F::two()),
@@ -106,7 +106,7 @@ mod tests {
         );
         assert_eq!(
             Fi::new(F::neg_one(), F::neg_one()) + Fi::new(F::one(), F::one()),
-            Fi::zero()
+            Fi::ZERO
         );
         assert_eq!(
             Fi::new(F::neg_one(), F::one()) + Fi::new(F::two(), F::new(F::ORDER_U32 - 2)),
@@ -117,25 +117,25 @@ mod tests {
     #[test]
     fn sub() {
         // real part
-        assert_eq!(Fi::one() - Fi::one(), Fi::zero());
-        assert_eq!(Fi::two() - Fi::two(), Fi::zero());
-        assert_eq!(Fi::neg_one() - Fi::neg_one(), Fi::zero());
+        assert_eq!(Fi::one() - Fi::one(), Fi::ZERO);
+        assert_eq!(Fi::two() - Fi::two(), Fi::ZERO);
+        assert_eq!(Fi::neg_one() - Fi::neg_one(), Fi::ZERO);
         assert_eq!(Fi::two() - Fi::one(), Fi::one());
-        assert_eq!(Fi::neg_one() - Fi::zero(), Fi::neg_one());
+        assert_eq!(Fi::neg_one() - Fi::ZERO, Fi::neg_one());
 
         // complex part
-        assert_eq!(Fi::new_imag(F::one()) - Fi::new_imag(F::one()), Fi::zero());
-        assert_eq!(Fi::new_imag(F::two()) - Fi::new_imag(F::two()), Fi::zero());
+        assert_eq!(Fi::new_imag(F::one()) - Fi::new_imag(F::one()), Fi::ZERO);
+        assert_eq!(Fi::new_imag(F::two()) - Fi::new_imag(F::two()), Fi::ZERO);
         assert_eq!(
             Fi::new_imag(F::neg_one()) - Fi::new_imag(F::neg_one()),
-            Fi::zero()
+            Fi::ZERO
         );
         assert_eq!(
             Fi::new_imag(F::two()) - Fi::new_imag(F::one()),
             Fi::new_imag(F::one())
         );
         assert_eq!(
-            Fi::new_imag(F::neg_one()) - Fi::zero(),
+            Fi::new_imag(F::neg_one()) - Fi::ZERO,
             Fi::new_imag(F::neg_one())
         );
     }

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -163,10 +163,7 @@ mod tests {
 
         // complex part
         // i * 2^0 = i.
-        assert_eq!(
-            Fi::new_imag(F::ONE).mul_2exp_u64(0),
-            Fi::new_imag(F::ONE)
-        );
+        assert_eq!(Fi::new_imag(F::ONE).mul_2exp_u64(0), Fi::new_imag(F::ONE));
         // (2i) * 2^30 = (2^31) * i = i.
         assert_eq!(
             Fi::new_imag(F::two()).mul_2exp_u64(30),

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -230,7 +230,7 @@ mod tests {
 
         let mut conv = Vec::with_capacity(N);
         for i in 0..N {
-            let mut t = Base::zero();
+            let mut t = Base::ZERO;
             for j in 0..N {
                 t += a.values[j] * b.values[(N + i - j) % N];
             }

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -101,7 +101,7 @@ fn idft_preprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<C> {
     // NB: The original real matrix had length 2h, hence log2(2h) = log2(h) + 1.
     // omega is a 2n-th root of unity
     let omega = C::two_adic_generator(log2_h + 1).inverse();
-    let mut omega_j = C::one();
+    let mut omega_j = C::ONE;
 
     let mut output = Vec::with_capacity(h * input.width());
     // TODO: Specialise j = 0 and j = n (which we know must be real)?

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -12,18 +12,12 @@ impl BinomiallyExtendable<3> for Mersenne31 {
     // R.<x> = F[]
     // assert (x^3 - 5).is_irreducible()
     // ```
-    #[inline(always)]
-    fn w() -> Self {
-        Self::new(5)
-    }
+    const W: Self = Self::new(5);
 
     // ```sage
     // F(5)^((p-1)/3)
     // ```
-    #[inline(always)]
-    fn dth_root() -> Self {
-        Self::new(1513477735)
-    }
+    const DTH_ROOT: Self = Self::new(1513477735);
 
     // ```sage
     // F.extension(x^3 - 5, 'u').multiplicative_generator()
@@ -42,16 +36,10 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     // f2 = y^2 - i - 2
     // assert f2.is_irreducible()
     // ```
-    #[inline(always)]
-    fn w() -> Complex<Self> {
-        Complex::new(Mersenne31::new(2), Mersenne31::ONE)
-    }
+    const W: Complex<Self> = Complex::new(Mersenne31::new(2), Mersenne31::ONE);
 
     // DTH_ROOT = W^((p^2 - 1)/2).
-    #[inline(always)]
-    fn dth_root() -> Complex<Self> {
-        Complex::new_real(Mersenne31::new(2147483646))
-    }
+    const DTH_ROOT: Complex<Self> = Complex::new_real(Mersenne31::new(2147483646));
 
     // Verifiable in Sage with
     // ```sage
@@ -90,14 +78,10 @@ impl HasComplexBinomialExtension<3> for Mersenne31 {
     // f2 = y^3 - 5*i
     // assert f2.is_irreducible()
     // ```
-    fn w() -> Complex<Self> {
-        Complex::new_imag(Mersenne31::new(5))
-    }
+    const W: Complex<Self> = Complex::new_imag(Mersenne31::new(5));
 
     // DTH_ROOT = W^((p^2 - 1)/2).
-    fn dth_root() -> Complex<Self> {
-        Complex::new_real(Mersenne31::new(634005911))
-    }
+    const DTH_ROOT: Complex<Self> = Complex::new_real(Mersenne31::new(634005911));
 
     // Verifiable in Sage with
     // ```sage

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -28,10 +28,7 @@ impl BinomiallyExtendable<3> for Mersenne31 {
     // ```sage
     // F.extension(x^3 - 5, 'u').multiplicative_generator()
     // ```
-    #[inline(always)]
-    fn ext_generator() -> [Self; 3] {
-        [Self::new(10), Self::new(1), Self::ZERO]
-    }
+    const EXT_GENERATOR: [Self; 3] = [Self::new(10), Self::new(1), Self::ZERO];
 }
 
 impl HasComplexBinomialExtension<2> for Mersenne31 {
@@ -63,10 +60,7 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     // for f in factor(p^4 - 1):
     //   assert g^((p^4-1) // f) != 1
     // ```
-    #[inline(always)]
-    fn ext_generator() -> [Complex<Self>; 2] {
-        [Complex::new_real(Mersenne31::new(6)), Complex::ONE]
-    }
+    const EXT_GENERATOR: [Complex<Self>; 2] = [Complex::new_real(Mersenne31::new(6)), Complex::ONE];
 }
 
 impl HasTwoAdicComplexBinomialExtension<2> for Mersenne31 {
@@ -112,13 +106,11 @@ impl HasComplexBinomialExtension<3> for Mersenne31 {
     // for f in factor(p^6 - 1):
     //   assert g^((p^6-1) // f) != 1
     // ```
-    fn ext_generator() -> [Complex<Self>; 3] {
-        [
-            Complex::new_real(Mersenne31::new(5)),
-            Complex::new_real(Mersenne31::ONE),
-            Complex::ZERO,
-        ]
-    }
+    const EXT_GENERATOR: [Complex<Self>; 3] = [
+        Complex::new_real(Mersenne31::new(5)),
+        Complex::new_real(Mersenne31::ONE),
+        Complex::ZERO,
+    ];
 }
 
 impl HasTwoAdicComplexBinomialExtension<3> for Mersenne31 {

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -47,7 +47,7 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     // ```
     #[inline(always)]
     fn w() -> Complex<Self> {
-        Complex::new(Mersenne31::new(2), Mersenne31::one())
+        Complex::new(Mersenne31::new(2), Mersenne31::ONE)
     }
 
     // DTH_ROOT = W^((p^2 - 1)/2).
@@ -65,7 +65,7 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     // ```
     #[inline(always)]
     fn ext_generator() -> [Complex<Self>; 2] {
-        [Complex::new_real(Mersenne31::new(6)), Complex::one()]
+        [Complex::new_real(Mersenne31::new(6)), Complex::ONE]
     }
 }
 
@@ -115,7 +115,7 @@ impl HasComplexBinomialExtension<3> for Mersenne31 {
     fn ext_generator() -> [Complex<Self>; 3] {
         [
             Complex::new_real(Mersenne31::new(5)),
-            Complex::new_real(Mersenne31::one()),
+            Complex::new_real(Mersenne31::ONE),
             Complex::ZERO,
         ]
     }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -30,7 +30,7 @@ impl BinomiallyExtendable<3> for Mersenne31 {
     // ```
     #[inline(always)]
     fn ext_generator() -> [Self; 3] {
-        [Self::new(10), Self::new(1), Self::zero()]
+        [Self::new(10), Self::new(1), Self::ZERO]
     }
 }
 
@@ -76,11 +76,11 @@ impl HasTwoAdicComplexBinomialExtension<2> for Mersenne31 {
         assert!(bits <= 33);
         if bits == 33 {
             [
-                Complex::zero(),
+                Complex::ZERO,
                 Complex::new(Mersenne31::new(1437746044), Mersenne31::new(946469285)),
             ]
         } else {
-            [Complex::two_adic_generator(bits), Complex::zero()]
+            [Complex::two_adic_generator(bits), Complex::ZERO]
         }
     }
 }
@@ -116,7 +116,7 @@ impl HasComplexBinomialExtension<3> for Mersenne31 {
         [
             Complex::new_real(Mersenne31::new(5)),
             Complex::new_real(Mersenne31::one()),
-            Complex::zero(),
+            Complex::ZERO,
         ]
     }
 }

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -95,13 +95,10 @@ impl AbstractField for Mersenne31 {
 
     const ZERO: Self = Self { value: 0 };
     const ONE: Self = Self { value: 1 };
-
-    fn two() -> Self {
-        Self::new(2)
-    }
-    fn neg_one() -> Self {
-        Self::new(Self::ORDER_U32 - 1)
-    }
+    const TWO: Self = Self { value: 2 };
+    const NEG_ONE: Self = Self {
+        value: Self::ORDER_U32 - 1,
+    };
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -163,12 +160,6 @@ impl AbstractField for Mersenne31 {
         Self::from_canonical_u32((n % Self::ORDER_U64) as u32)
     }
 
-    // Sage: GF(2^31 - 1).multiplicative_generator()
-    #[inline]
-    fn generator() -> Self {
-        Self::new(7)
-    }
-
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: repr(transparent) ensures transmutation safety.
@@ -205,6 +196,9 @@ impl Field for Mersenne31 {
         ),
     )))]
     type Packing = Self;
+
+    // Sage: GF(2^31 - 1).multiplicative_generator()
+    const GENERATOR: Self = Self::new(7);
 
     #[inline]
     fn is_zero(&self) -> bool {
@@ -446,19 +440,19 @@ mod tests {
 
     #[test]
     fn add() {
-        assert_eq!(F::ONE + F::ONE, F::two());
-        assert_eq!(F::neg_one() + F::ONE, F::ZERO);
-        assert_eq!(F::neg_one() + F::two(), F::ONE);
-        assert_eq!(F::neg_one() + F::neg_one(), F::new(F::ORDER_U32 - 2));
+        assert_eq!(F::ONE + F::ONE, F::TWO);
+        assert_eq!(F::NEG_ONE + F::ONE, F::ZERO);
+        assert_eq!(F::NEG_ONE + F::TWO, F::ONE);
+        assert_eq!(F::NEG_ONE + F::NEG_ONE, F::new(F::ORDER_U32 - 2));
     }
 
     #[test]
     fn sub() {
         assert_eq!(F::ONE - F::ONE, F::ZERO);
-        assert_eq!(F::two() - F::two(), F::ZERO);
-        assert_eq!(F::neg_one() - F::neg_one(), F::ZERO);
-        assert_eq!(F::two() - F::ONE, F::ONE);
-        assert_eq!(F::neg_one() - F::ZERO, F::neg_one());
+        assert_eq!(F::TWO - F::TWO, F::ZERO);
+        assert_eq!(F::NEG_ONE - F::NEG_ONE, F::ZERO);
+        assert_eq!(F::TWO - F::ONE, F::ONE);
+        assert_eq!(F::NEG_ONE - F::ZERO, F::NEG_ONE);
     }
 
     #[test]
@@ -466,7 +460,7 @@ mod tests {
         // 1 * 2^0 = 1.
         assert_eq!(F::ONE.mul_2exp_u64(0), F::ONE);
         // 2 * 2^30 = 2^31 = 1.
-        assert_eq!(F::two().mul_2exp_u64(30), F::ONE);
+        assert_eq!(F::TWO.mul_2exp_u64(30), F::ONE);
         // 5 * 2^2 = 20.
         assert_eq!(F::new(5).mul_2exp_u64(2), F::new(20));
     }
@@ -476,7 +470,7 @@ mod tests {
         // 1 / 2^0 = 1.
         assert_eq!(F::ONE.div_2exp_u64(0), F::ONE);
         // 2 / 2^0 = 2.
-        assert_eq!(F::two().div_2exp_u64(0), F::two());
+        assert_eq!(F::TWO.div_2exp_u64(0), F::TWO);
         // 32 / 2^5 = 1.
         assert_eq!(F::new(32).div_2exp_u64(5), F::new(1));
     }
@@ -490,7 +484,7 @@ mod tests {
 
         assert_eq!(m1.exp_u64(1717986917).exp_const_u64::<5>(), m1);
         assert_eq!(m2.exp_u64(1717986917).exp_const_u64::<5>(), m2);
-        assert_eq!(F::two().exp_u64(1717986917).exp_const_u64::<5>(), F::two());
+        assert_eq!(F::TWO.exp_u64(1717986917).exp_const_u64::<5>(), F::TWO);
     }
 
     test_field!(crate::Mersenne31);

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -93,9 +93,8 @@ impl Distribution<Mersenne31> for Standard {
 impl AbstractField for Mersenne31 {
     type F = Self;
 
-    fn zero() -> Self {
-        Self::new(0)
-    }
+    const ZERO: Self = Self { value: 0 };
+
     fn one() -> Self {
         Self::new(1)
     }
@@ -336,7 +335,7 @@ impl AddAssign for Mersenne31 {
 impl Sum for Mersenne31 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::zero()) for iterators of length >= 6.
+        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO) for iterators of length >= 6.
         // It assumes that iter.len() < 2^31.
 
         // This sum will not overflow so long as iter.len() < 2^33.
@@ -450,18 +449,18 @@ mod tests {
     #[test]
     fn add() {
         assert_eq!(F::one() + F::one(), F::two());
-        assert_eq!(F::neg_one() + F::one(), F::zero());
+        assert_eq!(F::neg_one() + F::one(), F::ZERO);
         assert_eq!(F::neg_one() + F::two(), F::one());
         assert_eq!(F::neg_one() + F::neg_one(), F::new(F::ORDER_U32 - 2));
     }
 
     #[test]
     fn sub() {
-        assert_eq!(F::one() - F::one(), F::zero());
-        assert_eq!(F::two() - F::two(), F::zero());
-        assert_eq!(F::neg_one() - F::neg_one(), F::zero());
+        assert_eq!(F::one() - F::one(), F::ZERO);
+        assert_eq!(F::two() - F::two(), F::ZERO);
+        assert_eq!(F::neg_one() - F::neg_one(), F::ZERO);
         assert_eq!(F::two() - F::one(), F::one());
-        assert_eq!(F::neg_one() - F::zero(), F::neg_one());
+        assert_eq!(F::neg_one() - F::ZERO, F::neg_one());
     }
 
     #[test]

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -94,10 +94,8 @@ impl AbstractField for Mersenne31 {
     type F = Self;
 
     const ZERO: Self = Self { value: 0 };
+    const ONE: Self = Self { value: 1 };
 
-    fn one() -> Self {
-        Self::new(1)
-    }
     fn two() -> Self {
         Self::new(2)
     }
@@ -399,7 +397,7 @@ impl MulAssign for Mersenne31 {
 impl Product for Mersenne31 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 
@@ -448,27 +446,27 @@ mod tests {
 
     #[test]
     fn add() {
-        assert_eq!(F::one() + F::one(), F::two());
-        assert_eq!(F::neg_one() + F::one(), F::ZERO);
-        assert_eq!(F::neg_one() + F::two(), F::one());
+        assert_eq!(F::ONE + F::ONE, F::two());
+        assert_eq!(F::neg_one() + F::ONE, F::ZERO);
+        assert_eq!(F::neg_one() + F::two(), F::ONE);
         assert_eq!(F::neg_one() + F::neg_one(), F::new(F::ORDER_U32 - 2));
     }
 
     #[test]
     fn sub() {
-        assert_eq!(F::one() - F::one(), F::ZERO);
+        assert_eq!(F::ONE - F::ONE, F::ZERO);
         assert_eq!(F::two() - F::two(), F::ZERO);
         assert_eq!(F::neg_one() - F::neg_one(), F::ZERO);
-        assert_eq!(F::two() - F::one(), F::one());
+        assert_eq!(F::two() - F::ONE, F::ONE);
         assert_eq!(F::neg_one() - F::ZERO, F::neg_one());
     }
 
     #[test]
     fn mul_2exp_u64() {
         // 1 * 2^0 = 1.
-        assert_eq!(F::one().mul_2exp_u64(0), F::one());
+        assert_eq!(F::ONE.mul_2exp_u64(0), F::ONE);
         // 2 * 2^30 = 2^31 = 1.
-        assert_eq!(F::two().mul_2exp_u64(30), F::one());
+        assert_eq!(F::two().mul_2exp_u64(30), F::ONE);
         // 5 * 2^2 = 20.
         assert_eq!(F::new(5).mul_2exp_u64(2), F::new(20));
     }
@@ -476,7 +474,7 @@ mod tests {
     #[test]
     fn div_2exp_u64() {
         // 1 / 2^0 = 1.
-        assert_eq!(F::one().div_2exp_u64(0), F::one());
+        assert_eq!(F::ONE.div_2exp_u64(0), F::ONE);
         // 2 / 2^0 = 2.
         assert_eq!(F::two().div_2exp_u64(0), F::two());
         // 32 / 2^5 = 1.

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -298,7 +298,7 @@ impl Sum for PackedMersenne31AVX2 {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -315,10 +315,7 @@ impl Product for PackedMersenne31AVX2 {
 impl AbstractField for PackedMersenne31AVX2 {
     type F = Mersenne31;
 
-    #[inline]
-    fn zero() -> Self {
-        Mersenne31::zero().into()
-    }
+    const ZERO: Self = Self([Mersenne31::ZERO; WIDTH]);
 
     #[inline]
     fn one() -> Self {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -315,7 +315,7 @@ impl Product for PackedMersenne31AVX2 {
 impl AbstractField for PackedMersenne31AVX2 {
     type F = Mersenne31;
 
-    const ZERO: Self = Self([Mersenne31::ZERO; WIDTH]);
+    const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -308,7 +308,7 @@ impl Product for PackedMersenne31AVX2 {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -316,11 +316,7 @@ impl AbstractField for PackedMersenne31AVX2 {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        Mersenne31::one().into()
-    }
+    const ONE: Self = Self::broadcast(Mersenne31::ONE);
 
     #[inline]
     fn two() -> Self {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -317,16 +317,8 @@ impl AbstractField for PackedMersenne31AVX2 {
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
     const ONE: Self = Self::broadcast(Mersenne31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        Mersenne31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        Mersenne31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(Mersenne31::TWO);
+    const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -365,11 +357,6 @@ impl AbstractField for PackedMersenne31AVX2 {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         Mersenne31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        Mersenne31::generator().into()
     }
 
     #[inline(always)]

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -337,16 +337,8 @@ impl AbstractField for PackedMersenne31AVX512 {
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
     const ONE: Self = Self::broadcast(Mersenne31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        Mersenne31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        Mersenne31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(Mersenne31::TWO);
+    const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -385,11 +377,6 @@ impl AbstractField for PackedMersenne31AVX512 {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         Mersenne31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        Mersenne31::generator().into()
     }
 
     #[inline(always)]

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -335,10 +335,7 @@ impl Product for PackedMersenne31AVX512 {
 impl AbstractField for PackedMersenne31AVX512 {
     type F = Mersenne31;
 
-    #[inline]
-    fn zero() -> Self {
-        Mersenne31::ZERO.into()
-    }
+    const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -328,7 +328,7 @@ impl Product for PackedMersenne31AVX512 {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -336,11 +336,7 @@ impl AbstractField for PackedMersenne31AVX512 {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        Mersenne31::one().into()
-    }
+    const ONE: Self = Self::broadcast(Mersenne31::ONE);
 
     #[inline]
     fn two() -> Self {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -318,7 +318,7 @@ impl Sum for PackedMersenne31AVX512 {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -337,7 +337,7 @@ impl AbstractField for PackedMersenne31AVX512 {
 
     #[inline]
     fn zero() -> Self {
-        Mersenne31::zero().into()
+        Mersenne31::ZERO.into()
     }
 
     #[inline]

--- a/monolith/benches/permute.rs
+++ b/monolith/benches/permute.rs
@@ -15,7 +15,7 @@ where
 {
     let monolith: MonolithMersenne31<_, WIDTH, 5> = MonolithMersenne31::new(mds);
 
-    let mut input: [Mersenne31; WIDTH] = [Mersenne31::zero(); WIDTH];
+    let mut input: [Mersenne31; WIDTH] = [Mersenne31::ZERO; WIDTH];
     for (i, inp) in input.iter_mut().enumerate() {
         *inp = Mersenne31::from_canonical_usize(i);
     }

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -110,7 +110,7 @@ where
     fn instantiate_round_constants() -> [[Mersenne31; WIDTH]; NUM_FULL_ROUNDS] {
         let mut shake = Self::init_shake();
 
-        [[Mersenne31::zero(); WIDTH]; NUM_FULL_ROUNDS]
+        [[Mersenne31::ZERO; WIDTH]; NUM_FULL_ROUNDS]
             .map(|arr| arr.map(|_| Self::random_field_element(&mut shake)))
     }
 
@@ -191,7 +191,7 @@ mod tests {
         let mds = MonolithMdsMatrixMersenne31::<6>;
         let monolith: MonolithMersenne31<_, 16, 5> = MonolithMersenne31::new(mds);
 
-        let mut input: [Mersenne31; 16] = [Mersenne31::zero(); 16];
+        let mut input: [Mersenne31; 16] = [Mersenne31::ZERO; 16];
         for (i, inp) in input.iter_mut().enumerate() {
             *inp = Mersenne31::from_canonical_usize(i);
         }

--- a/monolith/src/monolith_mds.rs
+++ b/monolith/src/monolith_mds.rs
@@ -54,7 +54,7 @@ fn apply_cauchy_mds_matrix<F: PrimeField32, const WIDTH: usize>(
     shake: &mut Shake128Reader,
     to_multiply: [F; WIDTH],
 ) -> [F; WIDTH] {
-    let mut output: [F; WIDTH] = [F::zero(); WIDTH];
+    let mut output: [F; WIDTH] = [F::ZERO; WIDTH];
 
     let bits = F::bits();
     let x_mask = (1 << (bits - 9)) - 1;

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -447,16 +447,8 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
     const ONE: Self = Self::broadcast(MontyField31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        MontyField31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        MontyField31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(MontyField31::TWO);
+    const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -495,11 +487,6 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         MontyField31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        MontyField31::generator().into()
     }
 
     #[inline]

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -438,7 +438,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31Neon<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -446,11 +446,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        MontyField31::one().into()
-    }
+    const ONE: Self = Self::broadcast(MontyField31::ONE);
 
     #[inline]
     fn two() -> Self {

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -445,10 +445,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31Neon<FP> {
 impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
     type F = MontyField31<FP>;
 
-    #[inline]
-    fn zero() -> Self {
-        MontyField31::ZERO.into()
-    }
+    const ZERO: Self = Self::broadcast(MontyField31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -428,7 +428,7 @@ impl<FP: FieldParameters> Sum for PackedMontyField31Neon<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -447,7 +447,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
 
     #[inline]
     fn zero() -> Self {
-        MontyField31::zero().into()
+        MontyField31::ZERO.into()
     }
 
     #[inline]

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -22,10 +22,7 @@ where
         <FP as BinomialExtensionData<WIDTH>>::DTH_ROOT
     }
 
-    #[inline(always)]
-    fn ext_generator() -> [Self; WIDTH] {
-        FP::EXT_GENERATOR
-    }
+    const EXT_GENERATOR: [Self; WIDTH] = FP::EXT_GENERATOR;
 }
 
 impl<const WIDTH: usize, FP> HasTwoAdicBionmialExtension<WIDTH> for MontyField31<FP>

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -12,15 +12,9 @@ impl<const WIDTH: usize, FP> BinomiallyExtendable<WIDTH> for MontyField31<FP>
 where
     FP: BinomialExtensionData<WIDTH> + FieldParameters,
 {
-    #[inline(always)]
-    fn w() -> Self {
-        <FP as BinomialExtensionData<WIDTH>>::W
-    }
+    const W: Self = <FP as BinomialExtensionData<WIDTH>>::W;
 
-    #[inline(always)]
-    fn dth_root() -> Self {
-        <FP as BinomialExtensionData<WIDTH>>::DTH_ROOT
-    }
+    const DTH_ROOT: Self = <FP as BinomialExtensionData<WIDTH>>::DTH_ROOT;
 
     const EXT_GENERATOR: [Self; WIDTH] = FP::EXT_GENERATOR;
 }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -151,10 +151,7 @@ impl<FP: FieldParameters> Packable for MontyField31<FP> {}
 impl<FP: FieldParameters> AbstractField for MontyField31<FP> {
     type F = Self;
 
-    #[inline(always)]
-    fn zero() -> Self {
-        FP::MONTY_ZERO
-    }
+    const ZERO: Self = FP::MONTY_ZERO;
 
     #[inline(always)]
     fn one() -> Self {
@@ -344,7 +341,7 @@ impl<FP: MontyParameters> AddAssign for MontyField31<FP> {
 impl<FP: MontyParameters> Sum for MontyField31<FP> {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::zero()) for iterators of length > 2.
+        // This is faster than iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO) for iterators of length > 2.
         // There might be a faster reduction method possible for lengths <= 16 which avoids %.
 
         // This sum will not overflow so long as iter.len() < 2^33.
@@ -377,7 +374,7 @@ impl<FP: FieldParameters> Neg for MontyField31<FP> {
 
     #[inline]
     fn neg(self) -> Self::Output {
-        Self::zero() - self
+        Self::ZERO - self
     }
 }
 

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -152,11 +152,7 @@ impl<FP: FieldParameters> AbstractField for MontyField31<FP> {
     type F = Self;
 
     const ZERO: Self = FP::MONTY_ZERO;
-
-    #[inline(always)]
-    fn one() -> Self {
-        FP::MONTY_ONE
-    }
+    const ONE: Self = FP::MONTY_ONE;
 
     #[inline(always)]
     fn two() -> Self {
@@ -398,7 +394,7 @@ impl<FP: MontyParameters> MulAssign for MontyField31<FP> {
 impl<FP: FieldParameters> Product for MontyField31<FP> {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::one())
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
     }
 }
 

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -153,16 +153,8 @@ impl<FP: FieldParameters> AbstractField for MontyField31<FP> {
 
     const ZERO: Self = FP::MONTY_ZERO;
     const ONE: Self = FP::MONTY_ONE;
-
-    #[inline(always)]
-    fn two() -> Self {
-        FP::MONTY_TWO
-    }
-
-    #[inline(always)]
-    fn neg_one() -> Self {
-        FP::MONTY_NEG_ONE
-    }
+    const TWO: Self = FP::MONTY_TWO;
+    const NEG_ONE: Self = FP::MONTY_NEG_ONE;
 
     #[inline(always)]
     fn from_f(f: Self::F) -> Self {
@@ -212,11 +204,6 @@ impl<FP: FieldParameters> AbstractField for MontyField31<FP> {
         Self::new_monty(to_monty_64::<FP>(n))
     }
 
-    #[inline(always)]
-    fn generator() -> Self {
-        FP::MONTY_GEN
-    }
-
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: repr(transparent) ensures transmutation safety.
@@ -253,6 +240,8 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
         ),
     )))]
     type Packing = Self;
+
+    const GENERATOR: Self = FP::MONTY_GEN;
 
     #[inline]
     fn mul_2exp_u64(&self, exp: u64) -> Self {

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -455,7 +455,7 @@ impl<FP: FieldParameters> Sum for PackedMontyField31AVX2<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -472,10 +472,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX2<FP> {
 impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
     type F = MontyField31<FP>;
 
-    #[inline]
-    fn zero() -> Self {
-        MontyField31::zero().into()
-    }
+    const ZERO: Self = Self::broadcast(MontyField31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -465,7 +465,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX2<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -473,11 +473,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        MontyField31::one().into()
-    }
+    const ONE: Self = Self::broadcast(MontyField31::ONE);
 
     #[inline]
     fn two() -> Self {
@@ -550,7 +546,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
         // The other powers could be specialised similarly but we ignore this for now.
         // These ideas could also be used to speed up the more generic exp_u64.
         match POWER {
-            0 => Self::one(),
+            0 => Self::ONE,
             1 => *self,
             2 => self.square(),
             3 => self.cube(),

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -474,16 +474,8 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
     const ONE: Self = Self::broadcast(MontyField31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        MontyField31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        MontyField31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(MontyField31::TWO);
+    const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -522,11 +514,6 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         MontyField31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        MontyField31::generator().into()
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -361,7 +361,7 @@ impl<FP: FieldParameters> Sum for PackedMontyField31AVX512<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::zero())
+        iter.reduce(|lhs, rhs| lhs + rhs).unwrap_or(Self::ZERO)
     }
 }
 
@@ -380,7 +380,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
 
     #[inline]
     fn zero() -> Self {
-        MontyField31::zero().into()
+        MontyField31::ZERO.into()
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -371,7 +371,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX512<FP> {
     where
         I: Iterator<Item = Self>,
     {
-        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::one())
+        iter.reduce(|lhs, rhs| lhs * rhs).unwrap_or(Self::ONE)
     }
 }
 
@@ -379,11 +379,7 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
-
-    #[inline]
-    fn one() -> Self {
-        MontyField31::one().into()
-    }
+    const ONE: Self = Self::broadcast(MontyField31::ONE);
 
     #[inline]
     fn two() -> Self {

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -378,10 +378,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX512<FP> {
 impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
     type F = MontyField31<FP>;
 
-    #[inline]
-    fn zero() -> Self {
-        MontyField31::ZERO.into()
-    }
+    const ZERO: Self = Self::broadcast(MontyField31::ZERO);
 
     #[inline]
     fn one() -> Self {

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -380,16 +380,8 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
     const ONE: Self = Self::broadcast(MontyField31::ONE);
-
-    #[inline]
-    fn two() -> Self {
-        MontyField31::two().into()
-    }
-
-    #[inline]
-    fn neg_one() -> Self {
-        MontyField31::neg_one().into()
-    }
+    const TWO: Self = Self::broadcast(MontyField31::TWO);
+    const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -428,11 +420,6 @@ impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
         MontyField31::from_wrapped_u64(n).into()
-    }
-
-    #[inline]
-    fn generator() -> Self {
-        MontyField31::generator().into()
     }
 
     #[inline(always)]

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -47,7 +47,7 @@ where
         mds,
         &mut rng,
     );
-    let input: [AF; WIDTH] = array::from_fn(|_| AF::zero());
+    let input: [AF; WIDTH] = array::from_fn(|_| AF::ZERO);
     let name = format!("poseidon::<{}, {}>", type_name::<AF>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -141,7 +141,7 @@ fn generate_trace_rows_for_perm<
     external_linear_layer: &MdsLight,
     internal_linear_layer: &Diffusion,
 ) {
-    perm.export = F::one();
+    perm.export = F::ONE;
     perm.inputs = state;
 
     external_linear_layer.permute_mut(&mut state);

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -60,7 +60,7 @@ fn poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64>(
         internal_linear_layer,
         &mut rng,
     );
-    let input = [F::Packing::zero(); WIDTH];
+    let input = [F::Packing::ZERO; WIDTH];
     let name = format!(
         "poseidon2::<{}, {}, {}, {}>",
         type_name::<F::Packing>(),
@@ -89,7 +89,7 @@ where
         internal_linear_layer,
         &mut rng,
     );
-    let input = [F::Packing::zero(); WIDTH];
+    let input = [F::Packing::ZERO; WIDTH];
     let name = format!(
         "poseidon2::<{}, {}, {}>",
         type_name::<F::Packing>(),

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -44,7 +44,7 @@ where
     let mds = Mds::default();
     let sbox = BasicSboxLayer::for_alpha(ALPHA);
     let rescue = Rescue::<AF::F, Mds, _, WIDTH>::new(NUM_ROUNDS, round_constants, mds, sbox);
-    let input: [AF; WIDTH] = array::from_fn(|_| AF::zero());
+    let input: [AF; WIDTH] = array::from_fn(|_| AF::ZERO);
     let name = format!("rescue::<{}, {}>", type_name::<AF>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -82,7 +82,7 @@ where
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         assert_eq!(
             x.into(),
-            F::zero(),
+            F::ZERO,
             "constraints had nonzero value on row {}",
             self.row_index
         );

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -173,7 +173,7 @@ where
                 width,
             );
 
-            let accumulator = PackedChallenge::<SC>::zero();
+            let accumulator = PackedChallenge::<SC>::ZERO;
             let mut folder = ProverConstraintFolder {
                 main: main.as_view(),
                 public_values,

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -78,10 +78,8 @@ impl<F: Field> AbstractField for SymbolicExpression<F> {
     type F = F;
 
     const ZERO: Self = Self::Constant(F::ZERO);
+    const ONE: Self = Self::Constant(F::ONE);
 
-    fn one() -> Self {
-        Self::Constant(F::one())
-    }
     fn two() -> Self {
         Self::Constant(F::two())
     }
@@ -260,6 +258,6 @@ where
     fn product<I: Iterator<Item = T>>(iter: I) -> Self {
         iter.map(Into::into)
             .reduce(|x, y| x * y)
-            .unwrap_or(Self::one())
+            .unwrap_or(Self::ONE)
     }
 }

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -64,7 +64,7 @@ impl<F> SymbolicExpression<F> {
 
 impl<F: Field> Default for SymbolicExpression<F> {
     fn default() -> Self {
-        Self::Constant(F::zero())
+        Self::Constant(F::ZERO)
     }
 }
 
@@ -77,9 +77,8 @@ impl<F: Field> From<F> for SymbolicExpression<F> {
 impl<F: Field> AbstractField for SymbolicExpression<F> {
     type F = F;
 
-    fn zero() -> Self {
-        Self::Constant(F::zero())
-    }
+    const ZERO: Self = Self::Constant(F::ZERO);
+
     fn one() -> Self {
         Self::Constant(F::one())
     }
@@ -170,7 +169,7 @@ where
     fn sum<I: Iterator<Item = T>>(iter: I) -> Self {
         iter.map(Into::into)
             .reduce(|x, y| x + y)
-            .unwrap_or(Self::zero())
+            .unwrap_or(Self::ZERO)
     }
 }
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -79,13 +79,8 @@ impl<F: Field> AbstractField for SymbolicExpression<F> {
 
     const ZERO: Self = Self::Constant(F::ZERO);
     const ONE: Self = Self::Constant(F::ONE);
-
-    fn two() -> Self {
-        Self::Constant(F::two())
-    }
-    fn neg_one() -> Self {
-        Self::Constant(F::neg_one())
-    }
+    const TWO: Self = Self::Constant(F::TWO);
+    const NEG_ONE: Self = Self::Constant(F::NEG_ONE);
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
@@ -122,10 +117,6 @@ impl<F: Field> AbstractField for SymbolicExpression<F> {
 
     fn from_wrapped_u64(n: u64) -> Self {
         Self::Constant(F::from_wrapped_u64(n))
-    }
-
-    fn generator() -> Self {
-        Self::Constant(F::generator())
     }
 }
 

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -138,7 +138,7 @@ where
         is_last_row: sels.is_last_row,
         is_transition: sels.is_transition,
         alpha,
-        accumulator: SC::Challenge::zero(),
+        accumulator: SC::Challenge::ZERO,
     };
     air.eval(&mut folder);
     let folded_constraints = folder.accumulator;

--- a/uni-stark/src/zerofier_coset.rs
+++ b/uni-stark/src/zerofier_coset.rs
@@ -27,7 +27,7 @@ impl<F: TwoAdicField> ZerofierOnCoset<F> {
         let evals = F::two_adic_generator(rate_bits)
             .powers()
             .take(1 << rate_bits)
-            .map(|x| s_pow_n * x - F::one())
+            .map(|x| s_pow_n * x - F::ONE)
             .collect::<Vec<_>>();
         let inverses = batch_multiplicative_inverse(&evals);
         Self {

--- a/uni-stark/src/zerofier_coset.rs
+++ b/uni-stark/src/zerofier_coset.rs
@@ -51,7 +51,7 @@ impl<F: TwoAdicField> ZerofierOnCoset<F> {
 
     /// Like `eval_inverse`, but for a range of indices starting with `i_start`.
     pub fn eval_inverse_packed<P: PackedField<Scalar = F>>(&self, i_start: usize) -> P {
-        let mut packed = P::zero();
+        let mut packed = P::ZERO;
         packed
             .as_slice_mut()
             .iter_mut()

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -76,7 +76,7 @@ impl MulAir {
 
             if !valid {
                 // make it invalid
-                *c *= F::two();
+                *c *= F::TWO;
             }
         }
         RowMajorMatrix::new(trace_values, TRACE_WIDTH)

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -68,7 +68,7 @@ impl MulAir {
                 rng.gen()
             };
             *b = if self.uses_boundary_constraints && row == 0 {
-                a.square() + F::one()
+                a.square() + F::ONE
             } else {
                 rng.gen()
             };
@@ -102,9 +102,7 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
             let c = main_local[start + 2];
             builder.assert_zero(a.into().exp_u64(self.degree - 1) * b - c);
             if self.uses_boundary_constraints {
-                builder
-                    .when_first_row()
-                    .assert_eq(a * a + AB::Expr::one(), b);
+                builder.when_first_row().assert_eq(a * a + AB::Expr::ONE, b);
             }
             if self.uses_transition_constraints {
                 let next_a = main_next[start];


### PR DESCRIPTION
(Replacing this heading comment by a later comment which better reflects this PR after some updates)

This PR looks a lot bigger than it really is as most of the changes are simply updating notation. (E.g. replacing `F::one()` by `F::ONE` throughout the code base). The main motivation for this change is "moral" as opposed to performance focused. This might though possible lead to some very small speedups if function inlining was not happening in some cases. Testing on the example `prove_poseidon2_koala_bear_keccak` the speed seems to be basically unchanged (at best there is maybe a `1-2%` speed up but this sort of tiny improvement is very hard to pick up)

The major changes are as follows:

## Changes to Field Traits

- In the AbstractField trait, the functions `zero()`, `one()`, `two()` and `neg_one()` have all been replaced by constants with the same name but capitalized.
- The function `generator()` has been removed from the AbstractField trait and replaced by a constant `GENERATOR` which can be found in the Field trait.
- In the BinomiallyExtendable trait, the functions  `w(), dth_root()` and `ext_generator()` have all been replaced by constants with the same name but capitalized. 
- In the ComplexExtendable trait, the function `complex_generator()` has all been replaced by a constant with the same name but capitalized. 
- In the HasComplexBinomialExtension trait, the functions  `w(), dth_root()` and `ext_generator()` have all been replaced by constants with the same name but capitalized.

## New Additions:
- A major rework to field_to_array in order to make it a constant function which is needed to generate constants for binomial extensions. This involves a somewhat sketchy workaround as none of the more natural methods are available in const environments on stable. If this merges I'll make an issue just to keep an eye on this code and get rid of it when possible. Happy to change the name and/or move it into utils or something if it fits better there.
- Added a couple of new tests to field-testing to check `F::ZERO, F::ONE, F::TWO, F::NEG_ONE` as some of these were previously untested.