### PR TITLE
Combining Interleave Code

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -23,3 +23,6 @@ tracing.workspace = true
 [dev-dependencies]
 p3-baby-bear.workspace = true
 p3-goldilocks.workspace = true
+
+[features]
+nightly-features = []

--- a/field/src/interleaves.rs
+++ b/field/src/interleaves.rs
@@ -139,7 +139,8 @@ pub mod interleave {
     target_feature = "avx512f"
 ))]
 pub mod interleave {
-    use core::arch::x86_64::{self, __m512i, __mmask8, __mmask16};
+    use core::{arch::x86_64::{self, __m512i, __mmask16, __mmask8}};
+    use core::mem::transmute;
 
     const EVENS: __mmask16 = 0b0101010101010101;
     const EVENS4: __mmask16 = 0x0f0f;
@@ -266,7 +267,7 @@ pub mod interleave {
 
         const INTERLEAVE4_INDICES: __m512i = unsafe {
             // Safety: `[u64; 8]` is trivially transmutable to `__m512i`.
-            transmute::<[u64; WIDTH / 2], _>([0o02, 0o03, 0o10, 0o11, 0o06, 0o07, 0o14, 0o15])
+            transmute::<[u64; 8], _>([0o02, 0o03, 0o10, 0o11, 0o06, 0o07, 0o14, 0o15])
         };
 
         unsafe {

--- a/field/src/interleaves.rs
+++ b/field/src/interleaves.rs
@@ -139,7 +139,7 @@ pub mod interleave {
     target_feature = "avx512f"
 ))]
 pub mod interleave {
-    use core::{arch::x86_64::{self, __m512i, __mmask16, __mmask8}};
+    use core::arch::x86_64::{self, __m512i, __mmask8, __mmask16};
     use core::mem::transmute;
 
     const EVENS: __mmask16 = 0b0101010101010101;

--- a/field/src/interleaves.rs
+++ b/field/src/interleaves.rs
@@ -1,0 +1,94 @@
+//! A file containing a collection of architecture-specific interleaving functions.
+//! Used for PackedFields to implement interleaving operations.
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(all(feature = "nightly-features", target_feature = "avx512f"))
+))]
+pub mod interleave_avx2 {
+    use core::arch::x86_64::{self, __m256i};
+
+    #[inline]
+    #[must_use]
+    pub fn interleave_u32(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
+        // We want this to compile to:
+        //      vpsllq    t, a, 32
+        //      vpsrlq    u, b, 32
+        //      vpblendd  res0, a, u, aah
+        //      vpblendd  res1, t, b, aah
+        // throughput: 1.33 cyc/2 vec (12 els/cyc)
+        // latency: (1 -> 1)  1 cyc
+        //          (1 -> 2)  2 cyc
+        //          (2 -> 1)  2 cyc
+        //          (2 -> 2)  1 cyc
+        unsafe {
+            // Safety: If this code got compiled then AVX2 intrinsics are available.
+
+            // We currently have:
+            //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
+            //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
+            // First form
+            //   t = [ a1   0  a3   0  a5   0  a7   0 ].
+            //   u = [  0  b0   0  b2   0  b4   0  b6 ].
+            let t = x86_64::_mm256_srli_epi64::<32>(a);
+            let u = x86_64::_mm256_slli_epi64::<32>(b);
+
+            // Then
+            //   res0 = [ a0  b0  a2  b2  a4  b4  a6  b6 ],
+            //   res1 = [ a1  b1  a3  b3  a5  b5  a7  b7 ].
+            (
+                x86_64::_mm256_blend_epi32::<0b10101010>(a, u),
+                x86_64::_mm256_blend_epi32::<0b10101010>(t, b),
+            )
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn interleave_u64(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
+        // We want this to compile to:
+        //      vpunpcklqdq   res0, a, b
+        //      vpunpckhqdq   res1, a, b
+        // throughput: 1 cyc/2 vec (16 els/cyc)
+        // latency: 1 cyc
+
+        unsafe {
+            // Safety: If this code got compiled then AVX2 intrinsics are available.
+            (
+                x86_64::_mm256_unpacklo_epi64(a, b),
+                x86_64::_mm256_unpackhi_epi64(a, b),
+            )
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn interleave_u128(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
+        // We want this to compile to:
+        //      vperm2i128  t, a, b, 21h
+        //      vpblendd    res0, a, t, f0h
+        //      vpblendd    res1, t, b, f0h
+        // throughput: 1 cyc/2 vec (16 els/cyc)
+        // latency: 4 cyc
+
+        unsafe {
+            // Safety: If this code got compiled then AVX2 intrinsics are available.
+
+            // We currently have:
+            //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
+            //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
+            // First form
+            //   t = [ a4  a5  a6  a7  b0  b1  b2  b3 ].
+            let t = x86_64::_mm256_permute2x128_si256::<0x21>(a, b);
+
+            // Then
+            //   res0 = [ a0  a1  a2  a3  b0  b1  b2  b3 ],
+            //   res1 = [ a4  a5  a6  a7  b4  b5  b6  b7 ].
+            (
+                x86_64::_mm256_blend_epi32::<0b11110000>(a, t),
+                x86_64::_mm256_blend_epi32::<0b11110000>(t, b),
+            )
+        }
+    }
+}

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -1,6 +1,14 @@
 //! A framework for finite fields.
 
 #![no_std]
+#![cfg_attr(
+    all(
+        feature = "nightly-features",
+        target_arch = "x86_64",
+        target_feature = "avx512f"
+    ),
+    feature(stdarch_x86_avx512)
+)]
 
 extern crate alloc;
 

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -28,5 +28,6 @@ pub use array::*;
 pub use batch_inverse::*;
 pub use field::*;
 pub use helpers::*;
+#[allow(unused_imports)] // Used when vectorization is available.
 pub use interleaves::*;
 pub use packed::*;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -20,7 +20,7 @@ pub mod extension;
 mod field;
 mod helpers;
 pub mod integers;
-mod interleaves;
+pub mod interleaves;
 pub mod op_assign_macros;
 mod packed;
 
@@ -28,9 +28,5 @@ pub use array::*;
 pub use batch_inverse::*;
 pub use field::*;
 pub use helpers::*;
-#[cfg(any(
-    all(target_arch = "x86_64", target_feature = "avx2"),
-    all(target_arch = "aarch64", target_feature = "neon")
-))]
 pub use interleaves::*;
 pub use packed::*;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -28,5 +28,9 @@ pub use array::*;
 pub use batch_inverse::*;
 pub use field::*;
 pub use helpers::*;
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "avx2"),
+    all(target_arch = "aarch64", target_feature = "neon")
+))]
 pub use interleaves::*;
 pub use packed::*;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -12,6 +12,7 @@ pub mod extension;
 mod field;
 mod helpers;
 pub mod integers;
