### PR TITLE
Field Crate Refactor: Make FieldAlgebra implement From<F>, Add<F>, and similar ops.

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -28,7 +28,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedBabyBearNeon::from_f);
+        let mut neon_input = input.map(Into::<PackedBabyBearNeon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);
@@ -49,7 +49,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedBabyBearNeon::from_f);
+        let mut neon_input = input.map(Into::<PackedBabyBearNeon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -112,7 +112,6 @@ impl InternalLayerParametersAVX2<BabyBearParameters, 24> for BabyBearInternalLay
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
@@ -135,7 +134,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedBabyBearAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -156,7 +155,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedBabyBearAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -146,7 +146,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedBabyBearAVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);
@@ -167,7 +167,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedBabyBearAVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -104,11 +104,6 @@ impl FieldAlgebra for Bn254Fr {
         0x30644e72e131a029,
     ]));
 
-    #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f
-    }
-
     fn from_bool(b: bool) -> Self {
         Self::new(FFBn254Fr::from(b as u64))
     }

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -43,11 +43,6 @@ impl<F: Field, const N: usize> FieldAlgebra for FieldArray<F, N> {
     const TWO: Self = FieldArray([F::TWO; N]);
     const NEG_ONE: Self = FieldArray([F::NEG_ONE; N]);
 
-    #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
     fn from_bool(b: bool) -> Self {
         [F::from_bool(b); N].into()
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -41,7 +41,7 @@ impl<F: Field, const D: usize> Default for BinomialExtensionField<F, D> {
 impl<F: Field, const D: usize> From<F> for BinomialExtensionField<F, D> {
     fn from(x: F) -> Self {
         Self {
-            value: field_to_array::<F, D>(x),
+            value: field_to_array(x),
         }
     }
 }
@@ -117,28 +117,28 @@ impl<F, const D: usize> FieldAlgebra for BinomialExtensionField<F, D>
 where
     F: BinomiallyExtendable<D>,
 {
-    type F = BinomialExtensionField<FA::F, D>;
-    type PrimeSubfield = <FA::F as FieldAlgebra>::PrimeSubfield;
+    type F = BinomialExtensionField<F, D>;
+    type PrimeSubfield = <F as FieldAlgebra>::PrimeSubfield;
 
     const ZERO: Self = Self {
         value: [F::ZERO; D],
     };
 
     const ONE: Self = Self {
-        value: field_to_array::<F, D>(F::ONE),
+        value: field_to_array(F::ONE),
     };
 
     const TWO: Self = Self {
-        value: field_to_array::<F, D>(F::TWO),
+        value: field_to_array(F::TWO),
     };
 
     const NEG_ONE: Self = Self {
-        value: field_to_array::<F, D>(F::NEG_ONE),
+        value: field_to_array(F::NEG_ONE),
     };
 
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
-        FA::from_f(<FA::F as FieldAlgebra>::from_prime_subfield(f)).into()
+        <F as FieldAlgebra>::from_prime_subfield(f).into()
     }
 
     #[inline(always)]
@@ -476,7 +476,7 @@ where
         for r in res.iter_mut() {
             *r = Standard.sample(rng);
         }
-        BinomialExtensionField::<F, D>::from_base_slice(&res)
+        BinomialExtensionField::from_base_slice(&res)
     }
 }
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -32,6 +32,16 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> Default
     }
 }
 
+impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+{
+    fn from(x: BinomialExtensionField<F, D>) -> Self {
+        Self {
+            value: x.value.map(Into::<PF>::into),
+        }
+    }
+}
+
 impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
     for PackedBinomialExtensionField<F, PF, D>
 {
@@ -64,13 +74,6 @@ where
     const NEG_ONE: Self = Self {
         value: field_to_array::<PF, D>(PF::NEG_ONE),
     };
-
-    #[inline]
-    fn from_f(f: Self::F) -> Self {
-        Self {
-            value: f.value.map(PF::from_f),
-        }
-    }
 
     #[inline]
     fn from_bool(b: bool) -> Self {
@@ -118,7 +121,7 @@ where
             2 => {
                 let a = self.value;
                 let mut res = Self::default();
-                res.value[0] = a[0].square() + a[1].square() * PF::from_f(F::W);
+                res.value[0] = a[0].square() + a[1].square() * F::W;
                 res.value[1] = a[0] * a[1].double();
                 res
             }
@@ -211,6 +214,24 @@ where
     }
 }
 
