### PR TITLE
fix: Clarify NEON transmute conversions

### DIFF
--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -11,7 +11,9 @@ fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
     // Safety: `[u32; 4]` has the same size as `uint32x4_t`.
     unsafe { transmute::<[u32; 4], uint32x4_t>(input) }
 }
-
+/// Convert a packed vector into a four element array of u32's.
+///
+/// This will be a no-op.
 #[inline(always)]
 fn uint32x4_to_array(input: uint32x4_t) -> [u32; 4] {
     // Safety: `[u32; 4]` has the same size and alignment as `uint32x4_t`.

--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -11,6 +11,7 @@ fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
     // Safety: `[u32; 4]` has the same size as `uint32x4_t`.
     unsafe { transmute::<[u32; 4], uint32x4_t>(input) }
 }
+
 /// Convert a packed vector into a four element array of u32's.
 ///
 /// This will be a no-op.

--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -3,6 +3,9 @@
 use core::arch::aarch64::{self, uint32x4_t};
 use core::mem::transmute;
 
+\\\ Convert a four element array of u32's into a packed vector.
+\\\
+\\\ This will be a no-op.
 #[inline(always)]
 fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
     // Safety: `[u32; 4]` has the same size and alignment as `uint32x4_t`.

--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -3,6 +3,18 @@
 use core::arch::aarch64::{self, uint32x4_t};
 use core::mem::transmute;
 
+#[inline(always)]
+fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
+    // Safety: `[u32; 4]` has the same size and alignment as `uint32x4_t`.
+    unsafe { transmute::<[u32; 4], uint32x4_t>(input) }
+}
+
+#[inline(always)]
+fn uint32x4_to_array(input: uint32x4_t) -> [u32; 4] {
+    // Safety: `[u32; 4]` has the same size and alignment as `uint32x4_t`.
+    unsafe { transmute::<uint32x4_t, [u32; 4]>(input) }
+}
+
 /// Add the packed vectors `a` and `b` modulo `p`.
 ///
 /// This allows us to add 4 elements at once.
