### PR TITLE
Make Poseidon2 single row generation public

### DIFF
--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -131,7 +131,7 @@ pub fn generate_trace_rows<
 }
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
-fn generate_trace_rows_for_perm<
+pub fn generate_trace_rows_for_perm<
     F: PrimeField,
     LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
     const WIDTH: usize,


### PR DESCRIPTION
This PR exposes the function `generate_trace_rows_for_perm` that generates a single Poseidon2 permutation row. The existing public API only provides a function that generates the entire matrix, but certain use cases require allocating the permutation inside an already-existing matrix rather than creating a new one.