### PR TITLE
Simplify lookup range-check test value extraction

### DIFF
--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -635,7 +635,8 @@ fn test_range_check_end_to_end_valid() {
         .row(aux_trace.height() - 1)
         .unwrap()
         .into_iter()
-        .collect::<Vec<EF>>()[0];
+        .next()
+        .unwrap();
     let last_row_data = main_trace
         .row(main_trace.height() - 1)
         .unwrap()


### PR DESCRIPTION
replace the intermediate `collect::<Vec<_>>()` in `test_range_check_end_to_end_valid`
read the first auxiliary value via `next().unwrap()` to avoid the redundant allocation
