### PR TITLE
Fix ignored doctest and add test for bn254_matmul_internal

### DIFF
--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -47,7 +47,7 @@ impl InternalLayerConstructor<Bn254Fr> for Poseidon2InternalLayerBn254 {
 
 /// A faster version of `matmul_internal` making use of the fact that
 /// the internal matrix is equal to:
-/// ```ignore
+/// ```text
 ///                             [2, 1, 1]
 ///     1 + Diag([1, 1, 2]) =   [1, 2, 1]
 ///                             [1, 1, 3]

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -118,6 +118,34 @@ mod tests {
     use super::*;
     use crate::FFBn254Fr;
 
+    #[test]
+    fn test_bn254_matmul_internal() {
+        // Initialize a test state
+        let mut state = [
+            Bn254Fr::from_u32(1),
+            Bn254Fr::from_u32(2),
+            Bn254Fr::from_u32(3),
+        ];
+        
+        // Expected values based on the matrix:
+        // [2, 1, 1]
+        // [1, 2, 1]
+        // [1, 1, 3]
+        // Applied to [1, 2, 3] with sum = 1 + 2 + 3 = 6
+        // [1 + 6, 2 + 6, 3*2 + 6] = [7, 8, 12]
+        let expected = [
+            Bn254Fr::from_u32(7),
+            Bn254Fr::from_u32(8),
+            Bn254Fr::from_u32(12),
+        ];
+        
+        // Apply the matrix multiplication
+        bn254_matmul_internal(&mut state);
+        
+        // Verify the result
+        assert_eq!(state, expected);
+    }
+
     fn bn254_from_ark_ff(input: ark_FpBN256) -> Bn254Fr {
         let mut full_bytes = [0; 32];
         let bytes = input.into_bigint().to_bytes_le();


### PR DESCRIPTION
1. Fixes an issue where a doctest was automatically generated from the function's documentation
   and then ignored during test runs. Changed the documentation code block from ```ignore to
   ```text to clarify that it's just a text illustration, not executable code.

2. Adds a proper unit test for the bn254_matmul_internal function that verifies its correctness
   by checking that applying it to state [1, 2, 3] produces the expected result [7, 8, 12].

These changes ensure that this critical component of the Poseidon2 implementation for BN254
is properly tested and removes confusing "ignored" test messages during test runs.