### PR TITLE
refactor: use `into` instead of `from` when possible

### DIFF
--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -103,19 +103,19 @@ impl AbstractField for Goldilocks {
     }
 
     fn from_bool(b: bool) -> Self {
-        Self::new(u64::from(b))
+        Self::new(b.into())
     }
 
     fn from_canonical_u8(n: u8) -> Self {
-        Self::new(u64::from(n))
+        Self::new(n.into())
     }
 
     fn from_canonical_u16(n: u16) -> Self {
-        Self::new(u64::from(n))
+        Self::new(n.into())
     }
 
     fn from_canonical_u32(n: u32) -> Self {
-        Self::new(u64::from(n))
+        Self::new(n.into())
     }
 
     #[inline(always)]
@@ -130,7 +130,7 @@ impl AbstractField for Goldilocks {
     fn from_wrapped_u32(n: u32) -> Self {
         // A u32 must be canonical, plus we don't store canonical encodings anyway, so there's no
         // need for a reduction.
-        Self::new(u64::from(n))
+        Self::new(n.into())
     }
 
     fn from_wrapped_u64(n: u64) -> Self {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -112,12 +112,12 @@ impl AbstractField for Mersenne31 {
 
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
-        Self::new(u32::from(n))
+        Self::new(n.into())
     }
 
     #[inline]
     fn from_canonical_u16(n: u16) -> Self {
-        Self::new(u32::from(n))
+        Self::new(n.into())
     }
 
     #[inline]
@@ -292,7 +292,7 @@ impl PrimeField64 for Mersenne31 {
 
     #[inline]
     fn as_canonical_u64(&self) -> u64 {
-        u64::from(self.as_canonical_u32())
+        self.as_canonical_u32().into()
     }
 }
 

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -281,7 +281,7 @@ impl<FP: FieldParameters> PrimeField64 for MontyField31<FP> {
 
     #[inline]
     fn as_canonical_u64(&self) -> u64 {
-        u64::from(self.as_canonical_u32())
+        self.as_canonical_u32().into()
     }
 }
 


### PR DESCRIPTION
I think that in the proposed scenarios, it makes it more Rust idiomatic and less verbose