### PR TITLE
Better Extension Field FFT's

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -116,10 +116,8 @@ mod tests {
     use core::array;
 
     use num_bigint::BigUint;
-    use p3_field::{
-        InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField,
-        extension::BinomialExtensionField,
-    };
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField};
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_32, test_prime_field_64,
         test_two_adic_field,

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -116,7 +116,10 @@ mod tests {
     use core::array;
 
     use num_bigint::BigUint;
-    use p3_field::{InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField};
+    use p3_field::{
+        InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField,
+        extension::BinomialExtensionField,
+    };
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_32, test_prime_field_64,
         test_two_adic_field,
@@ -125,6 +128,7 @@ mod tests {
     use super::*;
 
     type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
 
     #[test]
     fn test_baby_bear_two_adicity_generators() {
@@ -218,12 +222,18 @@ mod tests {
     );
     test_two_adic_field!(crate::BabyBear);
 
-    test_field_dft!(radix2dit, crate::BabyBear, p3_dft::Radix2Dit<_>);
-    test_field_dft!(bowers, crate::BabyBear, p3_dft::Radix2Bowers);
-    test_field_dft!(parallel, crate::BabyBear, p3_dft::Radix2DitParallel::<_>);
+    test_field_dft!(radix2dit, crate::BabyBear, super::EF, p3_dft::Radix2Dit<_>);
+    test_field_dft!(bowers, crate::BabyBear, super::EF, p3_dft::Radix2Bowers);
+    test_field_dft!(
+        parallel,
+        crate::BabyBear,
+        super::EF,
+        p3_dft::Radix2DitParallel::<_>
+    );
     test_field_dft!(
         recur_dft,
         crate::BabyBear,
+        super::EF,
         p3_monty_31::dft::RecursiveDft<_>
     );
     test_prime_field!(crate::BabyBear);

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -31,3 +31,4 @@ nightly-features = [
     "p3-baby-bear/nightly-features",
     "p3-mersenne-31/nightly-features",
 ]
+parallel = ["p3-maybe-rayon/parallel"]

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -45,11 +45,13 @@ fn bench_fft(c: &mut Criterion) {
     coset_lde::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
     coset_lde::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
 
-    fft::<BBExt, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
-    fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
-    fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
-    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
-    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
+    // The FFT is really slow when dealing with extension fields so we use smaller sizes:
+    let ext_log_sizes = &[10, 12, 14];
+    fft::<BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);
+    fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, BATCH_SIZE>(c, ext_log_sizes);
 }
 
 fn fft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion, log_sizes: &[usize])

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -45,13 +45,14 @@ fn bench_fft(c: &mut Criterion) {
     coset_lde::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
     coset_lde::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
 
-    // The FFT is really slow when dealing with extension fields so we use smaller sizes:
-    let ext_log_sizes = &[10];
-    fft::<BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);
-    fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, ext_log_sizes);
-    fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);
-    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, ext_log_sizes);
-    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, BATCH_SIZE>(c, ext_log_sizes);
+    // The FFT is much slower when handling extension fields so we use smaller sizes:
+    let ext_log_sizes = &[10, 12, 14];
+    const EXT_BATCH_SIZE: usize = 50;
+    fft::<BBExt, Radix2Dit<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
+    fft::<BBExt, Radix2DitParallel<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
+    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
 }
 
 fn fft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion, log_sizes: &[usize])

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -16,17 +16,14 @@ fn bench_fft(c: &mut Criterion) {
     // log_sizes correspond to the sizes of DFT we want to benchmark;
     // for the DFT over the quadratic extension "Mersenne31Complex" a
     // fairer comparison is to use half sizes, which is the log minus 1.
-    let log_sizes = &[18];
-    let log_half_sizes = &[];
+    let log_sizes = &[14, 16, 18, 20, 22];
+    let log_half_sizes = &[13, 15, 17];
 
-    const BATCH_SIZE: usize = 1;
+    const BATCH_SIZE: usize = 256;
     type BBExt = BinomialExtensionField<BabyBear, 5>;
 
-    fft::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
-    fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
-    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
+    fft::<BabyBear, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
     fft::<BabyBear, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
-    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
     fft::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
     fft::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
     fft::<Goldilocks, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
@@ -47,6 +44,12 @@ fn bench_fft(c: &mut Criterion) {
     coset_lde::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
     coset_lde::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
     coset_lde::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
+
+    fft::<BBExt, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
+    fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
+    fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
+    fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
 }
 
 fn fft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion, log_sizes: &[usize])

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -46,7 +46,7 @@ fn bench_fft(c: &mut Criterion) {
     coset_lde::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
 
     // The FFT is really slow when dealing with extension fields so we use smaller sizes:
-    let ext_log_sizes = &[10, 12, 14];
+    let ext_log_sizes = &[10];
     fft::<BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);
     fft::<BBExt, Radix2DitParallel<_>, BATCH_SIZE>(c, ext_log_sizes);
     fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, BATCH_SIZE>(c, ext_log_sizes);

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -133,8 +133,8 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     // as it avoids extension field multiplications and makes better use of vectorization.
 
     // If you are using this to compute FFT/IFFT's of a single polynomial (e.g. no batching)
-    // you should also ensure to use RecursiveDft instead of Radix2Dit if not using the parallel
-    // feature and either RecursiveDft or Radix2DitParallel if you are using that feature.
+    // you should also ensure to use `RecursiveDft` instead of `Radix2Dit` if not using the parallel
+    // feature and either `RecursiveDft` or `Radix2DitParallel` if you are using that feature.
 
     /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -8,12 +8,33 @@ use p3_matrix::util::swap_rows;
 
 use crate::util::{coset_shift_cols, divide_by_height};
 
