### PR TITLE
interpolation: add test for single interpolation with multiple polys

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -536,13 +536,11 @@ impl<F: PrimeCharacteristicRing> BasedVectorSpace<F> for F {
         (iter.len() == 1).then(|| iter.next().unwrap()) // Unwrap will not panic as we know the length is 1.
     }
 
-    #[must_use]
     #[inline]
     fn flatten_to_base(vec: Vec<Self>) -> Vec<F> {
         vec
     }
 
-    #[must_use]
     #[inline]
     fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self> {
         vec

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -258,7 +258,7 @@ mod tests {
         let subgroup_iter = EF4::two_adic_generator(3).powers().take(8);
 
         // Evaluate both polynomials on the subgroup
-        let evals: Vec<_> = subgroup_iter.flat_map(|&x| vec![f1(x), f2(x)]).collect();
+        let evals: Vec<_> = subgroup_iter.flat_map(|x| vec![f1(x), f2(x)]).collect();
 
         // Organize into a 2-column matrix (column-major: 8 rows × 2 columns)
         let evals_mat = RowMajorMatrix::new(evals, 2);

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -255,10 +255,10 @@ mod tests {
         let f2 = |x: EF4| x * x * F::from_u32(4) + x * F::from_u32(5) + F::from_u32(6);
 
         // Evaluation domain: 2^3 = 8-point subgroup
-        let subgroup: Vec<_> = EF4::two_adic_generator(3).powers().take(8).collect();
+        let subgroup_iter = EF4::two_adic_generator(3).powers().take(8);
 
         // Evaluate both polynomials on the subgroup
-        let evals: Vec<_> = subgroup.iter().flat_map(|&x| vec![f1(x), f2(x)]).collect();
+        let evals: Vec<_> = subgroup_iter.flat_map(|&x| vec![f1(x), f2(x)]).collect();
 
         // Organize into a 2-column matrix (column-major: 8 rows × 2 columns)
         let evals_mat = RowMajorMatrix::new(evals, 2);


### PR DESCRIPTION
@SyxtonPrime I saw that we were missing a test where we test an interpolation on 2 polynomials at a time, therefore with a two-element vector corresponding to the two output interpolations.