### PR TITLE
Deleting some unused stuff from Utils

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 
+use crate::transpose::transpose_in_place_square;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::type_name;
@@ -226,17 +227,6 @@ unsafe fn reverse_slice_index_bits_chunks<F>(
     }
 }
 
-/// Transpose a square matrix in place.
-/// SAFETY: ensure that `arr.len() == 1 << lb_chunk_size + lb_num_chunks`.
-unsafe fn transpose_in_place_square<T>(
-    arr: &mut [T],
-    lb_chunk_size: usize,
-    lb_num_chunks: usize,
-    offset: usize,
-) {
-    unsafe { transpose::transpose_in_place_square(arr, lb_chunk_size, lb_num_chunks, offset) }
-}
-
 #[inline(always)]
 pub fn assume(p: bool) {
     debug_assert!(p);
@@ -276,39 +266,6 @@ pub fn branch_hint() {
     unsafe {
         core::arch::asm!("", options(nomem, nostack, preserves_flags));
     }
-}
-
-/// Convenience methods for Vec.
-pub trait VecExt<T> {
-    /// Push `elem` and return a reference to it.
-    fn pushed_ref(&mut self, elem: T) -> &T;
-    /// Push `elem` and return a mutable reference to it.
-    fn pushed_mut(&mut self, elem: T) -> &mut T;
-}
-
-impl<T> VecExt<T> for alloc::vec::Vec<T> {
-    fn pushed_ref(&mut self, elem: T) -> &T {
-        self.push(elem);
-        self.last().unwrap()
-    }
-    fn pushed_mut(&mut self, elem: T) -> &mut T {
-        self.push(elem);
-        self.last_mut().unwrap()
-    }
-}
-
-pub fn transpose_vec<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
-    assert!(!v.is_empty());
-    let len = v[0].len();
-    let mut iters: Vec<_> = v.into_iter().map(|n| n.into_iter()).collect();
-    (0..len)
-        .map(|_| {
-            iters
-                .iter_mut()
-                .map(|n| n.next().unwrap())
-                .collect::<Vec<T>>()
-        })
-        .collect()
 }
 
 /// Return a String containing the name of T but with all the crate

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -4,13 +4,14 @@
 
 extern crate alloc;
 
-use crate::transpose::transpose_in_place_square;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::type_name;
 use core::hint::unreachable_unchecked;
 use core::mem;
 use core::mem::MaybeUninit;
+
+use crate::transpose::transpose_in_place_square;
 
 pub mod array_serialization;
 pub mod linear_map;

--- a/util/src/linear_map.rs
+++ b/util/src/linear_map.rs
@@ -1,8 +1,6 @@
 use alloc::vec::Vec;
 use core::mem;
 
-use crate::VecExt;
-
 /// O(n) Vec-backed map for keys that only implement Eq.
 /// Only use this for a very small number of keys, operations
 /// on it can easily become O(n^2).
@@ -40,7 +38,8 @@ impl<K: Eq, V> LinearMap<K, V> {
         if let Some(idx) = existing {
             &mut self.0[idx].1
         } else {
-            let slot = self.0.pushed_mut((k, f()));
+            self.0.push((k, f()));
+            let slot = self.0.last_mut().unwrap();
             &mut slot.1
         }
     }


### PR DESCRIPTION
This deletes a few unused/uneeded methods and traits in the utils file:

- `transpose_in_place_square`: this is currently a wrapper for an identical (same name and arguments) function in `src/transpose`. So I've just deleted this. 
- `VecExt` : Right now this is only used in `1` place, and only one of it's routines are used. It seems clearner to just copy that routine over and delete this trait.
- `transpose_vec`: this is unused (and would be very slow). We usually operate on `RowMajorMatrices` instead of `Vec<Vec<F>>` anyway so I don't this this really has a use case. As such I'm deleting this as well.