### PR TITLE
Moved CI caching after `cargo-sort` install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Install cargo-sort
+        run: cargo install cargo-sort
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -144,9 +147,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Install cargo-sort
-        run: cargo install cargo-sort --force
+        run: cargo install cargo-sort
 
       - name: Sort Cargo.toml
         run: cargo +stable sort --workspace --grouped --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
-        run: cargo install cargo-sort
-
+        
       - name: Sort Cargo.toml
         run: cargo +stable sort --workspace --grouped --check
 


### PR DESCRIPTION
We were caching before installing `cargo-sort`, and somehow (I actually don't fully understand the how) when a CI action was run multiple times in a PR, it would fail when it tried to install `cargo-sort` twice.