### PR TITLE
Fast Octic inverse

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -1051,9 +1051,6 @@ fn quintic_inv<F: BinomiallyExtendable<D>, const D: usize>(
 }
 
 /// Compute the inverse of a octic binomial extension field element.
-///
-/// Makes use of the in built field dot product code. This is optimized for the case that
-/// R is a prime field or its packing.
 #[inline]
 fn octic_inv<F: Field, const D: usize>(a: &[F; D], res: &mut [F; D], w: F) {
     assert_eq!(D, 8);

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -320,6 +320,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
             3 => cubic_inv(&self.value, &mut res.value, F::W),
             4 => quartic_inv(&self.value, &mut res.value, F::W),
             5 => res = quintic_inv(self),
+            8 => octic_inv(&self.value, &mut res.value, F::W),
             _ => res = self.frobenius_inv(),
         }
 
@@ -1047,4 +1048,64 @@ fn quintic_inv<F: BinomiallyExtendable<D>, const D: usize>(
     debug_assert_eq!(BinomialExtensionField::<F, D>::from(norm), *a * prod_conj);
 
     prod_conj * norm.inverse()
+}
+
+/// Compute the inverse of a octic binomial extension field element.
+///
+/// Makes use of the in built field dot product code. This is optimized for the case that
+/// R is a prime field or its packing.
+#[inline]
+fn octic_inv<F: Field, const D: usize>(a: &[F; D], res: &mut [F; D], w: F) {
+    assert_eq!(D, 8);
+
+    // We use the fact that the octic extension is a tower of extensions.
+    // Explicitly our tower looks like F < F[x]/(X⁴ - w) < F[x]/(X^8 - w).
+    // Using this, we can compute the inverse of a in three steps:
+
+    // Compute the norm of our element with respect to F[x]/(X⁴-w).
+    // Writing a = a0 + a1·X + a2·X² + a3·X³ + a4·X⁴ + a5·X⁵ + a6·X⁶ + a7·X⁷
+    //           = (a0 + a2·X² + a4·X⁴ + a6·X⁶) + (a1 + a3·X² + a5·X⁴ + a7·X⁶)·X
+    //           = evens + odds·X
+    //
+    // The norm is given by:
+    //    norm = (evens + odds·X) * (evens - odds·X)
+    //          = evens² - odds²·X²
+    //
+    // This costs 2 multiplications in the quartic extension field.
+    let evns = [a[0], a[2], a[4], a[6]];
+    let odds = [a[1], a[3], a[5], a[7]];
+    let mut evns_sq = [F::ZERO; 4];
+    let mut odds_sq = [F::ZERO; 4];
+    quartic_square(&evns, &mut evns_sq, w);
+    quartic_square(&odds, &mut odds_sq, w);
+    // odds_sq is multiplied by X^2 so we need to rotate it and multiply by a factor of w.
+    let norm = [
+        evns_sq[0] - w * odds_sq[3],
+        evns_sq[1] - odds_sq[0],
+        evns_sq[2] - odds_sq[1],
+        evns_sq[3] - odds_sq[2],
+    ];
+
+    // Now we compute the inverse of norm inside F[x]/(X⁴ - w). We already have an efficient function for this.
+    let mut norm_inv = [F::ZERO; 4];
+    quartic_inv(&norm, &mut norm_inv, w);
+
+    // Then the inverse of a is given by:
+    //      a⁻¹ = (evens - odds·X)·norm⁻¹
+    //          = evens·norm⁻¹ - odds·norm⁻¹·X
+    //
+    // Both of these multiplications can again be done in the quartic extension field.
+    let mut out_evn = [F::ZERO; 4];
+    let mut out_odd = [F::ZERO; 4];
+    quartic_mul(&evns, &norm_inv, &mut out_evn, w);
+    quartic_mul(&odds, &norm_inv, &mut out_odd, w);
+
+    res[0] = out_evn[0];
+    res[1] = -out_odd[0];
+    res[2] = out_evn[1];
+    res[3] = -out_odd[1];
+    res[4] = out_evn[2];
+    res[5] = -out_odd[2];
+    res[6] = out_evn[3];
+    res[7] = -out_odd[3];
 }

--- a/koala-bear/benches/extension.rs
+++ b/koala-bear/benches/extension.rs
@@ -37,8 +37,8 @@ fn bench_octic_extension(c: &mut Criterion) {
 }
 
 criterion_group!(
-    bench_babybear_ef,
+    bench_koalabear_ef,
     bench_quartic_extension,
     bench_octic_extension
 );
-criterion_main!(bench_babybear_ef);
+criterion_main!(bench_koalabear_ef);

--- a/koala-bear/benches/extension.rs
+++ b/koala-bear/benches/extension.rs
@@ -7,6 +7,7 @@ use p3_field_testing::{benchmark_add_slices, benchmark_add_throughput};
 use p3_koala_bear::KoalaBear;
 
 type EF4 = BinomialExtensionField<KoalaBear, 4>;
+type EF8 = BinomialExtensionField<KoalaBear, 8>;
 
 // Note that each round of throughput has 10 operations
 // So we should have 10 * more repetitions for latency tests.
@@ -24,5 +25,20 @@ fn bench_quartic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
-criterion_group!(bench_babybear_ef, bench_quartic_extension,);
+fn bench_octic_extension(c: &mut Criterion) {
+    let name = "BinomialExtensionField<KoalaBear, 8>";
+    benchmark_add_throughput::<EF8, REPS>(c, name);
+    benchmark_add_slices::<EF8, 8>(c, name);
+    benchmark_add_slices::<EF8, 1000>(c, name);
+    benchmark_square::<EF8>(c, name);
+    benchmark_inv::<EF8>(c, name);
+    benchmark_mul_throughput::<EF8, REPS>(c, name);
+    benchmark_mul_latency::<EF8, L_REPS>(c, name);
+}
+
+criterion_group!(
+    bench_babybear_ef,
+    bench_quartic_extension,
+    bench_octic_extension
+);
 criterion_main!(bench_babybear_ef);


### PR DESCRIPTION
We can do an inverse in an Octic extension by using the norm map to get an element in a quartic extension and using the quartic inverse.

This ends up being a lot faster (About `10x`, from `3000ns` to `300ns`). This time also matches pretty closely to `1` quartic inv and `4` quartic mul's which is exactly what we expect.

Plausibly we could speed this up a little further but it's not really worth the effort as further improvement will likely be pretty marginal.