### PR TITLE
Extension Field Tests

### DIFF
--- a/baby-bear/src/extension_test.rs
+++ b/baby-bear/src/extension_test.rs
@@ -40,6 +40,21 @@ mod test_quartic_extension {
     test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 
+    mod test_packed_quartic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::BabyBear;
+
+        type Pef = PackedBinomialExtensionField<BabyBear, <BabyBear as Field>::Packing, 4>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
+
     #[test]
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");
@@ -93,4 +108,19 @@ mod test_quintic_extension {
     );
     test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
+
+    mod test_packed_quintic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::BabyBear;
+
+        type Pef = PackedBinomialExtensionField<BabyBear, <BabyBear as Field>::Packing, 5>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }

--- a/baby-bear/src/extension_test.rs
+++ b/baby-bear/src/extension_test.rs
@@ -5,7 +5,7 @@ mod test_quartic_extension {
     use num_bigint::BigUint;
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;
 
@@ -37,6 +37,7 @@ mod test_quartic_extension {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
+    test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 
     #[test]
@@ -60,7 +61,7 @@ mod test_quintic_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::BabyBear;
 
@@ -90,5 +91,6 @@ mod test_quintic_extension {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
+    test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 }

--- a/field-testing/src/extension_testing.rs
+++ b/field-testing/src/extension_testing.rs
@@ -1,10 +1,9 @@
 use alloc::vec::Vec;
+
 use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue};
-use rand::{
-    Rng, SeedableRng,
-    distr::{Distribution, StandardUniform},
-    rngs::SmallRng,
-};
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 use crate::exp_biguint;
 

--- a/field-testing/src/extension_testing.rs
+++ b/field-testing/src/extension_testing.rs
@@ -1,0 +1,126 @@
+use alloc::vec::Vec;
+use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue};
+use rand::{
+    Rng, SeedableRng,
+    distr::{Distribution, StandardUniform},
+    rngs::SmallRng,
+};
+
+use crate::exp_biguint;
+
+pub fn test_to_from_extension_field<F, EF>()
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+
+    let base_elem = rng.random();
+    let base_elem_in_ext: EF = base_elem.into();
+    assert!(base_elem_in_ext.is_in_basefield());
+    assert_eq!(base_elem_in_ext.as_base(), Some(base_elem));
+
+    let extension_elem = EF::from_basis_coefficients_fn(|_| rng.random());
+    let ext_degree = EF::DIMENSION;
+
+    if ext_degree == 1 {
+        assert!(
+            extension_elem.is_in_basefield(),
+            "The element {} does not lie in the base field, but it should.",
+            extension_elem
+        );
+    } else {
+        // In principle it's possible that a randomly chosen element does lie in the base field.
+        // But this is very unlikely. If this comes up regularly, we can change the test.
+        assert!(
+            !extension_elem.is_in_basefield(),
+            "The randomly chosen element {} lies in the base field, but it (likely) should not.",
+            extension_elem
+        );
+        assert_eq!(extension_elem.as_base(), None);
+    }
+}
+
+/// Test that products and sums of galois conjugates lie in the base field.
+///
+/// This test can be skipped for extension fields of degree 1 as it is trivial.
+pub fn test_galois_extension<F, EF>()
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+
+    let extension_elem = EF::from_basis_coefficients_fn(|_| rng.random());
+    let ext_degree = EF::DIMENSION;
+
+    let field_degree = F::order();
+
+    // Let |F| = p and |EF| = p^d.
+    // Then `(|EF| - 1)/(|F| - 1) = 1 + p + ... + p^(d-1)`.
+    // Given any element `x`, any symmetric function of `x, x^p, ... x^{p^(d-1)}` must lie in the base field.
+    // In particular:
+    //
+    // `Norm(x)  = x^{(|EF| - 1)/(|F| - 1)} = x^{1 + p + ... + p^(d-1)}`
+    // `Trace(x) = x + x^p + ... + x^{p^{d - 1}}`
+    //
+    // We could test other symmetric functions but that seems unnecessary for now.
+
+    let mut mul = extension_elem;
+    let mut acc = extension_elem;
+    let mut current_power = extension_elem;
+    for _ in 1..ext_degree {
+        current_power = exp_biguint(current_power, &field_degree);
+        acc += current_power;
+        mul *= current_power;
+    }
+
+    assert!(
+        mul.is_in_basefield(),
+        "The product of galois conjugates {} of the element {} does not lie in the base field.",
+        mul,
+        extension_elem
+    );
+    assert!(
+        acc.is_in_basefield(),
+        "The sum of galois conjugates {} of the element {} does not lie in the base field.",
+        acc,
+        extension_elem
+    );
+}
+
+pub fn test_packed_extension<F, EF>()
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    let width = F::Packing::WIDTH;
+    let extension_elements: Vec<EF> = (0..width)
+        .map(|_| EF::from_basis_coefficients_fn(|_| rng.random()))
+        .collect();
+
+    let packed_extension = EF::ExtensionPacking::from_ext_slice(&extension_elements);
+    let unpacked_extension: Vec<EF> =
+        EF::ExtensionPacking::to_ext_iter([packed_extension]).collect();
+
+    assert_eq!(extension_elements, unpacked_extension);
+
+    let base_powers: Vec<EF> = extension_elements[0].powers().take(10 * width).collect();
+
+    let packed_powers = EF::ExtensionPacking::packed_ext_powers(extension_elements[0]);
+    let unpacked_powers: Vec<EF> = EF::ExtensionPacking::to_ext_iter(packed_powers)
+        .take(10 * width)
+        .collect();
+    assert_eq!(base_powers, unpacked_powers);
+
+    let packed_powers_capped =
+        EF::ExtensionPacking::packed_ext_powers_capped(extension_elements[0], 10 * width);
+
+    let unpacked_powers: Vec<EF> =
+        EF::ExtensionPacking::to_ext_iter(packed_powers_capped).collect();
+    assert_eq!(base_powers, unpacked_powers);
+}

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -697,6 +697,25 @@ where
     assert_eq!(combined_u64s, expected_combined_u64s);
 }
 
