### PR TITLE
Remove the method `try_div`

### DIFF
--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -50,7 +50,7 @@ impl<F: Field> Point<F> {
     /// and a simple pole at (-1,0), which in the paper is called v_0
     /// Circle STARKs, Section 5.1, Lemma 11 (page 21 of the first revision PDF)
     pub fn to_projective_line(self) -> Option<F> {
-        self.y.try_div(self.x + F::ONE)
+        (self.x + F::ONE).try_inverse().map(|x| x * self.y)
     }
 
     /// The "squaring map", or doubling in additive notation, denoted π(x,y)

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -246,14 +246,6 @@ pub trait FieldAlgebra:
         u.iter().zip(v).map(|(x, y)| x.clone() * y.clone()).sum()
     }
 
-    fn try_div<Rhs>(self, rhs: Rhs) -> Option<<Self as Mul<Rhs>>::Output>
-    where
-        Rhs: Field,
-        Self: Mul<Rhs>,
-    {
-        rhs.try_inverse().map(|inv| self * inv)
-    }
-
     /// Allocates a vector of zero elements of length `len`. Many operating systems zero pages
     /// before assigning them to a userspace process. In that case, our process should not need to
     /// write zeros, which would be redundant. However, the compiler may not always recognize this.


### PR DESCRIPTION
Currently `try_div` is a wrapper around a one line function which is more informative as to what is actually going on. It's also basically never used. Given that, I think it's worth just removing this method as it's basically just recreating functionality which already exists with `try_inverse`.