### PR TITLE
Saving a couple of multiplications by re-bracketing

### DIFF
--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -117,10 +117,11 @@ where
         .iter()
         .enumerate()
         .map(|(ch_i, ch)| {
-            ch.iter()
-                .enumerate()
-                .map(|(e_i, &c)| zps[ch_i] * SC::Challenge::monomial(e_i) * c)
-                .sum::<SC::Challenge>()
+            zps[ch_i]
+                * ch.iter()
+                    .enumerate()
+                    .map(|(e_i, &c)| SC::Challenge::monomial(e_i) * c)
+                    .sum::<SC::Challenge>()
         })
         .sum::<SC::Challenge>();
 


### PR DESCRIPTION
This doesn't really make a huge timing difference but is clearly a little bit better.

`z * ( a + b + c + ... )` is more efficient than `z * a + z * b + ... `.