### PR TITLE
Initialize Challenger through Stark Config

### DIFF
--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -10,7 +10,7 @@ use p3_fri::{TwoAdicFriPcs, create_benchmark_fri_config};
 use p3_keccak::{Keccak256Hash, KeccakF};
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CryptographicPermutation, PaddingFreeSponge, SerializingHasher32To64};
-use p3_uni_stark::{Proof, StarkConfig, StarkGenericConfig, prove, verify};
+use p3_uni_stark::{Proof, StarkGenericConfig, prove, verify};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 
@@ -81,8 +81,8 @@ where
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
-    let config = KeccakStarkConfig::new(pcs, (), |_| {
-        SerializingChallenger32::from_hasher(vec![], Keccak256Hash {})
+    let config = KeccakStarkConfig::new(pcs, Keccak256Hash {}, |hash| {
+        SerializingChallenger32::from_hasher(vec![], hash)
     });
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
@@ -124,7 +124,7 @@ where
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
-    let config = StarkConfig::new(pcs, perm24, DuplexChallenger::new);
+    let config = Poseidon2StarkConfig::new(pcs, perm24, DuplexChallenger::new);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
@@ -159,8 +159,8 @@ pub fn prove_m31_keccak<
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 
-    let config = KeccakCircleStarkConfig::new(pcs, (), |_| {
-        SerializingChallenger32::from_hasher(vec![], Keccak256Hash {})
+    let config = KeccakCircleStarkConfig::new(pcs, Keccak256Hash {}, |hash| {
+        SerializingChallenger32::from_hasher(vec![], hash)
     });
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
@@ -200,7 +200,7 @@ where
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 
-    let config = Poseidon2CircleStarkConfig::new(pcs, perm24.clone(), DuplexChallenger::new);
+    let config = Poseidon2CircleStarkConfig::new(pcs, perm24, DuplexChallenger::new);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -81,15 +81,14 @@ where
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
-    let config = KeccakStarkConfig::new(pcs);
+    let config = KeccakStarkConfig::new(pcs, (), |_| {
+        SerializingChallenger32::from_hasher(vec![], Keccak256Hash {})
+    });
 
-    let mut proof_challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
-    let mut verif_challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
-
-    let proof = prove(&config, &proof_goal, &mut proof_challenger, trace, &vec![]);
+    let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
 
-    verify(&config, &proof_goal, &mut verif_challenger, &proof, &vec![])
+    verify(&config, &proof_goal, &proof, &vec![])
 }
 
 /// Prove the given ProofGoal using the Poseidon2 hash function to build the merkle tree.
@@ -125,15 +124,12 @@ where
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
 
-    let config = StarkConfig::new(pcs);
+    let config = StarkConfig::new(pcs, perm24, DuplexChallenger::new);
 
-    let mut proof_challenger = DuplexChallenger::new(perm24.clone());
-    let mut verif_challenger = DuplexChallenger::new(perm24);
-
-    let proof = prove(&config, &proof_goal, &mut proof_challenger, trace, &vec![]);
+    let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
 
-    verify(&config, &proof_goal, &mut verif_challenger, &proof, &vec![])
+    verify(&config, &proof_goal, &proof, &vec![])
 }
 
 /// Prove the given ProofGoal using the Keccak hash function to build the merkle tree.
@@ -163,15 +159,14 @@ pub fn prove_m31_keccak<
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 
-    let config = KeccakCircleStarkConfig::new(pcs);
+    let config = KeccakCircleStarkConfig::new(pcs, (), |_| {
+        SerializingChallenger32::from_hasher(vec![], Keccak256Hash {})
+    });
 
-    let mut proof_challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
-    let mut verif_challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
-
-    let proof = prove(&config, &proof_goal, &mut proof_challenger, trace, &vec![]);
+    let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
 
-    verify(&config, &proof_goal, &mut verif_challenger, &proof, &vec![])
+    verify(&config, &proof_goal, &proof, &vec![])
 }
 
 /// Prove the given ProofGoal using the Keccak hash function to build the merkle tree.
@@ -205,15 +200,12 @@ where
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
 
-    let config = Poseidon2CircleStarkConfig::new(pcs);
+    let config = Poseidon2CircleStarkConfig::new(pcs, perm24.clone(), DuplexChallenger::new);
 
-    let mut proof_challenger = DuplexChallenger::new(perm24.clone());
-    let mut verif_challenger = DuplexChallenger::new(perm24);
-
-    let proof = prove(&config, &proof_goal, &mut proof_challenger, trace, &vec![]);
+    let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
 
-    verify(&config, &proof_goal, &mut verif_challenger, &proof, &vec![])
+    verify(&config, &proof_goal, &proof, &vec![])
 }
 
 /// Report the result of the proof.

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -80,10 +80,9 @@ where
     let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
