### PR TITLE
Remove unused Peekable iter

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -56,7 +56,6 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
                         .map(|t| DifButterfly(t))
                         .collect_vec()
                 })
-                .peekable()
         });
 
         assert_eq!(twiddles.len(), domain.log_n);
@@ -161,7 +160,6 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
                 .map(|ts| ts.into_iter().map(|t| DitButterfly(t)).collect_vec())
                 .rev()
                 .skip(domain.log_n - log_n)
-                .peekable()
         });
 
         for ts in twiddles.peeking_take_while(|ts| ts.len() < desired_num_jobs()) {


### PR DESCRIPTION
**Why is this bad?**
Creating a peekable iterator without using any of its methods is likely a mistake, or just a leftover after a refactor.

```
warning: `peek` never called on `Peekable` iterator
  --> circle/src/cfft.rs:50:17
   |
50 |         let mut twiddles = debug_span!("twiddles").in_scope(|| {
   |                 ^^^^^^^^
   |
   = help: consider removing the call to `peekable`
```