### PR TITLE
Modify `Radix2DitParallel` to treat a coset LDE...

### DIFF
--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -1,3 +1,6 @@
+use core::mem::MaybeUninit;
+
+use itertools::izip;
 use p3_field::{Field, PackedField, PackedValue};
 
 pub trait Butterfly<F: Field>: Copy + Send + Sync {
@@ -12,13 +15,44 @@ pub trait Butterfly<F: Field>: Copy + Send + Sync {
     fn apply_to_rows(&self, row_1: &mut [F], row_2: &mut [F]) {
         let (shorts_1, suffix_1) = F::Packing::pack_slice_with_suffix_mut(row_1);
         let (shorts_2, suffix_2) = F::Packing::pack_slice_with_suffix_mut(row_2);
-        assert_eq!(shorts_1.len(), shorts_2.len());
-        assert_eq!(suffix_1.len(), suffix_2.len());
+        debug_assert_eq!(shorts_1.len(), shorts_2.len());
+        debug_assert_eq!(suffix_1.len(), suffix_2.len());
         for (x_1, x_2) in shorts_1.iter_mut().zip(shorts_2) {
             self.apply_in_place(x_1, x_2);
         }
         for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2) {
             self.apply_in_place(x_1, x_2);
+        }
+    }
+
+    /// Like `apply_to_rows`, but out-of-place.
+    #[inline]
+    fn apply_to_rows_oop(
+        &self,
+        src_1: &[F],
+        dst_1: &mut [MaybeUninit<F>],
+        src_2: &[F],
+        dst_2: &mut [MaybeUninit<F>],
+    ) {
+        let (src_shorts_1, src_suffix_1) = F::Packing::pack_slice_with_suffix(src_1);
+        let (src_shorts_2, src_suffix_2) = F::Packing::pack_slice_with_suffix(src_2);
+        let (dst_shorts_1, dst_suffix_1) =
+            F::Packing::pack_maybe_uninit_slice_with_suffix_mut(dst_1);
+        let (dst_shorts_2, dst_suffix_2) =
+            F::Packing::pack_maybe_uninit_slice_with_suffix_mut(dst_2);
+        debug_assert_eq!(src_shorts_1.len(), src_shorts_2.len());
+        debug_assert_eq!(src_suffix_1.len(), src_suffix_2.len());
+        debug_assert_eq!(dst_shorts_1.len(), dst_shorts_2.len());
+        debug_assert_eq!(dst_suffix_1.len(), dst_suffix_2.len());
+        for (s_1, s_2, d_1, d_2) in izip!(src_shorts_1, src_shorts_2, dst_shorts_1, dst_shorts_2) {
+            let (res_1, res_2) = self.apply::<F::Packing>(*s_1, *s_2);
+            d_1.write(res_1);
+            d_2.write(res_2);
+        }
+        for (s_1, s_2, d_1, d_2) in izip!(src_suffix_1, src_suffix_2, dst_suffix_1, dst_suffix_2) {
+            let (res_1, res_2) = self.apply::<F>(*s_1, *s_2);
+            d_1.write(res_1);
+            d_2.write(res_2);
         }
     }
 }

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -1,19 +1,21 @@
 use alloc::collections::BTreeMap;
+use alloc::slice;
 use alloc::vec::Vec;
 use core::cell::RefCell;
+use core::mem::{transmute, MaybeUninit};
 
 use itertools::{izip, Itertools};
-use p3_field::{scale_slice_in_place, Field, Powers, TwoAdicField};
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
-use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
+use p3_field::{Field, Powers, TwoAdicField};
+use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
-use p3_util::{log2_strict_usize, reverse_slice_index_bits};
-use tracing::instrument;
+use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
+use tracing::{debug_span, info_span, instrument};
 
 use crate::butterflies::{Butterfly, DitButterfly};
-use crate::TwoAdicSubgroupDft;
+use crate::{divide_by_height, TwoAdicSubgroupDft};
 
 /// A parallel FFT algorithm which divides a butterfly network's layers into two halves.
 ///
