### PR TITLE
Reduce dependencies in Rescue by reimplementing `num_rounds`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,7 @@ halo2curves = "0.8.0"
 hashbrown = "0.15.0"
 hex-literal = "1.0.0"
 itertools = "0.14.0"
-num = "0.4.0"
 num-bigint = { version = "0.4.3", default-features = false }
-num-integer = "0.1.46"
 num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.0", default-features = false }

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -9,7 +9,6 @@ p3-util.workspace = true
 p3-maybe-rayon.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
-num-integer.workspace = true
 paste.workspace = true
 tracing.workspace = true
 

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -7,8 +7,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 itertools.workspace = true
 modinverse.workspace = true
-num.workspace = true
-num-integer.workspace = true
 p3-field.workspace = true
 p3-mds.workspace = true
 p3-symmetric.workspace = true

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -2,8 +2,6 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
-use num::{BigUint, One};
-use num_integer::binomial;
 use p3_field::{Algebra, PermutationMonomial, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
@@ -11,7 +9,7 @@ use rand::Rng;
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 
-use crate::util::shake256_hash;
+use crate::util::{log2_binom, shake256_hash};
 
 /// The Rescue-XLIX permutation.
 #[derive(Clone, Debug)]
@@ -33,22 +31,36 @@ where
         }
     }
 
