### PR TITLE
test: cover parallel add_scaled_slice

### DIFF
--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -25,6 +25,7 @@ mod helpers {
         let expected = vec![x1 + s * y1, x2 + s * y2];
 
         assert_eq!(x, expected);
+        assert_eq!(par_x, expected);
     }
 
     #[test]


### PR DESCRIPTION
Add the missing assertion for the parallel helper so the test actually catches divergences between the serial and parallel implementations