### PR TITLE
matrix: add `pad_to_power_of_two_height`

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -563,7 +563,7 @@ impl<T: Clone + Default + Send + Sync> DenseMatrix<T> {
     pub fn pad_to_power_of_two_height(&mut self, fill: T) {
         // Compute the target height as the next power of two.
         let target_height = self.height().next_power_of_two();
-        
+
         // If target_height == height, resize will have no effect.
         // Otherwise we pad the matrix to a power of two height by filling with the supplied value.
         self.values.resize(self.width * target_height, fill);


### PR DESCRIPTION
@Nashtare I feel like in lots of proving systems we are doing this quite frequently, including here

https://github.com/Plonky3/Plonky3-recursion/blob/65a3583d611c02828621016ce6b30e388a20b63a/circuit/src/utils.rs#L211-L228

Maybe could be nice to have this util directly here what do you think?
