### PR TITLE
Support hashing vector space elements

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -567,7 +567,7 @@ mod tests {
         type Challenge = BinomialExtensionField<Mersenne31, 3>;
 
         type ByteHash = Keccak256Hash;
-        type FieldHash = SerializingHasher32<ByteHash>;
+        type FieldHash = SerializingHasher32<Val, ByteHash>;
         let byte_hash = ByteHash {};
         let field_hash = FieldHash::new(byte_hash);
 

--- a/examples/src/types.rs
+++ b/examples/src/types.rs
@@ -23,7 +23,7 @@ pub(crate) type KeccakCompressionFunction =
 pub(crate) type KeccakMerkleMmcs<F> = MerkleTreeMmcs<
     [F; KECCAK_VECTOR_LEN],
     [u64; KECCAK_VECTOR_LEN],
-    SerializingHasher32To64<PaddingFreeSponge<KeccakF, 25, 17, 4>>,
+    SerializingHasher32To64<F, PaddingFreeSponge<KeccakF, 25, 17, 4>>,
     KeccakCompressionFunction,
     4,
 >;

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -211,7 +211,7 @@ mod m31_fri_pcs {
     type Challenge = BinomialExtensionField<Mersenne31, 3>;
 
     type ByteHash = Keccak256Hash;
-    type FieldHash = SerializingHasher32<ByteHash>;
+    type FieldHash = SerializingHasher32<Val, ByteHash>;
 
     type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
 

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 4>;
 
     type ByteHash = Sha256;
-    type FieldHash = SerializingHasher32<ByteHash>;
+    type FieldHash = SerializingHasher32<Val, ByteHash>;
     let byte_hash = ByteHash {};
     let field_hash = FieldHash::new(Sha256);
 

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 4>;
 
     type ByteHash = Sha256;
-    type FieldHash = SerializingHasher32<ByteHash>;
+    type FieldHash = SerializingHasher32<Val, ByteHash>;
     let byte_hash = ByteHash {};
     let field_hash = FieldHash::new(byte_hash);
 

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl Debug> {
 
     type ByteHash = Keccak256Hash;
     type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
-    type FieldHash = SerializingHasher64<U64Hash>;
+    type FieldHash = SerializingHasher64<Val, U64Hash>;
     let byte_hash = ByteHash {};
     let u64_hash = U64Hash::new(KeccakF {});
     let field_hash = FieldHash::new(u64_hash);

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 2>;
 
     type ByteHash = Sha256;
-    type FieldHash = SerializingHasher64<ByteHash>;
+    type FieldHash = SerializingHasher64<Val, ByteHash>;
     let byte_hash = ByteHash {};
     let field_hash = FieldHash::new(byte_hash);
 

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl Debug> {
     type Challenge = BinomialExtensionField<Val, 3>;
 
     type ByteHash = Sha256;
-    type FieldHash = SerializingHasher32<ByteHash>;
+    type FieldHash = SerializingHasher32<Val, ByteHash>;
     let byte_hash = ByteHash {};
     let field_hash = FieldHash::new(Sha256);
 

--- a/keccak/benches/bench_keccak.rs
+++ b/keccak/benches/bench_keccak.rs
@@ -51,7 +51,7 @@ pub fn keccak_field_32_hash(c: &mut Criterion) {
 
     type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
     let u64_hash = U64Hash::new(KeccakF {});
-    type FieldHash = SerializingHasher32To64<U64Hash>;
+    type FieldHash = SerializingHasher32To64<F, U64Hash>;
     let field_hash = FieldHash::new(u64_hash);
 
     let mut group = c.benchmark_group("keccak field 32 hash");

--- a/merkle-tree/benches/merkle_tree.rs
+++ b/merkle-tree/benches/merkle_tree.rs
@@ -77,7 +77,7 @@ fn bench_bb_rescue(criterion: &mut Criterion) {
 fn bench_bb_blake3(criterion: &mut Criterion) {
     type F = BabyBear;
 
-    type H = SerializingHasher32<Blake3>;
+    type H = SerializingHasher32<F, Blake3>;
     let h = H::new(Blake3 {});
 
     type C = CompressionFunctionFromHasher<Blake3, 2, 32>;
@@ -91,7 +91,7 @@ fn bench_bb_blake3(criterion: &mut Criterion) {
 fn bench_bb_keccak(criterion: &mut Criterion) {
     type F = BabyBear;
 
-    type H = SerializingHasher32<Keccak256Hash>;
+    type H = SerializingHasher32<F, Keccak256Hash>;
     let k = Keccak256Hash {};
     let h = H::new(k);
 

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), impl Debug> {
     type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
     let u64_hash = U64Hash::new(KeccakF {});
 
-    type FieldHash = SerializingHasher32To64<U64Hash>;
+    type FieldHash = SerializingHasher32To64<Val, U64Hash>;
     let field_hash = FieldHash::new(u64_hash);
 
     type MyCompress = CompressionFunctionFromHasher<U64Hash, 2, 4>;

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -66,7 +66,7 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     type U64Hash = PaddingFreeSponge<KeccakF, 25, 17, 4>;
     let u64_hash = U64Hash::new(KeccakF {});
 
-    type FieldHash = SerializingHasher32To64<U64Hash>;
+    type FieldHash = SerializingHasher32To64<Val, U64Hash>;
     let field_hash = FieldHash::new(u64_hash);
 
     type MyCompress = CompressionFunctionFromHasher<U64Hash, 2, 4>;

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -262,7 +262,7 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
     type Challenge = BinomialExtensionField<Val, 3>;
 
     type ByteHash = Keccak256Hash;
-    type FieldHash = SerializingHasher32<ByteHash>;
+    type FieldHash = SerializingHasher32<Val, ByteHash>;
     let byte_hash = ByteHash {};
     let field_hash = FieldHash::new(byte_hash);
 


### PR DESCRIPTION
This PR updates `SerializingHasher32, SerializingHasher64` and `MultiField32PaddingFreeSponge` to all implement `CryptographicHasher` over any vector space `V` over the base field `F`.

This should make it a little easier to use these hashes when working with extension field. 

@tcoratger Would this fix the problem you were having? 