### PR TITLE
Cargo.toml: Propagate features and formatting

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = ["p3-monty-31/nightly-features"]
-
 [dependencies]
 p3-field.workspace = true
 p3-mds.workspace = true
@@ -16,14 +13,20 @@ p3-symmetric.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-num-bigint.workspace = true
-rand.workspace = true
 p3-field-testing.workspace = true
 p3-dft.workspace = true
 p3-util.workspace = true
+
+num-bigint.workspace = true
+rand.workspace = true
 criterion.workspace = true
 serde_json.workspace = true
 rand_xoshiro.workspace = true
+
+[features]
+nightly-features = [
+    "p3-monty-31/nightly-features",
+]
 
 [[bench]]
 name = "bench_field"

--- a/blake3-air/Cargo.toml
+++ b/blake3-air/Cargo.toml
@@ -9,40 +9,12 @@ p3-air.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
+
 rand.workspace = true
 tracing.workspace = true
 itertools.workspace = true
 
-[dev-dependencies]
-p3-baby-bear.workspace = true
-p3-blake3.workspace = true
-p3-koala-bear.workspace = true
-p3-challenger.workspace = true
-p3-circle.workspace = true
-p3-commit.workspace = true
-p3-dft.workspace = true
-p3-fri.workspace = true
-p3-goldilocks.workspace = true
-p3-keccak.workspace = true
-p3-mds.workspace = true
-p3-merkle-tree.workspace = true
-p3-mersenne-31.workspace = true
-p3-monty-31.workspace = true
-p3-poseidon.workspace = true
-p3-poseidon2.workspace = true
-p3-sha256.workspace = true
-p3-symmetric.workspace = true
-p3-uni-stark.workspace = true
-tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
-tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
-
 [features]
-parallel = ["p3-maybe-rayon/parallel"]
-asm = ["p3-sha256/asm"]
-nightly-features = [
-    "p3-goldilocks/nightly-features",
-    "p3-monty-31/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-koala-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
+parallel = [
+    "p3-maybe-rayon/parallel", # Trace generation
 ]

--- a/blake3/Cargo.toml
+++ b/blake3/Cargo.toml
@@ -7,8 +7,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 p3-symmetric.workspace = true
 p3-util.workspace = true
-blake3.workspace = true
+blake3 = { workspace = true, default-features = false } # no default features disables `std`-dependent features.
 
 [features]
+# NEON is enabled by default for AArch64, but not for ARMv7 CPUs which don't all support NEON.
+# TODO(@adr1anh): Are we targeting ARMv7? If not, we could remove and avoid another flag.
 neon = ["blake3/neon"]
-parallel = ["blake3/rayon"]
+# Enable SIMD for all `wasm32-*` targets.
+wasm32_simd = ["blake3/wasm32_simd"]

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -13,21 +13,23 @@ num-bigint.workspace = true
 paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
-halo2curves = { version = "0.8.0", features = ["bits", "derive_serde"] }
+halo2curves = { version = "0.8.0", default-features = false, features = ["bits", "derive_serde"] }
+
+# Only on x86_64 do we actually pull in the “asm” feature for halo2curves:
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+halo2curves = { version = "0.8.0", default-features = false, features = ["bits", "derive_serde", "asm"] }
 
 [dev-dependencies]
 p3-field-testing.workspace = true
-
 criterion.workspace = true
 serde_json.workspace = true
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2" }
 
 [features]
-default = []
 table = [
-    "halo2curves/bn256-table",
-] # Generate cached table of [0, 2^16) in Bn254Fr at compile time
-asm = ["halo2curves/asm"]
+    # TODO(@adr1anh): Do we want this to be default?
+    "halo2curves/bn256-table", # Generate cached table of [0, 2^16) in Bn254Fr at compile time
+]
 
 [[bench]]
 name = "bench_field"

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -14,3 +14,8 @@ tracing.workspace = true
 [dev-dependencies]
 p3-goldilocks.workspace = true
 p3-baby-bear.workspace = true
+
+[features]
+parallel = [
+    "p3-maybe-rayon/parallel", # Grinding
+]

