### PR TITLE
fix: documentation and error message wording

### DIFF
--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -360,7 +360,7 @@ fn first_half_general_oop<F: Field>(
 /// This can be used as the second half of a DIT butterfly network. It works in bit-reversed order.
 ///
 /// The optional `scale` parameter is used to scale the matrix by a constant factor. Normally that
-/// would be a separate step, but it's best to merge it into a butterfly network a just to avoid a
+/// would be a separate step, but it's best to merge it into a butterfly network just to avoid a
 /// separate pass through main memory.
 #[instrument(level = "debug", skip_all)]
 #[inline(always)] // To avoid branch on scale

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -251,7 +251,7 @@ macro_rules! quotient_map_small_int {
 ///     /// Convert a given `u128` integer into an element of the `Mersenne31` field.
 ///     ///
 ///     /// # Safety
-///     /// The input mut lie in the range:", [0, 2^31 - 1].
+///     /// The input must lie in the range:", [0, 2^31 - 1].
 ///     #[inline]
 ///     unsafe fn from_canonical_unchecked(int: u128) -> Mersenne31 {
 ///         unsafe {
@@ -294,7 +294,7 @@ macro_rules! quotient_map_large_uint {
             #[doc = concat!("Convert a given `", stringify!($large_int), "` integer into an element of the `", stringify!($field), "` field.")]
             ///
             /// # Safety
-            #[doc = concat!("The input mut lie in the range:", $unchecked_bounds, ".")]
+            #[doc = concat!("The input must lie in the range:", $unchecked_bounds, ".")]
             #[inline]
             unsafe fn from_canonical_unchecked(int: $large_int) -> $field {
                 unsafe {
@@ -352,7 +352,7 @@ macro_rules! quotient_map_large_uint {
 ///     /// Convert a given `i128` integer into an element of the `Mersenne31` field.
 ///     ///
 ///     /// # Safety
-///     /// The input mut lie in the range:", `[1 - 2^31, 2^31 - 1]`.
+///     /// The input must lie in the range:", `[1 - 2^31, 2^31 - 1]`.
 ///     #[inline]
 ///     unsafe fn from_canonical_unchecked(int: i128) -> Mersenne31 {
 ///         unsafe {
@@ -392,7 +392,7 @@ macro_rules! quotient_map_large_iint {
             #[doc = concat!("Convert a given `", stringify!($large_int), "` integer into an element of the `", stringify!($field), "` field.")]
             ///
             /// # Safety
-            #[doc = concat!("The input mut lie in the range:", $unchecked_bounds, ".")]
+            #[doc = concat!("The input must lie in the range:", $unchecked_bounds, ".")]
             #[inline]
             unsafe fn from_canonical_unchecked(int: $large_signed_int) -> $field {
                 unsafe {
@@ -427,7 +427,7 @@ macro_rules! impl_u_i_size {
                     4 => Self::from_int(int as $int32),
                     8 => Self::from_int(int as $int64),
                     16 => Self::from_int(int as $int128),
-                    _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                    _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                 }
             }
 
@@ -439,7 +439,7 @@ macro_rules! impl_u_i_size {
                     4 => Self::from_canonical_checked(int as $int32),
                     8 => Self::from_canonical_checked(int as $int64),
                     16 => Self::from_canonical_checked(int as $int128),
-                    _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                    _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                 }
             }
 
@@ -452,7 +452,7 @@ macro_rules! impl_u_i_size {
                         4 => Self::from_canonical_unchecked(int as $int32),
                         8 => Self::from_canonical_unchecked(int as $int64),
                         16 => Self::from_canonical_unchecked(int as $int128),
-                        _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                        _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                     }
                 }
             }

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -570,7 +570,7 @@ pub(crate) unsafe fn apply_func_to_even_odd<MPAVX512: MontyParametersAVX512>(
         let input_evn = input;
         let input_odd = movehdup_epi32(input);
 
-        // Unlike the mul function, we need to receive back values the reduced
+        // Unlike the mul function, we need to receive back values that are reduced
         let output_even = func(input_evn);
         let output_odd = func(input_odd);
 


### PR DESCRIPTION
- Add missing space in error message in impl_u_i_size macro
- Correct "mut" to "must" in safety documentation for from_canonical_unchecked methods
- Fix grammatical error in butterfly network comment