### PR TITLE
circle: fix bench closure to destructure &(dft, m) correctly in cfft lde_twoadic

### DIFF
--- a/circle/benches/cfft.rs
+++ b/circle/benches/cfft.rs
@@ -60,7 +60,7 @@ fn lde_twoadic<F: TwoAdicField, Dft: TwoAdicSubgroupDft<F>, M: Measurement>(
             format!("log_n={log_n},log_w={log_w}"),
         ),
         &(dft, m),
-        |b, (dft, m)| {
+        |b, &(ref dft, ref m)| {
             b.iter_batched(
                 || (dft.clone(), m.clone()),
                 |(dft, m)| dft.coset_lde_batch(m, 1, F::GENERATOR),


### PR DESCRIPTION
Fix the Criterion bench in circle/benches/cfft.rs by properly destructuring a reference to the tuple input. The closure now matches &(dft, m) as &(ref dft, ref m), ensuring correct borrowing and subsequent cloning inside iter_batched.