+    let challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
 
-    let config = KeccakStarkConfig::new(pcs, Keccak256Hash {}, |hash| {
-        SerializingChallenger32::from_hasher(vec![], hash)
-    });
+    let config = KeccakStarkConfig::new(pcs, challenger);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
@@ -123,8 +122,9 @@ where
     let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = TwoAdicFriPcs::new(dft, val_mmcs, fri_config);
+    let challenger = DuplexChallenger::new(perm24);
 
-    let config = Poseidon2StarkConfig::new(pcs, perm24, DuplexChallenger::new);
+    let config = Poseidon2StarkConfig::new(pcs, challenger);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
@@ -158,10 +158,9 @@ pub fn prove_m31_keccak<
     let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
+    let challenger = SerializingChallenger32::from_hasher(vec![], Keccak256Hash {});
 
-    let config = KeccakCircleStarkConfig::new(pcs, Keccak256Hash {}, |hash| {
-        SerializingChallenger32::from_hasher(vec![], hash)
-    });
+    let config = KeccakCircleStarkConfig::new(pcs, challenger);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);
@@ -199,8 +198,9 @@ where
     let trace = proof_goal.generate_trace_rows(num_hashes, fri_config.log_blowup);
 
     let pcs = CirclePcs::new(val_mmcs, fri_config);
+    let challenger = DuplexChallenger::new(perm24);
 
-    let config = Poseidon2CircleStarkConfig::new(pcs, perm24, DuplexChallenger::new);
+    let config = Poseidon2CircleStarkConfig::new(pcs, challenger);
 
     let proof = prove(&config, &proof_goal, trace, &vec![]);
     report_proof_size(&proof);

--- a/examples/src/types.rs
+++ b/examples/src/types.rs
@@ -31,13 +31,13 @@ pub(crate) type KeccakMerkleMmcs<F> = MerkleTreeMmcs<
 pub(crate) type KeccakStarkConfig<F, EF, DFT> = StarkConfig<
     TwoAdicFriPcs<F, DFT, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
-    (),
+    Keccak256Hash,
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 pub(crate) type KeccakCircleStarkConfig<F, EF> = StarkConfig<
     CirclePcs<F, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
-    (),
+    Keccak256Hash,
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 

--- a/examples/src/types.rs
+++ b/examples/src/types.rs
@@ -31,11 +31,13 @@ pub(crate) type KeccakMerkleMmcs<F> = MerkleTreeMmcs<
 pub(crate) type KeccakStarkConfig<F, EF, DFT> = StarkConfig<
     TwoAdicFriPcs<F, DFT, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
+    (),
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 pub(crate) type KeccakCircleStarkConfig<F, EF> = StarkConfig<
     CirclePcs<F, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
+    (),
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 
@@ -57,6 +59,7 @@ pub(crate) type Poseidon2StarkConfig<F, EF, DFT, Perm16, Perm24> = StarkConfig<
         ExtensionMmcs<F, EF, Poseidon2MerkleMmcs<F, Perm16, Perm24>>,
     >,
     EF,
+    Perm24,
     DuplexChallenger<F, Perm24, 24, 16>,
 >;
 pub(crate) type Poseidon2CircleStarkConfig<F, EF, Perm16, Perm24> = StarkConfig<
@@ -66,5 +69,6 @@ pub(crate) type Poseidon2CircleStarkConfig<F, EF, Perm16, Perm24> = StarkConfig<
         ExtensionMmcs<F, EF, Poseidon2MerkleMmcs<F, Perm16, Perm24>>,
     >,
     EF,
+    Perm24,
     DuplexChallenger<F, Perm24, 24, 16>,
 >;

