### PR TITLE
build: update cache action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       id: rs-stable
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
         targets: ${{ env.target }}
       id: rs-stable
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/
@@ -135,7 +135,7 @@ jobs:
       with:
         components: rustfmt
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
Updates cache action to v4 for future-proofing. Workflows behave the same.