### PR TITLE
Speed Up Base-Extension Multiplication

### DIFF
--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -21,41 +21,41 @@ const L_REPS: usize = 10 * REPS;
 
 fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
-    benchmark_add_throughput::<EF4, REPS>(c, name);
-    benchmark_add_latency::<EF4, L_REPS>(c, name);
-    benchmark_sub_throughput::<EF4, REPS>(c, name);
-    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    // benchmark_add_throughput::<EF4, REPS>(c, name);
+    // benchmark_add_latency::<EF4, L_REPS>(c, name);
+    // benchmark_sub_throughput::<EF4, REPS>(c, name);
+    // benchmark_sub_latency::<EF4, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF4, REPS>(c, name);
-    benchmark_square::<EF4>(c, name);
-    benchmark_inv::<EF4>(c, name);
-    benchmark_mul_throughput::<EF4, REPS>(c, name);
-    benchmark_mul_latency::<EF4, L_REPS>(c, name);
+    // benchmark_square::<EF4>(c, name);
+    // benchmark_inv::<EF4>(c, name);
+    // benchmark_mul_throughput::<EF4, REPS>(c, name);
+    // benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
 fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
-    benchmark_add_throughput::<EF5, REPS>(c, name);
-    benchmark_add_latency::<EF5, L_REPS>(c, name);
-    benchmark_sub_throughput::<EF5, REPS>(c, name);
-    benchmark_sub_latency::<EF5, L_REPS>(c, name);
+    // benchmark_add_throughput::<EF5, REPS>(c, name);
+    // benchmark_add_latency::<EF5, L_REPS>(c, name);
+    // benchmark_sub_throughput::<EF5, REPS>(c, name);
+    // benchmark_sub_latency::<EF5, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF5, REPS>(c, name);
-    benchmark_square::<EF5>(c, name);
-    benchmark_inv::<EF5>(c, name);
-    benchmark_mul_throughput::<EF5, REPS>(c, name);
-    benchmark_mul_latency::<EF5, L_REPS>(c, name);
+    // benchmark_square::<EF5>(c, name);
+    // benchmark_inv::<EF5>(c, name);
+    // benchmark_mul_throughput::<EF5, REPS>(c, name);
+    // benchmark_mul_latency::<EF5, L_REPS>(c, name);
 }
 
 fn bench_octic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 8>";
