### PR TITLE
Add SmallBatchDft to example options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Currently the options for the command line arguments are:
 - `--field` (`-f`): `mersenne-31` or `koala-bear` or `baby-bear`.
 - `--objective` (`-o`): `blake-3-permutations, poseidon-2-permutations, keccak-f-permutations`.
 - `--log-trace-length` (`-l`): Accepts any integer between `0` and `255`. The number of permutations proven is `trace_length, 8*trace_length` and `trace_length/24` for `blake3, poseidon2` and `keccakf` respectively. 
-- `--discrete-fourier-transform` (`-d`): `radix-2-dit-parallel, recursive-dft`. This option should be omitted if the field choice is `mersenne-31` as the circle stark currently only supports a single discrete fourier transform.
+- `--discrete-fourier-transform` (`-d`): `radix-2-dit-parallel, recursive-dft` or `small-batch-dft`. This option should be omitted if the field choice is `mersenne-31` as the circle stark currently only supports a single discrete fourier transform.
 - `--merkle-hash` (`-m`): `poseidon-2, keccak-f`.
 
 Extra speedups may be possible with some configuration changes:

--- a/examples/examples/prove_prime_field_31.rs
+++ b/examples/examples/prove_prime_field_31.rs
@@ -124,8 +124,11 @@ fn main() {
                     DftChoice::Recursive(RecursiveDft::new(trace_height << 1))
                 }
                 DftOptions::Radix2DitParallel => DftChoice::Parallel(Radix2DitParallel::default()),
+                DftOptions::SmallBatch => {
+                    DftChoice::SmallBatch(p3_dft::Radix2DFTSmallBatch::new(trace_height << 1))
+                }
                 DftOptions::None => panic!(
-                    "Please specify what dft to use. Options are recursive-dft and radix-2-dit-parallel"
+                    "Please specify what dft to use. Options are recursive-dft, radix-2-dit-parallel and small-batch-dft"
                 ),
             };
 
@@ -177,8 +180,11 @@ fn main() {
                     DftChoice::Recursive(RecursiveDft::new(trace_height << 1))
                 }
                 DftOptions::Radix2DitParallel => DftChoice::Parallel(Radix2DitParallel::default()),
+                DftOptions::SmallBatch => {
+                    DftChoice::SmallBatch(p3_dft::Radix2DFTSmallBatch::new(trace_height << 1))
+                }
                 DftOptions::None => panic!(
-                    "Please specify what dft to use. Options are recursive-dft and radix-2-dit-parallel"
+                    "Please specify what dft to use. Options are recursive-dft, radix-2-dit-parallel and small-batch-dft"
                 ),
             };
 

--- a/examples/src/dfts.rs
+++ b/examples/src/dfts.rs
@@ -1,8 +1,161 @@
-use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
-use p3_field::TwoAdicField;
-use p3_matrix::bitrev::BitReversedMatrixView;
+use std::ops::Deref;
+
+use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft, Radix2DFTSmallBatch};
+use p3_field::{PackedValue, TwoAdicField};
+use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
 use p3_monty_31::dft::RecursiveDft;