+mod interleaves;
 pub mod op_assign_macros;
 mod packed;
 
@@ -19,4 +20,5 @@ pub use array::*;
 pub use batch_inverse::*;
 pub use field::*;
 pub use helpers::*;
+pub use interleaves::*;
 pub use packed::*;

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -28,6 +28,6 @@ pub use array::*;
 pub use batch_inverse::*;
 pub use field::*;
 pub use helpers::*;
-#[allow(unused_imports)] // Used when vectorization is available.
-pub use interleaves::*;
+#[allow(unused_imports)]
+pub use interleaves::*; // Only used when vectorization is available.
 pub use packed::*;

--- a/field/src/packed.rs
+++ b/field/src/packed.rs
@@ -265,6 +265,7 @@ pub unsafe trait PackedFieldPow2: PackedField {
     /// # Panics
     /// This may panic if `block_len` does not divide `WIDTH`. Since `WIDTH` is specified to be a power of 2,
     /// `block_len` must also be a power of 2. It cannot be 0 and it cannot exceed `WIDTH`.
+    #[must_use]
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self);
 }
 

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -6,7 +6,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_10540996611094048183;
-use p3_field::interleave_avx2::{interleave_u64, interleave_u128};
+use p3_field::interleave::{interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -13,7 +13,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -193,19 +193,14 @@ unsafe impl PackedField for PackedGoldilocksAVX2 {
     type Scalar = Goldilocks;
 }
 
-unsafe impl PackedFieldPow2 for PackedGoldilocksAVX2 {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u64(v0, v1),
-            2 => interleave_u128(v0, v1),
-            4 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        (Self::from_vector(res0), Self::from_vector(res1))
-    }
-}
+impl_packed_field_pow_2!(
+    PackedGoldilocksAVX2;
+    [
+        (1, interleave_u64),
+        (2, interleave_u128),
+    ],
+    WIDTH
+);
 
 // Resources:
 // 1. Intel Intrinsics Guide for explanation of each intrinsic:

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -6,6 +6,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_10540996611094048183;
+use p3_field::interleave_avx2::{interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -197,8 +198,8 @@ unsafe impl PackedFieldPow2 for PackedGoldilocksAVX2 {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
+            1 => interleave_u64(v0, v1),
+            2 => interleave_u128(v0, v1),
             4 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };
@@ -489,37 +490,6 @@ fn mul(x: __m256i, y: __m256i) -> __m256i {
 #[inline]
 fn square(x: __m256i) -> __m256i {
     reduce128(square64(x))
-}
-
-#[inline]
-fn interleave1(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
-    unsafe {
-        let a = _mm256_unpacklo_epi64(x, y);
-        let b = _mm256_unpackhi_epi64(x, y);
-        (a, b)
-    }
-}
-
-#[inline]
-fn interleave2(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
-    unsafe {
-        let y_lo = _mm256_castsi256_si128(y); // This has 0 cost.
-
-        // 1 places y_lo in the high half of x; 0 would place it in the lower half.
-        let a = _mm256_inserti128_si256::<1>(x, y_lo);
-        // NB: _mm256_permute2x128_si256 could be used here as well but _mm256_inserti128_si256 has
-        // lower latency on Zen 3 processors.
-
-        // Each nibble of the constant has the following semantics:
-        // 0 => src1[low 128 bits]
-        // 1 => src1[high 128 bits]
-        // 2 => src2[low 128 bits]
-        // 3 => src2[high 128 bits]
-        // The low (resp. high) nibble chooses the low (resp. high) 128 bits of the result.
-        let b = _mm256_permute2x128_si256::<0x31>(x, y);
-
-        (a, b)
-    }
 }
 
 #[cfg(test)]

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -13,7 +13,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -193,20 +193,15 @@ unsafe impl PackedField for PackedGoldilocksAVX512 {
     type Scalar = Goldilocks;
 }
 
-unsafe impl PackedFieldPow2 for PackedGoldilocksAVX512 {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u64(v0, v1),
-            2 => interleave_u128(v0, v1),
-            4 => interleave_u256(v0, v1),
-            8 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        (Self::from_vector(res0), Self::from_vector(res1))
-    }
-}
+impl_packed_field_pow_2!(
+    PackedGoldilocksAVX512;
+    [
+        (1, interleave_u64),
+        (2, interleave_u128),
+        (4, interleave_u256),
+    ],
+    WIDTH
+);
 
 const FIELD_ORDER: __m512i = unsafe { transmute([Goldilocks::ORDER_U64; WIDTH]) };
 const EPSILON: __m512i = unsafe { transmute([Goldilocks::ORDER_U64.wrapping_neg(); WIDTH]) };

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -12,7 +12,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -363,22 +363,14 @@ unsafe impl PackedField for PackedMersenne31Neon {
     type Scalar = Mersenne31;
 }
 
-unsafe impl PackedFieldPow2 for PackedMersenne31Neon {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u32(v0, v1),
-            2 => interleave_u64(v0, v1),
-            4 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        unsafe {
-            // Safety: all values are in canonical form (we haven't changed them).
-            (Self::from_vector(res0), Self::from_vector(res1))
-        }
-    }
-}
+impl_packed_field_pow_2!(
+    PackedMersenne31Neon;
+    [
+        (1, interleave_u32),
+        (2, interleave_u64)
+    ],
+    WIDTH
+);
 
 #[cfg(test)]
 mod tests {

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -5,6 +5,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
+use p3_field::interleave::{interleave_u32, interleave_u64};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -316,41 +317,6 @@ fn sub(lhs: uint32x4_t, rhs: uint32x4_t) -> uint32x4_t {
     }
 }
 
