### PR TITLE
Replace `div_2exp_u64(1)` by `halve()`

### DIFF
--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -77,7 +77,7 @@ fn dft_postprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<C> {
             let even = x + y.conjugate();
             // odd = (x - y.conjugate()) * -i
             let odd = C::new(x.imag() + y.imag(), y.real() - x.real());
-            (even + odd * omega_j).div_2exp_u64(1)
+            (even + odd * omega_j).halve()
         });
         output.extend(row);
         omega_j *= omega;
@@ -110,7 +110,7 @@ fn idft_preprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<C> {
             let even = x + y.conjugate();
             // odd = (x - y.conjugate()) * -i
             let odd = C::new(x.imag() + y.imag(), y.real() - x.real());
-            (even - odd * omega_j).div_2exp_u64(1)
+            (even - odd * omega_j).halve()
         });
         output.extend(row);
         omega_j *= omega;


### PR DESCRIPTION
This code is basically unused (so maybe we will just remove it at some point) but regardless `halve` should be vastly preferred over `div_2exp_u64(1)`.