+
+#[derive(Debug)]
+pub enum MaybeBitreversedMatrix<T> {
+    Yes(BitReversedMatrixView<RowMajorMatrix<T>>),
+    No(RowMajorMatrix<T>),
+}
+
+impl<T> From<RowMajorMatrix<T>> for MaybeBitreversedMatrix<T> {
+    fn from(mat: RowMajorMatrix<T>) -> Self {
+        Self::No(mat)
+    }
+}
+
+impl<T> From<BitReversedMatrixView<RowMajorMatrix<T>>> for MaybeBitreversedMatrix<T> {
+    fn from(mat: BitReversedMatrixView<RowMajorMatrix<T>>) -> Self {
+        Self::Yes(mat)
+    }
+}
+
+// TODO: This is pretty nasty. Anyne actually using the matrix trait for
+// MaybeBitreversedMatrix outside of the to_row_major_matrix trait is going to have
+// a bad time. Might want to refactor this somehow.
+impl<T> Matrix<T> for MaybeBitreversedMatrix<T>
+where 
+    T: Send + Sync + Clone,
+{
+    fn width(&self) -> usize {
+        match self {
+            Self::Yes(inner) => inner.width(),
+            Self::No(inner) => inner.width(),
+        }
+    }
+
+    fn height(&self) -> usize {
+        match self {
+            Self::Yes(inner) => inner.height(),
+            Self::No(inner) => inner.height(),
+        }
+    }
+
+    fn to_row_major_matrix(self) -> RowMajorMatrix<T>
+    where
+        Self: Sized,
+    {
+        match self {
+            Self::Yes(inner) => inner.to_row_major_matrix(),
+            Self::No(inner) => inner.to_row_major_matrix(),
+        }
+    }
+
+    unsafe fn get_unchecked(&self, r: usize, c: usize) -> T {
+        unsafe {
+            match self {
+                Self::Yes(inner) => inner.get_unchecked(r, c),
+                Self::No(inner) => inner.get_unchecked(r, c),
+            }
+        }
+    }
+
+    unsafe fn row_unchecked(
+        &self,
+        r: usize,
+    ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
+        match self {
+            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix") },
+            Self::No(inner) => unsafe { inner.row_unchecked(r) },
+            
+        }
+    }
+
+    unsafe fn row_subseq_unchecked(
+        &self,
+        r: usize,
+        start: usize,
+        end: usize,
+    ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
+        match self {
+            Self::Yes(inner) => unsafe { inner.row_subseq_unchecked(r, start, end) },
+            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            
+        }
+    }
+
+    unsafe fn row_slice_unchecked(&self, r: usize) -> impl Deref<Target = [T]> {
+        match self {
+            Self::Yes(inner) => unsafe { inner.row_slice_unchecked(r) },
+            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            
+        }
+    }
+
+    unsafe fn row_subslice_unchecked(
+        &self,
+        r: usize,
+        start: usize,
+        end: usize,
+    ) -> impl Deref<Target = [T]> {
+        match self {
+            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            Self::No(inner) => unsafe { inner.row_subslice_unchecked(r, start, end) },
+        }
+    }
+
+    fn horizontally_packed_row<'a, P>(
+        &'a self,
+        r: usize,
+    ) -> (
+        impl Iterator<Item = P> + Send + Sync,
+        impl Iterator<Item = T> + Send + Sync,
+    )
+    where
+        P: PackedValue<Value = T>,
+        T: Clone + 'a,
+    {
+        match self {
+            Self::Yes(inner) => inner.horizontally_packed_row(r),
+            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            
+        }
+    }
+
+    fn padded_horizontally_packed_row<'a, P>(
+        &'a self,
+        r: usize,
+    ) -> impl Iterator<Item = P> + Send + Sync
+    where
+        P: PackedValue<Value = T>,
+        T: Clone + Default + 'a,
+    {
+        match self {
+            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            Self::No(inner) => inner.padded_horizontally_packed_row(r),
+            
+        }
+    }
+}
+
+impl<T> BitReversibleMatrix<T> for MaybeBitreversedMatrix<T>
+where
+    T: Send + Sync + Clone,
+{
+    type BitRev = MaybeBitreversedMatrix<T>;
+
+    fn bit_reverse_rows(self) -> Self::BitRev {
+        match self {
+            Self::Yes(inner) => inner.inner.into(),
+            Self::No(inner) => BitReversalPerm::new_view(inner).into(),
+        }
+    }
+}
 
 /// An enum containing several different options for discrete Fourier Transform.
 ///
