### PR TITLE
Testing Large DFT's

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -119,8 +119,8 @@ mod tests {
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{InjectiveMonomial, PermutationMonomial, PrimeField64, TwoAdicField};
     use p3_field_testing::{
-        test_field, test_field_dft, test_prime_field, test_prime_field_32, test_prime_field_64,
-        test_two_adic_field,
+        test_field, test_field_dft, test_field_dft_large, test_prime_field, test_prime_field_32,
+        test_prime_field_64, test_two_adic_field,
     };
 
     use super::*;
@@ -222,7 +222,7 @@ mod tests {
 
     test_field_dft!(radix2dit, crate::BabyBear, super::EF, p3_dft::Radix2Dit<_>);
     test_field_dft!(
-        radix2ditsmallbatch,
+        radix2smallbatch,
         crate::BabyBear,
         super::EF,
         p3_dft::Radix2DFTSmallBatch<_>
@@ -239,6 +239,13 @@ mod tests {
         crate::BabyBear,
         super::EF,
         p3_monty_31::dft::RecursiveDft<_>
+    );
+    test_field_dft_large!(
+        radix2_smallbatch_and_ditparallel,
+        crate::BabyBear,
+        super::EF,
+        p3_dft::Radix2DFTSmallBatch<_>,
+        p3_dft::Radix2DitParallel<_>
     );
     test_prime_field!(crate::BabyBear);
     test_prime_field_64!(crate::BabyBear, &super::ZEROS, &super::ONES);

--- a/field-testing/src/dft_testing.rs
+++ b/field-testing/src/dft_testing.rs
@@ -257,6 +257,49 @@ where
     }
 }
 
+pub fn test_dft_idft_algebra_consistency_large<F, EF, Dft>()
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    StandardUniform: Distribution<EF>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    let dft = Dft::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in &[14, 15, 16, 17] {
+        let h = 1 << log_h;
+        let original = RowMajorMatrix::<EF>::rand(&mut rng, h, 3);
+        let dft_output = dft.dft_algebra_batch(original.clone());
+        let idft_output = dft.idft_algebra_batch(dft_output.to_row_major_matrix());
+        let eq = original == idft_output.to_row_major_matrix();
+        assert!(eq, "Error Found in size: {}", h);
+    }
+}
+
+pub fn test_large_coset_ldes_agree<F, Dft1, Dft2>()
+where
+    F: TwoAdicField,
+    StandardUniform: Distribution<F>,
+    Dft1: TwoAdicSubgroupDft<F>,
+    Dft2: TwoAdicSubgroupDft<F>,
+{
+    let dft1 = Dft1::default();
+    let dft2 = Dft2::default();
+    let mut rng = SmallRng::seed_from_u64(1);
+    for log_h in &[14, 15, 16, 17] {
+        let h = 1 << log_h;
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, h, 16);
+        let shift = F::GENERATOR;
+        let coset_lde_result1 = dft1.coset_lde_batch(mat.clone(), 1, shift);
+        let coset_lde_result2 = dft2.coset_lde_batch(mat, 1, shift);
+
+        assert_eq!(
+            coset_lde_result1.to_row_major_matrix(),
+            coset_lde_result2.to_row_major_matrix()
+        );
+    }
+}
+
 #[macro_export]
 macro_rules! test_field_dft {
     ($mod:ident, $field:ty, $extfield:ty, $dft:ty) => {
@@ -329,6 +372,28 @@ macro_rules! test_field_dft {
             #[test]
             fn dft_idft_algebra_consistency() {
                 $crate::test_dft_idft_algebra_consistency::<$field, $extfield, $dft>();
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! test_field_dft_large {
+    ($mod:ident, $field:ty, $extfield:ty, $dft1:ty, $dft2:ty) => {
+        mod $mod {
+            #[test]
+            fn test_dft1_idft_algebra_consistency_large() {
+                $crate::test_dft_idft_algebra_consistency_large::<$field, $extfield, $dft1>();
+            }
+
+            #[test]
+            fn test_dft2_idft_algebra_consistency_large() {
+                $crate::test_dft_idft_algebra_consistency_large::<$field, $extfield, $dft2>();
+            }
+
+            #[test]
+            fn test_large_coset_ldes_agree() {
+                $crate::test_large_coset_ldes_agree::<$field, $dft1, $dft2>();
             }
         }
     };


### PR DESCRIPTION
Some of our DFT's have different behavior once the size gets large enough (See the SmallBatchDft as an example). This presents a minor issue for testing as our current strategy of comparing to the Naive DFT will take too long.

We can at least check that the dft/idft loop gives back the identity and that different dft's give the same results. This just updates the dft testing code to test some larger dft sizes. I've tried to strike a balance between have the tests run quickly and testing as large a size as possible.