--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -32,6 +32,18 @@ criterion.workspace = true
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 
+[features]
+parallel = [
+    "p3-challenger/parallel", # Grinding
+    "p3-commit/parallel",
+    "p3-dft/parallel",
+    "p3-field/parallel",
+    "p3-fri/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+    "p3-util/parallel",
+]
+
 [[bench]]
 name = "cfft"
 harness = false

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-default = ["test-utils"]
-test-utils = ["p3-challenger", "p3-dft"]
-
 [dependencies]
 p3-field.workspace = true
 p3-matrix.workspace = true
@@ -23,3 +19,11 @@ p3-dft = { workspace = true, optional = true }
 [dev-dependencies]
 p3-challenger.workspace = true
 p3-dft.workspace = true
+
+[features]
+default = ["test-utils"]
+test-utils = ["p3-challenger", "p3-dft"]
+parallel = [
+    "p3-field/parallel",
+    "p3-matrix/parallel",
+]

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -9,6 +9,7 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+
 tracing.workspace = true
 itertools.workspace = true
 
@@ -17,18 +18,25 @@ p3-monty-31.workspace = true
 p3-baby-bear.workspace = true
 p3-goldilocks.workspace = true
 p3-mersenne-31.workspace = true
+
 criterion.workspace = true
 rand.workspace = true
 
-[[bench]]
-name = "fft"
-harness = false
-
 [features]
+parallel = [
+    "p3-field/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+    "p3-util/parallel"
+]
+# Benchmarking
 nightly-features = [
     "p3-goldilocks/nightly-features",
     "p3-monty-31/nightly-features",
     "p3-baby-bear/nightly-features",
     "p3-mersenne-31/nightly-features",
 ]
-parallel = ["p3-maybe-rayon/parallel"]
+
+[[bench]]
+name = "fft"
+harness = false

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ p3-poseidon2.workspace = true
 p3-poseidon2-air.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
+
 bincode = { workspace = true, features = ["serde", "alloc"] }
 clap.workspace = true
 rand.workspace = true
@@ -30,24 +31,37 @@ rand.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true
-p3-blake3.workspace = true
 p3-commit = { workspace = true, features = ["test-utils"] }
 p3-challenger.workspace = true
 p3-dft.workspace = true
 p3-koala-bear.workspace = true
 p3-matrix.workspace = true
-p3-sha256.workspace = true
-clap_derive.workspace = true
-postcard = { workspace = true, features = ["alloc"] }
-tracing.workspace = true
+
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 
 
 [features]
+parallel = [
+    "p3-field/parallel",
+    "p3-challenger/parallel",
+    "p3-circle/parallel",
+    "p3-commit/parallel",
+    "p3-dft/parallel",
+    "p3-fri/parallel",
+    "p3-keccak-air/parallel",
+    "p3-matrix/parallel",
+    "p3-merkle-tree/parallel",
+    "p3-mersenne-31/parallel",
+    "p3-monty-31/parallel",
+    "p3-uni-stark/parallel",
+]
+asm = ["p3-keccak-air/asm"]
 nightly-features = [
-    "p3-monty-31/nightly-features",
     "p3-baby-bear/nightly-features",
+    "p3-keccak/nightly-features",
     "p3-koala-bear/nightly-features",
     "p3-mersenne-31/nightly-features",
+    "p3-monty-31/nightly-features",
+    "p3-uni-stark/nightly-features",
 ]

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -8,10 +8,8 @@ license = "MIT OR Apache-2.0"
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
+p3-util.workspace = true
+
 rand.workspace = true
 criterion.workspace = true
 num-bigint.workspace = true
-p3-util.workspace = true
-
-[dev-dependencies]
-p3-baby-bear.workspace = true

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 p3-util.workspace = true
 p3-maybe-rayon.workspace = true
+
 num-bigint.workspace = true
 paste.workspace = true
 tracing.workspace = true
-
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -18,3 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 [dev-dependencies]
 p3-baby-bear.workspace = true
 p3-goldilocks.workspace = true
+
+[features]
+# Batch inversion
+parallel = ["p3-maybe-rayon/parallel"]

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -14,6 +14,9 @@ use crate::{FieldArray, PackedValue, PrimeCharacteristicRing};
 /// resulting in a long dependency chain. To increase instruction-level parallelism, we
 /// compute WIDTH separate cumulative product arrays that only meet at the end.
 ///
