### PR TITLE
Poly crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
         cargo check --verbose --package p3-merkle-tree
         cargo check --verbose --package p3-mersenne-31
         cargo check --verbose --package p3-monolith
+        cargo check --verbose --package p3-poly
         cargo check --verbose --package p3-poseidon
         cargo check --verbose --package p3-poseidon2
         cargo check --verbose --package p3-rescue

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "mersenne-31",
     "monolith",
     "monty-31",
+    "poly",
     "poseidon",
     "poseidon2",
     "poseidon2-air",
@@ -95,6 +96,7 @@ p3-mds = { path = "mds", version = "0.1.0" }
 p3-merkle-tree = { path = "merkle-tree", version = "0.1.0" }
 p3-mersenne-31 = { path = "mersenne-31", version = "0.1.0" }
 p3-monty-31 = { path = "monty-31", version = "0.1.0" }
+p3-poly = { path = "poly", version = "0.1.0" }
 p3-poseidon = { path = "poseidon", version = "0.1.0" }
 p3-poseidon2 = { path = "poseidon2", version = "0.1.0" }
 p3-poseidon2-air = { path = "poseidon2-air", version = "0.1.0" }

--- a/poly/Cargo.toml
+++ b/poly/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "p3-poly"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+p3-dft.workspace = true
+p3-field.workspace = true
+p3-matrix.workspace = true
+itertools.workspace = true
+rand = { workspace = true, optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+
+[dev-dependencies]
+p3-baby-bear.workspace = true
+p3-goldilocks.workspace = true
+rand.workspace = true
+
+[features]
+test-utils = ["dep:rand"]

--- a/poly/README.md
+++ b/poly/README.md
@@ -1,0 +1,54 @@
+# p3-poly
+
+A high-performance Rust crate providing dense univariate polynomial operations over finite fields. The crate is inspired by the [`ark-poly`](https://github.com/arkworks-rs/algebra/tree/master/poly) crate in the arkworks ecosystem.
+
+## Features
+
+- **Unique Representation**: A `Polynomial` is a wrapper around a `Vec<F>`. The API ensures that the polynomial is always stored in canonical form, i.e. that the leading coefficient is non-zero, with the zero polynomial being represented as an empty `Vec<F>`.
+
+- **Basic Operations**:
+  - Standard arithmetic operator overloading for polynomials and constants 
+  - Two multiplication algorithms on `TwoAdicField`s
+    - Naive multiplication for small degrees
+    - FFT-based multiplication for larger polynomials
+  - Degree computation that returns `Option<usize>` for better null case handling
+
+- **Advanced Operations**:
+  - Polynomial evaluation at points using Horner's method
+  - Generation of vanishing polynomials
+  - Lagrange interpolation
+  - Optimized algorithms for common operations:
+    - Division by linear terms (`x - a`)
+    - Multiplication by power polynomials (`1 + rx + r^2x^2 + ... + r^nx^n`)
+
+## Testing
+
+The crate contains a comprehensive test suite that covers all public methods, with a short description of the test case in the doc comments. To run the tests, use the command `cargo test`.
+
+## Adding to your project
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+p3-poly = "0.1"
+```
+
+The crate is `no_std` by default. To access test utility functions like `rand_poly`, enable the `test-utils` feature:
+
+```toml
+[dependencies]
+p3-poly = { version = "0.1", features = ["test-utils"] }
+```
+
+## Performance Considerations
+
+- All polynomial operations are implemented for references only. This design choice follows ark-poly's approach, as implementing operations for both owned values and references can lead to inconsistencies and unnecessary cloning. 
+
+- The overloaded `*` operator is only implemented for polynomials over `TwoAdicField`s. Depending on the degrees of the input polynomials, the operation may be performed using the naive or FFT-based multiplication algorithm.
+
+- Given a set of n points-evaluation pairs, the method `Polynomial::lagrange_interpolate` performs Lagrange interpolation in O(n^2) time. For more efficient evaluation/interpolation over cosets that runs in O(nlog n) time, use the `TwoAdicCoset` methods in the `p3-coset` crate.
+
+## Attribution
+
+Some of the polynomial algorithms in this crate are inspired by or adapted from the arkworks ecosystem. Specific attributions are provided in the relevant code sections.

--- a/poly/src/lib.rs
+++ b/poly/src/lib.rs
@@ -1,0 +1,625 @@
+//! Interface for working with dense univariate polynomials. It offers
+//! polynomial arithmetic, Lagrange interpolation, vanishing polynomials and
+//! many other convenience methods.
+//!
+
+// N. B.: The standard operators are implemented on references to polynomials
+// only.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::clone::Clone;
+use core::iter::Product;
+use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+
+use itertools::{iterate, Itertools};
+use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+use p3_field::{Field, TwoAdicField};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
+/// Polynomial stored as a dense list of coefficients
+///
+/// # Examples
+///
+/// ```
+/// # use p3_poly::Polynomial;
+/// # use p3_field::{Field, TwoAdicField, PrimeCharacteristicRing};
+/// # use p3_baby_bear::BabyBear;
+/// # use rand::Rng;
+/// #
+/// type F = BabyBear;
+/// let mut rng = rand::rng();
+/// let poly = Polynomial::from_coeffs(
+///     (0..10).map(|_| rng.random()).collect()
+/// );
+///
+/// // Polynomial evaluation
+/// let point = rng.random();
+/// assert_eq!(
+///     poly.evaluate(&point),
+///     poly.coeffs().iter().rfold(F::ZERO, |result, coeff| result * point + *coeff)
+/// );
+///
+/// // Polynomials support arithmetic operations with polynomials and field elements
+/// // Note that the operations are implemented on references to polynomials and field elements
+/// let other_poly = Polynomial::from_coeffs((0..10).map(|_| rng.random()).collect());
+/// let constant: F = rng.random();
+///
+/// let _ = &poly + &other_poly;
+/// let _ = &poly - &other_poly;
+/// let _ = &poly + &constant;
+/// let _ = &poly - &constant;
+/// let _ = &poly * &constant;
+/// let _ = &poly / &constant;
+///
+/// // Multiplication can be done using `mul_naive` which uses the
+/// // naive multiplication algorithm, and `mul` which can be used if the
+/// // base field is two-adic. The latter internally chooses whether to use
+/// // FFTs or the naive algorithm depending on the degrees of the polynomials.
+/// assert_eq!(&poly * &other_poly, poly.mul_naive(&other_poly));
+///
+/// // Division can be done using `divide_with_remainder`
+/// // or `Div::div` (i. e. the operator `/`). Note that `Div::div` will panic
+/// // if the remainder is not zero.
+/// let (quotient, remainder) = poly.divide_with_remainder(&other_poly);
+/// assert_eq!(quotient, &(&poly - &remainder) / &other_poly);
+///
+/// // Polynomials can be interpolated at an arbitrary set of points using
+/// // `lagrange_interpolation`. For efficient interpolation over two-adic cosets,
+/// // cf. the `p3-coset` crate.
+/// assert_eq!(
+///     Polynomial::lagrange_interpolation(
+///         vec![(F::ONE, F::ONE), (F::TWO, F::ZERO), (F::ZERO, F::ONE)]
+///     ),
+///     Polynomial::from_coeffs(
+///         vec![F::ONE, F::TWO.inverse(), F::TWO.inverse() - F::ONE]
+///     )
+/// );
+///
+/// // Other utility methods
+/// assert_eq!(
+///     Polynomial::vanishing_linear_polynomial(constant),
+///     Polynomial::from_coeffs(vec![-constant, F::ONE])
+/// );
+/// assert_eq!(poly.compose_with_exponent(2).degree(), Some(18));
+///
+/// let (quotient, remainder) = poly.divide_with_remainder(
+///     &Polynomial::from_coeffs(vec![-constant, F::ONE])
+/// );
+/// assert_eq!(
+///     poly.divide_by_vanishing_linear_polynomial(constant),
+///     (quotient, remainder.coeffs()[0])
+/// );
+/// assert_eq!(
+///     Polynomial::power_polynomial(constant, 3).degree(),
+///     Polynomial::from_coeffs(
+///         vec![F::ONE, constant, constant.exp_const_u64::<2>(), constant.exp_const_u64::<3>()]
+///     )
+///     .degree()
+/// );
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Serialize, Deserialize)]
+#[serde(bound(deserialize = "Vec<F>: Deserialize<'de>",))]
+pub struct Polynomial<F: Field> {
+    // The coefficient of `x^i` is stored at location `i` in `self.coeffs`. It
+    // is important for this field to remain private, as leading-zeroes trimming
+    // is handled internally and is abstracted from the user.
+    coeffs: Vec<F>,
+}
+
+impl<F: Field> Polynomial<F> {
+    /// Returns the coefficients of the polynomial in increasing-degree order
+    /// with no leading zeros
+    pub fn coeffs(&self) -> &[F] {
+        // This never has leading zeros for users of the public interface
+        &self.coeffs
+    }
+
+    /// Returns the leading coefficient of the polynomial
+    pub fn leading_coeff(&self) -> F {
+        *self.coeffs.last().unwrap_or(&F::ZERO)
+    }
+
+    /// Returns the zero polynomial
+    pub fn zero() -> Self {
+        Self { coeffs: vec![] }
+    }
+
+    /// Returns the constant polynomial 1
+    pub fn one() -> Self {
+        Self::constant(F::ONE)
+    }
+
+    /// Returns the polynomial with the given coefficients. Leading zeros are automatically trimmed.
+    pub fn from_coeffs(coeffs: Vec<F>) -> Self {
+        Self { coeffs }.truncate_leading_zeros()
+    }
+
+    /// Returns the constant term of the polynomial
+    pub fn constant_term(&self) -> F {
+        *self.coeffs.first().unwrap_or(&F::ZERO)
+    }
+
+    /// Returns the constant polynomial with the given constant term
+    pub fn constant(constant: F) -> Self {
+        Self {
+            coeffs: vec![constant],
+        }
+    }
+
+    /// Returns the unique monic polynomial of degree 1 with no constant term
+    pub fn x() -> Self {
+        Self {
+            coeffs: vec![F::ZERO, F::ONE],
+        }
+    }
+
+    /// Returns the linear polynomial `x - point`
+    pub fn vanishing_linear_polynomial(point: F) -> Self {
+        Self {
+            coeffs: vec![-point, F::ONE],
+        }
+    }
+
+    // Internal method which eliminates leading zeros from the polynomial,
+    // mutating the polynomial and returning it.
+    fn truncate_leading_zeros(mut self) -> Self {
+        if self.is_zero() || !self.coeffs.last().unwrap().is_zero() {
+            return self;
+        }
+
+        let mut leading_index = self.coeffs.len() - 1;
+
+        while self.coeffs[leading_index].is_zero() {
+            if leading_index == 0 {
+                return Self::zero();
+            }
+
+            leading_index -= 1;
+        }
+
+        self.coeffs.truncate(leading_index + 1);
+
+        self
+    }
+
+    /// Evaluates `self` at the given `point` using Horner's method
+    pub fn evaluate(&self, point: &F) -> F {
+        self.coeffs
+            .iter()
+            .rfold(F::ZERO, move |result, coeff| result * *point + *coeff)
+    }
+
+    /// Returns `None` if self is the zero polynomial and `Some(d)` if `self` is
+    /// a (non-zero) polynomial of degree `d`
+    pub fn degree(&self) -> Option<usize> {
+        if self.is_zero() {
+            None
+        } else {
+            Some(self.coeffs.len() - 1)
+        }
+    }
+
+    /// Returns `true` if and only if `self` is the zero polynomial
+    pub fn is_zero(&self) -> bool {
+        self.coeffs.is_empty()
+    }
+
+    /// Returns `true` if and only if `self` is a constant polynomial
+    pub fn is_constant(&self) -> bool {
+        self.coeffs.len() <= 1
+    }
+
+    /// Returns the unique polynomials `q` and `r` such that
+    /// `self = q * divisor + r` and `r` is zero or has degree less than
+    /// `divisor`
+    ///
+    /// # Panics
+    ///
+    /// Panics if `divisor` is the zero polynomial
+    // ** Credit to Arkworks/algebra for the core of the algorithm **
+    pub fn divide_with_remainder(&self, divisor: &Self) -> (Self, Self) {
+        let d_deg = divisor
+            .degree()
+            .expect("Cannot divide by the zero polynomial");
+
+        // Trivial division cases
+        if self.is_zero() {
+            return (Self::zero(), Self::zero());
+        }
+
+        let d_self = self.degree().unwrap();
+
+        if d_self < d_deg {
+            return (Self::zero(), self.clone());
+        }
+
+        let mut quotient_coeffs = vec![F::ZERO; d_self - d_deg + 1];
+        let mut remainder = self.clone();
+
+        let divisor_leading_coeff_inv = divisor.coeffs.last().unwrap().inverse();
+
+        // Ieratively compute the coefficients of the quotient
+        while !remainder.is_zero() && remainder.degree().unwrap() >= d_deg {
+            let cur_q_coeff = *remainder.coeffs.last().unwrap() * divisor_leading_coeff_inv;
+            let cur_q_degree = remainder.degree().unwrap() - d_deg;
+            quotient_coeffs[cur_q_degree] = cur_q_coeff;
+
+            for (i, div_coeff) in divisor.coeffs.iter().cloned().enumerate() {
+                remainder.coeffs[cur_q_degree + i] -= cur_q_coeff * div_coeff;
+            }
+            while let Some(true) = remainder.coeffs.last().map(|c| c.is_zero()) {
+                remainder.coeffs.pop();
+            }
+        }
+
+        (
+            Polynomial::from_coeffs(quotient_coeffs),
+            remainder.truncate_leading_zeros(),
+        )
+    }
+
+    /// Returns the quotient and remainder of the division of `self` by `x -
+    /// point`. Since the remainder is the constant polynomial with value
+    /// `self(point)`, it is directly returned as field element for convenience.
+    pub fn divide_by_vanishing_linear_polynomial(&self, point: F) -> (Self, F) {
+        if self.is_zero() {
+            return (Self::zero(), F::ZERO);
+        }
+
+        // Special case: division by x - 0 = 0
+        if point == F::ZERO {
+            let mut quotient_coeffs = self.coeffs.clone();
+            let remainder = quotient_coeffs.remove(0);
+            return (Polynomial::from_coeffs(quotient_coeffs), remainder);
+        }
+
+        // General case: use Ruffini's rule
+        let mut quotient_coeffs = self.coeffs.clone();
+
+        let mut quotient_coeffs_iter = quotient_coeffs.iter_mut().rev();
+
+        let mut last = *quotient_coeffs_iter.next().unwrap();
+
+        for new_c in quotient_coeffs_iter {
+            *new_c += point * last;
+            last = *new_c;
+        }
+
+        let remainder = quotient_coeffs.remove(0);
+
+        (Polynomial::from_coeffs(quotient_coeffs), remainder)
+    }
+
+    /// Returns the unique monic polynomial of degree equal to the number
+    /// of _distinct_ elements in `points` that vanishes at each
+    /// of those elements, that is, `(x - distinct_points[0]) * (x -
+    /// distinct_points[1]) * ... * (x - distinct_points[n - 1])`, where
+    /// `distinct_points` contains the distinct elements of `points` and `n` is
+    /// its length.
+    ///     
+    /// # Panics
+    ///
+    /// Panics if `points` is empty
+    pub fn vanishing_polynomial(points: impl IntoIterator<Item = F>) -> Polynomial<F> {
+        // Deduplicating the points
+        let mut points = points.into_iter().unique().collect_vec();
+
+        assert!(
+            !points.is_empty(),
+            "The vanishing polynomial of an empty set is undefined"
+        );
+
+        // We iteratively multiply the polynomial (x - points[0]) by each of the
+        // vanishing polynomials (x - points[i]) for i > 0
+        let mut coeffs = vec![-points.pop().unwrap(), F::ONE];
+
+        while let Some(point) = points.pop() {
+            // Basic idea: add shifted and scaled versions of the current polynomial
+            // For instance, if f has coefficients
+            //   [2, -3, 4, 1],
+            // then (x - 5) * f has coefficients
+            //   [0, 2, -3, 4, 1] + (-5) * [2, -3, 4, 1, 0]
+
+            let mut prev_coeff = F::ZERO;
+
+            for coeff in coeffs.iter_mut() {
+                let current_coeff = *coeff;
+                *coeff = prev_coeff - *coeff * point;
+                prev_coeff = current_coeff;
+            }
+
+            coeffs.push(F::ONE);
+        }
+
+        Polynomial::from_coeffs(coeffs)
+    }
+
+    /// Returns the unique polynomial of degree less than the number of
+    /// (distinct) pairs in `point_to_evals` that evaluates to `y_i` at `x_i`
+    /// for all `i`, where `(x_i, y_i)` denotes `point_to_evals[i]`. If two
+    /// points in `point_to_evals` have the same x coordinate, the following
+    /// happens:
+    /// - If their evaluations do not match, the function `panic`s.
+    /// - If their evaluations match, the function proceeds normally (note that
+    ///   this reduces expected degree by one).
+    ///
+    /// This distinction allows the function to be called transparently in
+    /// situations where, for instance, the x coordinates are generated randomly
+    /// and the evaluations come from evaluating a (larger-degree) polynomial.
+    ///
+    /// This method uses Lagrange interpolation, which has quadratic runtime in
+    /// the number of (distinct) pairs in `point_to_evals`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if
+    ///
+    /// - `point_to_evals` is empty
+    /// - `point_to_evals` has two points (i. e. x coordinates) with different
+    ///    requested evaluation (i. e. y coordinates)
+    pub fn lagrange_interpolation(point_to_evals: Vec<(F, F)>) -> Polynomial<F> {
+        if point_to_evals.is_empty() {
+            panic!("The Lagrange interpolation of an empty set is undefined");
+        }
+
+        // Testing for consistency and removing duplicate points
+        let point_to_evals = point_to_evals.into_iter().unique().collect_vec();
+
+        let points = point_to_evals
+            .iter()
+            .map(|(x, _)| *x)
+            .unique()
+            .collect_vec();
+
+        assert_eq!(
+            points.len(),
+            point_to_evals.len(),
+            "One point has two different requested evaluations"
+        );
+
+        let vanishing_poly = Self::vanishing_polynomial(points);
+
+        let mut result = Polynomial::zero();
+
+        for (point, eval) in point_to_evals.into_iter() {
+            // We obtain the (non-normalised) vanishing polynomial at all points
+            // other than point by removing the (x - point) factor from the full
+            // vanishing polynomial
+            let (polynomial, _) = vanishing_poly.divide_by_vanishing_linear_polynomial(point);
+
+            // We normalise it so that it takes the value `eval` at `point`
+            let denominator = polynomial.evaluate(&point);
+            result += &(&polynomial * &(eval / denominator));
+        }
+
+        result
+    }
+
+    /// Returns the composition of `self` with the polynomial `x^exponent`. In
+    /// other words, if `self` is given by `f(x)`, the result is `f(x^exponent)`.
+    pub fn compose_with_exponent(&self, exponent: usize) -> Polynomial<F> {
+        let d = if let Some(d) = self.degree() {
+            d
+        } else {
+            return Polynomial::zero();
+        };
+
+        // We "stretch out" the vector of coefficients by a factor of exponent
+        // filling the gaps with zeros
+        let mut coeffs = vec![F::ZERO; d * exponent + 1];
+
+        for (i, coeff) in self.coeffs.iter().enumerate() {
+            coeffs[i * exponent] = *coeff;
+        }
+
+        Polynomial::from_coeffs(coeffs)
+    }
+
+    /// Returns the polynomial `1 + r * x + r^2 * x^2 + ... + r^degree * x^degree`
+    pub fn power_polynomial(r: F, degree: usize) -> Polynomial<F> {
+        if r == F::ZERO {
+            Polynomial::one()
+        } else {
+            Polynomial::from_coeffs(iterate(F::ONE, |&prev| prev * r).take(degree + 1).collect())
+        }
+    }
+
+    /// Multiplies `self` and `other` using the standard naive algorithm (i. e.
+    /// the Cauchy product of the coefficients). If `F: TwoAdicField`, instead
+    /// consider using [`mul`](Mul::mul) or, equivalently, the operator `*`, which selects
+    /// the naive algorithm or the FFT depending on the degrees of the two
+    /// factors.
+    pub fn mul_naive(&self, other: &Self) -> Self {
+        if self.is_zero() || other.is_zero() {
+            return Self::zero();
+        }
+
+        let mut coeffs = vec![F::ZERO; self.coeffs.len() + other.coeffs.len() - 1];
+
+        for (i, &c1) in self.coeffs.iter().enumerate() {
+            for (j, &c2) in other.coeffs.iter().enumerate() {
+                coeffs[i + j] += c1 * c2;
+            }
+        }
+
+        Polynomial::from_coeffs(coeffs)
+    }
+}
+
+impl<'a, F: Field> Add<&'a Polynomial<F>> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn add(self, other: &'a Polynomial<F>) -> Polynomial<F> {
+        if self.is_zero() {
+            return other.clone();
+        } else if other.is_zero() {
+            return self.clone();
+        };
+
+        let (mut high, low) = if self.degree() >= other.degree() {
+            (self.clone(), other.clone())
+        } else {
+            (other.clone(), self.clone())
+        };
+
+        high.coeffs.iter_mut().zip(&low.coeffs).for_each(|(a, &b)| {
+            *a += b;
+        });
+
+        high.truncate_leading_zeros()
+    }
+}
+
+impl<F: Field> AddAssign<&Polynomial<F>> for Polynomial<F> {
+    fn add_assign(&mut self, other: &Polynomial<F>) {
+        *self = &*self + other;
+    }
+}
+
+impl<F: Field> Neg for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    #[inline]
+    fn neg(self) -> Polynomial<F> {
+        Polynomial {
+            coeffs: self.coeffs.iter().map(|&c| -c).collect(),
+        }
+    }
+}
+
+impl<F: Field> Sub<&Polynomial<F>> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn sub(self, other: &Polynomial<F>) -> Polynomial<F> {
+        self + &(-other)
+    }
+}
+
+/// Multiply the two polynomials using FFTs or the naive multiplication
+/// algorithm depending on what is expected to be faster based on their
+/// degrees.
+impl<F: TwoAdicField> Mul<&Polynomial<F>> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn mul(self, other: &Polynomial<F>) -> Polynomial<F> {
+        if self.is_zero() || other.is_zero() {
+            return Polynomial::zero();
+        }
+
+        let d_self = self.degree().unwrap();
+        let d_other = other.degree().unwrap();
+
+        let fft_domain_size = (d_self + d_other + 1).next_power_of_two();
+        let fft_domain_size_log = fft_domain_size.ilog2() as usize;
+
+        // This is only a rough estimate to avoid doing three [i]FFTs in very
+        // imbalanced cases (such as large poly times constant or deg-two poly).
+        // Only multiplications are taken into account.
+        let fft_cost = 3 * fft_domain_size * fft_domain_size_log + fft_domain_size;
+        let naive_cost = (d_self + 1) * (d_other + 1);
+
+        // We also use the naive algorithm in the unlikely case the poylnomials
+        // are so large that the two-adicity of F* does not support an FFT
+        // therein
+        if fft_cost > naive_cost || fft_domain_size_log > F::TWO_ADICITY {
+            return self.mul_naive(other);
+        }
+
+        let mut extended_self = self.coeffs.clone();
+        let mut extended_other = other.coeffs.clone();
+
+        extended_self.resize(fft_domain_size, F::ZERO);
+        extended_other.resize(fft_domain_size, F::ZERO);
+
+        let coeffs = RowMajorMatrix::new(
+            extended_self.into_iter().chain(extended_other).collect(),
+            fft_domain_size,
+        )
+        .transpose();
+
+        let fft = Radix2Dit::default();
+
+        // Evaluate the polynomials over the domain
+        let dft: RowMajorMatrix<F> = fft.dft_batch(coeffs).transpose();
+
+        // Multiply the polynomial evaluations pointwise
+        let eval_products = dft
+            .first_row()
+            .zip(dft.last_row())
+            .map(|(a, b): (F, F)| a * b)
+            .collect_vec();
+
+        // Interpolating the evaluations with an inverse FFT
+        Polynomial::from_coeffs(fft.idft(eval_products))
+    }
+}
+
+/// Exact polynomial division (using the classical algorithm).
+///
+/// # Panics
+///
+/// Panics if the remainder is not zero. If this is not guaranteed, use
+/// [`divide_with_remainder`](Polynomial::divide_with_remainder) instead.
+impl<F: TwoAdicField> Div<&Polynomial<F>> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn div(self, other: &Polynomial<F>) -> Polynomial<F> {
+        let (q, r) = self.divide_with_remainder(other);
+        assert!(
+            r.is_zero(),
+            "Non-zero remainder is not zero. Consider using `divide_with_remainder` instead."
+        );
+        q
+    }
+}
+
+impl<F: TwoAdicField> Product<Polynomial<F>> for Polynomial<F> {
+    fn product<I: Iterator<Item = Polynomial<F>>>(iter: I) -> Self {
+        iter.fold(Polynomial::one(), |acc, p| &acc * &p)
+    }
+}
+
+impl<F: Field> Add<&F> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn add(self, other: &F) -> Polynomial<F> {
+        self + &Polynomial::from_coeffs(vec![*other])
+    }
+}
+
+impl<F: Field> Sub<&F> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn sub(self, other: &F) -> Polynomial<F> {
+        self - &Polynomial::from_coeffs(vec![*other])
+    }
+}
+
+impl<F: Field> Mul<&F> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn mul(self, other: &F) -> Polynomial<F> {
+        Polynomial::from_coeffs(self.coeffs.iter().map(|&c| c * *other).collect())
+    }
+}
+
+impl<F: Field> Div<&F> for &Polynomial<F> {
+    type Output = Polynomial<F>;
+
+    fn div(self, other: &F) -> Polynomial<F> {
+        Polynomial::from_coeffs(self.coeffs.iter().map(|&c| c * other.inverse()).collect())
+    }
+}

