### PR TITLE
Packed Goldilocks Small Refactor

### DIFF
--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -19,25 +19,48 @@ use crate::Goldilocks;
 
 const WIDTH: usize = 4;
 
-/// AVX2 Goldilocks Field
-///
-/// Ideally `PackedGoldilocksAVX2` would wrap `__m256i`. Unfortunately, `__m256i` has an alignment of
-/// 32B, which would preclude us from casting `[Goldilocks; 4]` (alignment 8B) to
-/// `PackedGoldilocksAVX2`. We need to ensure that `PackedGoldilocksAVX2` has the same alignment as
-/// `Goldilocks`. Thus we wrap `[Goldilocks; 4]` and use the `new` and `get` methods to
-/// convert to and from `__m256i`.
+/// Vectorized AVX2 implementation of `Goldilocks` arithmetic.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(transparent)]
+#[repr(transparent)] // Needed to make `transmute`s safe.
 pub struct PackedGoldilocksAVX2(pub [Goldilocks; WIDTH]);
 
 impl PackedGoldilocksAVX2 {
     #[inline]
-    fn new(x: __m256i) -> Self {
-        unsafe { transmute(x) }
+    #[must_use]
+    /// Get an arch-specific vector representing the packed values.
+    pub(crate) fn to_vector(self) -> __m256i {
+        unsafe {
+            // Safety: `Goldilocks` is `repr(transparent)` so it can be transmuted to `u64`. It
+            // follows that `[Goldilocks; WIDTH]` can be transmuted to `[u64; WIDTH]`, which can be
+            // transmuted to `__m256i`, since arrays are guaranteed to be contiguous in memory.
+            // Finally `PackedGoldilocksAVX2` is `repr(transparent)` so it can be transmuted to
+            // `[Goldilocks; WIDTH]`.
+            transmute(self)
+        }
     }
+
     #[inline]
-    fn get(&self) -> __m256i {
-        unsafe { transmute(*self) }
+    #[must_use]
+    /// Make a packed field vector from an arch-specific vector.
+    ///
+    /// Elements of `Goldilocks` are allowed to be arbitrary u64s so this function
+    /// is safe unlike the `Mersenne31/MontyField31` variants.
+    pub(crate) fn from_vector(vector: __m256i) -> Self {
+        unsafe {
+            // Safety: `__m256i` can be transmuted to `[u64; WIDTH]` (since arrays elements are
+            // contiguous in memory), which can be transmuted to `[Goldilocks; WIDTH]` (since
+            // `Goldilocks` is `repr(transparent)`), which in turn can be transmuted to
+            // `PackedGoldilocksAVX2` (since `PackedGoldilocksAVX2` is also `repr(transparent)`).
+            transmute(vector)
+        }
+    }
+
+    /// Copy `value` to all positions in a packed vector. This is the same as
+    /// `From<Goldilocks>::from`, but `const`.
+    #[inline]
+    #[must_use]
+    const fn broadcast(value: Goldilocks) -> Self {
+        Self([value; WIDTH])
     }
 }
 
@@ -45,7 +68,7 @@ impl Add<Self> for PackedGoldilocksAVX2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::new(unsafe { add(self.get(), rhs.get()) })
+        Self::from_vector(add(self.to_vector(), rhs.to_vector()))
     }
 }
 impl Add<Goldilocks> for PackedGoldilocksAVX2 {
@@ -78,7 +101,7 @@ impl AddAssign<Goldilocks> for PackedGoldilocksAVX2 {
 impl Debug for PackedGoldilocksAVX2 {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "({:?})", self.get())
+        write!(f, "({:?})", self.to_vector())
     }
 }
 
@@ -107,7 +130,7 @@ impl DivAssign<Goldilocks> for PackedGoldilocksAVX2 {
 
 impl From<Goldilocks> for PackedGoldilocksAVX2 {
     fn from(x: Goldilocks) -> Self {
-        Self([x; WIDTH])
+        Self::broadcast(x)
     }
 }
 
@@ -115,7 +138,7 @@ impl Mul<Self> for PackedGoldilocksAVX2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self::new(unsafe { mul(self.get(), rhs.get()) })
+        Self::from_vector(mul(self.to_vector(), rhs.to_vector()))
     }
 }
 impl Mul<Goldilocks> for PackedGoldilocksAVX2 {
@@ -149,7 +172,7 @@ impl Neg for PackedGoldilocksAVX2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self::new(unsafe { neg(self.get()) })
+        Self::from_vector(neg(self.to_vector()))
     }
 }
 
