### PR TITLE
Add Comments to Merkle Tree with a minor Verifier refactor

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -192,7 +192,7 @@ where
     let next_len_padded = if prev_layer.len() == 2 {
         1
     } else {
-        // Round prev_layer.len() / 2 up to the next even number.
+        // Round prev_layer.len() / 2 up to the next even integer.
         (prev_layer.len() / 2 + 1) & !1
     };
 
@@ -256,7 +256,7 @@ where
     let next_len_padded = if prev_layer.len() == 2 {
         1
     } else {
-        // Round prev_layer.len() / 2 up to the next even number.
+        // Round prev_layer.len() / 2 up to the next even integer.
         (prev_layer.len() / 2 + 1) & !1
     };
     let next_len = prev_layer.len() / 2;

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -192,6 +192,7 @@ where
     let next_len_padded = if prev_layer.len() == 2 {
         1
     } else {
+        // Round prev_layer.len() / 2 up to the next even number.
         (prev_layer.len() / 2 + 1) & !1
     };
 
@@ -255,6 +256,7 @@ where
     let next_len_padded = if prev_layer.len() == 2 {
         1
     } else {
+        // Round prev_layer.len() / 2 up to the next even number.
         (prev_layer.len() / 2 + 1) & !1
     };
     let next_len = prev_layer.len() / 2;

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -5,16 +5,19 @@
 //! Let H denote the hash function and C the compression function for our tree.
 //! Then MerkleTreeMmcs produces a commitment to M and N using the following tree structure:
 //!
-//!                                       root = c00 = C(c10, c11)                              
-//!                         //                                               \\            
-//!           c10 = C(C(c20, c21), H(N[0]))                     c11 = C(C(c22, c23), H(N[1]))
-//!            //                    \\                          //                    \\     
-//!       c20 = C(L, R)            c21 = C(L, R)            c22 = C(L, R)            c23 = C(L, R)  
-//!    L//            \\R       L//            \\R       L//            \\R       L//            \\R     
-//!  H(M[0])         H(M[1])  H(M[2])         H(M[3])  H(M[4])         H(M[5])  H(M[6])         H(M[7])
-//!
+//! ```rust,ignore
+//! ///
+//! ///                                      root = c00 = C(c10, c11)                              
+//! ///                       /                                                \         
+//! ///         c10 = C(C(c20, c21), H(N[0]))                     c11 = C(C(c22, c23), H(N[1]))
+//! ///           /                      \                          /                      \     
+//! ///      c20 = C(L, R)            c21 = C(L, R)            c22 = C(L, R)            c23 = C(L, R)  
+//! ///   L/             \R        L/             \R        L/             \R        L/             \R     
+//! /// H(M[0])         H(M[1])  H(M[2])         H(M[3])  H(M[4])         H(M[5])  H(M[6])         H(M[7])
+//! ```
 //! E.g. we start by making a standard MerkleTree commitment for each row of M and then add in the rows of N when we
 //! get to the correct level. A proof for the values of say `M[5]` and `N[1]` consists of the siblings `H(M[4]), c23, c10`.
+//!
 
 use alloc::vec::Vec;
 use core::cmp::Reverse;

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -106,7 +106,7 @@ where
     /// Returns `(openings, proof)` where `openings` is a vector whose `i`th element is
     /// the `j`th row of the ith matrix `M[i]`, with
     ///     `j == index >> (log2_ceil(max_height) - log2_ceil(M[i].height))`
