### PR TITLE
Add generate_trace_rows methods to all of our airs.

### DIFF
--- a/blake3-air/Cargo.toml
+++ b/blake3-air/Cargo.toml
@@ -10,6 +10,7 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+rand.workspace = true
 tracing.workspace = true
 itertools.workspace = true
 
@@ -33,7 +34,6 @@ p3-poseidon2.workspace = true
 p3-sha256.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
-rand.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 

--- a/blake3-air/examples/prove_blake3_baby_bear_poseidon2.rs
+++ b/blake3-air/examples/prove_blake3_baby_bear_poseidon2.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_blake3_air::{generate_trace_rows, Blake3Air};
+use p3_blake3_air::Blake3Air;
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
@@ -11,7 +11,7 @@ use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -54,8 +54,8 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
+    let blake3_air = Blake3Air {};
+    let trace = blake3_air.generate_trace_rows::<Val>(NUM_HASHES);
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -10,6 +10,7 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+rand.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
@@ -30,11 +31,16 @@ p3-poseidon2.workspace = true
 p3-sha256.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
-rand.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
 asm = ["p3-sha256/asm"]
-nightly-features = ["p3-goldilocks/nightly-features", "p3-monty-31/nightly-features", "p3-baby-bear/nightly-features", "p3-koala-bear/nightly-features", "p3-mersenne-31/nightly-features"]
+nightly-features = [
+    "p3-goldilocks/nightly-features",
+    "p3-monty-31/nightly-features",
+    "p3-baby-bear/nightly-features",
+    "p3-koala-bear/nightly-features",
+    "p3-mersenne-31/nightly-features",
+]

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -6,11 +6,11 @@ use p3_commit::ExtensionMmcs;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
-use p3_keccak_air::{generate_trace_rows, KeccakAir};
+use p3_keccak_air::KeccakAir;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::layer::SubscriberExt;
@@ -58,8 +58,8 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
+    let keccak_air = KeccakAir {};
+    let trace = keccak_air.generate_trace_rows::<Val>(NUM_HASHES);
 
     let dft = Dft::default();
 
@@ -76,8 +76,8 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::new(perm24.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &keccak_air, &mut challenger, trace, &vec![]);
 
     let mut challenger = Challenger::new(perm24);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &keccak_air, &mut challenger, &proof, &vec![])
 }

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -1,18 +1,28 @@
+use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use p3_air::utils::{andn, xor, xor3};
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::FieldAlgebra;
+use p3_field::{FieldAlgebra, PrimeField64};
+use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
+use rand::random;
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
 use crate::constants::rc_value_bit;
 use crate::round_flags::eval_round_flags;
