### PR TITLE
Must Use

### DIFF
--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -54,6 +54,7 @@ pub(crate) const BN254_MONTY_R_SQ: [u64; 4] = [
 
 /// The BN254 curve scalar field prime, defined as `F_P` where `P = 21888242871839275222246405745257275088548364400416034343698204186575808495617`.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[must_use]
 pub struct Bn254 {
     /// The MONTY form of the field element, a 254-bit integer less than `P` saved as a collection of u64's using a little-endian order.
     pub(crate) value: [u64; 4],

--- a/field/src/array.rs
+++ b/field/src/array.rs
@@ -7,6 +7,7 @@ use crate::{Algebra, Field, PackedValue, PrimeCharacteristicRing};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct FieldArray<F: Field, const N: usize>(pub [F; N]);
 
 impl<F: Field, const N: usize> FieldArray<F, N> {

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -17,6 +17,7 @@ use crate::{FieldArray, PackedValue, PrimeCharacteristicRing};
 /// # Panics
 /// This will panic if any of the inputs is zero.
 #[instrument(level = "debug", skip_all)]
+#[must_use]
 pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
     // How many elements to invert in one thread.
     const CHUNK_SIZE: usize = 1024;

--- a/field/src/coset.rs
+++ b/field/src/coset.rs
@@ -73,6 +73,7 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     ///    shifted
     ///  - `log_size`: the size of the subgroup (and hence of the coset) is `2 ^
     ///    log_size`. This determines the subgroup uniquely.
+    #[must_use]
     pub fn new(shift: F, log_size: usize) -> Option<Self> {
         (shift != F::ZERO && log_size <= F::TWO_ADICITY).then(|| {
             let shift_inverse = shift.inverse();
@@ -86,30 +87,35 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
 
     /// Returns the generator of the subgroup of order `self.size()`.
     #[inline]
+    #[must_use]
     pub fn subgroup_generator(&self) -> F {
         F::two_adic_generator(self.log_size)
     }
 
     /// Returns the shift of the coset.
     #[inline]
+    #[must_use]
     pub const fn shift(&self) -> F {
         self.shift
     }
 
     /// Returns the inverse of the coset shift.
     #[inline]
+    #[must_use]
     pub const fn shift_inverse(&self) -> F {
         self.shift_inverse
     }
 
     /// Returns the log2 of the size of the coset.
     #[inline]
+    #[must_use]
     pub const fn log_size(&self) -> usize {
         self.log_size
     }
 
     /// Returns the size of the coset.
     #[inline]
+    #[must_use]
     pub const fn size(&self) -> usize {
         1 << self.log_size
     }
@@ -119,6 +125,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     /// `2^log_scale_factor`-th power of that of the original coset), leaving
     /// the shift untouched. Note that new coset is contained in the original one.
     /// Returns `None` if `log_scale_factor` is greater than `self.log_size()`.
+    #[inline]
+    #[must_use]
     pub fn shrink_coset(&self, log_scale_factor: usize) -> Option<Self> {
         self.log_size
             .checked_sub(log_scale_factor)
@@ -132,6 +140,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     /// Returns the coset `self^(2^log_scale_factor)` (i. e. with shift and
     /// subgroup generator equal to the `2^log_scale_factor`-th power of the
     /// original ones). Returns `None` if `log_scale_factor` is greater than `self.log_size()`.
+    #[inline]
+    #[must_use]
     pub fn exp_power_of_2(&self, log_scale_factor: usize) -> Option<Self> {
         self.shrink_coset(log_scale_factor).map(|mut coset| {
             coset.shift = self.shift.exp_power_of_2(log_scale_factor);
@@ -141,6 +151,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     }
 
     /// Returns a new coset of the same size whose shift is equal to `scale * self.shift`.
+    #[inline]
+    #[must_use]
     pub fn shift_by(&self, scale: F) -> Self {
         let shift = self.shift * scale;
         Self {
@@ -151,6 +163,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     }
 
     /// Returns a new coset where the shift has been set to `shift`
+    #[inline]
+    #[must_use]
     pub fn set_shift(&self, shift: F) -> Self {
         Self {
             shift,
@@ -160,6 +174,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     }
 
     /// Checks if the given field element is in the coset
+    #[inline]
+    #[must_use]
     pub fn contains(&self, element: F) -> bool {
         // Note that, in a finite field F (this is not true of a general finite
         // commutative ring), there is exactly one subgroup of |F^*| of order n
@@ -187,6 +203,7 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     /// self.size()`-th element of `self` (and, in particular, the `index`-th
     /// element of `self` whenever `index` < self.size()).
     #[inline]
+    #[must_use]
     pub fn element(&mut self, index: usize) -> F {
         self.shift * self.generator_exp(index)
     }
@@ -195,6 +212,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     // square-and-multiply algorithm with the caveat that squares of the
     // generator are queried from the field (which typically should have them
     // stored), i. e. rather "fetch-and-multiply".
+    #[inline]
+    #[must_use]
     fn generator_exp(&self, exp: usize) -> F {
         let mut gen_power = F::ONE;
         // As `generator` satisfies `generator^{self.size()} == 1` we can replace `exp` by `exp mod self.size()`.
@@ -217,6 +236,8 @@ impl<F: TwoAdicField> TwoAdicMultiplicativeCoset<F> {
     /// Returns an iterator over the elements of the coset in the canonical order
     /// `shift * generator^0, shift * generator^1, ...,
     /// shift * generator^(2^log_size - 1)`.
+    #[inline]
+    #[must_use]
     pub fn iter(&self) -> BoundedPowers<F> {
         self.subgroup_generator()
             .shifted_powers(self.shift)

--- a/field/src/exponentiation.rs
+++ b/field/src/exponentiation.rs
@@ -8,6 +8,7 @@ pub(crate) const fn bits_u64(n: u64) -> usize {
 ///
 /// This map computes the fifth root of `x` if `x` is a member of the field `Mersenne31`.
 /// This follows from the computation: `5 * 1717986917 = 4*(2^31 - 2) + 1 = 1 mod p - 1`.
+#[must_use]
 pub fn exp_1717986917<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1717986917 = 1100110011001100110011001100101_2
     // This uses 30 Squares + 7 Multiplications => 37 Operations total.
@@ -32,6 +33,7 @@ pub fn exp_1717986917<R: PrimeCharacteristicRing>(val: R) -> R {
 ///
 /// This map computes the third root of `x` if `x` is a member of the field `KoalaBear`.
 /// This follows from the computation: `3 * 1420470955 = 2*(2^31 - 2^24) + 1 = 1 mod (p - 1)`.
+#[must_use]
 pub fn exp_1420470955<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1420470955 = 1010100101010101010101010101011_2
     // This uses 29 Squares + 7 Multiplications => 36 Operations total.
@@ -56,6 +58,7 @@ pub fn exp_1420470955<R: PrimeCharacteristicRing>(val: R) -> R {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `BabyBear`.
 /// This follows from the computation: `7 * 1725656503 = 6*(2^31 - 2^27) + 1 = 1 mod (p - 1)`.
+#[must_use]
 pub fn exp_1725656503<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 1725656503 = 1100110110110110110110110110111_2
     // This uses 29 Squares + 8 Multiplications => 37 Operations total.
@@ -82,6 +85,7 @@ pub fn exp_1725656503<R: PrimeCharacteristicRing>(val: R) -> R {
 ///
 /// This map computes the seventh root of `x` if `x` is a member of the field `Goldilocks`.
 /// This follows from the computation: `7 * 10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1)`.
+#[must_use]
 pub fn exp_10540996611094048183<R: PrimeCharacteristicRing>(val: R) -> R {
     // Note the binary expansion: 10540996611094048183 = 1001001001001001001001001001000110110110110110110110110110110111_2.
     // This uses 63 Squares + 8 Multiplications => 71 Operations total.

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // Needed to make various casts safe.
+#[must_use]
 pub struct BinomialExtensionField<F, const D: usize, A = F> {
     #[serde(
         with = "p3_util::array_serialization",

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -45,11 +45,13 @@ impl<R: PrimeCharacteristicRing> Complex<R> {
     }
 
     #[inline(always)]
+    #[must_use]
     pub fn real(&self) -> R {
         self.value[0].clone()
     }
 
     #[inline(always)]
+    #[must_use]
     pub fn imag(&self) -> R {
         self.value[1].clone()
     }
@@ -60,17 +62,20 @@ impl<R: PrimeCharacteristicRing> Complex<R> {
     }
 
     #[inline]
+    #[must_use]
     pub fn norm(&self) -> R {
         self.real().square() + self.imag().square()
     }
 
     #[inline(always)]
+    #[must_use]
     pub fn to_array(&self) -> [R; 2] {
         self.value.clone()
     }
 
     // Sometimes we want to rotate over an extension that's not necessarily ComplexExtendable,
     // but still on the circle.
+    #[inline]
     pub fn rotate<Ext: Algebra<R>>(&self, rhs: &Complex<Ext>) -> Complex<Ext> {
         Complex::<Ext>::new_complex(
             rhs.real() * self.real() - rhs.imag() * self.imag(),

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -37,18 +37,37 @@ pub trait BinomiallyExtendable<const D: usize>:
     const EXT_GENERATOR: [Self; D];
 }
 
+/// Trait for algebras which support binomial extensions of the form `A[X]/(X^D - W)`
+/// with `W` in the base field `F`. 
 pub trait BinomiallyExtendableAlgebra<F: Field, const D: usize>: Algebra<F> {
+    /// Multiplication in the algebra extension ring `A<X> / (X^D - W)`.
+    ///
+    /// Some algebras may want to reimplement this with faster methods.
     #[inline]
     fn binomial_mul(a: &[Self; D], b: &[Self; D], res: &mut [Self; D], w: F) {
         binomial_mul::<F, Self, Self, D>(a, b, res, w);
     }
 
+    /// Addition of elements in the algebra extension ring `A<X> / (X^D - W)`.
+    ///
+    /// As addition has no dependence on `W` so this is equivalent
+    /// to an algorithm for adding arrays of elements of `A`.
+    ///
+    /// Some algebras may want to reimplement this with faster methods.
     #[inline]
+    #[must_use]
     fn binomial_add(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
         vector_add(a, b)
     }
 
+    /// Subtraction of elements in the algebra extension ring `A<X> / (X^D - W)`.
+    /// 
+    /// As subtraction has no dependence on `W` so this is equivalent
+    /// to an algorithm for subtracting arrays of elements of `A`.
+    ///
+    /// Some algebras may want to reimplement this with faster methods.
     #[inline]
+    #[must_use]
     fn binomial_sub(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
         vector_sub(a, b)
     }
@@ -64,22 +83,26 @@ pub trait HasFrobenius<F: Field>: ExtensionField<F> {
     /// Apply the Frobenius automorphism once.
     ///
     /// Equivalent to raising the element to the `n`th power.
+    #[must_use]
     fn frobenius(&self) -> Self;
 
     /// Apply the Frobenius automorphism `count` times.
     ///
     /// Equivalent to raising to the `n^count` power.
+    #[must_use]
     fn repeated_frobenius(&self, count: usize) -> Self;
 
     /// Compute the inverse Frobenius map.
     ///
     /// Returns the unique element `y` such that `self = y^n`.
+    #[must_use]
     fn frobenius_inv(&self) -> Self;
 
     /// Returns the full Galois orbit of the element under Frobenius.
     ///
     /// This is the sequence `[x, x^n, x^{n^2}, ..., x^{n^{D-1}}]`,
     /// where `D` is the extension degree.
+    #[must_use]
     fn galois_orbit(self) -> Vec<Self> {
         iter::successors(Some(self), |x| Some(x.frobenius()))
             .take(Self::DIMENSION)
@@ -98,5 +121,6 @@ pub trait HasTwoAdicBinomialExtension<const D: usize>: BinomiallyExtendable<D> {
     ///
     /// This is used to generate the 2^bits-th roots of unity in the extension field.
     /// Behavior is undefined if `bits > EXT_TWO_ADICITY`.
+    #[must_use]
     fn ext_two_adic_generator(bits: usize) -> [Self; D];
 }

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -38,7 +38,7 @@ pub trait BinomiallyExtendable<const D: usize>:
 }
 
 /// Trait for algebras which support binomial extensions of the form `A[X]/(X^D - W)`
-/// with `W` in the base field `F`. 
+/// with `W` in the base field `F`.
 pub trait BinomiallyExtendableAlgebra<F: Field, const D: usize>: Algebra<F> {
     /// Multiplication in the algebra extension ring `A<X> / (X^D - W)`.
     ///
@@ -61,7 +61,7 @@ pub trait BinomiallyExtendableAlgebra<F: Field, const D: usize>: Algebra<F> {
     }
 
     /// Subtraction of elements in the algebra extension ring `A<X> / (X^D - W)`.
-    /// 
+    ///
     /// As subtraction has no dependence on `W` so this is equivalent
     /// to an algorithm for subtracting arrays of elements of `A`.
     ///

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -18,6 +18,7 @@ use crate::{
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
 #[repr(transparent)] // Needed to make various casts safe.
+#[must_use]
 pub struct PackedBinomialExtensionField<F: Field, PF: PackedField<Scalar = F>, const D: usize> {
     #[serde(
         with = "p3_util::array_serialization",

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -113,6 +113,7 @@ pub trait PrimeCharacteristicRing:
     /// `from_prime_subfield([r])` will be equal to:
     ///
     /// `Self::ONE + ... + Self::ONE (r times)`
+    #[must_use]
     fn from_prime_subfield(f: Self::PrimeSubfield) -> Self;
 
     /// Return `Self::ONE` if `b` is `true` and `Self::ZERO` if `b` is `false`.
@@ -142,6 +143,7 @@ pub trait PrimeCharacteristicRing:
     /// # Panics
     /// The function will panic if the field has characteristic 2.
     #[must_use]
+    #[inline]
     fn halve(&self) -> Self {
         // This must be overwritten by PrimeField implementations as this definition
         // is circular when PrimeSubfield = Self. It should also be overwritten by
@@ -981,6 +983,7 @@ impl<R: PrimeCharacteristicRing> Iterator for Powers<R> {
 impl<R: PrimeCharacteristicRing> Powers<R> {
     /// Returns an iterator yielding the first `n` powers.
     #[inline]
+    #[must_use]
     pub fn take(self, n: usize) -> BoundedPowers<R> {
         BoundedPowers { iter: self, n }
     }
@@ -996,6 +999,7 @@ impl<R: PrimeCharacteristicRing> Powers<R> {
 
     /// Wrapper for `self.take(n).collect()`.
     #[inline]
+    #[must_use]
     pub fn collect_n(self, n: usize) -> Vec<R> {
         self.take(n).collect()
     }
@@ -1012,6 +1016,7 @@ impl<F: Field> BoundedPowers<F> {
     /// # Performance
     ///
     /// Enable the `parallel` feature to enable parallelization.
+    #[must_use]
     pub fn collect(self) -> Vec<F> {
         let num_powers = self.n;
 

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -104,6 +104,7 @@ pub fn par_add_scaled_slice_in_place<F: Field>(slice: &mut [F], other: &[F], s: 
 /// Extend a ring `R` element `x` to an array of length `D`
 /// by filling zeros.
 #[inline]
+#[must_use]
 pub const fn field_to_array<R: PrimeCharacteristicRing, const D: usize>(x: R) -> [R; D] {
     let mut arr = [const { MaybeUninit::uninit() }; D];
     arr[0] = MaybeUninit::new(x);
@@ -117,6 +118,7 @@ pub const fn field_to_array<R: PrimeCharacteristicRing, const D: usize>(x: R) ->
 
 /// Given an element x from a 32 bit field F_P compute x/2.
 #[inline]
+#[must_use]
 pub const fn halve_u32<const P: u32>(x: u32) -> u32 {
     let shift = (P + 1) >> 1;
     let half = x >> 1;
@@ -125,6 +127,7 @@ pub const fn halve_u32<const P: u32>(x: u32) -> u32 {
 
 /// Given an element x from a 64 bit field F_P compute x/2.
 #[inline]
+#[must_use]
 pub const fn halve_u64<const P: u64>(x: u64) -> u64 {
     let shift = (P + 1) >> 1;
     let half = x >> 1;
@@ -140,6 +143,7 @@ pub const fn halve_u64<const P: u64>(x: u64) -> u64 {
 ///     \text{reduce\_32}(vals) = \sum_{i=0}^{n-1} a_i \cdot 2^{32i}
 /// \end{equation}
 /// ```
+#[must_use]
 pub fn reduce_32<SF: PrimeField32, TF: PrimeField>(vals: &[SF]) -> TF {
     // If the characteristic of TF is > 2^64, from_int and from_canonical_unchecked act identically
     let base = TF::from_int(1u64 << 32);
@@ -158,6 +162,7 @@ pub fn reduce_32<SF: PrimeField32, TF: PrimeField>(vals: &[SF]) -> TF {
 /// ```
 ///
 /// Pads with zeros if needed.
+#[must_use]
 pub fn split_32<SF: PrimeField, TF: PrimeField32>(val: SF, n: usize) -> Vec<TF> {
     let mut result: Vec<TF> = val
         .as_canonical_biguint()
@@ -173,6 +178,7 @@ pub fn split_32<SF: PrimeField, TF: PrimeField32>(val: SF, n: usize) -> Vec<TF> 
 }
 
 /// Maximally generic dot product.
+#[must_use]
 pub fn dot_product<S, LI, RI>(li: LI, ri: RI) -> S
 where
     LI: Iterator,

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -55,6 +55,7 @@ pub trait QuotientMap<Int>: Sized {
     /// This method is also strongly preferred over `from_canonical_checked/from_canonical_unchecked`.
     /// It will usually be identical when `Int` is a small type, e.g. `u8/u16` and is safer for
     /// larger types.
+    #[must_use]
     fn from_int(int: Int) -> Self;
 
     /// Convert a given integer into an element of the field `ℤ/p`. The input is checked to
@@ -63,6 +64,7 @@ pub trait QuotientMap<Int>: Sized {
     /// - If `Int` is a signed integer type the input must lie in `[-(p - 1)/2, (p - 1)/2]`.
     ///
     /// Return `None` if the input lies outside this range and `Some(val)` otherwise.
+    #[must_use]
     fn from_canonical_checked(int: Int) -> Option<Self>;
 
     /// Convert a given integer into an element of the field `ℤ/p`. The input is guaranteed
@@ -75,6 +77,7 @@ pub trait QuotientMap<Int>: Sized {
     /// # Safety
     /// - If `Int` is an unsigned integer type then the allowed range will include `[0, p - 1]`.
     /// - If `Int` is a signed integer type then the allowed range will include `[-(p - 1)/2, (p - 1)/2]`.
+    #[must_use]
     unsafe fn from_canonical_unchecked(int: Int) -> Self;
 }
 

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -30,6 +30,7 @@ pub(crate) const P: u64 = 0xFFFF_FFFF_0000_0001;
 /// Note that the safety of deriving `Serialize` and `Deserialize` relies on the fact that the internal value can be any u64.
 #[derive(Copy, Clone, Default, Serialize, Deserialize)]
 #[repr(transparent)] // Important for reasoning about memory layout
+#[must_use]
 pub struct Goldilocks {
     /// Not necessarily canonical.
     pub(crate) value: u64,
@@ -44,7 +45,6 @@ impl Goldilocks {
     ///
     /// This is a const version of `.map(Goldilocks::new)`.
     #[inline]
-    #[must_use]
     pub(crate) const fn new_array<const N: usize>(input: [u64; N]) -> [Self; N] {
         let mut output = [Self::ZERO; N];
         let mut i = 0;

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -27,6 +27,7 @@ const WIDTH: usize = 4;
 /// Vectorized AVX2 implementation of `Goldilocks` arithmetic.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedGoldilocksAVX2(pub [Goldilocks; WIDTH]);
 
 impl PackedGoldilocksAVX2 {
@@ -49,7 +50,6 @@ impl PackedGoldilocksAVX2 {
     /// Elements of `Goldilocks` are allowed to be arbitrary u64s so this function
     /// is safe unlike the `Mersenne31/MontyField31` variants.
     #[inline]
-    #[must_use]
     pub(crate) fn from_vector(vector: __m256i) -> Self {
         unsafe {
             // Safety: `__m256i` can be transmuted to `[u64; WIDTH]` (since arrays elements are
@@ -63,7 +63,6 @@ impl PackedGoldilocksAVX2 {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<Goldilocks>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: Goldilocks) -> Self {
         Self([value; WIDTH])
     }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -27,6 +27,7 @@ const WIDTH: usize = 8;
 /// Vectorized AVX512 implementation of `Goldilocks` arithmetic.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedGoldilocksAVX512(pub [Goldilocks; WIDTH]);
 
 impl PackedGoldilocksAVX512 {
@@ -49,7 +50,6 @@ impl PackedGoldilocksAVX512 {
     /// Elements of `Goldilocks` are allowed to be arbitrary u64s so this function
     /// is safe unlike the `Mersenne31/MontyField31` variants.
     #[inline]
-    #[must_use]
     pub(crate) fn from_vector(vector: __m512i) -> Self {
         unsafe {
             // Safety: `__m512i` can be transmuted to `[u64; WIDTH]` (since arrays elements are
@@ -63,7 +63,6 @@ impl PackedGoldilocksAVX512 {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<Goldilocks>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: Goldilocks) -> Self {
         Self([value; WIDTH])
     }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -28,6 +28,7 @@ const P: uint32x4_t = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH])
 /// Vectorized NEON implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMersenne31Neon(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31Neon {
@@ -46,7 +47,6 @@ impl PackedMersenne31Neon {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid
@@ -65,7 +65,6 @@ impl PackedMersenne31Neon {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<Mersenne31>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: Mersenne31) -> Self {
         Self([value; WIDTH])
     }

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -29,6 +29,7 @@ const P: u32 = (1 << 31) - 1;
 /// The prime field `F_p` where `p = 2^31 - 1`.
 #[derive(Copy, Clone, Default)]
 #[repr(transparent)] // Important for reasoning about memory layout.
+#[must_use]
 pub struct Mersenne31 {
     /// Not necessarily canonical, but must fit in 31 bits.
     pub(crate) value: u32,

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -28,6 +28,7 @@ pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff;
 /// Vectorized AVX2 implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMersenne31AVX2(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31AVX2 {
@@ -46,7 +47,6 @@ impl PackedMersenne31AVX2 {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid
@@ -66,7 +66,6 @@ impl PackedMersenne31AVX2 {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<Mersenne31>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: Mersenne31) -> Self {
         Self([value; WIDTH])
     }

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -30,6 +30,7 @@ const ODDS: __mmask16 = 0b1010101010101010;
 /// Vectorized AVX-512F implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMersenne31AVX512(pub [Mersenne31; WIDTH]);
 
 impl PackedMersenne31AVX512 {
@@ -48,7 +49,6 @@ impl PackedMersenne31AVX512 {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid
@@ -68,7 +68,6 @@ impl PackedMersenne31AVX512 {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<Mersenne31>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: Mersenne31) -> Self {
         Self([value; WIDTH])
     }

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -36,6 +36,7 @@ pub trait MontyParametersNeon {
 /// Vectorized NEON implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMontyField31Neon<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
@@ -54,7 +55,6 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid `MontyField31`.
@@ -74,7 +74,6 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<MontyField31>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: MontyField31<PMP>) -> Self {
         Self([value; WIDTH])
     }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -32,6 +32,7 @@ use crate::{FieldParameters, MontyParameters, RelativelyPrimePower, TwoAdicData}
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)] // Important for reasoning about memory layout.
+#[must_use]
 pub struct MontyField31<MP: MontyParameters> {
     /// The MONTY form of the field element, saved as a positive integer less than `P`.
     ///

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -35,6 +35,7 @@ pub trait MontyParametersAVX2 {
 /// Vectorized AVX2 implementation of `MontyField31<FP>` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // This is needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMontyField31AVX2<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31AVX2<PMP> {
@@ -53,7 +54,6 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX2<PMP> {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid `MontyField31<FP>`.
@@ -73,7 +73,6 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX2<PMP> {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<MontyField31<FP>>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: MontyField31<PMP>) -> Self {
         Self([value; WIDTH])
     }

--- a/monty-31/src/x86_64_avx2/poseidon2.rs
+++ b/monty-31/src/x86_64_avx2/poseidon2.rs
@@ -31,7 +31,6 @@ pub struct InternalLayer16<PMP: PackedMontyParameters> {
 
 impl<PMP: PackedMontyParameters> InternalLayer16<PMP> {
     #[inline]
-    #[must_use]
     /// Convert from `InternalLayer16<PMP>` to `[PackedMontyField31AVX2<PMP>; 16]`
     ///
     /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.
@@ -75,7 +74,6 @@ pub struct InternalLayer24<PMP: PackedMontyParameters> {
 
 impl<PMP: PackedMontyParameters> InternalLayer24<PMP> {
     #[inline]
-    #[must_use]
     /// Convert from `InternalLayer24<PMP>` to `[PackedMontyField31AVX2<PMP>; 24]`
     ///
     /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -43,6 +43,7 @@ const EVENS: __mmask16 = 0b0101010101010101;
 /// Vectorized AVX-512F implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)] // Needed to make `transmute`s safe.
+#[must_use]
 pub struct PackedMontyField31AVX512<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {
@@ -61,7 +62,6 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {
     }
 
     #[inline]
-    #[must_use]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid
@@ -81,14 +81,12 @@ impl<PMP: PackedMontyParameters> PackedMontyField31AVX512<PMP> {
     /// Copy `value` to all positions in a packed vector. This is the same as
     /// `From<MontyField31>::from`, but `const`.
     #[inline]
-    #[must_use]
     const fn broadcast(value: MontyField31<PMP>) -> Self {
         Self([value; WIDTH])
     }
 
     /// Copy values from `arr` into the packed vector padding by zeros if necessary.
     #[inline]
-    #[must_use]
     fn from_monty_array<const N: usize>(arr: [MontyField31<PMP>; N]) -> Self
     where
         PMP: FieldParameters,

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -32,7 +32,6 @@ pub struct InternalLayer16<PMP: PackedMontyParameters> {
 
 impl<PMP: PackedMontyParameters> InternalLayer16<PMP> {
     #[inline]
-    #[must_use]
     /// Convert from `InternalLayer16<PMP>` to `[PackedMontyField31AVX512<PMP>; 16]`
     ///
     /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.
@@ -76,7 +75,6 @@ pub struct InternalLayer24<PMP: PackedMontyParameters> {
 
 impl<PMP: PackedMontyParameters> InternalLayer24<PMP> {
     #[inline]
-    #[must_use]
     /// Convert from `InternalLayer24<PMP>` to `[PackedMontyField31AVX512<PMP>; 24]`
     ///
     /// SAFETY: The caller must ensure that each element of `s_hi` represents a valid `MontyField31<PMP>`.


### PR DESCRIPTION
As Robin mentioned in a comment, we are currently a little inconsistent about when we add the `#[must_use]` attribute.

This PR looks at the route where we litter `#[must_use]` on many more things. In particular I went through the Field crate and checked out any public functions which don't modify their inputs and output something.

I also added `#[must_use]` to all of our custom `Field` and `PackedFields`. As far as I can tell there shouldn't ever really be a reason to just throw a computed field element away so if that happens it is likely a bug?