### PR TITLE
chore: remove redundant Clone bound from MontyParameters

### DIFF
--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -7,9 +7,7 @@ use crate::MontyField31;
 
 /// MontyParameters contains the prime P along with constants needed to convert elements into and out of MONTY form.
 /// The MONTY constant is assumed to be a power of 2.
-pub trait MontyParameters:
-    Copy + Clone + Default + Debug + Eq + PartialEq + Sync + Send + Hash + 'static
-{
+pub trait MontyParameters: Copy + Default + Debug + Eq + PartialEq + Sync + Send + Hash + 'static {
     // A 31-bit prime.
     const PRIME: u32;
 


### PR DESCRIPTION
drop the superfluous Clone requirement because Copy covers it, keep the trait surface minimal with no behavioural change