+/// # Performance
+/// To benefit from parallelization, the `parallel` feature must be enabled for this crate.
+///
 /// # Panics
 /// This will panic if any of the inputs is zero.
 #[instrument(level = "debug", skip_all)]

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -13,6 +13,7 @@ p3-interpolation.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+
 itertools.workspace = true
 rand.workspace = true
 tracing.workspace = true
@@ -26,9 +27,20 @@ p3-goldilocks.workspace = true
 p3-keccak.workspace = true
 p3-mersenne-31.workspace = true
 p3-merkle-tree.workspace = true
-p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
 criterion.workspace = true
+
+[features]
+parallel = [
+    "p3-challenger/parallel", # Grinding
+    "p3-commit/parallel",
+    "p3-dft/parallel",
+    "p3-field/parallel", # Batch inversion
+    "p3-interpolation/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+    "p3-util/parallel"
+]
 
 [[bench]]
 name = "fold_even_odd"

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = []
-
 [dependencies]
 p3-field.workspace = true
 p3-dft.workspace = true
@@ -14,6 +11,7 @@ p3-mds.workspace = true
 p3-symmetric.workspace = true
 p3-util.workspace = true
 p3-poseidon2.workspace = true
+
 num-bigint.workspace = true
 paste.workspace = true
 rand.workspace = true
@@ -21,9 +19,14 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 p3-field-testing.workspace = true
-p3-poseidon.workspace = true
 rand.workspace = true
 criterion.workspace = true
+
+[features]
+# Benchmarking
+nightly-features = [
+    "p3-poseidon2/nightly-features"
+]
 
 [[bench]]
 name = "bench_field"

--- a/interpolation/Cargo.toml
+++ b/interpolation/Cargo.toml
@@ -12,3 +12,10 @@ p3-util.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true
+
+[features]
+parallel = [
+    "p3-field/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+]

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -10,12 +10,12 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+
 rand.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true
-p3-koala-bear.workspace = true
 p3-challenger.workspace = true
 p3-circle.workspace = true
 p3-commit.workspace = true
@@ -26,20 +26,21 @@ p3-keccak.workspace = true
 p3-merkle-tree.workspace = true
 p3-mersenne-31.workspace = true
 p3-monty-31.workspace = true
-p3-poseidon2.workspace = true
 p3-sha256.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
+
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 
 [features]
+# Trace generation
 parallel = ["p3-maybe-rayon/parallel"]
 asm = ["p3-sha256/asm"]
+# Examples
 nightly-features = [
     "p3-goldilocks/nightly-features",
     "p3-monty-31/nightly-features",
     "p3-baby-bear/nightly-features",
-    "p3-koala-bear/nightly-features",
     "p3-mersenne-31/nightly-features",
 ]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = []
-
 [dependencies]
 p3-field.workspace = true
 p3-symmetric.workspace = true
@@ -16,6 +13,9 @@ tiny-keccak = { workspace = true, features = ["keccak"] }
 [dev-dependencies]
 p3-mersenne-31.workspace = true
 criterion.workspace = true
+
+[features]
+nightly-features = []
 
 [[bench]]
 name = "bench_keccak"

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = ["p3-monty-31/nightly-features"]
-
 [dependencies]
 p3-field.workspace = true
 p3-monty-31.workspace = true
@@ -15,14 +12,18 @@ p3-symmetric.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-num-bigint.workspace = true
 p3-dft.workspace = true
 p3-field-testing.workspace = true
 p3-util.workspace = true
+
+num-bigint.workspace = true
 rand.workspace = true
 criterion.workspace = true
 serde_json.workspace = true
 rand_xoshiro.workspace = true
+
+[features]
+nightly-features = ["p3-monty-31/nightly-features"]
 
 [[bench]]
 name = "bench_field"

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 p3-field.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -15,9 +16,13 @@ transpose.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear.workspace = true
 p3-mersenne-31.workspace = true
+criterion.workspace = true
+
+[features]
+# Parallel row ops and bit-reversing
+parallel = ["p3-maybe-rayon/parallel"]
 
 [[bench]]
 name = "transpose_benchmark"

--- a/maybe-rayon/Cargo.toml
+++ b/maybe-rayon/Cargo.toml
@@ -5,8 +5,8 @@ license = "MIT OR Apache-2.0"
 version = "0.1.0"
 edition = "2024"
 
-[features]
-parallel = ["rayon"]
-
 [dependencies]
 rayon = { workspace = true, optional = true }
+
+[features]
+parallel = ["rayon"]

--- a/mds/Cargo.toml
+++ b/mds/Cargo.toml
@@ -12,10 +12,10 @@ p3-util.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear.workspace = true
 p3-goldilocks.workspace = true
 p3-mersenne-31.workspace = true
+criterion.workspace = true
 
 [[bench]]
 name = "mds"

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -11,6 +11,7 @@ p3-maybe-rayon.workspace = true
 p3-symmetric.workspace = true
 p3-commit.workspace = true
 p3-util.workspace = true
+
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["alloc"] }
@@ -21,9 +22,16 @@ p3-blake3.workspace = true
 p3-keccak.workspace = true
 p3-baby-bear.workspace = true
 p3-mds.workspace = true