--- a/poly/src/test_utils.rs
+++ b/poly/src/test_utils.rs
@@ -1,0 +1,30 @@
+use alloc::vec::Vec;
+
+use p3_field::Field;
+use rand::distr::{Distribution, StandardUniform};
+use rand::Rng;
+
+use crate::Polynomial;
+
+// In order to use this auxiliary functionality, activate the `test-utils`
+// feature
+
+/// Returns a random polynomial of the exact given degree.
+pub fn rand_poly<F: Field>(degree: usize) -> Polynomial<F>
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = rand::rng();
+
+    let mut coeffs: Vec<F> = (0..degree).map(|_| rng.random()).collect();
+
+    let mut leading_coeff = F::ZERO;
+
+    while leading_coeff == F::ZERO {
+        leading_coeff = rng.random();
+    }
+
+    coeffs.push(leading_coeff);
+
+    Polynomial::from_coeffs(coeffs)
+}

--- a/poly/src/tests.rs
+++ b/poly/src/tests.rs
@@ -1,0 +1,560 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use itertools::Itertools;
+use p3_baby_bear::BabyBear;
+use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
+use p3_goldilocks::Goldilocks;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
+use rand::Rng;
+
+use crate::test_utils::rand_poly;
+use crate::Polynomial;
+
+type BB = BabyBear;
+type GL = Goldilocks;
+
+const TEST_ITERATIONS: usize = 30;
+
+fn field_element_from_i64<F: Field>(x: i64) -> F {
+    let sign = if x >= 0 { F::ONE } else { -F::ONE };
+    let value = F::from_u64(x.unsigned_abs());
+    sign * value
+}
+
+fn field_elements_from_i64<F: Field>(xs: Vec<i64>) -> Vec<F> {
+    xs.into_iter().map(|x| field_element_from_i64(x)).collect()
+}
+
+#[test]
+// Checks that leading zeros are trimmed appropriately
+fn test_trimmed_coeffs() {
+    let coeffs: Vec<GL> = field_elements_from_i64(vec![1, 9, -9, 2, 0, -3, 0, 0]);
+    let poly = Polynomial::from_coeffs(coeffs);
+
+    assert_eq!(
+        poly.coeffs,
+        field_elements_from_i64(vec![1, 9, -9, 2, 0, -3])
+    );
+
+    let coeffs = vec![GL::ZERO; 22];
+    let poly = Polynomial::from_coeffs(coeffs);
+
+    assert_eq!(poly.coeffs, vec![]);
+}
+
+#[test]
+// Checks the evaluate method manually and using an FFT
+fn test_evaluate() {
+    // a(x) = 3 + 2x + 5x^2 + 6x^3 + 8x^4
+    let mut a_coeffs = field_elements_from_i64(vec![3, 2, 5, 6, 8]);
+
+    let a = Polynomial::from_coeffs(a_coeffs.clone());
+    let x = GL::ONE;
+    let y = a.evaluate(&x);
+    assert_eq!(y, GL::from_u32(24));
+
+    a_coeffs.resize(8, GL::ZERO);
+    let dft = Radix2Dit::default();
+    let a_evals = dft
+        .dft_batch(RowMajorMatrix::new(a_coeffs, 1))
+        .transpose()
+        .first_row()
+        .collect_vec();
+
+    let gen = GL::two_adic_generator(3);
+
+    for (index, expected) in a_evals.into_iter().enumerate() {
+        let point = gen.exp_u64(index as u64);
+        assert_eq!(a.evaluate(&point), expected);
+    }
+}
+
+#[test]
+// Checks addition, subtraction, multiplication, and division where both operands
+// are polynomials. The expected result is computed manually.
+fn test_ops_manual() {
+    // a(x) = 3 + 2x + 5x^2 + 6x^3
+    let a_coeffs: Vec<BB> = field_elements_from_i64(vec![3, 2, 5, 6]);
+
+    // b(x) = 1 + 2x + 3x^2 + 4x^3 + 5x^4 + 7x^5 + 8x^6
+    let b_coeffs: Vec<BB> = field_elements_from_i64(vec![1, 2, 3, 4, 5, 7, 8]);
+
+    // a(x) + b(x) = 4 + 4x + 8x^2 + 10x^3 + 5x^4 + 7x^5 + 8x^6
+    let expected_coeffs_add = field_elements_from_i64(vec![4, 4, 8, 10, 5, 7, 8]);
+
+    // a(x) - b(x) = 2 + 0x + 2x^2 + 2x^3 - 5x^4 - 7x^5 - 8x^6
+    let expected_coeffs_sub = field_elements_from_i64(vec![2, 0, 2, 2, -5, -7, -8]);
+
+    // a(x) * b(x) = 3 + 8x + 18x^2 + 34x^3 + 50x^4 + 69x^5 + 87x^6 + 81x^7 + 82x^8 + 48x^9
+    let expected_coeffs_mul = field_elements_from_i64(vec![3, 8, 18, 34, 50, 69, 87, 81, 82, 48]);
+
+    // b(x) / a(x) =  (q(x), r(x))
+
+    // q(x) = -197/648 + (37 x)/108 + x^2/18 + (4 x^3)/3
+    let q_coeffs_noms: Vec<BB> = field_elements_from_i64(vec![-197, 37, 1, 4]);
+    let q_coeffs_denoms: Vec<BB> = field_elements_from_i64(vec![648, 108, 18, 3]);
+    let expected_coeffs_q = q_coeffs_noms
+        .into_iter()
+        .zip(q_coeffs_denoms)
+        .map(|(n, d)| n * d.inverse())
+        .collect_vec();
+
+    // r(x) = 413/216 + (128 x)/81 + (2377 x^2)/648
+    let r_coeffs_noms: Vec<BB> = field_elements_from_i64(vec![413, 128, 2377]);
+    let r_coeffs_denoms: Vec<BB> = field_elements_from_i64(vec![216, 81, 648]);
+    let expected_coeffs_r = r_coeffs_noms
+        .into_iter()
+        .zip(r_coeffs_denoms)
+        .map(|(n, d)| n * d.inverse())
+        .collect_vec();
+
+    let a = Polynomial::from_coeffs(a_coeffs);
+    let b = Polynomial::from_coeffs(b_coeffs);
+
+    let add = &a + &b;
+    assert_eq!(add.coeffs, expected_coeffs_add);
+
+    let sub = &a - &b;
+    assert_eq!(sub.coeffs, expected_coeffs_sub);
+
+    let mul = &a.mul_naive(&b);
+    assert_eq!(mul.coeffs, expected_coeffs_mul);
+
+    let (q, r) = &b.divide_with_remainder(&a);
+    assert_eq!(q.coeffs, expected_coeffs_q);
+    assert_eq!(r.coeffs, expected_coeffs_r);
+}
+
+#[test]
+// Checks addition, subtraction, multiplication, and division where both operands
+// are polynomials. Correctness is checked by evaluating at ()(degree + 1) points.
+fn test_ops_random() {
+    let mut rng = rand::rng();
+
+    for _ in 0..TEST_ITERATIONS {
+        let deg_a: usize = rng.random_range(0..100);
+        let a = rand_poly::<GL>(100);
+
+        let deg_b: usize = rng.random_range(0..100);
+        let b = rand_poly::<GL>(100);
+
+        let add = &a + &b;
+        let sub = &a - &b;
+        let mul = &a * &b;
+        let (q, r) = &a.divide_with_remainder(&b);
+
+        // In the case of addition, subtraction and multiplication, this tests
+        // at more points than necessary (which would be degree + 1), but these
+        // checks are cheap
+        for i in 0..(deg_a + deg_b + 1) {
+            let i_f = GL::from_u32(i as u32);
+            assert_eq!(add.evaluate(&i_f), a.evaluate(&i_f) + b.evaluate(&i_f));
+            assert_eq!(sub.evaluate(&i_f), a.evaluate(&i_f) - b.evaluate(&i_f));
+            assert_eq!(mul.evaluate(&i_f), a.evaluate(&i_f) * b.evaluate(&i_f));
+            assert_eq!(
+                a.evaluate(&i_f),
+                q.evaluate(&i_f) * b.evaluate(&i_f) + r.evaluate(&i_f)
+            );
+        }
+    }
+}
+
+#[test]
+// Checks that addition and subtraction operations that produce polynomials with leading
+// zeros are correctly trimmed.
+fn test_ops_leading_zeros() {
+    // a(x) = 3 + 2x + 5x^2 + 6x^3
+    let a_coeffs: Vec<BB> = field_elements_from_i64(vec![3, 2, 5, 6, 5, 7, 8]);
+
+    // b_add(x) = 1 + 2x + 3x^2 + 4x^3 - 5x^4 - 7x^5 - 8x^6
+    let b_add_coeffs: Vec<BB> = field_elements_from_i64(vec![1, 2, 3, 4, -5, -7, -8]);
+
+    // a(x) + b_add(x) = 4 + 4x + 8x^2 + 10x^3
+    let expected_coeffs_add = field_elements_from_i64(vec![4, 4, 8, 10]);
+
+    // b_sub(x) = 2 + 0x + 2x^2 + 2x^3 + 5x^4 + 7x^5 + 8x^6
+    let b_sub_coeffs: Vec<BB> = field_elements_from_i64(vec![1, 2, 3, 4, 5, 7, 8]);
+
+    // a(x) - b_sub(x) = 4 + 4x + 8x^2 + 10x^3
+    let expected_coeffs_sub = field_elements_from_i64(vec![2, 0, 2, 2]);
+
+    let a = Polynomial::from_coeffs(a_coeffs);
+    let b_add = Polynomial::from_coeffs(b_add_coeffs);
+    let b_sub = Polynomial::from_coeffs(b_sub_coeffs);
+
+    let add = &a + &b_add;
+    assert_eq!(add.coeffs, expected_coeffs_add);
+
+    let sub = &a - &b_sub;
+    assert_eq!(sub.coeffs, expected_coeffs_sub);
+}
+
+#[test]
+// Checks addition, subtraction, multiplication, and division where the right operand is
+// a random constant. Correctness is checked by manually computing the expected result.
+fn test_ops_constants() {
+    let mut rng = rand::rng();
+
+    for _ in 0..TEST_ITERATIONS {
+        let deg = rng.random_range(1..20);
+
+        let polynomial: Polynomial<GL> = rand_poly(deg);
+        let constant = GL::from_u32(rng.random_range(1..100));
+
+        let expected_add = {
+            let mut coeffs = polynomial.coeffs.clone();
+            coeffs[0] += constant;
+            Polynomial::from_coeffs(coeffs)
+        };
+
+        let expected_sub = {
+            let mut coeffs = polynomial.coeffs.clone();
+            coeffs[0] -= constant;
+            Polynomial::from_coeffs(coeffs)
+        };
+
+        let expected_mul = {
+            let mut coeffs = polynomial.coeffs.clone();
+            for c in coeffs.iter_mut() {
+                *c *= constant;
+            }
+            Polynomial::from_coeffs(coeffs)
+        };
+
+        let expected_div = {
+            let mut coeffs = polynomial.coeffs.clone();
+            for c in coeffs.iter_mut() {
+                *c *= constant.inverse();
+            }
+            Polynomial::from_coeffs(coeffs)
+        };
+
+        assert_eq!(&polynomial + &constant, expected_add);
+        assert_eq!(&polynomial - &constant, expected_sub);
+        assert_eq!(&polynomial * &constant, expected_mul);
+        assert_eq!(&polynomial / &constant, expected_div);
+    }
+}
+
+#[test]
+// Checks that operations where one of the polynomials is zero (in the case of
+// division: always the dividend) yields the expected results
+fn test_ops_zero() {
+    let mut rng = rand::rng();
+
+    let zero_poly: Polynomial<GL> = Polynomial::zero();
+
+    for _ in 0..TEST_ITERATIONS {
+        let deg = rng.random_range(0..20);
+
+        // op can never be the zero polynomial (degree 0 corresponds to non-zero constants)
+        let op = rand_poly(deg);
+
+        assert_eq!(&op + &zero_poly, op);
+        assert_eq!(&zero_poly + &op, op);
+
+        assert_eq!(&op - &zero_poly, op);
+        assert_eq!(&zero_poly - &op, -&op);
+
+        assert_eq!(&op * &zero_poly, zero_poly);
+        assert_eq!(&zero_poly * &op, zero_poly);
+
+        let (q, r) = zero_poly.divide_with_remainder(&op);
+        assert_eq!(q, zero_poly);
+        assert_eq!(r, zero_poly);
+    }
+}
+
+#[test]
+#[should_panic(expected = "Cannot divide by the zero polynomial")]
+// Checks that division by zero panics
+fn test_div_by_zero() {
+    let a = rand_poly::<BB>(100);
+    a.divide_with_remainder(&Polynomial::zero());
+}
+
+#[test]
+#[should_panic(expected = "Cannot divide by the zero polynomial")]
+// Checks that dividing zero by zero also panics
+fn test_div_zero_by_zero() {
+    Polynomial::<GL>::zero().divide_with_remainder(&Polynomial::zero());
+}
+
+#[test]
+// Checks that multiplication using the FFT and the naive algorithm return the
+// same result
+fn test_mul_fft_naive_consistency() {
+    for _ in 0..TEST_ITERATIONS {
+        let a = rand_poly::<GL>(63);
+        let b = rand_poly::<GL>(64);
+
+        // This uses the FFT algorithm due to the chosen degrees
+        let prod = &a * &b;
+
+        assert_eq!(prod, a.mul_naive(&b));
+    }
+}
+
+#[test]
+// Checks that Lagrange interpolation yields the expected polynomial
+fn test_lagrange_interpolation() {
+    let mut rng = rand::rng();
+
+    for _ in 0..TEST_ITERATIONS {
+        let deg = rng.random_range(15..20);
+
+        let polynomial = rand_poly::<GL>(deg);
+
+        let mut points = Vec::new();
+
+        while points.len() < deg + 1 {
+            let point = field_element_from_i64(rng.random::<i64>());
+            if !points.contains(&point) {
+                points.push(point);
+            }
+        }
+
+        let evals = points.iter().map(|p| polynomial.evaluate(p)).collect_vec();
+
+        let interpolator =
+            Polynomial::lagrange_interpolation(points.into_iter().zip(evals).collect_vec());
+        assert_eq!(interpolator, polynomial);
+    }
+}
+
+#[test]
+#[should_panic(expected = "One point has two different requested evaluations")]
+// Checks that Lagrange interpolation panics when two different evaluations are requested of the
+fn test_lagrange_interpolation_with_inconsistent_evals() {
+    let point_to_evals: Vec<(GL, GL)> = vec![(3, 4), (2, 6), (8, 7), (9, 15), (3, 5)]
+        .into_iter()
+        .map(|(p, e)| (field_element_from_i64(p), field_element_from_i64(e)))
+        .collect();
+    Polynomial::<GL>::lagrange_interpolation(point_to_evals);
+}
+
+#[test]
+#[should_panic(expected = "The Lagrange interpolation of an empty set is undefined")]
+// Checks that Lagrange interpolation panics when the set of points is empty
+fn test_lagrange_interpolation_empty() {
+    Polynomial::<GL>::lagrange_interpolation(Vec::new());
+}
+
+#[test]
+// Checks that Lagrange interpolation correctly handles duplicate (point,
+// evaluation) pairs
+fn test_lagrange_interpolation_duplicates() {
+    let mut rng = rand::rng();
+
+    for _ in 0..10 * TEST_ITERATIONS {
+        let num_points = rng.random_range(15..20);
+        let num_duplicates = rng.random_range(1..num_points);
+
+        let deg = num_points - num_duplicates - 1;
+
+        let polynomial = rand_poly::<GL>(deg);
+
+        let mut points = Vec::new();
+
+        // Creating a list of distinct points
+        while points.len() < deg + 1 {
+            let point = field_element_from_i64(rng.random::<i64>());
+            if !points.contains(&point) {
+                points.push(point);
+            }
+        }
+
+        // Adding duplicate points
+        for _ in 0..num_duplicates {
+            let index = rng.random_range(0..points.len());
+            points.push(points[index]);
+        }
+
+        let evals = points.iter().map(|p| polynomial.evaluate(p)).collect_vec();
+
+        let interpolator =
+            Polynomial::lagrange_interpolation(points.into_iter().zip(evals).collect_vec());
+        assert_eq!(interpolator, polynomial);
+    }
+}
+
+#[test]
+// Checks the correctness of compose_with_exponent by manually calculating the
+// expected result. Ensures the output matches the input when given a constant
+// or zero polynomial as input.
+fn test_compose_with_exponent() {
+    let rng = &mut rand::rng();
+
+    // p(x) = 3 + 2x + 6x^2 + 7x^3 + 9x^4
+    let polynomial = Polynomial::<BB>::from_coeffs(field_elements_from_i64(vec![3, 2, 6, 7, 9]));
+
+    let zero_poly = Polynomial::<BB>::zero();
+
+    let constant_poly = Polynomial::<BB>::constant(BB::from_u32(rng.random()));
+
+    let exponent = 3;
+
+    // p(x^3) = 3 + 2x^3 + 6x^6 + 7x^9 + 9x^12
+    assert_eq!(
+        polynomial.compose_with_exponent(exponent).coeffs(),
+        field_elements_from_i64(vec![3, 0, 0, 2, 0, 0, 6, 0, 0, 7, 0, 0, 9])
+    );
+
+    assert_eq!(zero_poly.compose_with_exponent(exponent), zero_poly);
+
+    assert_eq!(constant_poly.compose_with_exponent(exponent), constant_poly);
+}
+
+#[test]
+// Checks that vanishing_polynomial returns the expected polynomial computed
+// manually
+fn test_vanishing_manual() {
+    let points = field_elements_from_i64(vec![3, -5, 7, 2]);
+
+    // p(x) = (x - 3)(x + 5)(x - 7)(x - 2) = -210 + 163x - 19x^2 - 7x^3 + x^4
+    let expected_poly =
+        Polynomial::<BB>::from_coeffs(field_elements_from_i64(vec![-210, 163, -19, -7, 1]));
+
+    assert_eq!(
+        Polynomial::<BB>::vanishing_polynomial(points),
+        expected_poly
+    );
+}
+
+#[test]
+// Checks that vanishing_polynomial returns the expected polynomial by asserting
+// that the latter is zero at all given points and has the expected degree
+fn test_vanishing_random() {
+    let max_num_points = 100;
+
+    let mut rng = rand::rng();
+    let points = field_elements_from_i64(
+        (0..max_num_points)
+            .map(|_| rng.random::<i64>())
+            .unique()
+            .collect_vec(),
+    );
+
+    let num_points = points.len();
+
+    let vanishing_poly = Polynomial::<BB>::vanishing_polynomial(points.clone());
+
+    assert_eq!(vanishing_poly.degree().unwrap(), num_points);
+    assert!(points
+        .iter()
+        .all(|p| vanishing_poly.evaluate(p) == BB::ZERO));
+}
+
+#[test]
+#[should_panic(expected = "The vanishing polynomial of an empty set is undefined")]
+// Checks that vanishing_polynomial panics when the set of points is empty
+fn test_vanishing_empty() {
+    Polynomial::<BB>::vanishing_polynomial(Vec::new());
+}
+
+#[test]
+// Checks that vanishing_polynomial and lagrange_interpolation recover the same
+// polynomial
+fn test_vanishing_and_lagrange_interpolation() {
+    let max_num_points = 100;
+
+    let mut rng = rand::rng();
+    let points = field_elements_from_i64(
+        (0..max_num_points)
+            .map(|_| rng.random::<i64>())
+            .collect_vec(),
+    );
+
+    let vanishing_poly = Polynomial::<BB>::vanishing_polynomial(points.clone());
+
+    assert_eq!(vanishing_poly.degree().unwrap(), points.len());
+
+    // In order to recover the same polynomial through interpolation, we need
+    // one more value
+    let mut point_evals = points.iter().map(|p| (*p, BB::ZERO)).collect_vec();
+
+    let mut new_point = BB::ZERO;
+    while new_point.is_zero() {
+        new_point = field_element_from_i64(rng.random::<i64>());
+    }
+    let new_eval = vanishing_poly.evaluate(&new_point);
+    point_evals.push((new_point, new_eval));
+
+    let new_vanishing_poly = Polynomial::lagrange_interpolation(point_evals);
+
+    assert_eq!(new_vanishing_poly, vanishing_poly);
+}
+
+#[test]
+// Checks that division by a linear polynomial yields the expected quotient and
+// evaluation
+fn test_division_by_linear_polynomial() {
+    let mut rng = rand::rng();
+
+    for _ in 0..TEST_ITERATIONS {
+        let deg = rng.random_range(1..100);
+        let polynomial: Polynomial<GL> = rand_poly(deg);
+        let point = rng.random();
+
+        let divisor = Polynomial::vanishing_linear_polynomial(point);
+        let (expected_q, _) = polynomial.divide_with_remainder(&divisor);
+
+        let (q, r) = polynomial.divide_by_vanishing_linear_polynomial(point);
+
+        assert_eq!(q, expected_q);
+        assert_eq!(r, polynomial.evaluate(&point));
+    }
+}
+
+#[test]
+// Checks that dividing the vanishing polynomial of a set of points by the linar
+// vanishing polynomials at each point results in the constant polynomial 1.
+fn test_division_by_linear_polynomial_vanishing() {
+    let max_num_points = 20;
+
+    let mut rng = rand::rng();
+
+    let poly_one = Polynomial::<GL>::constant(GL::ONE);
+
+    for _ in 0..TEST_ITERATIONS {
+        let points = field_elements_from_i64(
+            (0..max_num_points)
+                .map(|_| rng.random::<i64>())
+                .unique()
+                .collect_vec(),
+        );
+
+        let mut vanishing_poly = Polynomial::<GL>::vanishing_polynomial(points.clone());
+
+        for point in points {
+            (vanishing_poly, _) = vanishing_poly.divide_by_vanishing_linear_polynomial(point);
+        }
+
+        assert_eq!(vanishing_poly, poly_one);
+    }
+}
+
+#[test]
+fn test_power_polynomial() {
+    let mut rng = rand::rng();
+
+    let degree = rng.random_range(50..100);
+
+    let mut r = GL::ZERO;
+
+    while r == GL::ZERO {
+        r = rng.random();
+    }
+
+    // (1 + rx + ... + (rx)^n) * (rx - 1) = (rx)^(n + 1) - 1
+    let power_polynomial = Polynomial::power_polynomial(r, degree);
+    let rxn_1 = &(&Polynomial::x().compose_with_exponent(degree + 1)
+        * &r.exp_u64((degree + 1) as u64))
+        - &GL::ONE;
+    let rx_1 = &(&Polynomial::x() * &r) - &GL::ONE;
+
+    assert_eq!(&power_polynomial * &rx_1, rxn_1);
+}


