### PR TITLE
Fix duplex sponge absorption to preserve transcript context

### DIFF
--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -78,9 +78,9 @@ where
     fn duplexing(&mut self) {
         assert!(self.input_buffer.len() <= RATE);
 
-        // Overwrite the first r elements with the inputs.
+        // Add the buffered inputs into the rate part of the state to preserve prior context.
         for (i, val) in self.input_buffer.drain(..).enumerate() {
-            self.sponge_state[i] = val;
+            self.sponge_state[i] += val;
         }
 
         // Apply the permutation.


### PR DESCRIPTION

## Summary
- additively mix absorbed rate elements into the duplex state instead of overwriting them
- ensure prior observations continue to influence subsequent challenges

