### PR TITLE
drop unused PrimeCharacteristicRing import in tests

### DIFF
--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -145,7 +145,7 @@ mod tests {
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_commit::Mmcs;
-    use p3_field::{Field, PrimeCharacteristicRing};
+    use p3_field::Field;
     use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};


### PR DESCRIPTION
remove the unused PrimeCharacteristicRing import from the hiding MMCS test module keep only Field, the sole trait required by the test helper code