### PR TITLE
Remove Nightly Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo test
 
 ## Known issues
 
+There is currently a bug in AVX512 compilation on some architectures (znver4, znver5, mic_avx512). This is a bug in LLVM and shoudl hopefully be fixed soon. In the meantime you can either compile with `target-cpu=znver3` or more generally any target which does not support `avx512`. This will hopefully be fixed in a rust update soon. (See issues #729, #905)
+
 The verifier might panic upon receiving certain invalid proofs.
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo test
 
 ## Known issues
 
-There is currently a bug in AVX512 compilation on some architectures (znver4, znver5, mic_avx512). This is a bug in LLVM and shoudl hopefully be fixed soon. In the meantime you can either compile with `target-cpu=znver3` or more generally any target which does not support `avx512`. This will hopefully be fixed in a rust update soon. (See issues #729, #905)
+There is currently a bug in AVX512 compilation on some architectures (znver4, znver5, mic_avx512). This is a bug in LLVM and should hopefully be fixed soon. In the meantime you can either compile with `target-cpu=znver3` or more generally any target which does not support `avx512`. This will hopefully be fixed in a rust update soon. (See issues #729, #905)
 
 The verifier might panic upon receiving certain invalid proofs.
 

--- a/README.md
+++ b/README.md
@@ -87,17 +87,6 @@ Plonky3 contains optimizations that rely on newer CPU instructions unavailable i
 RUSTFLAGS="-Ctarget-cpu=native" cargo test
 ```
 
-Support for some instructions, such as AVX-512, is still experimental. They are only available in the nightly build of Rustc and are enabled by the [`nightly-features` feature flag](#nightly-only-optimizations). To use them, you must enable the flag in Rustc (e.g. by setting `target-feature`) and you must also enable the `nightly-features` feature.
-
-
-## Nightly-only optimizations
-
-Some optimizations (in particular, AVX-512-optimized math) rely on features that are currently available only in the nightly build of Rustc. To use them, you need to enable the `nightly-features` feature. For example, to run the tests:
-```bash
-cargo test --features nightly-features
-```
-
-
 ## Known issues
 
 The verifier might panic upon receiving certain invalid proofs.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo test
 The verifier might panic upon receiving certain invalid proofs.
 
 
-
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo test
 
 ## Known issues
 
-There is currently a bug in AVX512 compilation on some architectures (znver4, znver5, mic_avx512). This is a bug in LLVM and should hopefully be fixed soon. In the meantime you can either compile with `target-cpu=znver3` or more generally any target which does not support `avx512`. This will hopefully be fixed in a rust update soon. (See issues #729, #905)
-
 The verifier might panic upon receiving certain invalid proofs.
 
 

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -29,9 +29,6 @@ rand.workspace = true
 rand_xoshiro.workspace = true
 serde_json.workspace = true
 
-[features]
-nightly-features = ["p3-monty-31/nightly-features"]
-
 [[bench]]
 name = "bench_field"
 harness = false

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -30,13 +30,7 @@ mod x86_64_avx2;
 ))]
 pub use x86_64_avx2::*;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 mod x86_64_avx512;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -1,12 +1,4 @@
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 extern crate alloc;
 
@@ -28,24 +20,22 @@ pub use aarch64_neon::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 mod x86_64_avx2;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 mod x86_64_avx512;
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -407,7 +407,7 @@ where
                 {
                     let batch_heights: Vec<usize> = mats
                         .iter()
-                        .map(|(domain, _)| (domain.size() << self.fri_params.log_blowup))
+                        .map(|(domain, _)| domain.size() << self.fri_params.log_blowup)
                         .collect_vec();
                     let batch_dims: Vec<Dimensions> = batch_heights
                         .iter()

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -28,12 +28,6 @@ criterion.workspace = true
 rand.workspace = true
 
 [features]
-nightly-features = [
-    "p3-goldilocks/nightly-features",
-    "p3-monty-31/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
-]
 parallel = ["p3-maybe-rayon/parallel"]
 
 [[bench]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,11 +44,3 @@ p3-matrix.workspace = true
 
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
-
-[features]
-nightly-features = [
-    "p3-monty-31/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-koala-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
-]

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -23,6 +23,3 @@ tracing.workspace = true
 [dev-dependencies]
 p3-baby-bear.workspace = true
 p3-goldilocks.workspace = true
-
-[features]
-nightly-features = []

--- a/field/src/interleaves.rs
+++ b/field/src/interleaves.rs
@@ -148,10 +148,7 @@ pub mod interleave {
     }
 }
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub mod interleave {
     use core::arch::x86_64::{self, __m512i, __mmask8, __mmask16};
     use core::mem::transmute;

--- a/field/src/interleaves.rs
+++ b/field/src/interleaves.rs
@@ -50,7 +50,7 @@ pub mod interleave {
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub mod interleave {
     use core::arch::x86_64::{self, __m256i};
@@ -149,7 +149,6 @@ pub mod interleave {
 }
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -1,15 +1,4 @@
 //! A framework for finite fields.
-
-#![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
-
 extern crate alloc;
 
 mod array;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -1,4 +1,6 @@
 //! A framework for finite fields.
+#![no_std]
+
 extern crate alloc;
 
 mod array;

--- a/field/src/packed/x86_64_avx.rs
+++ b/field/src/packed/x86_64_avx.rs
@@ -1,6 +1,6 @@
 //! A collection of helper methods when AVX2 is available
 
-#[cfg(all(feature = "nightly-features", target_feature = "avx512f"))]
+#[cfg(target_feature = "avx512f")]
 use core::arch::x86_64::__m512i;
 use core::arch::x86_64::{self, __m256i};
 
@@ -42,7 +42,7 @@ pub fn mm256_mod_add(a: __m256i, b: __m256i, p: __m256i) -> __m256i {
     }
 }
 
-#[cfg(all(feature = "nightly-features", target_feature = "avx512f"))]
+#[cfg(target_feature = "avx512f")]
 /// Add the two packed vectors `a` and `b` modulo `p`.
 ///
 /// This allows us to add 16 elements at once.

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -29,9 +29,6 @@ p3-poseidon.workspace = true
 criterion.workspace = true
 rand.workspace = true
 
-[features]
-nightly-features = []
-
 [[bench]]
 name = "bench_field"
 harness = false

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -296,12 +296,11 @@ impl Field for Goldilocks {
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        not(all(feature = "nightly-features", target_feature = "avx512f"))
+        not(target_feature = "avx512f")
     ))]
     type Packing = crate::PackedGoldilocksAVX2;
 
     #[cfg(all(
-        feature = "nightly-features",
         target_arch = "x86_64",
         target_feature = "avx512f"
     ))]
@@ -310,10 +309,9 @@ impl Field for Goldilocks {
         all(
             target_arch = "x86_64",
             target_feature = "avx2",
-            not(all(feature = "nightly-features", target_feature = "avx512f"))
+            not(target_feature = "avx512f")
         ),
         all(
-            feature = "nightly-features",
             target_arch = "x86_64",
             target_feature = "avx512f"
         ),

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -300,10 +300,7 @@ impl Field for Goldilocks {
     ))]
     type Packing = crate::PackedGoldilocksAVX2;
 
-    #[cfg(all(
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ))]
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedGoldilocksAVX512;
     #[cfg(not(any(
         all(
@@ -311,10 +308,7 @@ impl Field for Goldilocks {
             target_feature = "avx2",
             not(target_feature = "avx512f")
         ),
-        all(
-            target_arch = "x86_64",
-            target_feature = "avx512f"
-        ),
+        all(target_arch = "x86_64", target_feature = "avx512f"),
     )))]
     type Packing = Self;
 

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -27,14 +27,8 @@ mod x86_64_avx2;
 ))]
 pub use x86_64_avx2::*;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 mod x86_64_avx512;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -1,14 +1,6 @@
 //! The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 extern crate alloc;
 
@@ -24,26 +16,24 @@ pub use poseidon2::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 mod x86_64_avx2;
 
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 mod x86_64_avx512;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -41,9 +41,3 @@ tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
 asm = ["p3-sha256/asm"]
-nightly-features = [
-    "p3-goldilocks/nightly-features",
-    "p3-monty-31/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
-]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -21,9 +21,6 @@ p3-mersenne-31.workspace = true
 
 criterion.workspace = true
 
-[features]
-nightly-features = []
-
 [[bench]]
 name = "bench_keccak"
 harness = false

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -1,26 +1,16 @@
 //! The Keccak-f permutation, and hash functions built from it.
 
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 use p3_symmetric::{CryptographicHasher, CryptographicPermutation, Permutation};
 use tiny_keccak::{Hasher, Keccak, keccakf};
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 pub mod avx512;
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
@@ -29,13 +19,13 @@ pub use avx512::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub mod avx2;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use avx2::*;
 

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -5,15 +5,9 @@
 use p3_symmetric::{CryptographicHasher, CryptographicPermutation, Permutation};
 use tiny_keccak::{Hasher, Keccak, keccakf};
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub mod avx512;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use avx512::*;
 
 #[cfg(all(

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -28,9 +28,6 @@ rand.workspace = true
 rand_xoshiro.workspace = true
 serde_json.workspace = true
 
-[features]
-nightly-features = ["p3-monty-31/nightly-features"]
-
 [[bench]]
 name = "bench_field"
 harness = false

--- a/koala-bear/src/lib.rs
+++ b/koala-bear/src/lib.rs
@@ -1,12 +1,4 @@
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 extern crate alloc;
 
@@ -26,24 +18,22 @@ pub use aarch64_neon::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 mod x86_64_avx2;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 mod x86_64_avx512;
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/koala-bear/src/lib.rs
+++ b/koala-bear/src/lib.rs
@@ -28,13 +28,7 @@ mod x86_64_avx2;
 ))]
 pub use x86_64_avx2::*;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 mod x86_64_avx512;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -30,9 +30,6 @@ p3-field-testing.workspace = true
 criterion.workspace = true
 rand_xoshiro.workspace = true
 
-[features]
-nightly-features = []
-
 [[bench]]
 name = "bench_field"
 harness = false

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -1,14 +1,6 @@
 //! The prime field `F_p` where `p = 2^31 - 1`.
 
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 extern crate alloc;
 
@@ -34,24 +26,22 @@ pub use aarch64_neon::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 mod x86_64_avx2;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 mod x86_64_avx512;
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/mersenne-31/src/lib.rs
+++ b/mersenne-31/src/lib.rs
@@ -36,15 +36,9 @@ mod x86_64_avx2;
 ))]
 pub use x86_64_avx2::*;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 mod x86_64_avx512;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;
 
 #[cfg(not(any(

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -231,11 +231,10 @@ impl Field for Mersenne31 {
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        not(all(feature = "nightly-features", target_feature = "avx512f"))
+        not(target_feature = "avx512f")
     ))]
     type Packing = crate::PackedMersenne31AVX2;
     #[cfg(all(
-        feature = "nightly-features",
         target_arch = "x86_64",
         target_feature = "avx512f"
     ))]
@@ -245,10 +244,9 @@ impl Field for Mersenne31 {
         all(
             target_arch = "x86_64",
             target_feature = "avx2",
-            not(all(feature = "nightly-features", target_feature = "avx512f"))
+            not(target_feature = "avx512f")
         ),
         all(
-            feature = "nightly-features",
             target_arch = "x86_64",
             target_feature = "avx512f"
         ),

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -234,10 +234,7 @@ impl Field for Mersenne31 {
         not(target_feature = "avx512f")
     ))]
     type Packing = crate::PackedMersenne31AVX2;
-    #[cfg(all(
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ))]
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedMersenne31AVX512;
     #[cfg(not(any(
         all(target_arch = "aarch64", target_feature = "neon"),
@@ -246,10 +243,7 @@ impl Field for Mersenne31 {
             target_feature = "avx2",
             not(target_feature = "avx512f")
         ),
-        all(
-            target_arch = "x86_64",
-            target_feature = "avx512f"
-        ),
+        all(target_arch = "x86_64", target_feature = "avx512f"),
     )))]
     type Packing = Self;
 

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -26,6 +26,3 @@ rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 transpose.workspace = true
-
-[features]
-nightly-features = []

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -33,10 +33,7 @@ pub trait PackedMontyParameters: crate::MontyParametersNeon + MontyParameters {}
 ))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
 pub trait PackedMontyParameters: crate::MontyParametersAVX2 + MontyParameters {}
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
 pub trait PackedMontyParameters: crate::MontyParametersAVX512 + MontyParameters {}
 #[cfg(not(any(
@@ -46,10 +43,7 @@ pub trait PackedMontyParameters: crate::MontyParametersAVX512 + MontyParameters 
         target_feature = "avx2",
         not(target_feature = "avx512f")
     ),
-    all(
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
+    all(target_arch = "x86_64", target_feature = "avx512f"),
 )))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
 pub trait PackedMontyParameters: MontyParameters {}

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -29,12 +29,11 @@ pub trait PackedMontyParameters: crate::MontyParametersNeon + MontyParameters {}
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 /// PackedMontyParameters contains constants needed for MONTY operations for packings of Monty31 fields.
 pub trait PackedMontyParameters: crate::MontyParametersAVX2 + MontyParameters {}
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
@@ -45,10 +44,9 @@ pub trait PackedMontyParameters: crate::MontyParametersAVX512 + MontyParameters 
     all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        not(all(feature = "nightly-features", target_feature = "avx512f"))
+        not(target_feature = "avx512f")
     ),
     all(
-        feature = "nightly-features",
         target_arch = "x86_64",
         target_feature = "avx512f"
     ),

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -32,15 +32,9 @@ mod x86_64_avx2;
 ))]
 pub use x86_64_avx2::*;
 
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 mod x86_64_avx512;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;
 
 #[cfg(not(any(

--- a/monty-31/src/lib.rs
+++ b/monty-31/src/lib.rs
@@ -1,12 +1,4 @@
 #![no_std]
-#![cfg_attr(
-    all(
-        feature = "nightly-features",
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
-    feature(stdarch_x86_avx512)
-)]
 
 extern crate alloc;
 
@@ -30,24 +22,22 @@ pub use aarch64_neon::*;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 mod x86_64_avx2;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub use x86_64_avx2::*;
 
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
 mod x86_64_avx512;
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -363,11 +363,10 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        not(all(feature = "nightly-features", target_feature = "avx512f"))
+        not(target_feature = "avx512f")
     ))]
     type Packing = crate::PackedMontyField31AVX2<FP>;
     #[cfg(all(
-        feature = "nightly-features",
         target_arch = "x86_64",
         target_feature = "avx512f"
     ))]
@@ -377,10 +376,9 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
         all(
             target_arch = "x86_64",
             target_feature = "avx2",
-            not(all(feature = "nightly-features", target_feature = "avx512f"))
+            not(target_feature = "avx512f")
         ),
         all(
-            feature = "nightly-features",
             target_arch = "x86_64",
             target_feature = "avx512f"
         ),

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -366,10 +366,7 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
         not(target_feature = "avx512f")
     ))]
     type Packing = crate::PackedMontyField31AVX2<FP>;
-    #[cfg(all(
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ))]
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedMontyField31AVX512<FP>;
     #[cfg(not(any(
         all(target_arch = "aarch64", target_feature = "neon"),
@@ -378,10 +375,7 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
             target_feature = "avx2",
             not(target_feature = "avx512f")
         ),
-        all(
-            target_arch = "x86_64",
-            target_feature = "avx512f"
-        ),
+        all(target_arch = "x86_64", target_feature = "avx512f"),
     )))]
     type Packing = Self;
 

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -42,14 +42,13 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",
-    not(all(feature = "nightly-features", target_feature = "avx512f"))
+    not(target_feature = "avx512f")
 ))]
 pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     InternalLayerBaseParameters<FP, WIDTH> + crate::InternalLayerParametersAVX2<FP, WIDTH>
 {
 }
 #[cfg(all(
-    feature = "nightly-features",
     target_arch = "x86_64",
     target_feature = "avx512f"
 ))]
@@ -62,10 +61,9 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     all(
         target_arch = "x86_64",
         target_feature = "avx2",
-        not(all(feature = "nightly-features", target_feature = "avx512f"))
+        not(target_feature = "avx512f")
     ),
     all(
-        feature = "nightly-features",
         target_arch = "x86_64",
         target_feature = "avx512f"
     ),

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -48,10 +48,7 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     InternalLayerBaseParameters<FP, WIDTH> + crate::InternalLayerParametersAVX2<FP, WIDTH>
 {
 }
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx512f"
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     InternalLayerBaseParameters<FP, WIDTH> + crate::InternalLayerParametersAVX512<FP, WIDTH>
 {
@@ -63,10 +60,7 @@ pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
         target_feature = "avx2",
         not(target_feature = "avx512f")
     ),
-    all(
-        target_arch = "x86_64",
-        target_feature = "avx512f"
-    ),
+    all(target_arch = "x86_64", target_feature = "avx512f"),
 )))]
 pub trait InternalLayerParameters<FP: FieldParameters, const WIDTH: usize>:
     InternalLayerBaseParameters<FP, WIDTH>

--- a/poseidon2/Cargo.toml
+++ b/poseidon2/Cargo.toml
@@ -26,14 +26,6 @@ p3-mersenne-31.workspace = true
 
 criterion.workspace = true
 
-[features]
-nightly-features = [
-    "p3-koala-bear/nightly-features",
-    "p3-baby-bear/nightly-features",
-    "p3-mersenne-31/nightly-features",
-    "p3-goldilocks/nightly-features",
-]
-
 [[bench]]
 name = "poseidon2"
 harness = false

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -41,4 +41,3 @@ rand.workspace = true
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
-nightly-features = ["p3-baby-bear/nightly-features", "p3-mersenne-31/nightly-features"]


### PR DESCRIPTION
As of Rust 1.89.0, `feature(stdarch_x86_avx512)` is now part of the standard feature set and no longer needs to be manually enabled. This means we can completely get rid of our nightly-features flag!

This should make it a little easier to run AVX512 code as you no longer need to use nightly rust (or enable the feature). Due to this I've also deleted the relevant parts from the README.

Annoyingly there are still some bugs in AVX512 on certain systems (#729, #905) so I've added that to known issues now that they can be encountered in standard mode. They should be fixed soon.