-    benchmark_add_throughput::<EF8, REPS>(c, name);
-    benchmark_add_latency::<EF8, L_REPS>(c, name);
-    benchmark_sub_throughput::<EF8, REPS>(c, name);
-    benchmark_sub_latency::<EF8, L_REPS>(c, name);
+    // benchmark_add_throughput::<EF8, REPS>(c, name);
+    // benchmark_add_latency::<EF8, L_REPS>(c, name);
+    // benchmark_sub_throughput::<EF8, REPS>(c, name);
+    // benchmark_sub_latency::<EF8, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF8, REPS>(c, name);
-    benchmark_square::<EF8>(c, name);
-    benchmark_inv::<EF8>(c, name);
-    benchmark_mul_throughput::<EF8, REPS>(c, name);
-    benchmark_mul_latency::<EF8, L_REPS>(c, name);
+    // benchmark_square::<EF8>(c, name);
+    // benchmark_inv::<EF8>(c, name);
+    // benchmark_mul_throughput::<EF8, REPS>(c, name);
+    // benchmark_mul_latency::<EF8, L_REPS>(c, name);
 }
 
 criterion_group!(

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -36,8 +36,8 @@ fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
     benchmark_add_throughput::<EF5, REPS>(c, name);
     benchmark_add_latency::<EF5, L_REPS>(c, name);
-    benchmark_sub_throughput::<EF4, REPS>(c, name);
-    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF5, REPS>(c, name);
+    benchmark_sub_latency::<EF5, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF5, REPS>(c, name);
     benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
@@ -49,8 +49,8 @@ fn bench_octic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 8>";
     benchmark_add_throughput::<EF8, REPS>(c, name);
     benchmark_add_latency::<EF8, L_REPS>(c, name);
-    benchmark_sub_throughput::<EF4, REPS>(c, name);
-    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF8, REPS>(c, name);
+    benchmark_sub_latency::<EF8, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF8, REPS>(c, name);
     benchmark_square::<EF8>(c, name);
     benchmark_inv::<EF8>(c, name);

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -6,7 +6,7 @@ use p3_field_testing::bench_func::{
     benchmark_mul_throughput, benchmark_square,
 };
 use p3_field_testing::{
-    benchmark_base_mul_throughput, benchmark_sub_latency, benchmark_sub_throughput,
+    benchmark_base_mul_latency, benchmark_base_mul_throughput, benchmark_sub_latency, benchmark_sub_throughput
 };
 
 type F = BabyBear;
@@ -26,6 +26,7 @@ fn bench_quartic_extension(c: &mut Criterion) {
     benchmark_sub_throughput::<EF4, REPS>(c, name);
     benchmark_sub_latency::<EF4, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF4, REPS>(c, name);
+    benchmark_base_mul_latency::<F, EF4, L_REPS>(c, name);
     benchmark_square::<EF4>(c, name);
     benchmark_inv::<EF4>(c, name);
     benchmark_mul_throughput::<EF4, REPS>(c, name);
@@ -39,6 +40,7 @@ fn bench_qunitic_extension(c: &mut Criterion) {
     benchmark_sub_throughput::<EF5, REPS>(c, name);
     benchmark_sub_latency::<EF5, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF5, REPS>(c, name);
+    benchmark_base_mul_latency::<F, EF5, L_REPS>(c, name);
     benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);
@@ -52,6 +54,7 @@ fn bench_octic_extension(c: &mut Criterion) {
     benchmark_sub_throughput::<EF8, REPS>(c, name);
     benchmark_sub_latency::<EF8, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF8, REPS>(c, name);
+    benchmark_base_mul_latency::<F, EF8, L_REPS>(c, name);
     benchmark_square::<EF8>(c, name);
     benchmark_inv::<EF8>(c, name);
     benchmark_mul_throughput::<EF8, REPS>(c, name);

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -6,7 +6,8 @@ use p3_field_testing::bench_func::{
     benchmark_mul_throughput, benchmark_square,
 };
 use p3_field_testing::{
-    benchmark_base_mul_latency, benchmark_base_mul_throughput, benchmark_sub_latency, benchmark_sub_throughput
+    benchmark_base_mul_latency, benchmark_base_mul_throughput, benchmark_sub_latency,
+    benchmark_sub_throughput,
 };
 
 type F = BabyBear;

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -1,11 +1,15 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
-use p3_field_testing::bench_func::{
-    benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_mul_latency,
-    benchmark_mul_throughput, benchmark_square,
+use p3_field_testing::{
+    bench_func::{
+        benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_mul_latency,
+        benchmark_mul_throughput, benchmark_square,
+    },
+    benchmark_base_mul_throughput, benchmark_sub_latency, benchmark_sub_throughput,
 };
 
+type F = BabyBear;
 type EF4 = BinomialExtensionField<BabyBear, 4>;
 type EF5 = BinomialExtensionField<BabyBear, 5>;
 type EF8 = BinomialExtensionField<BabyBear, 8>;
@@ -19,6 +23,9 @@ fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
     benchmark_add_throughput::<EF4, REPS>(c, name);
     benchmark_add_latency::<EF4, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF4, REPS>(c, name);
+    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_base_mul_throughput::<F, EF4, REPS>(c, name);
     benchmark_square::<EF4>(c, name);
     benchmark_inv::<EF4>(c, name);
     benchmark_mul_throughput::<EF4, REPS>(c, name);
@@ -29,6 +36,9 @@ fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
     benchmark_add_throughput::<EF5, REPS>(c, name);
     benchmark_add_latency::<EF5, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF4, REPS>(c, name);
+    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_base_mul_throughput::<F, EF5, REPS>(c, name);
     benchmark_square::<EF5>(c, name);
     benchmark_inv::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);
@@ -39,6 +49,9 @@ fn bench_octic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 8>";
     benchmark_add_throughput::<EF8, REPS>(c, name);
     benchmark_add_latency::<EF8, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF4, REPS>(c, name);
+    benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_base_mul_throughput::<F, EF8, REPS>(c, name);
     benchmark_square::<EF8>(c, name);
     benchmark_inv::<EF8>(c, name);
     benchmark_mul_throughput::<EF8, REPS>(c, name);

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -1,11 +1,11 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
+use p3_field_testing::bench_func::{
+    benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_mul_latency,
+    benchmark_mul_throughput, benchmark_square,
+};
 use p3_field_testing::{
-    bench_func::{
-        benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_mul_latency,
-        benchmark_mul_throughput, benchmark_square,
-    },
     benchmark_base_mul_throughput, benchmark_sub_latency, benchmark_sub_throughput,
 };
 

--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -21,41 +21,41 @@ const L_REPS: usize = 10 * REPS;
 
 fn bench_quartic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 4>";
-    // benchmark_add_throughput::<EF4, REPS>(c, name);
-    // benchmark_add_latency::<EF4, L_REPS>(c, name);
-    // benchmark_sub_throughput::<EF4, REPS>(c, name);
-    // benchmark_sub_latency::<EF4, L_REPS>(c, name);
+    benchmark_add_throughput::<EF4, REPS>(c, name);
+    benchmark_add_latency::<EF4, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF4, REPS>(c, name);
+    benchmark_sub_latency::<EF4, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF4, REPS>(c, name);
-    // benchmark_square::<EF4>(c, name);
-    // benchmark_inv::<EF4>(c, name);
-    // benchmark_mul_throughput::<EF4, REPS>(c, name);
-    // benchmark_mul_latency::<EF4, L_REPS>(c, name);
+    benchmark_square::<EF4>(c, name);
+    benchmark_inv::<EF4>(c, name);
+    benchmark_mul_throughput::<EF4, REPS>(c, name);
+    benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
 fn bench_qunitic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
-    // benchmark_add_throughput::<EF5, REPS>(c, name);
-    // benchmark_add_latency::<EF5, L_REPS>(c, name);
-    // benchmark_sub_throughput::<EF5, REPS>(c, name);
-    // benchmark_sub_latency::<EF5, L_REPS>(c, name);
+    benchmark_add_throughput::<EF5, REPS>(c, name);
+    benchmark_add_latency::<EF5, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF5, REPS>(c, name);
+    benchmark_sub_latency::<EF5, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF5, REPS>(c, name);
-    // benchmark_square::<EF5>(c, name);
-    // benchmark_inv::<EF5>(c, name);
-    // benchmark_mul_throughput::<EF5, REPS>(c, name);
-    // benchmark_mul_latency::<EF5, L_REPS>(c, name);
+    benchmark_square::<EF5>(c, name);
+    benchmark_inv::<EF5>(c, name);
+    benchmark_mul_throughput::<EF5, REPS>(c, name);
+    benchmark_mul_latency::<EF5, L_REPS>(c, name);
 }
 
 fn bench_octic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 8>";
-    // benchmark_add_throughput::<EF8, REPS>(c, name);
-    // benchmark_add_latency::<EF8, L_REPS>(c, name);
-    // benchmark_sub_throughput::<EF8, REPS>(c, name);
-    // benchmark_sub_latency::<EF8, L_REPS>(c, name);
+    benchmark_add_throughput::<EF8, REPS>(c, name);
+    benchmark_add_latency::<EF8, L_REPS>(c, name);
+    benchmark_sub_throughput::<EF8, REPS>(c, name);
+    benchmark_sub_latency::<EF8, L_REPS>(c, name);
     benchmark_base_mul_throughput::<F, EF8, REPS>(c, name);
-    // benchmark_square::<EF8>(c, name);
-    // benchmark_inv::<EF8>(c, name);
-    // benchmark_mul_throughput::<EF8, REPS>(c, name);
-    // benchmark_mul_latency::<EF8, L_REPS>(c, name);
+    benchmark_square::<EF8>(c, name);
+    benchmark_inv::<EF8>(c, name);
+    benchmark_mul_throughput::<EF8, REPS>(c, name);
+    benchmark_mul_latency::<EF8, L_REPS>(c, name);
 }
 
 criterion_group!(

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -384,6 +384,29 @@ pub fn benchmark_mul_throughput<R: PrimeCharacteristicRing + Copy, const N: usiz
     });
 }
 
