### PR TITLE
refactor(poseidon2-air): accept generic iterables in trace generation…

### DIFF
--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -14,6 +14,7 @@ use crate::{FullRound, PartialRound, RoundConstants, SBox};
 pub fn generate_vectorized_trace_rows<
     F: PrimeField,
     LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    I: IntoIterator<Item = [F; WIDTH]>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -21,10 +22,11 @@ pub fn generate_vectorized_trace_rows<
     const PARTIAL_ROUNDS: usize,
     const VECTOR_LEN: usize,
 >(
-    inputs: Vec<[F; WIDTH]>,
+    inputs: I,
     round_constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
     extra_capacity_bits: usize,
 ) -> RowMajorMatrix<F> {
+    let inputs: Vec<[F; WIDTH]> = inputs.into_iter().collect();
     let n = inputs.len();
     assert!(
         n % VECTOR_LEN == 0 && (n / VECTOR_LEN).is_power_of_two(),
@@ -71,20 +73,21 @@ pub fn generate_vectorized_trace_rows<
     RowMajorMatrix::new(vec, ncols)
 }
 
-// TODO: Take generic iterable
 #[instrument(name = "generate Poseidon2 trace", skip_all)]
 pub fn generate_trace_rows<
     F: PrimeField,
     LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    I: IntoIterator<Item = [F; WIDTH]>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
 >(
-    inputs: Vec<[F; WIDTH]>,
+    inputs: I,
     constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
 ) -> RowMajorMatrix<F> {
+    let inputs: Vec<[F; WIDTH]> = inputs.into_iter().collect();
     let n = inputs.len();
     assert!(
         n.is_power_of_two(),

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -14,7 +14,6 @@ use crate::{FullRound, PartialRound, RoundConstants, SBox};
 pub fn generate_vectorized_trace_rows<
     F: PrimeField,
     LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
-    I: IntoIterator<Item = [F; WIDTH]>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -22,11 +21,10 @@ pub fn generate_vectorized_trace_rows<
     const PARTIAL_ROUNDS: usize,
     const VECTOR_LEN: usize,
 >(
-    inputs: I,
+    inputs: Vec<[F; WIDTH]>,
     round_constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
     extra_capacity_bits: usize,
 ) -> RowMajorMatrix<F> {
-    let inputs: Vec<[F; WIDTH]> = inputs.into_iter().collect();
     let n = inputs.len();
     assert!(
         n % VECTOR_LEN == 0 && (n / VECTOR_LEN).is_power_of_two(),
@@ -77,17 +75,15 @@ pub fn generate_vectorized_trace_rows<
 pub fn generate_trace_rows<
     F: PrimeField,
     LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
-    I: IntoIterator<Item = [F; WIDTH]>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
 >(
-    inputs: I,
+    inputs: Vec<[F; WIDTH]>,
     constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
 ) -> RowMajorMatrix<F> {
-    let inputs: Vec<[F; WIDTH]> = inputs.into_iter().collect();
     let n = inputs.len();
     assert!(
         n.is_power_of_two(),


### PR DESCRIPTION
… functions

Change generate_trace_rows and generate_vectorized_trace_rows functions to accept
generic iterables instead of Vec, making the API more flexible.

This change allows callers to pass any type that implements IntoIterator<Item = [F; WIDTH]>,
such as slices, arrays, or other collections, without having to convert them to Vec first.
The internal implementation still collects to Vec to preserve the existing behavior.