@@ -11,6 +164,7 @@ use p3_monty_31::dft::RecursiveDft;
 pub enum DftChoice<F> {
     Recursive(RecursiveDft<F>),
     Parallel(Radix2DitParallel<F>),
+    SmallBatch(Radix2DFTSmallBatch<F>)
 }
 
 impl<F: Default> Default for DftChoice<F> {
@@ -27,21 +181,23 @@ where
     Radix2DitParallel<F>:
         TwoAdicSubgroupDft<F, Evaluations = BitReversedMatrixView<RowMajorMatrix<F>>>,
 {
-    type Evaluations = BitReversedMatrixView<RowMajorMatrix<F>>;
+    type Evaluations = MaybeBitreversedMatrix<F>;
 
     #[inline]
     fn dft_batch(&self, mat: RowMajorMatrix<F>) -> Self::Evaluations {
         match self {
-            Self::Recursive(inner_dft) => inner_dft.dft_batch(mat),
-            Self::Parallel(inner_dft) => inner_dft.dft_batch(mat),
+            Self::Recursive(inner_dft) => inner_dft.dft_batch(mat).into(),
+            Self::Parallel(inner_dft) => inner_dft.dft_batch(mat).into(),
+            Self::SmallBatch(inner_dft) => inner_dft.dft_batch(mat).into(),
         }
     }
 
     #[inline]
     fn coset_dft_batch(&self, mat: RowMajorMatrix<F>, shift: F) -> Self::Evaluations {
         match self {
-            Self::Recursive(inner_dft) => inner_dft.coset_dft_batch(mat, shift),
-            Self::Parallel(inner_dft) => inner_dft.coset_dft_batch(mat, shift),
+            Self::Recursive(inner_dft) => inner_dft.coset_dft_batch(mat, shift).into(),
+            Self::Parallel(inner_dft) => inner_dft.coset_dft_batch(mat, shift).into(),
+            Self::SmallBatch(inner_dft) => inner_dft.coset_dft_batch(mat, shift).into(),
         }
     }
 
@@ -53,8 +209,9 @@ where
         shift: F,
     ) -> Self::Evaluations {
         match self {
-            Self::Recursive(inner_dft) => inner_dft.coset_lde_batch(mat, added_bits, shift),
-            Self::Parallel(inner_dft) => inner_dft.coset_lde_batch(mat, added_bits, shift),
+            Self::Recursive(inner_dft) => inner_dft.coset_lde_batch(mat, added_bits, shift).into(),
+            Self::Parallel(inner_dft) => inner_dft.coset_lde_batch(mat, added_bits, shift).into(),
+            Self::SmallBatch(inner_dft) => inner_dft.coset_lde_batch(mat, added_bits, shift).into(),
         }
     }
 }

--- a/examples/src/dfts.rs
+++ b/examples/src/dfts.rs
@@ -27,9 +27,10 @@ impl<T> From<BitReversedMatrixView<RowMajorMatrix<T>>> for MaybeBitreversedMatri
     }
 }
 
-// TODO: This is pretty nasty. Anyne actually using the matrix trait for
+// TODO: This is pretty nasty. Anyone actually using the matrix trait for
 // MaybeBitreversedMatrix outside of the to_row_major_matrix trait is going to have
-// a bad time. Might want to refactor this somehow.
+// a bad time. Might want to refactor this somehow. We only use to_row_major_matrix
+// from this trait in the proving loop so it's not a huge issue for now.
 impl<T> Matrix<T> for MaybeBitreversedMatrix<T>
 where
     T: Send + Sync + Clone,