+impl<F, PF, const D: usize> Add<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: BinomialExtensionField<F, D>) -> Self {
+        let mut res = self.value;
+        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
+            *r += rhs_val;
+        }
+        Self { value: res }
+    }
+}
+
 impl<F, PF, const D: usize> Add<PF> for PackedBinomialExtensionField<F, PF, D>
 where
     F: BinomiallyExtendable<D>,
@@ -232,6 +253,20 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
+        for i in 0..D {
+            self.value[i] += rhs.value[i];
+        }
+    }
+}
+
+impl<F, PF, const D: usize> AddAssign<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: BinomialExtensionField<F, D>) {
         for i in 0..D {
             self.value[i] += rhs.value[i];
         }
@@ -276,6 +311,24 @@ where
     }
 }
 
+impl<F, PF, const D: usize> Sub<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: BinomialExtensionField<F, D>) -> Self {
+        let mut res = self.value;
+        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
+            *r -= rhs_val;
+        }
+        Self { value: res }
+    }
+}
+
 impl<F, PF, const D: usize> Sub<PF> for PackedBinomialExtensionField<F, PF, D>
 where
     F: BinomiallyExtendable<D>,
@@ -302,6 +355,18 @@ where
     }
 }
 
+impl<F, PF, const D: usize> SubAssign<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: BinomialExtensionField<F, D>) {
+        *self = *self - rhs;
+    }
+}
+
 impl<F, PF, const D: usize> SubAssign<PF> for PackedBinomialExtensionField<F, PF, D>
 where
     F: BinomiallyExtendable<D>,
@@ -322,6 +387,45 @@ where
 
     #[inline]
     fn mul(self, rhs: Self) -> Self {
+        let a = self.value;
+        let b = rhs.value;
+        let mut res = Self::default();
+        let w: PF = F::W.into();
+
+        match D {
+            2 => {
+                res.value[0] = a[0] * b[0] + a[1] * w * b[1];
+                res.value[1] = a[0] * b[1] + a[1] * b[0];
+            }
+            3 => cubic_mul(&a, &b, &mut res.value, w),
+            _ =>
+            {
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..D {
+                    for j in 0..D {
+                        if i + j >= D {
+                            res.value[i + j - D] += a[i] * w * b[j];
+                        } else {
+                            res.value[i + j] += a[i] * b[j];
+                        }
+                    }
+                }
+            }
+        }
+        res
+    }
+}
+
+impl<F, PF, const D: usize> Mul<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: BinomialExtensionField<F, D>) -> Self {
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
@@ -383,6 +487,18 @@ where
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F, PF, const D: usize> MulAssign<BinomialExtensionField<F, D>>
+    for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    #[inline]
+    fn mul_assign(&mut self, rhs: BinomialExtensionField<F, D>) {
         *self = *self * rhs;
     }
 }

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -7,7 +7,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use p3_util::convert_vec;
 use serde::{Deserialize, Serialize};
 
-use super::{cubic_mul, cubic_square, BinomialExtensionField};
+use super::{binomial_mul, cubic_square, vector_add, vector_sub, BinomialExtensionField};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField};
@@ -206,11 +206,8 @@ where
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        let mut res = self.value;
-        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
-            *r += rhs_val;
-        }
-        Self { value: res }
+        let value = vector_add(&self.value, &rhs.value);
+        Self { value }
     }
 }
 