--- a/examples/src/types.rs
+++ b/examples/src/types.rs
@@ -31,13 +31,11 @@ pub(crate) type KeccakMerkleMmcs<F> = MerkleTreeMmcs<
 pub(crate) type KeccakStarkConfig<F, EF, DFT> = StarkConfig<
     TwoAdicFriPcs<F, DFT, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
-    Keccak256Hash,
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 pub(crate) type KeccakCircleStarkConfig<F, EF> = StarkConfig<
     CirclePcs<F, KeccakMerkleMmcs<F>, ExtensionMmcs<F, EF, KeccakMerkleMmcs<F>>>,
     EF,
-    Keccak256Hash,
     SerializingChallenger32<F, HashChallenger<u8, Keccak256Hash, 32>>,
 >;
 
@@ -59,7 +57,6 @@ pub(crate) type Poseidon2StarkConfig<F, EF, DFT, Perm16, Perm24> = StarkConfig<
         ExtensionMmcs<F, EF, Poseidon2MerkleMmcs<F, Perm16, Perm24>>,
     >,
     EF,
-    Perm24,
     DuplexChallenger<F, Perm24, 24, 16>,
 >;
 pub(crate) type Poseidon2CircleStarkConfig<F, EF, Perm16, Perm24> = StarkConfig<
@@ -69,6 +66,5 @@ pub(crate) type Poseidon2CircleStarkConfig<F, EF, Perm16, Perm24> = StarkConfig<
         ExtensionMmcs<F, EF, Poseidon2MerkleMmcs<F, Perm16, Perm24>>,
     >,
     EF,
-    Perm24,
     DuplexChallenger<F, Perm24, 24, 16>,
 >;

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -65,10 +66,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -65,12 +65,12 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -71,6 +71,5 @@ fn main() -> Result<(), impl Debug> {
     });
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -65,10 +66,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -65,12 +65,12 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -71,6 +71,5 @@ fn main() -> Result<(), impl Debug> {
     });
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -76,6 +76,5 @@ fn main() -> Result<(), impl Debug> {
     });
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     type Challenger = SerializingChallenger64<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -70,10 +71,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -70,12 +70,12 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -68,6 +68,5 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs, perm, Challenger::new);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -64,12 +64,10 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
+    let config = MyConfig::new(pcs, perm, Challenger::new);
 
-    let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     type Challenger = DuplexChallenger<Val, Perm, 8, 4>;
+    let challenger = Challenger::new(perm);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -64,8 +65,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
-    let config = MyConfig::new(pcs, perm, Challenger::new);
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -62,12 +62,12 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), impl Debug> {
     let dft = Dft::default();
 
     type Challenger = SerializingChallenger64<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -62,10 +63,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -68,6 +68,5 @@ fn main() -> Result<(), impl Debug> {
     });
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -64,12 +64,12 @@ fn main() -> Result<(), impl Debug> {
         _phantom: PhantomData,
     };
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -70,6 +70,5 @@ fn main() -> Result<(), impl Debug> {
     });
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-
     verify(&config, &KeccakAir {}, &proof, &vec![])
 }

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -50,6 +50,7 @@ fn main() -> Result<(), impl Debug> {
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let fri_config = create_benchmark_fri_config(challenge_mmcs);
 
@@ -64,10 +65,8 @@ fn main() -> Result<(), impl Debug> {
         _phantom: PhantomData,
     };
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
     verify(&config, &KeccakAir {}, &proof, &vec![])

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -79,6 +79,7 @@ fn main() -> Result<(), impl Debug> {
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     let air: VectorizedPoseidon2Air<
         Val,
@@ -100,10 +101,8 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config, 4, SmallRng::seed_from_u64(1));
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &air, trace, &vec![]);
 

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -100,12 +100,12 @@ fn main() -> Result<(), impl Debug> {
     type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config, 4, SmallRng::seed_from_u64(1));
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(&config, &air, &proof, &vec![])
 }

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -85,6 +85,7 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
     // WARNING: DO NOT USE SmallRng in proper applications! Use a real PRNG instead!
     let mut rng = SmallRng::seed_from_u64(1);
