### PR TITLE
Minor fixes throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![Plonky3-powered-by-polygon](https://github.com/Plonky3/Plonky3/assets/86010/7ec356ad-b0f3-4c4c-aa1d-3a151c1065e7)
 
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-MIT)
+[![License](https://img.shields.io/github/license/Plonky3/Plonky3)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-APACHE)
+
 Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs. It aims to support several polynomial commitment schemes, such as Brakedown.
 
 This is the "core" repo, but the plan is to move each crate into its own repo once APIs stabilize.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ is likely to be rejected. It's possible that we may relax this policy
 in the future, but we aim to minimize the use of unstable features;
 please discuss with us before enabling any.
 
+Please do not submit any PRs consisting of minor fixes to typos. They
+will not be accepted. If you find a typo that bothers you particularly,
+make an issue and we will fix it when we find the time.
+
 Here are a few specific guidelines for the three main categories of
 PRs that we expect:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 ![Plonky3-powered-by-polygon](https://github.com/Plonky3/Plonky3/assets/86010/7ec356ad-b0f3-4c4c-aa1d-3a151c1065e7)
 
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-MIT)
-[![License](https://img.shields.io/github/license/Plonky3/Plonky3)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-APACHE)
-
 Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs. It aims to support several polynomial commitment schemes, such as Brakedown.
 
 This is the "core" repo, but the plan is to move each crate into its own repo once APIs stabilize.

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ is likely to be rejected. It's possible that we may relax this policy
 in the future, but we aim to minimize the use of unstable features;
 please discuss with us before enabling any.
 
-Please do not submit any PRs consisting of minor fixes to typos. They
-will not be accepted. If you find a typo that bothers you particularly,
+Please do not submit any PRs consisting of merely minor fixes to documentation.
+They will not be accepted. If you find something that bothers you particularly,
 make an issue and we will fix it when we find the time.
 
 Here are a few specific guidelines for the three main categories of

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![Plonky3-powered-by-polygon](https://github.com/Plonky3/Plonky3/assets/86010/7ec356ad-b0f3-4c4c-aa1d-3a151c1065e7)
 
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-MIT)
+[![License](https://img.shields.io/github/license/Plonky3/Plonky3)](https://github.com/Plonky3/Plonky3/blob/main/LICENSE-APACHE)
+
 Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs. It aims to support several polynomial commitment schemes, such as Brakedown.
 
 This is the "core" repo, but the plan is to move each crate into its own repo once APIs stabilize.
@@ -14,7 +17,7 @@ Fields:
   - [x] AVX2
   - [x] AVX-512
   - [x] NEON
-- [x] BabyBear
+- [x] General 31 bit fields (BabyBear and KoalaBear)
   - [x] ~128 bit extension field
   - [x] AVX2
   - [x] AVX-512
@@ -62,7 +65,7 @@ Hashes
 Many variations are possible, with different fields, hashes, and so forth, which can be controlled through the command line.
 
 For example, to prove 2^20 Poseidon2 permutations of width 16, using the `KoalaBear` field, `Radix2DitParallel` DFT, and `KeccakF` as the Merkle tree hash:
-```
+```bash
 RUSTFLAGS="-Ctarget-cpu=native" cargo run --example prove_prime_field_31 --release --features parallel -- --field koala-bear --objective poseidon-2-permutations --log-trace-length 17 --discrete-fourier-transform radix-2-dit-parallel --merkle-hash keccak-f
 ```
 
@@ -80,7 +83,7 @@ Extra speedups may be possible with some configuration changes:
 ## CPU features
 
 Plonky3 contains optimizations that rely on newer CPU instructions unavailable in older processors. These instruction sets include x86's [BMI1 and 2](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set), [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2), and [AVX-512](https://en.wikipedia.org/wiki/AVX-512). Rustc does not emit those instructions by default; they must be explicitly enabled through the `target-feature` compiler option (or implicitly by setting `target-cpu`). To enable all features that are supported on your machine, you can set `target-cpu` to `native`. For example, to run the tests:
-```
+```bash
 RUSTFLAGS="-Ctarget-cpu=native" cargo test
 ```
 
@@ -90,7 +93,7 @@ Support for some instructions, such as AVX-512, is still experimental. They are 
 ## Nightly-only optimizations
 
 Some optimizations (in particular, AVX-512-optimized math) rely on features that are currently available only in the nightly build of Rustc. To use them, you need to enable the `nightly-features` feature. For example, to run the tests:
-```
+```bash
 cargo test --features nightly-features
 ```
 

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -1,4 +1,4 @@
-//! A collection of utility functions helpful in defining AIR's.
+//! A collection of utility functions helpful in defining AIRs.
 
 use core::array;
 
@@ -9,7 +9,7 @@ use crate::AirBuilder;
 
 /// Pack a collection of bits into a number.
 ///
-/// Given vec = [v0, v1, ..., v_n] returns v0 + 2v_1 + ... + 2^n v_n
+/// Given `vec = [v_0, v_1, ..., v_n]` returns `v_0 + 2v_1 + ... + 2^n v_n`
 #[inline]
 pub fn pack_bits_le<R, Var, I>(iter: I) -> R
 where

--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -197,7 +197,7 @@ fn generate_trace_row_for_round<F: PrimeField64>(
 
 /// Perform half of a quarter round on the given elements.
 ///
-/// The boolean flag, indicates if this is the first (false) or second (true) half round.
+/// The boolean flag, indicates whether this is the first (false) or second (true) half round.
 const fn verifiable_half_round(
     mut a: u32,
     mut b: u32,

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -360,7 +360,7 @@ fn first_half_general_oop<F: Field>(
 /// This can be used as the second half of a DIT butterfly network. It works in bit-reversed order.
 ///
 /// The optional `scale` parameter is used to scale the matrix by a constant factor. Normally that
-/// would be a separate step, but it's best to merge it into a butterfly network a just to avoid a
+/// would be a separate step, but it's best to merge it into a butterfly network to avoid a
 /// separate pass through main memory.
 #[instrument(level = "debug", skip_all)]
 #[inline(always)] // To avoid branch on scale

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -8,7 +8,7 @@ use itertools::{Itertools, izip};
 use p3_field::integers::QuotientMap;
 use p3_field::{Field, Powers, TwoAdicField};
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_maybe_rayon::prelude::*;

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::BitReversableMatrix;
+use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::util::swap_rows;
 
@@ -11,7 +11,7 @@ use crate::util::{coset_shift_cols, divide_by_height};
 pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     // Effectively this is either RowMajorMatrix or BitReversedMatrixView<RowMajorMatrix>.
     // Always owned.
-    type Evaluations: BitReversableMatrix<F> + 'static;
+    type Evaluations: BitReversibleMatrix<F> + 'static;
 
     /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft(&self, vec: Vec<F>) -> Vec<F> {

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -251,7 +251,7 @@ macro_rules! quotient_map_small_int {
 ///     /// Convert a given `u128` integer into an element of the `Mersenne31` field.
 ///     ///
 ///     /// # Safety
-///     /// The input mut lie in the range:", [0, 2^31 - 1].
+///     /// The input must lie in the range:", [0, 2^31 - 1].
 ///     #[inline]
 ///     unsafe fn from_canonical_unchecked(int: u128) -> Mersenne31 {
 ///         unsafe {
@@ -294,7 +294,7 @@ macro_rules! quotient_map_large_uint {
             #[doc = concat!("Convert a given `", stringify!($large_int), "` integer into an element of the `", stringify!($field), "` field.")]
             ///
             /// # Safety
-            #[doc = concat!("The input mut lie in the range:", $unchecked_bounds, ".")]
+            #[doc = concat!("The input must lie in the range:", $unchecked_bounds, ".")]
             #[inline]
             unsafe fn from_canonical_unchecked(int: $large_int) -> $field {
                 unsafe {
@@ -352,7 +352,7 @@ macro_rules! quotient_map_large_uint {
 ///     /// Convert a given `i128` integer into an element of the `Mersenne31` field.
 ///     ///
 ///     /// # Safety
-///     /// The input mut lie in the range:", `[1 - 2^31, 2^31 - 1]`.
+///     /// The input must lie in the range:", `[1 - 2^31, 2^31 - 1]`.
 ///     #[inline]
 ///     unsafe fn from_canonical_unchecked(int: i128) -> Mersenne31 {
 ///         unsafe {
@@ -392,7 +392,7 @@ macro_rules! quotient_map_large_iint {
             #[doc = concat!("Convert a given `", stringify!($large_int), "` integer into an element of the `", stringify!($field), "` field.")]
             ///
             /// # Safety
-            #[doc = concat!("The input mut lie in the range:", $unchecked_bounds, ".")]
+            #[doc = concat!("The input must lie in the range:", $unchecked_bounds, ".")]
             #[inline]
             unsafe fn from_canonical_unchecked(int: $large_signed_int) -> $field {
                 unsafe {
@@ -439,7 +439,7 @@ macro_rules! impl_u_i_size {
                     4 => Self::from_canonical_checked(int as $int32),
                     8 => Self::from_canonical_checked(int as $int64),
                     16 => Self::from_canonical_checked(int as $int128),
-                    _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                    _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                 }
             }
 
@@ -452,7 +452,7 @@ macro_rules! impl_u_i_size {
                         4 => Self::from_canonical_unchecked(int as $int32),
                         8 => Self::from_canonical_unchecked(int as $int64),
                         16 => Self::from_canonical_unchecked(int as $int128),
-                        _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                        _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                     }
                 }
             }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -13,7 +13,7 @@ use p3_field::{
     cyclic_subgroup_coset_known_order, dot_product,
 };
 use p3_interpolation::interpolate_coset;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm, BitReversedMatrixView};
+use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;

--- a/matrix/src/bitrev.rs
+++ b/matrix/src/bitrev.rs
@@ -8,8 +8,8 @@ use crate::util::reverse_matrix_index_bits;
 /// A matrix whose row indices are possibly bit-reversed, enabling easily switching
 /// between orderings. Pretty much just either `RowMajorMatrix` or
 /// `BitReversedMatrixView<RowMajorMatrix>`.
-pub trait BitReversableMatrix<T: Send + Sync>: Matrix<T> {
-    type BitRev: BitReversableMatrix<T>;
+pub trait BitReversibleMatrix<T: Send + Sync>: Matrix<T> {
+    type BitRev: BitReversibleMatrix<T>;
     fn bit_reverse_rows(self) -> Self::BitRev;
 }
 
@@ -53,7 +53,7 @@ impl RowIndexMap for BitReversalPerm {
 
 pub type BitReversedMatrixView<Inner> = RowIndexMappedView<BitReversalPerm, Inner>;
 
-impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T>
+impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversibleMatrix<T>
     for BitReversedMatrixView<DenseMatrix<T, S>>
 {
     type BitRev = DenseMatrix<T, S>;
@@ -62,7 +62,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T>
     }
 }
 
-impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversableMatrix<T> for DenseMatrix<T, S> {
+impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversibleMatrix<T> for DenseMatrix<T, S> {
     type BitRev = BitReversedMatrixView<Self>;
     fn bit_reverse_rows(self) -> Self::BitRev {
         BitReversalPerm::new_view(self)

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -4,13 +4,13 @@
 //! vector V composed of elements with efficient multiplication algorithms in AVX2/AVX512/NEON.
 //!
 //! This leads to using small values (e.g. 1, 2) where multiplication is implemented using addition
-//! and, powers of 2 where multiplication is implemented using shifts.
+//! and powers of 2 where multiplication is implemented using shifts.
 //! Additionally, for technical reasons, having the first entry be -2 is useful.
 //!
 //! Optimized Diagonal for Mersenne31 width 16:
-//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13,  2^14,  2^15, 2^16]
+//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13, 2^14, 2^15, 2^16]
 //! Optimized Diagonal for Mersenne31 width 24:
-//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13,  2^14,  2^15,  2^16,   2^17,   2^18,   2^19,    2^20,    2^21,    2^22]
+//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16,  2^17,  2^18,  2^19, 2^20, 2^21, 2^22]
 //! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
 
 use p3_field::Algebra;

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -10,7 +10,7 @@
 //! Optimized Diagonal for Mersenne31 width 16:
 //! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^10, 2^12, 2^13, 2^14, 2^15, 2^16]
 //! Optimized Diagonal for Mersenne31 width 24:
-//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16,  2^17,  2^18,  2^19, 2^20, 2^21, 2^22]
+//! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16, 2^17, 2^18, 2^19, 2^20, 2^21, 2^22]
 //! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
 
 use p3_field::Algebra;

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -61,7 +61,7 @@ fn convert_to_vec_neg_form(input: i32) -> __m256i {
 
 impl Poseidon2InternalLayerMersenne31 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31 from a vector containing
-    /// the constants for each round. Internally, the constants are transformed into th
+    /// the constants for each round. Internally, the constants are transformed into the
     /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         let packed_internal_constants = internal_constants
@@ -76,7 +76,7 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
@@ -254,7 +254,7 @@ fn diagonal_mul_24(state: &mut [PackedMersenne31AVX2; 24]) {
 
 /// Compute the map x -> (x + rc)^5 on Mersenne-31 field elements.
 /// x must be represented as a value in {0..P}.
-/// rc mut be represented as a value in {-P, ..., 0}.
+/// rc must be represented as a value in {-P, ..., 0}.
 /// If the inputs do not conform to these representations, the result is undefined.
 /// The output will be represented as a value in {0..P}.
 #[inline(always)]

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -311,7 +311,7 @@ fn partial_reduce_neg(x: __m512i) -> __m512i {
 /// Compute the square of the Mersenne-31 field elements located in the even indices.
 /// These field elements are represented as values in {-P, ..., P}. If the even inputs
 /// do not conform to this representation, the result is undefined.
-/// The top half of each 64-bit lane is is ignored.
+/// The top half of each 64-bit lane is ignored.
 /// The top half of each 64-bit lane in the result is 0.
 #[inline(always)]
 fn square_unred(x: __m512i) -> __m512i {

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -59,7 +59,7 @@ fn convert_to_vec_neg_form(input: i32) -> __m512i {
 
 impl Poseidon2InternalLayerMersenne31 {
     /// Construct an instance of Poseidon2InternalLayerMersenne31 from a vector containing
-    /// the constants for each round. Internally, the constants are transformed into th
+    /// the constants for each round. Internally, the constants are transformed into the
     /// {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(internal_constants: Vec<Mersenne31>) -> Self {
         let packed_internal_constants = internal_constants
@@ -74,7 +74,7 @@ impl Poseidon2InternalLayerMersenne31 {
 }
 
 impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(external_constants: ExternalLayerConstants<Mersenne31, WIDTH>) -> Self {
@@ -194,7 +194,7 @@ fn diagonal_mul_24(state: &mut [PackedMersenne31AVX512; 24]) {
 
 /// Compute the map x -> (x + rc)^5 on Mersenne-31 field elements.
 /// x must be represented as a value in {0..P}.
-/// rc mut be represented as a value in {-P, ..., 0}.
+/// rc must be represented as a value in {-P, ..., 0}.
 /// If the inputs do not conform to these representations, the result is undefined.
 /// The output will be represented as a value in {0..P}.
 #[inline(always)]

--- a/monty-31/src/dft/backward.rs
+++ b/monty-31/src/dft/backward.rs
@@ -180,7 +180,7 @@ impl<MP: FieldParameters + TwoAdicData> MontyField31<MP> {
         let half_n = input.len() / 2;
         assert_eq!(roots.len(), half_n);
 
-        // Safe because 0 <= half_n < a.len()
+        // Safe because 0 <= half_n < input.len()
         let (xs, ys) = unsafe { input.split_at_mut_unchecked(half_n) };
 
         let s = xs[0] + ys[0];

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -9,7 +9,7 @@ use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::{BitReversableMatrix, BitReversedMatrixView};
+use p3_matrix::bitrev::{BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use tracing::{debug_span, instrument};

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -197,7 +197,7 @@ fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m256i) -> __m256i 
 }
 
 /// Compute val -> (val + rc)^D. Each entry of val should be represented in canonical form.
-/// Each entry of rc should be represented by an element in in [-P, 0].
+/// Each entry of rc should be represented by an element in [-P, 0].
 /// Each entry of the output will be represented by an element in canonical form.
 /// If the inputs do not conform to this representation, the result is undefined.
 #[inline(always)]

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -158,7 +158,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
 impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -570,12 +570,11 @@ pub(crate) unsafe fn apply_func_to_even_odd<MPAVX512: MontyParametersAVX512>(
         let input_evn = input;
         let input_odd = movehdup_epi32(input);
 
-        // Unlike the mul function, we need to receive back values the reduced
         let output_even = func(input_evn);
         let output_odd = func(input_odd);
 
         // We need to recombine these even and odd parts and, at the same time reduce back to
-        // and output in [0, P).
+        // an output in [0, P).
 
         // We throw a confuse compiler here to prevent the compiler from
         // using vpmullq instead of vpmuludq in the computations for q_p.

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -197,7 +197,7 @@ fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m512i) -> __m512i 
 }
 
 /// Compute val -> (val + rc)^D. Each entry of val should be represented in canonical form.
-/// Each entry of rc should be represented by an element in in [-P, 0].
+/// Each entry of rc should be represented by an element in [-P, 0].
 /// Each entry of the output will be represented by an element in canonical form.
 /// If the inputs do not conform to this representation, the result is undefined.
 #[inline(always)]

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -158,7 +158,7 @@ pub struct Poseidon2ExternalLayerMonty31<PMP: PackedMontyParameters, const WIDTH
 impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyField31<FP>, WIDTH>
     for Poseidon2ExternalLayerMonty31<FP, WIDTH>
 {
-    /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from a array of
+    /// Construct an instance of Poseidon2ExternalLayerMersenne31AVX2 from an array of
     /// vectors containing the constants for each round. Internally, the constants
     ///  are transformed into the {-P, ..., 0} representation instead of the standard {0, ..., P} one.
     fn new_from_constants(


### PR DESCRIPTION
There has been a large increase in low effort PRs which simply fix a small typo (Or, often, suggest "fixes" which do not improve the relevant comment). These seem to be mostly bots likely looking for tokens awarded to ecosystem contributors so to avoid encouraging them, I've run though the suggested changes, added the ones which make sense to this PR and will close all of the bot PRs.

I've also added a line to the readme asking people to not submit PRs which simply fix a minor typo. This probably won't help with the bots but at least gives us something to point to.

Main Changes
- Removing duplicated words.
- Add license images to Readme.   (Happy to get rid of these if we don't want them).
- Fix spelling error: `Reversable -> Reversible` (This is technically an API breaking change but probably worth doing)
- Add to readme about not accepting minor typo PR's.  (Happy to get rid of this if we don't want them).