### PR TITLE
Partial Keccak-AIR revert

### DIFF
--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -44,8 +44,40 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         let local: &KeccakCols<AB::Var> = (*local).borrow();
         let next: &KeccakCols<AB::Var> = (*next).borrow();
 
+        let first_step = local.step_flags[0];
         let final_step = local.step_flags[NUM_ROUNDS - 1];
         let not_final_step = AB::Expr::ONE - final_step;
+
+        // If this is the first step, the input A must match the preimage.
+        for y in 0..5 {
+            for x in 0..5 {
+                for limb in 0..U64_LIMBS {
+                    builder
+                        .when(first_step)
+                        .assert_eq(local.preimage[y][x][limb], local.a[y][x][limb]);
+                }
+            }
+        }
+
+        // If this is not the final step, the local and next preimages must match.
+        for y in 0..5 {
+            for x in 0..5 {
+                for limb in 0..U64_LIMBS {
+                    builder
+                        .when(not_final_step.clone())
+                        .when_transition()
+                        .assert_eq(local.preimage[y][x][limb], next.preimage[y][x][limb]);
+                }
+            }
+        }
+
+        // The export flag must be 0 or 1.
+        builder.assert_bool(local.export);
+
+        // If this is not the final step, the export flag must be off.
+        builder
+            .when(not_final_step.clone())
+            .assert_zero(local.export);
 
         // C'[x, z] = xor(C[x, z], C[x - 1, z], C[x + 1, z - 1]).
         // Note that if all entries of C are boolean, the arithmetic generalization

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -47,13 +47,17 @@ pub fn generate_trace_rows<F: PrimeField64>(
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
 fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], input: [u64; 25]) {
-    // Populate the round input for the first round.
     let mut current_state: [[u64; 5]; 5] = unsafe { transmute(input) };
 
-    for y in 0..5 {
-        for (x, row) in current_state.iter().enumerate() {
-            rows[0].a[y][x] = u64_to_16_bit_limbs(row[y]);
-        }
+    let initial_state: [[[F; 4]; 5]; 5] =
+        array::from_fn(|y| array::from_fn(|x| u64_to_16_bit_limbs(current_state[x][y])));
+
+    // Populate the round input for the first round.
+    rows[0].a = initial_state;
+
+    // Copy rows[0].a to row.preimage for every row.
+    for row in rows.iter_mut() {
+        row.preimage = initial_state;
     }
 
     generate_trace_row_for_round(&mut rows[0], 0, &mut current_state);

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -55,14 +55,13 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], inp
     // Populate the round input for the first round.
     rows[0].a = initial_state;
 
-    // Copy rows[0].a to row.preimage for every row.
-    for row in rows.iter_mut() {
-        row.preimage = initial_state;
-    }
+    rows[0].preimage = initial_state;
 
     generate_trace_row_for_round(&mut rows[0], 0, &mut current_state);
 
     for round in 1..rows.len() {
+        rows[round].preimage = initial_state;
+
         // Copy previous row's output to next row's input.
         for y in 0..5 {
             for x in 0..5 {

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -54,7 +54,6 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(rows: &mut [KeccakCols<F>], inp
 
     // Populate the round input for the first round.
     rows[0].a = initial_state;
-
     rows[0].preimage = initial_state;
 
     generate_trace_row_for_round(&mut rows[0], 0, &mut current_state);


### PR DESCRIPTION
After discussions with @dlubarov, we are partially reverting the KECCAK-AIR changes we made a week or so ago, adding back in the `preimage` and `export` columns.

This makes the AIR a little slower `~(5-8%)` but is a little more realistic for the most common use case where it is handy to have the permutation input and output on the same row.