### PR TITLE
Add new_array methods for Goldilocks and Mersenne31

### DIFF
--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -41,7 +41,7 @@ impl Goldilocks {
     #[inline]
     #[must_use]
     pub(crate) const fn new_array<const N: usize>(input: [u64; N]) -> [Goldilocks; N] {
-        let mut output = [Goldilocks { value: 0 }; N];
+        let mut output = [Goldilocks::ZERO; N];
         let mut i = 0;
         loop {
             if i == N {

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -35,6 +35,24 @@ impl Goldilocks {
         Self { value }
     }
 
+    /// Convert a constant u64 array into a constant Goldilocks array.
+    ///
+    /// This is a const version of `.map(Goldilocks::new)`.
+    #[inline]
+    #[must_use]
+    pub(crate) const fn new_array<const N: usize>(input: [u64; N]) -> [Goldilocks; N] {
+        let mut output = [Goldilocks { value: 0 }; N];
+        let mut i = 0;
+        loop {
+            if i == N {
+                break;
+            }
+            output[i].value = input[i];
+            i += 1;
+        }
+        output
+    }
+
     /// Two's complement of `ORDER`, i.e. `2^64 - ORDER = 2^32 - 1`.
     const NEG_ORDER: u64 = Self::ORDER_U64.wrapping_neg();
 }
@@ -457,22 +475,6 @@ unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
     let (res_wrapped, carry) = x.overflowing_add(y);
     // Below cannot overflow unless the assumption if x + y < 2**64 + ORDER is incorrect.
     res_wrapped + Goldilocks::NEG_ORDER * u64::from(carry)
-}
-
-/// Convert a constant u64 array into a constant Goldilocks array.
-#[inline]
-#[must_use]
-pub(crate) const fn to_goldilocks_array<const N: usize>(input: [u64; N]) -> [Goldilocks; N] {
-    let mut output = [Goldilocks { value: 0 }; N];
-    let mut i = 0;
-    loop {
-        if i == N {
-            break;
-        }
-        output[i].value = input[i];
-        i += 1;
-    }
-    output
 }
 
 #[cfg(test)]

--- a/goldilocks/src/mds.rs
+++ b/goldilocks/src/mds.rs
@@ -230,14 +230,13 @@ impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
 
     use super::{Goldilocks, MdsMatrixGoldilocks};
 
     #[test]
     fn goldilocks8() {
-        let input: [Goldilocks; 8] = [
+        let input: [Goldilocks; 8] = Goldilocks::new_array([
             2434589605738284713,
             4817685620989478889,
             13397079175138649456,
@@ -246,12 +245,11 @@ mod tests {
             3092099742268329866,
             7160548811622790454,
             9959569614427134344,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 8] = [
+        let expected: [Goldilocks; 8] = Goldilocks::new_array([
             16726687146516531007,
             14721040752765534861,
             15566838577475948790,
@@ -260,15 +258,14 @@ mod tests {
             11056556168691087893,
             4199602889124860181,
             315643510993921470,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks12() {
-        let input: [Goldilocks; 12] = [
+        let input: [Goldilocks; 12] = Goldilocks::new_array([
             14847187883725400244,
             969392934980971521,
             6996647758016470432,
@@ -281,12 +278,11 @@ mod tests {
             12739925508864285577,
             11648637570857932167,
             14090978315217600393,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 12] = [
+        let expected: [Goldilocks; 12] = Goldilocks::new_array([
             9322351889214742299,
             8700136572060418355,
             4881757876459003977,
@@ -299,15 +295,14 @@ mod tests {
             1613225933948270736,
             3549006224849989171,
             12169032187873197425,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks16() {
-        let input: [Goldilocks; 16] = [
+        let input: [Goldilocks; 16] = Goldilocks::new_array([
             13216135600341032847,
             15626390207663319651,
             2052474569300149934,
@@ -324,12 +319,11 @@ mod tests {
             14134506582804571789,
             13283546413390931641,
             14711125975653831032,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 16] = [
+        let expected: [Goldilocks; 16] = Goldilocks::new_array([
             9484392671298797780,
             149770626972189150,
             12125722600598304117,
@@ -346,15 +340,14 @@ mod tests {
             7344117715971661026,
             4202436890275702092,
             681166793519210465,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks24() {
-        let input: [Goldilocks; 24] = [
+        let input: [Goldilocks; 24] = Goldilocks::new_array([
             11426771245122339662,
             5975488243963332229,
             11441424994503305651,
@@ -379,12 +372,11 @@ mod tests {
             9904943018174649533,
             16178194376951442671,
             1545799842160818502,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 24] = [
+        let expected: [Goldilocks; 24] = Goldilocks::new_array([
             18431075688485197060,
             14823984346528185622,
             7262979358411339215,
@@ -409,15 +401,14 @@ mod tests {
             9734499541452484536,
             11778274360927642637,
             3217831681350496533,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks32() {
-        let input: [Goldilocks; 32] = [
+        let input: [Goldilocks; 32] = Goldilocks::new_array([
             8401806579759049284,
             14709608922272986544,
             8130995604641968478,
@@ -450,12 +441,11 @@ mod tests {
             4801868480369948110,
             13202076339494141066,
             726396847460932316,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 32] = [
+        let expected: [Goldilocks; 32] = Goldilocks::new_array([
             1179701925859507209,
             5543239597787055637,
             5978278622530964070,
@@ -488,15 +478,14 @@ mod tests {
             6816598002359267850,
             12363049840026116993,
             13313901185845854868,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks64() {
-        let input: [Goldilocks; 64] = [
+        let input: [Goldilocks; 64] = Goldilocks::new_array([
             3471075506106776899,
             4817046918282259009,
             3480368692354016145,
@@ -561,12 +550,11 @@ mod tests {
             10579720164460442970,
             9596917135039689219,
             13761818390665814258,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 64] = [
+        let expected: [Goldilocks; 64] = Goldilocks::new_array([
             9158798369861934356,
             9224859686427886689,
             16948559910286211274,
@@ -631,15 +619,14 @@ mod tests {
             10879211614969476303,
             7265889003783205111,
             7322738272300165489,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn goldilocks68() {
-        let input: [Goldilocks; 68] = [
+        let input: [Goldilocks; 68] = Goldilocks::new_array([
             16450563043143968653,
             3688080826640678185,
             133253417037384537,
@@ -708,12 +695,11 @@ mod tests {
             7231705445010258971,
             12976071926225281356,
             8829402645443096358,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixGoldilocks.permute(input);
 
-        let expected: [Goldilocks; 68] = [
+        let expected: [Goldilocks; 68] = Goldilocks::new_array([
             4984914285749049383,
             10397959071664799177,
             3331616814639908945,
@@ -782,8 +768,7 @@ mod tests {
             10891613749697412017,
             6867760775372053830,
             12474954319307005079,
-        ]
-        .map(Goldilocks::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -17,7 +17,7 @@ use p3_poseidon2::{
     Poseidon2,
 };
 
-use crate::{to_goldilocks_array, Goldilocks};
+use crate::Goldilocks;
 
 /// Degree of the chosen permutation polynomial for Goldilocks, used as the Poseidon2 S-Box.
 ///
@@ -51,7 +51,7 @@ pub type Poseidon2GoldilocksHL<const WIDTH: usize> = Poseidon2<
     GOLDILOCKS_S_BOX_DEGREE,
 >;
 
-pub const MATRIX_DIAG_8_GOLDILOCKS: [Goldilocks; 8] = to_goldilocks_array([
+pub const MATRIX_DIAG_8_GOLDILOCKS: [Goldilocks; 8] = Goldilocks::new_array([
     0xa98811a1fed4e3a5,
     0x1cc48b54f377e2a0,
     0xe40cd4f6c5609a26,
@@ -62,7 +62,7 @@ pub const MATRIX_DIAG_8_GOLDILOCKS: [Goldilocks; 8] = to_goldilocks_array([
     0x3f7af9125da962fe,
 ]);
 
-pub const MATRIX_DIAG_12_GOLDILOCKS: [Goldilocks; 12] = to_goldilocks_array([
+pub const MATRIX_DIAG_12_GOLDILOCKS: [Goldilocks; 12] = Goldilocks::new_array([
     0xc3b6c08e23ba9300,
     0xd84b5de94a324fb6,
     0x0d0c371c5b35b84f,
@@ -77,7 +77,7 @@ pub const MATRIX_DIAG_12_GOLDILOCKS: [Goldilocks; 12] = to_goldilocks_array([
     0xd27dbb6944917b60,
 ]);
 
-pub const MATRIX_DIAG_16_GOLDILOCKS: [Goldilocks; 16] = to_goldilocks_array([
+pub const MATRIX_DIAG_16_GOLDILOCKS: [Goldilocks; 16] = Goldilocks::new_array([
     0xde9b91a467d6afc0,
     0xc5f16b9c76a9be17,
     0x0ab0fef2d540ac55,
@@ -96,7 +96,7 @@ pub const MATRIX_DIAG_16_GOLDILOCKS: [Goldilocks; 16] = to_goldilocks_array([
     0x774487b8c40089bb,
 ]);
 
-pub const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] = to_goldilocks_array([
+pub const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] = Goldilocks::new_array([
     0x95c381fda3b1fa57,
     0xf36fe9eb1288f42c,
     0x89f5dcdfef277944,
@@ -394,9 +394,9 @@ mod tests {
         let poseidon2: Poseidon2GoldilocksHL<WIDTH> = Poseidon2::new(
             ExternalLayerConstants::<Goldilocks, WIDTH>::new_from_saved_array(
                 HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS,
-                to_goldilocks_array,
+                Goldilocks::new_array,
             ),
-            to_goldilocks_array(HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS).to_vec(),
+            Goldilocks::new_array(HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS).to_vec(),
         );
 
         poseidon2.permute_mut(input);
@@ -405,9 +405,9 @@ mod tests {
     /// Test on the constant 0 input.
     #[test]
     fn test_poseidon2_width_8_zeroes() {
-        let mut input: [F; 8] = [0_u64; 8].map(F::from_wrapped_u64);
+        let mut input: [F; 8] = [Goldilocks::ZERO; 8];
 
-        let expected: [F; 8] = [
+        let expected: [F; 8] = Goldilocks::new_array([
             4214787979728720400,
             12324939279576102560,
             10353596058419792404,
@@ -416,8 +416,7 @@ mod tests {
             16227496357546636742,
             2959271128466640042,
             14285409611125725709,
-        ]
-        .map(F::from_canonical_u64);
+        ]);
         hl_poseidon2_goldilocks_width_8(&mut input);
         assert_eq!(input, expected);
     }
@@ -425,9 +424,9 @@ mod tests {
     /// Test on the input 0..16.
     #[test]
     fn test_poseidon2_width_8_range() {
-        let mut input: [F; 8] = array::from_fn(|i| F::from_wrapped_u64(i as u64));
+        let mut input: [F; 8] = array::from_fn(F::from_canonical_usize);
 
-        let expected: [F; 8] = [
+        let expected: [F; 8] = Goldilocks::new_array([
             14266028122062624699,
             5353147180106052723,
             15203350112844181434,
@@ -436,8 +435,7 @@ mod tests {
             10184091939013874068,
             16774100645754596496,
             12047415603622314780,
-        ]
-        .map(F::from_canonical_u64);
+        ]);
         hl_poseidon2_goldilocks_width_8(&mut input);
         assert_eq!(input, expected);
     }
@@ -448,7 +446,7 @@ mod tests {
     /// vector([ZZ.random_element(2**31) for t in range(16)])
     #[test]
     fn test_poseidon2_width_8_random() {
-        let mut input: [F; 8] = [
+        let mut input: [F; 8] = Goldilocks::new_array([
             5116996373749832116,
             8931548647907683339,
             17132360229780760684,
@@ -457,10 +455,9 @@ mod tests {
             15695650327991256125,
             17604752143022812942,
             543194415197607509,
-        ]
-        .map(F::from_wrapped_u64);
+        ]);
 
-        let expected: [F; 8] = [
+        let expected: [F; 8] = Goldilocks::new_array([
             1831346684315917658,
             13497752062035433374,
             12149460647271516589,
@@ -469,8 +466,7 @@ mod tests {
             3140092508031220630,
             4251208148861706881,
             6973971209430822232,
-        ]
-        .map(F::from_canonical_u64);
+        ]);
 
         hl_poseidon2_goldilocks_width_8(&mut input);
         assert_eq!(input, expected);

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -577,9 +577,8 @@ mod tests {
     use p3_field_testing::test_packed_field;
 
     use super::{Goldilocks, WIDTH};
-    use crate::to_goldilocks_array;
 
-    const SPECIAL_VALS: [Goldilocks; WIDTH] = to_goldilocks_array([
+    const SPECIAL_VALS: [Goldilocks; WIDTH] = Goldilocks::new_array([
         0xFFFF_FFFF_0000_0000,
         0xFFFF_FFFF_FFFF_FFFF,
         0x0000_0000_0000_0001,

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -474,9 +474,8 @@ mod tests {
     use p3_field_testing::test_packed_field;
 
     use super::{Goldilocks, WIDTH};
-    use crate::to_goldilocks_array;
 
-    const SPECIAL_VALS: [Goldilocks; WIDTH] = to_goldilocks_array([
+    const SPECIAL_VALS: [Goldilocks; WIDTH] = Goldilocks::new_array([
         0xFFFF_FFFF_0000_0001,
         0xFFFF_FFFF_0000_0000,
         0xFFFF_FFFE_FFFF_FFFF,

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -571,14 +571,13 @@ mod tests {
     use p3_field_testing::test_packed_field;
 
     use super::{Mersenne31, WIDTH};
-    use crate::to_mersenne31_array;
 
     /// Zero has a redundant representation, so let's test both.
     const ZEROS: [Mersenne31; WIDTH] =
-        to_mersenne31_array([0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff]);
+        Mersenne31::new_array([0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff]);
 
     const SPECIAL_VALS: [Mersenne31; WIDTH] =
-        to_mersenne31_array([0x00000000, 0x00000001, 0x00000002, 0x7ffffffe]);
+        Mersenne31::new_array([0x00000000, 0x00000001, 0x00000002, 0x7ffffffe]);
 
     test_packed_field!(
         crate::PackedMersenne31Neon,

--- a/mersenne-31/src/mds.rs
+++ b/mersenne-31/src/mds.rs
@@ -261,98 +261,89 @@ impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
 
     use super::{MdsMatrixMersenne31, Mersenne31};
 
     #[test]
     fn mersenne8() {
-        let input: [Mersenne31; 8] = [
+        let input: [Mersenne31; 8] = Mersenne31::new_array([
             1741044457, 327154658, 318297696, 1528828225, 468360260, 1271368222, 1906288587,
             1521884224,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixMersenne31.permute(input);
 
-        let expected: [Mersenne31; 8] = [
+        let expected: [Mersenne31; 8] = Mersenne31::new_array([
             895992680, 1343855369, 2107796831, 266468728, 846686506, 252887121, 205223309,
             260248790,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn mersenne12() {
-        let input: [Mersenne31; 12] = [
+        let input: [Mersenne31; 12] = Mersenne31::new_array([
             1232740094, 661555540, 11024822, 1620264994, 471137070, 276755041, 1316882747,
             1023679816, 1675266989, 743211887, 44774582, 1990989306,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixMersenne31.permute(input);
 
-        let expected: [Mersenne31; 12] = [
+        let expected: [Mersenne31; 12] = Mersenne31::new_array([
             860812289, 399778981, 1228500858, 798196553, 673507779, 1116345060, 829764188,
             138346433, 578243475, 553581995, 578183208, 1527769050,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn mersenne16() {
-        let input: [Mersenne31; 16] = [
+        let input: [Mersenne31; 16] = Mersenne31::new_array([
             1431168444, 963811518, 88067321, 381314132, 908628282, 1260098295, 980207659,
             150070493, 357706876, 2014609375, 387876458, 1621671571, 183146044, 107201572,
             166536524, 2078440788,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixMersenne31.permute(input);
 
-        let expected: [Mersenne31; 16] = [
+        let expected: [Mersenne31; 16] = Mersenne31::new_array([
             1858869691, 1607793806, 1200396641, 1400502985, 1511630695, 187938132, 1332411488,
             2041577083, 2014246632, 802022141, 796807132, 1647212930, 813167618, 1867105010,
             508596277, 1457551581,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn mersenne32() {
-        let input: [Mersenne31; 32] = [
+        let input: [Mersenne31; 32] = Mersenne31::new_array([
             873912014, 1112497426, 300405095, 4255553, 1234979949, 156402357, 1952135954,
             718195399, 1041748465, 683604342, 184275751, 1184118518, 214257054, 1293941921,
             64085758, 710448062, 1133100009, 350114887, 1091675272, 671421879, 1226105999,
             546430131, 1298443967, 1787169653, 2129310791, 1560307302, 471771931, 1191484402,
             1550203198, 1541319048, 229197040, 839673789,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixMersenne31.permute(input);
 
-        let expected: [Mersenne31; 32] = [
+        let expected: [Mersenne31; 32] = Mersenne31::new_array([
             1439049928, 890642852, 694402307, 713403244, 553213342, 1049445650, 321709533,
             1195683415, 2118492257, 623077773, 96734062, 990488164, 1674607608, 749155000,
             353377854, 966432998, 1114654884, 1370359248, 1624965859, 685087760, 1631836645,
             1615931812, 2061986317, 1773551151, 1449911206, 1951762557, 545742785, 582866449,
             1379774336, 229242759, 1871227547, 752848413,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }
 
     #[test]
     fn mersenne64() {
-        let input: [Mersenne31; 64] = [
+        let input: [Mersenne31; 64] = Mersenne31::new_array([
             837269696, 1509031194, 413915480, 1889329185, 315502822, 1529162228, 1454661012,
             1015826742, 973381409, 1414676304, 1449029961, 1968715566, 2027226497, 1721820509,
             434042616, 1436005045, 1680352863, 651591867, 260585272, 1078022153, 703990572,
@@ -363,12 +354,11 @@ mod tests {
             608714758, 1553060084, 1558941605, 980281686, 2014426559, 650527801, 53015148,
             1521176057, 720530872, 713593252, 88228433, 1194162313, 1922416934, 1075145779,
             344403794,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         let output = MdsMatrixMersenne31.permute(input);
 
-        let expected: [Mersenne31; 64] = [
+        let expected: [Mersenne31; 64] = Mersenne31::new_array([
             1599981950, 252630853, 1171557270, 116468420, 1269245345, 666203050, 46155642,
             1701131520, 530845775, 508460407, 630407239, 1731628135, 1199144768, 295132047,
             77536342, 1472377703, 30752443, 1300339617, 18647556, 1267774380, 1194573079,
@@ -379,8 +369,7 @@ mod tests {
             968523062, 1958918704, 1866282698, 849808680, 1193306222, 794153281, 822835360,
             135282913, 1149868448, 2068162123, 1474283743, 2039088058, 720305835, 746036736,
             671006610,
-        ]
-        .map(Mersenne31::from_canonical_u64);
+        ]);
 
         assert_eq!(output, expected);
     }

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -34,6 +34,25 @@ impl Mersenne31 {
         debug_assert!((value >> 31) == 0);
         Self { value }
     }
+
+    /// Convert a constant `u32` array into a constant array of field elements.
+    /// This allows inputs to be `> 2^31`, and just reduces them `mod P`.
+    ///
+    /// This means that this will be slower than `array.map(Mersenne31::new)` but
+    /// has the advantage of being able to be used in `const` environments.
+    #[inline]
+    pub const fn new_array<const N: usize>(input: [u32; N]) -> [Self; N] {
+        let mut output = [Mersenne31::ZERO; N];
+        let mut i = 0;
+        loop {
+            if i == N {
+                break;
+            }
+            output[i].value = input[i] % P;
+            i += 1;
+        }
+        output
+    }
 }
 
 impl PartialEq for Mersenne31 {
@@ -431,23 +450,6 @@ pub(crate) fn from_u62(input: u64) -> Mersenne31 {
     let input_lo = (input & ((1 << 31) - 1)) as u32;
     let input_high = (input >> 31) as u32;
     Mersenne31::new(input_lo) + Mersenne31::new(input_high)
-}
-
-/// Convert a constant u32 array into a constant Mersenne31 array.
-#[inline]
-#[must_use]
-pub const fn to_mersenne31_array<const N: usize>(input: [u32; N]) -> [Mersenne31; N] {
-    // This is currently used only in the test crates of the vectorized implementations.
-    let mut output = [Mersenne31 { value: 0 }; N];
-    let mut i = 0;
-    loop {
-        if i == N {
-            break;
-        }
-        output[i].value = input[i] % P;
-        i += 1;
-    }
-    output
 }
 
 #[cfg(test)]

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -174,7 +174,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
     use p3_symmetric::Permutation;
     use rand::SeedableRng;
     use rand_xoshiro::Xoroshiro128Plus;
@@ -192,19 +191,17 @@ mod tests {
     /// vector([M31.random_element() for t in range(16)]).
     #[test]
     fn test_poseidon2_width_16_random() {
-        let mut input: [F; 16] = [
+        let mut input: [F; 16] = Mersenne31::new_array([
             894848333, 1437655012, 1200606629, 1690012884, 71131202, 1749206695, 1717947831,
             120589055, 19776022, 42382981, 1831865506, 724844064, 171220207, 1299207443, 227047920,
             1783754913,
-        ]
-        .map(F::from_canonical_u32);
+        ]);
 
-        let expected: [F; 16] = [
+        let expected: [F; 16] = Mersenne31::new_array([
             1124552602, 2127602268, 1834113265, 1207687593, 1891161485, 245915620, 981277919,
             627265710, 1534924153, 1580826924, 887997842, 1526280482, 547791593, 1028672510,
             1803086471, 323071277,
-        ]
-        .map(F::from_canonical_u32);
+        ]);
 
         let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let perm = Poseidon2Mersenne31::new_from_rng_128(&mut rng);
@@ -219,21 +216,19 @@ mod tests {
     /// vector([M31.random_element() for t in range(24)]).
     #[test]
     fn test_poseidon2_width_24_random() {
-        let mut input: [F; 24] = [
+        let mut input: [F; 24] = Mersenne31::new_array([
             886409618, 1327899896, 1902407911, 591953491, 648428576, 1844789031, 1198336108,
             355597330, 1799586834, 59617783, 790334801, 1968791836, 559272107, 31054313,
             1042221543, 474748436, 135686258, 263665994, 1962340735, 1741539604, 2026927696,
             449439011, 1131357108, 50869465,
-        ]
-        .map(F::from_canonical_u32);
+        ]);
 
-        let expected: [F; 24] = [
+        let expected: [F; 24] = Mersenne31::new_array([
             87189408, 212775836, 954807335, 1424761838, 1222521810, 1264950009, 1891204592,
             710452896, 957091834, 1776630156, 1091081383, 786687731, 1101902149, 1281649821,
             436070674, 313565599, 1961711763, 2002894460, 2040173120, 854107426, 25198245,
             1967213543, 604802266, 2086190331,
-        ]
-        .map(F::from_canonical_u32);
+        ]);
 
         let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let perm = Poseidon2Mersenne31::new_from_rng_128(&mut rng);

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -743,15 +743,14 @@ mod tests {
     use p3_field_testing::test_packed_field;
 
     use super::{Mersenne31, WIDTH};
-    use crate::to_mersenne31_array;
 
     /// Zero has a redundant representation, so let's test both.
-    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
+    const ZEROS: [Mersenne31; WIDTH] = Mersenne31::new_array([
         0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
         0x7fffffff,
     ]);
 
-    const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
+    const SPECIAL_VALS: [Mersenne31; WIDTH] = Mersenne31::new_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff,
     ]);

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -844,16 +844,15 @@ mod tests {
     use p3_field_testing::test_packed_field;
 
     use super::{Mersenne31, WIDTH};
-    use crate::to_mersenne31_array;
 
     /// Zero has a redundant representation, so let's test both.
-    const ZEROS: [Mersenne31; WIDTH] = to_mersenne31_array([
+    const ZEROS: [Mersenne31; WIDTH] = Mersenne31::new_array([
         0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000,
         0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff, 0x00000000, 0x7fffffff,
         0x00000000, 0x7fffffff,
     ]);
 
-    const SPECIAL_VALS: [Mersenne31; WIDTH] = to_mersenne31_array([
+    const SPECIAL_VALS: [Mersenne31; WIDTH] = Mersenne31::new_array([
         0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd, 0x40000000,
         0x3fffffff, 0x00000000, 0x7fffffff, 0x00000001, 0x7ffffffe, 0x00000002, 0x7ffffffd,
         0x40000000, 0x3fffffff,

--- a/monolith/benches/permute.rs
+++ b/monolith/benches/permute.rs
@@ -1,3 +1,5 @@
+use std::array;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use p3_field::FieldAlgebra;
 use p3_mds::MdsPermutation;
@@ -15,10 +17,7 @@ where
 {
     let monolith: MonolithMersenne31<_, WIDTH, 5> = MonolithMersenne31::new(mds);
 
-    let mut input: [Mersenne31; WIDTH] = [Mersenne31::ZERO; WIDTH];
-    for (i, inp) in input.iter_mut().enumerate() {
-        *inp = Mersenne31::from_canonical_usize(i);
-    }
+    let mut input = array::from_fn(Mersenne31::from_canonical_usize);
 
     let name = format!("monolith::<Mersenne31, {}>", WIDTH);
     c.bench_function(name.as_str(), |b| {

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -180,6 +180,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use core::array;
+
     use p3_field::FieldAlgebra;
     use p3_mersenne_31::Mersenne31;
 
@@ -191,27 +193,17 @@ mod tests {
         let mds = MonolithMdsMatrixMersenne31::<6>;
         let monolith: MonolithMersenne31<_, 16, 5> = MonolithMersenne31::new(mds);
 
-        let mut input: [Mersenne31; 16] = [Mersenne31::ZERO; 16];
-        for (i, inp) in input.iter_mut().enumerate() {
-            *inp = Mersenne31::from_canonical_usize(i);
-        }
+        let mut input = array::from_fn(Mersenne31::from_canonical_usize);
+
+        let expected = [
+            609156607, 290107110, 1900746598, 1734707571, 2050994835, 1648553244, 1307647296,
+            1941164548, 1707113065, 1477714255, 1170160793, 93800695, 769879348, 375548503,
+            1989726444, 1349325635,
+        ]
+        .map(Mersenne31::from_canonical_u32);
+
         monolith.permutation(&mut input);
 
-        assert_eq!(input[0], Mersenne31::from_canonical_u64(609156607));
-        assert_eq!(input[1], Mersenne31::from_canonical_u64(290107110));
-        assert_eq!(input[2], Mersenne31::from_canonical_u64(1900746598));
-        assert_eq!(input[3], Mersenne31::from_canonical_u64(1734707571));
-        assert_eq!(input[4], Mersenne31::from_canonical_u64(2050994835));
-        assert_eq!(input[5], Mersenne31::from_canonical_u64(1648553244));
-        assert_eq!(input[6], Mersenne31::from_canonical_u64(1307647296));
-        assert_eq!(input[7], Mersenne31::from_canonical_u64(1941164548));
-        assert_eq!(input[8], Mersenne31::from_canonical_u64(1707113065));
-        assert_eq!(input[9], Mersenne31::from_canonical_u64(1477714255));
-        assert_eq!(input[10], Mersenne31::from_canonical_u64(1170160793));
-        assert_eq!(input[11], Mersenne31::from_canonical_u64(93800695));
-        assert_eq!(input[12], Mersenne31::from_canonical_u64(769879348));
-        assert_eq!(input[13], Mersenne31::from_canonical_u64(375548503));
-        assert_eq!(input[14], Mersenne31::from_canonical_u64(1989726444));
-        assert_eq!(input[15], Mersenne31::from_canonical_u64(1349325635));
+        assert_eq!(input, expected);
     }
 }


### PR DESCRIPTION
Minor clean up and making things more consistent. (Based on some comments on the larger refactor PR)

Monty31 already has a `new_array` method which avoids needing to use `.map`. This just defines the same method for `Mersenne31` and `Goldilocks`.

This shouldn't make any changes to the public API so we can do it here as opposed to needing to do it as part of a large API breaking change.