@@ -27,11 +29,12 @@ pub struct Radix2DitParallel<F> {
     /// Twiddles based on roots of unity, used in the forward DFT.
     twiddles: RefCell<BTreeMap<usize, VectorPair<F>>>,
 
+    /// A map from `(log_h, shift)` to forward DFT twiddles with that coset shift baked in.
+    #[allow(clippy::type_complexity)]
+    coset_twiddles: RefCell<BTreeMap<(usize, F), Vec<Vec<F>>>>,
+
     /// Twiddles based on inverse roots of unity, used in the inverse DFT.
     inverse_twiddles: RefCell<BTreeMap<usize, VectorPair<F>>>,
-
-    /// A map from (log_h, shift) to the weights used in the middle of the coset LDE.
-    coset_lde_weights: RefCell<BTreeMap<(usize, F), Vec<F>>>,
 }
 
 /// A pair of vectors, one with twiddle factors in their natural order, the other bit-reversed.
@@ -55,6 +58,29 @@ fn compute_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F> {
 }
 
 #[instrument(level = "debug", skip_all)]
+fn compute_coset_twiddles<F: TwoAdicField + Ord>(log_h: usize, shift: F) -> Vec<Vec<F>> {
+    let mid = log_h / 2;
+    let h = 1 << log_h;
+    let root = F::two_adic_generator(log_h);
+
+    (0..log_h)
+        .map(|layer| {
+            let shift_power = shift.exp_power_of_2(layer);
+            let powers = Powers {
+                base: root.exp_power_of_2(layer),
+                current: shift_power,
+            };
+            let mut twiddles: Vec<_> = powers.take(h >> (layer + 1)).collect();
+            let layer_rev = log_h - 1 - layer;
+            if layer_rev >= mid {
+                reverse_slice_index_bits(&mut twiddles);
+            }
+            twiddles
+        })
+        .collect()
+}
+
+#[instrument(level = "debug", skip_all)]
 fn compute_inverse_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F> {
     let half_h = (1 << log_h) >> 1;
     let root_inv = F::two_adic_generator(log_h).inverse();
@@ -68,21 +94,6 @@ fn compute_inverse_twiddles<F: TwoAdicField + Ord>(log_h: usize) -> VectorPair<F
         twiddles,
         bit_reversed_twiddles,
     }
-}
-
-/// weights used in the middle of the coset LDE.
-#[instrument(level = "debug", skip_all)]
-fn compute_coset_lde_weighs<F: TwoAdicField>(log_h: usize, shift: F) -> Vec<F> {
-    let h = 1 << log_h;
-    let h_inv = F::from_canonical_usize(h).inverse();
-    let mut weights = Powers {
-        base: shift,
-        current: h_inv,
-    }
-    .take(h)
-    .collect_vec();
-    reverse_slice_index_bits(&mut weights);
-    weights
 }
 
 impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
@@ -102,91 +113,239 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
 
         // The first half looks like a normal DIT.
         reverse_matrix_index_bits(&mut mat);
-        par_dit_layer(&mut mat, mid, &twiddles.twiddles);
+        first_half(&mut mat, mid, &twiddles.twiddles);
 
         // For the second half, we flip the DIT, working in bit-reversed order.
         reverse_matrix_index_bits(&mut mat);
-        par_dit_layer_rev(&mut mat, mid, &twiddles.bit_reversed_twiddles);
+        second_half(&mut mat, mid, &twiddles.bit_reversed_twiddles);
 
         mat.bit_reverse_rows()
     }
 
