### PR TITLE
Harden 32-bit challenger shifts using widened bases

### DIFF
--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -51,7 +51,7 @@ where
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U64);
+        assert!((1u128 << bits) < F::ORDER_U64 as u128);
 
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
@@ -78,7 +78,8 @@ where
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U32);
+        // Avoid shifting a 32-bit base; compare in u64 domain to prevent overflow when bits >= 32
+        assert!((1u64 << bits) < F::ORDER_U64);
         let witness = (0..F::ORDER_U32)
             .into_par_iter()
             .map(|i| unsafe {

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -183,7 +183,8 @@ where
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U32);
+        // Avoid shifting a 32-bit base; compare in u64 domain to prevent overflow when bits >= 32
+        assert!((1u64 << bits) < F::ORDER_U64);
         let rand_f: F = self.sample();
         let rand_usize = rand_f.as_canonical_u32() as usize;
         rand_usize & ((1 << bits) - 1)

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -121,7 +121,8 @@ where
     fn sample_bits(&mut self, bits: usize) -> usize {
         assert!(bits < (usize::BITS as usize));
         // Limiting the number of bits to the field size
-        assert!((1 << bits) <= F::ORDER_U64 as usize);
+        // Avoid shifting a 32-bit base; compare in u64 domain to prevent overflow when bits >= 32
+        assert!((1u64 << bits) <= F::ORDER_U64);
         let rand_usize = u32::from_le_bytes(self.inner.sample_array()) as usize;
         rand_usize & ((1 << bits) - 1)
     }
@@ -137,7 +138,8 @@ where
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U32);
+        // Avoid shifting a 32-bit base; compare in u64 domain to prevent overflow when bits >= 32
+        assert!((1u64 << bits) < F::ORDER_U64);
         let witness = (0..F::ORDER_U32)
             .into_par_iter()
             .map(|i| unsafe {


### PR DESCRIPTION
Changed comparison from assert!((1 << bits) < F::ORDER_U32); to assert!((1u64 << bits) < F::ORDER_U64); to avoid 32-bit left-shift overflow on large bits while preserving semantics. The mask computation ((1 << bits) - 1) remains on usize since bits < usize::BITS is enforced.
Changed comparison from assert!((1 << bits) < F::ORDER_U64); to assert!((1u128 << bits) < F::ORDER_U64 as u128); for consistency and safety at high bits.