### PR TITLE
remove redundant Option import

### DIFF
--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -1,7 +1,6 @@
 use core::iter::{FlatMap, IntoIterator, Iterator};
 use core::marker::{Send, Sized, Sync};
 use core::ops::{Fn, FnOnce};
-use core::option::Option;
 use core::slice::{
     Chunks, ChunksExact, ChunksExactMut, ChunksMut, RChunks, RChunksExact, RChunksExactMut,
     RChunksMut, Split, SplitMut, Windows,


### PR DESCRIPTION
drop the explicit core::option::Option import; it is provided by the core prelude already