### PR TITLE
Remove some unused functions

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -789,37 +789,3 @@ macro_rules! test_two_adic_extension_field {
         }
     };
 }
-
-#[cfg(test)]
-mod tests {
-    use alloc::vec;
-    use alloc::vec::Vec;
-
-    use p3_baby_bear::BabyBear;
-    use p3_field::extension::{BinomialExtensionField, HasFrobenius};
-    use p3_field::{PrimeCharacteristicRing, binomial_expand, eval_poly};
-    use rand::random;
-
-    use super::*;
-
-    #[test]
-    fn test_minimal_poly() {
-        type F = BabyBear;
-        type EF = BinomialExtensionField<F, 4>;
-        for _ in 0..1024 {
-            let x: EF = random();
-            let m: Vec<EF> = x.minimal_poly().into_iter().map(Into::<EF>::into).collect();
-            assert!(eval_poly(&m, x).is_zero());
-        }
-    }
-
-    #[test]
-    fn test_binomial_expand() {
-        type F = BabyBear;
-        // (x - 1)(x - 2) = x^2 - 3x + 2
-        assert_eq!(
-            binomial_expand(&[F::ONE, F::TWO]),
-            vec![F::TWO, -F::from_u8(3), F::ONE]
-        );
-    }
-}

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,13 +1,12 @@
-use core::{debug_assert, debug_assert_eq, iter};
+use core::iter;
 
+use crate::ExtensionField;
 use crate::field::Field;
-use crate::{ExtensionField, naive_poly_mul};
 
 mod binomial_extension;
 mod complex;
 mod packed_binomial_extension;
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 pub use binomial_extension::*;
@@ -34,23 +33,7 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
     fn repeated_frobenius(&self, count: usize) -> Self;
     fn frobenius_inv(&self) -> Self;
 
-    fn minimal_poly(mut self) -> Vec<F> {
-        let mut m = vec![Self::ONE];
-        for _ in 0..Self::DIMENSION {
-            m = naive_poly_mul(&m, &[-self, Self::ONE]);
-            self = self.frobenius();
-        }
-        let mut m_iter = m
-            .into_iter()
-            .map(|c| c.as_base().expect("Extension is not algebraic?"));
-        let m: Vec<F> = m_iter.by_ref().take(Self::DIMENSION + 1).collect();
-        debug_assert_eq!(m.len(), Self::DIMENSION + 1);
-        debug_assert_eq!(m.last(), Some(&F::ONE));
-        debug_assert!(m_iter.all(|c| c.is_zero()));
-        m
-    }
-
-    fn galois_group(self) -> Vec<Self> {
+    fn galois_orbit(self) -> Vec<Self> {
         iter::successors(Some(self), |x| Some(x.frobenius()))
             .take(Self::DIMENSION)
             .collect()

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 use core::iter::Sum;
 use core::mem::{ManuallyDrop, MaybeUninit};
@@ -36,17 +35,6 @@ pub fn cyclic_subgroup_coset_known_order<F: Field>(
     order: usize,
 ) -> impl Iterator<Item = F> + Clone {
     generator.shifted_powers(shift).take(order)
-}
-
-#[must_use]
-pub fn add_vecs<F: Field>(v: Vec<F>, w: Vec<F>) -> Vec<F> {
-    assert_eq!(v.len(), w.len());
-    v.into_iter().zip(w).map(|(x, y)| x + y).collect()
-}
-
-pub fn sum_vecs<F: Field, I: Iterator<Item = Vec<F>>>(iter: I) -> Vec<F> {
-    iter.reduce(|v, w| add_vecs(v, w))
-        .expect("sum_vecs: empty iterator")
 }
 
 pub fn scale_vec<F: Field>(s: F, vec: Vec<F>) -> Vec<F> {
@@ -138,40 +126,6 @@ pub const fn field_to_array<R: PrimeCharacteristicRing, const D: usize>(x: R) ->
     // Hence we are safe to reinterpret the array as [R; D].
 
     unsafe { HackyWorkAround::transpose(arr).assume_init() }
-}
-
-/// Naive polynomial multiplication.
-pub fn naive_poly_mul<R: PrimeCharacteristicRing>(a: &[R], b: &[R]) -> Vec<R> {
-    // Grade school algorithm
-    let mut product = vec![R::ZERO; a.len() + b.len() - 1];
-    for (i, c1) in a.iter().enumerate() {
-        for (j, c2) in b.iter().enumerate() {
-            product[i + j] += c1.clone() * c2.clone();
-        }
-    }
-    product
-}
-
-/// Expand a product of binomials `(x - roots[0])(x - roots[1])..` into polynomial coefficients.
-pub fn binomial_expand<R: PrimeCharacteristicRing>(roots: &[R]) -> Vec<R> {
-    let mut coeffs = vec![R::ZERO; roots.len() + 1];
-    coeffs[0] = R::ONE;
-    for (i, x) in roots.iter().enumerate() {
-        for j in (1..i + 2).rev() {
-            coeffs[j] = coeffs[j - 1].clone() - x.clone() * coeffs[j].clone();
-        }
-        coeffs[0] *= -x.clone();
-    }
-    coeffs
-}
-
-pub fn eval_poly<R: PrimeCharacteristicRing>(poly: &[R], x: R) -> R {
-    let mut acc = R::ZERO;
-    for coeff in poly.iter().rev() {
-        acc *= x.clone();
-        acc += coeff.clone();
-    }
-    acc
 }
 
 /// Given an element x from a 32 bit field F_P compute x/2.


### PR DESCRIPTION
There are a collection of functions in `field` which are basically never used (outside of testing themselves) and are definitely not optimized so we should probably just remove them.

There are two methods supporting addition on vectors of field elements:
- `add_vecs`: Compute v + w component wise.
- `sum_vecs`: Compute v + w + ... by calling `add_vecs` repeatedly.
If we want to support these, `add_vecs` should be summing the vectors as `PackedField` elements. Given how simple these are though, I think we should just delete them and let others implement them if they see fit.

There are a collection of methods supporting polynomials in the coefficient domain.
- `naive_poly_mul`: Multiply polynomials. (This is much slower than in the evaluation domain)
- `binomial_expand`: Expand a product of the form `(x - a0)(x - a1)...`. (In all cases this might be used, the `a0, a1, ...` usually have some additional algebraic properties (e.g. the values of a coset) so this can be computed more efficiently)
- `eval_poly`: Evaluate a polynomial at a given point. (Usually we want to do an `FFT` to batch a bunch of these)
- `minimal_poly` (Inside `HasFrobenius` trait): Given an element `alpha` in an extension field, find it's minimal polynomial. (It's possible that this could be useful in speeding up computations of a vector of powers `1, alpha, alpha^2, ...` but we don't use it currently and I doubt will ever as this really isn't a bottleneck of our proofs)
Plonky3 never works with polynomials in the coefficient domain as for almost all operations it is much faster to work in the evaluation domain. Hence I think we should also just delete these as they are slow and go against the general design principle.
