### PR TITLE
Move BatchOpening into MMCS

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{BatchOpening, Mmcs, OpenedValues, Pcs, PolynomialSpace};
+use p3_commit::{BatchOpening, BatchOpeningRef, Mmcs, OpenedValues, Pcs, PolynomialSpace};
 use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, Field};
 use p3_fri::FriConfig;
@@ -318,7 +318,7 @@ where
                 .fri_config
                 .mmcs
                 .open_batch(index >> 1, &first_layer_data)
-                .deconstruct();
+                .unpack();
             let first_layer_siblings = izip!(&first_layer_values, &log_heights)
                 .map(|(v, log_height)| {
                     let reduced_index = index >> (log_max_height - log_height);
@@ -428,7 +428,7 @@ where
                     };
 
                     self.mmcs
-                        .verify_batch(batch_commit, dims, idx, batch_opening)
+                        .verify_batch(batch_commit, dims, idx, batch_opening.into())
                         .map_err(InputError::InputMmcsError)?;
 
                     for (ps_at_x, (mat_domain, mat_points_and_values)) in zip_eq(
@@ -515,7 +515,7 @@ where
                         &proof.first_layer_commitment,
                         &fl_dims,
                         index >> 1,
-                        &BatchOpening::new(fl_leaves, first_layer_proof.clone()),
+                        BatchOpeningRef::new(&fl_leaves, first_layer_proof),
                     )
                     .map_err(InputError::FirstLayerMmcsError)?;
 

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -139,7 +139,8 @@ where
             let index_i_sibling = index_i ^ 1;
             let index_pair = index_i >> 1;
 
-            let (mut opened_rows, opening_proof) = config.mmcs.open_batch(index_pair, commit);
+            let (mut opened_rows, opening_proof) =
+                config.mmcs.open_batch(index_pair, commit).deconstruct();
             assert_eq!(opened_rows.len(), 1);
             let opened_row = opened_rows.pop().unwrap();
             assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -140,7 +140,7 @@ where
             let index_pair = index_i >> 1;
 
             let (mut opened_rows, opening_proof) =
-                config.mmcs.open_batch(index_pair, commit).deconstruct();
+                config.mmcs.open_batch(index_pair, commit).unpack();
             assert_eq!(opened_rows.len(), 1);
             let opened_row = opened_rows.pop().unwrap();
             assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::Mmcs;
+use p3_commit::{BatchOpening, Mmcs};
 use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriConfig, FriGenericConfig};
@@ -152,7 +152,12 @@ where
         // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
-            .verify_batch(comm, dims, index, &[evals.clone()], &opening.opening_proof)
+            .verify_batch(
+                comm,
+                dims,
+                index,
+                &BatchOpening::new(vec![evals.clone()], opening.opening_proof.clone()),
+            )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
         // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{BatchOpening, Mmcs};
+use p3_commit::{BatchOpeningRef, Mmcs};
 use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriConfig, FriGenericConfig};
@@ -149,6 +149,8 @@ where
         // Replace index with the index of the parent fri node.
         index >>= 1;
 
+        let evals_in_array = [evals];
+
         // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
@@ -156,12 +158,17 @@ where
                 comm,
                 dims,
                 index,
-                &BatchOpening::new(vec![evals.clone()], opening.opening_proof.clone()),
+                BatchOpeningRef::new(&evals_in_array, &opening.opening_proof),
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
         // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.
-        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
+        folded_eval = g.fold_row(
+            index,
+            log_folded_height,
+            beta,
+            evals_in_array.into_iter().flat_map(|v| v.into_iter()),
+        );
     }
 
     // If ro_iter is not empty, we failed to fold in some polynomial evaluations.

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -149,8 +149,6 @@ where
         // Replace index with the index of the parent fri node.
         index >>= 1;
 
-        let evals_in_array = [evals];
-
         // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
@@ -158,17 +156,12 @@ where
                 comm,
                 dims,
                 index,
-                BatchOpeningRef::new(&evals_in_array, &opening.opening_proof),
+                BatchOpeningRef::new(&[evals.clone()], &opening.opening_proof), // It's possible to remove the clone here but unnecessary as evals is tiny.
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
         // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.
-        folded_eval = g.fold_row(
-            index,
-            log_folded_height,
-            beta,
-            evals_in_array.into_iter().flat_map(|v| v.into_iter()),
-        );
+        folded_eval = g.fold_row(index, log_folded_height, beta, evals.into_iter());
     }
 
     // If ro_iter is not empty, we failed to fold in some polynomial evaluations.

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -47,15 +47,7 @@ where
         let (inner_opened_values, inner_proof) = self.inner.open_batch(index, prover_data).unpack();
         let opened_ext_values = inner_opened_values
             .into_iter()
