### PR TITLE
chore(fri): remove unused Debug import from hiding_pcs.rs

### DIFF
--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use core::cell::RefCell;
-use core::fmt::Debug;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};


### PR DESCRIPTION
Remove use core::fmt::Debug; from fri/src/hiding_pcs.rs because it is not referenced anywhere in the file. The #[derive(Debug)] on other types does not require bringing Debug into scope, and this file does not use Debug as a trait bound or otherwise. This avoids an unused import warning and keeps imports minimal.

Ran cargo check -p p3-fri: build green.