### PR TITLE
Avoid cloning in assign ops by using mem::take

### DIFF
--- a/uni-stark/src/symbolic_expression.rs
+++ b/uni-stark/src/symbolic_expression.rs
@@ -1,5 +1,4 @@
 use alloc::rc::Rc;
-use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -116,7 +115,7 @@ where
     T: Into<Self>,
 {
     fn add_assign(&mut self, rhs: T) {
-        *self = self.clone() + rhs.into();
+        *self = core::mem::take(self) + rhs.into();
     }
 }
 
@@ -151,7 +150,7 @@ where
     T: Into<Self>,
 {
     fn sub_assign(&mut self, rhs: T) {
-        *self = self.clone() - rhs.into();
+        *self = core::mem::take(self) - rhs.into();
     }
 }
 
@@ -189,7 +188,7 @@ where
     T: Into<Self>,
 {
     fn mul_assign(&mut self, rhs: T) {
-        *self = self.clone() * rhs.into();
+        *self = core::mem::take(self) * rhs.into();
     }
 }
 


### PR DESCRIPTION
 Replace self.clone() in AddAssign, SubAssign, and MulAssign for SymbolicExpression with core::mem::take(self) to eliminate unnecessary Rc reference count churn and value copies while preserving behavior. This change reduces overhead when building expression trees through in-place operators and is panic-safe for our usage since arithmetic is infallible and the only potential allocation is Rc::new; in the unlikely event of a panic, self would hold ZERO instead of the old value, which is acceptable for this internal symbolic construction path.
 Also removed unused import use core::fmt::Debug; derive Debug doesn't require use core::fmt::Debug;