-            .map(|row| {
-                // By construction, the width of the row is a multiple of EF::DIMENSION.
-                // So there will be no remainder when we call chunks_exact.
-                row.chunks_exact(EF::DIMENSION)
-                    // As each chunk has length EF::DIMENSION, from_basis_coefficients_slice
-                    // will produce some(elem) which into_iter converts to the iterator once(elem).
-                    .flat_map(EF::from_basis_coefficients_slice)
-                    .collect()
-            })
+            .map(|row| EF::reconstitute_from_base(row))
             .collect();
         BatchOpening::new(opened_ext_values, inner_proof)
     }
@@ -78,12 +70,7 @@ where
         let opened_base_values: Vec<Vec<F>> = batch_opening
             .opened_values
             .iter()
-            .map(|row| {
-                row.iter()
-                    .flat_map(|el| el.as_basis_coefficients_slice())
-                    .copied()
-                    .collect()
-            })
+            .map(|row| EF::flatten_to_base(row.clone()))
             .collect();
         let base_dimensions = dimensions
             .iter()

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -70,7 +70,8 @@ where
         let opened_base_values: Vec<Vec<F>> = batch_opening
             .opened_values
             .iter()
-            .map(|row| EF::flatten_to_base(row.clone()))
+            .cloned()
+            .map(EF::flatten_to_base)
             .collect();
         let base_dimensions = dimensions
             .iter()

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -6,7 +6,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::extension::FlatMatrixView;
 use p3_matrix::{Dimensions, Matrix};
 
-use crate::{BatchOpening, Mmcs};
+use crate::{BatchOpening, BatchOpeningRef, Mmcs};
 
 #[derive(Clone, Debug)]
 pub struct ExtensionMmcs<F, EF, InnerMmcs> {
@@ -44,8 +44,7 @@ where
         index: usize,
         prover_data: &Self::ProverData<M>,
     ) -> BatchOpening<EF, Self> {
-        let (inner_opened_values, inner_proof) =
-            self.inner.open_batch(index, prover_data).deconstruct();
+        let (inner_opened_values, inner_proof) = self.inner.open_batch(index, prover_data).unpack();
         let opened_ext_values = inner_opened_values
             .into_iter()
             .map(|row| {
@@ -74,7 +73,7 @@ where
         commit: &Self::Commitment,
         dimensions: &[Dimensions],
         index: usize,
-        batch_opening: &BatchOpening<EF, Self>,
+        batch_opening: BatchOpeningRef<EF, Self>,
     ) -> Result<(), Self::Error> {
         let opened_base_values: Vec<Vec<F>> = batch_opening
             .opened_values
@@ -97,7 +96,7 @@ where
             commit,
             &base_dimensions,
             index,
-            &BatchOpening::new(opened_base_values, batch_opening.opening_proof.clone()),
+            BatchOpeningRef::new(&opened_base_values, batch_opening.opening_proof),
         )
     }
 }

--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -47,7 +47,7 @@ where
         let (inner_opened_values, inner_proof) = self.inner.open_batch(index, prover_data).unpack();
         let opened_ext_values = inner_opened_values
             .into_iter()
