### PR TITLE
Perf: Custom code for inverse in quintic field extension.

### DIFF
--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -16,16 +16,16 @@ const L_REPS: usize = 10 * REPS;
 
 fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
-    benchmark_square::<EF4>(c, name);
-    benchmark_inv::<EF4>(c, name);
-    benchmark_mul::<EF5>(c, name);
-    benchmark_mul_throughput::<EF4, REPS>(c, name);
-    benchmark_mul_latency::<EF4, L_REPS>(c, name);
+    // benchmark_square::<EF4>(c, name);
+    // benchmark_inv::<EF4>(c, name);
+    // benchmark_mul::<EF5>(c, name);
+    // benchmark_mul_throughput::<EF4, REPS>(c, name);
+    // benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
 fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
-    benchmark_square::<EF5>(c, name);
+    // benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
     benchmark_mul::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -16,16 +16,16 @@ const L_REPS: usize = 10 * REPS;
 
 fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
-    // benchmark_square::<EF4>(c, name);
-    // benchmark_inv::<EF4>(c, name);
-    // benchmark_mul::<EF5>(c, name);
-    // benchmark_mul_throughput::<EF4, REPS>(c, name);
-    // benchmark_mul_latency::<EF4, L_REPS>(c, name);
+    benchmark_square::<EF4>(c, name);
+    benchmark_inv::<EF4>(c, name);
+    benchmark_mul::<EF5>(c, name);
+    benchmark_mul_throughput::<EF4, REPS>(c, name);
+    benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
 fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
-    // benchmark_square::<EF5>(c, name);
+    benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
     benchmark_mul::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -157,7 +157,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
 
         // Need to compute: a^(n^(D-1) + n^(D-2) + ... + n)
         // This requires a linear number of multiplications and Frobenius automorphisms.
-        // If D is known, it is possible to this this in a logarithmic number. See quintic_inv
+        // If D is known, it is possible to do this in a logarithmic number. See quintic_inv
         // for an example of this.
         let mut f = self.frobenius();
         for _ in 2..D {

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -874,7 +874,7 @@ where
     res[4] = R::dot_product::<5>(a[..].try_into().unwrap(), b_r_rev[..5].try_into().unwrap());
 }
 
-/// Section 11.3.6b in Handbook of Elliptic and Hyperelliptic Curve Cryptography.
+/// Compute the inverse of a quintic binomial extension field element.
 #[inline]
 fn quintic_inv<F: BinomiallyExtendable<D>, const D: usize>(
     a: &BinomialExtensionField<F, D>,
@@ -885,7 +885,7 @@ fn quintic_inv<F: BinomiallyExtendable<D>, const D: usize>(
     let a_exp_n_plus_n_sq = (*a * a_exp_n).frobenius();
     let a_r_min_1 = a_exp_n_plus_n_sq * a_exp_n_plus_n_sq.repeated_frobenius(2);
 
-    // g = a^r is in the base field, so only compute that
+    // norm = a^r is in the base field, so only compute that
     // coefficient rather than the full product.
     let a_vals = a.value;
     let mut b = a_r_min_1.value;


### PR DESCRIPTION
Gets a `10%` speed up for inversion for the degree 5 binomial Babybear extension.

Fewer fun math tricks than the degree 4 case, just finding ways to reduce the number of extension field muls.