### PR TITLE
chore(maybe-rayon): replace deprecated repeatn with repeat_n

### DIFF
--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -33,7 +33,7 @@ pub mod prelude {
 
 #[cfg(feature = "parallel")]
 pub mod iter {
-    pub use rayon::iter::{repeat, repeatn as repeat_n};
+    pub use rayon::iter::{repeat, repeat_n};
 }
 
 #[cfg(not(feature = "parallel"))]


### PR DESCRIPTION
Replace deprecated `rayon::iter::repeatn` re-export with `rayon::iter::repeat_n` in `maybe-rayon/src/lib.rs`.


Observed warning (before the fix):
warning: use of deprecated function `rayon::iter::repeatn`: use `repeat_n`
```text
warning: use of deprecated function `rayon::iter::repeatn`: use `repeat_n`
  --> maybe-rayon/src/lib.rs:36:35
   |
36 |     pub use rayon::iter::{repeat, repeatn as repeat_n};
   |                                   ^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```
