### PR TITLE
monty 31: more efficient aarch64 neon `quartic_mul_packed`

### DIFF
--- a/baby-bear/benches/extension.rs
+++ b/baby-bear/benches/extension.rs
@@ -34,7 +34,7 @@ fn bench_quartic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF4, L_REPS>(c, name);
 }
 
-fn bench_qunitic_extension(c: &mut Criterion) {
+fn bench_quintic_extension(c: &mut Criterion) {
     let name = "BinomialExtensionField<BabyBear, 5>";
     benchmark_add_throughput::<EF5, REPS>(c, name);
     benchmark_add_latency::<EF5, L_REPS>(c, name);
@@ -65,7 +65,7 @@ fn bench_octic_extension(c: &mut Criterion) {
 criterion_group!(
     bench_babybear_ef,
     bench_quartic_extension,
-    bench_qunitic_extension,
+    bench_quintic_extension,
     bench_octic_extension
 );
 criterion_main!(bench_babybear_ef);


### PR DESCRIPTION
New numbers on the related benchmark after this:

```shell
Gnuplot not found, using plotters backend
mul-throughput/100 BinomialExtensionField<BabyBear, 4>
                        time:   [5.6321 µs 5.6387 µs 5.6453 µs]
                        change: [−30.691% −30.482% −30.305%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

mul-latency/1000 BinomialExtensionField<BabyBear, 4>
                        time:   [19.127 µs 19.137 µs 19.147 µs]
                        change: [−20.274% −20.179% −20.095%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```