### PR TITLE
Add Panic documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ halo2curves = "0.8.0"
 hashbrown = "0.15.0"
 hex-literal = "1.0.0"
 itertools = "0.14.0"
-modinverse = "0.1.1"
 num = "0.4.0"
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = "0.1.46"

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -56,6 +56,9 @@ pub trait Mmcs<T: Send + Sync>: Clone {
     }
 
     /// Get the largest height of any committed matrix.
+    ///
+    /// # Panics
+    /// This may panic if there are no committed matrices.
     fn get_max_height<M: Matrix<T>>(&self, prover_data: &Self::ProverData<M>) -> usize {
         self.get_matrix_heights(prover_data)
             .into_iter()

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -596,7 +596,9 @@ pub trait Field:
 
     /// The multiplicative inverse of this field element.
     ///
-    /// NOTE: The inverse of `0` is undefined and will error.
+    /// # Panics
+    /// The function will panic if the field element is `0`.
+    /// Use try_inverse if you want to handle this case.
     #[must_use]
     fn inverse(&self) -> Self {
         self.try_inverse().expect("Tried to invert zero")

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -427,7 +427,7 @@ macro_rules! impl_u_i_size {
                     4 => Self::from_int(int as $int32),
                     8 => Self::from_int(int as $int64),
                     16 => Self::from_int(int as $int128),
-                    _ => panic!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
+                    _ => unreachable!(concat!(stringify!($intsize), "is not equivalent to any primitive integer types.")),
                 }
             }
 
@@ -439,7 +439,7 @@ macro_rules! impl_u_i_size {
                     4 => Self::from_canonical_checked(int as $int32),
                     8 => Self::from_canonical_checked(int as $int64),
                     16 => Self::from_canonical_checked(int as $int128),
-                    _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
+                    _ => unreachable!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                 }
             }
 
@@ -452,7 +452,7 @@ macro_rules! impl_u_i_size {
                         4 => Self::from_canonical_unchecked(int as $int32),
                         8 => Self::from_canonical_unchecked(int as $int64),
                         16 => Self::from_canonical_unchecked(int as $int128),
-                        _ => panic!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
+                        _ => unreachable!(concat!(stringify!($intsize), " is not equivalent to any primitive integer types.")),
                     }
                 }
             }

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -213,9 +213,11 @@ pub unsafe trait PackedFieldPow2: PackedField {
     /// We can also think about this as stacking the vectors, dividing them into 2x2 matrices, and
     /// transposing those matrices.
     ///
-    /// When `block_len = WIDTH`, this operation is a no-op. `block_len` must divide `WIDTH`. Since
-    /// `WIDTH` is specified to be a power of 2, `block_len` must also be a power of 2. It cannot be
-    /// 0 and it cannot exceed `WIDTH`.
+    /// When `block_len = WIDTH`, this operation is a no-op.
+    ///
+    /// # Panics
+    /// This may panic if `block_len` does not divide `WIDTH`. Since `WIDTH` is specified to be a power of 2,
+    /// `block_len` must also be a power of 2. It cannot be 0 and it cannot exceed `WIDTH`.
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self);
 }
 

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -183,9 +183,12 @@ impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyFiel
     }
 }
 
-/// Use hard coded methods to compute x -> x^d for the even index entries and small d.
-/// Inputs should be signed 32-bit integers in [-P, ..., P].
-/// Outputs will also be signed integers in (-P, ..., P) stored in the odd indices.
+/// Use hard coded methods to compute `x -> x^D` for the even index entries and small `D`.
+/// Inputs should be signed 32-bit integers in `[-P, ..., P]`.
+/// Outputs will also be signed integers in `(-P, ..., P)` stored in the odd indices.
+///
+/// # Panics
+/// This function will panic if `D` is not `3, 5` or `7`.
 #[inline(always)]
 #[must_use]
 fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m256i) -> __m256i {

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -183,9 +183,12 @@ impl<FP: FieldParameters, const WIDTH: usize> ExternalLayerConstructor<MontyFiel
     }
 }
 
-/// Use hard coded methods to compute x -> x^d for the even index entries and small d.
-/// Inputs should be signed 32-bit integers in [-P, ..., P].
-/// Outputs will also be signed integers in (-P, ..., P) stored in the odd indices.
+/// Use hard coded methods to compute `x -> x^D` for the even index entries and small `D`.
+/// Inputs should be signed 32-bit integers in `[-P, ..., P]`.
+/// Outputs will also be signed integers in `(-P, ..., P)` stored in the odd indices.
+///
+/// # Panics
+/// This function will panic if `D` is not `3, 5` or `7`.
 #[inline(always)]
 #[must_use]
 fn exp_small<PMP: PackedMontyParameters, const D: u64>(val: __m512i) -> __m512i {

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -243,6 +243,14 @@ fn generate_partial_round<
     LinearLayers::internal_linear_layer(state);
 }
 
