### PR TITLE
Thread safe dft

### DIFF
--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -18,6 +18,7 @@ p3-util.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 parking_lot = "0.12.4"
+rayon.workspace = true
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/dft/Cargo.toml
+++ b/dft/Cargo.toml
@@ -17,6 +17,7 @@ p3-util.workspace = true
 
 itertools.workspace = true
 tracing.workspace = true
+parking_lot = "0.12.4"
 
 [dev-dependencies]
 p3-baby-bear.workspace = true

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -11,6 +11,7 @@ use p3_util::pretty_name;
 use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
+use rayon::prelude::*;
 
 fn bench_fft(c: &mut Criterion) {
     // log_sizes correspond to the sizes of DFT we want to benchmark;
@@ -38,6 +39,10 @@ fn bench_fft(c: &mut Criterion) {
     m31_fft::<Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
     m31_fft::<Mersenne31ComplexRadix2Dit, BATCH_SIZE>(c, log_sizes);
 
+    const TOTAL_COLS: usize = 8192;
+    fft_on_the_fly::<Goldilocks, Radix2Dit<_>, TOTAL_COLS, BATCH_SIZE>(c, log_sizes);
+    fft_on_the_fly::<Goldilocks, Radix2DitParallel<_>, TOTAL_COLS, BATCH_SIZE>(c, log_sizes);
+
     ifft::<Goldilocks, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
 
     coset_lde::<BabyBear, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
@@ -55,6 +60,42 @@ fn bench_fft(c: &mut Criterion) {
     fft_algebra::<BabyBear, BBExt, Radix2Dit<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
     fft_algebra::<BabyBear, BBExt, Radix2DitParallel<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
     fft_algebra::<BabyBear, BBExt, RecursiveDft<_>, EXT_BATCH_SIZE>(c, ext_log_sizes);
+}
+
+fn fft_on_the_fly<F: Ord, Dft, const TOTAL_COLS: usize, const BATCH_SIZE: usize>(
+    c: &mut Criterion,
+    log_sizes: &[usize],
+) where
+    F: TwoAdicField,
+    Dft: TwoAdicSubgroupDft<F>,
+    StandardUniform: Distribution<F>,
+{
+    let mut group = c.benchmark_group(format!(
+        "fft_on_the_fly/{}/{}/ncols={}/batch_size={}",
+        pretty_name::<F>(),
+        pretty_name::<Dft>(),
+        TOTAL_COLS,
+        BATCH_SIZE
+    ));
+    group.sample_size(10);
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for n_log in log_sizes {
+        let n = 1 << n_log;
+
+        let messages_vec: Vec<RowMajorMatrix<F>> = (0..(TOTAL_COLS / BATCH_SIZE))
+            .map(|_| RowMajorMatrix::rand(&mut rng, n, BATCH_SIZE))
+            .collect();
+
+        let dft = Radix2DitParallel::<F>::default();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
+            b.iter(|| {
+                messages_vec.clone().par_iter().for_each(|messages| {
+                    dft.dft_batch(messages.clone());
+                });
+            });
+        });
+    }
 }
 
 fn fft<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion, log_sizes: &[usize])

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -26,3 +26,4 @@ rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 transpose.workspace = true
+parking_lot = "0.12.4"


### PR DESCRIPTION
The use of `RefCell` in many DFT implementations prevents sharing across threads (`RefCell` is `!Sync`). This has been noted in the code several times:
https://github.com/Plonky3/Plonky3/blob/9200da320029aa7b3dee281c1a0af89bf788d428/dft/src/radix_2_small_batch.rs#L42-L44
https://github.com/Plonky3/Plonky3/blob/9200da320029aa7b3dee281c1a0af89bf788d428/monty-31/src/dft/mod.rs#L49-L51

This PR makes the DFTs thread-safe by placing internal state (e.g., twiddle caches) behind `Arc<RwLock<…>>`. It also adds a simple Rayon-based benchmark that runs multiple batched DFTs in parallel.