@@ -86,10 +98,10 @@ pub fn packed_mod_add<const WIDTH: usize>(
         4 => {
             // Perfectly fits into a uint32x4_t vector.
             let out: [u32; 4] = unsafe {
-                let a: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
+                let a = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
-                transmute(uint32x4_mod_add(a, b, p))
+                uint32x4_to_array(uint32x4_mod_add(a, b, p))
             };
 
             res.copy_from_slice(&out);
@@ -98,10 +110,10 @@ pub fn packed_mod_add<const WIDTH: usize>(
             // We fit what we can into a uint32x4_t element.
             // The final add is done using a scalar addition.
             let out: [u32; 4] = unsafe {
-                let a: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
+                let a = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
-                transmute(uint32x4_mod_add(a, b, p))
+                uint32x4_to_array(uint32x4_mod_add(a, b, p))
             };
 
             res[4] = scalar_add(a[4], b[4]);
@@ -113,13 +125,13 @@ pub fn packed_mod_add<const WIDTH: usize>(
             let (out_lo, out_hi): ([u32; 4], [u32; 4]) = unsafe {
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
 
-                let a_lo: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b_lo: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
-                let out_lo = transmute(uint32x4_mod_add(a_lo, b_lo, p));
+                let a_lo = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b_lo = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
+                let out_lo = uint32x4_to_array(uint32x4_mod_add(a_lo, b_lo, p));
 
-                let a_hi: uint32x4_t = transmute([a[4], a[5], a[6], a[7]]);
-                let b_hi: uint32x4_t = transmute([b[4], b[5], b[6], b[7]]);
-                let out_hi = transmute(uint32x4_mod_add(a_hi, b_hi, p));
+                let a_hi = array_to_uint32x4([a[4], a[5], a[6], a[7]]);
+                let b_hi = array_to_uint32x4([b[4], b[5], b[6], b[7]]);
+                let out_hi = uint32x4_to_array(uint32x4_mod_add(a_hi, b_hi, p));
                 (out_lo, out_hi)
             };
 
@@ -155,10 +167,10 @@ pub fn packed_mod_sub<const WIDTH: usize>(
         4 => {
             // Perfectly fits into a uint32x4_t vector.
             let out: [u32; 4] = unsafe {
-                let a: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
+                let a = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
-                transmute(uint32x4_mod_sub(a, b, p))
+                uint32x4_to_array(uint32x4_mod_sub(a, b, p))
             };
 
             res.copy_from_slice(&out);
@@ -167,10 +179,10 @@ pub fn packed_mod_sub<const WIDTH: usize>(
             // We fit what we can into a uint32x4_t element.
             // The final sub is done using a scalar subtraction.
             let out: [u32; 4] = unsafe {
-                let a: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
+                let a = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
-                transmute(uint32x4_mod_sub(a, b, p))
+                uint32x4_to_array(uint32x4_mod_sub(a, b, p))
             };
 
             res[4] = scalar_sub(a[4], b[4]);
@@ -182,13 +194,13 @@ pub fn packed_mod_sub<const WIDTH: usize>(
             let (out_lo, out_hi): ([u32; 4], [u32; 4]) = unsafe {
                 let p: uint32x4_t = aarch64::vdupq_n_u32(p);
 
-                let a_lo: uint32x4_t = transmute([a[0], a[1], a[2], a[3]]);
-                let b_lo: uint32x4_t = transmute([b[0], b[1], b[2], b[3]]);
-                let out_lo = transmute(uint32x4_mod_sub(a_lo, b_lo, p));
+                let a_lo = array_to_uint32x4([a[0], a[1], a[2], a[3]]);
+                let b_lo = array_to_uint32x4([b[0], b[1], b[2], b[3]]);
+                let out_lo = uint32x4_to_array(uint32x4_mod_sub(a_lo, b_lo, p));
 
-                let a_hi: uint32x4_t = transmute([a[4], a[5], a[6], a[7]]);
-                let b_hi: uint32x4_t = transmute([b[4], b[5], b[6], b[7]]);
-                let out_hi = transmute(uint32x4_mod_sub(a_hi, b_hi, p));
+                let a_hi = array_to_uint32x4([a[4], a[5], a[6], a[7]]);
+                let b_hi = array_to_uint32x4([b[4], b[5], b[6], b[7]]);
+                let out_hi = uint32x4_to_array(uint32x4_mod_sub(a_hi, b_hi, p));
                 (out_lo, out_hi)
             };
 

--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -8,7 +8,7 @@ use core::mem::transmute;
 \\\ This will be a no-op.
 #[inline(always)]
 fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
-    // Safety: `[u32; 4]` has the same size and alignment as `uint32x4_t`.
+    // Safety: `[u32; 4]` has the same size as `uint32x4_t`.
     unsafe { transmute::<[u32; 4], uint32x4_t>(input) }
 }
 

--- a/field/src/packed/aarch64_neon.rs
+++ b/field/src/packed/aarch64_neon.rs
@@ -3,9 +3,9 @@
 use core::arch::aarch64::{self, uint32x4_t};
 use core::mem::transmute;
 
-\\\ Convert a four element array of u32's into a packed vector.
-\\\
-\\\ This will be a no-op.
+/// Convert a four element array of u32's into a packed vector.
+///
+/// This will be a no-op.
 #[inline(always)]
 fn array_to_uint32x4(input: [u32; 4]) -> uint32x4_t {
     // Safety: `[u32; 4]` has the same size as `uint32x4_t`.


### PR DESCRIPTION
- add typed helpers for converting between [u32; 4] and uint32x4_t
- localize and document the unsafe transmute usage in packed add/sub
- keep SIMD behaviour unchanged while silencing missing annotation lint