### PR TITLE
koalabear: add default poseidon constants

### DIFF
--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -18,7 +18,7 @@ use p3_monty_31::{
     GenericPoseidon2LinearLayersMonty31, InternalLayerBaseParameters, InternalLayerParameters,
     Poseidon2ExternalLayerMonty31, Poseidon2InternalLayerMonty31,
 };
-use p3_poseidon2::Poseidon2;
+use p3_poseidon2::{ExternalLayerConstants, Poseidon2};
 
 use crate::{KoalaBear, KoalaBearParameters};
 
@@ -53,6 +53,157 @@ pub type Poseidon2KoalaBear<const WIDTH: usize> = Poseidon2<
 /// to use `Poseidon2KoalaBear<WIDTH>` instead of building a Poseidon2 permutation using this.
 pub type GenericPoseidon2LinearLayersKoalaBear =
     GenericPoseidon2LinearLayersMonty31<KoalaBearParameters, KoalaBearInternalLayerParameters>;
+
+/// Initial round constants for the 16-width Poseidon2 external layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC16_EXTERNAL_INITIAL: [[KoalaBear; 16]; 4] = KoalaBear::new_2d_array([
+    [
+        2128964168, 288780357, 316938561, 2126233899, 426817493, 1714118888, 1045008582,
+        1738510837, 889721787, 8866516, 681576474, 419059826, 1596305521, 1583176088, 1584387047,
+        1529751136,
+    ],
+    [
+        1863858111, 1072044075, 517831365, 1464274176, 1138001621, 428001039, 245709561,
+        1641420379, 1365482496, 770454828, 693167409, 757905735, 136670447, 436275702, 525466355,
+        1559174242,
+    ],
+    [
+        1030087950, 869864998, 322787870, 267688717, 948964561, 740478015, 679816114, 113662466,
+        2066544572, 1744924186, 367094720, 1380455578, 1842483872, 416711434, 1342291586,
+        1692058446,
+    ],
+    [
+        1493348999, 1113949088, 210900530, 1071655077, 610242121, 1136339326, 2020858841,
+        1019840479, 678147278, 1678413261, 1361743414, 61132629, 1209546658, 64412292, 1936878279,
+        1980661727,
+    ],
+]);
+
+/// Final round constants for the 16-width Poseidon2's external layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC16_EXTERNAL_FINAL: [[KoalaBear; 16]; 4] = KoalaBear::new_2d_array([
+    [
+        1423960925, 2101391318, 1915532054, 275400051, 1168624859, 1141248885, 356546469,
+        1165250474, 1320543726, 932505663, 1204226364, 1452576828, 1774936729, 926808140,
+        1184948056, 1186493834,
+    ],
+    [
+        843181003, 185193011, 452207447, 510054082, 1139268644, 630873441, 669538875, 462500858,
+        876500520, 1214043330, 383937013, 375087302, 636912601, 307200505, 390279673, 1999916485,
+    ],
+    [
+        1518476730, 1606686591, 1410677749, 1581191572, 1004269969, 143426723, 1747283099,
+        1016118214, 1749423722, 66331533, 1177761275, 1581069649, 1851371119, 852520128,
+        1499632627, 1820847538,
+    ],
+    [
+        150757557, 884787840, 619710451, 1651711087, 505263814, 212076987, 1482432120, 1458130652,
+        382871348, 417404007, 2066495280, 1996518884, 902934924, 582892981, 1337064375, 1199354861,
+    ],
+]);
+
+/// Round constants for the 16-width Poseidon2's internal layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC16_INTERNAL: [KoalaBear; 20] = KoalaBear::new_array([
+    2102596038, 1533193853, 1436311464, 2012303432, 839997195, 1225781098, 2011967775, 575084315,
+    1309329169, 786393545, 995788880, 1702925345, 1444525226, 908073383, 1811535085, 1531002367,
+    1635653662, 1585100155, 867006515, 879151050,
+]);
+
+/// A default Poseidon2 for KoalaBear using the round constants from the original specification.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub fn default_koalabear_poseidon2_16() -> Poseidon2KoalaBear<16> {
+    Poseidon2::new(
+        ExternalLayerConstants::new(
+            KOALABEAR_RC16_EXTERNAL_INITIAL.to_vec(),
+            KOALABEAR_RC16_EXTERNAL_FINAL.to_vec(),
+        ),
+        KOALABEAR_RC16_INTERNAL.to_vec(),
+    )
+}
+
+/// Initial round constants for the 24-width Poseidon2 external layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC24_EXTERNAL_INITIAL: [[KoalaBear; 24]; 4] = KoalaBear::new_2d_array([
+    [
+        487143900, 1829048205, 1652578477, 646002781, 1044144830, 53279448, 1519499836, 22697702,
+        1768655004, 230479744, 1484895689, 705130286, 1429811285, 1695785093, 1417332623,
+        1115801016, 1048199020, 878062617, 738518649, 249004596, 1601837737, 24601614, 245692625,
+        364803730,
+    ],
+    [
+        1857019234, 1906668230, 1916890890, 835590867, 557228239, 352829675, 515301498, 973918075,
+        954515249, 1142063750, 1795549558, 608869266, 1850421928, 2028872854, 1197543771,
+        1027240055, 1976813168, 963257461, 652017844, 2113212249, 213459679, 90747280, 1540619478,
+        324138382,
+    ],
+    [
+        1377377119, 294744504, 512472871, 668081958, 907306515, 518526882, 1907091534, 1152942192,
+        1572881424, 720020214, 729527057, 1762035789, 86171731, 205890068, 453077400, 1201344594,
+        986483134, 125174298, 2050269685, 1895332113, 749706654, 40566555, 742540942, 1735551813,
+    ],
+    [
+        162985276, 1943496073, 1469312688, 703013107, 1979485151, 1278193166, 548674995,
+        2118718736, 749596440, 1476142294, 1293606474, 918523452, 890353212, 1691895663,
+        1932240646, 1180911992, 86098300, 1592168978, 895077289, 724819849, 1697986774, 1608418116,
+        1083269213, 691256798,
+    ],
+]);
+
+/// Final round constants for the 24-width Poseidon2's external layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC24_EXTERNAL_FINAL: [[KoalaBear; 24]; 4] = KoalaBear::new_2d_array([
+    [
+        328586442, 1572520009, 1375479591, 322991001, 967600467, 1172861548, 1973891356,
+        1503625929, 1881993531, 40601941, 1155570620, 571547775, 1361622243, 1495024047,
+        1733254248, 964808915, 763558040, 1887228519, 994888261, 718330940, 213359415, 603124968,
+        1038411577, 2099454809,
+    ],
+    [
+        949846777, 630926956, 1168723439, 222917504, 1527025973, 1009157017, 2029957881, 805977836,
+        1347511739, 540019059, 589807745, 440771316, 1530063406, 761076336, 87974206, 1412686751,
+        1230318064, 514464425, 1469011754, 1770970737, 1510972858, 965357206, 209398053, 778802532,
+    ],
+    [
+        40567006, 1984217577, 1545851069, 879801839, 1611910970, 1215591048, 330802499, 1051639108,
+        321036, 511927202, 591603098, 1775897642, 115598532, 278200718, 233743176, 525096211,
+        1335507608, 830017835, 1380629279, 560028578, 598425701, 302162385, 567434115, 1859222575,
+    ],
+    [
+        958294793, 1582225556, 1781487858, 1570246000, 1067748446, 526608119, 1666453343,
+        1786918381, 348203640, 1860035017, 1489902626, 1904576699, 860033965, 1954077639,
+        1685771567, 971513929, 1877873770, 137113380, 520695829, 806829080, 1408699405, 1613277964,
+        793223662, 648443918,
+    ],
+]);
+
+/// Round constants for the 24-width Poseidon2's internal layer on KoalaBear.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub const KOALABEAR_RC24_INTERNAL: [KoalaBear; 23] = KoalaBear::new_array([
+    893435011, 403879071, 1363789863, 1662900517, 2043370, 2109755796, 931751726, 2091644718,
+    606977583, 185050397, 946157136, 1350065230, 1625860064, 122045240, 880989921, 145137438,
+    1059782436, 1477755661, 335465138, 1640704282, 1757946479, 1551204074, 681266718,
+]);
+
+/// A default Poseidon2 for KoalaBear using the round constants from the original specification.
+///
+/// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+pub fn default_koalabear_poseidon2_24() -> Poseidon2KoalaBear<24> {
+    Poseidon2::new(
+        ExternalLayerConstants::new(
+            KOALABEAR_RC24_EXTERNAL_INITIAL.to_vec(),
+            KOALABEAR_RC24_EXTERNAL_FINAL.to_vec(),
+        ),
+        KOALABEAR_RC24_INTERNAL.to_vec(),
+    )
+}
 
 /// Contains data needed to define the internal layers of the Poseidon2 permutation.
 #[derive(Debug, Clone, Default)]

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -119,6 +119,7 @@ pub const KOALABEAR_RC16_INTERNAL: [KoalaBear; 20] = KoalaBear::new_array([
 /// A default Poseidon2 for KoalaBear using the round constants from the original specification.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub fn default_koalabear_poseidon2_16() -> Poseidon2KoalaBear<16> {
     Poseidon2::new(
         ExternalLayerConstants::new(
@@ -201,6 +202,7 @@ pub const KOALABEAR_RC24_INTERNAL: [KoalaBear; 23] = KoalaBear::new_array([
 /// A default Poseidon2 for KoalaBear using the round constants from the original specification.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub fn default_koalabear_poseidon2_24() -> Poseidon2KoalaBear<24> {
     Poseidon2::new(
         ExternalLayerConstants::new(

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -57,6 +57,7 @@ pub type GenericPoseidon2LinearLayersKoalaBear =
 /// Initial round constants for the 16-width Poseidon2 external layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC16_EXTERNAL_INITIAL: [[KoalaBear; 16]; 4] = KoalaBear::new_2d_array([
     [
         2128964168, 288780357, 316938561, 2126233899, 426817493, 1714118888, 1045008582,
@@ -83,6 +84,7 @@ pub const KOALABEAR_RC16_EXTERNAL_INITIAL: [[KoalaBear; 16]; 4] = KoalaBear::new
 /// Final round constants for the 16-width Poseidon2's external layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC16_EXTERNAL_FINAL: [[KoalaBear; 16]; 4] = KoalaBear::new_2d_array([
     [
         1423960925, 2101391318, 1915532054, 275400051, 1168624859, 1141248885, 356546469,
@@ -107,6 +109,7 @@ pub const KOALABEAR_RC16_EXTERNAL_FINAL: [[KoalaBear; 16]; 4] = KoalaBear::new_2
 /// Round constants for the 16-width Poseidon2's internal layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC16_INTERNAL: [KoalaBear; 20] = KoalaBear::new_array([
     2102596038, 1533193853, 1436311464, 2012303432, 839997195, 1225781098, 2011967775, 575084315,
     1309329169, 786393545, 995788880, 1702925345, 1444525226, 908073383, 1811535085, 1531002367,
@@ -129,6 +132,7 @@ pub fn default_koalabear_poseidon2_16() -> Poseidon2KoalaBear<16> {
 /// Initial round constants for the 24-width Poseidon2 external layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC24_EXTERNAL_INITIAL: [[KoalaBear; 24]; 4] = KoalaBear::new_2d_array([
     [
         487143900, 1829048205, 1652578477, 646002781, 1044144830, 53279448, 1519499836, 22697702,
@@ -158,6 +162,7 @@ pub const KOALABEAR_RC24_EXTERNAL_INITIAL: [[KoalaBear; 24]; 4] = KoalaBear::new
 /// Final round constants for the 24-width Poseidon2's external layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC24_EXTERNAL_FINAL: [[KoalaBear; 24]; 4] = KoalaBear::new_2d_array([
     [
         328586442, 1572520009, 1375479591, 322991001, 967600467, 1172861548, 1973891356,
@@ -186,6 +191,7 @@ pub const KOALABEAR_RC24_EXTERNAL_FINAL: [[KoalaBear; 24]; 4] = KoalaBear::new_2
 /// Round constants for the 24-width Poseidon2's internal layer on KoalaBear.
 ///
 /// See Poseidon paper for more details: https://eprint.iacr.org/2019/458
+/// Sage script used to generate these constants: https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
 pub const KOALABEAR_RC24_INTERNAL: [KoalaBear; 23] = KoalaBear::new_array([
     893435011, 403879071, 1363789863, 1662900517, 2043370, 2109755796, 931751726, 2091644718,
     606977583, 185050397, 946157136, 1350065230, 1625860064, 122045240, 880989921, 145137438,


### PR DESCRIPTION
This is done according to this Python spec https://github.com/leanEthereum/leanSpec/pull/6 where the round constants are produced according to the official paper.

@khovratovich Do we have an official public repo or something like this to link in the doc for the interested reader to be able to generate again the constants by himself?

I've used this Python script to check that the constants here in Rust correspond exactly to what we have in the Python spec:

```python
from typing import List

# Reference constants from your provided Python file
_RAW_CONSTANTS_16: List[int] = [
    2128964168,
    288780357,
    316938561,
    2126233899,
    426817493,
    1714118888,
    1045008582,
    1738510837,
    889721787,
    8866516,
    681576474,
    419059826,
    1596305521,
    1583176088,
    1584387047,
    1529751136,
    1863858111,
    1072044075,
    517831365,
    1464274176,
    1138001621,
    428001039,
    245709561,
    1641420379,
    1365482496,
    770454828,
    693167409,
    757905735,
    136670447,
    436275702,
    525466355,
    1559174242,
    1030087950,
    869864998,
    322787870,
    267688717,
    948964561,
    740478015,
    679816114,
    113662466,
    2066544572,
    1744924186,
    367094720,
    1380455578,
    1842483872,
    416711434,
    1342291586,
    1692058446,
    1493348999,
    1113949088,
    210900530,
    1071655077,
    610242121,
    1136339326,
    2020858841,
    1019840479,
    678147278,
    1678413261,
    1361743414,
    61132629,
    1209546658,
    64412292,
    1936878279,
    1980661727,
    1423960925,
    2101391318,
    1915532054,
    275400051,
    1168624859,
    1141248885,
    356546469,
    1165250474,
    1320543726,
    932505663,
    1204226364,
    1452576828,
    1774936729,
    926808140,
    1184948056,
    1186493834,
    843181003,
    185193011,
    452207447,
    510054082,
    1139268644,
    630873441,
    669538875,
    462500858,
    876500520,
    1214043330,
    383937013,
    375087302,
    636912601,
    307200505,
    390279673,
    1999916485,
    1518476730,
    1606686591,
    1410677749,
    1581191572,
    1004269969,
    143426723,
    1747283099,
    1016118214,
    1749423722,
    66331533,
    1177761275,
    1581069649,
    1851371119,
    852520128,
    1499632627,
    1820847538,
    150757557,
    884787840,
    619710451,
    1651711087,
    505263814,
    212076987,
    1482432120,
    1458130652,
    382871348,
    417404007,
    2066495280,
    1996518884,
    902934924,
    582892981,
    1337064375,
    1199354861,
    2102596038,
    1533193853,
    1436311464,
    2012303432,
    839997195,
    1225781098,
    2011967775,
    575084315,
    1309329169,
    786393545,
    995788880,
    1702925345,
    1444525226,
    908073383,
    1811535085,
    1531002367,
    1635653662,
    1585100155,
    867006515,
    879151050,
]

_RAW_CONSTANTS_24: List[int] = [
    487143900,
    1829048205,
    1652578477,
    646002781,
    1044144830,
    53279448,
    1519499836,
    22697702,
    1768655004,
    230479744,
    1484895689,
    705130286,
    1429811285,
    1695785093,
    1417332623,
    1115801016,
    1048199020,
    878062617,
    738518649,
    249004596,
    1601837737,
    24601614,
    245692625,
    364803730,
    1857019234,
    1906668230,
    1916890890,
    835590867,
    557228239,
    352829675,
    515301498,
    973918075,
    954515249,
    1142063750,
    1795549558,
    608869266,
    1850421928,
    2028872854,
    1197543771,
    1027240055,
    1976813168,
    963257461,
    652017844,
    2113212249,
    213459679,
    90747280,
    1540619478,
    324138382,
    1377377119,
    294744504,
    512472871,
    668081958,
    907306515,
    518526882,
    1907091534,
    1152942192,
    1572881424,
    720020214,
    729527057,
    1762035789,
    86171731,
    205890068,
    453077400,
    1201344594,
    986483134,
    125174298,
    2050269685,
    1895332113,
    749706654,
    40566555,
    742540942,
    1735551813,
    162985276,
    1943496073,
    1469312688,
    703013107,
    1979485151,
    1278193166,
    548674995,
    2118718736,
    749596440,
    1476142294,
    1293606474,
    918523452,
    890353212,
    1691895663,
    1932240646,
    1180911992,
    86098300,
    1592168978,
    895077289,
    724819849,
    1697986774,
    1608418116,
    1083269213,
    691256798,
    328586442,
    1572520009,
    1375479591,
    322991001,
    967600467,
    1172861548,
    1973891356,
    1503625929,
    1881993531,
    40601941,
    1155570620,
    571547775,
    1361622243,
    1495024047,
    1733254248,
    964808915,
    763558040,
    1887228519,
    994888261,
    718330940,
    213359415,
    603124968,
    1038411577,
    2099454809,
    949846777,
    630926956,
    1168723439,
    222917504,
    1527025973,
    1009157017,
    2029957881,
    805977836,
    1347511739,
    540019059,
    589807745,
    440771316,
    1530063406,
    761076336,
    87974206,
    1412686751,
    1230318064,
    514464425,
    1469011754,
    1770970737,
    1510972858,
    965357206,
    209398053,
    778802532,
    40567006,
    1984217577,
    1545851069,
    879801839,
    1611910970,
    1215591048,
    330802499,
    1051639108,
    321036,
    511927202,
    591603098,
    1775897642,
    115598532,
    278200718,
    233743176,
    525096211,
    1335507608,
    830017835,
    1380629279,
    560028578,
    598425701,
    302162385,
    567434115,
    1859222575,
    958294793,
    1582225556,
    1781487858,
    1570246000,
    1067748446,
    526608119,
    1666453343,
    1786918381,
    348203640,
    1860035017,
    1489902626,
    1904576699,
    860033965,
    1954077639,
    1685771567,
    971513929,
    1877873770,
    137113380,
    520695829,
    806829080,
    1408699405,
    1613277964,
    793223662,
    648443918,
    893435011,
    403879071,
    1363789863,
    1662900517,
    2043370,
    2109755796,
    931751726,
    2091644718,
    606977583,
    185050397,
    946157136,
    1350065230,
    1625860064,
    122045240,
    880989921,
    145137438,
    1059782436,
    1477755661,
    335465138,
    1640704282,
    1757946479,
    1551204074,
    681266718,
]

# Rust code constants to be flattened
rust_rc16_external_initial = [
    [
        2128964168,
        288780357,
        316938561,
        2126233899,
        426817493,
        1714118888,
        1045008582,
        1738510837,
        889721787,
        8866516,
        681576474,
        419059826,
        1596305521,
        1583176088,
        1584387047,
        1529751136,
    ],
    [
        1863858111,
        1072044075,
        517831365,
        1464274176,
        1138001621,
        428001039,
        245709561,
        1641420379,
        1365482496,
        770454828,
        693167409,
        757905735,
        136670447,
        436275702,
        525466355,
        1559174242,
    ],
    [
        1030087950,
        869864998,
        322787870,
        267688717,
        948964561,
        740478015,
        679816114,
        113662466,
        2066544572,
        1744924186,
        367094720,
        1380455578,
        1842483872,
        416711434,
        1342291586,
        1692058446,
    ],
    [
        1493348999,
        1113949088,
        210900530,
        1071655077,
        610242121,
        1136339326,
        2020858841,
        1019840479,
        678147278,
        1678413261,
        1361743414,
        61132629,
        1209546658,
        64412292,
        1936878279,
        1980661727,
    ],
]

rust_rc16_external_final = [
    [
        1423960925,
        2101391318,
        1915532054,
        275400051,
        1168624859,
        1141248885,
        356546469,
        1165250474,
        1320543726,
        932505663,
        1204226364,
        1452576828,
        1774936729,
        926808140,
        1184948056,
        1186493834,
    ],
    [
        843181003,
        185193011,
        452207447,
        510054082,
        1139268644,
        630873441,
        669538875,
        462500858,
        876500520,
        1214043330,
        383937013,
        375087302,
        636912601,
        307200505,
        390279673,
        1999916485,
    ],
    [
        1518476730,
        1606686591,
        1410677749,
        1581191572,
        1004269969,
        143426723,
        1747283099,
        1016118214,
        1749423722,
        66331533,
        1177761275,
        1581069649,
        1851371119,
        852520128,
        1499632627,
        1820847538,
    ],
    [
        150757557,
        884787840,
        619710451,
        1651711087,
        505263814,
        212076987,
        1482432120,
        1458130652,
        382871348,
        417404007,
        2066495280,
        1996518884,
        902934924,
        582892981,
        1337064375,
        1199354861,
    ],
]

rust_rc16_internal = [
    2102596038,
    1533193853,
    1436311464,
    2012303432,
    839997195,
    1225781098,
    2011967775,
    575084315,
    1309329169,
    786393545,
    995788880,
    1702925345,
    1444525226,
    908073383,
    1811535085,
    1531002367,
    1635653662,
    1585100155,
    867006515,
    879151050,
]

rust_rc24_external_initial = [
    [
        487143900,
        1829048205,
        1652578477,
        646002781,
        1044144830,
        53279448,
        1519499836,
        22697702,
        1768655004,
        230479744,
        1484895689,
        705130286,
        1429811285,
        1695785093,
        1417332623,
        1115801016,
        1048199020,
        878062617,
        738518649,
        249004596,
        1601837737,
        24601614,
        245692625,
        364803730,
    ],
    [
        1857019234,
        1906668230,
        1916890890,
        835590867,
        557228239,
        352829675,
        515301498,
        973918075,
        954515249,
        1142063750,
        1795549558,
        608869266,
        1850421928,
        2028872854,
        1197543771,
        1027240055,
        1976813168,
        963257461,
        652017844,
        2113212249,
        213459679,
        90747280,
        1540619478,
        324138382,
    ],
    [
        1377377119,
        294744504,
        512472871,
        668081958,
        907306515,
        518526882,
        1907091534,
        1152942192,
        1572881424,
        720020214,
        729527057,
        1762035789,
        86171731,
        205890068,
        453077400,
        1201344594,
        986483134,
        125174298,
        2050269685,
        1895332113,
        749706654,
        40566555,
        742540942,
        1735551813,
    ],
    [
        162985276,
        1943496073,
        1469312688,
        703013107,
        1979485151,
        1278193166,
        548674995,
        2118718736,
        749596440,
        1476142294,
        1293606474,
        918523452,
        890353212,
        1691895663,
        1932240646,
        1180911992,
        86098300,
        1592168978,
        895077289,
        724819849,
        1697986774,
        1608418116,
        1083269213,
        691256798,
    ],
]

rust_rc24_external_final = [
    [
        328586442,
        1572520009,
        1375479591,
        322991001,
        967600467,
        1172861548,
        1973891356,
        1503625929,
        1881993531,
        40601941,
        1155570620,
        571547775,
        1361622243,
        1495024047,
        1733254248,
        964808915,
        763558040,
        1887228519,
        994888261,
        718330940,
        213359415,
        603124968,
        1038411577,
        2099454809,
    ],
    [
        949846777,
        630926956,
        1168723439,
        222917504,
        1527025973,
        1009157017,
        2029957881,
        805977836,
        1347511739,
        540019059,
        589807745,
        440771316,
        1530063406,
        761076336,
        87974206,
        1412686751,
        1230318064,
        514464425,
        1469011754,
        1770970737,
        1510972858,
        965357206,
        209398053,
        778802532,
    ],
    [
        40567006,
        1984217577,
        1545851069,
        879801839,
        1611910970,
        1215591048,
        330802499,
        1051639108,
        321036,
        511927202,
        591603098,
        1775897642,
        115598532,
        278200718,
        233743176,
        525096211,
        1335507608,
        830017835,
        1380629279,
        560028578,
        598425701,
        302162385,
        567434115,
        1859222575,
    ],
    [
        958294793,
        1582225556,
        1781487858,
        1570246000,
        1067748446,
        526608119,
        1666453343,
        1786918381,
        348203640,
        1860035017,
        1489902626,
        1904576699,
        860033965,
        1954077639,
        1685771567,
        971513929,
        1877873770,
        137113380,
        520695829,
        806829080,
        1408699405,
        1613277964,
        793223662,
        648443918,
    ],
]

rust_rc24_internal = [
    893435011,
    403879071,
    1363789863,
    1662900517,
    2043370,
    2109755796,
    931751726,
    2091644718,
    606977583,
    185050397,
    946157136,
    1350065230,
    1625860064,
    122045240,
    880989921,
    145137438,
    1059782436,
    1477755661,
    335465138,
    1640704282,
    1757946479,
    1551204074,
    681266718,
]


# Flattening function
def flatten_list(nested_list: List[List[int]]):
    """Flattens a list of lists into a single list."""
    return [item for sublist in nested_list for item in sublist]


# Flatten Rust constants
flat_rc16_external = flatten_list(rust_rc16_external_initial) + flatten_list(
    rust_rc16_external_final
)

flat_rc24_external = flatten_list(rust_rc24_external_initial) + flatten_list(
    rust_rc24_external_final
)


# Combine and compare
def compare_constants():
    """Compares the flattened Rust constants with the Python reference."""
    # Combine the external and internal constants from the Rust data
    rust_combined_16 = flat_rc16_external + rust_rc16_internal
    rust_combined_24 = flat_rc24_external + rust_rc24_internal

    # Check for equality
    is_16_equal = rust_combined_16 == _RAW_CONSTANTS_16
    is_24_equal = rust_combined_24 == _RAW_CONSTANTS_24

    print(
        f"Comparison for Width 16: {'✅ Matched' if is_16_equal else '❌ Mismatched'}"
    )
    print(
        f"Comparison for Width 24: {'✅ Matched' if is_24_equal else '❌ Mismatched'}"
    )

    if not is_16_equal:
        # Find the first mismatch for debugging
        for i, (py_val, rust_val) in enumerate(
            zip(_RAW_CONSTANTS_16, rust_combined_16, strict=False)
        ):
            if py_val != rust_val:
                print(
                    f"Width 16 Mismatch at index {i}: Python value is {py_val}, Rust value is {rust_val}"
                )
                break

    if not is_24_equal:
        # Find the first mismatch for debugging
        for i, (py_val, rust_val) in enumerate(
            zip(_RAW_CONSTANTS_24, rust_combined_24, strict=False)
        ):
            if py_val != rust_val:
                print(
                    f"Width 24 Mismatch at index {i}: Python value is {py_val}, Rust value is {rust_val}"
                )
                break


if __name__ == "__main__":
    compare_constants()
```