-    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits))]
+    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits = added_bits))]
     fn coset_lde_batch(
         &self,
         mut mat: RowMajorMatrix<F>,
         added_bits: usize,
         shift: F,
     ) -> Self::Evaluations {
+        let w = mat.width;
         let h = mat.height();
         let log_h = log2_strict_usize(h);
         let mid = log_h / 2;
 
-        let mut twiddles_ref_mut = self.inverse_twiddles.borrow_mut();
-        let twiddles = twiddles_ref_mut
+        let mut inverse_twiddles_ref_mut = self.inverse_twiddles.borrow_mut();
+        let inverse_twiddles = inverse_twiddles_ref_mut
             .entry(log_h)
             .or_insert_with(|| compute_inverse_twiddles(log_h));
 
         // The first half looks like a normal DIT.
         reverse_matrix_index_bits(&mut mat);
-        par_dit_layer(&mut mat, mid, &twiddles.twiddles);
+        first_half(&mut mat, mid, &inverse_twiddles.twiddles);
 
         // For the second half, we flip the DIT, working in bit-reversed order.
         reverse_matrix_index_bits(&mut mat);
-        par_dit_layer_rev(&mut mat, mid, &twiddles.bit_reversed_twiddles);
+        second_half(&mut mat, mid, &inverse_twiddles.bit_reversed_twiddles);
         // We skip the final bit-reversal, since the next FFT expects bit-reversed input.
 
-        // Rescale coefficients in two ways:
-        // - divide by height (since we're doing an inverse DFT)
-        // - multiply by powers of the coset shift (see default coset LDE impl for an explanation)
-        let mut weights_ref_mut = self.coset_lde_weights.borrow_mut();
-        let weights = weights_ref_mut
-            .entry((log_h, shift))
-            .or_insert_with(|| compute_coset_lde_weighs(log_h, shift));
+        divide_by_height(&mut mat);
 
-        mat.par_rows_mut().enumerate().for_each(|(r, row)| {
-            scale_slice_in_place(weights[r], row);
-        });
+        let lde_elems = w * (h << added_bits);
+        let elems_to_add = lde_elems - w * h;
+        debug_span!("reserve_exact").in_scope(|| mat.values.reserve_exact(elems_to_add));
 
-        mat = mat.bit_reversed_zero_pad(added_bits);
+        let g_big = F::two_adic_generator(log_h + added_bits);
 
-        let h = mat.height();
-        let log_h = log2_strict_usize(h);
-        let mid = log_h / 2;
+        let mat_ptr = mat.values.as_mut_ptr();
+        let rest_ptr = unsafe { (mat_ptr as *mut MaybeUninit<F>).add(w * h) };
+        let first_slice: &mut [F] = unsafe { slice::from_raw_parts_mut(mat_ptr, w * h) };
+        let rest_slice: &mut [MaybeUninit<F>] =
+            unsafe { slice::from_raw_parts_mut(rest_ptr, lde_elems - w * h) };
+        let mut first_coset_mat = RowMajorMatrixViewMut::new(first_slice, w);
+        let mut rest_cosets_mat = rest_slice
+            .chunks_exact_mut(w * h)
+            .map(|slice| RowMajorMatrixViewMut::new(slice, w))
+            .collect_vec();
 
-        let mut twiddles_ref_mut = self.twiddles.borrow_mut();
-        let twiddles = twiddles_ref_mut
-            .entry(log_h)
-            .or_insert_with(|| compute_twiddles(log_h));
+        for coset_idx in 1..(1 << added_bits) {
+            let total_shift = g_big.exp_u64(coset_idx as u64) * shift;
+            let coset_idx = reverse_bits_len(coset_idx, added_bits);
+            let dest = &mut rest_cosets_mat[coset_idx - 1]; // - 1 because we removed the first matrix.
+            coset_dft_out_of_place(self, &first_coset_mat.as_view(), dest, total_shift);
+        }
 
-        // The first half looks like a normal DIT.
-        par_dit_layer(&mut mat, mid, &twiddles.twiddles);
+        // Now run a forward DFT on the very first coset, this time in-place.
+        coset_dft_in_place(self, &mut first_coset_mat.as_view_mut(), shift);
 
-        // For the second half, we flip the DIT, working in bit-reversed order.
-        reverse_matrix_index_bits(&mut mat);
-        par_dit_layer_rev(&mut mat, mid, &twiddles.bit_reversed_twiddles);
-
-        mat.bit_reverse_rows()
+        // SAFETY: We wrote all values above.
+        unsafe {
+            mat.values.set_len(lde_elems);
+        }
+        BitReversalPerm::new_view(mat)
     }
 }
 