+pub fn benchmark_base_mul_latency<F: Field, A: Algebra<F> + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    StandardUniform: Distribution<F> + Distribution<A>,
+{
+    c.bench_function(&format!("base_mul-latency/{N} {name}"), |b| {
+        b.iter_batched(
+            || {
+                let mut rng = SmallRng::seed_from_u64(1);
+                let mut vec = Vec::new();
+                for _ in 0..N {
+                    vec.push(rng.random::<F>())
+                }
+                let init_val = rng.random::<A>();
+                (vec, init_val)
+            },
+            |(x, init_val)| x.iter().fold(init_val, |x, y| x * *y),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
 pub fn benchmark_base_mul_throughput<F: Field, A: Algebra<F> + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use core::hint::black_box;
 
 use criterion::{BatchSize, Criterion};
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, PrimeCharacteristicRing};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 use rand::rngs::SmallRng;
@@ -375,6 +375,67 @@ pub fn benchmark_mul_throughput<R: PrimeCharacteristicRing + Copy, const N: usiz
                         h * i,
                         i * j,
                         j * a,
+                    );
+                }
+                (a, b, c, d, e, f, g, h, i, j)
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn benchmark_base_mul_throughput<F: Field, A: Algebra<F> + Copy, const N: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    StandardUniform: Distribution<F> + Distribution<A>,
+{
+    c.bench_function(&format!("base_mul-throughput/{N} {name}"), |b| {
+        b.iter_batched(
+            || {
+                let mut rng = SmallRng::seed_from_u64(1);
+                let a_tuple = (
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                    rng.random::<A>(),
+                );
+                let f_tuple = (
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                    rng.random::<F>(),
+                );
+                (a_tuple, f_tuple)
+            },
+            |(
+                (mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j),
+                (a_f, b_f, c_f, d_f, e_f, f_f, g_f, h_f, i_f, j_f),
+            )| {
+                for _ in 0..N {
+                    (a, b, c, d, e, f, g, h, i, j) = (
+                        a * a_f,
+                        b * b_f,
+                        c * c_f,
+                        d * d_f,
+                        e * e_f,
+                        f * f_f,
+                        g * g_f,
+                        h * h_f,
+                        i * i_f,
+                        j * j_f,
                     );
                 }
                 (a, b, c, d, e, f, g, h, i, j)

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -533,7 +533,7 @@ where
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(self.value.map(|x| x * rhs.clone()))
+        Self::new(A::binomial_base_mul(self.value, rhs))
     }
 }
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -52,6 +52,11 @@ pub trait BinomiallyExtendableAlgebra<F: Field, const D: usize>: Algebra<F> {
     fn binomial_sub(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
         vector_sub(a, b)
     }
+
+    #[inline]
+    fn binomial_base_mul(lhs: [Self; D], rhs: Self) -> [Self; D] {
+        lhs.map(|x| x * rhs.clone())
+    }
 }
 
 /// Trait for extension fields that support Frobenius automorphisms.

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -582,3 +582,43 @@ pub(crate) fn octic_mul_packed<FP, const WIDTH: usize>(
     res[..4].copy_from_slice(&dot_0);
     res[4..].copy_from_slice(&dot_1);
 }
+
+/// Multiplication by a base field element in a binomial extension field.
+#[inline]
+pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
+    a: [MontyField31<FP>; WIDTH],
+    b: MontyField31<FP>,
+    res: &mut [MontyField31<FP>; WIDTH],
+) where
+    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+{
+    match WIDTH {
+        1 => res[0] = a[0] * b,
+        4 => {
+            let lhs = PackedMontyField31Neon([a[0], a[1], a[2], a[3]]);
+
+            let out = lhs * b;
+
+            res.copy_from_slice(&out.0[..4]);
+        }
+        5 => {
+            let lhs = PackedMontyField31Neon([a[0], a[1], a[2], a[3]]);
+
+            let out = lhs * b;
+            res[4] = a[4] * b;
+
+            res[..4].copy_from_slice(&out.0[..4]);
+        }
+        8 => {
+            let lhs_lo = PackedMontyField31Neon([a[0], a[1], a[2], a[3]]);
+            let lhs_hi = PackedMontyField31Neon([a[4], a[5], a[6], a[7]]);
+
+            let out_lo = lhs_lo * b;
+            let out_hi = lhs_hi * b;
+
+            res[..4].copy_from_slice(&out_lo.0);
+            res[4..].copy_from_slice(&out_hi.0);
+        }
+        _ => panic!("Unsupported binomial extension degree: {}", WIDTH),
+    }
+}

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -7,8 +7,8 @@ use p3_field::{
 
 use crate::utils::{add, sub};
 use crate::{
-    BinomialExtensionData, FieldParameters, MontyField31, TwoAdicData, octic_mul_packed,
-    quartic_mul_packed, quintic_mul_packed,
+    BinomialExtensionData, FieldParameters, MontyField31, TwoAdicData, base_mul_packed,
+    octic_mul_packed, quartic_mul_packed, quintic_mul_packed,
 };
 
 // If a field implements BinomialExtensionData<WIDTH> then there is a natural
@@ -61,6 +61,13 @@ where
 
             packed_mod_sub(a, b, res, FP::PRIME, sub::<FP>);
         }
+        res
+    }
+
+    #[inline(always)]
+    fn binomial_base_mul(lhs: [Self; WIDTH], rhs: Self) -> [Self; WIDTH] {
+        let mut res = [Self::ZERO; WIDTH];
+        base_mul_packed(lhs, rhs, &mut res);
         res
     }
 }

--- a/monty-31/src/no_packing/mod.rs
+++ b/monty-31/src/no_packing/mod.rs
@@ -42,3 +42,15 @@ pub(crate) fn octic_mul_packed<FP, const WIDTH: usize>(
 {
     octic_mul(a, b, res, FP::W);
 }
+
+/// Multiplication by a base field element in a binomial extension field.
+#[inline]
+pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
+    a: [MontyField31<FP>; WIDTH],
+    b: MontyField31<FP>,
+    res: &mut [MontyField31<FP>; WIDTH],
+) where
+    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+{
+    res.iter_mut().zip(a.iter()).for_each(|(r, a)| *r = *a * b);
+}

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -1224,3 +1224,42 @@ pub(crate) fn octic_mul_packed<FP, const WIDTH: usize>(
 
     res[..].copy_from_slice(&dot);
 }
+
+/// Multiplication by a base field element in a binomial extension field.
+#[inline]
+pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
+    a: [MontyField31<FP>; WIDTH],
+    b: MontyField31<FP>,
+    res: &mut [MontyField31<FP>; WIDTH],
+) where
+    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+{
+    match WIDTH {
+        1 => res[0] = a[0] * b,
+        4 => {
+            let zero = MontyField31::<FP>::ZERO;
+            let lhs = PackedMontyField31AVX2([a[0], a[1], a[2], a[3], zero, zero, zero, zero]);
+
+            let out = lhs * b;
+
+            res.copy_from_slice(&out.0[..4]);
+        }
+        5 => {
+            let zero = MontyField31::<FP>::ZERO;
+            let lhs = PackedMontyField31AVX2([a[0], a[1], a[2], a[3], zero, zero, zero, zero]);
+
+            let out = lhs * b;
+            res[4] = a[4] * b;
+
+            res[..4].copy_from_slice(&out.0[..4]);
+        }
+        8 => {
+            let lhs = PackedMontyField31AVX2([a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]]);
+
+            let out = lhs * b;
+
+            res.copy_from_slice(&out.0);
+        }
+        _ => panic!("Unsupported binomial extension degree: {}", WIDTH),
+    }
+}

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -4,7 +4,7 @@
 
 use alloc::vec::Vec;
 use core::arch::asm;