+/// This trait gives an interface for computing discrete fourier transforms (DFT's) and their inverses over
+/// cosets of two-adic subgroups of a field `F`. It also contains combined methods which allow you to take the
+/// evaluation vector of a polynomial on a coset `gH` and extend it to a coset `g'K` for some possibly larger
+/// subgroup `K` and different shift `g'`. This is mainly optimised for batched cases where the input is a
+/// matrix and we want to perform the same operation on every column.
+///
+/// In addition to the above, we also support FFT's over any algebra `A` over the field with a chosen basis.
+/// This translates to `A` implementing both `Algebra<F>` and `BasedVectorSpace<F>`. In principal, the code
+/// here would compile without the `Algebra<F>` trait, but if a vector space does not implement `Algebra<F>`,
+/// applying an F-FFT to it is meaningless. The key observation is that as DFT's all linear, we can operator
+/// on the underlying base field elements of an algebra and avoid costly algebra operations. Thus, when `A`
+/// is an extension field, this will be much faster than using `TwoAdicSubgroupDft<A>`.
+///
+/// Plonky3 have several different implementations which are optimised for slightly different situations.
+/// Depending on your use case, you may want to be using `Radix2Dit, Radix2DitParallel, RecursiveDft` or `Radix2Bowers`.
 pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     // Effectively this is either RowMajorMatrix or BitReversedMatrixView<RowMajorMatrix>.
     // Always owned.
     type Evaluations: BitReversibleMatrix<F> + 'static;
 
-    /// Compute the discrete Fourier transform (DFT) `vec`.
+    /// Compute the discrete Fourier transform (DFT) of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as coefficients of a polynomial, compute the evaluations
+    /// of that polynomial on the subgroup `H`.
     fn dft(&self, vec: Vec<F>) -> Vec<F> {
         self.dft_batch(RowMajorMatrix::new_col(vec))
             .to_row_major_matrix()
@@ -23,34 +44,62 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     /// Compute the discrete Fourier transform (DFT) of each column in `mat`.
     /// This is the only method an implementer needs to define, all other
     /// methods can be derived from this one.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the coefficients of a polynomial, compute the
+    /// evaluations of those polynomials on the subgroup `H`.
     fn dft_batch(&self, mat: RowMajorMatrix<F>) -> Self::Evaluations;
 
-    /// Compute the "coset DFT" of `vec`. This can be viewed as interpolation onto a coset of a
-    /// multiplicative subgroup, rather than the subgroup itself.
+    /// Compute the "coset DFT" of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as coefficients of a polynomial, compute the evaluations
+    /// of that polynomials on the coset `shift * H`.
     fn coset_dft(&self, vec: Vec<F>, shift: F) -> Vec<F> {
         self.coset_dft_batch(RowMajorMatrix::new_col(vec), shift)
             .to_row_major_matrix()
             .values
     }
 
-    /// Compute the "coset DFT" of each column in `mat`. This can be viewed as interpolation onto a
-    /// coset of a multiplicative subgroup, rather than the subgroup itself.
+    /// Compute the "coset DFT" of each column in `mat`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the coefficients of a polynomial, compute the
+    /// evaluations of that polynomials on the coset `shift * H`.
     fn coset_dft_batch(&self, mut mat: RowMajorMatrix<F>, shift: F) -> Self::Evaluations {
         // Observe that
         //     y_i = \sum_j c_j (s g^i)^j
         //         = \sum_j (c_j s^j) (g^i)^j
-        // which has the structure of an ordinary DFT, except each coefficient c_j is first replaced
-        // by c_j s^j.
+        // which has the structure of an ordinary DFT, except each coefficient `c_j` is first replaced
+        // by `c_j s^j`.
         coset_shift_cols(&mut mat, shift);
         self.dft_batch(mat)
     }
 
     /// Compute the inverse DFT of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as the evaluations of a polynomial on `H`, compute the
+    /// coefficients of that polynomial.
     fn idft(&self, vec: Vec<F>) -> Vec<F> {
         self.idft_batch(RowMajorMatrix::new(vec, 1)).values
     }
 
     /// Compute the inverse DFT of each column in `mat`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
+    /// compute the coefficients of those polynomials.
     fn idft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
         let mut dft = self.dft_batch(mat).to_row_major_matrix();
         let h = dft.height();
@@ -64,24 +113,45 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         dft
     }
 
-    /// Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
-    /// "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than
-    /// subgroup itself.
+    /// Compute the "coset iDFT" of `vec`. This is the inverse operation of "coset DFT".
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as the evaluations of a polynomial on `shift * H`,
+    /// compute the coefficients of this polynomial.
     fn coset_idft(&self, vec: Vec<F>, shift: F) -> Vec<F> {
         self.coset_idft_batch(RowMajorMatrix::new(vec, 1), shift)
             .values
     }
 
-    /// Compute the "coset iDFT" of each column in `mat`. This can be viewed as an inverse operation
-    /// of "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than the
-    /// subgroup itself.
+    /// Compute the "coset iDFT" of each column in `mat`. This is the inverse operation
+    /// of "coset DFT".
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `shift * H`,
+    /// compute the coefficients of those polynomials.
     fn coset_idft_batch(&self, mut mat: RowMajorMatrix<F>, shift: F) -> RowMajorMatrix<F> {
+        // Let `f(x)` denote the polynomial we want. Then, if we reinterpret the columns
+        // as being over the subgroup `H`, this is equivalent to switching our polynomial
+        // to `g(x) = f(sx)`.
+        // The output of the iDFT is the coefficients of `g` so to get the coefficients of
+        // `f` we need to scale the `i`'th coefficient by `s^{-i}`.
         mat = self.idft_batch(mat);
         coset_shift_cols(&mut mat, shift.inverse());
         mat
     }
 
     /// Compute the low-degree extension of `vec` onto a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `vec.len()`