+/// A macro to generate tests for rings which implement equality but may not implement anything else.
+///
+/// Structs should prefer [test_field] or [test_packed_field] over this if they implement either of those traits.
+#[macro_export]
+macro_rules! test_ring {
+    ($ring:ty, $zeros: expr, $ones: expr) => {
+        mod ring_tests {
+            #[test]
+            fn test_ring_with_eq() {
+                $crate::test_ring_with_eq::<$ring>($zeros, $ones);
+            }
+            #[test]
+            fn test_mul_2exp_u64() {
+                $crate::test_mul_2exp_u64::<$ring>();
+            }
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! test_field {
     ($field:ty, $zeros: expr, $ones: expr, $factors: expr) => {
@@ -954,7 +973,7 @@ macro_rules! test_two_adic_field {
 #[macro_export]
 macro_rules! test_extension_field {
     ($field:ty, $ef:ty) => {
-        mod packed_extension_tests {
+        mod extension_field_tests {
             #[test]
             fn test_to_from_extension() {
                 $crate::test_to_from_extension_field::<$field, $ef>();

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -6,6 +6,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
 use p3_util::{flatten_to_base, reconstitute_from_base};
+use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -64,6 +65,17 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
         Self {
             value: field_to_array(x),
         }
+    }
+}
+
+impl<F: Field, PF: PackedField<Scalar = F>, const D: usize>
+    Distribution<PackedBinomialExtensionField<F, PF, D>> for StandardUniform
+where
+    Self: Distribution<PF>,
+{
+    #[inline]
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedBinomialExtensionField<F, PF, D> {
+        PackedBinomialExtensionField::new(array::from_fn(|_| self.sample(rng)))
     }
 }
 

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -108,6 +108,21 @@ mod test_quadratic_extension {
 
     test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
+
+    mod test_packed_quadratic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Goldilocks;
+
+        type Pef = PackedBinomialExtensionField<Goldilocks, <Goldilocks as Field>::Packing, 2>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }
 
 #[cfg(test)]
@@ -154,4 +169,19 @@ mod test_quintic_extension {
 
     test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
+
+    mod test_packed_quintic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Goldilocks;
+
+        type Pef = PackedBinomialExtensionField<Goldilocks, <Goldilocks as Field>::Packing, 5>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -71,7 +71,7 @@ mod test_quadratic_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::Goldilocks;
 
@@ -106,6 +106,7 @@ mod test_quadratic_extension {
         &super::multiplicative_group_prime_factorization()
     );
 
+    test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 }
 
@@ -115,7 +116,7 @@ mod test_quintic_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::Goldilocks;
 
@@ -151,5 +152,6 @@ mod test_quintic_extension {
         &super::multiplicative_group_prime_factorization()
     );
 
+    test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 }

--- a/koala-bear/src/extension_test.rs
+++ b/koala-bear/src/extension_test.rs
@@ -39,6 +39,21 @@ mod test_quartic_extension {
     test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 
+    mod test_packed_quartic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::KoalaBear;
+
+        type Pef = PackedBinomialExtensionField<KoalaBear, <KoalaBear as Field>::Packing, 4>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
+
     #[test]
     fn display() {
         assert_eq!(format!("{}", EF::ZERO), "0");

--- a/koala-bear/src/extension_test.rs
+++ b/koala-bear/src/extension_test.rs
@@ -5,7 +5,7 @@ mod test_quartic_extension {
     use num_bigint::BigUint;
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::KoalaBear;
 
@@ -36,6 +36,7 @@ mod test_quartic_extension {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
+    test_extension_field!(super::F, super::EF);
     test_two_adic_extension_field!(super::F, super::EF);
 
     #[test]

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -58,7 +58,7 @@ impl HasTwoAdicBinomialExtension<2> for Mersenne31 {
 mod tests {
     use num_bigint::BigUint;
     use p3_field::PrimeField32;
-    use p3_field_testing::{test_field, test_two_adic_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_field};
 
     use super::*;
 
@@ -190,5 +190,7 @@ mod tests {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
-    test_two_adic_field!(p3_field::extension::Complex<crate::Mersenne31>);
+
+    test_extension_field!(super::F, super::Fi);
+    test_two_adic_field!(super::Fi);
 }

--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -193,4 +193,19 @@ mod tests {
 
     test_extension_field!(super::F, super::Fi);
     test_two_adic_field!(super::Fi);
+
+    mod test_packed_complex_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Mersenne31;
+
+        type Pef = PackedBinomialExtensionField<Mersenne31, <Mersenne31 as Field>::Packing, 2>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -146,6 +146,21 @@ mod test_cubic_extension {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
+
+    mod test_packed_cubic_extension {
+        use p3_field::extension::PackedBinomialExtensionField;
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Mersenne31;
+
+        type Pef = PackedBinomialExtensionField<Mersenne31, <Mersenne31 as Field>::Packing, 3>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +211,22 @@ mod test_cubic_complex_extension {
     test_extension_field!(super::F, super::EF);
 
     test_two_adic_extension_field!(super::F, super::EF);
+
+    mod test_packed_cubic_complex_extension {
+        use p3_field::extension::{Complex, PackedBinomialExtensionField};
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Mersenne31;
+        type Fi = Complex<Mersenne31>;
+
+        type Pef = PackedBinomialExtensionField<Fi, <Fi as Field>::Packing, 3>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }
 
 #[cfg(test)]
@@ -244,4 +275,20 @@ mod test_quadratic_complex_extension {
     test_extension_field!(super::F, super::EF);
 
     test_two_adic_extension_field!(super::F, super::EF);
+
+    mod test_packed_quadratic_complex_extension {
+        use p3_field::extension::{Complex, PackedBinomialExtensionField};
+        use p3_field::{Field, PrimeCharacteristicRing};
+        use p3_field_testing::test_ring;
+
+        use crate::Mersenne31;
+        type Fi = Complex<Mersenne31>;
+
+        type Pef = PackedBinomialExtensionField<Fi, <Fi as Field>::Packing, 2>;
+
+        const PACKED_ZEROS: [Pef; 1] = [Pef::ZERO];
+        const PACKED_ONES: [Pef; 1] = [Pef::ONE];
+
+        test_ring!(super::Pef, &super::PACKED_ZEROS, &super::PACKED_ONES);
+    }
 }

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -110,7 +110,7 @@ mod test_cubic_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field_testing::test_field;
+    use p3_field_testing::{test_extension_field, test_field};
 
     use crate::Mersenne31;
 
@@ -138,6 +138,8 @@ mod test_cubic_extension {
         ]
     }
 
+    test_extension_field!(super::F, super::EF);
+
     test_field!(
         super::EF,
         &super::ZEROS,
@@ -151,7 +153,7 @@ mod test_cubic_complex_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::{BinomialExtensionField, Complex};
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::Mersenne31;
 
@@ -191,6 +193,8 @@ mod test_cubic_complex_extension {
         &super::multiplicative_group_prime_factorization()
     );
 
+    test_extension_field!(super::F, super::EF);
+
     test_two_adic_extension_field!(super::F, super::EF);
 }
 
@@ -200,7 +204,7 @@ mod test_quadratic_complex_extension {
     use num_bigint::BigUint;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::{BinomialExtensionField, Complex};
-    use p3_field_testing::{test_field, test_two_adic_extension_field};
+    use p3_field_testing::{test_extension_field, test_field, test_two_adic_extension_field};
 
     use crate::Mersenne31;
 
@@ -236,6 +240,8 @@ mod test_quadratic_complex_extension {
         &super::ONES,
         &super::multiplicative_group_prime_factorization()
     );
+
+    test_extension_field!(super::F, super::EF);
 
     test_two_adic_extension_field!(super::F, super::EF);
 }


### PR DESCRIPTION
Thanks to #873 I realized we were missing some tests for our extension fields.

This PR adds 3 simple tests ensuring that the extension field trait is working correctly.

Two of the tests are just directly testing methods in either ExtensionField or ExtensionPacking. The third is additionally doing some simple Galois theoretic tests to ensure the Extension field is functioning as expected.

Additionally we add testing for `PackedBinomialExtensionField` which had previously been untested.