### PR TITLE
Remove duplicated ZK-mode guard in multi-stark verifier

### DIFF
--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -45,11 +45,6 @@ where
         panic!("p3-multi-stark: ZK mode is not supported yet");
     }
 
-    // ZK mode is not supported yet
-    if config.is_zk() != 0 {
-        panic!("p3-multi-stark: ZK mode is not supported yet");
-    }
-
     // Sanity checks
     if airs.len() != opened_values.instances.len()
         || airs.len() != public_values.len()


### PR DESCRIPTION
keep the single panic guarding unsupported ZK mode in `verify_multi`
drop the redundant second check to reduce noise in this hot path