### PR TITLE
Move halve to ring

### DIFF
--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -212,6 +212,11 @@ impl PrimeCharacteristicRing for Bn254 {
     ]);
 
     #[inline]
+    fn halve(&self) -> Self {
+        Self::new_monty(halve_bn254(self.value))
+    }
+
+    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f
     }
@@ -305,11 +310,6 @@ impl Field for Bn254 {
     #[inline]
     fn is_zero(&self) -> bool {
         self.value.iter().all(|&x| x == 0)
-    }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new_monty(halve_bn254(self.value))
     }
 
     #[inline]

--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -212,13 +212,13 @@ impl PrimeCharacteristicRing for Bn254 {
     ]);
 
     #[inline]
-    fn halve(&self) -> Self {
-        Self::new_monty(halve_bn254(self.value))
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        f
     }
 
     #[inline]
-    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
-        f
+    fn halve(&self) -> Self {
+        Self::new_monty(halve_bn254(self.value))
     }
 }
 

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -51,6 +51,7 @@ where
         x.double(),
         "Error when comparing x.double() to x * 2"
     );
+    assert_eq!(x, x.halve() * R::TWO, "Error when testing halve.");
 
     // Check different representatives of Zero.
     for zero in zeros.iter().copied() {
@@ -228,7 +229,7 @@ where
     let x = rng.random::<F>();
     let y = rng.random::<F>();
     let z = rng.random::<F>();
-    assert_eq!(x, x.halve() * F::TWO);
+    assert_eq!(F::TWO.inverse(), F::ONE.halve());
     assert_eq!(x * x.inverse(), F::ONE);
     assert_eq!(x.inverse() * x, F::ONE);
     assert_eq!(x.square().inverse(), x.inverse().square());

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -47,6 +47,11 @@ impl<F: Field, const N: usize> PrimeCharacteristicRing for FieldArray<F, N> {
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         F::from_prime_subfield(f).into()
     }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self(self.0.map(|x| x.halve()))
+    }
 }
 
 impl<F: Field, const N: usize> Algebra<F> for FieldArray<F, N> {}

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -207,13 +207,13 @@ where
     const NEG_ONE: Self = Self::new(field_to_array(A::NEG_ONE));
 
     #[inline]
-    fn halve(&self) -> Self {
-        Self::new(self.value.clone().map(|x| x.halve()))
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        <A as PrimeCharacteristicRing>::from_prime_subfield(f).into()
     }
 
     #[inline]
-    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
-        <A as PrimeCharacteristicRing>::from_prime_subfield(f).into()
+    fn halve(&self) -> Self {
+        Self::new(self.value.clone().map(|x| x.halve()))
     }
 
     #[inline(always)]

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -207,6 +207,11 @@ where
     const NEG_ONE: Self = Self::new(field_to_array(A::NEG_ONE));
 
     #[inline]
+    fn halve(&self) -> Self {
+        Self::new(self.value.clone().map(|x| x.halve()))
+    }
+
+    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         <A as PrimeCharacteristicRing>::from_prime_subfield(f).into()
     }
@@ -314,11 +319,6 @@ impl<F: BinomiallyExtendable<D>, const D: usize> Field for BinomialExtensionFiel
         }
 
         Some(res)