-            .map(|row| EF::reconstitute_from_base(row))
+            .map(EF::reconstitute_from_base)
             .collect();
         BatchOpening::new(opened_ext_values, inner_proof)
     }

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -96,6 +96,7 @@ pub struct BatchOpening<T: Send + Sync + Clone, InputMmcs: Mmcs<T>> {
 
 impl<T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpening<T, InputMmcs> {
     /// Creates a new batch opening proof.
+    #[inline]
     pub fn new(opened_values: Vec<Vec<T>>, opening_proof: <InputMmcs as Mmcs<T>>::Proof) -> Self {
         Self {
             opened_values,
@@ -104,6 +105,7 @@ impl<T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpening<T, InputMmcs> {
     }
 
     /// Deconstructs the batch opening proof into its components.
+    #[inline]
     pub fn unpack(self) -> (Vec<Vec<T>>, <InputMmcs as Mmcs<T>>::Proof) {
         (self.opened_values, self.opening_proof)
     }
@@ -122,6 +124,7 @@ pub struct BatchOpeningRef<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> {
 
 impl<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpeningRef<'a, T, InputMmcs> {
     /// Creates a new batch opening proof.
+    #[inline]
     pub fn new(
         opened_values: &'a [Vec<T>],
         opening_proof: &'a <InputMmcs as Mmcs<T>>::Proof,
@@ -133,6 +136,7 @@ impl<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpeningRef<'a, T, Inpu
     }
 
     /// Deconstructs the batch opening proof into its components.
+    #[inline]
     pub fn unpack(&self) -> (&'a [Vec<T>], &'a <InputMmcs as Mmcs<T>>::Proof) {
         (self.opened_values, self.opening_proof)
     }
@@ -141,6 +145,7 @@ impl<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpeningRef<'a, T, Inpu
 impl<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> From<&'a BatchOpening<T, InputMmcs>>
     for BatchOpeningRef<'a, T, InputMmcs>
 {
+    #[inline]
     fn from(batch_opening: &'a BatchOpening<T, InputMmcs>) -> Self {
         BatchOpeningRef::new(&batch_opening.opened_values, &batch_opening.opening_proof)
     }

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -135,7 +135,7 @@ impl<'a, T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpeningRef<'a, T, Inpu
         }
     }
 
-    /// Deconstructs the batch opening proof into its components.
+    /// Unpacks the batch opening proof into its components.
     #[inline]
     pub fn unpack(&self) -> (&'a [Vec<T>], &'a <InputMmcs as Mmcs<T>>::Proof) {
         (self.opened_values, self.opening_proof)

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -104,7 +104,7 @@ impl<T: Send + Sync + Clone, InputMmcs: Mmcs<T>> BatchOpening<T, InputMmcs> {
         }
     }
 
-    /// Deconstructs the batch opening proof into its components.
+    /// Unpacks the batch opening proof into its components.
     #[inline]
     pub fn unpack(self) -> (Vec<Vec<T>>, <InputMmcs as Mmcs<T>>::Proof) {
         (self.opened_values, self.opening_proof)

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -82,7 +82,7 @@ pub trait Mmcs<T: Send + Sync + Clone>: Clone {
 
 /// A Batched opening proof.
 ///
-/// Contains a Merkle proof for a collection of opened_values.
+/// Contains a collection of opened values at a Merkle proof for those openings.
 ///
 /// Primarily used by the prover.
 #[derive(Serialize, Deserialize, Clone)]

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace};
+use p3_commit::{BatchOpening, Mmcs, OpenedValues, Pcs, PolynomialSpace};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse};
@@ -20,7 +20,7 @@ use rand::distr::{Distribution, StandardUniform};
 use tracing::{info_span, instrument};
 
 use crate::verifier::FriError;
-use crate::{BatchOpening, FriConfig, FriProof, TwoAdicFriPcs};
+use crate::{FriConfig, FriProof, TwoAdicFriPcs};
 
 /// A hiding FRI PCS. Both MMCSs must also be hiding; this is not enforced at compile time so it's
 /// the user's responsibility to configure.

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -164,7 +164,7 @@ where
             let index_pair = index_i >> 1;
 
             let (mut opened_rows, opening_proof) =
-                config.mmcs.open_batch(index_pair, commit).deconstruct();
+                config.mmcs.open_batch(index_pair, commit).unpack();
             assert_eq!(opened_rows.len(), 1);
             let opened_row = &opened_rows.pop().unwrap();
             assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -163,9 +163,10 @@ where
             let index_i_sibling = index_i ^ 1;
             let index_pair = index_i >> 1;
 
-            let (mut opened_rows, opening_proof) = config.mmcs.open_batch(index_pair, commit);
+            let (mut opened_rows, opening_proof) =
+                config.mmcs.open_batch(index_pair, commit).deconstruct();
             assert_eq!(opened_rows.len(), 1);
-            let opened_row = opened_rows.pop().unwrap();
+            let opened_row = &opened_rows.pop().unwrap();
             assert_eq!(opened_row.len(), 2, "Committed data should be in pairs");
             let sibling_value = opened_row[index_i_sibling % 2];
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -488,11 +488,16 @@ where
                     let bits_reduced = log_global_max_height - log_batch_max_height;
                     let reduced_index = index >> bits_reduced;
 
-                    self.mmcs
-                        .verify_batch(batch_commit, &batch_dims, reduced_index, batch_opening)
+                    self.mmcs.verify_batch(
+                        batch_commit,
+                        &batch_dims,
+                        reduced_index,
+                        batch_opening.into(),
+                    )
                 } else {
                     // Empty batch?
-                    self.mmcs.verify_batch(batch_commit, &[], 0, batch_opening)
+                    self.mmcs
+                        .verify_batch(batch_commit, &[], 0, batch_opening.into())
                 }
                 .map_err(FriError::InputError)?;
 

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::Mmcs;
+use p3_commit::{BatchOpening, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_util::reverse_bits_len;
@@ -186,7 +186,12 @@ where
         // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
-            .verify_batch(comm, dims, *index, &[evals.clone()], &opening.opening_proof)
+            .verify_batch(
+                comm,
+                dims,
+                *index,
+                &BatchOpening::new(vec![evals.clone()], opening.opening_proof.clone()),
+            )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
         // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -183,8 +183,6 @@ where
         // Replace index with the index of the parent fri node.
         *index >>= 1;
 
-        let evals_in_array = [evals];
-
         // Verify the commitment to the evaluations of the sibling nodes.
         config
             .mmcs
@@ -192,17 +190,12 @@ where
                 comm,
                 dims,
                 *index,
-                BatchOpeningRef::new(&evals_in_array, &opening.opening_proof),
+                BatchOpeningRef::new(&[evals.clone()], &opening.opening_proof), // It's possible to remove the clone here but unnecessary as evals is tiny.
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
         // Fold the pair of evaluations of sibling nodes into the evaluation of the parent fri node.
-        folded_eval = g.fold_row(
-            *index,
-            log_folded_height,
-            beta,
-            evals_in_array.into_iter().flat_map(|x| x.into_iter()),
-        );
+        folded_eval = g.fold_row(*index, log_folded_height, beta, evals.into_iter());
     }
 
     // If ro_iter is not empty, we failed to fold in some polynomial evaluations.

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 
 use itertools::Itertools;
-use p3_commit::Mmcs;
+use p3_commit::{BatchOpening, Mmcs};
 use p3_field::PackedValue;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::HorizontalPair;
@@ -97,8 +97,8 @@ where
         &self,
         index: usize,
         prover_data: &Self::ProverData<M>,
-    ) -> (Vec<Vec<P::Value>>, Self::Proof) {
-        let (salted_openings, siblings) = self.inner.open_batch(index, prover_data);
+    ) -> BatchOpening<P::Value, Self> {
+        let (salted_openings, siblings) = self.inner.open_batch(index, prover_data).deconstruct();
         let (openings, salts): (Vec<_>, Vec<_>) = salted_openings
             .into_iter()
             .map(|row| {
@@ -106,7 +106,7 @@ where
                 (a.to_vec(), b.to_vec())
             })
             .unzip();
-        (openings, (salts, siblings))
+        BatchOpening::new(openings, (salts, siblings))
     }
 
     fn get_matrices<'a, M: Matrix<P::Value>>(
@@ -121,17 +121,20 @@ where
         commit: &Self::Commitment,
         dimensions: &[Dimensions],
         index: usize,
-        opened_values: &[Vec<P::Value>],
-        proof: &Self::Proof,
+        batch_opening: &BatchOpening<P::Value, Self>,
     ) -> Result<(), Self::Error> {
-        let (salts, siblings) = proof;
+        let (opened_values, (salts, siblings)) = batch_opening.deconstruct_by_ref();
 
         let opened_salted_values = zip_eq(opened_values, salts, MerkleTreeError::WrongBatchSize)?
             .map(|(opened, salt)| opened.iter().chain(salt.iter()).copied().collect_vec())
             .collect_vec();
 
-        self.inner
-            .verify_batch(commit, dimensions, index, &opened_salted_values, siblings)
+        self.inner.verify_batch(
+            commit,
+            dimensions,
+            index,
+            &BatchOpening::new(opened_salted_values, siblings.clone()),
+        )
     }
 }
 
