### PR TITLE
fix: Missing size checks in FRI

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -16,6 +16,7 @@ use p3_matrix::row_index_mapped::RowIndexMappedView;
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
+use p3_util::zip_eq::zip_eq;
 use serde::{Deserialize, Serialize};
 use tracing::info_span;
 
@@ -68,6 +69,7 @@ pub struct CircleInputProof<
 pub enum InputError<InputMmcsError, FriMmcsError> {
     InputMmcsError(InputMmcsError),
     FirstLayerMmcsError(FriMmcsError),
+    InputShapeError,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -410,7 +412,9 @@ where
                     first_layer_proof,
                 } = input_proof;
 
-                for (batch_opening, (batch_commit, mats)) in izip!(input_openings, &rounds) {
+                for (batch_opening, (batch_commit, mats)) in
+                    zip_eq(input_openings, &rounds, InputError::InputShapeError)?
+                {
                     let batch_heights: Vec<usize> = mats
                         .iter()
                         .map(|(domain, _)| (domain.size() << self.fri_config.log_blowup))
@@ -443,9 +447,11 @@ where
                         )
                         .map_err(InputError::InputMmcsError)?;
 
-                    for (ps_at_x, (mat_domain, mat_points_and_values)) in
-                        izip!(&batch_opening.opened_values, mats)
-                    {
+                    for (ps_at_x, (mat_domain, mat_points_and_values)) in zip_eq(
+                        &batch_opening.opened_values,
+                        mats,
+                        InputError::InputShapeError,
+                    )? {
                         let log_height = mat_domain.log_n + self.fri_config.log_blowup;
                         let bits_reduced = log_global_max_height - log_height;
                         let orig_idx = cfft_permute_index(index >> bits_reduced, log_height);
@@ -471,43 +477,50 @@ where
 
                 // Verify bivariate fold and lambda correction
 
-                let (mut fri_input, fl_dims, fl_leaves): (Vec<_>, Vec<_>, Vec<_>) =
-                    izip!(reduced_openings, first_layer_siblings, &proof.lambdas)
-                        .map(|((log_height, (_, ro)), &fl_sib, &lambda)| {
-                            assert!(log_height > 0);
+                let (mut fri_input, fl_dims, fl_leaves): (Vec<_>, Vec<_>, Vec<_>) = zip_eq(
+                    zip_eq(
+                        reduced_openings,
+                        first_layer_siblings,
+                        InputError::InputShapeError,
+                    )?,
+                    &proof.lambdas,
+                    InputError::InputShapeError,
+                )?
+                .map(|(((log_height, (_, ro)), &fl_sib), &lambda)| {
+                    assert!(log_height > 0);
 
-                            let orig_size = log_height - self.fri_config.log_blowup;
-                            let bits_reduced = log_global_max_height - log_height;
-                            let orig_idx = cfft_permute_index(index >> bits_reduced, log_height);
+                    let orig_size = log_height - self.fri_config.log_blowup;
+                    let bits_reduced = log_global_max_height - log_height;
+                    let orig_idx = cfft_permute_index(index >> bits_reduced, log_height);
 
-                            let lde_domain = CircleDomain::standard(log_height);
-                            let p: Point<Val> = lde_domain.nth_point(orig_idx);
+                    let lde_domain = CircleDomain::standard(log_height);
+                    let p: Point<Val> = lde_domain.nth_point(orig_idx);
 
-                            let lambda_corrected = ro - lambda * p.v_n(orig_size);
+                    let lambda_corrected = ro - lambda * p.v_n(orig_size);
 
-                            let mut fl_values = vec![lambda_corrected; 2];
-                            fl_values[((index >> bits_reduced) & 1) ^ 1] = fl_sib;
+                    let mut fl_values = vec![lambda_corrected; 2];
+                    fl_values[((index >> bits_reduced) & 1) ^ 1] = fl_sib;
 
-                            let fri_input = (
-                                // - 1 here is because we have already folded a layer.
-                                log_height - 1,
-                                fold_y_row(
-                                    index >> (bits_reduced + 1),
-                                    // - 1 here is log_arity.
-                                    log_height - 1,
-                                    bivariate_beta,
-                                    fl_values.iter().cloned(),
-                                ),
-                            );
+                    let fri_input = (
+                        // - 1 here is because we have already folded a layer.
+                        log_height - 1,
+                        fold_y_row(
+                            index >> (bits_reduced + 1),
+                            // - 1 here is log_arity.
+                            log_height - 1,
+                            bivariate_beta,
+                            fl_values.iter().copied(),
+                        ),
+                    );
 
-                            let fl_dims = Dimensions {
-                                width: 0,
-                                height: 1 << (log_height - 1),
-                            };
+                    let fl_dims = Dimensions {
+                        width: 0,
+                        height: 1 << (log_height - 1),
+                    };
 
-                            (fri_input, fl_dims, fl_values)
-                        })
-                        .multiunzip();
+                    (fri_input, fl_dims, fl_values)
+                })
+                .multiunzip();
 
                 // sort descending
                 fri_input.reverse();
@@ -569,7 +582,7 @@ mod tests {
 
         type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
-        let fri_config = create_test_fri_config(challenge_mmcs);
+        let fri_config = create_test_fri_config(challenge_mmcs, 0);
 
         type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
         let pcs = Pcs {

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -1,13 +1,14 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use itertools::{izip, Itertools};
+use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriConfig, FriGenericConfig};
 use p3_matrix::Dimensions;
+use p3_util::zip_eq::zip_eq;
 
 use crate::{CircleCommitPhaseProofStep, CircleFriProof};
 
@@ -44,6 +45,7 @@ where
         return Err(FriError::InvalidPowWitness);
     }
 
+    // The log of the maximum domain size.
     let log_max_height = proof.commit_phase_commits.len() + config.log_blowup;
 
     for qp in &proof.query_proofs {
@@ -55,19 +57,29 @@ where
             "reduced openings sorted by height descending"
         );
 
+        // Starting at the evaluation at `index` of the initial domain,
+        // perform fri folds until the domain size reaches the final domain size.
+        // Check after each fold that the pair of sibling evaluations at the current
+        // node match the commitment.
         let folded_eval = verify_query(
             g,
             config,
             index >> g.extra_query_index_bits(),
-            izip!(
-                &betas,
-                &proof.commit_phase_commits,
-                &qp.commit_phase_openings
-            ),
+            zip_eq(
+                zip_eq(
+                    &betas,
+                    &proof.commit_phase_commits,
+                    FriError::InvalidProofShape,
+                )?,
+                &qp.commit_phase_openings,
+                FriError::InvalidProofShape,
+            )?,
             ro,
             log_max_height,
         )?;
 
+        // As we fold until the polynomial is constant, proof.final_poly should be a constant value and
+        // we do not need to do any polynomial evaluations.
         if folded_eval != proof.final_poly {
             return Err(FriError::FinalPolyMismatch);
         }
@@ -77,16 +89,25 @@ where
 }
 
 type CommitStep<'a, F, M> = (
-    &'a F,
-    &'a <M as Mmcs<F>>::Commitment,
-    &'a CircleCommitPhaseProofStep<F, M>,
+    (
+        &'a F, // The challenge point beta used for the next fold of Circle-FRI evaluations.
+        &'a <M as Mmcs<F>>::Commitment, // A commitment to the Circle-FRI evaluations on the current domain.
+    ),
+    &'a CircleCommitPhaseProofStep<F, M>, // The sibling and opening proof for the current Circle-FRI node.
 );
 
+/// Verifies a single query chain in the Circle-FRI proof.
+///
+/// Given an initial `index` corresponding to a point in the initial domain
+/// and a series of `reduced_openings` corresponding to evaluations of
+/// polynomials to be added in at specific domain sizes, perform the standard
+/// sequence of Circle-FRI folds, checking at each step that the pair of sibling evaluations
+/// match the commitment.
 fn verify_query<'a, G, F, M>(
     g: &G,
     config: &FriConfig<M>,
     mut index: usize,
-    steps: impl Iterator<Item = CommitStep<'a, F, M>>,
+    steps: impl ExactSizeIterator<Item = CommitStep<'a, F, M>>,
     reduced_openings: Vec<(usize, F)>,
     log_max_height: usize,
 ) -> Result<F, FriError<M::Error, G::InputError>>
