### PR TITLE
Add a macro for implying PackedValue for PackedFields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
           targets: ${{ env.target }}
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -139,7 +139,7 @@ jobs:
       - name: Install cargo-sort
         run: cargo install cargo-sort
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -291,15 +291,18 @@ macro_rules! impl_packed_value {
                     assert_eq!(slice.len(), Self::WIDTH);
                     unsafe { &*slice.as_ptr().cast() }
                 }
+                
                 #[inline]
                 fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
                     assert_eq!(slice.len(), Self::WIDTH);
                     unsafe { &mut *slice.as_mut_ptr().cast() }
                 }
+                
                 #[inline]
                 fn as_slice(&self) -> &[Self::Value] {
                     &self.0
                 }
+                
                 #[inline]
                 fn as_slice_mut(&mut self) -> &mut [Self::Value] {
                     &mut self.0

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -271,7 +271,51 @@ macro_rules! impl_rng {
     };
 }
 
+/// Given `Field` and `Algebra` structs where `Algebra` is simply a wrapper around `[Field; N]`
+/// implement `PackedValue` for `Algebra`.
+///
+/// # Safety
+/// `Algebra` must be `repr(transparent)` and castable from to/from `[Field; N]`. Assuming this
+/// holds, these types have the same alignment and size, so all our reference casts are safe.
+#[macro_export]
+macro_rules! impl_packed_value {
+    ($alg_type:ty, $field_type:ty, $width:expr $(, ($type_param:ty, $param_name:ty))?) => {
+        paste::paste! {
+            unsafe impl$(<$param_name: $type_param>)? PackedValue for $alg_type$(<$param_name>)? {
+                type Value = $field_type$(<$param_name>)?;
+
+                const WIDTH: usize = $width;
+
+                #[inline]
+                fn from_slice(slice: &[Self::Value]) -> &Self {
+                    assert_eq!(slice.len(), Self::WIDTH);
+                    unsafe { &*slice.as_ptr().cast() }
+                }
+                #[inline]
+                fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
+                    assert_eq!(slice.len(), Self::WIDTH);
+                    unsafe { &mut *slice.as_mut_ptr().cast() }
+                }
+                #[inline]
+                fn as_slice(&self) -> &[Self::Value] {
+                    &self.0
+                }
+                #[inline]
+                fn as_slice_mut(&mut self) -> &mut [Self::Value] {
+                    &mut self.0
+                }
+
+                #[inline]
+                fn from_fn<F: FnMut(usize) -> Self::Value>(f: F) -> Self {
+                    Self(core::array::from_fn(f))
+                }
+            }
+        }
+    };
+}
+
 pub use {
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -291,18 +291,18 @@ macro_rules! impl_packed_value {
                     assert_eq!(slice.len(), Self::WIDTH);
                     unsafe { &*slice.as_ptr().cast() }
                 }
-                
+
                 #[inline]
                 fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
                     assert_eq!(slice.len(), Self::WIDTH);
                     unsafe { &mut *slice.as_mut_ptr().cast() }
                 }
-                
+
                 #[inline]
                 fn as_slice(&self) -> &[Self::Value] {
                     &self.0
                 }
-                
+
                 #[inline]
                 fn as_slice_mut(&mut self) -> &mut [Self::Value] {
                     &mut self.0

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -146,27 +146,29 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
     type Value = T;
     const WIDTH: usize = WIDTH;
 
+    #[inline]
     fn from_slice(slice: &[Self::Value]) -> &Self {
         assert_eq!(slice.len(), Self::WIDTH);
-        slice.try_into().unwrap()
+        unsafe { &*slice.as_ptr().cast() }
     }
 
+    #[inline]
     fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
         assert_eq!(slice.len(), Self::WIDTH);
-        slice.try_into().unwrap()
+        unsafe { &mut *slice.as_mut_ptr().cast() }
     }
 
