### PR TITLE
Remove unused Borrow import in blake3-air

### DIFF
--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 
 use itertools::izip;
 use p3_air::utils::{add2, add3, pack_bits_le, xor_32_shift};


### PR DESCRIPTION

### Summary
Clean up `blake3-air/src/air.rs` by removing an unused `Borrow` import.

### Motivation
Reduce dead code and noise in imports to improve readability and maintenance.

### Changes
- Delete `use core::borrow::Borrow;` from `blake3-air/src/air.rs`.

