### PR TITLE
AVX512 Clippy Complaints

### DIFF
--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -437,7 +437,6 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
         unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
     }
 
-    #[must_use]
     #[inline(always)]
     fn exp_const_u64<const POWER: u64>(&self) -> Self {
         // We provide specialised code for power 5 as this turns up regularly.

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -1096,7 +1096,6 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
         }
     }
 
-    #[must_use]
     #[inline(always)]
     fn exp_const_u64<const POWER: u64>(&self) -> Self {
         // We provide specialised code for the powers 3, 5, 7 as these turn up regularly.


### PR DESCRIPTION
To quote clippy: #[must_use]` has no effect when applied to a provided trait method