@@ -109,10 +110,8 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let proof = prove(&config, &air, trace, &vec![]);
 

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -109,12 +109,12 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
-    let config = MyConfig::new(pcs);
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
+        Challenger::from_hasher(vec![], byte_hash)
+    });
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, trace, &vec![]);
 
-    let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(&config, &air, &proof, &vec![])
 }

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -42,8 +42,11 @@ pub trait StarkGenericConfig {
 
 #[derive(Debug)]
 pub struct StarkConfig<Pcs, Challenge, ChallengerConstants, Challenger> {
+    /// The PCS used to commit polynomials and prove opening proofs.
     pcs: Pcs,
+    /// Constants used to create an initialised challenger.
     challenger_constants: ChallengerConstants,
+    /// Function to create the initialised challenger.
     init_challenger: fn(ChallengerConstants) -> Challenger,
     _phantom: PhantomData<Challenge>,
 }

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -26,7 +26,6 @@ pub fn prove<
 >(
     config: &SC,
     air: &A,
-    challenger: &mut SC::Challenger,
     trace: RowMajorMatrix<Val<SC>>,
     public_values: &Vec<Val<SC>>,
 ) -> Proof<SC>
@@ -50,6 +49,7 @@ where
     let log_quotient_degree = log2_ceil_usize(constraint_degree - 1);
     let quotient_degree = 1 << log_quotient_degree;
 
+    let mut challenger = config.initialise_challenger();
     let pcs = config.pcs();
     let trace_domain = pcs.natural_domain_for_degree(degree);
 
@@ -105,7 +105,7 @@ where
                     (0..quotient_degree).map(|_| vec![zeta]).collect_vec(),
                 ),
             ],
-            challenger,
+            &mut challenger,
         )
     });
     let trace_local = opened_values[0][0][0].clone();

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -18,7 +18,6 @@ use crate::{PcsError, Proof, StarkGenericConfig, Val, VerifierConstraintFolder};
 pub fn verify<SC, A>(
     config: &SC,
     air: &A,
-    challenger: &mut SC::Challenger,
     proof: &Proof<SC>,
     public_values: &Vec<Val<SC>>,
 ) -> Result<(), VerificationError<PcsError<SC>>>
@@ -37,6 +36,7 @@ where
     let log_quotient_degree = get_log_quotient_degree::<Val<SC>, A>(air, 0, public_values.len());
     let quotient_degree = 1 << log_quotient_degree;
 
+    let mut challenger = config.initialise_challenger();
     let pcs = config.pcs();
     let trace_domain = pcs.natural_domain_for_degree(degree);
     let quotient_domain =
@@ -95,7 +95,7 @@ where
             ),
         ],
         opening_proof,
-        challenger,
+        &mut challenger,
     )
     .map_err(VerificationError::InvalidOpeningArgument)?;
 

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -110,7 +110,7 @@ type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
 type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel<Val>;
 type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
