### PR TITLE
Add `PrimeField64` bound to `BasicSboxLayer::for_alpha` for type safety

### DIFF
--- a/rescue/src/sbox.rs
+++ b/rescue/src/sbox.rs
@@ -41,7 +41,7 @@ impl<F: PrimeField> BasicSboxLayer<F> {
 impl<FA, const WIDTH: usize> SboxLayers<FA, WIDTH> for BasicSboxLayer<FA::F>
 where
     FA: FieldAlgebra,
-    FA::F: PrimeField,
+    FA::F: PrimeField + PrimeField64, 
 {
     fn sbox_layer(&self, state: &mut [FA; WIDTH]) {
         for x in state.iter_mut() {


### PR DESCRIPTION
Adding the `PrimeField64` bound is crucial because it ensures that `exp_u64` is only called on types that support it, preventing compilation errors. This change clarifies type requirements, improves code safety, documents assumptions, and ensures optimal performance by leveraging efficient 64-bit field operations.
