### PR TITLE
make air builder work with ExtensionPackedField

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -49,8 +49,15 @@ pub trait AirBuilder: Sized {
     /// Underlying field type.
     type F: Field;
 
+    /// An intermediary between `F` and `Expr`, usually equal to `F` or `F::Packing`.
+    ///
+    /// Rust will not allow generic implementations of both `Algebra<F>` and `Algebra<F::Packing>`
+    /// due to the possibility that `F = F::Packing`. This serves as a workaround to that
+    /// problem and lets us create an `AirBuilder` with `Expr = <EF as ExtensionField<F>>::ExtensionPacking`.
+    type I: Algebra<Self::F>;
+
     /// Serves as the output type for an AIR constraint evaluation.
-    type Expr: Algebra<Self::F> + Algebra<Self::Var>;
+    type Expr: Algebra<Self::I> + Algebra<Self::Var>;
 
     /// The type of the variable appearing in the trace matrix.
     ///
@@ -59,13 +66,13 @@ pub trait AirBuilder: Sized {
         + Clone
         + Send
         + Sync
-        + Add<Self::F, Output = Self::Expr>
+        + Add<Self::I, Output = Self::Expr>
         + Add<Self::Var, Output = Self::Expr>
         + Add<Self::Expr, Output = Self::Expr>
-        + Sub<Self::F, Output = Self::Expr>
+        + Sub<Self::I, Output = Self::Expr>
         + Sub<Self::Var, Output = Self::Expr>
         + Sub<Self::Expr, Output = Self::Expr>
-        + Mul<Self::F, Output = Self::Expr>
+        + Mul<Self::I, Output = Self::Expr>
         + Mul<Self::Var, Output = Self::Expr>
         + Mul<Self::Expr, Output = Self::Expr>;
 
@@ -254,6 +261,7 @@ impl<AB: AirBuilder> FilteredAirBuilder<'_, AB> {
 
 impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
     type F = AB::F;
+    type I = AB::I;
     type Expr = AB::Expr;
     type Var = AB::Var;
     type M = AB::M;

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -210,7 +210,7 @@ fn eval_full_round<
     builder: &mut AB,
 ) {
     for (i, (s, r)) in state.iter_mut().zip(round_constants.iter()).enumerate() {
-        *s += *r;
+        *s += AB::I::from(*r);
         eval_sbox(&full_round.sbox[i], s, builder);
     }
     LinearLayers::external_linear_layer(state);
@@ -233,7 +233,7 @@ fn eval_partial_round<
     round_constant: &AB::F,
     builder: &mut AB,
 ) {
-    state[0] += *round_constant;
+    state[0] += AB::I::from(*round_constant);
     eval_sbox(&partial_round.sbox, &mut state[0], builder);
 
     builder.assert_eq(state[0].clone(), partial_round.post_sbox.clone());

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -75,6 +75,7 @@ where
     F: Field,
 {
     type F = F;
+    type I = F;
     type Expr = F;
     type Var = F;
     type M = ViewPair<'a, F>;

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -59,6 +59,7 @@ pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
 
 impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     type F = Val<SC>;
+    type I = Val<SC>;
     type Expr = PackedVal<SC>;
     type Var = PackedVal<SC>;
     type M = RowMajorMatrixView<'a, PackedVal<SC>>;
@@ -121,6 +122,7 @@ impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFold
 
 impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC> {
     type F = Val<SC>;
+    type I = Val<SC>;
     type Expr = SC::Challenge;
     type Var = SC::Challenge;
     type M = ViewPair<'a, SC::Challenge>;

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -107,6 +107,7 @@ impl<F: Field> SymbolicAirBuilder<F> {
 
 impl<F: Field> AirBuilder for SymbolicAirBuilder<F> {
     type F = F;
+    type I = F;
     type Expr = SymbolicExpression<F>;
     type Var = SymbolicVariable<F>;
     type M = RowMajorMatrix<Self::Var>;


### PR DESCRIPTION
A subset of #966 , only focuses on making the AIR builder work over packed extension field, introducing an intermediary type `I`.