@@ -163,10 +186,10 @@ impl Product for PackedGoldilocksAVX2 {
 impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     type PrimeSubfield = Goldilocks;
 
-    const ZERO: Self = Self([Goldilocks::ZERO; WIDTH]);
-    const ONE: Self = Self([Goldilocks::ONE; WIDTH]);
-    const TWO: Self = Self([Goldilocks::TWO; WIDTH]);
-    const NEG_ONE: Self = Self([Goldilocks::NEG_ONE; WIDTH]);
+    const ZERO: Self = Self::broadcast(Goldilocks::ZERO);
+    const ONE: Self = Self::broadcast(Goldilocks::ONE);
+    const TWO: Self = Self::broadcast(Goldilocks::TWO);
+    const NEG_ONE: Self = Self::broadcast(Goldilocks::NEG_ONE);
 
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
@@ -175,7 +198,7 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
 
     #[inline]
     fn square(&self) -> Self {
-        Self::new(unsafe { square(self.get()) })
+        Self::from_vector(square(self.to_vector()))
     }
 
     #[inline]
@@ -238,14 +261,14 @@ unsafe impl PackedField for PackedGoldilocksAVX2 {
 unsafe impl PackedFieldPow2 for PackedGoldilocksAVX2 {
     #[inline]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.get(), other.get());
+        let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => unsafe { interleave1(v0, v1) },
-            2 => unsafe { interleave2(v0, v1) },
+            1 => interleave1(v0, v1),
+            2 => interleave2(v0, v1),
             4 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };
-        (Self::new(res0), Self::new(res1))
+        (Self::from_vector(res0), Self::from_vector(res1))
     }
 }
 
