### PR TITLE
matrix: make `HorizontallyTruncated` more generic

### DIFF
--- a/matrix/src/horizontally_truncated.rs
+++ b/matrix/src/horizontally_truncated.rs
@@ -71,6 +71,7 @@ where
     unsafe fn get_unchecked(&self, r: usize, c: usize) -> T {
         unsafe {
             // Safety: The caller must ensure that `c < self.width()` and `r < self.height()`.
+            //
             // We translate the column index by adding `column_range.start`.
             self.inner.get_unchecked(r, self.column_range.start + c)
         }


### PR DESCRIPTION
@Nashtare I think that we can make `HorizontallyTruncated` more generic in order to expose not just a number of columns of the inner matrix starting from the 0 index column but a column range instead.

This way, in Plonky3-recursion, we don't need to redefine `SubMatrixRowSlices` here https://github.com/Plonky3/Plonky3-recursion/blob/f38269e80c54a4899956f3aec3f834663a570b04/poseidon2-circuit-air/src/sub_builder.rs#L10-L15 and we can just reuse `HorizontallyTruncated` directly.