### PR TITLE
Relax Default bound for DftChoice to depend on Radix2DitParallel

### DIFF
--- a/examples/src/dfts.rs
+++ b/examples/src/dfts.rs
@@ -13,7 +13,10 @@ pub enum DftChoice<F> {
     Parallel(Radix2DitParallel<F>),
 }
 
-impl<F: Default> Default for DftChoice<F> {
+impl<F> Default for DftChoice<F>
+where
+    Radix2DitParallel<F>: Default,
+{
     // We have to fix a default for the `TwoAdicSubgroupDft` trait. We choose `Radix2DitParallel` as one of the features
     // of `RecursiveDft` is that it works better when initialized with knowledge of the expected size.
     fn default() -> Self {


### PR DESCRIPTION
Replace impl<F: Default> Default for DftChoice<F> with impl<F> Default for DftChoice<F> where Radix2DitParallel<F>: Default.
Removes an unnecessary F: Default constraint and ties the impl to the actual requirement.
No functional change; builds clean (cargo check -p p3-examples).