### PR TITLE
chore: make jemallocator dev-dependency

### DIFF
--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -30,7 +30,7 @@ p3-uni-stark.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 
-[target.'cfg(target_family = "unix")'.dependencies]
+[target.'cfg(target_family = "unix")'.dev-dependencies]
 tikv-jemallocator = "0.6"
 
 [features]


### PR DESCRIPTION
jemalloc is only used in the example so it shouldn't be a direct dependency, which can lead to some indirect compilation issues.

Specifically: it seems if you compile for a wasm target on a unix machine, the target_family is still unix but jemalloc won't compile.