### PR TITLE
fix: use log2(packing_width) in small-problem cutoff

### DIFF
--- a/multilinear-util/src/eq_batch.rs
+++ b/multilinear-util/src/eq_batch.rs
@@ -578,19 +578,19 @@ fn eval_eq_batch_common<F, IF, EF, E, const INITIALIZED: bool>(
 
     // For small problems, use the basic recursive approach
     let packing_width = F::Packing::WIDTH;
+    let log_packing_width = log2_strict_usize(packing_width);
     let num_threads = current_num_threads().next_power_of_two();
     let log_num_threads = log2_strict_usize(num_threads);
 
     // If the number of variables is small, there is no need to use
     // parallelization or packings.
-    if num_vars <= packing_width + 1 + log_num_threads {
+    if num_vars <= log_packing_width + 1 + log_num_threads {
         // Allocate workspace once for all recursive calls
         //
         // The max function ensures we allocate at least 1 element to avoid empty slice issues
         let mut workspace = EF::zero_vec((2 * evals.width() * num_vars).max(1));
         eval_eq_batch_basic::<F, IF, EF, INITIALIZED>(evals, scalars, out, &mut workspace);
     } else {
-        let log_packing_width = log2_strict_usize(packing_width);
         let eval_len_min_packing = num_vars - log_packing_width;
 
         // Split the variables into three parts:


### PR DESCRIPTION
The small-problem cutoff in eval_eq_batch_common() compared the number of variables to packing_width + 1 + log_num_threads, where packing_width is the SIMD lane count (F::Packing::WIDTH). This mixes units: the cutoff should reflect how many variables are “consumed” by packing, which is log2(packing_width), not packing_width. The rest of the function already splits variables using log_packing_width = log2(packing_width), and the tests compute the threshold as packing_width.ilog2() + 1 + log_num_threads to “force parallel path”. Using packing_width directly inflated the threshold and suppressed the SIMD+parallel path more than intended. This commit bases the cutoff on log_packing_width, computed once before the if, and removes the redundant recomputation inside the else branch, aligning units, code, and tests.