### PR TITLE
Field Crate Refactor: Binomial Extension accepting an Algebra

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::array;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
+use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
@@ -23,49 +24,55 @@ use crate::{
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // to make the zero_vec implementation safe
-pub struct BinomialExtensionField<F, const D: usize> {
+pub struct BinomialExtensionField<F, const D: usize, FA = F> {
     #[serde(
         with = "p3_util::array_serialization",
-        bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>")
+        bound(serialize = "FA: Serialize", deserialize = "FA: Deserialize<'de>")
     )]
-    pub(crate) value: [F; D],
+    pub(crate) value: [FA; D],
+    _phantom: PhantomData<F>,
 }
 
-impl<F: Field, const D: usize> Default for BinomialExtensionField<F, D> {
-    fn default() -> Self {
+impl<F, FA, const D: usize> BinomialExtensionField<F, D, FA> {
+    pub(crate) const fn new(value: [FA; D]) -> Self {
         Self {
-            value: array::from_fn(|_| F::ZERO),
+            value,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<F: Field, const D: usize> From<F> for BinomialExtensionField<F, D> {
-    fn from(x: F) -> Self {
-        Self {
-            value: field_to_array(x),
-        }
+impl<F: Field, A: Algebra<F>, const D: usize> Default for BinomialExtensionField<F, D, A> {
+    fn default() -> Self {
+        Self::new(array::from_fn(|_| A::ZERO))
+    }
+}
+
+impl<F: Field, A: Algebra<F>, const D: usize> From<A> for BinomialExtensionField<F, D, A> {
+    fn from(x: A) -> Self {
+        Self::new(field_to_array(x))
     }
 }
 
 impl<F: BinomiallyExtendable<D>, const D: usize> Packable for BinomialExtensionField<F, D> {}
 
-impl<F: BinomiallyExtendable<D>, const D: usize> Serializable<F> for BinomialExtensionField<F, D> {
+impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> Serializable<A>
+    for BinomialExtensionField<F, D, A>
+{
     const DIMENSION: usize = D;
 
     #[inline]
-    fn serialize_as_slice(&self) -> &[F] {
+    fn serialize_as_slice(&self) -> &[A] {
         &self.value
     }
 
     #[inline]
-    fn deserialize_fn<Fn: FnMut(usize) -> F>(f: Fn) -> Self {
-        Self {
-            value: array::from_fn(f),
-        }
+    fn deserialize_fn<Fn: FnMut(usize) -> A>(f: Fn) -> Self {
+        Self::new(array::from_fn(f))
     }
 
     #[inline]
-    fn deserialize_iter<I: Iterator<Item = F>>(iter: I) -> Self {
+    fn deserialize_iter<I: Iterator<Item = A>>(iter: I) -> Self {
         let mut res = Self::default();
         for (i, b) in iter.enumerate() {
             res.value[i] = b;
@@ -151,41 +158,34 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
     }
 }
 
-impl<F, const D: usize> PrimeCharacteristicRing for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> PrimeCharacteristicRing for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
-    type PrimeSubfield = <F as PrimeCharacteristicRing>::PrimeSubfield;
+    type PrimeSubfield = <A as PrimeCharacteristicRing>::PrimeSubfield;
 
-    const ZERO: Self = Self {
-        value: [F::ZERO; D],
-    };
+    const ZERO: Self = Self::new([A::ZERO; D]);
 
-    const ONE: Self = Self {
-        value: field_to_array(F::ONE),
-    };
+    const ONE: Self = Self::new(field_to_array(A::ONE));
 
-    const TWO: Self = Self {
-        value: field_to_array(F::TWO),
-    };
+    const TWO: Self = Self::new(field_to_array(A::TWO));
 
-    const NEG_ONE: Self = Self {
-        value: field_to_array(F::NEG_ONE),
-    };
+    const NEG_ONE: Self = Self::new(field_to_array(A::NEG_ONE));
 
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
-        <F as PrimeCharacteristicRing>::from_prime_subfield(f).into()
+        <A as PrimeCharacteristicRing>::from_prime_subfield(f).into()
     }
 
     #[inline(always)]
     fn square(&self) -> Self {
         match D {
             2 => {
-                let a = self.value;
+                let a = self.value.clone();
                 let mut res = Self::default();
                 res.value[0] = a[0].square() + a[1].square() * F::W;
-                res.value[1] = a[0] * a[1].double();
+                res.value[1] = a[0].clone() * a[1].double();
                 res
             }
             3 => {
@@ -193,7 +193,7 @@ where
                 cubic_square(&self.value, &mut res.value);
                 res
             }
-            _ => <Self as Mul<Self>>::mul(*self, *self),
+            _ => <Self as Mul<Self>>::mul(self.clone(), self.clone()),
         }
     }
 
@@ -209,9 +209,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Algebra<F> for BinomialExtensio
 impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionField<F, D> {
     type Packing = Self;
 
-    const GENERATOR: Self = Self {
-        value: F::EXT_GENERATOR,
-    };
+    const GENERATOR: Self = Self::new(F::EXT_GENERATOR);
 
     fn try_inverse(&self) -> Option<Self> {
         if self.is_zero() {
@@ -226,9 +224,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
     }
 
     fn halve(&self) -> Self {
-        Self {
-            value: self.value.map(|x| x.halve()),
-        }
+        Self::new(self.value.map(|x| x.halve()))
     }
 
     fn order() -> BigUint {
@@ -262,127 +258,138 @@ where
     }
 }
 
-impl<F, const D: usize> Neg for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Neg for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            value: self.value.map(F::neg),
-        }
+        Self::new(self.value.map(A::neg))
     }
 }
 
-impl<F, const D: usize> Add for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Add for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
         let value = vector_add(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
-impl<F, const D: usize> Add<F> for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Add<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
-    fn add(mut self, rhs: F) -> Self {
+    fn add(mut self, rhs: A) -> Self {
         self.value[0] += rhs;
         self
     }
 }
 
-impl<F, const D: usize> AddAssign for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> AddAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
         for i in 0..D {
-            self.value[i] += rhs.value[i];
+            self.value[i] += rhs.value[i].clone();
         }
     }
 }
 
-impl<F, const D: usize> AddAssign<F> for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> AddAssign<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     #[inline]
-    fn add_assign(&mut self, rhs: F) {
+    fn add_assign(&mut self, rhs: A) {
         self.value[0] += rhs;
     }
 }
 
-impl<F, const D: usize> Sum for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Sum for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ZERO, |acc, x| acc + x)
     }
 }
 
-impl<F, const D: usize> Sub for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Sub for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         let value = vector_sub(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
-impl<F, const D: usize> Sub<F> for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Sub<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
-    fn sub(self, rhs: F) -> Self {
+    fn sub(self, rhs: A) -> Self {
         let mut res = self.value;
         res[0] -= rhs;
-        Self { value: res }
+        Self::new(res)
     }
 }
 
-impl<F, const D: usize> SubAssign for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> SubAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
+        for i in 0..D {
+            self.value[i] -= rhs.value[i].clone();
+        }
     }
 }
 
-impl<F, const D: usize> SubAssign<F> for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> SubAssign<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     #[inline]
-    fn sub_assign(&mut self, rhs: F) {
-        *self = *self - rhs;
+    fn sub_assign(&mut self, rhs: A) {
+        self.value[0] -= rhs;
     }
 }
 
-impl<F, const D: usize> Mul for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Mul for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
@@ -399,23 +406,45 @@ where
     }
 }
 
-impl<F, const D: usize> Mul<F> for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> Mul<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     type Output = Self;
 
     #[inline]
-    fn mul(self, rhs: F) -> Self {
-        Self {
-            value: self.value.map(|x| x * rhs),
-        }
+    fn mul(self, rhs: A) -> Self {
+        Self::new(self.value.map(|x| x * rhs.clone()))
     }
 }
 
-impl<F, const D: usize> Product for BinomialExtensionField<F, D>
+impl<F, A, const D: usize> MulAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
+{
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = self.clone() * rhs;
+    }
+}
+
+impl<F, A, const D: usize> MulAssign<A> for BinomialExtensionField<F, D, A>
+where
+    F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
+{
+    #[inline]
+    fn mul_assign(&mut self, rhs: A) {
+        *self = self.clone() * rhs;
+    }
+}
+
+impl<F, A, const D: usize> Product for BinomialExtensionField<F, D, A>
+where
+    F: BinomiallyExtendable<D>,
+    A: Algebra<F>,
 {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::ONE, |acc, x| acc * x)
@@ -445,26 +474,6 @@ where
     }
 }
 