-use core::arch::x86_64::{self, __m256i, __m512i, __mmask16, __mmask8};
+use core::arch::x86_64::{self, __m256i, __m512i, __mmask8, __mmask16};
 use core::array;
 use core::hint::unreachable_unchecked;
 use core::iter::{Product, Sum};
@@ -336,7 +336,7 @@ fn confuse_compiler(x: __m512i) -> __m512i {
 }
 
 /// No-op. Prevents the compiler from deducing the value of the vector.
-/// 
+///
 /// A variant of [`confuse_compiler`] for use with `__m256i` vectors.
 ///
 /// Similar to `core::hint::black_box`, it can be used to stop the compiler applying undesirable
@@ -579,7 +579,7 @@ fn mul<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
 }
 
 /// Multiply a vector of unsigned field elements by a single field element.
-/// 
+///
 /// Return a vector of unsigned field elements lying in [0, P).
 ///
 /// Note that the input does not need to be in canonical form but must satisfy
@@ -1549,7 +1549,8 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
             // Surprisingly, the current version is only slightly faster than:
             // res.iter_mut().zip(a.iter()).for_each(|(r, a)| *r = *a * b);
             let out: [MontyField31<FP>; 8] = unsafe {
-                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, 0, 0, 0, 0]);
+                let lhs: __m256i =
+                    transmute([a[0].value, a[1].value, a[2].value, a[3].value, 0, 0, 0, 0]);
                 let prod = mul_256::<FP>(lhs, b.value as i32);
                 transmute(prod)
             };
