### PR TITLE
Generic Poseidon2 Simplifications

### DIFF
--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -9,7 +9,7 @@ use p3_poseidon2::GenericPoseidon2LinearLayers;
 use p3_poseidon2_air::{Poseidon2Air, VectorizedPoseidon2Air};
 use p3_uni_stark::{
     DebugConstraintBuilder, ProverConstraintFolder, StarkGenericConfig, SymbolicAirBuilder,
-    SymbolicExpression, VerifierConstraintFolder,
+    VerifierConstraintFolder,
 };
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
@@ -96,7 +96,7 @@ impl<
 
 impl<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -132,10 +132,7 @@ impl<
     Challenger: FieldChallenger<F>,
     Pcs: p3_commit::Pcs<EF, Challenger, Domain = Domain>,
     SC: StarkGenericConfig<Pcs = Pcs, Challenge = EF, Challenger = Challenger>,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>
-        + GenericPoseidon2LinearLayers<SymbolicExpression<F>, WIDTH>
-        + GenericPoseidon2LinearLayers<F::Packing, WIDTH>
-        + GenericPoseidon2LinearLayers<EF, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -224,10 +221,7 @@ impl<
     Challenger: FieldChallenger<F>,
     Pcs: p3_commit::Pcs<EF, Challenger, Domain = Domain>,
     SC: StarkGenericConfig<Pcs = Pcs, Challenge = EF, Challenger = Challenger>,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>
-        + GenericPoseidon2LinearLayers<SymbolicExpression<F>, WIDTH>
-        + GenericPoseidon2LinearLayers<F::Packing, WIDTH>
-        + GenericPoseidon2LinearLayers<EF, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -266,10 +260,7 @@ impl<
     Challenger: FieldChallenger<F>,
     Pcs: p3_commit::Pcs<EF, Challenger, Domain = Domain>,
     SC: StarkGenericConfig<Pcs = Pcs, Challenge = EF, Challenger = Challenger>,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>
-        + GenericPoseidon2LinearLayers<SymbolicExpression<F>, WIDTH>
-        + GenericPoseidon2LinearLayers<F::Packing, WIDTH>
-        + GenericPoseidon2LinearLayers<EF, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -13,10 +13,10 @@
 //! [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/16, 1/32, 1/64, 1/2^24, -1/2^8, -1/8, -1/16, -1/32, -1/64, -1/2^7, -1/2^9, -1/2^24]
 //! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
 
-use p3_field::{Algebra, PrimeCharacteristicRing, PrimeField32};
+use p3_field::PrimeCharacteristicRing;
 use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
-    MontyField31, Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
+    Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
 };
 use p3_poseidon2::Poseidon2;
 
@@ -54,196 +54,85 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 pub type GenericPoseidon2LinearLayersKoalaBear =
     GenericPoseidon2LinearLayersMonty31<KoalaBearParameters, KoalaBearInternalLayerParameters>;
 