-impl<F, const D: usize> MulAssign for BinomialExtensionField<F, D>
-where
-    F: BinomiallyExtendable<D>,
-{
-    #[inline]
-    fn mul_assign(&mut self, rhs: Self) {
-        *self = *self * rhs;
-    }
-}
-
-impl<F, const D: usize> MulAssign<F> for BinomialExtensionField<F, D>
-where
-    F: BinomiallyExtendable<D>,
-{
-    #[inline]
-    fn mul_assign(&mut self, rhs: F) {
-        *self = *self * rhs;
-    }
-}
-
 impl<F: BinomiallyExtendable<D>, const D: usize> Distribution<BinomialExtensionField<F, D>>
     for Standard
 where
@@ -486,9 +495,7 @@ impl<F: Field + HasTwoAdicBionmialExtension<D>, const D: usize> TwoAdicField
 
     #[inline]
     fn two_adic_generator(bits: usize) -> Self {
-        Self {
-            value: F::ext_two_adic_generator(bits),
-        }
+        Self::new(F::ext_two_adic_generator(bits))
     }
 }
 
@@ -521,14 +528,15 @@ pub(crate) fn vector_sub<
 /// Multiply two vectors representing elements in a binomial extension.
 #[inline]
 pub(super) fn binomial_mul<
