### PR TITLE
Pull Request: Fix Documentation Typos

### DIFF
--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -48,7 +48,7 @@ pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
     BABYBEAR_S_BOX_DEGREE,
 >;
 
-/// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
+/// An implementation of the matrix multiplications in the internal and external layers of Poseidon2.
 ///
 /// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by BabyBear field elements.
 /// If you have either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]` it will be much faster

--- a/monty-31/src/mds.rs
+++ b/monty-31/src/mds.rs
@@ -243,7 +243,7 @@ where
         // Thus the values appearing at the end are bounded by 3^n 2^50
         // where n is the maximal number of negacyclic_conv
         // recombination steps. When N = 64, we need to recombine for
-        // singed_conv_32, singed_conv_16, singed_conv_8 so the
+        // signed_conv_32, signed_conv_16, signed_conv_8 so the
         // overall bound will be 3^3 2^50 < 32 * 2^50 < 2^55.
         debug_assert!(z > -(1i64 << 55));
         debug_assert!(z < (1i64 << 55));


### PR DESCRIPTION


## Changes Made:

1. File: `baby-bear/src/poseidon2.rs`
   - Original: `An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.`
   - Revised: `An implementation of the matrix multiplications in the internal and external layers of Poseidon2.`
   - Reason: Removed the duplicate article "the" to correct the grammatical error.

2. File: `monty-31/src/mds.rs`
   - Original: `singed_conv_32, singed_conv_16, singed_conv_8 so the`
   - Revised: `signed_conv_32, signed_conv_16, signed_conv_8 so the`
   - Reason: Corrected the spelling of "singed" to "signed" to accurately reflect the technical term for operations involving signed numbers.

These changes ensure that the documentation and comments are grammatically correct and technically accurate, enhancing the readability and professionalism of the codebase.