--- a/examples/src/dfts.rs
+++ b/examples/src/dfts.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
-use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft, Radix2DFTSmallBatch};
+use p3_dft::{Radix2DFTSmallBatch, Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::{PackedValue, TwoAdicField};
+use p3_matrix::Matrix;
 use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::Matrix;
 use p3_monty_31::dft::RecursiveDft;
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ impl<T> From<BitReversedMatrixView<RowMajorMatrix<T>>> for MaybeBitreversedMatri
 // MaybeBitreversedMatrix outside of the to_row_major_matrix trait is going to have
 // a bad time. Might want to refactor this somehow.
 impl<T> Matrix<T> for MaybeBitreversedMatrix<T>
-where 
+where
     T: Send + Sync + Clone,
 {
     fn width(&self) -> usize {
@@ -73,9 +73,10 @@ where
         r: usize,
     ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
         match self {
-            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix") },
+            Self::Yes(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
             Self::No(inner) => unsafe { inner.row_unchecked(r) },
-            
         }
     }
 
@@ -87,16 +88,18 @@ where
     ) -> impl IntoIterator<Item = T, IntoIter = impl Iterator<Item = T> + Send + Sync> {
         match self {
             Self::Yes(inner) => unsafe { inner.row_subseq_unchecked(r, start, end) },
-            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
-            
+            Self::No(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
         }
     }
 
     unsafe fn row_slice_unchecked(&self, r: usize) -> impl Deref<Target = [T]> {
         match self {
             Self::Yes(inner) => unsafe { inner.row_slice_unchecked(r) },
-            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
-            
+            Self::No(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
         }
     }
 
@@ -107,7 +110,9 @@ where
         end: usize,
     ) -> impl Deref<Target = [T]> {
         match self {
-            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            Self::Yes(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
             Self::No(inner) => unsafe { inner.row_subslice_unchecked(r, start, end) },
         }
     }
@@ -125,8 +130,9 @@ where
     {
         match self {
             Self::Yes(inner) => inner.horizontally_packed_row(r),
-            Self::No(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
-            
+            Self::No(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
         }
     }
 
@@ -139,9 +145,10 @@ where
         T: Clone + Default + 'a,
     {
         match self {
-            Self::Yes(_) => { unimplemented!("Not implemented for MaybeBitreversedMatrix")},
+            Self::Yes(_) => {
+                unimplemented!("Not implemented for MaybeBitreversedMatrix")
+            }
             Self::No(inner) => inner.padded_horizontally_packed_row(r),
-            
         }
     }
 }
@@ -168,7 +175,7 @@ where
 pub enum DftChoice<F> {
     Recursive(RecursiveDft<F>),
     Parallel(Radix2DitParallel<F>),
-    SmallBatch(Radix2DFTSmallBatch<F>)
+    SmallBatch(Radix2DFTSmallBatch<F>),
 }
 
 impl<F: Default> Default for DftChoice<F> {

--- a/examples/src/dfts.rs
+++ b/examples/src/dfts.rs
@@ -14,12 +14,14 @@ pub enum MaybeBitreversedMatrix<T> {
 }
 
 impl<T> From<RowMajorMatrix<T>> for MaybeBitreversedMatrix<T> {
+    #[inline(always)]
     fn from(mat: RowMajorMatrix<T>) -> Self {
         Self::No(mat)
     }
 }
 
 impl<T> From<BitReversedMatrixView<RowMajorMatrix<T>>> for MaybeBitreversedMatrix<T> {
+    #[inline(always)]
     fn from(mat: BitReversedMatrixView<RowMajorMatrix<T>>) -> Self {
         Self::Yes(mat)
     }
@@ -46,6 +48,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn to_row_major_matrix(self) -> RowMajorMatrix<T>
     where
         Self: Sized,
@@ -149,6 +152,7 @@ where
 {
     type BitRev = MaybeBitreversedMatrix<T>;
 
+    #[inline(always)]
     fn bit_reverse_rows(self) -> Self::BitRev {
         match self {
             Self::Yes(inner) => inner.inner.into(),

--- a/examples/src/parsers.rs
+++ b/examples/src/parsers.rs
@@ -27,6 +27,7 @@ pub enum DftOptions {
     None,
     Radix2DitParallel,
     RecursiveDft,
+    SmallBatch
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -124,6 +125,11 @@ impl ValueEnum for DftOptions {
                 "radix-2-dit-parallel",
                 2,
                 Some(vec![("radix2ditparallel", 6), ("parallel", 1)]),
+            ),
+            Self::SmallBatch => get_aliases(
+                "small-batch-dft",
+                1,
+                Some(vec![("smallbatchdft", 6), ("sb", 2)]),
             ),
             Self::None => PossibleValue::new(""),
         })

--- a/examples/src/parsers.rs
+++ b/examples/src/parsers.rs
@@ -115,7 +115,7 @@ impl ValueEnum for ProofOptions {
 
 impl ValueEnum for DftOptions {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Radix2DitParallel, Self::RecursiveDft, Self::None]
+        &[Self::Radix2DitParallel, Self::RecursiveDft, Self::SmallBatch, Self::None]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {

--- a/examples/src/parsers.rs
+++ b/examples/src/parsers.rs
@@ -27,7 +27,7 @@ pub enum DftOptions {
     None,
     Radix2DitParallel,
     RecursiveDft,
-    SmallBatch
+    SmallBatch,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -115,7 +115,12 @@ impl ValueEnum for ProofOptions {
 
 impl ValueEnum for DftOptions {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Radix2DitParallel, Self::RecursiveDft, Self::SmallBatch, Self::None]
+        &[
+            Self::Radix2DitParallel,
+            Self::RecursiveDft,
+            Self::SmallBatch,
+            Self::None,
+        ]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {


### PR DESCRIPTION
Pretty self explanatory, adds `Radix2DFTSmallBatch` to the dft options in the examples.

In some cases it's about 10% faster than the current FFT's. (In other cases it is slower, not clear exactly when/why it is faster/slower).

Unfortunately, this required implementing an Enum for the possible return types as `Radix2DFTSmallBatch` returns a `RowMajorMatrix` whereas the other methods return a `BitReversedView<RowMajorMatrix>`. 