@@ -224,11 +221,8 @@ where
 
     #[inline]
     fn add(self, rhs: BinomialExtensionField<F, D>) -> Self {
-        let mut res = self.value;
-        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
-            *r += rhs_val;
-        }
-        Self { value: res }
+        let value = vector_add(&self.value, &rhs.value);
+        Self { value }
     }
 }
 
@@ -303,11 +297,8 @@ where
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        let mut res = self.value;
-        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
-            *r -= rhs_val;
-        }
-        Self { value: res }
+        let value = vector_sub(&self.value, &rhs.value);
+        Self { value }
     }
 }
 
@@ -321,11 +312,8 @@ where
 
     #[inline]
     fn sub(self, rhs: BinomialExtensionField<F, D>) -> Self {
-        let mut res = self.value;
-        for (r, rhs_val) in res.iter_mut().zip(rhs.value) {
-            *r -= rhs_val;
-        }
-        Self { value: res }
+        let value = vector_sub(&self.value, &rhs.value);
+        Self { value }
     }
 }
 
@@ -392,26 +380,8 @@ where
         let mut res = Self::default();
         let w: PF = F::W.into();
 
-        match D {
-            2 => {
-                res.value[0] = a[0] * b[0] + a[1] * w * b[1];
-                res.value[1] = a[0] * b[1] + a[1] * b[0];
-            }
-            3 => cubic_mul(&a, &b, &mut res.value, w),
-            _ =>
-            {
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..D {
-                    for j in 0..D {
-                        if i + j >= D {
-                            res.value[i + j - D] += a[i] * w * b[j];
-                        } else {
-                            res.value[i + j] += a[i] * b[j];
-                        }
-                    }
-                }
-            }
-        }
+        binomial_mul(&a, &b, &mut res.value, w);
+
         res
     }
 }
@@ -431,26 +401,8 @@ where
         let mut res = Self::default();
         let w: PF = F::W.into();
 
-        match D {
-            2 => {
-                res.value[0] = a[0] * b[0] + a[1] * w * b[1];
-                res.value[1] = a[0] * b[1] + a[1] * b[0];
-            }
-            3 => cubic_mul(&a, &b, &mut res.value, w),
-            _ =>
-            {
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..D {
-                    for j in 0..D {
-                        if i + j >= D {
-                            res.value[i + j - D] += a[i] * w * b[j];
-                        } else {
-                            res.value[i + j] += a[i] * b[j];
-                        }
-                    }
-                }
-            }
-        }
+        binomial_mul(&a, &b, &mut res.value, w);
+
         res
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -35,6 +35,13 @@ pub trait FieldAlgebra:
     Sized
     + Default
     + Clone
+    + From<Self::F>
+    + Add<Self::F, Output = Self>
+    + AddAssign<Self::F>
+    + Sub<Self::F, Output = Self>
+    + SubAssign<Self::F>
+    + Mul<Self::F, Output = Self>
+    + MulAssign<Self::F>
     + Add<Output = Self>
     + AddAssign
     + Sub<Output = Self>
@@ -47,7 +54,6 @@ pub trait FieldAlgebra:
     + Debug
 {
     type F: Field;
-
     /// The additive identity of the algebra.
     ///
     /// For every element `a` in the algebra we require the following properties:
@@ -84,13 +90,6 @@ pub trait FieldAlgebra:
     ///
     /// If the field has characteristic 2 this is equal to ONE.
     const NEG_ONE: Self;
-
-    /// Interpret a field element as a commutative algebra element.
-    ///
-    /// Mathematically speaking, this map is a ring homomorphism from the base field
-    /// to the commutative algebra. The existence of this map makes this structure
-    /// an algebra and not simply a commutative ring.
-    fn from_f(f: Self::F) -> Self;
 
     /// Convert from a `bool`.
     fn from_bool(b: bool) -> Self;
@@ -239,14 +238,14 @@ pub trait FieldAlgebra:
     /// E.g. if `PACKING::WIDTH = 4` this returns the elements:
     /// `[start, start*self, start*self^2, start*self^3], [start*self^4, start*self^5, start*self^6, start*self^7], ...`.
     fn shifted_powers_packed<P: PackedField<Scalar = Self>>(&self, start: Self) -> Powers<P> {
-        let mut current = P::from_f(start);
+        let mut current: P = start.into();
         let slice = current.as_slice_mut();
         for i in 1..P::WIDTH {
             slice[i] = slice[i - 1].clone() * self.clone();
         }
 
         Powers {
-            base: P::from_f(self.clone()).exp_u64(P::WIDTH as u64),
+            base: self.clone().exp_u64(P::WIDTH as u64).into(),
             current,
         }
     }

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -1,5 +1,5 @@
 use core::mem::MaybeUninit;
-use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Sub, SubAssign};
+use core::ops::Div;
 use core::slice;
 
 use crate::field::Field;
