### PR TITLE
Improve bn254 Poseidon2

### DIFF
--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -53,7 +53,9 @@ impl InternalLayerConstructor<Bn254Fr> for Poseidon2InternalLayerBn254 {
 ///                             [1, 1, 3]
 /// ```
 fn bn254_matmul_internal(state: &mut [Bn254Fr; 3]) {
-    let sum = state[0] + state[1] + state[2];
+    // We bracket in this way as the s-box is applied to state[0] so this lets us
+    // begin this computation before the s-box finishes.
+    let sum = state[0] + (state[1] + state[2]);
 
     state[0] += sum;
     state[1] += sum;

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -47,7 +47,7 @@ impl InternalLayerConstructor<Bn254Fr> for Poseidon2InternalLayerBn254 {
 
 /// A faster version of `matmul_internal` making use of the fact that
 /// the internal matrix is equal to:
-/// ```
+/// ```ignore
 ///                             [2, 1, 1]
 ///     1 + Diag([1, 1, 2]) =   [1, 2, 1]
 ///                             [1, 1, 3]


### PR DESCRIPTION
Add a custom internal layer multiplication for Bn254's poseidon2 implementation.

This avoids all multiplications and costs only `5` additions and `1` double. (As far as I can tell this should be optimal).

This seems to give a `~25%` speed up to the full Poseidon2 implementation. (Multiplications in `Bn254` are really expensive...)

(I asked co-pilot to review it as I'm curious about what it will say)