### PR TITLE
Safer Algebra's

### DIFF
--- a/baby-bear/src/extension.rs
+++ b/baby-bear/src/extension.rs
@@ -48,7 +48,7 @@ mod test_quartic_extension {
         assert_eq!(
             format!(
                 "{}",
-                EF::from_basis_coefficients_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
+                EF::from_basis_coefficients_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO]).unwrap()
             ),
             "2 + X + 2 X^3"
         );

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -57,8 +57,7 @@ pub trait FieldChallenger<F: Field>:
     }
 
     fn sample_algebra_element<A: BasedVectorSpace<F>>(&mut self) -> A {
-        let vec = self.sample_vec(A::DIMENSION);
-        A::from_basis_coefficients_slice(&vec)
+        A::from_basis_coefficients_fn(|_| self.sample())
     }
 }
 

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -49,7 +49,7 @@ where
             .into_iter()
             .map(|row| {
                 row.chunks(EF::DIMENSION)
-                    .map(EF::from_basis_coefficients_slice)
+                    .map(|chunk| EF::from_basis_coefficients_slice(chunk).unwrap()) // unwrap is safe as each chunk has length EF::DIMENSION
                     .collect()
             })
             .collect();

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -95,6 +95,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
 
 impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExtensionField<F, D> {
     /// FrobeniusField automorphisms: x -> x^n, where n is the order of BaseField.
+    #[inline]
     fn frobenius(&self) -> Self {
         self.repeated_frobenius(1)
     }
@@ -103,6 +104,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
     ///
     /// Follows precomputation suggestion in Section 11.3.3 of the
     /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    #[inline]
     fn repeated_frobenius(&self, count: usize) -> Self {
         if count == 0 {
             return *self;
@@ -124,6 +126,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
     }
 
     /// Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+    #[inline]
     fn frobenius_inv(&self) -> Self {
         // Writing 'a' for self, we need to compute a^(r-1):
         // r = n^D-1/n-1 = n^(D-1)+n^(D-2)+...+n

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -72,14 +72,8 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
     }
 
     #[inline]
-    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(iter: I) -> Option<Self> {
-        (iter.len() == D).then(|| {
-            let mut res = Self::default();
-            for (i, b) in iter.enumerate() {
-                res.value[i] = b;
-            }
-            res
-        })
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
+        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
     }
 }
 
@@ -88,10 +82,12 @@ impl<F: BinomiallyExtendable<D>, const D: usize> ExtensionField<F>
 {
     type ExtensionPacking = PackedBinomialExtensionField<F, F::Packing, D>;
 
+    #[inline]
     fn is_in_basefield(&self) -> bool {
         self.value[1..].iter().all(F::is_zero)
     }
 
+    #[inline]
     fn as_base(&self) -> Option<F> {
         <Self as ExtensionField<F>>::is_in_basefield(self).then(|| self.value[0])
     }
@@ -195,6 +191,7 @@ where
         }
     }
 
+    #[inline]
     fn mul_2exp_u64(&self, exp: u64) -> Self {
         Self::new(self.value.clone().map(|x| x.mul_2exp_u64(exp)))
     }
@@ -229,14 +226,17 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
         Some(res)
     }
 
+    #[inline]
     fn halve(&self) -> Self {
         Self::new(self.value.map(|x| x.halve()))
     }
 
+    #[inline]
     fn div_2exp_u64(&self, exp: u64) -> Self {
         Self::new(self.value.map(|x| x.div_2exp_u64(exp)))
     }
 
+    #[inline]
     fn order() -> BigUint {
         F::order().pow(D as u32)
     }
@@ -338,6 +338,7 @@ where
     F: BinomiallyExtendable<D>,
     A: Algebra<F>,
 {
+    #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|acc, x| acc + x).unwrap_or(Self::ZERO)
     }
@@ -456,6 +457,7 @@ where
     F: BinomiallyExtendable<D>,
     A: Algebra<F>,
 {
+    #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|acc, x| acc * x).unwrap_or(Self::ONE)
     }
@@ -489,6 +491,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Distribution<BinomialExtensionF
 where
     Self: Distribution<F>,
 {
+    #[inline]
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BinomialExtensionField<F, D> {
         BinomialExtensionField::new(array::from_fn(|_| self.sample(rng)))
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -73,7 +73,7 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
 
     #[inline]
     fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
-        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
+        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap()))) // The unwrap is safe as we just checked the length of iter.
     }
 }
 
@@ -111,7 +111,6 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
             // x^(n^(count % D))
             return self.repeated_frobenius(count % D);
         }
-        let arr: &[F] = self.as_basis_coefficients_slice();
 
         // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
         let mut z0 = F::DTH_ROOT;
