### PR TITLE
Add missing `mds` module to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "koala-bear",
     "matrix",
     "maybe-rayon",
+    "mds",
     "merkle-tree",
     "mersenne-31",
     "monolith",


### PR DESCRIPTION
Fix workspace configuration inconsistency where the `mds` module was defined in workspace.dependencies but missing from the members list. This ensures the module is properly included in workspace-wide operations like `cargo build`, `cargo test --workspace`, and CI/CD pipelines.

Changes:
- Added `mds` to workspace members list in alphabetical order