+    /// and `vec.len() << added_bits`, respectively.
+    /// Treating `vec` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of that polynomial on the subgroup `K`.
     fn lde(&self, vec: Vec<F>, added_bits: usize) -> Vec<F> {
         self.lde_batch(RowMajorMatrix::new(vec, 1), added_bits)
             .to_row_major_matrix()
@@ -89,6 +159,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `mat.height()`
+    /// and `mat.height() << added_bits`, respectively.
+    /// Treating each column of `mat` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of those polynomials on the subgroup `K`.
     fn lde_batch(&self, mat: RowMajorMatrix<F>, added_bits: usize) -> Self::Evaluations {
         let mut coeffs = self.idft_batch(mat);
         coeffs
@@ -98,6 +175,18 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of of `vec` onto a coset of a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `vec.len()`
+    /// and `vec.len() << added_bits`, respectively.
+    /// Treating `vec` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of that polynomial on the coset `shift * K`.
+    ///
+    /// There is another way to interpret this transformation which gives a larger
+    /// use case. We can also view it as treating `vec` as the evaluations of a polynomial
+    /// over a coset `gH` and then computing the evaluations of that polynomial
+    /// on the coset `g'K` where `g' = g * shift`.
     fn coset_lde(&self, vec: Vec<F>, added_bits: usize, shift: F) -> Vec<F> {
         self.coset_lde_batch(RowMajorMatrix::new(vec, 1), added_bits, shift)
             .to_row_major_matrix()
@@ -105,12 +194,30 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `mat.height()`
+    /// and `mat.height() << added_bits`, respectively.
+    /// Treating each column of `mat` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of those polynomials on the coset `shift * K`.
+    ///
+    /// There is another way to interpret this transformation which gives a larger
+    /// use case. We can also view it as treating columns of `mat` as evaluations
+    /// over a coset `gH` and then computing the evaluations of those polynomials
+    /// on the coset `g'K` where `g' = g * shift`.
     fn coset_lde_batch(
         &self,
         mat: RowMajorMatrix<F>,
         added_bits: usize,
         shift: F,
     ) -> Self::Evaluations {
+        // To briefly explain the additional interpretation, start with the evaluations of the polynomial
+        // `f(x)` over `gH`. If we reinterpret the evaluations as being over the subgroup `H`, this is equivalent to
+        // switching our polynomial to `g(x) = f(g x)`. Then the output of the iDFT is the coefficients of
+        // `g` so to get the coefficients of. Then when we scale by shift, we are effectively switching to the polynomial
+        // `h(x) = g(shift * x) = f(shift * g x)`. Applying the DFT to this, we get the evaluations of `h` over
+        // `K` which is the evaluations of `g` over `shift * K` which is the evaluations of `f` over `g * shift * K`.
         let mut coeffs = self.idft_batch(mat);
         // PANICS: possible panic if the new resized length overflows
         coeffs.values.resize(
@@ -124,19 +231,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         self.coset_dft_batch(coeffs, shift)
     }
 
-    // As FFT's are linear, we can lift these FFT algorithms to work on any algebra
-    // over the field. We don't actually need the `Algebra<F>` trait for this to
-    // compile but, if a vector space does not implement `Algebra<F>`, applying
-    // an F-FFT to it is meaningless.
-
-    // When `V` is an extension field, this is much faster than using `TwoAdicSubgroupDft<V>`
-    // as it avoids extension field multiplications and makes better use of vectorization.
-
-    // If you are using this to compute FFT/IFFT's of a single polynomial (e.g. no batching)
-    // you should also ensure to use `RecursiveDft` instead of `Radix2Dit` if not using the parallel
-    // feature and either `RecursiveDft` or `Radix2DitParallel` if you are using that feature.
-
-    /// Compute the discrete Fourier transform (DFT) `vec`.
+    /// Compute the discrete Fourier transform (DFT) of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as coefficients of a polynomial, compute the evaluations
+    /// of that polynomial on the subgroup `H`.
     fn dft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -145,6 +246,12 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the discrete Fourier transform (DFT) of each column in `mat`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the coefficients of a polynomial, compute the
+    /// evaluations of those polynomials on the subgroup `H`.
     fn dft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -159,8 +266,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         )
     }
 
-    /// Compute the "coset DFT" of `vec`. This can be viewed as interpolation onto a coset of a
-    /// multiplicative subgroup, rather than the subgroup itself.
+    /// Compute the "coset DFT" of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as coefficients of a polynomial, compute the evaluations
+    /// of that polynomials on the coset `shift * H`.
     fn coset_dft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -171,8 +283,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
-    /// Compute the "coset DFT" of each column in `mat`. This can be viewed as interpolation onto a
-    /// coset of a multiplicative subgroup, rather than the subgroup itself.
+    /// Compute the "coset DFT" of each column in `mat`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the coefficients of a polynomial, compute the
+    /// evaluations of that polynomials on the coset `shift * H`.
     fn coset_dft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -189,6 +306,12 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the inverse DFT of `vec`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as the evaluations of a polynomial on `H`, compute the
+    /// coefficients of that polynomial.
     fn idft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -197,6 +320,12 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the inverse DFT of each column in `mat`.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
+    /// compute the coefficients of those polynomials.
     fn idft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -211,9 +340,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         )
     }
 
-    /// Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
-    /// "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than
-    /// subgroup itself.
+    /// Compute the "coset iDFT" of `vec`. This is the inverse operation of "coset DFT".
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as the evaluations of a polynomial on `shift * H`,
+    /// compute the coefficients of this polynomial.
     fn coset_idft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -223,9 +356,14 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
-    /// Compute the "coset iDFT" of each column in `mat`. This can be viewed as an inverse operation
-    /// of "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than the
-    /// subgroup itself.
+    /// Compute the "coset iDFT" of each column in `mat`. This is the inverse operation
+    /// of "coset DFT".
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `shift * H`,
+    /// compute the coefficients of those polynomials.
     fn coset_idft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -242,6 +380,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of `vec` onto a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `vec.len()`
+    /// and `vec.len() << added_bits`, respectively.
+    /// Treating `vec` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of that polynomial on the subgroup `K`.
     fn lde_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -253,6 +398,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `mat.height()`
+    /// and `mat.height() << added_bits`, respectively.
+    /// Treating each column of `mat` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of those polynomials on the subgroup `K`.
     fn lde_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -268,7 +420,19 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         )
     }
 
