### PR TITLE
monty31: add halve for aarch64 neon

### DIFF
--- a/monty-31/src/aarch64_neon/mod.rs
+++ b/monty-31/src/aarch64_neon/mod.rs
@@ -1,5 +1,6 @@
 mod packing;
 mod poseidon2;
+mod utils;
 
 pub use packing::*;
 pub use poseidon2::*;

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -21,6 +21,7 @@ use p3_util::reconstitute_from_base;
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 
+use super::utils::halve_neon;
 use crate::{
     BinomialExtensionData, FieldParameters, MontyField31, PackedMontyParameters,
     RelativelyPrimePower,
@@ -160,8 +161,15 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
         f.into()
     }
 
-    // TODO: Add a custom implementation of `halve` that uses NEON intrinsics
-    // and avoids the multiplication.
+    #[inline]
+    fn halve(&self) -> Self {
+        let val = self.to_vector();
+        let halved = halve_neon::<FP>(val);
+        unsafe {
+            // Safety: `halve_neon` returns values in canonical form when given values in canonical form.
+            Self::from_vector(halved)
+        }
+    }
 
     #[inline]
     fn cube(&self) -> Self {

--- a/monty-31/src/aarch64_neon/utils.rs
+++ b/monty-31/src/aarch64_neon/utils.rs
@@ -1,0 +1,29 @@
+use core::arch::aarch64::{uint32x4_t, vaddq_u32, vandq_u32, vdupq_n_u32, vshrq_n_u32, vtstq_u32};
+
+use crate::PackedMontyParameters;
+
+/// Halve a vector of Monty31 field elements in canonical form using NEON.
+///
+/// - If `val` is even, computes `val / 2`.
+/// - If `val` is odd, computes `(val + P) / 2`.
+#[inline(always)]
+pub(crate) fn halve_neon<PMP: PackedMontyParameters>(input: uint32x4_t) -> uint32x4_t {
+    unsafe {
+        let one = vdupq_n_u32(1);
+        let half_p = vdupq_n_u32(PMP::PRIME.div_ceil(2));
+
+        // Check if the least significant bit is set (i.e., if the number is odd).
+        //
+        // vtstq_u32 returns a mask of all 1s if the bit is set, and all 0s otherwise.
+        let is_odd_mask = vtstq_u32(input, one);
+
+        // Right shift by 1 to perform the division by 2.
+        let val_div_2 = vshrq_n_u32(input, 1);
+
+        // Select `half_p` if odd, 0 otherwise.
+        let to_add = vandq_u32(half_p, is_odd_mask);
+
+        // Add the conditional term.
+        vaddq_u32(val_div_2, to_add)
+    }
+}


### PR DESCRIPTION
@SyxtonPrime The approach is really similar to the AVX one so I think this is the way to go but do you have a specific way to benchmark this efficiently to have apple to have comparisons with the other architectures?