### PR TITLE
Remove unused PackedValue import from field helpers

### DIFF
--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -6,7 +6,7 @@ use core::ops::Mul;
 use p3_maybe_rayon::prelude::*;
 
 use crate::field::Field;
-use crate::{PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32};
+use crate::{PrimeCharacteristicRing, PrimeField, PrimeField32};
 
 /// Computes a multiplicative subgroup whose order is known in advance.
 pub fn cyclic_subgroup_known_order<F: Field>(


### PR DESCRIPTION
Drop the unused `PackedValue` re-export from `field/src/helpers.rs` silence the compiler warning and keep the module’s public surface minimal