### PR TITLE
Implement make_col_map function in poseidon2-air/src/columns.rs

### DIFF
--- a/poseidon2-air/src/columns.rs
+++ b/poseidon2-air/src/columns.rs
@@ -1,5 +1,6 @@
 use core::borrow::{Borrow, BorrowMut};
 use core::mem::size_of;
+use p3_util::indices_arr;
 
 /// Columns for a Poseidon2 AIR which computes one permutation per row.
 ///
@@ -77,24 +78,23 @@ pub const fn make_col_map<
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
 >() -> Poseidon2Cols<usize, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS> {
-    todo!()
-    // let indices_arr = indices_arr::<
-    //     { num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>() },
-    // >();
-    // unsafe {
-    //     transmute::<
-    //         [usize;
-    //             num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()],
-    //         Poseidon2Cols<
-    //             usize,
-    //             WIDTH,
-    //             SBOX_DEGREE,
-    //             SBOX_REGISTERS,
-    //             HALF_FULL_ROUNDS,
-    //             PARTIAL_ROUNDS,
-    //         >,
-    //     >(indices_arr)
-    // }
+    let indices_arr = indices_arr::<
+        { num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>() },
+    >();
+    unsafe {
+        core::mem::transmute::<
+            [usize;
+                num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()],
+            Poseidon2Cols<
+                usize,
+                WIDTH,
+                SBOX_DEGREE,
+                SBOX_REGISTERS,
+                HALF_FULL_ROUNDS,
+                PARTIAL_ROUNDS,
+            >,
+        >(indices_arr)
+    }
 }
 
 impl<


### PR DESCRIPTION
This pull request implements the previously unimplemented make_col_map function in the poseidon2-air/src/columns.rs file. The function was marked with a todo!() placeholder.

The implementation:
1. Uses the indices_arr utility function from p3_util
2. Creates an array of indices and transmutes it to the Poseidon2Cols struct
3. Follows the same pattern as the implementation in keccak-air/src/columns.rs

This change completes the column mapping functionality needed for the Poseidon2 AIR implementation.