### PR TITLE
field: improve `ExtensionField::as_base`

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -543,7 +543,7 @@ where
         res
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_base_slice(&self) -> &[AF] {
         &self.value
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -387,9 +387,11 @@ pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
     fn is_in_basefield(&self) -> bool {
         self.as_base_slice()[1..].iter().all(Field::is_zero)
     }
+
     fn as_base(&self) -> Option<Base> {
-        if self.is_in_basefield() {
-            Some(self.as_base_slice()[0])
+        let base_slice = self.as_base_slice();
+        if base_slice[1..].iter().all(Field::is_zero) {
+            Some(base_slice[0])
         } else {
             None
         }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -384,14 +384,14 @@ pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
         + Send
         + Sync;
 
+    #[inline(always)]
     fn is_in_basefield(&self) -> bool {
         self.as_base_slice()[1..].iter().all(Field::is_zero)
     }
 
     fn as_base(&self) -> Option<Base> {
-        let base_slice = self.as_base_slice();
-        if base_slice[1..].iter().all(Field::is_zero) {
-            Some(base_slice[0])
+        if self.is_in_basefield() {
+            Some(self.as_base_slice()[0])
         } else {
             None
         }
@@ -436,6 +436,7 @@ impl<AF: AbstractField> AbstractExtensionField<AF> for AF {
         f(0)
     }
 
+    #[inline(always)]
     fn as_base_slice(&self) -> &[AF] {
         slice::from_ref(self)
     }


### PR DESCRIPTION
 We want to avoid calling two times `self.as_base_slice()` for perf reason so:
- We declare a variable
```rust
let base_slice = self.as_base_slice();
```
- We reuse this inside the method.