### PR TITLE
Rename AbstractField and AbstractExtensionField

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{AbstractExtensionField, AbstractField, ExtensionField, Field};
+use p3_field::{FieldExtensionAlgebra, FieldAlgebra, ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
@@ -29,7 +29,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: AbstractField
+    type Expr: FieldAlgebra
         + From<Self::F>
         + Add<Self::Var, Output = Self::Expr>
         + Add<Self::F, Output = Self::Expr>
@@ -130,7 +130,7 @@ pub trait PairBuilder: AirBuilder {
 pub trait ExtensionBuilder: AirBuilder {
     type EF: ExtensionField<Self::F>;
 
-    type ExprEF: AbstractExtensionField<Self::Expr, F = Self::EF>;
+    type ExprEF: FieldExtensionAlgebra<Self::Expr, F = Self::EF>;
 
     type VarEF: Into<Self::ExprEF> + Copy + Send + Sync;
 

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{FieldExtensionAlgebra, FieldAlgebra, ExtensionField, Field};
+use p3_field::{ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
 
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 
 /// An affine function over columns in a PAIR.
 #[derive(Clone, Debug)]
@@ -110,7 +110,7 @@ impl<F: Field> VirtualPairCol<F> {
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr
     where
         F: Into<Expr>,
-        Expr: AbstractField + Mul<F, Output = Expr>,
+        Expr: FieldAlgebra + Mul<F, Output = Expr>,
         Var: Into<Expr> + Copy,
     {
         let mut result = self.constant.into();

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
 
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 
 /// An affine function over columns in a PAIR.
 #[derive(Clone, Debug)]

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -1,4 +1,4 @@
-use p3_field::{exp_1725656503, exp_u64_by_squaring, AbstractField, Field};
+use p3_field::{exp_1725656503, exp_u64_by_squaring, Field, FieldAlgebra};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, TwoAdicData,
@@ -26,7 +26,7 @@ impl BarrettParameters for BabyBearParameters {}
 impl FieldParameters for BabyBearParameters {
     const MONTY_GEN: BabyBear = BabyBear::new(31);
 
-    fn exp_u64_generic<AF: AbstractField>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra>(val: FA, power: u64) -> FA {
         match power {
             1725656503 => exp_1725656503(val), // used to compute x^{1/7}
             _ => exp_u64_by_squaring(val, power),

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{AbstractExtensionField, AbstractField};
+    use p3_field::{FieldExtensionAlgebra, FieldAlgebra};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldExtensionAlgebra, FieldAlgebra};
+    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;

--- a/baby-bear/src/mds.rs
+++ b/baby-bear/src/mds.rs
@@ -49,7 +49,7 @@ pub type MdsMatrixBabyBear = MdsMatrixMontyField31<MDSBabyBearData>;
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
 
     use super::MdsMatrixBabyBear;

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{AbstractField, Field, PrimeField32};
+use p3_field::{Field, FieldAlgebra, PrimeField32};
 use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
     MontyField31, Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
@@ -50,7 +50,7 @@ pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [AF; WIDTH] for any AbstractField which implements multiplication by BabyBear field elements.
+/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by BabyBear field elements.
 /// If you have either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]` it will be much faster
 /// to use `Poseidon2BabyBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersBabyBear =
@@ -152,11 +152,11 @@ impl InternalLayerBaseParameters<BabyBearParameters, 16> for BabyBearInternalLay
         state[15] = sum - state[15];
     }
 
-    fn generic_internal_linear_layer<AF>(state: &mut [AF; 16])
+    fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
     where
-        AF: AbstractField + Mul<BabyBear, Output = AF>,
+        FA: FieldAlgebra + Mul<BabyBear, Output = FA>,
     {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -230,11 +230,11 @@ impl InternalLayerBaseParameters<BabyBearParameters, 24> for BabyBearInternalLay
         state[23] = sum - state[23];
     }
 
-    fn generic_internal_linear_layer<AF>(state: &mut [AF; 24])
+    fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
     where
-        AF: AbstractField + Mul<BabyBear, Output = AF>,
+        FA: FieldAlgebra + Mul<BabyBear, Output = FA>,
     {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -260,7 +260,7 @@ impl InternalLayerParameters<BabyBearParameters, 24> for BabyBearInternalLayerPa
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -112,7 +112,7 @@ impl InternalLayerParametersAVX2<BabyBearParameters, 24> for BabyBearInternalLay
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -12,7 +12,7 @@ use ff::{Field as FFField, PrimeField as FFPrimeField};
 pub use halo2curves::bn256::Fr as FFBn254Fr;
 use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
-use p3_field::{AbstractField, Field, Packable, PrimeField, TwoAdicField};
+use p3_field::{FieldAlgebra, Field, Packable, PrimeField, TwoAdicField};
 pub use poseidon2::Poseidon2Bn254;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -89,7 +89,7 @@ impl Debug for Bn254Fr {
     }
 }
 
-impl AbstractField for Bn254Fr {
+impl FieldAlgebra for Bn254Fr {
     type F = Self;
 
     const ZERO: Self = Self::new(FFBn254Fr::ZERO);

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -12,7 +12,7 @@ use ff::{Field as FFField, PrimeField as FFPrimeField};
 pub use halo2curves::bn256::Fr as FFBn254Fr;
 use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
-use p3_field::{FieldAlgebra, Field, Packable, PrimeField, TwoAdicField};
+use p3_field::{Field, FieldAlgebra, Packable, PrimeField, TwoAdicField};
 pub use poseidon2::Poseidon2Bn254;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -4,7 +4,7 @@
 
 use std::sync::OnceLock;
 
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -160,7 +160,7 @@ where
 mod tests {
     use core::iter;
 
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_goldilocks::Goldilocks;
     use p3_symmetric::Permutation;
 

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -83,7 +83,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_goldilocks::Goldilocks;
 
     use super::*;

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -17,7 +17,7 @@ pub use duplex_challenger::*;
 pub use grinding_challenger::*;
 pub use hash_challenger::*;
 pub use multi_field_challenger::*;
-use p3_field::{AbstractExtensionField, Field};
+use p3_field::{FieldExtensionAlgebra, Field};
 pub use serializing_challenger::*;
 
 pub trait CanObserve<T> {
@@ -52,11 +52,11 @@ pub trait CanSampleBits<T> {
 pub trait FieldChallenger<F: Field>:
     CanObserve<F> + CanSample<F> + CanSampleBits<usize> + Sync
 {
-    fn observe_ext_element<EF: AbstractExtensionField<F>>(&mut self, ext: EF) {
+    fn observe_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self, ext: EF) {
         self.observe_slice(ext.as_base_slice());
     }
 
-    fn sample_ext_element<EF: AbstractExtensionField<F>>(&mut self) -> EF {
+    fn sample_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self) -> EF {
         let vec = self.sample_vec(EF::D);
         EF::from_base_slice(&vec)
     }
@@ -115,12 +115,12 @@ where
     C: FieldChallenger<F>,
 {
     #[inline(always)]
-    fn observe_ext_element<EF: AbstractExtensionField<F>>(&mut self, ext: EF) {
+    fn observe_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self, ext: EF) {
         (**self).observe_ext_element(ext)
     }
 
     #[inline(always)]
-    fn sample_ext_element<EF: AbstractExtensionField<F>>(&mut self) -> EF {
+    fn sample_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self) -> EF {
         (**self).sample_ext_element()
     }
 }

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -17,7 +17,7 @@ pub use duplex_challenger::*;
 pub use grinding_challenger::*;
 pub use hash_challenger::*;
 pub use multi_field_challenger::*;
-use p3_field::{FieldExtensionAlgebra, Field};
+use p3_field::{Field, FieldExtensionAlgebra};
 pub use serializing_challenger::*;
 
 pub trait CanObserve<T> {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -124,7 +124,7 @@ mod tests {
     use alloc::vec;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
     use rand::{random, thread_rng};

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -233,7 +233,7 @@ mod tests {
 
     use hashbrown::HashSet;
     use itertools::izip;
-    use p3_field::{batch_multiplicative_inverse, AbstractField};
+    use p3_field::{batch_multiplicative_inverse, FieldAlgebra};
     use p3_mersenne_31::Mersenne31;
     use rand::thread_rng;
 

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -36,7 +36,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{AbstractField, Field};
+    use p3_field::{FieldAlgebra, Field};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::dense::RowMajorMatrix;
     use rand::thread_rng;

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -36,7 +36,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{FieldAlgebra, Field};
+    use p3_field::{Field, FieldAlgebra};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::dense::RowMajorMatrix;
     use rand::thread_rng;

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use criterion::{black_box, BatchSize, Criterion};
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -53,11 +53,9 @@ pub fn benchmark_iter_sum<F: Field, const N: usize, const REPS: usize>(
     });
 }
 
-pub fn benchmark_add_latency<AF: AbstractField + Copy, const N: usize>(
-    c: &mut Criterion,
-    name: &str,
-) where
-    Standard: Distribution<AF>,
+pub fn benchmark_add_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
+where
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("add-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -65,37 +63,37 @@ pub fn benchmark_add_latency<AF: AbstractField + Copy, const N: usize>(
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<AF>())
+                    vec.push(rng.gen::<FA>())
                 }
                 vec
             },
-            |x| x.iter().fold(AF::ZERO, |x, y| x + *y),
+            |x| x.iter().fold(FA::ZERO, |x, y| x + *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_add_throughput<AF: AbstractField + Copy, const N: usize>(
+pub fn benchmark_add_throughput<FA: FieldAlgebra + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<AF>,
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("add-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -120,11 +118,9 @@ pub fn benchmark_add_throughput<AF: AbstractField + Copy, const N: usize>(
     });
 }
 
-pub fn benchmark_sub_latency<AF: AbstractField + Copy, const N: usize>(
-    c: &mut Criterion,
-    name: &str,
-) where
-    Standard: Distribution<AF>,
+pub fn benchmark_sub_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
+where
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("sub-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -132,37 +128,37 @@ pub fn benchmark_sub_latency<AF: AbstractField + Copy, const N: usize>(
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<AF>())
+                    vec.push(rng.gen::<FA>())
                 }
                 vec
             },
-            |x| x.iter().fold(AF::ZERO, |x, y| x - *y),
+            |x| x.iter().fold(FA::ZERO, |x, y| x - *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_sub_throughput<AF: AbstractField + Copy, const N: usize>(
+pub fn benchmark_sub_throughput<FA: FieldAlgebra + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<AF>,
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("sub-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -187,11 +183,9 @@ pub fn benchmark_sub_throughput<AF: AbstractField + Copy, const N: usize>(
     });
 }
 
-pub fn benchmark_mul_latency<AF: AbstractField + Copy, const N: usize>(
-    c: &mut Criterion,
-    name: &str,
-) where
-    Standard: Distribution<AF>,
+pub fn benchmark_mul_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
+where
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("mul-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -199,37 +193,37 @@ pub fn benchmark_mul_latency<AF: AbstractField + Copy, const N: usize>(
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<AF>())
+                    vec.push(rng.gen::<FA>())
                 }
                 vec
             },
-            |x| x.iter().fold(AF::ZERO, |x, y| x * *y),
+            |x| x.iter().fold(FA::ZERO, |x, y| x * *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_mul_throughput<AF: AbstractField + Copy, const N: usize>(
+pub fn benchmark_mul_throughput<FA: FieldAlgebra + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<AF>,
+    Standard: Distribution<FA>,
 {
     c.bench_function(&format!("mul-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
-                    rng.gen::<AF>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
+                    rng.gen::<FA>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -201,7 +201,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{binomial_expand, eval_poly, FieldExtensionAlgebra, FieldAlgebra};
+    use p3_field::{binomial_expand, eval_poly, FieldAlgebra, FieldExtensionAlgebra};
     use rand::random;
 
     use super::*;

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -201,7 +201,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{binomial_expand, eval_poly, AbstractExtensionField, AbstractField};
+    use p3_field::{binomial_expand, eval_poly, FieldExtensionAlgebra, FieldAlgebra};
     use rand::random;
 
     use super::*;

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{Field, FieldAlgebra, PackedField, PackedFieldPow2, PackedValue};
 use rand::distributions::{Distribution, Standard};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -438,7 +438,7 @@ where
 macro_rules! test_packed_field {
     ($packedfield:ty, $zeros:expr, $specials:expr) => {
         mod packed_field_tests {
-            use p3_field::AbstractField;
+            use p3_field::FieldAlgebra;
 
             #[test]
             fn test_interleaves() {

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{FieldAlgebra, Field, PackedValue};
+use crate::{Field, FieldAlgebra, PackedValue};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{AbstractField, Field, PackedValue};
+use crate::{FieldAlgebra, Field, PackedValue};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.
@@ -35,7 +35,7 @@ impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
     }
 }
 
-impl<F: Field, const N: usize> AbstractField for FieldArray<F, N> {
+impl<F: Field, const N: usize> FieldAlgebra for FieldArray<F, N> {
     type F = F;
 
     const ZERO: Self = FieldArray([F::ZERO; N]);

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -4,7 +4,7 @@ use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::field::Field;
-use crate::{AbstractField, FieldArray, PackedValue};
+use crate::{FieldAlgebra, FieldArray, PackedValue};
 
 /// Batch multiplicative inverses with Montgomery's trick
 /// This is Montgomery's trick. At a high level, we invert the product of the given field
@@ -58,7 +58,7 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
 /// support inversion, this takes a custom inversion function.
 pub(crate) fn batch_multiplicative_inverse_general<F, Inv>(x: &[F], result: &mut [F], inv: Inv)
 where
-    F: AbstractField + Copy,
+    F: FieldAlgebra + Copy,
     Inv: Fn(F) -> F,
 {
     let n = x.len();

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -1,8 +1,8 @@
-use crate::AbstractField;
+use crate::FieldAlgebra;
 
-pub fn exp_u64_by_squaring<AF: AbstractField>(val: AF, power: u64) -> AF {
+pub fn exp_u64_by_squaring<FA: FieldAlgebra>(val: FA, power: u64) -> FA {
     let mut current = val;
-    let mut product = AF::ONE;
+    let mut product = FA::ONE;
 
     for j in 0..bits_u64(power) {
         if (power >> j & 1) != 0 {
@@ -17,7 +17,7 @@ const fn bits_u64(n: u64) -> usize {
     (64 - n.leading_zeros()) as usize
 }
 
-pub fn exp_1717986917<AF: AbstractField>(val: AF) -> AF {
+pub fn exp_1717986917<FA: FieldAlgebra>(val: FA) -> FA {
     // Note that 5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1.
     // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1717986917})^5 = a.
     // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
@@ -39,7 +39,7 @@ pub fn exp_1717986917<AF: AbstractField>(val: AF) -> AF {
     p1100110011001100110011001100000 * p101
 }
 
-pub fn exp_1420470955<AF: AbstractField>(val: AF) -> AF {
+pub fn exp_1420470955<FA: FieldAlgebra>(val: FA) -> FA {
     // Note that 3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1).
     // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1420470955})^3 = a.
     // Note the binary expansion: 1420470955 = 1010100101010101010101010101011_2
@@ -61,7 +61,7 @@ pub fn exp_1420470955<AF: AbstractField>(val: AF) -> AF {
     p1010100101010101010101010101010 * p1.clone()
 }
 
-pub fn exp_1725656503<AF: AbstractField>(val: AF) -> AF {
+pub fn exp_1725656503<FA: FieldAlgebra>(val: FA) -> FA {
     // Note that 7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1).
     // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{1725656503})^7 = a.
     // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
@@ -85,7 +85,7 @@ pub fn exp_1725656503<AF: AbstractField>(val: AF) -> AF {
     p1100110110110110110110110110000 * p111
 }
 
-pub fn exp_10540996611094048183<AF: AbstractField>(val: AF) -> AF {
+pub fn exp_10540996611094048183<FA: FieldAlgebra>(val: FA) -> FA {
     // Note that 7*10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1).
     // Thus as a^{p - 1} = 1 for all a \in F_p, (a^{10540996611094048183})^7 = a.
     // Also: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -17,31 +17,31 @@ use super::{HasFrobenius, HasTwoAdicBionmialExtension};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
-    field_to_array, AbstractExtensionField, AbstractField, ExtensionField, Packable, TwoAdicField,
+    field_to_array, ExtensionField, FieldAlgebra, FieldExtensionAlgebra, Packable, TwoAdicField,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // to make the zero_vec implementation safe
-pub struct BinomialExtensionField<AF, const D: usize> {
+pub struct BinomialExtensionField<FA, const D: usize> {
     #[serde(
         with = "p3_util::array_serialization",
-        bound(serialize = "AF: Serialize", deserialize = "AF: Deserialize<'de>")
+        bound(serialize = "FA: Serialize", deserialize = "FA: Deserialize<'de>")
     )]
-    pub(crate) value: [AF; D],
+    pub(crate) value: [FA; D],
 }
 
-impl<AF: AbstractField, const D: usize> Default for BinomialExtensionField<AF, D> {
+impl<FA: FieldAlgebra, const D: usize> Default for BinomialExtensionField<FA, D> {
     fn default() -> Self {
         Self {
-            value: array::from_fn(|_| AF::ZERO),
+            value: array::from_fn(|_| FA::ZERO),
         }
     }
 }
 
-impl<AF: AbstractField, const D: usize> From<AF> for BinomialExtensionField<AF, D> {
-    fn from(x: AF) -> Self {
+impl<FA: FieldAlgebra, const D: usize> From<FA> for BinomialExtensionField<FA, D> {
+    fn from(x: FA) -> Self {
         Self {
-            value: field_to_array::<AF, D>(x),
+            value: field_to_array::<FA, D>(x),
         }
     }
 }
@@ -113,74 +113,74 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
     }
 }
 
-impl<AF, const D: usize> AbstractField for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> FieldAlgebra for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
-    type F = BinomialExtensionField<AF::F, D>;
+    type F = BinomialExtensionField<FA::F, D>;
 
     const ZERO: Self = Self {
-        value: [AF::ZERO; D],
+        value: [FA::ZERO; D],
     };
 
     const ONE: Self = Self {
-        value: field_to_array::<AF, D>(AF::ONE),
+        value: field_to_array::<FA, D>(FA::ONE),
     };
 
     const TWO: Self = Self {
-        value: field_to_array::<AF, D>(AF::TWO),
+        value: field_to_array::<FA, D>(FA::TWO),
     };
 
     const NEG_ONE: Self = Self {
-        value: field_to_array::<AF, D>(AF::NEG_ONE),
+        value: field_to_array::<FA, D>(FA::NEG_ONE),
     };
 
     #[inline]
     fn from_f(f: Self::F) -> Self {
         Self {
-            value: f.value.map(AF::from_f),
+            value: f.value.map(FA::from_f),
         }
     }
 
     #[inline]
     fn from_bool(b: bool) -> Self {
-        AF::from_bool(b).into()
+        FA::from_bool(b).into()
     }
 
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
-        AF::from_canonical_u8(n).into()
+        FA::from_canonical_u8(n).into()
     }
 
     #[inline]
     fn from_canonical_u16(n: u16) -> Self {
-        AF::from_canonical_u16(n).into()
+        FA::from_canonical_u16(n).into()
     }
 
     #[inline]
     fn from_canonical_u32(n: u32) -> Self {
-        AF::from_canonical_u32(n).into()
+        FA::from_canonical_u32(n).into()
     }
 
     #[inline]
     fn from_canonical_u64(n: u64) -> Self {
-        AF::from_canonical_u64(n).into()
+        FA::from_canonical_u64(n).into()
     }
 
     #[inline]
     fn from_canonical_usize(n: usize) -> Self {
-        AF::from_canonical_usize(n).into()
+        FA::from_canonical_usize(n).into()
     }
 
     #[inline]
     fn from_wrapped_u32(n: u32) -> Self {
-        AF::from_wrapped_u32(n).into()
+        FA::from_wrapped_u32(n).into()
     }
 
     #[inline]
     fn from_wrapped_u64(n: u64) -> Self {
-        AF::from_wrapped_u64(n).into()
+        FA::from_wrapped_u64(n).into()
     }
 
     #[inline(always)]
@@ -189,13 +189,13 @@ where
             2 => {
                 let a = self.value.clone();
                 let mut res = Self::default();
-                res.value[0] = a[0].square() + a[1].square() * AF::from_f(AF::F::W);
+                res.value[0] = a[0].square() + a[1].square() * FA::from_f(FA::F::W);
                 res.value[1] = a[0].clone() * a[1].double();
                 res
             }
             3 => {
                 let mut res = Self::default();
-                cubic_square(&self.value, &mut res.value, AF::F::W);
+                cubic_square(&self.value, &mut res.value, FA::F::W);
                 res
             }
             _ => <Self as Mul<Self>>::mul(self.clone(), self.clone()),
@@ -205,7 +205,7 @@ where
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(AF::zero_vec(len * D)) }
+        unsafe { convert_vec(FA::zero_vec(len * D)) }
     }
 }
 
@@ -265,25 +265,25 @@ where
     }
 }
 
-impl<AF, const D: usize> Neg for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Neg for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
     #[inline]
     fn neg(self) -> Self {
         Self {
-            value: self.value.map(AF::neg),
+            value: self.value.map(FA::neg),
         }
     }
 }
 
-impl<AF, const D: usize> Add for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Add for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
@@ -297,24 +297,24 @@ where
     }
 }
 
-impl<AF, const D: usize> Add<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Add<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
     #[inline]
-    fn add(mut self, rhs: AF) -> Self {
+    fn add(mut self, rhs: FA) -> Self {
         self.value[0] += rhs;
         self
     }
 }
 
-impl<AF, const D: usize> AddAssign for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> AddAssign for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
@@ -324,31 +324,31 @@ where
     }
 }
 
-impl<AF, const D: usize> AddAssign<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> AddAssign<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
-    fn add_assign(&mut self, rhs: AF) {
+    fn add_assign(&mut self, rhs: FA) {
         self.value[0] += rhs;
     }
 }
 
-impl<AF, const D: usize> Sum for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Sum for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<AF, const D: usize> Sub for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Sub for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
@@ -362,25 +362,25 @@ where
     }
 }
 
-impl<AF, const D: usize> Sub<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Sub<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: AF) -> Self {
+    fn sub(self, rhs: FA) -> Self {
         let mut res = self.value;
         res[0] -= rhs;
         Self { value: res }
     }
 }
 
-impl<AF, const D: usize> SubAssign for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> SubAssign for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
@@ -388,21 +388,21 @@ where
     }
 }
 
-impl<AF, const D: usize> SubAssign<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> SubAssign<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
-    fn sub_assign(&mut self, rhs: AF) {
+    fn sub_assign(&mut self, rhs: FA) {
         *self = self.clone() - rhs;
     }
 }
 
-impl<AF, const D: usize> Mul for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Mul for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
@@ -411,8 +411,8 @@ where
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
-        let w = AF::F::W;
-        let w_af = AF::from_f(w);
+        let w = FA::F::W;
+        let w_af = FA::from_f(w);
 
         match D {
             2 => {
@@ -438,25 +438,25 @@ where
     }
 }
 
-impl<AF, const D: usize> Mul<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Mul<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     type Output = Self;
 
     #[inline]
-    fn mul(self, rhs: AF) -> Self {
+    fn mul(self, rhs: FA) -> Self {
         Self {
             value: self.value.map(|x| x * rhs.clone()),
         }
     }
 }
 
-impl<AF, const D: usize> Product for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> Product for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
@@ -486,10 +486,10 @@ where
     }
 }
 
-impl<AF, const D: usize> MulAssign for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> MulAssign for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
@@ -497,45 +497,45 @@ where
     }
 }
 
-impl<AF, const D: usize> MulAssign<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> MulAssign<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     #[inline]
-    fn mul_assign(&mut self, rhs: AF) {
+    fn mul_assign(&mut self, rhs: FA) {
         *self = self.clone() * rhs;
     }
 }
 
-impl<AF, const D: usize> AbstractExtensionField<AF> for BinomialExtensionField<AF, D>
+impl<FA, const D: usize> FieldExtensionAlgebra<FA> for BinomialExtensionField<FA, D>
 where
-    AF: AbstractField,
-    AF::F: BinomiallyExtendable<D>,
+    FA: FieldAlgebra,
+    FA::F: BinomiallyExtendable<D>,
 {
     const D: usize = D;
 
     #[inline]
-    fn from_base(b: AF) -> Self {
+    fn from_base(b: FA) -> Self {
         Self {
             value: field_to_array(b),
         }
     }
 
     #[inline]
-    fn from_base_slice(bs: &[AF]) -> Self {
+    fn from_base_slice(bs: &[FA]) -> Self {
         Self::from_base_fn(|i| bs[i].clone())
     }
 
     #[inline]
-    fn from_base_fn<F: FnMut(usize) -> AF>(f: F) -> Self {
+    fn from_base_fn<F: FnMut(usize) -> FA>(f: F) -> Self {
         Self {
             value: array::from_fn(f),
         }
     }
 
     #[inline]
-    fn from_base_iter<I: Iterator<Item = AF>>(iter: I) -> Self {
+    fn from_base_iter<I: Iterator<Item = FA>>(iter: I) -> Self {
         let mut res = Self::default();
         for (i, b) in iter.enumerate() {
             res.value[i] = b;
@@ -544,7 +544,7 @@ where
     }
 
     #[inline(always)]
-    fn as_base_slice(&self) -> &[AF] {
+    fn as_base_slice(&self) -> &[FA] {
         &self.value
     }
 }
@@ -606,12 +606,7 @@ fn cubic_inv<F: Field>(a: &[F], w: F) -> [F; 3] {
 
 /// karatsuba multiplication for cubic extension field
 #[inline]
-fn cubic_mul<AF: AbstractField, const D: usize>(
-    a: &[AF; D],
-    b: &[AF; D],
-    res: &mut [AF; D],
-    w: AF,
-) {
+fn cubic_mul<FA: FieldAlgebra, const D: usize>(a: &[FA; D], b: &[FA; D], res: &mut [FA; D], w: FA) {
     assert_eq!(D, 3);
 
     let a0_b0 = a[0].clone() * b[0].clone();
@@ -632,10 +627,10 @@ fn cubic_mul<AF: AbstractField, const D: usize>(
 
 /// Section 11.3.6a in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
 #[inline]
-fn cubic_square<AF: AbstractField, const D: usize>(a: &[AF; D], res: &mut [AF; D], w: AF::F) {
+fn cubic_square<FA: FieldAlgebra, const D: usize>(a: &[FA; D], res: &mut [FA; D], w: FA::F) {
     assert_eq!(D, 3);
 
-    let w_a2 = a[2].clone() * AF::from_f(w);
+    let w_a2 = a[2].clone() * FA::from_f(w);
 
     res[0] = a[0].square() + (a[1].clone() * w_a2.clone()).double();
     res[1] = w_a2 * a[2].clone() + (a[0].clone() * a[1].clone()).double();

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,7 +1,7 @@
 use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBionmialExtension};
-use crate::{AbstractExtensionField, AbstractField, Field};
+use crate::{Field, FieldAlgebra, FieldExtensionAlgebra};
 
-pub type Complex<AF> = BinomialExtensionField<AF, 2>;
+pub type Complex<FA> = BinomialExtensionField<FA, 2>;
 
 /// A field for which `p = 3 (mod 4)`. Equivalently, `-1` is not a square,
 /// so the complex extension can be defined `F[i] = F[X]/(X^2+1)`.
@@ -25,31 +25,31 @@ impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
 }
 
 /// Convenience methods for complex extensions
-impl<AF: AbstractField> Complex<AF> {
+impl<FA: FieldAlgebra> Complex<FA> {
     #[inline(always)]
-    pub const fn new(real: AF, imag: AF) -> Self {
+    pub const fn new(real: FA, imag: FA) -> Self {
         Self {
             value: [real, imag],
         }
     }
 
     #[inline(always)]
-    pub const fn new_real(real: AF) -> Self {
-        Self::new(real, AF::ZERO)
+    pub const fn new_real(real: FA) -> Self {
+        Self::new(real, FA::ZERO)
     }
 
     #[inline(always)]
-    pub const fn new_imag(imag: AF) -> Self {
-        Self::new(AF::ZERO, imag)
+    pub const fn new_imag(imag: FA) -> Self {
+        Self::new(FA::ZERO, imag)
     }
 
     #[inline(always)]
-    pub fn real(&self) -> AF {
+    pub fn real(&self) -> FA {
         self.value[0].clone()
     }
 
     #[inline(always)]
-    pub fn imag(&self) -> AF {
+    pub fn imag(&self) -> FA {
         self.value[1].clone()
     }
 
@@ -59,18 +59,18 @@ impl<AF: AbstractField> Complex<AF> {
     }
 
     #[inline]
-    pub fn norm(&self) -> AF {
+    pub fn norm(&self) -> FA {
         self.real().square() + self.imag().square()
     }
 
     #[inline(always)]
-    pub fn to_array(&self) -> [AF; 2] {
+    pub fn to_array(&self) -> [FA; 2] {
         self.value.clone()
     }
 
     // Sometimes we want to rotate over an extension that's not necessarily ComplexExtendable,
     // but still on the circle.
-    pub fn rotate<Ext: AbstractExtensionField<AF>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
+    pub fn rotate<Ext: FieldExtensionAlgebra<FA>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
         Complex::<Ext>::new(
             rhs.real() * self.real() - rhs.imag() * self.imag(),
             rhs.imag() * self.real() + rhs.real() * self.imag(),

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -19,13 +19,18 @@ use crate::Packable;
 
 /// A commutative algebra over a finite field.
 ///
-/// This is an algebraic structure with addition, multiplication
-/// and scalar multiplication. The addition and multiplication
+/// This permits elements like:
+/// - an actual field element
+/// - a symbolic expression which would evaluate to a field element
+/// - an array of field elements
+///
+/// Mathematically speaking, this is an algebraic structure with addition,
+/// multiplication and scalar multiplication. The addition and multiplication
 /// maps must be both commutative and associative, and there must
 /// exist identity elements for both (named `ZERO` and `ONE`
 /// respectively). Furthermore, multiplication must distribute over
 /// addition. Finally, the scalar multiplication must be realized by
-/// a ring homomorphism from `F` to `CA`.
+/// a ring homomorphism from the field to the algebra.
 pub trait FieldAlgebra:
     Sized
     + Default

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -70,6 +70,8 @@ pub trait FieldAlgebra:
     /// the proving system. This also is slightly faster than computing
     /// it via addition. Note that multiplication by `TWO` is discouraged.
     /// Instead of `a * TWO` use `a.double()` which will be faster.
+    ///
+    /// If the field has characteristic 2 this is equal to ZERO.
     const TWO: Self;
 
     /// The element in the algebra given by `-ONE`.
@@ -78,12 +80,12 @@ pub trait FieldAlgebra:
     /// the proving system. This also is slightly faster than computing
     /// it via negation. Note that where possible `NEG_ONE` should be absorbed
     /// into mathematical operations. For example `a - b` will be faster
-    /// than `a + NEG_ONE * b`.
+    /// than `a + NEG_ONE * b` and similarly `(-b)` is faster than `NEG_ONE * b`.
     ///
     /// If the field has characteristic 2 this is equal to ONE.
     const NEG_ONE: Self;
 
-    /// Interpret a field element as commutative algebra element.
+    /// Interpret a field element as a commutative algebra element.
     ///
     /// Mathematically speaking, this map is a ring homomorphism from the base field
     /// to the commutative algebra. The existence of this map makes this structure
@@ -128,7 +130,7 @@ pub trait FieldAlgebra:
 
     /// The elementary function `double(a) = 2*a`.
     ///
-    /// This will implement whatever method is fastest for the given algebra.
+    /// This function should be preferred over calling `a + a` or `TWO * a` as a faster implementation may be available for some algebras.
     /// If the field has characteristic 2 then this returns 0.
     #[must_use]
     fn double(&self) -> Self {
@@ -165,7 +167,7 @@ pub trait FieldAlgebra:
 
     /// Exponentiation by a constant power.
     ///
-    /// For a collection of small values we implement custom multiplication chain circuits which may be faster than the
+    /// For a collection of small values we implement custom multiplication chain circuits which can be faster than the
     /// simpler square and multiply approach.
     #[must_use]
     #[inline(always)]

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -17,11 +17,16 @@ use crate::exponentiation::exp_u64_by_squaring;
 use crate::packed::{PackedField, PackedValue};
 use crate::Packable;
 
-/// A generalization of `Field` which permits things like
-/// - an actual field element
-/// - a symbolic expression which would evaluate to a field element
-/// - an array of field elements
-pub trait AbstractField:
+/// A commutative algebra over a finite field.
+///
+/// This is an algebraic structure with addition, multiplication
+/// and scalar multiplication. The addition and multiplication
+/// maps must be both commutative and associative, and there must
+/// exist identity elements for both (named `ZERO` and `ONE`
+/// respectively). Furthermore, multiplication must distribute over
+/// addition. Finally, the scalar multiplication must be realized by
+/// a ring homomorphism from `F` to `CA`.
+pub trait FieldAlgebra:
     Sized
     + Default
     + Clone
@@ -38,11 +43,46 @@ pub trait AbstractField:
 {
     type F: Field;
 
+    /// The additive identity of the algebra.
+    ///
+    /// For every element `a` in the algebra we require the following properties:
+    ///
+    /// `a + ZERO = ZERO + a = a,`
+    ///
+    /// `a + (-a) = (-a) + a = ZERO.`
     const ZERO: Self;
+
+    /// The multiplicative identity of the Algebra
+    ///
+    /// For every element `a` in the algebra we require the following property:
+    ///
+    /// `a*ONE = ONE*a = a.`
     const ONE: Self;
+
+    /// The element in the algebra given by `ONE + ONE`.
+    ///
+    /// This is provided as a convenience as `TWO` occurs regularly in
+    /// the proving system. This also is slightly faster than computing
+    /// it via addition. Note that multiplication by `TWO` is discouraged.
+    /// Instead of `a * TWO` use `a.double()` which will be faster.
     const TWO: Self;
+
+    /// The element in the algebra given by `-ONE`.
+    ///
+    /// This is provided as a convenience as `NEG_ONE` occurs regularly in
+    /// the proving system. This also is slightly faster than computing
+    /// it via negation. Note that where possible `NEG_ONE` should be absorbed
+    /// into mathematical operations. For example `a - b` will be faster
+    /// than `a + NEG_ONE * b`.
+    ///
+    /// If the field has characteristic 2 this is equal to ONE.
     const NEG_ONE: Self;
 
+    /// Interpret a field element as commutative algebra element.
+    ///
+    /// Mathematically speaking, this map is a ring homomorphism from the base field
+    /// to the commutative algebra. The existence of this map makes this structure
+    /// an algebra and not simply a commutative ring.
     fn from_f(f: Self::F) -> Self;
 
     /// Convert from a `bool`.
@@ -81,16 +121,26 @@ pub trait AbstractField:
     fn from_wrapped_u32(n: u32) -> Self;
     fn from_wrapped_u64(n: u64) -> Self;
 
+    /// The elementary function `double(a) = 2*a`.
+    ///
+    /// This will implement whatever method is fastest for the given algebra.
+    /// If the field has characteristic 2 then this returns 0.
     #[must_use]
     fn double(&self) -> Self {
         self.clone() + self.clone()
     }
 
+    /// The elementary function `square(a) = a^2`.
+    ///
+    /// This will implement whatever method is fastest for the given algebra.
     #[must_use]
     fn square(&self) -> Self {
         self.clone() * self.clone()
     }
 
+    /// The elementary function `cube(a) = a^3`.
+    ///
+    /// This will implement whatever method is fastest for the given algebra.
     #[must_use]
     fn cube(&self) -> Self {
         self.square() * self.clone()
@@ -108,6 +158,10 @@ pub trait AbstractField:
         Self::F::exp_u64_generic(self.clone(), power)
     }
 
+    /// Exponentiation by a constant power.
+    ///
+    /// For a collection of small values we implement custom multiplication chain circuits which may be faster than the
+    /// simpler square and multiply approach.
     #[must_use]
     #[inline(always)]
     fn exp_const_u64<const POWER: u64>(&self) -> Self {
@@ -129,6 +183,7 @@ pub trait AbstractField:
         }
     }
 
+    /// Compute self^{2^power_log} by repeated squaring.
     #[must_use]
     fn exp_power_of_2(&self, power_log: usize) -> Self {
         let mut res = self.clone();
@@ -145,11 +200,13 @@ pub trait AbstractField:
         self.clone() * Self::TWO.exp_u64(exp)
     }
 
+    /// Construct an iterator which returns powers of `self: self^0, self^1, self^2, ...`.
     #[must_use]
     fn powers(&self) -> Powers<Self> {
         self.shifted_powers(Self::ONE)
     }
 
+    /// Construct an iterator which returns powers of `self` multiplied by `start: start, start*self^1, start*self^2, ...`.
     fn shifted_powers(&self, start: Self) -> Powers<Self> {
         Powers {
             base: self.clone(),
@@ -177,6 +234,7 @@ pub trait AbstractField:
         }
     }
 
+    /// Compute the dot product of two vectors.
     fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
         u.iter().zip(v).map(|(x, y)| x.clone() * y.clone()).sum()
     }
@@ -204,7 +262,7 @@ pub trait AbstractField:
 
 /// An element of a finite field.
 pub trait Field:
-    AbstractField<F = Self>
+    FieldAlgebra<F = Self>
     + Packable
     + 'static
     + Copy
@@ -244,7 +302,7 @@ pub trait Field:
     /// override this and handle certain powers with more optimal addition chains.
     #[must_use]
     #[inline]
-    fn exp_u64_generic<AF: AbstractField<F = Self>>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra<F = Self>>(val: FA, power: u64) -> FA {
         exp_u64_by_squaring(val, power)
     }
 
@@ -310,8 +368,15 @@ pub trait PrimeField32: PrimeField64 {
     fn as_canonical_u32(&self) -> u32;
 }
 
-pub trait AbstractExtensionField<Base: AbstractField>:
-    AbstractField
+/// A commutative algebra over an extension field.
+///
+/// Mathematically, this trait captures a slightly more interesting structure than the above one liner.
+/// As implemented here, A FieldExtensionAlgebra `FEA` over and extension field `EF` is
+/// really the result of applying extension of scalars to a FieldAlgebra `FA` to lift `FA`
+/// from an algebra over `F` to an algebra over `EF` and so `FEA = EF ⊗ FA` where the tensor
+/// product is over `F`.
+pub trait FieldExtensionAlgebra<Base: FieldAlgebra>:
+    FieldAlgebra
     + From<Base>
     + Add<Base, Output = Self>
     + AddAssign<Base>
@@ -377,8 +442,8 @@ pub trait AbstractExtensionField<Base: AbstractField>:
     }
 }
 
-pub trait ExtensionField<Base: Field>: Field + AbstractExtensionField<Base> {
-    type ExtensionPacking: AbstractExtensionField<Base::Packing, F = Self>
+pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> {
+    type ExtensionPacking: FieldExtensionAlgebra<Base::Packing, F = Self>
         + 'static
         + Copy
         + Send
@@ -416,28 +481,28 @@ impl<F: Field> ExtensionField<F> for F {
     type ExtensionPacking = F::Packing;
 }
 
-impl<AF: AbstractField> AbstractExtensionField<AF> for AF {
+impl<FA: FieldAlgebra> FieldExtensionAlgebra<FA> for FA {
     const D: usize = 1;
 
-    fn from_base(b: AF) -> Self {
+    fn from_base(b: FA) -> Self {
         b
     }
 
-    fn from_base_slice(bs: &[AF]) -> Self {
+    fn from_base_slice(bs: &[FA]) -> Self {
         assert_eq!(bs.len(), 1);
         bs[0].clone()
     }
 
-    fn from_base_iter<I: Iterator<Item = AF>>(mut iter: I) -> Self {
+    fn from_base_iter<I: Iterator<Item = FA>>(mut iter: I) -> Self {
         iter.next().unwrap()
     }
 
-    fn from_base_fn<F: FnMut(usize) -> AF>(mut f: F) -> Self {
+    fn from_base_fn<F: FnMut(usize) -> FA>(mut f: F) -> Self {
         f(0)
     }
 
     #[inline(always)]
-    fn as_base_slice(&self) -> &[AF] {
+    fn as_base_slice(&self) -> &[FA] {
         slice::from_ref(self)
     }
 }
@@ -461,10 +526,10 @@ pub struct Powers<F> {
     pub current: F,
 }
 
-impl<AF: AbstractField> Iterator for Powers<AF> {
-    type Item = AF;
+impl<FA: FieldAlgebra> Iterator for Powers<FA> {
+    type Item = FA;
 
-    fn next(&mut self) -> Option<AF> {
+    fn next(&mut self) -> Option<FA> {
         let result = self.current.clone();
         self.current *= self.base.clone();
         Some(result)
@@ -479,7 +544,7 @@ pub struct PackedPowers<F, P: PackedField<Scalar = F>> {
     pub current: P,
 }
 
-impl<AF: AbstractField, P: PackedField<Scalar = AF>> Iterator for PackedPowers<AF, P> {
+impl<FA: FieldAlgebra, P: PackedField<Scalar = FA>> Iterator for PackedPowers<FA, P> {
     type Item = P;
 
     fn next(&mut self) -> Option<P> {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -137,7 +137,7 @@ pub trait FieldAlgebra:
 
     /// The elementary function `square(a) = a^2`.
     ///
-    /// This will implement whatever method is fastest for the given algebra.
+    /// This function should be preferred over calling `a * a`, as a faster implementation may be available for some algebras.
     #[must_use]
     fn square(&self) -> Self {
         self.clone() * self.clone()
@@ -145,7 +145,7 @@ pub trait FieldAlgebra:
 
     /// The elementary function `cube(a) = a^3`.
     ///
-    /// This will implement whatever method is fastest for the given algebra.
+    /// This function should be preferred over calling `a * a * a`, as a faster implementation may be available for some algebras.
     #[must_use]
     fn cube(&self) -> Self {
         self.square() * self.clone()

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -3,7 +3,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
 use core::slice;
 
 use crate::field::Field;
-use crate::AbstractField;
+use crate::FieldAlgebra;
 
 /// A trait to constrain types that can be packed into a packed value.
 ///
@@ -130,7 +130,7 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
 
 /// # Safety
 /// - See `PackedValue` above.
-pub unsafe trait PackedField: AbstractField<F = Self::Scalar>
+pub unsafe trait PackedField: FieldAlgebra<F = Self::Scalar>
     + PackedValue<Value = Self::Scalar>
     + From<Self::Scalar>
     + Add<Self::Scalar, Output = Self>

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -6,7 +6,7 @@ use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};
 use p3_commit::ExtensionMmcs;
 use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_fri::{prover, verifier, FriConfig, TwoAdicFriGenericConfig};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::reverse_matrix_index_bits;

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -6,7 +6,7 @@ use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};
 use p3_commit::ExtensionMmcs;
 use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_fri::{prover, verifier, FriConfig, TwoAdicFriGenericConfig};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::reverse_matrix_index_bits;

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_sub_latency, benchmark_sub_throughput,

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_sub_latency, benchmark_sub_throughput,

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,5 +1,5 @@
 use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
-use p3_field::{AbstractField, TwoAdicField};
+use p3_field::{FieldAlgebra, TwoAdicField};
 
 use crate::Goldilocks;
 

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use num_bigint::BigUint;
 use p3_field::{
-    exp_10540996611094048183, exp_u64_by_squaring, halve_u64, AbstractField, Field, Packable,
+    exp_10540996611094048183, exp_u64_by_squaring, halve_u64, Field, FieldAlgebra, Packable,
     PrimeField, PrimeField64, TwoAdicField,
 };
 use p3_util::{assume, branch_hint};
@@ -89,7 +89,7 @@ impl Distribution<Goldilocks> for Standard {
     }
 }
 
-impl AbstractField for Goldilocks {
+impl FieldAlgebra for Goldilocks {
     type F = Self;
 
     const ZERO: Self = Self::new(0);
@@ -184,7 +184,7 @@ impl Field for Goldilocks {
     }
 
     #[inline]
-    fn exp_u64_generic<AF: AbstractField<F = Self>>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra<F = Self>>(val: FA, power: u64) -> FA {
         match power {
             10540996611094048183 => exp_10540996611094048183(val), // used to compute x^{1/7}
             _ => exp_u64_by_squaring(val, power),

--- a/goldilocks/src/mds.rs
+++ b/goldilocks/src/mds.rs
@@ -230,7 +230,7 @@ impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
 
     use super::{Goldilocks, MdsMatrixGoldilocks};

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -9,7 +9,7 @@
 //! Long term we will use more optimised internal and external linear layers.
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,
@@ -125,7 +125,7 @@ pub struct Poseidon2InternalLayerGoldilocks {
     internal_constants: Vec<Goldilocks>,
 }
 
-impl<AF: AbstractField<F = Goldilocks>> InternalLayerConstructor<AF>
+impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayerConstructor<FA>
     for Poseidon2InternalLayerGoldilocks
 {
     fn new_from_constants(internal_constants: Vec<Goldilocks>) -> Self {
@@ -133,12 +133,12 @@ impl<AF: AbstractField<F = Goldilocks>> InternalLayerConstructor<AF>
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 8, GOLDILOCKS_S_BOX_DEGREE>
+impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayer<FA, 8, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [AF; 8]) {
-        internal_permute_state::<AF, 8, GOLDILOCKS_S_BOX_DEGREE>(
+    fn permute_state(&self, state: &mut [FA; 8]) {
+        internal_permute_state::<FA, 8, GOLDILOCKS_S_BOX_DEGREE>(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_8_GOLDILOCKS),
             &self.internal_constants,
@@ -146,12 +146,12 @@ impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 8, GOLDILOCKS_S_BOX_DE
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 12, GOLDILOCKS_S_BOX_DEGREE>
+impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayer<FA, 12, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [AF; 12]) {
-        internal_permute_state::<AF, 12, GOLDILOCKS_S_BOX_DEGREE>(
+    fn permute_state(&self, state: &mut [FA; 12]) {
+        internal_permute_state::<FA, 12, GOLDILOCKS_S_BOX_DEGREE>(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_12_GOLDILOCKS),
             &self.internal_constants,
@@ -159,12 +159,12 @@ impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 12, GOLDILOCKS_S_BOX_D
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 16, GOLDILOCKS_S_BOX_DEGREE>
+impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayer<FA, 16, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [AF; 16]) {
-        internal_permute_state::<AF, 16, GOLDILOCKS_S_BOX_DEGREE>(
+    fn permute_state(&self, state: &mut [FA; 16]) {
+        internal_permute_state::<FA, 16, GOLDILOCKS_S_BOX_DEGREE>(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_16_GOLDILOCKS),
             &self.internal_constants,
@@ -172,12 +172,12 @@ impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 16, GOLDILOCKS_S_BOX_D
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> InternalLayer<AF, 20, GOLDILOCKS_S_BOX_DEGREE>
+impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayer<FA, 20, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [AF; 20]) {
-        internal_permute_state::<AF, 20, GOLDILOCKS_S_BOX_DEGREE>(
+    fn permute_state(&self, state: &mut [FA; 20]) {
+        internal_permute_state::<FA, 20, GOLDILOCKS_S_BOX_DEGREE>(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_20_GOLDILOCKS),
             &self.internal_constants,
@@ -191,7 +191,7 @@ pub struct Poseidon2ExternalLayerGoldilocks<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<AF, WIDTH>
+impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
     for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
@@ -199,11 +199,11 @@ impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstru
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize>
-    ExternalLayer<AF, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocks<WIDTH>
+impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize>
+    ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [AF; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [FA; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -213,7 +213,7 @@ impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize>
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [AF; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
@@ -229,7 +229,7 @@ pub struct Poseidon2ExternalLayerGoldilocksHL<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<AF, WIDTH>
+impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
     for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
@@ -237,12 +237,12 @@ impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstru
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize>
-    ExternalLayer<AF, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize>
+    ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [AF; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [FA; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -252,7 +252,7 @@ impl<AF: AbstractField<F = Goldilocks>, const WIDTH: usize>
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [AF; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
@@ -377,7 +377,7 @@ pub const HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS: [u64; 22] = [
 mod tests {
     use core::array;
 
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_poseidon2::Poseidon2;
     use p3_symmetric::Permutation;
 

--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -70,7 +70,7 @@ impl MdsPermutation<PackedGoldilocksAVX2, 24> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
     use rand::Rng;

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -6,7 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
+use p3_field::{Field, FieldAlgebra, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -6,7 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -156,7 +156,7 @@ impl Product for PackedGoldilocksAVX2 {
     }
 }
 
-impl AbstractField for PackedGoldilocksAVX2 {
+impl FieldAlgebra for PackedGoldilocksAVX2 {
     type F = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{AbstractField, Field};
+    use p3_field::{FieldAlgebra, Field};
     use p3_matrix::dense::RowMajorMatrix;
 
     use crate::{interpolate_coset, interpolate_subgroup};

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{FieldAlgebra, Field};
+    use p3_field::{Field, FieldAlgebra};
     use p3_matrix::dense::RowMajorMatrix;
 
     use crate::{interpolate_coset, interpolate_subgroup};

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -1,7 +1,7 @@
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::Matrix;
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};

--- a/keccak-air/src/logic.rs
+++ b/keccak-air/src/logic.rs
@@ -1,4 +1,4 @@
-use p3_field::{AbstractField, PrimeField64};
+use p3_field::{FieldAlgebra, PrimeField64};
 
 pub(crate) fn xor<F: PrimeField64, const N: usize>(xs: [F; N]) -> F {
     xs.into_iter().fold(F::ZERO, |acc, x| {
@@ -8,12 +8,12 @@ pub(crate) fn xor<F: PrimeField64, const N: usize>(xs: [F; N]) -> F {
 }
 
 /// Computes the arithmetic generalization of `xor(x, y)`, i.e. `x + y - 2 x y`.
-pub(crate) fn xor_gen<AF: AbstractField>(x: AF, y: AF) -> AF {
+pub(crate) fn xor_gen<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
     x.clone() + y.clone() - x * y.double()
 }
 
 /// Computes the arithmetic generalization of `xor3(x, y, z)`.
-pub(crate) fn xor3_gen<AF: AbstractField>(x: AF, y: AF, z: AF) -> AF {
+pub(crate) fn xor3_gen<FA: FieldAlgebra>(x: FA, y: FA, z: FA) -> FA {
     xor_gen(x, xor_gen(y, z))
 }
 
@@ -25,6 +25,6 @@ pub(crate) fn andn<F: PrimeField64>(x: F, y: F) -> F {
     F::from_canonical_u64(!x & y)
 }
 
-pub(crate) fn andn_gen<AF: AbstractField>(x: AF, y: AF) -> AF {
-    (AF::ONE - x) * y
+pub(crate) fn andn_gen<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
+    (FA::ONE - x) * y
 }

--- a/keccak/benches/bench_keccak.rs
+++ b/keccak/benches/bench_keccak.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_keccak::{KeccakF, VECTOR_LEN};
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CryptographicHasher, PaddingFreeSponge, Permutation, SerializingHasher32To64};

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldExtensionAlgebra, FieldAlgebra};
+    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{AbstractExtensionField, AbstractField};
+    use p3_field::{FieldExtensionAlgebra, FieldAlgebra};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -1,4 +1,4 @@
-use p3_field::{exp_1420470955, exp_u64_by_squaring, AbstractField, Field};
+use p3_field::{exp_1420470955, exp_u64_by_squaring, Field, FieldAlgebra};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, TwoAdicData,
@@ -29,7 +29,7 @@ impl BarrettParameters for KoalaBearParameters {}
 impl FieldParameters for KoalaBearParameters {
     const MONTY_GEN: KoalaBear = KoalaBear::new(3);
 
-    fn exp_u64_generic<AF: AbstractField>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra>(val: FA, power: u64) -> FA {
         match power {
             1420470955 => exp_1420470955(val), // used to compute x^{1/7}
             _ => exp_u64_by_squaring(val, power),

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{AbstractField, Field, PrimeField32};
+use p3_field::{Field, FieldAlgebra, PrimeField32};
 use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
     MontyField31, Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
@@ -50,7 +50,7 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [AF; WIDTH] for any AbstractField which implements multiplication by KoalaBear field elements.
+/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by KoalaBear field elements.
 /// If you have either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]` it will be much faster
 /// to use `Poseidon2KoalaBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersKoalaBear =
@@ -152,11 +152,11 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalL
         state[15] = sum - state[15];
     }
 
-    fn generic_internal_linear_layer<AF>(state: &mut [AF; 16])
+    fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
     where
-        AF: AbstractField + Mul<KoalaBear, Output = AF>,
+        FA: FieldAlgebra + Mul<KoalaBear, Output = FA>,
     {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -230,11 +230,11 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalL
         state[23] = sum - state[23];
     }
 
-    fn generic_internal_linear_layer<AF>(state: &mut [AF; 24])
+    fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
     where
-        AF: AbstractField + core::ops::Mul<KoalaBear, Output = AF>,
+        FA: FieldAlgebra + core::ops::Mul<KoalaBear, Output = FA>,
     {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -260,7 +260,7 @@ impl InternalLayerParameters<KoalaBearParameters, 24> for KoalaBearInternalLayer
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -193,7 +193,7 @@ impl InternalLayerParametersAVX2<KoalaBearParameters, 24> for KoalaBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -89,7 +89,7 @@ mod tests {
     use alloc::vec;
 
     use p3_field::extension::Complex;
-    use p3_field::{AbstractExtensionField, AbstractField};
+    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
     use p3_mersenne_31::Mersenne31;
 
     use super::*;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -10,7 +10,7 @@ use core::ops::Deref;
 
 use itertools::{izip, Itertools};
 use p3_field::{
-    dot_product, AbstractExtensionField, AbstractField, ExtensionField, Field, PackedValue,
+    dot_product, ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra, PackedValue,
 };
 use p3_maybe_rayon::prelude::*;
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
@@ -287,7 +287,7 @@ mod tests {
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use rand::thread_rng;
 
     use super::*;

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
@@ -37,16 +37,16 @@ fn bench_all_mds(c: &mut Criterion) {
     bench_mds::<Mersenne31, MdsMatrixMersenne31, 64>(c);
 }
 
-fn bench_mds<AF, Mds, const WIDTH: usize>(c: &mut Criterion)
+fn bench_mds<FA, Mds, const WIDTH: usize>(c: &mut Criterion)
 where
-    AF: AbstractField,
-    Standard: Distribution<AF>,
-    Mds: MdsPermutation<AF, WIDTH> + Default,
+    FA: FieldAlgebra,
+    Standard: Distribution<FA>,
+    Mds: MdsPermutation<FA, WIDTH> + Default,
 {
     let mds = Mds::default();
 
     let mut rng = thread_rng();
-    let input = rng.gen::<[AF; WIDTH]>();
+    let input = rng.gen::<[FA; WIDTH]>();
     let id = BenchmarkId::new(type_name::<Mds>(), WIDTH);
     c.bench_with_input(id, &input, |b, input| b.iter(|| mds.permute(input.clone())));
 }

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -1,37 +1,37 @@
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 
 /// DIT butterfly.
 #[inline]
-pub(crate) fn dit_butterfly<AF: AbstractField, const N: usize>(
-    values: &mut [AF; N],
+pub(crate) fn dit_butterfly<FA: FieldAlgebra, const N: usize>(
+    values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: AF::F,
+    twiddle: FA::F,
 ) {
     let val_1 = values[idx_1].clone();
-    let val_2 = values[idx_2].clone() * AF::from_f(twiddle);
+    let val_2 = values[idx_2].clone() * FA::from_f(twiddle);
     values[idx_1] = val_1.clone() + val_2.clone();
     values[idx_2] = val_1 - val_2;
 }
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<AF: AbstractField, const N: usize>(
-    values: &mut [AF; N],
+pub(crate) fn dif_butterfly<FA: FieldAlgebra, const N: usize>(
+    values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: AF::F,
+    twiddle: FA::F,
 ) {
     let val_1 = values[idx_1].clone();
     let val_2 = values[idx_2].clone();
     values[idx_1] = val_1.clone() + val_2.clone();
-    values[idx_2] = (val_1 - val_2) * AF::from_f(twiddle);
+    values[idx_2] = (val_1 - val_2) * FA::from_f(twiddle);
 }
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-pub(crate) fn twiddle_free_butterfly<AF: AbstractField, const N: usize>(
-    values: &mut [AF; N],
+pub(crate) fn twiddle_free_butterfly<FA: FieldAlgebra, const N: usize>(
+    values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,
 ) {

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, Powers, TwoAdicField};
+use p3_field::{FieldAlgebra, Powers, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -48,13 +48,13 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
     }
 }
 
-impl<AF: AbstractField, const N: usize> Permutation<[AF; N]> for IntegratedCosetMds<AF::F, N> {
-    fn permute(&self, mut input: [AF; N]) -> [AF; N] {
+impl<FA: FieldAlgebra, const N: usize> Permutation<[FA; N]> for IntegratedCosetMds<FA::F, N> {
+    fn permute(&self, mut input: [FA; N]) -> [FA; N] {
         self.permute_mut(&mut input);
         input
     }
 
-    fn permute_mut(&self, values: &mut [AF; N]) {
+    fn permute_mut(&self, values: &mut [FA; N]) {
         let log_n = log2_strict_usize(N);
 
         // Bit-reversed DIF, aka Bowers G
@@ -69,13 +69,13 @@ impl<AF: AbstractField, const N: usize> Permutation<[AF; N]> for IntegratedCoset
     }
 }
 
-impl<AF: AbstractField, const N: usize> MdsPermutation<AF, N> for IntegratedCosetMds<AF::F, N> {}
+impl<FA: FieldAlgebra, const N: usize> MdsPermutation<FA, N> for IntegratedCosetMds<FA::F, N> {}
 
 #[inline]
-fn bowers_g_layer<AF: AbstractField, const N: usize>(
-    values: &mut [AF; N],
+fn bowers_g_layer<FA: FieldAlgebra, const N: usize>(
+    values: &mut [FA; N],
     log_half_block_size: usize,
-    twiddles: &[AF::F],
+    twiddles: &[FA::F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -97,10 +97,10 @@ fn bowers_g_layer<AF: AbstractField, const N: usize>(
 }
 
 #[inline]
-fn bowers_g_t_layer<AF: AbstractField, const N: usize>(
-    values: &mut [AF; N],
+fn bowers_g_t_layer<FA: FieldAlgebra, const N: usize>(
+    values: &mut [FA; N],
     log_half_block_size: usize,
-    twiddles: &[AF::F],
+    twiddles: &[FA::F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -119,7 +119,7 @@ fn bowers_g_t_layer<AF: AbstractField, const N: usize>(
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-    use p3_field::{AbstractField, Field};
+    use p3_field::{Field, FieldAlgebra};
     use p3_symmetric::Permutation;
     use p3_util::reverse_slice_index_bits;
     use rand::{thread_rng, Rng};

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -3,7 +3,7 @@ use core::array;
 use core::ops::{AddAssign, Mul};
 
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{AbstractField, TwoAdicField};
+use p3_field::{FieldAlgebra, TwoAdicField};
 
 // NB: These are all MDS for M31, BabyBear and Goldilocks
 // const MATRIX_CIRC_MDS_8_2EXP: [u64; 8] = [1, 1, 2, 1, 8, 32, 4, 256];
@@ -41,18 +41,18 @@ where
 /// NB: This function is a naive implementation of the n²
 /// evaluation. It is a placeholder until we have FFT implementations
 /// for all combinations of field and size.
-pub fn apply_circulant<AF: AbstractField, const N: usize>(
+pub fn apply_circulant<FA: FieldAlgebra, const N: usize>(
     circ_matrix: &[u64; N],
-    input: [AF; N],
-) -> [AF; N] {
-    let mut matrix: [AF; N] = circ_matrix.map(AF::from_canonical_u64);
+    input: [FA; N],
+) -> [FA; N] {
+    let mut matrix: [FA; N] = circ_matrix.map(FA::from_canonical_u64);
 
-    let mut output = array::from_fn(|_| AF::ZERO);
+    let mut output = array::from_fn(|_| FA::ZERO);
     for out_i in output.iter_mut().take(N - 1) {
-        *out_i = AF::dot_product(&matrix, &input);
+        *out_i = FA::dot_product(&matrix, &input);
         matrix.rotate_right(1);
     }
-    output[N - 1] = AF::dot_product(&matrix, &input);
+    output[N - 1] = FA::dot_product(&matrix, &input);
     output
 }
 

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -146,7 +146,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{FieldAlgebra, Field};
+    use p3_field::{Field, FieldAlgebra};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::Matrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -146,7 +146,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{AbstractField, Field};
+    use p3_field::{FieldAlgebra, Field};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::Matrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -201,7 +201,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{AbstractField, Field};
+    use p3_field::{FieldAlgebra, Field};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::{Dimensions, Matrix};
     use p3_symmetric::{

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -201,7 +201,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{FieldAlgebra, Field};
+    use p3_field::{Field, FieldAlgebra};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::{Dimensions, Matrix};
     use p3_symmetric::{

--- a/mersenne-31/benches/bench_field.rs
+++ b/mersenne-31/benches/bench_field.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_sub_latency, benchmark_sub_throughput,

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -5,7 +5,7 @@
 //! kronecker(-1, p) = -1, that is, -1 is not square in F_p.
 
 use p3_field::extension::{Complex, ComplexExtendable, HasTwoAdicBionmialExtension};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use itertools::{izip, Itertools};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::extension::Complex;
-use p3_field::{FieldAlgebra, Field, TwoAdicField};
+use p3_field::{Field, FieldAlgebra, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use itertools::{izip, Itertools};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::extension::Complex;
-use p3_field::{AbstractField, Field, TwoAdicField};
+use p3_field::{FieldAlgebra, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,7 +1,7 @@
 use p3_field::extension::{
     BinomiallyExtendable, Complex, HasComplexBinomialExtension, HasTwoAdicComplexBinomialExtension,
 };
-use p3_field::{field_to_array, AbstractField, TwoAdicField};
+use p3_field::{field_to_array, FieldAlgebra, TwoAdicField};
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/mds.rs
+++ b/mersenne-31/src/mds.rs
@@ -6,7 +6,7 @@
 //! work by Angus Gruen and Hamish Ivey-Law. Other sizes are from Ulrich Haböck's
 //! database.
 
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_mds::karatsuba_convolution::Convolve;
 use p3_mds::util::{dot_product, first_row_to_first_col};
 use p3_mds::MdsPermutation;
@@ -261,7 +261,7 @@ impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
 
     use super::{MdsMatrixMersenne31, Mersenne31};

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use num_bigint::BigUint;
 use p3_field::{
-    exp_1717986917, exp_u64_by_squaring, halve_u32, AbstractField, Field, Packable, PrimeField,
+    exp_1717986917, exp_u64_by_squaring, halve_u32, Field, FieldAlgebra, Packable, PrimeField,
     PrimeField32, PrimeField64,
 };
 use rand::distributions::{Distribution, Standard};
@@ -90,7 +90,7 @@ impl Distribution<Mersenne31> for Standard {
     }
 }
 
-impl AbstractField for Mersenne31 {
+impl FieldAlgebra for Mersenne31 {
     type F = Self;
 
     const ZERO: Self = Self { value: 0 };
@@ -226,7 +226,7 @@ impl Field for Mersenne31 {
     }
 
     #[inline]
-    fn exp_u64_generic<AF: AbstractField<F = Self>>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra<F = Self>>(val: FA, power: u64) -> FA {
         match power {
             1717986917 => exp_1717986917(val), // used in x^{1/5}
             _ => exp_u64_by_squaring(val, power),
@@ -432,7 +432,7 @@ pub const fn to_mersenne31_array<const N: usize>(input: [u32; N]) -> [Mersenne31
 
 #[cfg(test)]
 mod tests {
-    use p3_field::{AbstractField, Field, PrimeField32};
+    use p3_field::{Field, FieldAlgebra, PrimeField32};
     use p3_field_testing::test_field;
 
     use crate::Mersenne31;

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4,
@@ -47,7 +47,7 @@ pub type Poseidon2Mersenne31<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [AF; WIDTH] for any AbstractField which implements multiplication by Mersenne31 field elements.
+/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by Mersenne31 field elements.
 /// If you have either `[Mersenne31::Packing; WIDTH]` or `[Mersenne31; WIDTH]` it will be much faster
 /// to use `Poseidon2Mersenne31<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub struct GenericPoseidon2LinearLayersMersenne31 {}
@@ -120,12 +120,12 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
     }
 }
 
-impl<AF> GenericPoseidon2LinearLayers<AF, 16> for GenericPoseidon2LinearLayersMersenne31
+impl<FA> GenericPoseidon2LinearLayers<FA, 16> for GenericPoseidon2LinearLayersMersenne31
 where
-    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+    FA: FieldAlgebra + Mul<Mersenne31, Output = FA>,
 {
-    fn internal_linear_layer(state: &mut [AF; 16]) {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+    fn internal_linear_layer(state: &mut [FA; 16]) {
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -146,12 +146,12 @@ where
     }
 }
 
-impl<AF> GenericPoseidon2LinearLayers<AF, 24> for GenericPoseidon2LinearLayersMersenne31
+impl<FA> GenericPoseidon2LinearLayers<FA, 24> for GenericPoseidon2LinearLayersMersenne31
 where
-    AF: AbstractField + Mul<Mersenne31, Output = AF>,
+    FA: FieldAlgebra + Mul<Mersenne31, Output = FA>,
 {
-    fn internal_linear_layer(state: &mut [AF; 24]) {
-        let part_sum: AF = state[1..].iter().cloned().sum();
+    fn internal_linear_layer(state: &mut [FA; 24]) {
+        let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -174,7 +174,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::SeedableRng;
     use rand_xoshiro::Xoroshiro128Plus;

--- a/mersenne-31/src/radix_2_dit.rs
+++ b/mersenne-31/src/radix_2_dit.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::extension::Complex;
-use p3_field::{AbstractField, PrimeField64, TwoAdicField};
+use p3_field::{FieldAlgebra, PrimeField64, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{Field, FieldAlgebra, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -392,7 +392,7 @@ impl Product for PackedMersenne31AVX2 {
     }
 }
 
-impl AbstractField for PackedMersenne31AVX2 {
+impl FieldAlgebra for PackedMersenne31AVX2 {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -337,7 +337,7 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/monolith/benches/permute.rs
+++ b/monolith/benches/permute.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use p3_monolith::MonolithMersenne31;

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, PrimeField32};
+use p3_field::{FieldAlgebra, PrimeField32};
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
 use sha3::digest::{ExtendableOutput, Update};
@@ -180,7 +180,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_mersenne_31::Mersenne31;
 
     use crate::monolith::MonolithMersenne31;

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use p3_field::{AbstractField, Field};
+use p3_field::{Field, FieldAlgebra};
 
 use crate::MontyField31;
 
@@ -77,7 +77,7 @@ pub trait FieldParameters: PackedMontyParameters + Sized {
 
     const HALF_P_PLUS_1: u32 = (Self::PRIME + 1) >> 1;
 
-    fn exp_u64_generic<AF: AbstractField>(val: AF, power: u64) -> AF;
+    fn exp_u64_generic<FA: FieldAlgebra>(val: FA, power: u64) -> FA;
     fn try_inverse<F: Field>(p1: F) -> Option<F>;
 }
 

--- a/monty-31/src/dft/forward.rs
+++ b/monty-31/src/dft/forward.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use itertools::izip;
-use p3_field::{AbstractField, TwoAdicField};
+use p3_field::{FieldAlgebra, TwoAdicField};
 use p3_util::log2_strict_usize;
 
 use crate::utils::monty_reduce;

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -6,7 +6,7 @@ use core::cell::RefCell;
 
 use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -6,7 +6,7 @@ use core::cell::RefCell;
 
 use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -11,7 +11,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use num_bigint::BigUint;
 use p3_field::{
-    AbstractField, Field, Packable, PrimeField, PrimeField32, PrimeField64, TwoAdicField,
+    Field, FieldAlgebra, Packable, PrimeField, PrimeField32, PrimeField64, TwoAdicField,
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -159,7 +159,7 @@ impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
 
 impl<FP: FieldParameters> Packable for MontyField31<FP> {}
 
-impl<FP: FieldParameters> AbstractField for MontyField31<FP> {
+impl<FP: FieldParameters> FieldAlgebra for MontyField31<FP> {
     type F = Self;
 
     const ZERO: Self = FP::MONTY_ZERO;
@@ -262,7 +262,7 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
     const GENERATOR: Self = FP::MONTY_GEN;
 
     #[inline]
-    fn exp_u64_generic<AF: AbstractField<F = Self>>(val: AF, power: u64) -> AF {
+    fn exp_u64_generic<FA: FieldAlgebra<F = Self>>(val: FA, power: u64) -> FA {
         FP::exp_u64_generic(val, power)
     }
 

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::Mul;
 
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4,
@@ -32,8 +32,8 @@ pub trait InternalLayerBaseParameters<MP: MontyParameters, const WIDTH: usize>:
 
     /// Perform the internal matrix multiplication for any Abstract field
     /// which implements multiplication by MontyField31 elements.
-    fn generic_internal_linear_layer<AF: AbstractField + Mul<MontyField31<MP>, Output = AF>>(
-        state: &mut [AF; WIDTH],
+    fn generic_internal_linear_layer<FA: FieldAlgebra + Mul<MontyField31<MP>, Output = FA>>(
+        state: &mut [FA; WIDTH],
     );
 }
 
@@ -125,7 +125,7 @@ where
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on `[AF; WIDTH]` for any AbstractField which implements multiplication by `Monty<31>` field elements.
+/// This can act on `[FA; WIDTH]` for any AbstractField which implements multiplication by `Monty<31>` field elements.
 /// This will usually be slower than the Poseidon2 permutation built from `Poseidon2InternalLayerMonty31` and
 /// `Poseidon2ExternalLayerMonty31` but it does work in more cases.
 pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {
@@ -133,16 +133,16 @@ pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {
     _phantom2: PhantomData<ILBP>,
 }
 
-impl<FP, AF, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<AF, WIDTH>
+impl<FP, FA, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<FA, WIDTH>
     for GenericPoseidon2LinearLayersMonty31<FP, ILBP>
 where
     FP: FieldParameters,
-    AF: AbstractField + Mul<MontyField31<FP>, Output = AF>,
+    FA: FieldAlgebra + Mul<MontyField31<FP>, Output = FA>,
     ILBP: InternalLayerBaseParameters<FP, WIDTH>,
 {
     /// Perform the external matrix multiplication for any Abstract field
     /// which implements multiplication by MontyField31 elements.
-    fn internal_linear_layer(state: &mut [AF; WIDTH]) {
+    fn internal_linear_layer(state: &mut [FA; WIDTH]) {
         ILBP::generic_internal_linear_layer(state);
     }
 }

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{Field, FieldAlgebra, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -469,7 +469,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX2<FP> {
     }
 }
 
-impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX2<FP> {
+impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX2<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{AbstractField, Field, PrimeField};
+use p3_field::{Field, FieldAlgebra, PrimeField};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::MdsPermutation;
@@ -27,12 +27,12 @@ fn bench_poseidon(c: &mut Criterion) {
     poseidon::<Mersenne31, MdsMatrixMersenne31, 32, 5>(c);
 }
 
-fn poseidon<AF, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
+fn poseidon<FA, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
-    Standard: Distribution<AF::F>,
-    Mds: MdsPermutation<AF, WIDTH> + Default,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
+    Standard: Distribution<FA::F>,
+    Mds: MdsPermutation<FA, WIDTH> + Default,
 {
     let mut rng = thread_rng();
     let mds = Mds::default();
@@ -41,14 +41,14 @@ where
     let half_num_full_rounds = 4;
     let num_partial_rounds = 22;
 
-    let poseidon = Poseidon::<AF::F, Mds, WIDTH, ALPHA>::new_from_rng(
+    let poseidon = Poseidon::<FA::F, Mds, WIDTH, ALPHA>::new_from_rng(
         half_num_full_rounds,
         num_partial_rounds,
         mds,
         &mut rng,
     );
-    let input: [AF; WIDTH] = array::from_fn(|_| AF::ZERO);
-    let name = format!("poseidon::<{}, {}>", type_name::<AF>(), ALPHA);
+    let input: [FA; WIDTH] = array::from_fn(|_| FA::ZERO);
+    let name = format!("poseidon::<{}, {}>", type_name::<FA>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| poseidon.permute(input.clone()))

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{AbstractField, PrimeField};
+use p3_field::{FieldAlgebra, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -69,10 +69,10 @@ where
         }
     }
 
-    fn half_full_rounds<AF>(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize)
+    fn half_full_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        AF: AbstractField<F = F>,
-        Mds: MdsPermutation<AF, WIDTH>,
+        FA: FieldAlgebra<F = F>,
+        Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.half_num_full_rounds {
             self.constant_layer(state, *round_ctr);
@@ -82,10 +82,10 @@ where
         }
     }
 
-    fn partial_rounds<AF>(&self, state: &mut [AF; WIDTH], round_ctr: &mut usize)
+    fn partial_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        AF: AbstractField<F = F>,
-        Mds: MdsPermutation<AF, WIDTH>,
+        FA: FieldAlgebra<F = F>,
+        Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.num_partial_rounds {
             self.constant_layer(state, *round_ctr);
@@ -95,40 +95,40 @@ where
         }
     }
 
-    fn full_sbox_layer<AF>(state: &mut [AF; WIDTH])
+    fn full_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        AF: AbstractField<F = F>,
+        FA: FieldAlgebra<F = F>,
     {
         for x in state.iter_mut() {
             *x = x.exp_const_u64::<ALPHA>();
         }
     }
 
-    fn partial_sbox_layer<AF>(state: &mut [AF; WIDTH])
+    fn partial_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        AF: AbstractField<F = F>,
+        FA: FieldAlgebra<F = F>,
     {
         state[0] = state[0].exp_const_u64::<ALPHA>();
     }
 
-    fn constant_layer<AF>(&self, state: &mut [AF; WIDTH], round: usize)
+    fn constant_layer<FA>(&self, state: &mut [FA; WIDTH], round: usize)
     where
-        AF: AbstractField<F = F>,
+        FA: FieldAlgebra<F = F>,
     {
         for (i, x) in state.iter_mut().enumerate() {
-            *x += AF::from_f(self.constants[round * WIDTH + i]);
+            *x += FA::from_f(self.constants[round * WIDTH + i]);
         }
     }
 }
 
-impl<AF, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[AF; WIDTH]>
-    for Poseidon<AF::F, Mds, WIDTH, ALPHA>
+impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
+    for Poseidon<FA::F, Mds, WIDTH, ALPHA>
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
-    Mds: MdsPermutation<AF, WIDTH>,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
+    Mds: MdsPermutation<FA, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [AF; WIDTH]) {
+    fn permute_mut(&self, state: &mut [FA; WIDTH]) {
         let mut round_ctr = 0;
         self.half_full_rounds(state, &mut round_ctr);
         self.partial_rounds(state, &mut round_ctr);
@@ -136,11 +136,11 @@ where
     }
 }
 
-impl<AF, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[AF; WIDTH]>
-    for Poseidon<AF::F, Mds, WIDTH, ALPHA>
+impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
+    for Poseidon<FA::F, Mds, WIDTH, ALPHA>
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
-    Mds: MdsPermutation<AF, WIDTH>,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
+    Mds: MdsPermutation<FA, WIDTH>,
 {
 }

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_matrix::Matrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_matrix::Matrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_bn254_fr::{Bn254Fr, Poseidon2Bn254};
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_bn254_fr::{Bn254Fr, Poseidon2Bn254};
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;
 use rand::distributions::{Distribution, Standard};
@@ -14,9 +14,9 @@ use rand::Rng;
 /// This uses the formula from the start of Appendix B in the Poseidon2 paper, with multiplications unrolled into additions.
 /// It is also the matrix used by the Horizon Labs implementation.
 #[inline(always)]
-fn apply_hl_mat4<AF>(x: &mut [AF; 4])
+fn apply_hl_mat4<FA>(x: &mut [FA; 4])
 where
-    AF: AbstractField,
+    FA: FieldAlgebra,
 {
     let t0 = x[0].clone() + x[1].clone();
     let t1 = x[2].clone() + x[3].clone();
@@ -40,9 +40,9 @@ where
 /// [ 1 1 2 3 ]
 /// [ 3 1 1 2 ].
 #[inline(always)]
-fn apply_mat4<AF>(x: &mut [AF; 4])
+fn apply_mat4<FA>(x: &mut [FA; 4])
 where
-    AF: AbstractField,
+    FA: FieldAlgebra,
 {
     let t01 = x[0].clone() + x[1].clone();
     let t23 = x[2].clone() + x[3].clone();
@@ -62,20 +62,20 @@ where
 #[derive(Clone, Default)]
 pub struct HLMDSMat4;
 
-impl<AF: AbstractField> Permutation<[AF; 4]> for HLMDSMat4 {
+impl<FA: FieldAlgebra> Permutation<[FA; 4]> for HLMDSMat4 {
     #[inline(always)]
-    fn permute(&self, input: [AF; 4]) -> [AF; 4] {
+    fn permute(&self, input: [FA; 4]) -> [FA; 4] {
         let mut output = input;
         self.permute_mut(&mut output);
         output
     }
 
     #[inline(always)]
-    fn permute_mut(&self, input: &mut [AF; 4]) {
+    fn permute_mut(&self, input: &mut [FA; 4]) {
         apply_hl_mat4(input)
     }
 }
-impl<AF: AbstractField> MdsPermutation<AF, 4> for HLMDSMat4 {}
+impl<FA: FieldAlgebra> MdsPermutation<FA, 4> for HLMDSMat4 {}
 
 /// The fastest 4x4 MDS matrix.
 ///
@@ -83,20 +83,20 @@ impl<AF: AbstractField> MdsPermutation<AF, 4> for HLMDSMat4 {}
 #[derive(Clone, Default)]
 pub struct MDSMat4;
 
-impl<AF: AbstractField> Permutation<[AF; 4]> for MDSMat4 {
+impl<FA: FieldAlgebra> Permutation<[FA; 4]> for MDSMat4 {
     #[inline(always)]
-    fn permute(&self, input: [AF; 4]) -> [AF; 4] {
+    fn permute(&self, input: [FA; 4]) -> [FA; 4] {
         let mut output = input;
         self.permute_mut(&mut output);
         output
     }
 
     #[inline(always)]
-    fn permute_mut(&self, input: &mut [AF; 4]) {
+    fn permute_mut(&self, input: &mut [FA; 4]) {
         apply_mat4(input)
     }
 }
-impl<AF: AbstractField> MdsPermutation<AF, 4> for MDSMat4 {}
+impl<FA: FieldAlgebra> MdsPermutation<FA, 4> for MDSMat4 {}
 
 /// Implement the matrix multiplication used by the external layer.
 ///
@@ -104,11 +104,11 @@ impl<AF: AbstractField> MdsPermutation<AF, 4> for MDSMat4 {}
 /// `[[2M M  ... M], [M  2M ... M], ..., [M  M ... 2M]]`.
 #[inline(always)]
 pub fn mds_light_permutation<
-    AF: AbstractField,
-    MdsPerm4: MdsPermutation<AF, 4>,
+    FA: FieldAlgebra,
+    MdsPerm4: MdsPermutation<FA, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [AF; WIDTH],
+    state: &mut [FA; WIDTH],
     mdsmat: &MdsPerm4,
 ) {
     match WIDTH {
@@ -134,11 +134,11 @@ pub fn mds_light_permutation<
             // Now, we apply the outer circulant matrix (to compute the y_i values).
 
             // We first precompute the four sums of every four elements.
-            let sums: [AF; 4] = core::array::from_fn(|k| {
+            let sums: [FA; 4] = core::array::from_fn(|k| {
                 (0..WIDTH)
                     .step_by(4)
                     .map(|j| state[j + k].clone())
-                    .sum::<AF>()
+                    .sum::<FA>()
             });
 
             // The formula for each y_i involves 2x_i' term and x_j' terms for each j that equals i mod 4.
@@ -211,41 +211,41 @@ impl<T, const WIDTH: usize> ExternalLayerConstants<T, WIDTH> {
 }
 
 /// Initialize an external layer from a set of constants.
-pub trait ExternalLayerConstructor<AF, const WIDTH: usize>
+pub trait ExternalLayerConstructor<FA, const WIDTH: usize>
 where
-    AF: AbstractField,
+    FA: FieldAlgebra,
 {
     /// A constructor which internally will convert the supplied
     /// constants into the appropriate form for the implementation.
-    fn new_from_constants(external_constants: ExternalLayerConstants<AF::F, WIDTH>) -> Self;
+    fn new_from_constants(external_constants: ExternalLayerConstants<FA::F, WIDTH>) -> Self;
 }
 
 /// A trait containing all data needed to implement the external layers of Poseidon2.
-pub trait ExternalLayer<AF, const WIDTH: usize, const D: u64>: Sync + Clone
+pub trait ExternalLayer<FA, const WIDTH: usize, const D: u64>: Sync + Clone
 where
-    AF: AbstractField,
+    FA: FieldAlgebra,
 {
     // permute_state_initial, permute_state_terminal are split as the Poseidon2 specifications are slightly different
     // with the initial rounds involving an extra matrix multiplication.
 
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [AF; WIDTH]);
+    fn permute_state_initial(&self, state: &mut [FA; WIDTH]);
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [AF; WIDTH]);
+    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]);
 }
 
 /// A helper method which allow any field to easily implement the terminal External Layer.
 #[inline]
 pub fn external_terminal_permute_state<
-    AF: AbstractField,
+    FA: FieldAlgebra,
     CT: Copy, // Whatever type the constants are stored as.
-    MdsPerm4: MdsPermutation<AF, 4>,
+    MdsPerm4: MdsPermutation<FA, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [AF; WIDTH],
+    state: &mut [FA; WIDTH],
     terminal_external_constants: &[[CT; WIDTH]],
-    add_rc_and_sbox: fn(&mut AF, CT),
+    add_rc_and_sbox: fn(&mut FA, CT),
     mat4: &MdsPerm4,
 ) {
     for elem in terminal_external_constants.iter() {
@@ -260,14 +260,14 @@ pub fn external_terminal_permute_state<
 /// A helper method which allow any field to easily implement the initial External Layer.
 #[inline]
 pub fn external_initial_permute_state<
-    AF: AbstractField,
+    FA: FieldAlgebra,
     CT: Copy, // Whatever type the constants are stored as.
-    MdsPerm4: MdsPermutation<AF, 4>,
+    MdsPerm4: MdsPermutation<FA, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [AF; WIDTH],
+    state: &mut [FA; WIDTH],
     initial_external_constants: &[[CT; WIDTH]],
-    add_rc_and_sbox: fn(&mut AF, CT),
+    add_rc_and_sbox: fn(&mut FA, CT),
     mat4: &MdsPerm4,
 ) {
     mds_light_permutation(state, mat4);

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -6,13 +6,13 @@
 //! - A power map x -> x^n.
 //! - Multiplication by an F valued matrix.
 //!
-//! This means that it is possible to define a Poseidon2 over any abstract field AF which has implementations of:
-//! - Add<F, Output = AF>
-//! - Mul<F, Output = AF>
+//! This means that it is possible to define a Poseidon2 over any abstract field FA which has implementations of:
+//! - Add<F, Output = FA>
+//! - Mul<F, Output = FA>
 //!
 //! This file implements the two matrix multiplications methods from which Poseidon2 can be built.
 
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 
 use crate::{mds_light_permutation, MDSMat4};
 
@@ -23,17 +23,17 @@ use crate::{mds_light_permutation, MDSMat4};
 /// This is a little slower than field specific implementations (particularly for packed fields) so should
 /// only be used in non performance critical places.
 #[inline(always)]
-pub fn add_rc_and_sbox_generic<AF: AbstractField, const D: u64>(val: &mut AF, rc: AF::F) {
-    *val += AF::from_f(rc);
+pub fn add_rc_and_sbox_generic<FA: FieldAlgebra, const D: u64>(val: &mut FA, rc: FA::F) {
+    *val += FA::from_f(rc);
     *val = val.exp_const_u64::<D>();
 }
 
-pub trait GenericPoseidon2LinearLayers<AF: AbstractField, const WIDTH: usize>: Sync {
+pub trait GenericPoseidon2LinearLayers<FA: FieldAlgebra, const WIDTH: usize>: Sync {
     /// A generic implementation of the internal linear layer.
-    fn internal_linear_layer(state: &mut [AF; WIDTH]);
+    fn internal_linear_layer(state: &mut [FA; WIDTH]);
 
     /// A generic implementation of the external linear layer.
-    fn external_linear_layer(state: &mut [AF; WIDTH]) {
+    fn external_linear_layer(state: &mut [FA; WIDTH]) {
         mds_light_permutation(state, &MDSMat4);
     }
 }

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
-use p3_field::{AbstractField, PrimeField, PrimeField64};
+use p3_field::{FieldAlgebra, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -100,14 +100,14 @@ where
     }
 }
 
-impl<AF, Mds, Sbox, const WIDTH: usize> Permutation<[AF; WIDTH]> for Rescue<AF::F, Mds, Sbox, WIDTH>
+impl<FA, Mds, Sbox, const WIDTH: usize> Permutation<[FA; WIDTH]> for Rescue<FA::F, Mds, Sbox, WIDTH>
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
-    Mds: MdsPermutation<AF, WIDTH>,
-    Sbox: SboxLayers<AF, WIDTH>,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
+    Mds: MdsPermutation<FA, WIDTH>,
+    Sbox: SboxLayers<FA, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [AF; WIDTH]) {
+    fn permute_mut(&self, state: &mut [FA; WIDTH]) {
         for round in 0..self.num_rounds {
             // S-box
             self.sbox.sbox_layer(state);
@@ -120,7 +120,7 @@ where
                 .iter_mut()
                 .zip(&self.round_constants[round * WIDTH * 2..])
             {
-                *state_item += AF::from_f(round_constant);
+                *state_item += FA::from_f(round_constant);
             }
 
             // Inverse S-box
@@ -134,25 +134,25 @@ where
                 .iter_mut()
                 .zip(&self.round_constants[round * WIDTH * 2 + WIDTH..])
             {
-                *state_item += AF::from_f(round_constant);
+                *state_item += FA::from_f(round_constant);
             }
         }
     }
 }
 
-impl<AF, Mds, Sbox, const WIDTH: usize> CryptographicPermutation<[AF; WIDTH]>
-    for Rescue<AF::F, Mds, Sbox, WIDTH>
+impl<FA, Mds, Sbox, const WIDTH: usize> CryptographicPermutation<[FA; WIDTH]>
+    for Rescue<FA::F, Mds, Sbox, WIDTH>
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
-    Mds: MdsPermutation<AF, WIDTH>,
-    Sbox: SboxLayers<AF, WIDTH>,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
+    Mds: MdsPermutation<FA, WIDTH>,
+    Sbox: SboxLayers<FA, WIDTH>,
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
     use p3_symmetric::{CryptographicHasher, PaddingFreeSponge, Permutation};
 

--- a/rescue/src/sbox.rs
+++ b/rescue/src/sbox.rs
@@ -1,17 +1,17 @@
 use core::marker::PhantomData;
 
-use p3_field::{AbstractField, PrimeField, PrimeField64};
+use p3_field::{FieldAlgebra, PrimeField, PrimeField64};
 
 use crate::util::get_inverse;
 
-pub trait SboxLayers<AF, const WIDTH: usize>: Clone + Sync
+pub trait SboxLayers<FA, const WIDTH: usize>: Clone + Sync
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
 {
-    fn sbox_layer(&self, state: &mut [AF; WIDTH]);
+    fn sbox_layer(&self, state: &mut [FA; WIDTH]);
 
-    fn inverse_sbox_layer(&self, state: &mut [AF; WIDTH]);
+    fn inverse_sbox_layer(&self, state: &mut [FA; WIDTH]);
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -38,18 +38,18 @@ impl<F: PrimeField> BasicSboxLayer<F> {
     }
 }
 
-impl<AF, const WIDTH: usize> SboxLayers<AF, WIDTH> for BasicSboxLayer<AF::F>
+impl<FA, const WIDTH: usize> SboxLayers<FA, WIDTH> for BasicSboxLayer<FA::F>
 where
-    AF: AbstractField,
-    AF::F: PrimeField,
+    FA: FieldAlgebra,
+    FA::F: PrimeField,
 {
-    fn sbox_layer(&self, state: &mut [AF; WIDTH]) {
+    fn sbox_layer(&self, state: &mut [FA; WIDTH]) {
         for x in state.iter_mut() {
             *x = x.exp_u64(self.alpha);
         }
     }
 
-    fn inverse_sbox_layer(&self, state: &mut [AF; WIDTH]) {
+    fn inverse_sbox_layer(&self, state: &mut [FA; WIDTH]) {
         for x in state.iter_mut() {
             *x = x.exp_u64(self.alpha_inv);
         }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use p3_air::{AirBuilder, AirBuilderWithPublicValues};
-use p3_field::AbstractField;
+use p3_field::FieldAlgebra;
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{FieldExtensionAlgebra, FieldAlgebra, PackedValue};
+use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PackedValue};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{AbstractExtensionField, AbstractField, PackedValue};
+use p3_field::{FieldExtensionAlgebra, FieldAlgebra, PackedValue};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 
 use crate::symbolic_variable::SymbolicVariable;
 
@@ -74,7 +74,7 @@ impl<F: Field> From<F> for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> AbstractField for SymbolicExpression<F> {
+impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
     type F = F;
 
     const ZERO: Self = Self::Constant(F::ZERO);

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 
 use crate::symbolic_variable::SymbolicVariable;
 

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{AbstractExtensionField, AbstractField, Field};
+use p3_field::{FieldExtensionAlgebra, FieldAlgebra, Field};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
@@ -49,7 +49,7 @@ where
         && opened_values
             .quotient_chunks
             .iter()
-            .all(|qc| qc.len() == <SC::Challenge as AbstractExtensionField<Val<SC>>>::D);
+            .all(|qc| qc.len() == <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D);
     if !valid_shape {
         return Err(VerificationError::InvalidProofShape);
     }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{FieldExtensionAlgebra, FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -6,7 +6,7 @@ use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{AbstractField, Field, PrimeField64};
+use p3_field::{FieldAlgebra, Field, PrimeField64};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -6,7 +6,7 @@ use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{FieldAlgebra, Field, PrimeField64};
+use p3_field::{Field, FieldAlgebra, PrimeField64};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -10,7 +10,7 @@ use p3_commit::testing::TrivialPcs;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{FieldAlgebra, Field};
+use p3_field::{Field, FieldAlgebra};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_matrix::dense::RowMajorMatrix;

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -10,7 +10,7 @@ use p3_commit::testing::TrivialPcs;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{AbstractField, Field};
+use p3_field::{FieldAlgebra, Field};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_matrix::dense::RowMajorMatrix;


### PR DESCRIPTION
Renaming `AbstractField` to `FieldAlgebra` and `AbstractExtensionField` to `FieldExtensionAlgebra`. These names are more suggestive as to what these traits actually entail. In addition to this I've added more detailed comments to many of the constants and functions contained inside `FieldAlgebra`.

This PR looks much larger than it is in actuality. Outside of the file p3_field/src/field all the changes simply consist of re-namings.

This is part one of a larger refactor on the various field traits but can be merged into main in the meantime.