### PR TITLE
fix typos: implementor → implementer in documentation comments

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -349,7 +349,7 @@ pub trait PrimeCharacteristicRing:
     /// write zeros, which would be redundant. However, the compiler may not always recognize this.
     ///
     /// In particular, `vec![Self::ZERO; len]` appears to result in redundant userspace zeroing.
-    /// This is the default implementation, but implementors may wish to provide their own
+    /// This is the default implementation, but implementers may wish to provide their own
     /// implementation which transmutes something like `vec![0u32; len]`.
     #[must_use]
     #[inline]

--- a/matrix/src/bitrev.rs
+++ b/matrix/src/bitrev.rs
@@ -7,7 +7,7 @@ use crate::util::reverse_matrix_index_bits;
 
 /// A trait for matrices that support *bit-reversed row reordering*.
 ///
-/// Implementors of this trait can switch between row-major order and bit-reversed
+/// Implementers of this trait can switch between row-major order and bit-reversed
 /// row order (i.e., reversing the binary representation of each row index).
 ///
 /// This trait allows interoperability between regular matrices and views

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -6,7 +6,7 @@ use crate::{BinomialExtensionData, FieldParameters, MontyField31, TwoAdicData};
 // If a field implements BinomialExtensionData<WIDTH> then there is a natural
 // field extension of degree WIDTH we can define.
 // We perform no checks to make sure the data given in BinomialExtensionData<WIDTH> is valid and
-// corresponds to an actual field extension. Ensuring that is left to the implementor.
+// corresponds to an actual field extension. Ensuring that is left to the implementer.
 
 impl<const WIDTH: usize, FP> BinomiallyExtendable<WIDTH> for MontyField31<FP>
 where


### PR DESCRIPTION


---


## Description
This pull request corrects several occurrences of the word "implementor" to the more widely accepted "implementer" in documentation comments across the codebase.  


---