### PR TITLE
chore: fix incorrect string interpolation in `println!`

### DIFF
--- a/examples/examples/prove_prime_field_31.rs
+++ b/examples/examples/prove_prime_field_31.rs
@@ -82,7 +82,7 @@ fn main() {
         }
         ProofOptions::KeccakFPermutations => {
             let num_hashes = trace_height / 24;
-            println!("Proving {num_hashes} Keccak-F permutations");
+            println!("Proving {} Keccak-F permutations", num_hashes);
             num_hashes
         }
     };


### PR DESCRIPTION
`println!` was using incorrect variable interpolation:  

```rust
println!("Proving {num_hashes} Keccak-F permutations");
```  

Rust doesn't support this kind of interpolation, so I fixed it by replacing it with the correct format:  

```rust
println!("Proving {} Keccak-F permutations", num_hashes);
```  

This ensures the value of `num_hashes` is properly included in the output.