### PR TITLE
Refactor Matrix Imports and Type Definitions

### DIFF
--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -8,7 +8,7 @@ use itertools::{Itertools, izip};
 use p3_field::integers::QuotientMap;
 use p3_field::{Field, Powers, TwoAdicField};
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::bitrev::{BitReversibleMatrix, BitReversalPerm, BitReversedMatrixView};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_maybe_rayon::prelude::*;

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::BitReversableMatrix;
+use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::swap_rows;
 
@@ -11,7 +11,7 @@ use crate::util::{coset_shift_cols, divide_by_height};
 pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     // Effectively this is either RowMajorMatrix or BitReversedMatrixView<RowMajorMatrix>.
     // Always owned.
-    type Evaluations: BitReversableMatrix<F> + 'static;
+    type Evaluations: BitReversibleMatrix<F> + 'static;
 
     /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft(&self, vec: Vec<F>) -> Vec<F> {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -13,7 +13,7 @@ use p3_field::{
     cyclic_subgroup_coset_known_order, dot_product,
 };
 use p3_interpolation::interpolate_coset;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::bitrev::{BitReversibleMatrix, BitReversalPerm, BitReversedMatrixView};
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;

--- a/matrix/src/bitrev.rs
+++ b/matrix/src/bitrev.rs
@@ -8,8 +8,8 @@ use crate::util::reverse_matrix_index_bits;
 /// A matrix whose row indices are possibly bit-reversed, enabling easily switching
 /// between orderings. Pretty much just either `RowMajorMatrix` or
 /// `BitReversedMatrixView<RowMajorMatrix>`.
-pub trait BitReversableMatrix<T: Send + Sync>: Matrix<T> {
-    type BitRev: BitReversableMatrix<T>;
+pub trait BitReversibleMatrix<T: Send + Sync>: Matrix<T> {
+    type BitRev: BitReversibleMatrix<T>;
     fn bit_reverse_rows(self) -> Self::BitRev;
 }
 
@@ -53,7 +53,7 @@ impl RowIndexMap for BitReversalPerm {
 
 pub type BitReversedMatrixView<Inner> = RowIndexMappedView<BitReversalPerm, Inner>;
 
-impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T>
+impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversibleMatrix<T>
     for BitReversedMatrixView<DenseMatrix<T, S>>
 {
     type BitRev = DenseMatrix<T, S>;
@@ -62,7 +62,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T>
     }
 }
 
-impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T> for DenseMatrix<T, S> {
+impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversibleMatrix<T> for DenseMatrix<T, S> {
     type BitRev = BitReversedMatrixView<Self>;
     fn bit_reverse_rows(self) -> Self::BitRev {
         BitReversalPerm::new_view(self)


### PR DESCRIPTION
This pull request updates the imports and type definitions related to `BitReversibleMatrix` in the `traits.rs` and `two_adic.rs` files. 

**The changes include:**
- Consolidation of BitReversibleMatrix imports for better readability and maintainability.
- Updated type definitions to ensure consistency across the codebase.
- Minor adjustments to improve code clarity.

These changes aim to enhance the overall structure and organization of the code, making it easier to understand and work with in future developments.