### PR TITLE
Minor prover refactor to remove duplicated computation

### DIFF
--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -72,7 +72,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             dot_product(alpha_powers.iter().copied(), ps_at_zeta.iter().copied());
 
         self.values
-            .dot_ext_vector::<EF>(&packed_alpha_powers)
+            .dot_packed_ext_vector::<EF>(&packed_alpha_powers)
             .zip(vp_nums.into_par_iter())
             .zip(vp_denom_invs.into_par_iter())
             .map(|((reduced_ps_at_x, vp_num), vp_denom_inv)| {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -72,7 +72,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             dot_product(alpha_powers.iter().copied(), ps_at_zeta.iter().copied());
 
         self.values
-            .dot_packed_ext_vector::<EF>(&packed_alpha_powers)
+            .rowwise_packed_dot_product::<EF>(&packed_alpha_powers)
             .zip(vp_nums.into_par_iter())
             .zip(vp_denom_invs.into_par_iter())
             .map(|((reduced_ps_at_x, vp_num), vp_denom_inv)| {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use itertools::{Itertools, izip};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, batch_multiplicative_inverse, dot_product};
+use p3_field::{ExtensionField, PackedFieldExtension, batch_multiplicative_inverse, dot_product};
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -61,10 +61,18 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             .unzip();
         let vp_denom_invs = batch_multiplicative_inverse(&vp_denoms);
 
-        let alpha_reduced_ps_at_zeta: EF = dot_product(alpha.powers(), ps_at_zeta.iter().copied());
+        // TODO: packed_alpha_powers and alpha_powers should be passed into deep_quotient_reduce instead of being recomputed every time.
+        let packed_alpha_powers =
+            EF::ExtensionPacking::packed_ext_powers_capped(alpha, self.values.width())
+                .collect_vec();
+        let alpha_powers =
+            EF::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied()).collect_vec();
+
+        let alpha_reduced_ps_at_zeta: EF =
+            dot_product(alpha_powers.iter().copied(), ps_at_zeta.iter().copied());
 
         self.values
-            .dot_ext_powers(alpha)
+            .dot_ext_vector::<EF>(&packed_alpha_powers)
             .zip(vp_nums.into_par_iter())
             .zip(vp_denom_invs.into_par_iter())
             .map(|((reduced_ps_at_x, vp_num), vp_denom_inv)| {

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -169,7 +169,6 @@ where
         assert_eq!(ext_slice.len(), width);
 
         let res = array::from_fn(|i| F::Packing::from_fn(|j| ext_slice[j].value[i]));
-
         Self::new(res)
     }
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -168,17 +168,22 @@ where
         let width = F::Packing::WIDTH;
         assert_eq!(ext_slice.len(), width);
 
-        let mut res = [F::Packing::ZERO; D];
-
-        res.iter_mut().enumerate().for_each(|(i, row_i)| {
-            let row_i = row_i.as_slice_mut();
-            ext_slice
-                .iter()
-                .enumerate()
-                .for_each(|(j, vec_j)| row_i[j] = vec_j.value[i])
-        });
+        let res = array::from_fn(|i| F::Packing::from_fn(|j| ext_slice[j].value[i]));
 
         Self::new(res)
+    }
+
+    #[inline]
+    fn to_ext_iter(
+        iter: impl IntoIterator<Item = Self>,
+    ) -> impl Iterator<Item = BinomialExtensionField<F, D>> {
+        let width = F::Packing::WIDTH;
+        iter.into_iter().flat_map(move |x| {
+            (0..width).map(move |i| {
+                let values = array::from_fn(|j| x.value[j].as_slice()[i]);
+                BinomialExtensionField::new(values)
+            })
+        })
     }
 
     #[inline]

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -2,6 +2,8 @@ use core::mem::MaybeUninit;
 use core::ops::Div;
 use core::{array, slice};
 
+use alloc::vec::Vec;
+
 use crate::field::Field;
 use crate::{Algebra, BasedVectorSpace, ExtensionField, Powers, PrimeCharacteristicRing};
 
@@ -239,9 +241,32 @@ pub trait PackedFieldExtension<
     /// `[[F; W]; D]` and then pack to get `[PF; D]`.
     fn from_ext_slice(ext_slice: &[ExtField]) -> Self;
 
-    /// Similar to packed_powers, construct an iterator which returns
+    /// Given a iterator of packed extension field elements, convert to an iterator of
+    /// extension field elements.
+    ///
+    /// This performs the inverse transformation to `from_ext_slice`.
+    #[inline]
+    fn to_ext_iter(iter: impl IntoIterator<Item = Self>) -> impl Iterator<Item = ExtField> {
+        iter.into_iter().flat_map(|x| {
+            let packed_coeffs = x.as_basis_coefficients_slice();
+            (0..BaseField::Packing::WIDTH)
+                .map(|i| ExtField::from_basis_coefficients_fn(|j| packed_coeffs[j].as_slice()[i]))
+                .collect::<Vec<_>>() // PackedFieldExtension's should reimplement this to avoid this allocation.
+        })
+    }
+
+    /// Similar to `packed_powers`, construct an iterator which returns
     /// powers of `base` packed into `PackedFieldExtension` elements.
     fn packed_ext_powers(base: ExtField) -> Powers<Self>;
+
+    /// Similar to `packed_ext_powers` but only returns `unpacked_len` powers of `base`.
+    ///
+    /// Note that the length of the returned iterator will be `unpacked_len / WIDTH` and
+    /// not `len` as the iterator is over packed extension field elements. If `unpacked_len`
+    /// is not divisible by `WIDTH`, `unpacked_len` will be rounded up to the next multiple of `WIDTH`.
+    fn packed_ext_powers_capped(base: ExtField, unpacked_len: usize) -> impl Iterator<Item = Self> {
+        Self::packed_ext_powers(base).take(unpacked_len.div_ceil(BaseField::Packing::WIDTH))
+    }
 }
 
 unsafe impl<T: Packable> PackedValue for T {

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -1,8 +1,7 @@
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use core::ops::Div;
 use core::{array, slice};
-
-use alloc::vec::Vec;
 
 use crate::field::Field;
 use crate::{Algebra, BasedVectorSpace, ExtensionField, Powers, PrimeCharacteristicRing};

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -365,7 +365,7 @@ where
                 // Compute the evaluations of `Mred(x) = M0(x) + alpha*M1(x) + ...`
                 let mat_compressed = info_span!("compress mat").in_scope(|| {
                     // This will be reused for all points z which M is opened at so we collect into a vector.
-                    mat.dot_ext_vector::<Challenge>(&packed_alpha_powers)
+                    mat.dot_packed_ext_vector::<Challenge>(&packed_alpha_powers)
                         .collect::<Vec<_>>()
                 });
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -365,7 +365,7 @@ where
                 // Compute the evaluations of `Mred(x) = M0(x) + alpha*M1(x) + ...`
                 let mat_compressed = info_span!("compress mat").in_scope(|| {
                     // This will be reused for all points z which M is opened at so we collect into a vector.
-                    mat.dot_packed_ext_vector::<Challenge>(&packed_alpha_powers)
+                    mat.rowwise_packed_dot_product::<Challenge>(&packed_alpha_powers)
                         .collect::<Vec<_>>()
                 });
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -10,7 +10,7 @@ use p3_commit::{Mmcs, OpenedValues, Pcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
-    ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse,
+    ExtensionField, Field, PackedFieldExtension, TwoAdicField, batch_multiplicative_inverse,
     cyclic_subgroup_coset_known_order, dot_product,
 };
 use p3_interpolation::interpolate_coset;
@@ -309,10 +309,39 @@ where
             .collect_vec();
 
         // Batch combination challenge
+        // TODO: Should we be computing a different alpha for each height?
         let alpha: Challenge = challenger.sample_algebra_element();
-        let alpha_powers = alpha.powers().take(global_max_width).collect_vec();
 
+        // We precompute powers of alpha as we need the same powers for each matrix.
+        // We compute both a vector of unpacked powers and a vector of packed powers.
+        // TODO: It should be possible to refactor this to only use the packed powers but
+        // this is not a bottleneck so is not a priority.
+        let packed_alpha_powers =
+            Challenge::ExtensionPacking::packed_ext_powers_capped(alpha, global_max_width)
+                .collect_vec();
+        let alpha_powers =
+            Challenge::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied())
+                .collect_vec();
+
+        // Now that we have sent the openings to the verifier, it remains to prove
+        // that those openings are correct.
+
+        // Given a low degree polynomial `f(x)` with claimed evaluation `f(zeta)`, we can check
+        // that `f(zeta)` is correct by doing a low degree test on `(f(zeta) - f(x))/(zeta - x)`.
+        // We will use `alpha` to batch together both different claimed openings `zeta` and
+        // different polynomials `f` whose evaluation vectors have the same height.
+
+        // TODO: If we allow different polynomials to have different blow_up factors
+        // we may need to revisit this and to ensure it is safe to batch them together.
+
+        // num_reduced records the number of reduced function opening point pairs
+        // of each given `log_height`.
         let mut num_reduced = [0; 32];
+
+        // For each `log_height` from 2^1 -> 2^32, reduced_openings will contain either `None`
+        // if there are no matrices of that height, Some(Vec) where Vec is equal to
+        // a sum of `(f(zeta) - f(x))/(zeta - x)` over all `f`'s of that height and
+        // opening points `zeta` with the sum weighted by powers of alpha.
         let mut reduced_openings: [_; 32] = core::array::from_fn(|_| None);
 
         for ((mats, points), openings_for_round) in
@@ -325,31 +354,45 @@ where
                     info_span!("reduce matrix quotient", dims = %mat.dimensions()).entered();
 
                 let log_height = log2_strict_usize(mat.height());
+
+                // If this is our first matrix at this height, initialise reduced_openings to zero.
+                // Otherwise, get a mutable reference to it.
                 let reduced_opening_for_log_height = reduced_openings[log_height]
                     .get_or_insert_with(|| vec![Challenge::ZERO; mat.height()]);
                 debug_assert_eq!(reduced_opening_for_log_height.len(), mat.height());
 
-                let mat_compressed = info_span!("compress mat")
-                    .in_scope(|| mat.dot_ext_powers(alpha).collect::<Vec<_>>());
+                // Treating our matrix M as the evaluations of functions M0, M1, ...
+                // Compute the evaluations of `Mred(x) = M0(x) + alpha*M1(x) + ...`
+                let mat_compressed = info_span!("compress mat").in_scope(|| {
+                    // This will be reused for all points z which M is opened at so we collect into a vector.
+                    mat.dot_ext_vector::<Challenge>(&packed_alpha_powers)
+                        .collect::<Vec<_>>()
+                });
 
                 for (&point, openings) in points_for_mat.iter().zip(openings_for_mat) {
+                    // If we have multiple matrices at the same height, we need to scale mat to combine them.
                     let alpha_pow_offset = alpha.exp_u64(num_reduced[log_height] as u64);
+
+                    // As we have all the openings `Mi(z)`, we can combine them using `alpha`
+                    // in an identical way to before to also compute `Mred(z)`.
                     let reduced_openings: Challenge =
                         dot_product(alpha_powers.iter().copied(), openings.iter().copied());
 
-                    info_span!("reduce rows").in_scope(|| {
-                        mat_compressed
-                            .par_iter()
-                            .zip(reduced_opening_for_log_height.par_iter_mut())
-                            // This might be longer, but zip will truncate to smaller subgroup
-                            // (which is ok because it's bitrev)
-                            .zip(inv_denoms.get(&point).unwrap().par_iter())
-                            .for_each(|((&reduced_row, ro), &inv_denom)| {
-                                *ro +=
-                                    alpha_pow_offset * (reduced_openings - reduced_row) * inv_denom
-                            });
-                    });
-
+                    mat_compressed
+                        .par_iter()
+                        .zip(reduced_opening_for_log_height.par_iter_mut())
+                        // inv_denoms contains `1/(point - x)` for `x` in a coset `gK`.
+                        // If `|K| =/= mat.height()` we actually want a subset of this
+                        // corresponding to the evaluations over `gH` for `|H| = mat.height()`.
+                        // As inv_denoms is bit reversed, the evaluations over `gH` are exactly
+                        // the evaluations over `gK` at the indices `0..mat.height()`.
+                        // So zip will truncate to the desired smaller length.
+                        .zip(inv_denoms.get(&point).unwrap().par_iter())
+                        // Map the function `Mred(x) -> (Mred(z) - Mred(x))/(z - x)`
+                        // across the evaluations vector of `Mred(x)`.
+                        .for_each(|((&reduced_row, ro), &inv_denom)| {
+                            *ro += alpha_pow_offset * (reduced_openings - reduced_row) * inv_denom
+                        });
                     num_reduced[log_height] += mat.width();
                 }
             }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -339,7 +339,7 @@ where
         let mut num_reduced = [0; 32];
 
         // For each `log_height` from 2^1 -> 2^32, reduced_openings will contain either `None`
