### PR TITLE
Fix: correct TWO_ADIC_GENERATOR constant to valid u64 value

### DIFF
--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -488,7 +488,7 @@ const TWO_ADIC_GENERATOR: [u64; 4] = [
     0x636e735580d13d9c,
     0xa22bf3742445ffd6,
     0x56452ac01eb203d8,
-    0x01860ef942963f9e7,
+    0x1860ef942963f9e7,
 ];
 
 impl TwoAdicField for Bn254 {


### PR DESCRIPTION
The last element of the TWO_ADIC_GENERATOR array was incorrectly set to 0x01860ef942963f9e7, which exceeds the valid range for a u64 constant (17 hex digits). 
This commit corrects it to 0x1860ef942963f9e7, ensuring the value fits within a u64 and preventing compilation errors.