### PR TITLE
fix: make create_benchmark_fri_params_zk const for API consistency

### DIFF
--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -100,7 +100,7 @@ pub const fn create_benchmark_fri_params<Mmcs>(mmcs: Mmcs) -> FriParameters<Mmcs
 
 /// Creates a set of `FriParameters` suitable for benchmarking with zk enabled.
 /// These parameters represent typical settings used in production-like scenarios.
-pub fn create_benchmark_fri_params_zk<Mmcs>(mmcs: Mmcs) -> FriParameters<Mmcs> {
+pub const fn create_benchmark_fri_params_zk<Mmcs>(mmcs: Mmcs) -> FriParameters<Mmcs> {
     FriParameters {
         log_blowup: 2,
         log_final_poly_len: 0,


### PR DESCRIPTION
Makes create_benchmark_fri_params_zk a const function to match the pattern of all other parameter constructor functions in the file. 