### PR TITLE
Fix: rename remaining `AbstractField`s as `FieldAlgebra`

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -50,7 +50,7 @@ pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by BabyBear field elements.
+/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by BabyBear field elements.
 /// If you have either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]` it will be much faster
 /// to use `Poseidon2BabyBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersBabyBear =
@@ -166,7 +166,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 16> for BabyBearInternalLay
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to AbstractField.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_16)
@@ -244,7 +244,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 24> for BabyBearInternalLay
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to AbstractField.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_24)

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -123,7 +123,7 @@ impl InternalLayerParametersAVX512<BabyBearParameters, 24> for BabyBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -54,7 +54,7 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
     batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| x_packed.inverse());
 }
 
-/// A simple single-threaded implementation of Montgomery's trick. Since not all `AbstractField`s
+/// A simple single-threaded implementation of Montgomery's trick. Since not all `FieldAlgebra`s
 /// support inversion, this takes a custom inversion function.
 pub(crate) fn batch_multiplicative_inverse_general<F, Inv>(x: &[F], result: &mut [F], inv: Inv)
 where

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -303,7 +303,7 @@ pub trait Field:
     }
 
     /// Exponentiation by a `u64` power. This is similar to `exp_u64`, but more general in that it
-    /// can be used with `AbstractField`s, not just this concrete field.
+    /// can be used with `FieldAlgebra`s, not just this concrete field.
     ///
     /// The default implementation uses naive square and multiply. Implementations may want to
     /// override this and handle certain powers with more optimal addition chains.

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -78,7 +78,7 @@ where
 // to allow us to convert FA constants to BinomialExtensionField<FA, D> constants.
 //
 // The natural approach would be:
-// fn field_to_array<FA: AbstractField, const D: usize>(x: FA) -> [FA; D]
+// fn field_to_array<FA: FieldAlgebra, const D: usize>(x: FA) -> [FA; D]
 //      let mut arr: [FA; D] = [FA::ZERO; D];
 //      arr[0] = x
 //      arr

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -70,7 +70,7 @@ impl MdsPermutation<PackedGoldilocksAVX512, 24> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
     use rand::Rng;

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -6,7 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue, PrimeField64};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -155,7 +155,7 @@ impl Product for PackedGoldilocksAVX512 {
     }
 }
 
-impl AbstractField for PackedGoldilocksAVX512 {
+impl FieldAlgebra for PackedGoldilocksAVX512 {
     type F = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);

--- a/koala-bear/src/aarch64_neon/poseidon2.rs
+++ b/koala-bear/src/aarch64_neon/poseidon2.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -50,7 +50,7 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by KoalaBear field elements.
+/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by KoalaBear field elements.
 /// If you have either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]` it will be much faster
 /// to use `Poseidon2KoalaBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersKoalaBear =
@@ -166,7 +166,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalL
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to AbstractField.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_16)
@@ -244,7 +244,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalL
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to AbstractField.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_24)

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -123,7 +123,7 @@ impl InternalLayerParametersAVX512<KoalaBearParameters, 24> for KoalaBearInterna
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -308,7 +308,7 @@ impl Product for PackedMersenne31Neon {
     }
 }
 
-impl AbstractField for PackedMersenne31Neon {
+impl FieldAlgebra for PackedMersenne31Neon {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -83,7 +83,7 @@ impl<const D: u64, const WIDTH: usize> ExternalLayer<PackedMersenne31Neon, WIDTH
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -47,7 +47,7 @@ pub type Poseidon2Mersenne31<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any AbstractField which implements multiplication by Mersenne31 field elements.
+/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by Mersenne31 field elements.
 /// If you have either `[Mersenne31::Packing; WIDTH]` or `[Mersenne31; WIDTH]` it will be much faster
 /// to use `Poseidon2Mersenne31<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub struct GenericPoseidon2LinearLayersMersenne31 {}

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -4,7 +4,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -412,7 +412,7 @@ impl Product for PackedMersenne31AVX512 {
     }
 }
 
-impl AbstractField for PackedMersenne31AVX512 {
+impl FieldAlgebra for PackedMersenne31AVX512 {
     type F = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -284,7 +284,7 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX512, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
-    use p3_field::AbstractField;
+    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -6,7 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -442,7 +442,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31Neon<FP> {
     }
 }
 
-impl<FP: FieldParameters> AbstractField for PackedMontyField31Neon<FP> {
+impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31Neon<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -64,7 +64,7 @@ pub trait BarrettParameters: MontyParameters {
     const MASK: i64 = !((1 << 10) - 1); // Lets us 0 out the bottom 10 digits of an i64.
 }
 
-/// FieldParameters contains constants and methods needed to imply AbstractField, Field and PrimeField32 for MontyField31.
+/// FieldParameters contains constants and methods needed to imply FieldAlgebra, Field and PrimeField32 for MontyField31.
 pub trait FieldParameters: PackedMontyParameters + Sized {
     // Simple field constants.
     const MONTY_ZERO: MontyField31<Self> = MontyField31::new(0);

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -125,7 +125,7 @@ where
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on `[FA; WIDTH]` for any AbstractField which implements multiplication by `Monty<31>` field elements.
+/// This can act on `[FA; WIDTH]` for any FieldAlgebra which implements multiplication by `Monty<31>` field elements.
 /// This will usually be slower than the Poseidon2 permutation built from `Poseidon2InternalLayerMonty31` and
 /// `Poseidon2ExternalLayerMonty31` but it does work in more cases.
 pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -6,7 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{AbstractField, Field, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{FieldAlgebra, Field, PackedField, PackedFieldPow2, PackedValue};
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -582,7 +582,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX512<FP> {
     }
 }
 
-impl<FP: FieldParameters> AbstractField for PackedMontyField31AVX512<FP> {
+impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX512<FP> {
     type F = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);


### PR DESCRIPTION
There are a few `AbstractField` imports left. This PR renames those to `FieldAlgebra`. Fixes build issues for neon