### PR TITLE
fix: addition must be modulo 2^32 in blake3 trace generation to avoid overflows

### DIFF
--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -214,14 +214,14 @@ fn verifiable_half_round(
     let (rot_1, rot_2) = if flag { (8, 7) } else { (16, 12) };
 
     // The first summation:
-    a += b;
-    a += m;
+    a = a.wrapping_add(b);
+    a = a.wrapping_add(m);
 
     // The first xor:
     d = (d ^ a).rotate_right(rot_1);
 
     // The second summation:
-    c += d;
+    c = c.wrapping_add(d);
 
     // The second xor:
     b = (b ^ c).rotate_right(rot_2);


### PR DESCRIPTION
### Bug Description

The trace generation for blake3-air uses simple `u32` addition which leads to overflow. We should instead perform addition modulo $2^{32}$ as per the original blake3 [specification](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) (see page 5).

This problem is on lines 217, 218 and 224 in the function `verifiable_half_round`:
https://github.com/Plonky3/Plonky3/blob/95f9774c435a629a7331d4fbabdb3f5a2b300de0/blake3-air/src/generation.rs#L203-L230

### Bug Verification

To reproduce this issue, run the command on the current `main` branch:
```bash
cargo run --package p3-examples --example prove_prime_field_31 --  --field BabyBear --objective blake-3-permutations --log-trace-length 8 --discrete-fourier-transform radix-2-dit-parallel --merkle-hash KeccakF
```
This crashes with the following error:
```bash
Proving 2^8 Blake-3 permutations
thread 'main' panicked at blake3-air/src/generation.rs:217:5:
attempt to add with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
INFO     generate Blake3 trace [ 195µs | 100.00% ]
```

Note that the bug does not trigger in release mode as overflow checks are disabled for performance, and integers wrap around instead of panicking in release mode.

### Proposed Fix

The fix is to use `wrapping_add` method for `u32` which effectively computes addition modulo $2^{32}$, for instance L217 should change to:
```rust
a = a.wrapping_add(b);
```

Now if you run the same command as above on the branch [`sb/fix-blake3-tracegen`](https://github.com/suyash67/Plonky3/tree/sb/fix-blake3-tracegen) it should pass.

### 