### PR TITLE
Weaken the trait bound of AirBuilder to allow `F` to be merely a Ring.

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -47,7 +47,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
 /// as well cases where the constraints are evaluated on an evaluation trace and combined using randomness.
 pub trait AirBuilder: Sized {
     /// Underlying field type.
-    type F: Field;
+    type F: PrimeCharacteristicRing + Sync;
 
     /// Serves as the output type for an AIR constraint evaluation.
     type Expr: Algebra<Self::F> + Algebra<Self::Var>;
@@ -182,7 +182,7 @@ pub trait PairBuilder: AirBuilder {
 }
 
 /// Extension of `AirBuilder` for working over extension fields.
-pub trait ExtensionBuilder: AirBuilder {
+pub trait ExtensionBuilder: AirBuilder<F: Field> {
     /// Extension field type.
     type EF: ExtensionField<Self::F>;
 

--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -2,7 +2,7 @@ use p3_air::{Air, AirBuilder, BaseAir};
 use p3_blake3_air::Blake3Air;
 use p3_challenger::FieldChallenger;
 use p3_commit::PolynomialSpace;
-use p3_field::{ExtensionField, Field, PrimeField64};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, PrimeField64};
 use p3_keccak_air::KeccakAir;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
@@ -18,7 +18,7 @@ use rand::prelude::Distribution;
 ///
 /// This implements `AIR` by passing to whatever the contained struct is.
 pub enum ProofObjective<
-    F: Field,
+    F: PrimeCharacteristicRing + Sync,
     LinearLayers,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
@@ -64,7 +64,7 @@ pub trait ExampleHashAir<F: Field, SC: StarkGenericConfig>:
 }
 
 impl<
-    F: Field,
+    F: PrimeCharacteristicRing + Sync,
     LinearLayers: Sync,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,

--- a/poseidon2-air/src/constants.rs
+++ b/poseidon2-air/src/constants.rs
@@ -1,11 +1,11 @@
-use p3_field::Field;
+use p3_field::PrimeCharacteristicRing;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
 /// Round constants for Poseidon2, in a format that's convenient for the AIR.
 #[derive(Debug, Clone)]
 pub struct RoundConstants<
-    F: Field,
+    F: PrimeCharacteristicRing,
     const WIDTH: usize,
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
@@ -15,8 +15,12 @@ pub struct RoundConstants<
     pub(crate) ending_full_round_constants: [[F; WIDTH]; HALF_FULL_ROUNDS],
 }
 
-impl<F: Field, const WIDTH: usize, const HALF_FULL_ROUNDS: usize, const PARTIAL_ROUNDS: usize>
-    RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+impl<
+    F: PrimeCharacteristicRing,
+    const WIDTH: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     pub const fn new(
         beginning_full_round_constants: [[F; WIDTH]; HALF_FULL_ROUNDS],

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -1,7 +1,7 @@
 use core::borrow::{Borrow, BorrowMut};
 
 use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{Field, PrimeField};
+use p3_field::{PrimeCharacteristicRing, PrimeField};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
@@ -134,7 +134,7 @@ impl<
 
 /// A "vectorized" version of Poseidon2Air, for computing multiple Poseidon2 permutations per row.
 pub struct VectorizedPoseidon2Air<
-    F: Field,
+    F: PrimeCharacteristicRing,
     LinearLayers,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
@@ -155,7 +155,7 @@ pub struct VectorizedPoseidon2Air<
 }
 
 impl<
-    F: Field,
+    F: PrimeCharacteristicRing,
     LinearLayers,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
@@ -209,7 +209,7 @@ impl<
 }
 
 impl<
-    F: Field,
+    F: PrimeCharacteristicRing + Sync,
     LinearLayers: Sync,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,


### PR DESCRIPTION
Possibly a simpler version of #967 if it works.