### PR TITLE
Field Crate Refactor: Split apart Field Algebra

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -29,7 +29,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: PrimeCharacteristicRing + Algebra<Self::F> + Algebra<Self::Var>;
+    type Expr: Algebra<Self::F> + Algebra<Self::Var>;
 
     type Var: Into<Self::Expr>
         + Copy

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,6 +1,8 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra};
+use p3_field::{
+    ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra, PrimeCharacteristicRing,
+};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
@@ -29,14 +31,11 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: FieldAlgebra
-        + From<Self::F>
+    type Expr: PrimeCharacteristicRing
+        + FieldAlgebra<Self::F>
         + Add<Self::Var, Output = Self::Expr>
-        + Add<Self::F, Output = Self::Expr>
         + Sub<Self::Var, Output = Self::Expr>
-        + Sub<Self::F, Output = Self::Expr>
-        + Mul<Self::Var, Output = Self::Expr>
-        + Mul<Self::F, Output = Self::Expr>;
+        + Mul<Self::Var, Output = Self::Expr>;
 
     type Var: Into<Self::Expr>
         + Copy
@@ -136,7 +135,7 @@ pub trait PairBuilder: AirBuilder {
 pub trait ExtensionBuilder: AirBuilder {
     type EF: ExtensionField<Self::F>;
 
-    type ExprEF: FieldExtensionAlgebra<Self::Expr, F = Self::EF>;
+    type ExprEF: FieldExtensionAlgebra<Self::Expr> + FieldAlgebra<Self::EF>;
 
     type VarEF: Into<Self::ExprEF> + Copy + Send + Sync;
 

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -31,11 +31,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: PrimeCharacteristicRing
-        + FieldAlgebra<Self::F>
-        + Add<Self::Var, Output = Self::Expr>
-        + Sub<Self::Var, Output = Self::Expr>
-        + Mul<Self::Var, Output = Self::Expr>;
+    type Expr: PrimeCharacteristicRing + FieldAlgebra<Self::F> + FieldAlgebra<Self::Var>;
 
     type Var: Into<Self::Expr>
         + Copy

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,8 +1,6 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{
-    ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra, PrimeCharacteristicRing,
-};
+use p3_field::{Algebra, ExtensionField, Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
@@ -31,7 +29,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 pub trait AirBuilder: Sized {
     type F: Field;
 
-    type Expr: PrimeCharacteristicRing + FieldAlgebra<Self::F> + FieldAlgebra<Self::Var>;
+    type Expr: PrimeCharacteristicRing + Algebra<Self::F> + Algebra<Self::Var>;
 
     type Var: Into<Self::Expr>
         + Copy
@@ -131,7 +129,7 @@ pub trait PairBuilder: AirBuilder {
 pub trait ExtensionBuilder: AirBuilder {
     type EF: ExtensionField<Self::F>;
 
-    type ExprEF: FieldExtensionAlgebra<Self::Expr> + FieldAlgebra<Self::EF>;
+    type ExprEF: FieldExtensionAlgebra<Self::Expr> + Algebra<Self::EF>;
 
     type VarEF: Into<Self::ExprEF> + Copy + Send + Sync;
 

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -3,7 +3,7 @@
 use core::array;
 
 use p3_field::integers::QuotientMap;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use crate::AirBuilder;
 
@@ -13,7 +13,7 @@ use crate::AirBuilder;
 #[inline]
 pub fn pack_bits_le<FA, Var, I>(iter: I) -> FA
 where
-    FA: FieldAlgebra,
+    FA: PrimeCharacteristicRing,
     Var: Into<FA> + Clone,
     I: DoubleEndedIterator<Item = Var>,
 {
@@ -29,7 +29,7 @@ where
 ///
 /// For boolean inputs, `x ^ y = x + y - 2 xy`.
 #[inline(always)]
-pub fn xor<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
+pub fn xor<FA: PrimeCharacteristicRing>(x: FA, y: FA) -> FA {
     x.clone() + y.clone() - x * y.double()
 }
 
@@ -37,7 +37,7 @@ pub fn xor<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
 ///
 /// For boolean inputs `x ^ y ^ z = x + y + z - 2(xy + xz + yz) + 4xyz`.
 #[inline(always)]
-pub fn xor3<FA: FieldAlgebra>(x: FA, y: FA, z: FA) -> FA {
+pub fn xor3<FA: PrimeCharacteristicRing>(x: FA, y: FA, z: FA) -> FA {
     // The cheapest way to implement this polynomial is to simply apply xor twice.
     // This costs 2 adds, 2 subs, 2 muls and 2 doubles.
     xor(x, xor(y, z))
@@ -47,7 +47,7 @@ pub fn xor3<FA: FieldAlgebra>(x: FA, y: FA, z: FA) -> FA {
 ///
 /// For boolean inputs `(!x) & y = (1 - x)y`
 #[inline(always)]
-pub fn andn<FA: FieldAlgebra>(x: FA, y: FA) -> FA {
+pub fn andn<FA: PrimeCharacteristicRing>(x: FA, y: FA) -> FA {
     (FA::ONE - x) * y
 }
 
@@ -76,7 +76,7 @@ pub fn checked_andn<F: Field>(x: F, y: F) -> F {
 ///
 /// The output array is in little-endian order.
 #[inline]
-pub fn u32_to_bits_le<FA: FieldAlgebra>(val: u32) -> [FA; 32] {
+pub fn u32_to_bits_le<FA: PrimeCharacteristicRing>(val: u32) -> [FA; 32] {
     // We do this over F::from_u32 as from_u32 can be slow
     // like in the case of monty field.
     array::from_fn(|i| {
@@ -131,7 +131,8 @@ pub fn add3<AB: AirBuilder>(
     // By assumption P > 3*2^16 so 1 << 16 will be less than P. We use the checked version just to be safe.
     // The compiler should optimize it away.
     let two_16 =
-        <AB::Expr as FieldAlgebra>::PrimeSubfield::from_canonical_checked(1 << 16).unwrap();
+        <AB::Expr as PrimeCharacteristicRing>::PrimeSubfield::from_canonical_checked(1 << 16)
+            .unwrap();
     let two_32 = two_16.square();
 
     let acc_16 = a[0] - b[0] - c[0].clone() - d[0].clone();
@@ -192,7 +193,8 @@ pub fn add2<AB: AirBuilder>(
     // By assumption P > 2^17 so 1 << 16 will be less than P. We use the checked version just to be safe.
     // The compiler should optimize it away.
     let two_16 =
-        <AB::Expr as FieldAlgebra>::PrimeSubfield::from_canonical_checked(1 << 16).unwrap();
+        <AB::Expr as PrimeCharacteristicRing>::PrimeSubfield::from_canonical_checked(1 << 16)
+            .unwrap();
     let two_32 = two_16.square();
 
     let acc_16 = a[0] - b[0] - c[0].clone();

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -11,13 +11,13 @@ use crate::AirBuilder;
 ///
 /// Given vec = [v0, v1, ..., v_n] returns v0 + 2v_1 + ... + 2^n v_n
 #[inline]
-pub fn pack_bits_le<FA, Var, I>(iter: I) -> FA
+pub fn pack_bits_le<R, Var, I>(iter: I) -> R
 where
-    FA: PrimeCharacteristicRing,
-    Var: Into<FA> + Clone,
+    R: PrimeCharacteristicRing,
+    Var: Into<R> + Clone,
     I: DoubleEndedIterator<Item = Var>,
 {
-    let mut output = FA::ZERO;
+    let mut output = R::ZERO;
     for elem in iter.rev() {
         output = output.double();
         output += elem.clone().into();
@@ -29,7 +29,7 @@ where
 ///
 /// For boolean inputs, `x ^ y = x + y - 2 xy`.
 #[inline(always)]
-pub fn xor<FA: PrimeCharacteristicRing>(x: FA, y: FA) -> FA {
+pub fn xor<R: PrimeCharacteristicRing>(x: R, y: R) -> R {
     x.clone() + y.clone() - x * y.double()
 }
 
@@ -37,7 +37,7 @@ pub fn xor<FA: PrimeCharacteristicRing>(x: FA, y: FA) -> FA {
 ///
 /// For boolean inputs `x ^ y ^ z = x + y + z - 2(xy + xz + yz) + 4xyz`.
 #[inline(always)]
-pub fn xor3<FA: PrimeCharacteristicRing>(x: FA, y: FA, z: FA) -> FA {
+pub fn xor3<R: PrimeCharacteristicRing>(x: R, y: R, z: R) -> R {
     // The cheapest way to implement this polynomial is to simply apply xor twice.
     // This costs 2 adds, 2 subs, 2 muls and 2 doubles.
     xor(x, xor(y, z))
@@ -47,8 +47,8 @@ pub fn xor3<FA: PrimeCharacteristicRing>(x: FA, y: FA, z: FA) -> FA {
 ///
 /// For boolean inputs `(!x) & y = (1 - x)y`
 #[inline(always)]
-pub fn andn<FA: PrimeCharacteristicRing>(x: FA, y: FA) -> FA {
-    (FA::ONE - x) * y
+pub fn andn<R: PrimeCharacteristicRing>(x: R, y: R) -> R {
+    (R::ONE - x) * y
 }
 
 /// Compute `xor` on a list of boolean field elements.
@@ -76,16 +76,10 @@ pub fn checked_andn<F: Field>(x: F, y: F) -> F {
 ///
 /// The output array is in little-endian order.
 #[inline]
-pub fn u32_to_bits_le<FA: PrimeCharacteristicRing>(val: u32) -> [FA; 32] {
+pub fn u32_to_bits_le<R: PrimeCharacteristicRing>(val: u32) -> [R; 32] {
     // We do this over F::from_u32 as from_u32 can be slow
     // like in the case of monty field.
-    array::from_fn(|i| {
-        if val & (1 << i) != 0 {
-            FA::ONE
-        } else {
-            FA::ZERO
-        }
-    })
+    array::from_fn(|i| if val & (1 << i) != 0 { R::ONE } else { R::ZERO })
 }
 
 /// Verify that `a = b + c + d mod 2^32`

--- a/air/src/virtual_column.rs
+++ b/air/src/virtual_column.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Mul;
 
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 
 /// An affine function over columns in a PAIR.
 #[derive(Clone, Debug)]
@@ -110,7 +110,7 @@ impl<F: Field> VirtualPairCol<F> {
     pub fn apply<Expr, Var>(&self, preprocessed: &[Var], main: &[Var]) -> Expr
     where
         F: Into<Expr>,
-        Expr: FieldAlgebra + Mul<F, Output = Expr>,
+        Expr: PrimeCharacteristicRing + Mul<F, Output = Expr>,
         Var: Into<Expr> + Copy,
     {
         let mut result = self.constant.into();

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use p3_baby_bear::BabyBear;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -5,7 +5,6 @@
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -1,5 +1,5 @@
 use p3_field::exponentiation::exp_1725656503;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, RelativelyPrimePower, TwoAdicData,
@@ -61,7 +61,7 @@ impl RelativelyPrimePower<7> for BabyBearParameters {
     /// In the field `BabyBear`, `a^{1/7}` is equal to a^{1725656503}.
     ///
     /// This follows from the calculation `7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1)`.
-    fn exp_root_d<FA: FieldAlgebra>(val: FA) -> FA {
+    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA {
         // We use a custom addition chain.
         // This could possibly by further optimised.
         exp_1725656503(val)

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -61,7 +61,7 @@ impl RelativelyPrimePower<7> for BabyBearParameters {
     /// In the field `BabyBear`, `a^{1/7}` is equal to a^{1725656503}.
     ///
     /// This follows from the calculation `7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1)`.
-    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+    fn exp_root_d<R: PrimeCharacteristicRing>(val: R) -> R {
         // We use a custom addition chain.
         // This could possibly by further optimised.
         exp_1725656503(val)

--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{FieldExtensionAlgebra, PrimeCharacteristicRing};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -50,7 +50,7 @@ pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by BabyBear field elements.
+/// This can act on `[A; WIDTH]` for any algebra which implements multiplication by BabyBear field elements.
 /// If you have either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]` it will be much faster
 /// to use `Poseidon2BabyBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersBabyBear =
@@ -166,7 +166,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 16> for BabyBearInternalLay
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_16)
@@ -244,7 +244,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 24> for BabyBearInternalLay
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_24)

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -42,7 +42,6 @@ const BABYBEAR_S_BOX_DEGREE: u64 = 7;
 /// wherever possible, input arrays should of the form `[BabyBear::Packing; WIDTH]`.
 pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
     BabyBear,
-    <BabyBear as Field>::Packing,
     Poseidon2ExternalLayerBabyBear<WIDTH>,
     Poseidon2InternalLayerBabyBear<WIDTH>,
     WIDTH,

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{Field, FieldAlgebra, PrimeField32};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
     MontyField31, Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
@@ -41,6 +41,7 @@ const BABYBEAR_S_BOX_DEGREE: u64 = 7;
 /// It acts on arrays of the form either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]`. For speed purposes,
 /// wherever possible, input arrays should of the form `[BabyBear::Packing; WIDTH]`.
 pub type Poseidon2BabyBear<const WIDTH: usize> = Poseidon2<
+    BabyBear,
     <BabyBear as Field>::Packing,
     Poseidon2ExternalLayerBabyBear<WIDTH>,
     Poseidon2InternalLayerBabyBear<WIDTH>,
@@ -154,7 +155,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 16> for BabyBearInternalLay
 
     fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
     where
-        FA: FieldAlgebra + Mul<BabyBear, Output = FA>,
+        FA: PrimeCharacteristicRing + Mul<BabyBear, Output = FA>,
     {
         let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
@@ -232,7 +233,7 @@ impl InternalLayerBaseParameters<BabyBearParameters, 24> for BabyBearInternalLay
 
     fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
     where
-        FA: FieldAlgebra + Mul<BabyBear, Output = FA>,
+        FA: PrimeCharacteristicRing + Mul<BabyBear, Output = FA>,
     {
         let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -152,11 +152,11 @@ impl InternalLayerBaseParameters<BabyBearParameters, 16> for BabyBearInternalLay
         state[15] = sum - state[15];
     }
 
-    fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
+    fn generic_internal_linear_layer<R>(state: &mut [R; 16])
     where
-        FA: PrimeCharacteristicRing + Mul<BabyBear, Output = FA>,
+        R: PrimeCharacteristicRing + Mul<BabyBear, Output = R>,
     {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -230,11 +230,11 @@ impl InternalLayerBaseParameters<BabyBearParameters, 24> for BabyBearInternalLay
         state[23] = sum - state[23];
     }
 
-    fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
+    fn generic_internal_linear_layer<R>(state: &mut [R; 24])
     where
-        FA: PrimeCharacteristicRing + Mul<BabyBear, Output = FA>,
+        R: PrimeCharacteristicRing + Mul<BabyBear, Output = R>,
     {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -123,7 +123,6 @@ impl InternalLayerParametersAVX512<BabyBearParameters, 24> for BabyBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -123,7 +123,7 @@ impl InternalLayerParametersAVX512<BabyBearParameters, 24> for BabyBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -3,7 +3,7 @@ use core::borrow::Borrow;
 use itertools::izip;
 use p3_air::utils::{add2, add3, pack_bits_le, xor, xor_32_shift};
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 
 use crate::columns::{Blake3Cols, NUM_BLAKE3_COLS};

--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -215,21 +215,21 @@ fn verifiable_half_round(
     (a, b, c, d)
 }
 
-fn save_state_to_trace<FA: PrimeCharacteristicRing>(
-    trace: &mut Blake3State<FA>,
+fn save_state_to_trace<R: PrimeCharacteristicRing>(
+    trace: &mut Blake3State<R>,
     state: &[[u32; 4]; 4],
 ) {
     trace.row0 = array::from_fn(|i| {
         [
-            FA::from_u16(state[0][i] as u16), // Store the bottom 16 bits packed.
-            FA::from_u16((state[0][i] >> 16) as u16), // Store the top 16 bits packed.
+            R::from_u16(state[0][i] as u16), // Store the bottom 16 bits packed.
+            R::from_u16((state[0][i] >> 16) as u16), // Store the top 16 bits packed.
         ]
     });
     trace.row1 = array::from_fn(|i| u32_to_bits_le(state[1][i])); // Store all 32 bits unpacked.
     trace.row2 = array::from_fn(|i| {
         [
-            FA::from_u16(state[2][i] as u16), // Store the bottom 16 bits packed.
-            FA::from_u16((state[2][i] >> 16) as u16), // Store the top 16 bits packed.
+            R::from_u16(state[2][i] as u16), // Store the bottom 16 bits packed.
+            R::from_u16((state[2][i] >> 16) as u16), // Store the top 16 bits packed.
         ]
     });
     trace.row3 = array::from_fn(|i| u32_to_bits_le(state[3][i])); // Store all 32 bits unpacked.

--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::array;
 
 use p3_air::utils::u32_to_bits_le;
-use p3_field::{FieldAlgebra, PrimeField64};
+use p3_field::{PrimeCharacteristicRing, PrimeField64};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
@@ -215,7 +215,10 @@ fn verifiable_half_round(
     (a, b, c, d)
 }
 
-fn save_state_to_trace<FA: FieldAlgebra>(trace: &mut Blake3State<FA>, state: &[[u32; 4]; 4]) {
+fn save_state_to_trace<FA: PrimeCharacteristicRing>(
+    trace: &mut Blake3State<FA>,
+    state: &[[u32; 4]; 4],
+) {
     trace.row0 = array::from_fn(|i| {
         [
             FA::from_u16(state[0][i] as u16), // Store the bottom 16 bits packed.

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -14,8 +14,8 @@ use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
 use p3_field::integers::QuotientMap;
 use p3_field::{
-    quotient_map_small_int, Field, FieldAlgebra, InjectiveMonomial, Packable, PrimeField,
-    TwoAdicField,
+    quotient_map_small_int, Field, InjectiveMonomial, Packable, PrimeCharacteristicRing,
+    PrimeField, TwoAdicField,
 };
 pub use poseidon2::Poseidon2Bn254;
 use rand::distributions::{Distribution, Standard};
@@ -93,8 +93,7 @@ impl Debug for Bn254Fr {
     }
 }
 
-impl FieldAlgebra for Bn254Fr {
-    type F = Self;
+impl PrimeCharacteristicRing for Bn254Fr {
     type PrimeSubfield = Self;
 
     const ZERO: Self = Self::new(FFBn254Fr::ZERO);

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -23,7 +23,6 @@ const BN254_S_BOX_DEGREE: u64 = 5;
 /// It acts on arrays of the form `[Bn254Fr; WIDTH]`.
 pub type Poseidon2Bn254<const WIDTH: usize> = Poseidon2<
     Bn254Fr,
-    Bn254Fr,
     Poseidon2ExternalLayerBn254<WIDTH>,
     Poseidon2InternalLayerBn254,
     WIDTH,

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -44,7 +44,7 @@ pub struct Poseidon2InternalLayerBn254 {
     internal_constants: Vec<Bn254Fr>,
 }
 
-impl InternalLayerConstructor<Bn254Fr, Bn254Fr> for Poseidon2InternalLayerBn254 {
+impl InternalLayerConstructor<Bn254Fr> for Poseidon2InternalLayerBn254 {
     fn new_from_constants(internal_constants: Vec<Bn254Fr>) -> Self {
         Self { internal_constants }
     }
@@ -63,7 +63,7 @@ impl InternalLayer<Bn254Fr, BN254_WIDTH, BN254_S_BOX_DEGREE> for Poseidon2Intern
 
 pub type Poseidon2ExternalLayerBn254<const WIDTH: usize> = ExternalLayerConstants<Bn254Fr, WIDTH>;
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Bn254Fr, Bn254Fr, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Bn254Fr, WIDTH>
     for Poseidon2ExternalLayerBn254<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Bn254Fr, WIDTH>) -> Self {

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -160,7 +160,7 @@ where
 mod tests {
     use core::iter;
 
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
     use p3_symmetric::Permutation;
 

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -83,7 +83,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
 
     use super::*;

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -124,7 +124,7 @@ mod tests {
     use alloc::vec;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
     use rand::{random, thread_rng};

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -233,7 +233,7 @@ mod tests {
 
     use hashbrown::HashSet;
     use itertools::izip;
-    use p3_field::{batch_multiplicative_inverse, FieldAlgebra};
+    use p3_field::{batch_multiplicative_inverse, PrimeCharacteristicRing};
     use p3_mersenne_31::Mersenne31;
     use rand::thread_rng;
 

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -36,7 +36,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{Field, FieldAlgebra};
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::dense::RowMajorMatrix;
     use rand::thread_rng;

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -53,11 +53,11 @@ pub fn benchmark_iter_sum<F: Field, const N: usize, const REPS: usize>(
     });
 }
 
-pub fn benchmark_add_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_add_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("add-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -65,37 +65,37 @@ pub fn benchmark_add_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<FA>())
+                    vec.push(rng.gen::<R>())
                 }
                 vec
             },
-            |x| x.iter().fold(FA::ZERO, |x, y| x + *y),
+            |x| x.iter().fold(R::ZERO, |x, y| x + *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_add_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_add_throughput<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("add-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -120,11 +120,11 @@ pub fn benchmark_add_throughput<FA: PrimeCharacteristicRing + Copy, const N: usi
     });
 }
 
-pub fn benchmark_sub_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_sub_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("sub-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -132,37 +132,37 @@ pub fn benchmark_sub_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<FA>())
+                    vec.push(rng.gen::<R>())
                 }
                 vec
             },
-            |x| x.iter().fold(FA::ZERO, |x, y| x - *y),
+            |x| x.iter().fold(R::ZERO, |x, y| x - *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_sub_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_sub_throughput<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("sub-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
@@ -187,11 +187,11 @@ pub fn benchmark_sub_throughput<FA: PrimeCharacteristicRing + Copy, const N: usi
     });
 }
 
-pub fn benchmark_mul_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_mul_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("mul-latency/{} {}", N, name), |b| {
         b.iter_batched(
@@ -199,37 +199,37 @@ pub fn benchmark_mul_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>
                 let mut rng = rand::thread_rng();
                 let mut vec = Vec::new();
                 for _ in 0..N {
-                    vec.push(rng.gen::<FA>())
+                    vec.push(rng.gen::<R>())
                 }
                 vec
             },
-            |x| x.iter().fold(FA::ZERO, |x, y| x * *y),
+            |x| x.iter().fold(R::ZERO, |x, y| x * *y),
             BatchSize::SmallInput,
         )
     });
 }
 
-pub fn benchmark_mul_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+pub fn benchmark_mul_throughput<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
-    Standard: Distribution<FA>,
+    Standard: Distribution<R>,
 {
     c.bench_function(&format!("mul-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
                 (
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
-                    rng.gen::<FA>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
+                    rng.gen::<R>(),
                 )
             },
             |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -2,7 +2,7 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use criterion::{black_box, BatchSize, Criterion};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::Rng;
@@ -53,8 +53,10 @@ pub fn benchmark_iter_sum<F: Field, const N: usize, const REPS: usize>(
     });
 }
 
-pub fn benchmark_add_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
-where
+pub fn benchmark_add_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
     Standard: Distribution<FA>,
 {
     c.bench_function(&format!("add-latency/{} {}", N, name), |b| {
@@ -73,7 +75,7 @@ where
     });
 }
 
-pub fn benchmark_add_throughput<FA: FieldAlgebra + Copy, const N: usize>(
+pub fn benchmark_add_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
@@ -118,8 +120,10 @@ pub fn benchmark_add_throughput<FA: FieldAlgebra + Copy, const N: usize>(
     });
 }
 
-pub fn benchmark_sub_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
-where
+pub fn benchmark_sub_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
     Standard: Distribution<FA>,
 {
     c.bench_function(&format!("sub-latency/{} {}", N, name), |b| {
@@ -138,7 +142,7 @@ where
     });
 }
 
-pub fn benchmark_sub_throughput<FA: FieldAlgebra + Copy, const N: usize>(
+pub fn benchmark_sub_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
@@ -183,8 +187,10 @@ pub fn benchmark_sub_throughput<FA: FieldAlgebra + Copy, const N: usize>(
     });
 }
 
-pub fn benchmark_mul_latency<FA: FieldAlgebra + Copy, const N: usize>(c: &mut Criterion, name: &str)
-where
+pub fn benchmark_mul_latency<FA: PrimeCharacteristicRing + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
     Standard: Distribution<FA>,
 {
     c.bench_function(&format!("mul-latency/{} {}", N, name), |b| {
@@ -203,7 +209,7 @@ where
     });
 }
 
-pub fn benchmark_mul_throughput<FA: FieldAlgebra + Copy, const N: usize>(
+pub fn benchmark_mul_throughput<FA: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -163,7 +163,7 @@ macro_rules! test_prime_field {
     ($field:ty) => {
         mod from_integer_small_tests {
             use p3_field::integers::QuotientMap;
-            use p3_field::{Field, FieldAlgebra};
+            use p3_field::{Field, PrimeCharacteristicRing};
 
             #[test]
             fn test_small_integer_conversions() {
@@ -189,7 +189,7 @@ macro_rules! test_prime_field_64 {
     ($field:ty) => {
         mod from_integer_tests_prime_field_64 {
             use p3_field::integers::QuotientMap;
-            use p3_field::{Field, FieldAlgebra, PrimeField64};
+            use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 
             #[test]
             fn test_large_unsigned_integer_conversions() {
@@ -209,7 +209,7 @@ macro_rules! test_prime_field_32 {
     ($field:ty) => {
         mod from_integer_tests_prime_field_32 {
             use p3_field::integers::QuotientMap;
-            use p3_field::{Field, FieldAlgebra, PrimeField32};
+            use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 
             #[test]
             fn test_large_unsigned_integer_conversions() {
@@ -276,7 +276,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{binomial_expand, eval_poly, FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{binomial_expand, eval_poly, FieldExtensionAlgebra, PrimeCharacteristicRing};
     use rand::random;
 
     use super::*;

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -276,7 +276,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{binomial_expand, eval_poly, FieldExtensionAlgebra, PrimeCharacteristicRing};
+    use p3_field::{binomial_expand, eval_poly, PrimeCharacteristicRing};
     use rand::random;
 
     use super::*;

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, PackedField, PackedFieldPow2, PackedValue};
+use p3_field::{Field, PackedField, PackedFieldPow2, PackedValue, PrimeCharacteristicRing};
 use rand::distributions::{Distribution, Standard};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -438,7 +438,7 @@ where
 macro_rules! test_packed_field {
     ($packedfield:ty, $zeros:expr, $specials:expr) => {
         mod packed_field_tests {
-            use p3_field::FieldAlgebra;
+            use p3_field::PrimeCharacteristicRing;
 
             #[test]
             fn test_interleaves() {

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{Field, FieldAlgebra, PackedValue};
+use crate::{Field, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.
@@ -35,8 +35,7 @@ impl<F: Field, const N: usize> From<[F; N]> for FieldArray<F, N> {
     }
 }
 
-impl<F: Field, const N: usize> FieldAlgebra for FieldArray<F, N> {
-    type F = F;
+impl<F: Field, const N: usize> PrimeCharacteristicRing for FieldArray<F, N> {
     type PrimeSubfield = F::PrimeSubfield;
 
     const ZERO: Self = FieldArray([F::ZERO; N]);

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{Field, Algebra, PackedValue, PrimeCharacteristicRing};
+use crate::{Algebra, Field, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{Field, PackedValue, PrimeCharacteristicRing};
+use crate::{Field, FieldAlgebra, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.
@@ -48,6 +48,8 @@ impl<F: Field, const N: usize> PrimeCharacteristicRing for FieldArray<F, N> {
         F::from_prime_subfield(f).into()
     }
 }
+
+impl<F: Field, const N: usize> FieldAlgebra<F> for FieldArray<F, N> {}
 
 unsafe impl<F: Field, const N: usize> PackedValue for FieldArray<F, N> {
     type Value = F;

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -3,7 +3,7 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::batch_inverse::batch_multiplicative_inverse_general;
-use crate::{Field, FieldAlgebra, PackedValue, PrimeCharacteristicRing};
+use crate::{Field, Algebra, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // This needed to make `transmute`s safe.
@@ -49,7 +49,7 @@ impl<F: Field, const N: usize> PrimeCharacteristicRing for FieldArray<F, N> {
     }
 }
 
-impl<F: Field, const N: usize> FieldAlgebra<F> for FieldArray<F, N> {}
+impl<F: Field, const N: usize> Algebra<F> for FieldArray<F, N> {}
 
 unsafe impl<F: Field, const N: usize> PackedValue for FieldArray<F, N> {
     type Value = F;

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -4,7 +4,7 @@ use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::field::Field;
-use crate::{FieldAlgebra, FieldArray, PackedValue};
+use crate::{FieldArray, PackedValue, PrimeCharacteristicRing};
 
 /// Batch multiplicative inverses with Montgomery's trick
 /// This is Montgomery's trick. At a high level, we invert the product of the given field
@@ -54,11 +54,11 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
     batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| x_packed.inverse());
 }
 
-/// A simple single-threaded implementation of Montgomery's trick. Since not all `FieldAlgebra`s
+/// A simple single-threaded implementation of Montgomery's trick. Since not all `PrimeCharacteristicRing`s
 /// support inversion, this takes a custom inversion function.
 pub(crate) fn batch_multiplicative_inverse_general<F, Inv>(x: &[F], result: &mut [F], inv: Inv)
 where
-    F: FieldAlgebra + Copy,
+    F: PrimeCharacteristicRing + Copy,
     Inv: Fn(F) -> F,
 {
     let n = x.len();

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -1,4 +1,4 @@
-use crate::FieldAlgebra;
+use crate::PrimeCharacteristicRing;
 
 pub(crate) const fn bits_u64(n: u64) -> usize {
     (64 - n.leading_zeros()) as usize
@@ -8,7 +8,7 @@ pub(crate) const fn bits_u64(n: u64) -> usize {
 ///
 /// This map computes the fifth root of `x` if `x` is a member of the field `Mersenne31`.
 /// This follows from the computation: `5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1`.
-pub fn exp_1717986917<FA: FieldAlgebra>(val: FA) -> FA {
+pub fn exp_1717986917<FA: PrimeCharacteristicRing>(val: FA) -> FA {
     // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
     // This uses 30 Squares + 7 Multiplications => 37 Operations total.
     // Suspect it's possible to improve this with enough effort. For example 1717986918 takes only 4 Multiplications.
@@ -32,7 +32,7 @@ pub fn exp_1717986917<FA: FieldAlgebra>(val: FA) -> FA {
 ///
 /// This map computes the third root of `x` if `x` is a member of the field `KoalaBear`.
 /// This follows from the computation: `3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1)`.
-pub fn exp_1420470955<FA: FieldAlgebra>(val: FA) -> FA {
+pub fn exp_1420470955<FA: PrimeCharacteristicRing>(val: FA) -> FA {
     // Note the binary expansion: 1420470955 = 1010100101010101010101010101011_2
     // This uses 29 Squares + 7 Multiplications => 36 Operations total.
     // Suspect it's possible to improve this with enough effort.
@@ -56,7 +56,7 @@ pub fn exp_1420470955<FA: FieldAlgebra>(val: FA) -> FA {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `BabyBear`.
 /// This follows from the computation: `7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1)`.
-pub fn exp_1725656503<FA: FieldAlgebra>(val: FA) -> FA {
+pub fn exp_1725656503<FA: PrimeCharacteristicRing>(val: FA) -> FA {
     // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
     // This uses 29 Squares + 8 Multiplications => 37 Operations total.
     // Suspect it's possible to improve this with enough effort.
@@ -82,7 +82,7 @@ pub fn exp_1725656503<FA: FieldAlgebra>(val: FA) -> FA {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `Goldilocks`.
 /// This follows from the computation: `7 * 10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1)`.
-pub fn exp_10540996611094048183<FA: FieldAlgebra>(val: FA) -> FA {
+pub fn exp_10540996611094048183<FA: PrimeCharacteristicRing>(val: FA) -> FA {
     // Note the binary expansion: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.
     // This uses 63 Squares + 8 Multiplications => 71 Operations total.
     // Suspect it's possible to improve this a little with enough effort.

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -8,7 +8,7 @@ pub(crate) const fn bits_u64(n: u64) -> usize {
 ///
 /// This map computes the fifth root of `x` if `x` is a member of the field `Mersenne31`.
 /// This follows from the computation: `5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1`.
-pub fn exp_1717986917<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+pub fn exp_1717986917<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
     // This uses 30 Squares + 7 Multiplications => 37 Operations total.
     // Suspect it's possible to improve this with enough effort. For example 1717986918 takes only 4 Multiplications.
@@ -32,7 +32,7 @@ pub fn exp_1717986917<FA: PrimeCharacteristicRing>(val: FA) -> FA {
 ///
 /// This map computes the third root of `x` if `x` is a member of the field `KoalaBear`.
 /// This follows from the computation: `3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1)`.
-pub fn exp_1420470955<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+pub fn exp_1420470955<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1420470955 = 1010100101010101010101010101011_2
     // This uses 29 Squares + 7 Multiplications => 36 Operations total.
     // Suspect it's possible to improve this with enough effort.
@@ -56,7 +56,7 @@ pub fn exp_1420470955<FA: PrimeCharacteristicRing>(val: FA) -> FA {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `BabyBear`.
 /// This follows from the computation: `7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1)`.
-pub fn exp_1725656503<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+pub fn exp_1725656503<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
     // This uses 29 Squares + 8 Multiplications => 37 Operations total.
     // Suspect it's possible to improve this with enough effort.
@@ -82,7 +82,7 @@ pub fn exp_1725656503<FA: PrimeCharacteristicRing>(val: FA) -> FA {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `Goldilocks`.
 /// This follows from the computation: `7 * 10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1)`.
-pub fn exp_10540996611094048183<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+pub fn exp_10540996611094048183<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.
     // This uses 63 Squares + 8 Multiplications => 71 Operations total.
     // Suspect it's possible to improve this a little with enough effort.

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -659,7 +659,7 @@ pub fn cubic_square<
 ) {
     assert_eq!(D, 3);
 
-    let w_a2 = a[2].clone() * Into::<FA>::into(F::W);
+    let w_a2 = a[2].clone() * F::W;
 
     res[0] = a[0].square() + (a[1].clone() * w_a2.clone()).double();
     res[1] = w_a2 * a[2].clone() + (a[0].clone() * a[1].clone()).double();

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -649,13 +649,9 @@ pub(crate) fn cubic_mul<
 
 /// Section 11.3.6a in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
 #[inline]
-pub fn cubic_square<
-    F: BinomiallyExtendable<D>,
-    R: PrimeCharacteristicRing + Algebra<F>,
-    const D: usize,
->(
-    a: &[R; D],
-    res: &mut [R; D],
+pub fn cubic_square<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize>(
+    a: &[A; D],
+    res: &mut [A; D],
 ) {
     assert_eq!(D, 3);
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -17,8 +17,8 @@ use super::{HasFrobenius, HasTwoAdicBionmialExtension, PackedBinomialExtensionFi
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
-    field_to_array, ExtensionField, FieldAlgebra, FieldExtensionAlgebra, Packable, PackedValue,
-    Powers, PrimeCharacteristicRing, Serializable, TwoAdicField,
+    field_to_array, Algebra, ExtensionField, FieldExtensionAlgebra, Packable, PackedValue, Powers,
+    PrimeCharacteristicRing, Serializable, TwoAdicField,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
@@ -234,7 +234,7 @@ where
     }
 }
 
-impl<F: BinomiallyExtendable<D>, const D: usize> FieldAlgebra<F> for BinomialExtensionField<F, D> {}
+impl<F: BinomiallyExtendable<D>, const D: usize> Algebra<F> for BinomialExtensionField<F, D> {}
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionField<F, D> {
     type Packing = Self;
@@ -651,7 +651,7 @@ pub(crate) fn cubic_mul<
 #[inline]
 pub fn cubic_square<
     F: BinomiallyExtendable<D>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
+    FA: Algebra<F> + PrimeCharacteristicRing,
     const D: usize,
 >(
     a: &[FA; D],

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -532,40 +532,40 @@ impl<F: Field + HasTwoAdicBionmialExtension<D>, const D: usize> TwoAdicField
 /// Add two vectors element wise.
 #[inline]
 pub(crate) fn vector_add<
-    FA: PrimeCharacteristicRing + Add<FA2, Output = FA>,
-    FA2: Clone,
+    R: PrimeCharacteristicRing + Add<R2, Output = R>,
+    R2: Clone,
     const D: usize,
 >(
-    a: &[FA; D],
-    b: &[FA2; D],
-) -> [FA; D] {
+    a: &[R; D],
+    b: &[R2; D],
+) -> [R; D] {
     array::from_fn(|i| a[i].clone() + b[i].clone())
 }
 
 /// Subtract two vectors element wise.
 #[inline]
 pub(crate) fn vector_sub<
-    FA: PrimeCharacteristicRing + Sub<FA2, Output = FA>,
-    FA2: Clone,
+    R: PrimeCharacteristicRing + Sub<R2, Output = R>,
+    R2: Clone,
     const D: usize,
 >(
-    a: &[FA; D],
-    b: &[FA2; D],
-) -> [FA; D] {
+    a: &[R; D],
+    b: &[R2; D],
+) -> [R; D] {
     array::from_fn(|i| a[i].clone() - b[i].clone())
 }
 
 /// Multiply two vectors representing elements in a binomial extension.
 #[inline]
 pub(super) fn binomial_mul<
-    FA: PrimeCharacteristicRing + Mul<FA2, Output = FA>,
-    FA2: Add<Output = FA2> + Clone,
+    R: PrimeCharacteristicRing + Mul<R2, Output = R>,
+    R2: Add<Output = R2> + Clone,
     const D: usize,
 >(
-    a: &[FA; D],
-    b: &[FA2; D],
-    res: &mut [FA; D],
-    w: FA,
+    a: &[R; D],
+    b: &[R2; D],
+    res: &mut [R; D],
+    w: R,
 ) {
     match D {
         2 => {
@@ -620,14 +620,14 @@ fn cubic_inv<F: Field>(a: &[F], w: F) -> [F; 3] {
 /// karatsuba multiplication for cubic extension field
 #[inline]
 pub(crate) fn cubic_mul<
-    FA: PrimeCharacteristicRing + Mul<FA2, Output = FA>,
-    FA2: Add<Output = FA2> + Clone,
+    R: PrimeCharacteristicRing + Mul<R2, Output = R>,
+    R2: Add<Output = R2> + Clone,
     const D: usize,
 >(
-    a: &[FA; D],
-    b: &[FA2; D],
-    res: &mut [FA; D],
-    w: FA,
+    a: &[R; D],
+    b: &[R2; D],
+    res: &mut [R; D],
+    w: R,
 ) {
     assert_eq!(D, 3);
 
@@ -651,11 +651,11 @@ pub(crate) fn cubic_mul<
 #[inline]
 pub fn cubic_square<
     F: BinomiallyExtendable<D>,
-    FA: Algebra<F> + PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing + Algebra<F>,
     const D: usize,
 >(
-    a: &[FA; D],
-    res: &mut [FA; D],
+    a: &[R; D],
+    res: &mut [R; D],
 ) {
     assert_eq!(D, 3);
 

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,7 +1,7 @@
 use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBionmialExtension};
 use crate::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
 
-pub type Complex<FA> = BinomialExtensionField<FA, 2>;
+pub type Complex<F> = BinomialExtensionField<F, 2>;
 
 /// A field for which `p = 3 (mod 4)`. Equivalently, `-1` is not a square,
 /// so the complex extension can be defined `F[i] = F[X]/(X^2+1)`.
@@ -25,31 +25,31 @@ impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
 }
 
 /// Convenience methods for complex extensions
-impl<FA: PrimeCharacteristicRing> Complex<FA> {
+impl<R: PrimeCharacteristicRing> Complex<R> {
     #[inline(always)]
-    pub const fn new(real: FA, imag: FA) -> Self {
+    pub const fn new(real: R, imag: R) -> Self {
         Self {
             value: [real, imag],
         }
     }
 
     #[inline(always)]
-    pub const fn new_real(real: FA) -> Self {
-        Self::new(real, FA::ZERO)
+    pub const fn new_real(real: R) -> Self {
+        Self::new(real, R::ZERO)
     }
 
     #[inline(always)]
-    pub const fn new_imag(imag: FA) -> Self {
-        Self::new(FA::ZERO, imag)
+    pub const fn new_imag(imag: R) -> Self {
+        Self::new(R::ZERO, imag)
     }
 
     #[inline(always)]
-    pub fn real(&self) -> FA {
+    pub fn real(&self) -> R {
         self.value[0].clone()
     }
 
     #[inline(always)]
-    pub fn imag(&self) -> FA {
+    pub fn imag(&self) -> R {
         self.value[1].clone()
     }
 
@@ -59,18 +59,18 @@ impl<FA: PrimeCharacteristicRing> Complex<FA> {
     }
 
     #[inline]
-    pub fn norm(&self) -> FA {
+    pub fn norm(&self) -> R {
         self.real().square() + self.imag().square()
     }
 
     #[inline(always)]
-    pub fn to_array(&self) -> [FA; 2] {
+    pub fn to_array(&self) -> [R; 2] {
         self.value.clone()
     }
 
     // Sometimes we want to rotate over an extension that's not necessarily ComplexExtendable,
     // but still on the circle.
-    pub fn rotate<Ext: FieldExtensionAlgebra<FA>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
+    pub fn rotate<Ext: FieldExtensionAlgebra<R>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
         Complex::<Ext>::new(
             rhs.real() * self.real() - rhs.imag() * self.imag(),
             rhs.imag() * self.real() + rhs.real() * self.imag(),

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,5 +1,5 @@
 use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBionmialExtension};
-use crate::{Field, FieldAlgebra, FieldExtensionAlgebra};
+use crate::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
 
 pub type Complex<FA> = BinomialExtensionField<FA, 2>;
 
@@ -25,7 +25,7 @@ impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
 }
 
 /// Convenience methods for complex extensions
-impl<FA: FieldAlgebra> Complex<FA> {
+impl<FA: PrimeCharacteristicRing> Complex<FA> {
     #[inline(always)]
     pub const fn new(real: FA, imag: FA) -> Self {
         Self {

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use super::{binomial_mul, cubic_square, vector_add, vector_sub, BinomialExtensionField};
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
-use crate::{field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField};
+use crate::{
+    field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField, PrimeCharacteristicRing,
+};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // to make the zero_vec implementation safe
@@ -52,13 +54,21 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
     }
 }
 
-impl<F, PF, const D: usize> FieldAlgebra for PackedBinomialExtensionField<F, PF, D>
+impl<F: BinomiallyExtendable<D>, PF: PackedField<Scalar = F>, const D: usize>
+    FieldAlgebra<BinomialExtensionField<F, D>> for PackedBinomialExtensionField<F, PF, D>
+{
+}
+
+impl<F: BinomiallyExtendable<D>, PF: PackedField<Scalar = F>, const D: usize> FieldAlgebra<PF>
+    for PackedBinomialExtensionField<F, PF, D>
+{
+}
+
+impl<F, PF, const D: usize> PrimeCharacteristicRing for PackedBinomialExtensionField<F, PF, D>
 where
     F: BinomiallyExtendable<D>,
     PF: PackedField<Scalar = F>,
 {
-    type F = BinomialExtensionField<F, D>;
-
     type PrimeSubfield = PF::PrimeSubfield;
 
     const ZERO: Self = Self {
@@ -99,7 +109,7 @@ where
             }
             3 => {
                 let mut res = Self::default();
-                cubic_square(&self.value, &mut res.value, F::W);
+                cubic_square(&self.value, &mut res.value);
                 res
             }
             _ => <Self as Mul<Self>>::mul(*self, *self),

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -11,7 +11,7 @@ use super::{binomial_mul, cubic_square, vector_add, vector_sub, BinomialExtensio
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
-    field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField, PrimeCharacteristicRing,
+    field_to_array, Algebra, FieldExtensionAlgebra, PackedField, PrimeCharacteristicRing,
     Serializable,
 };
 
@@ -56,11 +56,11 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
 }
 
 impl<F: BinomiallyExtendable<D>, PF: PackedField<Scalar = F>, const D: usize>
-    FieldAlgebra<BinomialExtensionField<F, D>> for PackedBinomialExtensionField<F, PF, D>
+    Algebra<BinomialExtensionField<F, D>> for PackedBinomialExtensionField<F, PF, D>
 {
 }
 
-impl<F: BinomiallyExtendable<D>, PF: PackedField<Scalar = F>, const D: usize> FieldAlgebra<PF>
+impl<F: BinomiallyExtendable<D>, PF: PackedField<Scalar = F>, const D: usize> Algebra<PF>
     for PackedBinomialExtensionField<F, PF, D>
 {
 }

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -12,7 +12,8 @@ use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
     field_to_array, FieldAlgebra, FieldExtensionAlgebra, PackedField, PrimeCharacteristicRing,
-, Serializable};
+    Serializable,
+};
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // to make the zero_vec implementation safe

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -424,8 +424,7 @@ pub trait PermutationMonomial<const N: u64>: InjectiveMonomial<N> {
 /// ### Mathematical Description
 ///
 /// Let `x` and `y` denote arbitrary elements of the `S`. Then
-/// by "natural" map we require that our map `from`
-/// has the following properties:
+/// we require that our map `from` has the properties:
 /// - Preserves Identity: `from(F::ONE) = R::ONE`
 /// - Commutes with Addition: `from(x + y) = from(x) + from(y)`
 /// - Commutes with Multiplication: `from(x * y) = from(x) * from(y)`

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -413,9 +413,9 @@ pub trait PermutationMonomial<const N: u64>: InjectiveMonomial<N> {
     fn injective_exp_root_n(&self) -> Self;
 }
 
-/// A ring `R` implements `FieldAlgebra<F>` if there is a natural
-/// map from `F` into `R` such that the only element which maps
-/// to `R::ZERO` is `F::ZERO`.
+/// A ring `R` implements `FieldAlgebra<F>` if there is an injective
+/// homomorphism from `F` into `R`; in particular only `F::ZERO` maps to
+/// `R::ZERO`.
 ///
 /// For the most part, we will usually expect `F` to be a field but there
 /// are a few cases where it is handy to allow it to just be a ring. In

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -434,7 +434,8 @@ pub trait PermutationMonomial<const N: u64>: InjectiveMonomial<N> {
 /// The existence of this map makes `R` into an `F`-module and hence an `F`-algebra.
 /// If, additionally, `R` is a field, then this makes `R` a field extension of `F`.
 pub trait Algebra<F>:
-    From<F>
+    PrimeCharacteristicRing
+    + From<F>
     + Add<F, Output = Self>
     + AddAssign<F>
     + Sub<F, Output = Self>
@@ -450,7 +451,6 @@ impl<R: PrimeCharacteristicRing> Algebra<R> for R {}
 /// An element of a finite field.
 pub trait Field:
     Algebra<Self>
-    + PrimeCharacteristicRing
     + Packable
     + 'static
     + Copy
@@ -599,7 +599,7 @@ pub trait PrimeField32: PrimeField64 {
 /// This will be deleted in a future PR. It's currently only needed to give some traits for
 /// ExtensionPacking and so we will soon replace it by a new packed extension field trait.
 pub trait FieldExtensionAlgebra<Base: PrimeCharacteristicRing>:
-    PrimeCharacteristicRing + Algebra<Base> + Serializable<Base>
+    Algebra<Base> + Serializable<Base>
 {
     const D: usize;
 }
@@ -641,7 +641,7 @@ impl<F: Field> ExtensionField<F> for F {
     }
 }
 
-impl<PCR: PrimeCharacteristicRing> FieldExtensionAlgebra<PCR> for PCR {
+impl<R: PrimeCharacteristicRing> FieldExtensionAlgebra<R> for R {
     const D: usize = 1;
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -447,6 +447,7 @@ pub trait FieldAlgebra<F>:
 {
 }
 
+// Every ring is an algebra over itself.
 impl<R: PrimeCharacteristicRing> FieldAlgebra<R> for R {}
 
 /// An element of a finite field.

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -664,10 +664,10 @@ pub struct Powers<F> {
     pub current: F,
 }
 
-impl<FA: PrimeCharacteristicRing> Iterator for Powers<FA> {
-    type Item = FA;
+impl<R: PrimeCharacteristicRing> Iterator for Powers<R> {
+    type Item = R;
 
-    fn next(&mut self) -> Option<FA> {
+    fn next(&mut self) -> Option<R> {
         let result = self.current.clone();
         self.current *= self.base.clone();
         Some(result)

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -433,9 +433,8 @@ pub trait PermutationMonomial<const N: u64>: InjectiveMonomial<N> {
 /// Such maps are known as ring homomorphisms and are injective if the
 /// only element which maps to `R::ZERO` is `F::ZERO`.
 ///
-/// The existence of this map makes `R` into an `F`-module. If `F` is a field
-/// then this makes `R` into an `F`-Algebra and if `R` is also a field then
-/// this means that `R` is a field extension of `F`.
+/// The existence of this map makes `R` into an `F`-module and hence an `F`-algebra, 
+/// and if moreover `R` is a field, then `R` is a field extension of `F`.
 pub trait FieldAlgebra<F>:
     From<F>
     + Add<F, Output = Self>

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -8,7 +8,7 @@ use num_bigint::BigUint;
 use p3_maybe_rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::field::Field;
-use crate::{FieldAlgebra, PackedValue, PrimeField, PrimeField32, TwoAdicField};
+use crate::{PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32, TwoAdicField};
 
 /// Computes `Z_H(x)`, where `Z_H` is the zerofier of a multiplicative subgroup of order `2^log_n`.
 pub fn two_adic_subgroup_zerofier<F: TwoAdicField>(log_n: usize, x: F) -> F {
@@ -78,7 +78,7 @@ where
 // to allow us to convert FA constants to BinomialExtensionField<FA, D> constants.
 //
 // The natural approach would be:
-// fn field_to_array<FA: FieldAlgebra, const D: usize>(x: FA) -> [FA; D]
+// fn field_to_array<FA: PrimeCharacteristicRing, const D: usize>(x: FA) -> [FA; D]
 //      let mut arr: [FA; D] = [FA::ZERO; D];
 //      arr[0] = x
 //      arr
@@ -122,7 +122,7 @@ impl<T, const D: usize> HackyWorkAround<T, D> {
 /// Extend a field `FA` element `x` to an array of length `D`
 /// by filling zeros.
 #[inline]
-pub const fn field_to_array<FA: FieldAlgebra, const D: usize>(x: FA) -> [FA; D] {
+pub const fn field_to_array<FA: PrimeCharacteristicRing, const D: usize>(x: FA) -> [FA; D] {
     let mut arr: [MaybeUninit<FA>; D] = unsafe { MaybeUninit::uninit().assume_init() };
 
     arr[0] = MaybeUninit::new(x);
@@ -141,7 +141,7 @@ pub const fn field_to_array<FA: FieldAlgebra, const D: usize>(x: FA) -> [FA; D] 
 }
 
 /// Naive polynomial multiplication.
-pub fn naive_poly_mul<FA: FieldAlgebra>(a: &[FA], b: &[FA]) -> Vec<FA> {
+pub fn naive_poly_mul<FA: PrimeCharacteristicRing>(a: &[FA], b: &[FA]) -> Vec<FA> {
     // Grade school algorithm
     let mut product = vec![FA::ZERO; a.len() + b.len() - 1];
     for (i, c1) in a.iter().enumerate() {
@@ -153,7 +153,7 @@ pub fn naive_poly_mul<FA: FieldAlgebra>(a: &[FA], b: &[FA]) -> Vec<FA> {
 }
 
 /// Expand a product of binomials `(x - roots[0])(x - roots[1])..` into polynomial coefficients.
-pub fn binomial_expand<FA: FieldAlgebra>(roots: &[FA]) -> Vec<FA> {
+pub fn binomial_expand<FA: PrimeCharacteristicRing>(roots: &[FA]) -> Vec<FA> {
     let mut coeffs = vec![FA::ZERO; roots.len() + 1];
     coeffs[0] = FA::ONE;
     for (i, x) in roots.iter().enumerate() {
@@ -165,7 +165,7 @@ pub fn binomial_expand<FA: FieldAlgebra>(roots: &[FA]) -> Vec<FA> {
     coeffs
 }
 
-pub fn eval_poly<FA: FieldAlgebra>(poly: &[FA], x: FA) -> FA {
+pub fn eval_poly<FA: PrimeCharacteristicRing>(poly: &[FA], x: FA) -> FA {
     let mut acc = FA::ZERO;
     for coeff in poly.iter().rev() {
         acc *= x.clone();

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -3,7 +3,7 @@ use core::ops::Div;
 use core::slice;
 
 use crate::field::Field;
-use crate::FieldAlgebra;
+use crate::{FieldAlgebra, PrimeCharacteristicRing};
 
 /// A trait to constrain types that can be packed into a packed value.
 ///
@@ -130,7 +130,7 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
 
 /// # Safety
 /// - See `PackedValue` above.
-pub unsafe trait PackedField: FieldAlgebra<F = Self::Scalar>
+pub unsafe trait PackedField: PrimeCharacteristicRing + FieldAlgebra<Self::Scalar>
     + PackedValue<Value = Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -3,7 +3,7 @@ use core::ops::Div;
 use core::slice;
 
 use crate::field::Field;
-use crate::{FieldAlgebra, PrimeCharacteristicRing};
+use crate::{Algebra, PrimeCharacteristicRing};
 
 /// A trait to constrain types that can be packed into a packed value.
 ///
@@ -130,7 +130,7 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
 
 /// # Safety
 /// - See `PackedValue` above.
-pub unsafe trait PackedField: PrimeCharacteristicRing + FieldAlgebra<Self::Scalar>
+pub unsafe trait PackedField: PrimeCharacteristicRing + Algebra<Self::Scalar>
     + PackedValue<Value = Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -3,7 +3,7 @@ use core::ops::Div;
 use core::slice;
 
 use crate::field::Field;
-use crate::{Algebra, PrimeCharacteristicRing};
+use crate::Algebra;
 
 /// A trait to constrain types that can be packed into a packed value.
 ///
@@ -130,7 +130,7 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
 
 /// # Safety
 /// - See `PackedValue` above.
-pub unsafe trait PackedField: PrimeCharacteristicRing + Algebra<Self::Scalar>
+pub unsafe trait PackedField: Algebra<Self::Scalar>
     + PackedValue<Value = Self::Scalar>
     // TODO: Implement packed / packed division
     + Div<Self::Scalar, Output = Self>

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -6,7 +6,7 @@ use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};
 use p3_commit::ExtensionMmcs;
 use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::{prover, verifier, FriConfig, TwoAdicFriGenericConfig};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::reverse_matrix_index_bits;

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_sub_latency, benchmark_sub_throughput,

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,5 +1,5 @@
 use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBionmialExtension};
-use p3_field::{FieldAlgebra, TwoAdicField};
+use p3_field::{PrimeCharacteristicRing, TwoAdicField};
 
 use crate::Goldilocks;
 

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -12,8 +12,8 @@ use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::integers::QuotientMap;
 use p3_field::{
     halve_u64, quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int, Field,
-    FieldAlgebra, InjectiveMonomial, Packable, PermutationMonomial, PrimeField, PrimeField64,
-    TwoAdicField,
+    InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
+    PrimeField64, TwoAdicField,
 };
 use p3_util::{assume, branch_hint};
 use rand::distributions::{Distribution, Standard};
@@ -94,8 +94,7 @@ impl Distribution<Goldilocks> for Standard {
     }
 }
 
-impl FieldAlgebra for Goldilocks {
-    type F = Self;
+impl PrimeCharacteristicRing for Goldilocks {
     type PrimeSubfield = Self;
 
     const ZERO: Self = Self::new(0);

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -9,7 +9,7 @@
 //! Long term we will use more optimised internal and external linear layers.
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial};
+use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,
@@ -30,6 +30,7 @@ const GOLDILOCKS_S_BOX_DEGREE: u64 = 7;
 /// Currently the internal layers are unoptimized. These could be sped up in a similar way to
 /// how it was done for Monty31 fields.
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
+    Goldilocks,
     <Goldilocks as Field>::Packing,
     Poseidon2ExternalLayerGoldilocks<WIDTH>,
     Poseidon2InternalLayerGoldilocks,
@@ -44,6 +45,7 @@ pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
 /// This implementation is slightly slower than `Poseidon2Goldilocks` as is uses a slower matrix
 /// for the external rounds.
 pub type Poseidon2GoldilocksHL<const WIDTH: usize> = Poseidon2<
+    Goldilocks,
     <Goldilocks as Field>::Packing,
     Poseidon2ExternalLayerGoldilocksHL<WIDTH>,
     Poseidon2InternalLayerGoldilocks,
@@ -125,20 +127,23 @@ pub struct Poseidon2InternalLayerGoldilocks {
     internal_constants: Vec<Goldilocks>,
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks>> InternalLayerConstructor<FA>
-    for Poseidon2InternalLayerGoldilocks
+impl<FA: FieldAlgebra<Goldilocks> + PrimeCharacteristicRing>
+    InternalLayerConstructor<Goldilocks, FA> for Poseidon2InternalLayerGoldilocks
 {
     fn new_from_constants(internal_constants: Vec<Goldilocks>) -> Self {
         Self { internal_constants }
     }
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
-    InternalLayer<FA, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<
+        FA: FieldAlgebra<Goldilocks>
+            + PrimeCharacteristicRing
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<FA, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [FA; 8]) {
-        internal_permute_state::<FA, 8, GOLDILOCKS_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_8_GOLDILOCKS),
             &self.internal_constants,
@@ -146,12 +151,15 @@ impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGRE
     }
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
-    InternalLayer<FA, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<
+        FA: FieldAlgebra<Goldilocks>
+            + PrimeCharacteristicRing
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<FA, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [FA; 12]) {
-        internal_permute_state::<FA, 12, GOLDILOCKS_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_12_GOLDILOCKS),
             &self.internal_constants,
@@ -159,12 +167,15 @@ impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGRE
     }
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
-    InternalLayer<FA, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<
+        FA: FieldAlgebra<Goldilocks>
+            + PrimeCharacteristicRing
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<FA, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [FA; 16]) {
-        internal_permute_state::<FA, 16, GOLDILOCKS_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_16_GOLDILOCKS),
             &self.internal_constants,
@@ -172,12 +183,15 @@ impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGRE
     }
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
-    InternalLayer<FA, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<
+        FA: FieldAlgebra<Goldilocks>
+            + PrimeCharacteristicRing
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<FA, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [FA; 20]) {
-        internal_permute_state::<FA, 20, GOLDILOCKS_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_20_GOLDILOCKS),
             &self.internal_constants,
@@ -191,8 +205,8 @@ pub struct Poseidon2ExternalLayerGoldilocks<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
-    for Poseidon2ExternalLayerGoldilocks<WIDTH>
+impl<FA: PrimeCharacteristicRing + FieldAlgebra<Goldilocks>, const WIDTH: usize>
+    ExternalLayerConstructor<Goldilocks, FA, WIDTH> for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
         Self { external_constants }
@@ -200,7 +214,9 @@ impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstruc
 }
 
 impl<
-        FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+        FA: PrimeCharacteristicRing
+            + FieldAlgebra<Goldilocks>
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
     > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2ExternalLayerGoldilocks<WIDTH>
@@ -210,7 +226,7 @@ impl<
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
-            add_rc_and_sbox_generic::<_, GOLDILOCKS_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -220,7 +236,7 @@ impl<
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
-            add_rc_and_sbox_generic::<_, GOLDILOCKS_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -232,8 +248,8 @@ pub struct Poseidon2ExternalLayerGoldilocksHL<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstructor<FA, WIDTH>
-    for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
+impl<FA: PrimeCharacteristicRing + FieldAlgebra<Goldilocks>, const WIDTH: usize>
+    ExternalLayerConstructor<Goldilocks, FA, WIDTH> for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
         Self { external_constants }
@@ -241,7 +257,9 @@ impl<FA: FieldAlgebra<F = Goldilocks>, const WIDTH: usize> ExternalLayerConstruc
 }
 
 impl<
-        FA: FieldAlgebra<F = Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+        FA: PrimeCharacteristicRing
+            + FieldAlgebra<Goldilocks>
+            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
     > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
@@ -251,7 +269,7 @@ impl<
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
-            add_rc_and_sbox_generic::<_, GOLDILOCKS_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &HLMDSMat4,
         );
     }
@@ -261,7 +279,7 @@ impl<
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
-            add_rc_and_sbox_generic::<_, GOLDILOCKS_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &HLMDSMat4,
         );
     }

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -9,7 +9,7 @@
 //! Long term we will use more optimised internal and external linear layers.
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,
@@ -31,7 +31,6 @@ const GOLDILOCKS_S_BOX_DEGREE: u64 = 7;
 /// how it was done for Monty31 fields.
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
     Goldilocks,
-    <Goldilocks as Field>::Packing,
     Poseidon2ExternalLayerGoldilocks<WIDTH>,
     Poseidon2InternalLayerGoldilocks,
     WIDTH,
@@ -46,7 +45,6 @@ pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
 /// for the external rounds.
 pub type Poseidon2GoldilocksHL<const WIDTH: usize> = Poseidon2<
     Goldilocks,
-    <Goldilocks as Field>::Packing,
     Poseidon2ExternalLayerGoldilocksHL<WIDTH>,
     Poseidon2InternalLayerGoldilocks,
     WIDTH,

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -9,7 +9,7 @@
 //! Long term we will use more optimised internal and external linear layers.
 use alloc::vec::Vec;
 
-use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, InjectiveMonomial};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,
@@ -131,12 +131,11 @@ impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocks {
     }
 }
 
-impl<
-        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<R, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
+    InternalLayer<A, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [R; 8]) {
+    fn permute_state(&self, state: &mut [A; 8]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_8_GOLDILOCKS),
@@ -145,12 +144,11 @@ impl<
     }
 }
 
-impl<
-        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<R, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
+    InternalLayer<A, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [R; 12]) {
+    fn permute_state(&self, state: &mut [A; 12]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_12_GOLDILOCKS),
@@ -159,12 +157,11 @@ impl<
     }
 }
 
-impl<
-        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<R, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
+    InternalLayer<A, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [R; 16]) {
+    fn permute_state(&self, state: &mut [A; 16]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_16_GOLDILOCKS),
@@ -173,12 +170,11 @@ impl<
     }
 }
 
-impl<
-        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<R, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
+    InternalLayer<A, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [R; 20]) {
+    fn permute_state(&self, state: &mut [A; 20]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_20_GOLDILOCKS),
@@ -201,13 +197,11 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
     }
 }
 
-impl<
-        R: PrimeCharacteristicRing + Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-        const WIDTH: usize,
-    > ExternalLayer<R, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocks<WIDTH>
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>, const WIDTH: usize>
+    ExternalLayer<A, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [R; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [A; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -217,7 +211,7 @@ impl<
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [R; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [A; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
@@ -241,14 +235,11 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
     }
 }
 
-impl<
-        R: PrimeCharacteristicRing + Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-        const WIDTH: usize,
-    > ExternalLayer<R, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
-    for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
+impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>, const WIDTH: usize>
+    ExternalLayer<A, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [R; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [A; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -258,7 +249,7 @@ impl<
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [R; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [A; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
@@ -383,6 +374,7 @@ pub const HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS: [u64; 22] = [
 mod tests {
     use core::array;
 
+    use p3_field::PrimeCharacteristicRing;
     use p3_poseidon2::Poseidon2;
     use p3_symmetric::Permutation;
 

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -132,13 +132,11 @@ impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocks {
 }
 
 impl<
-        FA: Algebra<Goldilocks>
-            + PrimeCharacteristicRing
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<FA, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<R, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [FA; 8]) {
+    fn permute_state(&self, state: &mut [R; 8]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_8_GOLDILOCKS),
@@ -148,13 +146,11 @@ impl<
 }
 
 impl<
-        FA: Algebra<Goldilocks>
-            + PrimeCharacteristicRing
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<FA, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<R, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [FA; 12]) {
+    fn permute_state(&self, state: &mut [R; 12]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_12_GOLDILOCKS),
@@ -164,13 +160,11 @@ impl<
 }
 
 impl<
-        FA: Algebra<Goldilocks>
-            + PrimeCharacteristicRing
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<FA, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<R, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [FA; 16]) {
+    fn permute_state(&self, state: &mut [R; 16]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_16_GOLDILOCKS),
@@ -180,13 +174,11 @@ impl<
 }
 
 impl<
-        FA: Algebra<Goldilocks>
-            + PrimeCharacteristicRing
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
-    > InternalLayer<FA, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
+        R: Algebra<Goldilocks> + PrimeCharacteristicRing + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+    > InternalLayer<R, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [FA; 20]) {
+    fn permute_state(&self, state: &mut [R; 20]) {
         internal_permute_state(
             state,
             |x| matmul_internal(x, MATRIX_DIAG_20_GOLDILOCKS),
@@ -210,15 +202,12 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
 }
 
 impl<
-        FA: PrimeCharacteristicRing
-            + Algebra<Goldilocks>
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+        R: PrimeCharacteristicRing + Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
-    > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
-    for Poseidon2ExternalLayerGoldilocks<WIDTH>
+    > ExternalLayer<R, WIDTH, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [FA; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [R; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -228,7 +217,7 @@ impl<
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [R; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
@@ -253,15 +242,13 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
 }
 
 impl<
-        FA: PrimeCharacteristicRing
-            + Algebra<Goldilocks>
-            + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+        R: PrimeCharacteristicRing + Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
-    > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+    > ExternalLayer<R, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
     for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [FA; WIDTH]) {
+    fn permute_state_initial(&self, state: &mut [R; WIDTH]) {
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
@@ -271,7 +258,7 @@ impl<
     }
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]) {
+    fn permute_state_terminal(&self, state: &mut [R; WIDTH]) {
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -127,9 +127,7 @@ pub struct Poseidon2InternalLayerGoldilocks {
     internal_constants: Vec<Goldilocks>,
 }
 
-impl<FA: FieldAlgebra<Goldilocks> + PrimeCharacteristicRing>
-    InternalLayerConstructor<Goldilocks, FA> for Poseidon2InternalLayerGoldilocks
-{
+impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocks {
     fn new_from_constants(internal_constants: Vec<Goldilocks>) -> Self {
         Self { internal_constants }
     }
@@ -205,8 +203,8 @@ pub struct Poseidon2ExternalLayerGoldilocks<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<FA: PrimeCharacteristicRing + FieldAlgebra<Goldilocks>, const WIDTH: usize>
-    ExternalLayerConstructor<Goldilocks, FA, WIDTH> for Poseidon2ExternalLayerGoldilocks<WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
+    for Poseidon2ExternalLayerGoldilocks<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
         Self { external_constants }
@@ -248,8 +246,8 @@ pub struct Poseidon2ExternalLayerGoldilocksHL<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }
 
-impl<FA: PrimeCharacteristicRing + FieldAlgebra<Goldilocks>, const WIDTH: usize>
-    ExternalLayerConstructor<Goldilocks, FA, WIDTH> for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
+    for Poseidon2ExternalLayerGoldilocksHL<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
         Self { external_constants }

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -9,7 +9,7 @@
 //! Long term we will use more optimised internal and external linear layers.
 use alloc::vec::Vec;
 
-use p3_field::{FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, matmul_internal, ExternalLayer, ExternalLayerConstants,
@@ -132,7 +132,7 @@ impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocks {
 }
 
 impl<
-        FA: FieldAlgebra<Goldilocks>
+        FA: Algebra<Goldilocks>
             + PrimeCharacteristicRing
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
     > InternalLayer<FA, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
@@ -148,7 +148,7 @@ impl<
 }
 
 impl<
-        FA: FieldAlgebra<Goldilocks>
+        FA: Algebra<Goldilocks>
             + PrimeCharacteristicRing
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
     > InternalLayer<FA, 12, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
@@ -164,7 +164,7 @@ impl<
 }
 
 impl<
-        FA: FieldAlgebra<Goldilocks>
+        FA: Algebra<Goldilocks>
             + PrimeCharacteristicRing
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
     > InternalLayer<FA, 16, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
@@ -180,7 +180,7 @@ impl<
 }
 
 impl<
-        FA: FieldAlgebra<Goldilocks>
+        FA: Algebra<Goldilocks>
             + PrimeCharacteristicRing
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
     > InternalLayer<FA, 20, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocks
@@ -211,7 +211,7 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
 
 impl<
         FA: PrimeCharacteristicRing
-            + FieldAlgebra<Goldilocks>
+            + Algebra<Goldilocks>
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
     > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
@@ -254,7 +254,7 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
 
 impl<
         FA: PrimeCharacteristicRing
-            + FieldAlgebra<Goldilocks>
+            + Algebra<Goldilocks>
             + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
         const WIDTH: usize,
     > ExternalLayer<FA, WIDTH, GOLDILOCKS_S_BOX_DEGREE>

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
 use p3_util::convert_vec;
@@ -200,7 +200,7 @@ impl PermutationMonomial<7> for PackedGoldilocksAVX2 {
     }
 }
 
-impl FieldAlgebra<Goldilocks> for PackedGoldilocksAVX2 {}
+impl Algebra<Goldilocks> for PackedGoldilocksAVX2 {}
 
 unsafe impl PackedValue for PackedGoldilocksAVX2 {
     type Value = Goldilocks;

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::{
     Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeField64,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -160,8 +160,7 @@ impl Product for PackedGoldilocksAVX2 {
     }
 }
 
-impl FieldAlgebra for PackedGoldilocksAVX2 {
-    type F = Goldilocks;
+impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     type PrimeSubfield = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
@@ -182,7 +181,7 @@ impl FieldAlgebra for PackedGoldilocksAVX2 {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(Goldilocks::zero_vec(len * WIDTH)) }
     }
 }
 
@@ -200,6 +199,8 @@ impl PermutationMonomial<7> for PackedGoldilocksAVX2 {
         exp_10540996611094048183(*self)
     }
 }
+
+impl FieldAlgebra<Goldilocks> for PackedGoldilocksAVX2 {}
 
 unsafe impl PackedValue for PackedGoldilocksAVX2 {
     type Value = Goldilocks;

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -70,7 +70,6 @@ impl MdsPermutation<PackedGoldilocksAVX512, 24> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
     use rand::Rng;

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -70,7 +70,7 @@ impl MdsPermutation<PackedGoldilocksAVX512, 24> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
     use rand::Rng;

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -8,8 +8,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeField64,
+    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    PrimeCharacteristicRing, PrimeField64,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -159,7 +159,7 @@ impl Product for PackedGoldilocksAVX512 {
     }
 }
 
-impl FieldAlgebra for PackedGoldilocksAVX512 {
+impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     type F = Goldilocks;
     type PrimeSubfield = Goldilocks;
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -8,8 +8,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::{
-    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
-    PrimeCharacteristicRing, PrimeField64,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -160,7 +160,6 @@ impl Product for PackedGoldilocksAVX512 {
 }
 
 impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
-    type F = Goldilocks;
     type PrimeSubfield = Goldilocks;
 
     const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
@@ -181,9 +180,11 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(Goldilocks::zero_vec(len * WIDTH)) }
     }
 }
+
+impl FieldAlgebra<Goldilocks> for PackedGoldilocksAVX512 {}
 
 // Degree of the smallest permutation polynomial for Goldilocks.
 //

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
 use p3_util::convert_vec;
@@ -184,7 +184,7 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     }
 }
 
-impl FieldAlgebra<Goldilocks> for PackedGoldilocksAVX512 {}
+impl Algebra<Goldilocks> for PackedGoldilocksAVX512 {}
 
 // Degree of the smallest permutation polynomial for Goldilocks.
 //

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -82,7 +82,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::{batch_multiplicative_inverse, Field, FieldAlgebra};
+    use p3_field::{batch_multiplicative_inverse, Field, PrimeCharacteristicRing};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_util::log2_strict_usize;
 

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 
 use p3_air::utils::{andn, xor, xor3};
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};

--- a/keccak/benches/bench_keccak.rs
+++ b/keccak/benches/bench_keccak.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_keccak::{KeccakF, VECTOR_LEN};
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CryptographicHasher, PaddingFreeSponge, Permutation, SerializingHasher32To64};

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{FieldExtensionAlgebra, PrimeCharacteristicRing};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -3,7 +3,7 @@ mod test_quartic_extension {
     use alloc::format;
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{FieldExtensionAlgebra, PrimeCharacteristicRing};
+    use p3_field::{PrimeCharacteristicRing, Serializable};
     use p3_field_testing::{test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -61,7 +61,7 @@ impl RelativelyPrimePower<3> for KoalaBearParameters {
     /// In the field `KoalaBear`, `a^{1/3}` is equal to a^{1420470955}.
     ///
     /// This follows from the calculation `3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1)`.
-    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA {
+    fn exp_root_d<R: PrimeCharacteristicRing>(val: R) -> R {
         // We use a custom addition chain.
         // This could possibly by further optimised.
         exp_1420470955(val)

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -1,5 +1,5 @@
 use p3_field::exponentiation::exp_1420470955;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, RelativelyPrimePower, TwoAdicData,
@@ -61,7 +61,7 @@ impl RelativelyPrimePower<3> for KoalaBearParameters {
     /// In the field `KoalaBear`, `a^{1/3}` is equal to a^{1420470955}.
     ///
     /// This follows from the calculation `3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1)`.
-    fn exp_root_d<FA: FieldAlgebra>(val: FA) -> FA {
+    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA {
         // We use a custom addition chain.
         // This could possibly by further optimised.
         exp_1420470955(val)

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -152,11 +152,11 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalL
         state[15] = sum - state[15];
     }
 
-    fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
+    fn generic_internal_linear_layer<R>(state: &mut [R; 16])
     where
-        FA: PrimeCharacteristicRing + Mul<KoalaBear, Output = FA>,
+        R: PrimeCharacteristicRing + Mul<KoalaBear, Output = R>,
     {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -230,11 +230,11 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalL
         state[23] = sum - state[23];
     }
 
-    fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
+    fn generic_internal_linear_layer<R>(state: &mut [R; 24])
     where
-        FA: PrimeCharacteristicRing + core::ops::Mul<KoalaBear, Output = FA>,
+        R: PrimeCharacteristicRing + core::ops::Mul<KoalaBear, Output = R>,
     {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -42,7 +42,6 @@ const KOALABEAR_S_BOX_DEGREE: u64 = 3;
 /// wherever possible, input arrays should of the form `[KoalaBear::Packing; WIDTH]`.
 pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
     KoalaBear,
-    <KoalaBear as Field>::Packing,
     Poseidon2ExternalLayerKoalaBear<WIDTH>,
     Poseidon2InternalLayerKoalaBear<WIDTH>,
     WIDTH,

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -50,7 +50,7 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by KoalaBear field elements.
+/// This can act on [A; WIDTH] for any algebra which implements multiplication by KoalaBear field elements.
 /// If you have either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]` it will be much faster
 /// to use `Poseidon2KoalaBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersKoalaBear =
@@ -166,7 +166,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalL
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_16)
@@ -244,7 +244,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalL
 
         // For the remaining elements we use multiplication.
         // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to FieldAlgebra.
+        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
         state
             .iter_mut()
             .zip(INTERNAL_DIAG_MONTY_24)

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{Field, FieldAlgebra, PrimeField32};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
 use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
     MontyField31, Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
@@ -41,6 +41,7 @@ const KOALABEAR_S_BOX_DEGREE: u64 = 3;
 /// It acts on arrays of the form either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]`. For speed purposes,
 /// wherever possible, input arrays should of the form `[KoalaBear::Packing; WIDTH]`.
 pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
+    KoalaBear,
     <KoalaBear as Field>::Packing,
     Poseidon2ExternalLayerKoalaBear<WIDTH>,
     Poseidon2InternalLayerKoalaBear<WIDTH>,
@@ -154,7 +155,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalL
 
     fn generic_internal_linear_layer<FA>(state: &mut [FA; 16])
     where
-        FA: FieldAlgebra + Mul<KoalaBear, Output = FA>,
+        FA: PrimeCharacteristicRing + Mul<KoalaBear, Output = FA>,
     {
         let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
@@ -232,7 +233,7 @@ impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalL
 
     fn generic_internal_linear_layer<FA>(state: &mut [FA; 24])
     where
-        FA: FieldAlgebra + core::ops::Mul<KoalaBear, Output = FA>,
+        FA: PrimeCharacteristicRing + core::ops::Mul<KoalaBear, Output = FA>,
     {
         let part_sum: FA = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -92,7 +92,7 @@ mod tests {
     use alloc::vec;
 
     use p3_field::extension::Complex;
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::{FieldExtensionAlgebra, PrimeCharacteristicRing};
     use p3_mersenne_31::Mersenne31;
 
     use super::*;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -10,7 +10,7 @@ use core::ops::Deref;
 
 use itertools::{izip, Itertools};
 use p3_field::{
-    dot_product, ExtensionField, Field, FieldAlgebra, FieldExtensionAlgebra, PackedValue,
+    dot_product, ExtensionField, Field, FieldExtensionAlgebra, PackedValue, PrimeCharacteristicRing,
 };
 use p3_maybe_rayon::prelude::*;
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
@@ -289,7 +289,7 @@ mod tests {
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use rand::thread_rng;
 
     use super::*;

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -37,16 +37,16 @@ fn bench_all_mds(c: &mut Criterion) {
     bench_mds::<Mersenne31, MdsMatrixMersenne31, 64>(c);
 }
 
-fn bench_mds<FA, Mds, const WIDTH: usize>(c: &mut Criterion)
+fn bench_mds<R, Mds, const WIDTH: usize>(c: &mut Criterion)
 where
-    FA: PrimeCharacteristicRing,
-    Standard: Distribution<FA>,
-    Mds: MdsPermutation<FA, WIDTH> + Default,
+    R: PrimeCharacteristicRing,
+    Standard: Distribution<R>,
+    Mds: MdsPermutation<R, WIDTH> + Default,
 {
     let mds = Mds::default();
 
     let mut rng = thread_rng();
-    let input = rng.gen::<[FA; WIDTH]>();
+    let input = rng.gen::<[R; WIDTH]>();
     let id = BenchmarkId::new(type_name::<Mds>(), WIDTH);
     c.bench_with_input(id, &input, |b, input| b.iter(|| mds.permute(input.clone())));
 }

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
@@ -39,7 +39,7 @@ fn bench_all_mds(c: &mut Criterion) {
 
 fn bench_mds<FA, Mds, const WIDTH: usize>(c: &mut Criterion)
 where
-    FA: FieldAlgebra,
+    FA: PrimeCharacteristicRing,
     Standard: Distribution<FA>,
     Mds: MdsPermutation<FA, WIDTH> + Default,
 {

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -1,10 +1,10 @@
-use p3_field::{Field, FieldAlgebra, PrimeCharacteristicRing};
+use p3_field::{Field, Algebra, PrimeCharacteristicRing};
 
 /// DIT butterfly.
 #[inline]
 pub(crate) fn dit_butterfly<
     F: Field,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    FA: PrimeCharacteristicRing + Algebra<F>,
     const N: usize,
 >(
     values: &mut [FA; N],
@@ -22,7 +22,7 @@ pub(crate) fn dit_butterfly<
 #[inline]
 pub(crate) fn dif_butterfly<
     F: Field,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    FA: PrimeCharacteristicRing + Algebra<F>,
     const N: usize,
 >(
     values: &mut [FA; N],
@@ -40,7 +40,7 @@ pub(crate) fn dif_butterfly<
 #[inline]
 pub(crate) fn twiddle_free_butterfly<
     F: Field,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    FA: PrimeCharacteristicRing + Algebra<F>,
     const N: usize,
 >(
     values: &mut [FA; N],

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -1,12 +1,16 @@
-use p3_field::FieldAlgebra;
+use p3_field::{Field, FieldAlgebra, PrimeCharacteristicRing};
 
 /// DIT butterfly.
 #[inline]
-pub(crate) fn dit_butterfly<FA: FieldAlgebra, const N: usize>(
+pub(crate) fn dit_butterfly<
+    F: Field,
+    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    const N: usize,
+>(
     values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: FA::F,
+    twiddle: F,
 ) {
     let val_1 = values[idx_1].clone();
     let val_2 = values[idx_2].clone() * twiddle;
@@ -16,11 +20,15 @@ pub(crate) fn dit_butterfly<FA: FieldAlgebra, const N: usize>(
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<FA: FieldAlgebra, const N: usize>(
+pub(crate) fn dif_butterfly<
+    F: Field,
+    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    const N: usize,
+>(
     values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,
-    twiddle: FA::F,
+    twiddle: F,
 ) {
     let val_1 = values[idx_1].clone();
     let val_2 = values[idx_2].clone();
@@ -30,7 +38,11 @@ pub(crate) fn dif_butterfly<FA: FieldAlgebra, const N: usize>(
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-pub(crate) fn twiddle_free_butterfly<FA: FieldAlgebra, const N: usize>(
+pub(crate) fn twiddle_free_butterfly<
+    F: Field,
+    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    const N: usize,
+>(
     values: &mut [FA; N],
     idx_1: usize,
     idx_2: usize,

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -1,13 +1,9 @@
-use p3_field::{Field, Algebra, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, PrimeCharacteristicRing};
 
 /// DIT butterfly.
 #[inline]
-pub(crate) fn dit_butterfly<
-    F: Field,
-    FA: PrimeCharacteristicRing + Algebra<F>,
-    const N: usize,
->(
-    values: &mut [FA; N],
+pub(crate) fn dit_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     idx_1: usize,
     idx_2: usize,
     twiddle: F,
@@ -20,12 +16,8 @@ pub(crate) fn dit_butterfly<
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<
-    F: Field,
-    FA: PrimeCharacteristicRing + Algebra<F>,
-    const N: usize,
->(
-    values: &mut [FA; N],
+pub(crate) fn dif_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     idx_1: usize,
     idx_2: usize,
     twiddle: F,
@@ -40,10 +32,10 @@ pub(crate) fn dif_butterfly<
 #[inline]
 pub(crate) fn twiddle_free_butterfly<
     F: Field,
-    FA: PrimeCharacteristicRing + Algebra<F>,
+    R: PrimeCharacteristicRing + Algebra<F>,
     const N: usize,
 >(
-    values: &mut [FA; N],
+    values: &mut [R; N],
     idx_1: usize,
     idx_2: usize,
 ) {

--- a/mds/src/butterflies.rs
+++ b/mds/src/butterflies.rs
@@ -1,9 +1,9 @@
-use p3_field::{Algebra, Field, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field};
 
 /// DIT butterfly.
 #[inline]
-pub(crate) fn dit_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [R; N],
+pub(crate) fn dit_butterfly<F: Field, A: Algebra<F>, const N: usize>(
+    values: &mut [A; N],
     idx_1: usize,
     idx_2: usize,
     twiddle: F,
@@ -16,8 +16,8 @@ pub(crate) fn dit_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, c
 
 /// DIF butterfly.
 #[inline]
-pub(crate) fn dif_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [R; N],
+pub(crate) fn dif_butterfly<F: Field, A: Algebra<F>, const N: usize>(
+    values: &mut [A; N],
     idx_1: usize,
     idx_2: usize,
     twiddle: F,
@@ -30,12 +30,8 @@ pub(crate) fn dif_butterfly<F: Field, R: PrimeCharacteristicRing + Algebra<F>, c
 
 /// Butterfly with twiddle factor 1 (works in either DIT or DIF).
 #[inline]
-pub(crate) fn twiddle_free_butterfly<
-    F: Field,
-    R: PrimeCharacteristicRing + Algebra<F>,
-    const N: usize,
->(
-    values: &mut [R; N],
+pub(crate) fn twiddle_free_butterfly<F: Field, A: Algebra<F>, const N: usize>(
+    values: &mut [A; N],
     idx_1: usize,
     idx_2: usize,
 ) {

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{Field, Algebra, PrimeCharacteristicRing, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -53,7 +53,7 @@ where
 impl<F, FA, const N: usize> Permutation<[FA; N]> for CosetMds<F, N>
 where
     F: TwoAdicField,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    FA: PrimeCharacteristicRing + Algebra<F>,
 {
     fn permute(&self, mut input: [FA; N]) -> [FA; N] {
         self.permute_mut(&mut input);
@@ -77,14 +77,14 @@ where
 impl<F, FA, const N: usize> MdsPermutation<FA, N> for CosetMds<F, N>
 where
     F: TwoAdicField,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
+    FA: PrimeCharacteristicRing + Algebra<F>,
 {
 }
 
 /// Executes the Bowers G network. This is like a DFT, except it assumes the input is in
 /// bit-reversed order.
 #[inline]
-fn bowers_g<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     twiddles: &[F],
 ) {
@@ -97,7 +97,7 @@ fn bowers_g<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: us
 /// Executes the Bowers G^T network. This is like an inverse DFT, except we skip rescaling by
 /// `1/N`, and the output is bit-reversed.
 #[inline]
-fn bowers_g_t<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g_t<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     twiddles: &[F],
 ) {
@@ -109,7 +109,7 @@ fn bowers_g_t<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: 
 
 /// One layer of a Bowers G network. Equivalent to `bowers_g_t_layer` except for the butterfly.
 #[inline]
-fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
     twiddles: &[F],
@@ -135,7 +135,7 @@ fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const
 
 /// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
 #[inline]
-fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
     twiddles: &[F],

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Field, Algebra, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{Algebra, Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -50,17 +50,17 @@ where
     }
 }
 
-impl<F, FA, const N: usize> Permutation<[FA; N]> for CosetMds<F, N>
+impl<F, R, const N: usize> Permutation<[R; N]> for CosetMds<F, N>
 where
     F: TwoAdicField,
-    FA: PrimeCharacteristicRing + Algebra<F>,
+    R: PrimeCharacteristicRing + Algebra<F>,
 {
-    fn permute(&self, mut input: [FA; N]) -> [FA; N] {
+    fn permute(&self, mut input: [R; N]) -> [R; N] {
         self.permute_mut(&mut input);
         input
     }
 
-    fn permute_mut(&self, values: &mut [FA; N]) {
+    fn permute_mut(&self, values: &mut [R; N]) {
         // Inverse DFT, except we skip bit reversal and rescaling by 1/N.
         bowers_g_t(values, &self.ifft_twiddles);
 
@@ -74,18 +74,18 @@ where
     }
 }
 
-impl<F, FA, const N: usize> MdsPermutation<FA, N> for CosetMds<F, N>
+impl<F, R, const N: usize> MdsPermutation<R, N> for CosetMds<F, N>
 where
     F: TwoAdicField,
-    FA: PrimeCharacteristicRing + Algebra<F>,
+    R: PrimeCharacteristicRing + Algebra<F>,
 {
 }
 
 /// Executes the Bowers G network. This is like a DFT, except it assumes the input is in
 /// bit-reversed order.
 #[inline]
-fn bowers_g<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     twiddles: &[F],
 ) {
     let log_n = log2_strict_usize(N);
@@ -97,8 +97,8 @@ fn bowers_g<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
 /// Executes the Bowers G^T network. This is like an inverse DFT, except we skip rescaling by
 /// `1/N`, and the output is bit-reversed.
 #[inline]
-fn bowers_g_t<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g_t<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     twiddles: &[F],
 ) {
     let log_n = log2_strict_usize(N);
@@ -109,8 +109,8 @@ fn bowers_g_t<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize
 
 /// One layer of a Bowers G network. Equivalent to `bowers_g_t_layer` except for the butterfly.
 #[inline]
-fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
@@ -135,8 +135,8 @@ fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: u
 
 /// One layer of a Bowers G^T network. Equivalent to `bowers_g_layer` except for the butterfly.
 #[inline]
-fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g_t_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Algebra, Field, Powers, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{Algebra, Field, Powers, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -48,15 +48,13 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
     }
 }
 
-impl<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permutation<[R; N]>
-    for IntegratedCosetMds<F, N>
-{
-    fn permute(&self, mut input: [R; N]) -> [R; N] {
+impl<F: Field, A: Algebra<F>, const N: usize> Permutation<[A; N]> for IntegratedCosetMds<F, N> {
+    fn permute(&self, mut input: [A; N]) -> [A; N] {
         self.permute_mut(&mut input);
         input
     }
 
-    fn permute_mut(&self, values: &mut [R; N]) {
+    fn permute_mut(&self, values: &mut [A; N]) {
         let log_n = log2_strict_usize(N);
 
         // Bit-reversed DIF, aka Bowers G
@@ -71,14 +69,11 @@ impl<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permutat
     }
 }
 
-impl<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize> MdsPermutation<R, N>
-    for IntegratedCosetMds<F, N>
-{
-}
+impl<F: Field, A: Algebra<F>, const N: usize> MdsPermutation<A, N> for IntegratedCosetMds<F, N> {}
 
 #[inline]
-fn bowers_g_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [R; N],
+fn bowers_g_layer<F: Field, A: Algebra<F>, const N: usize>(
+    values: &mut [A; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
@@ -102,8 +97,8 @@ fn bowers_g_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: us
 }
 
 #[inline]
-fn bowers_g_t_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [R; N],
+fn bowers_g_t_layer<F: Field, A: Algebra<F>, const N: usize>(
+    values: &mut [A; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, Powers, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{Field, Algebra, Powers, PrimeCharacteristicRing, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -48,7 +48,7 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
     }
 }
 
-impl<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize> Permutation<[FA; N]>
+impl<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permutation<[FA; N]>
     for IntegratedCosetMds<F, N>
 {
     fn permute(&self, mut input: [FA; N]) -> [FA; N] {
@@ -71,13 +71,13 @@ impl<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize> Pe
     }
 }
 
-impl<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize> MdsPermutation<FA, N>
+impl<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize> MdsPermutation<FA, N>
     for IntegratedCosetMds<F, N>
 {
 }
 
 #[inline]
-fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
     twiddles: &[F],
@@ -102,7 +102,7 @@ fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const
 }
 
 #[inline]
-fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
+fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
     twiddles: &[F],

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Field, Algebra, Powers, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{Algebra, Field, Powers, PrimeCharacteristicRing, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -48,15 +48,15 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
     }
 }
 
-impl<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permutation<[FA; N]>
+impl<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permutation<[R; N]>
     for IntegratedCosetMds<F, N>
 {
-    fn permute(&self, mut input: [FA; N]) -> [FA; N] {
+    fn permute(&self, mut input: [R; N]) -> [R; N] {
         self.permute_mut(&mut input);
         input
     }
 
-    fn permute_mut(&self, values: &mut [FA; N]) {
+    fn permute_mut(&self, values: &mut [R; N]) {
         let log_n = log2_strict_usize(N);
 
         // Bit-reversed DIF, aka Bowers G
@@ -71,14 +71,14 @@ impl<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize> Permuta
     }
 }
 
-impl<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize> MdsPermutation<FA, N>
+impl<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize> MdsPermutation<R, N>
     for IntegratedCosetMds<F, N>
 {
 }
 
 #[inline]
-fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {
@@ -102,8 +102,8 @@ fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: u
 }
 
 #[inline]
-fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
-    values: &mut [FA; N],
+fn bowers_g_t_layer<F: Field, R: PrimeCharacteristicRing + Algebra<F>, const N: usize>(
+    values: &mut [R; N],
     log_half_block_size: usize,
     twiddles: &[F],
 ) {

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{FieldAlgebra, Powers, TwoAdicField};
+use p3_field::{Field, FieldAlgebra, Powers, PrimeCharacteristicRing, TwoAdicField};
 use p3_symmetric::Permutation;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 
@@ -48,7 +48,9 @@ impl<F: TwoAdicField, const N: usize> Default for IntegratedCosetMds<F, N> {
     }
 }
 
-impl<FA: FieldAlgebra, const N: usize> Permutation<[FA; N]> for IntegratedCosetMds<FA::F, N> {
+impl<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize> Permutation<[FA; N]>
+    for IntegratedCosetMds<F, N>
+{
     fn permute(&self, mut input: [FA; N]) -> [FA; N] {
         self.permute_mut(&mut input);
         input
@@ -69,13 +71,16 @@ impl<FA: FieldAlgebra, const N: usize> Permutation<[FA; N]> for IntegratedCosetM
     }
 }
 
-impl<FA: FieldAlgebra, const N: usize> MdsPermutation<FA, N> for IntegratedCosetMds<FA::F, N> {}
+impl<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize> MdsPermutation<FA, N>
+    for IntegratedCosetMds<F, N>
+{
+}
 
 #[inline]
-fn bowers_g_layer<FA: FieldAlgebra, const N: usize>(
+fn bowers_g_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
-    twiddles: &[FA::F],
+    twiddles: &[F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -97,10 +102,10 @@ fn bowers_g_layer<FA: FieldAlgebra, const N: usize>(
 }
 
 #[inline]
-fn bowers_g_t_layer<FA: FieldAlgebra, const N: usize>(
+fn bowers_g_t_layer<F: Field, FA: PrimeCharacteristicRing + FieldAlgebra<F>, const N: usize>(
     values: &mut [FA; N],
     log_half_block_size: usize,
-    twiddles: &[FA::F],
+    twiddles: &[F],
 ) {
     let log_block_size = log_half_block_size + 1;
     let half_block_size = 1 << log_half_block_size;
@@ -119,7 +124,7 @@ fn bowers_g_t_layer<FA: FieldAlgebra, const N: usize>(
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-    use p3_field::{Field, FieldAlgebra};
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_symmetric::Permutation;
     use p3_util::reverse_slice_index_bits;
     use rand::{thread_rng, Rng};

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -3,7 +3,7 @@ use core::array;
 use core::ops::{AddAssign, Mul};
 
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{FieldAlgebra, TwoAdicField};
+use p3_field::{PrimeCharacteristicRing, TwoAdicField};
 
 // NB: These are all MDS for M31, BabyBear and Goldilocks
 // const MATRIX_CIRC_MDS_8_2EXP: [u64; 8] = [1, 1, 2, 1, 8, 32, 4, 256];
@@ -41,7 +41,7 @@ where
 /// NB: This function is a naive implementation of the n²
 /// evaluation. It is a placeholder until we have FFT implementations
 /// for all combinations of field and size.
-pub fn apply_circulant<FA: FieldAlgebra, const N: usize>(
+pub fn apply_circulant<FA: PrimeCharacteristicRing, const N: usize>(
     circ_matrix: &[u64; N],
     input: [FA; N],
 ) -> [FA; N] {

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -41,18 +41,18 @@ where
 /// NB: This function is a naive implementation of the n²
 /// evaluation. It is a placeholder until we have FFT implementations
 /// for all combinations of field and size.
-pub fn apply_circulant<FA: PrimeCharacteristicRing, const N: usize>(
+pub fn apply_circulant<R: PrimeCharacteristicRing, const N: usize>(
     circ_matrix: &[u64; N],
-    input: [FA; N],
-) -> [FA; N] {
-    let mut matrix: [FA; N] = circ_matrix.map(FA::from_u64);
+    input: [R; N],
+) -> [R; N] {
+    let mut matrix: [R; N] = circ_matrix.map(R::from_u64);
 
-    let mut output = array::from_fn(|_| FA::ZERO);
+    let mut output = array::from_fn(|_| R::ZERO);
     for out_i in output.iter_mut().take(N - 1) {
-        *out_i = FA::dot_product(&matrix, &input);
+        *out_i = R::dot_product(&matrix, &input);
         matrix.rotate_right(1);
     }
-    output[N - 1] = FA::dot_product(&matrix, &input);
+    output[N - 1] = R::dot_product(&matrix, &input);
     output
 }
 

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -146,7 +146,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{Field, FieldAlgebra};
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::Matrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -201,7 +201,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{Field, FieldAlgebra};
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_matrix::{Dimensions, Matrix};
     use p3_symmetric::{

--- a/mersenne-31/benches/bench_field.rs
+++ b/mersenne-31/benches/bench_field.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_iter_sum,
     benchmark_sub_latency, benchmark_sub_throughput,

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -6,8 +6,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
-    PrimeCharacteristicRing,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -313,7 +313,6 @@ impl Product for PackedMersenne31Neon {
 }
 
 impl PrimeCharacteristicRing for PackedMersenne31Neon {
-    type F = Mersenne31;
     type PrimeSubfield = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
@@ -329,9 +328,11 @@ impl PrimeCharacteristicRing for PackedMersenne31Neon {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
     }
 }
+
+impl FieldAlgebra<Mersenne31> for PackedMersenne31Neon {}
 
 // Degree of the smallest permutation polynomial for Mersenne31.
 //

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -6,8 +6,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -312,7 +312,7 @@ impl Product for PackedMersenne31Neon {
     }
 }
 
-impl FieldAlgebra for PackedMersenne31Neon {
+impl PrimeCharacteristicRing for PackedMersenne31Neon {
     type F = Mersenne31;
     type PrimeSubfield = Mersenne31;
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -332,7 +332,7 @@ impl PrimeCharacteristicRing for PackedMersenne31Neon {
     }
 }
 
-impl FieldAlgebra<Mersenne31> for PackedMersenne31Neon {}
+impl Algebra<Mersenne31> for PackedMersenne31Neon {}
 
 // Degree of the smallest permutation polynomial for Mersenne31.
 //

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -83,7 +83,7 @@ impl<const D: u64, const WIDTH: usize> ExternalLayer<PackedMersenne31Neon, WIDTH
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -28,13 +28,15 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Mersenne31, WIDTH>,
 }
 
-impl InternalLayerConstructor<PackedMersenne31Neon> for Poseidon2InternalLayerMersenne31 {
+impl InternalLayerConstructor<Mersenne31, PackedMersenne31Neon>
+    for Poseidon2InternalLayerMersenne31
+{
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         Self { internal_constants }
     }
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<PackedMersenne31Neon, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31Neon, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
@@ -83,7 +85,6 @@ impl<const D: u64, const WIDTH: usize> ExternalLayer<PackedMersenne31Neon, WIDTH
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -28,15 +28,13 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Mersenne31, WIDTH>,
 }
 
-impl InternalLayerConstructor<Mersenne31, PackedMersenne31Neon>
-    for Poseidon2InternalLayerMersenne31
-{
+impl InternalLayerConstructor<Mersenne31> for Poseidon2InternalLayerMersenne31 {
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         Self { internal_constants }
     }
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31Neon, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -5,7 +5,7 @@
 //! kronecker(-1, p) = -1, that is, -1 is not square in F_p.
 
 use p3_field::extension::{Complex, ComplexExtendable, HasTwoAdicBionmialExtension};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -15,7 +15,7 @@ use alloc::vec::Vec;
 use itertools::{izip, Itertools};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::extension::Complex;
-use p3_field::{Field, FieldAlgebra, TwoAdicField};
+use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,7 +1,7 @@
 use p3_field::extension::{
     BinomiallyExtendable, Complex, HasComplexBinomialExtension, HasTwoAdicComplexBinomialExtension,
 };
-use p3_field::{field_to_array, FieldAlgebra, TwoAdicField};
+use p3_field::{field_to_array, PrimeCharacteristicRing, TwoAdicField};
 
 use crate::Mersenne31;
 

--- a/mersenne-31/src/mds.rs
+++ b/mersenne-31/src/mds.rs
@@ -7,7 +7,7 @@
 //! database.
 
 use p3_field::integers::QuotientMap;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_mds::karatsuba_convolution::Convolve;
 use p3_mds::util::{dot_product, first_row_to_first_col};
 use p3_mds::MdsPermutation;

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -12,8 +12,8 @@ use p3_field::exponentiation::exp_1717986917;
 use p3_field::integers::QuotientMap;
 use p3_field::{
     halve_u32, quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int, Field,
-    FieldAlgebra, InjectiveMonomial, Packable, PermutationMonomial, PrimeField, PrimeField32,
-    PrimeField64,
+    InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
+    PrimeField32, PrimeField64,
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -113,8 +113,7 @@ impl<'a> Deserialize<'a> for Mersenne31 {
     }
 }
 
-impl FieldAlgebra for Mersenne31 {
-    type F = Self;
+impl PrimeCharacteristicRing for Mersenne31 {
     type PrimeSubfield = Self;
 
     const ZERO: Self = Self { value: 0 };
@@ -511,7 +510,9 @@ pub const fn to_mersenne31_array<const N: usize>(input: [u32; N]) -> [Mersenne31
 
 #[cfg(test)]
 mod tests {
-    use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PermutationMonomial, PrimeField32};
+    use p3_field::{
+        Field, InjectiveMonomial, PermutationMonomial, PrimeCharacteristicRing, PrimeField32,
+    };
     use p3_field_testing::{
         test_field, test_prime_field, test_prime_field_32, test_prime_field_64,
     };

--- a/mersenne-31/src/no_packing/poseidon2.rs
+++ b/mersenne-31/src/no_packing/poseidon2.rs
@@ -20,13 +20,13 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Mersenne31, WIDTH>,
 }
 
-impl InternalLayerConstructor<Mersenne31> for Poseidon2InternalLayerMersenne31 {
+impl InternalLayerConstructor<Mersenne31, Mersenne31> for Poseidon2InternalLayerMersenne31 {
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         Self { internal_constants }
     }
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, Mersenne31, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/no_packing/poseidon2.rs
+++ b/mersenne-31/src/no_packing/poseidon2.rs
@@ -20,13 +20,13 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Mersenne31, WIDTH>,
 }
 
-impl InternalLayerConstructor<Mersenne31, Mersenne31> for Poseidon2InternalLayerMersenne31 {
+impl InternalLayerConstructor<Mersenne31> for Poseidon2InternalLayerMersenne31 {
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         Self { internal_constants }
     }
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, Mersenne31, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::PrimeCharacteristicRing;
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4,
@@ -39,7 +39,6 @@ pub(crate) const MERSENNE31_S_BOX_DEGREE: u64 = 5;
 /// wherever possible, input arrays should of the form `[Mersenne31::Packing; WIDTH]`.
 pub type Poseidon2Mersenne31<const WIDTH: usize> = Poseidon2<
     Mersenne31,
-    <Mersenne31 as Field>::Packing,
     Poseidon2ExternalLayerMersenne31<WIDTH>,
     Poseidon2InternalLayerMersenne31,
     WIDTH,

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -47,7 +47,7 @@ pub type Poseidon2Mersenne31<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on [FA; WIDTH] for any FieldAlgebra which implements multiplication by Mersenne31 field elements.
+/// This can act on `[A; WIDTH]` for any algebra which implements multiplication by Mersenne31 field elements.
 /// If you have either `[Mersenne31::Packing; WIDTH]` or `[Mersenne31; WIDTH]` it will be much faster
 /// to use `Poseidon2Mersenne31<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub struct GenericPoseidon2LinearLayersMersenne31 {}

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -15,7 +15,7 @@
 
 use core::ops::Mul;
 
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     internal_permute_state, ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4,
@@ -38,6 +38,7 @@ pub(crate) const MERSENNE31_S_BOX_DEGREE: u64 = 5;
 /// It acts on arrays of the form either `[Mersenne31::Packing; WIDTH]` or `[Mersenne31; WIDTH]`. For speed purposes,
 /// wherever possible, input arrays should of the form `[Mersenne31::Packing; WIDTH]`.
 pub type Poseidon2Mersenne31<const WIDTH: usize> = Poseidon2<
+    Mersenne31,
     <Mersenne31 as Field>::Packing,
     Poseidon2ExternalLayerMersenne31<WIDTH>,
     Poseidon2InternalLayerMersenne31,
@@ -77,7 +78,7 @@ fn permute_mut<const N: usize>(state: &mut [Mersenne31; N], shifts: &[u8]) {
 impl InternalLayer<Mersenne31, 16, MERSENNE31_S_BOX_DEGREE> for Poseidon2InternalLayerMersenne31 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [Mersenne31; 16]) {
-        internal_permute_state::<Mersenne31, 16, MERSENNE31_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| permute_mut(x, &POSEIDON2_INTERNAL_MATRIX_DIAG_16_SHIFTS),
             &self.internal_constants,
@@ -88,7 +89,7 @@ impl InternalLayer<Mersenne31, 16, MERSENNE31_S_BOX_DEGREE> for Poseidon2Interna
 impl InternalLayer<Mersenne31, 24, MERSENNE31_S_BOX_DEGREE> for Poseidon2InternalLayerMersenne31 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [Mersenne31; 24]) {
-        internal_permute_state::<Mersenne31, 24, MERSENNE31_S_BOX_DEGREE>(
+        internal_permute_state(
             state,
             |x| permute_mut(x, &POSEIDON2_INTERNAL_MATRIX_DIAG_24_SHIFTS),
             &self.internal_constants,
@@ -104,7 +105,7 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
-            add_rc_and_sbox_generic::<_, MERSENNE31_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -114,7 +115,7 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
-            add_rc_and_sbox_generic::<_, MERSENNE31_S_BOX_DEGREE>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -122,7 +123,7 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
 
 impl<FA> GenericPoseidon2LinearLayers<FA, 16> for GenericPoseidon2LinearLayersMersenne31
 where
-    FA: FieldAlgebra + Mul<Mersenne31, Output = FA>,
+    FA: PrimeCharacteristicRing + Mul<Mersenne31, Output = FA>,
 {
     fn internal_linear_layer(state: &mut [FA; 16]) {
         let part_sum: FA = state[1..].iter().cloned().sum();
@@ -148,7 +149,7 @@ where
 
 impl<FA> GenericPoseidon2LinearLayers<FA, 24> for GenericPoseidon2LinearLayersMersenne31
 where
-    FA: FieldAlgebra + Mul<Mersenne31, Output = FA>,
+    FA: PrimeCharacteristicRing + Mul<Mersenne31, Output = FA>,
 {
     fn internal_linear_layer(state: &mut [FA; 24]) {
         let part_sum: FA = state[1..].iter().cloned().sum();
@@ -174,7 +175,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::SeedableRng;
     use rand_xoshiro::Xoroshiro128Plus;

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -120,12 +120,12 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
     }
 }
 
-impl<FA> GenericPoseidon2LinearLayers<FA, 16> for GenericPoseidon2LinearLayersMersenne31
+impl<R> GenericPoseidon2LinearLayers<R, 16> for GenericPoseidon2LinearLayersMersenne31
 where
-    FA: PrimeCharacteristicRing + Mul<Mersenne31, Output = FA>,
+    R: PrimeCharacteristicRing + Mul<Mersenne31, Output = R>,
 {
-    fn internal_linear_layer(state: &mut [FA; 16]) {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+    fn internal_linear_layer(state: &mut [R; 16]) {
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -146,12 +146,12 @@ where
     }
 }
 
-impl<FA> GenericPoseidon2LinearLayers<FA, 24> for GenericPoseidon2LinearLayersMersenne31
+impl<R> GenericPoseidon2LinearLayers<R, 24> for GenericPoseidon2LinearLayersMersenne31
 where
-    FA: PrimeCharacteristicRing + Mul<Mersenne31, Output = FA>,
+    R: PrimeCharacteristicRing + Mul<Mersenne31, Output = R>,
 {
-    fn internal_linear_layer(state: &mut [FA; 24]) {
-        let part_sum: FA = state[1..].iter().cloned().sum();
+    fn internal_linear_layer(state: &mut [R; 24]) {
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.

--- a/mersenne-31/src/radix_2_dit.rs
+++ b/mersenne-31/src/radix_2_dit.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::extension::Complex;
-use p3_field::{FieldAlgebra, PrimeField64, TwoAdicField};
+use p3_field::{PrimeCharacteristicRing, PrimeField64, TwoAdicField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_matrix::Matrix;

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -458,7 +458,7 @@ impl PermutationMonomial<5> for PackedMersenne31AVX2 {
     }
 }
 
-impl FieldAlgebra<Mersenne31> for PackedMersenne31AVX2 {}
+impl Algebra<Mersenne31> for PackedMersenne31AVX2 {}
 
 impl Add<Mersenne31> for PackedMersenne31AVX2 {
     type Output = Self;

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -7,7 +7,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
     Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -396,8 +396,7 @@ impl Product for PackedMersenne31AVX2 {
     }
 }
 
-impl FieldAlgebra for PackedMersenne31AVX2 {
-    type F = Mersenne31;
+impl PrimeCharacteristicRing for PackedMersenne31AVX2 {
     type PrimeSubfield = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
@@ -440,7 +439,7 @@ impl FieldAlgebra for PackedMersenne31AVX2 {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
     }
 }
 
@@ -458,6 +457,8 @@ impl PermutationMonomial<5> for PackedMersenne31AVX2 {
         exp_1717986917(*self)
     }
 }
+
+impl FieldAlgebra<Mersenne31> for PackedMersenne31AVX2 {}
 
 impl Add<Mersenne31> for PackedMersenne31AVX2 {
     type Output = Self;

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -22,9 +22,7 @@ pub struct Poseidon2InternalLayerMersenne31 {
     packed_internal_constants: Vec<__m256i>,
 }
 
-impl InternalLayerConstructor<Mersenne31, PackedMersenne31AVX2>
-    for Poseidon2InternalLayerMersenne31
-{
+impl InternalLayerConstructor<Mersenne31> for Poseidon2InternalLayerMersenne31 {
     /// We save the round constants in the {-P, ..., 0} representation instead of the standard
     /// {0, ..., P} one. This saves several instructions later.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
@@ -44,7 +42,7 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     packed_terminal_external_constants: Vec<[__m256i; WIDTH]>,
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31AVX2, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -22,7 +22,9 @@ pub struct Poseidon2InternalLayerMersenne31 {
     packed_internal_constants: Vec<__m256i>,
 }
 
-impl InternalLayerConstructor<PackedMersenne31AVX2> for Poseidon2InternalLayerMersenne31 {
+impl InternalLayerConstructor<Mersenne31, PackedMersenne31AVX2>
+    for Poseidon2InternalLayerMersenne31
+{
     /// We save the round constants in the {-P, ..., 0} representation instead of the standard
     /// {0, ..., P} one. This saves several instructions later.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
@@ -42,7 +44,7 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     packed_terminal_external_constants: Vec<[__m256i; WIDTH]>,
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<PackedMersenne31AVX2, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31AVX2, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -6,8 +6,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -416,7 +416,7 @@ impl Product for PackedMersenne31AVX512 {
     }
 }
 
-impl FieldAlgebra for PackedMersenne31AVX512 {
+impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
     type F = Mersenne31;
     type PrimeSubfield = Mersenne31;
 

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -463,7 +463,7 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
     }
 }
 
-impl FieldAlgebra<Mersenne31> for PackedMersenne31AVX512 {}
+impl Algebra<Mersenne31> for PackedMersenne31AVX512 {}
 
 // Degree of the smallest permutation polynomial for Mersenne31.
 //

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -6,8 +6,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::{
-    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
-    PrimeCharacteristicRing,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -417,7 +417,6 @@ impl Product for PackedMersenne31AVX512 {
 }
 
 impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
-    type F = Mersenne31;
     type PrimeSubfield = Mersenne31;
 
     const ZERO: Self = Self::broadcast(Mersenne31::ZERO);
@@ -433,7 +432,7 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
     }
 
     #[must_use]
@@ -463,6 +462,8 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
         }
     }
 }
+
+impl FieldAlgebra<Mersenne31> for PackedMersenne31AVX512 {}
 
 // Degree of the smallest permutation polynomial for Mersenne31.
 //

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -20,9 +20,7 @@ pub struct Poseidon2InternalLayerMersenne31 {
     packed_internal_constants: Vec<__m512i>,
 }
 
-impl InternalLayerConstructor<Mersenne31, PackedMersenne31AVX512>
-    for Poseidon2InternalLayerMersenne31
-{
+impl InternalLayerConstructor<Mersenne31> for Poseidon2InternalLayerMersenne31 {
     /// We save the round constants in the {-P, ..., 0} representation instead of the standard
     /// {0, ..., P} one. This saves several instructions later.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
@@ -42,7 +40,7 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     packed_terminal_external_constants: Vec<[__m512i; WIDTH]>,
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31AVX512, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -20,7 +20,9 @@ pub struct Poseidon2InternalLayerMersenne31 {
     packed_internal_constants: Vec<__m512i>,
 }
 
-impl InternalLayerConstructor<PackedMersenne31AVX512> for Poseidon2InternalLayerMersenne31 {
+impl InternalLayerConstructor<Mersenne31, PackedMersenne31AVX512>
+    for Poseidon2InternalLayerMersenne31
+{
     /// We save the round constants in the {-P, ..., 0} representation instead of the standard
     /// {0, ..., P} one. This saves several instructions later.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
@@ -40,7 +42,7 @@ pub struct Poseidon2ExternalLayerMersenne31<const WIDTH: usize> {
     packed_terminal_external_constants: Vec<[__m512i; WIDTH]>,
 }
 
-impl<const WIDTH: usize> ExternalLayerConstructor<PackedMersenne31AVX512, WIDTH>
+impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, PackedMersenne31AVX512, WIDTH>
     for Poseidon2ExternalLayerMersenne31<WIDTH>
 {
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
@@ -284,7 +286,6 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX512, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -284,7 +284,7 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX512, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use rand::Rng;
 

--- a/monolith/benches/permute.rs
+++ b/monolith/benches/permute.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use p3_monolith::MonolithMersenne31;

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -7,7 +7,7 @@ use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
 use p3_field::integers::QuotientMap;
-use p3_field::{FieldAlgebra, PrimeField32};
+use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
 use sha3::digest::{ExtendableOutput, Update};
@@ -187,7 +187,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_mersenne_31::Mersenne31;
 
     use crate::monolith::MonolithMersenne31;

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -7,7 +7,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -475,7 +475,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31Neon<FP> {}
+impl<FP: FieldParameters> Algebra<MontyField31<FP>> for PackedMontyField31Neon<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31Neon<FP>

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -7,7 +7,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
     PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -446,7 +446,6 @@ impl<FP: FieldParameters> Product for PackedMontyField31Neon<FP> {
 }
 
 impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP> {
-    type F = MontyField31<FP>;
     type PrimeSubfield = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
@@ -472,9 +471,11 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(MontyField31<FP>::zero_vec(len * WIDTH)) }
     }
 }
+
+impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31Neon<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31Neon<FP>

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -7,8 +7,8 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
-    PrimeCharacteristicRing,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -471,7 +471,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(MontyField31<FP>::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -7,8 +7,8 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -445,7 +445,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31Neon<FP> {
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31Neon<FP> {
+impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP> {
     type F = MontyField31<FP>;
     type PrimeSubfield = MontyField31<FP>;
 

--- a/monty-31/src/aarch64_neon/poseidon2.rs
+++ b/monty-31/src/aarch64_neon/poseidon2.rs
@@ -39,7 +39,7 @@ pub struct Poseidon2ExternalLayerMonty31<MP: MontyParameters, const WIDTH: usize
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<FP, WIDTH>>
-    InternalLayerConstructor<PackedMontyField31Neon<FP>>
+    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31Neon<FP>>
     for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     fn new_from_constants(internal_constants: Vec<MontyField31<FP>>) -> Self {
@@ -51,7 +51,7 @@ impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<F
 }
 
 impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<PackedMontyField31Neon<FP>, WIDTH>
+    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31Neon<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     fn new_from_constants(

--- a/monty-31/src/aarch64_neon/poseidon2.rs
+++ b/monty-31/src/aarch64_neon/poseidon2.rs
@@ -39,8 +39,7 @@ pub struct Poseidon2ExternalLayerMonty31<MP: MontyParameters, const WIDTH: usize
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<FP, WIDTH>>
-    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31Neon<FP>>
-    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+    InternalLayerConstructor<MontyField31<FP>> for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     fn new_from_constants(internal_constants: Vec<MontyField31<FP>>) -> Self {
         Self {
@@ -50,8 +49,7 @@ impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<F
     }
 }
 
-impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31Neon<FP>, WIDTH>
+impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     fn new_from_constants(

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -84,7 +84,7 @@ pub trait FieldParameters: PackedMontyParameters + Sized {
 pub trait RelativelyPrimePower<const D: u64> {
     /// Compute `x -> x^{1/D}` using the modular inverse
     /// of `D mod p - 1`.
-    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA;
+    fn exp_root_d<R: PrimeCharacteristicRing>(val: R) -> R;
 }
 
 /// TwoAdicData contains constants needed to imply TwoAdicField for Monty31 fields.

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use crate::MontyField31;
 
@@ -64,7 +64,7 @@ pub trait BarrettParameters: MontyParameters {
     const MASK: i64 = !((1 << 10) - 1); // Lets us 0 out the bottom 10 digits of an i64.
 }
 
-/// FieldParameters contains constants and methods needed to imply FieldAlgebra, Field and PrimeField32 for MontyField31.
+/// FieldParameters contains constants and methods needed to imply PrimeCharacteristicRing, Field and PrimeField32 for MontyField31.
 pub trait FieldParameters: PackedMontyParameters + Sized {
     // Simple field constants.
     const MONTY_ZERO: MontyField31<Self> = MontyField31::new(0);
@@ -84,7 +84,7 @@ pub trait FieldParameters: PackedMontyParameters + Sized {
 pub trait RelativelyPrimePower<const D: u64> {
     /// Compute `x -> x^{1/D}` using the modular inverse
     /// of `D mod p - 1`.
-    fn exp_root_d<FA: FieldAlgebra>(val: FA) -> FA;
+    fn exp_root_d<FA: PrimeCharacteristicRing>(val: FA) -> FA;
 }
 
 /// TwoAdicData contains constants needed to imply TwoAdicField for Monty31 fields.

--- a/monty-31/src/dft/backward.rs
+++ b/monty-31/src/dft/backward.rs
@@ -8,14 +8,14 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use itertools::izip;
-use p3_field::{Field, FieldAlgebra, PackedFieldPow2, PackedValue};
+use p3_field::{Field, PackedFieldPow2, PackedValue, PrimeCharacteristicRing};
 use p3_util::log2_strict_usize;
 
 use crate::utils::monty_reduce;
 use crate::{FieldParameters, MontyField31, TwoAdicData};
 
 #[inline(always)]
-fn backward_butterfly<T: FieldAlgebra + Copy>(x: T, y: T, roots: T) -> (T, T) {
+fn backward_butterfly<T: PrimeCharacteristicRing + Copy>(x: T, y: T, roots: T) -> (T, T) {
     let t = y * roots;
     (x + t, x - t)
 }

--- a/monty-31/src/dft/forward.rs
+++ b/monty-31/src/dft/forward.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use itertools::izip;
-use p3_field::{Field, FieldAlgebra, PackedFieldPow2, PackedValue, TwoAdicField};
+use p3_field::{Field, PackedFieldPow2, PackedValue, PrimeCharacteristicRing, TwoAdicField};
 use p3_util::log2_strict_usize;
 
 use crate::utils::monty_reduce;
@@ -37,7 +37,7 @@ impl<MP: FieldParameters + TwoAdicData> MontyField31<MP> {
 }
 
 #[inline(always)]
-fn forward_butterfly<T: FieldAlgebra + Copy>(x: T, y: T, roots: T) -> (T, T) {
+fn forward_butterfly<T: PrimeCharacteristicRing + Copy>(x: T, y: T, roots: T) -> (T, T) {
     let t = x - y;
     (x + y, t * roots)
 }

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -7,7 +7,7 @@ use core::iter;
 
 use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -12,8 +12,8 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use num_bigint::BigUint;
 use p3_field::integers::QuotientMap;
 use p3_field::{
-    quotient_map_small_int, Field, FieldAlgebra, InjectiveMonomial, Packable, PermutationMonomial,
-    PrimeField, PrimeField32, PrimeField64, TwoAdicField,
+    quotient_map_small_int, Field, InjectiveMonomial, Packable, PermutationMonomial,
+    PrimeCharacteristicRing, PrimeField, PrimeField32, PrimeField64, TwoAdicField,
 };
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -167,8 +167,7 @@ impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
 
 impl<FP: FieldParameters> Packable for MontyField31<FP> {}
 
-impl<FP: FieldParameters> FieldAlgebra for MontyField31<FP> {
-    type F = Self;
+impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
     type PrimeSubfield = Self;
 
     const ZERO: Self = FP::MONTY_ZERO;
@@ -177,7 +176,7 @@ impl<FP: FieldParameters> FieldAlgebra for MontyField31<FP> {
     const NEG_ONE: Self = FP::MONTY_NEG_ONE;
 
     #[inline(always)]
-    fn from_prime_subfield(f: Self::F) -> Self {
+    fn from_prime_subfield(f: Self) -> Self {
         f
     }
 

--- a/monty-31/src/no_packing/poseidon2.rs
+++ b/monty-31/src/no_packing/poseidon2.rs
@@ -27,8 +27,7 @@ pub struct Poseidon2ExternalLayerMonty31<MP: MontyParameters, const WIDTH: usize
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<FP, WIDTH>>
-    InternalLayerConstructor<MontyField31<FP>, MontyField31<FP>>
-    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+    InternalLayerConstructor<MontyField31<FP>> for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     fn new_from_constants(internal_constants: Vec<MontyField31<FP>>) -> Self {
         Self {
@@ -38,8 +37,7 @@ impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<F
     }
 }
 
-impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<MontyField31<FP>, MontyField31<FP>, WIDTH>
+impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     fn new_from_constants(

--- a/monty-31/src/no_packing/poseidon2.rs
+++ b/monty-31/src/no_packing/poseidon2.rs
@@ -27,7 +27,8 @@ pub struct Poseidon2ExternalLayerMonty31<MP: MontyParameters, const WIDTH: usize
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<FP, WIDTH>>
-    InternalLayerConstructor<MontyField31<FP>> for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+    InternalLayerConstructor<MontyField31<FP>, MontyField31<FP>>
+    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     fn new_from_constants(internal_constants: Vec<MontyField31<FP>>) -> Self {
         Self {
@@ -37,7 +38,8 @@ impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerBaseParameters<F
     }
 }
 
-impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
+impl<FP: FieldParameters, const WIDTH: usize>
+    ExternalLayerConstructor<MontyField31<FP>, MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     fn new_from_constants(

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::Mul;
 
-use p3_field::{FieldAlgebra, InjectiveMonomial};
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
 use p3_poseidon2::{
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
     ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4,
@@ -32,7 +32,9 @@ pub trait InternalLayerBaseParameters<MP: MontyParameters, const WIDTH: usize>:
 
     /// Perform the internal matrix multiplication for any Abstract field
     /// which implements multiplication by MontyField31 elements.
-    fn generic_internal_linear_layer<FA: FieldAlgebra + Mul<MontyField31<MP>, Output = FA>>(
+    fn generic_internal_linear_layer<
+        FA: PrimeCharacteristicRing + Mul<MontyField31<MP>, Output = FA>,
+    >(
         state: &mut [FA; WIDTH],
     );
 }
@@ -107,7 +109,7 @@ where
         external_initial_permute_state(
             state,
             self.external_constants.get_initial_constants(),
-            add_rc_and_sbox_generic::<_, D>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -117,7 +119,7 @@ where
         external_terminal_permute_state(
             state,
             self.external_constants.get_terminal_constants(),
-            add_rc_and_sbox_generic::<_, D>,
+            add_rc_and_sbox_generic,
             &MDSMat4,
         );
     }
@@ -137,7 +139,7 @@ impl<FP, FA, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<FA, WIDTH>
     for GenericPoseidon2LinearLayersMonty31<FP, ILBP>
 where
     FP: FieldParameters,
-    FA: FieldAlgebra + Mul<MontyField31<FP>, Output = FA>,
+    FA: PrimeCharacteristicRing + Mul<MontyField31<FP>, Output = FA>,
     ILBP: InternalLayerBaseParameters<FP, WIDTH>,
 {
     /// Perform the external matrix multiplication for any Abstract field

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -33,9 +33,9 @@ pub trait InternalLayerBaseParameters<MP: MontyParameters, const WIDTH: usize>:
     /// Perform the internal matrix multiplication for any Abstract field
     /// which implements multiplication by MontyField31 elements.
     fn generic_internal_linear_layer<
-        FA: PrimeCharacteristicRing + Mul<MontyField31<MP>, Output = FA>,
+        R: PrimeCharacteristicRing + Mul<MontyField31<MP>, Output = R>,
     >(
-        state: &mut [FA; WIDTH],
+        state: &mut [R; WIDTH],
     );
 }
 
@@ -135,16 +135,16 @@ pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {
     _phantom2: PhantomData<ILBP>,
 }
 
-impl<FP, FA, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<FA, WIDTH>
+impl<FP, R, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<R, WIDTH>
     for GenericPoseidon2LinearLayersMonty31<FP, ILBP>
 where
     FP: FieldParameters,
-    FA: PrimeCharacteristicRing + Mul<MontyField31<FP>, Output = FA>,
+    R: PrimeCharacteristicRing + Mul<MontyField31<FP>, Output = R>,
     ILBP: InternalLayerBaseParameters<FP, WIDTH>,
 {
     /// Perform the external matrix multiplication for any Abstract field
     /// which implements multiplication by MontyField31 elements.
-    fn internal_linear_layer(state: &mut [FA; WIDTH]) {
+    fn internal_linear_layer(state: &mut [R; WIDTH]) {
         ILBP::generic_internal_linear_layer(state);
     }
 }

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -127,7 +127,7 @@ where
 
 /// An implementation of the the matrix multiplications in the internal and external layers of Poseidon2.
 ///
-/// This can act on `[FA; WIDTH]` for any FieldAlgebra which implements multiplication by `Monty<31>` field elements.
+/// This can act on `[A; WIDTH]` for any algebra which implements multiplication by `Monty<31>` field elements.
 /// This will usually be slower than the Poseidon2 permutation built from `Poseidon2InternalLayerMonty31` and
 /// `Poseidon2ExternalLayerMonty31` but it does work in more cases.
 pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
     Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -472,8 +472,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX2<FP> {
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX2<FP> {
-    type F = MontyField31<FP>;
+impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX2<FP> {
     type PrimeSubfield = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
@@ -532,9 +531,11 @@ impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX2<FP> {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 }
+
+impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31AVX2<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31AVX2<FP>

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -5,7 +5,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -535,7 +535,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX2<FP>
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31AVX2<FP> {}
+impl<FP: FieldParameters> Algebra<MontyField31<FP>> for PackedMontyField31AVX2<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31AVX2<FP>

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -120,7 +120,7 @@ pub struct Poseidon2InternalLayerMonty31<
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX2<FP, WIDTH>>
-    InternalLayerConstructor<PackedMontyField31AVX2<FP>>
+    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX2<FP>>
     for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31AVX2 from a vector containing
@@ -152,7 +152,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
 }
 
 impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<PackedMontyField31AVX2<FP>, WIDTH>
+    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX2<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -120,8 +120,7 @@ pub struct Poseidon2InternalLayerMonty31<
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX2<FP, WIDTH>>
-    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX2<FP>>
-    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+    InternalLayerConstructor<MontyField31<FP>> for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31AVX2 from a vector containing
     /// the constants for each round. Internally, the constants are transformed into the
@@ -151,8 +150,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
     packed_terminal_external_constants: Vec<[__m256i; WIDTH]>,
 }
 
-impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX2<FP>, WIDTH>
+impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -7,8 +7,8 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial,
+    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -585,7 +585,7 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX512<FP> {
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra for PackedMontyField31AVX512<FP> {
+impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<FP> {
     type F = MontyField31<FP>;
     type PrimeSubfield = MontyField31<FP>;
 

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -7,7 +7,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -648,7 +648,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
     }
 }
 
-impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31AVX512<FP> {}
+impl<FP: FieldParameters> Algebra<MontyField31<FP>> for PackedMontyField31AVX512<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31AVX512<FP>

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -7,7 +7,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
     PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
@@ -586,7 +586,6 @@ impl<FP: FieldParameters> Product for PackedMontyField31AVX512<FP> {
 }
 
 impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<FP> {
-    type F = MontyField31<FP>;
     type PrimeSubfield = MontyField31<FP>;
 
     const ZERO: Self = Self::broadcast(MontyField31::ZERO);
@@ -602,7 +601,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Self::F::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(MontyField31<FP>::zero_vec(len * WIDTH)) }
     }
 
     #[inline]
@@ -648,6 +647,8 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
         }
     }
 }
+
+impl<FP: FieldParameters> FieldAlgebra<MontyField31<FP>> for PackedMontyField31AVX512<FP> {}
 
 impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> InjectiveMonomial<D>
     for PackedMontyField31AVX512<FP>

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -7,8 +7,8 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::{
-    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue, PermutationMonomial,
-    PrimeCharacteristicRing,
+    Field, FieldAlgebra, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::convert_vec;
 use rand::distributions::{Distribution, Standard};
@@ -601,7 +601,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(MontyField31<FP>::zero_vec(len * WIDTH)) }
+        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -121,8 +121,7 @@ pub struct Poseidon2InternalLayerMonty31<
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX512<FP, WIDTH>>
-    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX512<FP>>
-    for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
+    InternalLayerConstructor<MontyField31<FP>> for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31AVX2 from a vector containing
     /// the constants for each round. Internally, the constants are transformed into the
@@ -152,8 +151,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
     packed_terminal_external_constants: Vec<[__m512i; WIDTH]>,
 }
 
-impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX512<FP>, WIDTH>
+impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -121,7 +121,7 @@ pub struct Poseidon2InternalLayerMonty31<
 }
 
 impl<FP: FieldParameters, const WIDTH: usize, ILP: InternalLayerParametersAVX512<FP, WIDTH>>
-    InternalLayerConstructor<PackedMontyField31AVX512<FP>>
+    InternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX512<FP>>
     for Poseidon2InternalLayerMonty31<FP, WIDTH, ILP>
 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31AVX2 from a vector containing
@@ -153,7 +153,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
 }
 
 impl<FP: FieldParameters, const WIDTH: usize>
-    ExternalLayerConstructor<PackedMontyField31AVX512<FP>, WIDTH>
+    ExternalLayerConstructor<MontyField31<FP>, PackedMontyField31AVX512<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
     /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::MdsPermutation;
@@ -27,12 +27,12 @@ fn bench_poseidon(c: &mut Criterion) {
     poseidon::<Mersenne31, Mersenne31, MdsMatrixMersenne31, 32, 5>(c);
 }
 
-fn poseidon<F, FA, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
+fn poseidon<F, R, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Standard: Distribution<F>,
-    Mds: MdsPermutation<FA, WIDTH> + Default,
+    Mds: MdsPermutation<R, WIDTH> + Default,
 {
     let mut rng = thread_rng();
     let mds = Mds::default();
@@ -47,8 +47,8 @@ where
         mds,
         &mut rng,
     );
-    let input: [FA; WIDTH] = array::from_fn(|_| FA::ZERO);
-    let name = format!("poseidon::<{}, {}>", type_name::<FA>(), ALPHA);
+    let input: [R; WIDTH] = array::from_fn(|_| R::ZERO);
+    let name = format!("poseidon::<{}, {}>", type_name::<R>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| poseidon.permute(input.clone()))

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::MdsPermutation;
@@ -30,7 +30,7 @@ fn bench_poseidon(c: &mut Criterion) {
 fn poseidon<F, FA, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Standard: Distribution<F>,
     Mds: MdsPermutation<FA, WIDTH> + Default,
 {

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeField};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::coset_mds::CosetMds;
 use p3_mds::MdsPermutation;
@@ -27,12 +27,12 @@ fn bench_poseidon(c: &mut Criterion) {
     poseidon::<Mersenne31, Mersenne31, MdsMatrixMersenne31, 32, 5>(c);
 }
 
-fn poseidon<F, R, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
+fn poseidon<F, A, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    A: Algebra<F> + InjectiveMonomial<ALPHA>,
     Standard: Distribution<F>,
-    Mds: MdsPermutation<R, WIDTH> + Default,
+    Mds: MdsPermutation<A, WIDTH> + Default,
 {
     let mut rng = thread_rng();
     let mds = Mds::default();
@@ -47,8 +47,8 @@ where
         mds,
         &mut rng,
     );
-    let input: [R; WIDTH] = array::from_fn(|_| R::ZERO);
-    let name = format!("poseidon::<{}, {}>", type_name::<R>(), ALPHA);
+    let input: [A; WIDTH] = array::from_fn(|_| A::ZERO);
+    let name = format!("poseidon::<{}, {}>", type_name::<A>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| poseidon.permute(input.clone()))

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -69,10 +69,10 @@ where
         }
     }
 
-    fn half_full_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
+    fn half_full_rounds<R>(&self, state: &mut [R; WIDTH], round_ctr: &mut usize)
     where
-        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-        Mds: MdsPermutation<FA, WIDTH>,
+        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        Mds: MdsPermutation<R, WIDTH>,
     {
         for _ in 0..self.half_num_full_rounds {
             self.constant_layer(state, *round_ctr);
@@ -82,10 +82,10 @@ where
         }
     }
 
-    fn partial_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
+    fn partial_rounds<R>(&self, state: &mut [R; WIDTH], round_ctr: &mut usize)
     where
-        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-        Mds: MdsPermutation<FA, WIDTH>,
+        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        Mds: MdsPermutation<R, WIDTH>,
     {
         for _ in 0..self.num_partial_rounds {
             self.constant_layer(state, *round_ctr);
@@ -95,25 +95,25 @@ where
         }
     }
 
-    fn full_sbox_layer<FA>(state: &mut [FA; WIDTH])
+    fn full_sbox_layer<R>(state: &mut [R; WIDTH])
     where
-        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         for x in state.iter_mut() {
             *x = x.injective_exp_n();
         }
     }
 
-    fn partial_sbox_layer<FA>(state: &mut [FA; WIDTH])
+    fn partial_sbox_layer<R>(state: &mut [R; WIDTH])
     where
-        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         state[0] = state[0].injective_exp_n();
     }
 
-    fn constant_layer<FA>(&self, state: &mut [FA; WIDTH], round: usize)
+    fn constant_layer<R>(&self, state: &mut [R; WIDTH], round: usize)
     where
-        FA: Algebra<F> + PrimeCharacteristicRing,
+        R: Algebra<F> + PrimeCharacteristicRing,
     {
         for (i, x) in state.iter_mut().enumerate() {
             *x += self.constants[round * WIDTH + i];
@@ -121,14 +121,14 @@ where
     }
 }
 
-impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
+impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[R; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-    Mds: MdsPermutation<FA, WIDTH>,
+    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    Mds: MdsPermutation<R, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [FA; WIDTH]) {
+    fn permute_mut(&self, state: &mut [R; WIDTH]) {
         let mut round_ctr = 0;
         self.half_full_rounds(state, &mut round_ctr);
         self.partial_rounds(state, &mut round_ctr);
@@ -136,11 +136,11 @@ where
     }
 }
 
-impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
+impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[R; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-    Mds: MdsPermutation<FA, WIDTH>,
+    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    Mds: MdsPermutation<R, WIDTH>,
 {
 }

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -71,7 +71,7 @@ where
 
     fn half_full_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
         Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.half_num_full_rounds {
@@ -84,7 +84,7 @@ where
 
     fn partial_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
         Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.num_partial_rounds {
@@ -97,7 +97,7 @@ where
 
     fn full_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         for x in state.iter_mut() {
             *x = x.injective_exp_n();
@@ -106,14 +106,14 @@ where
 
     fn partial_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         state[0] = state[0].injective_exp_n();
     }
 
     fn constant_layer<FA>(&self, state: &mut [FA; WIDTH], round: usize)
     where
-        FA: FieldAlgebra<F> + PrimeCharacteristicRing,
+        FA: Algebra<F> + PrimeCharacteristicRing,
     {
         for (i, x) in state.iter_mut().enumerate() {
             *x += self.constants[round * WIDTH + i];
@@ -125,7 +125,7 @@ impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
     fn permute_mut(&self, state: &mut [FA; WIDTH]) {
@@ -140,7 +140,7 @@ impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
 }

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{FieldAlgebra, InjectiveMonomial, PrimeField};
+use p3_field::{FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -71,7 +71,7 @@ where
 
     fn half_full_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        FA: FieldAlgebra<F = F> + InjectiveMonomial<ALPHA>,
+        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
         Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.half_num_full_rounds {
@@ -84,7 +84,7 @@ where
 
     fn partial_rounds<FA>(&self, state: &mut [FA; WIDTH], round_ctr: &mut usize)
     where
-        FA: FieldAlgebra<F = F> + InjectiveMonomial<ALPHA>,
+        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
         Mds: MdsPermutation<FA, WIDTH>,
     {
         for _ in 0..self.num_partial_rounds {
@@ -97,7 +97,7 @@ where
 
     fn full_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        FA: FieldAlgebra<F = F> + InjectiveMonomial<ALPHA>,
+        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         for x in state.iter_mut() {
             *x = x.injective_exp_n();
@@ -106,14 +106,14 @@ where
 
     fn partial_sbox_layer<FA>(state: &mut [FA; WIDTH])
     where
-        FA: FieldAlgebra<F = F> + InjectiveMonomial<ALPHA>,
+        FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     {
         state[0] = state[0].injective_exp_n();
     }
 
     fn constant_layer<FA>(&self, state: &mut [FA; WIDTH], round: usize)
     where
-        FA: FieldAlgebra<F = F>,
+        FA: FieldAlgebra<F> + PrimeCharacteristicRing,
     {
         for (i, x) in state.iter_mut().enumerate() {
             *x += self.constants[round * WIDTH + i];
@@ -121,11 +121,11 @@ where
     }
 }
 
-impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
-    for Poseidon<FA::F, Mds, WIDTH, ALPHA>
+impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
+    for Poseidon<F, Mds, WIDTH, ALPHA>
 where
-    FA: FieldAlgebra + InjectiveMonomial<ALPHA>,
-    FA::F: PrimeField + InjectiveMonomial<ALPHA>,
+    F: PrimeField + InjectiveMonomial<ALPHA>,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
     fn permute_mut(&self, state: &mut [FA; WIDTH]) {
@@ -136,11 +136,11 @@ where
     }
 }
 
-impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
-    for Poseidon<FA::F, Mds, WIDTH, ALPHA>
+impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
+    for Poseidon<F, Mds, WIDTH, ALPHA>
 where
-    FA: FieldAlgebra + InjectiveMonomial<ALPHA>,
-    FA::F: PrimeField + InjectiveMonomial<ALPHA>,
+    F: PrimeField + InjectiveMonomial<ALPHA>,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
 }

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField};
+use p3_field::{Algebra, InjectiveMonomial, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -69,10 +69,10 @@ where
         }
     }
 
-    fn half_full_rounds<R>(&self, state: &mut [R; WIDTH], round_ctr: &mut usize)
+    fn half_full_rounds<A>(&self, state: &mut [A; WIDTH], round_ctr: &mut usize)
     where
-        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-        Mds: MdsPermutation<R, WIDTH>,
+        A: Algebra<F> + InjectiveMonomial<ALPHA>,
+        Mds: MdsPermutation<A, WIDTH>,
     {
         for _ in 0..self.half_num_full_rounds {
             self.constant_layer(state, *round_ctr);
@@ -82,10 +82,10 @@ where
         }
     }
 
-    fn partial_rounds<R>(&self, state: &mut [R; WIDTH], round_ctr: &mut usize)
+    fn partial_rounds<A>(&self, state: &mut [A; WIDTH], round_ctr: &mut usize)
     where
-        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-        Mds: MdsPermutation<R, WIDTH>,
+        A: Algebra<F> + InjectiveMonomial<ALPHA>,
+        Mds: MdsPermutation<A, WIDTH>,
     {
         for _ in 0..self.num_partial_rounds {
             self.constant_layer(state, *round_ctr);
@@ -95,25 +95,25 @@ where
         }
     }
 
-    fn full_sbox_layer<R>(state: &mut [R; WIDTH])
+    fn full_sbox_layer<A>(state: &mut [A; WIDTH])
     where
-        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        A: Algebra<F> + InjectiveMonomial<ALPHA>,
     {
         for x in state.iter_mut() {
             *x = x.injective_exp_n();
         }
     }
 
-    fn partial_sbox_layer<R>(state: &mut [R; WIDTH])
+    fn partial_sbox_layer<A>(state: &mut [A; WIDTH])
     where
-        R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
+        A: Algebra<F> + InjectiveMonomial<ALPHA>,
     {
         state[0] = state[0].injective_exp_n();
     }
 
-    fn constant_layer<R>(&self, state: &mut [R; WIDTH], round: usize)
+    fn constant_layer<A>(&self, state: &mut [A; WIDTH], round: usize)
     where
-        R: Algebra<F> + PrimeCharacteristicRing,
+        A: Algebra<F>,
     {
         for (i, x) in state.iter_mut().enumerate() {
             *x += self.constants[round * WIDTH + i];
@@ -121,14 +121,14 @@ where
     }
 }
 
-impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[R; WIDTH]>
+impl<F, A, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[A; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-    Mds: MdsPermutation<R, WIDTH>,
+    A: Algebra<F> + InjectiveMonomial<ALPHA>,
+    Mds: MdsPermutation<A, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [R; WIDTH]) {
+    fn permute_mut(&self, state: &mut [A; WIDTH]) {
         let mut round_ctr = 0;
         self.half_full_rounds(state, &mut round_ctr);
         self.partial_rounds(state, &mut round_ctr);
@@ -136,11 +136,11 @@ where
     }
 }
 
-impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[R; WIDTH]>
+impl<F, A, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[A; WIDTH]>
     for Poseidon<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + InjectiveMonomial<ALPHA>,
-    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<ALPHA>,
-    Mds: MdsPermutation<R, WIDTH>,
+    A: Algebra<F> + InjectiveMonomial<ALPHA>,
+    Mds: MdsPermutation<A, WIDTH>,
 {
 }

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -2,7 +2,7 @@ use core::borrow::Borrow;
 use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_bn254_fr::{Bn254Fr, Poseidon2Bn254};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, PrimeCharacteristicRing};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;
 use rand::distributions::{Distribution, Standard};
@@ -211,10 +211,9 @@ impl<T, const WIDTH: usize> ExternalLayerConstants<T, WIDTH> {
 }
 
 /// Initialize an external layer from a set of constants.
-pub trait ExternalLayerConstructor<F, FA, const WIDTH: usize>
+pub trait ExternalLayerConstructor<F, const WIDTH: usize>
 where
     F: Field,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
 {
     /// A constructor which internally will convert the supplied
     /// constants into the appropriate form for the implementation.

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -14,9 +14,9 @@ use rand::Rng;
 /// This uses the formula from the start of Appendix B in the Poseidon2 paper, with multiplications unrolled into additions.
 /// It is also the matrix used by the Horizon Labs implementation.
 #[inline(always)]
-fn apply_hl_mat4<FA>(x: &mut [FA; 4])
+fn apply_hl_mat4<R>(x: &mut [R; 4])
 where
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
 {
     let t0 = x[0].clone() + x[1].clone();
     let t1 = x[2].clone() + x[3].clone();
@@ -40,9 +40,9 @@ where
 /// [ 1 1 2 3 ]
 /// [ 3 1 1 2 ].
 #[inline(always)]
-fn apply_mat4<FA>(x: &mut [FA; 4])
+fn apply_mat4<R>(x: &mut [R; 4])
 where
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
 {
     let t01 = x[0].clone() + x[1].clone();
     let t23 = x[2].clone() + x[3].clone();
@@ -62,20 +62,20 @@ where
 #[derive(Clone, Default)]
 pub struct HLMDSMat4;
 
-impl<FA: PrimeCharacteristicRing> Permutation<[FA; 4]> for HLMDSMat4 {
+impl<R: PrimeCharacteristicRing> Permutation<[R; 4]> for HLMDSMat4 {
     #[inline(always)]
-    fn permute(&self, input: [FA; 4]) -> [FA; 4] {
+    fn permute(&self, input: [R; 4]) -> [R; 4] {
         let mut output = input;
         self.permute_mut(&mut output);
         output
     }
 
     #[inline(always)]
-    fn permute_mut(&self, input: &mut [FA; 4]) {
+    fn permute_mut(&self, input: &mut [R; 4]) {
         apply_hl_mat4(input)
     }
 }
-impl<FA: PrimeCharacteristicRing> MdsPermutation<FA, 4> for HLMDSMat4 {}
+impl<R: PrimeCharacteristicRing> MdsPermutation<R, 4> for HLMDSMat4 {}
 
 /// The fastest 4x4 MDS matrix.
 ///
@@ -83,20 +83,20 @@ impl<FA: PrimeCharacteristicRing> MdsPermutation<FA, 4> for HLMDSMat4 {}
 #[derive(Clone, Default)]
 pub struct MDSMat4;
 
-impl<FA: PrimeCharacteristicRing> Permutation<[FA; 4]> for MDSMat4 {
+impl<R: PrimeCharacteristicRing> Permutation<[R; 4]> for MDSMat4 {
     #[inline(always)]
-    fn permute(&self, input: [FA; 4]) -> [FA; 4] {
+    fn permute(&self, input: [R; 4]) -> [R; 4] {
         let mut output = input;
         self.permute_mut(&mut output);
         output
     }
 
     #[inline(always)]
-    fn permute_mut(&self, input: &mut [FA; 4]) {
+    fn permute_mut(&self, input: &mut [R; 4]) {
         apply_mat4(input)
     }
 }
-impl<FA: PrimeCharacteristicRing> MdsPermutation<FA, 4> for MDSMat4 {}
+impl<R: PrimeCharacteristicRing> MdsPermutation<R, 4> for MDSMat4 {}
 
 /// Implement the matrix multiplication used by the external layer.
 ///
@@ -104,11 +104,11 @@ impl<FA: PrimeCharacteristicRing> MdsPermutation<FA, 4> for MDSMat4 {}
 /// `[[2M M  ... M], [M  2M ... M], ..., [M  M ... 2M]]`.
 #[inline(always)]
 pub fn mds_light_permutation<
-    FA: PrimeCharacteristicRing,
-    MdsPerm4: MdsPermutation<FA, 4>,
+    R: PrimeCharacteristicRing,
+    MdsPerm4: MdsPermutation<R, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [FA; WIDTH],
+    state: &mut [R; WIDTH],
     mdsmat: &MdsPerm4,
 ) {
     match WIDTH {
@@ -134,11 +134,11 @@ pub fn mds_light_permutation<
             // Now, we apply the outer circulant matrix (to compute the y_i values).
 
             // We first precompute the four sums of every four elements.
-            let sums: [FA; 4] = core::array::from_fn(|k| {
+            let sums: [R; 4] = core::array::from_fn(|k| {
                 (0..WIDTH)
                     .step_by(4)
                     .map(|j| state[j + k].clone())
-                    .sum::<FA>()
+                    .sum::<R>()
             });
 
             // The formula for each y_i involves 2x_i' term and x_j' terms for each j that equals i mod 4.
@@ -221,31 +221,31 @@ where
 }
 
 /// A trait containing all data needed to implement the external layers of Poseidon2.
-pub trait ExternalLayer<FA, const WIDTH: usize, const D: u64>: Sync + Clone
+pub trait ExternalLayer<R, const WIDTH: usize, const D: u64>: Sync + Clone
 where
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
 {
     // permute_state_initial, permute_state_terminal are split as the Poseidon2 specifications are slightly different
     // with the initial rounds involving an extra matrix multiplication.
 
     /// Perform the initial external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_initial(&self, state: &mut [FA; WIDTH]);
+    fn permute_state_initial(&self, state: &mut [R; WIDTH]);
 
     /// Perform the terminal external layers of the Poseidon2 permutation on the given state.
-    fn permute_state_terminal(&self, state: &mut [FA; WIDTH]);
+    fn permute_state_terminal(&self, state: &mut [R; WIDTH]);
 }
 
 /// A helper method which allow any field to easily implement the terminal External Layer.
 #[inline]
 pub fn external_terminal_permute_state<
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
     CT: Copy, // Whatever type the constants are stored as.
-    MdsPerm4: MdsPermutation<FA, 4>,
+    MdsPerm4: MdsPermutation<R, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [FA; WIDTH],
+    state: &mut [R; WIDTH],
     terminal_external_constants: &[[CT; WIDTH]],
-    add_rc_and_sbox: fn(&mut FA, CT),
+    add_rc_and_sbox: fn(&mut R, CT),
     mat4: &MdsPerm4,
 ) {
     for elem in terminal_external_constants.iter() {
@@ -260,14 +260,14 @@ pub fn external_terminal_permute_state<
 /// A helper method which allow any field to easily implement the initial External Layer.
 #[inline]
 pub fn external_initial_permute_state<
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
     CT: Copy, // Whatever type the constants are stored as.
-    MdsPerm4: MdsPermutation<FA, 4>,
+    MdsPerm4: MdsPermutation<R, 4>,
     const WIDTH: usize,
 >(
-    state: &mut [FA; WIDTH],
+    state: &mut [R; WIDTH],
     initial_external_constants: &[[CT; WIDTH]],
-    add_rc_and_sbox: fn(&mut FA, CT),
+    add_rc_and_sbox: fn(&mut R, CT),
     mat4: &MdsPerm4,
 ) {
     mds_light_permutation(state, mat4);

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -6,13 +6,11 @@
 //! - A power map x -> x^n.
 //! - Multiplication by an F valued matrix.
 //!
-//! This means that it is possible to define a Poseidon2 over any abstract field FA which has implementations of:
-//! - Add<F, Output = FA>
-//! - Mul<F, Output = FA>
+//! This means that it is possible to define a Poseidon2 over any algebra A over F.
 //!
 //! This file implements the two matrix multiplications methods from which Poseidon2 can be built.
 
-use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::{mds_light_permutation, MDSMat4};
 
@@ -25,24 +23,24 @@ use crate::{mds_light_permutation, MDSMat4};
 #[inline(always)]
 pub fn add_rc_and_sbox_generic<
     F: Field,
-    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
     const D: u64,
 >(
-    val: &mut FA,
+    val: &mut R,
     rc: F,
 ) {
     *val += rc;
     *val = val.injective_exp_n();
 }
 
-pub trait GenericPoseidon2LinearLayers<FA: PrimeCharacteristicRing, const WIDTH: usize>:
+pub trait GenericPoseidon2LinearLayers<R: PrimeCharacteristicRing, const WIDTH: usize>:
     Sync
 {
     /// A generic implementation of the internal linear layer.
-    fn internal_linear_layer(state: &mut [FA; WIDTH]);
+    fn internal_linear_layer(state: &mut [R; WIDTH]);
 
     /// A generic implementation of the external linear layer.
-    fn external_linear_layer(state: &mut [FA; WIDTH]) {
+    fn external_linear_layer(state: &mut [R; WIDTH]) {
         mds_light_permutation(state, &MDSMat4);
     }
 }

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -12,7 +12,7 @@
 //!
 //! This file implements the two matrix multiplications methods from which Poseidon2 can be built.
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::{mds_light_permutation, MDSMat4};
 
@@ -25,7 +25,7 @@ use crate::{mds_light_permutation, MDSMat4};
 #[inline(always)]
 pub fn add_rc_and_sbox_generic<
     F: Field,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
     const D: u64,
 >(
     val: &mut FA,

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -21,12 +21,8 @@ use crate::{mds_light_permutation, MDSMat4};
 /// This is a little slower than field specific implementations (particularly for packed fields) so should
 /// only be used in non performance critical places.
 #[inline(always)]
-pub fn add_rc_and_sbox_generic<
-    F: Field,
-    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
-    const D: u64,
->(
-    val: &mut R,
+pub fn add_rc_and_sbox_generic<F: Field, A: Algebra<F> + InjectiveMonomial<D>, const D: u64>(
+    val: &mut A,
     rc: F,
 ) {
     *val += rc;

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -12,7 +12,7 @@
 //!
 //! This file implements the two matrix multiplications methods from which Poseidon2 can be built.
 
-use p3_field::{FieldAlgebra, InjectiveMonomial};
+use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::{mds_light_permutation, MDSMat4};
 
@@ -23,15 +23,21 @@ use crate::{mds_light_permutation, MDSMat4};
 /// This is a little slower than field specific implementations (particularly for packed fields) so should
 /// only be used in non performance critical places.
 #[inline(always)]
-pub fn add_rc_and_sbox_generic<FA: FieldAlgebra + InjectiveMonomial<D>, const D: u64>(
+pub fn add_rc_and_sbox_generic<
+    F: Field,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    const D: u64,
+>(
     val: &mut FA,
-    rc: FA::F,
+    rc: F,
 ) {
     *val += rc;
     *val = val.injective_exp_n();
 }
 
-pub trait GenericPoseidon2LinearLayers<FA: FieldAlgebra, const WIDTH: usize>: Sync {
+pub trait GenericPoseidon2LinearLayers<FA: PrimeCharacteristicRing, const WIDTH: usize>:
+    Sync
+{
     /// A generic implementation of the internal linear layer.
     fn internal_linear_layer(state: &mut [FA; WIDTH]);
 

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -34,10 +34,9 @@ use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 use crate::add_rc_and_sbox_generic;
 
 /// Initialize an internal layer from a set of constants.
-pub trait InternalLayerConstructor<F, FA>
+pub trait InternalLayerConstructor<F>
 where
     F: Field,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
 {
     /// A constructor which internally will convert the supplied
     /// constants into the appropriate form for the implementation.

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -29,22 +29,27 @@
 
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial};
+use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::add_rc_and_sbox_generic;
 
 /// Initialize an internal layer from a set of constants.
-pub trait InternalLayerConstructor<FA>
+pub trait InternalLayerConstructor<F, FA>
 where
-    FA: FieldAlgebra,
+    F: Field,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
 {
     /// A constructor which internally will convert the supplied
     /// constants into the appropriate form for the implementation.
-    fn new_from_constants(internal_constants: Vec<FA::F>) -> Self;
+    fn new_from_constants(internal_constants: Vec<F>) -> Self;
 }
 
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
-pub fn matmul_internal<F: Field, FA: FieldAlgebra<F = F>, const WIDTH: usize>(
+pub fn matmul_internal<
+    F: Field,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
+    const WIDTH: usize,
+>(
     state: &mut [FA; WIDTH],
     mat_internal_diag_m_1: [F; WIDTH],
 ) {
@@ -58,7 +63,7 @@ pub fn matmul_internal<F: Field, FA: FieldAlgebra<F = F>, const WIDTH: usize>(
 /// A trait containing all data needed to implement the internal layers of Poseidon2.
 pub trait InternalLayer<FA, const WIDTH: usize, const D: u64>: Sync + Clone
 where
-    FA: FieldAlgebra,
+    FA: PrimeCharacteristicRing,
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [FA; WIDTH]);
@@ -68,16 +73,17 @@ where
 /// This should only be used in places where performance is not critical.
 #[inline]
 pub fn internal_permute_state<
-    FA: FieldAlgebra + InjectiveMonomial<D>,
+    F: Field,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
     const WIDTH: usize,
     const D: u64,
 >(
     state: &mut [FA; WIDTH],
     diffusion_mat: fn(&mut [FA; WIDTH]),
-    internal_constants: &[FA::F],
+    internal_constants: &[F],
 ) {
     for elem in internal_constants.iter() {
-        add_rc_and_sbox_generic::<FA, D>(&mut state[0], *elem);
+        add_rc_and_sbox_generic(&mut state[0], *elem);
         diffusion_mat(state);
     }
 }
@@ -85,7 +91,7 @@ pub fn internal_permute_state<
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-fn sum_7<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
+fn sum_7<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
     assert_eq!(state.len(), 7);
 
     let s01 = state[0] + state[1];
@@ -100,7 +106,7 @@ fn sum_7<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-fn sum_8<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
+fn sum_8<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
     assert_eq!(state.len(), 8);
 
     let s01 = state[0] + state[1];
@@ -116,7 +122,7 @@ fn sum_8<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-pub fn sum_15<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
+pub fn sum_15<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
     assert_eq!(state.len(), 15);
 
     let bot_sum = sum_8(&state[..8]);
@@ -128,7 +134,7 @@ pub fn sum_15<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-pub fn sum_23<FA: FieldAlgebra + Copy>(state: &[FA]) -> FA {
+pub fn sum_23<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
     assert_eq!(state.len(), 23);
 
     let bot_sum = sum_8(&state[..8]);

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -29,7 +29,7 @@
 
 use alloc::vec::Vec;
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::add_rc_and_sbox_generic;
 
@@ -46,7 +46,7 @@ where
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
 pub fn matmul_internal<
     F: Field,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
+    FA: Algebra<F> + PrimeCharacteristicRing,
     const WIDTH: usize,
 >(
     state: &mut [FA; WIDTH],
@@ -73,7 +73,7 @@ where
 #[inline]
 pub fn internal_permute_state<
     F: Field,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
     const WIDTH: usize,
     const D: u64,
 >(

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -44,11 +44,11 @@ where
 }
 
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
-pub fn matmul_internal<F: Field, R: Algebra<F> + PrimeCharacteristicRing, const WIDTH: usize>(
-    state: &mut [R; WIDTH],
+pub fn matmul_internal<F: Field, A: Algebra<F>, const WIDTH: usize>(
+    state: &mut [A; WIDTH],
     mat_internal_diag_m_1: [F; WIDTH],
 ) {
-    let sum: R = state.iter().cloned().sum();
+    let sum: A = state.iter().cloned().sum();
     for i in 0..WIDTH {
         state[i] *= mat_internal_diag_m_1[i];
         state[i] += sum.clone();
@@ -69,12 +69,12 @@ where
 #[inline]
 pub fn internal_permute_state<
     F: Field,
-    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    A: Algebra<F> + InjectiveMonomial<D>,
     const WIDTH: usize,
     const D: u64,
 >(
-    state: &mut [R; WIDTH],
-    diffusion_mat: fn(&mut [R; WIDTH]),
+    state: &mut [A; WIDTH],
+    diffusion_mat: fn(&mut [A; WIDTH]),
     internal_constants: &[F],
 ) {
     for elem in internal_constants.iter() {

--- a/poseidon2/src/internal.rs
+++ b/poseidon2/src/internal.rs
@@ -29,7 +29,7 @@
 
 use alloc::vec::Vec;
 
-use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::add_rc_and_sbox_generic;
 
@@ -44,15 +44,11 @@ where
 }
 
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
-pub fn matmul_internal<
-    F: Field,
-    FA: Algebra<F> + PrimeCharacteristicRing,
-    const WIDTH: usize,
->(
-    state: &mut [FA; WIDTH],
+pub fn matmul_internal<F: Field, R: Algebra<F> + PrimeCharacteristicRing, const WIDTH: usize>(
+    state: &mut [R; WIDTH],
     mat_internal_diag_m_1: [F; WIDTH],
 ) {
-    let sum: FA = state.iter().cloned().sum();
+    let sum: R = state.iter().cloned().sum();
     for i in 0..WIDTH {
         state[i] *= mat_internal_diag_m_1[i];
         state[i] += sum.clone();
@@ -60,12 +56,12 @@ pub fn matmul_internal<
 }
 
 /// A trait containing all data needed to implement the internal layers of Poseidon2.
-pub trait InternalLayer<FA, const WIDTH: usize, const D: u64>: Sync + Clone
+pub trait InternalLayer<R, const WIDTH: usize, const D: u64>: Sync + Clone
 where
-    FA: PrimeCharacteristicRing,
+    R: PrimeCharacteristicRing,
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
-    fn permute_state(&self, state: &mut [FA; WIDTH]);
+    fn permute_state(&self, state: &mut [R; WIDTH]);
 }
 
 /// A helper method which allows any field to easily implement Internal Layer.
@@ -73,12 +69,12 @@ where
 #[inline]
 pub fn internal_permute_state<
     F: Field,
-    FA: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
+    R: Algebra<F> + PrimeCharacteristicRing + InjectiveMonomial<D>,
     const WIDTH: usize,
     const D: u64,
 >(
-    state: &mut [FA; WIDTH],
-    diffusion_mat: fn(&mut [FA; WIDTH]),
+    state: &mut [R; WIDTH],
+    diffusion_mat: fn(&mut [R; WIDTH]),
     internal_constants: &[F],
 ) {
     for elem in internal_constants.iter() {
@@ -90,7 +86,7 @@ pub fn internal_permute_state<
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-fn sum_7<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
+fn sum_7<R: PrimeCharacteristicRing + Copy>(state: &[R]) -> R {
     assert_eq!(state.len(), 7);
 
     let s01 = state[0] + state[1];
@@ -105,7 +101,7 @@ fn sum_7<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-fn sum_8<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
+fn sum_8<R: PrimeCharacteristicRing + Copy>(state: &[R]) -> R {
     assert_eq!(state.len(), 8);
 
     let s01 = state[0] + state[1];
@@ -121,7 +117,7 @@ fn sum_8<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-pub fn sum_15<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
+pub fn sum_15<R: PrimeCharacteristicRing + Copy>(state: &[R]) -> R {
     assert_eq!(state.len(), 15);
 
     let bot_sum = sum_8(&state[..8]);
@@ -133,7 +129,7 @@ pub fn sum_15<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
 /// The compiler doesn't realize that add is associative
 /// so we help it out and minimize the dependency chains by hand.
 #[inline(always)]
-pub fn sum_23<FA: PrimeCharacteristicRing + Copy>(state: &[FA]) -> FA {
+pub fn sum_23<R: PrimeCharacteristicRing + Copy>(state: &[R]) -> R {
     assert_eq!(state.len(), 23);
 
     let bot_sum = sum_8(&state[..8]);

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -18,7 +18,7 @@ use core::marker::PhantomData;
 pub use external::*;
 pub use generic::*;
 pub use internal::*;
-use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64};
+use p3_field::{Algebra, InjectiveMonomial, PrimeField, PrimeField64};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -91,27 +91,27 @@ where
     }
 }
 
-impl<F, R, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permutation<[R; WIDTH]>
+impl<F, A, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permutation<[A; WIDTH]>
     for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    R: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
-    ExternalPerm: ExternalLayer<R, WIDTH, D>,
-    InternalPerm: InternalLayer<R, WIDTH, D>,
+    A: Algebra<F> + Sync + InjectiveMonomial<D>,
+    ExternalPerm: ExternalLayer<A, WIDTH, D>,
+    InternalPerm: InternalLayer<A, WIDTH, D>,
 {
-    fn permute_mut(&self, state: &mut [R; WIDTH]) {
+    fn permute_mut(&self, state: &mut [A; WIDTH]) {
         self.external_layer.permute_state_initial(state);
         self.internal_layer.permute_state(state);
         self.external_layer.permute_state_terminal(state);
     }
 }
 
-impl<F, R, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
-    CryptographicPermutation<[R; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
+impl<F, A, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
+    CryptographicPermutation<[A; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    R: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
-    ExternalPerm: ExternalLayer<R, WIDTH, D>,
-    InternalPerm: InternalLayer<R, WIDTH, D>,
+    A: Algebra<F> + Sync + InjectiveMonomial<D>,
+    ExternalPerm: ExternalLayer<A, WIDTH, D>,
+    InternalPerm: InternalLayer<A, WIDTH, D>,
 {
 }

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -30,22 +30,20 @@ const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
 
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
-pub struct Poseidon2<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> {
+pub struct Poseidon2<F, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> {
     /// The permutations used in External Rounds.
     external_layer: ExternalPerm,
 
     /// The permutation used in Internal Rounds.
     internal_layer: InternalPerm,
 
-    _phantom1: PhantomData<F>,
-    _phantom2: PhantomData<FA>,
+    _phantom: PhantomData<F>,
 }
 
-impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
-    Poseidon2<F, FA, ExternalPerm, InternalPerm, WIDTH, D>
+impl<F, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
+    Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing,
     ExternalPerm: ExternalLayerConstructor<F, WIDTH>,
     InternalPerm: InternalLayerConstructor<F>,
 {
@@ -62,8 +60,7 @@ where
         Self {
             external_layer,
             internal_layer,
-            _phantom1: PhantomData,
-            _phantom2: PhantomData,
+            _phantom: PhantomData,
         }
     }
 
@@ -79,11 +76,10 @@ where
     }
 }
 
-impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
-    Poseidon2<F, FA, ExternalPerm, InternalPerm, WIDTH, D>
+impl<F, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
+    Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField64,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F>,
     ExternalPerm: ExternalLayerConstructor<F, WIDTH>,
     InternalPerm: InternalLayerConstructor<F>,
 {
@@ -98,7 +94,7 @@ where
 }
 
 impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permutation<[FA; WIDTH]>
-    for Poseidon2<F, F::Packing, ExternalPerm, InternalPerm, WIDTH, D>
+    for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
     FA: FieldAlgebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
@@ -113,8 +109,7 @@ where
 }
 
 impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
-    CryptographicPermutation<[FA; WIDTH]>
-    for Poseidon2<F, F::Packing, ExternalPerm, InternalPerm, WIDTH, D>
+    CryptographicPermutation<[FA; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
     FA: FieldAlgebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -46,8 +46,8 @@ impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
 where
     F: PrimeField,
     FA: FieldAlgebra<F> + PrimeCharacteristicRing,
-    ExternalPerm: ExternalLayerConstructor<F, FA, WIDTH>,
-    InternalPerm: InternalLayerConstructor<F, FA>,
+    ExternalPerm: ExternalLayerConstructor<F, WIDTH>,
+    InternalPerm: InternalLayerConstructor<F>,
 {
     /// Create a new Poseidon2 configuration.
     /// This internally converts the given constants to the relevant packed versions.
@@ -84,8 +84,8 @@ impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
 where
     F: PrimeField64,
     FA: PrimeCharacteristicRing + FieldAlgebra<F>,
-    ExternalPerm: ExternalLayerConstructor<F, FA, WIDTH>,
-    InternalPerm: InternalLayerConstructor<F, FA>,
+    ExternalPerm: ExternalLayerConstructor<F, WIDTH>,
+    InternalPerm: InternalLayerConstructor<F>,
 {
     /// Create a new Poseidon2 configuration with 128 bit security and random rounds constants.
     pub fn new_from_rng_128<R: Rng>(rng: &mut R) -> Self

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -19,7 +19,7 @@ pub use external::*;
 pub use generic::*;
 pub use internal::*;
 use p3_field::{
-    FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
+    Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
 };
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};
@@ -97,7 +97,7 @@ impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permut
     for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
+    FA: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
     ExternalPerm: ExternalLayer<FA, WIDTH, D>,
     InternalPerm: InternalLayer<FA, WIDTH, D>,
 {
@@ -112,7 +112,7 @@ impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
     CryptographicPermutation<[FA; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
+    FA: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
     ExternalPerm: ExternalLayer<FA, WIDTH, D>,
     InternalPerm: InternalLayer<FA, WIDTH, D>,
 {

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -18,9 +18,7 @@ use core::marker::PhantomData;
 pub use external::*;
 pub use generic::*;
 pub use internal::*;
-use p3_field::{
-    Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
-};
+use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -93,27 +91,27 @@ where
     }
 }
 
-impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permutation<[FA; WIDTH]>
+impl<F, R, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64> Permutation<[R; WIDTH]>
     for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    FA: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
-    ExternalPerm: ExternalLayer<FA, WIDTH, D>,
-    InternalPerm: InternalLayer<FA, WIDTH, D>,
+    R: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
+    ExternalPerm: ExternalLayer<R, WIDTH, D>,
+    InternalPerm: InternalLayer<R, WIDTH, D>,
 {
-    fn permute_mut(&self, state: &mut [FA; WIDTH]) {
+    fn permute_mut(&self, state: &mut [R; WIDTH]) {
         self.external_layer.permute_state_initial(state);
         self.internal_layer.permute_state(state);
         self.external_layer.permute_state_terminal(state);
     }
 }
 
-impl<F, FA, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
-    CryptographicPermutation<[FA; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
+impl<F, R, ExternalPerm, InternalPerm, const WIDTH: usize, const D: u64>
+    CryptographicPermutation<[R; WIDTH]> for Poseidon2<F, ExternalPerm, InternalPerm, WIDTH, D>
 where
     F: PrimeField + InjectiveMonomial<D>,
-    FA: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
-    ExternalPerm: ExternalLayer<FA, WIDTH, D>,
-    InternalPerm: InternalLayer<FA, WIDTH, D>,
+    R: Algebra<F> + PrimeCharacteristicRing + Sync + InjectiveMonomial<D>,
+    ExternalPerm: ExternalLayer<R, WIDTH, D>,
+    InternalPerm: InternalLayer<R, WIDTH, D>,
 {
 }

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Field, Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{Algebra, Field, PermutationMonomial, PrimeCharacteristicRing, PrimeField64};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
 use p3_mds::MdsPermutation;
@@ -27,12 +27,12 @@ fn bench_rescue(c: &mut Criterion) {
     rescue::<Mersenne31, Mersenne31, MdsMatrixMersenne31, 32, 5>(c);
 }
 
-fn rescue<F, FA, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
+fn rescue<F, R, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField64 + PermutationMonomial<ALPHA>,
-    FA: PrimeCharacteristicRing + Algebra<F> + PermutationMonomial<ALPHA>,
+    R: PrimeCharacteristicRing + Algebra<F> + PermutationMonomial<ALPHA>,
     Standard: Distribution<F>,
-    Mds: MdsPermutation<FA, WIDTH> + Default,
+    Mds: MdsPermutation<R, WIDTH> + Default,
 {
     // 8 rounds seems to work for the configs we use in practice. For benchmarking purposes we will
     // assume it suffices; for real usage the Sage calculation in the paper should be used.
@@ -43,8 +43,8 @@ where
     let round_constants = rng.sample_iter(Standard).take(num_constants).collect();
     let mds = Mds::default();
     let rescue = Rescue::<F, Mds, WIDTH, ALPHA>::new(NUM_ROUNDS, round_constants, mds);
-    let input: [FA; WIDTH] = array::from_fn(|_| FA::ZERO);
-    let name = format!("rescue::<{}, {}>", type_name::<FA>(), ALPHA);
+    let input: [R; WIDTH] = array::from_fn(|_| R::ZERO);
+    let name = format!("rescue::<{}, {}>", type_name::<R>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| rescue.permute(input.clone()))

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Algebra, Field, PermutationMonomial, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{Algebra, Field, PermutationMonomial, PrimeField64};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
 use p3_mds::MdsPermutation;
@@ -27,12 +27,12 @@ fn bench_rescue(c: &mut Criterion) {
     rescue::<Mersenne31, Mersenne31, MdsMatrixMersenne31, 32, 5>(c);
 }
 
-fn rescue<F, R, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
+fn rescue<F, A, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField64 + PermutationMonomial<ALPHA>,
-    R: PrimeCharacteristicRing + Algebra<F> + PermutationMonomial<ALPHA>,
+    A: Algebra<F> + PermutationMonomial<ALPHA>,
     Standard: Distribution<F>,
-    Mds: MdsPermutation<R, WIDTH> + Default,
+    Mds: MdsPermutation<A, WIDTH> + Default,
 {
     // 8 rounds seems to work for the configs we use in practice. For benchmarking purposes we will
     // assume it suffices; for real usage the Sage calculation in the paper should be used.
@@ -43,8 +43,8 @@ where
     let round_constants = rng.sample_iter(Standard).take(num_constants).collect();
     let mds = Mds::default();
     let rescue = Rescue::<F, Mds, WIDTH, ALPHA>::new(NUM_ROUNDS, round_constants, mds);
-    let input: [R; WIDTH] = array::from_fn(|_| R::ZERO);
-    let name = format!("rescue::<{}, {}>", type_name::<R>(), ALPHA);
+    let input: [A; WIDTH] = array::from_fn(|_| A::ZERO);
+    let name = format!("rescue::<{}, {}>", type_name::<A>(), ALPHA);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, input| {
         b.iter(|| rescue.permute(input.clone()))

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -3,7 +3,7 @@ use std::array;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Field, FieldAlgebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{Field, Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField64};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
 use p3_mds::MdsPermutation;
@@ -30,7 +30,7 @@ fn bench_rescue(c: &mut Criterion) {
 fn rescue<F, FA, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
     F: PrimeField64 + PermutationMonomial<ALPHA>,
-    FA: PrimeCharacteristicRing + FieldAlgebra<F> + PermutationMonomial<ALPHA>,
+    FA: PrimeCharacteristicRing + Algebra<F> + PermutationMonomial<ALPHA>,
     Standard: Distribution<F>,
     Mds: MdsPermutation<FA, WIDTH> + Default,
 {

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
 use p3_field::{
-    FieldAlgebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
+    Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
 };
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
@@ -103,7 +103,7 @@ impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
+    FA: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
     fn permute_mut(&self, state: &mut [FA; WIDTH]) {
@@ -143,7 +143,7 @@ impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    FA: FieldAlgebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
+    FA: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
 }

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -4,7 +4,9 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
-use p3_field::{FieldAlgebra, PermutationMonomial, PrimeField, PrimeField64};
+use p3_field::{
+    FieldAlgebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
+};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -97,11 +99,11 @@ where
     }
 }
 
-impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
-    for Rescue<FA::F, Mds, WIDTH, ALPHA>
+impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
+    for Rescue<F, Mds, WIDTH, ALPHA>
 where
-    FA: FieldAlgebra + PermutationMonomial<ALPHA>,
-    FA::F: PrimeField + PermutationMonomial<ALPHA>,
+    F: PrimeField + PermutationMonomial<ALPHA>,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
     fn permute_mut(&self, state: &mut [FA; WIDTH]) {
@@ -137,18 +139,18 @@ where
     }
 }
 
-impl<FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
-    for Rescue<FA::F, Mds, WIDTH, ALPHA>
+impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
+    for Rescue<F, Mds, WIDTH, ALPHA>
 where
-    FA: FieldAlgebra + PermutationMonomial<ALPHA>,
-    FA::F: PrimeField + PermutationMonomial<ALPHA>,
+    F: PrimeField + PermutationMonomial<ALPHA>,
+    FA: FieldAlgebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
     Mds: MdsPermutation<FA, WIDTH>,
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
     use p3_symmetric::{CryptographicHasher, PaddingFreeSponge, Permutation};
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -4,9 +4,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
-use p3_field::{
-    Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64,
-};
+use p3_field::{Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -99,14 +97,14 @@ where
     }
 }
 
-impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[FA; WIDTH]>
+impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[R; WIDTH]>
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    FA: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
-    Mds: MdsPermutation<FA, WIDTH>,
+    R: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
+    Mds: MdsPermutation<R, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [FA; WIDTH]) {
+    fn permute_mut(&self, state: &mut [R; WIDTH]) {
         for round in 0..self.num_rounds {
             // S-box
             state.iter_mut().for_each(|x| *x = x.injective_exp_n());
@@ -139,12 +137,12 @@ where
     }
 }
 
-impl<F, FA, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[FA; WIDTH]>
+impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[R; WIDTH]>
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    FA: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
-    Mds: MdsPermutation<FA, WIDTH>,
+    R: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
+    Mds: MdsPermutation<R, WIDTH>,
 {
 }
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use num::{BigUint, One};
 use num_integer::binomial;
-use p3_field::{Algebra, PermutationMonomial, PrimeCharacteristicRing, PrimeField, PrimeField64};
+use p3_field::{Algebra, PermutationMonomial, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distributions::Standard;
@@ -97,14 +97,14 @@ where
     }
 }
 
-impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[R; WIDTH]>
+impl<F, A, Mds, const WIDTH: usize, const ALPHA: u64> Permutation<[A; WIDTH]>
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    R: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
-    Mds: MdsPermutation<R, WIDTH>,
+    A: Algebra<F> + PermutationMonomial<ALPHA>,
+    Mds: MdsPermutation<A, WIDTH>,
 {
-    fn permute_mut(&self, state: &mut [R; WIDTH]) {
+    fn permute_mut(&self, state: &mut [A; WIDTH]) {
         for round in 0..self.num_rounds {
             // S-box
             state.iter_mut().for_each(|x| *x = x.injective_exp_n());
@@ -137,12 +137,12 @@ where
     }
 }
 
-impl<F, R, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[R; WIDTH]>
+impl<F, A, Mds, const WIDTH: usize, const ALPHA: u64> CryptographicPermutation<[A; WIDTH]>
     for Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
-    R: Algebra<F> + PrimeCharacteristicRing + PermutationMonomial<ALPHA>,
-    Mds: MdsPermutation<R, WIDTH>,
+    A: Algebra<F> + PermutationMonomial<ALPHA>,
+    Mds: MdsPermutation<A, WIDTH>,
 {
 }
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{FieldExtensionAlgebra, PackedValue, PrimeCharacteristicRing};
+use p3_field::{PackedValue, PrimeCharacteristicRing, Serializable};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PackedValue};
+use p3_field::{FieldExtensionAlgebra, PackedValue, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::symbolic_variable::SymbolicVariable;
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial};
+use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::symbolic_variable::SymbolicVariable;
 
@@ -74,8 +74,7 @@ impl<F: Field> From<F> for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
-    type F = F;
+impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
     type PrimeSubfield = F::PrimeSubfield;
 
     const ZERO: Self = Self::Constant(F::ZERO);
@@ -92,6 +91,8 @@ impl<F: Field> FieldAlgebra for SymbolicExpression<F> {
         Self::Constant(F::from_bool(b))
     }
 }
+
+impl<F: Field> FieldAlgebra<F> for SymbolicExpression<F> {}
 
 impl<F: Field + InjectiveMonomial<N>, const N: u64> InjectiveMonomial<N> for SymbolicExpression<F> {}
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::{Field, FieldAlgebra, InjectiveMonomial, PrimeCharacteristicRing};
+use p3_field::{Field, Algebra, InjectiveMonomial, PrimeCharacteristicRing};
 
 use crate::symbolic_variable::SymbolicVariable;
 
@@ -92,9 +92,9 @@ impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
     }
 }
 
-impl<F: Field> FieldAlgebra<F> for SymbolicExpression<F> {}
+impl<F: Field> Algebra<F> for SymbolicExpression<F> {}
 
-impl<F: Field> FieldAlgebra<SymbolicVariable<F>> for SymbolicExpression<F> {}
+impl<F: Field> Algebra<SymbolicVariable<F>> for SymbolicExpression<F> {}
 
 impl<F: Field + InjectiveMonomial<N>, const N: u64> InjectiveMonomial<N> for SymbolicExpression<F> {}
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -94,6 +94,8 @@ impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
 
 impl<F: Field> FieldAlgebra<F> for SymbolicExpression<F> {}
 
+impl<F: Field> FieldAlgebra<SymbolicVariable<F>> for SymbolicExpression<F> {}
+
 impl<F: Field + InjectiveMonomial<N>, const N: u64> InjectiveMonomial<N> for SymbolicExpression<F> {}
 
 impl<F: Field, T> Add<T> for SymbolicExpression<F>

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
+use p3_field::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing, Serializable};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
+use p3_field::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -6,7 +6,7 @@ use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, FieldAlgebra, PrimeField64};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -10,7 +10,7 @@ use p3_commit::testing::TrivialPcs;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_matrix::dense::RowMajorMatrix;


### PR DESCRIPTION
Note this is not merging into main. The plan is to develop the Field crate refactor in a separate branch and then merge it all in in a single PR. This will avoid the need for a collection of small API breaking changes.

The point of this PR is to split the FieldAlgebra trait into `2` traits: `PrimeCharacteristicRing` and `FieldAlgebra<F>`.

`PrimeCharacteristicRing` contains most of what is currently in `FieldAlgebra` and basically serves at the general trait which all rings should implement. E.g. it contains the `Addition/Multiplication` operations as well as a collection of methods which convert integers into ring elements.

A ring should implement `FieldAlgebra<F>` if that ring is an algebra over `F`. In particular this means the ring should implement `From<F>` along with `Addition/Multiplication` by elements of `F`. We promote `F` to a generic type as this means that a ring can implement `FieldAlgebra<F>` multiple times. This is useful for things like extension fields which can now implement both `FieldAlgebra<F>` and `FieldAlgebra<EF>`. It's also conceptually cleaner.

The `PR` looks larger than it actually is. The vast majority of changes are simply renaming `FieldAlgebra` to `PrimeCharacteristicRing` throughout the codebase. Additionally, while Github claims that this increases the number of lines of code, all of that increase is coming from longer comments and some places where the rust formatter has split an impl definition over several lines instead of just one.