### PR TITLE
Remove unused Fn import from maybe-rayon

### DIFF
--- a/maybe-rayon/src/lib.rs
+++ b/maybe-rayon/src/lib.rs
@@ -3,7 +3,6 @@
 #[cfg(feature = "parallel")]
 pub mod prelude {
     use core::marker::{Send, Sync};
-    use core::ops::Fn;
 
     pub use rayon::prelude::*;
     pub use rayon::{current_num_threads, join};
@@ -45,7 +44,6 @@ pub mod prelude {
         ExactSizeIterator as IndexedParallelIterator, Iterator as ParallelIterator,
     };
     use core::marker::{Send, Sync};
-    use core::ops::Fn;
 
     pub use super::serial::*;
 


### PR DESCRIPTION
Drop the redundant core::ops::Fn import in the maybe-rayon prelude modules; the trait is already in scope via the prelude.