### PR TITLE
GCD based inversion for 31 bit fields

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -1,5 +1,5 @@
+use p3_field::PrimeCharacteristicRing;
 use p3_field::exponentiation::exp_1725656503;
-use p3_field::{Field, PrimeCharacteristicRing};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, RelativelyPrimePower, TwoAdicData,
@@ -26,36 +26,6 @@ impl BarrettParameters for BabyBearParameters {}
 
 impl FieldParameters for BabyBearParameters {
     const MONTY_GEN: BabyBear = BabyBear::new(31);
-
-    #[inline]
-    fn try_inverse<F: Field>(p1: F) -> Option<F> {
-        if p1.is_zero() {
-            return None;
-        }
-
-        // From Fermat's little theorem, in a prime field `F_p`, the inverse of `a` is `a^(p-2)`.
-        // Here p-2 = 2013265919 = 1110111111111111111111111111111_2.
-        // Uses 30 Squares + 7 Multiplications => 37 Operations total.
-
-        let p100000000 = p1.exp_power_of_2(8);
-        let p100000001 = p100000000 * p1;
-        let p10000000000000000 = p100000000.exp_power_of_2(8);
-        let p10000000100000001 = p10000000000000000 * p100000001;
-        let p10000000100000001000 = p10000000100000001.exp_power_of_2(3);
-        let p1000000010000000100000000 = p10000000100000001000.exp_power_of_2(5);
-        let p1000000010000000100000001 = p1000000010000000100000000 * p1;
-        let p1000010010000100100001001 = p1000000010000000100000001 * p10000000100000001000;
-        let p10000000100000001000000010 = p1000000010000000100000001.square();
-        let p11000010110000101100001011 = p10000000100000001000000010 * p1000010010000100100001001;
-        let p100000001000000010000000100 = p10000000100000001000000010.square();
-        let p111000011110000111100001111 =
-            p100000001000000010000000100 * p11000010110000101100001011;
-        let p1110000111100001111000011110000 = p111000011110000111100001111.exp_power_of_2(4);
-        let p1110111111111111111111111111111 =
-            p1110000111100001111000011110000 * p111000011110000111100001111;
-
-        Some(p1110111111111111111111111111111)
-    }
 }
 
 impl RelativelyPrimePower<7> for BabyBearParameters {

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -27,6 +27,7 @@ impl BarrettParameters for BabyBearParameters {}
 impl FieldParameters for BabyBearParameters {
     const MONTY_GEN: BabyBear = BabyBear::new(31);
 
+    #[inline]
     fn try_inverse<F: Field>(p1: F) -> Option<F> {
         if p1.is_zero() {
             return None;

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -1,5 +1,5 @@
+use p3_field::PrimeCharacteristicRing;
 use p3_field::exponentiation::exp_1420470955;
-use p3_field::{Field, PrimeCharacteristicRing};
 use p3_monty_31::{
     BarrettParameters, BinomialExtensionData, FieldParameters, MontyField31, MontyParameters,
     PackedMontyParameters, RelativelyPrimePower, TwoAdicData,
@@ -29,32 +29,6 @@ impl BarrettParameters for KoalaBearParameters {}
 
 impl FieldParameters for KoalaBearParameters {
     const MONTY_GEN: KoalaBear = KoalaBear::new(3);
-
-    fn try_inverse<F: Field>(p1: F) -> Option<F> {
-        if p1.is_zero() {
-            return None;
-        }
-
-        // From Fermat's little theorem, in a prime field `F_p`, the inverse of `a` is `a^(p-2)`.
-        // Here p-2 = 2130706431 = 1111110111111111111111111111111_2
-        // Uses 29 Squares + 7 Multiplications => 36 Operations total.
-
-        let p10 = p1.square();
-        let p11 = p10 * p1;
-        let p1100 = p11.exp_power_of_2(2);
-        let p1111 = p1100 * p11;
-        let p110000 = p1100.exp_power_of_2(2);
-        let p111111 = p110000 * p1111;
-        let p1111110000 = p111111.exp_power_of_2(4);
-        let p1111111111 = p1111110000 * p1111;
-        let p11111101111 = p1111111111 * p1111110000;
-        let p111111011110000000000 = p11111101111.exp_power_of_2(10);
-        let p111111011111111111111 = p111111011110000000000 * p1111111111;
-        let p1111110111111111111110000000000 = p111111011111111111111.exp_power_of_2(10);
-        let p1111110111111111111111111111111 = p1111110111111111111110000000000 * p1111111111;
-
-        Some(p1111110111111111111111111111111)
-    }
 }
 
 impl RelativelyPrimePower<3> for KoalaBearParameters {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -14,7 +14,7 @@ use p3_field::{
     PrimeField32, PrimeField64, RawDataSerializable, halve_u32, impl_raw_serializable_primefield32,
     quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int,
 };
-use p3_util::{flatten_to_base, gcd_inversion_31_bit_field};
+use p3_util::{flatten_to_base, gcd_inversion_prime_field_32};
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::de::Error;
@@ -279,7 +279,7 @@ impl Field for Mersenne31 {
         }
 
         // gcd_inversion returns the inverse multiplied by 2^60 so we need to correct for that.
-        let inverse_i64 = gcd_inversion_31_bit_field(self.value, P);
+        let inverse_i64 = gcd_inversion_prime_field_32::<31>(self.value, P);
         Some(Self::from_int(inverse_i64).div_2exp_u64(60))
     }
 

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -278,8 +278,11 @@ impl Field for Mersenne31 {
             return None;
         }
 
+        // Number of bits in the Mersenne31 prime.
+        const NUM_PRIME_BITS: u32 = 31;
+
         // gcd_inversion returns the inverse multiplied by 2^60 so we need to correct for that.
-        let inverse_i64 = gcd_inversion_prime_field_32::<31>(self.value, P);
+        let inverse_i64 = gcd_inversion_prime_field_32::<NUM_PRIME_BITS>(self.value, P);
         Some(Self::from_int(inverse_i64).div_2exp_u64(60))
     }
 

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -14,7 +14,7 @@ use p3_field::{
     PrimeField32, PrimeField64, RawDataSerializable, halve_u32, impl_raw_serializable_primefield32,
     quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int,
 };
-use p3_util::flatten_to_base;
+use p3_util::{flatten_to_base, gcd_inversion_31_bit_field};
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::de::Error;
@@ -278,21 +278,9 @@ impl Field for Mersenne31 {
             return None;
         }
 
-        // From Fermat's little theorem, in a prime field `F_p`, the inverse of `a` is `a^(p-2)`.
-        // Here p-2 = 2147483645 = 1111111111111111111111111111101_2.
-        // Uses 30 Squares + 7 Multiplications => 37 Operations total.
-
-        let p1 = *self;
-        let p101 = p1.exp_power_of_2(2) * p1;
-        let p1111 = p101.square() * p101;
-        let p11111111 = p1111.exp_power_of_2(4) * p1111;
-        let p111111110000 = p11111111.exp_power_of_2(4);
-        let p111111111111 = p111111110000 * p1111;
-        let p1111111111111111 = p111111110000.exp_power_of_2(4) * p11111111;
-        let p1111111111111111111111111111 = p1111111111111111.exp_power_of_2(12) * p111111111111;
-        let p1111111111111111111111111111101 =
-            p1111111111111111111111111111.exp_power_of_2(3) * p101;
-        Some(p1111111111111111111111111111101)
+        // gcd_inversion returns the inverse multiplied by 2^60 so we need to correct for that.
+        let inverse_i64 = gcd_inversion_31_bit_field(self.value, P);
+        Some(Self::from_int(inverse_i64).div_2exp_u64(60))
     }
 
     #[inline]

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::PrimeCharacteristicRing;
 
 use crate::MontyField31;
 
@@ -76,8 +76,6 @@ pub trait FieldParameters: PackedMontyParameters + Sized {
     const MONTY_GEN: MontyField31<Self>;
 
     const HALF_P_PLUS_1: u32 = (Self::PRIME + 1) >> 1;
-
-    fn try_inverse<F: Field>(p1: F) -> Option<F>;
 }
 
 /// An integer `D` such that `gcd(D, p - 1) = 1`.

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -394,8 +394,6 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
             return None;
         }
 
-        // FP::try_inverse(*self)
-
         // The number of bits of FP::PRIME. By the very name of MontyField31 this should always be 31.
         const NUM_PRIME_BITS: u32 = 31;
 

--- a/monty-31/src/utils.rs
+++ b/monty-31/src/utils.rs
@@ -63,8 +63,9 @@ pub(crate) const fn halve_u32<FP: FieldParameters>(input: u32) -> u32 {
 }
 
 /// Montgomery reduction of a value in `0..P << MONTY_BITS`.
-/// the input must be in `[0, MONTY * P)`.
-/// the output will be in `[0, P)`.
+///
+/// The input must be in `[0, MONTY * P)`.
+/// The output will be in `[0, P)`.
 #[inline]
 #[must_use]
 pub(crate) const fn monty_reduce<MP: MontyParameters>(x: u64) -> u32 {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -627,6 +627,27 @@ pub const fn relatively_prime_u64(mut u: u64, mut v: u64) -> bool {
     false
 }
 
+#[inline]
+pub fn gcd_inversion_31_bit_field(mut a: u32, mut b: u32) -> i64 {
+    let (mut u, mut v) = (1_i64, 0_i64);
+
+    for _ in 0..60 {
+        if a & 1 == 0 {
+            a >>= 1
+        } else {
+            if a < b {
+                (a, b) = (b, a);
+                (u, v) = (v, u);
+            }
+            a -= b;
+            a >>= 1;
+            u -= v;
+        }
+        v <<= 1;
+    }
+    v
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -634,7 +634,7 @@ pub const fn relatively_prime_u64(mut u: u64, mut v: u64) -> bool {
 ///  - b: The value of the prime `P > 2`.
 ///
 /// Output:
-/// - A `64` bit signed integer `v` equal to `2^{2 * FIELD_BITS - 2} a^{-1} mod P` with
+/// - A `64-bit` signed integer `v` equal to `2^{2 * FIELD_BITS - 2} a^{-1} mod P` with
 ///   size `|v| < 2^{2 * FIELD_BITS - 2}`.
 ///
 /// It is up to the user to ensure that `b` is an odd prime with at most `FIELD_BITS` bits and


### PR DESCRIPTION
Following #920 I was wondering if a similar approach could speed up inversions for our 31 bit fields. Turns out the answer is yes!

The following gcd based inversion algorithm gives over a `2x` speed up for inversions of MontyField31's and Mersenne31 (along with their extensions):

|Field | Old Inv Speed (ns) | New Inv Speed (ns) |
| --- | --- | --- |
| BabyBear | 346 | 131 |
| KoalaBear | 343 | 128 |
| Mersenne31 | 183 | 91|
| BabyBear Deg 4 Ext | 475 | 167 |
| BabyBear Deg 5 Ext | 673 | 379 |
| KoalaBear Deg 4 Ext | 477 | 163 |
| Mersenne31 Deg 4 Ext | 322 | 177 |
| Mersenne31 Deg 6 Ext | 432 | 291 |