@@ -98,13 +119,21 @@ where
     let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
-    for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {
+    // We start with evaluations over a domain of size (1 << log_max_height). We fold
+    // using FRI until the domain size reaches (1 << log_final_height). This is equal to 1 << log_blowup
+    // currently as we have not yet implemented early stopping.
+    for (log_folded_height, ((&beta, comm), opening)) in zip_eq(
+        (config.log_blowup..log_max_height).rev(),
+        steps,
+        FriError::InvalidProofShape,
+    )? {
+        // If there are new polynomials to roll in at this height, do so.
         if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height + 1) {
             folded_eval += ro;
         }
 
+        // Get the index of the other sibling of the current fri node.
         let index_sibling = index ^ 1;
-        let index_pair = index >> 1;
 
         let mut evals = vec![folded_eval; 2];
         evals[index_sibling % 2] = opening.sibling_value;
@@ -113,27 +142,26 @@ where
             width: 2,
             height: 1 << log_folded_height,
         }];
+
+        // Replace index with the index of the parent fri node.
+        index >>= 1;
+
+        // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
-            .verify_batch(
-                comm,
-                dims,
-                index_pair,
-                &[evals.clone()],
-                &opening.opening_proof,
-            )
+            .verify_batch(comm, dims, index, &[evals.clone()], &opening.opening_proof)
             .map_err(FriError::CommitPhaseMmcsError)?;
 
