### PR TITLE
wrap transmute with unsafe (clippy)

### DIFF
--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -57,7 +57,7 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
             // be transmuted to `[MontyField31; WIDTH]` (since `MontyField31` is `repr(transparent)`), which in
             // turn can be transmuted to `PackedMontyField31Neon` (since `PackedMontyField31Neon` is also
             // `repr(transparent)`).
-            transmute(vector)
+            unsafe { transmute(vector) }
         }
     }
 


### PR DESCRIPTION
Add unsafe to transmute call in NEON packing implementation