### PR TITLE
feat: revert `builder.assert_bool` to previous impl

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -206,7 +206,7 @@ pub trait PrimeCharacteristicRing:
     fn bool_check(&self) -> Self {
         // Note: We could delegate to `andn`, but to maintain backwards
         // compatible AIR definitions, we stick with `x * (x - 1)` here.
-        self.clone() * (self.clone() - Self::ONE);
+        self.clone() * (self.clone() - Self::ONE)
     }
 
     /// Exponentiation by a `u64` power.


### PR DESCRIPTION
At some point `assert_bool(x)` changed from defining the constraint polynomial `x * (x - 1)` to defining `(1 - x) * x`. This change in implementation is problematic for deployed systems (such as OpenVM) because it changes the definitions of the AIRs (note that the two alternatives here are not just syntactically different but actually define different polynomials).