-    /// Compute the low-degree extension of `vec` onto a coset of a larger subgroup.
+    /// Compute the low-degree extension of of `vec` onto a coset of a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `vec.len()`
+    /// and `vec.len() << added_bits`, respectively.
+    /// Treating `vec` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of that polynomial on the coset `shift * K`.
+    ///
+    /// There is another way to interpret this transformation which gives a larger
+    /// use case. We can also view it as treating `vec` as the evaluations of a polynomial
+    /// over a coset `gH` and then computing the evaluations of that polynomial
+    /// on the coset `g'K` where `g' = g * shift`.
     fn coset_lde_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -281,6 +445,18 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     }
 
     /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H, K` denote the unique multiplicative subgroups of order `mat.height()`
+    /// and `mat.height() << added_bits`, respectively.
+    /// Treating each column of `mat` as the evaluations of a polynomial on the subgroup `H`,
+    /// compute the evaluations of those polynomials on the coset `shift * K`.
+    ///
+    /// There is another way to interpret this transformation which gives a larger
+    /// use case. We can also view it as treating columns of `mat` as evaluations
+    /// over a coset `gH` and then computing the evaluations of those polynomials
+    /// on the coset `g'K` where `g' = g * shift`.
     fn coset_lde_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -208,7 +208,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
     }
 
-    // Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
+    /// Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
     /// "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than
     /// subgroup itself.
     fn coset_idft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -97,7 +97,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         self.dft_batch(coeffs)
     }
 
-    /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
+    /// Compute the low-degree extension of of `vec` onto a coset of a larger subgroup.
     fn coset_lde(&self, vec: Vec<F>, added_bits: usize, shift: F) -> Vec<F> {
         self.coset_lde_batch(RowMajorMatrix::new(vec, 1), added_bits, shift)
             .to_row_major_matrix()
@@ -136,6 +136,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
     // you should also ensure to use RecursiveDft instead of Radix2Dit if not using the parallel
     // feature and either RecursiveDft or Radix2DitParallel if you are using that feature.
 
+    /// Compute the discrete Fourier transform (DFT) `vec`.
     fn dft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -143,6 +144,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         self.dft_algebra_batch(RowMajorMatrix::new_col(vec)).values
     }
 
+    /// Compute the discrete Fourier transform (DFT) of each column in `mat`.
     fn dft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -156,6 +158,8 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
     }
 
+    /// Compute the "coset DFT" of `vec`. This can be viewed as interpolation onto a coset of a
+    /// multiplicative subgroup, rather than the subgroup itself.
     fn coset_dft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -166,6 +170,8 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
+    /// Compute the "coset DFT" of each column in `mat`. This can be viewed as interpolation onto a
+    /// coset of a multiplicative subgroup, rather than the subgroup itself.
     fn coset_dft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -202,6 +208,9 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
     }
 
+    // Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
+    /// "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than
+    /// subgroup itself.
     fn coset_idft_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -211,6 +220,9 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
+    /// Compute the "coset iDFT" of each column in `mat`. This can be viewed as an inverse operation
+    /// of "coset DFT", that interpolates over a coset of a multiplicative subgroup, rather than the
+    /// subgroup itself.
     fn coset_idft_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -225,6 +237,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
     }
 
+    /// Compute the low-degree extension of `vec` onto a larger subgroup.
     fn lde_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -235,6 +248,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
+    /// Compute the low-degree extension of each column in `mat` onto a larger subgroup.
     fn lde_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,
@@ -249,6 +263,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
     }
 
+    /// Compute the low-degree extension of `vec` onto a coset of a larger subgroup.
     fn coset_lde_algebra<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         vec: Vec<V>,
@@ -260,6 +275,7 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
+    /// Compute the low-degree extension of each column in `mat` onto a coset of a larger subgroup.
     fn coset_lde_algebra_batch<V: Algebra<F> + BasedVectorSpace<F> + Clone + Send + Sync>(
         &self,
         mat: RowMajorMatrix<V>,

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -150,12 +150,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         mat: RowMajorMatrix<V>,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self.dft_batch(base_mat).to_row_major_matrix();
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 
     /// Compute the "coset DFT" of `vec`. This can be viewed as interpolation onto a coset of a
@@ -178,12 +179,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         shift: F,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self.coset_dft_batch(base_mat, shift).to_row_major_matrix();
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 
     /// Compute the inverse DFT of `vec`.
@@ -200,12 +202,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         mat: RowMajorMatrix<V>,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self.idft_batch(base_mat);
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 
     /// Compute the "coset iDFT" of `vec`. This can be viewed as an inverse operation of
@@ -229,12 +232,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         shift: F,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self.coset_idft_batch(base_mat, shift);
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 
     /// Compute the low-degree extension of `vec` onto a larger subgroup.
@@ -255,12 +259,13 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         added_bits: usize,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self.lde_batch(base_mat, added_bits).to_row_major_matrix();
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 
     /// Compute the low-degree extension of `vec` onto a coset of a larger subgroup.
@@ -283,13 +288,14 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         shift: F,
     ) -> RowMajorMatrix<V> {
         let init_width = mat.width();
-        let base_mat = RowMajorMatrix::new(
-            V::convert_to_base_vec(mat.values),
-            init_width * V::DIMENSION,
-        );
+        let base_mat =
+            RowMajorMatrix::new(V::flatten_to_base(mat.values), init_width * V::DIMENSION);
         let base_dft_output = self
             .coset_lde_batch(base_mat, added_bits, shift)
             .to_row_major_matrix();
-        RowMajorMatrix::new(V::convert_from_base_vec(base_dft_output.values), init_width)
+        RowMajorMatrix::new(
+            V::reconstitute_from_base(base_dft_output.values),
+            init_width,
+        )
     }
 }

--- a/field-testing/src/dft_testing.rs
+++ b/field-testing/src/dft_testing.rs
@@ -1,5 +1,5 @@
 use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-use p3_field::TwoAdicField;
+use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use rand::SeedableRng;
@@ -14,7 +14,7 @@ where
 {
     let dft = Dft::default();
     let mut rng = SmallRng::seed_from_u64(1);
-    for log_h in 0..12 {
+    for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
         let dft_naive = NaiveDft.dft_batch(mat.clone());
@@ -49,7 +49,7 @@ where
 {
     let dft = Dft::default();
     let mut rng = SmallRng::seed_from_u64(1);
-    for log_h in 0..12 {
+    for log_h in 0..5 {
         let h = 1 << log_h;
         let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
         let idft_naive = NaiveDft.idft_batch(mat.clone());
@@ -119,7 +119,7 @@ where
 {
     let dft = Dft::default();
     let mut rng = SmallRng::seed_from_u64(1);
-    for log_h in 0..12 {
+    for log_h in 0..5 {
         let h = 1 << log_h;
         let original = RowMajorMatrix::<F>::rand(&mut rng, h, 3);
         let dft_output = dft.dft_batch(original.clone());
@@ -128,9 +128,138 @@ where
     }
 }
 
+pub fn test_dft_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let dft_naive = NaiveDft.dft_batch(mat.clone());
+        let dft_result = dft.dft_algebra_batch(mat);
+        assert_eq!(dft_naive, dft_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_coset_dft_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let shift = F::GENERATOR;
+        let coset_dft_naive = NaiveDft.coset_dft_batch(mat.clone(), EF::from(shift));
+        let coset_dft_result = dft.coset_dft_algebra_batch(mat, shift);
+        assert_eq!(coset_dft_naive, coset_dft_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_idft_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let idft_naive = NaiveDft.idft_batch(mat.clone());
+        let idft_result = dft.idft_algebra_batch(mat.clone());
+        assert_eq!(idft_naive, idft_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_coset_idft_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let shift = F::GENERATOR;
+        let idft_naive = NaiveDft.coset_idft_batch(mat.clone(), EF::from(shift));
+        let idft_result = dft.coset_idft_algebra_batch(mat, shift);
+        assert_eq!(idft_naive, idft_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_lde_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let lde_naive = NaiveDft.lde_batch(mat.clone(), 1);
+        let lde_result = dft.lde_algebra_batch(mat, 1);
+        assert_eq!(lde_naive, lde_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_coset_lde_algebra_matches_naive<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let shift = F::GENERATOR;
+        let coset_lde_naive = NaiveDft.coset_lde_batch(mat.clone(), 1, EF::from(shift));
+        let coset_lde_result = dft.coset_lde_algebra_batch(mat, 1, shift);
+        assert_eq!(coset_lde_naive, coset_lde_result.to_row_major_matrix());
+    }
+}
+
+pub fn test_dft_idft_algebra_consistency<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in 0..5 {
+        let h = 1 << log_h;
+        let original = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let dft_output = dft.dft_algebra_batch(original.clone());
+        let idft_output = dft.idft_algebra_batch(dft_output.to_row_major_matrix());
+        assert_eq!(original, idft_output.to_row_major_matrix());
+    }
+}
+
 #[macro_export]
 macro_rules! test_field_dft {
-    ($mod:ident, $field:ty, $dft:ty) => {
+    ($mod:ident, $field:ty, $extfield:ty, $dft:ty) => {
         mod $mod {
             #[test]
             fn dft_matches_naive() {
@@ -165,6 +294,41 @@ macro_rules! test_field_dft {
             #[test]
             fn dft_idft_consistency() {
                 $crate::test_dft_idft_consistency::<$field, $dft>();
+            }
+
+            #[test]
+            fn dft_algebra_matches_naive() {
+                $crate::test_dft_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn coset_dft_algebra_matches_naive() {
+                $crate::test_coset_dft_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn idft_algebra_matches_naive() {
+                $crate::test_idft_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn coset_idft_algebra_matches_naive() {
+                $crate::test_coset_idft_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn lde_algebra_matches_naive() {
+                $crate::test_lde_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn coset_lde_algebra_matches_naive() {
+                $crate::test_coset_lde_algebra_matches_naive::<$field, $extfield, $dft>();
+            }
+
+            #[test]
+            fn dft_idft_algebra_consistency() {
+                $crate::test_dft_idft_algebra_consistency::<$field, $extfield, $dft>();
             }
         }
     };

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -6,7 +6,7 @@ use crate::batch_inverse::batch_multiplicative_inverse_general;
 use crate::{Algebra, Field, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct FieldArray<F: Field, const N: usize>(pub [F; N]);
 
 impl<F: Field, const N: usize> FieldArray<F, N> {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -80,7 +80,7 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
     fn flatten_to_base(vec: Vec<Self>) -> Vec<A> {
         unsafe {
             // Safety:
-            // As `Self` is a `repr(transparent)`, it can be transmuted to `[A; D]`
+            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
             flatten_to_base::<A, Self>(vec)
         }
     }
@@ -89,7 +89,7 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
     fn reconstitute_from_base(vec: Vec<A>) -> Vec<Self> {
         unsafe {
             // Safety:
-            // As `Self` is a `repr(transparent)`, it can be transmuted to `[A; D]`
+            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
             reconstitute_from_base::<A, Self>(vec)
         }
     }

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -85,8 +85,9 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
 
         let buf_ptr = vec.as_ptr().cast::<A>();
         let n = vec.len() * D;
+        // Ideally we could use Vec::from_raw_parts but that seems to be dangerous.
         let slice = unsafe { slice::from_raw_parts(buf_ptr, n) };
-        slice.to_vec()
+        slice.to_vec() // Hopefully the compiler will optimize this away.
     }
 
     #[inline]
@@ -104,8 +105,9 @@ impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace
         );
         let buf_ptr = vec.as_mut_ptr().cast::<Self>();
         let n = vec.len() / D;
+        // Ideally we could use Vec::from_raw_parts but that seems to be dangerous.
         let slice = unsafe { slice::from_raw_parts(buf_ptr, n) };
-        slice.to_vec()
+        slice.to_vec() // Hopefully the compiler will optimize this away.
     }
 }
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -5,13 +5,10 @@ use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
-use p3_util::convert_vec;
+use p3_util::{flatten_to_base, reconstitute_from_base};
 use serde::{Deserialize, Serialize};
 
-use super::{
-    BinomialExtensionField, binomial_mul, cubic_square, flatten_to_base, reconstitute_from_base,
-    vector_add, vector_sub,
-};
+use super::{BinomialExtensionField, binomial_mul, cubic_square, vector_add, vector_sub};
 use crate::extension::BinomiallyExtendable;
 use crate::{
     Algebra, BasedVectorSpace, Field, PackedField, PackedFieldExtension, PackedValue, Powers,
@@ -132,7 +129,7 @@ where
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(PF::zero_vec(len * D)) }
+        unsafe { reconstitute_from_base(PF::zero_vec(len * D)) }
     }
 }
 
@@ -165,7 +162,7 @@ where
         unsafe {
             // Safety:
             // As `Self` is a `repr(transparent)`, it can be transmuted to `[PF; D]`
-            flatten_to_base::<PF, Self, D>(vec)
+            flatten_to_base::<PF, Self>(vec)
         }
     }
 
@@ -174,7 +171,7 @@ where
         unsafe {
             // Safety:
             // As `Self` is a `repr(transparent)`, it can be transmuted to `[PF; D]`
-            reconstitute_from_base::<PF, Self, D>(vec)
+            reconstitute_from_base::<PF, Self>(vec)
         }
     }
 }

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -161,7 +161,7 @@ where
     fn flatten_to_base(vec: Vec<Self>) -> Vec<PF> {
         unsafe {
             // Safety:
-            // As `Self` is a `repr(transparent)`, it can be transmuted to `[PF; D]`
+            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[PF; D]`
             flatten_to_base::<PF, Self>(vec)
         }
     }
