### PR TITLE
Fix index formula in transpose_in_place_square doc comment

### DIFF
--- a/util/src/transpose.rs
+++ b/util/src/transpose.rs
@@ -181,7 +181,7 @@ pub(super) unsafe fn transpose_swap<T: Copy>(
 /// Each matrix element `M[i,j]` is stored at:
 /// ```text
 /// \begin{equation}
-///     \text{index}(i,j) = i + x + ((i + x) << log_stride) + (j + x)
+///     \text{index}(i,j) = ((i + x) << log_stride) + (j + x)
 /// \end{equation}
 /// ```
 ///


### PR DESCRIPTION
Corrected the documentation comment for transpose_in_place_square to accurately reflect the index calculation used in the code. The previous formula included an extra term (`i + x + ...`) that did not match the actual indexing logic. The updated formula now matches the implementation: `((i + x) << log_stride) + (j + x)`.