### PR TITLE
Challenger sampled bits

### DIFF
--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -13,3 +13,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 p3-goldilocks.workspace = true
+p3-baby-bear.workspace = true

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -148,8 +148,8 @@ where
     P: CryptographicPermutation<[F; WIDTH]>,
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
-        debug_assert!(bits < (usize::BITS as usize));
-        debug_assert!((1 << bits) < F::ORDER_U64);
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U64);
         let rand_f: F = self.sample();
         let rand_usize = rand_f.as_canonical_u64() as usize;
         rand_usize & ((1 << bits) - 1)

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -160,13 +160,13 @@ where
 mod tests {
     use core::iter;
 
-    use crate::grinding_challenger::GrindingChallenger;
     use p3_baby_bear::BabyBear;
     use p3_field::FieldAlgebra;
     use p3_goldilocks::Goldilocks;
     use p3_symmetric::Permutation;
 
     use super::*;
+    use crate::grinding_challenger::GrindingChallenger;
 
     const WIDTH: usize = 24;
     const RATE: usize = 16;
@@ -235,8 +235,13 @@ mod tests {
         let permutation = TestPermutation {};
         let mut duplex_challenger = GoldilocksChal::new(permutation);
 
-        // This grinding should never finish on a regular machine
-        let witness = duplex_challenger.grind(129);
-        assert!(duplex_challenger.check_witness(129, witness));
+        // This should cause sample_bits (and hence grind and check_witness) to
+        // panic. If bit sizes were not constrained correctly inside the
+        // challenger, (1 << too_many_bits) would loop around, incorrectly
+        // grinding and accepting a 1-bit PoW.
+        let too_many_bits = usize::BITS as usize;
+
+        let witness = duplex_challenger.grind(too_many_bits);
+        assert!(duplex_challenger.check_witness(too_many_bits, witness));
     }
 }

--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -29,6 +29,9 @@ where
 
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U64);
+
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
             .map(|i| F::from_canonical_u64(i))
@@ -50,6 +53,8 @@ where
 
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U64);
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
             .map(F::from_canonical_u64)

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -182,8 +182,8 @@ where
     P: CryptographicPermutation<[PF; WIDTH]>,
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
-        debug_assert!(bits < (usize::BITS as usize));
-        debug_assert!((1 << bits) < F::ORDER_U32);
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U32);
         let rand_f: F = self.sample();
         let rand_usize = rand_f.as_canonical_u32() as usize;
         rand_usize & ((1 << bits) - 1)

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -116,9 +116,9 @@ where
     Inner: CanSample<u8>,
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
-        debug_assert!(bits < (usize::BITS as usize));
+        assert!(bits < (usize::BITS as usize));
         // Limiting the number of bits to the field size
-        debug_assert!((1 << bits) <= F::ORDER_U64 as usize);
+        assert!((1 << bits) <= F::ORDER_U64 as usize);
         let rand_usize = u32::from_le_bytes(self.inner.sample_array()) as usize;
         rand_usize & ((1 << bits) - 1)
     }
@@ -226,9 +226,9 @@ where
     Inner: CanSample<u8>,
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
-        debug_assert!(bits < (usize::BITS as usize));
+        assert!(bits < (usize::BITS as usize));
         // Limiting the number of bits to the field size
-        debug_assert!((1 << bits) <= F::ORDER_U64 as usize);
+        assert!((1 << bits) <= F::ORDER_U64 as usize);
         let rand_usize = u64::from_le_bytes(self.inner.sample_array()) as usize;
         rand_usize & ((1 << bits) - 1)
     }

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -133,6 +133,8 @@ where
 
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U64);
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
             .map(|i| F::from_canonical_u64(i))
@@ -243,6 +245,8 @@ where
 
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize));
+        assert!((1 << bits) < F::ORDER_U64);
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
             .map(|i| F::from_canonical_u64(i))


### PR DESCRIPTION
While working on a Plonky3 implementation of some protocol, @Cesar199999 and I realised our prover was grinding way more bits than it should be able to and our verifier was happily accepting the witnesses. This boils down to the fact that, for `DuplexChallenger`s, grinding and verification resort to `sample_bits`, which contains two assertions:

```
debug_assert!(bits < (usize::BITS as usize));
debug_assert!((1 << bits) < F::ORDER_U64);
```

In our case, we were running a protocol where the configuration was asking the `DuplexChallenger` for a PoW of 131 bits. In release mode, none of the above assertions were being checked and the prover and verifier were secretly performing grinding (computation and verification) for (1 << 131) = 8 bits. This arithmetic overflow should be prevented by the default `#[deny(arithmetic_overflow)]`, but that is not done due to the repo's configuration. In summary, the verifier was getting seriously short-changed security-wise.

**Steps to reproduce:**
The PR is two commits ahead of `main`. The first one adds two tests highlighting the issue and the second one swaps the problematic `debug_assert`s by `assert`s, which fixes the tests. In order to see the problem, the commands below should be run on the first of the two commit, i. e. `71ecd33`:
 - PoC 1: Sampling 129 bits results in numbers between 0 and 3:
   ```cargo test --release test_duplex_challenger_sample_bits_security```
 - PoC 2: Sampling 40 bits results in numbers between 0 and ~2^31 if the field is BabyBear:
   ```cargo test --release test_duplex_challenger_sample_bits_security_small_field ```
 - PoC 3: The receiver happily accepts a false proof of work of too many bits (129, which should never be able to be sampled on a regular machine):
   ```cargo test --release test_duplex_challenger_grind```