@@ -132,13 +132,6 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
 /// - See `PackedValue` above.
 pub unsafe trait PackedField: FieldAlgebra<F = Self::Scalar>
     + PackedValue<Value = Self::Scalar>
-    + From<Self::Scalar>
-    + Add<Self::Scalar, Output = Self>
-    + AddAssign<Self::Scalar>
-    + Sub<Self::Scalar, Output = Self>
-    + SubAssign<Self::Scalar>
-    + Mul<Self::Scalar, Output = Self>
-    + MulAssign<Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>
 {

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -100,11 +100,6 @@ impl FieldAlgebra for Goldilocks {
     const TWO: Self = Self::new(2);
     const NEG_ONE: Self = Self::new(Self::ORDER_U64 - 1);
 
-    #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f
-    }
-
     fn from_bool(b: bool) -> Self {
         Self::new(b.into())
     }

--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -70,7 +70,6 @@ impl MdsPermutation<PackedGoldilocksAVX2, 24> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
     use rand::Rng;
@@ -89,7 +88,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX2>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -108,7 +107,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX2>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -127,7 +126,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX2>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -146,7 +145,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX2>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -169,11 +169,6 @@ impl FieldAlgebra for PackedGoldilocksAVX2 {
     const NEG_ONE: Self = Self([Goldilocks::NEG_ONE; WIDTH]);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Goldilocks::from_bool(b).into()
     }

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -89,7 +89,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX512::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX512>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -108,7 +108,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX512::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX512>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -127,7 +127,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX512::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX512>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -146,7 +146,7 @@ mod tests {
         let mut expected = input;
         poseidon.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedGoldilocksAVX512::from_f);
+        let mut avx2_input = input.map(Into::<PackedGoldilocksAVX512>::into);
         poseidon.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -168,11 +168,6 @@ impl FieldAlgebra for PackedGoldilocksAVX512 {
     const NEG_ONE: Self = Self([Goldilocks::NEG_ONE; WIDTH]);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Goldilocks::from_bool(b).into()
     }

--- a/koala-bear/src/aarch64_neon/poseidon2.rs
+++ b/koala-bear/src/aarch64_neon/poseidon2.rs
@@ -5,7 +5,6 @@
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
@@ -28,7 +27,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedKoalaBearNeon::from_f);
+        let mut neon_input = input.map(Into::<PackedKoalaBearNeon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);
@@ -49,7 +48,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedKoalaBearNeon::from_f);
+        let mut neon_input = input.map(Into::<PackedKoalaBearNeon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -193,7 +193,6 @@ impl InternalLayerParametersAVX2<KoalaBearParameters, 24> for KoalaBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
@@ -216,7 +215,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedKoalaBearAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -237,7 +236,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedKoalaBearAVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -123,7 +123,6 @@ impl InternalLayerParametersAVX512<KoalaBearParameters, 24> for KoalaBearInterna
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
@@ -146,7 +145,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedKoalaBearAVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);
@@ -167,7 +166,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedKoalaBearAVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -9,7 +9,7 @@ pub(crate) fn dit_butterfly<FA: FieldAlgebra, const N: usize>(
     twiddle: FA::F,
 ) {
     let val_1 = values[idx_1].clone();
-    let val_2 = values[idx_2].clone() * FA::from_f(twiddle);
+    let val_2 = values[idx_2].clone() * twiddle;
     values[idx_1] = val_1.clone() + val_2.clone();
     values[idx_2] = val_1 - val_2;
 }
