### PR TITLE
Prove Poseidon2 Examples

### DIFF
--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -27,7 +27,7 @@ const WIDTH: usize = 16;
 const SBOX_DEGREE: u64 = 7;
 const SBOX_REGISTERS: usize = 1;
 const HALF_FULL_ROUNDS: usize = 4;
-const PARTIAL_ROUNDS: usize = 20;
+const PARTIAL_ROUNDS: usize = 13;
 
 const NUM_ROWS: usize = 1 << 16;
 const VECTOR_LEN: usize = 1 << 3;

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_poseidon2.rs
@@ -1,0 +1,118 @@
+use std::fmt::Debug;
+
+use p3_baby_bear::{BabyBear, GenericPoseidon2LinearLayersBabyBear, Poseidon2BabyBear};
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
+use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+const WIDTH: usize = 16;
+const SBOX_DEGREE: u64 = 7;
+const SBOX_REGISTERS: usize = 1;
+const HALF_FULL_ROUNDS: usize = 4;
+const PARTIAL_ROUNDS: usize = 13;
+
+const NUM_ROWS: usize = 1 << 16;
+const VECTOR_LEN: usize = 1 << 3;
+const NUM_PERMUTATIONS: usize = NUM_ROWS * VECTOR_LEN;
+
+#[cfg(feature = "parallel")]
+type Dft = p3_dft::Radix2DitParallel<BabyBear>;
+#[cfg(not(feature = "parallel"))]
+type Dft = p3_dft::Radix2Bowers;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+
+    type Perm16 = Poseidon2BabyBear<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
+
+    type Perm24 = Poseidon2BabyBear<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
+
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
+
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+    let val_mmcs = ValMmcs::new(hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    let dft = Dft::default();
+
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
+
+    let constants = RoundConstants::from_rng(&mut thread_rng());
+    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_vectorized_trace_rows::<
+        Val,
+        GenericPoseidon2LinearLayersBabyBear,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    >(inputs, &constants);
+
+    let air: VectorizedPoseidon2Air<
+        Val,
+        GenericPoseidon2LinearLayersBabyBear,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    > = VectorizedPoseidon2Air::new(constants);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::new(perm24.clone());
+    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::new(perm24);
+    verify(&config, &air, &mut challenger, &proof, &vec![])
+}

--- a/poseidon2-air/examples/prove_poseidon2_m31_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_poseidon2.rs
@@ -1,0 +1,117 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use p3_challenger::DuplexChallenger;
+use p3_circle::CirclePcs;
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
+use p3_fri::FriConfig;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_mersenne_31::{GenericPoseidon2LinearLayersMersenne31, Mersenne31, Poseidon2Mersenne31};
+use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+const WIDTH: usize = 16;
+const SBOX_DEGREE: u64 = 5;
+const SBOX_REGISTERS: usize = 1;
+const HALF_FULL_ROUNDS: usize = 4;
+const PARTIAL_ROUNDS: usize = 14;
+
+const NUM_ROWS: usize = 1 << 16;
+const VECTOR_LEN: usize = 1 << 3;
+const NUM_PERMUTATIONS: usize = NUM_ROWS * VECTOR_LEN;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
+
+    type Perm16 = Poseidon2Mersenne31<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
+
+    type Perm24 = Poseidon2Mersenne31<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
+
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
+
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+    let val_mmcs = ValMmcs::new(hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
+
+    let constants = RoundConstants::from_rng(&mut thread_rng());
+    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_vectorized_trace_rows::<
+        Val,
+        GenericPoseidon2LinearLayersMersenne31,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    >(inputs, &constants);
+
+    let air: VectorizedPoseidon2Air<
+        Val,
+        GenericPoseidon2LinearLayersMersenne31,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+        VECTOR_LEN,
+    > = VectorizedPoseidon2Air::new(constants);
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_config,
+        _phantom: PhantomData,
+    };
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let mut challenger = Challenger::new(perm24.clone());
+    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::new(perm24.clone());
+    verify(&config, &air, &mut challenger, &proof, &vec![])
+}


### PR DESCRIPTION
I'm doing a pass through all our examples to try and get some benchmarks, and thought I'd try to make things a little more systematic while I do that.

The goal will be that all three of our large airs (`Poseidon2-AIR, KECCAK-AIR, Blake3-AIR`) to have one example for each `31` bit field `BabyBear, KoalaBear, M31` and choice of hash function `Keccak` vs `Poseidon2`.

Additionally, within each example we should be using whatever `FFT` is optimal.

This PR just handles the `Poseidon2-AIR`s. We add two new examples using `BabyBear/M31` with hash function `Poseidon2`. Additionally we fix a small bug in the current `BabyBear` example where the number of partial rounds is higher than it should be. This improves that example slightly.

