### PR TITLE
fix(mds): assert N>0 in apply_circulant to match dot_product and avoid N-1 underflow

### DIFF
--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -43,6 +43,7 @@ pub fn apply_circulant<R: PrimeCharacteristicRing, const N: usize>(
     circ_matrix: &[u64; N],
     input: &[R; N],
 ) -> [R; N] {
+    debug_assert_ne!(N, 0);
     let mut matrix = circ_matrix.map(R::from_u64);
 
     let mut output = [R::ZERO; N];


### PR DESCRIPTION
Add a debug assertion debug_assert_ne!(N, 0) at the start of apply_circulant()
Rationale:
- The function indexed with N - 1 and iterated over take(N - 1), which can underflow and panic for N == 0. While callers currently use only positive widths (by design for MDS), this assertion makes the contract explicit and catches misuse in debug builds.
- This aligns the behavior with dot_product() in the same file, which already asserts N != 0. R::dot_product() from PrimeCharacteristicRing gracefully handles empty vectors, but apply_circulant()’s indexing would panic earlier without a clear signal.