### PR TITLE
Update GitHub Actions Cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -73,7 +73,7 @@ jobs:
           targets: ${{ env.target }}
         id: rs-stable
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -139,7 +139,7 @@ jobs:
       - name: Install cargo-sort
         run: cargo install cargo-sort
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION

---


**Description:**  
This pull request updates the GitHub Actions workflow to use `actions/cache@v4` instead of `v3`.  



---