### PR TITLE
Optimize bit reversal

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,3 +6,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -9,3 +9,8 @@ serde.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "bit_reverse"
+harness = false

--- a/util/benches/bit_reverse.rs
+++ b/util/benches/bit_reverse.rs
@@ -1,0 +1,38 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use p3_util::{reverse_bits, reverse_slice_index_bits};
+use rand::{thread_rng, Rng};
+
+fn bench_reverse_bits(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reverse_bits");
+    for log_size in [1, 3, 5, 8, 16, 24] {
+        let bits = 1 << log_size;
+        group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |b, &bits| {
+            let n = 1 << bits;
+            let x = thread_rng().gen_range(0..n);
+            b.iter(|| {
+                black_box(reverse_bits(black_box(x), black_box(n)));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_reverse_slice_index_bits(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reverse_slice_index_bits");
+    for log_size in [1, 3, 5, 8, 16, 24] {
+        let size = 1 << log_size;
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let mut rng = thread_rng();
+            let data: Vec<u64> = (0..size).map(|_| rng.gen()).collect();
+            b.iter(|| {
+                let mut test_data = data.clone();
+                reverse_slice_index_bits(black_box(&mut test_data));
+                black_box(test_data)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_reverse_bits, bench_reverse_slice_index_bits);
+criterion_main!(benches); 

--- a/util/benches/bit_reverse.rs
+++ b/util/benches/bit_reverse.rs
@@ -35,4 +35,4 @@ fn bench_reverse_slice_index_bits(c: &mut Criterion) {
 }
 
 criterion_group!(benches, bench_reverse_bits, bench_reverse_slice_index_bits);
-criterion_main!(benches); 
+criterion_main!(benches);

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -163,7 +163,9 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
         for src in 0..vals.len() {
             let dst = (BIT_REVERSE_6BIT[src] as usize).wrapping_shr(dst_shr_amt);
             if src < dst {
-                vals.swap(src, dst);
+                unsafe {
+                    core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
+                }
             }
         }
     } else {
@@ -181,7 +183,9 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
                 let src = src_hi + src_lo;
                 let dst = dst_hi + dst_lo;
                 if src < dst {
-                    vals.swap(src, dst);
+                    unsafe {
+                        core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
+                    }
                 }
             }
         }
@@ -194,7 +198,9 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     for src in 0..vals.len() {
         let dst = src.reverse_bits().wrapping_shr(usize::BITS - lb_n as u32);
         if src < dst {
-            vals.swap(src, dst);
+            unsafe {
+                core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
+            }
         }
     }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -13,6 +13,7 @@ use core::mem::MaybeUninit;
 
 pub mod array_serialization;
 pub mod linear_map;
+pub mod transpose;
 
 /// Computes `ceil(log_2(n))`.
 #[must_use]
@@ -230,14 +231,7 @@ unsafe fn transpose_in_place_square<T>(
     lb_num_chunks: usize,
     offset: usize,
 ) {
-    let n = 1 << lb_num_chunks;
-    for i in 0..n {
-        for j in 0..i {
-            let a = offset + (i << lb_chunk_size) + j;
-            let b = offset + (j << lb_chunk_size) + i;
-            core::ptr::swap(arr.get_unchecked_mut(a), arr.get_unchecked_mut(b));
-        }
-    }
+    transpose::transpose_in_place_square(arr, lb_chunk_size, lb_num_chunks, offset)
 }
 
 #[inline(always)]

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -163,9 +163,7 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
         for src in 0..vals.len() {
             let dst = (BIT_REVERSE_6BIT[src] as usize).wrapping_shr(dst_shr_amt);
             if src < dst {
-                unsafe {
-                    core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
-                }
+                vals.swap(src, dst);
             }
         }
     } else {
@@ -183,9 +181,7 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
                 let src = src_hi + src_lo;
                 let dst = dst_hi + dst_lo;
                 if src < dst {
-                    unsafe {
-                        core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
-                    }
+                    vals.swap(src, dst);
                 }
             }
         }
@@ -198,9 +194,7 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     for src in 0..vals.len() {
         let dst = src.reverse_bits().wrapping_shr(usize::BITS - lb_n as u32);
         if src < dst {
-            unsafe {
-                core::ptr::swap(vals.get_unchecked_mut(src), vals.get_unchecked_mut(dst));
-            }
+            vals.swap(src, dst);
         }
     }
 }

--- a/util/src/transpose.rs
+++ b/util/src/transpose.rs
@@ -1,0 +1,112 @@
+use core::ptr::swap;
+
+const LB_BLOCK_SIZE: usize = 3;
+
+/// Transpose square matrix in-place
+/// The matrix is of size `1 << lb_size` by `1 << lb_size`. It occupies
+/// `M[i, j] == arr[(i + x << lb_stride) + j + x]` for `0 <= i, j < 1 << lb_size`. The transposition
+/// swaps `M[i, j]` and `M[j, i]`.
+///
+/// SAFETY:
+/// Make sure that `(i + x << lb_stride) + j + x` is a valid index in `arr` for all
+/// `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to prevent overlap.
+unsafe fn transpose_in_place_square_small<T>(
+    arr: &mut [T],
+    lb_stride: usize,
+    lb_size: usize,
+    x: usize,
+) {
+    for i in x + 1..x + (1 << lb_size) {
+        for j in x..i {
+            swap(
+                arr.get_unchecked_mut(i + (j << lb_stride)),
+                arr.get_unchecked_mut((i << lb_stride) + j),
+            );
+        }
+    }
+}
+
+/// Transpose square matrices and swap
+/// The matrices are of size `1 << lb_size` by `1 << lb_size`. They occupy
+/// `M0[i, j] == arr[(i + x << lb_stride) + j + y]`, `M1[i, j] == arr[i + x + (j + y << lb_stride)]`
+/// for `0 <= i, j < 1 << lb_size. The transposition swaps `M0[i, j]` and `M1[j, i]`.
+///
+/// SAFETY:
+/// Make sure that `(i + x << lb_stride) + j + y` and `i + x + (j + y << lb_stride)` are valid
+/// indices in `arr` for all `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to
+/// prevent overlap.
+unsafe fn transpose_swap_square_small<T>(
+    arr: &mut [T],
+    lb_stride: usize,
+    lb_size: usize,
+    x: usize,
+    y: usize,
+) {
+    for i in x..x + (1 << lb_size) {
+        for j in y..y + (1 << lb_size) {
+            swap(
+                arr.get_unchecked_mut(i + (j << lb_stride)),
+                arr.get_unchecked_mut((i << lb_stride) + j),
+            );
+        }
+    }
+}
+
+/// Transpose square matrices and swap
+/// The matrices are of size `1 << lb_size` by `1 << lb_size`. They occupy
+/// `M0[i, j] == arr[(i + x << lb_stride) + j + y]`, `M1[i, j] == arr[i + x + (j + y << lb_stride)]`
+/// for `0 <= i, j < 1 << lb_size. The transposition swaps `M0[i, j]` and `M1[j, i]`.
+///
+/// SAFETY:
+/// Make sure that `(i + x << lb_stride) + j + y` and `i + x + (j + y << lb_stride)` are valid
+/// indices in `arr` for all `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to
+/// prevent overlap.
+unsafe fn transpose_swap_square<T>(
+    arr: &mut [T],
+    lb_stride: usize,
+    lb_size: usize,
+    x: usize,
+    y: usize,
+) {
+    if lb_size <= LB_BLOCK_SIZE {
+        transpose_swap_square_small(arr, lb_stride, lb_size, x, y);
+    } else {
+        let lb_block_size = lb_size - 1;
+        let block_size = 1 << lb_block_size;
+        transpose_swap_square(arr, lb_stride, lb_block_size, x, y);
+        transpose_swap_square(arr, lb_stride, lb_block_size, x + block_size, y);
+        transpose_swap_square(arr, lb_stride, lb_block_size, x, y + block_size);
+        transpose_swap_square(
+            arr,
+            lb_stride,
+            lb_block_size,
+            x + block_size,
+            y + block_size,
+        );
+    }
+}
+
+/// Transpose square matrix in-place
+/// The matrix is of size `1 << lb_size` by `1 << lb_size`. It occupies
+/// `M[i, j] == arr[(i + x << lb_stride) + j + x]` for `0 <= i, j < 1 << lb_size`. The transposition
+/// swaps `M[i, j]` and `M[j, i]`.
+///
+/// SAFETY:
+/// Make sure that `(i + x << lb_stride) + j + x` is a valid index in `arr` for all
+/// `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to prevent overlap.
+pub(crate) unsafe fn transpose_in_place_square<T>(
+    arr: &mut [T],
+    lb_stride: usize,
+    lb_size: usize,
+    x: usize,
+) {
+    if lb_size <= LB_BLOCK_SIZE {
+        transpose_in_place_square_small(arr, lb_stride, lb_size, x);
+    } else {
+        let lb_block_size = lb_size - 1;
+        let block_size = 1 << lb_block_size;
+        transpose_in_place_square(arr, lb_stride, lb_block_size, x);
+        transpose_swap_square(arr, lb_stride, lb_block_size, x, x + block_size);
+        transpose_in_place_square(arr, lb_stride, lb_block_size, x + block_size);
+    }
+}


### PR DESCRIPTION
This imports the bit reversal implementation from Plonky2, focusing on `reverse_slice_index_bits`. FIxes #444.
This also imports some unit tests on the edge cases of `log2_strict_usize`, which were in the same file.

I have not tuned `BIG_T_SIZE` and `SMALL_ARR_SIZE` currently set for a rather conservative 64KB L1.
Values for bench machines are for M3 Max:
```
huitseeker@binky➜tmp/plonky3/util(add_tests)» sysctl -a | grep -Ee 'hw\.l[12].*?cachesize'                                                                                                                                          
hw.l1icachesize: 131072
hw.l1dcachesize: 65536
hw.l2cachesize: 4194304
```
For Ryzen 9950X:
```
huitseeker@sleipnir➜huitseeker/tmp/plonky3(add_tests)» lscpu | grep "cache"                                                                                                                                                        
L1d cache:                            768 KiB (16 instances)
L1i cache:                            512 KiB (16 instances)
L2 cache:                             16 MiB (16 instances)
L3 cache:                             64 MiB (2 instances)
```
(the later compiled with `target-cpu=native`)

~~As the benches are mitigated on performance (considering the priority of x86_64), I'm happy to revert to the more Pareto-efficient 1419ae529dc77decad50cfa70e60afbbf72af9f4.~~ (see [this comment](https://github.com/Plonky3/Plonky3/pull/596#issuecomment-2598437978))

<details><summary>Benches on 1419ae529dc77decad50cfa70e60afbbf72af9f4 (toggle me!) </summary>

**x86_64 benches (Ryzen 9 9950X)**:

```
reverse_bits/2          time:   [554.71 ps 554.73 ps 554.76 ps]
                        change: [+0.0497% +0.0697% +0.0897%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_bits/8          time:   [555.11 ps 555.22 ps 555.37 ps]
                        change: [+5.0627% +5.1082% +5.1658%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/32         time:   [530.03 ps 530.37 ps 530.77 ps]
                        change: [+0.1313% +0.1753% +0.2252%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_bits/256        time:   [554.59 ps 554.62 ps 554.65 ps]
                        change: [+4.9471% +4.9616% +4.9781%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/65536      time:   [554.67 ps 554.70 ps 554.73 ps]
                        change: [+4.5514% +4.5659% +4.5803%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/16777216   time:   [529.43 ps 530.02 ps 530.60 ps]
                        change: [-4.9272% -4.8555% -4.7821%] (p = 0.00 < 0.05)
                        Performance has improved.

reverse_slice_index_bits/2
                        time:   [7.7681 ns 7.7864 ns 7.8056 ns]
                        change: [-0.0547% +0.2431% +0.5594%] (p = 0.14 > 0.05)
                        No change in performance detected.
reverse_slice_index_bits/8
                        time:   [9.3444 ns 9.3565 ns 9.3694 ns]
                        change: [-4.7702% -4.5714% -4.3713%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/32
                        time:   [16.041 ns 16.047 ns 16.053 ns]
                        change: [-15.261% -15.012% -14.785%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/256
                        time:   [98.456 ns 98.489 ns 98.524 ns]
                        change: [-47.381% -47.127% -46.867%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/65536
                        time:   [205.94 µs 205.97 µs 205.99 µs]
                        change: [-0.3076% -0.2808% -0.2556%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking reverse_slice_index_bits/16777216: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.4s, or reduce sample count to 30.
reverse_slice_index_bits/16777216
                        time:   [162.85 ms 163.16 ms 163.53 ms]
                        change: [-3.3245% -3.1013% -2.8419%] (p = 0.00 < 0.05)
                        Performance has improved.
```

**aarch64 benches (M3 Max)**:

```
reverse_bits/2          time:   [649.86 ps 654.88 ps 658.72 ps]
                        change: [-1.6618% -0.9119% -0.2410%] (p = 0.01 < 0.05)
                        Change within noise threshold.
reverse_bits/8          time:   [657.96 ps 660.17 ps 662.11 ps]
                        change: [+0.0576% +0.3996% +0.7267%] (p = 0.02 < 0.05)
                        Change within noise threshold.
reverse_bits/32         time:   [658.14 ps 660.56 ps 662.78 ps]
                        change: [-0.2617% +0.1755% +0.6037%] (p = 0.43 > 0.05)
                        No change in performance detected.
reverse_bits/256        time:   [606.35 ps 619.43 ps 632.47 ps]
                        change: [+13.039% +14.560% +16.052%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/65536      time:   [578.02 ps 589.20 ps 601.88 ps]
                        change: [+8.9996% +10.968% +12.852%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/16777216   time:   [555.35 ps 556.69 ps 558.12 ps]
                        change: [-4.8527% -3.3453% -1.9049%] (p = 0.00 < 0.05)
                        Performance has improved.

reverse_slice_index_bits/2
                        time:   [15.511 ns 15.543 ns 15.576 ns]
                        change: [+1.7267% +1.9085% +2.0940%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/8
                        time:   [21.351 ns 21.396 ns 21.441 ns]
                        change: [+0.1883% +0.5824% +0.9700%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_slice_index_bits/32
                        time:   [35.606 ns 35.680 ns 35.759 ns]
                        change: [+10.806% +11.128% +11.422%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/256
                        time:   [200.90 ns 201.90 ns 202.83 ns]
                        change: [+40.215% +40.784% +41.378%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/65536
                        time:   [144.72 µs 144.96 µs 145.18 µs]
                        change: [+2.8216% +3.3257% +3.8254%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking reverse_slice_index_bits/16777216: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.8s, or reduce sample count to 40.
reverse_slice_index_bits/16777216
                        time:   [107.27 ms 107.65 ms 108.07 ms]
                        change: [+0.6871% +1.4264% +2.1466%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```
</details>

<details><summary>Benches on bc711ef22cd342dcf007ccb7031d201789a3ee1d (toggle me!)</summary>

**x86 benches (Ryzen 9 9950X):**

```
reverse_bits/2          time:   [554.25 ps 554.27 ps 554.30 ps]
                        change: [+0.2328% +0.2456% +0.2576%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_bits/8          time:   [554.39 ps 554.41 ps 554.44 ps]
                        change: [+4.7186% +4.7534% +4.7817%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/32         time:   [554.67 ps 554.69 ps 554.72 ps]
                        change: [+4.7319% +4.7471% +4.7608%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_bits/256        time:   [529.74 ps 529.76 ps 529.78 ps]
                        change: [+0.1329% +0.1951% +0.2496%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_bits/65536      time:   [552.72 ps 553.38 ps 553.94 ps]
                        change: [-1.7682% -1.4123% -0.9860%] (p = 0.00 < 0.05)
                        Change within noise threshold.
reverse_bits/16777216   time:   [554.71 ps 554.74 ps 554.78 ps]
                        change: [+0.1098% +0.1230% +0.1354%] (p = 0.00 < 0.05)
                        Change within noise threshold.

reverse_slice_index_bits/2
                        time:   [7.7281 ns 7.7405 ns 7.7534 ns]
                        change: [+1.2297% +1.7211% +2.2094%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/8
                        time:   [9.1964 ns 9.2168 ns 9.2380 ns]
                        change: [-6.5340% -6.3151% -6.0937%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/32
                        time:   [16.022 ns 16.030 ns 16.040 ns]
                        change: [-17.666% -17.372% -17.082%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/256
                        time:   [97.458 ns 97.495 ns 97.536 ns]
                        change: [-45.120% -44.876% -44.633%] (p = 0.00 < 0.05)
                        Performance has improved.
reverse_slice_index_bits/65536
                        time:   [200.46 µs 200.56 µs 200.63 µs]
                        change: [+0.9489% +0.9977% +1.0456%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking reverse_slice_index_bits/16777216: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 29.1s, or reduce sample count to 10.
reverse_slice_index_bits/16777216
                        time:   [268.27 ms 269.06 ms 269.92 ms]
                        change: [+65.295% +65.787% +66.340%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

**aarch64 benches (M3 Max)**:

```
reverse_bits/2          time:   [658.53 ps 659.63 ps 660.85 ps]
                        change: [-0.3605% +0.2031% +0.8141%] (p = 0.52 > 0.05)
                        No change in performance detected.
reverse_bits/8          time:   [657.96 ps 658.89 ps 659.89 ps]
                        change: [-0.4917% -0.1500% +0.2002%] (p = 0.40 > 0.05)
                        No change in performance detected.
reverse_bits/32         time:   [651.35 ps 656.26 ps 659.17 ps]
                        change: [-0.9491% -0.5186% -0.0554%] (p = 0.02 < 0.05)
                        Change within noise threshold.
reverse_bits/256        time:   [639.64 ps 648.70 ps 655.37 ps]
                        change: [-3.6259% -1.7284% +0.2640%] (p = 0.09 > 0.05)
                        No change in performance detected.
reverse_bits/65536      time:   [621.40 ps 631.53 ps 639.65 ps]
                        change: [+0.1756% +2.4584% +4.7819%] (p = 0.04 < 0.05)
                        Change within noise threshold.
reverse_bits/16777216   time:   [641.48 ps 647.11 ps 651.37 ps]
                        change: [-2.1677% +0.1160% +2.3395%] (p = 0.93 > 0.05)
                        No change in performance detected.

reverse_slice_index_bits/2
                        time:   [15.593 ns 15.644 ns 15.706 ns]
                        change: [+1.1210% +1.6573% +2.1595%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/8
                        time:   [21.113 ns 21.153 ns 21.203 ns]
                        change: [+0.2235% +0.7705% +1.2916%] (p = 0.01 < 0.05)
                        Change within noise threshold.
reverse_slice_index_bits/32
                        time:   [33.069 ns 33.174 ns 33.311 ns]
                        change: [+2.0886% +2.4791% +2.8463%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/256
                        time:   [150.98 ns 152.05 ns 153.30 ns]
                        change: [+4.3236% +4.9794% +5.6499%] (p = 0.00 < 0.05)
                        Performance has regressed.
reverse_slice_index_bits/65536
                        time:   [120.80 µs 121.13 µs 121.46 µs]
                        change: [-15.077% -14.663% -14.249%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking reverse_slice_index_bits/16777216: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.3s, or reduce sample count to 70.
reverse_slice_index_bits/16777216
                        time:   [62.464 ms 62.634 ms 62.829 ms]
                        change: [-41.714% -41.338% -40.973%] (p = 0.00 < 0.05)
                        Performance has improved.
```

</details>