-    /// and `proof` is the vector of sibling Merkle tree nodes allowing the verifier to 
+    /// and `proof` is the vector of sibling Merkle tree nodes allowing the verifier to
     /// reconstruct the committed root.
     fn open_batch<M: Matrix<P::Value>>(
         &self,

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -5,9 +5,9 @@
 //! Let H denote the hash function and C the compression function for our tree.
 //! Then MerkleTreeMmcs produces a commitment to M and N using the following tree structure:
 //!
-//!                                  root = c00 = C(c10, c11)                              
-//!                        //                                                  \\            
-//!           c10 = C(C(c20, c21), H(N[0]))                      c11 = C(C(c22, c23), H(N[1]))
+//!                                       root = c00 = C(c10, c11)                              
+//!                         //                                               \\            
+//!           c10 = C(C(c20, c21), H(N[0]))                     c11 = C(C(c22, c23), H(N[1]))
 //!            //                    \\                          //                    \\     
 //!       c20 = C(L, R)            c21 = C(L, R)            c22 = C(L, R)            c23 = C(L, R)  
 //!    L//            \\R       L//            \\R       L//            \\R       L//            \\R     

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -1,5 +1,5 @@
 //! A MerkleTreeMmcs is a generalization of the standard MerkleTree commitment scheme which supports
-//! committing to several matrices of different heights.
+//! committing to several matrices of different dimensions.
 //!
 //! Say we wish to commit to 2 matrices M and N with dimensions (8, i) and (2, j) respectively.
 //! Let H denote the hash function and C the compression function for our tree.

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -1,22 +1,20 @@
 //! A MerkleTreeMmcs is a generalization of the standard MerkleTree commitment scheme which supports
-//! committing to several vectors of different sizes.
+//! committing to several matrices of different heights.
 //!
-//! Say we wish to commit to 2 vectors M0 and M1 of length 32 and 8 where we wish to reveal values in groups of 4.
+//! Say we wish to commit to 2 matrices M and N with dimensions (8, i) and (2, j) respectively.
 //! Let H denote the hash function and C the compression function for our tree.
-//! Then MerkleTreeMmcs produces a commitment to M0 and M1 using the following tree structure:
+//! Then MerkleTreeMmcs produces a commitment to M and N using the following tree structure:
 //!
-//!                                  c00 = root = C(c10, c11)                              
-//!                 //                                                    \\            
-//!          c10 = C(C(c20, c21), H(M1[..4]))                      c11 = C(C(c22, c23), H(M1[4..8]))
-//!           //                      \\                            //                          \\     
-//!       c20 = C(L, R)            c21 = C(L, R)                c22 = C(L, R)                c23 = C(L, R)  
-//!    L//            \\R      L//                \\R      L//                 \\R      L//                 \\R     
-//!  H(M0[..4]) H(M0[4..8])  H(M0[8..12]) H(M0[12..16])  H(M0[16..20]) H(M0[20..24])  H(M0[24..28]) H(M0[28..32])
+//!                                  root = c00 = C(c10, c11)                              
+//!                        //                                                  \\            
+//!           c10 = C(C(c20, c21), H(N[0]))                      c11 = C(C(c22, c23), H(N[1]))
+//!            //                    \\                          //                    \\     
+//!       c20 = C(L, R)            c21 = C(L, R)            c22 = C(L, R)            c23 = C(L, R)  
+//!    L//            \\R       L//            \\R       L//            \\R       L//            \\R     
+//!  H(M[0])         H(M[1])  H(M[2])         H(M[3])  H(M[4])         H(M[5])  H(M[6])         H(M[7])
 //!
-//! E.g. we start by making a standard MerkleTree commitment to M0 and then add in M1 by hashing when we
-//! get to the correct level.
-//!
-//! Then a proof for the values of say M0[8..12] consists of `H(M0[12..16]), c20, H(M1[..4]), c11`.
+//! E.g. we start by making a standard MerkleTree commitment for each row of M and then add in the rows of N when we
+//! get to the correct level. A proof for the values of say `M[5]` and `N[1]` consists of the siblings `H(M[4]), c23, c10`.
 
 use alloc::vec::Vec;
 use core::cmp::Reverse;

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -143,6 +143,18 @@ where
         prover_data.leaves.iter().collect()
     }
 
+    /// Verifies an opened batch of rows with respect to a given commitment.
+    ///
+    /// - `commit`: The merkle root of the tree.
+    /// - `dimensions`: A vector of the dimensions of the matrices committed to.
+    /// - `index`: The index of a leaf in the tree.
+    /// - `opened_values`: A vector of matrix rows. Assume that the tallest matrix committed
+    ///     to has height `2^n >= M_tall.height() > 2^{n - 1}` and the `j`th matrix has height
+    ///     `2^m >= Mj.height() > 2^{m - 1}`. Then `j`'th value of opened values must be the row `Mj[index >> (m - n)]`.
+    /// - `proof`: A vector of sibling nodes. The `i`th element should be the node at level `i`
+    ///     with index `(index << i) ^ 1`.
+    ///
+    /// Returns nothing if the verification is successful, otherwise returns an error.
     fn verify_batch(
         &self,
         commit: &Self::Commitment,

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::MerkleTree;
 use crate::MerkleTreeError::{
-    EmptyBatch, MatrixHeightError, RootMismatch, WrongBatchSize, WrongHeight,
+    EmptyBatch, IncompatibleHeights, RootMismatch, WrongBatchSize, WrongHeight,
 };
 
 /// A vector commitment scheme backed by a `MerkleTree`.
@@ -58,7 +58,7 @@ pub enum MerkleTreeError {
         log_max_height: usize,
         num_siblings: usize,
     },
-    MatrixHeightError,
+    IncompatibleHeights,
     RootMismatch,
     EmptyBatch,
 }
@@ -176,7 +176,7 @@ where
                 curr == next || curr.next_power_of_two() != next.next_power_of_two()
             })
         {
-            return Err(MatrixHeightError);
+            return Err(IncompatibleHeights);
         }
 
         // Get the initial height padded to a power of two. As heights_tallest_first is sorted,

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -218,13 +218,13 @@ where
             index >>= 1;
             curr_height_padded >>= 1;
 
-            // Check if there are any new entries to inject at the next height.
+            // Check if there are any new matrix rows to inject at the next height.
             let next_height = heights_tallest_first
                 .peek()
                 .map(|(_, dims)| dims.height)
                 .filter(|h| h.next_power_of_two() == curr_height_padded);
             if let Some(next_height) = next_height {
-                // If there are new entries, hash them all together and then hash with the current root.
+                // If there are new matrix rows, hash the rows together and then combine with the current root.
                 let next_height_openings_digest = self.hash.hash_iter_slices(
                     heights_tallest_first
                         .peeking_take_while(|(_, dims)| dims.height == next_height)


### PR DESCRIPTION
Adding some comments to `merkle-tree/mmcs`.

Was going through and trying to understand how the verifier worked in this instance and thought I'd slightly improve the comments as I did. I also gave the verification code a slight refactor. Changes:

- Currently we compute `max_height`, check it against `proof_length` and then, provided all the checks pass, sort the input matrices by height. It's a little simpler just to sort them first. This also lets us combine the two places which would return `return Err(EmptyBatch)`.
- When constructing a MerkleTree, we have a condition that matrices whose heights pad to the same power of two, must have equal heights. Currently the verifier does not check this so I've added that. (It's not completely clear to me if we need the verifier to check this or not so I'm happy to remove this if it's unwanted).