### PR TITLE
feat: add PoW phase for batching in FRI commit phase

### DIFF
--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -1156,7 +1156,8 @@ fn test_circle_stark_batch() -> Result<(), impl Debug> {
         log_blowup: 1,
         log_final_poly_len: 0,
         num_queries: 40,
-        proof_of_work_bits: 8,
+        commit_proof_of_work_bits: 8,
+        query_proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
 

--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -35,6 +35,9 @@ pub trait GrindingChallenger:
     /// Returns `true` if the witness passes the PoW check, `false` otherwise.
     #[must_use]
     fn check_witness(&mut self, bits: usize, witness: Self::Witness) -> bool {
+        if bits == 0 {
+            return true;
+        }
         self.observe(witness);
         self.sample_bits(bits) == 0
     }

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -40,7 +40,7 @@ where
 
     let commit_phase_result = commit_phase(folding, params, inputs, challenger);
 
-    let pow_witness = challenger.grind(params.proof_of_work_bits);
+    let pow_witness = challenger.grind(params.query_proof_of_work_bits);
 
     let query_proofs = info_span!("query phase").in_scope(|| {
         iter::repeat_with(|| {

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -46,7 +46,7 @@ where
     }
 
     // Check PoW.
-    if !challenger.check_witness(params.proof_of_work_bits, proof.pow_witness) {
+    if !challenger.check_witness(params.query_proof_of_work_bits, proof.pow_witness) {
         return Err(FriError::InvalidPowWitness);
     }
 

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -11,7 +11,10 @@ pub struct FriParameters<M> {
     // TODO: This parameter and FRI early stopping are not yet implemented in `CirclePcs`.
     pub log_final_poly_len: usize,
     pub num_queries: usize,
-    pub proof_of_work_bits: usize,
+    /// Number of bits for the PoW phase before sampling _each_ batching challenge.
+    pub commit_proof_of_work_bits: usize,
+    /// Number of bits for the PoW phase before sampling the queries.
+    pub query_proof_of_work_bits: usize,
     pub mmcs: M,
 }
 
@@ -30,7 +33,7 @@ impl<M> FriParameters<M> {
     /// Certain users may instead want to look at proven soundness, a more complex calculation which
     /// isn't currently supported by this crate.
     pub const fn conjectured_soundness_bits(&self) -> usize {
-        self.log_blowup * self.num_queries + self.proof_of_work_bits
+        self.log_blowup * self.num_queries + self.query_proof_of_work_bits
     }
 }
 
@@ -69,7 +72,8 @@ pub const fn create_test_fri_params<Mmcs>(
         log_blowup: 2,
         log_final_poly_len,
         num_queries: 2,
-        proof_of_work_bits: 1,
+        commit_proof_of_work_bits: 1,
+        query_proof_of_work_bits: 1,
         mmcs,
     }
 }
@@ -81,7 +85,8 @@ pub const fn create_test_fri_params_zk<Mmcs>(mmcs: Mmcs) -> FriParameters<Mmcs> 
         log_blowup: 2,
         log_final_poly_len: 0,
         num_queries: 2,
-        proof_of_work_bits: 1,
+        commit_proof_of_work_bits: 1,
+        query_proof_of_work_bits: 1,
         mmcs,
     }
 }
@@ -93,7 +98,8 @@ pub const fn create_benchmark_fri_params<Mmcs>(mmcs: Mmcs) -> FriParameters<Mmcs
         log_blowup: 1,
         log_final_poly_len: 0,
         num_queries: 100,
-        proof_of_work_bits: 16,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 16,
         mmcs,
     }
 }
@@ -105,7 +111,8 @@ pub const fn create_benchmark_fri_params_zk<Mmcs>(mmcs: Mmcs) -> FriParameters<M
         log_blowup: 2,
         log_final_poly_len: 0,
         num_queries: 100,
-        proof_of_work_bits: 16,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 16,
         mmcs,
     }
 }

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -11,9 +11,10 @@ use serde::{Deserialize, Serialize};
 ))]
 pub struct FriProof<F: Field, M: Mmcs<F>, Witness, InputProof> {
     pub commit_phase_commits: Vec<M::Commitment>,
+    pub commit_pow_witnesses: Vec<Witness>,
     pub query_proofs: Vec<QueryProof<F, M, InputProof>>,
     pub final_poly: Vec<F>,
-    pub pow_witness: Witness,
+    pub query_pow_witness: Witness,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -89,17 +89,25 @@ where
     let log_global_max_height =
         proof.commit_phase_commits.len() + params.log_blowup + params.log_final_poly_len;
 
-    // Generate all of the random challenges for the FRI rounds.
+    if proof.commit_pow_witnesses.len() != proof.commit_phase_commits.len() {
+        return Err(FriError::InvalidProofShape);
+    }
+
+    // Generate all of the random challenges for the FRI rounds, checking PoW per round.
     let betas: Vec<Challenge> = proof
         .commit_phase_commits
         .iter()
-        .map(|comm| {
-            // To match with the prover (and for security purposes),
-            // we observe the commitment before sampling the challenge.
+        .zip(&proof.commit_pow_witnesses)
+        .map(|(comm, witness)| {
+            // Observe the commitment, check the PoW witness, then sample the
+            // folding challenge.
             challenger.observe(comm.clone());
-            challenger.sample_algebra_element()
+            if !challenger.check_witness(params.commit_proof_of_work_bits, *witness) {
+                return Err(FriError::InvalidPowWitness);
+            }
+            Ok(challenger.sample_algebra_element())
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Ensure that the final polynomial has the expected degree.
     if proof.final_poly.len() != params.final_poly_len() {
@@ -118,7 +126,7 @@ where
     }
 
     // Check PoW.
-    if !challenger.check_witness(params.proof_of_work_bits, proof.pow_witness) {
+    if !challenger.check_witness(params.query_proof_of_work_bits, proof.query_pow_witness) {
         return Err(FriError::InvalidPowWitness);
     }
 

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -35,7 +35,8 @@ fn get_ldt_for_testing<R: Rng>(rng: &mut R, log_final_poly_len: usize) -> (Perm,
         log_blowup: 1,
         log_final_poly_len,
         num_queries: 10,
-        proof_of_work_bits: 8,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 8,
         mmcs: fri_mmcs,
     };
     let dft = Radix2Dit::default();

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -180,7 +180,8 @@ mod babybear_fri_pcs {
             log_blowup,
             log_final_poly_len: 0,
             num_queries: 10,
-            proof_of_work_bits: 8,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 8,
             mmcs: challenge_mmcs,
         };
 
@@ -233,7 +234,8 @@ mod m31_fri_pcs {
             log_blowup,
             log_final_poly_len: 0,
             num_queries: 10,
-            proof_of_work_bits: 8,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 8,
             mmcs: challenge_mmcs,
         };
         let pcs = Pcs {

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -215,7 +215,8 @@ fn do_test_bb_twoadic(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         log_blowup,
         log_final_poly_len: 3,
         num_queries: 40,
-        proof_of_work_bits: 8,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
@@ -326,7 +327,8 @@ fn do_test_m31_circle(log_blowup: usize, degree: u64, log_n: usize) -> Result<()
         log_blowup,
         log_final_poly_len: 0,
         num_queries: 40,
-        proof_of_work_bits: 8,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 8,
         mmcs: challenge_mmcs,
     };
 


### PR DESCRIPTION
Add a proof-of-work phase before each commit-phase fold challenge, using new configuration parameter `commit_proof_of_work_bits`. Note for simplicity, there is a single `commit_proof_of_work_bits` shared across all rounds.

We also change the `check_witness` logic to be a no-op when `bits == 0`.