### PR TITLE
Refactor: Remove Unnecessary unwrap in from_basis_coefficients_iter

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -533,7 +533,11 @@ impl<F: PrimeCharacteristicRing> BasedVectorSpace<F> for F {
 
     #[inline]
     fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = F>>(mut iter: I) -> Option<Self> {
-        (iter.len() == 1).then(|| iter.next().unwrap()) // Unwrap will not panic as we know the length is 1.
+        if iter.len() == 1 {
+            iter.next()
+        } else {
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION


## Description
This PR improves the robustness of the `from_basis_coefficients_iter` implementation for `BasedVectorSpace<F> for F` by removing the use of `unwrap()`.  
Now, the function safely returns `None` if the iterator does not yield an element, preventing potential panics in edge cases.

- Replaces `unwrap()` with a safe check and return.
- Enhances code reliability and defensive programming.