@@ -253,7 +276,7 @@ impl Sub<Self> for PackedGoldilocksAVX2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::new(unsafe { sub(self.get(), rhs.get()) })
+        Self::from_vector(sub(self.to_vector(), rhs.to_vector()))
     }
 }
 impl Sub<Goldilocks> for PackedGoldilocksAVX2 {
@@ -356,7 +379,7 @@ const EPSILON: __m256i = unsafe { transmute([Goldilocks::ORDER_U64.wrapping_neg(
 ///  # Safety
 /// TODO
 #[inline]
-pub unsafe fn shift(x: __m256i) -> __m256i {
+pub fn shift(x: __m256i) -> __m256i {
     unsafe { _mm256_xor_si256(x, SIGN_BIT) }
 }
 
@@ -387,8 +410,11 @@ unsafe fn add_no_double_overflow_64_64s_s(x: __m256i, y_s: __m256i) -> __m256i {
     }
 }
 
+/// Goldilocks modular addition. Computes `x + y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
 #[inline]
-unsafe fn add(x: __m256i, y: __m256i) -> __m256i {
+fn add(x: __m256i, y: __m256i) -> __m256i {
     unsafe {
         let y_s = shift(y);
         let res_s = add_no_double_overflow_64_64s_s(x, canonicalize_s(y_s));
@@ -396,8 +422,11 @@ unsafe fn add(x: __m256i, y: __m256i) -> __m256i {
     }
 }
 
+/// Goldilocks modular subtraction. Computes `x - y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
 #[inline]
-unsafe fn sub(x: __m256i, y: __m256i) -> __m256i {
+fn sub(x: __m256i, y: __m256i) -> __m256i {
     unsafe {
         let mut y_s = shift(y);
         y_s = canonicalize_s(y_s);
@@ -409,8 +438,11 @@ unsafe fn sub(x: __m256i, y: __m256i) -> __m256i {
     }
 }
 
+/// Goldilocks modular negation. Computes `-x mod FIELD_ORDER`.
+///
+/// Input can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
 #[inline]
-unsafe fn neg(y: __m256i) -> __m256i {
+fn neg(y: __m256i) -> __m256i {
     unsafe {
         let y_s = shift(y);
         _mm256_sub_epi64(SHIFTED_FIELD_ORDER, canonicalize_s(y_s))
@@ -420,7 +452,7 @@ unsafe fn neg(y: __m256i) -> __m256i {
 /// Full 64-bit by 64-bit multiplication. This emulated multiplication is 1.33x slower than the
 /// scalar instruction, but may be worth it if we want our data to live in vector registers.
 #[inline]
-unsafe fn mul64_64(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
+fn mul64_64(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
     unsafe {
         // We want to move the high 32 bits to the low position. The multiplication instruction ignores
         // the high 32 bits, so it's ok to just duplicate it into the low position. This duplication can
@@ -463,7 +495,7 @@ unsafe fn mul64_64(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
 
 /// Full 64-bit squaring. This routine is 1.2x faster than the scalar instruction.
 #[inline]
-unsafe fn square64(x: __m256i) -> (__m256i, __m256i) {
+fn square64(x: __m256i) -> (__m256i, __m256i) {
     unsafe {
         // Get high 32 bits of x. See comment in mul64_64_s.
         let x_hi = _mm256_castps_si256(_mm256_movehdup_ps(_mm256_castsi256_ps(x)));
@@ -537,20 +569,24 @@ unsafe fn reduce128(x: (__m256i, __m256i)) -> __m256i {
     }
 }
 
-/// Multiply two integers modulo FIELD_ORDER.
+/// Goldilocks modular multiplication. Computes `x * y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
 #[inline]
-unsafe fn mul(x: __m256i, y: __m256i) -> __m256i {
+fn mul(x: __m256i, y: __m256i) -> __m256i {
     unsafe { reduce128(mul64_64(x, y)) }
 }
 
-/// Square an integer modulo FIELD_ORDER.
+/// Goldilocks modular square. Computes `x^2 mod FIELD_ORDER`.
+///
+/// Input can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
 #[inline]
-unsafe fn square(x: __m256i) -> __m256i {
+fn square(x: __m256i) -> __m256i {
     unsafe { reduce128(square64(x)) }
 }
 
 #[inline]
-unsafe fn interleave1(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
+fn interleave1(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
     unsafe {
         let a = _mm256_unpacklo_epi64(x, y);
         let b = _mm256_unpackhi_epi64(x, y);
@@ -559,7 +595,7 @@ unsafe fn interleave1(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
 }
 
 #[inline]
-unsafe fn interleave2(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
+fn interleave2(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
     unsafe {
         let y_lo = _mm256_castsi256_si128(y); // This has 0 cost.
 

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -28,9 +28,9 @@ const WIDTH: usize = 4;
 pub struct PackedGoldilocksAVX2(pub [Goldilocks; WIDTH]);
 
 impl PackedGoldilocksAVX2 {
+    /// Get an arch-specific vector representing the packed values.
     #[inline]
     #[must_use]
-    /// Get an arch-specific vector representing the packed values.
     pub(crate) fn to_vector(self) -> __m256i {
         unsafe {
             // Safety: `Goldilocks` is `repr(transparent)` so it can be transmuted to `u64`. It
@@ -42,12 +42,12 @@ impl PackedGoldilocksAVX2 {
         }
     }
 
-    #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// Elements of `Goldilocks` are allowed to be arbitrary u64s so this function
     /// is safe unlike the `Mersenne31/MontyField31` variants.
+    #[inline]
+    #[must_use]
     pub(crate) fn from_vector(vector: __m256i) -> Self {
         unsafe {
             // Safety: `__m256i` can be transmuted to `[u64; WIDTH]` (since arrays elements are

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -264,8 +264,6 @@ const EPSILON: __m256i = unsafe { transmute([Goldilocks::ORDER_U64.wrapping_neg(
 
 /// Add 2^63 with overflow. Needed to emulate unsigned comparisons (see point 3. in
 /// packed_prime_field.rs).
-///  # Safety
-/// TODO
 #[inline]
 pub fn shift(x: __m256i) -> __m256i {
     unsafe { _mm256_xor_si256(x, SIGN_BIT) }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -28,8 +28,9 @@ const WIDTH: usize = 8;
 pub struct PackedGoldilocksAVX512(pub [Goldilocks; WIDTH]);
 
 impl PackedGoldilocksAVX512 {
-    #[must_use]
     /// Get an arch-specific vector representing the packed values.
+    #[inline]
+    #[must_use]
     pub(crate) fn to_vector(self) -> __m512i {
         unsafe {
             // Safety: `Goldilocks` is `repr(transparent)` so it can be transmuted to `u64`. It
@@ -41,12 +42,12 @@ impl PackedGoldilocksAVX512 {
         }
     }
 
-    #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// Elements of `Goldilocks` are allowed to be arbitrary u64s so this function
     /// is safe unlike the `Mersenne31/MontyField31` variants.
+    #[inline]
+    #[must_use]
     pub(crate) fn from_vector(vector: __m512i) -> Self {
         unsafe {
             // Safety: `__m512i` can be transmuted to `[u64; WIDTH]` (since arrays elements are

--- a/util/src/transpose.rs
+++ b/util/src/transpose.rs
@@ -181,7 +181,7 @@ pub(super) unsafe fn transpose_swap<T: Copy>(
 /// Each matrix element `M[i,j]` is stored at:
 /// ```text
 /// \begin{equation}
-///     \text{index}(i,j) = i + x + ((i + x) << log_stride) + (j + x)
+///     \text{index}(i,j) = ((i + x) << log_stride) + (j + x)
 /// \end{equation}
 /// ```
 ///


### PR DESCRIPTION
Minor refactors for the AVX2 and AVX512 Goldilocks implementations. Goal is to make the file/implementation more similar to the  `Mersenne31/MontyField31` packed implementations.

Key Changes
- Rename `new` and `get` to `to_vector` and `from_vector`. Add some comments about memory safety.
- Introduce `broadcast` giving a constant version of `From`.
- Add comments and remove some unsafes.

As Goldilocks elements are allowed to be any `u64`, most of the generic `add/sub/mul` and similar functions are not actually unsafe. There are no unchecked invariants that the caller needs to ensure. Hence we can remove many of these unsafe keywords. Similarly `reduce128` will work given any generic `u128` split into `2` `64` bit limbs.