### PR TITLE
Remove some unnecessary TwoAdicField constraints

### DIFF
--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -61,7 +61,7 @@ const fn get_poseidon2_mmcs<
 #[inline]
 pub fn prove_monty31_keccak<
     F: PrimeField32 + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    EF: ExtensionField<F>,
     DFT: TwoAdicSubgroupDft<F>,
     PG: ExampleHashAir<F, KeccakStarkConfig<F, EF, DFT>>,
 >(
@@ -99,7 +99,7 @@ where
 #[inline]
 pub fn prove_monty31_poseidon2<
     F: PrimeField32 + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    EF: ExtensionField<F>,
     DFT: TwoAdicSubgroupDft<F>,
     Perm16: CryptographicPermutation<[F; 16]> + CryptographicPermutation<[F::Packing; 16]>,
     Perm24: CryptographicPermutation<[F; 24]> + CryptographicPermutation<[F::Packing; 24]>,

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -22,8 +22,8 @@ pub fn prove<G, Val, Challenge, M, Challenger>(
     open_input: impl Fn(usize) -> G::InputProof,
 ) -> FriProof<Challenge, M, Challenger::Witness, G::InputProof>
 where
-    Val: Field,
-    Challenge: ExtensionField<Val> + TwoAdicField,
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     G: FriGenericConfig<Val, Challenge>,
@@ -83,8 +83,8 @@ fn commit_phase<G, Val, Challenge, M, Challenger>(
     challenger: &mut Challenger,
 ) -> CommitPhaseResult<Challenge, M>
 where
-    Val: Field,
-    Challenge: ExtensionField<Val> + TwoAdicField,
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + CanObserve<M::Commitment>,
     G: FriGenericConfig<Val, Challenge>,
@@ -126,7 +126,8 @@ where
     folded.truncate(config.final_poly_len());
     reverse_slice_index_bits(&mut folded);
 
-    let final_poly = debug_span!("idft final poly").in_scope(|| Radix2Dit::default().idft(folded));
+    let final_poly =
+        debug_span!("idft final poly").in_scope(|| Radix2Dit::default().idft_algebra(folded));
 
     // Observe all coefficients of the final polynomial.
     for &x in &final_poly {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -132,7 +132,7 @@ where
     Dft: TwoAdicSubgroupDft<Val>,
     InputMmcs: Mmcs<Val>,
     FriMmcs: Mmcs<Challenge>,
-    Challenge: TwoAdicField + ExtensionField<Val>,
+    Challenge: ExtensionField<Val>,
     Challenger:
         FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
 {

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -32,8 +32,8 @@ pub fn verify<G, Val, Challenge, M, Challenger>(
     ) -> Result<Vec<(usize, Challenge)>, FriError<M::Error, G::InputError>>,
 ) -> Result<(), FriError<M::Error, G::InputError>>
 where
-    Val: Field,
-    Challenge: ExtensionField<Val> + TwoAdicField,
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     G: FriGenericConfig<Val, Challenge>,
@@ -109,7 +109,7 @@ where
         // We open the final polynomial at index `domain_index`, which corresponds to evaluating
         // the polynomial at x^k, where x is the 2-adic generator of order `max_height` and k is
         // `reverse_bits_len(domain_index, log_max_height)`.
-        let x = Challenge::two_adic_generator(log_max_height)
+        let x = Val::two_adic_generator(log_max_height)
             .exp_u64(reverse_bits_len(domain_index, log_max_height) as u64);
 
         // Evaluate the final polynomial at x.

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -18,7 +18,7 @@ use p3_util::log2_strict_usize;
 pub fn interpolate_subgroup<F, EF, Mat>(subgroup_evals: &Mat, point: EF) -> Vec<EF>
 where
     F: TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    EF: ExtensionField<F>,
     Mat: Matrix<F>,
 {
     interpolate_coset(subgroup_evals, F::ONE, point)
@@ -33,7 +33,7 @@ where
 pub fn interpolate_coset<F, EF, Mat>(coset_evals: &Mat, shift: F, point: EF) -> Vec<EF>
 where
     F: TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    EF: ExtensionField<F>,
     Mat: Matrix<F>,
 {
     let height = coset_evals.height();
@@ -71,7 +71,7 @@ pub fn interpolate_coset_with_precomputation<F, EF, Mat>(
 ) -> Vec<EF>
 where
     F: TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    EF: ExtensionField<F>,
     Mat: Matrix<F>,
 {
     // Slight variation of this approach: https://hackmd.io/@vbuterin/barycentric_evaluation


### PR DESCRIPTION
In several places, our prover has the constraint: `EF: ExtensionField<F> + TwoAdicField `

But this is unnecessary. In all cases we can just remove the `TwoAdicField` with either no changes or by making use of the fact that `F` is a `TwoAdicField`.

While it's true that these extension fields are `TwoAdic` we don't need to enforce/use this.