-    }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new(self.value.map(|x| x.halve()))
     }
 
     #[inline]

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -119,6 +119,11 @@ where
         PF::from_bool(b).into()
     }
 
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::new(self.value.map(|x| x.halve()))
+    }
+
     #[inline(always)]
     fn square(&self) -> Self {
         let mut res = Self::default();

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -143,7 +143,7 @@ pub trait PrimeCharacteristicRing:
     /// The function will panic if the field has characteristic 2.
     #[must_use]
     fn halve(&self) -> Self {
-        // This must be overwritten by most field implementations as this definition
+        // This must be overwritten by PrimeField implementations as this definition
         // is circular when PrimeSubfield = Self. It should also be overwritten by
         // most rings to avoid the multiplication.
         let half = Self::from_prime_subfield(Self::PrimeSubfield::ONE.halve());

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -137,6 +137,21 @@ pub trait PrimeCharacteristicRing:
         self.clone() + self.clone()
     }
 
+    /// The elementary function `halve(a) = a/2`.
+    ///
+    /// # Panics
+    /// The function will panic if the field has characteristic 2.
+    #[must_use]
+    fn halve(&self) -> Self {
+        // This should be overwritten by most field implementations.
+        let half = Self::from_prime_subfield(
+            Self::PrimeSubfield::TWO
+                .try_inverse()
+                .expect("Cannot divide by 2 in fields with characteristic 2"),
+        );
+        self.clone() * half
+    }
+
     /// The elementary function `square(a) = a^2`.
     ///
     /// This function should be preferred over calling `a * a`, as a faster implementation may be available for some rings.
@@ -769,21 +784,6 @@ pub trait Field:
     #[must_use]
     fn inverse(&self) -> Self {
         self.try_inverse().expect("Tried to invert zero")
-    }
-
-    /// The elementary function `halve(a) = a/2`.
-    ///
-    /// # Panics
-    /// The function will panic if the field has characteristic 2.
-    #[must_use]
-    fn halve(&self) -> Self {
-        // This should be overwritten by most field implementations.
-        let half = Self::from_prime_subfield(
-            Self::PrimeSubfield::TWO
-                .try_inverse()
-                .expect("Cannot divide by 2 in fields with characteristic 2"),
-        );
-        *self * half
     }
 
     /// Divide by a given power of two. `div_2exp_u64(a, exp) = a/2^exp`

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -142,15 +142,16 @@ pub trait PrimeCharacteristicRing:
     /// # Panics
     /// The function will panic if the field has characteristic 2.
     #[must_use]
-    fn halve(&self) -> Self {
-        // This should be overwritten by most field implementations.
-        let half = Self::from_prime_subfield(
-            Self::PrimeSubfield::TWO
-                .try_inverse()
-                .expect("Cannot divide by 2 in fields with characteristic 2"),
-        );
-        self.clone() * half
-    }
+    fn halve(&self) -> Self;
+    //  {
+    //     // This should be overwritten by most field implementations.
+    //     let half = Self::from_prime_subfield(
+    //         Self::PrimeSubfield::TWO
+    //             .try_inverse()
+    //             .expect("Cannot divide by 2 in fields with characteristic 2"),
+    //     );
+    //     self.clone() * half
+    // }
 
     /// The elementary function `square(a) = a^2`.
     ///

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -142,16 +142,13 @@ pub trait PrimeCharacteristicRing:
     /// # Panics
     /// The function will panic if the field has characteristic 2.
     #[must_use]
-    fn halve(&self) -> Self;
-    //  {
-    //     // This should be overwritten by most field implementations.
-    //     let half = Self::from_prime_subfield(
-    //         Self::PrimeSubfield::TWO
-    //             .try_inverse()
-    //             .expect("Cannot divide by 2 in fields with characteristic 2"),
-    //     );
-    //     self.clone() * half
-    // }
+    fn halve(&self) -> Self {
+        // This must be overwritten by most field implementations as this definition
+        // is circular when PrimeSubfield = Self. It should also be overwritten by
+        // most rings to avoid the multiplication.
+        let half = Self::from_prime_subfield(Self::PrimeSubfield::ONE.halve());
+        self.clone() * half
+    }
 
     /// The elementary function `square(a) = a^2`.
     ///

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -23,7 +23,7 @@ use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
 /// The Goldilocks prime
-const P: u64 = 0xFFFF_FFFF_0000_0001;
+pub(crate) const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 ///

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -180,11 +180,6 @@ impl PrimeCharacteristicRing for Goldilocks {
     const NEG_ONE: Self = Self::new(Self::ORDER_U64 - 1);
 
     #[inline]
-    fn halve(&self) -> Self {
-        Self::new(halve_u64::<P>(self.value))
-    }
-
-    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f
     }
@@ -192,6 +187,11 @@ impl PrimeCharacteristicRing for Goldilocks {
     #[inline]
     fn from_bool(b: bool) -> Self {
         Self::new(b.into())
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::new(halve_u64::<P>(self.value))
     }
 
     #[inline]

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -180,6 +180,11 @@ impl PrimeCharacteristicRing for Goldilocks {
     const NEG_ONE: Self = Self::new(Self::ORDER_U64 - 1);
 
     #[inline]
+    fn halve(&self) -> Self {
+        Self::new(halve_u64::<P>(self.value))
+    }
+
+    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f
     }
@@ -336,11 +341,6 @@ impl Field for Goldilocks {
         }
 
         Some(gcd_inversion(*self))
-    }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new(halve_u64::<P>(self.value))
     }
 
     #[inline]

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -20,7 +20,7 @@ use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
-use crate::Goldilocks;
+use crate::{Goldilocks, P};
 
 const WIDTH: usize = 4;
 
