### PR TITLE
Add extra_capacity_bits argument to all trace generation

### DIFF
--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -18,9 +18,13 @@ use crate::{generate_trace_rows, Blake3State, FullRound, QuarterRound};
 pub struct Blake3Air {}
 
 impl Blake3Air {
-    pub fn generate_trace_rows<F: PrimeField64>(&self, num_hashes: usize) -> RowMajorMatrix<F> {
+    pub fn generate_trace_rows<F: PrimeField64>(
+        &self,
+        num_hashes: usize,
+        extra_capacity_bits: usize,
+    ) -> RowMajorMatrix<F> {
         let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
-        generate_trace_rows(inputs)
+        generate_trace_rows(inputs, extra_capacity_bits)
     }
 
     /// Verify that the quarter round function has been correctly computed.

--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -54,7 +54,11 @@ pub trait ExampleHashAir<F: Field, SC: StarkGenericConfig>:
     + for<'a> Air<ProverConstraintFolder<'a, SC>>
     + for<'a> Air<VerifierConstraintFolder<'a, SC>>
 {
-    fn generate_trace_rows(&self, num_hashes: usize) -> RowMajorMatrix<F>
+    fn generate_trace_rows(
+        &self,
+        num_hashes: usize,
+        extra_capacity_bits: usize,
+    ) -> RowMajorMatrix<F>
     where
         Standard: Distribution<F>;
 }
@@ -151,14 +155,24 @@ impl<
     >
 {
     #[inline]
-    fn generate_trace_rows(&self, num_hashes: usize) -> RowMajorMatrix<F>
+    fn generate_trace_rows(
+        &self,
+        num_hashes: usize,
+        extra_capacity_bits: usize,
+    ) -> RowMajorMatrix<F>
     where
         Standard: Distribution<F>,
     {
         match self {
-            ProofObjective::Blake3(b3_air) => b3_air.generate_trace_rows(num_hashes),
-            ProofObjective::Poseidon2(p2_air) => p2_air.generate_vectorized_trace_rows(num_hashes),
-            ProofObjective::Keccak(k_air) => k_air.generate_trace_rows(num_hashes),
+            ProofObjective::Blake3(b3_air) => {
+                b3_air.generate_trace_rows(num_hashes, extra_capacity_bits)
+            }
+            ProofObjective::Poseidon2(p2_air) => {
+                p2_air.generate_vectorized_trace_rows(num_hashes, extra_capacity_bits)
+            }
+            ProofObjective::Keccak(k_air) => {
+                k_air.generate_trace_rows(num_hashes, extra_capacity_bits)
+            }
         }
     }
 }

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -77,7 +77,7 @@ where
     let challenge_mmcs = ExtensionMmcs::<F, EF, _>::new(val_mmcs.clone());
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let trace = proof_goal.generate_trace_rows(num_hashes);
+    let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
@@ -119,7 +119,7 @@ where
     let challenge_mmcs = ExtensionMmcs::<F, EF, _>::new(val_mmcs.clone());
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let trace = proof_goal.generate_trace_rows(num_hashes);
+    let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
@@ -155,7 +155,7 @@ pub fn prove_m31_keccak<
     let challenge_mmcs = ExtensionMmcs::<F, EF, _>::new(val_mmcs.clone());
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let trace = proof_goal.generate_trace_rows(num_hashes);
+    let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 
@@ -195,7 +195,7 @@ where
     let challenge_mmcs = ExtensionMmcs::<F, EF, _>::new(val_mmcs.clone());
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let trace = proof_goal.generate_trace_rows(num_hashes);
+    let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -55,10 +55,10 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -55,10 +55,11 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
+
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -60,10 +60,11 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger64<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
+
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -54,10 +54,11 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = DuplexChallenger<Val, Perm, 8, 4>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
+
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -52,10 +52,11 @@ fn main() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger64<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
-
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
+
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -52,6 +52,9 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
+    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
+
     type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs {
         mmcs: val_mmcs,
@@ -61,9 +64,6 @@ fn main() -> Result<(), impl Debug> {
 
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs);
-
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
-    let trace = generate_trace_rows::<Val>(inputs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
     let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -18,9 +18,13 @@ use crate::{generate_trace_rows, BITS_PER_LIMB, NUM_ROUNDS, U64_LIMBS};
 pub struct KeccakAir {}
 
 impl KeccakAir {
-    pub fn generate_trace_rows<F: PrimeField64>(&self, num_hashes: usize) -> RowMajorMatrix<F> {
+    pub fn generate_trace_rows<F: PrimeField64>(
+        &self,
+        num_hashes: usize,
+        extra_capacity_bits: usize,
+    ) -> RowMajorMatrix<F> {
         let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
-        generate_trace_rows(inputs)
+        generate_trace_rows(inputs, extra_capacity_bits)
     }
 }
 

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -89,11 +89,12 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
+    let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS, fri_config.log_blowup);
 
     let dft = Dft::default();
 
-    let fri_config = create_benchmark_fri_config(challenge_mmcs);
     type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config, 4, StdRng::from_entropy());
 

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -97,11 +97,12 @@ fn prove_and_verify() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants);
 
-    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS);
+    let fri_config = create_benchmark_fri_config(challenge_mmcs);
+
+    let trace = air.generate_vectorized_trace_rows(NUM_PERMUTATIONS, fri_config.log_blowup);
 
     let dft = Dft::default();
 
-    let fri_config = create_benchmark_fri_config(challenge_mmcs);
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -23,6 +23,7 @@ pub fn generate_vectorized_trace_rows<
 >(
     inputs: Vec<[F; WIDTH]>,
     round_constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
+    extra_capacity_bits: usize,
 ) -> RowMajorMatrix<F> {
     let n = inputs.len();
     assert!(
@@ -33,7 +34,7 @@ pub fn generate_vectorized_trace_rows<
     let nrows = n.div_ceil(VECTOR_LEN);
     let ncols = num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()
         * VECTOR_LEN;
-    let mut vec = Vec::with_capacity(nrows * ncols * 2);
+    let mut vec = Vec::with_capacity((nrows * ncols) << extra_capacity_bits);
     let trace: &mut [MaybeUninit<F>] = &mut vec.spare_capacity_mut()[..nrows * ncols];
     let trace: RowMajorMatrixViewMut<MaybeUninit<F>> = RowMajorMatrixViewMut::new(trace, ncols);
 

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -181,7 +181,11 @@ impl<
         }
     }
 
-    pub fn generate_vectorized_trace_rows(&self, num_hashes: usize) -> RowMajorMatrix<F>
+    pub fn generate_vectorized_trace_rows(
+        &self,
+        num_hashes: usize,
+        extra_capacity_bits: usize,
+    ) -> RowMajorMatrix<F>
     where
         F: PrimeField,
         LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
@@ -197,7 +201,7 @@ impl<
             HALF_FULL_ROUNDS,
             PARTIAL_ROUNDS,
             VECTOR_LEN,
-        >(inputs, &self.air.constants)
+        >(inputs, &self.air.constants, extra_capacity_bits)
     }
 }
 