@@ -119,12 +118,12 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
             z0 *= F::DTH_ROOT;
         }
 
-        let mut res = [F::ZERO; D];
+        let mut res = Self::ZERO;
         for (i, z) in z0.powers().take(D).enumerate() {
-            res[i] = arr[i] * z;
+            res.value[i] = self.value[i] * z;
         }
 
-        Self::from_basis_coefficients_slice(&res).unwrap()
+        res
     }
 
     /// Algorithm 11.3.4 in Handbook of Elliptic and Hyperelliptic Curve Cryptography.

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -113,10 +113,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
         }
 
         // z0 = DTH_ROOT^count = W^(k * count) where k = floor((n-1)/D)
-        let mut z0 = F::DTH_ROOT;
-        for _ in 1..count {
-            z0 *= F::DTH_ROOT;
-        }
+        let z0 = F::DTH_ROOT.exp_u64(count as u64);
 
         let mut res = Self::ZERO;
         for (i, z) in z0.powers().take(D).enumerate() {

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -154,7 +154,7 @@ where
 
     #[inline]
     fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = PF>>(mut iter: I) -> Option<Self> {
-        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
+        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap()))) // The unwrap is safe as we just checked the length of iter.
     }
 }
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -34,6 +34,7 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> PackedBinomialExtens
 impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> Default
     for PackedBinomialExtensionField<F, PF, D>
 {
+    #[inline]
     fn default() -> Self {
         Self {
             value: array::from_fn(|_| PF::ZERO),
@@ -44,6 +45,7 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> Default
 impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<BinomialExtensionField<F, D>>
     for PackedBinomialExtensionField<F, PF, D>
 {
+    #[inline]
     fn from(x: BinomialExtensionField<F, D>) -> Self {
         Self {
             value: x.value.map(Into::into),
@@ -54,6 +56,7 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<BinomialExtensi
 impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
     for PackedBinomialExtensionField<F, PF, D>
 {
+    #[inline]
     fn from(x: PF) -> Self {
         Self {
             value: field_to_array(x),
@@ -137,24 +140,21 @@ where
 {
     const DIMENSION: usize = D;
 
+    #[inline]
     fn as_basis_coefficients_slice(&self) -> &[PF] {
         &self.value
     }
 
+    #[inline]
     fn from_basis_coefficients_fn<Fn: FnMut(usize) -> PF>(f: Fn) -> Self {
         Self {
             value: array::from_fn(f),
         }
     }
 
-    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = PF>>(iter: I) -> Option<Self> {
-        (iter.len() == D).then(|| {
-            let mut res = Self::default();
-            for (i, b) in iter.enumerate() {
-                res.value[i] = b;
-            }
-            res
-        })
+    #[inline]
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = PF>>(mut iter: I) -> Option<Self> {
+        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
     }
 }
 
@@ -163,6 +163,7 @@ impl<F, const D: usize> PackedFieldExtension<F, BinomialExtensionField<F, D>>
 where
     F: BinomiallyExtendable<D>,
 {
+    #[inline]
     fn from_ext_slice(ext_slice: &[BinomialExtensionField<F, D>]) -> Self {
         let width = F::Packing::WIDTH;
         assert_eq!(ext_slice.len(), width);
@@ -180,6 +181,7 @@ where
         Self::new(res)
     }
 
+    #[inline]
     fn packed_ext_powers(base: BinomialExtensionField<F, D>) -> crate::Powers<Self> {
         let width = F::Packing::WIDTH;
         let powers = base.powers().take(width + 1).collect_vec();
@@ -297,6 +299,7 @@ where
     F: BinomiallyExtendable<D>,
     PF: PackedField<Scalar = F>,
 {
+    #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|acc, x| acc + x).unwrap_or(Self::ZERO)
     }
@@ -441,6 +444,7 @@ where
     F: BinomiallyExtendable<D>,
     PF: PackedField<Scalar = F>,
 {
+    #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|acc, x| acc * x).unwrap_or(Self::ZERO)
     }

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -147,12 +147,14 @@ where
         }
     }
 
-    fn from_basis_coefficients_iter<I: Iterator<Item = PF>>(iter: I) -> Self {
-        let mut res = Self::default();
-        for (i, b) in iter.enumerate() {
-            res.value[i] = b;
-        }
-        res
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = PF>>(iter: I) -> Option<Self> {
+        (iter.len() == D).then(|| {
+            let mut res = Self::default();
+            for (i, b) in iter.enumerate() {
+                res.value[i] = b;
+            }
+            res
+        })
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -409,19 +409,17 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
     ///
-    /// The user should ensure that the slice has length `DIMENSION`. If
-    /// it is shorter than this, the function will panic, if it is longer the
-    /// extra elements will be ignored.
+    /// Returns `None` if the length of the slice is different to `DIMENSION`.
     #[must_use]
     #[inline]
-    fn from_basis_coefficients_slice(slice: &[F]) -> Self {
-        Self::from_basis_coefficients_fn(|i| slice[i].clone())
+    fn from_basis_coefficients_slice(slice: &[F]) -> Option<Self> {
+        Self::from_basis_coefficients_iter(slice.iter().cloned())
     }
 
     /// Fixes a basis for the algebra `A` and uses this to
     /// map `DIMENSION` `F` elements to an element of `A`. Similar
     /// to `core:array::from_fn`, the `DIMENSION` `F` elements are
-    /// given by `Fn(0), ..., Fn(DIMENSION - 1)`.
+    /// given by `Fn(0), ..., Fn(DIMENSION - 1)` called in that order.
     ///
     /// # Safety
     ///
@@ -444,10 +442,9 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
     ///
-    /// If the iterator contains more than `DIMENSION` many elements,
-    /// the rest will be ignored.
+    /// Returns `None` if the length of the iterator is different to `DIMENSION`.
     #[must_use]
-    fn from_basis_coefficients_iter<I: Iterator<Item = F>>(iter: I) -> Self;
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = F>>(iter: I) -> Option<Self>;
 
     /// Given a basis for the Algebra `A`, return the i'th basis element.
     ///
@@ -458,10 +455,12 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// to ensure portability if these values might ever be passed to
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
+    ///
+    /// Returns `None` if `i` is greater than or equal to `DIMENSION`.
     #[must_use]
     #[inline]
-    fn ith_basis_element(i: usize) -> Self {
-        Self::from_basis_coefficients_fn(|j| F::from_bool(i == j))
+    fn ith_basis_element(i: usize) -> Option<Self> {
+        (i < Self::DIMENSION).then(|| Self::from_basis_coefficients_fn(|j| F::from_bool(i == j)))
     }
 }
 
@@ -479,8 +478,8 @@ impl<F: PrimeCharacteristicRing> BasedVectorSpace<F> for F {
     }
 
     #[inline]
-    fn from_basis_coefficients_iter<I: Iterator<Item = F>>(mut iter: I) -> Self {
-        iter.next().unwrap()
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = F>>(mut iter: I) -> Option<Self> {
+        (iter.len() == 1).then(|| iter.next().unwrap()) // Unwrap will not panic as we know the length is 1.
     }
 }
 

--- a/koala-bear/src/extension.rs
+++ b/koala-bear/src/extension.rs
@@ -47,7 +47,7 @@ mod test_quartic_extension {
         assert_eq!(
             format!(
                 "{}",
-                EF::from_basis_coefficients_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO])
+                EF::from_basis_coefficients_slice(&[F::TWO, F::ONE, F::ZERO, F::TWO]).unwrap()
             ),
             "2 + X + 2 X^3"
         );

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -122,10 +122,13 @@ where
         .iter()
         .enumerate()
         .map(|(ch_i, ch)| {
+            // We checked in valid_shape the length of "ch" is equal to
+            // <SC::Challenge as BasedVectorSpace<Val<SC>>>::DIMENSION. Hence
+            // the unwrap() will never panic.
             zps[ch_i]
                 * ch.iter()
                     .enumerate()
-                    .map(|(e_i, &c)| SC::Challenge::ith_basis_element(e_i) * c)
+                    .map(|(e_i, &c)| SC::Challenge::ith_basis_element(e_i).unwrap() * c)
                     .sum::<SC::Challenge>()
         })
         .sum::<SC::Challenge>();


### PR DESCRIPTION
The main goal of this PR is to:
- Switch `from_basis_coefficients_iter, from_basis_coefficients_slice` and `ith_basis_element` to output `Option<Self>` instead of `Self`.  This should catch errors coming from cases where for some reason someone tries to construct an extension field element out of too few field elements.
- Pull in the simplifications from PR #754. This relies on behavior which the current implementation of array::from_fn satisfies and will become guaranteed in the near future once https://github.com/rust-lang/rust/pull/139099 merges so this seems safe to merge now.
- Adds `unwrap()`'s where necessary, with comments guaranteeing safety (For `.unwrap()`'s appearing outside tests)

While going through the updates/adding some `.unwrap()` in places that need it due to the above changes, I came across several function calls which didn't really need to exist. Thus the PR also:
- Simplifies the implementation of the Frobenius map along with a minor refactor of `quadratic_inv` and `cubic_inv`.
- Simplifies the implementation of `sample_algebra_element`.
- Adds a few missing `#[inline]`.