-#[inline]
-#[must_use]
-fn interleave1(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
-    // We want this to compile to:
-    //      trn1  res0.4s, v0.4s, v1.4s
-    //      trn2  res1.4s, v0.4s, v1.4s
-    // throughput: .5 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-    unsafe {
-        // Safety: If this code got compiled then NEON intrinsics are available.
-        (aarch64::vtrn1q_u32(v0, v1), aarch64::vtrn2q_u32(v0, v1))
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
-    // We want this to compile to:
-    //      trn1  res0.2d, v0.2d, v1.2d
-    //      trn2  res1.2d, v0.2d, v1.2d
-    // throughput: .5 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-
-    // To transpose 64-bit blocks, cast the [u32; 4] vectors to [u64; 2], transpose, and cast back.
-    unsafe {
-        // Safety: If this code got compiled then NEON intrinsics are available.
-        let v0 = aarch64::vreinterpretq_u64_u32(v0);
-        let v1 = aarch64::vreinterpretq_u64_u32(v1);
-        (
-            aarch64::vreinterpretq_u32_u64(aarch64::vtrn1q_u64(v0, v1)),
-            aarch64::vreinterpretq_u32_u64(aarch64::vtrn2q_u64(v0, v1)),
-        )
-    }
-}
-
 unsafe impl PackedValue for PackedMersenne31Neon {
     type Value = Mersenne31;
 
@@ -402,8 +368,8 @@ unsafe impl PackedFieldPow2 for PackedMersenne31Neon {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
             4 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -5,6 +5,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
+use p3_field::interleave_avx2::{interleave_u32, interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -428,101 +429,6 @@ pub(crate) fn exp5(x: __m256i) -> __m256i {
     }
 }
 
-#[inline]
-#[must_use]
-fn interleave1(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vpsllq    t, a, 32
-    //      vpsrlq    u, b, 32
-    //      vpblendd  res0, a, u, aah
-    //      vpblendd  res1, t, b, aah
-    // throughput: 1.33 cyc/2 vec (12 els/cyc)
-    // latency: (1 -> 1)  1 cyc
-    //          (1 -> 2)  2 cyc
-    //          (2 -> 1)  2 cyc
-    //          (2 -> 2)  1 cyc
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a1   0  a3   0  a5   0  a7   0 ].
-        //   u = [  0  b0   0  b2   0  b4   0  b6 ].
-        let t = x86_64::_mm256_srli_epi64::<32>(a);
-        let u = x86_64::_mm256_slli_epi64::<32>(b);
-
-        // Then
-        //   res0 = [ a0  b0  a2  b2  a4  b4  a6  b6 ],
-        //   res1 = [ a1  b1  a3  b3  a5  b5  a7  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b10101010>(a, u),
-            x86_64::_mm256_blend_epi32::<0b10101010>(t, b),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vpalignr  t, b, a, 8
-    //      vpblendd  res0, a, t, cch
-    //      vpblendd  res1, t, b, cch
-    // throughput: 1 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a2  a3  b0  b1  a6  a7  b4  b5 ].
-        let t = x86_64::_mm256_alignr_epi8::<8>(b, a);
-
-        // Then
-        //   res0 = [ a0  a1  b0  b1  a4  a5  b4  b5 ],
-        //   res1 = [ a2  a3  b2  b3  a6  a7  b6  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b11001100>(a, t),
-            x86_64::_mm256_blend_epi32::<0b11001100>(t, b),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave4(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vperm2i128  t, a, b, 21h
-    //      vpblendd    res0, a, t, f0h
-    //      vpblendd    res1, t, b, f0h
-    // throughput: 1 cyc/2 vec (16 els/cyc)
-    // latency: 4 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a4  a5  a6  a7  b0  b1  b2  b3 ].
-        let t = x86_64::_mm256_permute2x128_si256::<0x21>(a, b);
-
-        // Then
-        //   res0 = [ a0  a1  a2  a3  b0  b1  b2  b3 ],
-        //   res1 = [ a4  a5  a6  a7  b4  b5  b6  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b11110000>(a, t),
-            x86_64::_mm256_blend_epi32::<0b11110000>(t, b),
-        )
-    }
-}
-
 unsafe impl PackedValue for PackedMersenne31AVX2 {
     type Value = Mersenne31;
 
@@ -574,9 +480,9 @@ unsafe impl PackedFieldPow2 for PackedMersenne31AVX2 {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
-            4 => interleave4(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
+            4 => interleave_u128(v0, v1),
             8 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -5,7 +5,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
-use p3_field::interleave_avx2::{interleave_u32, interleave_u64, interleave_u128};
+use p3_field::interleave::{interleave_u32, interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -12,7 +12,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -475,23 +475,15 @@ unsafe impl PackedField for PackedMersenne31AVX2 {
     type Scalar = Mersenne31;
 }
 
-unsafe impl PackedFieldPow2 for PackedMersenne31AVX2 {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u32(v0, v1),
-            2 => interleave_u64(v0, v1),
-            4 => interleave_u128(v0, v1),
-            8 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        unsafe {
-            // Safety: all values are in canonical form (we haven't changed them).
-            (Self::from_vector(res0), Self::from_vector(res1))
-        }
-    }
-}
+impl_packed_field_pow_2!(
+    PackedMersenne31AVX2;
+    [
+        (1, interleave_u32),
+        (2, interleave_u64),
+        (4, interleave_u128)
+    ],
+    WIDTH
+);
 
 #[cfg(test)]
 mod tests {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -5,6 +5,7 @@ use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_field::exponentiation::exp_1717986917;
+use p3_field::interleave::{interleave_u32, interleave_u64, interleave_u128, interleave_u256};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -448,181 +449,6 @@ pub(crate) fn exp5(x: __m512i) -> __m512i {
     }
 }
 
-// vpshrdq requires AVX-512VBMI2.
-#[cfg(target_feature = "avx512vbmi2")]
-#[inline]
-#[must_use]
-fn interleave1_antidiagonal(x: __m512i, y: __m512i) -> __m512i {
-    unsafe {
-        // Safety: If this code got compiled then AVX-512VBMI2 intrinsics are available.
-        x86_64::_mm512_shrdi_epi64::<32>(x, y)
-    }
-}
-
-// If we can't use vpshrdq, then do a vpermi2d, but we waste a register and double the latency.
-#[cfg(not(target_feature = "avx512vbmi2"))]
-#[inline]
-#[must_use]
-fn interleave1_antidiagonal(x: __m512i, y: __m512i) -> __m512i {
-    const INTERLEAVE1_INDICES: __m512i = unsafe {
-        // Safety: `[u32; 16]` is trivially transmutable to `__m512i`.
-        transmute::<[u32; WIDTH], _>([
-            0x01, 0x10, 0x03, 0x12, 0x05, 0x14, 0x07, 0x16, 0x09, 0x18, 0x0b, 0x1a, 0x0d, 0x1c,
-            0x0f, 0x1e,
-        ])
-    };
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-        x86_64::_mm512_permutex2var_epi32(x, INTERLEAVE1_INDICES, y)
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave1(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // If we have AVX-512VBMI2, we want this to compile to:
-    //      vpshrdq    t, x, y, 32
-    //      vpblendmd  res0 {EVENS}, t, x
-    //      vpblendmd  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 2 cyc
-    //
-    // Otherwise, we want it to compile to:
-    //      vmovdqa32  t, INTERLEAVE1_INDICES
-    //      vpermi2d   t, x, y
-    //      vpblendmd  res0 {EVENS}, t, x
-    //      vpblendmd  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    // We currently have:
-    //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-    //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-    // First form
-    //   t = [ x1  y0  x3  y2  x5  y4  x7  y6  x9  y8  xb  ya  xd  yc  xf  ye ].
-    let t = interleave1_antidiagonal(x, y);
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // Then
-        //   res0 = [ x0  y0  x2  y2  x4  y4  x6  y6  x8  y8  xa  ya  xc  yc  xe  ye ],
-        //   res1 = [ x1  y1  x3  y3  x5  y5  x7  y7  x9  y9  xb  yb  xd  yd  xf  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi32(EVENS, t, x),
-            x86_64::_mm512_mask_blend_epi32(EVENS, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn shuffle_epi64<const MASK: i32>(a: __m512i, b: __m512i) -> __m512i {
-    // The instruction is only available in the floating-point flavor; this distinction is only for
-    // historical reasons and no longer matters. We cast to floats, do the thing, and cast back.
-    unsafe {
-        let a = x86_64::_mm512_castsi512_pd(a);
-        let b = x86_64::_mm512_castsi512_pd(b);
-        x86_64::_mm512_castpd_si512(x86_64::_mm512_shuffle_pd::<MASK>(a, b))
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vshufpd    t, x, y, 55h
-    //      vpblendmq  res0 {EVENS}, t, x
-    //      vpblendmq  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 2 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x2  x3  y0  y1  x6  x7  y4  y5  xa  xb  y8  y9  xe  xf  yc  yd ].
-        let t = shuffle_epi64::<0b01010101>(x, y);
-
-        // Then
-        //   res0 = [ x0  x1  y0  y1  x4  x5  y4  y5  x8  x9  y8  y9  xc  xd  yc  yd ],
-        //   res1 = [ x2  x3  y2  y3  x6  x7  y6  y7  xa  xb  ya  yb  xe  xf  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi64(EVENS as __mmask8, t, x),
-            x86_64::_mm512_mask_blend_epi64(EVENS as __mmask8, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave4(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vmovdqa64   t, INTERLEAVE4_INDICES
-    //      vpermi2q    t, x, y
-    //      vpblendmd   res0 {EVENS4}, t, x
-    //      vpblendmd   res1 {EVENS4}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    const INTERLEAVE4_INDICES: __m512i = unsafe {
-        // Safety: `[u64; 8]` is trivially transmutable to `__m512i`.
-        transmute::<[u64; WIDTH / 2], _>([0o02, 0o03, 0o10, 0o11, 0o06, 0o07, 0o14, 0o15])
-    };
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x4  x5  x6  x7  y0  y1  y2  y3  xc  xd  xe  xf  y8  y9  ya  yb ].
-        let t = x86_64::_mm512_permutex2var_epi64(x, INTERLEAVE4_INDICES, y);
-
-        // Then
-        //   res0 = [ x0  x1  x2  x3  y0  y1  y2  y3  x8  x9  xa  xb  y8  y9  ya  yb ],
-        //   res1 = [ x4  x5  x6  x7  y4  y5  y6  y7  xc  xd  xe  xf  yc  yd  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi32(EVENS4, t, x),
-            x86_64::_mm512_mask_blend_epi32(EVENS4, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave8(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vshufi64x2  t, x, b, 4eh
-    //      vpblendmq   res0 {EVENS4}, t, x
-    //      vpblendmq   res1 {EVENS4}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x8  x9  xa  xb  xc  xd  xe  xf  y0  y1  y2  y3  y4  y5  y6  y7 ].
-        let t = x86_64::_mm512_shuffle_i64x2::<0b01_00_11_10>(x, y);
-
-        // Then
-        //   res0 = [ x0  x1  x2  x3  x4  x5  x6  x7  y0  y1  y2  y3  y4  y5  y6  y7 ],
-        //   res1 = [ x8  x9  xa  xb  xc  xd  xe  xf  y8  y9  ya  yb  yc  yd  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi64(EVENS4 as __mmask8, t, x),
-            x86_64::_mm512_mask_blend_epi64(EVENS4 as __mmask8, y, t),
-        )
-    }
-}
-
 unsafe impl PackedValue for PackedMersenne31AVX512 {
     type Value = Mersenne31;
 
@@ -674,10 +500,10 @@ unsafe impl PackedFieldPow2 for PackedMersenne31AVX512 {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
-            4 => interleave4(v0, v1),
-            8 => interleave8(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
+            4 => interleave_u128(v0, v1),
+            8 => interleave_u256(v0, v1),
             16 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -12,7 +12,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -495,24 +495,16 @@ unsafe impl PackedField for PackedMersenne31AVX512 {
     type Scalar = Mersenne31;
 }
 
-unsafe impl PackedFieldPow2 for PackedMersenne31AVX512 {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u32(v0, v1),
-            2 => interleave_u64(v0, v1),
-            4 => interleave_u128(v0, v1),
-            8 => interleave_u256(v0, v1),
-            16 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        unsafe {
-            // Safety: all values are in canonical form (we haven't changed them).
-            (Self::from_vector(res0), Self::from_vector(res1))
-        }
-    }
-}
+impl_packed_field_pow_2!(
+    PackedMersenne31AVX512;
+    [
+        (1, interleave_u32),
+        (2, interleave_u64),
+        (4, interleave_u128),
+        (8, interleave_u256)
+    ],
+    WIDTH
+);
 
 #[cfg(test)]
 mod tests {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use core::arch::x86_64::{self, __m512i, __mmask8, __mmask16};
+use core::arch::x86_64::{self, __m512i, __mmask16};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -24,7 +24,6 @@ const WIDTH: usize = 16;
 pub(crate) const P: __m512i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
 const EVENS: __mmask16 = 0b0101010101010101;
 const ODDS: __mmask16 = 0b1010101010101010;
-const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -13,7 +13,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -519,19 +519,11 @@ unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31Neon<FP> {
     type Scalar = MontyField31<FP>;
 }
 
-unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31Neon<FP> {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u32(v0, v1),
-            2 => interleave_u64(v0, v1),
-            4 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        unsafe {
-            // Safety: all values are in canonical form (we haven't changed them).
-            (Self::from_vector(res0), Self::from_vector(res1))
-        }
-    }
-}
+impl_packed_field_pow_2!(
+    PackedMontyField31Neon, (FieldParameters, FP);
+    [
+        (1, interleave_u32),
+        (2, interleave_u64),
+    ],
+    WIDTH
+);

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -6,6 +6,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use p3_field::interleave::{interleave_u32, interleave_u64};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -472,41 +473,6 @@ fn sub<MPNeon: MontyParametersNeon>(lhs: uint32x4_t, rhs: uint32x4_t) -> uint32x
     }
 }
 
-#[inline]
-#[must_use]
-fn interleave1(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
-    // We want this to compile to:
-    //      trn1  res0.4s, v0.4s, v1.4s
-    //      trn2  res1.4s, v0.4s, v1.4s
-    // throughput: .5 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-    unsafe {
-        // Safety: If this code got compiled then NEON intrinsics are available.
-        (aarch64::vtrn1q_u32(v0, v1), aarch64::vtrn2q_u32(v0, v1))
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(v0: uint32x4_t, v1: uint32x4_t) -> (uint32x4_t, uint32x4_t) {
-    // We want this to compile to:
-    //      trn1  res0.2d, v0.2d, v1.2d
-    //      trn2  res1.2d, v0.2d, v1.2d
-    // throughput: .5 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-
-    // To transpose 64-bit blocks, cast the [u32; 4] vectors to [u64; 2], transpose, and cast back.
-    unsafe {
-        // Safety: If this code got compiled then NEON intrinsics are available.
-        let v0 = aarch64::vreinterpretq_u64_u32(v0);
-        let v1 = aarch64::vreinterpretq_u64_u32(v1);
-        (
-            aarch64::vreinterpretq_u32_u64(aarch64::vtrn1q_u64(v0, v1)),
-            aarch64::vreinterpretq_u32_u64(aarch64::vtrn2q_u64(v0, v1)),
-        )
-    }
-}
-
 unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31Neon<FP> {
     type Value = MontyField31<FP>;
     const WIDTH: usize = WIDTH;
@@ -558,8 +524,8 @@ unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31Neon<FP> 
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
             4 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -5,7 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use p3_field::interleave_avx2::{interleave_u32, interleave_u64, interleave_u128};
+use p3_field::interleave::{interleave_u32, interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -5,6 +5,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use p3_field::interleave_avx2::{interleave_u32, interleave_u64, interleave_u128};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -1018,101 +1019,6 @@ impl<FP: FieldParameters + RelativelyPrimePower<D>, const D: u64> PermutationMon
     }
 }
 
-#[inline]
-#[must_use]
-fn interleave1(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vpsllq    t, a, 32
-    //      vpsrlq    u, b, 32
-    //      vpblendd  res0, a, u, aah
-    //      vpblendd  res1, t, b, aah
-    // throughput: 1.33 cyc/2 vec (12 els/cyc)
-    // latency: (1 -> 1)  1 cyc
-    //          (1 -> 2)  2 cyc
-    //          (2 -> 1)  2 cyc
-    //          (2 -> 2)  1 cyc
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a1   0  a3   0  a5   0  a7   0 ].
-        //   u = [  0  b0   0  b2   0  b4   0  b6 ].
-        let t = x86_64::_mm256_srli_epi64::<32>(a);
-        let u = x86_64::_mm256_slli_epi64::<32>(b);
-
-        // Then
-        //   res0 = [ a0  b0  a2  b2  a4  b4  a6  b6 ],
-        //   res1 = [ a1  b1  a3  b3  a5  b5  a7  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b10101010>(a, u),
-            x86_64::_mm256_blend_epi32::<0b10101010>(t, b),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vpalignr  t, b, a, 8
-    //      vpblendd  res0, a, t, cch
-    //      vpblendd  res1, t, b, cch
-    // throughput: 1 cyc/2 vec (16 els/cyc)
-    // latency: 2 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a2  a3  b0  b1  a6  a7  b4  b5 ].
-        let t = x86_64::_mm256_alignr_epi8::<8>(b, a);
-
-        // Then
-        //   res0 = [ a0  a1  b0  b1  a4  a5  b4  b5 ],
-        //   res1 = [ a2  a3  b2  b3  a6  a7  b6  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b11001100>(a, t),
-            x86_64::_mm256_blend_epi32::<0b11001100>(t, b),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave4(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
-    // We want this to compile to:
-    //      vperm2i128  t, a, b, 21h
-    //      vpblendd    res0, a, t, f0h
-    //      vpblendd    res1, t, b, f0h
-    // throughput: 1 cyc/2 vec (16 els/cyc)
-    // latency: 4 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
-
-        // We currently have:
-        //   a = [ a0  a1  a2  a3  a4  a5  a6  a7 ],
-        //   b = [ b0  b1  b2  b3  b4  b5  b6  b7 ].
-        // First form
-        //   t = [ a4  a5  a6  a7  b0  b1  b2  b3 ].
-        let t = x86_64::_mm256_permute2x128_si256::<0x21>(a, b);
-
-        // Then
-        //   res0 = [ a0  a1  a2  a3  b0  b1  b2  b3 ],
-        //   res1 = [ a4  a5  a6  a7  b4  b5  b6  b7 ].
-        (
-            x86_64::_mm256_blend_epi32::<0b11110000>(a, t),
-            x86_64::_mm256_blend_epi32::<0b11110000>(t, b),
-        )
-    }
-}
-
 unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX2<FP> {
     type Value = MontyField31<FP>;
 
@@ -1169,9 +1075,9 @@ unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31AVX2<FP> 
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
-            4 => interleave4(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
+            4 => interleave_u128(v0, v1),
             8 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -4,7 +4,7 @@
 
 use alloc::vec::Vec;
 use core::arch::asm;
-use core::arch::x86_64::{self, __m512i, __mmask8, __mmask16};
+use core::arch::x86_64::{self, __m512i, __mmask16};
 use core::array;
 use core::hint::unreachable_unchecked;
 use core::iter::{Product, Sum};

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -11,6 +11,7 @@ use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use p3_field::interleave::{interleave_u32, interleave_u64, interleave_u128, interleave_u256};
 use p3_field::op_assign_macros::{
     impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
     impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field, ring_sum,
@@ -33,7 +34,6 @@ pub trait MontyParametersAVX512 {
 }
 
 const EVENS: __mmask16 = 0b0101010101010101;
-const EVENS4: __mmask16 = 0x0f0f;
 
 /// Vectorized AVX-512F implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1137,181 +1137,6 @@ fn general_dot_product<
     }
 }
 
-// vpshrdq requires AVX-512VBMI2.
-#[cfg(target_feature = "avx512vbmi2")]
-#[inline]
-#[must_use]
-fn interleave1_antidiagonal(x: __m512i, y: __m512i) -> __m512i {
-    unsafe {
-        // Safety: If this code got compiled then AVX-512VBMI2 intrinsics are available.
-        x86_64::_mm512_shrdi_epi64::<32>(x, y)
-    }
-}
-
-// If we can't use vpshrdq, then do a vpermi2d, but we waste a register and double the latency.
-#[cfg(not(target_feature = "avx512vbmi2"))]
-#[inline]
-#[must_use]
-fn interleave1_antidiagonal(x: __m512i, y: __m512i) -> __m512i {
-    const INTERLEAVE1_INDICES: __m512i = unsafe {
-        // Safety: `[u32; 16]` is trivially transmutable to `__m512i`.
-        transmute::<[u32; WIDTH], _>([
-            0x01, 0x10, 0x03, 0x12, 0x05, 0x14, 0x07, 0x16, 0x09, 0x18, 0x0b, 0x1a, 0x0d, 0x1c,
-            0x0f, 0x1e,
-        ])
-    };
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-        x86_64::_mm512_permutex2var_epi32(x, INTERLEAVE1_INDICES, y)
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave1(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // If we have AVX-512VBMI2, we want this to compile to:
-    //      vpshrdq    t, x, y, 32
-    //      vpblendmd  res0 {EVENS}, t, x
-    //      vpblendmd  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 2 cyc
-    //
-    // Otherwise, we want it to compile to:
-    //      vmovdqa32  t, INTERLEAVE1_INDICES
-    //      vpermi2d   t, x, y
-    //      vpblendmd  res0 {EVENS}, t, x
-    //      vpblendmd  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    // We currently have:
-    //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-    //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-    // First form
-    //   t = [ x1  y0  x3  y2  x5  y4  x7  y6  x9  y8  xb  ya  xd  yc  xf  ye ].
-    let t = interleave1_antidiagonal(x, y);
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // Then
-        //   res0 = [ x0  y0  x2  y2  x4  y4  x6  y6  x8  y8  xa  ya  xc  yc  xe  ye ],
-        //   res1 = [ x1  y1  x3  y3  x5  y5  x7  y7  x9  y9  xb  yb  xd  yd  xf  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi32(EVENS, t, x),
-            x86_64::_mm512_mask_blend_epi32(EVENS, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn shuffle_epi64<const MASK: i32>(a: __m512i, b: __m512i) -> __m512i {
-    // The instruction is only available in the floating-point flavor; this distinction is only for
-    // historical reasons and no longer matters. We cast to floats, do the thing, and cast back.
-    unsafe {
-        let a = x86_64::_mm512_castsi512_pd(a);
-        let b = x86_64::_mm512_castsi512_pd(b);
-        x86_64::_mm512_castpd_si512(x86_64::_mm512_shuffle_pd::<MASK>(a, b))
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave2(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vshufpd    t, x, y, 55h
-    //      vpblendmq  res0 {EVENS}, t, x
-    //      vpblendmq  res1 {EVENS}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 2 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x2  x3  y0  y1  x6  x7  y4  y5  xa  xb  y8  y9  xe  xf  yc  yd ].
-        let t = shuffle_epi64::<0b01010101>(x, y);
-
-        // Then
-        //   res0 = [ x0  x1  y0  y1  x4  x5  y4  y5  x8  x9  y8  y9  xc  xd  yc  yd ],
-        //   res1 = [ x2  x3  y2  y3  x6  x7  y6  y7  xa  xb  ya  yb  xe  xf  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi64(EVENS as __mmask8, t, x),
-            x86_64::_mm512_mask_blend_epi64(EVENS as __mmask8, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave4(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vmovdqa64   t, INTERLEAVE4_INDICES
-    //      vpermi2q    t, x, y
-    //      vpblendmd   res0 {EVENS4}, t, x
-    //      vpblendmd   res1 {EVENS4}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    const INTERLEAVE4_INDICES: __m512i = unsafe {
-        // Safety: `[u64; 8]` is trivially transmutable to `__m512i`.
-        transmute::<[u64; WIDTH / 2], _>([0o02, 0o03, 0o10, 0o11, 0o06, 0o07, 0o14, 0o15])
-    };
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x4  x5  x6  x7  y0  y1  y2  y3  xc  xd  xe  xf  y8  y9  ya  yb ].
-        let t = x86_64::_mm512_permutex2var_epi64(x, INTERLEAVE4_INDICES, y);
-
-        // Then
-        //   res0 = [ x0  x1  x2  x3  y0  y1  y2  y3  x8  x9  xa  xb  y8  y9  ya  yb ],
-        //   res1 = [ x4  x5  x6  x7  y4  y5  y6  y7  xc  xd  xe  xf  yc  yd  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi32(EVENS4, t, x),
-            x86_64::_mm512_mask_blend_epi32(EVENS4, y, t),
-        )
-    }
-}
-
-#[inline]
-#[must_use]
-fn interleave8(x: __m512i, y: __m512i) -> (__m512i, __m512i) {
-    // We want this to compile to:
-    //      vshufi64x2  t, x, b, 4eh
-    //      vpblendmq   res0 {EVENS4}, t, x
-    //      vpblendmq   res1 {EVENS4}, y, t
-    // throughput: 1.5 cyc/2 vec (21.33 els/cyc)
-    // latency: 4 cyc
-
-    unsafe {
-        // Safety: If this code got compiled then AVX-512F intrinsics are available.
-
-        // We currently have:
-        //   x = [ x0  x1  x2  x3  x4  x5  x6  x7  x8  x9  xa  xb  xc  xd  xe  xf ],
-        //   y = [ y0  y1  y2  y3  y4  y5  y6  y7  y8  y9  ya  yb  yc  yd  ye  yf ].
-        // First form
-        //   t = [ x8  x9  xa  xb  xc  xd  xe  xf  y0  y1  y2  y3  y4  y5  y6  y7 ].
-        let t = x86_64::_mm512_shuffle_i64x2::<0b01_00_11_10>(x, y);
-
-        // Then
-        //   res0 = [ x0  x1  x2  x3  x4  x5  x6  x7  y0  y1  y2  y3  y4  y5  y6  y7 ],
-        //   res1 = [ x8  x9  xa  xb  xc  xd  xe  xf  y8  y9  ya  yb  yc  yd  ye  yf ].
-        (
-            x86_64::_mm512_mask_blend_epi64(EVENS4 as __mmask8, t, x),
-            x86_64::_mm512_mask_blend_epi64(EVENS4 as __mmask8, y, t),
-        )
-    }
-}
-
 unsafe impl<FP: FieldParameters> PackedValue for PackedMontyField31AVX512<FP> {
     type Value = MontyField31<FP>;
 
@@ -1368,10 +1193,10 @@ unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31AVX512<FP
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
-            1 => interleave1(v0, v1),
-            2 => interleave2(v0, v1),
-            4 => interleave4(v0, v1),
-            8 => interleave8(v0, v1),
+            1 => interleave_u32(v0, v1),
+            2 => interleave_u64(v0, v1),
+            4 => interleave_u128(v0, v1),
+            8 => interleave_u256(v0, v1),
             16 => (v0, v1),
             _ => panic!("unsupported block_len"),
         };

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -18,7 +18,7 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::Rng;
@@ -1188,21 +1188,13 @@ unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX512<FP> {
     }
 }
 
-unsafe impl<FP: FieldParameters> PackedFieldPow2 for PackedMontyField31AVX512<FP> {
-    #[inline]
-    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
-        let (v0, v1) = (self.to_vector(), other.to_vector());
-        let (res0, res1) = match block_len {
-            1 => interleave_u32(v0, v1),
-            2 => interleave_u64(v0, v1),
-            4 => interleave_u128(v0, v1),
-            8 => interleave_u256(v0, v1),
-            16 => (v0, v1),
-            _ => panic!("unsupported block_len"),
-        };
-        unsafe {
-            // Safety: all values are in canonical form (we haven't changed them).
-            (Self::from_vector(res0), Self::from_vector(res1))
-        }
-    }
-}
+impl_packed_field_pow_2!(
+    PackedMontyField31AVX512, (FieldParameters, FP);
+    [
+        (1, interleave_u32),
+        (2, interleave_u64),
+        (4, interleave_u128),
+        (8, interleave_u256)
+    ],
+    WIDTH
+);


### PR DESCRIPTION
Moving the interleave code which is identical between `Mersenne31` and `MontyField31` and mostly similar for `Goldilocks` into a shared crate.

For the most part I've just copied the `Mersenne31/MontyField31` code over. The only exception was with the `AVX2`, `interleave_u64` (Used to be `interleave2`) where the corresponding `Goldilocks` function seems to be faster.

Also added a macro allowing `PackedFieldPow2` to be implemented a little more simply.

Annoyingly, this means we need to add in `nightly-features` to the field crate, but it shouldn't be there for long as we can remove it as soon as Rust 1.89 arrives.