-p3-poseidon2.workspace = true
+#p3-poseidon2.workspace = true
 p3-rescue.workspace = true
 criterion.workspace = true
+
+[features]
+parallel = [
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+    "p3-commit/parallel",
+]
 
 [[bench]]
 name = "merkle_tree"

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = []
-
 [dependencies]
-itertools.workspace = true
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
@@ -16,15 +12,25 @@ p3-mds.workspace = true
 p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
 p3-util.workspace = true
+
+itertools.workspace = true
 num-bigint.workspace = true
 paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-criterion.workspace = true
 p3-field-testing.workspace = true
+criterion.workspace = true
 rand_xoshiro.workspace = true
+
+[features]
+# DFT
+parallel = [
+    "p3-dft/parallel",
+    "p3-matrix/parallel",
+]
+nightly-features = []
 
 [[bench]]
 name = "bench_field"

--- a/monolith/Cargo.toml
+++ b/monolith/Cargo.toml
@@ -14,6 +14,9 @@ sha3.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 
+[features]
+nightly-features = ["p3-mersenne-31/nightly-features"]
+
 [[bench]]
 name = "permute"
 harness = false

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = []
-
 [dependencies]
-itertools.workspace = true
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
@@ -17,9 +13,21 @@ p3-mds.workspace = true
 p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
 p3-util.workspace = true
+
+itertools.workspace = true
 num-bigint.workspace = true
 paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 transpose.workspace = true
