### PR TITLE
refactor(verifier): remove redundant clone of Option in random commitment

### DIFF
--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -102,8 +102,8 @@ where
 
     // We've already checked that commitments.random is present if and only if ZK is enabled.
     // Observe the random commitment if it is present.
-    if let Some(r_commit) = commitments.random.clone() {
-        challenger.observe(r_commit);
+    if let Some(r_commit) = &commitments.random {
+        challenger.observe(r_commit.clone());
     }
 
     // Get an out-of-domain point to open our values at.


### PR DESCRIPTION

### Summary
Avoid cloning the `Option` wrapper; borrow and clone only the inner commitment when present.

