### PR TITLE
Minor Improvements to Hashing and Serialization/Deserialization.

### DIFF
--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -183,9 +183,9 @@ where
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
         debug_assert!(bits < (usize::BITS as usize));
-        debug_assert!((1 << bits) < F::ORDER_U64);
+        debug_assert!((1 << bits) < F::ORDER_U32);
         let rand_f: F = self.sample();
-        let rand_usize = rand_f.as_canonical_u64() as usize;
+        let rand_usize = rand_f.to_unique_u32() as usize;
         rand_usize & ((1 << bits) - 1)
     }
 }

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -63,7 +63,7 @@ where
 impl<F: PrimeField32, Inner: CanObserve<u8>> CanObserve<F> for SerializingChallenger32<F, Inner> {
     fn observe(&mut self, value: F) {
         self.inner
-            .observe_slice(&value.as_canonical_u32().to_le_bytes());
+            .observe_slice(&value.to_unique_u32().to_le_bytes());
     }
 }
 
@@ -172,7 +172,7 @@ where
 impl<F: PrimeField64, Inner: CanObserve<u8>> CanObserve<F> for SerializingChallenger64<F, Inner> {
     fn observe(&mut self, value: F) {
         self.inner
-            .observe_slice(&value.as_canonical_u64().to_le_bytes());
+            .observe_slice(&value.to_unique_u64().to_le_bytes());
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -368,7 +368,7 @@ pub trait PrimeField64: PrimeField {
     /// are converted to the same `u64` if and only if they represent the same value.
     ///
     /// This will be the fastest way to convert a field element to a `u64` and
-    /// is intended for use in hashing.
+    /// is intended for use in hashing. It will also be consistent across different targets.
     fn to_unique_u64(&self) -> u64 {
         // A simple default which is optimal for some fields.
         self.as_canonical_u64()
@@ -386,7 +386,7 @@ pub trait PrimeField32: PrimeField64 {
     /// are converted to the same `u32` if and only if they represent the same value.
     ///
     /// This will be the fastest way to convert a field element to a `u32` and
-    /// is intended for use in hashing.
+    /// is intended for use in hashing. It will also be consistent across different targets.
     fn to_unique_u32(&self) -> u32 {
         // A simple default which is optimal for some fields.
         self.as_canonical_u32()

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -363,6 +363,16 @@ pub trait PrimeField64: PrimeField {
 
     /// Return the representative of `value` that is less than `ORDER_U64`.
     fn as_canonical_u64(&self) -> u64;
+
+    /// Convert the field element to a `u64` such that any two field elements
+    /// representing the same value are converted to the same `u64`.
+    ///
+    /// This will be the fastest way to convert a field element to a `u64` and
+    /// is intended for use in hashing.
+    fn to_unique_u64(&self) -> u64 {
+        // A simple default which is optimal for some fields.
+        self.as_canonical_u64()
+    }
 }
 
 /// A prime field of order less than `2^32`.
@@ -371,6 +381,16 @@ pub trait PrimeField32: PrimeField64 {
 
     /// Return the representative of `value` that is less than `ORDER_U32`.
     fn as_canonical_u32(&self) -> u32;
+
+    /// Convert the field element to a `u32` such that any two field elements
+    /// representing the same value are converted to the same `u32`.
+    ///
+    /// This will be the fastest way to convert a field element to a `u32` and
+    /// is intended for use in hashing.
+    fn to_unique_u32(&self) -> u32 {
+        // A simple default which is optimal for some fields.
+        self.as_canonical_u32()
+    }
 }
 
 /// A commutative algebra over an extension field.

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -364,8 +364,8 @@ pub trait PrimeField64: PrimeField {
     /// Return the representative of `value` that is less than `ORDER_U64`.
     fn as_canonical_u64(&self) -> u64;
 
-    /// Convert the field element to a `u64` such that any two field elements
-    /// representing the same value are converted to the same `u64`.
+    /// Convert a field element to a `u64` such that any two field elements
+    /// are converted to the same `u64` if and only if they represent the same value.
     ///
     /// This will be the fastest way to convert a field element to a `u64` and
     /// is intended for use in hashing.
@@ -382,8 +382,8 @@ pub trait PrimeField32: PrimeField64 {
     /// Return the representative of `value` that is less than `ORDER_U32`.
     fn as_canonical_u32(&self) -> u32;
 
-    /// Convert the field element to a `u32` such that any two field elements
-    /// representing the same value are converted to the same `u32`.
+    /// Convert a field element to a `u32` such that any two field elements
+    /// are converted to the same `u32` if and only if they represent the same value.
     ///
     /// This will be the fastest way to convert a field element to a `u32` and
     /// is intended for use in hashing.

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -21,8 +21,9 @@ use serde::{Deserialize, Serialize};
 const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
+///
+/// Note that the safety of deriving `Serialize` and `Deserialize` relies on the fact that the internal value can be any u64.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
-// Note that it's safe to derive Serialize, Deserialize because the internal value can be any u64. If we change this assumption this needs to be changed.
 #[repr(transparent)] // Packed field implementations rely on this!
 pub struct Goldilocks {
     /// Not necessarily canonical.

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -22,6 +22,7 @@ const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
+// Note that it's safe to derive Serialize, Deserialize because the internal value can be any u64. If we change this assumption this needs to be changed.
 #[repr(transparent)] // Packed field implementations rely on this!
 pub struct Goldilocks {
     /// Not necessarily canonical.

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -101,7 +101,7 @@ impl Serialize for Mersenne31 {
 impl<'a> Deserialize<'a> for Mersenne31 {
     fn deserialize<D: Deserializer<'a>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
-        // Ensure that `val` came from a valid field element
+        // Ensure that `val` satisfies our invariant. i.e. Not necessarily canonical, but must fit in 31 bits.
         if val <= P {
             Ok(Mersenne31::new(val))
         } else {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -101,7 +101,7 @@ impl Serialize for Mersenne31 {
 impl<'a> Deserialize<'a> for Mersenne31 {
     fn deserialize<D: Deserializer<'a>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
-        // We need to ensure that val is a valid u32 which could have can come from a field element.
+        // Ensure that `val` came from a valid field element
         if val <= P {
             Ok(Mersenne31::new(val))
         } else {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -98,8 +98,8 @@ impl Serialize for Mersenne31 {
     }
 }
 
-impl<'de> Deserialize<'de> for Mersenne31 {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+impl<'a> Deserialize<'a> for Mersenne31 {
+    fn deserialize<D: Deserializer<'a>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
         // We need to ensure that val is a valid u32 which could have can come from a field element.
         if val <= P {

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -24,8 +24,10 @@ use crate::{FieldParameters, MontyParameters, TwoAdicData};
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)] // Packed field implementations rely on this!
 pub struct MontyField31<MP: MontyParameters> {
-    // This is `pub(crate)` for tests and delayed reduction strategies. If you're accessing `value` outside of those, you're
-    // likely doing something fishy.
+    /// The MONTY form of the field element, saved as a positive integer less than `P`.
+    ///
+    /// This is `pub(crate)` for tests and delayed reduction strategies. If you're accessing `value` outside of those, you're
+    /// likely doing something fishy.
     pub(crate) value: u32,
     _phantom: PhantomData<MP>,
 }
@@ -155,7 +157,7 @@ impl<FP: FieldParameters> Serialize for MontyField31<FP> {
 impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
-        // Ensure that `val` came from a valid field element
+        // Ensure that `val` satisfies our invariant, namely is `< P`.
         if val < FP::PRIME {
             // It's faster to Serialize and Deserialize in monty form.
             Ok(MontyField31::new_monty(val))

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -155,7 +155,7 @@ impl<FP: FieldParameters> Serialize for MontyField31<FP> {
 impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
-        // We need to ensure that val is a valid u32 which could have can come from a field element.
+        // Ensure that `val` came from a valid field element
         if val < FP::PRIME {
             // It's faster to Serialize and Deserialize in monty form.
             Ok(MontyField31::new_monty(val))

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -15,6 +15,7 @@ use p3_field::{
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
+use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::utils::{from_monty, halve_u32, monty_reduce, to_monty, to_monty_64};
@@ -146,14 +147,21 @@ impl<FP: MontyParameters> Distribution<MontyField31<FP>> for Standard {
 
 impl<FP: FieldParameters> Serialize for MontyField31<FP> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_u32(self.as_canonical_u32())
+        // It's faster to Serialize and Deserialize in monty form.
+        serializer.serialize_u32(self.value)
     }
 }
 
 impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let val = u32::deserialize(d)?;
-        Ok(MontyField31::from_canonical_u32(val))
+        // We need to ensure that val is a valid u32 which could have can come from a field element.
+        if val < FP::PRIME {
+            // It's faster to Serialize and Deserialize in monty form.
+            Ok(MontyField31::new_monty(val))
+        } else {
+            Err(D::Error::custom("Value is out of range"))
+        }
     }
 }
 
@@ -294,6 +302,13 @@ impl<FP: FieldParameters> PrimeField64 for MontyField31<FP> {
     fn as_canonical_u64(&self) -> u64 {
         self.as_canonical_u32().into()
     }
+
+    #[inline]
+    fn to_unique_u64(&self) -> u64 {
+        // The internal representation is already a unique u32 for each field element.
+        // It's fine to hash things in monty form.
+        self.value as u64
+    }
 }
 
 impl<FP: FieldParameters> PrimeField32 for MontyField31<FP> {
@@ -302,6 +317,13 @@ impl<FP: FieldParameters> PrimeField32 for MontyField31<FP> {
     #[inline]
     fn as_canonical_u32(&self) -> u32 {
         MontyField31::to_u32(self)
+    }
+
+    #[inline]
+    fn to_unique_u32(&self) -> u32 {
+        // The internal representation is already a unique u32 for each field element.
+        // It's fine to hash things in monty form.
+        self.value
     }
 }
 

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -55,7 +55,7 @@ where
         self.inner.hash_iter(
             input
                 .into_iter()
-                .flat_map(|x| x.as_canonical_u32().to_le_bytes()),
+                .flat_map(|x| x.to_unique_u32().to_le_bytes()),
         )
     }
 }
@@ -74,7 +74,7 @@ where
         self.inner.hash_iter(
             input
                 .into_iter()
-                .map(|x| PW::from_fn(|i| x.as_slice()[i].as_canonical_u32())),
+                .map(|x| PW::from_fn(|i| x.as_slice()[i].to_unique_u32())),
         )
     }
 }
@@ -99,13 +99,13 @@ where
                 let b = input.next();
                 if let (Some(a), Some(b)) = (a, b) {
                     let ab = PW::from_fn(|i| {
-                        let a_i = a.as_slice()[i].as_canonical_u64();
-                        let b_i = b.as_slice()[i].as_canonical_u64();
+                        let a_i = a.as_slice()[i].to_unique_u64();
+                        let b_i = b.as_slice()[i].to_unique_u64();
                         a_i | (b_i << 32)
                     });
                     Some(ab)
                 } else {
-                    a.map(|a| PW::from_fn(|i| a.as_slice()[i].as_canonical_u64()))
+                    a.map(|a| PW::from_fn(|i| a.as_slice()[i].to_unique_u64()))
                 }
             },
         ))
@@ -124,7 +124,7 @@ where
         self.inner.hash_iter(
             input
                 .into_iter()
-                .flat_map(|x| x.as_canonical_u64().to_le_bytes()),
+                .flat_map(|x| x.to_unique_u64().to_le_bytes()),
         )
     }
 }
@@ -143,7 +143,7 @@ where
         self.inner.hash_iter(
             input
                 .into_iter()
-                .map(|x| PW::from_fn(|i| x.as_slice()[i].as_canonical_u64())),
+                .map(|x| PW::from_fn(|i| x.as_slice()[i].to_unique_u64())),
         )
     }
 }


### PR DESCRIPTION
Originally this was going to be part of the larger Field crate refactor but there are actually no API breaking changes here so we can just merge it now.

This PR add a method to both `PrimeField64` and `PrimeField32` called `to_unique_u64` and `to_unique_u32`. As can be inferred from the name, given a field element these output a unique `u64/u32`. Where unique means that two field elements output the same value if and only if they are equal. This is intended for use in hashing and allows us to hash `MontyField31` elements without needing to convert out of MONTY form.

Propagating these changes through to serializing_hasher.rs, this gives a very small speed up to proof times when using KECCAK. (`1-2%` as best).

Additionally, we make similar change to Serialization/Deserialization for `MontyField31` where we now Serialize the MONTY form instead of converting back to canonical. This should speed these up noticeably.

Finally, we fix the Serialization/Deserialization of `Mersenne31`. Currently its possible to trigger undefined behaviour by Deserializing an invalid `Mersenne31` element. (E.g. one whose value is bigger than `2^31`). We fix this possible bug/exploit.