### PR TITLE
matrix: implement `Deref` for `FlatMatrixView`

### DIFF
--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use core::ops::Deref;
 
 use p3_field::{ExtensionField, Field};
 use p3_matrix::extension::FlatMatrixView;
@@ -55,7 +56,7 @@ where
         self.inner
             .get_matrices(prover_data)
             .into_iter()
-            .map(|mat| mat.inner_ref())
+            .map(|mat| mat.deref())
             .collect()
     }
 

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -16,7 +16,12 @@ impl<F, EF, Inner> FlatMatrixView<F, EF, Inner> {
     pub fn new(inner: Inner) -> Self {
         Self(inner, PhantomData)
     }
-    pub fn inner_ref(&self) -> &Inner {
+}
+
+impl<F, EF, Inner> Deref for FlatMatrixView<F, EF, Inner> {
+    type Target = Inner;
+
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -54,14 +54,12 @@ where
     }
 
     fn row_slice(&self, r: usize) -> impl Deref<Target = [F]> {
-        let ef_row: Vec<F> = self
-            .0
+        self.0
             .row_slice(r)
             .iter()
             .flat_map(|val| val.as_base_slice())
             .copied()
-            .collect();
-        ef_row
+            .collect::<Vec<_>>()
     }
 }
 


### PR DESCRIPTION
The behaviour is the same as `inner_ref` but should be more Rust idiomatic.