+/// Computes the S-box `x -> x^{DEGREE}` and stores the partial data required to
+/// verify the computation.
+///
+/// # Panics
+///
+/// This method panics if the number of `REGISTERS` is not chosen optimally for the given
+/// `DEGREE` or if the `DEGREE` is not supported by the S-box. The supported degrees are
+/// `3`, `5`, `7`, and `11`.
 #[inline]
 fn generate_sbox<F: PrimeField, const DEGREE: u64, const REGISTERS: usize>(
     sbox: &mut SBox<MaybeUninit<F>, DEGREE, REGISTERS>,

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -88,6 +88,10 @@ impl<R: PrimeCharacteristicRing> MdsPermutation<R, 4> for MDSMat4 {}
 ///
 /// Given a 4x4 MDS matrix M, we multiply by the `4N x 4N` matrix
 /// `[[2M M  ... M], [M  2M ... M], ..., [M  M ... 2M]]`.
+///
+/// # Panics
+/// This will panic if `WIDTH` is not supported. Currently, the
+/// supported `WIDTH` values are 2, 3, 4, 8, 12, 16, 20, 24.`
 #[inline(always)]
 pub fn mds_light_permutation<
     R: PrimeCharacteristicRing,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -82,11 +82,17 @@ where
     InternalPerm: InternalLayerConstructor<F>,
 {
     /// Create a new Poseidon2 configuration with 128 bit security and random rounds constants.
+    ///
+    /// # Panics
+    /// This will panic if D and F::ORDER_U64 - 1 are not relatively prime.
+    /// This will panic if the optimal parameters for the given field and width have not been computed.
     pub fn new_from_rng_128<R: Rng>(rng: &mut R) -> Self
     where
         StandardUniform: Distribution<F> + Distribution<[F; WIDTH]>,
     {
-        let (rounds_f, rounds_p) = poseidon2_round_numbers_128::<F>(WIDTH, D);
+        let round_numbers = poseidon2_round_numbers_128::<F>(WIDTH, D);
+        let (rounds_f, rounds_p) =
+            round_numbers.unwrap_or_else(|_| panic!("{}", round_numbers.unwrap_err()));
         Self::new_from_rng(rounds_f, rounds_p, rng)
     }
 }

--- a/poseidon2/src/round_numbers.rs
+++ b/poseidon2/src/round_numbers.rs
@@ -28,48 +28,53 @@ use p3_field::PrimeField64;
 use p3_util::relatively_prime_u64;
 
 /// Given a field, a width and an D return the number of full and partial rounds needed to achieve 128 bit security.
-pub const fn poseidon2_round_numbers_128<F: PrimeField64>(width: usize, d: u64) -> (usize, usize) {
+///
+/// If d is not a valid permutation of the given field or the optimal parameters for that size of prime
+/// have not been computed, an error is returned.
+pub const fn poseidon2_round_numbers_128<F: PrimeField64>(
+    width: usize,
+    d: u64,
+) -> Result<(usize, usize), &'static str> {
     // Start by checking that d is a valid permutation.
-    assert!(
-        relatively_prime_u64(d, F::ORDER_U64 - 1),
-        "Invalid permutation: gcd(d, F::ORDER_U64 - 1) must be 1"
-    );
+    if !relatively_prime_u64(d, F::ORDER_U64 - 1) {
+        return Err("Invalid permutation: gcd(d, F::ORDER_U64 - 1) must be 1");
+    }
 
     // Next compute the number of bits in p.
     let prime_bit_number = F::ORDER_U64.ilog2() + 1;
 
     match prime_bit_number {
         31 => match (width, d) {
-            (16, 3) => (8, 20),
-            (16, 5) => (8, 14),
-            (16, 7) => (8, 13),
-            (16, 9) => (8, 13),
-            (16, 11) => (8, 13),
-            (24, 3) => (8, 23),
-            (24, 5) => (8, 22),
-            (24, 7) => (8, 21),
-            (24, 9) => (8, 21),
-            (24, 11) => (8, 21),
-            _ => panic!("The given pair of width and D has not been checked for these fields"),
+            (16, 3) => Ok((8, 20)),
+            (16, 5) => Ok((8, 14)),
+            (16, 7) => Ok((8, 13)),
+            (16, 9) => Ok((8, 13)),
+            (16, 11) => Ok((8, 13)),
+            (24, 3) => Ok((8, 23)),
+            (24, 5) => Ok((8, 22)),
+            (24, 7) => Ok((8, 21)),
+            (24, 9) => Ok((8, 21)),
+            (24, 11) => Ok((8, 21)),
+            _ => Err("The given pair of width and D has not been checked for these fields"),
         },
         64 => match (width, d) {
-            (8, 3) => (8, 41),
-            (8, 5) => (8, 27),
-            (8, 7) => (8, 22),
-            (8, 9) => (8, 19),
-            (8, 11) => (8, 17),
-            (12, 3) => (8, 42),
-            (12, 5) => (8, 27),
-            (12, 7) => (8, 22),
-            (12, 9) => (8, 20),
-            (12, 11) => (8, 18),
-            (16, 3) => (8, 42),
-            (16, 5) => (8, 27),
-            (16, 7) => (8, 22),
-            (16, 9) => (8, 20),
-            (16, 11) => (8, 18),
-            _ => panic!("The given pair of width and D has not been checked for these fields"),
+            (8, 3) => Ok((8, 41)),
+            (8, 5) => Ok((8, 27)),
+            (8, 7) => Ok((8, 22)),
+            (8, 9) => Ok((8, 19)),
+            (8, 11) => Ok((8, 17)),
+            (12, 3) => Ok((8, 42)),
+            (12, 5) => Ok((8, 27)),
+            (12, 7) => Ok((8, 22)),
+            (12, 9) => Ok((8, 20)),
+            (12, 11) => Ok((8, 18)),
+            (16, 3) => Ok((8, 42)),
+            (16, 5) => Ok((8, 27)),
+            (16, 7) => Ok((8, 22)),
+            (16, 9) => Ok((8, 20)),
+            (16, 11) => Ok((8, 18)),
+            _ => Err("The given pair of width and D has not been checked for these fields"),
         },
-        _ => panic!("The optimal parameters for that size of prime have not been computed."),
+        _ => Err("The optimal parameters for that size of prime have not been computed."),
     }
 }

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 itertools.workspace = true
-modinverse.workspace = true
 num.workspace = true
 num-integer.workspace = true
 p3-field.workspace = true

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -1,36 +1,8 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use modinverse::modinverse;
-use p3_field::PrimeField64;
-use p3_util::relatively_prime_u64;
 use sha3::Shake256;
 use sha3::digest::{ExtendableOutput, Update, XofReader};
-
-/// Generate alpha, the smallest integer relatively prime to `p − 1`.
-pub(crate) const fn get_alpha<F: PrimeField64>() -> u64 {
-    let p = F::ORDER_U64;
-    let mut a = 3;
-
-    while a < p {
-        if relatively_prime_u64(a, p - 1) {
-            return a;
-        }
-        a += 1;
-    }
-
-    panic!("No valid alpha found. Rescue does not support fields of order 2 or 3.");
-}
-
-/// Given alpha, find its multiplicative inverse in `Z/⟨p − 1⟩`.
-pub(crate) fn get_inverse<F: PrimeField64>(alpha: u64) -> u64 {
-    let p = F::ORDER_U64 as i128;
-    modinverse(alpha as i128, p - 1)
-        .expect("x^alpha not a permutation")
-        .unsigned_abs()
-        .try_into()
-        .unwrap()
-}
 
 /// Compute the SHAKE256 variant of SHA-3.
 /// This is used to generate the round constants from a seed string.

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -71,6 +71,8 @@ where
         self.is_last_row
     }
 
