### PR TITLE
fix(util): simplify assume_init_ref pointer cast

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -335,11 +335,12 @@ where
 /// Once that is stabilized, this should be removed.
 #[inline(always)]
 pub const unsafe fn assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {
-    // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
+    // SAFETY: casting the element pointer to `*const T` is safe since the caller guarantees that
     // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
     // The pointer obtained is valid since it refers to memory owned by `slice` which is a
     // reference and thus guaranteed to be valid for reads.
-    unsafe { &*(slice as *const [MaybeUninit<T>] as *const [T]) }
+    let ptr = slice.as_ptr().cast::<T>();
+    unsafe { core::slice::from_raw_parts(ptr, slice.len()) }
 }
 
 /// Split an iterator into small arrays and apply `func` to each.


### PR DESCRIPTION
I rewired `assume_init_ref` so it no longer chains two `as` casts. Instead we take the element pointer (`slice.as_ptr().cast::<T>()`) and rebuild the slice via `core::slice::from_raw_parts`, matching the pattern we already use elsewhere (see `as_base_slice` in `util/src/lib.rs`, lines 423–434). The safety comment now describes this new flow; the rest of the function remains unchanged