### PR TITLE
refactor: use next().is_none() instead of collect().is_empty() in tests

### DIFF
--- a/matrix/src/horizontally_truncated.rs
+++ b/matrix/src/horizontally_truncated.rs
@@ -215,8 +215,7 @@ mod tests {
         assert_eq!(truncated.height(), 1);
 
         // Row should be empty.
-        let row: Vec<_> = truncated.row(0).unwrap().into_iter().collect();
-        assert!(row.is_empty());
+        assert!(truncated.row(0).unwrap().into_iter().next().is_none());
 
         assert!(truncated.get(0, 0).is_none()); // Width out of bounds
         assert!(truncated.get(1, 0).is_none()); // Height out of bounds

--- a/matrix/src/row_index_mapped.rs
+++ b/matrix/src/row_index_mapped.rs
@@ -302,11 +302,10 @@ mod tests {
         };
 
         // Extract the packed and suffix iterators from row 0 (which is reversed row 1).
-        let (packed_iter, suffix_iter) = mapped_view.horizontally_packed_row::<Packed>(0);
+        let (packed_iter, mut suffix_iter) = mapped_view.horizontally_packed_row::<Packed>(0);
 
         // Collect iterators to concrete values.
         let packed: Vec<_> = packed_iter.collect();
-        let suffix: Vec<_> = suffix_iter.collect();
 
         // Check the packed row values match reversed second row.
         assert_eq!(
@@ -315,7 +314,7 @@ mod tests {
         );
 
         // Check there are no suffix leftovers.
-        assert!(suffix.is_empty());
+        assert!(suffix_iter.next().is_none());
     }
 
     #[test]

--- a/util/src/zip_eq.rs
+++ b/util/src/zip_eq.rs
@@ -101,12 +101,10 @@ mod tests {
         let b: [char; 0] = [];
 
         // Zipping two empty iterators should succeed and produce an empty iterator.
-        let zipped = zip_eq(a, b, "mismatch").unwrap();
-
-        let result: Vec<_> = zipped.collect();
+        let mut zipped = zip_eq(a, b, "mismatch").unwrap();
 
         // The result should be an empty vector.
-        assert!(result.is_empty());
+        assert!(zipped.next().is_none());
     }
 
     #[test]


### PR DESCRIPTION

Replaced collect().is_empty() with next().is_none() for iterator emptiness checks in test code. This avoids unnecessary memory allocations and is more idiomatic Rust. 