@@ -1559,7 +1560,9 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
         5 => {
             // This could likely be sped up by a completely custom implementation of mul.
             let out: [MontyField31<FP>; 8] = unsafe {
-                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, 0, 0, 0]);
+                let lhs: __m256i = transmute([
+                    a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, 0, 0, 0,
+                ]);
                 let prod = mul_256::<FP>(lhs, b.value as i32);
                 transmute(prod)
             };
@@ -1569,7 +1572,10 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
         8 => {
             // This could likely be sped up by a completely custom implementation of mul.
             let out: [MontyField31<FP>; 8] = unsafe {
-                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, a[5].value, a[6].value, a[7].value]);
+                let lhs: __m256i = transmute([
+                    a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, a[5].value,
+                    a[6].value, a[7].value,
+                ]);
                 let prod = mul_256::<FP>(lhs, b.value as i32);
                 transmute(prod)
             };

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -4,7 +4,7 @@
 
 use alloc::vec::Vec;
 use core::arch::asm;
-use core::arch::x86_64::{self, __m512i, __mmask16};
+use core::arch::x86_64::{self, __m256i, __m512i, __mmask16, __mmask8};
 use core::array;
 use core::hint::unreachable_unchecked;
 use core::iter::{Product, Sum};
@@ -39,6 +39,7 @@ pub trait MontyParametersAVX512 {
 }
 
 const EVENS: __mmask16 = 0b0101010101010101;