@@ -198,7 +201,7 @@ mod tests {
         let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
 
         let (commit, prover_data) = mmcs.commit(mats);
-        let (opened_values, proof) = mmcs.open_batch(17, &prover_data);
-        mmcs.verify_batch(&commit, &dims, 17, &opened_values, &proof)
+        let batch_proof = mmcs.open_batch(17, &prover_data);
+        mmcs.verify_batch(&commit, &dims, 17, &batch_proof)
     }
 }

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -24,7 +24,7 @@ use core::cmp::Reverse;
 use core::marker::PhantomData;
 
 use itertools::Itertools;
-use p3_commit::Mmcs;
+use p3_commit::{BatchOpening, Mmcs};
 use p3_field::PackedValue;
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};
@@ -112,7 +112,7 @@ where
         &self,
         index: usize,
         prover_data: &MerkleTree<P::Value, PW::Value, M, DIGEST_ELEMS>,
-    ) -> (Vec<Vec<P::Value>>, Self::Proof) {
+    ) -> BatchOpening<P::Value, Self> {
         let max_height = self.get_max_height(prover_data);
         let log_max_height = log2_ceil_usize(max_height);
 
@@ -133,7 +133,7 @@ where
             .map(|i| prover_data.digest_layers[i][(index >> i) ^ 1])
             .collect();
 
-        (openings, proof)
+        BatchOpening::new(openings, proof)
     }
 
     fn get_matrices<'a, M: Matrix<P::Value>>(