-/// This can be used as the first half of a parallelized butterfly network.
+fn coset_dft_out_of_place<F: TwoAdicField + Ord>(
+    dft: &Radix2DitParallel<F>,
+    src: &RowMajorMatrixView<F>,
+    dst_maybe: &mut RowMajorMatrixViewMut<MaybeUninit<F>>,
+    shift: F,
+) {
+    assert_eq!(src.dimensions(), dst_maybe.dimensions());
+
+    let log_h = log2_strict_usize(dst_maybe.height());
+
+    if log_h == 0 {
+        // The entire network has zero layers of butterflies, so just copy.
+        let src_maybe = unsafe {
+            transmute::<&RowMajorMatrixView<F>, &RowMajorMatrixView<MaybeUninit<F>>>(src)
+        };
+        dst_maybe.copy_from(src_maybe);
+        return;
+    }
+
+    // In general either div_floor or div_ceil would work, but here we prefer div_ceil because it
+    // lets us assume below that the "first half" of the network has at least one layer of
+    // butterflies, even in the case of log_h = 1.
+    let mid = log_h.div_ceil(2);
+
+    let mut twiddles_ref_mut = dft.coset_twiddles.borrow_mut();
+    let twiddles = twiddles_ref_mut
+        .entry((log_h, shift))
+        .or_insert_with(|| compute_coset_twiddles(log_h, shift));
+
+    // The first half looks like a normal DIT.
+    // first_half(&mut mat, mid, &old_twiddles.twiddles);
+    info_span!("modified first_half_dit").in_scope(|| {
+        src.par_row_chunks_exact(1 << mid)
+            .zip(dst_maybe.par_row_chunks_exact_mut(1 << mid))
+            .for_each(|(src_submat, mut dst_submat_maybe)| {
+                debug_assert_eq!(src_submat.dimensions(), dst_submat_maybe.dimensions());
+
+                // The first layer is special, done out-of-place.
+                // (Recall from the mid definition that there must be at least one layer here.)
+                let layer_rev = log_h - 1;
+                dit_layer_oop(
+                    &src_submat,
+                    &mut dst_submat_maybe,
+                    0,
+                    twiddles[layer_rev].iter().copied(),
+                );
+
+                // submat is now initialized.
+                let mut dst_submat = unsafe {
+                    transmute::<RowMajorMatrixViewMut<MaybeUninit<F>>, RowMajorMatrixViewMut<F>>(
+                        dst_submat_maybe,
+                    )
+                };
+
+                // Subsequent layers.
+                for layer in 1..mid {
+                    let layer_rev = log_h - 1 - layer;
+                    dit_layer(&mut dst_submat, layer, twiddles[layer_rev].iter().copied());
+                }
+            });
+    });
+
+    // dst is now initialized.
+    let dst = unsafe {
+        transmute::<&mut RowMajorMatrixViewMut<MaybeUninit<F>>, &mut RowMajorMatrixViewMut<F>>(
+            dst_maybe,
+        )
+    };
+
+    // For the second half, we flip the DIT, working in bit-reversed order.
+    reverse_matrix_index_bits(dst);
+
+    // second_half(&mut mat, mid, &old_twiddles.bit_reversed_twiddles);
+    info_span!("modified second_half_dit").in_scope(|| {
+        dst.par_row_chunks_exact_mut(1 << (log_h - mid))
+            .enumerate()
+            .for_each(|(thread, mut submat)| {
+                for layer in mid..log_h {
+                    let layer_rev = log_h - 1 - layer;
+                    let first_block = thread << (layer - mid);
+                    dit_layer_rev(
+                        &mut submat,
+                        log_h,
+                        layer,
+                        twiddles[layer_rev][first_block..].iter().copied(),
+                    );
+                }
+            });
+    });
+}
+
+fn coset_dft_in_place<F: TwoAdicField + Ord>(
+    dft: &Radix2DitParallel<F>,
+    mat: &mut RowMajorMatrixViewMut<F>,
+    shift: F,
+) {
+    let log_h = log2_strict_usize(mat.height());
+    let mid = log_h / 2;
+
+    let mut twiddles_ref_mut = dft.coset_twiddles.borrow_mut();
+    let twiddles = twiddles_ref_mut
+        .entry((log_h, shift))
+        .or_insert_with(|| compute_coset_twiddles(log_h, shift));
+
+    // The first half looks like a normal DIT.
+    // first_half(&mut mat, mid, &old_twiddles.twiddles);
+    info_span!("modified first_half_dit").in_scope(|| {
+        mat.par_row_chunks_exact_mut(1 << mid)
+            .for_each(|mut submat| {
+                for layer in 0..mid {
+                    let layer_rev = log_h - 1 - layer;
+                    dit_layer(&mut submat, layer, twiddles[layer_rev].iter().copied());
+                }
+            });
+    });
+
+    // For the second half, we flip the DIT, working in bit-reversed order.
+    reverse_matrix_index_bits(mat);
+
+    // second_half(&mut mat, mid, &old_twiddles.bit_reversed_twiddles);
+    info_span!("modified second_half_dit").in_scope(|| {
+        mat.par_row_chunks_exact_mut(1 << (log_h - mid))
+            .enumerate()
+            .for_each(|(thread, mut submat)| {
+                for layer in mid..log_h {
+                    let layer_rev = log_h - 1 - layer;
+                    let first_block = thread << (layer - mid);
+                    dit_layer_rev(
+                        &mut submat,
+                        log_h,
+                        layer,
+                        twiddles[layer_rev][first_block..].iter().copied(),
+                    );
+                }
+            });
+    });
+}
+
+/// This can be used as the first half of a DIT butterfly network.
 #[instrument(level = "debug", skip_all)]
