### PR TITLE
Fix typo in function name

### DIFF
--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -12,7 +12,7 @@ type EF2 = BinomialExtensionField<Goldilocks, 2>;
 const REPS: usize = 50;
 const L_REPS: usize = 10 * REPS;
 
-fn bench_qudratic_extension(c: &mut Criterion) {
+fn bench_quadratic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Goldilocks, 2>";
     benchmark_square::<EF2>(c, name);
     benchmark_inv::<EF2>(c, name);
@@ -20,5 +20,5 @@ fn bench_qudratic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF2, L_REPS>(c, name);
 }
 
-criterion_group!(bench_goldilocks_ef2, bench_qudratic_extension);
+criterion_group!(bench_goldilocks_ef2, bench_quadratic_extension);
 criterion_main!(bench_goldilocks_ef2);


### PR DESCRIPTION
Fix typo in function name: "qudratic" -> "quadratic"