### PR TITLE
Cleaning up KECCAK AIR and speeding up its trace generation.

### DIFF
--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -87,6 +87,32 @@ pub fn u32_to_bits_le<FA: FieldAlgebra>(val: u32) -> [FA; 32] {
     })
 }
 
+/// Convert a 64-bit integer into an array of 64 0 or 1 field elements.
+///
+/// The output array is in little-endian order.
+#[inline]
+pub fn u64_to_bits_le<FA: FieldAlgebra>(val: u64) -> [FA; 64] {
+    // We do this over F::from_canonical_u64 as from_canonical_u64 can be slow
+    // like in the case of monty field.
+    array::from_fn(|i| {
+        if val & (1 << i) != 0 {
+            FA::ONE
+        } else {
+            FA::ZERO
+        }
+    })
+}
+
+/// Convert a 64-bit integer into an array of four field elements representing the 16 bit limb decomposition.
+///
+/// The output array is in little-endian order.
+#[inline]
+pub fn u64_to_16_bit_limbs<FA: FieldAlgebra>(val: u64) -> [FA; 4] {
+    // We do this over F::from_canonical_u64 as from_canonical_u64 can be slow
+    // like in the case of monty field.
+    array::from_fn(|i| FA::from_canonical_u16((val >> (16 * i)) as u16))
+}
+
 /// Verify that `a = b + c + d mod 2^32`
 ///
 /// We assume that a, b, c, d are all given as `2, 16` bit limbs (e.g. `a = a[0] + 2^16 a[1]`) and

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -76,15 +76,7 @@ pub fn checked_andn<F: Field>(x: F, y: F) -> F {
 /// The output array is in little-endian order.
 #[inline]
 pub fn u32_to_bits_le<FA: FieldAlgebra>(val: u32) -> [FA; 32] {
-    // We do this over F::from_canonical_u32 as from_canonical_u32 can be slow
-    // like in the case of monty field.
-    array::from_fn(|i| {
-        if val & (1 << i) != 0 {
-            FA::ONE
-        } else {
-            FA::ZERO
-        }
-    })
+    array::from_fn(|i| FA::from_bool(val & (1 << i) != 0))
 }
 
 /// Convert a 64-bit integer into an array of 64 0 or 1 field elements.
@@ -92,15 +84,7 @@ pub fn u32_to_bits_le<FA: FieldAlgebra>(val: u32) -> [FA; 32] {
 /// The output array is in little-endian order.
 #[inline]
 pub fn u64_to_bits_le<FA: FieldAlgebra>(val: u64) -> [FA; 64] {
-    // We do this over F::from_canonical_u64 as from_canonical_u64 can be slow
-    // like in the case of monty field.
-    array::from_fn(|i| {
-        if val & (1 << i) != 0 {
-            FA::ONE
-        } else {
-            FA::ZERO
-        }
-    })
+    array::from_fn(|i| FA::from_bool(val & (1 << i) != 0))
 }
 
 /// Convert a 64-bit integer into an array of four field elements representing the 16 bit limb decomposition.
@@ -108,8 +92,6 @@ pub fn u64_to_bits_le<FA: FieldAlgebra>(val: u64) -> [FA; 64] {
 /// The output array is in little-endian order.
 #[inline]
 pub fn u64_to_16_bit_limbs<FA: FieldAlgebra>(val: u64) -> [FA; 4] {
-    // We do this over F::from_canonical_u64 as from_canonical_u64 can be slow
-    // like in the case of monty field.
     array::from_fn(|i| FA::from_canonical_u16((val >> (16 * i)) as u16))
 }
 

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -109,10 +109,6 @@ impl FieldAlgebra for Bn254Fr {
         f
     }
 
-    fn from_bool(b: bool) -> Self {
-        Self::new(FFBn254Fr::from(b as u64))
-    }
-
     fn from_canonical_u8(n: u8) -> Self {
         Self::new(FFBn254Fr::from(n as u64))
     }

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -48,10 +48,6 @@ impl<F: Field, const N: usize> FieldAlgebra for FieldArray<F, N> {
         f.into()
     }
 
-    fn from_bool(b: bool) -> Self {
-        [F::from_bool(b); N].into()
-    }
-
     fn from_canonical_u8(n: u8) -> Self {
         [F::from_canonical_u8(n); N].into()
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -144,11 +144,6 @@ where
     }
 
     #[inline]
-    fn from_bool(b: bool) -> Self {
-        FA::from_bool(b).into()
-    }
-
-    #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         FA::from_canonical_u8(n).into()
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -93,7 +93,13 @@ pub trait FieldAlgebra:
     fn from_f(f: Self::F) -> Self;
 
     /// Convert from a `bool`.
-    fn from_bool(b: bool) -> Self;
+    fn from_bool(b: bool) -> Self {
+        if b {
+            Self::ONE
+        } else {
+            Self::ZERO
+        }
+    }
 
     /// Convert from a canonical `u8`.
     ///

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -170,10 +170,6 @@ impl FieldAlgebra for PackedGoldilocksAVX2 {
     }
 
     #[inline]
-    fn from_bool(b: bool) -> Self {
-        Goldilocks::from_bool(b).into()
-    }
-    #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         Goldilocks::from_canonical_u8(n).into()
     }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -167,11 +167,6 @@ impl FieldAlgebra for PackedGoldilocksAVX512 {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        Goldilocks::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         Goldilocks::from_canonical_u8(n).into()

--- a/keccak-air/src/columns.rs
+++ b/keccak-air/src/columns.rs
@@ -19,14 +19,6 @@ pub struct KeccakCols<T> {
     /// The `i`th value is set to 1 if we are in the `i`th round, otherwise 0.
     pub step_flags: [T; NUM_ROUNDS],
 
-    /// A register which indicates if a row should be exported, i.e. included in a multiset equality
-    /// argument. Should be 1 only for certain rows which are final steps, i.e. with
-    /// `step_flags[23] = 1`.
-    pub export: T,
-
-    /// Permutation inputs, stored in y-major order.
-    pub preimage: [[[T; U64_LIMBS]; 5]; 5],
-
     pub a: [[[T; U64_LIMBS]; 5]; 5],
 
     /// ```ignore
@@ -89,19 +81,6 @@ impl<T: Copy> KeccakCols<T> {
             self.a_prime_prime[y][x][limb]
         }
     }
-}
-
-pub fn input_limb(i: usize) -> usize {
-    debug_assert!(i < RATE_LIMBS);
-
-    let i_u64 = i / U64_LIMBS;
-    let limb_index = i % U64_LIMBS;
-
-    // The 5x5 state is treated as y-major, as per the Keccak spec.
-    let y = i_u64 / 5;
-    let x = i_u64 % 5;
-
-    KECCAK_COL_MAP.preimage[y][x][limb_index]
 }
 
 pub fn output_limb(i: usize) -> usize {

--- a/keccak-air/src/constants.rs
+++ b/keccak-air/src/constants.rs
@@ -1,5 +1,3 @@
-use crate::BITS_PER_LIMB;
-
 pub(crate) const R: [[u8; 5]; 5] = [
     [0, 36, 3, 41, 18],
     [1, 44, 10, 45, 2],
@@ -157,10 +155,6 @@ const RC_BITS: [[u8; 64]; 24] = [
         0, 0, 0, 1,
     ],
 ];
-
-pub(crate) const fn rc_value_limb(round: usize, limb: usize) -> u16 {
-    (RC[round] >> (limb * BITS_PER_LIMB)) as u16
-}
 
 pub(crate) const fn rc_value_bit(round: usize, bit_index: usize) -> u8 {
     RC_BITS[round][bit_index]

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -1,6 +1,9 @@
+use core::array;
+use core::mem::transmute;
+
 use alloc::vec::Vec;
 
-use p3_air::utils::{checked_andn, checked_xor};
+use p3_air::utils::{u64_to_16_bit_limbs, u64_to_bits_le};
 use p3_field::PrimeField64;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::iter::repeat;
@@ -8,8 +11,7 @@ use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
-use crate::constants::rc_value_limb;
-use crate::{BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
+use crate::{NUM_ROUNDS, R, RC, U64_LIMBS};
 
 // TODO: Take generic iterable
 #[instrument(name = "generate Keccak trace", skip_all)]
@@ -37,30 +39,16 @@ pub fn generate_trace_rows<F: PrimeField64>(inputs: Vec<[u64; 25]>) -> RowMajorM
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
 fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], input: [u64; 25]) {
-    // Populate the preimage for each row.
-    for row in rows.iter_mut() {
-        for y in 0..5 {
-            for x in 0..5 {
-                let input_xy = input[y * 5 + x];
-                for limb in 0..U64_LIMBS {
-                    row.preimage[y][x][limb] =
-                        F::from_canonical_u64((input_xy >> (16 * limb)) & 0xFFFF);
-                }
-            }
-        }
-    }
-
     // Populate the round input for the first round.
+    let mut current_state: [[u64; 5]; 5] = unsafe { transmute(input) };
+
     for y in 0..5 {
-        for x in 0..5 {
-            let input_xy = input[y * 5 + x];
-            for limb in 0..U64_LIMBS {
-                rows[0].a[y][x][limb] = F::from_canonical_u64((input_xy >> (16 * limb)) & 0xFFFF);
-            }
+        for (x, row) in current_state.iter().enumerate() {
+            rows[0].a[y][x] = u64_to_16_bit_limbs(row[y]);
         }
     }
 
-    generate_trace_row_for_round(&mut rows[0], 0);
+    generate_trace_row_for_round(&mut rows[0], 0, &mut current_state);
 
     for round in 1..rows.len() {
         // Copy previous row's output to next row's input.
@@ -72,92 +60,68 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], inp
             }
         }
 
-        generate_trace_row_for_round(&mut rows[round], round);
+        generate_trace_row_for_round(&mut rows[round], round, &mut current_state);
     }
 }
 
-fn generate_trace_row_for_round<F: PrimeField64>(row: &mut KeccakCols<F>, round: usize) {
+fn generate_trace_row_for_round<F: PrimeField64>(
+    row: &mut KeccakCols<F>,
+    round: usize,
+    current_state: &mut [[u64; 5]; 5],
+) {
     row.step_flags[round] = F::ONE;
 
     // Populate C[x] = xor(A[x, 0], A[x, 1], A[x, 2], A[x, 3], A[x, 4]).
-    for x in 0..5 {
-        for z in 0..64 {
-            let limb = z / BITS_PER_LIMB;
-            let bit_in_limb = z % BITS_PER_LIMB;
-            let a = (0..5).map(|y| {
-                let a_limb = row.a[y][x][limb].as_canonical_u64() as u16;
-                ((a_limb >> bit_in_limb) & 1) != 0
-            });
-            row.c[x][z] = F::from_bool(a.fold(false, |acc, x| acc ^ x));
-        }
+    let state_c: [u64; 5] = current_state.map(|row| row.iter().fold(0, |acc, y| acc ^ y));
+    for (x, elem) in state_c.iter().enumerate() {
+        row.c[x] = u64_to_bits_le(*elem);
     }
 
     // Populate C'[x, z] = xor(C[x, z], C[x - 1, z], C[x + 1, z - 1]).
-    for x in 0..5 {
-        for z in 0..64 {
-            row.c_prime[x][z] = checked_xor([
-                row.c[x][z],
-                row.c[(x + 4) % 5][z],
-                row.c[(x + 1) % 5][(z + 63) % 64],
-            ]);
-        }
+    let state_c_prime: [u64; 5] =
+        array::from_fn(|x| state_c[x] ^ state_c[(x + 4) % 5] ^ state_c[(x + 1) % 5].rotate_left(1));
+    for (x, elem) in state_c_prime.iter().enumerate() {
+        row.c_prime[x] = u64_to_bits_le(*elem);
     }
 
     // Populate A'. To avoid shifting indices, we rewrite
     //     A'[x, y, z] = xor(A[x, y, z], C[x - 1, z], C[x + 1, z - 1])
     // as
     //     A'[x, y, z] = xor(A[x, y, z], C[x, z], C'[x, z]).
-    for x in 0..5 {
-        for y in 0..5 {
-            for z in 0..64 {
-                let limb = z / BITS_PER_LIMB;
-                let bit_in_limb = z % BITS_PER_LIMB;
-                let a_limb = row.a[y][x][limb].as_canonical_u64() as u16;
-                let a_bit = F::from_bool(((a_limb >> bit_in_limb) & 1) != 0);
-                row.a_prime[y][x][z] = checked_xor([a_bit, row.c[x][z], row.c_prime[x][z]]);
-            }
+    *current_state =
+        array::from_fn(|i| array::from_fn(|j| current_state[i][j] ^ state_c[i] ^ state_c_prime[i]));
+    for (x, x_row) in current_state.iter().enumerate() {
+        for (y, elem) in x_row.iter().enumerate() {
+            row.a_prime[y][x] = u64_to_bits_le(*elem);
         }
     }
+
+    // Rotate the current state to get the B array.
+    *current_state = array::from_fn(|i| {
+        array::from_fn(|j| {
+            let new_i = (i + 3 * j) % 5;
+            let new_j = i;
+            current_state[new_i][new_j].rotate_left(R[new_i][new_j] as u32)
+        })
+    });
 
     // Populate A''.
     // A''[x, y] = xor(B[x, y], andn(B[x + 1, y], B[x + 2, y])).
-    for y in 0..5 {
-        for x in 0..5 {
-            for limb in 0..U64_LIMBS {
-                row.a_prime_prime[y][x][limb] = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
-                    .rev()
-                    .fold(F::ZERO, |acc, z| {
-                        let bit = checked_xor([
-                            row.b(x, y, z),
-                            checked_andn(row.b((x + 1) % 5, y, z), row.b((x + 2) % 5, y, z)),
-                        ]);
-                        acc.double() + bit
-                    });
-            }
+    *current_state = array::from_fn(|i| {
+        array::from_fn(|j| {
+            current_state[i][j] ^ ((!current_state[(i + 1) % 5][j]) & current_state[(i + 2) % 5][j])
+        })
+    });
+    for (x, x_row) in current_state.iter().enumerate() {
+        for (y, elem) in x_row.iter().enumerate() {
+            row.a_prime_prime[y][x] = u64_to_16_bit_limbs(*elem);
         }
     }
 
-    // For the XOR, we split A''[0, 0] to bits.
-    let mut val = 0;
-    for limb in 0..U64_LIMBS {
-        let val_limb = row.a_prime_prime[0][0][limb].as_canonical_u64();
-        val |= val_limb << (limb * BITS_PER_LIMB);
-    }
-    let val_bits: Vec<bool> = (0..64)
-        .scan(val, |acc, _| {
-            let bit = (*acc & 1) != 0;
-            *acc >>= 1;
-            Some(bit)
-        })
-        .collect();
-    for (i, bit) in row.a_prime_prime_0_0_bits.iter_mut().enumerate() {
-        *bit = F::from_bool(val_bits[i]);
-    }
+    row.a_prime_prime_0_0_bits = u64_to_bits_le(current_state[0][0]);
 
     // A''[0, 0] is additionally xor'd with RC.
-    for limb in 0..U64_LIMBS {
-        let rc_lo = rc_value_limb(round, limb);
-        row.a_prime_prime_prime_0_0_limbs[limb] =
-            F::from_canonical_u16(row.a_prime_prime[0][0][limb].as_canonical_u64() as u16 ^ rc_lo);
-    }
+    current_state[0][0] ^= RC[round];
+
+    row.a_prime_prime_prime_0_0_limbs = u64_to_16_bit_limbs(current_state[0][0]);
 }

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -1,7 +1,6 @@
+use alloc::vec::Vec;
 use core::array;
 use core::mem::transmute;
-
-use alloc::vec::Vec;
 
 use p3_air::utils::{u64_to_16_bit_limbs, u64_to_bits_le};
 use p3_field::PrimeField64;

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -320,11 +320,6 @@ impl FieldAlgebra for PackedMersenne31Neon {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        Mersenne31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         Mersenne31::from_canonical_u8(n).into()

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -404,11 +404,6 @@ impl FieldAlgebra for PackedMersenne31AVX2 {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        Mersenne31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         Mersenne31::from_canonical_u8(n).into()

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -424,11 +424,6 @@ impl FieldAlgebra for PackedMersenne31AVX512 {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        Mersenne31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         Mersenne31::from_canonical_u8(n).into()

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -454,11 +454,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31Neon<FP> {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        MontyField31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         MontyField31::from_canonical_u8(n).into()

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -183,11 +183,6 @@ impl<FP: FieldParameters> FieldAlgebra for MontyField31<FP> {
     }
 
     #[inline(always)]
-    fn from_bool(b: bool) -> Self {
-        Self::from_canonical_u32(b as u32)
-    }
-
-    #[inline(always)]
     fn from_canonical_u8(n: u8) -> Self {
         Self::from_canonical_u32(n as u32)
     }

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -481,11 +481,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX2<FP> {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        MontyField31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         MontyField31::from_canonical_u8(n).into()

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -594,11 +594,6 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX512<FP> {
     fn from_f(f: Self::F) -> Self {
         f.into()
     }
-
-    #[inline]
-    fn from_bool(b: bool) -> Self {
-        MontyField31::from_bool(b).into()
-    }
     #[inline]
     fn from_canonical_u8(n: u8) -> Self {
         MontyField31::from_canonical_u8(n).into()

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -87,10 +87,6 @@ impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
         f.into()
     }
 
-    fn from_bool(b: bool) -> Self {
-        Self::Constant(F::from_bool(b))
-    }
-
     fn from_canonical_u8(n: u8) -> Self {
         Self::Constant(F::from_canonical_u8(n))
     }


### PR DESCRIPTION
Two main changes here:

I removed the columns in the AIR for the export and preimage. Both of these are basically unused in AIR currently and don't seem to be serving a purpose. The preimage was just the input to the permutation copied to every row, but this input is already saved as the input to the very first row. Similarly, the export column seems to be able to be implied from the step flags. Let me know if you want me to re add in either of these.

The bigger change is a revamp over how the trace generation works. It's a lot faster to keep track of the current state as a `[[u64; 5]; 5]` array and then periodically convert each `u64` into `64` boolean values or `4`,  `16`-bit limbs. This cuts down the trace generation by about 85%. (On my machine generating the trace for `10922` permutations goes from `600ms` to `90ms`).

If we care about trace generation + proving time, this PR gives about a `10%` improvement on my machine.