### PR TITLE
fix: Use absolute tolerance in pow2_no_std and absolute error in log2_no_std test

### DIFF
--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -31,7 +31,7 @@ fn pow2_no_std(x: f32, tol: f32) -> f32 {
     let mut two_pow_x = t;
     for i in 1.. {
         t *= y / (i as f32);
-        if t < tol {
+        if t.abs() < tol {
             break;
         }
         two_pow_x += t;
@@ -106,7 +106,7 @@ mod test {
             7.409391, 7.491853, 7.569856, 7.643856,
         ];
         for (&x, y) in inputs.iter().zip(expected) {
-            assert!((log2_no_std(x) - y) < TOLERANCE);
+            assert!((log2_no_std(x) - y).abs() < TOLERANCE);
         }
     }
 }


### PR DESCRIPTION
Reason: For x < 0, the Taylor series terms in pow2_no_std alternate in sign. The previous early-exit condition t < tol could stop prematurely on negative terms, violating the documented |y − 2^x| < tol guarantee and risking larger error. The test for log2_no_std also compared signed error, which could mask negative deviations.


Changes:
- Update pow2_no_std to break on t.abs() < tol to enforce the documented absolute error criterion and ensure correctness for negative inputs.
- Update test_log2_no_std to assert on absolute error (…) .abs() < TOLERANCE.


Goal: Align implementation with documentation, improve numerical robustness, and prevent false-positive tests.


Impact: No API changes; no behavior change for current call sites (they pass non-negative x); tests remain green.