### PR TITLE
Added placeholder descriptions to all plonky3 sub-crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ p3-uni-stark = { path = "uni-stark", version = "0.3.0" }
 p3-util = { path = "util", version = "0.3.0" }
 
 [workspace.package]
+# General description field used for the sub-crates that are currently missing a description.
+description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
 version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-air"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "p3-baby-bear"
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/blake3-air/Cargo.toml
+++ b/blake3-air/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-blake3-air"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/blake3/Cargo.toml
+++ b/blake3/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-blake3"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/bn254-fr/Cargo.toml
+++ b/bn254-fr/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-bn254-fr"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-challenger"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-circle"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-commit"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-dft"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-examples"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-field-testing"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-field"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-fri"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-goldilocks"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/interpolation/Cargo.toml
+++ b/interpolation/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-interpolation"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-keccak-air"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-keccak"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-koala-bear"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-matrix"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/mds/Cargo.toml
+++ b/mds/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-mds"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-merkle-tree"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-mersenne-31"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/monolith/Cargo.toml
+++ b/monolith/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-monolith"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-monty-31"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-poseidon"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-poseidon2-air"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-poseidon2"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-rescue"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/symmetric/Cargo.toml
+++ b/symmetric/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-symmetric"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-uni-stark"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "p3-util"
+# TODO: Replace this generic plonky3 description with one specific to this crate...
+description.workspace = true
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
- `crates.io` requires that all crates have a description field.
- Ideally we should have a specific description for each crate, but until then, we are going to use a generic string.