### PR TITLE
Add an associated type for `Pcs::get_evaluations_on_domain` 

### DIFF
--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -27,6 +27,9 @@ where
     /// Data that the prover stores for committed polynomials, to help the prover with opening.
     type ProverData;
 
+    /// Type of the output of `get_evaluations_on_domain`.
+    type EvaluationsOnDomain<'a>: Matrix<Val<Self::Domain>> + 'a;
+
     /// The opening argument.
     type Proof: Clone + Serialize + DeserializeOwned;
 
@@ -46,7 +49,7 @@ where
         prover_data: &'a Self::ProverData,
         idx: usize,
         domain: Self::Domain,
-    ) -> impl Matrix<Val<Self::Domain>> + 'a;
+    ) -> Self::EvaluationsOnDomain<'a>;
 
     fn open(
         &self,

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -49,6 +49,7 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = Vec<Vec<Val>>;
     type ProverData = Vec<RowMajorMatrix<Val>>;
+    type EvaluationsOnDomain<'a> = Dft::Evaluations;
     type Proof = ();
     type Error = ();
 
@@ -94,7 +95,7 @@ where
         prover_data: &'a Self::ProverData,
         idx: usize,
         domain: Self::Domain,
-    ) -> impl Matrix<Val> + 'a {
+    ) -> Self::EvaluationsOnDomain<'a> {
         let mut coeffs = prover_data[idx].clone();
         assert!(domain.log_n >= self.log_n);
         coeffs.values.resize(

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -6,8 +6,10 @@ use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::{Mmcs, OpenedValues, Pcs, TwoAdicMultiplicativeCoset};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::bitrev::BitReversalPerm;
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
+use p3_matrix::row_index_mapped::RowIndexMappedView;
 use p3_matrix::Matrix;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
@@ -58,6 +60,10 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
     type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
+    type EvaluationsOnDomain<'a> = HorizontallyTruncated<
+        Val,
+        RowIndexMappedView<BitReversalPerm, DenseMatrix<Val, &'a [Val]>>,
+    >;
     /// The first item contains the openings of the random polynomials added by this wrapper.
     /// The second item is the usual FRI proof.
     type Proof = (
@@ -95,7 +101,7 @@ where
         prover_data: &'a Self::ProverData,
         idx: usize,
         domain: Self::Domain,
-    ) -> impl Matrix<Val> + 'a {
+    ) -> Self::EvaluationsOnDomain<'a> {
         let inner_evals = <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<
             Challenge,
             Challenger,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -13,8 +13,8 @@ use p3_field::{
     Field, TwoAdicField,
 };
 use p3_interpolation::interpolate_coset;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
@@ -143,6 +143,7 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
     type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
+    type EvaluationsOnDomain<'a> = BitReversedMatrixView<DenseMatrix<Val, &'a [Val]>>;
     type Proof = FriProof<Challenge, FriMmcs, Val, Vec<BatchOpening<Val, InputMmcs>>>;
     type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
 
@@ -179,7 +180,7 @@ where
         prover_data: &'a Self::ProverData,
         idx: usize,
         domain: Self::Domain,
-    ) -> impl Matrix<Val> + 'a {
+    ) -> Self::EvaluationsOnDomain<'a> {
         // todo: handle extrapolation for LDEs we don't have
         assert_eq!(domain.shift, Val::GENERATOR);
         let lde = self.mmcs.get_matrices(prover_data)[idx];


### PR DESCRIPTION
Raise the output of `get_evaluations_on_domain` to an associated type instead of `impl Matrix<..>`.

In response to issue #626 