### PR TITLE
Compile Time asserts 

### DIFF
--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -92,8 +92,8 @@ macro_rules! quotient_map_small_internals {
         \n Due to the integer type, the input value is always canonical.")]
         #[inline]
         fn from_int(int: $small_int) -> Self {
-            // Should be removed by the compiler.
-            assert!(size_of::<$small_int>() < size_of::<$field_size>());
+            // Check at compile time.
+            const { assert!(size_of::<$small_int>() < size_of::<$field_size>()); }
             unsafe {
                 Self::from_canonical_unchecked(int as $field_size)
             }
@@ -103,8 +103,8 @@ macro_rules! quotient_map_small_internals {
         \n Due to the integer type, the input value is always canonical.")]
         #[inline]
         fn from_canonical_checked(int: $small_int) -> Option<Self> {
-            // Should be removed by the compiler.
-            assert!(size_of::<$small_int>() < size_of::<$field_size>());
+            // Check at compile time.
+            const { assert!(size_of::<$small_int>() < size_of::<$field_size>()); }
             Some(unsafe {
                 Self::from_canonical_unchecked(int as $field_size)
             })
@@ -114,8 +114,8 @@ macro_rules! quotient_map_small_internals {
         \n Due to the integer type, the input value is always canonical.")]
         #[inline]
         unsafe fn from_canonical_unchecked(int: $small_int) -> Self {
-            // We use debug_assert to ensure this is removed by the compiler in release mode.
-            debug_assert!(size_of::<$small_int>() < size_of::<$field_size>());
+            // Check at compile time.
+            const { assert!(size_of::<$small_int>() < size_of::<$field_size>()); }
             unsafe {
                 Self::from_canonical_unchecked(int as $field_size)
             }
@@ -149,8 +149,8 @@ macro_rules! quotient_map_small_internals {
 ///     /// Due to the integer type, the input value is always canonical.
 ///     #[inline]
 ///     fn from_int(int: u8) -> Mersenne31 {
-///         // Should be removed by the compiler.
-///         assert!(size_of::<u8>() < size_of::<u32>());
+///         // Check at compile time.
+///         const { assert!(size_of::<u8>() < size_of::<u32>()); }
 ///         unsafe {
 ///             Self::from_canonical_unchecked(int as u32)
 ///         }
@@ -161,8 +161,8 @@ macro_rules! quotient_map_small_internals {
 ///     /// Due to the integer type, the input value is always canonical.
 ///     #[inline]
 ///     fn from_canonical_checked(int: u8) -> Option<Mersenne31> {
-///         // Should be removed by the compiler.
-///         assert!(size_of::<u8>() < size_of::<u32>());
+///         // Check at compile time.
+///         const { assert!(size_of::<u8>() < size_of::<u32>()); }
 ///         Some(unsafe {
 ///             Self::from_canonical_unchecked(int as u32)
 ///         })
@@ -173,8 +173,8 @@ macro_rules! quotient_map_small_internals {
 ///     /// Due to the integer type, the input value is always canonical.
 ///     #[inline]
 ///     unsafe fn from_canonical_unchecked(int: u8) -> Mersenne31 {
-///         // We use debug_assert to ensure this is removed by the compiler in release mode.
-///         debug_assert!(size_of::<u8>() < size_of::<u32>());
+///         // Check at compile time.
+///         const { assert!(size_of::<u8>() < size_of::<u32>()); }
 ///         unsafe {
 ///             Self::from_canonical_unchecked(int as u32)
 ///         }
@@ -229,8 +229,8 @@ macro_rules! quotient_map_small_int {
 ///     /// This should be avoided in performance critical locations.
 ///     #[inline]
 ///     fn from_int(int: u128) -> Mersenne31 {
-///         // Should be removed by the compiler.
-///         assert!(size_of::<u128>() > size_of::<u32>());
+///         // Check at compile time.
+///         const { assert!(size_of::<u128>() > size_of::<u32>()); }
 ///         let red = (int % (Mersenne31::ORDER_U32 as u128)) as u32;
 ///            unsafe {
 ///                // This is safe as red is less than the field order by assumption.
@@ -274,7 +274,7 @@ macro_rules! quotient_map_large_uint {
                 \n Uses a modular reduction to reduce to canonical form. \n This should be avoided in performance critical locations.")]
             #[inline]
             fn from_int(int: $large_int) -> $field {
-                assert!(size_of::<$large_int>() > size_of::<$field_size>());
+                const { assert!(size_of::<$large_int>() > size_of::<$field_size>()); }
                 let red = (int % ($field_order as $large_int)) as $field_size;
                 unsafe {
                     // This is safe as red is less than the field order by assumption.

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -62,7 +62,9 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[must_use]
     fn pack_slice(buf: &[Self::Value]) -> &[Self] {
         // Sources vary, but this should be true on all platforms we care about.
-        const { assert!(align_of::<Self>() <= align_of::<Self::Value>()); }
+        const {
+            assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        }
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -89,7 +91,9 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[inline]
     #[must_use]
     fn pack_slice_mut(buf: &mut [Self::Value]) -> &mut [Self] {
-        const { assert!(align_of::<Self>() <= align_of::<Self::Value>());}
+        const {
+            assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        }
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -111,7 +115,9 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     fn pack_maybe_uninit_slice_mut(
         buf: &mut [MaybeUninit<Self::Value>],
     ) -> &mut [MaybeUninit<Self>] {
-        const { assert!(align_of::<Self>() <= align_of::<Self::Value>());}
+        const {
+            assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        }
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -152,7 +158,9 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[inline]
     #[must_use]
     fn unpack_slice(buf: &[Self]) -> &[Self::Value] {
-        const { assert!(align_of::<Self>() >= align_of::<Self::Value>());}
+        const {
+            assert!(align_of::<Self>() >= align_of::<Self::Value>());
+        }
         let buf_ptr = buf.as_ptr().cast::<Self::Value>();
         let n = buf.len() * Self::WIDTH;
         unsafe { slice::from_raw_parts(buf_ptr, n) }

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -62,9 +62,7 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[must_use]
     fn pack_slice(buf: &[Self::Value]) -> &[Self] {
         // Sources vary, but this should be true on all platforms we care about.
-        // This should be a const assert, but trait methods can't access `Self` in a const context,
-        // even with inner struct instantiation. So we will trust LLVM to optimize this out.
-        assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        const { assert!(align_of::<Self>() <= align_of::<Self::Value>()); }
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -91,7 +89,7 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[inline]
     #[must_use]
     fn pack_slice_mut(buf: &mut [Self::Value]) -> &mut [Self] {
-        assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        const { assert!(align_of::<Self>() <= align_of::<Self::Value>());}
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -113,7 +111,7 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     fn pack_maybe_uninit_slice_mut(
         buf: &mut [MaybeUninit<Self::Value>],
     ) -> &mut [MaybeUninit<Self>] {
-        assert!(align_of::<Self>() <= align_of::<Self::Value>());
+        const { assert!(align_of::<Self>() <= align_of::<Self::Value>());}
         assert!(
             buf.len().is_multiple_of(Self::WIDTH),
             "Slice length (got {}) must be a multiple of packed field width ({}).",
@@ -154,7 +152,7 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
     #[inline]
     #[must_use]
     fn unpack_slice(buf: &[Self]) -> &[Self::Value] {
-        assert!(align_of::<Self>() >= align_of::<Self::Value>());
+        const { assert!(align_of::<Self>() >= align_of::<Self::Value>());}
         let buf_ptr = buf.as_ptr().cast::<Self::Value>();
         let n = buf.len() * Self::WIDTH;
         unsafe { slice::from_raw_parts(buf_ptr, n) }

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -426,7 +426,7 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
         // We could do a % operation here, but monty reduction is faster.
         // This does remove a factor of `R` from the result so we will need to
         // correct for that.
-        let uncorrected_value = Self::new_monty(monty_reduce::<FP>(pos_inverse as u64));
+        let uncorrected_value = Self::new_monty(monty_reduce::<FP>(pos_inverse));
 
         // Currently, uncorrected_value = R^{-1} * 2^{60} * val^{-1} mod P = 2^{28} * val^{-1} mod P`.
         // But `val` is really the monty form of some value `x` satisfying `val = xR mod P`. We want

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -420,10 +420,13 @@ pub fn iter_array_chunks_padded<T: Copy, const N: usize>(
 /// This panics if the size of `BaseArray` is not a multiple of the size of `Base`.
 #[inline]
 pub unsafe fn as_base_slice<Base, BaseArray>(buf: &[BaseArray]) -> &[Base] {
-    assert_eq!(align_of::<Base>(), align_of::<BaseArray>());
+    const {
+        assert!(align_of::<Base>() == align_of::<BaseArray>());
+        assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
+        }
+
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
-    assert!(align_of::<BaseArray>() >= align_of::<Base>());
     let buf_ptr = buf.as_ptr().cast::<Base>();
     let n = buf.len() * d;
     unsafe { slice::from_raw_parts(buf_ptr, n) }
@@ -446,10 +449,13 @@ pub unsafe fn as_base_slice<Base, BaseArray>(buf: &[BaseArray]) -> &[Base] {
 /// This panics if the size of `BaseArray` is not a multiple of the size of `Base`.
 #[inline]
 pub unsafe fn as_base_slice_mut<Base, BaseArray>(buf: &mut [BaseArray]) -> &mut [Base] {
-    assert_eq!(align_of::<Base>(), align_of::<BaseArray>());
+    const {
+        assert!(align_of::<Base>() == align_of::<BaseArray>());
+        assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
+        }
+
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
-    assert!(align_of::<BaseArray>() >= align_of::<Base>());
     let buf_ptr = buf.as_mut_ptr().cast::<Base>();
     let n = buf.len() * d;
     unsafe { slice::from_raw_parts_mut(buf_ptr, n) }
@@ -475,14 +481,10 @@ pub unsafe fn as_base_slice_mut<Base, BaseArray>(buf: &mut [BaseArray]) -> &mut 
 /// This panics if the size of `BaseArray` is not a multiple of the size of `Base`.
 #[inline]
 pub unsafe fn flatten_to_base<Base, BaseArray>(vec: Vec<BaseArray>) -> Vec<Base> {
-    debug_assert_eq!(align_of::<Base>(), align_of::<BaseArray>());
-
-    assert!(
-        size_of::<BaseArray>().is_multiple_of(size_of::<Base>()),
-        "Size of BaseArray (got {}) must be a multiple of the size of Base ({}).",
-        size_of::<BaseArray>(),
-        size_of::<Base>()
-    );
+    const {
+        assert!(align_of::<Base>() == align_of::<BaseArray>());
+        assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
+        }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
     // Prevent running `vec`'s destructor so we are in complete control
@@ -528,12 +530,10 @@ pub unsafe fn flatten_to_base<Base, BaseArray>(vec: Vec<BaseArray>) -> Vec<Base>
 /// This panics if the length of the vector is not a multiple of the ratio of the sizes.
 #[inline]
 pub unsafe fn reconstitute_from_base<Base, BaseArray: Clone>(mut vec: Vec<Base>) -> Vec<BaseArray> {
-    assert!(
-        size_of::<BaseArray>().is_multiple_of(size_of::<Base>()),
-        "Size of BaseArray (got {}) must be a multiple of the size of Base ({}).",
-        size_of::<BaseArray>(),
-        size_of::<Base>()
-    );
+    const {
+        assert!(align_of::<Base>() == align_of::<BaseArray>());
+        assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
+        }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
@@ -692,7 +692,7 @@ pub fn gcd_inner<const NUM_ROUNDS: usize>(a: &mut u64, b: &mut u64) -> (i64, i64
 /// `a < b`. If either of these assumptions break, the output is undefined.
 #[inline]
 pub fn gcd_inversion_prime_field_32<const FIELD_BITS: u32>(mut a: u32, mut b: u32) -> i64 {
-    assert!(FIELD_BITS <= 32);
+    const { assert!(FIELD_BITS <= 32); }
     debug_assert!(((1_u64 << FIELD_BITS) - 1) >= b as u64);
 
     // Initialise u, v. Note that |u|, |v| <= 2^0

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -423,7 +423,7 @@ pub unsafe fn as_base_slice<Base, BaseArray>(buf: &[BaseArray]) -> &[Base] {
     const {
         assert!(align_of::<Base>() == align_of::<BaseArray>());
         assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
-        }
+    }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
@@ -452,7 +452,7 @@ pub unsafe fn as_base_slice_mut<Base, BaseArray>(buf: &mut [BaseArray]) -> &mut 
     const {
         assert!(align_of::<Base>() == align_of::<BaseArray>());
         assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
-        }
+    }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
@@ -484,7 +484,7 @@ pub unsafe fn flatten_to_base<Base, BaseArray>(vec: Vec<BaseArray>) -> Vec<Base>
     const {
         assert!(align_of::<Base>() == align_of::<BaseArray>());
         assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
-        }
+    }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
     // Prevent running `vec`'s destructor so we are in complete control
@@ -533,7 +533,7 @@ pub unsafe fn reconstitute_from_base<Base, BaseArray: Clone>(mut vec: Vec<Base>)
     const {
         assert!(align_of::<Base>() == align_of::<BaseArray>());
         assert!(size_of::<BaseArray>().is_multiple_of(size_of::<Base>()));
-        }
+    }
 
     let d = size_of::<BaseArray>() / size_of::<Base>();
 
@@ -692,7 +692,9 @@ pub fn gcd_inner<const NUM_ROUNDS: usize>(a: &mut u64, b: &mut u64) -> (i64, i64
 /// `a < b`. If either of these assumptions break, the output is undefined.
 #[inline]
 pub fn gcd_inversion_prime_field_32<const FIELD_BITS: u32>(mut a: u32, mut b: u32) -> i64 {
-    const { assert!(FIELD_BITS <= 32); }
+    const {
+        assert!(FIELD_BITS <= 32);
+    }
     debug_assert!(((1_u64 << FIELD_BITS) - 1) >= b as u64);
 
     // Initialise u, v. Note that |u|, |v| <= 2^0


### PR DESCRIPTION
First pass at #1014 

Had a look through and fixed the ones I came across. I assume there are many more out there.

We can also replace some debug_asserts as this will not affect run times.

Unfortunately, we cannot use assert_eq so I had to remove those (and any string formatting for error messages)