+const EVENS_8: __mmask8 = 0b01010101;
 
 /// Vectorized AVX-512F implementation of `MontyField31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -334,6 +335,34 @@ fn confuse_compiler(x: __m512i) -> __m512i {
     y
 }
 
+/// No-op. Prevents the compiler from deducing the value of the vector.
+/// 
+/// A variant of [`confuse_compiler`] for use with `__m256i` vectors.
+///
+/// Similar to `core::hint::black_box`, it can be used to stop the compiler applying undesirable
+/// "optimizations". Unlike the built-in `black_box`, it does not force the value to be written to
+/// and then read from the stack.
+#[inline]
+#[must_use]
+fn confuse_compiler_256(x: __m256i) -> __m256i {
+    let y;
+    unsafe {
+        asm!(
+            "/*{0}*/",
+            inlateout(ymm_reg) x => y,
+            options(nomem, nostack, preserves_flags, pure),
+        );
+        // Below tells the compiler the semantics of this so it can still do constant folding, etc.
+        // You may ask, doesn't it defeat the point of the inline asm block to tell the compiler
+        // what it does? The answer is that we still inhibit the transform we want to avoid, so
+        // apparently not. Idk, LLVM works in mysterious ways.
+        if transmute::<__m256i, [u32; 8]>(x) != transmute::<__m256i, [u32; 8]>(y) {
+            unreachable_unchecked();
+        }
+    }
+    y
+}
+
 // MONTGOMERY MULTIPLICATION
 //   This implementation is based on [1] but with minor changes. The reduction is as follows:
 //
@@ -408,6 +437,20 @@ fn movehdup_epi32(a: __m512i) -> __m512i {
     }
 }
 
+/// Viewing the input as a vector of 8 `u32`s, copy the odd elements into the even elements below
+/// them. In other words, for all `0 <= i < 4`, set the even elements according to
+/// `res[2 * i] := a[2 * i + 1]`, and the odd elements according to
+/// `res[2 * i + 1] := a[2 * i + 1]`.
+#[inline]
+#[must_use]
+fn movehdup_epi32_256(a: __m256i) -> __m256i {
+    // The instruction is only available in the floating-point flavor; this distinction is only for
+    // historical reasons and no longer matters. We cast to floats, do the thing, and cast back.
+    unsafe {
+        x86_64::_mm256_castps_si256(x86_64::_mm256_movehdup_ps(x86_64::_mm256_castsi256_ps(a)))
+    }
+}
+
 /// Viewing `a` as a vector of 16 `u32`s, copy the odd elements into the even elements below them,
 /// then merge with `src` according to the mask provided. In other words, for all `0 <= i < 8`, set
 /// the even elements according to `res[2 * i] := if k[2 * i] { a[2 * i + 1] } else { src[2 * i] }`,