+    /// # Panics
+    /// This function panics if `size` is not `2`.
     fn is_transition_window(&self, size: usize) -> Self::Expr {
         if size == 2 {
             self.is_transition

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -54,6 +54,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
         self.is_last_row
     }
 
+    /// # Panics
+    /// This function panics if `size` is not `2`.
     #[inline]
     fn is_transition_window(&self, size: usize) -> Self::Expr {
         if size == 2 {
@@ -110,6 +112,8 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
         self.is_last_row
     }
 
+    /// # Panics
+    /// This function panics if `size` is not `2`.
     fn is_transition_window(&self, size: usize) -> Self::Expr {
         if size == 2 {
             self.is_transition

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -121,6 +121,8 @@ impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
         SymbolicExpression::IsLastRow
     }
 
+    /// # Panics
+    /// This function panics if `size` is not `2`.
     fn is_transition_window(&self, size: usize) -> Self::Expr {
         if size == 2 {
             SymbolicExpression::IsTransition


### PR DESCRIPTION
Following the spirit of #168 and the ensuing discussion, we should be trying to mostly avoid panicking.

While this is probably impossible (without compromising speed), we can at least mark functions which might panic with `# Panic` and give the conditions upon which panicking might occur. Ideally, for function whose performance is not critical, we should try and replace `panic!` by returning a result. (In particular we should probably do this for `Poseidon2::new_from_rng_128` but that looks a little painful so for now I've just marked that with a `# Panic`.

I've ignored any `panic!`'s which occur in test code as those are fine.

2 Specific comments:
- In `field/src/integers`, the `panic!` is only reached if `usize` is not the same size as any integer type (`u8, u16, u32, u64, u128`). As far as I can tell, this should be impossible so I switched the `panic!` for an `unreachable!`. We could probably even use `unreachable_unchecked!` but we don't need to and that might bite someone in the foot on some far off day.
- When looking for placed we used `panic!` I came across two functions in `rescue/utils` which are unused, so I've deleted them. These functions were public but I really doubt anyone was using them. This also let me delete the `modinverse` dependency from Plonky3.