### PR TITLE
Fix `PackedFieldExtension::from_ext_slice` for `F::Packing`

### DIFF
--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -354,7 +354,7 @@ unsafe impl<F: Field> PackedFieldPow2 for F {
 
 impl<F: Field> PackedFieldExtension<F, F> for F::Packing {
     fn from_ext_slice(ext_slice: &[F]) -> Self {
-        ext_slice[0].into()
+        *F::Packing::from_slice(ext_slice)
     }
 
     fn packed_ext_powers(base: F) -> Powers<Self> {


### PR DESCRIPTION
The `PackedFieldExtension` impl for `F::Packing` is useful when setting `Chalenge = F` for debugging, but the extension packing of `F as ExtensionField<F>` doesn't really pack, if I understand the trait correctly it should pack the slice as `F::Packing` does.

(in optimised/production impl this might never be called tho, because one would probably want to check the degree of extension field and fallback to use trait `PackedValue` if the degree is 1, or because setting `Challenge = F` is not sound at all).