@@ -25,7 +25,7 @@ pub(crate) fn dif_butterfly<FA: FieldAlgebra, const N: usize>(
     let val_1 = values[idx_1].clone();
     let val_2 = values[idx_2].clone();
     values[idx_1] = val_1.clone() + val_2.clone();
-    values[idx_2] = (val_1 - val_2) * FA::from_f(twiddle);
+    values[idx_2] = (val_1 - val_2) * twiddle;
 }
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -66,7 +66,7 @@ where
 
         // Multiply by powers of the coset shift (see default coset LDE impl for an explanation)
         for (value, weight) in values.iter_mut().zip(self.weights) {
-            *value = value.clone() * FA::from_f(weight);
+            *value = value.clone() * weight;
         }
 
         // DFT, assuming bit-reversed input.

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -321,11 +321,6 @@ impl FieldAlgebra for PackedMersenne31Neon {
     const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Mersenne31::from_bool(b).into()
     }

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -107,7 +107,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedMersenne31Neon::from_f);
+        let mut neon_input = input.map(Into::<PackedMersenne31Neon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);
@@ -128,7 +128,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut neon_input = input.map(PackedMersenne31Neon::from_f);
+        let mut neon_input = input.map(Into::<PackedMersenne31Neon>::into);
         poseidon2.permute_mut(&mut neon_input);
 
         let neon_output = neon_input.map(|x| x.0[0]);

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -122,11 +122,6 @@ impl FieldAlgebra for Mersenne31 {
     };
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Self::new(b as u32)
     }

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -405,11 +405,6 @@ impl FieldAlgebra for PackedMersenne31AVX2 {
     const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Mersenne31::from_bool(b).into()
     }

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -337,7 +337,6 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::Rng;
 
@@ -361,7 +360,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedMersenne31AVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);
@@ -382,7 +381,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx2_input = input.map(PackedMersenne31AVX2::from_f);
+        let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
         poseidon2.permute_mut(&mut avx2_input);
 
         let avx2_output = avx2_input.map(|x| x.0[0]);

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -425,11 +425,6 @@ impl FieldAlgebra for PackedMersenne31AVX512 {
     const NEG_ONE: Self = Self::broadcast(Mersenne31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         Mersenne31::from_bool(b).into()
     }

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -308,7 +308,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedMersenne31AVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);
@@ -329,7 +329,7 @@ mod tests {
         let mut expected = input;
         poseidon2.permute_mut(&mut expected);
 
-        let mut avx512_input = input.map(PackedMersenne31AVX512::from_f);
+        let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
         poseidon2.permute_mut(&mut avx512_input);
 
         let avx512_output = avx512_input.map(|x| x.0[0]);

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -454,11 +454,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31Neon<FP> {
     const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         MontyField31::from_bool(b).into()
     }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -179,11 +179,6 @@ impl<FP: FieldParameters> FieldAlgebra for MontyField31<FP> {
     const NEG_ONE: Self = FP::MONTY_NEG_ONE;
 
     #[inline(always)]
-    fn from_f(f: Self::F) -> Self {
-        f
-    }
-
-    #[inline(always)]
     fn from_bool(b: bool) -> Self {
         Self::from_canonical_u32(b as u32)
     }

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -481,11 +481,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX2<FP> {
     const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         MontyField31::from_bool(b).into()
     }

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -594,11 +594,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX512<FP> {
     const NEG_ONE: Self = Self::broadcast(MontyField31::NEG_ONE);
 
     #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
-    #[inline]
     fn from_bool(b: bool) -> Self {
         MontyField31::from_bool(b).into()
     }

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -116,7 +116,7 @@ where
         FA: FieldAlgebra<F = F>,
     {
         for (i, x) in state.iter_mut().enumerate() {
-            *x += FA::from_f(self.constants[round * WIDTH + i]);
+            *x += self.constants[round * WIDTH + i];
         }
     }
 }

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -27,7 +27,7 @@ pub fn add_rc_and_sbox_generic<FA: FieldAlgebra + InjectiveMonomial<D>, const D:
     val: &mut FA,
     rc: FA::F,
 ) {
-    *val += FA::from_f(rc);
+    *val += rc;
     *val = val.injective_exp_n();
 }
 

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -50,7 +50,7 @@ pub fn matmul_internal<F: Field, FA: FieldAlgebra<F = F>, const WIDTH: usize>(
 ) {
     let sum: FA = state.iter().cloned().sum();
     for i in 0..WIDTH {
-        state[i] *= FA::from_f(mat_internal_diag_m_1[i]);
+        state[i] *= mat_internal_diag_m_1[i];
         state[i] += sum.clone();
     }
 }

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -117,7 +117,7 @@ where
                 .iter_mut()
                 .zip(&self.round_constants[round * WIDTH * 2..])
             {
-                *state_item += FA::from_f(round_constant);
+                *state_item += round_constant;
             }
 
             // Inverse S-box
@@ -131,7 +131,7 @@ where
                 .iter_mut()
                 .zip(&self.round_constants[round * WIDTH * 2 + WIDTH..])
             {
-                *state_item += FA::from_f(round_constant);
+                *state_item += round_constant;
             }
         }
     }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 
 use p3_air::{AirBuilder, AirBuilderWithPublicValues};
