### PR TITLE
Hiding FRI PCS

### DIFF
--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -14,6 +14,7 @@ p3-matrix = { path = "../matrix" }
 p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-util = { path = "../util" }
 itertools = "0.13.0"
+rand = "0.8.5"
 tracing = "0.1.37"
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 
@@ -29,7 +30,6 @@ p3-merkle-tree = { path = "../merkle-tree" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
 criterion = "0.5.1"
-rand = "0.8.5"
 rand_chacha = "0.3.1"
 
 [[bench]]

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -1,0 +1,212 @@
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt::Debug;
+
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_commit::{Mmcs, OpenedValues, Pcs, TwoAdicMultiplicativeCoset};
+use p3_dft::TwoAdicSubgroupDft;
+use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::horizontally_truncated::HorizontallyTruncated;
+use p3_matrix::Matrix;
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
+use tracing::instrument;
+
+use crate::verifier::FriError;
+use crate::{BatchOpening, FriConfig, FriProof, TwoAdicFriPcs};
+
+/// A hiding FRI PCS. Both MMCSs must also be hiding; this is not enforced at compile time so it's
+/// the user's responsibility to configure.
+#[derive(Debug)]
+pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
+    inner: TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>,
+    num_random_codewords: usize,
+    rng: RefCell<R>,
+}
+
+impl<Val, Dft, InputMmcs, FriMmcs, R> HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
+    pub fn new(
+        dft: Dft,
+        mmcs: InputMmcs,
+        fri: FriConfig<FriMmcs>,
+        num_random_codewords: usize,
+        rng: R,
+    ) -> Self {
+        let inner = TwoAdicFriPcs::new(dft, mmcs, fri);
+        Self {
+            inner,
+            num_random_codewords,
+            rng: rng.into(),
+        }
+    }
+}
+
+impl<Val, Dft, InputMmcs, FriMmcs, Challenge, Challenger, R> Pcs<Challenge, Challenger>
+    for HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R>
+where
+    Val: TwoAdicField,
+    Standard: Distribution<Val>,
+    Dft: TwoAdicSubgroupDft<Val>,
+    InputMmcs: Mmcs<Val>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenge: TwoAdicField + ExtensionField<Val>,
+    Challenger:
+        FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
+    R: Rng + Send + Sync,
+{
+    type Domain = TwoAdicMultiplicativeCoset<Val>;
+    type Commitment = InputMmcs::Commitment;
+    type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
+    /// The first item contains the openings of the random polynomials added by this wrapper.
+    /// The second item is the usual FRI proof.
+    type Proof = (
+        OpenedValues<Challenge>,
+        FriProof<Challenge, FriMmcs, Val, Vec<BatchOpening<Val, InputMmcs>>>,
+    );
+    type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
+
+    fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
+        <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+            &self.inner, degree)
+    }
+
+    fn commit(
+        &self,
+        evaluations: Vec<(Self::Domain, RowMajorMatrix<Val>)>,
+    ) -> (Self::Commitment, Self::ProverData) {
+        let randomized_evaluations = evaluations
+            .into_iter()
+            .map(|(domain, mat)| {
+                (
+                    domain,
+                    add_random_cols(mat, self.num_random_codewords, &mut *self.rng.borrow_mut()),
+                )
+            })
+            .collect();
+        <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::commit(
+            &self.inner,
+            randomized_evaluations,
+        )
+    }
+
+    fn get_evaluations_on_domain<'a>(
+        &self,
+        prover_data: &'a Self::ProverData,
+        idx: usize,
+        domain: Self::Domain,
+    ) -> impl Matrix<Val> + 'a {
+        let inner_evals = <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<
+            Challenge,
+            Challenger,
+        >>::get_evaluations_on_domain(
+            &self.inner, prover_data, idx, domain
+        );
+        let inner_width = inner_evals.width();
+        // Truncate off the columns representing random codewords we added in `commit` above.
+        HorizontallyTruncated::new(inner_evals, inner_width - self.num_random_codewords)
+    }
+
+    fn open(
+        &self,
+        // For each round,
+        rounds: Vec<(
+            &Self::ProverData,
+            // for each matrix,
+            Vec<
+                // points to open
+                Vec<Challenge>,
+            >,
+        )>,
+        challenger: &mut Challenger,
+    ) -> (OpenedValues<Challenge>, Self::Proof) {
+        let (mut inner_opened_values, inner_proof) = self.inner.open(rounds, challenger);
+
+        // inner_opened_values includes opened values for the random codewords. Those should be
+        // hidden from our caller, so we split them off and store them in the proof.
+        let opened_values_rand = inner_opened_values
+            .iter_mut()
+            .map(|opened_values_for_round| {
+                opened_values_for_round
+                    .iter_mut()
+                    .map(|opened_values_for_mat| {
+                        opened_values_for_mat
+                            .iter_mut()
+                            .map(|opened_values_for_point| {
+                                let split =
+                                    opened_values_for_point.len() - self.num_random_codewords;
+                                opened_values_for_point.drain(split..).collect()
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
+
+        (inner_opened_values, (opened_values_rand, inner_proof))
+    }
+
+    fn verify(
+        &self,
+        // For each round:
+        mut rounds: Vec<(
+            Self::Commitment,
+            // for each matrix:
+            Vec<(
+                // its domain,
+                Self::Domain,
+                // for each point:
+                Vec<(
+                    // the point,
+                    Challenge,
+                    // values at the point
+                    Vec<Challenge>,
+                )>,
+            )>,
+        )>,
+        proof: &Self::Proof,
+        challenger: &mut Challenger,
+    ) -> Result<(), Self::Error> {
+        let (opened_values_for_rand_cws, inner_proof) = proof;
+        // Now we merge `opened_values_for_rand_cws` into the opened values in `rounds`, undoing
+        // the split that we did in `open`, to get a complete set of opened values for the inner PCS
+        // to check.
+        for (round, rand_round) in rounds.iter_mut().zip(opened_values_for_rand_cws) {
+            for (mat, rand_mat) in round.1.iter_mut().zip(rand_round) {
+                for (point, rand_point) in mat.1.iter_mut().zip(rand_mat) {
+                    point.1.extend(rand_point);
+                }
+            }
+        }
+        self.inner.verify(rounds, inner_proof, challenger)
+    }
+}
+
+#[instrument(level = "debug", skip_all)]
+fn add_random_cols<Val, R>(
+    mat: RowMajorMatrix<Val>,
+    num_random_codewords: usize,
+    mut rng: R,
+) -> RowMajorMatrix<Val>
+where
+    Val: Field,
+    R: Rng + Send + Sync,
+    Standard: Distribution<Val>,
+{
+    let old_w = mat.width();
+    let new_w = old_w + num_random_codewords;
+    let h = mat.height();
+
+    let new_values = Val::zero_vec(new_w * h);
+    let mut result = RowMajorMatrix::new(new_values, new_w);
+    // Can be parallelized by adding par_, but there are some complications with the RNG.
+    // We could just use thread_rng(), but ideally we want to keep it generic...
+    result
+        .rows_mut()
+        .zip(mat.row_slices())
+        .for_each(|(new_row, old_row)| {
+            new_row[..old_w].copy_from_slice(old_row);
+            new_row[old_w..].iter_mut().for_each(|v| *v = rng.gen());
+        });
+    result
+}

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 
 mod config;
 mod fold_even_odd;
+mod hiding_pcs;
 mod proof;
 pub mod prover;
 mod two_adic_pcs;
@@ -13,5 +14,6 @@ pub mod verifier;
 
 pub use config::*;
 pub use fold_even_odd::*;
+pub use hiding_pcs::*;
 pub use proof::*;
 pub use two_adic_pcs::*;

--- a/matrix/src/horizontally_truncated.rs
+++ b/matrix/src/horizontally_truncated.rs
@@ -1,0 +1,56 @@
+use core::iter::Take;
+use core::marker::PhantomData;
+
+use crate::Matrix;
+
+pub struct HorizontallyTruncated<T, Inner> {
+    inner: Inner,
+    truncated_width: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, Inner: Matrix<T>> HorizontallyTruncated<T, Inner>
+where
+    T: Send + Sync,
+{
+    pub fn new(inner: Inner, truncated_width: usize) -> Self {
+        assert!(truncated_width <= inner.width());
+        Self {
+            inner,
+            truncated_width,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, Inner> Matrix<T> for HorizontallyTruncated<T, Inner>
+where
+    T: Send + Sync,
+    Inner: Matrix<T>,
+{
+    #[inline(always)]
+    fn width(&self) -> usize {
+        self.truncated_width
+    }
+
+    #[inline(always)]
+    fn height(&self) -> usize {
+        self.inner.height()
+    }
+
+    #[inline(always)]
+    fn get(&self, r: usize, c: usize) -> T {
+        debug_assert!(c < self.truncated_width);
+        self.inner.get(c, r)
+    }
+
+    type Row<'a>
+        = Take<Inner::Row<'a>>
+    where
+        Self: 'a;
+
+    #[inline(always)]
+    fn row(&self, r: usize) -> Self::Row<'_> {
+        self.inner.row(r).take(self.truncated_width)
+    }
+}

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -21,6 +21,7 @@ use crate::dense::RowMajorMatrix;
 pub mod bitrev;
 pub mod dense;
 pub mod extension;
+pub mod horizontally_truncated;
 pub mod mul;
 pub mod row_index_mapped;
 pub mod sparse;

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -4,7 +4,7 @@ use p3_baby_bear::{BabyBear, BabyBearDiffusionMatrixParameters, BabyBearParamete
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
 use p3_field::extension::BinomialExtensionField;
-use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_fri::{FriConfig, HidingFriPcs};
 use p3_keccak::{Keccak256Hash, KeccakF};
 use p3_merkle_tree::MerkleTreeHidingMmcs;
 use p3_monty_31::GenericDiffusionMatrixMontyField31;
@@ -12,8 +12,8 @@ use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
 use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::rngs::ThreadRng;
-use rand::{random, thread_rng};
+use rand::rngs::{StdRng, ThreadRng};
+use rand::{random, thread_rng, SeedableRng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -125,8 +125,8 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
-    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+    type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config, 4, StdRng::from_entropy());
 
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);


### PR DESCRIPTION
This isn't the full thing yet, after this we need to blind each polynomial, adding randomness and padding to the next power of two.

In this approach, every input matrix gets extended with several random codewords. We might be able to get by with less, like at least grouping matrices of the same height and only extending one of them. But this seemed simplest in a way, and I suspect the performance difference won't be too important.