### PR TITLE
p3-field: more packing and cleanup

### DIFF
--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::iter;
 
-use p3_field::{Field, PackedField, PackedValue, TwoAdicField, scale_slice_in_place};
+use p3_field::{Field, PackedField, PackedValue, TwoAdicField, scale_slice_in_place_single_core};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
@@ -432,7 +432,7 @@ fn par_initial_layers<F: Field>(
         .enumerate()
         .for_each(|(index, chunk)| {
             // Divide all elements by the height of the matrix.
-            scale_slice_in_place(chunk, height_inv);
+            scale_slice_in_place_single_core(chunk, height_inv);
 
             for (layer, twiddles) in root_table.iter().enumerate() {
                 let num_twiddles_per_block = 1 << (num_rounds - layer - 1);

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::iter;
 
-use p3_field::{Field, PackedField, PackedValue, TwoAdicField, scale_slice_in_place_single_core};
+use p3_field::{Field, PackedField, PackedValue, TwoAdicField, scale_slice_in_place};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
@@ -432,7 +432,7 @@ fn par_initial_layers<F: Field>(
         .enumerate()
         .for_each(|(index, chunk)| {
             // Divide all elements by the height of the matrix.
-            scale_slice_in_place_single_core(height_inv, chunk);
+            scale_slice_in_place(chunk, height_inv);
 
             for (layer, twiddles) in root_table.iter().enumerate() {
                 let num_twiddles_per_block = 1 << (num_rounds - layer - 1);

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -501,6 +501,7 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
     #[must_use]
+    #[inline]
     fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self>
     where
         F: Sync,

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -501,7 +501,6 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     /// (or rederived within) another compilation environment where a
     /// different basis might have been used.
     #[must_use]
-    #[inline]
     fn reconstitute_from_base(vec: Vec<F>) -> Vec<Self>
     where
         F: Sync,

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -29,7 +29,11 @@ pub fn cyclic_subgroup_coset_known_order<F: Field>(
 ///
 /// # Performance
 /// For large slices, use [`par_scale_slice_in_place`].
-pub fn scale_slice_in_place<F: Field>(slice: &mut [F], s: F) {
+///
+/// # Deprecation
+/// This function will be replaced with [`scale_slice_in_place`] whose semantics and arguments
+/// will be the same as this one.
+pub fn scale_slice_in_place_single_core<F: Field>(slice: &mut [F], s: F) {
     let (packed, sfx) = F::Packing::pack_slice_with_suffix_mut(slice);
     let packed_s: F::Packing = s.into();
     packed.iter_mut().for_each(|x| *x *= packed_s);
@@ -39,13 +43,23 @@ pub fn scale_slice_in_place<F: Field>(slice: &mut [F], s: F) {
 /// Scales each element of the slice by `s` using packing and parallelization.
 ///
 /// # Performance
-/// For small slices, use [`scale_slice_in_place`].
+/// For small slices, use [`scale_slice_in_place_single_core`].
 /// Requires the `parallel` feature.
+#[inline]
 pub fn par_scale_slice_in_place<F: Field>(slice: &mut [F], s: F) {
     let (packed, sfx) = F::Packing::pack_slice_with_suffix_mut(slice);
     let packed_s: F::Packing = s.into();
     packed.par_iter_mut().for_each(|x| *x *= packed_s);
     sfx.iter_mut().for_each(|x| *x *= s);
+}
+
+/// This function is deprecated. It is currently a wrapper for [`par_scale_slice_in_place`], which
+/// it should be replaced with if parallelization is required.
+#[deprecated(
+    note = "use `par_scale_slice_in_place` instead which will replace this method in the future"
+)]
+pub fn scale_slice_in_place<F: Field>(s: F, slice: &mut [F]) {
+    par_scale_slice_in_place(slice, s)
 }
 
 /// Adds `other`, scaled by `s`, to the mutable `slice` using packing, or `slice += other * s`.

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -1,25 +1,9 @@
 mod helpers {
     use p3_baby_bear::BabyBear;
     use p3_field::{
-        PrimeCharacteristicRing, add_scaled_slice_in_place, dot_product, field_to_array, reduce_32,
-        scale_vec, split_32,
+        PrimeCharacteristicRing, add_scaled_slice_in_place, dot_product, field_to_array,
+        par_add_scaled_slice_in_place, reduce_32, split_32,
     };
-
-    #[test]
-    fn test_scale_vec() {
-        // Scale [1, 2, 3] by 7
-        let v = vec![BabyBear::ONE, BabyBear::TWO, BabyBear::ONE + BabyBear::TWO];
-        let s = BabyBear::from_u8(7);
-        let result = scale_vec(s, v);
-
-        let expected = vec![
-            s * BabyBear::ONE,
-            s * BabyBear::TWO,
-            s * BabyBear::from_u8(3),
-        ];
-
-        assert_eq!(result, expected);
-    }
 
     #[test]
     fn test_add_scaled_slice_in_place() {
@@ -27,13 +11,15 @@ mod helpers {
         let x1 = BabyBear::ONE;
         let x2 = BabyBear::TWO;
         let mut x = vec![x1, x2];
+        let mut par_x = x.clone();
 
         let y1 = BabyBear::from_u8(10);
         let y2 = BabyBear::from_u8(20);
         let y = vec![y1, y2];
         let s = BabyBear::from_u8(3);
 
-        add_scaled_slice_in_place(&mut x, y.into_iter(), s);
+        add_scaled_slice_in_place(&mut x, &y, s);
+        par_add_scaled_slice_in_place(&mut par_x, &y, s);
 
         // x = [x1 + s * y1, x2 + s * y2]
         let expected = vec![x1 + s * y1, x2 + s * y2];
@@ -45,12 +31,15 @@ mod helpers {
     fn test_add_scaled_slice_in_place_zero_scale() {
         let original = vec![BabyBear::from_u8(4), BabyBear::from_u8(5)];
         let mut x = original.clone();
+        let mut par_x = original.clone();
         let y = vec![BabyBear::from_u8(6), BabyBear::from_u8(7)];
         let s = BabyBear::ZERO;
 
-        add_scaled_slice_in_place(&mut x, y.into_iter(), s);
+        add_scaled_slice_in_place(&mut x, &y, s);
+        par_add_scaled_slice_in_place(&mut par_x, &y, s);
 
         assert_eq!(x, original);
+        assert_eq!(par_x, original);
     }
 
     #[test]

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -6,7 +6,9 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{ExtensionField, TwoAdicField, batch_multiplicative_inverse, scale_slice_in_place};
+use p3_field::{
+    ExtensionField, TwoAdicField, batch_multiplicative_inverse, scale_slice_in_place_single_core,
+};
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -118,7 +120,7 @@ where
     // For each column polynomial `f_j`, compute `\sum_i h^i/(gh^i - z) * f_j(gh^i)`,
     // then scale by s.
     let mut evals = coset_evals.columnwise_dot_product(&col_scale);
-    scale_slice_in_place(&mut evals, scaling_factor);
+    scale_slice_in_place_single_core(&mut evals, scaling_factor);
     evals
 }
 

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use p3_field::{ExtensionField, TwoAdicField, batch_multiplicative_inverse, scale_vec};
+use p3_field::{ExtensionField, TwoAdicField, batch_multiplicative_inverse, scale_slice_in_place};
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -103,9 +103,6 @@ where
         .map(|(&sg, &diff_inv)| diff_inv * sg)
         .collect();
 
-    // For each column polynomial `f_j`, compute `\sum_i h^i/(gh^i - z) * f_j(gh^i)`.
-    let sum = coset_evals.columnwise_dot_product(&col_scale);
-
     let point_pow_height = point.exp_power_of_2(log_height);
     let shift_pow_height = shift.exp_power_of_2(log_height);
 
@@ -114,7 +111,15 @@ where
 
     // Compute N * g^N
     let denominator = shift_pow_height.mul_2exp_u64(log_height as u64);
-    scale_vec(vanishing_polynomial * denominator.inverse(), sum)
+
+    // Scaling factor s = Z_{sH}(z)/(N * g^N)
+    let scaling_factor = vanishing_polynomial * denominator.inverse();
+
+    // For each column polynomial `f_j`, compute `\sum_i h^i/(gh^i - z) * f_j(gh^i)`,
+    // then scale by s.
+    let mut evals = coset_evals.columnwise_dot_product(&col_scale);
+    scale_slice_in_place(&mut evals, scaling_factor);
+    evals
 }
 
 #[cfg(test)]

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 
 use p3_field::{
-    ExtensionField, Field, PackedValue, par_scale_slice_in_place, scale_slice_in_place,
+    ExtensionField, Field, PackedValue, par_scale_slice_in_place, scale_slice_in_place_single_core,
 };
 use p3_maybe_rayon::prelude::*;
 use rand::Rng;
@@ -207,7 +207,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         T: Field,
         S: BorrowMut<[T]>,
     {
-        scale_slice_in_place(self.row_mut(r), scale);
+        scale_slice_in_place_single_core(self.row_mut(r), scale);
     }
 
     /// Scale the given row by the given value.

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -6,7 +6,9 @@ use core::iter;
 use core::marker::PhantomData;
 use core::ops::Deref;
 
-use p3_field::{ExtensionField, Field, PackedValue, scale_slice_in_place};
+use p3_field::{
+    ExtensionField, Field, PackedValue, par_scale_slice_in_place, scale_slice_in_place,
+};
 use p3_maybe_rayon::prelude::*;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
@@ -205,7 +207,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         T: Field,
         S: BorrowMut<[T]>,
     {
-        scale_slice_in_place(scale, self.row_mut(r));
+        scale_slice_in_place(self.row_mut(r), scale);
     }
 
     /// Scale the entire matrix by the given value.
@@ -214,7 +216,7 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         T: Field,
         S: BorrowMut<[T]>,
     {
-        scale_slice_in_place(scale, self.values.borrow_mut());
+        par_scale_slice_in_place(self.values.borrow_mut(), scale);
     }
 
     /// Split the matrix into two matrix views, one with the first `r` rows and one with the remaining rows.

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -210,6 +210,22 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> DenseMatrix<T, S> {
         scale_slice_in_place(self.row_mut(r), scale);
     }
 
+    /// Scale the given row by the given value.
+    ///
+    /// # Performance
+    /// This function is parallelized, which may introduce some overhead compared to
+    /// [`Self::scale_row`] when the width is small.
+    ///
+    /// # Panics
+    /// Panics if `r` larger than `self.height()`.
+    pub fn par_scale_row(&mut self, r: usize, scale: T)
+    where
+        T: Field,
+        S: BorrowMut<[T]>,
+    {
+        par_scale_slice_in_place(self.row_mut(r), scale);
+    }
+
     /// Scale the entire matrix by the given value.
     pub fn scale(&mut self, scale: T)
     where


### PR DESCRIPTION
Some small cleanups in `p3-field`. The goal is to make the slice operations more uniform (serial vs parallel). 

This PR could go further, and would be happy to discuss.
- make use of the slice functions in other places to benefit of packing 
- move them to `PackedField` (similar to `linear_combination`)

# Details

- `scale_vec` -> remove in favor of `scale_slice_in_place` (in p3-interpolation)
- `scale_slice_in_place_single_core` -> `scale_slice_in_place`, make arguments uniform
- `scale_slice_in_place` -> `par_scale_slice_in_place`
- `add_scaled_slice_in_place` -> use packing
- `par_add_scaled_slice_in_place` -> completeness
- `par_add_scaled_slice_in_place` -> added for completeness
- p3-matrix: don't parallelize row scaling
- field.rs: remove unnecessary `#[must_use]`