### PR TITLE
dft: accelerate `coset_lde_batch` using `copy_from_slice`

### DIFF
--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -237,14 +237,14 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         // `K` which is the evaluations of `f1` over `shift * K` which is the evaluations of `f` over `g * shift * K`.
         let mut coeffs = self.idft_batch(mat);
         // PANICS: possible panic if the new resized length overflows
-        coeffs.values.resize(
+        let coeffs_zeros = F::zero_vec(
             coeffs
                 .values
                 .len()
                 .checked_shl(added_bits.try_into().unwrap())
                 .unwrap(),
-            F::ZERO,
         );
+        coeffs.values.copy_from_slice(&coeffs_zeros);
         self.coset_dft_batch(coeffs, shift)
     }
 


### PR DESCRIPTION
@SyxtonPrime After reading the comment here https://github.com/tcoratger/whir-p3/pull/76, I thought it might be a good idea to apply it here. I've run the benchmarks, and I saw a slight trend toward something faster, but within the noise threshold. I'm not sure if this optimization applies here; feel free to close if running this on your side doesn't add anything significant.

If necessary, I can add a comment in the code to explain why the resize isn't used so that we don't revert to the old version in the future when trying to refactor.