### PR TITLE
circle: batch inverses in selectors_on_coset

### DIFF
--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -207,7 +207,8 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
 
         let z_vals: Vec<Self::Val> = pts.iter().map(|&at| self.vanishing_poly(at)).collect();
         let den_shift: Vec<Self::Val> = pts.iter().map(|&at| self.shift.v_tilde_p(at)).collect();
-        let den_negshift_k: Vec<Self::Val> = pts.iter().map(|&at| neg_shift.v_tilde_p(at) * k).collect();
+        let den_negshift_k: Vec<Self::Val> =
+            pts.iter().map(|&at| neg_shift.v_tilde_p(at) * k).collect();
 
         // Batch inverses
         let inv_vanishing = batch_multiplicative_inverse(&z_vals);


### PR DESCRIPTION
- Replace per-point selector computation with vectorized evaluation and batch multiplicative inverses.
- Avoid repeated to_projective_line conversions; operate directly on Point values.

Bench before: 
<img width="894" height="232" alt="image" src="https://github.com/user-attachments/assets/77350e8c-2bd0-483a-b647-4da4bc5cdf56" />

After: 
<img width="913" height="240" alt="image" src="https://github.com/user-attachments/assets/51636dbb-d0dd-4394-8697-b20558843ad9" />
