### PR TITLE
Leftover automated build cleanup

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-air"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-baby-bear"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/blake3-air/Cargo.toml
+++ b/blake3-air/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-blake3-air"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-air.workspace = true

--- a/blake3/Cargo.toml
+++ b/blake3/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-blake3"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-symmetric.workspace = true

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-bn254-fr"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-challenger"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-circle"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-challenger.workspace = true

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-commit"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-dft"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-examples"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-air.workspace = true

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-field-testing"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-dft.workspace = true

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-field"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-maybe-rayon.workspace = true

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-fri"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-challenger.workspace = true

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-goldilocks"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-dft.workspace = true

--- a/interpolation/Cargo.toml
+++ b/interpolation/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-interpolation"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-keccak-air"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-air.workspace = true

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-keccak"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-koala-bear"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-matrix"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/maybe-rayon/Cargo.toml
+++ b/maybe-rayon/Cargo.toml
@@ -4,6 +4,10 @@ description = "Feature-gated wrapper around rayon"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 rayon = { workspace = true, optional = true }

--- a/maybe-rayon/Cargo.toml
+++ b/maybe-rayon/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "p3-maybe-rayon"
 description = "Feature-gated wrapper around rayon"
-license = "MIT OR Apache-2.0"
-version = "0.3.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 rayon = { workspace = true, optional = true }

--- a/mds/Cargo.toml
+++ b/mds/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-mds"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-dft.workspace = true

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-merkle-tree"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-commit.workspace = true

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-mersenne-31"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-dft.workspace = true

--- a/monolith/Cargo.toml
+++ b/monolith/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-monolith"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-monty-31"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-dft.workspace = true

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-poseidon"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-poseidon2-air"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-air.workspace = true

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-poseidon2"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-rescue"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -4,6 +4,10 @@ description = "Plonky3 hash trait implementations for the SHA2-256 hash function
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-symmetric.workspace = true

--- a/sha256/Cargo.toml
+++ b/sha256/Cargo.toml
@@ -4,10 +4,6 @@ description = "Plonky3 hash trait implementations for the SHA2-256 hash function
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-repository.workspace = true
-homepage.workspace = true
-keywords.workspace = true
-categories.workspace = true
 
 [dependencies]
 p3-symmetric.workspace = true

--- a/symmetric/Cargo.toml
+++ b/symmetric/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-symmetric"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-uni-stark"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 p3-air.workspace = true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,6 +3,10 @@ name = "p3-util"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 rayon = { workspace = true, optional = true }


### PR DESCRIPTION
Just a bit of leftover work from #546 that got accidentally auto merged. Essentially the changes are:
- All sub-crates now use the workspace `repository`/`homepage`/`keywords`/`categories` fields in their `Cargo.toml`s.
- Fixed a few crates not using the workspace fields.