### PR TITLE
chore: remove unused QuotientMap import from air utils

### DIFF
--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -2,7 +2,6 @@
 
 use core::array;
 
-use p3_field::integers::QuotientMap;
 use p3_field::{Field, PrimeCharacteristicRing};
 
 use crate::AirBuilder;


### PR DESCRIPTION
drop the unused p3_field::integers::QuotientMap import from air/src/utils.rs silence the unused import warning and keep the module dependency surface minimal