### PR TITLE
Field Crate Refactor: Remove the FieldExtensionAlgebra trait

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Mul, Sub};
 
-use p3_field::{Algebra, ExtensionField, Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
+use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 
@@ -129,7 +129,7 @@ pub trait PairBuilder: AirBuilder {
 pub trait ExtensionBuilder: AirBuilder {
     type EF: ExtensionField<Self::F>;
 
-    type ExprEF: FieldExtensionAlgebra<Self::Expr> + Algebra<Self::EF>;
+    type ExprEF: Algebra<Self::Expr> + Algebra<Self::EF>;
 
     type VarEF: Into<Self::ExprEF> + Copy + Send + Sync;
 

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -47,7 +47,11 @@ where
         let (opened_base_values, proof) = self.inner.open_batch(index, prover_data);
         let opened_ext_values = opened_base_values
             .into_iter()
-            .map(|row| row.chunks(EF::D).map(EF::deserialize_slice).collect())
+            .map(|row| {
+                row.chunks(EF::DIMENSION)
+                    .map(EF::deserialize_slice)
+                    .collect()
+            })
             .collect();
         (opened_ext_values, proof)
     }
@@ -80,7 +84,7 @@ where
         let base_dimensions = dimensions
             .iter()
             .map(|dim| Dimensions {
-                width: dim.width * EF::D,
+                width: dim.width * EF::DIMENSION,
                 height: dim.height,
             })
             .collect::<Vec<_>>();

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -77,8 +77,6 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Serializable<F> for BinomialExt
 impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
     for BinomialExtensionField<F, D>
 {
-    const D: usize = D;
-
     type ExtensionPacking = PackedBinomialExtensionField<F, F::Packing, D>;
 
     fn is_in_basefield(&self) -> bool {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -17,8 +17,8 @@ use super::{HasFrobenius, HasTwoAdicBionmialExtension, PackedBinomialExtensionFi
 use crate::extension::BinomiallyExtendable;
 use crate::field::Field;
 use crate::{
-    field_to_array, Algebra, ExtensionField, FieldExtensionAlgebra, Packable, PackedValue, Powers,
-    PrimeCharacteristicRing, Serializable, TwoAdicField,
+    field_to_array, Algebra, ExtensionField, Packable, PrimeCharacteristicRing, Serializable,
+    TwoAdicField,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
@@ -77,6 +77,8 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Serializable<F> for BinomialExt
 impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
     for BinomialExtensionField<F, D>
 {
+    const D: usize = D;
+
     type ExtensionPacking = PackedBinomialExtensionField<F, F::Packing, D>;
 
     fn is_in_basefield(&self) -> bool {
@@ -88,36 +90,6 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
             Some(self.value[0])
         } else {
             None
-        }
-    }
-
-    // This is just here as a placeholder for now. Going to move this function to packed_binomial_extension
-    // in a future PR (before this is merged onto the main branch.)
-    fn ext_powers_packed(&self) -> crate::Powers<Self::ExtensionPacking> {
-        let width = F::Packing::WIDTH;
-        let powers = self.powers().take(width + 1).collect_vec();
-        // Transpose first WIDTH powers
-        let mut packed_powers = PackedBinomialExtensionField::<F, F::Packing, D> {
-            value: [F::Packing::ZERO; D],
-        };
-        packed_powers
-            .value
-            .iter_mut()
-            .enumerate()
-            .for_each(|(i, row_i)| {
-                let row_i = row_i.as_slice_mut();
-                powers[..width]
-                    .iter()
-                    .enumerate()
-                    .for_each(|(j, vec_j)| row_i[j] = vec_j.value[i])
-            });
-
-        // Broadcast self^WIDTH
-        let multiplier = powers[width].into();
-
-        Powers {
-            base: multiplier,
-            current: packed_powers,
         }
     }
 }
@@ -493,13 +465,6 @@ where
     fn mul_assign(&mut self, rhs: F) {
         *self = *self * rhs;
     }
-}
-
-impl<F, const D: usize> FieldExtensionAlgebra<F> for BinomialExtensionField<F, D>
-where
-    F: BinomiallyExtendable<D>,
-{
-    const D: usize = D;
 }
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Distribution<BinomialExtensionField<F, D>>

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,5 +1,5 @@
 use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBionmialExtension};
-use crate::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing};
+use crate::{Algebra, Field, PrimeCharacteristicRing};
 
 pub type Complex<F> = BinomialExtensionField<F, 2>;
 
@@ -70,7 +70,7 @@ impl<R: PrimeCharacteristicRing> Complex<R> {
 
     // Sometimes we want to rotate over an extension that's not necessarily ComplexExtendable,
     // but still on the circle.
-    pub fn rotate<Ext: FieldExtensionAlgebra<R>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
+    pub fn rotate<Ext: Algebra<R>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
         Complex::<Ext>::new(
             rhs.real() * self.real() - rhs.imag() * self.imag(),
             rhs.imag() * self.real() + rhs.real() * self.imag(),

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -36,15 +36,15 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
 
     fn minimal_poly(mut self) -> Vec<F> {
         let mut m = vec![Self::ONE];
-        for _ in 0..Self::D {
+        for _ in 0..Self::DIMENSION {
             m = naive_poly_mul(&m, &[-self, Self::ONE]);
             self = self.frobenius();
         }
         let mut m_iter = m
             .into_iter()
             .map(|c| c.as_base().expect("Extension is not algebraic?"));
-        let m: Vec<F> = m_iter.by_ref().take(Self::D + 1).collect();
-        debug_assert_eq!(m.len(), Self::D + 1);
+        let m: Vec<F> = m_iter.by_ref().take(Self::DIMENSION + 1).collect();
+        debug_assert_eq!(m.len(), Self::DIMENSION + 1);
         debug_assert_eq!(m.last(), Some(&F::ONE));
         debug_assert!(m_iter.all(|c| c.is_zero()));
         m
@@ -52,7 +52,7 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
 
     fn galois_group(self) -> Vec<Self> {
         iter::successors(Some(self), |x| Some(x.frobenius()))
-            .take(Self::D)
+            .take(Self::DIMENSION)
             .collect()
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -565,8 +565,6 @@ pub trait PrimeField32: PrimeField64 {
 pub trait ExtensionField<Base: Field>: Field + Algebra<Base> + Serializable<Base> {
     type ExtensionPacking: PackedFieldExtension<Base, Self> + 'static + Copy + Send + Sync;
 
-    const D: usize;
-
     /// Determine if the given element lies in the base field.
     fn is_in_basefield(&self) -> bool;
 
@@ -577,8 +575,6 @@ pub trait ExtensionField<Base: Field>: Field + Algebra<Base> + Serializable<Base
 
 impl<F: Field> ExtensionField<F> for F {
     type ExtensionPacking = F::Packing;
-
-    const D: usize = 1;
 
     fn is_in_basefield(&self) -> bool {
         true

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -3,7 +3,7 @@ use core::ops::Div;
 use core::slice;
 
 use crate::field::Field;
-use crate::Algebra;
+use crate::{Algebra, ExtensionField, Powers, PrimeCharacteristicRing, Serializable};
 
 /// A trait to constrain types that can be packed into a packed value.
 ///
@@ -136,6 +136,31 @@ pub unsafe trait PackedField: Algebra<Self::Scalar>
     + Div<Self::Scalar, Output = Self>
 {
     type Scalar: Field;
+
+    /// Construct an iterator which returns powers of `base` packed into packed field elements.
+    /// 
+    /// E.g. if `Self::WIDTH = 4`, returns: `[base^0, base^1, base^2, base^3], [base^4, base^5, base^6, base^7], ...`.
+    #[must_use]
+    fn packed_powers(base: Self::Scalar) -> Powers<Self> {
+        Self::packed_shifted_powers(base, Self::Scalar::ONE)
+    }
+
+    /// Construct an iterator which returns powers of `base` multiplied by `start` and packed into packed field elements.
+    /// 
+    /// E.g. if `Self::WIDTH = 4`, returns: `[start, start*base, start*base^2, start*base^3], [start*base^4, start*base^5, start*base^6, start*base^7], ...`.
+    #[must_use]
+    fn packed_shifted_powers(base: Self::Scalar, start: Self::Scalar) -> Powers<Self> {
+        let mut current: Self = start.into();
+        let slice = current.as_slice_mut();
+        for i in 1..Self::WIDTH {
+            slice[i] = slice[i - 1] * base;
+        }
+
+        Powers {
+            base: base.exp_u64(Self::WIDTH as u64).into(),
+            current,
+        }
+    }
 }
 
 /// # Safety
@@ -178,6 +203,29 @@ pub unsafe trait PackedFieldPow2: PackedField {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self);
 }
 
+/// Fix a field `F` a packing width `W` and an extension field `EF` of `F`.
+///
+/// By choosing a basis `B`, `EF` can be transformed into an array `[F; D]`.
+///
+/// A type should implement PackedFieldExtension if it can be transformed into `[F::Packing; D] ~ [[F; W]; D]`
+///
+/// This is interpreted by taking a transpose to get `[[F; D]; W]` which can then be reinterpreted
+/// as `[EF; W]` by making use of the chosen basis `B` again.
+pub trait PackedFieldExtension<
+    BaseField: Field,
+    ExtField: ExtensionField<BaseField, ExtensionPacking = Self>,
+>: Algebra<ExtField> + Algebra<BaseField::Packing> + Serializable<BaseField::Packing>
+{
+    /// Given a slice of extension field `EF` elements of length `W`,
+    /// convert into the array `[[F; D]; W]` transpose to
+    /// `[[F; W]; D]` and then pack to get `[PF; D]`.
+    fn from_ext_slice(ext_slice: &[ExtField]) -> Self;
+
+    /// Similar to packed_powers, construct an iterator which returns
+    /// powers of `base` packed into `PackedFieldExtension` elements.
+    fn packed_ext_powers(base: ExtField) -> Powers<Self>;
+}
+
 unsafe impl<T: Packable> PackedValue for T {
     type Value = Self;
 
@@ -217,6 +265,16 @@ unsafe impl<F: Field> PackedFieldPow2 for F {
             1 => (*self, other),
             _ => panic!("unsupported block length"),
         }
+    }
+}
+
+impl<F: Field> PackedFieldExtension<F, F> for F::Packing {
+    fn from_ext_slice(ext_slice: &[F]) -> Self {
+        ext_slice[0].into()
+    }
+
+    fn packed_ext_powers(base: F) -> Powers<Self> {
+        F::Packing::packed_powers(base)
     }
 }
 

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -115,7 +115,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
     where
         T: ExtensionField<F>,
     {
-        let width = self.width * T::D;
+        let width = self.width * T::DIMENSION;
         let values = self
             .values
             .borrow()

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -33,7 +33,7 @@ where
     Inner: Matrix<EF>,
 {
     fn width(&self) -> usize {
-        self.0.width() * EF::D
+        self.0.width() * EF::DIMENSION
     }
 
     fn height(&self) -> usize {
@@ -77,7 +77,7 @@ where
 {
     type Item = F;
     fn next(&mut self) -> Option<Self::Item> {
-        if self.idx == EF::D {
+        if self.idx == EF::DIMENSION {
             self.idx = 0;
             self.inner.next();
         }

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -10,7 +10,8 @@ use core::ops::Deref;
 
 use itertools::{izip, Itertools};
 use p3_field::{
-    dot_product, ExtensionField, Field, PackedValue, PrimeCharacteristicRing, Serializable,
+    dot_product, ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
+    Serializable,
 };
 use p3_maybe_rayon::prelude::*;
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
@@ -261,8 +262,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
-        let powers_packed = base
-            .ext_powers_packed()
+        let powers_packed = EF::ExtensionPacking::packed_ext_powers(base)
             .take(self.width().next_multiple_of(T::Packing::WIDTH))
             .collect_vec();
         self.par_padded_horizontally_packed_rows::<T::Packing>()

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{Field, FieldExtensionAlgebra, PrimeCharacteristicRing, Serializable};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, Serializable};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
@@ -49,7 +49,7 @@ where
         && opened_values
             .quotient_chunks
             .iter()
-            .all(|qc| qc.len() == <SC::Challenge as FieldExtensionAlgebra<Val<SC>>>::D);
+            .all(|qc| qc.len() == <SC::Challenge as ExtensionField<Val<SC>>>::D);
     if !valid_shape {
         return Err(VerificationError::InvalidProofShape);
     }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, Serializable};
+use p3_field::{Field, PrimeCharacteristicRing, Serializable};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
@@ -49,7 +49,7 @@ where
         && opened_values
             .quotient_chunks
             .iter()
-            .all(|qc| qc.len() == <SC::Challenge as ExtensionField<Val<SC>>>::D);
+            .all(|qc| qc.len() == <SC::Challenge as Serializable<Val<SC>>>::DIMENSION);
     if !valid_shape {
         return Err(VerificationError::InvalidProofShape);
     }


### PR DESCRIPTION
Note this is not merging into main. The plan is to develop the field crate refactor in a separate branch and then merge it all in in a single PR. This will avoid the need for a collection of small API breaking changes.

The point of this PR is to remove the FieldExtensionAlgebra trait. Instead we replace it by `PackedFieldExtension` which provides methods to produce a `PackedFieldExtension` element from a slice of `ExtensionField` elements as well as a iterator which computes the powers of a given element.

Additionally, we move a couple of methods from `Field` into `PackedField` where they more naturally live.