### PR TITLE
More general matrix Transpose

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -470,7 +470,7 @@ impl<T: Copy + Default + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
         RowMajorMatrix::new(values, self.height())
     }
 
-    /// Transpose the matrix out of place copying the results into the given matrix.
+    /// Transpose the matrix returning the result in `other` without intermediate allocation.
     pub fn transpose_into<W: DenseStorage<T> + BorrowMut<[T]>>(
         &self,
         other: &mut DenseMatrix<T, W>,

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -457,7 +457,7 @@ impl<T: Clone + Default + Send + Sync> DenseMatrix<T> {
 }
 
 impl<T: Copy + Default + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
-    /// Take the transpose the matrix, returning a new matrix with the rows and columns swapped.
+    /// Return the transpose of this matrix.
     pub fn transpose(&self) -> RowMajorMatrix<T> {
         let nelts = self.height() * self.width();
         let mut values = vec![T::default(); nelts];

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -486,6 +486,9 @@ impl<T: Copy + Default + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
     }
 
     /// Transpose the matrix in place, modifying the original matrix.
+    ///
+    /// TODO: Currently this uses a temporary buffer to perform the transpose.
+    /// This should eventually be optimized to make this truly in-place.
     pub fn transpose_in_place(&mut self)
     where
         V: BorrowMut<[T]>,

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -484,28 +484,6 @@ impl<T: Copy + Default + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
             self.height(),
         );
     }
-
-    /// Transpose the matrix in place, modifying the original matrix.
-    ///
-    /// TODO: Currently this uses a temporary buffer to perform the transpose.
-    /// This should eventually be optimized to make this truly in-place.
-    pub fn transpose_in_place(&mut self)
-    where
-        V: BorrowMut<[T]>,
-    {
-        let nelts = self.height() * self.width();
-        let mut values = vec![T::default(); nelts];
-        transpose::transpose(
-            self.values.borrow(),
-            &mut values,
-            self.width(),
-            self.height(),
-        );
-        self.values.borrow_mut().copy_from_slice(&values);
-
-        // Update the width of the matrix to reflect the transposition.
-        self.width = self.height();
-    }
 }
 
 impl<'a, T: Clone + Default + Send + Sync> RowMajorMatrixView<'a, T> {
@@ -1097,25 +1075,6 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn test_transpose_view_mut() {
-        // Original matrix: 2 rows x 3 cols
-        // [1, 2, 3]
-        // [4, 5, 6]
-        let mut values = vec![1, 2, 3, 4, 5, 6];
-        let mut matrix = RowMajorMatrixViewMut::new(&mut values, 3);
-
-        matrix.transpose_in_place();
-
-        // After transpose: 3 rows x 2 cols
-        // [1, 4]
-        // [2, 5]
-        // [3, 6]
-        assert_eq!(matrix.width, 2);
-        assert_eq!(matrix.height(), 3);
-        assert_eq!(matrix.values, &[1, 4, 2, 5, 3, 6]);
     }
 
     #[test]


### PR DESCRIPTION
A slight variant of the approach in #834. Currently the `.transpose()` methods only work for `RowMajorMatrices`. This PR just adds a couple of generic parameters so that the transpose function works with any `DenseMatrix<T, DenseStorage<T>>` but the functionality should be identical.

Additionally we add a `transpose_in_place` method for `DenseMatrix<T, V>` where `V: DenseStorage<T> + BorrowMut<T>`. Currently this added method uses a temporary so I've left a Todo to fix this.