### PR TITLE
Updates Bincode requirement to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 ]
 
 [workspace.dependencies]
+bincode = { version = "2.0.0", default-features = false }
 blake3 = "1.5"
 clap = { version = "4.5.23", features = ["derive"] }
 clap_derive = "4.5.18"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,11 +25,12 @@ p3-poseidon2-air.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
 p3-util.workspace = true
+bincode = { workspace = true, features = ["serde", "alloc"] }
 clap.workspace = true
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
-bincode = "1.3.3"
+
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -237,6 +237,10 @@ pub fn report_proof_size<SC>(proof: &Proof<SC>)
 where
     SC: StarkGenericConfig,
 {
-    let proof_bytes = bincode::serialize(proof).expect("Failed to serialize proof");
+    let config = bincode::config::standard()
+        .with_little_endian()
+        .with_fixed_int_encoding();
+    let proof_bytes =
+        bincode::serde::encode_to_vec(proof, config).expect("Failed to serialize proof");
     println!("Proof size: {} bytes", proof_bytes.len());
 }


### PR DESCRIPTION
There were some API changes in the jump from 1.3.3 to 2.0.0 so the bot was unable to do it by itself.