### PR TITLE
from_biguint method for Bn254

### DIFF
--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -71,6 +71,27 @@ impl Bn254 {
         Self { value }
     }
 
+    #[inline]
+    pub fn from_big_u_int(value: BigUint) -> Option<Self> {
+        let digits = value.to_u64_digits();
+        let num_dig = digits.len();
+
+        match num_dig {
+            0 => Some(Self::ZERO),
+            1..=4 => {
+                let mut inner = [0; 4];
+                inner[..num_dig].copy_from_slice(&digits);
+
+                // We don't need to check that the value is less than the prime as, provided
+                // one entry of `monty_mul` is less than `P`, the result will be less than `P`.
+                let unadjusted_value = Self::new_monty(inner);
+                // Adjust the value into Montgomery form by multiplying by `R^2` and doing a monty reduction.
+                Some(unadjusted_value * BN254_MONTY_R_SQ)
+            }
+            _ => None, // Too many digits for BN254
+        }
+    }
+
     /// Converts the a byte array in little-endian order to a field element.
     ///
     /// Assumes the bytes correspond to the Montgomery form of the desired field element.
@@ -530,8 +551,36 @@ mod tests {
 
     #[test]
     fn test_bn254fr() {
-        let f = F::from_u8(100);
-        assert_eq!(f.as_canonical_biguint(), BigUint::from(100u32));
+        let big_int_100 = BigUint::from(100u32);
+        let big_int_p = to_biguint(BN254_PRIME);
+        let big_int_2_256_min_1 = to_biguint([
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+            0xffffffffffffffff,
+        ]);
+        let big_int_2_256_mod_p = to_biguint([
+            0xac96341c4ffffffb,
+            0x36fc76959f60cd29,
+            0x666ea36f7879462e,
+            0x0e0a77c19a07df2f,
+        ]);
+
+        let f_100 = F::from_big_u_int(big_int_100.clone()).unwrap();
+        assert_eq!(f_100.as_canonical_biguint(), BigUint::from(100u32));
+        assert_eq!(F::from_big_u_int(BigUint::ZERO), Some(F::ZERO));
+        for i in 0_u32..6_u32 {
+            assert_eq!(F::from_big_u_int(big_int_p.clone() * i), Some(F::ZERO));
+            assert_eq!(
+                F::from_big_u_int((big_int_100.clone() + big_int_p.clone()) * i),
+                Some(f_100 * F::from_int(i))
+            );
+        }
+        assert_eq!(F::from_big_u_int(big_int_p.clone() * 6_u32), None);
+        assert_eq!(
+            F::from_big_u_int(big_int_2_256_min_1).unwrap(),
+            F::NEG_ONE + F::from_big_u_int(big_int_2_256_mod_p).unwrap()
+        );
 
         // Generator check
         let expected_multiplicative_group_generator = F::from_u8(5);
@@ -543,9 +592,9 @@ mod tests {
         let f_r_minus_1 = F::NEG_ONE;
         let f_r_minus_2 = F::NEG_ONE + F::NEG_ONE;
 
-        let f_serialized = serde_json::to_string(&f).unwrap();
+        let f_serialized = serde_json::to_string(&f_100).unwrap();
         let f_deserialized: F = serde_json::from_str(&f_serialized).unwrap();
-        assert_eq!(f, f_deserialized);
+        assert_eq!(f_100, f_deserialized);
 
         let f_1_serialized = serde_json::to_string(&f_1).unwrap();
         let f_1_deserialized: F = serde_json::from_str(&f_1_serialized).unwrap();

--- a/bn254/src/helpers.rs
+++ b/bn254/src/helpers.rs
@@ -140,6 +140,11 @@ fn mul_mod_2_exp_256(lhs: [u64; 4], rhs: [u64; 4]) -> [u64; 4] {
 ///
 /// Uses the montgomery constant `2^256` making division free as we can
 /// simply ignore the bottom 4 u64s.
+///
+/// Assuming the product of the inputs is less than `2^256 P`, the output
+/// will be less than `P`. In particular this means we only need to
+/// assume that one of the inputs is less than `P` as both inputs are
+/// trivially less than `2^256`.
 #[inline]
 pub(crate) fn monty_mul(lhs: [u64; 4], rhs: [u64; 4]) -> [u64; 4] {
     // TODO: It's likely worth it to remove the 'prod' variable here


### PR DESCRIPTION
In the comments of #913 I realized there isn't really a good way to create new `Bn254` elements.

In particular, this makes is hard to merge together different implementations of `Bn254`. (E.g. porting values from the `halo2curves`  `FFBn254Fr` to our `Bn254`).

This PR adds a `from_biguint`  which should basically solve the problem. It takes a biguint less than `2^256` and converts into the corresponding field element (internally it converts it into Montgomery form which also ensures the size is small enough).

Also added some tests and added to the `monty_mul` doc comment justifying that the use case is valid.