### PR TITLE
Update Keccak method used in Goldilocks Example

### DIFF
--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -186,6 +186,16 @@ impl<F: PrimeField64, const N: usize, Inner: CanObserve<u8>> CanObserve<Hash<F, 
     }
 }
 
+impl<F: PrimeField64, const N: usize, Inner: CanObserve<u8>> CanObserve<Hash<F, u64, N>>
+    for SerializingChallenger64<F, Inner>
+{
+    fn observe(&mut self, values: Hash<F, u64, N>) {
+        for value in values {
+            self.inner.observe_slice(&value.to_le_bytes());
+        }
+    }
+}
+
 impl<F, EF, Inner> CanSample<EF> for SerializingChallenger64<F, Inner>
 where
     F: PrimeField64,


### PR DESCRIPTION
Updating the Goldilocks example to make use of the faster Keccak method. This gives around a `10%` speed up.

In order to do this we need to add a simple impl for `SerializingChallenger64` which was missing.

Hopefully in a future PR we can fold this into the customizable example in PR #576. This method for `SerializingChallenger64` will  need to be added in order to do that though so we just add it here.