@@ -170,7 +170,7 @@ where
     fn reconstitute_from_base(vec: Vec<PF>) -> Vec<Self> {
         unsafe {
             // Safety:
-            // As `Self` is a `repr(transparent)`, it can be transmuted to `[PF; D]`
+            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[PF; D]`
             reconstitute_from_base::<PF, Self>(vec)
         }
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -477,7 +477,7 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// different basis might have been used.
     #[must_use]
     #[inline]
-    fn convert_to_base_vec(vec: Vec<Self>) -> Vec<F> {
+    fn flatten_to_base(vec: Vec<Self>) -> Vec<F> {
         vec.into_iter()
             .flat_map(|x| x.as_basis_coefficients_slice().to_vec())
             .collect()
@@ -500,11 +500,11 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// different basis might have been used.
     #[must_use]
     #[inline]
-    fn convert_from_base_vec(vec: Vec<F>) -> Vec<Self> {
+    fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self> {
         assert_eq!(vec.len() % Self::DIMENSION, 0);
 
         vec.chunks_exact(Self::DIMENSION)
-            .map(|chunk| Self::from_basis_coefficients_slice(chunk).unwrap())
+            .flat_map(|chunk| Self::from_basis_coefficients_slice(chunk))
             .collect::<Vec<_>>()
     }
 }
@@ -529,13 +529,13 @@ impl<F: PrimeCharacteristicRing> BasedVectorSpace<F> for F {
 
     #[must_use]
     #[inline]
-    fn convert_to_base_vec(vec: Vec<Self>) -> Vec<F> {
+    fn flatten_to_base(vec: Vec<Self>) -> Vec<F> {
         vec
     }
 
     #[must_use]
     #[inline]
-    fn convert_from_base_vec(vec: Vec<F>) -> Vec<Self> {
+    fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self> {
         vec
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -462,6 +462,22 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     fn ith_basis_element(i: usize) -> Option<Self> {
         (i < Self::DIMENSION).then(|| Self::from_basis_coefficients_fn(|j| F::from_bool(i == j)))
     }
+
+    #[must_use]
+    #[inline]
+    fn convert_to_base_vec(vec: Vec<Self>) -> Vec<F> {
+        vec.into_iter()
+            .flat_map(|x| x.as_basis_coefficients_slice().to_vec())
+            .collect()
+    }
+
+    #[must_use]
+    #[inline]
+    fn convert_from_base_vec(vec: Vec<F>) -> Vec<Self> {
+        vec.chunks_exact(Self::DIMENSION)
+            .map(|chunk| Self::from_basis_coefficients_slice(chunk).unwrap())
+            .collect::<Vec<_>>()
+    }
 }
 
 impl<F: PrimeCharacteristicRing> BasedVectorSpace<F> for F {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -505,7 +505,7 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
 
         vec.chunks_exact(Self::DIMENSION)
             .flat_map(|chunk| Self::from_basis_coefficients_slice(chunk))
-            .collect::<Vec<_>>()
+            .collect()
     }
 }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -465,8 +465,8 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
 
     /// Convert from a vector of `Self` to a vector of `F` by flattening the basis coefficients.
     ///
-    /// For some `BasedVectorSpaces` we may be able to do this directly and avoid passing through
-    /// the iterator and `as_basis_coefficients_slice`.
+    /// Depending on the `BasedVectorSpace` this may be essentially a no-op and should certainly
+    /// be reimplemented in those cases.
     ///
     /// # Safety
     ///
@@ -485,8 +485,8 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
 
     /// Convert from a vector of `F` to a vector of `Self` by combining the basis coefficients.
     ///
-    /// For some `BasedVectorSpaces` we may be able to do this directly and avoid passing through
-    /// the iterator and `from_basis_coefficients_slice`.
+    /// Depending on the `BasedVectorSpace` this may be essentially a no-op and should certainly
+    /// be reimplemented in those cases.
     ///
     /// # Panics
     /// This will panic if the length of `vec` is not a multiple of `Self::DIMENSION`.

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -182,8 +182,9 @@ impl PrimeCharacteristicRing for Goldilocks {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY:
-        // Due to repr transparent, the memory layout of Goldilocks is the same as u64.
-        // Hence this will create Goldilocks elements with value set to 0.
+        // Due to `#[repr(transparent)]`, Goldilocks and u64 have the same size, alignment
+        // and memory layout making `flatten_to_base` safe. This this will create
+        // a vector Goldilocks elements with value set to 0.
         unsafe { flatten_to_base(vec![0u64; len]) }
     }
 }

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -593,6 +593,7 @@ unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use p3_field::extension::BinomialExtensionField;
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_64, test_two_adic_field,
     };
