### PR TITLE
Fix repository URLs in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,8 @@ description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), su
 version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/0xPolygonZero/Plonky3"
-homepage = "https://github.com/0xPolygonZero/Plonky3"
+repository = "https://github.com/Plonky3/Plonky3"
+homepage = "https://github.com/Plonky3/Plonky3"
 keywords = ["cryptography", "SNARK", "PLONK", "FRI", "plonky3"]
 categories = ["cryptography::cryptocurrencies"]
 


### PR DESCRIPTION
Fixes incorrect repository and homepage URLs in Cargo.toml.
Changed from non-existent https://github.com/0xPolygonZero/Plonky3 to the correct https://github.com/Plonky3/Plonky3.