### PR TITLE
Derive `Clone` for `PreprocessedInstanceMeta`

### DIFF
--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -21,6 +21,7 @@ use crate::prover::StarkInstance;
 
 /// Per-instance metadata for a preprocessed trace that lives inside a
 /// global preprocessed commitment.
+#[derive(Clone)]
 pub struct PreprocessedInstanceMeta {
     /// Index of this instance's preprocessed matrix inside the global PCS
     /// commitment / prover data.


### PR DESCRIPTION
Simple PR to derive `Clone` for `PreprocessedInstanceMeta`, so it makes reusing that metadata easier in recursion (and potentially other projects).