### PR TITLE
Minor FRI refactor - make open input its own function

### DIFF
--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -276,6 +276,10 @@ where
         .collect()
 }
 
+/// Given an index, produce batch opening proofs for each collection of matrices
+/// combined into a single mmcs commitment. In cases where the maximum height of
+/// a batch of matrices is smaller than the global max height, shift the index down
+/// to compensate.
 fn open_input<Val, Challenge, InputMmcs>(
     log_global_max_height: usize,
     index: usize,
@@ -290,10 +294,6 @@ where
     Challenge: ExtensionField<Val>,
     InputMmcs: Mmcs<Val>,
 {
-    // Given an index, produce batch opening proofs for each collection of matrices
-    // combined into a single mmcs commitment. In cases where the maximum height of
-    // a batch of matrices is smaller than the global max height, shift the index down
-    // to compensate.
     // This gives the verifier access to evaluations `f(x)` from which it can compute
     // `(f(zeta) - f(x))/(zeta - x)` and then combine them together and roll into FRI
     // as appropriate.

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -239,6 +239,7 @@ where
 /// - `folded_polynomial_commits`: A slice of commitments to the intermediate stage polynomials.
 /// - `start_index`: The opening index for the unfolded polynomial. For folded polynomials
 ///   we use this this index right shifted by the number of folds.
+#[inline]
 fn answer_query<F, M>(
     config: &FriParameters<M>,
     folded_polynomial_commits: &[M::ProverData<RowMajorMatrix<F>>],
@@ -289,6 +290,7 @@ where
 /// - `prover_data_with_opening_points`: A list of pairs of a batch commitment to a collection
 ///   of matrices and a list of points to open those matrices at.
 /// - `mmcs`: The mixed matrix commitment scheme used to produce the batch commitments.
+#[inline]
 fn open_input<Val, Challenge, InputMmcs>(
     log_global_max_height: usize,
     index: usize,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -508,7 +508,6 @@ where
         let folding: TwoAdicFriFoldingForMmcs<Val, InputMmcs> = TwoAdicFriFolding(PhantomData);
 
         // Produce the FRI proof.
-        // TODO: Move the |index| closure out of this function into another function.
         let fri_proof = prover::prove_fri(
             &folding,
             &self.fri,

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -307,6 +307,12 @@ where
     Ok(folded_eval)
 }
 
+/// index is the query position we are checking
+/// input_proof is a vector of batch openings. Each batch opening contains a
+/// list of opened values for a collection of matrices along with a batched opening proof.
+/// We check the proofs and then combine the functions by mapping each function and opening point
+/// pair to `(f(z) - f(x))/(z - x)` and then combining functions of the same height using
+/// the challenge alpha.
 fn open_input<Val, Challenge, InputMmcs, FriMmcs>(
     params: &FriParameters<FriMmcs>,
     log_global_max_height: usize,
@@ -326,13 +332,6 @@ where
     InputMmcs: Mmcs<Val>,
     FriMmcs: Mmcs<Challenge>,
 {
-    // index is the query position we are checking
-    // input_proof is a vector of batch openings. Each batch opening contains a
-    // list of opened values for a collection of matrices along with a batched opening proof.
-    // We check the proofs and then combine the functions by mapping each function and opening point
-    // pair to `(f(z) - f(x))/(z - x)` and then combining functions of the same height using
-    // the challenge alpha.
-
     // For each log_height, we store the alpha power and compute the reduced opening.
     // log_height -> (alpha_pow, reduced_opening)
     let mut reduced_openings = BTreeMap::<usize, (Challenge, Challenge)>::new();
@@ -424,6 +423,6 @@ where
     Ok(reduced_openings
         .into_iter()
         .rev()
-        .map(|(log_height, (_alpha_pow, ro))| (log_height, ro))
+        .map(|(log_height, (_, ro))| (log_height, ro))
         .collect())
 }

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -306,12 +306,11 @@ where
     Ok(folded_eval)
 }
 
-// - `open_input`: A function that takes an index and opening proofs and returns a vector of reduced openings
-//   used as FRI inputs. The opening proofs prove that the values `f(x)` are the ones committed
-//   to and these are then combined into the FRI inputs.
-
 /// Given an index and a collection of opening proofs, check all opening proofs and combine
 /// the opened values into the FRI inputs along the path specified by the index.
+///
+/// In cases where the maximum height of a batch of matrices is smaller than the
+/// global max height, shift the index down to compensate.
 ///
 /// We combine the functions by mapping each function and opening point pair to `(f(z) - f(x))/(z - x)`
 /// and then combining functions of the same degree using the challenge alpha.

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -219,6 +219,7 @@ type CommitStep<'a, F, M> = (
 ///   the FRI folding chain once the domain size reaches the size specified in the pair.
 /// - `log_max_height`: The log of the maximum domain size.
 /// - `log_final_height`: The log of the final domain size.
+#[inline]
 fn verify_query<'a, Folding, F, EF, M>(
     folding: &Folding,
     params: &FriParameters<M>,
@@ -325,6 +326,7 @@ where
 /// - `input_mmcs`: The input multi-matrix commitment scheme.
 /// - `commitments_with_opening_points`: A vector of joint commitments to collections of matrices
 ///   and openings of those matrices at a collection of points.
+#[inline]
 fn open_input<Val, Challenge, InputMmcs, FriMmcs>(
     params: &FriParameters<FriMmcs>,
     log_global_max_height: usize,

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -426,7 +426,7 @@ where
         // `reduced_openings` would have a log_height = log_blowup entry only if there was a
         // trace matrix of height 1. In this case `f` is constant, so `f(zeta) - f(x))/(zeta - x)`
         // must equal `0`.
-        if let Some((_alpha_pow, ro)) = reduced_openings.get(&params.log_blowup)
+        if let Some((_, ro)) = reduced_openings.get(&params.log_blowup)
             && !ro.is_zero()
         {
             return Err(FriError::FinalPolyMismatch);

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -316,7 +316,7 @@ where
 /// We combine the functions by mapping each function and opening point pair to `(f(z) - f(x))/(z - x)`
 /// and then combining functions of the same degree using the challenge alpha.
 ///
-/// Arguments:
+/// ## Arguments:
 /// - `params`: The FRI parameters.
 /// - `log_global_max_height`: The log of the maximum height of the input matrices.
 /// - `index`: The index at which to open the functions.

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -369,11 +369,14 @@ where
             .map(|&height| Dimensions { width: 0, height })
             .collect_vec();
 
+        // If the maximum height of the batch is smaller than the global max height,
+        // we need to correct the index by right shifting it.
+        // If the batch is empty, we set the index to 0.
         let reduced_index = batch_heights
             .iter()
             .max()
             .map(|&h| index >> (log_global_max_height - log2_strict_usize(h)))
-            .unwrap_or(0); // If the batch is empty, we use 0.
+            .unwrap_or(0);
 
         input_mmcs
             .verify_batch(

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -320,7 +320,7 @@ where
 /// - `log_global_max_height`: The log of the maximum height of the input matrices.
 /// - `index`: The index at which to open the functions.
 /// - `input_proof`: A vector of batch openings with each opening containing a
-///    list of opened values for a collection of matrices along with a batched opening proof.
+///   list of opened values for a collection of matrices along with a batched opening proof.
 /// - `alpha`: The challenge used to combine the functions.
 /// - `input_mmcs`: The input multi-matrix commitment scheme.
 /// - `commitments_with_opening_points`: A vector of joint commitments to collections of matrices

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -1,22 +1,14 @@
-use core::marker::PhantomData;
-
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{CanObserve, CanSampleBits, DuplexChallenger, FieldChallenger};
-use p3_commit::{BatchOpening, ExtensionMmcs, Mmcs, Pcs};
-use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+use p3_commit::{ExtensionMmcs, Pcs};
+use p3_dft::Radix2Dit;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_fri::{
-    CommitmentWithOpeningPoints, FriParameters, ProverDataWithOpeningPoints, TwoAdicFriFolding,
-    TwoAdicFriPcs, prover, verifier,
-};
-use p3_matrix::Matrix;
+use p3_fri::{FriParameters, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::util::reverse_matrix_index_bits;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_util::log2_strict_usize;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 


### PR DESCRIPTION
Currently the `prove_fri` and `verify_fri` functions accept, as an input, a function `open_input` which either produces (or checks in the case of the verifier) a collection of opening points of our committed matrices at a given index.

These functions are then defined as closures in `fri/src/two_adic_pcs.rs` inside the `open` and `verify` functions. This makes it difficult to follow the logic of those function and of `prove_fri` and `verify_fri` and generally provides some unneeded obfuscation.

This PR replaces both of these closures by functions in `fri/src/prover.rs` and `fri/src/verifier.rs` which should make it easier to follow what's going on. Unfortunately this change completely broke the tests in `fri/tests/fri` as we can no longer pass in a `trivial` `open_input` function. Hence, I've reworked the tests in `fri/tests/fri` to properly test the `pcs.commit, pcs.open, pcs.verify` loop, ensuring that none of the functions error and the data produced by `pcs.commit, pcs.open` produces a valid proof which is accepted by `pcs.verify`.