### PR TITLE
Poseidon2 doc comment fixes

### DIFF
--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -311,11 +311,16 @@ pub trait InternalLayerParametersAVX512<PMP: PackedMontyParameters, const WIDTH:
     /// If either of these does not hold, the result is undefined.
     ///
     /// Morally this function is computing `x -> x + sum` however there are some places where
-    /// the output of `diagonal_mul` is the negative of the expected value.
+    /// the output of `diagonal_mul` is the negative of the expected value and might lie
+    /// in [0, P] instead of being in canonical form.
+    /// 
     /// It is the job of add_sum to correct for these irregularities. Where the output is negative
     /// we compute `x -> sum - x` instead.
     #[inline(always)]
     unsafe fn add_sum(input: &mut Self::ArrayLike, sum: __m512i) {
+        // Both mm512_mod_add and mm512_mod_sub will return correct values in [0, P) when one
+        // input is in [0, P) and the other is in [0, P].
+
         // Diagonal mul multiplied these by 1, 2, 1/2, 3, 4 so we simply need to add the sum.
         input.as_mut()[..5]
             .iter_mut()
@@ -328,8 +333,8 @@ pub trait InternalLayerParametersAVX512<PMP: PackedMontyParameters, const WIDTH:
             .iter_mut()
             .for_each(|x| *x = mm512_mod_sub(sum, *x, PMP::PACKED_P));
 
-        // Diagonal mul output a signed value in (-P, P) so we need to do a signed add.
-        // Note that signed add's parameters are not interchangeable. The first parameter must be positive.
+        // The remainder are all correctly multiplied by negative inverse powers of two so
+        // we just need to add the sum.
         input.as_mut()[8 + Self::NUM_POS..]
             .iter_mut()
             .for_each(|x| *x = mm512_mod_add(sum, *x, PMP::PACKED_P));

--- a/monty-31/src/x86_64_avx512/poseidon2.rs
+++ b/monty-31/src/x86_64_avx512/poseidon2.rs
@@ -313,7 +313,7 @@ pub trait InternalLayerParametersAVX512<PMP: PackedMontyParameters, const WIDTH:
     /// Morally this function is computing `x -> x + sum` however there are some places where
     /// the output of `diagonal_mul` is the negative of the expected value and might lie
     /// in [0, P] instead of being in canonical form.
-    /// 
+    ///
     /// It is the job of add_sum to correct for these irregularities. Where the output is negative
     /// we compute `x -> sum - x` instead.
     #[inline(always)]

--- a/monty-31/src/x86_64_avx512/utils.rs
+++ b/monty-31/src/x86_64_avx512/utils.rs
@@ -125,7 +125,7 @@ pub unsafe fn mul_neg_2exp_neg_n_avx512<
 ///
 /// The prime P must be of the form P = r * 2^j + 1 with r odd and r < 2^7.
 /// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+/// Output may not be in canonical form but will lie in [0, P].
 #[inline(always)]
 pub unsafe fn mul_neg_2exp_neg_8_avx512<
     TAD: TwoAdicData + PackedMontyParameters,
@@ -178,7 +178,7 @@ pub unsafe fn mul_neg_2exp_neg_8_avx512<
 ///
 /// The prime P must have the form P = 2^31 - 2^N + 1.
 /// Input must be given in canonical form.
-/// Output is not in canonical form, outputs are only guaranteed to lie in (-P, P).
+/// Output may not be in canonical form but will lie in [0, P].
 #[inline(always)]
 pub unsafe fn mul_neg_2exp_neg_two_adicity_avx512<
     TAD: TwoAdicData + PackedMontyParameters,
@@ -223,6 +223,7 @@ pub unsafe fn mul_neg_2exp_neg_two_adicity_avx512<
 
         // When lo = 0, return P - hi
         // When lo > 0 return r*lo - hi
+        // As hi < r x_lo < P, the output is always in [0, P]. It is equal to P only when input x = 0.
         x86_64::_mm512_sub_epi32(lo_shft, lo_plus_hi)
     }
 }


### PR DESCRIPTION
#1069 pointed out that the doc comments in the AVX512 impl are pretty bad (and wrong in places).

Serves me right copy-pasting from the AVX2 impl. The code is all right atleast.