### PR TITLE
Adding Goldilocks quintinc extension field

### DIFF
--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,5 +1,5 @@
 use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBinomialExtension};
-use p3_field::{field_to_array, PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{PrimeCharacteristicRing, TwoAdicField, field_to_array};
 
 use crate::Goldilocks;
 
@@ -85,7 +85,9 @@ mod test_quadratic_extension {
 mod test_quintic_extension {
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::{test_add_neg_sub_mul, test_inv_div, test_inverse, test_two_adic_extension_field};
+    use p3_field_testing::{
+        test_add_neg_sub_mul, test_inv_div, test_inverse, test_two_adic_extension_field,
+    };
 
     use crate::Goldilocks;
 

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -31,6 +31,30 @@ impl HasTwoAdicBinomialExtension<2> for Goldilocks {
     }
 }
 
+impl BinomiallyExtendable<5> for Goldilocks {
+    // Verifiable via:
+    //  ```sage
+    //  # Define Fp
+    //  p = 2**64 - 2**32 + 1
+    //  F = GF(p)
+
+    //  # Define Fp[z]
+    //  R.<z> = PolynomialRing(F)
+
+    //  # The polynomial x^5-3 is irreducible
+    //  assert(R(z^5-3).is_irreducible())
+    //  ```
+    const W: Self = Self::new(3);
+
+    // 5-th root = w^((p - 1)/5)
+    const DTH_ROOT: Self = Self::new(1041288259238279555);
+
+    // Generator of the extension field
+    // Obtained by finding the smallest Hamming weight vector
+    // with appropriate order, starting at [0,1,0,0,0]
+    const EXT_GENERATOR: [Self; 5] = [Self::TWO, Self::ONE, Self::ZERO, Self::ZERO, Self::ZERO];
+}
+
 #[cfg(test)]
 mod test_quadratic_extension {
 
@@ -45,4 +69,31 @@ mod test_quadratic_extension {
     test_field!(super::EF);
 
     test_two_adic_extension_field!(super::F, super::EF);
+}
+
+#[cfg(test)]
+mod test_quintic_extension {
+
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field_testing::{test_add_neg_sub_mul, test_inv_div, test_inverse};
+
+    use crate::Goldilocks;
+
+    type F = Goldilocks;
+    type EF = BinomialExtensionField<F, 5>;
+
+    #[test]
+    fn test_add_neg_sub_mul_w() {
+        test_add_neg_sub_mul::<EF>();
+    }
+
+    #[test]
+    fn test_inv_div_w() {
+        test_inv_div::<EF>();
+    }
+
+    #[test]
+    fn test_inverse_w() {
+        test_inverse::<EF>();
+    }
 }

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,5 +1,5 @@
 use p3_field::extension::{BinomiallyExtendable, HasTwoAdicBinomialExtension};
-use p3_field::{PrimeCharacteristicRing, TwoAdicField};
+use p3_field::{field_to_array, PrimeCharacteristicRing, TwoAdicField};
 
 use crate::Goldilocks;
 
@@ -55,6 +55,16 @@ impl BinomiallyExtendable<5> for Goldilocks {
     const EXT_GENERATOR: [Self; 5] = [Self::TWO, Self::ONE, Self::ZERO, Self::ZERO, Self::ZERO];
 }
 
+impl HasTwoAdicBinomialExtension<5> for Goldilocks {
+    const EXT_TWO_ADICITY: usize = 32;
+
+    fn ext_two_adic_generator(bits: usize) -> [Self; 5] {
+        assert!(bits <= 32);
+
+        field_to_array(Self::two_adic_generator(bits))
+    }
+}
+
 #[cfg(test)]
 mod test_quadratic_extension {
 
@@ -75,7 +85,7 @@ mod test_quadratic_extension {
 mod test_quintic_extension {
 
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::{test_add_neg_sub_mul, test_inv_div, test_inverse};
+    use p3_field_testing::{test_add_neg_sub_mul, test_inv_div, test_inverse, test_two_adic_extension_field};
 
     use crate::Goldilocks;
 
@@ -96,4 +106,6 @@ mod test_quintic_extension {
     fn test_inverse_w() {
         test_inverse::<EF>();
     }
+
+    test_two_adic_extension_field!(super::F, super::EF);
 }


### PR DESCRIPTION
I have implemented the Goldilocks quintic extension field, as defined in the [EcGFp5 paper](https://eprint.iacr.org/2022/274.pdf). This enhancement enables the definition of secure elliptic curves over Goldilocks, ensuring a 128-bit security level.

Note the extension order factorizes as:
```sage
2^32 * 3 * 5^2 * 17 * 257 * 45971 * 65537 * 255006435240067831 * 280083648770327405561 * 7053197395277272939628824863222181
```
so there is no need of implementing the `HasTwoAdicBinomialExtension` for this extension, as all the power-of-to order subgroups are defined over the base field.