### PR TITLE
refactor: remove redundant clones in crypto modules

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -53,7 +53,7 @@ fn bench_field(c: &mut Criterion) {
 }
 
 fn bench_packedfield(c: &mut Criterion) {
-    let name = pretty_name::<<F as Field>::Packing>().to_string();
+    let name = pretty_name::<<F as Field>::Packing>();
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.
     const REPS: usize = 100;

--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -540,7 +540,7 @@ mod tests {
                 Some(f_100 * F::from_int(i))
             );
         }
-        assert_eq!(F::from_biguint(big_int_p.clone() * 6_u32), None);
+        assert_eq!(F::from_biguint(big_int_p * 6_u32), None);
         assert_eq!(
             F::from_biguint(big_int_2_256_min_1).unwrap(),
             F::NEG_ONE + F::from_biguint(big_int_2_256_mod_p).unwrap()

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -114,7 +114,7 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R, log_final_poly_len: usize, polynomial_lo
         // Initialize the verifier's challenger with the same permutation.
         // Observe the `polynomial_log_sizes` and `commitment` in the same order
         // as the prover.
-        let mut challenger = Challenger::new(perm.clone());
+        let mut challenger = Challenger::new(perm);
         challenger.observe_slice(&val_sizes);
         challenger.observe(commitment);
 

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -188,7 +188,7 @@ mod tests {
         // Regardless of x, f(x) = c, so interpolation must always return c
         let c = F::from_u32(42); // constant polynomial
         let evals = vec![c; 8];
-        let evals_mat = RowMajorMatrix::new(evals.clone(), 1);
+        let evals_mat = RowMajorMatrix::new(evals, 1);
 
         let shift = F::GENERATOR;
         let point = F::from_u16(1337);

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -315,7 +315,7 @@ mod tests {
     fn test_symbolic_air_builder_assert_zero() {
         let mut builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3);
         let expr = SymbolicExpression::Constant(BabyBear::new(5));
-        builder.assert_zero(expr.clone());
+        builder.assert_zero(expr);
 
         let constraints = builder.constraints();
         assert_eq!(constraints.len(), 1, "One constraint should be recorded");

--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -317,8 +317,8 @@ mod tests {
         );
 
         let mul_expr = SymbolicExpression::<BabyBear>::Mul {
-            x: Rc::new(variable_expr.clone()),
-            y: Rc::new(preprocessed_var.clone()),
+            x: Rc::new(variable_expr),
+            y: Rc::new(preprocessed_var),
             degree_multiple: 2,
         };
         assert_eq!(
@@ -383,7 +383,7 @@ mod tests {
             Entry::Main { offset: 0 },
             2,
         ));
-        let result = a.clone() + b.clone();
+        let result = a + b;
         match result {
             SymbolicExpression::Add {
                 degree_multiple,
@@ -412,7 +412,7 @@ mod tests {
             Entry::Main { offset: 0 },
             2,
         ));
-        let result = a.clone() * b.clone();
+        let result = a * b;
 
         match result {
             SymbolicExpression::Mul {


### PR DESCRIPTION
Remove unnecessary .clone() calls in:

- fri/tests and bn254 test files
- baby-bear benchmark utilities  
- interpolation and uni-stark modules