### PR TITLE
Optimizing the Prove KECCAK Examples.

### DIFF
--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -7,9 +7,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
-use p3_matrix::Matrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_monty_31::dft::RecursiveDft;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::{random, thread_rng};
@@ -18,6 +16,11 @@ use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(feature = "parallel")]
+type Dft = p3_dft::Radix2DitParallel<BabyBear>;
+#[cfg(not(feature = "parallel"))]
+type Dft = p3_dft::Radix2Bowers;
 
 const NUM_HASHES: usize = 1365;
 
@@ -34,14 +37,17 @@ fn main() -> Result<(), impl Debug> {
     type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type Perm = Poseidon2BabyBear<16>;
-    let perm = Perm::new_from_rng_128(&mut thread_rng());
+    type Perm16 = Poseidon2BabyBear<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
 
-    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-    let hash = MyHash::new(perm.clone());
+    type Perm24 = Poseidon2BabyBear<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
 
-    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-    let compress = MyCompress::new(perm.clone());
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
 
     type ValMmcs =
         MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
@@ -50,13 +56,12 @@ fn main() -> Result<(), impl Debug> {
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
-    type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
 
-    type Dft = RecursiveDft<Val>;
-    let dft = Dft::new(trace.height());
+    let dft = Dft::default();
 
     let fri_config = FriConfig {
         log_blowup: 1,
@@ -70,9 +75,9 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);
 
-    let mut challenger = Challenger::new(perm.clone());
+    let mut challenger = Challenger::new(perm24.clone());
     let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
 
-    let mut challenger = Challenger::new(perm);
+    let mut challenger = Challenger::new(perm24);
     verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
@@ -17,6 +16,11 @@ use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(feature = "parallel")]
+type Dft = p3_dft::Radix2DitParallel<BabyBear>;
+#[cfg(not(feature = "parallel"))]
+type Dft = p3_dft::Radix2Bowers;
 
 const NUM_HASHES: usize = 1_365;
 
@@ -47,7 +51,6 @@ fn main() -> Result<(), impl Debug> {
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
-    type Dft = Radix2DitParallel<Val>;
     let dft = Dft::default();
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;

--- a/keccak-air/examples/prove_koala_bear_keccak.rs
+++ b/keccak-air/examples/prove_koala_bear_keccak.rs
@@ -1,14 +1,14 @@
 use std::fmt::Debug;
 
-use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
 use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_koala_bear::KoalaBear;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_sha256::{Sha256, Sha256Compress};
-use p3_symmetric::SerializingHasher32;
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
@@ -18,11 +18,11 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
 #[cfg(feature = "parallel")]
-type Dft = p3_dft::Radix2DitParallel<BabyBear>;
+type Dft = p3_dft::Radix2DitParallel<KoalaBear>;
 #[cfg(not(feature = "parallel"))]
 type Dft = p3_dft::Radix2Bowers;
 
-const NUM_HASHES: usize = 1_365;
+const NUM_HASHES: usize = 1365;
 
 fn main() -> Result<(), impl Debug> {
     let env_filter = EnvFilter::builder()
@@ -34,24 +34,22 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    type Val = BabyBear;
+    type Val = KoalaBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type ByteHash = Sha256;
+    type ByteHash = Keccak256Hash;
     type FieldHash = SerializingHasher32<ByteHash>;
     let byte_hash = ByteHash {};
-    let field_hash = FieldHash::new(byte_hash);
+    let field_hash = FieldHash::new(Keccak256Hash {});
 
-    type MyCompress = Sha256Compress;
-    let compress = MyCompress {};
+    type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
+    let compress = MyCompress::new(byte_hash);
 
     type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
     let val_mmcs = ValMmcs::new(field_hash, compress);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
-    let challenge_mmcs = ChallengeMmcs::new(val_mmcs);
-
-    let dft = Dft::default();
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
@@ -64,6 +62,9 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
+
+    let dft = Dft::default();
+
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 


### PR DESCRIPTION
A few of the examples use the `RecursiveDft` but, currently for the trace dimensions, `Radix2DitParallel` is noticeably faster. Switching this gives a `10-20%` speed boost.

Similarly, when working with `Poseidon2`, we should be using the `WIDTH=24` hash where possible as its faster than running the `WIDTH=16` hash twice. This is the relevant comparison if we are compressing by hashing the union of `8` elements from the old state and padding to the width by new elements. This seems to give a further `5-10%` speed up.

Finally, we add an extra example, `prove_koala_bear_keccak`. This examples timing data should be essentially identical to `prove_baby_bear_keccak` but it's useful to have for completeness sake.