### PR TITLE
Speeding Up Extension Field Muls

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -20,6 +20,7 @@ num-bigint.workspace = true
 rand.workspace = true
 p3-field-testing.workspace = true
 p3-dft.workspace = true
+p3-util.workspace = true
 criterion.workspace = true
 serde_json.workspace = true
 rand_xoshiro.workspace = true

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -23,10 +23,14 @@ fn bench_field(c: &mut Criterion) {
     // benchmark_iter_sum::<F, 8, REPS>(c, name);
     // benchmark_iter_sum::<F, 12, REPS>(c, name);
 
-    // benchmark_dot_array::<F, 2, REPS>(c, name);
-    // benchmark_dot_array::<F, 3, REPS>(c, name);
+    benchmark_dot_array::<F, 2, REPS>(c, name);
+    benchmark_dot_array::<F, 3, REPS>(c, name);
     benchmark_dot_array::<F, 4, REPS>(c, name);
     benchmark_dot_array::<F, 5, REPS>(c, name);
+    benchmark_dot_array::<F, 6, REPS>(c, name);
+    benchmark_dot_array::<F, 7, REPS>(c, name);
+    benchmark_dot_array::<F, 8, REPS>(c, name);
+    benchmark_dot_array::<F, 9, REPS>(c, name);
     benchmark_dot_array::<F, 16, REPS>(c, name);
     benchmark_dot_array::<F, 64, REPS>(c, name);
 

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,5 +1,3 @@
-use core::any::type_name;
-
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -17,18 +15,15 @@ type F = BabyBear;
 
 fn bench_field(c: &mut Criterion) {
     let name = "BabyBear";
-    const REPS: usize = 100;
-    // benchmark_inv::<F>(c, name);
-    // benchmark_iter_sum::<F, 4, REPS>(c, name);
-    // benchmark_iter_sum::<F, 8, REPS>(c, name);
-    // benchmark_iter_sum::<F, 12, REPS>(c, name);
+    const REPS: usize = 1000;
+    benchmark_inv::<F>(c, name);
+    benchmark_iter_sum::<F, 4, REPS>(c, name);
+    benchmark_iter_sum::<F, 8, REPS>(c, name);
+    benchmark_iter_sum::<F, 12, REPS>(c, name);
 
     benchmark_dot_array::<F, 2, REPS>(c, name);
-    benchmark_dot_array::<F, 3, REPS>(c, name);
     benchmark_dot_array::<F, 4, REPS>(c, name);
     benchmark_dot_array::<F, 5, REPS>(c, name);
-    benchmark_dot_array::<F, 6, REPS>(c, name);
-    benchmark_dot_array::<F, 7, REPS>(c, name);
     benchmark_dot_array::<F, 8, REPS>(c, name);
     benchmark_dot_array::<F, 9, REPS>(c, name);
     benchmark_dot_array::<F, 16, REPS>(c, name);
@@ -39,8 +34,8 @@ fn bench_field(c: &mut Criterion) {
     const L_REPS: usize = 10 * REPS;
     benchmark_add_latency::<F, L_REPS>(c, name);
     benchmark_add_throughput::<F, REPS>(c, name);
-    // benchmark_sub_latency::<F, L_REPS>(c, name);
-    // benchmark_sub_throughput::<F, REPS>(c, name);
+    benchmark_sub_latency::<F, L_REPS>(c, name);
+    benchmark_sub_throughput::<F, REPS>(c, name);
     benchmark_mul_latency::<F, L_REPS>(c, name);
     benchmark_mul_throughput::<F, REPS>(c, name);
 

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -21,13 +21,16 @@ fn bench_field(c: &mut Criterion) {
     benchmark_iter_sum::<F, 8, REPS>(c, name);
     benchmark_iter_sum::<F, 12, REPS>(c, name);
 
-    benchmark_dot_array::<F, 2, REPS>(c, name);
-    benchmark_dot_array::<F, 4, REPS>(c, name);
-    benchmark_dot_array::<F, 5, REPS>(c, name);
-    benchmark_dot_array::<F, 8, REPS>(c, name);
-    benchmark_dot_array::<F, 9, REPS>(c, name);
-    benchmark_dot_array::<F, 16, REPS>(c, name);
-    benchmark_dot_array::<F, 64, REPS>(c, name);
+    benchmark_dot_array::<F, 2>(c, name);
+    benchmark_dot_array::<F, 3>(c, name);
+    benchmark_dot_array::<F, 4>(c, name);
+    benchmark_dot_array::<F, 5>(c, name);
+    benchmark_dot_array::<F, 6>(c, name);
+    benchmark_dot_array::<F, 7>(c, name);
+    benchmark_dot_array::<F, 8>(c, name);
+    benchmark_dot_array::<F, 9>(c, name);
+    benchmark_dot_array::<F, 16>(c, name);
+    benchmark_dot_array::<F, 64>(c, name);
 
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.

--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -8,6 +8,8 @@ use p3_field_testing::bench_func::{
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,
     benchmark_sub_throughput,
 };
+use p3_field_testing::benchmark_dot_array;
+use p3_util::pretty_name;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -15,19 +17,28 @@ type F = BabyBear;
 
 fn bench_field(c: &mut Criterion) {
     let name = "BabyBear";
-    const REPS: usize = 1000;
-    benchmark_inv::<F>(c, name);
-    benchmark_iter_sum::<F, 4, REPS>(c, name);
-    benchmark_iter_sum::<F, 8, REPS>(c, name);
-    benchmark_iter_sum::<F, 12, REPS>(c, name);
+    const REPS: usize = 100;
+    // benchmark_inv::<F>(c, name);
+    // benchmark_iter_sum::<F, 4, REPS>(c, name);
+    // benchmark_iter_sum::<F, 8, REPS>(c, name);
+    // benchmark_iter_sum::<F, 12, REPS>(c, name);
+
+    // benchmark_dot_array::<F, 2, REPS>(c, name);
+    // benchmark_dot_array::<F, 3, REPS>(c, name);
+    benchmark_dot_array::<F, 4, REPS>(c, name);
+    benchmark_dot_array::<F, 5, REPS>(c, name);
+    benchmark_dot_array::<F, 16, REPS>(c, name);
+    benchmark_dot_array::<F, 64, REPS>(c, name);
 
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.
     const L_REPS: usize = 10 * REPS;
     benchmark_add_latency::<F, L_REPS>(c, name);
     benchmark_add_throughput::<F, REPS>(c, name);
-    benchmark_sub_latency::<F, L_REPS>(c, name);
-    benchmark_sub_throughput::<F, REPS>(c, name);
+    // benchmark_sub_latency::<F, L_REPS>(c, name);
+    // benchmark_sub_throughput::<F, REPS>(c, name);
+    benchmark_mul_latency::<F, L_REPS>(c, name);
+    benchmark_mul_throughput::<F, REPS>(c, name);
 
     let mut rng = SmallRng::seed_from_u64(1);
     c.bench_function("7th_root", |b| {
@@ -40,7 +51,7 @@ fn bench_field(c: &mut Criterion) {
 }
 
 fn bench_packedfield(c: &mut Criterion) {
-    let name = type_name::<<F as Field>::Packing>().to_string();
+    let name = pretty_name::<<F as Field>::Packing>().to_string();
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.
     const REPS: usize = 100;

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -4,6 +4,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field_testing::bench_func::{
     benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
 };
+use p3_field_testing::benchmark_mul;
 
 type EF4 = BinomialExtensionField<BabyBear, 4>;
 type EF5 = BinomialExtensionField<BabyBear, 5>;
@@ -17,6 +18,7 @@ fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
     benchmark_square::<EF4>(c, name);
     benchmark_inv::<EF4>(c, name);
+    benchmark_mul::<EF5>(c, name);
     benchmark_mul_throughput::<EF4, REPS>(c, name);
     benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
@@ -25,6 +27,7 @@ fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
     benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
+    benchmark_mul::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);
     benchmark_mul_latency::<EF5, L_REPS>(c, name);
 }

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -115,11 +115,7 @@ pub fn benchmark_sum_array<R: PrimeCharacteristicRing + Copy, const N: usize, co
     });
 }
 
-/// Benchmark the time taken to sum an array [[F; N]; REPS] by summing each array
-/// [F; N] using sum_array method and accumulating the sums into an accumulator.
-///
-/// Making N larger and REPS smaller (vs the opposite) leans the benchmark more sensitive towards
-/// the latency (resp throughput) of the sum method.
+/// Benchmark the time taken to do `REPS` dot products on a pair of `[R; N]` arrays.
 pub fn benchmark_dot_array<R: PrimeCharacteristicRing + Copy, const N: usize, const REPS: usize>(
     c: &mut Criterion,
     name: &str,
@@ -135,7 +131,7 @@ pub fn benchmark_dot_array<R: PrimeCharacteristicRing + Copy, const N: usize, co
         b.iter(|| {
             let mut out = R::zero_vec(REPS);
             for (i, (lhs, rhs)) in input.iter().enumerate() {
-                out[i] += R::dot_product::<N>(lhs, rhs)
+                out[i] = R::dot_product::<N>(lhs, rhs)
             }
             out
         })

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -8,6 +8,20 @@ use rand::prelude::Distribution;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
+/// Not useful for benchmarking prime fields as multiplication is too fast but
+/// handy for extension fields.
+pub fn benchmark_mul<F: Field>(c: &mut Criterion, name: &str)
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    let x = rng.random::<F>();
+    let y = rng.random::<F>();
+    c.bench_function(&format!("{} mul", name), |b| {
+        b.iter(|| black_box(black_box(x) * black_box(y)))
+    });
+}
+
 pub fn benchmark_square<F: Field>(c: &mut Criterion, name: &str)
 where
     StandardUniform: Distribution<F>,
@@ -115,26 +129,22 @@ pub fn benchmark_sum_array<R: PrimeCharacteristicRing + Copy, const N: usize, co
     });
 }
 
