### PR TITLE
`reconstitute_from_base`: make chunks parallel

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -504,13 +504,17 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self>
     where
         F: Sync,
+        Self: Send,
     {
         use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
 
         assert_eq!(vec.len() % Self::DIMENSION, 0);
 
         vec.par_chunks_exact(Self::DIMENSION)
-            .flat_map(|chunk| Self::from_basis_coefficients_slice(chunk))
+            .map(|chunk| {
+                Self::from_basis_coefficients_slice(chunk)
+                    .expect("Chunk length not equal to dimension")
+            })
             .collect()
     }
 }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -7,6 +7,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::{array, slice};
 
 use num_bigint::BigUint;
+use p3_maybe_rayon::prelude::ParallelSlice;
 use p3_util::iter_array_chunks_padded;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -501,10 +502,13 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// different basis might have been used.
     #[must_use]
     #[inline]
-    fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self> {
+    fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self>
+    where
+        F: Sync,
+    {
         assert_eq!(vec.len() % Self::DIMENSION, 0);
 
-        vec.chunks_exact(Self::DIMENSION)
+        vec.par_chunks_exact(Self::DIMENSION)
             .flat_map(|chunk| Self::from_basis_coefficients_slice(chunk))
             .collect()
     }

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -7,7 +7,6 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::{array, slice};
 
 use num_bigint::BigUint;
-use p3_maybe_rayon::prelude::ParallelSlice;
 use p3_util::iter_array_chunks_padded;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -506,6 +505,8 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     where
         F: Sync,
     {
+        use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
+
         assert_eq!(vec.len() % Self::DIMENSION, 0);
 
         vec.par_chunks_exact(Self::DIMENSION)

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -7,6 +7,7 @@ use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::{array, slice};
 
 use num_bigint::BigUint;
+use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
 use p3_util::iter_array_chunks_padded;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -506,8 +507,6 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
         F: Sync,
         Self: Send,
     {
-        use p3_maybe_rayon::prelude::{ParallelIterator, ParallelSlice};
-
         assert_eq!(vec.len() % Self::DIMENSION, 0);
 
         vec.par_chunks_exact(Self::DIMENSION)


### PR DESCRIPTION
@SyxtonPrime can you check that this is appropriate? On my side running the algebra dft benchmarks I've seen improvements from 0% on small dimensions to 7%