### PR TITLE
Fix typos and formatting in Poseidon2 implementation comments

### DIFF
--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -50,7 +50,7 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 ///
 /// This can act on `[A; WIDTH]` for any ring implementing `Algebra<BabyBear>`.
 /// If you have either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]` it will be much faster
-/// to use `Poseidon2KoalaBear<WIDTH>` instead of building a Poseidon2 permutation using this.
+/// to use `Poseidon2KoalaBear<WIDTH>` instead of building the Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersKoalaBear =
     GenericPoseidon2LinearLayersMonty31<KoalaBearParameters, KoalaBearInternalLayerParameters>;
 

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -4,13 +4,13 @@
 //! vector V composed of elements with efficient multiplication algorithms in AVX2/AVX512/NEON.
 //!
 //! This leads to using small values (e.g. 1, 2) where multiplication is implemented using addition
-//! and, powers of 2 where multiplication is implemented using shifts.
+//! and powers of 2 where multiplication is implemented using shifts.
 //! Additionally, for technical reasons, having the first entry be -2 is useful.
 //!
 //! Optimized Diagonal for Mersenne31 width 16:
-//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13,  2^14,  2^15, 2^16]
+//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13, 2^14, 2^15, 2^16]
 //! Optimized Diagonal for Mersenne31 width 24:
-//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13,  2^14,  2^15,  2^16,   2^17,   2^18,   2^19,    2^20,    2^21,    2^22]
+//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16, 2^17, 2^18, 2^19, 2^20, 2^21, 2^22]
 //! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
 
 use p3_field::Algebra;

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -61,7 +61,7 @@ fn convert_to_vec_neg_form(input: i32) -> __m256i {
 
 impl Poseidon2InternalLayerMersenne31 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31 from a vector containing
-    /// the constants for each round. Internally, the constants are transformed into th
+    /// the constants for each round. Internally, the constants are transformed into the
     /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         let packed_internal_constants = internal_constants
@@ -76,9 +76,9 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
-    ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
+    /// are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
         let packed_initial_external_constants = external_constants
             .get_initial_constants()

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -311,7 +311,7 @@ fn partial_reduce_neg(x: __m512i) -> __m512i {
 /// Compute the square of the Mersenne-31 field elements located in the even indices.
 /// These field elements are represented as values in {-P, ..., P}. If the even inputs
 /// do not conform to this representation, the result is undefined.
-/// The top half of each 64-bit lane is is ignored.
+/// The top half of each 64-bit lane is ignored.
 /// The top half of each 64-bit lane in the result is 0.
 #[inline(always)]
 fn square_unred(x: __m512i) -> __m512i {

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -59,7 +59,7 @@ fn convert_to_vec_neg_form(input: i32) -> __m512i {
 
 impl Poseidon2InternalLayerMersenne31 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31 from a vector containing
-    /// the constants for each round. Internally, the constants are transformed into th
+    /// the constants for each round. Internally, the constants are transformed into the
     /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         let packed_internal_constants = internal_constants
@@ -74,9 +74,9 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
-    ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
+    /// are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
         let packed_initial_external_constants = external_constants
             .get_initial_constants()
@@ -194,7 +194,7 @@ fn diagonal_mul_24(state: &mut [PackedMersenne31AVX512; 24]) {
 
 /// Compute the map x -> (x + rc)^5 on Mersenne-31 field elements.
 /// x must be represented as a value in {0..P}.
-/// rc mut be represented as a value in {-P, ..., 0}.
+/// rc must be represented as a value in {-P, ..., 0}.
 /// If the inputs do not conform to these representations, the result is undefined.
 /// The output will be represented as a value in {0..P}.
 #[inline(always)]

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -197,7 +197,7 @@ fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m256i) -> __m256i 
 }
 
 /// Compute val -> (val + rc)^D. Each entry of val should be represented in canonical form.
-/// Each entry of rc should be represented by an element in in [-P, 0].
+/// Each entry of rc should be represented by an element in [-P, 0].
 /// Each entry of the output will be represented by an element in canonical form.
 /// If the inputs do not conform to this representation, the result is undefined.
 #[inline(always)]


### PR DESCRIPTION


This PR fixes several issues in the Poseidon2 implementation comments:

- Fixes typo in `mersenne-31/src/poseidon2.rs`: removes extra comma in "and, powers of 2"
- Improves readability of diagonal vector representation in comments
- Updates comment formatting for consistency in `koala-bear/src/poseidon2.rs`
- Fixes article usage in implementation description ("a" -> "the")

These changes improve code documentation readability without affecting the implementation functionality.


---
Note: The changes are documentation-only and do not modify any functional code.
