### PR TITLE
Adding custom mul/div_exp_2_u64 for the Goldilocks field.

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -251,6 +251,10 @@ where
             x.clone() * R::from_u128(1_u128 << i)
         );
     }
+    // Goldilocks behaviour changes at 96, 192 so we want to test larger numbers than that.
+    for i in 128..256 {
+        assert_eq!(x.clone().mul_2exp_u64(i), x.clone() * R::TWO.exp_u64(i));
+    }
 }
 
 pub fn test_div_2exp_u64<F: Field>()
@@ -267,6 +271,15 @@ where
             x.div_2exp_u64(i),
             // Best to invert in the prime subfield in case F is an extension field.
             x * F::from_prime_subfield(F::PrimeSubfield::from_u128(1_u128 << i).inverse())
+        );
+    }
+    // Goldilocks behaviour changes at 96, 192 so we want to test larger numbers than that.
+    for i in 128..256 {
+        assert_eq!(x.mul_2exp_u64(i).div_2exp_u64(i), x);
+        assert_eq!(
+            x.div_2exp_u64(i),
+            // Best to invert in the prime subfield in case F is an extension field.
+            x * F::from_prime_subfield(F::PrimeSubfield::TWO.inverse().exp_u64(i))
         );
     }
 }

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -94,6 +94,10 @@ impl Goldilocks {
         0x185629dcda58878c,
     ]);
 
+    /// A list of powers of two from 0 to 95.
+    ///
+    /// Note that 2^{96} = -1 mod P so all powers of two can be simply
+    /// derived from this list.
     const POWERS_OF_TWO: [Self; 96] = {
         let mut powers_of_two = [Goldilocks::ONE; 96];
 
@@ -373,6 +377,7 @@ impl Field for Goldilocks {
         Self::new(halve_u64::<P>(self.value))
     }
 
+    #[inline]
     fn div_2exp_u64(&self, mut exp: u64) -> Self {
         // In the goldilocks field, 2^192 = 1 mod P.
         // Thus 2^{-n} = 2^{192 - n} mod P.


### PR DESCRIPTION
Mostly copying across work from the Monty31 fields but also `2^{192} = 1 mod P` so if we save the constants for `2^0, ..., 2^{91}` all of these products can be computed with a single multiplication.

This is much faster than the current methods which involve a field exponential and (for div) a field inversion. (Originally needed this for the `gcd_inverse` but realized I could spin it out)