@@ -600,6 +601,7 @@ mod tests {
     use super::*;
 
     type F = Goldilocks;
+    type EF = BinomialExtensionField<F, 5>;
 
     #[test]
     fn test_goldilocks() {
@@ -668,11 +670,17 @@ mod tests {
     test_prime_field_64!(crate::Goldilocks);
     test_two_adic_field!(crate::Goldilocks);
 
-    test_field_dft!(radix2dit, crate::Goldilocks, p3_dft::Radix2Dit<_>);
-    test_field_dft!(bowers, crate::Goldilocks, p3_dft::Radix2Bowers);
+    test_field_dft!(
+        radix2dit,
+        crate::Goldilocks,
+        super::EF,
+        p3_dft::Radix2Dit<_>
+    );
+    test_field_dft!(bowers, crate::Goldilocks, super::EF, p3_dft::Radix2Bowers);
     test_field_dft!(
         parallel,
         crate::Goldilocks,
+        super::EF,
         p3_dft::Radix2DitParallel<crate::Goldilocks>
     );
 }

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -4,7 +4,6 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
-use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use num_bigint::BigUint;
@@ -15,7 +14,7 @@ use p3_field::{
     PrimeField64, TwoAdicField, halve_u64, quotient_map_large_iint, quotient_map_large_uint,
     quotient_map_small_int,
 };
-use p3_util::{assume, branch_hint};
+use p3_util::{assume, branch_hint, flatten_to_base};
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
@@ -27,7 +26,7 @@ const P: u64 = 0xFFFF_FFFF_0000_0001;
 ///
 /// Note that the safety of deriving `Serialize` and `Deserialize` relies on the fact that the internal value can be any u64.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
-#[repr(transparent)] // Packed field implementations rely on this!
+#[repr(transparent)] // Important for reasoning about memory layout
 pub struct Goldilocks {
     /// Not necessarily canonical.
     pub(crate) value: u64,
@@ -182,8 +181,10 @@ impl PrimeCharacteristicRing for Goldilocks {
 
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
-        // SAFETY: repr(transparent) ensures transmutation safety.
-        unsafe { transmute(vec![0u64; len]) }
+        // SAFETY:
+        // Due to repr transparent, the memory layout of Goldilocks is the same as u64.
+        // Hence this will create Goldilocks elements with value set to 0.
+        unsafe { flatten_to_base(vec![0u64; len]) }
     }
 }
 

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -11,7 +11,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -181,7 +181,7 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Goldilocks::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -11,7 +11,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -180,7 +180,7 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Goldilocks::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -106,10 +106,8 @@ impl BinomialExtensionData<4> for KoalaBearParameters {
 #[cfg(test)]
 mod tests {
     use num_bigint::BigUint;
-    use p3_field::{
-        InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField,
-        extension::BinomialExtensionField,
-    };
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField};
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_32, test_prime_field_64,
         test_two_adic_field,

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -106,7 +106,10 @@ impl BinomialExtensionData<4> for KoalaBearParameters {
 #[cfg(test)]
 mod tests {
     use num_bigint::BigUint;
-    use p3_field::{InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField};
+    use p3_field::{
+        InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField,
+        extension::BinomialExtensionField,
+    };
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_32, test_prime_field_64,
         test_two_adic_field,
@@ -115,6 +118,7 @@ mod tests {
     use super::*;
 
     type F = KoalaBear;
+    type EF = BinomialExtensionField<F, 4>;
 
     #[test]
     fn test_koala_bear_two_adicity_generators() {
@@ -195,16 +199,18 @@ mod tests {
     );
     test_two_adic_field!(crate::KoalaBear);
 
-    test_field_dft!(radix2dit, crate::KoalaBear, p3_dft::Radix2Dit<_>);
-    test_field_dft!(bowers, crate::KoalaBear, p3_dft::Radix2Bowers);
+    test_field_dft!(radix2dit, crate::KoalaBear, super::EF, p3_dft::Radix2Dit<_>);
+    test_field_dft!(bowers, crate::KoalaBear, super::EF, p3_dft::Radix2Bowers);
     test_field_dft!(
         parallel,
         crate::KoalaBear,
+        super::EF,
         p3_dft::Radix2DitParallel::<crate::KoalaBear>
     );
     test_field_dft!(
         recur_dft,
         crate::KoalaBear,
+        super::EF,
         p3_monty_31::dft::RecursiveDft<_>
     );
     test_prime_field!(crate::KoalaBear);

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -9,7 +9,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -328,7 +328,7 @@ impl PrimeCharacteristicRing for PackedMersenne31Neon {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -20,7 +20,7 @@ const P: uint32x4_t = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH])
 
 /// Vectorized NEON implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31Neon(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31Neon {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -5,7 +5,6 @@ use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use p3_util::flatten_to_base;
 
 use num_bigint::BigUint;
 use p3_field::exponentiation::exp_1717986917;
@@ -15,6 +14,7 @@ use p3_field::{
     PrimeField32, PrimeField64, halve_u32, quotient_map_large_iint, quotient_map_large_uint,
     quotient_map_small_int,
 };
+use p3_util::flatten_to_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::de::Error;

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -200,8 +200,9 @@ impl PrimeCharacteristicRing for Mersenne31 {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY:
-        // Due to repr transparent, the memory layout of Mersenne31 is the same as u32.
-        // Hence this will create Mersenne31 elements with value set to 0.
+        // Due to `#[repr(transparent)]`, Mersenne31 and u32 have the same size, alignment
+        // and memory layout making `flatten_to_base` safe. This this will create
+        // a vector Mersenne31 elements with value set to 0.
         unsafe { flatten_to_base(vec![0u32; len]) }
     }
 }

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -4,8 +4,8 @@ use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
-use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use p3_util::flatten_to_base;
 
 use num_bigint::BigUint;
 use p3_field::exponentiation::exp_1717986917;
@@ -25,7 +25,7 @@ const P: u32 = (1 << 31) - 1;
 
 /// The prime field `F_p` where `p = 2^31 - 1`.
 #[derive(Copy, Clone, Default)]
-#[repr(transparent)] // Packed field implementations rely on this!
+#[repr(transparent)] // Important for reasoning about memory layout.
 pub struct Mersenne31 {
     /// Not necessarily canonical, but must fit in 31 bits.
     pub(crate) value: u32,
@@ -199,8 +199,10 @@ impl PrimeCharacteristicRing for Mersenne31 {
 
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
-        // SAFETY: repr(transparent) ensures transmutation safety.
-        unsafe { transmute(vec![0u32; len]) }
+        // SAFETY:
+        // Due to repr transparent, the memory layout of Mersenne31 is the same as u32.
+        // Hence this will create Mersenne31 elements with value set to 0.
+        unsafe { flatten_to_base(vec![0u32; len]) }
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -20,7 +20,7 @@ pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff;
 
 /// Vectorized AVX2 implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31AVX2(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31AVX2 {

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -9,7 +9,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -440,7 +440,7 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX2 {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -23,7 +23,7 @@ const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31AVX512(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31AVX512 {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -9,7 +9,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -434,7 +434,7 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(Mersenne31::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
     }
 
     #[must_use]

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -10,7 +10,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -473,7 +473,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -25,7 +25,7 @@ pub trait MontyParametersNeon {
 
 /// Vectorized NEON implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMontyField31Neon<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -191,8 +191,9 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY:
-        // Due to #[repr(transparent)], the memory layout of MontyField31 is the same as u32.
-        // Hence this will create MontyField31 elements with value set to 0 which is the
+        // Due to `#[repr(transparent)]`, MontyField31 and u32 have the same size, alignment
+        // and memory layout making `flatten_to_base` safe. This this will create
+        // a vector MontyField31 elements with value set to 0 which is the
         // MONTY form of 0.
         unsafe { flatten_to_base(vec![0u32; len]) }
     }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -7,7 +7,6 @@ use core::hash::Hash;
 use core::iter::{Product, Sum};
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-use p3_util::flatten_to_base;
 
 use num_bigint::BigUint;
 use p3_field::integers::QuotientMap;
@@ -15,6 +14,7 @@ use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField32, PrimeField64, TwoAdicField, quotient_map_small_int,
 };
+use p3_util::flatten_to_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Deserializer, Serialize};

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -6,8 +6,8 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::Hash;
 use core::iter::{Product, Sum};
 use core::marker::PhantomData;
-use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+use p3_util::flatten_to_base;
 
 use num_bigint::BigUint;
 use p3_field::integers::QuotientMap;
@@ -25,7 +25,7 @@ use crate::utils::{
 use crate::{FieldParameters, MontyParameters, RelativelyPrimePower, TwoAdicData};
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
-#[repr(transparent)] // Packed field implementations rely on this!
+#[repr(transparent)] // Important for reasoning about memory layout.
 pub struct MontyField31<MP: MontyParameters> {
     /// The MONTY form of the field element, saved as a positive integer less than `P`.
     ///
@@ -190,8 +190,11 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
 
     #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
-        // SAFETY: repr(transparent) ensures transmutation safety.
-        unsafe { transmute(vec![0u32; len]) }
+        // SAFETY:
+        // Due to #[repr(transparent)], the memory layout of MontyField31 is the same as u32.
+        // Hence this will create MontyField31 elements with value set to 0 which is the
+        // MONTY form of 0.
+        unsafe { flatten_to_base(vec![0u32; len]) }
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -9,7 +9,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -1019,7 +1019,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX2<FP>
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 }
 

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -15,7 +15,7 @@ use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing,
 };
-use p3_util::convert_vec;
+use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
@@ -1061,7 +1061,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
-        unsafe { convert_vec(MontyField31::<FP>::zero_vec(len * WIDTH)) }
+        unsafe { reconstitute_from_base(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -33,7 +33,7 @@ const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)] // This needed to make `transmute`s safe.
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMontyField31AVX512<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -343,13 +343,13 @@ where
 /// reallocations.
 ///
 /// This is useful to convert `Vec<[F; N]>` to `Vec<F>` or `Vec<A>` to `Vec<F>` where
-/// `A` has the same size, alignment and memory layout as `[F; N]` for some `N`. In particular,
-/// it can also be used to safely convert `Vec<u32>` to `Vec<F>` if `F` is a `32` bit field
+/// `A` has the same size, alignment and memory layout as `[F; N]` for some `N`. It can also,
+/// be used to safely convert `Vec<u32>` to `Vec<F>` if `F` is a `32` bit field
 /// or `Vec<u64>` to `Vec<F>` if `F` is a `64` bit field.
 ///
 /// # Safety
 ///
-/// This is assumes that `BaseArray` as the same alignment and memory layout as `[Base; N]`.
+/// This is assumes that `BaseArray` has the same alignment and memory layout as `[Base; N]`.
 /// As Rust guarantees that arrays elements are contiguous in memory and the alignment of
 /// the array is the same as the alignment of its elements, this means that `BaseArray`
 /// must have the same alignment as `Base`.
@@ -401,7 +401,7 @@ pub unsafe fn flatten_to_base<Base, BaseArray>(vec: Vec<BaseArray>) -> Vec<Base>
 ///
 /// # Safety
 ///
-/// This is assumes that `BaseArray` as the same alignment and memory layout as `[Base; N]`.
+/// This is assumes that `BaseArray` has the same alignment and memory layout as `[Base; N]`.
 /// As Rust guarantees that arrays elements are contiguous in memory and the alignment of
 /// the array is the same as the alignment of its elements, this means that `BaseArray`
 /// must have the same alignment as `Base`.


### PR DESCRIPTION
Currently most of our FFT methods (e.g. `Radix2Dit`, `Radix2DitParallel`) naturally work over any two-adic finite field. This however turns out to lead to a rather impressive degradation in performance when handling extension fields.

When given an extension field, these methods lift all the twiddles to the extension field requiring expensive extension field multiplications and, all of our `Packing` code breaks down. (Most extension fields have `Self::Packing = Self`).

There is a simple solution to this however. Because FFT's are linear we can just split all Extension field elements (or more generally vector space elements) into their base field coefficient form and do the FFT on that. This gives almost a `10x` speed up to the speed of these FFT's.

The main downside is that it does require a reasonable amount of copy-pasted code. We could just add the `convert_to_base_vec` and `convert_from_base_vec` methods to `BasedVectorSpace` if we want to add less code. The advantage of the `dft_algebra` methods and similar is that we can abstract away converting extension field elements into and out of their base slices.

Our code base currently doesn't make use of it but it came up when I was looking at STIR and WHIR and so this would definitely get used in those code bases. (Those code bases also care about non batch FFT's so a future PR might look into speeding up those or providing one as an option).