### PR TITLE
refactor: Replace &Vec<T> with &[T] in function parameters

### DIFF
--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -104,10 +104,10 @@ where
 
     let config = KeccakStarkConfig::new(pcs, challenger);
 
-    let proof = prove(&config, proof_goal, trace, &vec![]);
+    let proof = prove(&config, proof_goal, trace, &[]);
     report_proof_size(&proof);
 
-    verify(&config, proof_goal, &proof, &vec![])
+    verify(&config, proof_goal, &proof, &[])
 }
 
 /// Prove the given ProofGoal using the Poseidon2 hash function to build the merkle tree.
@@ -146,10 +146,10 @@ where
 
     let config = Poseidon2StarkConfig::new(pcs, challenger);
 
-    let proof = prove(&config, proof_goal, trace, &vec![]);
+    let proof = prove(&config, proof_goal, trace, &[]);
     report_proof_size(&proof);
 
-    verify(&config, proof_goal, &proof, &vec![])
+    verify(&config, proof_goal, &proof, &[])
 }
 
 /// Prove the given ProofGoal using the Keccak hash function to build the merkle tree.
@@ -182,10 +182,10 @@ pub fn prove_m31_keccak<
 
     let config = KeccakCircleStarkConfig::new(pcs, challenger);
 
-    let proof = prove(&config, proof_goal, trace, &vec![]);
+    let proof = prove(&config, proof_goal, trace, &[]);
     report_proof_size(&proof);
 
-    verify(&config, proof_goal, &proof, &vec![])
+    verify(&config, proof_goal, &proof, &[])
 }
 
 /// Prove the given ProofGoal using the Keccak hash function to build the merkle tree.
@@ -222,10 +222,10 @@ where
 
     let config = Poseidon2CircleStarkConfig::new(pcs, challenger);
 
-    let proof = prove(&config, proof_goal, trace, &vec![]);
+    let proof = prove(&config, proof_goal, trace, &[]);
     report_proof_size(&proof);
 
-    verify(&config, proof_goal, &proof, &vec![])
+    verify(&config, proof_goal, &proof, &[])
 }
 
 /// Report the result of the proof.

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -69,6 +69,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -69,6 +69,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -74,6 +74,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -68,6 +68,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -66,6 +66,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -68,6 +68,6 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &KeccakAir {}, trace, &vec![]);
-    verify(&config, &KeccakAir {}, &proof, &vec![])
+    let proof = prove(&config, &KeccakAir {}, trace, &[]);
+    verify(&config, &KeccakAir {}, &proof, &[])
 }

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &air, trace, &vec![]);
+    let proof = prove(&config, &air, trace, &[]);
 
-    verify(&config, &air, &proof, &vec![])
+    verify(&config, &air, &proof, &[])
 }

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -113,7 +113,7 @@ fn prove_and_verify() -> Result<(), impl Debug> {
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);
 
-    let proof = prove(&config, &air, trace, &vec![]);
+    let proof = prove(&config, &air, trace, &[]);
 
-    verify(&config, &air, &proof, &vec![])
+    verify(&config, &air, &proof, &[])
 }

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues};
 use p3_field::Field;
 use p3_matrix::Matrix;
@@ -18,7 +16,7 @@ use tracing::instrument;
 /// - `main`: The trace matrix (rows of witness values)
 /// - `public_values`: Public values provided to the builder
 #[instrument(name = "check constraints", skip_all)]
-pub(crate) fn check_constraints<F, A>(air: &A, main: &RowMajorMatrix<F>, public_values: &Vec<F>)
+pub(crate) fn check_constraints<F, A>(air: &A, main: &RowMajorMatrix<F>, public_values: &[F])
 where
     F: Field,
     A: for<'a> Air<DebugConstraintBuilder<'a, F>>,
@@ -193,7 +191,7 @@ mod tests {
             BabyBear::new(4), // Row 3 (last)
         ];
         let main = RowMajorMatrix::new(values, 2);
-        check_constraints(&air, &main, &vec![BabyBear::new(4); 2]);
+        check_constraints(&air, &main, &[BabyBear::new(4); 2]);
     }
 
     #[test]
@@ -212,7 +210,7 @@ mod tests {
             BabyBear::new(6), // Row 3
         ];
         let main = RowMajorMatrix::new(values, 2);
-        check_constraints(&air, &main, &vec![BabyBear::new(6); 2]);
+        check_constraints(&air, &main, &[BabyBear::new(6); 2]);
     }
 
     #[test]