-fn par_dit_layer<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles: &[F]) {
+fn first_half<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles: &[F]) {
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^mid
     mat.par_row_chunks_exact_mut(1 << mid)
         .for_each(|mut submat| {
             for layer in 0..mid {
-                dit_layer(&mut submat, log_h, layer, twiddles);
+                let layer_rev = log_h - 1 - layer;
+                let layer_pow = 1 << layer_rev;
+                dit_layer(
+                    &mut submat,
+                    layer,
+                    twiddles.iter().copied().step_by(layer_pow),
+                );
             }
         });
 }
 
-/// This can be used as the second half of a parallelized butterfly network.
+/// This can be used as the second half of a DIT butterfly network. It works in bit-reversed order.
 #[instrument(level = "debug", skip_all)]
-fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles_rev: &[F]) {
+fn second_half<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles_rev: &[F]) {
     let log_h = log2_strict_usize(mat.height());
 
     // max block size: 2^(log_h - mid)
@@ -195,7 +354,12 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
         .for_each(|(thread, mut submat)| {
             for layer in mid..log_h {
                 let first_block = thread << (layer - mid);
-                dit_layer_rev(&mut submat, log_h, layer, &twiddles_rev[first_block..]);
+                dit_layer_rev(
+                    &mut submat,
+                    log_h,
+                    layer,
+                    twiddles_rev[first_block..].iter().copied(),
+                );
             }
         });
 }
