### PR TITLE
Updates actions/cache from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
           targets: ${{ env.target }}
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -138,7 +138,7 @@ jobs:
       - name: Install cargo-sort
         run: cargo install cargo-sort
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
Updates actions/cache from v3 to v4
uses: actions/cache@v4
uses: actions/cache@v3
Reference: https://github.com/actions/cache/releases/tag/v4.2.3
Key changes: SAS tokens for cache entries are now masked in debug logs