### PR TITLE
Full Suite of prove blake-3 air examples

### DIFF
--- a/blake3-air/examples/prove_blake3_baby_bear_keccak.rs
+++ b/blake3-air/examples/prove_blake3_baby_bear_keccak.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use p3_baby_bear::BabyBear;
 use p3_blake3_air::{generate_trace_rows, Blake3Air};
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
@@ -7,7 +8,6 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
-use p3_koala_bear::KoalaBear;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{prove, verify, StarkConfig};
@@ -30,7 +30,7 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    type Val = KoalaBear;
+    type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
     type ByteHash = Keccak256Hash;
@@ -58,6 +58,7 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
+
     type Dft = Radix2DitParallel<Val>;
     let dft = Dft::default();
 

--- a/blake3-air/examples/prove_blake3_baby_bear_poseidon2.rs
+++ b/blake3-air/examples/prove_blake3_baby_bear_poseidon2.rs
@@ -1,17 +1,17 @@
 use std::fmt::Debug;
 
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_blake3_air::{generate_trace_rows, Blake3Air};
-use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
-use p3_keccak::Keccak256Hash;
-use p3_koala_bear::KoalaBear;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::random;
+use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -30,24 +30,29 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    type Val = KoalaBear;
+    type Val = BabyBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type ByteHash = Keccak256Hash;
-    type FieldHash = SerializingHasher32<ByteHash>;
-    let byte_hash = ByteHash {};
-    let field_hash = FieldHash::new(Keccak256Hash {});
+    type Perm16 = Poseidon2BabyBear<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
 
-    type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
-    let compress = MyCompress::new(byte_hash);
+    type Perm24 = Poseidon2BabyBear<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
 
-    type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
-    let val_mmcs = ValMmcs::new(field_hash, compress);
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
+
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+    let val_mmcs = ValMmcs::new(hash, compress);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
-    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
@@ -58,6 +63,7 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
+
     type Dft = Radix2DitParallel<Val>;
     let dft = Dft::default();
 
@@ -67,9 +73,9 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let mut challenger = Challenger::new(perm24.clone());
     let proof = prove(&config, &Blake3Air {}, &mut challenger, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let mut challenger = Challenger::new(perm24.clone());
     verify(&config, &Blake3Air {}, &mut challenger, &proof, &vec![])
 }

--- a/blake3-air/examples/prove_blake3_koala_bear_poseidon2.rs
+++ b/blake3-air/examples/prove_blake3_koala_bear_poseidon2.rs
@@ -1,17 +1,17 @@
 use std::fmt::Debug;
 
 use p3_blake3_air::{generate_trace_rows, Blake3Air};
-use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
-use p3_keccak::Keccak256Hash;
-use p3_koala_bear::KoalaBear;
+use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::random;
+use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -33,21 +33,26 @@ fn main() -> Result<(), impl Debug> {
     type Val = KoalaBear;
     type Challenge = BinomialExtensionField<Val, 4>;
 
-    type ByteHash = Keccak256Hash;
-    type FieldHash = SerializingHasher32<ByteHash>;
-    let byte_hash = ByteHash {};
-    let field_hash = FieldHash::new(Keccak256Hash {});
+    type Perm16 = Poseidon2KoalaBear<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
 
-    type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
-    let compress = MyCompress::new(byte_hash);
+    type Perm24 = Poseidon2KoalaBear<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
 
-    type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 32>;
-    let val_mmcs = ValMmcs::new(field_hash, compress);
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
+
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+    let val_mmcs = ValMmcs::new(hash, compress);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
-    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs);
@@ -58,6 +63,7 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
+
     type Dft = Radix2DitParallel<Val>;
     let dft = Dft::default();
 
@@ -67,9 +73,9 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let mut challenger = Challenger::new(perm24.clone());
     let proof = prove(&config, &Blake3Air {}, &mut challenger, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
+    let mut challenger = Challenger::new(perm24.clone());
     verify(&config, &Blake3Air {}, &mut challenger, &proof, &vec![])
 }

--- a/blake3-air/examples/prove_blake3_m31_keccak.rs
+++ b/blake3-air/examples/prove_blake3_m31_keccak.rs
@@ -1,14 +1,15 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use p3_blake3_air::{generate_trace_rows, Blake3Air};
 use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_circle::CirclePcs;
 use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_fri::{FriConfig, TwoAdicFriPcs};
+use p3_fri::FriConfig;
 use p3_keccak::Keccak256Hash;
-use p3_koala_bear::KoalaBear;
 use p3_merkle_tree::MerkleTreeMmcs;
+use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::random;
@@ -30,8 +31,8 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    type Val = KoalaBear;
-    type Challenge = BinomialExtensionField<Val, 4>;
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
 
     type ByteHash = Keccak256Hash;
     type FieldHash = SerializingHasher32<ByteHash>;
@@ -49,23 +50,25 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = FriConfig {
         log_blowup: 1,
         num_queries: 100,
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
-    type Dft = Radix2DitParallel<Val>;
-    let dft = Dft::default();
 
-    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-    let pcs = Pcs::new(dft, val_mmcs, fri_config);
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_config,
+        _phantom: PhantomData,
+    };
 
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
     let proof = prove(&config, &Blake3Air {}, &mut challenger, trace, &vec![]);

--- a/blake3-air/examples/prove_blake3_m31_poseidon2.rs
+++ b/blake3-air/examples/prove_blake3_m31_poseidon2.rs
@@ -1,0 +1,83 @@
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+use p3_blake3_air::{generate_trace_rows, Blake3Air};
+use p3_challenger::DuplexChallenger;
+use p3_circle::CirclePcs;
+use p3_commit::ExtensionMmcs;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
+use p3_fri::FriConfig;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{prove, verify, StarkConfig};
+use rand::{random, thread_rng};
+use tracing_forest::util::LevelFilter;
+use tracing_forest::ForestLayer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+const NUM_HASHES: usize = 1365;
+
+fn main() -> Result<(), impl Debug> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
+
+    type Perm16 = Poseidon2Mersenne31<16>;
+    let perm16 = Perm16::new_from_rng_128(&mut thread_rng());
+
+    type Perm24 = Poseidon2Mersenne31<24>;
+    let perm24 = Perm24::new_from_rng_128(&mut thread_rng());
+
+    type MyHash = PaddingFreeSponge<Perm24, 24, 16, 8>;
+    let hash = MyHash::new(perm24.clone());
+
+    type MyCompress = TruncatedPermutation<Perm16, 2, 8, 16>;
+    let compress = MyCompress::new(perm16.clone());
+
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 8>;
+    let val_mmcs = ValMmcs::new(hash, compress);
+
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
+
+    let fri_config = FriConfig {
+        log_blowup: 1,
+        num_queries: 100,
+        proof_of_work_bits: 16,
+        mmcs: challenge_mmcs,
+    };
+
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_config,
+        _phantom: PhantomData,
+    };
+
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs);
+
+    let mut challenger = Challenger::new(perm24.clone());
+    let proof = prove(&config, &Blake3Air {}, &mut challenger, trace, &vec![]);
+
+    let mut challenger = Challenger::new(perm24);
+    verify(&config, &Blake3Air {}, &mut challenger, &proof, &vec![])
+}


### PR DESCRIPTION
Adding examples so that we can prove Blake3 with all 6 options of three fields: `Mersenne31, BabyBear, KoalaBear`  and `2` hashing methods, `KECCAK` and `Poseidon2`.

This annoyingly involves quite a lot of copy/paste. It would be really nice to find a way to combine some of these different examples using command line arguments. Unfortunately rust makes this pretty hard to do.