### PR TITLE
Better error management in mmcs/two_adic_pcs

### DIFF
--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -8,8 +8,10 @@ use crate::BabyBearParameters;
 const WIDTH: usize = 4;
 
 impl MontyParametersNeon for BabyBearParameters {
+    // SAFETY: This is a valid packed representation of P.
     const PACKED_P: uint32x4_t = unsafe { transmute::<[u32; WIDTH], _>([0x78000001; WIDTH]) };
     // This MU is the same 0x88000001 as elsewhere, just interpreted as an `i32`.
+    // SAFETY: This is a valid packed representation of MU.
     const PACKED_MU: int32x4_t = unsafe { transmute::<[i32; WIDTH], _>([-0x77ffffff; WIDTH]) };
 }
 

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -137,6 +137,8 @@ where
         )
     }
 
+    // This is a testing function, so we allow panics for convenience.
+    #[allow(clippy::panic_in_result_fn)]
     fn verify(
         &self,
         // For each round:

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -389,18 +389,29 @@ where
                     .map(|&height| Dimensions { width: 0, height })
                     .collect_vec();
 
-                let batch_max_height = batch_heights.iter().max().expect("Empty batch?");
-                let log_batch_max_height = log2_strict_usize(*batch_max_height);
-                let bits_reduced = log_global_max_height - log_batch_max_height;
-                let reduced_index = index >> bits_reduced;
+                if let Some(batch_max_height) = batch_heights.iter().max() {
+                    let log_batch_max_height = log2_strict_usize(*batch_max_height);
+                    let bits_reduced = log_global_max_height - log_batch_max_height;
+                    let reduced_index = index >> bits_reduced;
 
-                self.mmcs.verify_batch(
-                    batch_commit,
-                    &batch_dims,
-                    reduced_index,
-                    &batch_opening.opened_values,
-                    &batch_opening.opening_proof,
-                )?;
+                    self.mmcs.verify_batch(
+                        batch_commit,
+                        &batch_dims,
+                        reduced_index,
+                        &batch_opening.opened_values,
+                        &batch_opening.opening_proof,
+                    )?;
+                } else {
+                    // Empty batch?
+                    self.mmcs.verify_batch(
+                        batch_commit,
+                        &[],
+                        0,
+                        &batch_opening.opened_values,
+                        &batch_opening.opening_proof,
+                    )?;
+                }
+
                 for (mat_opening, (mat_domain, mat_points_and_values)) in
                     izip!(&batch_opening.opened_values, mats)
                 {
@@ -442,8 +453,7 @@ where
                 .rev()
                 .map(|(log_height, (_alpha_pow, ro))| (log_height, ro))
                 .collect())
-        })
-        .expect("fri err");
+        })?;
 
         Ok(())
     }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -442,9 +442,8 @@ where
             // `reduced_openings` would have a log_height = log_blowup entry only if there was a
             // trace matrix of height 1. In this case the reduced opening can be skipped as it will
             // not be checked against any commit phase commit.
-            #[cfg(debug_assertions)]
             if let Some((_alpha_pow, ro)) = reduced_openings.remove(&self.fri.log_blowup) {
-                debug_assert!(ro.is_zero());
+                assert!(ro.is_zero());
             }
 
             // Return reduced openings descending by log_height.

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -431,6 +431,7 @@ where
             // `reduced_openings` would have a log_height = log_blowup entry only if there was a
             // trace matrix of height 1. In this case the reduced opening can be skipped as it will
             // not be checked against any commit phase commit.
+            #[cfg(debug_assertions)]
             if let Some((_alpha_pow, ro)) = reduced_openings.remove(&self.fri.log_blowup) {
                 debug_assert!(ro.is_zero());
             }

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -11,7 +11,7 @@ use p3_util::log2_ceil_usize;
 use serde::{Deserialize, Serialize};
 
 use crate::MerkleTree;
-use crate::MerkleTreeError::{RootMismatch, WrongBatchSize, WrongHeight};
+use crate::MerkleTreeError::{EmptyBatch, RootMismatch, WrongBatchSize, WrongHeight};
 
 /// A vector commitment scheme backed by a `MerkleTree`.
 ///
@@ -36,6 +36,7 @@ pub enum MerkleTreeError {
         num_siblings: usize,
     },
     RootMismatch,
+    EmptyBatch,
 }
 
 impl<P, PW, H, C, const DIGEST_ELEMS: usize> MerkleTreeMmcs<P, PW, H, C, DIGEST_ELEMS> {
@@ -132,7 +133,7 @@ where
         // TODO: Disabled for now, CirclePcs sometimes passes a height that's off by 1 bit.
         let Some(max_height) = dimensions.iter().map(|dim| dim.height).max() else {
             // dimensions is empty
-            return Err(MerkleTreeError::WrongWidth);
+            return Err(EmptyBatch);
         };
         let log_max_height = log2_ceil_usize(max_height);
         if proof.len() != log_max_height {


### PR DESCRIPTION
This eliminates a few sources of panics in the API, notably this removes an `.expect("fri error")` at the end of a failing call to `<TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::verify`. T

Contributes to #168.