@@ -429,6 +472,33 @@ fn mask_movehdup_epi32(src: __m512i, k: __mmask16, a: __m512i) -> __m512i {
             src_dst = inlateout(zmm_reg) src => dst,
             k = in(kreg) k,
             a = in(zmm_reg) a,
+            options(nomem, nostack, preserves_flags, pure),
+        );
+        dst
+    }
+}
+
+/// Viewing `a` as a vector of 8 `u32`s, copy the odd elements into the even elements below them,
+/// then merge with `src` according to the mask provided. In other words, for all `0 <= i < 4`, set
+/// the even elements according to `res[2 * i] := if k[2 * i] { a[2 * i + 1] } else { src[2 * i] }`,
+/// and the odd elements according to
+/// `res[2 * i + 1] := if k[2 * i + 1] { a[2 * i + 1] } else { src[2 * i + 1] }`.
+#[inline]
+#[must_use]
+fn mask_movehdup_epi32_256(src: __m256i, k: __mmask8, a: __m256i) -> __m256i {
+    // The instruction is only available in the floating-point flavor; this distinction is only for
+    // historical reasons and no longer matters.
+
+    // While we can write this using intrinsics, when inlined, the intrinsic often compiles
+    // to a vpermt2ps which has worse latency, see https://godbolt.org/z/489aaPhz3.
+    // Hence we use inline assembly to force the compiler to do the right thing.
+    unsafe {
+        let dst: __m256i;
+        asm!(
+            "vmovshdup {src_dst}{{{k}}}, {a}",
+            src_dst = inlateout(ymm_reg) src => dst,
+            k = in(kreg) k,
+            a = in(ymm_reg) a,
             options(nomem, nostack, preserves_flags, pure),
         );
         dst
@@ -505,6 +575,79 @@ fn mul<MPAVX512: MontyParametersAVX512>(lhs: __m512i, rhs: __m512i) -> __m512i {
         let underflow = x86_64::_mm512_cmplt_epu32_mask(prod_hi, q_p_hi);
         let t = x86_64::_mm512_sub_epi32(prod_hi, q_p_hi);
         x86_64::_mm512_mask_add_epi32(t, underflow, t, MPAVX512::PACKED_P)
+    }
+}
+
+/// Multiply a vector of unsigned field elements by a single field element.
+/// 
+/// Return a vector of unsigned field elements lying in [0, P).
+///
+/// Note that the input does not need to be in canonical form but must satisfy
+/// the bound `lhs * rhs < 2^32 * P`. If this bound is not satisfied, the result
+/// is undefined.
+#[inline]
+#[must_use]
+fn mul_256<MPAVX512: MontyParametersAVX512>(lhs: __m256i, rhs: i32) -> __m256i {
+    // We want this to compile to:
+    //      vmovshdup  lhs_odd, lhs
+    //      vpbroadcastd  rhs, rhs
+    //      vpmuludq   prod_evn, lhs, rhs
+    //      vpmuludq   prod_hi, lhs_odd, rhs_odd
+    //      vpmuludq   q_evn, prod_evn, MU
+    //      vpmuludq   q_odd, prod_hi, MU
+    //      vmovshdup  prod_hi{EVENS}, prod_evn
+    //      vpmuludq   q_p_evn, q_evn, P
+    //      vpmuludq   q_p_hi, q_odd, P
+    //      vmovshdup  q_p_hi{EVENS}, q_p_evn
+    //      vpcmpltud  underflow, prod_hi, q_p_hi
+    //      vpsubd     res, prod_hi, q_p_hi
+    //      vpaddd     res{underflow}, res, P
+    // throughput: 6.5 cyc/vec (2.46 els/cyc)
+    // latency: 21 cyc
+    unsafe {
+        // `vpmuludq` only reads the even doublewords, so when we pass `lhs` directly we
+        // get the four products at even positions.
+        let lhs_evn = lhs;
+        let rhs = x86_64::_mm256_set1_epi32(rhs);
+
+        // Copy the odd doublewords into even positions to compute the four products at odd
+        // positions.
+        // NB: The odd doublewords are ignored by `vpmuludq`, so we have a lot of choices for how to
+        // do this; `vmovshdup` is nice because it runs on a memory port if the operand is in
+        // memory, thus improving our throughput.
+        let lhs_odd = movehdup_epi32_256(lhs);
+
+        let prod_evn = x86_64::_mm256_mul_epu32(lhs_evn, rhs);
+        let prod_odd = x86_64::_mm256_mul_epu32(lhs_odd, rhs);
+
+        let mu_256 = x86_64::_mm512_castsi512_si256(MPAVX512::PACKED_MU);
+        let q_evn = confuse_compiler_256(x86_64::_mm256_mul_epu32(prod_evn, mu_256));
+        let q_odd = confuse_compiler_256(x86_64::_mm256_mul_epu32(prod_odd, mu_256));
+
+        // Get all the high halves as one vector: this is `(lhs * rhs) >> 32`.
+        // NB: `vpermt2d` may feel like a more intuitive choice here, but it has much higher
+        // latency.
+        let prod_hi = mask_movehdup_epi32_256(prod_odd, EVENS_8, prod_evn);
+
+        // Normally we'd want to mask to perform % 2**32, but the instruction below only reads the
+        // low 32 bits anyway.
+        let p_256 = x86_64::_mm512_castsi512_si256(MPAVX512::PACKED_P);
+        let q_p_evn = x86_64::_mm256_mul_epu32(q_evn, p_256);
+        let q_p_odd = x86_64::_mm256_mul_epu32(q_odd, p_256);
+
+        // We can ignore all the low halves of `q_p` as they cancel out. Get all the high halves as
+        // one vector.
+        let q_p_hi = mask_movehdup_epi32_256(q_p_odd, EVENS_8, q_p_evn);
+
+        // Subtraction `prod_hi - q_p_hi` modulo `P`.
+        // NB: Normally we'd `vpaddd P` and take the `vpminud`, but `vpminud` runs on port 0, which
+        // is already under a lot of pressure performing multiplications. To relieve this pressure,
+        // we check for underflow to generate a mask, and then conditionally add `P`. The underflow
+        // check runs on port 5, increasing our throughput, although it does cost us an additional
+        // cycle of latency.
+        let underflow = x86_64::_mm256_cmplt_epu32_mask(prod_hi, q_p_hi);
+        let t = x86_64::_mm256_sub_epi32(prod_hi, q_p_hi);
+        x86_64::_mm256_mask_add_epi32(t, underflow, t, p_256)
     }
 }
 
@@ -1402,38 +1545,36 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
     match WIDTH {
         1 => res[0] = a[0] * b,
         4 => {
-            let zero = MontyField31::<FP>::ZERO;
-            let lhs = PackedMontyField31AVX512([
-                a[0], a[1], a[2], a[3], zero, zero, zero, zero, zero, zero, zero, zero, zero, zero,
-                zero, zero,
-            ]);
+            // This could likely be sped up by a completely custom implementation of mul.
+            // Surprisingly, the current version is only slightly faster than:
+            // res.iter_mut().zip(a.iter()).for_each(|(r, a)| *r = *a * b);
+            let out: [MontyField31<FP>; 8] = unsafe {
+                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, 0, 0, 0, 0]);
+                let prod = mul_256::<FP>(lhs, b.value as i32);
+                transmute(prod)
+            };
 
-            let out = lhs * b;
-
-            res.copy_from_slice(&out.0[..4]);
+            res.copy_from_slice(&out[..4]);
         }
         5 => {
-            let zero = MontyField31::<FP>::ZERO;
-            let lhs = PackedMontyField31AVX512([
-                a[0], a[1], a[2], a[3], zero, zero, zero, zero, zero, zero, zero, zero, zero, zero,
-                zero, zero,
-            ]);
+            // This could likely be sped up by a completely custom implementation of mul.
+            let out: [MontyField31<FP>; 8] = unsafe {
+                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, 0, 0, 0]);
+                let prod = mul_256::<FP>(lhs, b.value as i32);
+                transmute(prod)
+            };
 
