### PR TITLE
rm Debug, Default impls for PackedFields

### DIFF
--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::arch::x86_64::*;
-use core::fmt;
-use core::fmt::{Debug, Formatter};
+use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -26,7 +25,7 @@ const WIDTH: usize = 4;
 /// `PackedGoldilocksAVX2`. We need to ensure that `PackedGoldilocksAVX2` has the same alignment as
 /// `Goldilocks`. Thus we wrap `[Goldilocks; 4]` and use the `new` and `get` methods to
 /// convert to and from `__m256i`.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PackedGoldilocksAVX2(pub [Goldilocks; WIDTH]);
 
@@ -72,20 +71,6 @@ impl AddAssign<Goldilocks> for PackedGoldilocksAVX2 {
     #[inline]
     fn add_assign(&mut self, rhs: Goldilocks) {
         *self = *self + rhs;
-    }
-}
-
-impl Debug for PackedGoldilocksAVX2 {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "({:?})", self.get())
-    }
-}
-
-impl Default for PackedGoldilocksAVX2 {
-    #[inline]
-    fn default() -> Self {
-        Self::ZERO
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use core::arch::x86_64::*;
-use core::fmt;
-use core::fmt::{Debug, Formatter};
+use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -25,7 +24,7 @@ const WIDTH: usize = 8;
 /// `PackedGoldilocksAVX512`. We need to ensure that `PackedGoldilocksAVX512` has the same alignment as
 /// `Goldilocks`. Thus we wrap `[Goldilocks; 8]` and use the `new` and `get` methods to
 /// convert to and from `__m512i`.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct PackedGoldilocksAVX512(pub [Goldilocks; WIDTH]);
 
@@ -71,20 +70,6 @@ impl AddAssign<Goldilocks> for PackedGoldilocksAVX512 {
     #[inline]
     fn add_assign(&mut self, rhs: Goldilocks) {
         *self = *self + rhs;
-    }
-}
-
-impl Debug for PackedGoldilocksAVX512 {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "({:?})", self.get())
-    }
-}
-
-impl Default for PackedGoldilocksAVX512 {
-    #[inline]
-    fn default() -> Self {
-        Self::ZERO
     }
 }
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -19,7 +19,7 @@ const WIDTH: usize = 4;
 const P: uint32x4_t = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
 
 /// Vectorized NEON implementation of `Mersenne31` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31Neon(pub [Mersenne31; WIDTH]);
 
@@ -261,13 +261,6 @@ impl From<Mersenne31> for PackedMersenne31Neon {
     #[inline]
     fn from(value: Mersenne31) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl Default for PackedMersenne31Neon {
-    #[inline]
-    fn default() -> Self {
-        Mersenne31::default().into()
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -19,7 +19,7 @@ const WIDTH: usize = 8;
 pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
 
 /// Vectorized AVX2 implementation of `Mersenne31` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31AVX2(pub [Mersenne31; WIDTH]);
 
@@ -347,13 +347,6 @@ impl From<Mersenne31> for PackedMersenne31AVX2 {
     #[inline]
     fn from(value: Mersenne31) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl Default for PackedMersenne31AVX2 {
-    #[inline]
-    fn default() -> Self {
-        Mersenne31::default().into()
     }
 }
 

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -22,7 +22,7 @@ const ODDS: __mmask16 = 0b1010101010101010;
 const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `Mersenne31` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMersenne31AVX512(pub [Mersenne31; WIDTH]);
 
@@ -367,13 +367,6 @@ impl From<Mersenne31> for PackedMersenne31AVX512 {
     #[inline]
     fn from(value: Mersenne31) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl Default for PackedMersenne31AVX512 {
-    #[inline]
-    fn default() -> Self {
-        Mersenne31::default().into()
     }
 }
 

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -24,7 +24,7 @@ pub trait MontyParametersNeon {
 }
 
 /// Vectorized NEON implementation of `MontyField31` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMontyField31Neon<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
@@ -396,13 +396,6 @@ impl<PMP: PackedMontyParameters> From<MontyField31<PMP>> for PackedMontyField31N
     #[inline]
     fn from(value: MontyField31<PMP>) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl<PMP: PackedMontyParameters> Default for PackedMontyField31Neon<PMP> {
-    #[inline]
-    fn default() -> Self {
-        MontyField31::<PMP>::default().into()
     }
 }
 

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -25,7 +25,7 @@ pub trait MontyParametersAVX2 {
 }
 
 /// Vectorized AVX2 implementation of `MontyField31<FP>` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // This is needed to make `transmute`s safe.
 pub struct PackedMontyField31AVX2<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
@@ -883,13 +883,6 @@ impl<PMP: PackedMontyParameters> From<MontyField31<PMP>> for PackedMontyField31A
     #[inline]
     fn from(value: MontyField31<PMP>) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl<PMP: PackedMontyParameters> Default for PackedMontyField31AVX2<PMP> {
-    #[inline]
-    fn default() -> Self {
-        MontyField31::<PMP>::default().into()
     }
 }
 

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -32,7 +32,7 @@ const EVENS: __mmask16 = 0b0101010101010101;
 const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `MontyField31` arithmetic.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedMontyField31AVX512<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
@@ -994,13 +994,6 @@ impl<PMP: PackedMontyParameters> From<MontyField31<PMP>> for PackedMontyField31A
     #[inline]
     fn from(value: MontyField31<PMP>) -> Self {
         Self::broadcast(value)
-    }
-}
-
-impl<PMP: PackedMontyParameters> Default for PackedMontyField31AVX512<PMP> {
-    #[inline]
-    fn default() -> Self {
-        MontyField31::default().into()
     }
 }
 


### PR DESCRIPTION
We can use `#[derive(...)]` for Debug and Default for packed fields instead of having custom impls.

These are all implemented as wrappers over `[F; N]` for the base field. As we have already implemented Debug and Default for the base field, the ``#[derive(...)]` should default to that which is exactly what we want.

For some reason, currently for packed fields over goldilocks, Debug ports the result to a packed vector and prints that. I doubt this is really what we want though. Having the same semantics as `[Goldilocks; N]` (and the other packed fields) makes more sense.