### PR TITLE
chore: update rayon version in main Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ postcard = { version = "1.0.0", default-features = false }
 proptest = "1.7"
 rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 rand_xoshiro = "0.7.0"
-rayon = "1.7.0"
+rayon = "1.11.0"
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0.113"
 sha2 = { version = "0.10.8", default-features = false }


### PR DESCRIPTION
PR #1064 changed `repeatn` to `repeat_n`, which was only added in rayon 1.11.0. The Cargo.toml specified `rayon = "1.7.0"` but the ci pipeline still fetches `rayon = "1.11.0"` making the compilation succeed.

Thin PR makes the requirement for `rayon = "1.11.0"` explicit.