-            let out = lhs * b;
-            res[4] = a[4] * b;
-
-            res[..4].copy_from_slice(&out.0[..4]);
+            res.copy_from_slice(&out[..5]);
         }
         8 => {
-            let zero = MontyField31::<FP>::ZERO;
-            let lhs = PackedMontyField31AVX512([
-                a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], zero, zero, zero, zero, zero, zero,
-                zero, zero,
-            ]);
+            // This could likely be sped up by a completely custom implementation of mul.
+            let out: [MontyField31<FP>; 8] = unsafe {
+                let lhs: __m256i = transmute([a[0].value, a[1].value, a[2].value, a[3].value, a[4].value, a[5].value, a[6].value, a[7].value]);
+                let prod = mul_256::<FP>(lhs, b.value as i32);
+                transmute(prod)
+            };
 
-            let out = lhs * b;
-
-            res.copy_from_slice(&out.0);
+            res.copy_from_slice(&out);
         }
         _ => panic!("Unsupported binomial extension degree: {}", WIDTH),
     }


### PR DESCRIPTION
Same idea as #988 and #980 but for base x extension multiplication.

It would be nice to do a small refactor letting us use `AVX2` and `AVX512` code at the same time but that will have to be a larger PR. Ideally the AVX512 code here should really just be using the AVX2 code instead of padding by zeroes a lot.

At any rate, we seem to get around a `2-2.5x` speed up to throughput on AVX2 for sizes `4, 5, 8`.
Surprisingly, for AVX512 this gives basically no speed up in the `4` case and only about a `1.5x` speed up in the `8` case. Probably due to the scalar code being vectorized by the compiler more efficiently for some reason? Might be related to the fact that there are too few field elements to really efficiently pack into 512 bit vector, or this could also be an indication that the benchmark I'm using is a little dodgy.

I check latency measurements and we do seem to be getting a small speed up there in all cases so I think it's still worth merging but just a shame the improvement is so much smaller on AVX512.