-    R: PrimeCharacteristicRing + Mul<R2, Output = R>,
+    F: Field,
+    R: Algebra<F> + Mul<R2, Output = R>,
     R2: Add<Output = R2> + Clone,
     const D: usize,
 >(
     a: &[R; D],
     b: &[R2; D],
     res: &mut [R; D],
-    w: R,
+    w: F,
 ) {
     match D {
         2 => {
@@ -542,7 +550,7 @@ pub(super) fn binomial_mul<
             for i in 0..D {
                 for j in 0..D {
                     if i + j >= D {
-                        res[i + j - D] += a[i].clone() * w.clone() * b[j].clone();
+                        res[i + j - D] += a[i].clone() * w * b[j].clone();
                     } else {
                         res[i + j] += a[i].clone() * b[j].clone();
                     }
@@ -583,14 +591,15 @@ fn cubic_inv<F: Field>(a: &[F], w: F) -> [F; 3] {
 /// karatsuba multiplication for cubic extension field
 #[inline]
 pub(crate) fn cubic_mul<
-    R: PrimeCharacteristicRing + Mul<R2, Output = R>,
+    F: Field,
+    R: Algebra<F> + Mul<R2, Output = R>,
     R2: Add<Output = R2> + Clone,
     const D: usize,
 >(
     a: &[R; D],
     b: &[R2; D],
     res: &mut [R; D],
-    w: R,
+    w: F,
 ) {
     assert_eq!(D, 3);
 
@@ -602,7 +611,7 @@ pub(crate) fn cubic_mul<
         + ((a[1].clone() + a[2].clone()) * (b[1].clone() + b[2].clone())
             - a1_b1.clone()
             - a2_b2.clone())
-            * w.clone();
+            * w;
     res[1] = (a[0].clone() + a[1].clone()) * (b[0].clone() + b[1].clone())
         - a0_b0.clone()
         - a1_b1.clone()

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -27,20 +27,18 @@ impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
 /// Convenience methods for complex extensions
 impl<R: PrimeCharacteristicRing> Complex<R> {
     #[inline(always)]
-    pub const fn new(real: R, imag: R) -> Self {
-        Self {
-            value: [real, imag],
-        }
+    pub const fn new_complex(real: R, imag: R) -> Self {
+        Self::new([real, imag])
     }
 
     #[inline(always)]
     pub const fn new_real(real: R) -> Self {
-        Self::new(real, R::ZERO)
+        Self::new_complex(real, R::ZERO)
     }
 
     #[inline(always)]
     pub const fn new_imag(imag: R) -> Self {
-        Self::new(R::ZERO, imag)
+        Self::new_complex(R::ZERO, imag)
     }
 
     #[inline(always)]
@@ -55,7 +53,7 @@ impl<R: PrimeCharacteristicRing> Complex<R> {
 
     #[inline(always)]
     pub fn conjugate(&self) -> Self {
-        Self::new(self.real(), self.imag().neg())
+        Self::new_complex(self.real(), self.imag().neg())
     }
 
     #[inline]
@@ -71,7 +69,7 @@ impl<R: PrimeCharacteristicRing> Complex<R> {
     // Sometimes we want to rotate over an extension that's not necessarily ComplexExtendable,
     // but still on the circle.
     pub fn rotate<Ext: Algebra<R>>(&self, rhs: Complex<Ext>) -> Complex<Ext> {
-        Complex::<Ext>::new(
+        Complex::<Ext>::new_complex(
             rhs.real() * self.real() - rhs.imag() * self.imag(),
             rhs.imag() * self.real() + rhs.real() * self.imag(),
         )

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -390,7 +390,7 @@ where
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
-        let w: PF = F::W.into();
+        let w = F::W;
 
         binomial_mul(&a, &b, &mut res.value, w);
 
@@ -411,7 +411,7 @@ where
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
-        let w: PF = F::W.into();
+        let w = F::W;
 
         binomial_mul(&a, &b, &mut res.value, w);
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -3,8 +3,8 @@ use core::array;
 use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use itertools::Itertools;
 
+use itertools::Itertools;
 use p3_util::convert_vec;
 use serde::{Deserialize, Serialize};
 

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -18,7 +18,8 @@ impl ComplexExtendable for Mersenne31 {
     // sage: F2.<u> = F.extension(x^2 + 1)
     // sage: F2.multiplicative_generator()
     // u + 12
-    const COMPLEX_GENERATOR: Complex<Self> = Complex::new(Mersenne31::new(12), Mersenne31::ONE);
+    const COMPLEX_GENERATOR: Complex<Self> =
+        Complex::new_complex(Mersenne31::new(12), Mersenne31::ONE);
 
     fn circle_two_adic_generator(bits: usize) -> Complex<Self> {
         // Generator of the whole 2^TWO_ADICITY group
@@ -30,7 +31,8 @@ impl ComplexExtendable for Mersenne31 {
         // 1584694829*u + 311014874
         // sage: assert(g.multiplicative_order() == 2^31)
         // sage: assert(g.norm() == 1)
-        let base = Complex::new(Mersenne31::new(311_014_874), Mersenne31::new(1_584_694_829));
+        let base =
+            Complex::new_complex(Mersenne31::new(311_014_874), Mersenne31::new(1_584_694_829));
         base.exp_power_of_2(Self::CIRCLE_TWO_ADICITY - bits)
     }
 }
@@ -49,7 +51,7 @@ impl HasTwoAdicBionmialExtension<2> for Mersenne31 {
         // sage: g = F2.multiplicative_generator()^((p^2 - 1) / 2^32); g
         // 1117296306*u + 1166849849
         // sage: assert(g.multiplicative_order() == 2^32)
-        let base = Complex::<Self>::new(
+        let base = Complex::<Self>::new_complex(
             Mersenne31::new(1_166_849_849),
             Mersenne31::new(1_117_296_306),
         );
@@ -95,16 +97,16 @@ mod tests {
 
         // further tests
         assert_eq!(
-            Fi::new(F::ONE, F::TWO) + Fi::new(F::ONE, F::ONE),
-            Fi::new(F::TWO, F::new(3))
+            Fi::new_complex(F::ONE, F::TWO) + Fi::new_complex(F::ONE, F::ONE),
+            Fi::new_complex(F::TWO, F::new(3))
         );
         assert_eq!(
-            Fi::new(F::NEG_ONE, F::NEG_ONE) + Fi::new(F::ONE, F::ONE),
+            Fi::new_complex(F::NEG_ONE, F::NEG_ONE) + Fi::new_complex(F::ONE, F::ONE),
             Fi::ZERO
         );
         assert_eq!(
-            Fi::new(F::NEG_ONE, F::ONE) + Fi::new(F::TWO, F::new(F::ORDER_U32 - 2)),
-            Fi::new(F::ONE, F::NEG_ONE)
+            Fi::new_complex(F::NEG_ONE, F::ONE) + Fi::new_complex(F::TWO, F::new(F::ORDER_U32 - 2)),
+            Fi::new_complex(F::ONE, F::NEG_ONE)
         );
     }
 
@@ -137,8 +139,8 @@ mod tests {
     #[test]
     fn mul() {
         assert_eq!(
-            Fi::new(F::TWO, F::TWO) * Fi::new(F::new(4), F::new(5)),
-            Fi::new(-F::TWO, F::new(18))
+            Fi::new_complex(F::TWO, F::TWO) * Fi::new_complex(F::new(4), F::new(5)),
+            Fi::new_complex(-F::TWO, F::new(18))
         );
     }
 

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -47,7 +47,7 @@ fn dft_preprocess(input: RowMajorMatrix<F>) -> RowMajorMatrix<C> {
                 // two-element column into a Mersenne31Complex
                 // treating the first row as the real part and the
                 // second row as the imaginary part.
-                row_0.zip(row_1).map(|(x, y)| C::new(x, y))
+                row_0.zip(row_1).map(|(x, y)| C::new_complex(x, y))
             })
             .collect(),
         input.width(),
@@ -76,7 +76,7 @@ fn dft_postprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<C> {
         let row = izip!(input.row(j), input.row(h - j)).map(|(x, y)| {
             let even = x + y.conjugate();
             // odd = (x - y.conjugate()) * -i
-            let odd = C::new(x.imag() + y.imag(), y.real() - x.real());
+            let odd = C::new_complex(x.imag() + y.imag(), y.real() - x.real());
             (even + odd * omega_j).halve()
         });
         output.extend(row);
@@ -109,7 +109,7 @@ fn idft_preprocess(input: RowMajorMatrix<C>) -> RowMajorMatrix<C> {
         let row = izip!(input.row(j), input.row(h - j)).map(|(x, y)| {
             let even = x + y.conjugate();
             // odd = (x - y.conjugate()) * -i
-            let odd = C::new(x.imag() + y.imag(), y.real() - x.real());
+            let odd = C::new_complex(x.imag() + y.imag(), y.real() - x.real());
             (even - odd * omega_j).halve()
         });
         output.extend(row);

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -36,7 +36,7 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     // f2 = y^2 - i - 2
     // assert f2.is_irreducible()
     // ```
-    const W: Complex<Self> = Complex::new(Mersenne31::new(2), Mersenne31::ONE);
+    const W: Complex<Self> = Complex::new_complex(Mersenne31::new(2), Mersenne31::ONE);
 
     // DTH_ROOT = W^((p^2 - 1)/2).
     const DTH_ROOT: Complex<Self> = Complex::new_real(Mersenne31::new(2147483646));
@@ -59,7 +59,7 @@ impl HasTwoAdicComplexBinomialExtension<2> for Mersenne31 {
         if bits == 33 {
             [
                 Complex::ZERO,
-                Complex::new(Mersenne31::new(1437746044), Mersenne31::new(946469285)),
+                Complex::new_complex(Mersenne31::new(1437746044), Mersenne31::new(946469285)),
             ]
         } else {
             [Complex::two_adic_generator(bits), Complex::ZERO]

--- a/mersenne-31/src/radix_2_dit.rs
+++ b/mersenne-31/src/radix_2_dit.rs
@@ -152,6 +152,6 @@ fn dit_butterfly_inner(x: &mut C, y: &mut C, twiddle: C) {
     // -2*P^2 <= x2 - z2 <= P
     let b2 = F::from_u64((TWO_P_SQR + x2 - z2) as u64);
 
-    *x = C::new(a1, a2);
-    *y = C::new(b1, b2);
+    *x = C::new_complex(a1, a2);
+    *y = C::new_complex(b1, b2);
 }


### PR DESCRIPTION
Note this is not merging into main. The plan is to develop the Field crate refactor in a separate branch and then merge it all in in a single PR. This will avoid the need for a collection of small API breaking changes.

The point of this PR is to update Binomial Extension to allow it to accept an Algebra instead of only accepting a field. This functionality isn't currently used in Plonky3, but was useful in Plonky2 (and is supported in main) so we restore it.

The main drawback is it requires us to use some PhantomData but otherwise should have little to no effect.