### PR TITLE
Replace `std::` with `core::` where possible.

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;

--- a/circle/examples/lde.rs
+++ b/circle/examples/lde.rs
@@ -1,4 +1,4 @@
-use std::hint::black_box;
+use core::hint::black_box;
 use std::time::{Duration, Instant};
 
 use p3_baby_bear::BabyBear;

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_challenger::{DuplexChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;

--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use itertools::Itertools;

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -1,5 +1,5 @@
 use core::cmp::Reverse;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{CanSampleBits, DuplexChallenger, FieldChallenger};

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -197,7 +197,7 @@ mod babybear_fri_pcs {
 }
 
 mod m31_fri_pcs {
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     use p3_challenger::{HashChallenger, SerializingChallenger32};
     use p3_circle::CirclePcs;

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_field::{Field, PrimeCharacteristicRing};

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_challenger::{HashChallenger, SerializingChallenger64};
 use p3_commit::ExtensionMmcs;

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_challenger::{HashChallenger, SerializingChallenger64};
 use p3_commit::ExtensionMmcs;

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use core::fmt::Debug;
+use core::marker::PhantomData;
 
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "parallel")]
 pub mod prelude {
+    use core::marker::{Send, Sync};
+    use core::ops::Fn;
     pub use rayon::prelude::*;
     pub use rayon::{current_num_threads, join};
 
@@ -41,6 +43,8 @@ pub mod prelude {
     pub use core::iter::{
         ExactSizeIterator as IndexedParallelIterator, Iterator as ParallelIterator,
     };
+    use core::marker::{Send, Sync};
+    use core::ops::Fn;
 
     pub use super::serial::*;
 

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod prelude {
     use core::marker::{Send, Sync};
     use core::ops::Fn;
+
     pub use rayon::prelude::*;
     pub use rayon::{current_num_threads, join};
 

--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 #[cfg(feature = "parallel")]
 pub mod prelude {
     pub use rayon::prelude::*;

--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -1,4 +1,7 @@
-use core::iter::FlatMap;
+use core::iter::{FlatMap, IntoIterator, Iterator};
+use core::marker::{Send, Sized, Sync};
+use core::ops::{Fn, FnOnce};
+use core::option::Option;
 use core::slice::{
     Chunks, ChunksExact, ChunksExactMut, ChunksMut, RChunks, RChunksExact, RChunksExactMut,
     RChunksMut, Split, SplitMut, Windows,

--- a/mds/benches/mds.rs
+++ b/mds/benches/mds.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};

--- a/monolith/benches/permute.rs
+++ b/monolith/benches/permute.rs
@@ -1,4 +1,4 @@
-use std::array;
+use core::array;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use p3_field::PrimeCharacteristicRing;

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -127,7 +127,7 @@ impl<PMP: PackedMontyParameters> Sub for PackedMontyField31Neon<PMP> {
 
 /// No-op. Prevents the compiler from deducing the value of the vector.
 ///
-/// Similar to `std::hint::black_box`, it can be used to stop the compiler applying undesirable
+/// Similar to `core::hint::black_box`, it can be used to stop the compiler applying undesirable
 /// "optimizations". Unlike the built-in `black_box`, it does not force the value to be written to
 /// and then read from the stack.
 #[inline]

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -195,7 +195,7 @@ pub(crate) fn sub<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -
 
 /// No-op. Prevents the compiler from deducing the value of the vector.
 ///
-/// Similar to `std::hint::black_box`, it can be used to stop the compiler applying undesirable
+/// Similar to `core::hint::black_box`, it can be used to stop the compiler applying undesirable
 /// "optimizations". Unlike the built-in `black_box`, it does not force the value to be written to
 /// and then read from the stack.
 #[inline]

--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -1,5 +1,5 @@
-use std::any::type_name;
-use std::array;
+use core::any::type_name;
+use core::array;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_baby_bear::{BabyBear, GenericPoseidon2LinearLayersBabyBear};
 use p3_challenger::{HashChallenger, SerializingChallenger32};

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;

--- a/rescue/benches/rescue.rs
+++ b/rescue/benches/rescue.rs
@@ -1,5 +1,5 @@
-use std::any::type_name;
-use std::array;
+use core::any::type_name;
+use core::array;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use core::fmt::Debug;
+use core::marker::PhantomData;
 
 use itertools::Itertools;
 use p3_air::{Air, AirBuilder, BaseAir};

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -281,7 +281,7 @@ pub fn pretty_name<T>() -> String {
 }
 
 /// A C-style buffered input reader, similar to
-/// `std::iter::Iterator::next_chunk()` from nightly.
+/// `core::iter::Iterator::next_chunk()` from nightly.
 ///
 /// Unsafe because the returned array may contain uninitialised
 /// elements.


### PR DESCRIPTION
Like it says on the tin; also adds `#![no_std]` to `maybe-rayon`, which had been overlooked. Continued work addressing #594.

Note that the `use core::blah` stuff in `maybe-rayon` isn't required when compiling on "typical" targets, but is required on embedded targets like `thumbv7em-none-eabi` for example.