### PR TITLE
documentation grammar

### DIFF
--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -61,7 +61,7 @@ fn convert_to_vec_neg_form(input: i32) -> __m256i {
 
 impl Poseidon2InternalLayerMersenne31 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31 from a vector containing
-    /// the constants for each round. Internally, the constants are transformed into th
+    /// the constants for each round. Internally, the constants are transformed into the
     /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         let packed_internal_constants = internal_constants
@@ -76,7 +76,7 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {


### PR DESCRIPTION

Changes in mersenne-31/src/x86_64_avx2/poseidon2.rs

"into th" -> "into the"
"from a array" -> "from an array"