### PR TITLE
feat: calculate Poseidon round numbers based on field, width and ALPHA

### DIFF
--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -3,12 +3,13 @@ use core::array;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::{Algebra, Field, InjectiveMonomial, PrimeField};
+use p3_field::{Algebra, Field, InjectiveMonomial, PrimeField, PrimeField64};
 use p3_goldilocks::{Goldilocks, MdsMatrixGoldilocks};
 use p3_mds::MdsPermutation;
 use p3_mds::coset_mds::CosetMds;
 use p3_mersenne_31::{MdsMatrixMersenne31, Mersenne31};
 use p3_poseidon::Poseidon;
+use p3_poseidon2::poseidon2_round_numbers_128;
 use p3_symmetric::Permutation;
 use rand::SeedableRng;
 use rand::distr::{Distribution, StandardUniform};
@@ -30,7 +31,7 @@ fn bench_poseidon(c: &mut Criterion) {
 
 fn poseidon<F, A, Mds, const WIDTH: usize, const ALPHA: u64>(c: &mut Criterion)
 where
-    F: PrimeField + InjectiveMonomial<ALPHA>,
+    F: PrimeField + PrimeField64 + InjectiveMonomial<ALPHA>,
     A: Algebra<F> + InjectiveMonomial<ALPHA>,
     StandardUniform: Distribution<F>,
     Mds: MdsPermutation<A, WIDTH> + Default,
@@ -38,9 +39,9 @@ where
     let mut rng = SmallRng::seed_from_u64(1);
     let mds = Mds::default();
 
-    // TODO: Should be calculated for the particular field, width and ALPHA.
-    let half_num_full_rounds = 4;
-    let num_partial_rounds = 22;
+    let (full_rounds, num_partial_rounds) = poseidon2_round_numbers_128::<F>(WIDTH, ALPHA)
+        .expect("Invalid parameters for Poseidon round numbers");
+    let half_num_full_rounds = full_rounds / 2;
 
     let poseidon = Poseidon::<F, Mds, WIDTH, ALPHA>::new_from_rng(
         half_num_full_rounds,


### PR DESCRIPTION
Implement TODO to calculate half_num_full_rounds and num_partial_rounds dynamically using poseidon2_round_numbers_128 instead of hardcoded values.

Changes:
- Add p3-poseidon2 as dev-dependency
- Use poseidon2_round_numbers_128 to compute round numbers based on field type, width, and ALPHA
- Add PrimeField64 bound to function signature