### PR TITLE
fix: fixed random number generation with `rand::Rng`

### DIFF
--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -22,7 +22,9 @@ impl KeccakAir {
         num_hashes: usize,
         extra_capacity_bits: usize,
     ) -> RowMajorMatrix<F> {
-        let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
+
+        let mut rng = rand::thread_rng();
+        let inputs = (0..num_hashes).map(|_| rng.gen()).collect::<Vec<_>>();
         generate_trace_rows(inputs, extra_capacity_bits)
     }
 }


### PR DESCRIPTION
I noticed that the external `rand` crate doesn't expose the `random()` function directly.
This is now fixed by switching to `rand::Rng`, which resolves the issue and aligns with the current crate API.