+
+[features]
+# DFT
+parallel = [
+    "p3-dft/parallel",
+    "p3-field/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+]
+nightly-features = []

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -10,23 +10,22 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-poseidon2.workspace = true
+
 rand.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true
 p3-challenger.workspace = true
-p3-circle.workspace = true
 p3-commit.workspace = true
 p3-dft.workspace = true
 p3-fri.workspace = true
 p3-keccak.workspace = true
 p3-koala-bear.workspace = true
 p3-merkle-tree.workspace = true
-p3-mersenne-31.workspace = true
-p3-monty-31.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
+
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -4,14 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
-[features]
-nightly-features = [
-    "p3-koala-bear/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
-    "p3-goldilocks/nightly-features",
-]
-
 [dependencies]
 p3-field.workspace = true
 p3-symmetric.workspace = true
@@ -26,6 +18,15 @@ p3-koala-bear.workspace = true
 p3-bn254-fr.workspace = true
 p3-goldilocks.workspace = true
 criterion.workspace = true
+
+[features]
+# Benchmarking
+nightly-features = [
+    "p3-koala-bear/nightly-features",
+    "p3-baby-bear/nightly-features",
+    "p3-mersenne-31/nightly-features",
+    "p3-goldilocks/nightly-features",
+]
 
 [[bench]]
 name = "poseidon2"

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-itertools.workspace = true
 p3-field.workspace = true
 p3-mds.workspace = true
 p3-symmetric.workspace = true
 p3-util.workspace = true
+
+itertools.workspace = true
 rand.workspace = true
 sha3.workspace = true
 

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -8,16 +8,19 @@ description = "Plonky3 hash trait implementations for the SHA2-256 hash function
 [dependencies]
 p3-symmetric.workspace = true
 p3-util.workspace = true
-sha2 = { workspace = true, features = ["compress"] }
-
-[features]
-default = []
-asm = [
-    "sha2/asm",
-] # Enable either x86 or aarch assembly implementation based on target.
-force-soft = [
-    "sha2/force-soft",
-] # Force software implementation (default if "asm" feature is not enabled).
+sha2 = { workspace = true, default-features = false, features = ["compress"] } # no default features avoids `std`
 
 [dev-dependencies]
 hex-literal.workspace = true
+
+[features]
+default = ["asm"]
+# Enable either x86 or aarch assembly implementation based on target.
+asm = [
+    "sha2/asm",
+]
+# Force software implementation (default if "asm" feature is not enabled).
+# If `asm` is not available, this crate must be imported with `default-feautures = false`
+no-asm = [
+    "sha2/force-soft",
+]

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -13,27 +13,33 @@ p3-dft.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
+
 itertools.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 p3-baby-bear.workspace = true
-p3-challenger.workspace = true
 p3-circle.workspace = true
 p3-commit = { workspace = true, features = ["test-utils"] }
-p3-dft.workspace = true
 p3-fri.workspace = true
 p3-keccak.workspace = true
-p3-matrix.workspace = true
 p3-merkle-tree.workspace = true
 p3-mersenne-31.workspace = true
 p3-symmetric.workspace = true
+
 postcard = { workspace = true, features = ["alloc"] }
 rand.workspace = true
 
 [features]
-parallel = ["p3-maybe-rayon/parallel"]
+parallel = [
+    "p3-field/parallel",
+    "p3-challenger/parallel",
+    "p3-commit/parallel",
+    "p3-dft/parallel",
+    "p3-matrix/parallel",
+    "p3-maybe-rayon/parallel",
+]
 nightly-features = [
     "p3-baby-bear/nightly-features",
     "p3-mersenne-31/nightly-features",

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -98,6 +98,10 @@ const SMALL_ARR_SIZE: usize = 1 << 16;
 ///
 /// If the whole array fits in fast cache, then the trivial algorithm is cache friendly. Also, if
 /// `T` is really big, then the trivial algorithm is cache-friendly, no matter the size of the array.
+///
+/// # Performance
+///
+/// Enable the `parallel` feature to parallelize.
 pub fn reverse_slice_index_bits<F>(vals: &mut [F])
 where
     F: Copy + Send + Sync,


### PR DESCRIPTION
This PR introduces several changes to the project's `Cargo.toml` configuration files. It was motivated by an observation that the `parallel` feature did not seem to properly propagate correctly. The main culprits were

- matrix: any calls to `par_*` or bit-reversal
- util: `reverse_slice_index_bits`
- field: `batch_multiplicative_inverse` as well as several slice function helpers

Formatting was unified, hence the minimal changes to some `toml`.

Some features were simplified, in particular when propagating external crate features.

For now, the PR remains as draft to gather some feedback. Namely
- What default behavior do we want when it comes to custom assembly implementations? The easiest would be to enable them by default, optionally providing a `no-asm` flag (same as the `sha2/force-soft).
- Do we want `halo2-curves/table` enabled by default?
- How can we ensure proper propagation in future contributions, and what policy do we want to actually enforce.

## Details

**Format**
- Deps -> Features -> Bench
- P3 - new line - external
- parallel -> nightly-features
- Comments for usage

**Feature: parallel**
- monty31: DFT
- blake3: large inputs
- *-air: trace-gen
- challenger: grinding
- circle: DFT
- field: batch inversion and powers collection
- matrix: bit-reverse-rows
- mersenne-31: DFT
- uni-stark/examples: use all features

**Simplification**
- bn254: remove `asm` feature and always enable on x86
- blake3:
  - remove default features (no std)
  - remove `parallel` (only useful for lots of data)
  - add `wasm32_simd` feature propagation
  - `neon` comment
- sha256:
  - `force-soft` -> `no-asm`
  - make `asm` default