-        index = index_pair;
-
+        // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.
         folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
     }
 
-    debug_assert!(index < config.blowup(), "index was {}", index);
-    debug_assert!(
-        ro_iter.next().is_none(),
-        "verifier reduced_openings were not in descending order?"
-    );
+    // If ro_iter is not empty, we failed to fold in some polynomial evaluations.
+    if ro_iter.next().is_some() {
+        return Err(FriError::InvalidProofShape);
+    }
 
+    // If we reached this point, we have verified that, starting at the initial index,
+    // the chain of folds has produced folded_eval.
     Ok(folded_eval)
 }

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -8,6 +8,7 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;
+use p3_util::zip_eq::zip_eq;
 use serde::{Deserialize, Serialize};
 
 use crate::{OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
@@ -163,7 +164,7 @@ where
         _challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         for (comm, round_opening) in rounds {
-            for (coeff_vec, (domain, points_and_values)) in comm.into_iter().zip(round_opening) {
+            for (coeff_vec, (domain, points_and_values)) in zip_eq(comm, round_opening, ())? {
                 let width = coeff_vec.len() / domain.size();
                 assert_eq!(width * domain.size(), coeff_vec.len());
                 let coeffs = RowMajorMatrix::new(coeff_vec, width);

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -60,10 +60,13 @@ pub trait FriGenericConfig<F: Field> {
 
 /// Creates a minimal `FriConfig` for testing purposes.
 /// This configuration is designed to reduce computational cost during tests.
-pub const fn create_test_fri_config<Mmcs>(mmcs: Mmcs) -> FriConfig<Mmcs> {
+pub const fn create_test_fri_config<Mmcs>(
+    mmcs: Mmcs,
+    log_final_poly_len: usize,
+) -> FriConfig<Mmcs> {
     FriConfig {
-        log_blowup: 1,
-        log_final_poly_len: 0,
+        log_blowup: 2,
+        log_final_poly_len,
         num_queries: 2,
         proof_of_work_bits: 1,
         mmcs,

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -11,6 +11,7 @@ use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 use p3_matrix::row_index_mapped::RowIndexMappedView;
 use p3_matrix::Matrix;
+use p3_util::zip_eq::zip_eq;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use tracing::instrument;
@@ -177,9 +178,17 @@ where
         // Now we merge `opened_values_for_rand_cws` into the opened values in `rounds`, undoing
         // the split that we did in `open`, to get a complete set of opened values for the inner PCS
         // to check.
-        for (round, rand_round) in rounds.iter_mut().zip(opened_values_for_rand_cws) {
-            for (mat, rand_mat) in round.1.iter_mut().zip(rand_round) {
-                for (point, rand_point) in mat.1.iter_mut().zip(rand_mat) {
+        for (round, rand_round) in zip_eq(
+            rounds.iter_mut(),
+            opened_values_for_rand_cws,
+            FriError::InvalidProofShape,
+        )? {
+            for (mat, rand_mat) in
+                zip_eq(round.1.iter_mut(), rand_round, FriError::InvalidProofShape)?
+            {
+                for (point, rand_point) in
+                    zip_eq(mat.1.iter_mut(), rand_mat, FriError::InvalidProofShape)?
+                {
                     point.1.extend(rand_point);
                 }
             }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -18,6 +18,7 @@ use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
+use p3_util::zip_eq::zip_eq;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
@@ -422,7 +423,9 @@ where
             // log_height -> (alpha_pow, reduced_opening)
             let mut reduced_openings = BTreeMap::<usize, (Challenge, Challenge)>::new();
 
-            for (batch_opening, (batch_commit, mats)) in izip!(input_proof, &rounds) {
+            for (batch_opening, (batch_commit, mats)) in
+                zip_eq(input_proof, &rounds, FriError::InvalidProofShape)?
+            {
                 let batch_heights = mats
                     .iter()
                     .map(|(domain, _)| domain.size() << self.fri.log_blowup)
@@ -444,7 +447,7 @@ where
                         reduced_index,
                         &batch_opening.opened_values,
                         &batch_opening.opening_proof,
-                    )?;
+                    )
                 } else {
                     // Empty batch?
                     self.mmcs.verify_batch(
@@ -453,12 +456,15 @@ where
                         0,
                         &batch_opening.opened_values,
                         &batch_opening.opening_proof,
-                    )?;
+                    )
                 }
+                .map_err(FriError::InputError)?;
 
-                for (mat_opening, (mat_domain, mat_points_and_values)) in
-                    izip!(&batch_opening.opened_values, mats)
-                {
+                for (mat_opening, (mat_domain, mat_points_and_values)) in zip_eq(
+                    &batch_opening.opened_values,
+                    mats,
+                    FriError::InvalidProofShape,
+                )? {
                     let log_height = log2_strict_usize(mat_domain.size()) + self.fri.log_blowup;
 
                     let bits_reduced = log_global_max_height - log_height;
@@ -474,7 +480,9 @@ where
                         .or_insert((Challenge::ONE, Challenge::ZERO));
 
                     for (z, ps_at_z) in mat_points_and_values {
-                        for (&p_at_x, &p_at_z) in izip!(mat_opening, ps_at_z) {
+                        for (&p_at_x, &p_at_z) in
+                            zip_eq(mat_opening, ps_at_z, FriError::InvalidProofShape)?
+                        {
                             let quotient = (-p_at_z + p_at_x) / (-*z + x);
                             *ro += *alpha_pow * quotient;
                             *alpha_pow *= alpha;

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,12 +1,13 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use itertools::{izip, Itertools};
+use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_util::reverse_bits_len;
+use p3_util::zip_eq::zip_eq;
 
 use crate::{CommitPhaseProofStep, FriConfig, FriGenericConfig, FriProof};
 
@@ -24,7 +25,10 @@ pub fn verify<G, Val, Challenge, M, Challenger>(
     config: &FriConfig<M>,
     proof: &FriProof<Challenge, M, Challenger::Witness, G::InputProof>,
     challenger: &mut Challenger,
-    open_input: impl Fn(usize, &G::InputProof) -> Result<Vec<(usize, Challenge)>, G::InputError>,
+    open_input: impl Fn(
+        usize,
+        &G::InputProof,
+    ) -> Result<Vec<(usize, Challenge)>, FriError<M::Error, G::InputError>>,
 ) -> Result<(), FriError<M::Error, G::InputError>>
 where
     Val: Field,
@@ -57,40 +61,53 @@ where
         return Err(FriError::InvalidPowWitness);
     }
 
+    // The log of the maximum domain size.
     let log_max_height =
         proof.commit_phase_commits.len() + config.log_blowup + config.log_final_poly_len;
 
+    // The log of the final domain size.
+    let log_final_height = config.log_blowup + config.log_final_poly_len;
+
     for qp in &proof.query_proofs {
         let index = challenger.sample_bits(log_max_height + g.extra_query_index_bits());
-        let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
+        let ro = open_input(index, &qp.input_proof)?;
 
         debug_assert!(
             ro.iter().tuple_windows().all(|((l, _), (r, _))| l > r),
             "reduced openings sorted by height descending"
         );
 
+        let mut domain_index = index >> g.extra_query_index_bits();
+
+        // Starting at the evaluation at `index` of the initial domain,
+        // perform fri folds until the domain size reaches the final domain size.
+        // Check after each fold that the pair of sibling evaluations at the current
+        // node match the commitment.
         let folded_eval = verify_query(
             g,
             config,
-            index >> g.extra_query_index_bits(),
-            izip!(
-                &betas,
-                &proof.commit_phase_commits,
-                &qp.commit_phase_openings
-            ),
+            &mut domain_index,
+            zip_eq(
+                zip_eq(
+                    &betas,
+                    &proof.commit_phase_commits,
+                    FriError::InvalidProofShape,
+                )?,
+                &qp.commit_phase_openings,
+                FriError::InvalidProofShape,
+            )?,
             ro,
             log_max_height,
+            log_final_height,
         )?;
-
-        let final_poly_index = index >> (proof.commit_phase_commits.len());
 
         let mut eval = Challenge::ZERO;
 
-        // We open the final polynomial at index `final_poly_index`, which corresponds to evaluating
+        // We open the final polynomial at index `domain_index`, which corresponds to evaluating
         // the polynomial at x^k, where x is the 2-adic generator of order `max_height` and k is
-        // `reverse_bits_len(final_poly_index, log_max_height)`.
+        // `reverse_bits_len(domain_index, log_max_height)`.
         let x = Challenge::two_adic_generator(log_max_height)
-            .exp_u64(reverse_bits_len(final_poly_index, log_max_height) as u64);
+            .exp_u64(reverse_bits_len(domain_index, log_max_height) as u64);
         let mut x_pow = Challenge::ONE;
 
         // Evaluate the final polynomial at x.
@@ -108,18 +125,28 @@ where
 }
 
 type CommitStep<'a, F, M> = (
-    &'a F,
-    &'a <M as Mmcs<F>>::Commitment,
-    &'a CommitPhaseProofStep<F, M>,
+    (
+        &'a F, // The challenge point beta used for the next fold of FRI evaluations.
+        &'a <M as Mmcs<F>>::Commitment, // A commitment to the FRI evaluations on the current domain.
+    ),
+    &'a CommitPhaseProofStep<F, M>, // The sibling and opening proof for the current FRI node.
 );
 
+/// Verifies a single query chain in the FRI proof.
+///
+/// Given an initial `index` corresponding to a point in the initial domain
+/// and a series of `reduced_openings` corresponding to evaluations of
+/// polynomials to be added in at specific domain sizes, perform the standard
+/// sequence of FRI folds, checking at each step that the pair of sibling evaluations
+/// match the commitment.
 fn verify_query<'a, G, F, M>(
     g: &G,
     config: &FriConfig<M>,
-    mut index: usize,
-    steps: impl Iterator<Item = CommitStep<'a, F, M>>,
+    index: &mut usize,
+    steps: impl ExactSizeIterator<Item = CommitStep<'a, F, M>>,
     reduced_openings: Vec<(usize, F)>,
     log_max_height: usize,
+    log_final_height: usize,
 ) -> Result<F, FriError<M::Error, G::InputError>>
 where
     F: Field,
@@ -129,13 +156,20 @@ where
     let mut folded_eval = F::ZERO;
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
-    for (log_folded_height, (&beta, comm, opening)) in izip!((0..log_max_height).rev(), steps) {
+    // We start with evaluations over a domain of size (1 << log_max_height). We fold
+    // using FRI until the domain size reaches (1 << log_final_height).
+    for (log_folded_height, ((&beta, comm), opening)) in zip_eq(
+        (log_final_height..log_max_height).rev(),
+        steps,
+        FriError::InvalidProofShape,
+    )? {
+        // If there are new polynomials to roll in at this height, do so.
         if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_folded_height + 1) {
             folded_eval += ro;
         }
 
-        let index_sibling = index ^ 1;
-        let index_pair = index >> 1;
+        // Get the index of the other sibling of the current fri node.
+        let index_sibling = *index ^ 1;
 
         let mut evals = vec![folded_eval; 2];
         evals[index_sibling % 2] = opening.sibling_value;
@@ -144,31 +178,26 @@ where
             width: 2,
             height: 1 << log_folded_height,
         }];
+
+        // Replace index with the index of the parent fri node.
+        *index >>= 1;
+
+        // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
-            .verify_batch(
-                comm,
-                dims,
-                index_pair,
-                &[evals.clone()],
-                &opening.opening_proof,
-            )
+            .verify_batch(comm, dims, *index, &[evals.clone()], &opening.opening_proof)
             .map_err(FriError::CommitPhaseMmcsError)?;
 
-        index = index_pair;
-
-        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+        // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.
+        folded_eval = g.fold_row(*index, log_folded_height, beta, evals.into_iter());
     }
 
-    debug_assert!(
-        index < config.blowup() * config.final_poly_len(),
-        "index was {}",
-        index,
-    );
-    debug_assert!(
-        ro_iter.next().is_none(),
-        "verifier reduced_openings were not in descending order?"
-    );
+    // If ro_iter is not empty, we failed to fold in some polynomial evaluations.
+    if ro_iter.next().is_some() {
+        return Err(FriError::InvalidProofShape);
+    }
 
+    // If we reached this point, we have verified that, starting at the initial index,
+    // the chain of folds has produced folded_eval.
     Ok(folded_eval)
 }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -8,6 +8,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::HorizontalPair;
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};
+use p3_util::zip_eq::zip_eq;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 use serde::de::DeserializeOwned;
@@ -128,9 +129,7 @@ where
     ) -> Result<(), Self::Error> {
         let (salts, siblings) = proof;
 
-        let opened_salted_values = opened_values
-            .iter()
-            .zip(salts.iter())
+        let opened_salted_values = zip_eq(opened_values, salts, MerkleTreeError::WrongBatchSize)?
             .map(|(opened, salt)| opened.iter().chain(salt.iter()).copied().collect_vec())
             .collect_vec();
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -124,7 +124,7 @@ where
         }
 
         // TODO: Disabled for now since TwoAdicFriPcs and CirclePcs currently pass 0 for width.
-        // for (dims, opened_vals) in dimensions.iter().zip(opened_values) {
+        // for (dims, opened_vals) in zip_eq(dimensions.iter(), opened_values) {
         //     if opened_vals.len() != dims.width {
         //         return Err(WrongWidth);
         //     }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -8,6 +8,7 @@ use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Field, FieldAlgebra, FieldExtensionAlgebra};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
+use p3_util::zip_eq::zip_eq;
 use tracing::instrument;
 
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
@@ -84,11 +85,13 @@ where
             ),
             (
                 commitments.quotient_chunks.clone(),
-                quotient_chunks_domains
-                    .iter()
-                    .zip(&opened_values.quotient_chunks)
-                    .map(|(domain, values)| (*domain, vec![(zeta, values.clone())]))
-                    .collect_vec(),
+                zip_eq(
+                    quotient_chunks_domains.iter(),
+                    &opened_values.quotient_chunks,
+                    VerificationError::InvalidProofShape,
+                )?
+                .map(|(domain, values)| (*domain, vec![(zeta, values.clone())]))
+                .collect_vec(),
             ),
         ],
         opening_proof,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -112,7 +112,7 @@ type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 
 /// n-th Fibonacci number expected to be x
-fn test_public_value_impl(n: usize, x: u64) {
+fn test_public_value_impl(n: usize, x: u64, log_final_poly_len: usize) {
     let perm = Perm::new_from_rng_128(&mut thread_rng());
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
@@ -120,7 +120,7 @@ fn test_public_value_impl(n: usize, x: u64) {
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
     let trace = generate_trace_rows::<Val>(0, 1, n);
-    let fri_config = create_test_fri_config(challenge_mmcs);
+    let fri_config = create_test_fri_config(challenge_mmcs, log_final_poly_len);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
     let config = MyConfig::new(pcs);
     let mut challenger = Challenger::new(perm.clone());
@@ -136,12 +136,13 @@ fn test_public_value_impl(n: usize, x: u64) {
 
 #[test]
 fn test_one_row_trace() {
-    test_public_value_impl(1, 1);
+    // Need to set log_final_poly_len to ensure log_min_height > config.log_final_poly_len + config.log_blowup
+    test_public_value_impl(1, 1, 0);
 }
 
 #[test]
 fn test_public_value() {
-    test_public_value_impl(1 << 3, 21);
+    test_public_value_impl(1 << 3, 21, 2);
 }
 
 #[cfg(debug_assertions)]
@@ -154,7 +155,7 @@ fn test_incorrect_public_value() {
     let val_mmcs = ValMmcs::new(hash, compress);
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
-    let fri_config = create_test_fri_config(challenge_mmcs);
+    let fri_config = create_test_fri_config(challenge_mmcs, 1);
     let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
     let config = MyConfig::new(pcs);

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -14,6 +14,7 @@ use core::mem::MaybeUninit;
 pub mod array_serialization;
 pub mod linear_map;
 pub mod transpose;
+pub mod zip_eq;
 
 /// Computes `ceil(log_2(n))`.
 #[must_use]

--- a/util/src/zip_eq.rs
+++ b/util/src/zip_eq.rs
@@ -1,0 +1,63 @@
+/// An iterator which iterates two other iterators of the same length simultaneously.
+///
+/// Equality of the lengths of `a` abd `b` are at construction time.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct ZipEq<A, B> {
+    a: A,
+    b: B,
+}
+
+/// Zips two iterators but **panics** if they are not of the same length.
+///
+/// Similar to `itertools::zip_eq`, but we check the lengths at construction time.
+pub fn zip_eq<A, AIter, B, BIter, Error>(
+    a: A,
+    b: B,
+    err: Error,
+) -> Result<ZipEq<A::IntoIter, B::IntoIter>, Error>
+where
+    A: IntoIterator<IntoIter = AIter>,
+    AIter: ExactSizeIterator,
+    B: IntoIterator<IntoIter = BIter>,
+    BIter: ExactSizeIterator,
+{
+    let a_iter = a.into_iter();
+    let b_iter = b.into_iter();
+    match a_iter.len() == b_iter.len() {
+        true => Ok(ZipEq {
+            a: a_iter,
+            b: b_iter,
+        }),
+        false => Err(err),
+    }
+}
+
+impl<A, B> Iterator for ZipEq<A, B>
+where
+    A: ExactSizeIterator, // We need to use ExactSizeIterator here otherwise the size_hint() methods could differ.
+    B: ExactSizeIterator,
+{
+    type Item = (A::Item, B::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a.next(), self.b.next()) {
+            (Some(a), Some(b)) => Some((a, b)),
+            (None, None) => None,
+            _ => unreachable!("The iterators must have the same length."),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // self.a.size_hint() = self.b.size_hint() as a and b are ExactSizeIterators
+        // and we checked that they are the same length at construction time.
+        debug_assert_eq!(self.a.size_hint(), self.b.size_hint());
+        self.a.size_hint()
+    }
+}
+
+impl<A, B> ExactSizeIterator for ZipEq<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator,
+{
+}

--- a/util/src/zip_eq.rs
+++ b/util/src/zip_eq.rs
@@ -1,6 +1,6 @@
 /// An iterator which iterates two other iterators of the same length simultaneously.
 ///
-/// Equality of the lengths of `a` abd `b` are at construction time.
+/// Equality of the lengths of `a` and `b` are checked at construction time.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct ZipEq<A, B> {
     a: A,


### PR DESCRIPTION
This is not merging to `main`. This is a patch commit to branch `openvm-v1.0` that cherry-picks fix https://github.com/Plonky3/Plonky3/commit/367f76133c3e614f65e856ef21c4963237d6907d for https://github.com/Plonky3/Plonky3/security/advisories/GHSA-m23j-cj9m-ppg9 onto the commit https://github.com/Plonky3/Plonky3/commit/88d7f059500fd956a7c1eb121e08653e5974728d that OpenVM is using for v1.0.0. This commit is prior to the large `p3-field` trait refactors.

* Introducing `ZipEq` and Fixes to `fri/src/verifier`

* Fixing hiding_pcs, merkle_tree, mmcs.

Just got circle_stark stuff left to go.

* Fixing Circle Stark zip appearances

* cargo fmt

* Minor changes to testing.

* Fixing a couple more instances of zip/izip appearing.

* Remove unused ZipEqError

* Update to remove the need for raise_error.

* ExactSizeIterators need to implement `size_hint` correctly.

Also added some doc comments. Trying to have this file roughly mirror:

https://docs.rs/itertools/latest/src/itertools/zip_eq_impl.rs.html