### PR TITLE
Fix: Implement `make_col_map` in poseidon2-air

### DIFF
--- a/poseidon2-air/src/columns.rs
+++ b/poseidon2-air/src/columns.rs
@@ -1,5 +1,7 @@
 use core::borrow::{Borrow, BorrowMut};
-use core::mem::size_of;
+use core::mem::{size_of, transmute};
+
+use p3_util::indices_arr;
 
 /// Columns for a Poseidon2 AIR which computes one permutation per row.
 ///
@@ -77,24 +79,23 @@ pub const fn make_col_map<
     const HALF_FULL_ROUNDS: usize,
     const PARTIAL_ROUNDS: usize,
 >() -> Poseidon2Cols<usize, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS> {
-    todo!()
-    // let indices_arr = indices_arr::<
-    //     { num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>() },
-    // >();
-    // unsafe {
-    //     transmute::<
-    //         [usize;
-    //             num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()],
-    //         Poseidon2Cols<
-    //             usize,
-    //             WIDTH,
-    //             SBOX_DEGREE,
-    //             SBOX_REGISTERS,
-    //             HALF_FULL_ROUNDS,
-    //             PARTIAL_ROUNDS,
-    //         >,
-    //     >(indices_arr)
-    // }
+    let indices_arr = indices_arr::<
+        { num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>() },
+    >();
+    unsafe {
+        transmute::<
+            [usize;
+                num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()],
+            Poseidon2Cols<
+                usize,
+                WIDTH,
+                SBOX_DEGREE,
+                SBOX_REGISTERS,
+                HALF_FULL_ROUNDS,
+                PARTIAL_ROUNDS,
+            >,
+        >(indices_arr)
+    }
 }
 
 impl<


### PR DESCRIPTION


The `make_col_map` function in `poseidon2-air/src/columns.rs` was left unimplemented with a `todo!()`, causing a panic on any call to this public API. This made the column mapping functionality completely unusable.