-/// Benchmark the time taken to do `REPS` dot products on a pair of `[R; N]` arrays.
-pub fn benchmark_dot_array<R: PrimeCharacteristicRing + Copy, const N: usize, const REPS: usize>(
+/// Benchmark the time taken to do dot products on a pair of `[R; N]` arrays.
+///
+/// These numbers get more trustworthy as N increases. Small N leads to the
+/// computation being too fast to be measured accurately.
+pub fn benchmark_dot_array<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,
 ) where
     StandardUniform: Distribution<R>,
 {
     let mut rng = SmallRng::seed_from_u64(1);
-    let mut input = Vec::new();
-    for _ in 0..REPS {
-        input.push((rng.random::<[R; N]>(), rng.random::<[R; N]>()));
-    }
-    c.bench_function(&format!("{} dot product/{}, {}", name, REPS, N), |b| {
-        b.iter(|| {
-            let mut out = R::zero_vec(REPS);
-            for (i, (lhs, rhs)) in input.iter().enumerate() {
-                out[i] = R::dot_product::<N>(lhs, rhs)
-            }
-            out
-        })
+    let lhs = rng.random::<[R; N]>();
+    let rhs = rng.random::<[R; N]>();
+
+    c.bench_function(&format!("{} dot product/{}", name, N), |b| {
+        b.iter(|| black_box(R::dot_product(black_box(&lhs), black_box(&rhs))))
     });
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -615,7 +615,7 @@ pub(crate) fn vector_sub<
 pub(super) fn binomial_mul<
     F: Field,
     R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F> + Add<Output = R2> + Clone,
+    R2: Algebra<F>,
     const D: usize,
 >(
     a: &[R; D],
@@ -662,7 +662,7 @@ fn quadratic_mul<F, R, R2, const D: usize>(a: &[R; D], b: &[R2; D], res: &mut [R
 where
     F: Field,
     R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F> + Add<Output = R2> + Clone,
+    R2: Algebra<F>,
 {
     let b1_w = b[1].clone() * w;
 
@@ -710,12 +710,7 @@ fn cubic_inv<F: Field, const D: usize>(a: &[F; D], res: &mut [F; D], w: F) {
 
 /// karatsuba multiplication for cubic extension field
 #[inline]
-pub(crate) fn cubic_mul<
-    F: Field,
-    R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F> + Add<Output = R2> + Clone,
-    const D: usize,
->(
+pub(crate) fn cubic_mul<F: Field, R: Algebra<F> + Algebra<R2>, R2: Algebra<F>, const D: usize>(
     a: &[R; D],
     b: &[R2; D],
     res: &mut [R; D],
@@ -765,7 +760,7 @@ fn quartic_mul<F, R, R2, const D: usize>(a: &[R; D], b: &[R2; D], res: &mut [R; 
 where
     F: Field,
     R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F> + Add<Output = R2> + Clone,
+    R2: Algebra<F>,
 {
     assert_eq!(D, 4);
     let b_r_rev: [R; 5] = [
@@ -813,7 +808,7 @@ fn quintic_mul<F, R, R2, const D: usize>(a: &[R; D], b: &[R2; D], res: &mut [R; 
 where
     F: Field,
     R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F> + Add<Output = R2> + Clone,
+    R2: Algebra<F>,
 {
     assert_eq!(D, 5);
     let b_r_rev: [R; 6] = [

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -647,7 +647,7 @@ pub(super) fn binomial_mul<
 /// Optimized multiplication for quadratic extension field.
 ///
 /// Makes use of the in built field dot product code. This is optimized for the case that
-/// R is a prime field or it's packing.
+/// R is a prime field or its packing.
 ///
 /// ```text
 ///     A = a0 + a1·X
@@ -754,7 +754,7 @@ pub(crate) fn cubic_square<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: u
 /// Multiplication in a quartic binomial extension field.
 ///
 /// Makes use of the in built field dot product code. This is optimized for the case that
-/// R is a prime field or it's packing.
+/// R is a prime field or its packing.
 #[inline]
 fn quartic_mul<F, R, R2, const D: usize>(a: &[R; D], b: &[R2; D], res: &mut [R; D], w: F)
 where
@@ -803,7 +803,7 @@ where
 /// Multiplication in a quintic binomial extension field.
 ///
 /// Makes use of the in built field dot product code. This is optimized for the case that
-/// R is a prime field or it's packing.
+/// R is a prime field or its packing.
 fn quintic_mul<F, R, R2, const D: usize>(a: &[R; D], b: &[R2; D], res: &mut [R; D], w: F)
 where
     F: Field,

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -419,7 +419,7 @@ where
         let mut res = Self::default();
         let w = F::W;
 
-        binomial_mul(&a, &b, &mut res.value, w);
+        binomial_mul::<F, PF, PF, D>(&a, &b, &mut res.value, w);
 
         res
     }

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -27,3 +27,7 @@ rand_xoshiro.workspace = true
 [[bench]]
 name = "bench_field"
 harness = false
+
+[[bench]]
+name = "extension"
+harness = false

--- a/koala-bear/benches/extension.rs
+++ b/koala-bear/benches/extension.rs
@@ -1,0 +1,24 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use p3_field::extension::BinomialExtensionField;
+use p3_field_testing::bench_func::{
+    benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
+};
+use p3_koala_bear::KoalaBear;
+
+type EF4 = BinomialExtensionField<KoalaBear, 4>;
+
+// Note that each round of throughput has 10 operations
+// So we should have 10 * more repetitions for latency tests.
+const REPS: usize = 100;
+const L_REPS: usize = 10 * REPS;
+
+fn bench_quartic_extension(c: &mut Criterion) {
+    let name = "BinomialExtensionField<KoalaBear, 4>";
+    benchmark_square::<EF4>(c, name);
+    benchmark_inv::<EF4>(c, name);
+    benchmark_mul_throughput::<EF4, REPS>(c, name);
+    benchmark_mul_latency::<EF4, L_REPS>(c, name);
+}
+
+criterion_group!(bench_babybear_ef, bench_quartic_extension,);
+criterion_main!(bench_babybear_ef);

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -222,7 +222,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
-        assert!(N <= (1 << 34));
+        assert!(N as u64 <= (1 << 34));
         // This code relies on assumptions about the relative size of the
         // prime and the monty parameter. If these are changes this needs to be checked.
         debug_assert!(FP::MONTY_BITS == 32);

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -220,6 +220,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
         }
     }
 
+    #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
         match N {
             0 => Self::ZERO,

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -255,24 +255,30 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
             // We need to stop at 4 as it's possible to overflow a u64 with 5 products.
             // That being said, the probability of this is tiny.
             _ => {
-                let lhs_chunks = lhs.chunks_exact(4);
-                let rhs_chunks = rhs.chunks_exact(4);
-                let acc = lhs_chunks.zip(rhs_chunks).fold(Self::ZERO, |acc, (l, r)| {
-                    acc + Self::dot_product::<4>(l.try_into().unwrap(), r.try_into().unwrap())
-                });
+                let acc =
+                    lhs.chunks_exact(4)
+                        .zip(rhs.chunks_exact(4))
+                        .fold(Self::ZERO, |acc, (l, r)| {
+                            acc + Self::dot_product::<4>(
+                                l.try_into().unwrap(),
+                                r.try_into().unwrap(),
+                            )
+                        });
+                // Index of first element of remaining:
+                let base = 4 * (N / 4);
                 match N & 3 {
                     0 => acc,
-                    1 => acc + lhs[4 * (N / 4)] * rhs[4 * (N / 4)],
+                    1 => acc + lhs[base] * rhs[base],
                     2 => {
                         acc + Self::dot_product::<2>(
-                            &lhs[(4 * (N / 4))..].try_into().unwrap(),
-                            &rhs[(4 * (N / 4))..].try_into().unwrap(),
+                            &lhs[base..].try_into().unwrap(),
+                            &rhs[base..].try_into().unwrap(),
                         )
                     }
                     3 => {
                         acc + Self::dot_product::<3>(
-                            &lhs[(4 * (N / 4))..].try_into().unwrap(),
-                            &rhs[(4 * (N / 4))..].try_into().unwrap(),
+                            &lhs[base..].try_into().unwrap(),
+                            &rhs[base..].try_into().unwrap(),
                         )
                     }
                     _ => unreachable!(),

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -22,8 +22,8 @@ use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::utils::{
-    from_monty, halve_u32, large_monty_reduce, monty_reduce, to_monty, to_monty_64,
-    to_monty_64_signed, to_monty_signed,
+    from_monty, halve_u32, large_monty_reduce, monty_reduce, monty_reduce_u128, to_monty,
+    to_monty_64, to_monty_64_signed, to_monty_signed,
 };
 use crate::{FieldParameters, MontyParameters, RelativelyPrimePower, TwoAdicData};
 
@@ -222,12 +222,17 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        assert!(N <= (1 << 34));
+        // This code relies on assumptions about the relative size of the
+        // prime and the monty parameter. If these are changes this needs to be checked.
+        debug_assert!(FP::MONTY_BITS == 32);
+        debug_assert!((FP::PRIME as u64) < (1 << 31));
         match N {
             0 => Self::ZERO,
             1 => lhs[0] * rhs[0],
             2 => {
                 // As all values are < P < 2^31, the products are < P^2 < 2^31P.
-                // Hence, summing two together we stay below 2^32P which means
+                // Hence, summing two together we stay below MONTY*P which means
                 // monty_reduce will produce a valid result.
                 let u64_prod_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
                     + (lhs[1].value as u64) * (rhs[1].value as u64);
@@ -235,8 +240,7 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
             }
             3 => {
                 // As all values are < P < 2^31, the products are < P^2 < 2^31P.
-                // Hence, summing three together will not overflow a u64 but will be
-                // larger than 2^32P.
+                // Hence, summing three together will be less than 2 * MONTY * P
                 let u64_prod_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
                     + (lhs[1].value as u64) * (rhs[1].value as u64)
                     + (lhs[2].value as u64) * (rhs[2].value as u64);
@@ -244,45 +248,93 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
             }
             4 => {
                 // As all values are < P < 2^31, the products are < P^2 < 2^31P.
-                // Hence, summing four together will not overflow a u64 but will be
-                // larger than 2^32P.
+                // Hence, summing four together will be less than 2 * MONTY * P.
                 let u64_prod_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
                     + (lhs[1].value as u64) * (rhs[1].value as u64)
                     + (lhs[2].value as u64) * (rhs[2].value as u64)
                     + (lhs[3].value as u64) * (rhs[3].value as u64);
                 Self::new_monty(large_monty_reduce::<FP>(u64_prod_sum))
             }
-            // We need to stop at 4 as it's possible to overflow a u64 with 5 products.
-            // That being said, the probability of this is tiny.
+            5 => {
+                let head_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
+                    + (lhs[1].value as u64) * (rhs[1].value as u64)
+                    + (lhs[2].value as u64) * (rhs[2].value as u64)
+                    + (lhs[3].value as u64) * (rhs[3].value as u64);
+                let tail_sum = (lhs[4].value as u64) * (rhs[4].value as u64);
+                // head_sum < 4*P^2, tail_sum < P^2.
+                let head_sum_corr = head_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                // head_sum.min(head_sum_corr) is guaranteed to be < 2*P^2.
+                // Hence sum < 4P^2 < 2 * MONTY * P
+                let sum = head_sum.min(head_sum_corr) + tail_sum;
+                Self::new_monty(large_monty_reduce::<FP>(sum))
+            }
+            6 => {
+                let head_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
+                    + (lhs[1].value as u64) * (rhs[1].value as u64)
+                    + (lhs[2].value as u64) * (rhs[2].value as u64)
+                    + (lhs[3].value as u64) * (rhs[3].value as u64);
+                let tail_sum = (lhs[4].value as u64) * (rhs[4].value as u64)
+                    + (lhs[5].value as u64) * (rhs[5].value as u64);
+                // head_sum < 4*P^2, tail_sum < 2*P^2.
+                let head_sum_corr = head_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                // head_sum.min(head_sum_corr) is guaranteed to be < 2*P^2.
+                // Hence sum < 4P^2 < 2 * MONTY * P
+                let sum = head_sum.min(head_sum_corr) + tail_sum;
+                Self::new_monty(large_monty_reduce::<FP>(sum))
+            }
+            7 => {
+                let head_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
+                    + (lhs[1].value as u64) * (rhs[1].value as u64)
+                    + (lhs[2].value as u64) * (rhs[2].value as u64)
+                    + (lhs[3].value as u64) * (rhs[3].value as u64);
+                let tail_sum = (lhs[4].value as u64) * (rhs[4].value as u64)
+                    + lhs[5].value as u64 * (rhs[5].value as u64)
+                    + lhs[6].value as u64 * (rhs[6].value as u64);
+                // head_sum, tail_sum are guaranteed to be < 4*P^2.
+                let head_sum_corr = head_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                let tail_sum_corr = tail_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                // head_sum.min(head_sum_corr), tail_sum.min(tail_sum_corr) is guaranteed to be < 2*P^2.
+                // Hence sum < 4P^2 < 2 * MONTY * P
+                let sum = head_sum.min(head_sum_corr) + tail_sum.min(tail_sum_corr);
+                Self::new_monty(large_monty_reduce::<FP>(sum))
+            }
+            8 => {
+                let head_sum = (lhs[0].value as u64) * (rhs[0].value as u64)
+                    + (lhs[1].value as u64) * (rhs[1].value as u64)
+                    + (lhs[2].value as u64) * (rhs[2].value as u64)
+                    + (lhs[3].value as u64) * (rhs[3].value as u64);
+                let tail_sum = (lhs[4].value as u64) * (rhs[4].value as u64)
+                    + lhs[5].value as u64 * (rhs[5].value as u64)
+                    + lhs[6].value as u64 * (rhs[6].value as u64)
+                    + lhs[7].value as u64 * (rhs[7].value as u64);
+                // head_sum, tail_sum are guaranteed to be < 4*P^2.
+                let head_sum_corr = head_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                let tail_sum_corr = tail_sum.wrapping_sub((FP::PRIME as u64) << FP::MONTY_BITS);
+                // head_sum.min(head_sum_corr), tail_sum.min(tail_sum_corr) is guaranteed to be < 2*P^2.
+                // Hence sum < 4P^2 < 2 * MONTY * P
+                let sum = head_sum.min(head_sum_corr) + tail_sum.min(tail_sum_corr);
+                Self::new_monty(large_monty_reduce::<FP>(sum))
+            }
             _ => {
-                let acc =
-                    lhs.chunks_exact(4)
-                        .zip(rhs.chunks_exact(4))
-                        .fold(Self::ZERO, |acc, (l, r)| {
-                            acc + Self::dot_product::<4>(
-                                l.try_into().unwrap(),
-                                r.try_into().unwrap(),
-                            )
-                        });
-                // Index of first element of remaining:
-                let base = 4 * (N / 4);
-                match N & 3 {
-                    0 => acc,
-                    1 => acc + lhs[base] * rhs[base],
-                    2 => {
-                        acc + Self::dot_product::<2>(
-                            &lhs[base..].try_into().unwrap(),
-                            &rhs[base..].try_into().unwrap(),
-                        )
-                    }
-                    3 => {
-                        acc + Self::dot_product::<3>(
-                            &lhs[base..].try_into().unwrap(),
-                            &rhs[base..].try_into().unwrap(),
-                        )
-                    }
-                    _ => unreachable!(),
-                }
+                // For large enough N, we accumulate into a u128. This helps the compiler as it lets
+                // it do a lot of computation in parallel as it knows that summing u128's is associative.
+                let acc_u128 = lhs
+                    .chunks(4)
+                    .zip(rhs.chunks(4))
+                    .map(|(l, r)| {
+                        // As all values are < P < 2^31, the products are < P^2 < 2^31P.
+                        // Hence, summing four together will not overflow a u64 but will be
+                        // larger than 2^32P.
+                        let u64_prod_sum = l
+                            .iter()
+                            .zip(r)
+                            .map(|(l, r)| (l.value as u64) * (r.value as u64))
+                            .sum::<u64>();
+                        u64_prod_sum as u128
+                    })
+                    .sum();
+                // As N <= 2^34 by the earlier assertion, acc_u128 <= 2^34 * P^2 < 2^34 * 2^62 < 2^96.
+                Self::new_monty(monty_reduce_u128::<FP>(acc_u128))
             }
         }
     }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -251,6 +251,39 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
                     + (u[3].value as u64) * (v[3].value as u64);
                 Self::new_monty(large_monty_reduce::<FP>(u64_prod_sum))
             }
+            5 => {
+                let (u_left, u_right) = u.split_at(4);
+                let (v_left, v_right) = u.split_at(4);
+                Self::dot_product::<4>(u_left.try_into().unwrap(), v_left.try_into().unwrap())
+                    + u_right[0] * v_right[0]
+            }
+            6 => {
+                let (u_left, u_right) = u.split_at(4);
+                let (v_left, v_right) = u.split_at(4);
+                Self::dot_product::<4>(u_left.try_into().unwrap(), v_left.try_into().unwrap())
+                    + Self::dot_product::<2>(
+                        u_right.try_into().unwrap(),
+                        v_right.try_into().unwrap(),
+                    )
+            }
+            7 => {
+                let (u_left, u_right) = u.split_at(4);
+                let (v_left, v_right) = u.split_at(4);
+                Self::dot_product::<4>(u_left.try_into().unwrap(), v_left.try_into().unwrap())
+                    + Self::dot_product::<3>(
+                        u_right.try_into().unwrap(),
+                        v_right.try_into().unwrap(),
+                    )
+            }
+            8 => {
+                let (u_left, u_right) = u.split_at(4);
+                let (v_left, v_right) = u.split_at(4);
+                Self::dot_product::<4>(u_left.try_into().unwrap(), v_left.try_into().unwrap())
+                    + Self::dot_product::<4>(
+                        u_right.try_into().unwrap(),
+                        v_right.try_into().unwrap(),
+                    )
+            }
             // We need to stop at 4 as it's possible to overflow a u64 with 5 products.
             // That being said, the probability of this is tiny.
             _ => {

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -22,7 +22,8 @@ use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::utils::{
-    from_monty, halve_u32, monty_reduce, to_monty, to_monty_64, to_monty_64_signed, to_monty_signed,
+    from_monty, halve_u32, large_monty_reduce, monty_reduce, monty_reduce_u128, to_monty,
+    to_monty_64, to_monty_64_signed, to_monty_signed,
 };
 use crate::{FieldParameters, MontyParameters, RelativelyPrimePower, TwoAdicData};
 
@@ -216,6 +217,50 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
             6 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<2>(&input[4..]),
             7 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<3>(&input[4..]),
             _ => input.iter().copied().sum(),
+        }
+    }
+
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        match N {
+            0 => Self::ZERO,
+            1 => u[0] * v[0],
+            2 => {
+                // As all values are < P < 2^31, the products are < P^2 < 2^31P.
+                // Hence, summing two together we stay below 2^32P which means
+                // monty_reduce will produce a valid result.
+                let u64_prod_sum = (u[0].value as u64) * (v[0].value as u64)
+                    + (u[1].value as u64) * (v[1].value as u64);
+                Self::new_monty(monty_reduce::<FP>(u64_prod_sum))
+            }
+            3 => {
+                // As all values are < P < 2^31, the products are < P^2 < 2^31P.
+                // Hence, summing three together will not overflow a u64 but will be
+                // larger than 2^32P.
+                let u64_prod_sum = (u[0].value as u64) * (v[0].value as u64)
+                    + (u[1].value as u64) * (v[1].value as u64)
+                    + (u[2].value as u64) * (v[2].value as u64);
+                Self::new_monty(large_monty_reduce::<FP>(u64_prod_sum))
+            }
+            4 => {
+                // As all values are < P < 2^31, the products are < P^2 < 2^31P.
+                // Hence, summing four together will not overflow a u64 but will be
+                // larger than 2^32P.
+                let u64_prod_sum = (u[0].value as u64) * (v[0].value as u64)
+                    + (u[1].value as u64) * (v[1].value as u64)
+                    + (u[2].value as u64) * (v[2].value as u64)
+                    + (u[3].value as u64) * (v[3].value as u64);
+                Self::new_monty(large_monty_reduce::<FP>(u64_prod_sum))
+            }
+            // We need to stop at 4 as it's possible to overflow a u64 with 5 products.
+            // That being said, the probability of this is tiny.
+            _ => {
+                let u128_prod_sum = u
+                    .iter()
+                    .zip(v)
+                    .map(|(a, b)| a.value as u128 * b.value as u128)
+                    .sum::<u128>();
+                Self::new_monty(monty_reduce_u128::<FP>(u128_prod_sum))
+            }
         }
     }
 }

--- a/monty-31/src/utils.rs
+++ b/monty-31/src/utils.rs
@@ -121,3 +121,23 @@ pub(crate) const fn large_monty_reduce<MP: MontyParameters>(x: u64) -> u32 {
     let corr = if over { MP::PRIME } else { 0 };
     x_sub_u_hi.wrapping_add(corr)
 }
+
+/// Perform a monty reduction on a u128 in the range `[0, 2^96)`
+///
+/// The input will be in `[0, P)` and be equal to `x * MONTY^{-1} mod P`.
+pub(crate) fn monty_reduce_u128<MP: MontyParameters>(x: u128) -> u32 {
+    // TODO: There is probably a way to do this faster than using %.
+
+    // Need to find MONTY^{-1} mod P.
+    // As P * MONTY_MU = 1 mod MONTY, we know that P * MONTY_MU = 1 + k * MONTY for some k.
+    // Thus k * MONTY = -1 mod P.
+    // Rearranging, we get k = (P * MONTY_MU - 1) / MONTY.
+    // Thus we want -k = P - k = P - (P * MONTY_MU - 1) / MONTY.
+
+    // Compiler should realize that this is a constant.
+    let monty_inv_mod_p =
+        MP::PRIME - ((((MP::PRIME as u64) * (MP::MONTY_MU as u64)) - 1) >> MP::MONTY_BITS) as u32;
+
+    // As monty_inv_mod_p < 2^32, x * monty_inv_mod_p < 2^128 so the product below will not overflow.
+    ((x * (monty_inv_mod_p as u128)) % (MP::PRIME as u128)) as u32
+}

--- a/monty-31/src/utils.rs
+++ b/monty-31/src/utils.rs
@@ -121,24 +121,3 @@ pub(crate) const fn large_monty_reduce<MP: MontyParameters>(x: u64) -> u32 {
     let corr = if over { MP::PRIME } else { 0 };
     x_sub_u_hi.wrapping_add(corr)
 }
-
-/// Montgomery reduction of a `u128` value in the range `[0, 2^96)`.
-/// the output will lie in `[0, P)`.
-///
-/// This is slower than `monty_reduce` but has a larger input range.
-#[inline]
-#[must_use]
-pub(crate) const fn monty_reduce_u128<MP: MontyParameters>(x: u128) -> u32 {
-    // Need to find MONTY^{-1} mod P.
-    // As P * MONTY_MU = 1 mod MONTY, we know that P * MONTY_MU = 1 + k * MONTY for some k.
-    // Thus k * MONTY = -1 mod P.
-    // Rearranging, we get k = (P * MONTY_MU - 1) / MONTY.
-    // Thus we want -k = P - k = P - (P * MONTY_MU - 1) / MONTY.
-
-    // Compiler should realize that this is a constant.
-    let monty_inv_mod_p =
-        MP::PRIME - ((((MP::PRIME as u64) * (MP::MONTY_MU as u64)) - 1) >> MP::MONTY_BITS) as u32;
-
-    // Note that k < P as MONTY_MU < MONTY.
-    ((x * (monty_inv_mod_p as u128)) % (MP::PRIME as u128)) as u32
-}

--- a/monty-31/src/utils.rs
+++ b/monty-31/src/utils.rs
@@ -90,8 +90,8 @@ pub(crate) const fn monty_reduce<MP: MontyParameters>(x: u64) -> u32 {
 }
 
 /// Montgomery reduction of a value in `0..P << MONTY_BITS`.
-/// the input must be in [0, 2 * MONTY * P).
-/// the output will be in [0, P).
+/// The input must be in [0, 2 * MONTY * P).
+/// The output will be in [0, P).
 ///
 /// This is slower than `monty_reduce` but has a larger input range.
 #[inline]

--- a/monty-31/src/utils.rs
+++ b/monty-31/src/utils.rs
@@ -2,7 +2,7 @@ use crate::{FieldParameters, MontyParameters};
 
 /// Convert a u32 into MONTY form.
 /// There are no constraints on the input.
-/// The output will be a u32 in range [0, P).
+/// The output will be a u32 in range `[0, P)`.
 #[inline]
 pub(crate) const fn to_monty<MP: MontyParameters>(x: u32) -> u32 {
     (((x as u64) << MP::MONTY_BITS) % MP::PRIME as u64) as u32
@@ -10,7 +10,7 @@ pub(crate) const fn to_monty<MP: MontyParameters>(x: u32) -> u32 {
 
 /// Convert an i32 into MONTY form.
 /// There are no constraints on the input.
-/// The output will be a u32 in range [0, P).
+/// The output will be a u32 in range `[0, P)`.
 #[inline]
 pub(crate) const fn to_monty_signed<MP: MontyParameters>(x: i32) -> u32 {
     let red = (((x as i64) << MP::MONTY_BITS) % MP::PRIME as i64) as i32;
@@ -23,7 +23,7 @@ pub(crate) const fn to_monty_signed<MP: MontyParameters>(x: i32) -> u32 {
 
 /// Convert a u64 into MONTY form.
 /// There are no constraints on the input.
-/// The output will be a u32 in range [0, P).
+/// The output will be a u32 in range `[0, P)`.
 #[inline]
 pub(crate) const fn to_monty_64<MP: MontyParameters>(x: u64) -> u32 {
     (((x as u128) << MP::MONTY_BITS) % MP::PRIME as u128) as u32
@@ -31,7 +31,7 @@ pub(crate) const fn to_monty_64<MP: MontyParameters>(x: u64) -> u32 {
 
 /// Convert an i64 into MONTY form.
 /// There are no constraints on the input.
-/// The output will be a u32 in range [0, P).
+/// The output will be a u32 in range `[0, P)`.
 #[inline]
 pub(crate) const fn to_monty_64_signed<MP: MontyParameters>(x: i64) -> u32 {
     let red = (((x as i128) << MP::MONTY_BITS) % MP::PRIME as i128) as i32;
@@ -44,16 +44,16 @@ pub(crate) const fn to_monty_64_signed<MP: MontyParameters>(x: i64) -> u32 {
 
 /// Convert a u32 out of MONTY form.
 /// There are no constraints on the input.
-/// The output will be a u32 in range [0, P).
+/// The output will be a u32 in range `[0, P)`.
 #[inline]
 #[must_use]
 pub(crate) const fn from_monty<MP: MontyParameters>(x: u32) -> u32 {
     monty_reduce::<MP>(x as u64)
 }
 
-/// Given an element x from a 31 bit field F_P compute x/2.
-/// The input must be in [0, P).
-/// The output will also be in [0, P).
+/// Given an element `x` from a 31 bit field `F` compute `x/2`.
+/// The input must be in `[0, P)`.
+/// The output will also be in `[0, P)`.
 #[inline]
 pub(crate) const fn halve_u32<FP: FieldParameters>(input: u32) -> u32 {
     let shr = input >> 1;
@@ -63,16 +63,82 @@ pub(crate) const fn halve_u32<FP: FieldParameters>(input: u32) -> u32 {
 }
 
 /// Montgomery reduction of a value in `0..P << MONTY_BITS`.
-/// the input must be in [0, MONTY * P).
-/// the output will be in [0, P).
+/// the input must be in `[0, MONTY * P)`.
+/// the output will be in `[0, P)`.
 #[inline]
 #[must_use]
 pub(crate) const fn monty_reduce<MP: MontyParameters>(x: u64) -> u32 {
+    // t = x * MONTY_MU mod MONTY
     let t = x.wrapping_mul(MP::MONTY_MU as u64) & (MP::MONTY_MASK as u64);
+
+    // u = t * P
     let u = t * (MP::PRIME as u64);
+
+    // Thus:
+    // 1. x - u = x - t * P = x mod P
+    // 2. x - u = x - x * MONTY_MU * P mod MONTY = 0 mod MONTY
+    // For the second point note that MONTY_MU = P^{-1} mod MONTY.
+
+    // Additionally, u < MONTY * P so: - MONTY * P < x - u < MONTY * P
+    // Thus after dividing by MONTY, -P < (x - u)/MONTY < P.
+    // So we can just add P to the result if it is negative.
 
     let (x_sub_u, over) = x.overflowing_sub(u);
     let x_sub_u_hi = (x_sub_u >> MP::MONTY_BITS) as u32;
     let corr = if over { MP::PRIME } else { 0 };
     x_sub_u_hi.wrapping_add(corr)
+}
+
+/// Montgomery reduction of a value in `0..P << MONTY_BITS`.
+/// the input must be in [0, 2 * MONTY * P).
+/// the output will be in [0, P).
+///
+/// This is slower than `monty_reduce` but has a larger input range.
+#[inline]
+#[must_use]
+pub(crate) const fn large_monty_reduce<MP: MontyParameters>(x: u64) -> u32 {
+    // t = x * MONTY_MU mod MONTY
+    let t = x.wrapping_mul(MP::MONTY_MU as u64) & (MP::MONTY_MASK as u64);
+
+    // u = t * P
+    let u = t * (MP::PRIME as u64);
+
+    // Thus:
+    // 1. x - u = x - t * P = x mod P
+    // 2. x - u = x - x * MONTY_MU * P mod MONTY = 0 mod MONTY
+    // For the second point note that MONTY_MU = P^{-1} mod MONTY.
+
+    // This time, - MONTY * P < x - u < 2 * MONTY * P so we need to be
+    // more careful with our reduction.
+    // The trick is just to first reduce x to lie in [0, MONTY * P).
+    let (x_prime, over) = x.overflowing_sub((MP::PRIME as u64) << MP::MONTY_BITS);
+    let x_corr = if over { x } else { x_prime };
+
+    // Now we can do the same as before.
+
+    let (x_sub_u, over) = x_corr.overflowing_sub(u);
+    let x_sub_u_hi = (x_sub_u >> MP::MONTY_BITS) as u32;
+    let corr = if over { MP::PRIME } else { 0 };
+    x_sub_u_hi.wrapping_add(corr)
+}
+
+/// Montgomery reduction of a `u128` value in the range `[0, 2^96)`.
+/// the output will lie in `[0, P)`.
+///
+/// This is slower than `monty_reduce` but has a larger input range.
+#[inline]
+#[must_use]
+pub(crate) const fn monty_reduce_u128<MP: MontyParameters>(x: u128) -> u32 {
+    // Need to find MONTY^{-1} mod P.
+    // As P * MONTY_MU = 1 mod MONTY, we know that P * MONTY_MU = 1 + k * MONTY for some k.
+    // Thus k * MONTY = -1 mod P.
+    // Rearranging, we get k = (P * MONTY_MU - 1) / MONTY.
+    // Thus we want -k = P - k = P - (P * MONTY_MU - 1) / MONTY.
+
+    // Compiler should realize that this is a constant.
+    let monty_inv_mod_p =
+        MP::PRIME - ((((MP::PRIME as u64) * (MP::MONTY_MU as u64)) - 1) >> MP::MONTY_BITS) as u32;
+
+    // Note that k < P as MONTY_MU < MONTY.
+    ((x * (monty_inv_mod_p as u128)) % (MP::PRIME as u128)) as u32
 }


### PR DESCRIPTION
Given #832, I wanted to play around a little with different options to speed up extension field multiplication.

This PR updates the binomial extension field operations to make use of the `dot_product` method from `PrimeCharacteristicRing`. Additionally we implement fast dot product code for Monty31 Fields. (Doing this for Mersenne31/Goldilocks is left as a TODO. I'll make an issue)

Benchmarks are a little jittery, but this improved dot-product is much better for small values of `N`. The timings around `N = 64` confuse me as they seem to fluctuate a lot depending on if the compiler works out how to vectorize everything so different compilers give different results) At any rate, if you are doing a dot product that large, you should be making use of packedfields to speed it up so it's fine if this implementation is possibly less optimal `N = 16` or so.

Coming back to Extension fields, this gives a `2x` speed up for multiplication in `BinomialextensionField<BabyBear, 4>, BinomialextensionField<BabyBear, 5>, BinomialextensionField<KoalaBear, 4>`.

This doesn't really affect our end-end proofs much but might help some downstream users.