### PR TITLE
util: accelerate square transpose using rayon

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,11 +6,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde.workspace = true
+rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
 criterion.workspace = true
 serde_json.workspace = true
+
+[features]
+parallel = ["rayon"]
 
 [[bench]]
 name = "bit_reverse"

--- a/util/benches/bit_reverse.rs
+++ b/util/benches/bit_reverse.rs
@@ -24,7 +24,7 @@ fn bench_reverse_bits(c: &mut Criterion) {
 fn bench_reverse_slice_index_bits(c: &mut Criterion) {
     let mut group = c.benchmark_group("reverse_slice_index_bits");
     let mut rng = SmallRng::seed_from_u64(1);
-    for log_size in [1, 3, 5, 8, 16, 24] {
+    for log_size in [1, 3, 5, 8, 16, 24, 26] {
         let size = 1 << log_size;
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
             let data: Vec<u64> = (0..size).map(|_| rng.random()).collect();

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -98,7 +98,10 @@ const SMALL_ARR_SIZE: usize = 1 << 16;
 ///
 /// If the whole array fits in fast cache, then the trivial algorithm is cache friendly. Also, if
 /// `T` is really big, then the trivial algorithm is cache-friendly, no matter the size of the array.
-pub fn reverse_slice_index_bits<F>(vals: &mut [F]) {
+pub fn reverse_slice_index_bits<F>(vals: &mut [F])
+where
+    F: Copy + Send + Sync,
+{
     let n = vals.len();
     if n == 0 {
         return;

--- a/util/src/transpose.rs
+++ b/util/src/transpose.rs
@@ -1,15 +1,31 @@
-use core::ptr::swap;
+use core::ptr::{swap, swap_nonoverlapping};
+#[cfg(feature = "parallel")]
+use core::sync::atomic::{AtomicPtr, Ordering};
 
-const LB_BLOCK_SIZE: usize = 3;
+/// Log2 of the matrix dimension below which we use the base-case direct swap loop.
+/// e.g. LB_BASE_CASE_LOG = 3 means base case is used for ≤ 8×8 submatrices
+const LB_BASE_CASE_LOG: usize = 3;
 
-/// Transpose square matrix in-place
-/// The matrix is of size `1 << lb_size` by `1 << lb_size`. It occupies
-/// `M[i, j] == arr[(i + x << lb_stride) + j + x]` for `0 <= i, j < 1 << lb_size`. The transposition
-/// swaps `M[i, j]` and `M[j, i]`.
+/// Absolute size threshold (in elements) below which recursive swap stops
+const BASE_CASE_ELEMENT_THRESHOLD: usize = 1 << LB_BASE_CASE_LOG;
+
+#[cfg(feature = "parallel")]
+/// Threshold (in number of elements) beyond which we enable parallel recursion
+const PARALLEL_RECURSION_THRESHOLD: usize = 1 << 10;
+
+/// Transpose a small square matrix in-place using element-wise swaps.
 ///
-/// SAFETY:
-/// Make sure that `(i + x << lb_stride) + j + x` is a valid index in `arr` for all
-/// `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to prevent overlap.
+/// # Parameters
+/// - `arr`: A mutable reference to a 1D array representing a larger row-major matrix.
+/// - `lb_stride`: Log2 of the stride between rows in the array.
+/// - `lb_size`: Log2 of the dimension of the square matrix to transpose.
+/// - `x`: Offset (in rows and columns) from the top-left corner of the full array.
+///
+/// The matrix occupies a logical square region starting at `(x, x)` and of size `1 << lb_size`.
+///
+/// ## SAFETY
+/// - All accesses to `arr` must be in-bounds.
+/// - `lb_size <= lb_stride` must hold to prevent overlapping indices during swaps.
 unsafe fn transpose_in_place_square_small<T>(
     arr: &mut [T],
     lb_stride: usize,
@@ -17,8 +33,10 @@ unsafe fn transpose_in_place_square_small<T>(
     x: usize,
 ) {
     unsafe {
+        // Loop over upper triangle (excluding diagonal)
         for i in x + 1..x + (1 << lb_size) {
             for j in x..i {
+                // Compute memory offsets and swap M[i, j] <-> M[j, i]
                 swap(
                     arr.get_unchecked_mut(i + (j << lb_stride)),
                     arr.get_unchecked_mut((i << lb_stride) + j),
@@ -28,94 +46,246 @@ unsafe fn transpose_in_place_square_small<T>(
     }
 }
 
-/// Transpose square matrices and swap
-/// The matrices are of size `1 << lb_size` by `1 << lb_size`. They occupy
-/// `M0[i, j] == arr[(i + x << lb_stride) + j + y]`, `M1[i, j] == arr[i + x + (j + y << lb_stride)]`
-/// for `0 <= i, j < 1 << lb_size. The transposition swaps `M0[i, j]` and `M1[j, i]`.
+/// Recursively swaps two submatrices across the main diagonal as part of a larger transposition.
 ///
-/// SAFETY:
-/// Make sure that `(i + x << lb_stride) + j + y` and `i + x + (j + y << lb_stride)` are valid
-/// indices in `arr` for all `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to
-/// prevent overlap.
-unsafe fn transpose_swap_square_small<T>(
-    arr: &mut [T],
-    lb_stride: usize,
-    lb_size: usize,
-    x: usize,
-    y: usize,
+/// Given two submatrices `A` and `B` with dimensions `(rows × cols)`, this function swaps
+/// element `A[i, j]` with `B[j, i]`, effectively transposing them relative to each other.
+///
+/// `A` is assumed to be row-major, starting at pointer `a`, where A[i,j] = a[i * stride + j].
+/// `B` is assumed to be column-major, starting at pointer `b`, where B[j,i] = b[j * stride + i].
+///
+/// The recursion always splits along the longer dimension to balance cache and workload.
+///
+/// # Safety
+/// - `a` and `b` must be valid for `rows * cols` reads and writes.
+/// - The regions pointed to by `a` and `b` must be disjoint.
+/// - `stride` must be large enough to avoid overlapping accesses during index calculations.
+pub(super) unsafe fn transpose_swap_square<T: Copy>(
+    a: *mut T,
+    b: *mut T,
+    stride: usize,
+    (rows, cols): (usize, usize),
 ) {
-    unsafe {
-        for i in x..x + (1 << lb_size) {
-            for j in y..y + (1 << lb_size) {
-                swap(
-                    arr.get_unchecked_mut(i + (j << lb_stride)),
-                    arr.get_unchecked_mut((i << lb_stride) + j),
-                );
+    let size = rows * cols;
+
+    // Base case: directly swap A[i,j] with B[j,i] using pointer offsets
+    if size < BASE_CASE_ELEMENT_THRESHOLD {
+        for i in 0..rows {
+            for j in 0..cols {
+                let ai = i * stride + j;
+                let bi = j * stride + i;
+                unsafe {
+                    swap_nonoverlapping(a.add(ai), b.add(bi), 1);
+                }
             }
         }
+        return;
     }
-}
 
-/// Transpose square matrices and swap
-/// The matrices are of size `1 << lb_size` by `1 << lb_size`. They occupy
-/// `M0[i, j] == arr[(i + x << lb_stride) + j + y]`, `M1[i, j] == arr[i + x + (j + y << lb_stride)]`
-/// for `0 <= i, j < 1 << lb_size. The transposition swaps `M0[i, j]` and `M1[j, i]`.
-///
-/// SAFETY:
-/// Make sure that `(i + x << lb_stride) + j + y` and `i + x + (j + y << lb_stride)` are valid
-/// indices in `arr` for all `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to
-/// prevent overlap.
-unsafe fn transpose_swap_square<T>(
-    arr: &mut [T],
-    lb_stride: usize,
-    lb_size: usize,
-    x: usize,
-    y: usize,
-) {
-    unsafe {
-        if lb_size <= LB_BLOCK_SIZE {
-            transpose_swap_square_small(arr, lb_stride, lb_size, x, y);
-        } else {
-            let lb_block_size = lb_size - 1;
-            let block_size = 1 << lb_block_size;
-            transpose_swap_square(arr, lb_stride, lb_block_size, x, y);
-            transpose_swap_square(arr, lb_stride, lb_block_size, x + block_size, y);
-            transpose_swap_square(arr, lb_stride, lb_block_size, x, y + block_size);
-            transpose_swap_square(
-                arr,
-                lb_stride,
-                lb_block_size,
-                x + block_size,
-                y + block_size,
-            );
+    #[cfg(feature = "parallel")]
+    {
+        // If large enough, split work recursively in parallel
+        if size > PARALLEL_RECURSION_THRESHOLD {
+            let a = AtomicPtr::new(a);
+            let b = AtomicPtr::new(b);
+
+            // Prefer splitting the longer dimension for better balance and locality
+            if rows > cols {
+                let top = rows / 2;
+                let bottom = rows - top;
+                rayon::join(
+                    || {
+                        let a = a.load(Ordering::Relaxed);
+                        let b = b.load(Ordering::Relaxed);
+                        unsafe {
+                            transpose_swap_square(a, b, stride, (top, cols));
+                        }
+                    },
+                    || {
+                        let a = a.load(Ordering::Relaxed);
+                        let b = b.load(Ordering::Relaxed);
+                        unsafe {
+                            transpose_swap_square(
+                                a.add(top * stride),
+                                b.add(top),
+                                stride,
+                                (bottom, cols),
+                            );
+                        }
+                    },
+                );
+            } else {
+                let left = cols / 2;
+                let right = cols - left;
+                rayon::join(
+                    || {
+                        let a = a.load(Ordering::Relaxed);
+                        let b = b.load(Ordering::Relaxed);
+                        unsafe {
+                            transpose_swap_square(a, b, stride, (rows, left));
+                        }
+                    },
+                    || {
+                        let a = a.load(Ordering::Relaxed);
+                        let b = b.load(Ordering::Relaxed);
+                        unsafe {
+                            transpose_swap_square(
+                                a.add(left),
+                                b.add(left * stride),
+                                stride,
+                                (rows, right),
+                            );
+                        }
+                    },
+                );
+            }
+            return;
+        }
+    }
+
+    // Sequential case: same recursive logic without threading
+    if rows > cols {
+        let top = rows / 2;
+        let bottom = rows - top;
+        unsafe {
+            transpose_swap_square(a, b, stride, (top, cols));
+            transpose_swap_square(a.add(top * stride), b.add(top), stride, (bottom, cols));
+        }
+    } else {
+        let left = cols / 2;
+        let right = cols - left;
+        unsafe {
+            transpose_swap_square(a, b, stride, (rows, left));
+            transpose_swap_square(a.add(left), b.add(left * stride), stride, (rows, right));
         }
     }
 }
 
-/// Transpose square matrix in-place
-/// The matrix is of size `1 << lb_size` by `1 << lb_size`. It occupies
-/// `M[i, j] == arr[(i + x << lb_stride) + j + x]` for `0 <= i, j < 1 << lb_size`. The transposition
-/// swaps `M[i, j]` and `M[j, i]`.
+/// In-place recursive transposition of a square matrix of size `2^lb_size × 2^lb_size`,
+/// embedded inside a larger row-major array at offset `(x, x)`.
 ///
-/// SAFETY:
-/// Make sure that `(i + x << lb_stride) + j + x` is a valid index in `arr` for all
-/// `0 <= i, j < 1 << lb_size`. Ensure also that `lb_size <= lb_stride` to prevent overlap.
+/// Each matrix element `M[i,j]` is stored at:
+/// ```text
+/// \begin{equation}
+///     \text{index}(i,j) = i + x + ((i + x) << lb_stride) + (j + x)
+/// \end{equation}
+/// ```
+///
+/// The matrix is recursively split into four quadrants:
+/// ```text
+/// +----+----+
+/// | TL | TR |
+/// +----+----+
+/// | BL | BR |
+/// +----+----+
+/// ```
+/// Transposition proceeds by:
+/// 1. Recursively transposing `TL`
+/// 2. Swapping `TR` and `BL` across the diagonal
+/// 3. Recursively transposing `BR`
+///
+/// # Safety
+/// - Assumes all accesses via `((i + x) << lb_stride) + (j + x)` are in-bounds.
+/// - Requires `lb_size <= lb_stride` to avoid index overlap.
 pub(crate) unsafe fn transpose_in_place_square<T>(
     arr: &mut [T],
     lb_stride: usize,
     lb_size: usize,
     x: usize,
-) {
-    unsafe {
-        if lb_size <= LB_BLOCK_SIZE {
+) where
+    T: Copy + Send + Sync,
+{
+    // If small, switch to base case
+    if lb_size <= LB_BASE_CASE_LOG {
+        unsafe {
             transpose_in_place_square_small(arr, lb_stride, lb_size, x);
-        } else {
-            let lb_block_size = lb_size - 1;
-            let block_size = 1 << lb_block_size;
-            transpose_in_place_square(arr, lb_stride, lb_block_size, x);
-            transpose_swap_square(arr, lb_stride, lb_block_size, x, x + block_size);
-            transpose_in_place_square(arr, lb_stride, lb_block_size, x + block_size);
         }
+        return;
+    }
+
+    #[cfg(feature = "parallel")]
+    {
+        // Log2 of half the matrix dimension
+        let lb_half = lb_size - 1;
+        // Half the matrix size (e.g. 8 for 16×16)
+        let half = 1 << lb_half;
+        // Total number of elements in the full square matrix
+        let elements = 1 << (2 * lb_size);
+
+        if elements >= PARALLEL_RECURSION_THRESHOLD {
+            // Shared base pointer for parallel recursion
+            let base = AtomicPtr::new(arr.as_mut_ptr());
+            // Total length of the backing array
+            let len = arr.len();
+            // Row stride in physical memory
+            let stride = 1 << lb_stride;
+            // Size of each quadrant (half x half)
+            let dim = 1 << lb_half;
+
+            // Coordinate each quadrant via `rayon::join`:
+            // - TL and BR are recursive calls
+            // - TR and BL are swapped directly
+            rayon::join(
+                || unsafe {
+                    transpose_in_place_square(
+                        core::slice::from_raw_parts_mut(base.load(Ordering::Relaxed), len),
+                        lb_stride,
+                        lb_half,
+                        x,
+                    )
+                },
+                || {
+                    rayon::join(
+                        // TR: starts at (x, x + half)
+                        // BL: starts at (x + half, x)
+                        || unsafe {
+                            let ptr = base.load(Ordering::Relaxed);
+                            transpose_swap_square(
+                                ptr.add((x << lb_stride) + (x + half)),
+                                ptr.add(((x + half) << lb_stride) + x),
+                                stride,
+                                (dim, dim),
+                            );
+                        },
+                        || unsafe {
+                            transpose_in_place_square(
+                                core::slice::from_raw_parts_mut(base.load(Ordering::Relaxed), len),
+                                lb_stride,
+                                lb_half,
+                                x + half,
+                            )
+                        },
+                    )
+                },
+            );
+            return;
+        }
+    }
+
+    // Sequential version of above logic
+    // Log2 of the new quadrant size (we're splitting the matrix in half)
+    let lb_block_size = lb_size - 1;
+    // Actual size of each quadrant (i.e., half the current matrix size)
+    let block_size = 1 << lb_block_size;
+    // Physical stride between rows in memory (in elements)
+    let stride = 1 << lb_stride;
+    // The size of each submatrix (used as a dimension for swapping TR/BL)
+    let dim = block_size;
+    // Raw pointer to the base of the array for manual offset calculations
+    let ptr = arr.as_mut_ptr();
+
+    unsafe {
+        // Transpose TL quadrant (top-left)
+        transpose_in_place_square(arr, lb_stride, lb_block_size, x);
+        // Swap TR (top-right) with BL (bottom-left)
+        transpose_swap_square(
+            ptr.add((x << lb_stride) + (x + block_size)),
+            ptr.add(((x + block_size) << lb_stride) + x),
+            stride,
+            (dim, dim),
+        );
+        // Transpose BR quadrant (bottom-right)
+        transpose_in_place_square(arr, lb_stride, lb_block_size, x + block_size);
     }
 }
 
@@ -144,46 +314,27 @@ mod tests {
         transposed
     }
 
-    /// Helper to test the full transpose and assert equality with reference
-    fn test_transpose(log_size: usize) {
-        let size = 1 << log_size;
-        let mut mat = generate_matrix(log_size);
+    #[test]
+    fn transpose_square() {
+        // Loop over matrix sizes:
+        // Each size is of the form 2^log_size × 2^log_size
+        for log_size in 1..=10 {
+            // Compute the actual dimension: size = 2^log_size
+            let size = 1 << log_size;
 
-        let expected = transpose_reference(&mat, log_size);
+            // Generate a flat matrix of size×size elements
+            let mut mat = generate_matrix(log_size);
 
-        unsafe {
-            transpose_in_place_square(&mut mat, log_size, log_size, 0);
+            // Compute the reference result using a naive transpose implementation
+            let expected = transpose_reference(&mat, log_size);
+
+            // Perform the in-place transpose on `mat`.
+            unsafe {
+                transpose_in_place_square(&mut mat, log_size, log_size, 0);
+            }
+
+            // Compare the transposed matrix against the reference.
+            assert_eq!(mat, expected, "Transpose failed for {size}x{size} matrix");
         }
-
-        assert_eq!(
-            mat, expected,
-            "Transpose failed for {}x{} matrix",
-            size, size
-        );
-    }
-
-    #[test]
-    fn test_transpose_2x2() {
-        test_transpose(1);
-    }
-
-    #[test]
-    fn test_transpose_4x4() {
-        test_transpose(2);
-    }
-
-    #[test]
-    fn test_transpose_8x8() {
-        test_transpose(3);
-    }
-
-    #[test]
-    fn test_transpose_16x16() {
-        test_transpose(4);
-    }
-
-    #[test]
-    fn test_transpose_32x32() {
-        test_transpose(5);
     }
 }


### PR DESCRIPTION
This approach is directly inspired by https://github.com/recmo/goldilocks/blob/main/ntt/src/permute/square.rs

I noticed that currently the transposition of square matrices never uses parallelization, and we could gain by doing this for large matrices. So basically, I added a parallelization threshold to enable this parallelization when needed.
- I added a unified approach for unit tests to avoid duplicating tests and to be able to test larger dimensions in a single loop and be able to trigger the parallelization strategy.
- When the parallel cfg is disabled, it should revert exactly to the previous logic.
- I've run the benchmarks of the crate to confirm the effect on large matrices and I also added 1 << 26 to confirm this on an even bigger matrix. Here are the results:

```shell
reverse_slice_index_bits/2
                        time:   [23.612 ns 23.870 ns 24.309 ns]
                        change: [−0.3428% +1.1072% +3.2738%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high severe
reverse_slice_index_bits/8
                        time:   [31.910 ns 31.981 ns 32.076 ns]
                        change: [−3.5554% −1.7324% −0.3097%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
reverse_slice_index_bits/32
                        time:   [50.220 ns 50.243 ns 50.268 ns]
                        change: [−1.1057% −0.5154% −0.1680%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
reverse_slice_index_bits/256
                        time:   [216.02 ns 216.68 ns 217.92 ns]
                        change: [−0.8548% −0.3059% +0.1152%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
reverse_slice_index_bits/65536
                        time:   [134.02 µs 136.70 µs 140.57 µs]
                        change: [+1.9106% +12.805% +21.804%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
reverse_slice_index_bits/16777216
                        time:   [29.594 ms 29.852 ms 30.130 ms]
                        change: [−35.150% −34.000% −32.937%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking reverse_slice_index_bits/67108864: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 13.4s, or reduce sample count to 30.
reverse_slice_index_bits/67108864
                        time:   [137.48 ms 140.69 ms 144.33 ms]
                        change: [−43.812% −41.142% −38.775%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe
```

I believe that as you said here https://github.com/tcoratger/whir-p3/pull/59 for some reason, case 16 is very special as the parallel computation seems to be slower for this case and I cannot really understand why but for all the other tests of high dimensions this is the opposite and we can observe speedups up to 40% for the largest test (1 << 26).

I also wrote a write up about the method here https://hackmd.io/@tcoratger/Hyu8A-KWee in addition to the documentation that I reformulated for everyone to understand this tricky algorithm in the future.