### PR TITLE
refactor: remove SHAKE256-based constants in rescue

### DIFF
--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -17,7 +17,6 @@ p3-util.workspace = true
 
 itertools.workspace = true
 rand.workspace = true
-sha3.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/rescue/src/lib.rs
+++ b/rescue/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // TODO: remove when we settle on implementation details and publicly export
 #![no_std]
 
 extern crate alloc;

--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -1,20 +1,4 @@
-use alloc::vec;
-use alloc::vec::Vec;
-
 use p3_util::log2_ceil_u64;
-use sha3::Shake256;
-use sha3::digest::{ExtendableOutput, Update, XofReader};
-
-/// Compute the SHAKE256 variant of SHA-3.
-/// This is used to generate the round constants from a seed string.
-pub(crate) fn shake256_hash(seed_bytes: &[u8], num_bytes: usize) -> Vec<u8> {
-    let mut hasher = Shake256::default();
-    hasher.update(seed_bytes);
-    let mut reader = hasher.finalize_xof();
-    let mut result = vec![0u8; num_bytes];
-    reader.read(&mut result);
-    result
-}
 
 /// Return y such that |y - 2^x| < tol for x an f32.
 ///


### PR DESCRIPTION
Replaced with RNG-based constants, dropped unused code and test vectors.
- Removed shake256_hash and related deterministic constant generation logic.
- Switched to RNG-based round constant generation in tests.
- Cleaned up unused imports and test vectors.