-use p3_field::FieldAlgebra;
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 
@@ -66,7 +65,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         let x: PackedVal<SC> = x.into();
         let alpha_power = self.alpha_powers[self.constraint_index];
-        self.accumulator += PackedChallenge::<SC>::from_f(alpha_power) * x;
+        self.accumulator += Into::<PackedChallenge<SC>>::into(alpha_power) * x;
         self.constraint_index += 1;
     }
 }

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -82,11 +82,6 @@ impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
     const TWO: Self = Self::Constant(F::TWO);
     const NEG_ONE: Self = Self::Constant(F::NEG_ONE);
 
-    #[inline]
-    fn from_f(f: Self::F) -> Self {
-        f.into()
-    }
-
     fn from_bool(b: bool) -> Self {
         Self::Constant(F::from_bool(b))
     }


### PR DESCRIPTION
Note this is not merging into main. The plan is to develop the Field crate refactor in a separate branch and then merge it all in in a single PR. This will avoid the need for a collection of small API breaking changes.

This PR adds a collection of useful traits to `FieldAlgebra`. Explicitly we add `From<F>` (replacing the `from_f` function along with Addition, Subtraction and Multiplication by elements of `F`.

This is justified as, if `FA` is a field algebra over `F`, then then there is an injective map from `F` into `FA`. Hence the `From` trait applies as the map both never fails and is a bijection onto its image. All of the arithmetic operations should be equivalent to using this from map to embed an element of `F` into `FA` and then using the in-built operations on `FA`. (I'll add a bunch of tests for this later)

The is one minor piece of functionality that we lose in this PR though. I've had to change `BinomialExtensionField<FA, D>` to always assume that `FA` is in fact the field `F`. As far as I can tell, this is a reasonable thing to lose. The only place we are using it in the code currently is `FA = F::PACKING` which we are replacing in this PR by `PackedBinomialExtensionField` anyway. I should be able to restore this functionality in a future PR after I have split apart the `FieldAlgebra` trait. The blocking issue is that we cannot imply `From<BinomialExtensionField<FA::F, D>> for BinomialExtensionField<FA, D>` as when `FA = F` this conflicts with the generic `From<T> for T>`.