### PR TITLE
monty31: add aarch64 neon custom `exp_5` and `exp_7`

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -6,7 +6,7 @@ use p3_field_testing::bench_func::{
     benchmark_mul_latency, benchmark_mul_throughput, benchmark_sub_latency,
     benchmark_sub_throughput,
 };
-use p3_field_testing::benchmark_dot_array;
+use p3_field_testing::{benchmark_dot_array, benchmark_exp_const};
 use p3_util::pretty_name;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -65,6 +65,11 @@ fn bench_packedfield(c: &mut Criterion) {
     benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
     benchmark_mul_latency::<<F as Field>::Packing, L_REPS>(c, &name);
     benchmark_mul_throughput::<<F as Field>::Packing, REPS>(c, &name);
+
+    const EXP_REPS: usize = 1000;
+    benchmark_exp_const::<<F as Field>::Packing, 3, EXP_REPS>(c, &name);
+    benchmark_exp_const::<<F as Field>::Packing, 5, EXP_REPS>(c, &name);
+    benchmark_exp_const::<<F as Field>::Packing, 7, EXP_REPS>(c, &name);
 }
 
 criterion_group!(baby_bear_arithmetic, bench_field, bench_packedfield);

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -467,3 +467,30 @@ pub fn benchmark_base_mul_throughput<F: Field, A: Algebra<F> + Copy, const N: us
         )
     });
 }
