### PR TITLE
Field Crate Refactor: Emptying out the FieldExtensionAlgebra trait

### DIFF
--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{FieldAlgebra, Serializable};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;
@@ -23,7 +23,7 @@ mod test_quartic_extension {
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
+                EF::deserialize_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
             ),
             "2 + X + 2 X^3"
         );

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{ExtensionField, Field, PrimeField64};
+use p3_field::{Field, PrimeField64, Serializable};
 use p3_symmetric::{CryptographicPermutation, Hash};
 
 use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
@@ -123,11 +123,11 @@ impl<F, EF, P, const WIDTH: usize, const RATE: usize> CanSample<EF>
     for DuplexChallenger<F, P, WIDTH, RATE>
 where
     F: Field,
-    EF: ExtensionField<F>,
+    EF: Serializable<F>,
     P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn sample(&mut self) -> EF {
-        EF::from_base_fn(|_| {
+        EF::deserialize_fn(|_| {
             // If we have buffered inputs, we must perform a duplexing so that the challenge will
             // reflect them. Or if we've run out of outputs, we must perform a duplexing to get more.
             if !self.input_buffer.is_empty() || self.output_buffer.is_empty() {

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -17,7 +17,7 @@ pub use duplex_challenger::*;
 pub use grinding_challenger::*;
 pub use hash_challenger::*;
 pub use multi_field_challenger::*;
-use p3_field::{Field, FieldExtensionAlgebra};
+use p3_field::{Field, Serializable};
 pub use serializing_challenger::*;
 
 pub trait CanObserve<T> {
@@ -52,13 +52,13 @@ pub trait CanSampleBits<T> {
 pub trait FieldChallenger<F: Field>:
     CanObserve<F> + CanSample<F> + CanSampleBits<usize> + Sync
 {
-    fn observe_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self, ext: EF) {
-        self.observe_slice(ext.as_base_slice());
+    fn observe_algebra_element<A: Serializable<F>>(&mut self, alg_elem: A) {
+        self.observe_slice(alg_elem.serialize_as_slice());
     }
 
-    fn sample_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self) -> EF {
-        let vec = self.sample_vec(EF::D);
-        EF::from_base_slice(&vec)
+    fn sample_algebra_element<A: Serializable<F>>(&mut self) -> A {
+        let vec = self.sample_vec(A::DIMENSION);
+        A::deserialize_slice(&vec)
     }
 }
 
@@ -115,12 +115,12 @@ where
     C: FieldChallenger<F>,
 {
     #[inline(always)]
-    fn observe_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self, ext: EF) {
-        (**self).observe_ext_element(ext)
+    fn observe_algebra_element<EF: Serializable<F>>(&mut self, ext: EF) {
+        (**self).observe_algebra_element(ext)
     }
 
     #[inline(always)]
-    fn sample_ext_element<EF: FieldExtensionAlgebra<F>>(&mut self) -> EF {
-        (**self).sample_ext_element()
+    fn sample_algebra_element<EF: Serializable<F>>(&mut self) -> EF {
+        (**self).sample_algebra_element()
     }
 }

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{reduce_32, split_32, ExtensionField, Field, PrimeField, PrimeField32};
+use p3_field::{reduce_32, split_32, Field, PrimeField, PrimeField32, Serializable};
 use p3_symmetric::{CryptographicPermutation, Hash};
 
 use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
@@ -155,12 +155,12 @@ impl<F, EF, PF, P, const WIDTH: usize, const RATE: usize> CanSample<EF>
     for MultiField32Challenger<F, PF, P, WIDTH, RATE>
 where
     F: PrimeField32,
-    EF: ExtensionField<F>,
+    EF: Serializable<F>,
     PF: PrimeField,
     P: CryptographicPermutation<[PF; WIDTH]>,
 {
     fn sample(&mut self) -> EF {
-        EF::from_base_fn(|_| {
+        EF::deserialize_fn(|_| {
             // If we have buffered inputs, we must perform a duplexing so that the challenge will
             // reflect them. Or if we've run out of outputs, we must perform a duplexing to get more.
             if !self.input_buffer.is_empty() || self.output_buffer.is_empty() {

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use p3_field::{ExtensionField, PrimeField32, PrimeField64};
+use p3_field::{PrimeField32, PrimeField64, Serializable};
 use p3_maybe_rayon::prelude::*;
 use p3_symmetric::{CryptographicHasher, Hash};
 use p3_util::log2_ceil_u64;
@@ -90,7 +90,7 @@ impl<F: PrimeField32, const N: usize, Inner: CanObserve<u8>> CanObserve<Hash<F, 
 impl<F, EF, Inner> CanSample<EF> for SerializingChallenger32<F, Inner>
 where
     F: PrimeField32,
-    EF: ExtensionField<F>,
+    EF: Serializable<F>,
     Inner: CanSample<u8>,
 {
     fn sample(&mut self) -> EF {
@@ -109,7 +109,7 @@ where
                 };
             }
         };
-        EF::from_base_fn(|_| sample_base(&mut self.inner))
+        EF::deserialize_fn(|_| sample_base(&mut self.inner))
     }
 }
 
@@ -195,7 +195,7 @@ impl<F: PrimeField64, const N: usize, Inner: CanObserve<u8>> CanObserve<Hash<F, 
 impl<F, EF, Inner> CanSample<EF> for SerializingChallenger64<F, Inner>
 where
     F: PrimeField64,
-    EF: ExtensionField<F>,
+    EF: Serializable<F>,
     Inner: CanSample<u8>,
 {
     fn sample(&mut self) -> EF {
@@ -215,7 +215,7 @@ where
                 };
             }
         };
-        EF::from_base_fn(|_| sample_base(&mut self.inner))
+        EF::deserialize_fn(|_| sample_base(&mut self.inner))
     }
 }
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -155,7 +155,7 @@ where
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample_ext_element();
+        let alpha: Challenge = challenger.sample_algebra_element();
 
         /*
         We are reducing columns ("ro" = reduced opening) with powers of alpha:
@@ -248,7 +248,7 @@ where
         let (first_layer_commitment, first_layer_data) =
             self.fri_config.mmcs.commit(first_layer_mats);
         challenger.observe(first_layer_commitment.clone());
-        let bivariate_beta: Challenge = challenger.sample_ext_element();
+        let bivariate_beta: Challenge = challenger.sample_algebra_element();
 
         // Fold all first layers at bivariate_beta.
 
@@ -335,9 +335,9 @@ where
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample_ext_element();
+        let alpha: Challenge = challenger.sample_algebra_element();
         challenger.observe(proof.first_layer_commitment.clone());
-        let bivariate_beta: Challenge = challenger.sample_ext_element();
+        let bivariate_beta: Challenge = challenger.sample_algebra_element();
 
         // +1 to account for first layer
         let log_global_max_height =

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -92,7 +92,7 @@ where
         let (commit, prover_data) = config.mmcs.commit_matrix(leaves);
         challenger.observe(commit.clone());
 
-        let beta: Challenge = challenger.sample_ext_element();
+        let beta: Challenge = challenger.sample_algebra_element();
         // We passed ownership of `current` to the MMCS, so get a reference to it
         let leaves = config.mmcs.get_matrices(&prover_data).pop().unwrap();
         folded = g.fold_matrix(beta, leaves.as_view());
@@ -111,7 +111,7 @@ where
     for x in folded {
         assert_eq!(x, final_poly);
     }
-    challenger.observe_ext_element(final_poly);
+    challenger.observe_algebra_element(final_poly);
 
     CommitPhaseResult {
         commits,

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -30,10 +30,10 @@ where
         .iter()
         .map(|comm| {
             challenger.observe(comm.clone());
-            challenger.sample_ext_element()
+            challenger.sample_algebra_element()
         })
         .collect();
-    challenger.observe_ext_element(proof.final_poly);
+    challenger.observe_algebra_element(proof.final_poly);
 
     if proof.query_proofs.len() != config.num_queries {
         return Err(FriError::InvalidProofShape);

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -47,7 +47,7 @@ where
         let (opened_base_values, proof) = self.inner.open_batch(index, prover_data);
         let opened_ext_values = opened_base_values
             .into_iter()
-            .map(|row| row.chunks(EF::D).map(EF::from_base_slice).collect())
+            .map(|row| row.chunks(EF::D).map(EF::deserialize_slice).collect())
             .collect();
         (opened_ext_values, proof)
     }
@@ -72,7 +72,7 @@ where
             .iter()
             .map(|row| {
                 row.iter()
-                    .flat_map(|el| el.as_base_slice())
+                    .flat_map(|el| el.serialize_as_slice())
                     .copied()
                     .collect()
             })

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -276,7 +276,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{binomial_expand, eval_poly, FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{binomial_expand, eval_poly, FieldAlgebra};
     use rand::random;
 
     use super::*;

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -129,7 +129,7 @@ pub fn test_ef_two_adic_generator_consistency<
     EF: TwoAdicField + ExtensionField<F>,
 >() {
     assert_eq!(
-        EF::from_base(F::two_adic_generator(F::TWO_ADICITY)),
+        Into::<EF>::into(F::two_adic_generator(F::TWO_ADICITY)),
         EF::two_adic_generator(F::TWO_ADICITY)
     );
 }
@@ -287,7 +287,7 @@ mod tests {
         type EF = BinomialExtensionField<F, 4>;
         for _ in 0..1024 {
             let x: EF = random();
-            let m: Vec<EF> = x.minimal_poly().into_iter().map(EF::from_base).collect();
+            let m: Vec<EF> = x.minimal_poly().into_iter().map(Into::<EF>::into).collect();
             assert!(eval_poly(&m, x).is_zero());
         }
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -91,12 +91,6 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
         }
     }
 
-    fn from_base(val: F) -> Self {
-        Self {
-            value: field_to_array(val),
-        }
-    }
-
     fn ext_powers_packed(&self) -> crate::Powers<Self::ExtensionPacking> {
         let width = F::Packing::WIDTH;
         let powers = self.powers().take(width + 1).collect_vec();

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -17,7 +17,8 @@ use super::{HasFrobenius, HasTwoAdicBionmialExtension, PackedBinomialExtensionFi
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
-    field_to_array, ExtensionField, FieldAlgebra, FieldExtensionAlgebra, Packable, TwoAdicField,
+    field_to_array, ExtensionField, FieldAlgebra, FieldExtensionAlgebra, Packable, PackedValue,
+    Powers, Serializable, TwoAdicField,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
@@ -48,10 +49,81 @@ impl<F: Field, const D: usize> From<F> for BinomialExtensionField<F, D> {
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Packable for BinomialExtensionField<F, D> {}
 
+impl<F: BinomiallyExtendable<D>, const D: usize> Serializable<F> for BinomialExtensionField<F, D> {
+    const DIMENSION: usize = D;
+
+    #[inline]
+    fn serialize_as_slice(&self) -> &[F] {
+        &self.value
+    }
+
+    #[inline]
+    fn deserialize_fn<Fn: FnMut(usize) -> F>(f: Fn) -> Self {
+        Self {
+            value: array::from_fn(f),
+        }
+    }
+
+    #[inline]
+    fn deserialize_iter<I: Iterator<Item = F>>(iter: I) -> Self {
+        let mut res = Self::default();
+        for (i, b) in iter.enumerate() {
+            res.value[i] = b;
+        }
+        res
+    }
+}
+
 impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
     for BinomialExtensionField<F, D>
 {
     type ExtensionPacking = PackedBinomialExtensionField<F, F::Packing, D>;
+
+    fn is_in_basefield(&self) -> bool {
+        self.value[1..].iter().all(F::is_zero)
+    }
+
+    fn as_base(&self) -> Option<F> {
+        if <Self as ExtensionField<F>>::is_in_basefield(self) {
+            Some(self.value[0])
+        } else {
+            None
+        }
+    }
+
+    fn from_base(val: F) -> Self {
+        Self {
+            value: field_to_array(val),
+        }
+    }
+
+    fn ext_powers_packed(&self) -> crate::Powers<Self::ExtensionPacking> {
+        let width = F::Packing::WIDTH;
+        let powers = self.powers().take(width + 1).collect_vec();
+        // Transpose first WIDTH powers
+        let mut packed_powers = PackedBinomialExtensionField::<F, F::Packing, D> {
+            value: [F::Packing::ZERO; D],
+        };
+        packed_powers
+            .value
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, row_i)| {
+                let row_i = row_i.as_slice_mut();
+                powers[..width]
+                    .iter()
+                    .enumerate()
+                    .for_each(|(j, vec_j)| row_i[j] = vec_j.value[i])
+            });
+
+        // Broadcast self^WIDTH
+        let multiplier = powers[width].into();
+
+        Powers {
+            base: multiplier,
+            current: packed_powers,
+        }
+    }
 }
 
 impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExtensionField<F, D> {
@@ -72,7 +144,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
             // x^(n^(count % D))
             return self.repeated_frobenius(count % D);
         }
-        let arr: &[F] = self.as_base_slice();
+        let arr: &[F] = self.serialize_as_slice();
 
         // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
         let mut z0 = F::DTH_ROOT;
@@ -85,7 +157,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
             res[i] = arr[i] * z;
         }
 
-        Self::from_base_slice(&res)
+        Self::deserialize_slice(&res)
     }
 
     /// Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
@@ -180,8 +252,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
         }
 
         match D {
-            2 => Some(Self::from_base_slice(&qudratic_inv(&self.value, F::W))),
-            3 => Some(Self::from_base_slice(&cubic_inv(&self.value, F::W))),
+            2 => Some(Self::deserialize_slice(&qudratic_inv(&self.value, F::W))),
+            3 => Some(Self::deserialize_slice(&cubic_inv(&self.value, F::W))),
             _ => Some(self.frobenius_inv()),
         }
     }
@@ -431,39 +503,6 @@ where
     F: BinomiallyExtendable<D>,
 {
     const D: usize = D;
-
-    #[inline]
-    fn from_base(b: F) -> Self {
-        Self {
-            value: field_to_array(b),
-        }
-    }
-
-    #[inline]
-    fn from_base_slice(bs: &[F]) -> Self {
-        Self::from_base_fn(|i| bs[i])
-    }
-
-    #[inline]
-    fn from_base_fn<Fn: FnMut(usize) -> F>(f: Fn) -> Self {
-        Self {
-            value: array::from_fn(f),
-        }
-    }
-
-    #[inline]
-    fn from_base_iter<I: Iterator<Item = F>>(iter: I) -> Self {
-        let mut res = Self::default();
-        for (i, b) in iter.enumerate() {
-            res.value[i] = b;
-        }
-        res
-    }
-
-    #[inline(always)]
-    fn as_base_slice(&self) -> &[F] {
-        &self.value
-    }
 }
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Distribution<BinomialExtensionField<F, D>>
@@ -476,7 +515,7 @@ where
         for r in res.iter_mut() {
             *r = Standard.sample(rng);
         }
-        BinomialExtensionField::from_base_slice(&res)
+        BinomialExtensionField::deserialize_slice(&res)
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -91,6 +91,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
         }
     }
 
+    // This is just here as a placeholder for now. Going to move this function to packed_binomial_extension
+    // in a future PR (before this is merged onto the main branch.)
     fn ext_powers_packed(&self) -> crate::Powers<Self::ExtensionPacking> {
         let width = F::Packing::WIDTH;
         let powers = self.powers().take(width + 1).collect_vec();

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use super::{binomial_mul, cubic_square, vector_add, vector_sub, BinomialExtensionField};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
-use crate::{field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField};
+use crate::{field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField, Serializable};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // to make the zero_vec implementation safe
@@ -113,45 +113,38 @@ where
     }
 }
 
-impl<F, PF, const D: usize> FieldExtensionAlgebra<PF> for PackedBinomialExtensionField<F, PF, D>
+impl<F, PF, const D: usize> Serializable<PF> for PackedBinomialExtensionField<F, PF, D>
 where
     F: BinomiallyExtendable<D>,
     PF: PackedField<Scalar = F>,
 {
-    const D: usize = D;
+    const DIMENSION: usize = D;
 
-    #[inline]
-    fn from_base(b: PF) -> Self {
-        Self {
-            value: field_to_array(b),
-        }
+    fn serialize_as_slice(&self) -> &[PF] {
+        &self.value
     }
 
-    #[inline]
-    fn from_base_slice(bs: &[PF]) -> Self {
-        Self::from_base_fn(|i| bs[i])
-    }
-
-    #[inline]
-    fn from_base_fn<Fn: FnMut(usize) -> PF>(f: Fn) -> Self {
+    fn deserialize_fn<Fn: FnMut(usize) -> PF>(f: Fn) -> Self {
         Self {
             value: array::from_fn(f),
         }
     }
 
-    #[inline]
-    fn from_base_iter<I: Iterator<Item = PF>>(iter: I) -> Self {
+    fn deserialize_iter<I: Iterator<Item = PF>>(iter: I) -> Self {
         let mut res = Self::default();
         for (i, b) in iter.enumerate() {
             res.value[i] = b;
         }
         res
     }
+}
 
-    #[inline(always)]
-    fn as_base_slice(&self) -> &[PF] {
-        &self.value
-    }
+impl<F, PF, const D: usize> FieldExtensionAlgebra<PF> for PackedBinomialExtensionField<F, PF, D>
+where
+    F: BinomiallyExtendable<D>,
+    PF: PackedField<Scalar = F>,
+{
+    const D: usize = D;
 }
 
 impl<F, PF, const D: usize> Neg for PackedBinomialExtensionField<F, PF, D>

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -6,7 +6,6 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::slice;
 
-use itertools::Itertools;
 use num_bigint::BigUint;
 use num_traits::One;
 use nums::{Factorizer, FactorizerFromSplitter, MillerRabin, PollardRho};
@@ -15,7 +14,7 @@ use serde::Serialize;
 
 use crate::exponentiation::bits_u64;
 use crate::integers::{from_integer_types, QuotientMap};
-use crate::packed::{PackedField, PackedValue};
+use crate::packed::PackedField;
 use crate::Packable;
 
 /// A commutative algebra over a finite field.
@@ -257,6 +256,115 @@ pub trait FieldAlgebra:
     }
 }
 
+/// A field algebra which can be serialized into and out of a
+/// collection of field elements.
+///
+/// We make no guarantees about consistency of this Serialization/Deserialization
+/// across different versions of Plonky3.
+///
+/// ### Mathematical Description
+///
+/// Mathematically a more accurate name for this trait would be BasedFreeVectorSpace.
+///
+/// As `F` is a field, every field algebra `A`, over `F` is an `F`-vector space.
+/// This means we can pick a basis of elements `B = {b_0, ..., b_{n-1}}` in `A`
+/// such that, given any element `a`, we can find a unique set of `n` elements of `F`,
+/// `f_0, ..., f_{n - 1}` satisfying `a = f_0 b_0 + ... + f_{n - 1} b_{n - 1}`.
+///
+/// Thus choosing this basis `B` allows us to map between elements of `A` and
+/// arrays of `n` elements of `F`. Clearly this map depends entirely on the
+/// choice of basis `B` which may change across versions of Plonky3.
+pub trait Serializable<F: FieldAlgebra>: Sized {
+    // We could alternatively call this BasedAlgebra?
+    // The name is currently trying to indicate what this is meant to be
+    // used for as opposed to being mathematically accurate.
+
+    const DIMENSION: usize;
+
+    /// Fixes a basis for the algebra `A` and uses this to
+    /// map an element of `A` to a vector of `n` `F` elements.
+    ///
+    /// # Safety
+    ///
+    /// The value produced by this function fundamentally depends
+    /// on the choice of basis. Care must be taken
+    /// to ensure portability if these values might ever be passed to
+    /// (or rederived within) another compilation environment where a
+    /// different basis might have been used.
+    fn serialize_as_slice(&self) -> &[F];
+
+    /// Fixes a basis for the algebra `A` and uses this to
+    /// map `n` `F` elements to an element of `A`.
+    ///
+    /// # Safety
+    ///
+    /// The value produced by this function fundamentally depends
+    /// on the choice of basis. Care must be taken
+    /// to ensure portability if these values might ever be passed to
+    /// (or rederived within) another compilation environment where a
+    /// different basis might have been used.
+    #[inline]
+    fn deserialize_slice(slice: &[F]) -> Self {
+        Self::deserialize_fn(|i| slice[i].clone())
+    }
+
+    /// Fixes a basis for the algebra `A` and uses this to
+    /// map `n` `F` elements to an element of `A`. Similar
+    /// to `core:array::from_fn`, the `n` `F` elements are
+    /// given by `Fn(0), ..., Fn(n - 1)`.
+    ///
+    /// # Safety
+    ///
+    /// The value produced by this function fundamentally depends
+    /// on the choice of basis. Care must be taken
+    /// to ensure portability if these values might ever be passed to
+    /// (or rederived within) another compilation environment where a
+    /// different basis might have been used.
+    fn deserialize_fn<Fn: FnMut(usize) -> F>(f: Fn) -> Self;
+
+    fn ith_basis_element(i: usize) -> Self {
+        Self::deserialize_fn(|j| {
+            if i == j {
+                F::ONE.clone()
+            } else {
+                F::ZERO.clone()
+            }
+        })
+    }
+
+    /// Fixes a basis for the algebra `A` and uses this to
+    /// map `n` `F` elements to an element of `A`.
+    ///
+    /// # Safety
+    ///
+    /// The value produced by this function fundamentally depends
+    /// on the choice of basis. Care must be taken
+    /// to ensure portability if these values might ever be passed to
+    /// (or rederived within) another compilation environment where a
+    /// different basis might have been used.
+    fn deserialize_iter<I: Iterator<Item = F>>(iter: I) -> Self;
+}
+
+impl<F: FieldAlgebra> Serializable<F> for F {
+    const DIMENSION: usize = 1;
+
+    fn serialize_as_slice(&self) -> &[F] {
+        slice::from_ref(self)
+    }
+
+    fn deserialize_slice(slice: &[F]) -> Self {
+        slice[0].clone()
+    }
+
+    fn deserialize_fn<Fn: FnMut(usize) -> F>(mut f: Fn) -> Self {
+        f(0)
+    }
+
+    fn deserialize_iter<I: Iterator<Item = F>>(mut iter: I) -> Self {
+        iter.next().unwrap()
+    }
+}
+
 /// A ring implements `InjectiveMonomial<N>` if the algebraic function
 /// `f(x) = x^N` is an injective map on elements of the ring.
 ///
@@ -434,62 +542,9 @@ pub trait FieldExtensionAlgebra<Base: FieldAlgebra>:
     + SubAssign<Base>
     + Mul<Base, Output = Self>
     + MulAssign<Base>
+    + Serializable<Base>
 {
     const D: usize;
-
-    fn from_base(b: Base) -> Self;
-
-    /// Suppose this field extension is represented by the quotient
-    /// ring `B[X]/(f(X))` where B is `Base` and f is an irreducible
-    /// polynomial of degree `D`. This function takes a slice `bs` of
-    /// length at exactly D, and constructs the field element
-    /// `\sum_i bs[i] * X^i`.
-    ///
-    /// NB: The value produced by this function fundamentally depends
-    /// on the choice of irreducible polynomial f. Care must be taken
-    /// to ensure portability if these values might ever be passed to
-    /// (or rederived within) another compilation environment where a
-    /// different f might have been used.
-    fn from_base_slice(bs: &[Base]) -> Self;
-
-    /// Similar to `core:array::from_fn`, with the same caveats as
-    /// `from_base_slice`.
-    fn from_base_fn<F: FnMut(usize) -> Base>(f: F) -> Self;
-    fn from_base_iter<I: Iterator<Item = Base>>(iter: I) -> Self;
-
-    /// Suppose this field extension is represented by the quotient
-    /// ring `B[X]/(f(X))` where B is `Base` and f is an irreducible
-    /// polynomial of degree `D`. This function takes a field element
-    /// `\sum_i bs[i] * X^i` and returns the coefficients as a slice
-    /// `bs` of length at most D containing, from lowest degree to
-    /// highest.
-    ///
-    /// NB: The value produced by this function fundamentally depends
-    /// on the choice of irreducible polynomial f. Care must be taken
-    /// to ensure portability if these values might ever be passed to
-    /// (or rederived within) another compilation environment where a
-    /// different f might have been used.
-    fn as_base_slice(&self) -> &[Base];
-
-    /// Suppose this field extension is represented by the quotient
-    /// ring `B[X]/(f(X))` where B is `Base` and f is an irreducible
-    /// polynomial of degree `D`. This function returns the field
-    /// element `X^exponent` if `exponent < D` and panics otherwise.
-    /// (The fact that f is not known at the point that this function
-    /// is defined prevents implementing exponentiation of higher
-    /// powers since the reduction cannot be performed.)
-    ///
-    /// NB: The value produced by this function fundamentally depends
-    /// on the choice of irreducible polynomial f. Care must be taken
-    /// to ensure portability if these values might ever be passed to
-    /// (or rederived within) another compilation environment where a
-    /// different f might have been used.
-    fn monomial(exponent: usize) -> Self {
-        assert!(exponent < Self::D, "requested monomial of too high degree");
-        let mut vec = vec![Base::ZERO; Self::D];
-        vec[exponent] = Base::ONE;
-        Self::from_base_slice(&vec)
-    }
 }
 
 pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> {
@@ -499,69 +554,41 @@ pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> {
         + Send
         + Sync;
 
-    #[inline(always)]
-    fn is_in_basefield(&self) -> bool {
-        self.as_base_slice()[1..].iter().all(Field::is_zero)
-    }
+    fn is_in_basefield(&self) -> bool;
 
-    fn as_base(&self) -> Option<Base> {
-        if self.is_in_basefield() {
-            Some(self.as_base_slice()[0])
-        } else {
-            None
-        }
-    }
+    fn as_base(&self) -> Option<Base>;
+
+    fn from_base(val: Base) -> Self;
 
     /// Construct an iterator which returns powers of `self` packed into `ExtensionPacking` elements.
     ///
     /// E.g. if `PACKING::WIDTH = 4` this returns the elements:
     /// `[self^0, self^1, self^2, self^3], [self^4, self^5, self^6, self^7], ...`.
-    fn ext_powers_packed(&self) -> Powers<Self::ExtensionPacking> {
-        let powers = self.powers().take(Base::Packing::WIDTH + 1).collect_vec();
-        // Transpose first WIDTH powers
-        let current = Self::ExtensionPacking::from_base_fn(|i| {
-            Base::Packing::from_fn(|j| powers[j].as_base_slice()[i])
-        });
-        // Broadcast self^WIDTH
-        let multiplier = Self::ExtensionPacking::from_base_fn(|i| {
-            Base::Packing::from(powers[Base::Packing::WIDTH].as_base_slice()[i])
-        });
-
-        Powers {
-            base: multiplier,
-            current,
-        }
-    }
+    fn ext_powers_packed(&self) -> Powers<Self::ExtensionPacking>;
 }
 
 impl<F: Field> ExtensionField<F> for F {
     type ExtensionPacking = F::Packing;
+
+    fn is_in_basefield(&self) -> bool {
+        true
+    }
+
+    fn as_base(&self) -> Option<F> {
+        Some(*self)
+    }
+
+    fn from_base(val: F) -> Self {
+        val
+    }
+
+    fn ext_powers_packed(&self) -> Powers<Self::ExtensionPacking> {
+        self.powers_packed()
+    }
 }
 
 impl<FA: FieldAlgebra> FieldExtensionAlgebra<FA> for FA {
     const D: usize = 1;
-
-    fn from_base(b: FA) -> Self {
-        b
-    }
-
-    fn from_base_slice(bs: &[FA]) -> Self {
-        assert_eq!(bs.len(), 1);
-        bs[0].clone()
-    }
-
-    fn from_base_iter<I: Iterator<Item = FA>>(mut iter: I) -> Self {
-        iter.next().unwrap()
-    }
-
-    fn from_base_fn<F: FnMut(usize) -> FA>(mut f: F) -> Self {
-        f(0)
-    }
-
-    #[inline(always)]
-    fn as_base_slice(&self) -> &[FA] {
-        slice::from_ref(self)
-    }
 }
 
 /// A field which supplies information like the two-adicity of its multiplicative group, and methods

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -303,6 +303,10 @@ pub trait Serializable<F: FieldAlgebra>: Sized {
     /// to ensure portability if these values might ever be passed to
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
+    ///
+    /// The user should ensure that the slice has length `DIMENSION`. If
+    /// it is shorter than this, the function will panic, if it is longer the
+    /// extra elements will be ignored.
     #[inline]
     fn deserialize_slice(slice: &[F]) -> Self {
         Self::deserialize_fn(|i| slice[i].clone())
@@ -332,6 +336,9 @@ pub trait Serializable<F: FieldAlgebra>: Sized {
     /// to ensure portability if these values might ever be passed to
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
+    ///
+    /// If the iterator contains more than `DIMENSION` many elements,
+    /// the rest will be ignored.
     fn deserialize_iter<I: Iterator<Item = F>>(iter: I) -> Self;
 
     /// Given a basis for the Algebra `A`, return the i'th basis element.

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -547,7 +547,7 @@ pub trait FieldExtensionAlgebra<Base: FieldAlgebra>:
     const D: usize;
 }
 
-pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> {
+pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> + From<Base> {
     type ExtensionPacking: FieldExtensionAlgebra<Base::Packing, F = Self>
         + 'static
         + Copy
@@ -557,8 +557,6 @@ pub trait ExtensionField<Base: Field>: Field + FieldExtensionAlgebra<Base> {
     fn is_in_basefield(&self) -> bool;
 
     fn as_base(&self) -> Option<Base>;
-
-    fn from_base(val: Base) -> Self;
 
     /// Construct an iterator which returns powers of `self` packed into `ExtensionPacking` elements.
     ///
@@ -576,10 +574,6 @@ impl<F: Field> ExtensionField<F> for F {
 
     fn as_base(&self) -> Option<F> {
         Some(*self)
-    }
-
-    fn from_base(val: F) -> Self {
-        val
     }
 
     fn ext_powers_packed(&self) -> Powers<Self::ExtensionPacking> {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -344,13 +344,7 @@ pub trait Serializable<F: FieldAlgebra>: Sized {
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
     fn ith_basis_element(i: usize) -> Self {
-        Self::deserialize_fn(|j| {
-            if i == j {
-                F::ONE.clone()
-            } else {
-                F::ZERO.clone()
-            }
-        })
+        Self::deserialize_fn(|j| F::from_bool(i == j))
     }
 }
 

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -91,7 +91,7 @@ where
         let (commit, prover_data) = config.mmcs.commit_matrix(leaves);
         challenger.observe(commit.clone());
 
-        let beta: Challenge = challenger.sample_ext_element();
+        let beta: Challenge = challenger.sample_algebra_element();
         // We passed ownership of `current` to the MMCS, so get a reference to it
         let leaves = config.mmcs.get_matrices(&prover_data).pop().unwrap();
         folded = g.fold_matrix(beta, leaves.as_view());
@@ -110,7 +110,7 @@ where
     for x in folded {
         assert_eq!(x, final_poly);
     }
-    challenger.observe_ext_element(final_poly);
+    challenger.observe_algebra_element(final_poly);
 
     CommitPhaseResult {
         commits,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -238,7 +238,7 @@ where
         */
 
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample_ext_element();
+        let alpha: Challenge = challenger.sample_algebra_element();
 
         let mats_and_points = rounds
             .iter()
@@ -364,7 +364,7 @@ where
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         // Batch combination challenge
-        let alpha: Challenge = challenger.sample_ext_element();
+        let alpha: Challenge = challenger.sample_algebra_element();
 
         let log_global_max_height = proof.commit_phase_commits.len() + self.fri.log_blowup;
 

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -37,10 +37,10 @@ where
         .iter()
         .map(|comm| {
             challenger.observe(comm.clone());
-            challenger.sample_ext_element()
+            challenger.sample_algebra_element()
         })
         .collect();
-    challenger.observe_ext_element(proof.final_poly);
+    challenger.observe_algebra_element(proof.final_poly);
 
     if proof.query_proofs.len() != config.num_queries {
         return Err(FriError::InvalidProofShape);

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -61,7 +61,7 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
     let (proof, p_sample) = {
         // Prover world
         let mut chal = Challenger::new(perm.clone());
-        let alpha: Challenge = chal.sample_ext_element();
+        let alpha: Challenge = chal.sample_algebra_element();
 
         let input: [_; 32] = core::array::from_fn(|log_height| {
             let matrices_with_log_height: Vec<&RowMajorMatrix<Val>> = ldes
@@ -109,7 +109,7 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R) {
     };
 
     let mut v_challenger = Challenger::new(perm);
-    let _alpha: Challenge = v_challenger.sample_ext_element();
+    let _alpha: Challenge = v_challenger.sample_algebra_element();
     verifier::verify(
         &TwoAdicFriGenericConfig::<Vec<(usize, Challenge)>, ()>(PhantomData),
         &fc,

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -59,7 +59,7 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
     assert_eq!(data_by_round.len(), num_rounds);
     p_challenger.observe_slice(&commits_by_round);
 
-    let zeta: Challenge = p_challenger.sample_ext_element();
+    let zeta: Challenge = p_challenger.sample_algebra_element();
 
     let points_by_round = log_degrees_by_round
         .iter()
@@ -72,7 +72,7 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
     // Verify the proof.
     let mut v_challenger = challenger.clone();
     v_challenger.observe_slice(&commits_by_round);
-    let verifier_zeta: Challenge = v_challenger.sample_ext_element();
+    let verifier_zeta: Challenge = v_challenger.sample_algebra_element();
     assert_eq!(verifier_zeta, zeta);
 
     let commits_and_claims_by_round = izip!(

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -67,7 +67,7 @@ where
     };
     let sum = coset_evals.columnwise_dot_product(&col_scale);
 
-    let zerofier = two_adic_coset_zerofier::<EF>(log_height, EF::from_base(shift), point);
+    let zerofier = two_adic_coset_zerofier::<EF>(log_height, shift.into(), point);
 
     // In principle, height could be bigger than the characteristic of F.
     let denominator = shift

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -2,8 +2,8 @@
 mod test_quartic_extension {
     use alloc::format;
 
-    use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::FieldAlgebra;
+    use p3_field::{extension::BinomialExtensionField, Serializable};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;
@@ -23,7 +23,7 @@ mod test_quartic_extension {
         assert_eq!(
             format!(
                 "{}",
-                EF::from_base_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
+                EF::deserialize_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
             ),
             "2 + X + 2 X^3"
         );

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -120,7 +120,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
             .values
             .borrow()
             .iter()
-            .flat_map(|x| x.as_base_slice().iter().copied())
+            .flat_map(|x| x.serialize_as_slice().iter().copied())
             .collect();
         RowMajorMatrix::new(values, width)
     }

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -57,7 +57,7 @@ where
         self.0
             .row_slice(r)
             .iter()
-            .flat_map(|val| val.as_base_slice())
+            .flat_map(|val| val.serialize_as_slice())
             .copied()
             .collect::<Vec<_>>()
     }
@@ -81,7 +81,7 @@ where
             self.idx = 0;
             self.inner.next();
         }
-        let value = self.inner.peek()?.as_base_slice()[self.idx];
+        let value = self.inner.peek()?.serialize_as_slice()[self.idx];
         self.idx += 1;
         Some(value)
     }
@@ -92,7 +92,7 @@ mod tests {
     use alloc::vec;
 
     use p3_field::extension::Complex;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{FieldAlgebra, Serializable};
     use p3_mersenne_31::Mersenne31;
 
     use super::*;
@@ -103,10 +103,10 @@ mod tests {
     #[test]
     fn flat_matrix() {
         let values = vec![
-            EF::from_base_fn(|i| F::from_u8(i as u8 + 10)),
-            EF::from_base_fn(|i| F::from_u8(i as u8 + 20)),
-            EF::from_base_fn(|i| F::from_u8(i as u8 + 30)),
-            EF::from_base_fn(|i| F::from_u8(i as u8 + 40)),
+            EF::deserialize_fn(|i| F::from_u8(i as u8 + 10)),
+            EF::deserialize_fn(|i| F::from_u8(i as u8 + 20)),
+            EF::deserialize_fn(|i| F::from_u8(i as u8 + 30)),
+            EF::deserialize_fn(|i| F::from_u8(i as u8 + 40)),
         ];
         let ext = RowMajorMatrix::<EF>::new(values, 2);
         let flat = FlatMatrixView::<F, EF, _>::new(ext);

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PackedValue};
+use p3_field::{FieldAlgebra, PackedValue, Serializable};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
@@ -63,7 +63,7 @@ where
 
     challenger.observe(trace_commit.clone());
     challenger.observe_slice(public_values);
-    let alpha: SC::Challenge = challenger.sample_ext_element();
+    let alpha: SC::Challenge = challenger.sample_algebra_element();
 
     let quotient_domain =
         trace_domain.create_disjoint_domain(1 << (log_degree + log_quotient_degree));
@@ -192,8 +192,8 @@ where
 
             // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
             (0..core::cmp::min(quotient_size, PackedVal::<SC>::WIDTH)).map(move |idx_in_packing| {
-                SC::Challenge::from_base_fn(|coeff_idx| {
-                    quotient.as_base_slice()[coeff_idx].as_slice()[idx_in_packing]
+                SC::Challenge::deserialize_fn(|coeff_idx| {
+                    quotient.serialize_as_slice()[coeff_idx].as_slice()[idx_in_packing]
                 })
             })
         })

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
+use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra, Serializable};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
@@ -64,7 +64,7 @@ where
 
     challenger.observe(commitments.trace.clone());
     challenger.observe_slice(public_values);
-    let alpha: SC::Challenge = challenger.sample_ext_element();
+    let alpha: SC::Challenge = challenger.sample_algebra_element();
     challenger.observe(commitments.quotient_chunks.clone());
 
     let zeta: SC::Challenge = challenger.sample();
@@ -119,7 +119,7 @@ where
         .map(|(ch_i, ch)| {
             ch.iter()
                 .enumerate()
-                .map(|(e_i, &c)| zps[ch_i] * SC::Challenge::monomial(e_i) * c)
+                .map(|(e_i, &c)| zps[ch_i] * SC::Challenge::ith_basis_element(e_i) * c)
                 .sum::<SC::Challenge>()
         })
         .sum::<SC::Challenge>();


### PR DESCRIPTION
Note this is not merging into main. The plan is to develop the Field crate refactor in a separate branch and then merge it all in in a single PR. This will avoid the need for a collection of small API breaking changes.

The point of this PR is to do about the half the work required in order to delete the `FieldExtensionAlgebra` trait. Here we move most of it's functionality into a new trait: `Serializable<F>`. (I haven't yest deleted `FieldExtensionAlgebra` but will do that in a future PR before this merges onto main).

A struct `A` should implement `Serializable<F>` if it is naturally convertible to and from a collection of `F` elements. When `F` is a field and `A` some `FieldAlgebra` over `F`, implementing `Serializable<F>` corresponds to choosing a basis for `A`. This is used when we need to draw random elements of `A` or commit/observe `A` elements as it lets us instead draw/commit to an array of `F` elements.

It makes sense to have this functionality somewhere other than `FieldExtensionAlgebra` as this is more general and a little clearer about what is fundamentally going on.

2 current problems it would be good to get feedback on:
1 - I'm not super happy with the names. Both `Serializable` and the functions within it could maybe be given clearer names. I basically used these as we want to somewhat discourage people from using these as we may change the basis we use for a given algebra if we find a more efficient one.
2 - There is quite a bit of overlap between `Serializable` and `PackedValue`. The main difference is that `PackedValue` is explicitly reasoning about memory layouts but the basic idea behind the two traits is almost identical.