@@ -232,7 +230,7 @@ mod tests {
         ];
         let main = RowMajorMatrix::new(values, 2);
         // Wrong public value on column 1
-        check_constraints(&air, &main, &vec![BabyBear::new(4), BabyBear::new(5)]);
+        check_constraints(&air, &main, &[BabyBear::new(4), BabyBear::new(5)]);
     }
 
     #[test]
@@ -246,6 +244,6 @@ mod tests {
             BabyBear::new(77), // Row 0
         ];
         let main = RowMajorMatrix::new(values, 2);
-        check_constraints(&air, &main, &vec![BabyBear::new(99), BabyBear::new(77)]);
+        check_constraints(&air, &main, &[BabyBear::new(99), BabyBear::new(77)]);
     }
 }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -17,7 +17,7 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     /// The matrix containing rows on which the constraint polynomial is to be evaluated
     pub main: RowMajorMatrixView<'a, PackedVal<SC>>,
     /// Public inputs to the AIR
-    pub public_values: &'a Vec<Val<SC>>,
+    pub public_values: &'a [Val<SC>],
     /// Evaluations of the Selector polynomial for the first row of the trace
     pub is_first_row: PackedVal<SC>,
     /// Evaluations of the Selector polynomial for the last row of the trace
@@ -44,7 +44,7 @@ pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     /// Pair of consecutive rows from the committed polynomial evaluations
     pub main: ViewPair<'a, SC::Challenge>,
     /// Public values that are inputs to the computation
-    pub public_values: &'a Vec<Val<SC>>,
+    pub public_values: &'a [Val<SC>],
     /// Evaluations of the Selector polynomial for the first row of the trace
     pub is_first_row: SC::Challenge,
     /// Evaluations of the Selector polynomial for the last row of the trace

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -27,7 +27,7 @@ pub fn prove<
     config: &SC,
     air: &A,
     trace: RowMajorMatrix<Val<SC>>,
-    public_values: &Vec<Val<SC>>,
+    public_values: &[Val<SC>],
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
@@ -288,7 +288,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn quotient_values<SC, A, Mat>(
     air: &A,
-    public_values: &Vec<Val<SC>>,
+    public_values: &[Val<SC>],
     trace_domain: Domain<SC>,
     quotient_domain: Domain<SC>,
     trace_on_quotient_domain: &Mat,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -71,7 +71,7 @@ pub fn verify_constraints<SC, A, PcsErr>(
     air: &A,
     trace_local: &[SC::Challenge],
     trace_next: &[SC::Challenge],
-    public_values: &Vec<Val<SC>>,
+    public_values: &[Val<SC>],
     trace_domain: Domain<SC>,
     zeta: SC::Challenge,
     alpha: SC::Challenge,
@@ -113,7 +113,7 @@ pub fn verify<SC, A>(
     config: &SC,
     air: &A,
     proof: &Proof<SC>,
-    public_values: &Vec<Val<SC>>,
+    public_values: &[Val<SC>],
 ) -> Result<(), VerificationError<PcsError<SC>>>
 where
     SC: StarkGenericConfig,

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -127,7 +127,7 @@ where
 {
     let trace = air.random_valid_trace(log_height, true);
 
-    let proof = prove(&config, &air, trace, &vec![]);
+    let proof = prove(&config, &air, trace, &[]);
 
     let serialized_proof = postcard::to_allocvec(&proof).expect("unable to serialize proof");
     tracing::debug!("serialized_proof len: {} bytes", serialized_proof.len());
@@ -135,7 +135,7 @@ where
     let deserialized_proof =
         postcard::from_bytes(&serialized_proof).expect("unable to deserialize proof");
 
-    verify(&config, &air, &deserialized_proof, &vec![])
+    verify(&config, &air, &deserialized_proof, &[])
 }
 
 fn do_test_bb_trivial(degree: u64, log_n: usize) -> Result<(), impl Debug> {


### PR DESCRIPTION
Fixes a common Rust anti-pattern where function parameters were using &Vec<T> instead of &[T].

Changed the public_values parameter type in uni-stark module functions from &Vec<Val<SC>> to &[Val<SC>]. This makes the API more flexible since it now accepts any slice-like type, not just Vec.

As a nice side effect, this allowed cleaning up 24 call sites across the codebase where we were doing &vec![] when we can just use &[] now.