-// In order to use KoalaBear::new_array we need to convert our vector to a vector of u32's.
-// To do this we make use of the fact that KoalaBear::ORDER_U32 - 1 = 127 * 2^24 so for 0 <= n <= 24:
-// -1/2^n = (KoalaBear::ORDER_U32 - 1) >> n
-// 1/2^n = -(-1/2^n) = KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> n)
-
-/// The vector [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/8, 1/2^24, -1/2^8, -1/8, -1/16, -1/2^24]
-/// saved as an array of KoalaBear elements.
-const INTERNAL_DIAG_MONTY_16: [KoalaBear; 16] = KoalaBear::new_array([
-    KoalaBear::ORDER_U32 - 2,
-    1,
-    2,
-    (KoalaBear::ORDER_U32 + 1) >> 1,
-    3,
-    4,
-    (KoalaBear::ORDER_U32 - 1) >> 1,
-    KoalaBear::ORDER_U32 - 3,
-    KoalaBear::ORDER_U32 - 4,
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 8),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 3),
-    KoalaBear::ORDER_U32 - 127,
-    (KoalaBear::ORDER_U32 - 1) >> 8,
-    (KoalaBear::ORDER_U32 - 1) >> 3,
-    (KoalaBear::ORDER_U32 - 1) >> 4,
-    127,
-]);
-
-/// The vector [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/16, 1/32, 1/64, 1/2^24, -1/2^8, -1/8, -1/16, -1/32, -1/64, -1/2^7, -1/2^9, -1/2^24]
-/// saved as an array of KoalaBear elements.
-const INTERNAL_DIAG_MONTY_24: [KoalaBear; 24] = KoalaBear::new_array([
-    KoalaBear::ORDER_U32 - 2,
-    1,
-    2,
-    (KoalaBear::ORDER_U32 + 1) >> 1,
-    3,
-    4,
-    (KoalaBear::ORDER_U32 - 1) >> 1,
-    KoalaBear::ORDER_U32 - 3,
-    KoalaBear::ORDER_U32 - 4,
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 8),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 2),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 3),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 4),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 5),
-    KoalaBear::ORDER_U32 - ((KoalaBear::ORDER_U32 - 1) >> 6),
-    KoalaBear::ORDER_U32 - 127,
-    (KoalaBear::ORDER_U32 - 1) >> 8,
-    (KoalaBear::ORDER_U32 - 1) >> 3,
-    (KoalaBear::ORDER_U32 - 1) >> 4,
-    (KoalaBear::ORDER_U32 - 1) >> 5,
-    (KoalaBear::ORDER_U32 - 1) >> 6,
-    (KoalaBear::ORDER_U32 - 1) >> 7,
-    (KoalaBear::ORDER_U32 - 1) >> 9,
-    127,
-]);
-
 /// Contains data needed to define the internal layers of the Poseidon2 permutation.
 #[derive(Debug, Clone, Default)]
 pub struct KoalaBearInternalLayerParameters;
 
 impl InternalLayerBaseParameters<KoalaBearParameters, 16> for KoalaBearInternalLayerParameters {
-    type ArrayLike = [MontyField31<KoalaBearParameters>; 15];
-
-    const INTERNAL_DIAG_MONTY: [MontyField31<KoalaBearParameters>; 16] = INTERNAL_DIAG_MONTY_16;
-
     /// Perform the internal matrix multiplication: s -> (1 + Diag(V))s.
     /// We ignore `state[0]` as it is handled separately.
-    fn internal_layer_mat_mul(
-        state: &mut [MontyField31<KoalaBearParameters>; 16],
-        sum: MontyField31<KoalaBearParameters>,
-    ) {
+    fn internal_layer_mat_mul<R: PrimeCharacteristicRing>(state: &mut [R; 16], sum: R) {
         // The diagonal matrix is defined by the vector:
         // V = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/8, 1/2^24, -1/2^8, -1/8, -1/16, -1/2^24]
-        state[1] += sum;
-        state[2] = state[2].double() + sum;
-        state[3] = state[3].halve() + sum;
-        state[4] = sum + state[4].double() + state[4];
-        state[5] = sum + state[5].double().double();
-        state[6] = sum - state[6].halve();
-        state[7] = sum - (state[7].double() + state[7]);
-        state[8] = sum - state[8].double().double();
+        state[1] += sum.clone();
+        state[2] = state[2].double() + sum.clone();
+        state[3] = state[3].halve() + sum.clone();
+        state[4] = sum.clone() + state[4].double() + state[4].clone();
+        state[5] = sum.clone() + state[5].double().double();
+        state[6] = sum.clone() - state[6].halve();
+        state[7] = sum.clone() - (state[7].double() + state[7].clone());
+        state[8] = sum.clone() - state[8].double().double();
         state[9] = state[9].div_2exp_u64(8);
-        state[9] += sum;
+        state[9] += sum.clone();
         state[10] = state[10].div_2exp_u64(3);
-        state[10] += sum;
+        state[10] += sum.clone();
         state[11] = state[11].div_2exp_u64(24);
-        state[11] += sum;
+        state[11] += sum.clone();
         state[12] = state[12].div_2exp_u64(8);
-        state[12] = sum - state[12];
+        state[12] = sum.clone() - state[12].clone();
         state[13] = state[13].div_2exp_u64(3);
-        state[13] = sum - state[13];
+        state[13] = sum.clone() - state[13].clone();
         state[14] = state[14].div_2exp_u64(4);
-        state[14] = sum - state[14];
+        state[14] = sum.clone() - state[14].clone();
         state[15] = state[15].div_2exp_u64(24);
-        state[15] = sum - state[15];
-    }
-
-    fn generic_internal_linear_layer<A: Algebra<KoalaBear>>(state: &mut [A; 16]) {
-        let part_sum: A = state[1..].iter().cloned().sum();
-        let full_sum = part_sum.clone() + state[0].clone();
-
-        // The first three diagonal elements are -2, 1, 2 so we do something custom.
-        state[0] = part_sum - state[0].clone();
-        state[1] = full_sum.clone() + state[1].clone();
-        state[2] = full_sum.clone() + state[2].double();
-
-        // For the remaining elements we use multiplication.
-        // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
-        state
-            .iter_mut()
-            .zip(INTERNAL_DIAG_MONTY_16)
-            .skip(3)
-            .for_each(|(val, diag_elem)| {
-                *val = full_sum.clone() + val.clone() * diag_elem;
-            });
+        state[15] = sum.clone() - state[15].clone();
     }
 }
 
 impl InternalLayerBaseParameters<KoalaBearParameters, 24> for KoalaBearInternalLayerParameters {
-    type ArrayLike = [MontyField31<KoalaBearParameters>; 23];
-
-    const INTERNAL_DIAG_MONTY: [MontyField31<KoalaBearParameters>; 24] = INTERNAL_DIAG_MONTY_24;
-
     /// Perform the internal matrix multiplication: s -> (1 + Diag(V))s.
     /// We ignore `state[0]` as it is handled separately.
-    fn internal_layer_mat_mul(
-        state: &mut [MontyField31<KoalaBearParameters>; 24],
-        sum: MontyField31<KoalaBearParameters>,
-    ) {
+    fn internal_layer_mat_mul<R: PrimeCharacteristicRing>(state: &mut [R; 24], sum: R) {
         // The diagonal matrix is defined by the vector:
         // V = [-2, 1, 2, 1/2, 3, 4, -1/2, -3, -4, 1/2^8, 1/4, 1/8, 1/16, 1/32, 1/64, 1/2^24, -1/2^8, -1/8, -1/16, -1/32, -1/64, -1/2^7, -1/2^9, -1/2^24]
-        state[1] += sum;
-        state[2] = state[2].double() + sum;
-        state[3] = state[3].halve() + sum;
-        state[4] = sum + state[4].double() + state[4];
-        state[5] = sum + state[5].double().double();
-        state[6] = sum - state[6].halve();
-        state[7] = sum - (state[7].double() + state[7]);
-        state[8] = sum - state[8].double().double();
+        state[1] += sum.clone();
+        state[2] = state[2].double() + sum.clone();
+        state[3] = state[3].halve() + sum.clone();
+        state[4] = sum.clone() + state[4].double() + state[4].clone();
+        state[5] = sum.clone() + state[5].double().double();
+        state[6] = sum.clone() - state[6].halve();
+        state[7] = sum.clone() - (state[7].double() + state[7].clone());
+        state[8] = sum.clone() - state[8].double().double();
         state[9] = state[9].div_2exp_u64(8);
-        state[9] += sum;
+        state[9] += sum.clone();
         state[10] = state[10].div_2exp_u64(2);
-        state[10] += sum;
+        state[10] += sum.clone();
         state[11] = state[11].div_2exp_u64(3);
-        state[11] += sum;
+        state[11] += sum.clone();
         state[12] = state[12].div_2exp_u64(4);
-        state[12] += sum;
+        state[12] += sum.clone();
         state[13] = state[13].div_2exp_u64(5);
-        state[13] += sum;
+        state[13] += sum.clone();
         state[14] = state[14].div_2exp_u64(6);
-        state[14] += sum;
+        state[14] += sum.clone();
         state[15] = state[15].div_2exp_u64(24);
-        state[15] += sum;
+        state[15] += sum.clone();
         state[16] = state[16].div_2exp_u64(8);
-        state[16] = sum - state[16];
+        state[16] = sum.clone() - state[16].clone();
         state[17] = state[17].div_2exp_u64(3);
-        state[17] = sum - state[17];
+        state[17] = sum.clone() - state[17].clone();
         state[18] = state[18].div_2exp_u64(4);
-        state[18] = sum - state[18];
+        state[18] = sum.clone() - state[18].clone();
         state[19] = state[19].div_2exp_u64(5);
-        state[19] = sum - state[19];
+        state[19] = sum.clone() - state[19].clone();
         state[20] = state[20].div_2exp_u64(6);
-        state[20] = sum - state[20];
+        state[20] = sum.clone() - state[20].clone();
         state[21] = state[21].div_2exp_u64(7);
-        state[21] = sum - state[21];
+        state[21] = sum.clone() - state[21].clone();
         state[22] = state[22].div_2exp_u64(9);
-        state[22] = sum - state[22];
+        state[22] = sum.clone() - state[22].clone();
         state[23] = state[23].div_2exp_u64(24);
-        state[23] = sum - state[23];
-    }
-
-    fn generic_internal_linear_layer<A: Algebra<KoalaBear>>(state: &mut [A; 24]) {
-        let part_sum: A = state[1..].iter().cloned().sum();
-        let full_sum = part_sum.clone() + state[0].clone();
-
-        // The first three diagonal elements are -2, 1, 2 so we do something custom.
-        state[0] = part_sum - state[0].clone();
-        state[1] = full_sum.clone() + state[1].clone();
-        state[2] = full_sum.clone() + state[2].double();
-
-        // For the remaining elements we use multiplication.
-        // This could probably be improved slightly by making use of the
-        // mul_2exp_u64 and div_2exp_u64 but this would involve porting div_2exp_u64 to PrimeCharacteristicRing.
-        state
-            .iter_mut()
-            .zip(INTERNAL_DIAG_MONTY_24)
-            .skip(3)
-            .for_each(|(val, diag_elem)| {
-                *val = full_sum.clone() + val.clone() * diag_elem;
-            });
+        state[23] = sum.clone() - state[23].clone();
     }
 }
 

--- a/mersenne-31/src/aarch64_neon/poseidon2.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon2.rs
@@ -42,8 +42,7 @@ impl<const WIDTH: usize> ExternalLayerConstructor<Mersenne31, WIDTH>
 impl<const WIDTH: usize, const D: u64> InternalLayer<PackedMersenne31Neon, WIDTH, D>
     for Poseidon2InternalLayerMersenne31
 where
-    GenericPoseidon2LinearLayersMersenne31:
-        GenericPoseidon2LinearLayers<PackedMersenne31Neon, WIDTH>,
+    GenericPoseidon2LinearLayersMersenne31: GenericPoseidon2LinearLayers<WIDTH>,
 {
     /// Perform the internal layers of the Poseidon2 permutation on the given state.
     fn permute_state(&self, state: &mut [PackedMersenne31Neon; WIDTH]) {

--- a/mersenne-31/src/poseidon2.rs
+++ b/mersenne-31/src/poseidon2.rs
@@ -13,7 +13,7 @@
 //! [-2, 2^0, 2, 4, 8, 16, 32, 64, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16, 2^17, 2^18, 2^19, 2^20, 2^21, 2^22]
 //! See poseidon2\src\diffusion.rs for information on how to double check these matrices in Sage.
 
-use p3_field::Algebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_poseidon2::{
     ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4, Poseidon2,
     add_rc_and_sbox_generic, external_initial_permute_state, external_terminal_permute_state,
@@ -118,11 +118,9 @@ impl<const WIDTH: usize> ExternalLayer<Mersenne31, WIDTH, MERSENNE31_S_BOX_DEGRE
     }
 }
 
-impl<A: Algebra<Mersenne31>> GenericPoseidon2LinearLayers<A, 16>
-    for GenericPoseidon2LinearLayersMersenne31
-{
-    fn internal_linear_layer(state: &mut [A; 16]) {
-        let part_sum: A = state[1..].iter().cloned().sum();
+impl GenericPoseidon2LinearLayers<16> for GenericPoseidon2LinearLayersMersenne31 {
+    fn internal_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; 16]) {
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.
@@ -143,11 +141,9 @@ impl<A: Algebra<Mersenne31>> GenericPoseidon2LinearLayers<A, 16>
     }
 }
 
-impl<A: Algebra<Mersenne31>> GenericPoseidon2LinearLayers<A, 24>
-    for GenericPoseidon2LinearLayersMersenne31
-{
-    fn internal_linear_layer(state: &mut [A; 24]) {
-        let part_sum: A = state[1..].iter().cloned().sum();
+impl GenericPoseidon2LinearLayers<24> for GenericPoseidon2LinearLayersMersenne31 {
+    fn internal_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; 24]) {
+        let part_sum: R = state[1..].iter().cloned().sum();
         let full_sum = part_sum.clone() + state[0].clone();
 
         // The first three diagonal elements are -2, 1, 2 so we do something custom.

--- a/monty-31/src/poseidon2.rs
+++ b/monty-31/src/poseidon2.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use p3_field::{Algebra, InjectiveMonomial};
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
 use p3_poseidon2::{
     ExternalLayer, GenericPoseidon2LinearLayers, InternalLayer, MDSMat4, add_rc_and_sbox_generic,
     external_initial_permute_state, external_terminal_permute_state,
@@ -18,20 +18,19 @@ use crate::{
 pub trait InternalLayerBaseParameters<MP: MontyParameters, const WIDTH: usize>:
     Clone + Sync
 {
-    // Most of the time, ArrayLike will be `[u8; WIDTH - 1]`.
-    type ArrayLike: AsRef<[MontyField31<MP>]> + Sized;
-
-    // Long term INTERNAL_DIAG_MONTY will be removed.
-    // Currently it is needed for the Packed field implementations.
-    const INTERNAL_DIAG_MONTY: [MontyField31<MP>; WIDTH];
-
     /// Perform the internal matrix multiplication: s -> (1 + Diag(V))s.
     /// We ignore `state[0]` as it is handled separately.
-    fn internal_layer_mat_mul(state: &mut [MontyField31<MP>; WIDTH], sum: MontyField31<MP>);
+    fn internal_layer_mat_mul<R: PrimeCharacteristicRing>(state: &mut [R; WIDTH], sum: R);
 
-    /// Perform the internal matrix multiplication for any Abstract field
-    /// which implements multiplication by MontyField31 elements.
-    fn generic_internal_linear_layer<A: Algebra<MontyField31<MP>>>(state: &mut [A; WIDTH]);
+    /// Perform the matrix multiplication corresponding to the internal linear
+    /// layer.
+    fn generic_internal_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; WIDTH]) {
+        // We mostly delegate to internal_layer_mat_mul but have to handle state[0] separately.
+        let part_sum: R = state[1..].iter().cloned().sum();
+        let full_sum = part_sum.clone() + state[0].clone();
+        state[0] = part_sum - state[0].clone();
+        Self::internal_layer_mat_mul(state, full_sum);
+    }
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
@@ -122,16 +121,13 @@ pub struct GenericPoseidon2LinearLayersMonty31<FP, ILBP> {
     _phantom2: PhantomData<ILBP>,
 }
 
-impl<FP, A, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<A, WIDTH>
+impl<FP, ILBP, const WIDTH: usize> GenericPoseidon2LinearLayers<WIDTH>
     for GenericPoseidon2LinearLayersMonty31<FP, ILBP>
 where
     FP: FieldParameters,
-    A: Algebra<MontyField31<FP>>,
     ILBP: InternalLayerBaseParameters<FP, WIDTH>,
 {
-    /// Perform the external matrix multiplication for any Abstract field
-    /// which implements multiplication by MontyField31 elements.
-    fn internal_linear_layer(state: &mut [A; WIDTH]) {
+    fn internal_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; WIDTH]) {
         ILBP::generic_internal_linear_layer(state);
     }
 }

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -64,7 +64,7 @@ impl<
     ) -> RowMajorMatrix<F>
     where
         F: PrimeField,
-        LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+        LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
         StandardUniform: Distribution<[F; WIDTH]>,
     {
         let mut rng = SmallRng::seed_from_u64(1);
@@ -107,7 +107,7 @@ impl<
 
 pub(crate) fn eval<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -167,7 +167,7 @@ pub(crate) fn eval<
 
 impl<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -199,7 +199,7 @@ impl<
 #[inline]
 fn eval_full_round<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -223,7 +223,7 @@ fn eval_full_round<
 #[inline]
 fn eval_partial_round<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -13,7 +13,7 @@ use crate::{FullRound, PartialRound, RoundConstants, SBox};
 #[instrument(name = "generate vectorized Poseidon2 trace", skip_all)]
 pub fn generate_vectorized_trace_rows<
     F: PrimeField,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -75,7 +75,7 @@ pub fn generate_vectorized_trace_rows<
 #[instrument(name = "generate Poseidon2 trace", skip_all)]
 pub fn generate_trace_rows<
     F: PrimeField,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -133,7 +133,7 @@ pub fn generate_trace_rows<
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
 fn generate_trace_rows_for_perm<
     F: PrimeField,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -197,7 +197,7 @@ fn generate_trace_rows_for_perm<
 #[inline]
 fn generate_full_round<
     F: PrimeField,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,
@@ -229,7 +229,7 @@ fn generate_full_round<
 #[inline]
 fn generate_partial_round<
     F: PrimeField,
-    LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -190,7 +190,7 @@ impl<
     ) -> RowMajorMatrix<F>
     where
         F: PrimeField,
-        LinearLayers: GenericPoseidon2LinearLayers<F, WIDTH>,
+        LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
         StandardUniform: Distribution<[F; WIDTH]>,
     {
         let mut rng = SmallRng::seed_from_u64(1);
@@ -236,7 +236,7 @@ impl<
 
 impl<
     AB: AirBuilder,
-    LinearLayers: GenericPoseidon2LinearLayers<AB::Expr, WIDTH>,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,
     const SBOX_DEGREE: u64,
     const SBOX_REGISTERS: usize,

--- a/poseidon2/src/generic.rs
+++ b/poseidon2/src/generic.rs
@@ -29,14 +29,14 @@ pub fn add_rc_and_sbox_generic<F: Field, A: Algebra<F> + InjectiveMonomial<D>, c
     *val = val.injective_exp_n();
 }
 
-pub trait GenericPoseidon2LinearLayers<R: PrimeCharacteristicRing, const WIDTH: usize>:
-    Sync
-{
-    /// A generic implementation of the internal linear layer.
-    fn internal_linear_layer(state: &mut [R; WIDTH]);
+pub trait GenericPoseidon2LinearLayers<const WIDTH: usize>: Sync {
+    /// A generic implementation of the matrix multiplication
+    /// corresponding to the internal linear layer.
+    fn internal_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; WIDTH]);
 
-    /// A generic implementation of the external linear layer.
-    fn external_linear_layer(state: &mut [R; WIDTH]) {
+    /// A generic implementation of the matrix multiplication
+    /// corresponding to the external linear layer.
+    fn external_linear_layer<R: PrimeCharacteristicRing>(state: &mut [R; WIDTH]) {
         mds_light_permutation(state, &MDSMat4);
     }
 }


### PR DESCRIPTION
Now that `halve` and `div_2_exp_u64` are both part of `PrimeCharacteristicRing` we can update `GenericPoseidon2LinearLayers` to make use of this.

Currently, `GenericPoseidon2LinearLayers<R, WIDTH>` takes `2` parameters and implements the external and internal layer matrix multiplication for arrays of the form `[R; WIDTH]`.

This PR drops the `R` parameter, leaving us with `GenericPoseidon2LinearLayers<WIDTH>` and then has this trait implement external and internal layer matrix multiplication for arrays of the form `[R; WIDTH]` for all `R: PrimeCharacteristicRing`. This is much simpler and leads to not having to implement this trait multiple times.

Propagating the change through to the MontyField31's we can simplify the trait `InternalLayerBaseParameters` as we can now implement the same matrix multiplication for all `R`. The only downside of this is it adds some `.clone()`. Note that when packings are available, the Poseidon2 transformation is done using custom NEON/AVX code so this shouldn't affect speeds.

It should however be a minor speed up to the verifier and any symbolic logic the prover does with Poseidon2.

This should replace the other half of #966.

