### PR TITLE
fix: remove unused alloc::format imports

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon2.rs
+++ b/baby-bear/src/aarch64_neon/poseidon2.rs
@@ -102,8 +102,6 @@ impl InternalLayerParametersNeon<BabyBearParameters, 24> for BabyBearInternalLay
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
-
     use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use proptest::prelude::*;

--- a/koala-bear/src/aarch64_neon/poseidon2.rs
+++ b/koala-bear/src/aarch64_neon/poseidon2.rs
@@ -100,8 +100,6 @@ impl InternalLayerParametersNeon<KoalaBearParameters, 24> for KoalaBearInternalL
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
-
     use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
     use proptest::prelude::*;


### PR DESCRIPTION
Remove unused `alloc::format` imports from NEON Poseidon2 implementations:

  - `baby-bear/src/aarch64_neon/poseidon2.rs`
  - `koala-bear/src/aarch64_neon/poseidon2.rs`