### PR TITLE
Ensure vectors of matrices have same length as vectors of opening points

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -172,6 +172,11 @@ where
             .iter()
             .map(|(data, points_for_mats)| {
                 let mats = self.mmcs.get_matrices(data);
+                debug_assert_eq!(
+                    mats.len(),
+                    points_for_mats.len(),
+                    "Mismatched number of matrices and points"
+                );
                 izip!(mats, points_for_mats)
                     .map(|(mat, points_for_mat)| {
                         let log_height = log2_strict_usize(mat.height());

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -122,6 +122,8 @@ where
             rounds
                 .into_iter()
                 .map(|(coeffs_for_round, points_for_round)| {
+                    // ensure that each matrix corresponds to a set of opening points
+                    debug_assert_eq!(coeffs_for_round.len(), points_for_round.len());
                     coeffs_for_round
                         .iter()
                         .zip(points_for_round)

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -241,14 +241,18 @@ where
         let mats_and_points = rounds
             .iter()
             .map(|(data, points)| {
-                (
-                    self.mmcs
-                        .get_matrices(data)
-                        .into_iter()
-                        .map(|m| m.as_view())
-                        .collect_vec(),
-                    points,
-                )
+                let mats = self
+                    .mmcs
+                    .get_matrices(data)
+                    .into_iter()
+                    .map(|m| m.as_view())
+                    .collect_vec();
+                debug_assert_eq!(
+                    mats.len(),
+                    points.len(),
+                    "each matrix should have a corresponding set of evaluation points"
+                );
+                (mats, points)
             })
             .collect_vec();
         let mats = mats_and_points


### PR DESCRIPTION
This PR adds a single `debug_assert!` to each of `TwoAdicFriPcs::open()`, `CirclePcs::open()`,
 and `TrivialPcs::open()`, verifying that for each round of batch openings, the vector of 
matrices to be opened has the same length as the vector of sets of opening points. Without this 
check, these functions will silently truncate the larger of these two vectors. This was resulting
in some hard-to-diagnose errors in Valida, where the number of matrices to open in each round 
varies (e.g. because some chips do not have a preprocessed trace). 

