### PR TITLE
Make Blake3 and Sha3 `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 
 [workspace.dependencies]
 bincode = { version = "2.0.0", default-features = false }
-blake3 = "1.5"
+blake3 = { version = "1.5", default-features = false }
 clap = { version = "4.5.23", features = ["derive"] }
 clap_derive = "4.5.18"
 criterion = "0.5.1"
@@ -56,7 +56,7 @@ rayon = "1.7.0"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0.113"
 sha2 = { version = "0.10.8", default-features = false }
-sha3 = "0.10.8"
+sha3 = { version = "0.10.8", default-features = false }
 tiny-keccak = "2.0.2"
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
 tracing-forest = "0.1.6"

--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -61,7 +61,7 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(
         array::from_fn(|i| array::from_fn(|j| u32_to_bits_le(input[16 + 4 * i + j])));
 
     row.counter_low = u32_to_bits_le(counter as u32);
-    row.counter_hi = u32_to_bits_le((counter >> 32) as u32);
+    row.counter_hi = u32_to_bits_le(counter.overflowing_shr(32).0 as u32);
     row.block_len = u32_to_bits_le(block_len as u32);
 
     // We set the flags initial value to just be 0.
@@ -88,7 +88,12 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(
             (IV[2][0] as u32) + ((IV[2][1] as u32) << 16),
             (IV[3][0] as u32) + ((IV[3][1] as u32) << 16),
         ],
-        [counter as u32, (counter >> 32) as u32, block_len as u32, 0],
+        [
+            counter as u32,
+            counter.overflowing_shr(32).0 as u32,
+            block_len as u32,
+            0,
+        ],
     ];
 
     generate_trace_row_for_round(&mut row.full_rounds[0], &mut state, &m_vec); // round 1

--- a/blake3-air/src/generation.rs
+++ b/blake3-air/src/generation.rs
@@ -61,7 +61,7 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(
         array::from_fn(|i| array::from_fn(|j| u32_to_bits_le(input[16 + 4 * i + j])));
 
     row.counter_low = u32_to_bits_le(counter as u32);
-    row.counter_hi = u32_to_bits_le(counter.overflowing_shr(32).0 as u32);
+    row.counter_hi = u32_to_bits_le(counter.wrapping_shr(32) as u32);
     row.block_len = u32_to_bits_le(block_len as u32);
 
     // We set the flags initial value to just be 0.
@@ -90,7 +90,7 @@ fn generate_trace_rows_for_perm<F: PrimeField64>(
         ],
         [
             counter as u32,
-            counter.overflowing_shr(32).0 as u32,
+            counter.wrapping_shr(32) as u32,
             block_len as u32,
             0,
         ],


### PR DESCRIPTION
Like it says on the tin.

Mysteriously, having made Blake3 `no_std` and compiling for `thumbv7em-none-eabi`, rustc complains about unchecked overflow of the right shifts in the Blake3 AIR. Hence I've made the desired shift behaviour explicit.