### PR TITLE
monty: fix AVX512 Poseidon2 internal add_sum to use signed add

### DIFF
--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -12,7 +12,7 @@ use p3_poseidon2::{
     external_terminal_permute_state,
 };
 
-use super::halve_avx512;
+use super::{halve_avx512, signed_add_avx512};
 use crate::{
     FieldParameters, MontyField31, MontyParameters, PackedMontyField31AVX512,
     PackedMontyParameters, RelativelyPrimePower, apply_func_to_even_odd, packed_exp_3,
@@ -332,7 +332,7 @@ pub trait InternalLayerParametersAVX512<PMP: PackedMontyParameters, const WIDTH:
         // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
         input.as_mut()[8 + Self::NUM_POS..]
             .iter_mut()
-            .for_each(|x| *x = mm512_mod_add(sum, *x, PMP::PACKED_P));
+            .for_each(|x| *x = signed_add_avx512::<PMP>(sum, *x));
     }
 }
 


### PR DESCRIPTION
Problem:
- In AVX512 Poseidon2 internal layer (InternalLayerParametersAVX512::add_sum), the final segment used mm512_mod_add to add a value that can lie in (-P, P).
- mm512_mod_add assumes both operands are in [0, P) with bounded sum; adding a signed operand breaks this assumption and can yield incorrect reductions.

Solution:
Implemented signed_add_avx512 that supports lhs in [0, P) and rhs in (-P, P):
   - Compute sum = lhs + rhs
   - Conditionally correct by −P when rhs > 0 and by +P when rhs < 0 using AVX512 mask ops
   - Return min_u32(sum, corrected) per lane
- Replaced the tail of add_sum to use signed_add_avx512 instead of mm512_mod_add.
- Imported the new helper in poseidon2.rs.