### PR TITLE
Optimize flatten_to_base to avoid per-element allocations

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -509,9 +509,12 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     #[must_use]
     #[inline]
     fn flatten_to_base(vec: Vec<Self>) -> Vec<F> {
-        vec.into_iter()
-            .flat_map(|x| x.as_basis_coefficients_slice().to_vec())
-            .collect()
+        // Pre-allocate and extend slices to avoid per-element Vec allocations.
+        let mut out = Vec::with_capacity(vec.len() * Self::DIMENSION);
+        for x in vec {
+            out.extend_from_slice(x.as_basis_coefficients_slice());
+        }
+        out
     }
 
     /// Convert from a vector of `F` to a vector of `Self` by combining the basis coefficients.


### PR DESCRIPTION

### Summary
Optimize `flatten_to_base` in `field/src/field.rs` by replacing `flat_map(... .to_vec())` with a preallocated buffer and `extend_from_slice`, eliminating per-element `Vec` allocations.

### Motivation
Reduce unnecessary allocations and copies on a hot path (e.g., matrix flattening), improving performance and memory efficiency.

### Changes
- Rewrote `flatten_to_base` to preallocate and extend slices.

