### PR TITLE
feat: FRI higher arity

### DIFF
--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -17,6 +17,7 @@ itertools.workspace = true
 rand.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -17,7 +17,6 @@ itertools.workspace = true
 rand.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
-tracing-subscriber.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -8,9 +8,11 @@ use p3_matrix::Matrix;
 pub struct FriConfig<M> {
     pub log_blowup: usize,
     // TODO: This parameter and FRI early stopping are not yet implemented in `CirclePcs`.
+    /// log of the number of coefficients in the final polynomial
     pub log_final_poly_len: usize,
     pub num_queries: usize,
     pub proof_of_work_bits: usize,
+    pub arity_bits: usize,
     pub mmcs: M,
 }
 
@@ -21,6 +23,10 @@ impl<M> FriConfig<M> {
 
     pub const fn final_poly_len(&self) -> usize {
         1 << self.log_final_poly_len
+    }
+
+    pub const fn arity(&self) -> usize {
+        1 << self.arity_bits
     }
 
     /// Returns the soundness bits of this FRI instance based on the
@@ -66,6 +72,7 @@ pub fn create_test_fri_config<Mmcs>(mmcs: Mmcs) -> FriConfig<Mmcs> {
         log_final_poly_len: 0,
         num_queries: 2,
         proof_of_work_bits: 1,
+        arity_bits: 1,
         mmcs,
     }
 }
