### PR TITLE
Remove unused_imports suppression from packed field module

### DIFF
--- a/field/src/packed/mod.rs
+++ b/field/src/packed/mod.rs
@@ -1,7 +1,6 @@
 pub mod interleaves;
 mod packed_traits;
 
-#[allow(unused_imports)]
 pub use interleaves::*; // Only used when vectorizations are available
 pub use packed_traits::*;
 


### PR DESCRIPTION
drop #[allow(unused_imports)] in field/src/packed/mod.rs so real unused re-exports surface instead of being silenced
no observable behaviour change; keeps module interface intact


Testing: cargo check, cargo clippy