### PR TITLE
fix: typos in documentation files

### DIFF
--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -33,7 +33,7 @@ pub struct SerializingChallenger32<F, Inner> {
 /// -  Takes a field element will serialize it into a byte array and observe each byte.
 ///
 /// **Sampling**:
-/// -  Samples a field element in a prime field of size `p` by sampling unofrmly an element in the
+/// -  Samples a field element in a prime field of size `p` by sampling uniformly an element in the
 ///    range (0..1 << log_2(p)). This avoids modulo bias.
 #[derive(Clone, Debug)]
 pub struct SerializingChallenger64<F, Inner> {


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `unofrmly` to `uniformly`

Please review the changes and let me know if any additional changes are needed.