### PR DESCRIPTION
Currently, when using the `Radix2DitParallel` a surprisingly large amount of time (5 - 10% of full proof time) is spent by "reserve_exact" which takes the trace and reserves more space for the DFT to populate. Strangely, reserving this extra space is massively more expensive than the initial trace generation. (Like 5-6x worse). On the other hand, if we absorb reserving the extra space into the initial trace generation, the cost goes to 0.

Hence this PR adds an extra parameter to the `generate_trace_rows` functions which indicates how much extra capacity to reserve.

This gives a little over a `5%` speed up to the `Keccak` and `Blake` examples. The `Poseidon2` example is unchanged as this had already been implicitly implemented in that case.

The current solution is to call `F::zero_vec` to get vector of zeroes covering full length and then use `.truncate` to reduce the length of the vector to the desired initial length. There might be a cleaner solution which uses `MaybeUnint`'s (As it already done for `Poseidon2`) but I couldn't get this working easily with the way the Blake3/Keccak traces are currently generated.

Bizzarly, running `F::zero_vec` on a larger length and then using `.truncate` is much faster (About 15 micro seconds vs 350 milliseconds so more than 20000 times faster) than running `F::zero_vec` on the initial length and then using `.reserve_exact()` or `.reserve()`. I don't really have any idea why this is the case given that you'd expect these to compile to basically the same thing.