-    fn num_rounds(capacity: usize, sec_level: usize, alpha: u64) -> usize {
-        let rate = WIDTH - capacity;
-        let dcon = |n: usize| {
-            (0.5 * ((alpha - 1) * WIDTH as u64 * (n as u64 - 1)) as f64 + 2.0).floor() as usize
-        };
-        let v = |n: usize| WIDTH * (n - 1) + rate;
-        let target = BigUint::one() << sec_level;
+    /// Calculate the number of rounds needed to attain 2^sec_level security.
+    ///
+    /// The formulas here are direct translations of those from the
+    /// Rescue Prime paper in Section 2.5 and following. See the paper
+    /// for justifications.
+    pub fn num_rounds(capacity: usize, sec_level: usize) -> usize {
+        let rate = (WIDTH - capacity) as u64;
+        // This iterator produces pairs (dcon, v) increasing by a fixed
+        // amount (determined by the formula in the paper) each iteration,
+        // together with the value log2(binomial(v + dcon, v)). These values
+        // are fed into `find` which picks the first that exceed the desired
+        // security level.
+        let rnds = (1..)
+            .scan((rate + 2, rate), |(dcon, v), r| {
+                let log2_bin = log2_binom(*v + *dcon, *v);
 
-        let is_sufficient = |l1: &usize| {
-            let n = BigUint::from(v(*l1) + dcon(*l1));
-            let k = BigUint::from(v(*l1));
-            let bin = binomial(n, k);
-            &bin * &bin > target
-        };
-        let l1 = (1..25).find(is_sufficient).unwrap();
-        (l1.max(5) as f32 * 1.5).ceil() as usize
+                // ALPHA is a prime > 2, so ALPHA + 1 is even, hence this
+                // division is exact.
+                *dcon += WIDTH as u64 * (ALPHA + 1) / 2;
+                *v += WIDTH as u64;
+
+                Some((r, log2_bin))
+            })
+            .find(|(_r, log2_bin)| 2.0 * log2_bin > sec_level as f32)
+            .unwrap(); // Guaranteed to succeed for suff. large (dcon,v).
+        let rnds = rnds.0;
+
+        // The paper mandates a minimum of 5 rounds and adds a 50%
+        // safety margin: ceil(1.5 * max{5, rnds})
+        (3 * rnds.max(5) + 1) / 2
     }
 
     // For a general field, we provide a generic constructor for the round constants.
@@ -161,7 +173,7 @@ mod tests {
     type RescuePrimeM31Default = Rescue<Mersenne31, MdsMatrixMersenne31, WIDTH, ALPHA>;
 
     fn new_rescue_prime_m31_default() -> RescuePrimeM31Default {
-        let num_rounds = RescuePrimeM31Default::num_rounds(6, 128, ALPHA);
+        let num_rounds = RescuePrimeM31Default::num_rounds(6, 128);
         let round_constants =
             RescuePrimeM31Default::get_round_constants_rescue_prime(num_rounds, 6, 128);
         let mds = MdsMatrixMersenne31 {};

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -44,7 +44,7 @@ where
         // are fed into `find` which picks the first that exceed the desired
         // security level.
         let rnds = (1..)
-            .scan((rate + 2, rate), |(dcon, v), r| {
+            .scan((2, rate), |(dcon, v), r| {
                 let log2_bin = log2_binom(*v + *dcon, *v);
 
                 // ALPHA is a prime > 2, so ALPHA + 1 is even, hence this

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -54,8 +54,7 @@ pub(crate) fn shake256_hash(seed_bytes: &[u8], num_bytes: usize) -> Vec<u8> {
 /// accuracy is sufficient.
 #[must_use]
 fn pow2_no_std<const P: usize>(x: f32) -> f32 {
-    const LN_2: f32 = 0.69314718056; // log(2)
-    let y = x * LN_2;
+    let y = x * core::f32::consts::LN_2;
     let mut t = 1.0; // ith Taylor term = (x ln(2))^i/i!
     let mut two_pow_x = t;
     for i in 1..P {
@@ -79,7 +78,7 @@ fn pow2_no_std<const P: usize>(x: f32) -> f32 {
 /// passed to pow2_no_std) before being used more widely.
 #[must_use]
 fn log2_no_std(x: u64) -> f32 {
-    const LOG2_E: f32 = 1.44269504;
+    const LOG2_E: f32 = core::f32::consts::LOG2_E;
     // Initial estimate x0 = floor(log2(x))
     let x0 = log2_ceil_u64(x + 1) - 1;
     let p0 = (1 << x0) as f32; // 2^x0
@@ -88,8 +87,7 @@ fn log2_no_std(x: u64) -> f32 {
     let p1 = pow2_no_std::<20>(x1);
     let x2 = x1 - LOG2_E * (1.0 - x as f32 / p1);
     let p2 = pow2_no_std::<20>(x2);
-    let x3 = x2 - LOG2_E * (1.0 - x as f32 / p2);
-    x3
+    x2 - LOG2_E * (1.0 - x as f32 / p2)
 }
 
 /// Compute an approximation to log2(binomial(n, k)).
@@ -104,7 +102,7 @@ fn log2_no_std(x: u64) -> f32 {
 ///
 /// coming from Stirling's approximation for n!.
 pub(crate) fn log2_binom(n: u64, k: u64) -> f32 {
-    const LOG2_2PI: f32 = 2.65149613;
+    const LOG2_2PI: f32 = 2.6514961;
     let log2_n = log2_no_std(n);
     let log2_k = log2_no_std(k);
     let log2_nmk = log2_no_std(n - k);
@@ -122,30 +120,13 @@ mod test {
     #[test]
     fn test_log2_no_std() {
         let inputs = [
-            10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190,
+            11, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190,
             200,
         ];
         let expected = [
-            3.321928094887362,
-            4.321928094887363,
-            4.906890595608519,
-            5.321928094887363,
-            5.643856189774724,
-            5.906890595608519,
-            6.129283016944966,
-            6.321928094887363,
-            6.491853096329675,
-            6.643856189774724,
-            6.78135971352466,
-            6.906890595608519,
-            7.022367813028454,
-            7.129283016944966,
-            7.22881869049588,
-            7.321928094887363,
-            7.409390936137702,
-            7.491853096329675,
-            7.569855608330948,
-            7.643856189774724,
+            3.459432, 4.321928, 4.906891, 5.321928, 5.643856, 5.906891, 6.129283, 6.321928,
+            6.491853, 6.643856, 6.78136, 6.906891, 7.022368, 7.129283, 7.228819, 7.321928,
+            7.409391, 7.491853, 7.569856, 7.643856,
         ];
         for (&x, y) in inputs.iter().zip(expected) {
             assert!((log2_no_std(x) - y) < TOLERANCE);

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use modinverse::modinverse;
 use p3_field::PrimeField64;
+use p3_util::log2_ceil_u64;
 use p3_util::relatively_prime_u64;
 use sha3::Shake256;
 use sha3::digest::{ExtendableOutput, Update, XofReader};
@@ -41,4 +42,113 @@ pub(crate) fn shake256_hash(seed_bytes: &[u8], num_bytes: usize) -> Vec<u8> {
     let mut result = vec![0u8; num_bytes];
     reader.read(&mut result);
     result
+}
+
+/// Return 2^x for x an f32.
+///
+/// This is a replacement for f32::powf() when libm isn't available;
+/// it is slow and shouldn't be used for anything important.
+///
+/// Algorithm is a direct evaluation of the corresponding Taylor
+/// series. As x increases, increase the precision P until the
+/// accuracy is sufficient.
+#[must_use]
+fn pow2_no_std<const P: usize>(x: f32) -> f32 {
+    const LN_2: f32 = 0.69314718056; // log(2)
+    let y = x * LN_2;
+    let mut t = 1.0; // ith Taylor term = (x ln(2))^i/i!
+    let mut two_pow_x = t;
+    for i in 1..P {
+        t *= y / (i as f32);
+        two_pow_x += t;
+    }
+    two_pow_x
+}
+
+/// Return log2(x) for x a u64.
+///
+/// This is a replacement for f64::log2() when libm isn't available;
+/// it is slow and shouldn't be used for anything important.
+///
+/// At least for inputs up to a few hundred the accuracy of this function
+/// is better than 0.001.
+///
+/// Algorithm is just three iterations of Newton-Raphson. This is
+/// sufficient for the one use in this crate. It should be generalised
+/// to multiple iterations (with a suitable analysis of the precision
+/// passed to pow2_no_std) before being used more widely.
+#[must_use]
+fn log2_no_std(x: u64) -> f32 {
+    const LOG2_E: f32 = 1.44269504;
+    // Initial estimate x0 = floor(log2(x))
+    let x0 = log2_ceil_u64(x + 1) - 1;
+    let p0 = (1 << x0) as f32; // 2^x0
+    let x1 = x0 as f32 - LOG2_E * (1.0 - x as f32 / p0);
+    // precision 20 determined by experiment
+    let p1 = pow2_no_std::<20>(x1);
+    let x2 = x1 - LOG2_E * (1.0 - x as f32 / p1);
+    let p2 = pow2_no_std::<20>(x2);
+    let x3 = x2 - LOG2_E * (1.0 - x as f32 / p2);
+    x3
+}
+
+/// Compute an approximation to log2(binomial(n, k)).
+///
+/// This calculation relies on a slow version of log2 and shouldn't be
+/// used for anything important.
+///
+/// The algorithm uses the approximation
+///
+///   log2(binom(n,k)) ≈ n log2(n) - k log2(k) - (n-k) log2(n-k)
+///               + (log2(n) - log2(k) - log2(n-k) - log2(2π))/2
+///
+/// coming from Stirling's approximation for n!.
+pub(crate) fn log2_binom(n: u64, k: u64) -> f32 {
+    const LOG2_2PI: f32 = 2.65149613;
+    let log2_n = log2_no_std(n);
+    let log2_k = log2_no_std(k);
+    let log2_nmk = log2_no_std(n - k);
+
+    n as f32 * log2_n - k as f32 * log2_k - (n - k) as f32 * log2_nmk
+        + 0.5 * (log2_n - log2_k - log2_nmk - LOG2_2PI)
+}
+
+#[cfg(test)]
+mod test {
+    use super::log2_no_std;
+
+    const TOLERANCE: f32 = 0.001;
+
+    #[test]
+    fn test_log2_no_std() {
+        let inputs = [
+            10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190,
+            200,
+        ];
+        let expected = [
+            3.321928094887362,
+            4.321928094887363,
+            4.906890595608519,
+            5.321928094887363,
+            5.643856189774724,
+            5.906890595608519,
+            6.129283016944966,
+            6.321928094887363,
+            6.491853096329675,
+            6.643856189774724,
+            6.78135971352466,
+            6.906890595608519,
+            7.022367813028454,
+            7.129283016944966,
+            7.22881869049588,
+            7.321928094887363,
+            7.409390936137702,
+            7.491853096329675,
+            7.569855608330948,
+            7.643856189774724,
+        ];
+        for (&x, y) in inputs.iter().zip(expected) {
+            assert!((log2_no_std(x) - y) < TOLERANCE);
+        }
+    }
 }

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -3,8 +3,7 @@ use alloc::vec::Vec;
 
 use modinverse::modinverse;
 use p3_field::PrimeField64;
-use p3_util::log2_ceil_u64;
-use p3_util::relatively_prime_u64;
+use p3_util::{log2_ceil_u64, relatively_prime_u64};
 use sha3::Shake256;
 use sha3::digest::{ExtendableOutput, Update, XofReader};
 


### PR DESCRIPTION
The `num_rounds` function calculates the number of rounds that the Rescue Prime paper claims is necessary for a given security level. The original implementation was private, even though it's quite useful, so we've started by making it public. However the implementation also pulls in dependencies on bignum crates that can be avoided, and indeed must be avoided in order to remove dependency on `std` (ongoing work addressing #594).

This PR includes an function that directly approximates `log2(binomial(n, k))` thus avoiding the need to pass to bignums. The implementation depends on new functions for log2 and pow2, which are included to avoid depending on floating point libraries (this is required to address #594). The accuracy of all of these functions is a bit mediocre by usual standards, but is enough for this one task of calculating the number of rounds to perform for a given security level.

If anyone can see a way to get a good estimate of `log2(binomial(n, k))` by just using `log2_ceil_u64` and avoiding passing to floating point, please let me know!