### PR TITLE
fix: Add bounds check to circle_two_adic_generator to prevent underflow

### DIFF
--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -30,6 +30,7 @@ impl ComplexExtendable for Mersenne31 {
         // 1584694829*u + 311014874
         // sage: assert(g.multiplicative_order() == 2^31)
         // sage: assert(g.norm() == 1)
+        assert!(bits <= Self::CIRCLE_TWO_ADICITY);
         let base = Complex::new_complex(Self::new(311_014_874), Self::new(1_584_694_829));
         base.exp_power_of_2(Self::CIRCLE_TWO_ADICITY - bits)
     }


### PR DESCRIPTION
Add assert!(bits <= Self::CIRCLE_TWO_ADICITY) in mersenne-31/src/complex.rs within circle_two_adic_generator.
Reason: Without validation, when bits > CIRCLE_TWO_ADICITY the subtraction CIRCLE_TWO_ADICITY - bits underflows. In debug builds this panics; in release builds it wraps and leads to an excessive number of squarings and an incorrect generator element.
This change aligns with existing patterns in the codebase (e.g., ext_two_adic_generator and Goldilocks implementations) that assert bounds for two-adic generators.