+
+/// Benchmarks the `exp_const_u64` implementation for a given `POWER`.
+///
+/// This function measures the throughput of the exponentiation by applying the operation
+/// to a vector of `REPS` random elements.
+pub fn benchmark_exp_const<R: PrimeCharacteristicRing + Copy, const POWER: u64, const REPS: usize>(
+    c: &mut Criterion,
+    name: &str,
+) where
+    StandardUniform: Distribution<R>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    let input: Vec<R> = (0..REPS).map(|_| rng.random()).collect();
+
+    c.bench_function(&format!("{name} exp_const<{POWER}>/{REPS}"), |b| {
+        b.iter_batched(
+            || input.clone(),
+            |mut data| {
+                for x in data.iter_mut() {
+                    *x = x.exp_const_u64::<POWER>();
+                }
+                black_box(data);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -440,8 +440,6 @@ fn cube<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
 #[inline]
 #[must_use]
 fn exp_5<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
-    // throughput: 4.25 cyc/vec (0.94 els/cyc)
-    // latency: 33 cyc
     unsafe {
         let val_s = aarch64::vreinterpretq_s32_u32(val);
         let mu_val = mulby_mu::<MPNeon>(val_s);
@@ -470,8 +468,6 @@ fn exp_5<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
 #[inline]
 #[must_use]
 fn exp_7<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
-    // throughput: 5.25 cyc/vec (0.76 els/cyc)
-    // latency: 41 cyc
     unsafe {
         let val_s = aarch64::vreinterpretq_s32_u32(val);
         let mu_val = mulby_mu::<MPNeon>(val_s);

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -186,6 +186,37 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(MontyField31::<FP>::zero_vec(len * WIDTH)) }
     }
+
+    #[inline(always)]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        // We provide specialised code for the powers 3, 5, 7 as these turn up regularly.
+        // The other powers could be specialised similarly but we ignore this for now.
+        match POWER {
+            0 => Self::ONE,
+            1 => *self,
+            2 => self.square(),
+            3 => self.cube(),
+            4 => self.square().square(),
+            5 => {
+                let val = self.to_vector();
+                unsafe {
+                    // Safety: `exp_5` returns values in canonical form when given values in canonical form.
+                    let res = exp_5::<FP>(val);
+                    Self::from_vector(res)
+                }
+            }
+            6 => self.square().cube(),
+            7 => {
+                let val = self.to_vector();
+                unsafe {
+                    // Safety: `exp_7` returns values in canonical form when given values in canonical form.
+                    let res = exp_7::<FP>(val);
+                    Self::from_vector(res)
+                }
+            }
+            _ => self.exp_u64(POWER),
+        }
+    }
 }
 
 impl_add_base_field!(
@@ -400,6 +431,72 @@ fn cube<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
         let c_hi_3 = get_c_hi(val_2, val);
         let qp_hi_3 = get_qp_hi::<MPNeon>(val_2, mu_val);
         get_reduced_d::<MPNeon>(c_hi_3, qp_hi_3)
+    }
+}
+
+/// Compute `val^5` using the addition chain `x^5 = (x^2)^2 * x`.
+///
+/// This minimizes full reductions.
+#[inline]
+#[must_use]
+fn exp_5<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
+    // throughput: 4.25 cyc/vec (0.94 els/cyc)
+    // latency: 33 cyc
+    unsafe {
+        let val_s = aarch64::vreinterpretq_s32_u32(val);
+        let mu_val = mulby_mu::<MPNeon>(val_s);
+
+        // Compute val^2 in signed form (-P < val_2 < P)
+        let c_hi_2 = get_c_hi(val_s, val_s);
+        let qp_hi_2 = get_qp_hi::<MPNeon>(val_s, mu_val);
+        let val_2 = get_d(c_hi_2, qp_hi_2);
+
+        // Compute val^4 in signed form (-P < val_4 < P)
+        let mu_val_2 = mulby_mu::<MPNeon>(val_2);
+        let c_hi_4 = get_c_hi(val_2, val_2);
+        let qp_hi_4 = get_qp_hi::<MPNeon>(val_2, mu_val_2);
+        let val_4 = get_d(c_hi_4, qp_hi_4);
+
+        // Compute val^5 = val^4 * val and do a final reduction.
+        let c_hi_5 = get_c_hi(val_4, val_s);
+        let qp_hi_5 = get_qp_hi::<MPNeon>(val_4, mu_val);
+        get_reduced_d::<MPNeon>(c_hi_5, qp_hi_5)
+    }
+}
+
+/// Compute `val^7` using the addition chain `x^7 = (x^2 * x) * (x^2)^2`.
+///
+/// This minimizes full reductions by reusing intermediate products.
+#[inline]
+#[must_use]
+fn exp_7<MPNeon: MontyParametersNeon>(val: uint32x4_t) -> uint32x4_t {
+    // throughput: 5.25 cyc/vec (0.76 els/cyc)
+    // latency: 41 cyc
+    unsafe {
+        let val_s = aarch64::vreinterpretq_s32_u32(val);
+        let mu_val = mulby_mu::<MPNeon>(val_s);
+
+        // Compute val^2 in signed form (-P < val_2 < P)
+        let c_hi_2 = get_c_hi(val_s, val_s);
+        let qp_hi_2 = get_qp_hi::<MPNeon>(val_s, mu_val);
+        let val_2 = get_d(c_hi_2, qp_hi_2);
+
+        // Compute val^3 in signed form (-P < val_3 < P)
+        let c_hi_3 = get_c_hi(val_2, val_s);
+        let qp_hi_3 = get_qp_hi::<MPNeon>(val_2, mu_val);
+        let val_3 = get_d(c_hi_3, qp_hi_3);
+
+        // Compute val^4 in signed form (-P < val_4 < P)
+        let mu_val_2 = mulby_mu::<MPNeon>(val_2);
+        let c_hi_4 = get_c_hi(val_2, val_2);
+        let qp_hi_4 = get_qp_hi::<MPNeon>(val_2, mu_val_2);
+        let val_4 = get_d(c_hi_4, qp_hi_4);
+
+        // Compute val^7 = val^4 * val^3 and do a final reduction.
+        let mu_val_3 = mulby_mu::<MPNeon>(val_3);
+        let c_hi_7 = get_c_hi(val_4, val_3);
+        let qp_hi_7 = get_qp_hi::<MPNeon>(val_4, mu_val_3);
+        get_reduced_d::<MPNeon>(c_hi_7, qp_hi_7)
     }
 }
 


### PR DESCRIPTION
@SyxtonPrime I've just added the benchmarks for BabyBear, here are the numbers:

```shell
Gnuplot not found, using plotters backend
PackedMontyField31Neon<BabyBearParameters> exp_const<3>/1000
                        time:   [1.7778 µs 1.8266 µs 1.8722 µs]
                        change: [−1.2886% +2.9637% +7.3390%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

PackedMontyField31Neon<BabyBearParameters> exp_const<5>/1000
                        time:   [2.1960 µs 2.2297 µs 2.2635 µs]
                        change: [−20.431% −18.566% −16.706%] (p = 0.00 < 0.05)
                        Performance has improved.

PackedMontyField31Neon<BabyBearParameters> exp_const<7>/1000
                        time:   [2.7236 µs 2.7589 µs 2.7981 µs]
                        change: [−24.865% −23.264% −21.674%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```