### PR TITLE
fix: revert behavior of `MultiField32Challenger::sample_bits`

### DIFF
--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -185,7 +185,7 @@ where
         debug_assert!(bits < (usize::BITS as usize));
         debug_assert!((1 << bits) < F::ORDER_U32);
         let rand_f: F = self.sample();
-        let rand_usize = rand_f.to_unique_u32() as usize;
+        let rand_usize = rand_f.as_canonical_u32() as usize;
         rand_usize & ((1 << bits) - 1)
     }
 }


### PR DESCRIPTION
I noticed a change in behavior in `MultiField32Challenger::sample_bits` after recent `FieldAlgebra` refactors.

This line https://github.com/Plonky3/Plonky3/blob/784b7dd1fa87c1202e63350cc8182d7c5327a7af/challenger/src/multi_field_challenger.rs#L188 has been changed to use `to_unique_u32()`, which for Monty31 fields will use the monty reduced form and not the canonical form for bit sampling.

Since the main use case (AFAIK) of `MultiField32Challenger` is when you need to embed 31-bit fields into larger fields like `Bn254Fr`, it is very unwieldy to have to work with the Montgomery form. For example, I noticed this behavior when trying to update the plonky3 commit and it changed the FRI verifier's behavior.

I looked through the current other uses of `to_unique_u32` and I agree the use in `SerializingHasher` makes sense and provides a nice speedup. But in the `MultiField32Challenger` case, since I don't believe the grinding is a big performance factor, it would make verification a lot more convenient if we reverted back to using `as_canonical_u32` here.