### PR TITLE
perf(challenger): eliminate redundant allocations in HashChallenger::flush

### DIFF
--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -37,10 +37,11 @@ where
         let inputs = self.input_buffer.drain(..);
         let output = self.hasher.hash_iter(inputs);
 
-        self.output_buffer = output.to_vec();
+        self.output_buffer.clear();
+        self.output_buffer.extend_from_slice(&output);
 
         // Chaining values.
-        self.input_buffer.extend(output.to_vec());
+        self.input_buffer.extend_from_slice(&output);
     }
 }
 


### PR DESCRIPTION
Replace output.to_vec() calls with extend_from_slice() to avoid
unnecessary Vec allocations and improve memory efficiency.

-Remove 2 temporary allocations per flush operation
-Maintain identical behavior and API
-All tests pass, clippy clean