-    fn from_fn<F>(f: F) -> Self
-    where
-        F: FnMut(usize) -> Self::Value,
-    {
+    #[inline]
+    fn from_fn<F: FnMut(usize) -> Self::Value>(f: F) -> Self {
         core::array::from_fn(f)
     }
 
+    #[inline]
     fn as_slice(&self) -> &[Self::Value] {
         self
     }
 
+    #[inline]
     fn as_slice_mut(&mut self) -> &mut [Self::Value] {
         self
     }
@@ -319,25 +321,29 @@ unsafe impl<T: Packable> PackedValue for T {
 
     const WIDTH: usize = 1;
 
+    #[inline]
     fn from_slice(slice: &[Self::Value]) -> &Self {
+        assert_eq!(slice.len(), Self::WIDTH);
         &slice[0]
     }
 
+    #[inline]
     fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
+        assert_eq!(slice.len(), Self::WIDTH);
         &mut slice[0]
     }
 
-    fn from_fn<Fn>(mut f: Fn) -> Self
-    where
-        Fn: FnMut(usize) -> Self::Value,
-    {
+    #[inline]
+    fn from_fn<Fn: FnMut(usize) -> Self::Value>(mut f: Fn) -> Self {
         f(0)
     }
 
+    #[inline]
     fn as_slice(&self) -> &[Self::Value] {
         slice::from_ref(self)
     }
 
+    #[inline]
     fn as_slice_mut(&mut self) -> &mut [Self::Value] {
         slice::from_mut(self)
     }

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -159,7 +159,10 @@ unsafe impl<T: Packable, const WIDTH: usize> PackedValue for [T; WIDTH] {
     }
 
     #[inline]
-    fn from_fn<F: FnMut(usize) -> Self::Value>(f: F) -> Self {
+    fn from_fn<Fn>(f: Fn) -> Self
+    where
+        Fn: FnMut(usize) -> Self::Value,
+    {
         core::array::from_fn(f)
     }
 
@@ -334,7 +337,10 @@ unsafe impl<T: Packable> PackedValue for T {
     }
 
     #[inline]
-    fn from_fn<Fn: FnMut(usize) -> Self::Value>(mut f: Fn) -> Self {
+    fn from_fn<Fn>(mut f: Fn) -> Self
+    where
+        Fn: FnMut(usize) -> Self::Value,
+    {
         f(0)
     }
 

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -8,7 +8,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -158,35 +159,7 @@ impl_sum_prod_base_field!(PackedGoldilocksAVX2, Goldilocks);
 
 impl Algebra<Goldilocks> for PackedGoldilocksAVX2 {}
 
-unsafe impl PackedValue for PackedGoldilocksAVX2 {
-    type Value = Goldilocks;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[Goldilocks]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe { &*slice.as_ptr().cast() }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [Goldilocks]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe { &mut *slice.as_mut_ptr().cast() }
-    }
-    #[inline]
-    fn as_slice(&self) -> &[Goldilocks] {
-        &self.0
-    }
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [Goldilocks] {
-        &mut self.0
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> Goldilocks>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-}
+impl_packed_value!(PackedGoldilocksAVX2, Goldilocks, WIDTH);
 
 unsafe impl PackedField for PackedGoldilocksAVX2 {
     type Scalar = Goldilocks;

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -8,7 +8,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_10540996611094048183;
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -158,35 +158,7 @@ impl PermutationMonomial<7> for PackedGoldilocksAVX512 {
     }
 }
 
-unsafe impl PackedValue for PackedGoldilocksAVX512 {
-    type Value = Goldilocks;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[Goldilocks]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe { &*slice.as_ptr().cast() }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [Goldilocks]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe { &mut *slice.as_mut_ptr().cast() }
-    }
-    #[inline]
-    fn as_slice(&self) -> &[Goldilocks] {
-        &self.0
-    }
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [Goldilocks] {
-        &mut self.0
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> Goldilocks>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-}
+impl_packed_value!(PackedGoldilocksAVX512, Goldilocks, WIDTH);
 
 unsafe impl PackedField for PackedGoldilocksAVX512 {
     type Scalar = Goldilocks;

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -7,7 +7,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -351,47 +352,7 @@ fn interleave2(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
     }
 }
 
-unsafe impl PackedValue for PackedMersenne31Neon {
-    type Value = Mersenne31;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[Mersenne31]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31Neon` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast
-            // is safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [Mersenne31]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31Neon` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast
-            // is safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> Mersenne31>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[Mersenne31] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [Mersenne31] {
-        &mut self.0
-    }
-}
+impl_packed_value!(PackedMersenne31Neon, Mersenne31, WIDTH);
 
 unsafe impl PackedField for PackedMersenne31Neon {
     type Scalar = Mersenne31;

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -7,7 +7,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -523,47 +524,7 @@ fn interleave4(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
     }
 }
 
-unsafe impl PackedValue for PackedMersenne31AVX2 {
-    type Value = Mersenne31;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[Mersenne31]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31AVX2` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [Mersenne31]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31AVX2` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> Mersenne31>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[Mersenne31] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [Mersenne31] {
-        &mut self.0
-    }
-}
+impl_packed_value!(PackedMersenne31AVX2, Mersenne31, WIDTH);
 
 unsafe impl PackedField for PackedMersenne31AVX2 {
     type Scalar = Mersenne31;

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -7,7 +7,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use p3_field::exponentiation::exp_1717986917;
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -623,47 +624,7 @@ fn interleave8(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
     }
 }
 
-unsafe impl PackedValue for PackedMersenne31AVX512 {
-    type Value = Mersenne31;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[Mersenne31]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31AVX512` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [Mersenne31]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[Mersenne31; WIDTH]` can be transmuted to `PackedMersenne31AVX512` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> Mersenne31>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[Mersenne31] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [Mersenne31] {
-        &mut self.0
-    }
-}
+impl_packed_value!(PackedMersenne31AVX512, Mersenne31, WIDTH);
 
 unsafe impl PackedField for PackedMersenne31AVX512 {
     type Scalar = Mersenne31;

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -8,7 +8,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -507,47 +508,12 @@ fn interleave2(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
     }
 }
 
-unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31Neon<FP> {
-    type Value = MontyField31<FP>;
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[MontyField31<FP>]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31; WIDTH]` can be transmuted to `PackedMontyField31Neon` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_slice_mut(slice: &mut [MontyField31<FP>]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31; WIDTH]` can be transmuted to `PackedMontyField31Neon` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> MontyField31<FP>>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[MontyField31<FP>] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [MontyField31<FP>] {
-        &mut self.0
-    }
-}
+impl_packed_value!(
+    PackedMontyField31Neon,
+    MontyField31,
+    WIDTH,
+    (PackedMontyParameters, PMP)
+);
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31Neon<FP> {
     type Scalar = MontyField31<FP>;

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -166,7 +166,7 @@ impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
     }
 }
 
-impl<FP: FieldParameters> Packable for MontyField31<FP> {}
+impl<MP: MontyParameters> Packable for MontyField31<MP> {}
 
 impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
     type PrimeSubfield = Self;

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -7,7 +7,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -1113,47 +1114,12 @@ fn interleave4(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
     }
 }
 
-unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX2<FP> {
-    type Value = MontyField31<FP>;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[MontyField31<FP>]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31<FP>; WIDTH]` can be transmuted to `PackedMontyField31AVX2<FP>` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [MontyField31<FP>]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31<FP>; WIDTH]` can be transmuted to `PackedMontyField31AVX2<FP>` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> MontyField31<FP>>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[MontyField31<FP>] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [MontyField31<FP>] {
-        &mut self.0
-    }
-}
+impl_packed_value!(
+    PackedMontyField31AVX2,
+    MontyField31,
+    WIDTH,
+    (PackedMontyParameters, PMP)
+);
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX2<FP> {
     type Scalar = MontyField31<FP>;

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -13,7 +13,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
@@ -1312,47 +1313,12 @@ fn interleave8(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
     }
 }
 
-unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX512<FP> {
-    type Value = MontyField31<FP>;
-
-    const WIDTH: usize = WIDTH;
-
-    #[inline]
-    fn from_slice(slice: &[MontyField31<FP>]) -> &Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31<FP>; WIDTH]` can be transmuted to `PackedMontyField31AVX512` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &*slice.as_ptr().cast()
-        }
-    }
-    #[inline]
-    fn from_slice_mut(slice: &mut [MontyField31<FP>]) -> &mut Self {
-        assert_eq!(slice.len(), Self::WIDTH);
-        unsafe {
-            // Safety: `[MontyField31<FP>; WIDTH]` can be transmuted to `PackedMontyField31AVX512` since the
-            // latter is `repr(transparent)`. They have the same alignment, so the reference cast is
-            // safe too.
-            &mut *slice.as_mut_ptr().cast()
-        }
-    }
-
-    #[inline]
-    fn from_fn<F: FnMut(usize) -> MontyField31<FP>>(f: F) -> Self {
-        Self(core::array::from_fn(f))
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[MontyField31<FP>] {
-        &self.0
-    }
-
-    #[inline]
-    fn as_slice_mut(&mut self) -> &mut [MontyField31<FP>] {
-        &mut self.0
-    }
-}
+impl_packed_value!(
+    PackedMontyField31AVX512,
+    MontyField31,
+    WIDTH,
+    (PackedMontyParameters, PMP)
+);
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX512<FP> {
     type Scalar = MontyField31<FP>;


### PR DESCRIPTION
Currently all 8 of these implementations are totally identical so we add a simple macro to handle them all.

Copied across the `PackedValue` impl to `[T; WIDTH]` which is a little faster and cleaned up the `PackedValue` impl for `T` as well, adding a couple of asserts which should be there. We can't use the macro for these as they have a slightly different structure.