@@ -78,6 +85,8 @@ pub fn create_benchmark_fri_config<Mmcs>(mmcs: Mmcs) -> FriConfig<Mmcs> {
         log_final_poly_len: 0,
         num_queries: 100,
         proof_of_work_bits: 16,
+        // TODO[osama]: consider increasing this
+        arity_bits: 1,
         mmcs,
     }
 }

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -85,7 +85,6 @@ pub fn create_benchmark_fri_config<Mmcs>(mmcs: Mmcs) -> FriConfig<Mmcs> {
         log_final_poly_len: 0,
         num_queries: 100,
         proof_of_work_bits: 16,
-        // TODO[osama]: consider increasing this
         arity_bits: 1,
         mmcs,
     }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -13,6 +13,7 @@ pub struct FriProof<F: Field, M: Mmcs<F>, Witness, InputProof> {
     pub commit_phase_commits: Vec<M::Commitment>,
     pub query_proofs: Vec<QueryProof<F, M, InputProof>>,
     pub final_poly: Vec<F>,
+    pub log_max_height: usize,
     pub pow_witness: Witness,
 }
 

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -31,10 +31,10 @@ pub struct QueryProof<F: Field, M: Mmcs<F>, InputProof> {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub struct CommitPhaseProofStep<F: Field, M: Mmcs<F>> {
-    /// The opening of the commit phase codeword at the sibling location.
-    // This may change to Vec<FC::Challenge> if the library is generalized to support other FRI
-    // folding arities besides 2, meaning that there can be multiple siblings.
-    pub sibling_value: F,
+    /// The opened rows of the commit phase. The first element is the evaluation of the folded
+    /// polynomials so far, and the other elements are evaluations of polynomials of smaller size
+    /// that enter before the next commitment round. See prover::commit_phase for more details
+    pub opened_rows: Vec<Vec<F>>,
 
     pub opening_proof: M::Proof,
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -145,7 +145,7 @@ where
         challenger.observe(commit.clone());
 
         // Next, we fold `folded` and `polys_before_next_round` to prepare for the next round
-        let beta: Challenge = challenger.sample_ext_element();
+        let mut beta: Challenge = challenger.sample_ext_element();
 
         // Get a reference to the committed matrices
         let leaves = config.mmcs.get_matrices(&prover_data);
@@ -156,6 +156,7 @@ where
         while folded.len() > next_folded_len {
             let matrix_to_fold = RowMajorMatrix::new(folded, 2);
             folded = g.fold_matrix(beta, matrix_to_fold);
+            beta = beta.square();
 
             if let Some(poly_eval) = leaves_iter.next_if(|v| v.values.len() == folded.len()) {
                 izip!(&mut folded, &poly_eval.values).for_each(|(f, v)| *f += *v);

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -91,22 +91,22 @@ where
     G: FriGenericConfig<Challenge>,
 {
     // To illustrate the folding logic with arity > 2, let's go through an example.
-    // Suppose `inputs` consists of three polynomials with degrees 8, 4, and 2.
-    // There will be two FRI commitment layers: one at height 8 and one at height 2.
+    // Suppose `inputs` consists of three polynomials with degrees 16, 8, and 4, and
+    // suppose that arity = 4 and final_poly_len = 1.
+    // There will be two FRI commitment layers: one at height 16 and one at height 4.
 
     // The first commitment layer will consist of two matrices:
-    // - one of dimensions 2x4 corresponding to the first polynomial's evaluations
-    // - one of dimensions 2x2 corresponding to the second polynomial's evaluations
+    // - one of dimensions 4x4 corresponding to the first polynomial's evaluations
+    // - one of dimensions 4x2 corresponding to the second polynomial's evaluations
 
     // The polynomial folding happens incrementally as follows: the first polynomial is folded
     // once so its number of evaluations is halved, the second polynomial's evaluations are added
-    // to that, and then the sum is folded further to reduce the number of evaluations to 2.
+    // to that, and then the sum is folded by 2 further to reduce the number of evaluations to 4.
 
     // At that point, the third polynomial's evaluations are added to the running sum, and that sum
-    // is committed to form the second FRI commitment layer. The only matrix in this layer is of
-    // dimensions 2x1
-
-    // TODO[osama]: update all heights above ^
+    // is committed to form the second FRI commitment layer. The only matrix in that layer is of
+    // dimensions 4x1. The final polynomial's evaluation can then be computed through those 4
+    // evaluations.
 
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -7,10 +7,8 @@ use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::{
-    dense::{DenseMatrix, RowMajorMatrix},
-    Matrix,
-};
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
+use p3_matrix::Matrix;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 use tracing::{debug, debug_span, info_span, instrument};
 

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -68,6 +68,7 @@ where
         commit_phase_commits: commit_phase_result.commits,
         query_proofs,
         final_poly: commit_phase_result.final_poly,
+        log_max_height,
         pow_witness,
     }
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -20,7 +20,7 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits, VecExt};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info_span, instrument};
+use tracing::{info_span, instrument};
 
 use crate::verifier::{self, FriError};
 use crate::{prover, FriConfig, FriGenericConfig, FriProof};
@@ -96,13 +96,6 @@ impl<F: TwoAdicField, InputProof, InputError: Debug> FriGenericConfig<F>
     }
 
     fn fold_matrix<M: Matrix<F>>(&self, beta: F, m: M) -> Vec<F> {
-        // TODO[osama]: remove extra info
-        debug!(
-            "folding matrix with dimensions: width: {}, height: {}",
-            m.width(),
-            m.height()
-        );
-
         // We use the fact that
         //     p_e(x^2) = (p(x) + p(-x)) / 2
         //     p_o(x^2) = (p(x) - p(-x)) / (2 x)

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -57,12 +57,7 @@ where
         return Err(FriError::InvalidPowWitness);
     }
 
-    // TODO[osama]: make sure this is correct
-    let log_max_height = proof.commit_phase_commits.len() * config.arity_bits
-        + config.log_blowup
-        + config.log_final_poly_len;
-
-    debug!("in verifier::verify, log_max_height: {:?}", log_max_height);
+    let log_max_height = proof.log_max_height;
 
     for qp in &proof.query_proofs {
         let index = challenger.sample_bits(log_max_height + g.extra_query_index_bits());
@@ -160,8 +155,6 @@ where
         for row in opening.opened_rows.iter().skip(1) {
             // TODO[osama]: consider adding an assert for the length of row to make sure the right thing is being read
             let (lh, ro) = ro_iter.next().unwrap();
-            debug!("lh: {:?}", lh);
-            debug!("row.len(): {:?}", row.len());
             let current_index = index >> (log_folded_height - lh);
             assert_eq!(
                 ro,
@@ -176,11 +169,9 @@ where
             .iter()
             .map(|opened_row| Dimensions {
                 width: opened_row.len(),
-                height: 1 << (log_folded_height - config.arity_bits), // TODO[osama]: revisit
+                height: 1 << (log_folded_height - config.arity_bits),
             })
             .collect();
-
-        debug!("dims: {:#?}", dims);
 
         config
             .mmcs
@@ -197,34 +188,26 @@ where
 
         let mut opened_rows_iter = opening.opened_rows.iter().peekable();
         let mut folded_row = opened_rows_iter.next().unwrap().clone();
-        let mut cnt = 1;
+        let mut index_folded_row = index_row << config.arity_bits;
         while folded_row.len() > 1 {
             index >>= 1;
             log_folded_height -= 1;
+            index_folded_row >>= 1;
 
-            debug!("folding iteration: folded.len(): {:?}", folded_row.len());
-
-            debug!("cnt: {:?}", cnt);
             // TODO[osama]: factor this out
             let folded_matrix = RowMajorMatrix::new(folded_row, 2);
             folded_row = folded_matrix
                 .par_rows()
                 .enumerate()
                 .map(|(i, row)| {
-                    debug!(
-                        "folding row at index: {:?}",
-                        (index_row << (config.arity_bits - cnt)) + i
-                    );
                     g.fold_row(
-                        (index_row << (config.arity_bits - cnt)) + i,
+                        index_folded_row + i,
                         log_folded_height,
                         beta,
                         row.into_iter(),
                     )
                 })
                 .collect();
-
-            cnt += 1;
 
             if let Some(poly_eval) = opened_rows_iter.next_if(|v| v.len() == folded_row.len()) {
                 izip!(&mut folded_row, poly_eval).for_each(|(f, v)| *f += *v);

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -226,7 +226,7 @@ where
 {
     let folded_matrix = RowMajorMatrix::new(evals, 2);
     folded_matrix
-        .par_rows()
+        .rows()
         .enumerate()
         .map(|(i, row)| g.fold_row(index + i, log_height, beta, row.into_iter()))
         .collect()

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -74,7 +74,7 @@ where
             config,
             index >> g.extra_query_index_bits(),
             izip!(
-                &betas,
+                betas.clone(),
                 &proof.commit_phase_commits,
                 &qp.commit_phase_openings
             ),
@@ -108,7 +108,7 @@ where
 }
 
 type CommitStep<'a, F, M> = (
-    &'a F,
+    F,
     &'a <M as Mmcs<F>>::Commitment,
     &'a CommitPhaseProofStep<F, M>,
 );
@@ -138,7 +138,7 @@ where
             folded_eval += ro;
         }
 
-        let (&beta, comm, opening) = steps.next().unwrap();
+        let (mut beta, comm, opening) = steps.next().unwrap();
 
         let index_row = index >> cur_arity_bits;
 
@@ -190,6 +190,7 @@ where
             index_folded_row >>= 1;
 
             folded_row = fold_partial_row(g, index_folded_row, log_folded_height, beta, folded_row);
+            beta = beta.square();
 
             if let Some(poly_eval) = opened_rows_iter.next_if(|v| v.len() == folded_row.len()) {
                 izip!(&mut folded_row, poly_eval).for_each(|(f, v)| *f += *v);

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -4,7 +4,8 @@ use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::{dense::RowMajorMatrix, Dimensions, Matrix};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::{Dimensions, Matrix};
 use p3_util::reverse_bits_len;
 use tracing::debug;
 

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,12 +1,12 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::Dimensions;
+use p3_matrix::{dense::RowMajorMatrix, Dimensions, Matrix};
 use p3_util::reverse_bits_len;
+use tracing::debug;
 
 use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof};
 
@@ -57,8 +57,12 @@ where
         return Err(FriError::InvalidPowWitness);
     }
 
-    let log_max_height =
-        proof.commit_phase_commits.len() + config.log_blowup + config.log_final_poly_len;
+    // TODO[osama]: make sure this is correct
+    let log_max_height = proof.commit_phase_commits.len() * config.arity_bits
+        + config.log_blowup
+        + config.log_final_poly_len;
+
+    debug!("in verifier::verify, log_max_height: {:?}", log_max_height);
 
     for qp in &proof.query_proofs {
         let index = challenger.sample_bits(log_max_height + g.extra_query_index_bits());
@@ -82,7 +86,7 @@ where
             log_max_height,
         )?;
 
-        let final_poly_index = index >> (proof.commit_phase_commits.len());
+        let final_poly_index = index >> (proof.commit_phase_commits.len() * config.arity_bits);
 
         let mut eval = Challenge::ZERO;
 
@@ -117,7 +121,7 @@ fn verify_query<'a, G, F, M>(
     g: &G,
     config: &FriConfig<M>,
     mut index: usize,
-    steps: impl Iterator<Item = CommitStep<'a, F, M>>,
+    mut steps: impl Iterator<Item = CommitStep<'a, F, M>>,
     reduced_openings: Vec<(usize, F)>,
     log_max_height: usize,
 ) -> Result<F, FriError<M::Error, G::InputError>>
@@ -126,38 +130,109 @@ where
     M: Mmcs<F> + 'a,
     G: FriGenericConfig<F>,
 {
+    debug!(
+        "verifying query proof, index: {:?}, reduced_openings: {:#?}",
+        index, reduced_openings
+    );
+
     let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
-    for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {
-        if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height + 1) {
+    let mut log_folded_height = log_max_height;
+
+    while log_folded_height > config.log_blowup + config.log_final_poly_len {
+        debug!(
+            "query iteration, log_folded_height: {:?}",
+            log_folded_height
+        );
+
+        if let Some((lh, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height) {
+            debug!("adding directly from reduced openings at lh: {:?}", lh);
             folded_eval += ro;
         }
 
-        let index_sibling = index ^ 1;
-        let index_pair = index >> 1;
+        let (&beta, comm, opening) = steps.next().unwrap();
 
-        let mut evals = vec![folded_eval; 2];
-        evals[index_sibling % 2] = opening.sibling_value;
+        let index_row = index >> config.arity_bits;
 
-        let dims = &[Dimensions {
-            width: 2,
-            height: 1 << log_folded_height,
-        }];
+        // Verify that `folded_eval` and evals from reduced_openings match opened_rows
+        assert_eq!(folded_eval, opening.opened_rows[0][index % config.arity()]);
+        for row in opening.opened_rows.iter().skip(1) {
+            // TODO[osama]: consider adding an assert for the length of row to make sure the right thing is being read
+            let (lh, ro) = ro_iter.next().unwrap();
+            debug!("lh: {:?}", lh);
+            debug!("row.len(): {:?}", row.len());
+            let current_index = index >> (log_folded_height - lh);
+            assert_eq!(
+                ro,
+                row[current_index % row.len()],
+                "reduced opening mismatch at level {:?}",
+                lh
+            );
+        }
+
+        let dims: Vec<_> = opening
+            .opened_rows
+            .iter()
+            .map(|opened_row| Dimensions {
+                width: opened_row.len(),
+                height: 1 << (log_folded_height - config.arity_bits), // TODO[osama]: revisit
+            })
+            .collect();
+
+        debug!("dims: {:#?}", dims);
+
         config
             .mmcs
             .verify_batch(
                 comm,
-                dims,
-                index_pair,
-                &[evals.clone()],
+                &dims,
+                index_row,
+                &opening.opened_rows,
                 &opening.opening_proof,
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
-        index = index_pair;
+        // Do the folding logic
 
-        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+        let mut opened_rows_iter = opening.opened_rows.iter().peekable();
+        let mut folded_row = opened_rows_iter.next().unwrap().clone();
+        let mut cnt = 1;
+        while folded_row.len() > 1 {
+            index >>= 1;
+            log_folded_height -= 1;
+
+            debug!("folding iteration: folded.len(): {:?}", folded_row.len());
+
+            debug!("cnt: {:?}", cnt);
+            // TODO[osama]: factor this out
+            let folded_matrix = RowMajorMatrix::new(folded_row, 2);
+            folded_row = folded_matrix
+                .par_rows()
+                .enumerate()
+                .map(|(i, row)| {
+                    debug!(
+                        "folding row at index: {:?}",
+                        (index_row << (config.arity_bits - cnt)) + i
+                    );
+                    g.fold_row(
+                        (index_row << (config.arity_bits - cnt)) + i,
+                        log_folded_height,
+                        beta,
+                        row.into_iter(),
+                    )
+                })
+                .collect();
+
+            cnt += 1;
+
+            if let Some(poly_eval) = opened_rows_iter.next_if(|v| v.len() == folded_row.len()) {
+                izip!(&mut folded_row, poly_eval).for_each(|(f, v)| *f += *v);
+            }
+        }
+
+        folded_eval = folded_row.remove(0);
+        assert!(folded_row.is_empty());
     }
 
     debug_assert!(

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -7,7 +7,6 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Dimensions, Matrix};
 use p3_util::reverse_bits_len;
-use tracing::debug;
 
 use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof};
 
@@ -126,24 +125,13 @@ where
     M: Mmcs<F> + 'a,
     G: FriGenericConfig<F>,
 {
-    debug!(
-        "verifying query proof, index: {:?}, reduced_openings: {:#?}",
-        index, reduced_openings
-    );
-
     let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
     let mut log_folded_height = log_max_height;
 
     while log_folded_height > config.log_blowup + config.log_final_poly_len {
-        debug!(
-            "query iteration, log_folded_height: {:?}",
-            log_folded_height
-        );
-
-        if let Some((lh, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height) {
-            debug!("adding directly from reduced openings at lh: {:?}", lh);
+        if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height) {
             folded_eval += ro;
         }
 

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -39,6 +39,8 @@ fn get_ldt_for_testing<R: Rng>(rng: &mut R, log_final_poly_len: usize) -> (Perm,
         log_final_poly_len,
         num_queries: 10,
         proof_of_work_bits: 8,
+        // TODO[osama]: have tests with higher fri arity
+        arity_bits: 2,
         mmcs,
     };
     (perm, fri_config)
@@ -129,10 +131,15 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R, log_final_poly_len: usize) {
 
 #[test]
 fn test_fri_ldt() {
+    // TODO[osama]: delete this and delete form cargo.toml
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
+
     // FRI is kind of flaky depending on indexing luck
-    for i in 0..4 {
+    for i in 0..2 {
         let mut rng = ChaCha20Rng::seed_from_u64(i as u64);
-        do_test_fri_ldt(&mut rng, i + 1);
+        do_test_fri_ldt(&mut rng, i + 1); // TODO[osama]: can log_final_poly_len be 0?
     }
 }
 

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -181,7 +181,6 @@ mod babybear_fri_pcs {
             log_final_poly_len: 0,
             num_queries: 10,
             proof_of_work_bits: 8,
-            // TODO[osama]: have tests with higher fri arity
             arity_bits: 1,
             mmcs: challenge_mmcs,
         };
@@ -225,7 +224,7 @@ mod m31_fri_pcs {
 
     type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
 
-    fn get_pcs(log_blowup: usize) -> (Pcs, Challenger) {
+    fn get_pcs(arity_bits: usize, log_blowup: usize) -> (Pcs, Challenger) {
         let byte_hash = ByteHash {};
         let field_hash = FieldHash::new(byte_hash);
         let compress = MyCompress::new(byte_hash);
@@ -236,8 +235,7 @@ mod m31_fri_pcs {
             log_final_poly_len: 0,
             num_queries: 10,
             proof_of_work_bits: 8,
-            // TODO[osama]: add tests with higher fri arity
-            arity_bits: 1,
+            arity_bits,
             mmcs: challenge_mmcs,
         };
         let pcs = Pcs {
@@ -249,9 +247,17 @@ mod m31_fri_pcs {
     }
 
     mod blowup_1 {
-        make_tests_for_pcs!(super::get_pcs(1));
+        make_tests_for_pcs!(super::get_pcs(1, 1));
     }
     mod blowup_2 {
-        make_tests_for_pcs!(super::get_pcs(2));
+        make_tests_for_pcs!(super::get_pcs(1, 2));
+    }
+
+    mod arity_4 {
+        make_tests_for_pcs!(super::get_pcs(2, 2));
+    }
+
+    mod arity_8 {
+        make_tests_for_pcs!(super::get_pcs(3, 2));
     }
 }

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -181,6 +181,8 @@ mod babybear_fri_pcs {
             log_final_poly_len: 0,
             num_queries: 10,
             proof_of_work_bits: 8,
+            // TODO[osama]: have tests with higher fri arity
+            arity_bits: 1,
             mmcs: challenge_mmcs,
         };
 
@@ -234,6 +236,8 @@ mod m31_fri_pcs {
             log_final_poly_len: 0,
             num_queries: 10,
             proof_of_work_bits: 8,
+            // TODO[osama]: add tests with higher fri arity
+            arity_bits: 1,
             mmcs: challenge_mmcs,
         };
         let pcs = Pcs {

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::cmp::Reverse;
 use core::marker::PhantomData;
-use tracing::debug;
 
 use itertools::Itertools;
 use p3_commit::Mmcs;

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -82,9 +82,6 @@ where
         index: usize,
         prover_data: &MerkleTree<P::Value, PW::Value, M, DIGEST_ELEMS>,
     ) -> (Vec<Vec<P::Value>>, Vec<[PW::Value; DIGEST_ELEMS]>) {
-        // TODO[osama]: delete this
-        debug!("opening batch with index: {}", index);
-
         let max_height = self.get_max_height(prover_data);
         let log_max_height = log2_ceil_usize(max_height);
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use core::cmp::Reverse;
 use core::marker::PhantomData;
+use tracing::debug;
 
 use itertools::Itertools;
 use p3_commit::Mmcs;
@@ -81,6 +82,9 @@ where
         index: usize,
         prover_data: &MerkleTree<P::Value, PW::Value, M, DIGEST_ELEMS>,
     ) -> (Vec<Vec<P::Value>>, Vec<[PW::Value; DIGEST_ELEMS]>) {
+        // TODO[osama]: delete this
+        debug!("opening batch with index: {}", index);
+
         let max_height = self.get_max_height(prover_data);
         let log_max_height = log2_ceil_usize(max_height);
 

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -219,6 +219,7 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         log_final_poly_len: 5,
         num_queries: 40,
         proof_of_work_bits: 8,
+        arity_bits: 1,
         mmcs: challenge_mmcs,
     };
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
@@ -280,6 +281,7 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         log_final_poly_len: 0,
         num_queries: 40,
         proof_of_work_bits: 8,
+        arity_bits: 1,
         mmcs: challenge_mmcs,
     };
 


### PR DESCRIPTION
Added support for FRI higher folding arity that can be configured in `FriConfig`.

Some implementation details: the scheme is mostly the same, but now there are fewer FRI commitment layers, and every commitment could include multiple matrices. The running `folded` matrix is still committed to in every FRI commitment layer, but the evaluations of the input polynomials that enter between the commitment layers are now also included in the commitment. The verifier uses the `folded` matrix from the commitment and the evaluations of the other input polynomials needed (that also are in the commitment) to compute the expected value in the following commitment layer.

Here is an example illustrating the commitment layers' shapes and the folding (included in fri/src/prover.rs).
```
Suppose `inputs` consists of three polynomials with degrees 16, 8, and 4, and
suppose that arity = 4 and final_poly_len = 1.
There will be two FRI commitment layers: one at height 16 and one at height 4.

The first commitment layer will consist of two matrices:
- one of dimensions 4x4 corresponding to the first polynomial's evaluations
- one of dimensions 4x2 corresponding to the second polynomial's evaluations

The polynomial folding happens incrementally as follows: the first polynomial is folded
once so its number of evaluations is halved, the second polynomial's evaluations are added
to that, and then the sum is folded by 2 further to reduce the number of evaluations to 4.

At that point, the third polynomial's evaluations are added to the running sum, and that sum
is committed to form the second FRI commitment layer. The only matrix in that layer is of
dimensions 4x1. The final polynomial's evaluation can then be computed through those 4
evaluations.
```