### PR TITLE
chore: update proptest version in main Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ itertools = { version = "0.14.0", default-features = false, features = [
 num-bigint = { version = "0.4.3", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.0.0", default-features = false }
-proptest = "1.7"
+proptest = "1.8"
 rand = { version = "0.9.0", default-features = false, features = ["small_rng"] }
 rand_xoshiro = "0.7.0"
 rayon = "1.11.0"


### PR DESCRIPTION
Solving a very similar problem to #1099:

#1066 rightfully removes unnecessary `use alloc::format;` from the scope of `prop_assert_eq!`, however this only becomes possible with the use of `proptest = "1.8"`. The CI pipeline fetches `proptest = "1.8"` making it pass.

This PR makes the necessary version update explicit.

_Note_: Should we enforce a check to make sure that the correct dependency versions are present in the workspace`Cargo.toml`?