-use crate::{BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
+use crate::{generate_trace_rows, BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
 
 /// Assumes the field size is at least 16 bits.
 #[derive(Debug)]
 pub struct KeccakAir {}
+
+impl KeccakAir {
+    pub fn generate_trace_rows<F: PrimeField64>(&self, num_hashes: usize) -> RowMajorMatrix<F> {
+        let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
+        generate_trace_rows(inputs)
+    }
+}
 
 impl<F> BaseAir<F> for KeccakAir {
     fn width(&self) -> usize {

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -11,7 +11,7 @@ use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
 use p3_uni_stark::{prove, verify, StarkConfig};
 use rand::rngs::{StdRng, ThreadRng};
-use rand::{random, thread_rng, SeedableRng};
+use rand::{thread_rng, SeedableRng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -78,7 +78,6 @@ fn main() -> Result<(), impl Debug> {
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersBabyBear,
@@ -90,7 +89,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let dft = Dft::default();
 

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_poseidon2.rs
@@ -10,7 +10,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -75,7 +75,6 @@ fn main() -> Result<(), impl Debug> {
     type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersBabyBear,
@@ -87,7 +86,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -10,7 +10,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -86,7 +86,6 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersKoalaBear,
@@ -98,7 +97,7 @@ fn prove_and_verify() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let dft = Dft::default();
 

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
@@ -11,7 +11,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -72,7 +72,6 @@ fn main() -> Result<(), impl Debug> {
     type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersKoalaBear,
@@ -84,7 +83,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
@@ -12,7 +12,7 @@ use p3_mersenne_31::{GenericPoseidon2LinearLayersMersenne31, Mersenne31};
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -75,7 +75,6 @@ fn main() -> Result<(), impl Debug> {
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersMersenne31,
@@ -87,7 +86,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/poseidon2-air/examples/prove_poseidon2_m31_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_poseidon2.rs
@@ -12,7 +12,7 @@ use p3_mersenne_31::{GenericPoseidon2LinearLayersMersenne31, Mersenne31, Poseido
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{prove, verify, StarkConfig};
-use rand::{random, thread_rng};
+use rand::thread_rng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::util::LevelFilter;
@@ -70,7 +70,6 @@ fn main() -> Result<(), impl Debug> {
     type Challenger = DuplexChallenger<Val, Perm24, 24, 16>;
 
     let constants = RoundConstants::from_rng(&mut thread_rng());
-    let inputs = (0..NUM_PERMUTATIONS).map(|_| random()).collect::<Vec<_>>();
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersMersenne31,
@@ -82,7 +81,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(inputs);
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -8,42 +8,7 @@ use p3_poseidon2::GenericPoseidon2LinearLayers;
 use tracing::instrument;
 
 use crate::columns::{num_cols, Poseidon2Cols};
-use crate::{FullRound, PartialRound, RoundConstants, SBox, VectorizedPoseidon2Air};
-
-impl<
-        F: PrimeField,
-        LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
-        const WIDTH: usize,
-        const SBOX_DEGREE: u64,
-        const SBOX_REGISTERS: usize,
-        const HALF_FULL_ROUNDS: usize,
-        const PARTIAL_ROUNDS: usize,
-        const VECTOR_LEN: usize,
-    >
-    VectorizedPoseidon2Air<
-        F,
-        LinearLayers,
-        WIDTH,
-        SBOX_DEGREE,
-        SBOX_REGISTERS,
-        HALF_FULL_ROUNDS,
-        PARTIAL_ROUNDS,
-        VECTOR_LEN,
-    >
-{
-    pub fn generate_vectorized_trace_rows(&self, inputs: Vec<[F; WIDTH]>) -> RowMajorMatrix<F> {
-        generate_vectorized_trace_rows::<
-            F,
-            LinearLayers,
-            WIDTH,
-            SBOX_DEGREE,
-            SBOX_REGISTERS,
-            HALF_FULL_ROUNDS,
-            PARTIAL_ROUNDS,
-            VECTOR_LEN,
-        >(inputs, &self.air.constants)
-    }
-}
+use crate::{FullRound, PartialRound, RoundConstants, SBox};
 
 #[instrument(name = "generate vectorized Poseidon2 trace", skip_all)]
 pub fn generate_vectorized_trace_rows<

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -1,13 +1,18 @@
+use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::Field;
+use p3_field::{Field, PrimeField};
+use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use rand::random;
 
 use crate::air::eval;
 use crate::constants::RoundConstants;
-use crate::{Poseidon2Air, Poseidon2Cols};
+use crate::{generate_vectorized_trace_rows, Poseidon2Air, Poseidon2Cols};
 
 /// A "vectorized" version of Poseidon2Cols, for computing multiple Poseidon2 permutations per row.
 #[repr(C)]
@@ -174,6 +179,25 @@ impl<
         Self {
             air: Poseidon2Air::new(constants),
         }
+    }
+
+    pub fn generate_vectorized_trace_rows(&self, num_hashes: usize) -> RowMajorMatrix<F>
+    where
+        F: PrimeField,
+        LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+        Standard: Distribution<[F; WIDTH]>,
+    {
+        let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
+        generate_vectorized_trace_rows::<
+            F,
+            LinearLayers,
+            WIDTH,
+            SBOX_DEGREE,
+            SBOX_REGISTERS,
+            HALF_FULL_ROUNDS,
+            PARTIAL_ROUNDS,
+            VECTOR_LEN,
+        >(inputs, &self.air.constants)
     }
 }
 


### PR DESCRIPTION
This means we can easily imply a methods for `Enum {Blake3Air, KeccakAir, Poseidon2Air}`.

I'll split off some of the code in prove_monty_31_keccak into another file in a future PR so we can have some equivalently easy to customize examples for other fields and merkle hash functions.