### PR TITLE
Small Neon Refactor

### DIFF
--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -41,9 +41,9 @@ pub trait MontyParametersNeon {
 pub struct PackedMontyField31Neon<PMP: PackedMontyParameters>(pub [MontyField31<PMP>; WIDTH]);
 
 impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
+    /// Get an arch-specific vector representing the packed values.
     #[inline]
     #[must_use]
-    /// Get an arch-specific vector representing the packed values.
     pub(crate) fn to_vector(self) -> uint32x4_t {
         unsafe {
             // Safety: `MontyField31` is `repr(transparent)` so it can be transmuted to `u32`. It
@@ -55,9 +55,9 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
         }
     }
 
+    /// Get an arch-specific vector representing the packed values.
     #[inline]
     #[must_use]
-    /// Get an arch-specific vector representing the packed values.
     pub(crate) fn to_signed_vector(self) -> int32x4_t {
         unsafe {
             // Safety: `MontyField31` is `repr(transparent)` so it can be transmuted to `u32` furthermore
@@ -70,11 +70,11 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
         }
     }
 
-    #[inline]
     /// Make a packed field vector from an arch-specific vector.
     ///
     /// SAFETY: The caller must ensure that each element of `vector` represents a valid `MontyField31`.
     /// In particular, each element of vector must be in `0..P` (canonical form).
+    #[inline]
     pub(crate) unsafe fn from_vector(vector: uint32x4_t) -> Self {
         unsafe {
             // Safety: It is up to the user to ensure that elements of `vector` represent valid


### PR DESCRIPTION
Minor neon refactor.

- Updating `mul` methods to make it clear that they can be used with signed inputs. This actually didn't require any changes to the methods, they could already be used with signed inputs they just only accepted unsigned inputs as we hadn't considered the signed input case.
- Introduced `mul_with_precomp` which lets us reduce code duplication in the rest of the code.
- Added some comments with some latency/throughput numbers for `exp_5` and `exp_7`.
- In general added many more comments.
- Minor refactor on `exp_5` to reduce the latency. The chain `x -> x^2 -> x^3 -> x^5` has sightly better latency than `x -> x^2 -> x^4 -> x^5` as we can do some more work in parallel.