### PR TITLE
refactor: remove redundant imports in symbolic_builder tests

### DIFF
--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -153,9 +153,6 @@ impl<F: Field> PairBuilder for SymbolicAirBuilder<F> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-    use alloc::vec::Vec;
-
     use p3_air::BaseAir;
     use p3_baby_bear::BabyBear;
 


### PR DESCRIPTION
Remove redundant `alloc::vec` imports from test module (already available via `use super::*`).

Verified: All tests pass, build succeeds, no warnings