-        // if there are no matrices of that height, Some(Vec) where Vec is equal to
+        // if there are no matrices of that height, or `Some(vec)` where `vec` is equal to
         // a sum of `(f(zeta) - f(x))/(zeta - x)` over all `f`'s of that height and
         // opening points `zeta` with the sum weighted by powers of alpha.
         let mut reduced_openings: [_; 32] = core::array::from_fn(|_| None);

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -363,10 +363,11 @@ where
 
                 // Treating our matrix M as the evaluations of functions M0, M1, ...
                 // Compute the evaluations of `Mred(x) = M0(x) + alpha*M1(x) + ...`
-                // This will be reused for all points z which M is opened at so we collect into a vector.
-                let mat_compressed = mat
-                    .rowwise_packed_dot_product::<Challenge>(&packed_alpha_powers)
-                    .collect::<Vec<_>>();
+                let mat_compressed = info_span!("compress mat").in_scope(|| {
+                    // This will be reused for all points z which M is opened at so we collect into a vector.
+                    mat.rowwise_packed_dot_product::<Challenge>(&packed_alpha_powers)
+                        .collect::<Vec<_>>()
+                });
 
                 for (&point, openings) in points_for_mat.iter().zip(openings_for_mat) {
                     // If we have multiple matrices at the same height, we need to scale mat to combine them.

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -363,11 +363,10 @@ where
 
                 // Treating our matrix M as the evaluations of functions M0, M1, ...
                 // Compute the evaluations of `Mred(x) = M0(x) + alpha*M1(x) + ...`
-                let mat_compressed = info_span!("compress mat").in_scope(|| {
-                    // This will be reused for all points z which M is opened at so we collect into a vector.
-                    mat.rowwise_packed_dot_product::<Challenge>(&packed_alpha_powers)
-                        .collect::<Vec<_>>()
-                });
+                // This will be reused for all points z which M is opened at so we collect into a vector.
+                let mat_compressed = mat
+                    .rowwise_packed_dot_product::<Challenge>(&packed_alpha_powers)
+                    .collect::<Vec<_>>();
 
                 for (&point, openings) in points_for_mat.iter().zip(openings_for_mat) {
                     // If we have multiple matrices at the same height, we need to scale mat to combine them.

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -270,7 +270,6 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     ///
     /// # Panics
     /// This function panics if the length of `vec` is less than `self.width().div_ceil(T::Packing::WIDTH)`.
-    #[instrument(level = "debug", skip_all, fields(dims = %self.dimensions()))]
     fn rowwise_packed_dot_product<EF>(
         &self,
         vec: &[EF::ExtensionPacking],

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -270,6 +270,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     ///
     /// # Panics
     /// This function panics if the length of `vec` is less than `self.width().div_ceil(T::Packing::WIDTH)`.
+    #[instrument(level = "debug", skip_all, fields(dims = %self.dimensions()))]
     fn rowwise_packed_dot_product<EF>(
         &self,
         vec: &[EF::ExtensionPacking],

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -270,7 +270,7 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
     ///
     /// # Panics
     /// This function panics if the length of `vec` is less than `self.width().div_ceil(T::Packing::WIDTH)`.
-    fn dot_packed_ext_vector<EF>(
+    fn rowwise_packed_dot_product<EF>(
         &self,
         vec: &[EF::ExtensionPacking],
     ) -> impl IndexedParallelIterator<Item = EF>

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -261,7 +261,11 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
             .collect()
     }
 
-    /// Multiply this matrix by the vector of powers of `base`, which is an extension element.
+    /// Multiply this matrix by the vector `vec` containing Extension Field elements packed into
+    /// `ExtensionPacking` elements.
+    ///
+    /// Note that zip will truncate whichever iterator is longer so the user should ensure that
+    /// `vec` is longer than `self.width().div_ceil(T::Packing::WIDTH)`.
     fn dot_ext_vector<EF>(
         &self,
         vec: &[EF::ExtensionPacking],
@@ -270,6 +274,8 @@ pub trait Matrix<T: Send + Sync>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
+        // TODO: This is a base - extension dot product and so it should
+        // be possible to speed this up using ideas in `packed_linear_combination`.
         self.par_padded_horizontally_packed_rows::<T::Packing>()
             .map(move |row_packed| {
                 let packed_sum_of_packed: EF::ExtensionPacking =


### PR DESCRIPTION
The primary goal here is to rework the prover slightly to avoid computing powers of `alpha` multiple times.

This turned out to be a little more complicated than I initially suspected and the cleanest approach I ended up finding was to add a couple of new methods to `PackedFieldExtension` allowing users to convert from an iterator of `PackedFieldExtension` elements to an iterator of `FieldExtension` elements and a method similar to `packed_powers` but handles the case where you only want to compute a finite number of powers while still making use of the packing.

I also had to rework `dot_ext_powers` to accept a vector of packed field elements instead of computing the packed field elements vector internally. (Note the previous implementation also contained a bug where it was computing far more packed field elements than it required. The `.take(self.width().next_multiple_of(T::Packing::WIDTH))` should have been `.take(self.width().div_ceil(T::Packing::WIDTH))`).

I also folded in a bunch of the relevant comments from #776. (Note that half of the added lines are comments, so the PR is a little smaller than it appears)

