### PR TITLE
Binomial

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -13,7 +13,7 @@ use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use serde::{Deserialize, Serialize};
 
-use super::{HasFrobenius, HasTwoAdicBionmialExtension};
+use super::{HasFrobenius, HasTwoAdicBinomialExtension};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
@@ -563,7 +563,7 @@ where
     }
 }
 
-impl<F: Field + HasTwoAdicBionmialExtension<D>, const D: usize> TwoAdicField
+impl<F: Field + HasTwoAdicBinomialExtension<D>, const D: usize> TwoAdicField
     for BinomialExtensionField<F, D>
 {
     const TWO_ADICITY: usize = F::EXT_TWO_ADICITY;

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,4 +1,4 @@
-use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBinomialExtension};
 use crate::{Field, FieldAlgebra, FieldExtensionAlgebra};
 
 pub type Complex<FA> = BinomialExtensionField<FA, 2>;
@@ -113,7 +113,7 @@ pub trait HasTwoAdicComplexBinomialExtension<const D: usize>:
     fn complex_ext_two_adic_generator(bits: usize) -> [Complex<Self>; D];
 }
 
-impl<F, const D: usize> HasTwoAdicBionmialExtension<D> for Complex<F>
+impl<F, const D: usize> HasTwoAdicBinomialExtension<D> for Complex<F>
 where
     F: HasTwoAdicComplexBinomialExtension<D>,
 {

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -56,7 +56,7 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
 }
 
 /// Optional trait for implementing Two Adic Binomial Extension Field.
-pub trait HasTwoAdicBionmialExtension<const D: usize>: BinomiallyExtendable<D> {
+pub trait HasTwoAdicBinomialExtension<const D: usize>: BinomiallyExtendable<D> {
     const EXT_TWO_ADICITY: usize;
 
     /// Assumes the multiplicative group size has at least `bits` powers of two, otherwise the

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,4 +1,4 @@
-use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBinomialExtension};
 use p3_field::{FieldAlgebra, TwoAdicField};
 
 use crate::Goldilocks;
@@ -17,7 +17,7 @@ impl BinomiallyExtendable<2> for Goldilocks {
     ];
 }
 
-impl HasTwoAdicBionmialExtension<2> for Goldilocks {
+impl HasTwoAdicBinomialExtension<2> for Goldilocks {
     const EXT_TWO_ADICITY: usize = 33;
 
     fn ext_two_adic_generator(bits: usize) -> [Self; 2] {

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -4,7 +4,7 @@
 //! Note that X^2 + 1 is irreducible over p = Mersenne31 field because
 //! kronecker(-1, p) = -1, that is, -1 is not square in F_p.
 
-use p3_field::extension::{Complex, ComplexExtendable, HasTwoAdicBionmialExtension};
+use p3_field::extension::{Complex, ComplexExtendable, HasTwoAdicBinomialExtension};
 use p3_field::FieldAlgebra;
 
 use crate::Mersenne31;
@@ -35,7 +35,7 @@ impl ComplexExtendable for Mersenne31 {
     }
 }
 
-impl HasTwoAdicBionmialExtension<2> for Mersenne31 {
+impl HasTwoAdicBinomialExtension<2> for Mersenne31 {
     const EXT_TWO_ADICITY: usize = 32;
 
     fn ext_two_adic_generator(bits: usize) -> [Self; 2] {

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -1,4 +1,4 @@
-use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
+use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBinomialExtension};
 use p3_field::{field_to_array, TwoAdicField};
 
 use crate::{BinomialExtensionData, FieldParameters, MontyField31, TwoAdicData};
@@ -19,7 +19,7 @@ where
     const EXT_GENERATOR: [Self; WIDTH] = FP::EXT_GENERATOR;
 }
 
-impl<const WIDTH: usize, FP> HasTwoAdicBionmialExtension<WIDTH> for MontyField31<FP>
+impl<const WIDTH: usize, FP> HasTwoAdicBinomialExtension<WIDTH> for MontyField31<FP>
 where
     FP: BinomialExtensionData<WIDTH> + TwoAdicData + FieldParameters,
 {


### PR DESCRIPTION
This PR fixes a typo in the trait name where "Binomial" was incorrectly spelled as "Bionmial".