### PR TITLE
refactor: precompute coset rather than subgroup for interpolation

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -18,7 +18,7 @@ use num_bigint::BigUint;
 use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, PrimeField32, PrimeField64, TwoAdicField,
     cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order,
-    two_adic_coset_vanishing_polynomial, two_adic_subgroup_vanishing_polynomial,
+    two_adic_subgroup_vanishing_polynomial,
 };
 use p3_util::iter_array_chunks_padded;
 pub use packedfield_testing::*;
@@ -575,17 +575,6 @@ pub fn test_two_adic_subgroup_vanishing_polynomial<F: TwoAdicField>() {
     }
 }
 
-pub fn test_two_adic_coset_vanishing_polynomial<F: TwoAdicField>() {
-    for log_n in 0..5 {
-        let g = F::two_adic_generator(log_n);
-        let shift = F::GENERATOR;
-        for x in cyclic_subgroup_coset_known_order(g, shift, 1 << log_n) {
-            let vanishing_polynomial_eval = two_adic_coset_vanishing_polynomial(log_n, shift, x);
-            assert_eq!(vanishing_polynomial_eval, F::ZERO);
-        }
-    }
-}
-
 pub fn test_two_adic_generator_consistency<F: TwoAdicField>() {
     let log_n = F::TWO_ADICITY;
     let g = F::two_adic_generator(log_n);
@@ -939,10 +928,6 @@ macro_rules! test_two_adic_field {
             #[test]
             fn test_two_adic_field_subgroup_vanishing_polynomial() {
                 $crate::test_two_adic_subgroup_vanishing_polynomial::<$field>();
-            }
-            #[test]
-            fn test_two_adic_coset_vanishing_polynomial() {
-                $crate::test_two_adic_coset_vanishing_polynomial::<$field>();
             }
             #[test]
             fn test_two_adic_consistency() {

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -17,8 +17,6 @@ pub use dft_testing::*;
 use num_bigint::BigUint;
 use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, PrimeField32, PrimeField64, TwoAdicField,
-    cyclic_subgroup_coset_known_order, cyclic_subgroup_known_order,
-    two_adic_subgroup_vanishing_polynomial,
 };
 use p3_util::iter_array_chunks_padded;
 pub use packedfield_testing::*;
@@ -565,16 +563,6 @@ pub fn test_generator<F: Field>(multiplicative_group_factors: &[(BigUint, u32)])
     }
 }
 
-pub fn test_two_adic_subgroup_vanishing_polynomial<F: TwoAdicField>() {
-    for log_n in 0..5 {
-        let g = F::two_adic_generator(log_n);
-        for x in cyclic_subgroup_known_order(g, 1 << log_n) {
-            let vanishing_polynomial_eval = two_adic_subgroup_vanishing_polynomial(log_n, x);
-            assert_eq!(vanishing_polynomial_eval, F::ZERO);
-        }
-    }
-}
-
 pub fn test_two_adic_generator_consistency<F: TwoAdicField>() {
     let log_n = F::TWO_ADICITY;
     let g = F::two_adic_generator(log_n);
@@ -925,10 +913,6 @@ macro_rules! test_prime_field_32 {
 macro_rules! test_two_adic_field {
     ($field:ty) => {
         mod two_adic_field_tests {
-            #[test]
-            fn test_two_adic_field_subgroup_vanishing_polynomial() {
-                $crate::test_two_adic_subgroup_vanishing_polynomial::<$field>();
-            }
             #[test]
             fn test_two_adic_consistency() {
                 $crate::test_two_adic_generator_consistency::<$field>();

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -6,12 +6,7 @@ use core::ops::Mul;
 use p3_maybe_rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::field::Field;
-use crate::{PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32, TwoAdicField};
-
-/// Computes `Z_H(x)`, where `Z_H` is the vanishing polynomial of a multiplicative subgroup of order `2^log_n`.
-pub fn two_adic_subgroup_vanishing_polynomial<F: TwoAdicField>(log_n: usize, x: F) -> F {
-    x.exp_power_of_2(log_n) - F::ONE
-}
+use crate::{PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32};
 
 /// Computes a multiplicative subgroup whose order is known in advance.
 pub fn cyclic_subgroup_known_order<F: Field>(

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -13,12 +13,6 @@ pub fn two_adic_subgroup_vanishing_polynomial<F: TwoAdicField>(log_n: usize, x: 
     x.exp_power_of_2(log_n) - F::ONE
 }
 
-/// Computes `Z_{sH}(x)`, where `Z_{sH}` is the vanishing polynomial of the given coset of a multiplicative
-/// subgroup of order `2^log_n`.
-pub fn two_adic_coset_vanishing_polynomial<F: TwoAdicField>(log_n: usize, shift: F, x: F) -> F {
-    x.exp_power_of_2(log_n) - shift.exp_power_of_2(log_n)
-}
-
 /// Computes a multiplicative subgroup whose order is known in advance.
 pub fn cyclic_subgroup_known_order<F: Field>(
     generator: F,

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -2,22 +2,8 @@ mod helpers {
     use p3_baby_bear::BabyBear;
     use p3_field::{
         PrimeCharacteristicRing, add_scaled_slice_in_place, dot_product, field_to_array, reduce_32,
-        scale_vec, split_32, two_adic_subgroup_vanishing_polynomial,
+        scale_vec, split_32,
     };
-
-    #[test]
-    fn test_two_adic_subgroup_vanishing_polynomial() {
-        // x = 3, log_n = 3 → compute x^8 - 1
-        let x = BabyBear::TWO + BabyBear::ONE;
-        let log_n = 3;
-
-        // x^8 = 3^8 = 6561
-        let x_pow = BabyBear::from_u16(6561);
-
-        let expected = x_pow - BabyBear::ONE;
-        let result = two_adic_subgroup_vanishing_polynomial(log_n, x);
-        assert_eq!(result, expected);
-    }
 
     #[test]
     fn test_scale_vec() {

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -2,8 +2,7 @@ mod helpers {
     use p3_baby_bear::BabyBear;
     use p3_field::{
         PrimeCharacteristicRing, add_scaled_slice_in_place, dot_product, field_to_array, reduce_32,
-        scale_vec, split_32, two_adic_coset_vanishing_polynomial,
-        two_adic_subgroup_vanishing_polynomial,
+        scale_vec, split_32, two_adic_subgroup_vanishing_polynomial,
     };
 
     #[test]
@@ -17,24 +16,6 @@ mod helpers {
 
         let expected = x_pow - BabyBear::ONE;
         let result = two_adic_subgroup_vanishing_polynomial(log_n, x);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_two_adic_coset_vanishing_polynomial() {
-        // x = 2, shift = 5, log_n = 2 → compute x^4 - shift^4
-        let x = BabyBear::TWO;
-        let shift = BabyBear::from_u64(5);
-        let log_n = 2;
-
-        // x^4 = 2^4
-        let x_pow = x * x * x * x;
-
-        // shift^4 = 5^4
-        let shift_pow = shift * shift * shift * shift;
-
-        let expected = x_pow - shift_pow;
-        let result = two_adic_coset_vanishing_polynomial(log_n, shift, x);
         assert_eq!(result, expected);
     }
 


### PR DESCRIPTION
Was originally an optimization attempt, but it doesn't do much perf-wise. Still seems cleaner to deal with the coset directly.