### PR TITLE
Chore: drop redundant Clone bound from MontyParameters

### DIFF
--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -8,7 +8,7 @@ use crate::MontyField31;
 /// MontyParameters contains the prime P along with constants needed to convert elements into and out of MONTY form.
 /// The MONTY constant is assumed to be a power of 2.
 pub trait MontyParameters:
-    Copy + Clone + Default + Debug + Eq + PartialEq + Sync + Send + Hash + 'static
+    Copy + Default + Debug + Eq + PartialEq + Sync + Send + Hash + 'static
 {
     // A 31-bit prime.
     const PRIME: u32;


### PR DESCRIPTION
Remove the explicit Clone bound from MontyParameters since Copy already implies it. Simplifies the trait’s contract without changing behavior or requirements for implementors.