### PR TITLE
Fix typo in benchmark function names: qudratic -> quadratic

### DIFF
--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -12,7 +12,7 @@ type EF2 = BinomialExtensionField<Goldilocks, 2>;
 const REPS: usize = 50;
 const L_REPS: usize = 10 * REPS;
 
-fn bench_qudratic_extension(c: &mut Criterion) {
+fn bench_quadratic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Goldilocks, 2>";
     benchmark_square::<EF2>(c, name);
     benchmark_inv::<EF2>(c, name);
@@ -20,5 +20,5 @@ fn bench_qudratic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF2, L_REPS>(c, name);
 }
 
-criterion_group!(bench_goldilocks_ef2, bench_qudratic_extension);
+criterion_group!(bench_goldilocks_ef2, bench_quadratic_extension);
 criterion_main!(bench_goldilocks_ef2);

--- a/mersenne-31/benches/extension.rs
+++ b/mersenne-31/benches/extension.rs
@@ -11,7 +11,7 @@ type EF3 = BinomialExtensionField<Complex<Mersenne31>, 3>;
 const REPS: usize = 100;
 const L_REPS: usize = 10 * REPS;
 
-fn bench_qudratic_extension(c: &mut Criterion) {
+fn bench_quadratic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<Mersenne31Complex<Mersenne31>, 2>";
     benchmark_square::<EF2>(c, name);
     benchmark_inv::<EF2>(c, name);
@@ -27,7 +27,7 @@ fn bench_cubic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF3, L_REPS>(c, name);
 }
 
-criterion_group!(bench_mersennecomplex_ef2, bench_qudratic_extension);
+criterion_group!(bench_mersennecomplex_ef2, bench_quadratic_extension);
 criterion_group!(bench_mersennecomplex_ef3, bench_cubic_extension);
 
 criterion_main!(bench_mersennecomplex_ef2, bench_mersennecomplex_ef3);


### PR DESCRIPTION
This PR fixes a typo in benchmark function names where `qudratic` was incorrectly spelled instead of `quadratic`
**The changes include:**
- Renamed `bench_qudratic_extension` to `bench_quadratic_extension` in multiple benchmark files
- Updated corresponding function calls in `criterion_group! macros`
The fix ensures consistent and correct spelling across the codebase. This is a minor change that only affects function names and has no functional impact on the benchmarks themselves.

**Files modified:**
`main...kilavvy-Plonky3:main`
`mersenne-31/benches/extension.rs`