### PR TITLE
Remove redundant zk guard in multi-stark verifier

### DIFF
--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -45,11 +45,6 @@ where
         panic!("p3-multi-stark: ZK mode is not supported yet");
     }
 
-    // ZK mode is not supported yet
-    if config.is_zk() != 0 {
-        panic!("p3-multi-stark: ZK mode is not supported yet");
-    }
-
     // Sanity checks
     if airs.len() != opened_values.instances.len()
         || airs.len() != public_values.len()


### PR DESCRIPTION
remove the duplicate `config.is_zk()` guard in `verify_multi`, keeping the single panic path for unsupported zk mode