### PR DESCRIPTION
This PR, developed in collaboration with @Antonio95, implements the `p3-poly` crate which, together with `p3-coset`, provides essential building blocks for implementing the STIR low-degree test in Plonky3. By separating this functionality into a dedicated crate, we aim to make the main PR more modular and easier to review. The history of the `p3-poly` crate can still be tracked in the STIR PR: https://github.com/Plonky3/Plonky3/pull/674

The `README.md` file contains a high-level overview of the crate and its functionality.

## Implementation Details

- The `Polynomial` struct is a wrapper around a vector of field elements. A polynomial is always stored in canonical form, i.e. the leading coefficient is non-zero, with the zero polynomial being represented as an empty `Vec<F>`. The only way to create a new polynomial is by using the `from_coeffs` constructor, which ensures that the polynomial is in canonical form by zero-trimming the input vector with `truncate_leading_zeros`.

- Arithmetic operations on polynomials are implemented as both methods (`Polynomial::mul_naive` and `Polynomial::divide_with_remainder`) and operator overloading (`*`, `/`, `-`, `+`) for `&Polynomial<F>` and `&F` objects. with a few caveats:
  - The `*` operator can only be used for polynomials over `TwoAdicField`s and implements an adaptive strategy, it dynamically selects between FFT-based multiplication for larger degrees and naive multiplication for smaller ones. This selection is made at runtime by comparing the computational costs of both approaches based on the input polynomials' degrees and FFT overhead  (c.f. `poly/src/lib.rs#L512`). For polynomials over non-`TwoAdicField` types, the `Polynomial::mul_naive` method is available.
  - The `/` operator internally uses the `divide_with_remainder` method and returns only the quotient. If the division is not exact, it panics.

- A few additional methods for common operations are provided:
  - `evaluate` uses Horner's method to evaluate the polynomial at a given point.
  - `vanishing_polynomial` generates the vanishing polynomial of a given set of points (i.e. `(x - points[0]) * (x - points[1]) * ... * (x - points[n - 1])`).
  - `lagrange_interpolation` interpolates a polynomial from a given set of points and values.
  - `power_polynomial` computes the power polynomial (`1 + rx + r^2x^2 + ... + r^nx^n`).
  - `compose_with_exponent` given a polynomial `p(x)` and an exponent `e`, it computes the polynomial `p(x^e)`.
  - `divide_by_vanishing_linear_polynomial` divides `self` by a polynomial of the form `(x - point)`

- All polynomials returned by the methods above are guaranteed to be in canonical form. 

## Attribution

Some of the polynomial algorithms in this crate are inspired by or adapted from the arkworks ecosystem. Specific attributions are provided in the relevant code sections.