### PR TITLE
Angus/minor field updates

### DIFF
--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// The BN254 curve scalar field prime, defined as `F_r` where `r = 21888242871839275222246405745257275088548364400416034343698204186575808495617`.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
 pub struct Bn254Fr {
-    pub value: FFBn254Fr,
+    pub(crate) value: FFBn254Fr,
 }
 
 impl Bn254Fr {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -33,7 +33,7 @@ pub struct Mersenne31 {
 
 impl Mersenne31 {
     #[inline]
-    pub const fn new(value: u32) -> Self {
+    pub(crate) const fn new(value: u32) -> Self {
         debug_assert!((value >> 31) == 0);
         Self { value }
     }
@@ -43,8 +43,9 @@ impl Mersenne31 {
     ///
     /// This means that this will be slower than `array.map(Mersenne31::new)` but
     /// has the advantage of being able to be used in `const` environments.
+    #[cfg(test)]
     #[inline]
-    pub const fn new_array<const N: usize>(input: [u32; N]) -> [Self; N] {
+    pub(crate) const fn new_array<const N: usize>(input: [u32; N]) -> [Self; N] {
         let mut output = [Self::ZERO; N];
         let mut i = 0;
         while i < N {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -47,9 +47,12 @@ impl Mersenne31 {
     /// # Panics
     /// This will panic if the element does not lie in the range: `[0, 2^31 - 1]`.
     #[inline]
-    pub const fn new_checked(value: u32) -> Self {
-        assert!((value >> 31) == 0);
-        Self { value }
+    pub const fn new_checked(value: u32) -> Option<Self> {
+        if (value >> 31) == 0 {
+            Some(Self { value })
+        } else {
+            None
+        }
     }
 
     /// Convert a constant `u32` array into a constant array of field elements.

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -32,20 +32,33 @@ pub struct Mersenne31 {
 }
 
 impl Mersenne31 {
+    /// Convert a u32 element into a Mersenne31 element.
+    ///
+    /// # Safety
+    /// The element must lie in the range: `[0, 2^31 - 1]`.
     #[inline]
     pub(crate) const fn new(value: u32) -> Self {
         debug_assert!((value >> 31) == 0);
         Self { value }
     }
 
+    /// Convert a u32 element into a Mersenne31 element.
+    ///
+    /// # Panics
+    /// This will panic if the element does not lie in the range: `[0, 2^31 - 1]`.
+    #[inline]
+    pub const fn new_checked(value: u32) -> Self {
+        assert!((value >> 31) == 0);
+        Self { value }
+    }
+
     /// Convert a constant `u32` array into a constant array of field elements.
     /// This allows inputs to be `> 2^31`, and just reduces them `mod P`.
     ///
-    /// This means that this will be slower than `array.map(Mersenne31::new)` but
+    /// This means that this will be slower than `array.map(Mersenne31::new_checked)` but
     /// has the advantage of being able to be used in `const` environments.
-    #[cfg(test)]
     #[inline]
-    pub(crate) const fn new_array<const N: usize>(input: [u32; N]) -> [Self; N] {
+    pub const fn new_array<const N: usize>(input: [u32; N]) -> [Self; N] {
         let mut output = [Self::ZERO; N];
         let mut i = 0;
         while i < N {

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -36,8 +36,8 @@ pub struct MontyField31<MP: MontyParameters> {
 }
 
 impl<MP: MontyParameters> MontyField31<MP> {
-    // The standard way to crate a new element.
-    // Note that new converts the input into MONTY form so should be avoided in performance critical implementations.
+    /// The standard way to crate a new element.
+    /// Note that new converts the input into MONTY form so should be avoided in performance critical implementations.
     #[inline(always)]
     pub const fn new(value: u32) -> Self {
         Self {
@@ -46,9 +46,9 @@ impl<MP: MontyParameters> MontyField31<MP> {
         }
     }
 
-    // Create a new field element from something already in MONTY form.
-    // This is `pub(crate)` for tests and delayed reduction strategies. If you're using it outside of those, you're
-    // likely doing something fishy.
+    /// Create a new field element from something already in MONTY form.
+    /// This is `pub(crate)` for tests and delayed reduction strategies. If you're using it outside of those, you're
+    /// likely doing something fishy.
     #[inline(always)]
     pub(crate) const fn new_monty(value: u32) -> Self {
         Self {


### PR DESCRIPTION
A couple of small changes in our field crates.

- In Bn254, the value of the field should be pub(crate) not pub. If users want the value stored inside they can always use `.to_canonical_biguint()`. The values are stored in MONTY form so we don't want to expose that.
- In Mersenne31, `new` is now `pub(crate)` and not `pub`. The `new` function should really be marked unsafe (As should `new_monty` in `MontyField31 ` but I think the ship has sailed on those). At any rate these functions should not be public as if the input does not conform to the expected range, we violate memory safety. For the most part, users should be using `from_int` to create `Mersenne31` elements. If you really need to create on in a constant environment, I've introduced a new function `new_checked` which functions like `new` but with an assert! instead of a debug_assert!. This might panic but it should be pretty obvious what caused such a panic.
- Updated some comments in MontyField31 to be doc comments.

Note that the `new` methods in `Goldilocks` and `MontyField31` are actually safe as they can accept any `u64/u32` so it's okay for those to be public.