### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       id: rs-stable
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
         targets: ${{ env.target }}
       id: rs-stable
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -135,7 +135,7 @@ jobs:
       with:
         components: rustfmt
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION


**Description:**
This PR updates the GitHub Actions cache action from v3 to v4 to use the latest version with improved performance and reliability.

Changes made:
- Updated all instances of `actions/cache@v3` to `actions/cache@v4` in CI workflow
- This affects caching for build artifacts and dependencies across all jobs