@@ -124,6 +124,11 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::from_vector(halve(self.to_vector()))
     }
 
     #[inline]
@@ -301,6 +306,42 @@ fn neg(y: __m256i) -> __m256i {
     unsafe {
         let y_s = shift(y);
         _mm256_sub_epi64(SHIFTED_FIELD_ORDER, canonicalize_s(y_s))
+    }
+}
+
+/// Halve a vector of Goldilocks field elements.
+#[inline(always)]
+pub(crate) fn halve(input: __m256i) -> __m256i {
+    /*
+        We want this to compile to:
+            vpand    least_bit, val, ONE
+            vpsrlq   t, val, 1
+            vpsubq   neg_least_bit, ZERO, least_bit
+            vpand    maybe_half, HALF, neg_least_bit
+            vpaddq   res, t, maybe_half
+        throughput: 1.67 cyc/vec
+        latency: 4 cyc
+
+        Given an element val in [0, P), we want to compute val/2 mod P.
+        If val is even: val/2 mod P = val/2 = val >> 1.
+        If val is odd: val/2 mod P = (val + P)/2 = (val >> 1) + (P + 1)/2
+    */
+    unsafe {
+        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        const ONE: __m256i = unsafe { transmute([1_i64; 4]) };
+        const ZERO: __m256i = unsafe { transmute([0_i64; 4]) };
+        let half = _mm256_set1_epi64x(P.div_ceil(2) as i64); // Compiler should realise this is constant.
+
+        let least_bit = _mm256_and_si256(input, ONE); // Determine the parity of val.
+        let t = _mm256_srli_epi64::<1>(input);
+
+        // Negate the least bit giving us either 0 (all bits 0) or -1 (all bits 1).
+        // It would be better to use vpsignq but this instruction does not exist.
+        let neg_least_bit = _mm256_sub_epi64(ZERO, least_bit);
+
+        // This does nothing when least_bit = 1 and sets the corresponding entry to 0 when least_bit = 0
+        let maybe_half = _mm256_and_si256(half, neg_least_bit);
+        _mm256_add_epi64(t, maybe_half)
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -20,7 +20,7 @@ use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
-use crate::Goldilocks;
+use crate::{Goldilocks, P};
 
 const WIDTH: usize = 8;
 
@@ -269,13 +269,13 @@ pub(crate) fn halve(input: __m512i) -> __m512i {
     */
     unsafe {
         // Safety: If this code got compiled then AVX512 intrinsics are available.
-        const ONE: __m512i = unsafe { transmute([1_i64; 16]) };
-        let half = x86_64::_mm512_set1_epi64(P.div_ceil(2) as i64); // Compiler realises this is constant.
+        const ONE: __m512i = unsafe { transmute([1_i64; 8]) };
+        let half = _mm512_set1_epi64(P.div_ceil(2) as i64); // Compiler realises this is constant.
 
-        let least_bit = x86_64::_mm512_test_epi64_mask(input, ONE); // Determine the parity of val.
-        let t = x86_64::_mm512_srli_epi64::<1>(input);
+        let least_bit = _mm512_test_epi64_mask(input, ONE); // Determine the parity of val.
+        let t = _mm512_srli_epi64::<1>(input);
         // This does nothing when least_bit = 1 and sets the corresponding entry to 0 when least_bit = 0
-        x86_64::_mm512_mask_add_epi64(t, least_bit, t, half)
+        _mm512_mask_add_epi64(t, least_bit, t, half)
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -254,7 +254,7 @@ fn neg(y: __m512i) -> __m512i {
 
 /// Halve a vector of Goldilocks field elements.
 #[inline(always)]
-pub(crate) fn halve<MP: MontyParameters>(input: __m512i) -> __m512i {
+pub(crate) fn halve(input: __m512i) -> __m512i {
     /*
         We want this to compile to:
             vptestmq  least_bit, val, ONE

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -275,7 +275,7 @@ pub(crate) fn halve(input: __m512i) -> __m512i {
         let least_bit = x86_64::_mm512_test_epi64_mask(input, ONE); // Determine the parity of val.
         let t = x86_64::_mm512_srli_epi64::<1>(input);
         // This does nothing when least_bit = 1 and sets the corresponding entry to 0 when least_bit = 0
-        x86_64::_mm512_mask_add_epi32(t, least_bit, t, half)
+        x86_64::_mm512_mask_add_epi64(t, least_bit, t, half)
     }
 }
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -151,6 +151,9 @@ impl PrimeCharacteristicRing for PackedMersenne31Neon {
         f.into()
     }
 
+    // TODO: Add a custom implementation of `halve` that uses NEON intrinsics
+    // and avoids the multiplication.
+
     #[inline(always)]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -164,6 +164,11 @@ impl PrimeCharacteristicRing for Mersenne31 {
     };
 
     #[inline]
+    fn halve(&self) -> Self {
+        Self::new(halve_u32::<P>(self.value))
+    }
+
+    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f
     }
@@ -287,11 +292,6 @@ impl Field for Mersenne31 {
         // gcd_inversion returns the inverse multiplied by 2^60 so we need to correct for that.
         let inverse_i64 = gcd_inversion_prime_field_32::<NUM_PRIME_BITS>(self.value, P);
         Some(Self::from_int(inverse_i64).div_2exp_u64(60))
-    }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new(halve_u32::<P>(self.value))
     }
 
     #[inline]

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -164,11 +164,6 @@ impl PrimeCharacteristicRing for Mersenne31 {
     };
 
     #[inline]
-    fn halve(&self) -> Self {
-        Self::new(halve_u32::<P>(self.value))
-    }
-
-    #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f
     }
@@ -176,6 +171,11 @@ impl PrimeCharacteristicRing for Mersenne31 {
     #[inline]
     fn from_bool(b: bool) -> Self {
         Self::new(b as u32)
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::new(halve_u32::<P>(self.value))
     }
 
     #[inline]

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -19,7 +19,7 @@ use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
-use crate::Mersenne31;
+use crate::{Mersenne31, mul_2exp_i};
 
 const WIDTH: usize = 8;
 pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
@@ -150,6 +150,12 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX2 {
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        // 2^{-1} = 2^30 mod P so we implement halve by multiplying by 2^30.
+        mul_2exp_i::<30, 1>(*self)
     }
 
     #[inline(always)]

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -104,7 +104,9 @@ impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
 /// This requires 2 generic parameters, `I` and `I_PRIME` satisfying `I + I_PRIME = 31`.
 /// If the inputs do not conform to this representations, the result is undefined.
 #[inline(always)]
-fn mul_2exp_i<const I: i32, const I_PRIME: i32>(val: PackedMersenne31AVX2) -> PackedMersenne31AVX2 {
+pub(crate) fn mul_2exp_i<const I: i32, const I_PRIME: i32>(
+    val: PackedMersenne31AVX2,
+) -> PackedMersenne31AVX2 {
     /*
         We want this to compile to:
             vpslld   hi_dirty, val,      I

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -19,7 +19,7 @@ use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
-use crate::Mersenne31;
+use crate::{Mersenne31, mul_2exp_i};
 
 const WIDTH: usize = 16;
 pub(crate) const P: __m512i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
@@ -152,6 +152,12 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        // 2^{-1} = 2^30 mod P so we implement halve by multiplying by 2^30.
+        mul_2exp_i::<30, 1>(*self)
     }
 
     #[inline(always)]

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -97,11 +97,12 @@ impl<const WIDTH: usize> Poseidon2ExternalLayerMersenne31<WIDTH> {
 }
 
 /// Compute the map x -> 2^I x on Mersenne-31 field elements.
+///
 /// x must be represented as a value in {0..P}.
 /// This requires 2 generic parameters, I and I_PRIME satisfying I + I_PRIME = 31.
 /// If the inputs do not conform to this representations, the result is undefined.
 #[inline(always)]
-fn mul_2exp_i<const I: u32, const I_PRIME: u32>(
+pub(crate) fn mul_2exp_i<const I: u32, const I_PRIME: u32>(
     val: PackedMersenne31AVX512,
 ) -> PackedMersenne31AVX512 {
     assert_eq!(I + I_PRIME, 31);

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -160,6 +160,9 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
         f.into()
     }
 
+    // TODO: Add a custom implementation of `halve` that uses NEON intrinsics
+    // and avoids the multiplication.
+
     #[inline]
     fn cube(&self) -> Self {
         let val = self.to_vector();

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -176,14 +176,14 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
     const TWO: Self = FP::MONTY_TWO;
     const NEG_ONE: Self = FP::MONTY_NEG_ONE;
 
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new_monty(halve_u32::<FP>(self.value))
-    }
-
     #[inline(always)]
     fn from_prime_subfield(f: Self) -> Self {
         f
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::new_monty(halve_u32::<FP>(self.value))
     }
 
     #[inline]

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -176,6 +176,11 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
     const TWO: Self = FP::MONTY_TWO;
     const NEG_ONE: Self = FP::MONTY_NEG_ONE;
 
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::new_monty(halve_u32::<FP>(self.value))
+    }
+
     #[inline(always)]
     fn from_prime_subfield(f: Self) -> Self {
         f
@@ -423,11 +428,6 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
         // Unrolling the definitions a little, this 36 comes from: 3 * FP::MONTY_BITS - (2 * NUM_PRIME_BITS - 2)
 
         Some(uncorrected_value.mul_2exp_u64((3 * FP::MONTY_BITS - (2 * NUM_PRIME_BITS - 2)) as u64))
-    }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        Self::new_monty(halve_u32::<FP>(self.value))
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -21,7 +21,7 @@ use rand::distr::{Distribution, StandardUniform};
 
 use crate::{
     BinomialExtensionData, FieldParameters, MontyField31, PackedMontyParameters,
-    RelativelyPrimePower, signed_add_avx2,
+    RelativelyPrimePower, halve_avx2, signed_add_avx2,
 };
 
 const WIDTH: usize = 8;
@@ -159,6 +159,16 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX2<FP>
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        let val = self.to_vector();
+        let halved = halve_avx2::<FP>(val);
+        unsafe {
+            // Safety: `halve_avx2` returns values in canonical form when given values in canonical form.
+            Self::from_vector(halved)
+        }
     }
 
     #[inline]

--- a/monty-31/src/x86_64_avx2/utils.rs
+++ b/monty-31/src/x86_64_avx2/utils.rs
@@ -7,6 +7,7 @@ use crate::{MontyParameters, MontyParametersAVX2, TwoAdicData};
 // https://godbolt.org/z/9P71nYrqh
 
 /// Halve a vector of Monty31 field elements in canonical form.
+///
 /// If the inputs are not in canonical form, the result is undefined.
 #[inline(always)]
 pub(crate) fn halve_avx2<MP: MontyParameters>(input: __m256i) -> __m256i {

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -27,7 +27,7 @@ use rand::distr::{Distribution, StandardUniform};
 
 use crate::{
     BinomialExtensionData, FieldParameters, MontyField31, PackedMontyParameters,
-    RelativelyPrimePower,
+    RelativelyPrimePower, halve_avx512,
 };
 
 const WIDTH: usize = 16;
@@ -178,6 +178,16 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31AVX512<F
     #[inline]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        let val = self.to_vector();
+        let halved = halve_avx512::<FP>(val);
+        unsafe {
+            // Safety: `halve_avx512` returns values in canonical form when given values in canonical form.
+            Self::from_vector(halved)
+        }
     }
 
     #[inline(always)]

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -7,6 +7,7 @@ use crate::{MontyParameters, PackedMontyParameters, TwoAdicData};
 // https://godbolt.org/z/dvW7r1zjj
 
 /// Halve a vector of Monty31 field elements in canonical form.
+///
 /// If the inputs are not in canonical form, the result is undefined.
 #[inline(always)]
 pub(crate) fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
@@ -23,7 +24,7 @@ pub(crate) fn halve_avx512<MP: MontyParameters>(input: __m512i) -> __m512i {
         If val is odd: val/2 mod P = (val + P)/2 = (val >> 1) + (P + 1)/2
     */
     unsafe {
-        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        // Safety: If this code got compiled then AVX512 intrinsics are available.
         const ONE: __m512i = unsafe { transmute([1u32; 16]) };
         let half = x86_64::_mm512_set1_epi32((MP::PRIME as i32 + 1) / 2); // Compiler realises this is constant.
 

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -83,6 +83,13 @@ impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         F::from_prime_subfield(f).into()
     }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        // Use F's halve method.
+        let half = Self::Constant(F::ONE.halve());
+        self.clone() * half
+    }
 }
 
 impl<F: Field> Algebra<F> for SymbolicExpression<F> {}

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -83,13 +83,6 @@ impl<F: Field> PrimeCharacteristicRing for SymbolicExpression<F> {
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
         F::from_prime_subfield(f).into()
     }
-
-    #[inline]
-    fn halve(&self) -> Self {
-        // Use F's halve method.
-        let half = Self::Constant(F::ONE.halve());
-        self.clone() * half
-    }
 }
 
 impl<F: Field> Algebra<F> for SymbolicExpression<F> {}


### PR DESCRIPTION
Currently `.halve()` is only available for Fields. There is no real reason though why we couldn't also make it available for `PrimeCharacteristicRing`s. Moving this (and `.div_2_exp_u64(a)` which I'll put in a seperate PR) to `PrimeCharacteristicRing` is nice from a consistency standpoint as that is where `.double()` and `.mul_2_exp_u64(a)` are and can also be used to speed up some computations.

(I've checked that this compiles and tests pass on AVX512)

The biggest question here is what should be default implementation of `halve` look like? We have four options:
- Don't give a default and make all rings write what implementation they desire. (Basically all rings should overwrite whatever default we give so we could just force them to).
- Give a default based on multiplying by `Self::PrimeSubfield::TWO.inverse()`. Advantage is that this will always work. Disadvantage is that this is a very slow.
- Give a default based on multiplying by `Self::PrimeSubfield::ONE.halve()`. Advantage is that this is a fast enough default that it becomes less important for rings to overwrite it. Disadvantage is that the definition is circular if `Self = Self::PrimeSubfield` so PrimeFields will need to re-implement it and it is more of a breaking API change. (If someone has built a new prime field on top of Plonky3 this might break the field until they do a custom impl for half). 
- Add `INVERSE_TWO` as a constant to `PrimeField` and use that. (Unclear how to handle the case that this might not exist).

I've currently gone with option 3 but I can see an argument with sticking to option 2 (which mirrors the current default)