### PR TITLE
Make `bn254-fr` no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,6 @@ blake3 = "1.5"
 clap = { version = "4.5.23", features = ["derive"] }
 clap_derive = "4.5.18"
 criterion = "0.5.1"
-ff = "0.13"
-halo2curves = "0.8.0"
 hashbrown = "0.15.0"
 hex-literal = "1.0.0"
 itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
@@ -62,7 +60,6 @@ tracing = { version = "0.1.37", default-features = false, features = ["attribute
 tracing-forest = "0.1.6"
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["alloc"] }
 transpose = "0.2.3"
-zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
 
 # Local dependencies
 p3-air = { path = "air", version = "0.1.0" }

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -9,19 +9,18 @@ p3-field.workspace = true
 p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
 
-ff = { workspace = true, features = ["derive", "derive_bits"] }
 num-bigint.workspace = true
 paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
-halo2curves = { workspace = true, features = ["bits", "derive_serde"] }
+halo2curves = { version = "0.8.0", features = ["bits", "derive_serde"] }
 
 [dev-dependencies]
 p3-field-testing.workspace = true
 
 criterion.workspace = true
 serde_json.workspace = true
-zkhash.workspace = true
+zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
 
 [features]
 default = []

--- a/bn254-fr/src/lib.rs
+++ b/bn254-fr/src/lib.rs
@@ -1,15 +1,19 @@
 //! The scalar field of the BN254 curve, defined as `F_r` where `r = 21888242871839275222246405745257275088548364400416034343698204186575808495617`.
+#![no_std]
 
 mod poseidon2;
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::{fmt, stringify};
 
-use ff::{Field as FFField, PrimeField as FFPrimeField};
 pub use halo2curves::bn256::Fr as FFBn254Fr;
+use halo2curves::ff::{Field as FFField, PrimeField as FFPrimeField};
 use halo2curves::serde::SerdeObject;
 use num_bigint::BigUint;
 use p3_field::integers::QuotientMap;
@@ -144,7 +148,7 @@ impl Field for Bn254Fr {
 
     /// r = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
     fn order() -> BigUint {
-        BigUint::new(vec![
+        BigUint::from_slice(&[
             0xf0000001, 0x43e1f593, 0x79b97091, 0x2833e848, 0x8181585d, 0xb85045b6, 0xe131a029,
             0x30644e72,
         ])
@@ -321,7 +325,7 @@ mod tests {
     #[test]
     fn test_bn254fr() {
         let f = F::new(FFBn254Fr::from_u128(100));
-        assert_eq!(f.as_canonical_biguint(), BigUint::new(vec![100]));
+        assert_eq!(f.as_canonical_biguint(), BigUint::from(100u32));
 
         let f = F::new(FFBn254Fr::from_str_vartime(&F::order().to_str_radix(10)).unwrap());
         assert!(f.is_zero());
@@ -329,7 +333,7 @@ mod tests {
         // Generator check
         let expected_multiplicative_group_generator = F::new(FFBn254Fr::from_u128(5));
         assert_eq!(F::GENERATOR, expected_multiplicative_group_generator);
-        assert_eq!(F::GENERATOR.as_canonical_biguint(), BigUint::new(vec![5]));
+        assert_eq!(F::GENERATOR.as_canonical_biguint(), BigUint::from(5u32));
 
         let f_1 = F::ONE;
         let f_2 = F::TWO;

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -2,7 +2,9 @@
 //!
 //! Reference: https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_bn256.rs
 
-use std::sync::OnceLock;
+extern crate alloc;
+
+use alloc::vec::Vec;
 
 use p3_field::PrimeCharacteristicRing;
 use p3_poseidon2::{
@@ -32,12 +34,6 @@ pub type Poseidon2Bn254<const WIDTH: usize> = Poseidon2<
 /// Currently we only support a single width for Poseidon2 BN254.
 const BN254_WIDTH: usize = 3;
 
-#[inline]
-fn get_diffusion_matrix_3() -> &'static [Bn254Fr; 3] {
-    static MAT_DIAG3_M_1: OnceLock<[Bn254Fr; 3]> = OnceLock::new();
-    MAT_DIAG3_M_1.get_or_init(|| [Bn254Fr::ONE, Bn254Fr::ONE, Bn254Fr::TWO])
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct Poseidon2InternalLayerBn254 {
     internal_constants: Vec<Bn254Fr>,
@@ -52,9 +48,10 @@ impl InternalLayerConstructor<Bn254Fr> for Poseidon2InternalLayerBn254 {
 impl InternalLayer<Bn254Fr, BN254_WIDTH, BN254_S_BOX_DEGREE> for Poseidon2InternalLayerBn254 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [Bn254Fr; BN254_WIDTH]) {
+        const MAT_DIAG3_M_1: [Bn254Fr; 3] = [Bn254Fr::ONE, Bn254Fr::ONE, Bn254Fr::TWO];
         internal_permute_state(
             state,
-            |x| matmul_internal(x, *get_diffusion_matrix_3()),
+            |x| matmul_internal(x, MAT_DIAG3_M_1),
             &self.internal_constants,
         )
     }


### PR DESCRIPTION
Main change is to remove the completely redundant use of `OnceLock`.

I also moved the dependencies from the root `Cargo.toml` into the package's `Cargo.toml`, and I removed the redundant `ff` dependency (which is already included by `halo2curves`).