### PR TITLE
Fix unsafe Result handling in Poseidon2

### DIFF
--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -91,8 +91,7 @@ where
         StandardUniform: Distribution<F> + Distribution<[F; WIDTH]>,
     {
         let round_numbers = poseidon2_round_numbers_128::<F>(WIDTH, D);
-        let (rounds_f, rounds_p) =
-            round_numbers.unwrap_or_else(|_| panic!("{}", round_numbers.unwrap_err()));
+        let (rounds_f, rounds_p) = round_numbers.unwrap_or_else(|e| panic!("{e}"));
         Self::new_from_rng(rounds_f, rounds_p, rng)
     }
 }


### PR DESCRIPTION


## Description

Fixed a potential move-after-use error in `poseidon2/src/lib.rs` where `unwrap_or_else` closure was accessing a moved `Result` value.

**Before:**
```rust
round_numbers.unwrap_or_else(|_| panic!("{}", round_numbers.unwrap_err()));
```

**After:**
```rust
round_numbers.unwrap_or_else(|e| panic!("{e}"));
```

