### PR TITLE
linear_map.rs: Add convenience methods

### DIFF
--- a/util/src/linear_map.rs
+++ b/util/src/linear_map.rs
@@ -31,6 +31,7 @@ impl<K: Eq, V> LinearMap<K, V> {
         Default::default()
     }
 
+    /// Creates a new empty `LinearMap` with a pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self(Vec::with_capacity(capacity))
     }


### PR DESCRIPTION
Added a few methods to `LinearMap` that are often associated with maps. 