@@ -160,9 +160,9 @@ where
         commit: &Self::Commitment,
         dimensions: &[Dimensions],
         mut index: usize,
-        opened_values: &[Vec<P::Value>],
-        proof: &Self::Proof,
+        batch_proof: &BatchOpening<P::Value, Self>,
     ) -> Result<(), Self::Error> {
+        let (opened_values, opening_proof) = batch_proof.deconstruct_by_ref();
         // Check that the openings have the correct shape.
         if dimensions.len() != opened_values.len() {
             return Err(WrongBatchSize);
@@ -202,10 +202,10 @@ where
             Some((_, dims)) => {
                 let max_height = dims.height.next_power_of_two();
                 let log_max_height = log2_strict_usize(max_height);
-                if proof.len() != log_max_height {
+                if opening_proof.len() != log_max_height {
                     return Err(WrongHeight {
                         log_max_height,
-                        num_siblings: proof.len(),
+                        num_siblings: opening_proof.len(),
                     });
                 }
                 max_height
@@ -222,7 +222,7 @@ where
                 .map(|(i, _)| opened_values[i].as_slice()),
         );
 
-        for &sibling in proof {
+        for &sibling in opening_proof {
             // The last bit of index informs us whether the current node is on the left or right.
             let (left, right) = if index & 1 == 0 {
                 (root, sibling)
@@ -475,7 +475,7 @@ mod tests {
 
         assert_eq!(commit, expected_result);
 
-        let (opened_values, _proof) = mmcs.open_batch(2, &prover_data);
+        let (opened_values, _) = mmcs.open_batch(2, &prover_data).deconstruct();
         assert_eq!(
             opened_values,
             vec![vec![F::TWO, F::TWO], vec![F::ZERO, F::TWO, F::TWO]]
@@ -538,14 +538,13 @@ mod tests {
         let (commit, prover_data) = mmcs.commit(mats);
 
         // open the 3rd row of each matrix, mess with proof, and verify
-        let (opened_values, mut proof) = mmcs.open_batch(3, &prover_data);
-        proof[0][0] += F::ONE;
+        let mut batch_opening = mmcs.open_batch(3, &prover_data);
+        batch_opening.opening_proof[0][0] += F::ONE;
         mmcs.verify_batch(
             &commit,
             &large_mat_dims.chain(small_mat_dims).collect_vec(),
             3,
-            &opened_values,
-            &proof,
+            &batch_opening,
         )
         .expect_err("expected verification to fail");
     }
@@ -591,7 +590,7 @@ mod tests {
         let (commit, prover_data) = mmcs.commit(mats);
 
         // open the 6th row of each matrix and verify
-        let (opened_values, proof) = mmcs.open_batch(6, &prover_data);
+        let batch_opening = mmcs.open_batch(6, &prover_data);
         mmcs.verify_batch(
             &commit,
             &large_mat_dims
@@ -600,8 +599,7 @@ mod tests {
                 .chain(tiny_mat_dims)
                 .collect_vec(),
             6,
-            &opened_values,
-            &proof,
+            &batch_opening,
         )
         .expect("expected verification to succeed");
     }
@@ -621,8 +619,8 @@ mod tests {
         let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
 
         let (commit, prover_data) = mmcs.commit(mats);
-        let (opened_values, proof) = mmcs.open_batch(17, &prover_data);
-        mmcs.verify_batch(&commit, &dims, 17, &opened_values, &proof)
+        let batch_opening = mmcs.open_batch(17, &prover_data);
+        mmcs.verify_batch(&commit, &dims, 17, &batch_opening)
             .expect("expected verification to succeed");
     }
 }


### PR DESCRIPTION
Currently `BatchOpening` is defined both in `fri/two_adic_pcs` and `circle/pcs`. This PR moves it into `commit/src/mmcs` which seems like a more natural place for it.

In addition, we slightly modify `mmcs` to make use of `BatchOpening` in some of its related methods.