### PR TITLE
Fix duplicate

### DIFF
--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -14,7 +14,7 @@ impl MontyParameters for KoalaBearParameters {
     /// The KoalaBear prime: 2^31 - 2^24 + 1
     /// This is a 31-bit prime with the highest possible two adicity if we additionally demand that
     /// the cube map (x -> x^3) is an automorphism of the multiplicative group.
-    /// Its not unique, as there is one other option with equal 2 adicity: 2^30 + 2^27 + 2^24 + 1.
+    /// It's not unique, as there is one other option with equal 2 adicity: 2^30 + 2^27 + 2^24 + 1.
     /// There is also one 29-bit prime with higher two adicity which might be appropriate for some applications: 2^29 - 2^26 + 1.
     const PRIME: u32 = 0x7f000001;
 

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -48,7 +48,7 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
     KOALABEAR_S_BOX_DEGREE,
 >;
 
-/// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
+/// An implementation of the matrix multiplications in the internal and external layers of Poseidon2.
 ///
 /// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by KoalaBear field elements.
 /// If you have either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]` it will be much faster

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -123,7 +123,7 @@ where
     }
 }
 
-/// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
+/// An implementation of the matrix multiplications in the internal and external layers of Poseidon2.
 ///
 /// This can act on `[FA; WIDTH]` for any FieldAlgebra which implements multiplication by `Monty<31>` field elements.
 /// This will usually be slower than the Poseidon2 permutation built from `Poseidon2InternalLayerMonty31` and


### PR DESCRIPTION
Changed:
"implementation of the the matrix" -> "implementation of the matrix"

Removes redundant word for better readability.