@@ -203,13 +367,9 @@ fn par_dit_layer_rev<F: Field>(mat: &mut RowMajorMatrix<F>, mid: usize, twiddles
 /// One layer of a DIT butterfly network.
 fn dit_layer<F: Field>(
     submat: &mut RowMajorMatrixViewMut<'_, F>,
-    log_h: usize,
     layer: usize,
-    twiddles: &[F],
+    twiddles: impl Iterator<Item = F> + Clone,
 ) {
-    let layer_rev = log_h - 1 - layer;
-    let layer_pow = 1 << layer_rev;
-
     let half_block_size = 1 << layer;
     let block_size = half_block_size * 2;
     let width = submat.width();
@@ -218,12 +378,43 @@ fn dit_layer<F: Field>(
     for block in submat.values.chunks_mut(block_size * width) {
         let (lows, highs) = block.split_at_mut(half_block_size * width);
 
-        for (lo, hi, &twiddle) in izip!(
+        for (lo, hi, twiddle) in izip!(
             lows.chunks_mut(width),
             highs.chunks_mut(width),
-            twiddles.iter().step_by(layer_pow)
+            twiddles.clone()
         ) {
             DitButterfly(twiddle).apply_to_rows(lo, hi);
+        }
+    }
+}
+
+/// One layer of a DIT butterfly network.
+fn dit_layer_oop<F: Field>(
+    src: &RowMajorMatrixView<F>,
+    dst: &mut RowMajorMatrixViewMut<'_, MaybeUninit<F>>,
+    layer: usize,
+    twiddles: impl Iterator<Item = F> + Clone,
+) {
+    debug_assert_eq!(src.dimensions(), dst.dimensions());
+    let half_block_size = 1 << layer;
+    let block_size = half_block_size * 2;
+    let width = dst.width();
+    debug_assert!(dst.height() >= block_size);
+
+    let src_chunks = src.values.chunks(block_size * width);
+    let dst_chunks = dst.values.chunks_mut(block_size * width);
+    for (src_block, dst_block) in src_chunks.zip(dst_chunks) {
+        let (src_lows, src_highs) = src_block.split_at(half_block_size * width);
+        let (dst_lows, dst_highs) = dst_block.split_at_mut(half_block_size * width);
+
+        for (src_lo, dst_lo, src_hi, dst_hi, twiddle) in izip!(
+            src_lows.chunks(width),
+            dst_lows.chunks_mut(width),
+            src_highs.chunks(width),
+            dst_highs.chunks_mut(width),
+            twiddles.clone()
+        ) {
+            DitButterfly(twiddle).apply_to_rows_oop(src_lo, dst_lo, src_hi, dst_hi);
         }
     }
 }
@@ -234,7 +425,7 @@ fn dit_layer_rev<F: Field>(
     submat: &mut RowMajorMatrixViewMut<'_, F>,
     log_h: usize,
     layer: usize,
-    twiddles_rev: &[F],
+    twiddles_rev: impl Iterator<Item = F>,
 ) {
     let layer_rev = log_h - 1 - layer;
 
@@ -243,7 +434,7 @@ fn dit_layer_rev<F: Field>(
     let width = submat.width();
     debug_assert!(submat.height() >= block_size);
 
-    for (block, &twiddle) in submat
+    for (block, twiddle) in submat
         .values
         .chunks_mut(block_size * width)
         .zip(twiddles_rev)

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -5,6 +5,7 @@ use core::iter::Sum;
 use core::ops::Mul;
 
 use num_bigint::BigUint;
+use p3_maybe_rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::field::Field;
 use crate::{AbstractField, PackedValue, PrimeField, PrimeField32, TwoAdicField};
@@ -55,7 +56,7 @@ pub fn scale_vec<F: Field>(s: F, vec: Vec<F>) -> Vec<F> {
 pub fn scale_slice_in_place<F: Field>(s: F, slice: &mut [F]) {
     let (packed, sfx) = F::Packing::pack_slice_with_suffix_mut(slice);
     let packed_s: F::Packing = s.into();
-    packed.iter_mut().for_each(|x| *x *= packed_s);
+    packed.par_iter_mut().for_each(|x| *x *= packed_s);
     sfx.iter_mut().for_each(|x| *x *= s);
 }
 

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -1,3 +1,4 @@
+use core::mem::MaybeUninit;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
 use core::slice;
 
@@ -62,9 +63,31 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
         unsafe { slice::from_raw_parts_mut(buf_ptr, n) }
     }
 
+    fn pack_maybe_uninit_slice_mut(
+        buf: &mut [MaybeUninit<Self::Value>],
+    ) -> &mut [MaybeUninit<Self>] {
+        assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        assert!(
+            buf.len() % Self::WIDTH == 0,
+            "Slice length (got {}) must be a multiple of packed field width ({}).",
+            buf.len(),
+            Self::WIDTH
+        );
+        let buf_ptr = buf.as_mut_ptr().cast::<MaybeUninit<Self>>();
+        let n = buf.len() / Self::WIDTH;
+        unsafe { slice::from_raw_parts_mut(buf_ptr, n) }
+    }
+
     fn pack_slice_with_suffix_mut(buf: &mut [Self::Value]) -> (&mut [Self], &mut [Self::Value]) {
         let (packed, suffix) = buf.split_at_mut(buf.len() - buf.len() % Self::WIDTH);
         (Self::pack_slice_mut(packed), suffix)
+    }
+
+    fn pack_maybe_uninit_slice_with_suffix_mut(
+        buf: &mut [MaybeUninit<Self::Value>],
+    ) -> (&mut [MaybeUninit<Self>], &mut [MaybeUninit<Self::Value>]) {
+        let (packed, suffix) = buf.split_at_mut(buf.len() - buf.len() % Self::WIDTH);
+        (Self::pack_maybe_uninit_slice_mut(packed), suffix)
     }
 
     fn unpack_slice(buf: &[Self]) -> &[Self::Value] {

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -95,6 +95,22 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         RowMajorMatrixViewMut::new(self.values.borrow_mut(), self.width)
     }
 
+    pub fn copy_from<S2>(&mut self, source: &DenseMatrix<T, S2>)
+    where
+        T: Copy,
+        S: BorrowMut<[T]>,
+        S2: DenseStorage<T>,
+    {
+        assert_eq!(self.dimensions(), source.dimensions());
+        // Equivalent to:
+        // self.values.borrow_mut().copy_from_slice(source.values.borrow());
+        self.par_rows_mut()
+            .zip(source.par_row_slices())
+            .for_each(|(dst, src)| {
+                dst.copy_from_slice(src);
+            });
+    }
+
     pub fn flatten_to_base<F: Field>(&self) -> RowMajorMatrix<F>
     where
         T: ExtensionField<F>,
@@ -225,6 +241,20 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         self.values
             .borrow_mut()
             .par_chunks_mut(self.width * chunk_rows)
+            .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
+    }
+
+    pub fn row_chunks_exact_mut(
+        &mut self,
+        chunk_rows: usize,
+    ) -> impl Iterator<Item = RowMajorMatrixViewMut<T>>
+    where
+        T: Send,
+        S: BorrowMut<[T]>,
+    {
+        self.values
+            .borrow_mut()
+            .chunks_exact_mut(self.width * chunk_rows)
             .map(|slice| RowMajorMatrixViewMut::new(slice, self.width))
     }
 

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -28,7 +28,7 @@ pub mod stack;
 pub mod strided;
 pub mod util;
 
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Dimensions {
     pub width: usize,
     pub height: usize,

--- a/matrix/src/util.rs
+++ b/matrix/src/util.rs
@@ -1,16 +1,22 @@
+use core::borrow::BorrowMut;
+
 use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 use tracing::instrument;
 
-use crate::dense::RowMajorMatrix;
+use crate::dense::{DenseMatrix, DenseStorage, RowMajorMatrix};
 use crate::Matrix;
 
 #[instrument(level = "debug", skip_all)]
-pub fn reverse_matrix_index_bits<F: Clone + Send + Sync>(mat: &mut RowMajorMatrix<F>) {
+pub fn reverse_matrix_index_bits<'a, F, S>(mat: &mut DenseMatrix<F, S>)
+where
+    F: Clone + Send + Sync + 'a,
+    S: DenseStorage<F> + BorrowMut<[F]>,
+{
     let w = mat.width();
     let h = mat.height();
     let log_h = log2_strict_usize(h);
-    let values = mat.values.as_mut_ptr() as usize;
+    let values = mat.values.borrow_mut().as_mut_ptr() as usize;
 
     (0..h).into_par_iter().for_each(|i| {
         let values = values as *mut F;

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -120,7 +120,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     let fri_config = FriConfig {
-        log_blowup: 1,
+        log_blowup: 1, // TODO: Should this be 3? Why is it working?
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), impl Debug> {
 
     const PROOFS: usize = 2;
     for _ in 1..PROOFS {
-        let _ = prove_and_verify()?;
+        prove_and_verify()?;
     }
     prove_and_verify()
 }

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -50,6 +50,14 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
+    const PROOFS: usize = 2;
+    for _ in 1..PROOFS {
+        let _ = prove_and_verify()?;
+    }
+    prove_and_verify()
+}
+
+fn prove_and_verify() -> Result<(), impl Debug> {
     type Val = KoalaBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -1,7 +1,8 @@
 use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 use p3_field::PrimeField;
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_maybe_rayon::prelude::*;
 use p3_poseidon2::{DiffusionPermutation, MdsLightPermutation};
 use tracing::instrument;
@@ -35,11 +36,13 @@ pub fn generate_vectorized_trace_rows<
     let nrows = n.div_ceil(VECTOR_LEN);
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
-    let mut trace = RowMajorMatrix::new(F::zero_vec(nrows * ncols), ncols);
+    let mut vec = Vec::with_capacity(nrows * ncols * 2);
+    let trace: &mut [MaybeUninit<F>] = &mut vec.spare_capacity_mut()[..nrows * ncols];
+    let trace: RowMajorMatrixViewMut<MaybeUninit<F>> = RowMajorMatrixViewMut::new(trace, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
-            F,
+            MaybeUninit<F>,
             WIDTH,
             SBOX_DEGREE,
             SBOX_REGISTERS,
@@ -61,7 +64,10 @@ pub fn generate_vectorized_trace_rows<
         );
     });
 
-    trace
+    unsafe {
+        vec.set_len(nrows * ncols);
+    }
+    RowMajorMatrix::new(vec, ncols)
 }
 
 // TODO: Take generic iterable
@@ -88,11 +94,13 @@ pub fn generate_trace_rows<
     );
 
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>();
-    let mut trace = RowMajorMatrix::new(F::zero_vec(n * ncols), ncols);
+    let mut vec = Vec::with_capacity(n * ncols * 2);
+    let trace: &mut [MaybeUninit<F>] = &mut vec.spare_capacity_mut()[..n * ncols];
+    let trace: RowMajorMatrixViewMut<MaybeUninit<F>> = RowMajorMatrixViewMut::new(trace, ncols);
 
     let (prefix, perms, suffix) = unsafe {
         trace.values.align_to_mut::<Poseidon2Cols<
-            F,
+            MaybeUninit<F>,
             WIDTH,
             SBOX_DEGREE,
             SBOX_REGISTERS,
@@ -114,7 +122,10 @@ pub fn generate_trace_rows<
         );
     });
 
-    trace
+    unsafe {
+        vec.set_len(n * ncols);
+    }
+    RowMajorMatrix::new(vec, ncols)
 }
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
@@ -129,7 +140,7 @@ fn generate_trace_rows_for_perm<
     const PARTIAL_ROUNDS: usize,
 >(
     perm: &mut Poseidon2Cols<
-        F,
+        MaybeUninit<F>,
         WIDTH,
         SBOX_DEGREE,
         SBOX_REGISTERS,
@@ -141,8 +152,13 @@ fn generate_trace_rows_for_perm<
     external_linear_layer: &MdsLight,
     internal_linear_layer: &Diffusion,
 ) {
-    perm.export = F::one();
-    perm.inputs = state;
+    perm.export.write(F::one());
+    perm.inputs
+        .iter_mut()
+        .zip(state.iter())
+        .for_each(|(input, &x)| {
+            input.write(x);
+        });
 
     external_linear_layer.permute_mut(&mut state);
 
@@ -195,7 +211,7 @@ fn generate_full_round<
     const SBOX_REGISTERS: usize,
 >(
     state: &mut [F; WIDTH],
-    full_round: &mut FullRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
+    full_round: &mut FullRound<MaybeUninit<F>, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constants: &[F; WIDTH],
     external_linear_layer: &MdsLight,
 ) {
@@ -206,7 +222,13 @@ fn generate_full_round<
         generate_sbox(sbox_i, state_i);
     }
     external_linear_layer.permute_mut(state);
-    full_round.post = *state;
+    full_round
+        .post
+        .iter_mut()
+        .zip(*state)
+        .for_each(|(post, x)| {
+            post.write(x);
+        });
 }
 
 #[inline]
@@ -218,19 +240,19 @@ fn generate_partial_round<
     const SBOX_REGISTERS: usize,
 >(
     state: &mut [F; WIDTH],
-    partial_round: &mut PartialRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
+    partial_round: &mut PartialRound<MaybeUninit<F>, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constant: F,
     internal_linear_layer: &Diffusion,
 ) {
     state[0] += round_constant;
     generate_sbox(&mut partial_round.sbox, &mut state[0]);
-    partial_round.post_sbox = state[0];
+    partial_round.post_sbox.write(state[0]);
     internal_linear_layer.permute_mut(state);
 }
 
 #[inline]
 fn generate_sbox<F: PrimeField, const DEGREE: usize, const REGISTERS: usize>(
-    sbox: &mut SBox<F, DEGREE, REGISTERS>,
+    sbox: &mut SBox<MaybeUninit<F>, DEGREE, REGISTERS>,
     x: &mut F,
 ) {
     *x = match (DEGREE, REGISTERS) {
@@ -240,20 +262,20 @@ fn generate_sbox<F: PrimeField, const DEGREE: usize, const REGISTERS: usize>(
         (5, 1) => {
             let x2 = x.square();
             let x3 = x2 * *x;
-            sbox.0[0] = x3;
+            sbox.0[0].write(x3);
             x3 * x2
         }
         (7, 1) => {
             let x3 = x.cube();
-            sbox.0[0] = x3;
+            sbox.0[0].write(x3);
             x3 * x3 * *x
         }
         (11, 2) => {
             let x2 = x.square();
             let x3 = x2 * *x;
             let x9 = x3.cube();
-            sbox.0[0] = x3;
-            sbox.0[1] = x9;
+            sbox.0[0].write(x3);
+            sbox.0[1].write(x9);
             x9 * x2
         }
         _ => panic!(


### PR DESCRIPTION
... as the union of several DFTs onto several smaller cosets.

Also change it to resize the input vector rather than allocating a separate vector for the result. This works well iff the input vector was already allocated with extra capacity.

Also do the first layer of most coset DFTs out-of-place. This is effectively like merging the steps where we copy coefficients onto other cosets into the next layers that use those coefficients.

Also alternative forward and backward traversals, which should increase the hit rate when outgrowing cache, as Jaqui suggested.

For the the Poseidon2 bench on my laptop, the big LDE time goes from ~122ms to ~82ms.