### PR TITLE
Fix typos across multiple modules

### DIFF
--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -11,7 +11,7 @@
 //! [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/2^27, -1/2^8, -1/16, -1/2^27].
 //! Optimized Diagonal for BabyBear24:
 //! [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/16, 1/2^7, 1/2^9, 1/2^27, -1/2^8, -1/4, -1/8, -1/16, -1/32, -1/64, -1/2^7, -1/2^27]
-//! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
+//! See poseidon2\src\diffusion.rs for information on how to double-check these matrices in Sage.
 
 use core::ops::Mul;
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -253,7 +253,7 @@ pub trait FieldAlgebra:
     }
 
     /// Allocates a vector of zero elements of length `len`. Many operating systems zero pages
-    /// before assigning them to a userspace process. In that case, our process should not need to
+    /// before assigning them to an userspace process. In that case, our process should not need to
     /// write zeros, which would be redundant. However, the compiler may not always recognize this.
     ///
     /// In particular, `vec![Self::ZERO; len]` appears to result in redundant userspace zeroing.

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -11,7 +11,7 @@
 //! [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/8, 1/2^24, -1/2^8, -1/8, -1/16, -1/2^24]
 //! Optimized Diagonal for KoalaBear24:
 //! [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/16, 1/32, 1/64, 1/2^24, -1/2^8, -1/8, -1/16, -1/32, -1/64, -1/2^7, -1/2^9, -1/2^24]
-//! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
+//! See poseidon2\src\diffusion.rs for information on how to double-check these matrices in Sage.
 
 use core::ops::Mul;
 

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -11,7 +11,7 @@
 //! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13,  2^14,  2^15, 2^16]
 //! Optimized Diagonal for Mersenne31 width 24:
 //! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13,  2^14,  2^15,  2^16,   2^17,   2^18,   2^19,    2^20,    2^21,    2^22]
-//! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
+//! See poseidon2\src\diffusion.rs for information on how to double-check these matrices in Sage.
 
 use core::ops::Mul;
 

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -76,7 +76,7 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -74,7 +74,7 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {


### PR DESCRIPTION
This PR fixes several typos and improves grammatical correctness across multiple modules. Below are the changes made:

- **`field.rs`**: Replaced "a userspace process" with "an userspace process" for grammatical correctness.
- **`poseidon2.rs`** (in multiple locations):
  - Updated "double check" to "double-check" for consistency and correctness.
  - Adjusted "a array" to "an array" in relevant contexts.
- **Modules affected**:
  - `baby-bear/src/poseidon2.rs`
  - `field/src/field.rs`
  - `koala-bear/src/poseidon2.rs`
  - `mersenne-31/src/poseidon2.rs`
  - `mersenne-31/src/x86_64_avx2/poseidon2.rs`
  - `mersenne-31/src/x86_64_avx512/poseidon2.rs`
