### PR TITLE
[CI]: Force `cargo-sort` install to prevent cache issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install cargo-sort
-        run: cargo install cargo-sort
+        run: cargo install cargo-sort --force
 
       - name: Sort Cargo.toml
         run: cargo +stable sort --workspace --grouped --check


### PR DESCRIPTION
There was a caching issue with #894 that prevented the lint workflow from running (see [here](https://github.com/Plonky3/Plonky3/actions/runs/15448482932/job/43485284272)) because the binary was already installed. 