+type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 
 /// n-th Fibonacci number expected to be x
 fn test_public_value_impl(n: usize, x: u64, log_final_poly_len: usize) {
@@ -124,8 +124,9 @@ fn test_public_value_impl(n: usize, x: u64, log_final_poly_len: usize) {
     let trace = generate_trace_rows::<Val>(0, 1, n);
     let fri_config = create_test_fri_config(challenge_mmcs, log_final_poly_len);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
+    let challenger = Challenger::new(perm);
 
-    let config = MyConfig::new(pcs, perm, Challenger::new);
+    let config = MyConfig::new(pcs, challenger);
     let pis = vec![BabyBear::ZERO, BabyBear::ONE, BabyBear::from_u64(x)];
 
     let proof = prove(&config, &FibonacciAir {}, trace, &pis);
@@ -157,7 +158,8 @@ fn test_incorrect_public_value() {
     let fri_config = create_test_fri_config(challenge_mmcs, 1);
     let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let config = MyConfig::new(pcs, perm, Challenger::new);
+    let challenger = Challenger::new(perm);
+    let config = MyConfig::new(pcs, challenger);
     let pis = vec![
         BabyBear::ZERO,
         BabyBear::ONE,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -110,7 +110,7 @@ type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
 type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel<Val>;
 type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
 
 /// n-th Fibonacci number expected to be x
 fn test_public_value_impl(n: usize, x: u64, log_final_poly_len: usize) {
@@ -124,12 +124,12 @@ fn test_public_value_impl(n: usize, x: u64, log_final_poly_len: usize) {
     let trace = generate_trace_rows::<Val>(0, 1, n);
     let fri_config = create_test_fri_config(challenge_mmcs, log_final_poly_len);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let config = MyConfig::new(pcs);
-    let mut challenger = Challenger::new(perm.clone());
+
+    let config = MyConfig::new(pcs, perm, Challenger::new);
     let pis = vec![BabyBear::ZERO, BabyBear::ONE, BabyBear::from_u64(x)];
-    let proof = prove(&config, &FibonacciAir {}, &mut challenger, trace, &pis);
-    let mut challenger = Challenger::new(perm);
-    verify(&config, &FibonacciAir {}, &mut challenger, &proof, &pis).expect("verification failed");
+
+    let proof = prove(&config, &FibonacciAir {}, trace, &pis);
+    verify(&config, &FibonacciAir {}, &proof, &pis).expect("verification failed");
 }
 
 #[test]
@@ -157,12 +157,11 @@ fn test_incorrect_public_value() {
     let fri_config = create_test_fri_config(challenge_mmcs, 1);
     let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
-    let config = MyConfig::new(pcs);
-    let mut challenger = Challenger::new(perm);
+    let config = MyConfig::new(pcs, perm, Challenger::new);
     let pis = vec![
         BabyBear::ZERO,
         BabyBear::ONE,
         BabyBear::from_u32(123_123), // incorrect result
     ];
-    prove(&config, &FibonacciAir {}, &mut challenger, trace, &pis);
+    prove(&config, &FibonacciAir {}, trace, &pis);
 }

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -148,13 +148,15 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), impl Debug> {
 
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 
+    type Pcs = TrivialPcs<Val, Radix2DitParallel<Val>>;
     let pcs = TrivialPcs {
         dft,
         log_n,
         _phantom: PhantomData,
     };
 
-    let config = new(pcs, move || Challenger::new(perm.clone()));
+    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
+    let config = MyConfig::new(pcs, perm, Challenger::new);
 
     let air = MulAir {
         degree,
@@ -215,7 +217,8 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
 
-    let config = StarkConfig::<_, Challenge, _>::new(pcs, move || Challenger::new(perm.clone()));
+    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
+    let config = MyConfig::new(pcs, perm, Challenger::new);
 
     let air = MulAir {
         degree,
@@ -280,7 +283,8 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         _phantom: PhantomData,
     };
 
-    let config = StarkConfig::<_, Challenge, _>::new(pcs, move || {
+    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
+    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
         Challenger::from_hasher(vec![], byte_hash)
     });
 

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -154,9 +154,10 @@ fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), impl Debug> {
         log_n,
         _phantom: PhantomData,
     };
+    let challenger = Challenger::new(perm);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
-    let config = MyConfig::new(pcs, perm, Challenger::new);
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let air = MulAir {
         degree,
@@ -216,9 +217,10 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
     };
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);
+    let challenger = Challenger::new(perm);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, Perm, Challenger>;
-    let config = MyConfig::new(pcs, perm, Challenger::new);
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let air = MulAir {
         degree,
@@ -282,11 +284,10 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         fri_config,
         _phantom: PhantomData,
     };
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
 
-    type MyConfig = StarkConfig<Pcs, Challenge, ByteHash, Challenger>;
-    let config = MyConfig::new(pcs, byte_hash, |byte_hash| {
-        Challenger::from_hasher(vec![], byte_hash)
-    });
+    type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
+    let config = MyConfig::new(pcs, challenger);
 
     let air = MulAir {
         degree,


### PR DESCRIPTION
As opposed to initializing `2` identical challengers in all our examples (one for the prover and one for the verifier), it makes more sense to move this functionality into the StarkConfig.

This PR adds a new method to `StarkGenericConfig` which initializes the challenger (similar to how to get the PCS from the config file).

Additionally, to support this we add a field to Stark Config containing the challenger (which must now implement clone) and the prover and verifier code starts by getting a new clone of this challenger in a similar way to how they get a copy of the PCS.

This is pretty similar to a change in #776 so also accomplishes the goal of moving that PR closer to only adding comments.