### PR TITLE
Remove `thread_rng` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ hashbrown = "0.15.0"
 hex-literal = "1.0.0"
 itertools = "0.14.0"
 num-bigint = { version = "0.4.3", default-features = false }
-num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.0", default-features = false }
 rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ num-integer = "0.1.46"
 num-traits = { version = "0.2.19", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.0", default-features = false }
-rand = "0.9.0"
+rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 rand_chacha = "0.9.0"
 rand_xoshiro = "0.7.0"
 rayon = "1.7.0"

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,5 +1,3 @@
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use std::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -10,6 +8,8 @@ use p3_field_testing::bench_func::{
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,
     benchmark_sub_throughput,
 };
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 type F = BabyBear;
 

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,3 +1,5 @@
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use std::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -27,9 +29,10 @@ fn bench_field(c: &mut Criterion) {
     benchmark_sub_latency::<F, L_REPS>(c, name);
     benchmark_sub_throughput::<F, REPS>(c, name);
 
+    let mut rng = SmallRng::seed_from_u64(1);
     c.bench_function("7th_root", |b| {
         b.iter_batched(
-            rand::random::<F>,
+            || rng.random::<F>(),
             |x| x.exp_u64(1725656503),
             BatchSize::SmallInput,
         )

--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -6,7 +6,8 @@
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{BabyBear, PackedBabyBearNeon, Poseidon2BabyBear};
 
@@ -17,7 +18,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -38,7 +39,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -408,6 +408,7 @@ impl InternalLayerParameters<BabyBearParameters, 24> for BabyBearInternalLayerPa
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;
 
@@ -475,7 +476,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut input1: [F; 16] = rng.random();
         let mut input2 = input1;
 
@@ -494,7 +495,7 @@ mod tests {
     /// for a random input of width 24.
     #[test]
     fn test_generic_internal_linear_layer_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut input1: [F; 24] = rng.random();
         let mut input2 = input1;
 

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -408,7 +408,6 @@ impl InternalLayerParameters<BabyBearParameters, 24> for BabyBearInternalLayerPa
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;
 
@@ -476,7 +475,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_16() {
-        let mut rng = SmallRng::seed_from_u64(1);
+        let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let mut input1: [F; 16] = rng.random();
         let mut input2 = input1;
 
@@ -495,7 +494,7 @@ mod tests {
     /// for a random input of width 24.
     #[test]
     fn test_generic_internal_linear_layer_24() {
-        let mut rng = SmallRng::seed_from_u64(1);
+        let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let mut input1: [F; 24] = rng.random();
         let mut input2 = input1;
 

--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -117,7 +117,8 @@ impl InternalLayerParametersAVX2<BabyBearParameters, 24> for BabyBearInternalLay
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{BabyBear, PackedBabyBearAVX2, Poseidon2BabyBear};
 
@@ -128,7 +129,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx2_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -149,7 +150,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx2_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -128,7 +128,8 @@ impl InternalLayerParametersAVX512<BabyBearParameters, 24> for BabyBearInternalL
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{BabyBear, PackedBabyBearAVX512, Poseidon2BabyBear};
 
@@ -139,7 +140,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx512_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -160,7 +161,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx512_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -7,7 +7,8 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField64};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 use crate::columns::{Blake3Cols, NUM_BLAKE3_COLS};
 use crate::constants::{BITS_PER_LIMB, IV, permute};
@@ -23,7 +24,8 @@ impl Blake3Air {
         num_hashes: usize,
         extra_capacity_bits: usize,
     ) -> RowMajorMatrix<F> {
-        let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
+        let mut rng = SmallRng::seed_from_u64(1);
+        let inputs = (0..num_hashes).map(|_| rng.random()).collect::<Vec<_>>();
         generate_trace_rows(inputs, extra_capacity_bits)
     }
 

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -20,7 +20,6 @@ halo2curves = { workspace = true, features = ["bits", "derive_serde"] }
 p3-field-testing.workspace = true
 
 criterion.workspace = true
-num-traits.workspace = true
 serde_json.workspace = true
 zkhash.workspace = true
 

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -99,7 +99,8 @@ mod tests {
     use num_bigint::BigUint;
     use p3_poseidon2::ExternalLayerConstants;
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
     use zkhash::ark_ff::{BigInteger, PrimeField as ark_PrimeField};
     use zkhash::fields::bn256::FpBN256 as ark_FpBN256;
     use zkhash::poseidon2::poseidon2::Poseidon2 as Poseidon2Ref;
@@ -136,7 +137,7 @@ mod tests {
 
         type F = Bn254Fr;
 
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Poiseidon2 reference implementation from zkhash repo.
         let poseidon2_ref = Poseidon2Ref::new(&POSEIDON2_BN256_PARAMS);

--- a/circle/benches/cfft.rs
+++ b/circle/benches/cfft.rs
@@ -7,8 +7,9 @@ use p3_field::TwoAdicField;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_mersenne_31::Mersenne31;
 use p3_util::pretty_name;
+use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
-use rand::rng;
+use rand::rngs::SmallRng;
 
 fn bench_lde(c: &mut Criterion) {
     let log_n = 18;
@@ -24,7 +25,8 @@ fn bench_lde(c: &mut Criterion) {
 
 fn lde_cfft<M: Measurement>(g: &mut BenchmarkGroup<M>, log_n: usize, log_w: usize) {
     type F = Mersenne31;
-    let m = RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, 1 << log_w);
+    let mut rng = SmallRng::seed_from_u64(1);
+    let m = RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, 1 << log_w);
     g.bench_with_input(
         BenchmarkId::new("Cfft<M31>", format!("log_n={log_n},log_w={log_w}")),
         &m,
@@ -50,7 +52,8 @@ fn lde_twoadic<F: TwoAdicField, Dft: TwoAdicSubgroupDft<F>, M: Measurement>(
     StandardUniform: Distribution<F>,
 {
     let dft = Dft::default();
-    let m = RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, 1 << log_w);
+    let mut rng = SmallRng::seed_from_u64(1);
+    let m = RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, 1 << log_w);
     g.bench_with_input(
         BenchmarkId::new(
             format!("{},{}", pretty_name::<F>(), pretty_name::<Dft>()),

--- a/circle/examples/lde.rs
+++ b/circle/examples/lde.rs
@@ -8,7 +8,8 @@ use p3_field::Field;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_mersenne_31::Mersenne31;
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -31,7 +32,8 @@ fn main() {
     let log_w = args.next().map(|s| s.parse().unwrap()).unwrap_or(8);
     println!("log_n={log_n}, log_w={log_w}");
 
-    let m = RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, 1 << log_w);
+    let mut rng = SmallRng::seed_from_u64(1);
+    let m = RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, 1 << log_w);
     let evals = CircleEvaluations::from_natural_order(CircleDomain::standard(log_n), m);
 
     println!("warming up for 1s...");
@@ -47,6 +49,6 @@ fn main() {
 
     black_box(go(black_box(evals), log_n + 1));
 
-    let m = RowMajorMatrix::<BabyBear>::rand(&mut rng(), 1 << log_n, 1 << log_w);
+    let m = RowMajorMatrix::<BabyBear>::rand(&mut rng, 1 << log_n, 1 << log_w);
     black_box(Radix2DitParallel::default().coset_lde_batch(black_box(m), 1, BabyBear::GENERATOR));
 }

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -280,7 +280,8 @@ mod tests {
     use itertools::iproduct;
     use p3_field::extension::BinomialExtensionField;
     use p3_mersenne_31::Mersenne31;
-    use rand::{random, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -289,10 +290,11 @@ mod tests {
 
     #[test]
     fn test_cfft_icfft() {
+        let mut rng = SmallRng::seed_from_u64(1);
         for (log_n, width) in iproduct!(2..5, [1, 4, 11]) {
-            let shift = Point::generator(F::CIRCLE_TWO_ADICITY) * (random::<u16>() as usize);
+            let shift = Point::generator(F::CIRCLE_TWO_ADICITY) * (rng.random::<u16>() as usize);
             let domain = CircleDomain::<F>::new(log_n, shift);
-            let trace = RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, width);
+            let trace = RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, width);
             let coeffs = CircleEvaluations::from_natural_order(domain, trace.clone()).interpolate();
             assert_eq!(
                 CircleEvaluations::evaluate(domain, coeffs.clone())
@@ -313,10 +315,11 @@ mod tests {
 
     #[test]
     fn test_extrapolation() {
+        let mut rng = SmallRng::seed_from_u64(1);
         for (log_n, log_blowup) in iproduct!(2..5, [1, 2, 3]) {
             let evals = CircleEvaluations::<F>::from_natural_order(
                 CircleDomain::standard(log_n),
-                RowMajorMatrix::rand(&mut rng(), 1 << log_n, 11),
+                RowMajorMatrix::rand(&mut rng, 1 << log_n, 11),
             );
             let lde = evals
                 .clone()
@@ -336,13 +339,14 @@ mod tests {
 
     #[test]
     fn eval_at_point_matches_cfft() {
+        let mut rng = SmallRng::seed_from_u64(1);
         for (log_n, width) in iproduct!(2..5, [1, 4, 11]) {
             let evals = CircleEvaluations::<F>::from_natural_order(
                 CircleDomain::standard(log_n),
-                RowMajorMatrix::rand(&mut rng(), 1 << log_n, width),
+                RowMajorMatrix::rand(&mut rng, 1 << log_n, width),
             );
 
-            let pt = Point::<EF>::from_projective_line(random());
+            let pt = Point::<EF>::from_projective_line(rng.random());
 
             assert_eq!(
                 evals.clone().evaluate_at_point(pt),
@@ -355,15 +359,16 @@ mod tests {
 
     #[test]
     fn eval_at_point_matches_lde() {
+        let mut rng = SmallRng::seed_from_u64(1);
         for (log_n, width, log_blowup) in iproduct!(2..8, [1, 4, 11], [1, 2]) {
             let evals = CircleEvaluations::<F>::from_natural_order(
                 CircleDomain::standard(log_n),
-                RowMajorMatrix::rand(&mut rng(), 1 << log_n, width),
+                RowMajorMatrix::rand(&mut rng, 1 << log_n, width),
             );
             let lde = evals
                 .clone()
                 .extrapolate(CircleDomain::standard(log_n + log_blowup));
-            let zeta = Point::<EF>::from_projective_line(random());
+            let zeta = Point::<EF>::from_projective_line(rng.random());
             assert_eq!(evals.evaluate_at_point(zeta), lde.evaluate_at_point(zeta));
             assert_eq!(
                 evals.evaluate_at_point(zeta),

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -127,7 +127,8 @@ mod tests {
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
-    use rand::{random, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -136,14 +137,15 @@ mod tests {
 
     #[test]
     fn reduce_row_same_as_reduce_matrix() {
+        let mut rng = SmallRng::seed_from_u64(1);
         let domain = CircleDomain::standard(5);
         let evals = CircleEvaluations::from_cfft_order(
             domain,
-            RowMajorMatrix::<F>::rand(&mut rng(), 1 << domain.log_n, 1 << 3),
+            RowMajorMatrix::<F>::rand(&mut rng, 1 << domain.log_n, 1 << 3),
         );
 
-        let alpha: EF = random();
-        let zeta: Point<EF> = Point::from_projective_line(random());
+        let alpha: EF = rng.random();
+        let zeta: Point<EF> = Point::from_projective_line(rng.random());
         let ps_at_zeta = evals.evaluate_at_point(zeta);
 
         let mat_reduced = evals.deep_quotient_reduce(alpha, zeta, &ps_at_zeta);
@@ -160,19 +162,20 @@ mod tests {
 
     #[test]
     fn reduce_evaluations_low_degree() {
+        let mut rng = SmallRng::seed_from_u64(1);
         let log_n = 5;
         let log_blowup = 1;
         let evals = CircleEvaluations::from_cfft_order(
             CircleDomain::standard(log_n),
-            RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, 1 << 3),
+            RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, 1 << 3),
         );
         let lde = evals
             .clone()
             .extrapolate(CircleDomain::standard(log_n + log_blowup));
         assert!(lde.dim() <= (1 << log_n));
 
-        let alpha: EF = random();
-        let zeta: Point<EF> = Point::from_projective_line(random());
+        let alpha: EF = rng.random();
+        let zeta: Point<EF> = Point::from_projective_line(rng.random());
 
         let ps_at_zeta = evals.evaluate_at_point(zeta);
         let reduced0 = CircleEvaluations::<F>::from_cfft_order(
@@ -193,11 +196,12 @@ mod tests {
 
     #[test]
     fn reduce_multiple_evaluations() {
+        let mut rng = SmallRng::seed_from_u64(1);
         let domain = CircleDomain::standard(5);
         let lde_domain = CircleDomain::standard(8);
 
-        let alpha: EF = random();
-        let zeta: Point<EF> = Point::from_projective_line(random());
+        let alpha: EF = rng.random();
+        let zeta: Point<EF> = Point::from_projective_line(rng.random());
 
         let mut alpha_offset = EF::ONE;
         let mut ros = vec![EF::ZERO; 1 << lde_domain.log_n];
@@ -205,7 +209,7 @@ mod tests {
         for _ in 0..4 {
             let evals = CircleEvaluations::from_cfft_order(
                 domain,
-                RowMajorMatrix::<F>::rand(&mut rng(), 1 << domain.log_n, 1 << 3),
+                RowMajorMatrix::<F>::rand(&mut rng, 1 << domain.log_n, 1 << 3),
             );
             let ps_at_zeta = evals.evaluate_at_point(zeta);
             let lde = evals.extrapolate(lde_domain);
@@ -226,9 +230,10 @@ mod tests {
 
     #[test]
     fn test_extract_lambda() {
+        let mut rng = SmallRng::seed_from_u64(1);
         let log_n = 5;
         for log_blowup in [1, 2, 3] {
-            let mut coeffs = RowMajorMatrix::<F>::rand(&mut rng(), (1 << log_n) + 1, 1);
+            let mut coeffs = RowMajorMatrix::<F>::rand(&mut rng, (1 << log_n) + 1, 1);
             coeffs.pad_to_height(1 << (log_n + log_blowup), F::ZERO);
 
             let domain = CircleDomain::standard(log_n + log_blowup);

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -228,7 +228,8 @@ mod tests {
     use itertools::izip;
     use p3_field::{PrimeCharacteristicRing, batch_multiplicative_inverse};
     use p3_mersenne_31::Mersenne31;
-    use rand::rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use super::*;
     use crate::CircleEvaluations;
@@ -283,8 +284,10 @@ mod tests {
             );
         }
 
+        let mut rng = SmallRng::seed_from_u64(1);
+
         // split domains
-        let evals = RowMajorMatrix::rand(&mut rng(), n, width);
+        let evals = RowMajorMatrix::rand(&mut rng, n, width);
         let orig: Vec<(Point<F>, Vec<F>)> = d
             .points()
             .zip(evals.rows().map(|r| r.collect_vec()))

--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -133,7 +133,8 @@ mod tests {
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
-    use rand::{random, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::CircleEvaluations;
@@ -143,9 +144,10 @@ mod tests {
 
     #[test]
     fn fold_matrix_same_as_row() {
+        let mut rng = SmallRng::seed_from_u64(1);
         let log_folded_height = 5;
-        let m = RowMajorMatrix::<EF>::rand(&mut rng(), 1 << log_folded_height, 2);
-        let beta: EF = random();
+        let m = RowMajorMatrix::<EF>::rand(&mut rng, 1 << log_folded_height, 2);
+        let beta: EF = rng.random();
 
         let mat_y_folded = fold_y::<F, EF>(beta, m.as_view());
         let row_y_folded = (0..(1 << log_folded_height))
@@ -170,18 +172,19 @@ mod tests {
             .dim()
         };
 
+        let mut rng = SmallRng::seed_from_u64(1);
         for (log_n, log_blowup) in iproduct!(3..6, 1..4) {
             let mut values = CircleEvaluations::evaluate(
                 CircleDomain::standard(log_n + log_blowup),
-                RowMajorMatrix::<F>::rand(&mut rng(), 1 << log_n, 1),
+                RowMajorMatrix::<F>::rand(&mut rng, 1 << log_n, 1),
             )
             .to_cfft_order()
             .values;
 
-            values = fold_y(random(), RowMajorMatrix::new(values, 2));
+            values = fold_y(rng.random(), RowMajorMatrix::new(values, 2));
             assert_eq!(vec_dim(&values), values.len() >> log_blowup);
             for _ in 0..(log_n - 1) {
-                values = fold_x(random(), RowMajorMatrix::new(values, 2));
+                values = fold_x(rng.random(), RowMajorMatrix::new(values, 2));
                 assert_eq!(vec_dim(&values), values.len() >> log_blowup);
             }
         }

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -8,8 +8,9 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_mersenne_31::{Mersenne31, Mersenne31ComplexRadix2Dit, Mersenne31Dft};
 use p3_monty_31::dft::RecursiveDft;
 use p3_util::pretty_name;
+use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
-use rand::rng;
+use rand::rngs::SmallRng;
 
 fn bench_fft(c: &mut Criterion) {
     // log_sizes correspond to the sizes of DFT we want to benchmark;
@@ -58,7 +59,7 @@ where
     ));
     group.sample_size(10);
 
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for n_log in log_sizes {
         let n = 1 << n_log;
 
@@ -85,7 +86,7 @@ where
     ));
     group.sample_size(10);
 
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for n_log in log_sizes {
         let n = 1 << n_log;
 
@@ -113,7 +114,7 @@ where
     ));
     group.sample_size(10);
 
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for n_log in log_sizes {
         let n = 1 << n_log;
 
@@ -142,7 +143,7 @@ where
     ));
     group.sample_size(10);
 
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for n_log in log_sizes {
         let n = 1 << n_log;
 

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -39,7 +39,8 @@ mod tests {
     use p3_field::{Field, PrimeCharacteristicRing};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::dense::RowMajorMatrix;
-    use rand::rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use crate::{NaiveDft, TwoAdicSubgroupDft};
 
@@ -87,7 +88,7 @@ mod tests {
     #[test]
     fn dft_idft_consistency() {
         type F = Goldilocks;
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let original = RowMajorMatrix::<F>::rand(&mut rng, 8, 3);
         let dft = NaiveDft.dft_batch(original.clone());
         let idft = NaiveDft.idft_batch(dft);
@@ -98,7 +99,7 @@ mod tests {
     fn coset_dft_idft_consistency() {
         type F = Goldilocks;
         let generator = F::GENERATOR;
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let original = RowMajorMatrix::<F>::rand(&mut rng, 8, 3);
         let dft = NaiveDft.coset_dft_batch(original.clone(), generator);
         let idft = NaiveDft.coset_idft_batch(dft, generator);

--- a/examples/examples/prove_prime_field_31.rs
+++ b/examples/examples/prove_prime_field_31.rs
@@ -15,7 +15,8 @@ use p3_koala_bear::{GenericPoseidon2LinearLayersKoalaBear, KoalaBear, Poseidon2K
 use p3_mersenne_31::{GenericPoseidon2LinearLayersMersenne31, Mersenne31, Poseidon2Mersenne31};
 use p3_monty_31::dft::RecursiveDft;
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -86,6 +87,9 @@ fn main() {
         }
     };
 
+    // WARNING: Use a real cryptographic PRNG in applications!!
+    let mut rng = SmallRng::seed_from_u64(1);
+
     match args.field {
         FieldOptions::KoalaBear => {
             type EF = BinomialExtensionField<KoalaBear, 4>;
@@ -94,7 +98,7 @@ fn main() {
                 ProofOptions::Blake3Permutations => ProofObjective::Blake3(Blake3Air {}),
                 ProofOptions::KeccakFPermutations => ProofObjective::Keccak(KeccakAir {}),
                 ProofOptions::Poseidon2Permutations => {
-                    let constants = RoundConstants::from_rng(&mut rng());
+                    let constants = RoundConstants::from_rng(&mut rng);
 
                     // Field specific constants for constructing the Poseidon2 AIR.
                     const SBOX_DEGREE: u64 = 3;
@@ -131,8 +135,8 @@ fn main() {
                     report_result(result);
                 }
                 MerkleHashOptions::Poseidon2 => {
-                    let perm16 = Poseidon2KoalaBear::<16>::new_from_rng_128(&mut rng());
-                    let perm24 = Poseidon2KoalaBear::<24>::new_from_rng_128(&mut rng());
+                    let perm16 = Poseidon2KoalaBear::<16>::new_from_rng_128(&mut rng);
+                    let perm24 = Poseidon2KoalaBear::<24>::new_from_rng_128(&mut rng);
                     let result = prove_monty31_poseidon2::<_, EF, _, _, _, _>(
                         proof_goal, dft, num_hashes, perm16, perm24,
                     );
@@ -147,7 +151,7 @@ fn main() {
                 ProofOptions::Blake3Permutations => ProofObjective::Blake3(Blake3Air {}),
                 ProofOptions::KeccakFPermutations => ProofObjective::Keccak(KeccakAir {}),
                 ProofOptions::Poseidon2Permutations => {
-                    let constants = RoundConstants::from_rng(&mut rng());
+                    let constants = RoundConstants::from_rng(&mut rng);
 
                     // Field specific constants for constructing the Poseidon2 AIR.
                     const SBOX_DEGREE: u64 = 7;
@@ -184,8 +188,8 @@ fn main() {
                     report_result(result);
                 }
                 MerkleHashOptions::Poseidon2 => {
-                    let perm16 = Poseidon2BabyBear::<16>::new_from_rng_128(&mut rng());
-                    let perm24 = Poseidon2BabyBear::<24>::new_from_rng_128(&mut rng());
+                    let perm16 = Poseidon2BabyBear::<16>::new_from_rng_128(&mut rng);
+                    let perm24 = Poseidon2BabyBear::<24>::new_from_rng_128(&mut rng);
                     let result = prove_monty31_poseidon2::<_, EF, _, _, _, _>(
                         proof_goal, dft, num_hashes, perm16, perm24,
                     );
@@ -200,7 +204,7 @@ fn main() {
                 ProofOptions::Blake3Permutations => ProofObjective::Blake3(Blake3Air {}),
                 ProofOptions::KeccakFPermutations => ProofObjective::Keccak(KeccakAir {}),
                 ProofOptions::Poseidon2Permutations => {
-                    let constants = RoundConstants::from_rng(&mut rng());
+                    let constants = RoundConstants::from_rng(&mut rng);
 
                     // Field specific constants for constructing the Poseidon2 AIR.
                     const SBOX_DEGREE: u64 = 5;
@@ -234,8 +238,8 @@ fn main() {
                     report_result(result);
                 }
                 MerkleHashOptions::Poseidon2 => {
-                    let perm16 = Poseidon2Mersenne31::<16>::new_from_rng_128(&mut rng());
-                    let perm24 = Poseidon2Mersenne31::<24>::new_from_rng_128(&mut rng());
+                    let perm16 = Poseidon2Mersenne31::<16>::new_from_rng_128(&mut rng);
+                    let perm24 = Poseidon2Mersenne31::<24>::new_from_rng_128(&mut rng);
                     let result = prove_m31_poseidon2::<_, EF, _, _, _>(
                         proof_goal, num_hashes, perm16, perm24,
                     );

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -9,10 +9,8 @@ p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 rand.workspace = true
-rand_chacha.workspace = true
 criterion.workspace = true
 num-bigint.workspace = true
-num-traits.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -3,15 +3,16 @@ use alloc::vec::Vec;
 
 use criterion::{BatchSize, Criterion, black_box};
 use p3_field::{Field, PrimeCharacteristicRing};
-use rand::Rng;
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 pub fn benchmark_square<F: Field>(c: &mut Criterion, name: &str)
 where
     StandardUniform: Distribution<F>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<F>();
     c.bench_function(&format!("{} square", name), |b| {
         b.iter(|| black_box(black_box(x).square()))
@@ -22,7 +23,7 @@ pub fn benchmark_inv<F: Field>(c: &mut Criterion, name: &str)
 where
     StandardUniform: Distribution<F>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<F>();
     c.bench_function(&format!("{} inv", name), |b| {
         b.iter(|| black_box(black_box(x)).inverse())
@@ -36,7 +37,7 @@ pub fn benchmark_mul_2exp<R: PrimeCharacteristicRing + Copy, const REPS: usize>(
 ) where
     StandardUniform: Distribution<R>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let mut input = Vec::new();
     for _ in 0..REPS {
         input.push(rng.random::<R>())
@@ -50,7 +51,7 @@ pub fn benchmark_div_2exp<F: Field, const REPS: usize>(c: &mut Criterion, name: 
 where
     StandardUniform: Distribution<F>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let mut input = Vec::new();
     for _ in 0..REPS {
         input.push(rng.random::<F>())
@@ -71,7 +72,7 @@ pub fn benchmark_iter_sum<R: PrimeCharacteristicRing + Copy, const N: usize, con
 ) where
     StandardUniform: Distribution<R>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let mut input = Vec::new();
     for _ in 0..REPS {
         input.push(rng.random::<[R; N]>())
@@ -98,7 +99,7 @@ pub fn benchmark_sum_array<R: PrimeCharacteristicRing + Copy, const N: usize, co
 ) where
     StandardUniform: Distribution<R>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let mut input = Vec::new();
     for _ in 0..REPS {
         input.push(rng.random::<[R; N]>())
@@ -123,7 +124,7 @@ pub fn benchmark_add_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c.bench_function(&format!("add-latency/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 let mut vec = Vec::new();
                 for _ in 0..N {
                     vec.push(rng.random::<R>())
@@ -145,7 +146,7 @@ pub fn benchmark_add_throughput<R: PrimeCharacteristicRing + Copy, const N: usiz
     c.bench_function(&format!("add-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 (
                     rng.random::<R>(),
                     rng.random::<R>(),
@@ -190,7 +191,7 @@ pub fn benchmark_sub_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c.bench_function(&format!("sub-latency/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 let mut vec = Vec::new();
                 for _ in 0..N {
                     vec.push(rng.random::<R>())
@@ -212,7 +213,7 @@ pub fn benchmark_sub_throughput<R: PrimeCharacteristicRing + Copy, const N: usiz
     c.bench_function(&format!("sub-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 (
                     rng.random::<R>(),
                     rng.random::<R>(),
@@ -257,7 +258,7 @@ pub fn benchmark_mul_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c.bench_function(&format!("mul-latency/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 let mut vec = Vec::new();
                 for _ in 0..N {
                     vec.push(rng.random::<R>())
@@ -279,7 +280,7 @@ pub fn benchmark_mul_throughput<R: PrimeCharacteristicRing + Copy, const N: usiz
     c.bench_function(&format!("mul-throughput/{} {}", N, name), |b| {
         b.iter_batched(
             || {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 (
                     rng.random::<R>(),
                     rng.random::<R>(),

--- a/field-testing/src/dft_testing.rs
+++ b/field-testing/src/dft_testing.rs
@@ -2,8 +2,9 @@ use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
-use rand::rng;
+use rand::rngs::SmallRng;
 
 pub fn test_dft_matches_naive<F, Dft>()
 where
@@ -12,7 +13,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..12 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -29,7 +30,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -47,7 +48,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..12 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -64,7 +65,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -82,7 +83,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -99,7 +100,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
@@ -117,7 +118,7 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let dft = Dft::default();
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_h in 0..12 {
         let h = 1 << log_h;
         let original = RowMajorMatrix::<F>::rand(&mut rng, h, 3);

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -14,15 +14,15 @@ use alloc::vec::Vec;
 pub use bench_func::*;
 pub use dft_testing::*;
 use num_bigint::BigUint;
-use num_traits::identities::One;
 use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField,
     cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order,
     two_adic_coset_vanishing_polynomial, two_adic_subgroup_vanishing_polynomial,
 };
 pub use packedfield_testing::*;
-use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 #[allow(clippy::eq_op)]
 pub fn test_ring_with_eq<R: PrimeCharacteristicRing + Copy + Eq>(zeros: &[R], ones: &[R])
@@ -31,7 +31,7 @@ where
 {
     // zeros should be a vector containing differenent representatives of `R::ZERO`.
     // ones should be a vector containing differenent representatives of `R::ONE`.
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<R>();
     let y = rng.random::<R>();
     let z = rng.random::<R>();
@@ -219,7 +219,7 @@ pub fn test_inv_div<F: Field>()
 where
     StandardUniform: Distribution<F>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<F>();
     let y = rng.random::<F>();
     let z = rng.random::<F>();
@@ -236,7 +236,7 @@ pub fn test_mul_2exp_u64<R: PrimeCharacteristicRing + Eq>()
 where
     StandardUniform: Distribution<R>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<R>();
     assert_eq!(x.mul_2exp_u64(0), x);
     assert_eq!(x.mul_2exp_u64(1), x.double());
@@ -252,7 +252,7 @@ pub fn test_div_2exp_u64<F: Field>()
 where
     StandardUniform: Distribution<F>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let x = rng.random::<F>();
     assert_eq!(x.div_2exp_u64(0), x);
     assert_eq!(x.div_2exp_u64(1), x.halve());
@@ -271,10 +271,8 @@ where
     StandardUniform: Distribution<F>,
 {
     assert_eq!(None, F::ZERO.try_inverse());
-
     assert_eq!(Some(F::ONE), F::ONE.try_inverse());
-
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     for _ in 0..1000 {
         let x = rng.random::<F>();
         if !x.is_zero() && !x.is_one() {
@@ -526,7 +524,7 @@ pub fn test_generator<F: Field>(multiplicative_group_factors: &[(BigUint, u32)])
         .iter()
         .map(|(factor, exponent)| factor.pow(*exponent))
         .product();
-    assert_eq!(product + BigUint::one(), F::order());
+    assert_eq!(product + BigUint::from(1u32), F::order());
 
     // Given a prime factorization r = p1^e1 * p2^e2 * ... * pk^ek, an element g has order
     // r if and only if g^r = 1 and g^(r/pi) != 1 for all pi in the prime factorization of r.
@@ -670,11 +668,12 @@ macro_rules! test_prime_field_64 {
         mod from_integer_tests_prime_field_64 {
             use p3_field::integers::QuotientMap;
             use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
-            use rand::Rng;
+            use rand::rngs::SmallRng;
+            use rand::{Rng, SeedableRng};
 
             #[test]
             fn test_as_canonical_u64() {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 let x: u64 = rng.random();
                 let x_mod_order = x % <$field>::ORDER_U64;
 
@@ -732,11 +731,12 @@ macro_rules! test_prime_field_32 {
         mod from_integer_tests_prime_field_32 {
             use p3_field::integers::QuotientMap;
             use p3_field::{Field, PrimeCharacteristicRing, PrimeField32};
-            use rand::Rng;
+            use rand::rngs::SmallRng;
+            use rand::{Rng, SeedableRng};
 
             #[test]
             fn test_as_canonical_u32() {
-                let mut rng = rand::rng();
+                let mut rng = SmallRng::seed_from_u64(1);
                 let x: u32 = rng.random();
                 let x_mod_order = x % <$field>::ORDER_U32;
 

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -5,14 +5,13 @@ use p3_field::{Field, PackedField, PackedFieldPow2, PackedValue, PrimeCharacteri
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 
 fn packed_from_random<PV>(seed: u64) -> PV
 where
     PV: PackedValue,
     StandardUniform: Distribution<PV::Value>,
 {
-    let mut rng = ChaCha20Rng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     PV::from_fn(|_| rng.random())
 }
 

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use p3_field::{Field, PackedField, PackedFieldPow2, PackedValue, PrimeCharacteristicRing};
 use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 
@@ -98,7 +99,7 @@ pub fn test_packed_linear_combination<PF: PackedField + Eq>()
 where
     StandardUniform: Distribution<PF> + Distribution<PF::Scalar>,
 {
-    let mut rng = rand::rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let u: [PF::Scalar; 64] = rng.random();
     let v: [PF; 64] = rng.random();
 

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 p3-util.workspace = true
 p3-maybe-rayon.workspace = true
 num-bigint.workspace = true
-num-traits.workspace = true
 paste.workspace = true
 tracing.workspace = true
 

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -9,7 +9,8 @@ use p3_fri::fold_even_odd;
 use p3_goldilocks::Goldilocks;
 use p3_mersenne_31::Mersenne31;
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 fn bench<F: TwoAdicField>(c: &mut Criterion, log_sizes: &[usize])
 where
@@ -22,7 +23,7 @@ where
     for log_size in log_sizes {
         let n = 1 << log_size;
 
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(n as u64);
         let beta = rng.sample(StandardUniform);
         let poly = rng.sample_iter(StandardUniform).take(n).collect_vec();
 

--- a/fri/src/fold_even_odd.rs
+++ b/fri/src/fold_even_odd.rs
@@ -57,7 +57,8 @@ mod tests {
     use itertools::izip;
     use p3_baby_bear::BabyBear;
     use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
-    use rand::{Rng, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -65,7 +66,7 @@ mod tests {
     fn test_fold_even_odd() {
         type F = BabyBear;
 
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         let log_n = 10;
         let n = 1 << log_n;

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,5 +1,3 @@
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use std::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -10,6 +8,8 @@ use p3_field_testing::bench_func::{
 };
 use p3_field_testing::{benchmark_mul_latency, benchmark_mul_throughput, benchmark_sum_array};
 use p3_goldilocks::Goldilocks;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 type F = Goldilocks;
 

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,3 +1,5 @@
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use std::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
@@ -28,9 +30,10 @@ fn bench_field(c: &mut Criterion) {
     benchmark_sub_latency::<F, L_REPS>(c, name);
     benchmark_sub_throughput::<F, REPS>(c, name);
 
+    let mut rng = SmallRng::seed_from_u64(1);
     c.bench_function("7th_root", |b| {
         b.iter_batched(
-            rand::random::<F>,
+            || rng.random::<F>(),
             |x| x.exp_u64(10540996611094048183),
             BatchSize::SmallInput,
         )

--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -72,16 +72,17 @@ impl MdsPermutation<PackedGoldilocksAVX2, 24> for MdsMatrixGoldilocks {}
 mod tests {
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{Goldilocks, MdsMatrixGoldilocks, PackedGoldilocksAVX2};
 
     #[test]
     fn test_avx2_poseidon_width_8() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 8, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 8] = rng.random();
 
@@ -97,10 +98,10 @@ mod tests {
 
     #[test]
     fn test_avx2_poseidon_width_12() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 12, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 12] = rng.random();
 
@@ -116,10 +117,10 @@ mod tests {
 
     #[test]
     fn test_avx2_poseidon_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 16, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 16] = rng.random();
 
@@ -135,10 +136,10 @@ mod tests {
 
     #[test]
     fn test_avx2_poseidon_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 24, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 24] = rng.random();
 

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -72,16 +72,17 @@ impl MdsPermutation<PackedGoldilocksAVX512, 24> for MdsMatrixGoldilocks {}
 mod tests {
     use p3_poseidon::Poseidon;
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{Goldilocks, MdsMatrixGoldilocks, PackedGoldilocksAVX512};
 
     #[test]
     fn test_avx512_poseidon_width_8() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 8, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 8] = rng.random();
 
@@ -97,10 +98,10 @@ mod tests {
 
     #[test]
     fn test_avx512_poseidon_width_12() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 12, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 12] = rng.random();
 
@@ -116,10 +117,10 @@ mod tests {
 
     #[test]
     fn test_avx512_poseidon_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 16, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 16] = rng.random();
 
@@ -135,10 +136,10 @@ mod tests {
 
     #[test]
     fn test_avx512_poseidon_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         type F = Goldilocks;
         type Perm = Poseidon<F, MdsMatrixGoldilocks, 24, 7>;
-        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rand::rng());
+        let poseidon = Perm::new_from_rng(4, 22, MdsMatrixGoldilocks, &mut rng);
 
         let input: [F; 24] = rng.random();
 

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -10,7 +10,8 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -57,7 +58,8 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -10,7 +10,8 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::{Sha256, Sha256Compress};
 use p3_symmetric::SerializingHasher32;
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -57,7 +58,8 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -11,7 +11,8 @@ use p3_keccak_air::{KeccakAir, generate_trace_rows};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher64};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -62,7 +63,8 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -11,7 +11,8 @@ use p3_keccak_air::{KeccakAir, generate_trace_rows};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::{random, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -34,7 +35,8 @@ fn main() -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 2>;
 
     type Perm = Poseidon2Goldilocks<8>;
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
 
     type MyHash = PaddingFreeSponge<Perm, 8, 4, 4>;
     let hash = MyHash::new(perm.clone());
@@ -56,7 +58,7 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -11,7 +11,8 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher64};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -54,7 +55,8 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -12,7 +12,8 @@ use p3_mersenne_31::Mersenne31;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -52,7 +53,8 @@ fn main() -> Result<(), impl Debug> {
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
-    let inputs = (0..NUM_HASHES).map(|_| random()).collect::<Vec<_>>();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let inputs = (0..NUM_HASHES).map(|_| rng.random()).collect::<Vec<_>>();
     let trace = generate_trace_rows::<Val>(inputs, fri_config.log_blowup);
 
     type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -6,7 +6,8 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField64};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
 use crate::constants::rc_value_bit;
@@ -23,7 +24,8 @@ impl KeccakAir {
         num_hashes: usize,
         extra_capacity_bits: usize,
     ) -> RowMajorMatrix<F> {
-        let inputs = (0..num_hashes).map(|_| random()).collect::<Vec<_>>();
+        let mut rng = SmallRng::seed_from_u64(1);
+        let inputs = (0..num_hashes).map(|_| rng.random()).collect::<Vec<_>>();
         generate_trace_rows(inputs, extra_capacity_bits)
     }
 }

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -8,6 +8,8 @@ use p3_field_testing::bench_func::{
 use p3_field_testing::benchmark_sum_array;
 use p3_koala_bear::KoalaBear;
 use p3_util::pretty_name;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 type F = KoalaBear;
 type PF = <KoalaBear as Field>::Packing;
@@ -35,9 +37,10 @@ fn bench_field(c: &mut Criterion) {
     benchmark_sub_latency::<F, L_REPS>(c, name);
     benchmark_sub_throughput::<F, REPS>(c, name);
 
+    let mut rng = SmallRng::seed_from_u64(1);
     c.bench_function("3rd_root", |b| {
         b.iter_batched(
-            rand::random::<F>,
+            || rng.random::<F>(),
             |x| x.exp_u64(1420470955),
             BatchSize::SmallInput,
         )

--- a/koala-bear/src/aarch64_neon/poseidon2.rs
+++ b/koala-bear/src/aarch64_neon/poseidon2.rs
@@ -6,7 +6,8 @@
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{KoalaBear, PackedKoalaBearNeon, Poseidon2KoalaBear};
 
@@ -17,7 +18,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -38,7 +39,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -253,6 +253,7 @@ impl InternalLayerParameters<KoalaBearParameters, 24> for KoalaBearInternalLayer
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;
 
@@ -319,7 +320,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut input1: [F; 16] = rng.random();
         let mut input2 = input1;
 
@@ -338,7 +339,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut input1: [F; 24] = rng.random();
         let mut input2 = input1;
 

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -253,7 +253,6 @@ impl InternalLayerParameters<KoalaBearParameters, 24> for KoalaBearInternalLayer
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
     use rand_xoshiro::Xoroshiro128Plus;
 
@@ -320,7 +319,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_16() {
-        let mut rng = SmallRng::seed_from_u64(1);
+        let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let mut input1: [F; 16] = rng.random();
         let mut input2 = input1;
 
@@ -339,7 +338,7 @@ mod tests {
     /// for a random input of width 16.
     #[test]
     fn test_generic_internal_linear_layer_24() {
-        let mut rng = SmallRng::seed_from_u64(1);
+        let mut rng = Xoroshiro128Plus::seed_from_u64(1);
         let mut input1: [F; 24] = rng.random();
         let mut input2 = input1;
 

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -198,7 +198,8 @@ impl InternalLayerParametersAVX2<KoalaBearParameters, 24> for KoalaBearInternalL
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{KoalaBear, PackedKoalaBearAVX2, Poseidon2KoalaBear};
 
@@ -209,7 +210,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx2_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -230,7 +231,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx2_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -132,7 +132,8 @@ impl InternalLayerParametersAVX512<KoalaBearParameters, 24> for KoalaBearInterna
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::{KoalaBear, PackedKoalaBearAVX512, Poseidon2KoalaBear};
 
@@ -143,7 +144,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx512_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -164,7 +165,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_avx512_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/matrix/benches/transpose_benchmark.rs
+++ b/matrix/benches/transpose_benchmark.rs
@@ -1,13 +1,14 @@
 use criterion::{BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main};
 use p3_matrix::dense::RowMajorMatrix;
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 
 fn transpose_benchmark(c: &mut Criterion) {
     const SMALL_DIMS: [(usize, usize); 4] = [(4, 4), (8, 8), (10, 10), (12, 12)];
     const LARGE_DIMS: [(usize, usize); 4] = [(20, 8), (21, 8), (22, 8), (23, 8)];
 
     let inner = |g: &mut BenchmarkGroup<_>, dims: &[(usize, usize)]| {
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         for (lg_nrows, lg_ncols) in dims {
             let nrows = 1 << lg_nrows;
             let ncols = 1 << lg_ncols;

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -296,7 +296,8 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
-    use rand::rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use super::*;
 
@@ -305,8 +306,9 @@ mod tests {
         type F = BabyBear;
         type EF = BinomialExtensionField<BabyBear, 4>;
 
-        let m = RowMajorMatrix::<F>::rand(&mut rng(), 1 << 8, 1 << 4);
-        let v = RowMajorMatrix::<EF>::rand(&mut rng(), 1 << 8, 1).values;
+        let mut rng = SmallRng::seed_from_u64(1);
+        let m = RowMajorMatrix::<F>::rand(&mut rng, 1 << 8, 1 << 4);
+        let v = RowMajorMatrix::<EF>::rand(&mut rng, 1 << 8, 1).values;
 
         let mut expected = vec![EF::ZERO; m.width()];
         for (row, &scale) in izip!(m.rows(), &v) {

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -9,7 +9,8 @@ use p3_mds::coset_mds::CosetMds;
 use p3_mds::integrated_coset_mds::IntegratedCosetMds;
 use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 fn bench_all_mds(c: &mut Criterion) {
     bench_mds::<BabyBear, IntegratedCosetMds<BabyBear, 16>, 16>(c);
@@ -45,7 +46,7 @@ where
 {
     let mds = Mds::default();
 
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let input = rng.random::<[R; WIDTH]>();
     let id = BenchmarkId::new(type_name::<Mds>(), WIDTH);
     c.bench_with_input(id, &input, |b, input| b.iter(|| mds.permute(input.clone())));

--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -150,7 +150,8 @@ mod tests {
     use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
     use p3_field::{Field, PrimeCharacteristicRing};
     use p3_symmetric::Permutation;
-    use rand::{Rng, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::coset_mds::CosetMds;
 
@@ -159,7 +160,7 @@ mod tests {
         type F = BabyBear;
         const N: usize = 8;
 
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut arr: [F; N] = rng.random();
 
         let shift = F::GENERATOR;

--- a/mds/src/integrated_coset_mds.rs
+++ b/mds/src/integrated_coset_mds.rs
@@ -122,7 +122,8 @@ mod tests {
     use p3_field::{Field, PrimeCharacteristicRing};
     use p3_symmetric::Permutation;
     use p3_util::reverse_slice_index_bits;
-    use rand::{Rng, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use crate::integrated_coset_mds::IntegratedCosetMds;
 
@@ -131,7 +132,7 @@ mod tests {
 
     #[test]
     fn matches_naive() {
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut arr: [F; N] = rng.random();
 
         let mut arr_rev = arr.to_vec();

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -15,8 +15,9 @@ use p3_symmetric::{
     CompressionFunctionFromHasher, CryptographicHasher, PaddingFreeSponge,
     PseudoCompressionFunction, SerializingHasher32, TruncatedPermutation,
 };
+use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
-use rand::rng;
+use rand::rngs::SmallRng;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
@@ -30,8 +31,9 @@ fn bench_merkle_trees(criterion: &mut Criterion) {
 fn bench_bb_poseidon2(criterion: &mut Criterion) {
     type F = BabyBear;
 
+    let mut rng = SmallRng::seed_from_u64(1);
     type Perm = Poseidon2BabyBear<16>;
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let perm = Perm::new_from_rng_128(&mut rng);
 
     type H = PaddingFreeSponge<Perm, 16, 8, 8>;
     let h = H::new(perm.clone());
@@ -54,7 +56,8 @@ fn bench_bb_rescue(criterion: &mut Criterion) {
     let mds = Mds::default();
 
     type Perm = Rescue<F, Mds, 16, 7>;
-    let round_constants = Perm::get_round_constants_from_rng(8, &mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let round_constants = Perm::get_round_constants_from_rng(8, &mut rng);
     let perm = Perm::new(8, round_constants, mds);
 
     type H = PaddingFreeSponge<Perm, 16, 8, 8>;
@@ -115,7 +118,8 @@ where
     const ROWS: usize = 1 << 15;
     const COLS: usize = 135;
 
-    let matrix = RowMajorMatrix::<P::Scalar>::rand(&mut rng(), ROWS, COLS);
+    let mut rng = SmallRng::seed_from_u64(1);
+    let matrix = RowMajorMatrix::<P::Scalar>::rand(&mut rng, ROWS, COLS);
     let dims = matrix.dimensions();
     let leaves = vec![matrix];
 
@@ -151,8 +155,9 @@ where
     const ROWS: usize = 1 << 15;
     const COLS: usize = 135;
 
-    let matrix_1 = RowMajorMatrix::<P::Scalar>::rand(&mut rng(), ROWS + 1, COLS);
-    let matrix_2 = RowMajorMatrix::<P::Scalar>::rand(&mut rng(), ROWS / 2 + 1, COLS);
+    let mut rng = SmallRng::seed_from_u64(1);
+    let matrix_1 = RowMajorMatrix::<P::Scalar>::rand(&mut rng, ROWS + 1, COLS);
+    let matrix_2 = RowMajorMatrix::<P::Scalar>::rand(&mut rng, ROWS / 2 + 1, COLS);
     let dims = vec![matrix_1.dimensions(), matrix_2.dimensions()];
     let leaves = vec![matrix_1, matrix_2];
 

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -147,8 +147,8 @@ mod tests {
     use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-    use rand::prelude::ThreadRng;
-    use rand::rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use super::MerkleTreeHidingMmcs;
     use crate::MerkleTreeError;
@@ -164,7 +164,7 @@ mod tests {
         <F as Field>::Packing,
         MyHash,
         MyCompress,
-        ThreadRng,
+        SmallRng,
         8,
         SALT_ELEMS,
     >;
@@ -172,10 +172,11 @@ mod tests {
     #[test]
     #[should_panic]
     fn mismatched_heights() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, rng());
+        let mmcs = MyMmcs::new(hash, compress, rng);
 
         // attempt to commit to a mat with 8 rows and a mat with 7 rows. this should panic.
         let large_mat = RowMajorMatrix::new([1, 2, 3, 4, 5, 6, 7, 8].map(F::from_u8).to_vec(), 1);
@@ -185,15 +186,16 @@ mod tests {
 
     #[test]
     fn different_widths() -> Result<(), MerkleTreeError> {
-        let perm = Perm::new_from_rng_128(&mut rng());
-        let hash = MyHash::new(perm.clone());
-        let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, rng());
-
+        let mut rng = SmallRng::seed_from_u64(1);
         // 10 mats with 32 rows where the ith mat has i + 1 cols
         let mats = (0..10)
-            .map(|i| RowMajorMatrix::<F>::rand(&mut rng(), 32, i + 1))
+            .map(|i| RowMajorMatrix::<F>::rand(&mut rng, 32, i + 1))
             .collect_vec();
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, rng);
+
         let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
 
         let (commit, prover_data) = mmcs.commit(mats);

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -298,7 +298,8 @@ fn unpack_array<P: PackedValue, const N: usize>(
 #[cfg(test)]
 mod tests {
     use p3_symmetric::PseudoCompressionFunction;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -342,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_compress_random_values() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let prev_layer: Vec<[u8; 32]> = (0..8).map(|_| rng.random()).collect();
         let compressor = DummyCompressionFunction;
         let expected: Vec<[u8; 32]> = prev_layer

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -212,7 +212,8 @@ mod tests {
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
-    use rand::rng;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use super::MerkleTreeMmcs;
 
@@ -226,7 +227,8 @@ mod tests {
 
     #[test]
     fn commit_single_1x8() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -259,12 +261,13 @@ mod tests {
 
     #[test]
     fn commit_single_8x1() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress);
 
-        let mat = RowMajorMatrix::<F>::rand(&mut rng(), 1, 8);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 1, 8);
         let (commit, _) = mmcs.commit(vec![mat.clone()]);
 
         let expected_result = hash.hash_iter(mat.vertically_packed_row(0));
@@ -273,7 +276,8 @@ mod tests {
 
     #[test]
     fn commit_single_2x2() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -295,7 +299,8 @@ mod tests {
 
     #[test]
     fn commit_single_2x3() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -322,7 +327,8 @@ mod tests {
 
     #[test]
     fn commit_mixed() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash.clone(), compress.clone());
@@ -416,7 +422,7 @@ mod tests {
 
     #[test]
     fn commit_either_order() {
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
@@ -433,7 +439,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn mismatched_heights() {
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
@@ -447,24 +453,27 @@ mod tests {
 
     #[test]
     fn verify_tampered_proof_fails() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
 
         // 4 8x1 matrixes, 4 8x2 matrixes
-        let large_mats = (0..4).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 8, 1));
+        let mut mats = (0..4)
+            .map(|_| RowMajorMatrix::<F>::rand(&mut rng, 8, 1))
+            .collect_vec();
         let large_mat_dims = (0..4).map(|_| Dimensions {
             height: 8,
             width: 1,
         });
-        let small_mats = (0..4).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 8, 2));
+        mats.extend((0..4).map(|_| RowMajorMatrix::<F>::rand(&mut rng, 8, 2)));
         let small_mat_dims = (0..4).map(|_| Dimensions {
             height: 8,
             width: 2,
         });
 
-        let (commit, prover_data) = mmcs.commit(large_mats.chain(small_mats).collect_vec());
+        let (commit, prover_data) = mmcs.commit(mats);
 
         // open the 3rd row of each matrix, mess with proof, and verify
         let (opened_values, mut proof) = mmcs.open_batch(3, &prover_data);
@@ -481,46 +490,43 @@ mod tests {
 
     #[test]
     fn size_gaps() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
 
         // 4 mats with 1000 rows, 8 columns
-        let large_mats = (0..4).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 1000, 8));
+        let mut mats = (0..4)
+            .map(|_| RowMajorMatrix::<F>::rand(&mut rng, 1000, 8))
+            .collect_vec();
         let large_mat_dims = (0..4).map(|_| Dimensions {
             height: 1000,
             width: 8,
         });
 
         // 5 mats with 70 rows, 8 columns
-        let medium_mats = (0..5).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 70, 8));
+        mats.extend((0..5).map(|_| RowMajorMatrix::<F>::rand(&mut rng, 70, 8)));
         let medium_mat_dims = (0..5).map(|_| Dimensions {
             height: 70,
             width: 8,
         });
 
         // 6 mats with 8 rows, 8 columns
-        let small_mats = (0..6).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 8, 8));
+        mats.extend((0..6).map(|_| RowMajorMatrix::<F>::rand(&mut rng, 8, 8)));
         let small_mat_dims = (0..6).map(|_| Dimensions {
             height: 8,
             width: 8,
         });
 
         // 7 tiny mat with 1 row, 8 columns
-        let tiny_mats = (0..7).map(|_| RowMajorMatrix::<F>::rand(&mut rng(), 1, 8));
+        mats.extend((0..7).map(|_| RowMajorMatrix::<F>::rand(&mut rng, 1, 8)));
         let tiny_mat_dims = (0..7).map(|_| Dimensions {
             height: 1,
             width: 8,
         });
 
-        let (commit, prover_data) = mmcs.commit(
-            large_mats
-                .chain(medium_mats)
-                .chain(small_mats)
-                .chain(tiny_mats)
-                .collect_vec(),
-        );
+        let (commit, prover_data) = mmcs.commit(mats);
 
         // open the 6th row of each matrix and verify
         let (opened_values, proof) = mmcs.open_batch(6, &prover_data);
@@ -540,14 +546,15 @@ mod tests {
 
     #[test]
     fn different_widths() {
-        let perm = Perm::new_from_rng_128(&mut rng());
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
         let mmcs = MyMmcs::new(hash, compress);
 
         // 10 mats with 32 rows where the ith mat has i + 1 cols
         let mats = (0..10)
-            .map(|i| RowMajorMatrix::<F>::rand(&mut rng(), 32, i + 1))
+            .map(|i| RowMajorMatrix::<F>::rand(&mut rng, 32, i + 1))
             .collect_vec();
         let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
 

--- a/mersenne-31/benches/bench_field.rs
+++ b/mersenne-31/benches/bench_field.rs
@@ -5,6 +5,8 @@ use p3_field_testing::bench_func::{
     benchmark_sub_latency, benchmark_sub_throughput, benchmark_sum_array,
 };
 use p3_mersenne_31::Mersenne31;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 type F = Mersenne31;
 
@@ -25,9 +27,10 @@ fn bench_field(c: &mut Criterion) {
     benchmark_sub_latency::<F, L_REPS>(c, name);
     benchmark_sub_throughput::<F, REPS>(c, name);
 
+    let mut rng = SmallRng::seed_from_u64(1);
     c.bench_function("5th_root", |b| {
         b.iter_batched(
-            rand::random::<F>,
+            || rng.random::<F>(),
             |x| x.exp_u64(1717986917),
             BatchSize::SmallInput,
         )

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -81,7 +81,8 @@ impl<const D: u64, const WIDTH: usize> ExternalLayer<PackedMersenne31Neon, WIDTH
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::Poseidon2Mersenne31;
@@ -93,7 +94,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -114,7 +115,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
     fn test_neon_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/mersenne-31/src/dft.rs
+++ b/mersenne-31/src/dft.rs
@@ -174,7 +174,8 @@ impl Mersenne31Dft {
 #[cfg(test)]
 mod tests {
     use rand::distr::{Distribution, StandardUniform};
-    use rand::{Rng, rng};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::Mersenne31ComplexRadix2Dit;
@@ -188,7 +189,8 @@ mod tests {
         StandardUniform: Distribution<Base>,
     {
         const N: usize = 1 << 12;
-        let input = rng()
+        let rng = SmallRng::seed_from_u64(1);
+        let input = rng
             .sample_iter(StandardUniform)
             .take(N)
             .collect::<Vec<Base>>();
@@ -204,16 +206,13 @@ mod tests {
         StandardUniform: Distribution<Base>,
     {
         const N: usize = 1 << 6;
-        let a = rng()
+        let rng = SmallRng::seed_from_u64(1);
+        let v = rng
             .sample_iter(StandardUniform)
-            .take(N)
+            .take(2 * N)
             .collect::<Vec<Base>>();
-        let a = RowMajorMatrix::new_col(a);
-        let b = rng()
-            .sample_iter(StandardUniform)
-            .take(N)
-            .collect::<Vec<Base>>();
-        let b = RowMajorMatrix::new_col(b);
+        let a = RowMajorMatrix::new_col(v[..N].to_vec());
+        let b = RowMajorMatrix::new_col(v[N..].to_vec());
 
         let fft_a = Mersenne31Dft::dft_batch::<Dft>(a.clone());
         let fft_b = Mersenne31Dft::dft_batch::<Dft>(b.clone());

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -338,7 +338,8 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::Poseidon2Mersenne31;
@@ -350,7 +351,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input of length 16.
     #[test]
     fn test_avx2_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -371,7 +372,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input of length 24.
     #[test]
     fn test_avx2_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -285,7 +285,8 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX512, WIDTH, 5>
 #[cfg(test)]
 mod tests {
     use p3_symmetric::Permutation;
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use crate::Poseidon2Mersenne31;
@@ -297,7 +298,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input of length 16.
     #[test]
     fn test_avx512_poseidon2_width_16() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm16::new_from_rng_128(&mut rng);
@@ -318,7 +319,7 @@ mod tests {
     /// Test that the output is the same as the scalar version on a random input of length 24.
     #[test]
     fn test_avx512_poseidon2_width_24() {
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
 
         // Our Poseidon2 implementation.
         let poseidon2 = Perm24::new_from_rng_128(&mut rng);

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -10,8 +10,9 @@ use p3_mds::coset_mds::CosetMds;
 use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use p3_poseidon::Poseidon;
 use p3_symmetric::Permutation;
+use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
-use rand::rng;
+use rand::rngs::SmallRng;
 
 fn bench_poseidon(c: &mut Criterion) {
     poseidon::<BabyBear, BabyBear, MdsMatrixBabyBear, 16, 7>(c);
@@ -34,7 +35,7 @@ where
     StandardUniform: Distribution<F>,
     Mds: MdsPermutation<A, WIDTH> + Default,
 {
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
     let mds = Mds::default();
 
     // TODO: Should be calculated for the particular field, width and ALPHA.

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -10,7 +10,8 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::ForestLayer;
@@ -85,7 +86,9 @@ fn prove_and_verify() -> Result<(), impl Debug> {
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
-    let constants = RoundConstants::from_rng(&mut rng());
+    // WARNING: DO NOT USE SmallRng in proper applications! Use a real PRNG instead!
+    let mut rng = SmallRng::seed_from_u64(1);
+    let constants = RoundConstants::from_rng(&mut rng);
     let air: VectorizedPoseidon2Air<
         Val,
         GenericPoseidon2LinearLayersKoalaBear,

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -7,7 +7,8 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
-use rand::random;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 use crate::air::eval;
 use crate::constants::RoundConstants;
@@ -192,7 +193,8 @@ impl<
         LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
         StandardUniform: Distribution<[F; WIDTH]>,
     {
-        let inputs = (0..num_hashes).map(|_| random()).collect();
+        let mut rng = SmallRng::seed_from_u64(1);
+        let inputs = (0..num_hashes).map(|_| rng.random()).collect();
         generate_vectorized_trace_rows::<
             _,
             LinearLayers,

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -7,10 +7,11 @@ use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};
 use p3_symmetric::Permutation;
 use p3_util::pretty_name;
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 
 fn bench_poseidon2(c: &mut Criterion) {
-    let mut rng = rng();
+    let mut rng = SmallRng::seed_from_u64(1);
 
     let poseidon2_bb_16 = Poseidon2BabyBear::<16>::new_from_rng_128(&mut rng);
     poseidon2::<BabyBear, Poseidon2BabyBear<16>, 16>(c, poseidon2_bb_16);

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -11,7 +11,8 @@ use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use p3_rescue::Rescue;
 use p3_symmetric::Permutation;
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 fn bench_rescue(c: &mut Criterion) {
     rescue::<BabyBear, BabyBear, IntegratedCosetMds<_, 16>, 16, 7>(c);
@@ -38,7 +39,7 @@ where
     // assume it suffices; for real usage the Sage calculation in the paper should be used.
     const NUM_ROUNDS: usize = 8;
 
-    let rng = rng();
+    let rng = SmallRng::seed_from_u64(1);
     let num_constants = 2 * WIDTH * NUM_ROUNDS;
     let round_constants = rng
         .sample_iter(StandardUniform)

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -13,7 +13,8 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{StarkConfig, prove, verify};
-use rand::rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
 
 /// For testing the public values feature
 pub struct FibonacciAir {}
@@ -113,7 +114,8 @@ type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 
 /// n-th Fibonacci number expected to be x
 fn test_public_value_impl(n: usize, x: u64) {
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);
@@ -144,7 +146,8 @@ fn test_public_value() {
 #[test]
 #[should_panic(expected = "assertion `left == right` failed: constraints had nonzero value")]
 fn test_incorrect_public_value() {
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
     let val_mmcs = ValMmcs::new(hash, compress);

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -22,7 +22,8 @@ use p3_symmetric::{
 };
 use p3_uni_stark::{StarkConfig, StarkGenericConfig, Val, prove, verify};
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 /// How many `a * b = c` operations to do per row in the AIR.
 const REPETITIONS: usize = 20; // This should be < 255 so it can fit into a u8.
@@ -56,7 +57,7 @@ impl MulAir {
     where
         StandardUniform: Distribution<F>,
     {
-        let mut rng = rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         let mut trace_values = F::zero_vec(rows * TRACE_WIDTH);
         for (i, (a, b, c)) in trace_values.iter_mut().tuples().enumerate() {
             let row = i / REPETITIONS;
@@ -148,7 +149,8 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 4>;
 
     type Perm = Poseidon2BabyBear<16>;
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
 
     type Dft = Radix2DitParallel<Val>;
     let dft = Dft::default();
@@ -193,7 +195,8 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
     type Challenge = BinomialExtensionField<Val, 4>;
 
     type Perm = Poseidon2BabyBear<16>;
-    let perm = Perm::new_from_rng_128(&mut rng());
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
 
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
     let hash = MyHash::new(perm.clone());

--- a/util/benches/bit_reverse.rs
+++ b/util/benches/bit_reverse.rs
@@ -1,14 +1,16 @@
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use p3_util::{reverse_bits, reverse_slice_index_bits};
-use rand::{Rng, rng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 fn bench_reverse_bits(c: &mut Criterion) {
     let mut group = c.benchmark_group("reverse_bits");
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_size in [1, 3, 5, 8, 16, 24] {
         let bits = 1 << log_size;
         group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |b, &bits| {
             let n = 1 << bits;
-            let x = rng().random_range(0..n);
+            let x = rng.random_range(0..n);
             b.iter(|| {
                 black_box(reverse_bits(black_box(x), black_box(n)));
             });
@@ -19,10 +21,10 @@ fn bench_reverse_bits(c: &mut Criterion) {
 
 fn bench_reverse_slice_index_bits(c: &mut Criterion) {
     let mut group = c.benchmark_group("reverse_slice_index_bits");
+    let mut rng = SmallRng::seed_from_u64(1);
     for log_size in [1, 3, 5, 8, 16, 24] {
         let size = 1 << log_size;
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let mut rng = rng();
             let data: Vec<u64> = (0..size).map(|_| rng.random()).collect();
             b.iter(|| {
                 let mut test_data = data.clone();

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -407,7 +407,8 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use rand::Rng;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
 
     use super::*;
 
@@ -539,7 +540,7 @@ mod tests {
     #[test]
     fn test_reverse_slice_index_bits_random() {
         let lengths = [32, 128, 1 << 16];
-        let mut rng = rand::rng();
+        let mut rng = SmallRng::seed_from_u64(1);
         for _ in 0..32 {
             for &length in &lengths {
                 let mut rand_list: Vec<u32> = Vec::with_capacity(length);


### PR DESCRIPTION
This PR replaces all uses of the operating system's random number generator with (weak) the `SmallRng` seedable rng. The motivation is to avoid OS dependencies which are currently blocking #594.

The vast majority of the changes apply to the use of rngs in the testing and benchmarking suites. The quality of randomness in these cases is obviously unimportant.

There are a few cases where the weak `SmallRng` has been used in the example code where such a use would be very unwise in production code. These places have been highlighted with a shouty comment.