### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,45 +96,45 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.3.0" }
-p3-baby-bear = { path = "baby-bear", version = "0.3.0" }
-p3-blake3 = { path = "blake3", version = "0.3.0" }
-p3-blake3-air = { path = "blake3-air", version = "0.3.0" }
-p3-bn254 = { path = "bn254", version = "0.3.0" }
-p3-challenger = { path = "challenger", version = "0.3.0" }
-p3-circle = { path = "circle", version = "0.3.0" }
-p3-commit = { path = "commit", version = "0.3.0" }
-p3-dft = { path = "dft", version = "0.3.0" }
+p3-air = { path = "air", version = "0.4.0" }
+p3-baby-bear = { path = "baby-bear", version = "0.4.0" }
+p3-blake3 = { path = "blake3", version = "0.4.0" }
+p3-blake3-air = { path = "blake3-air", version = "0.4.0" }
+p3-bn254 = { path = "bn254", version = "0.4.0" }
+p3-challenger = { path = "challenger", version = "0.4.0" }
+p3-circle = { path = "circle", version = "0.4.0" }
+p3-commit = { path = "commit", version = "0.4.0" }
+p3-dft = { path = "dft", version = "0.4.0" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.3.0" }
-p3-field-testing = { path = "field-testing", version = "0.3.0" }
-p3-fri = { path = "fri", version = "0.3.0" }
-p3-goldilocks = { path = "goldilocks", version = "0.3.0" }
-p3-interpolation = { path = "interpolation", version = "0.3.0" }
-p3-keccak = { path = "keccak", version = "0.3.0" }
-p3-keccak-air = { path = "keccak-air", version = "0.3.0" }
-p3-koala-bear = { path = "koala-bear", version = "0.3.0" }
-p3-lookup = { path = "lookup", version = "0.3.0" }
-p3-matrix = { path = "matrix", version = "0.3.0" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.3.0" }
-p3-mds = { path = "mds", version = "0.3.0" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.3.0" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.3.0" }
-p3-monty-31 = { path = "monty-31", version = "0.3.0" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.3.0" }
-p3-poseidon = { path = "poseidon", version = "0.3.0" }
-p3-poseidon2 = { path = "poseidon2", version = "0.3.0" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.3.0" }
-p3-rescue = { path = "rescue", version = "0.3.0" }
-p3-sha256 = { path = "sha256", version = "0.3.0" }
-p3-symmetric = { path = "symmetric", version = "0.3.0" }
-p3-uni-stark = { path = "uni-stark", version = "0.3.0" }
-p3-util = { path = "util", version = "0.3.0" }
+p3-field = { path = "field", version = "0.4.0" }
+p3-field-testing = { path = "field-testing", version = "0.4.0" }
+p3-fri = { path = "fri", version = "0.4.0" }
+p3-goldilocks = { path = "goldilocks", version = "0.4.0" }
+p3-interpolation = { path = "interpolation", version = "0.4.0" }
+p3-keccak = { path = "keccak", version = "0.4.0" }
+p3-keccak-air = { path = "keccak-air", version = "0.4.0" }
+p3-koala-bear = { path = "koala-bear", version = "0.4.0" }
+p3-lookup = { path = "lookup", version = "0.4.0" }
+p3-matrix = { path = "matrix", version = "0.4.0" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.4.0" }
+p3-mds = { path = "mds", version = "0.4.0" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.4.0" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.4.0" }
+p3-monty-31 = { path = "monty-31", version = "0.4.0" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.4.0" }
+p3-poseidon = { path = "poseidon", version = "0.4.0" }
+p3-poseidon2 = { path = "poseidon2", version = "0.4.0" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.4.0" }
+p3-rescue = { path = "rescue", version = "0.4.0" }
+p3-sha256 = { path = "sha256", version = "0.4.0" }
+p3-symmetric = { path = "symmetric", version = "0.4.0" }
+p3-uni-stark = { path = "uni-stark", version = "0.4.0" }
+p3-util = { path = "util", version = "0.4.0" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Air: more unit tests for air utils (#936) (Thomas Coratger)
+- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
+- Air: better doc for traits (#935) (Thomas Coratger)
+- Chore: various small changes (#944) (Thomas Coratger)
+- Weaken the trait bound of AirBuilder to allow `F` to be merely a Ring. (#977) (AngusG)
+- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
+- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
+
+### Authors
+- AngusG
+- Himess
+- Linda Guiga
+- Thomas Coratger
+- o-k-d
+

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- GCD based inversion for 31 bit fields (#921) (AngusG)
+- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Refactor to packed add methods (#972) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Speed Up Base-Extension Multiplication (#998) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
+- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
+- Fix: remove unused alloc::format imports (#1066) (Skylar Ray)
+- Monty 31: more efficient aarch64 neon `quartic_mul_packed` (#1060) (Thomas Coratger)
+- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- AngusG
+- Himess
+- Jeremi Do Dinh
+- Sebastian
+- Skylar Ray
+- Thomas Coratger
+- andrewshab
+

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Rename multi-stark crate to batch-stark (#1122) (Sai)
+- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
+- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
+- Add preprocessed column support in batch-STARK  (#1151) (Sai)
+- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
+- Derive Clone for PreprocessedInstanceMeta (#1166) (Linda Guiga)
+- Clarify quotient degree vs quotient chunks naming (#1156) (Sai)
+- Doc: add intra-doc links (#1174) (Robin Salen)
+- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
+- Core: small touchups (#1186) (Thomas Coratger)
+- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- Linda Guiga
+- Robin Salen
+- Sai
+- Sebastian
+- Thomas Coratger
+- Zach Langley
+- o-k-d
+

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+
+### Authors
+- Himess
+- Linda Guiga
+- Thomas Coratger
+

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Clippy: small step (#1102) (Thomas Coratger)
+
+### Authors
+- Himess
+- Thomas Coratger
+

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Porting BN254 to our own code base (#913) (AngusG)
+- Interleaved Montgomery Multiplication (#915) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Custom halve impl for Bn254 (#919) (AngusG)
+- From_biguint method for Bn254 (#914) (AngusG)
+- Bn254 Binary Euclidean Inversion (#920) (AngusG)
+- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
+- Adding Macros to remove boilerplate impls (#943) (AngusG)
+- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
+- Move halve to ring (#969) (AngusG)
+- Must Use (#996) (AngusG)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
+
+### Authors
+- AngusG
+- Himess
+- Skylar Ray
+- Thomas Coratger
+- andrewshab
+

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Add a comment about non-uniformity in `CanSampleBits` (#1026) (Tom Wambsgans)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
+- Challenger: add unit tests for `observe_base_as_algebra_element` (#1155) (Thomas Coratger)
+- Challenger: add `observe_algebra_elements` method (#1176) (Thomas Coratger)
+- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- Himess
+- Sebastian
+- Thomas Coratger
+- Tom Wambsgans
+- Zach Langley
+

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Remove Nightly Features (#932) (AngusG)
+- Docs: improve documentation for Circle STARKs deep quotient algorithms (#1079) (Adrian)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Circle: batch inverses in selectors_on_coset (#1068) (Forostovec)
+- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
+- Challenger: use `observe_algebra_slice` when possible (#1187) (Thomas Coratger)
+- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
+
+### Authors
+- Adrian
+- AngusG
+- Forostovec
+- Himess
+- Thomas Coratger
+- Zach Langley
+

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Mmcs: better doc for `ExtensionMmcs` (#947) (Thomas Coratger)
+- Optimize split_evals to reduce copying (#1043) (sashass1315)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
+
+### Authors
+- Adrian Hamelink
+- Himess
+- Thomas Coratger
+- o-k-d
+- sashass1315
+

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- More Clippy Complaints (#931) (AngusG)
+- Small refactor trying to clean up #897 (#900) (AngusG)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Remove Nightly Features (#932) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Himess
+- Jeremi Do Dinh
+- Sebastian
+- Thomas Coratger
+

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Custom halve impl for Bn254 (#919) (AngusG)
+- Adding custom mul/div_exp_2_u64 for the Goldilocks field. (#923) (AngusG)
+- More Clippy Complaints (#931) (AngusG)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Move halve to ring (#969) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Speed Up Base-Extension Multiplication (#998) (AngusG)
+- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Himess
+- Jeremi Do Dinh
+- Thomas Coratger
+- andrewshab
+

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- From_biguint method for Bn254 (#914) (AngusG)
+- More Clippy Complaints (#931) (AngusG)
+- Adding Macros to remove boilerplate impls (#943) (AngusG)
+- Combining Interleave Code (#950) (AngusG)
+- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
+- Fast Octic inverse (#955) (AngusG)
+- Fast Optic Square (#957) (AngusG)
+- Fast Octic Multiplication (#956) (AngusG)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Refactor to packed add methods (#972) (AngusG)
+- Speed up Extension Field Addition (#980) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move halve to ring (#969) (AngusG)
+- Packed Sub Refactor (#979) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Speed Up Extension Field Subtraction (#988) (AngusG)
+- Must Use (#996) (AngusG)
+- Move Interleave into the Packed submodule (#997) (AngusG)
+- Speed Up Base-Extension Multiplication (#998) (AngusG)
+- Compile Time asserts  (#1015) (AngusG)
+- Rename frobenius_inv -> pseudo_inv and fix doc (#1049) (Tom Wambsgans)
+- Fix: Clarify NEON transmute conversions (#1073) (Skylar Ray)
+- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
+- Feat: revert `builder.assert_bool` to previous impl (#1191) (Zach Langley)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Himess
+- Skylar Ray
+- Thomas Coratger
+- Tom Wambsgans
+- Zach Langley
+

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- More Clippy Complaints (#931) (AngusG)
+- Shrink some test sizes (#524) (Daniel Lubarov)
+- Update doc comment and some other comment fixes. (#959) (AngusG)
+- Minor FRI refactor - make open input its own function (#961) (AngusG)
+- Remove duplicated definition (#1031) (AngusG)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
+- Challenger: use `observe_algebra_slice` when possible (#1187) (Thomas Coratger)
+- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Daniel Lubarov
+- Himess
+- Skylar Ray
+- Thomas Coratger
+- Zach Langley
+

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Adding custom mul/div_exp_2_u64 for the Goldilocks field. (#923) (AngusG)
+- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
+- Packing: small touchups (#937) (Thomas Coratger)
+- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
+- Adding Macros to remove boilerplate impls (#943) (AngusG)
+- Packed Goldilocks Small Refactor (#946) (AngusG)
+- Combining Interleave Code (#950) (AngusG)
+- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move halve to ring (#969) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Must Use (#996) (AngusG)
+- Make Assume unsafe and add a doc comment (#1005) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- AngusG
+- Himess
+- Sebastian
+- Thomas Coratger
+

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+
+### Authors
+- Adrian Hamelink
+- Himess
+- Skylar Ray
+- Thomas Coratger
+

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
+- Keccak air: better doc and some touchups (#942) (Thomas Coratger)
+- Remove Nightly Features (#932) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
+- Fix(keccak-air): align state indexing with Keccak specification (#1177) (Himess)
+
+### Authors
+- AngusG
+- Himess
+- Linda Guiga
+- Merkel Tranjes
+- Thomas Coratger
+

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Remove Nightly Features (#932) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Fixing a few clippy lints (#1115) (AngusG)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+
+### Authors
+- AngusG
+- Himess
+- Thomas Coratger
+

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- GCD based inversion for 31 bit fields (#921) (AngusG)
+- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
+- Fast Octic inverse (#955) (AngusG)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Refactor to packed add methods (#972) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- Koalabear: add default poseidon constants (#1008) (Thomas Coratger)
+- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
+- Fix: remove unused alloc::format imports (#1066) (Skylar Ray)
+- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- AngusG
+- Himess
+- Sebastian
+- Skylar Ray
+- Thomas Coratger
+- andrewshab
+

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Add modular lookups (local and global) with logup implementation (#1090) (Linda Guiga)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
+- ExtensionBuilder for SymbolicAirBuilder (#1161) (Linda Guiga)
+- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
+- Doc: add intra-doc links (#1174) (Robin Salen)
+- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
+- Core: small touchups (#1186) (Thomas Coratger)
+
+### Authors
+- Linda Guiga
+- Robin Salen
+- Thomas Coratger
+

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- From_biguint method for Bn254 (#914) (AngusG)
+- More Clippy Complaints (#931) (AngusG)
+- Chore: various small changes (#944) (Thomas Coratger)
+- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
+- Eq poly: implement batched eval_eq (#1051) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Matrix: make `HorizontallyTruncated` more generic (#1170) (Thomas Coratger)
+- Matrix: add `pad_to_power_of_two_height` (#1185) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Thomas Coratger
+

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore(maybe-rayon): replace deprecated repeatn with repeat_n (#1064) (Skylar Ray)
+- Update lib.rs (#1091) (AJoX)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
+
+### Authors
+- AJoX
+- Skylar Ray
+- Thomas Coratger
+

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Refactor(mds): Eliminate code duplication in bowers_g_layer functions (#1098) (andrewshab)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Himess
+- Thomas Coratger
+- andrewshab
+

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Merkle tree: add documentation for MerkleTreeMmcs and errors (#908) (Thomas Coratger)
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Merkle tree: full documentation for first_digest_layer (#924) (Thomas Coratger)
+- Merkle tree: very small doc touchup (#928) (Thomas Coratger)
+- Merkle tree: add const assert (#1040) (Thomas Coratger)
+- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Add input size checks in MMCS (#1119) (Sai)
+- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Sai
+- Thomas Coratger
+

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- GCD based inversion for 31 bit fields (#921) (AngusG)
+- Fixing a pair of clippy complaints in AVX512 (#926) (AngusG)
+- More Clippy Complaints (#931) (AngusG)
+- Packing: small touchups (#937) (Thomas Coratger)
+- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
+- Adding Macros to remove boilerplate impls (#943) (AngusG)
+- Combining Interleave Code (#950) (AngusG)
+- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Refactor to packed add methods (#972) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move halve to ring (#969) (AngusG)
+- Packed Sub Refactor (#979) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Must Use (#996) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- More Const Assert fixes (#1024) (AngusG)
+- Perf: optimize ext_two_adic_generator with precomputed table (#1038) (Avory)
+- Mersenne-31: Implement NEON-optimized halve for PackedMersenne31Neon (#1054) (VolodymyrBg)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Fixing a few clippy lints (#1115) (AngusG)
+- Fix: Add bounds check to circle_two_adic_generator to prevent underflow (#1130) (Fibonacci747)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+- Implement uniform sampling of bits from field elements (#1050) (Sebastian)
+
+### Authors
+- AngusG
+- Avory
+- Fibonacci747
+- Himess
+- Sebastian
+- Thomas Coratger
+- VolodymyrBg
+

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+
+### Authors
+- AngusG
+- Himess
+- Thomas Coratger
+

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- From_biguint method for Bn254 (#914) (AngusG)
+- GCD based inversion for 31 bit fields (#921) (AngusG)
+- Fixing a pair of clippy complaints in AVX512 (#926) (AngusG)
+- Monty31: small touchups for packing (#927) (Thomas Coratger)
+- Packing: small touchups (#937) (Thomas Coratger)
+- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
+- Adding Macros to remove boilerplate impls (#943) (AngusG)
+- Combining Interleave Code (#950) (AngusG)
+- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
+- Packing Trick for Field Extensions (#958) (AngusG)
+- Chore: small touchups and poseidon external unit tests (#971) (Thomas Coratger)
+- Refactor to packed add methods (#972) (AngusG)
+- Speed up Extension Field Addition (#980) (AngusG)
+- Remove Nightly Features (#932) (AngusG)
+- Move halve to ring (#969) (AngusG)
+- Packed Sub Refactor (#979) (AngusG)
+- Move div_2_exp_u64 to ring (#970) (AngusG)
+- Speed Up Extension Field Subtraction (#988) (AngusG)
+- Must Use (#996) (AngusG)
+- Speed Up Base-Extension Multiplication (#998) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- Compile Time asserts  (#1015) (AngusG)
+- Monty31: add halve for aarch64 neon (#1020) (Thomas Coratger)
+- More Const Assert fixes (#1024) (AngusG)
+- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
+- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
+- Small Neon Refactor (#1037) (AngusG)
+- Monty31: better Poseidon2 for aarch64 neon using `exp_small` (#1035) (Thomas Coratger)
+- Monty 31: more efficient aarch64 neon `quartic_mul_packed` (#1060) (Thomas Coratger)
+- Poseidon2 doc comment fixes (#1071) (AngusG)
+- Monty-31: implement more efficient `dot_product_2` for neon (#1070) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Fixing a few clippy lints (#1115) (AngusG)
+- Monty31: const assert in dot product (#1154) (Thomas Coratger)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+- Core: small touchups (#1186) (Thomas Coratger)
+
+### Authors
+- Adrian Hamelink
+- AngusG
+- Himess
+- Jeremi Do Dinh
+- Thomas Coratger
+

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Possible different take on PR #973 (#978) (AngusG)
+- Multilinear utils: add multilinear point (#1011) (Thomas Coratger)
+- Rm Multilinear Point (#1018) (AngusG)
+- Fix(multilinear-util): use core::marker::PhantomData in no_std (#1063) (Skylar Ray)
+- Eq poly: implement batched eval_eq (#1051) (Thomas Coratger)
+- Multilinear utils: rm `eval_eq` (#1087) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Skylar Ray
+- Thomas Coratger
+

--- a/poseidon/CHANGELOG.md
+++ b/poseidon/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+
+### Authors
+- Himess
+- Thomas Coratger
+

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- More Clippy Complaints (#931) (AngusG)
+- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
+- Weaken the trait bound of AirBuilder to allow `F` to be merely a Ring. (#977) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
+- Make generate_trace_rows_for_perm public (#1159) (Alonso González)
+
+### Authors
+- Alonso González
+- AngusG
+- Himess
+- Linda Guiga
+- Merkel Tranjes
+- Thomas Coratger
+

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Porting BN254 to our own code base (#913) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Poseidon: make ExternalLayerConstants new const (#968) (Thomas Coratger)
+- Chore: small touchups and poseidon external unit tests (#971) (Thomas Coratger)
+- Remove Nightly Features (#932) (AngusG)
+- Packed Sub Refactor (#979) (AngusG)
+- Generic Poseidon2 Simplifications (#987) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Himess
+- Thomas Coratger
+

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Possible different take on PR #973 (#978) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Himess
+- Thomas Coratger
+

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Sha256: fix clippy warning (#1081) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+
+### Authors
+- Thomas Coratger
+

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Hasher: add more documentation for `CryptographicHasher` trait (#922) (Thomas Coratger)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Allow users to impl either permute or permute_mut (#1175) (AngusG)
+
+### Authors
+- AngusG
+- Himess
+- Thomas Coratger
+

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
+- Uni stark: small touchups on the verifier (#910) (Thomas Coratger)
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Fixed "attempt to subtract with overflow" issue in uni-stark (#934) (Gabriel Barreto)
+- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
+- Docs: Add comprehensive documentation to constraint folder implementation (#856) (Ragnar)
+- Shrink some test sizes (#524) (Daniel Lubarov)
+- Fixing error on main (#939) (AngusG)
+- Chore: various small changes (#944) (Thomas Coratger)
+- Remove Nightly Features (#932) (AngusG)
+- Small visibility changes for recursion (#1046) (Linda Guiga)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
+- Add modular lookups (local and global) with logup implementation (#1090) (Linda Guiga)
+- Add multi-STARK prover and verifier (#1088) (Sai)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Update symbolic_builder.rs (#1106) (AJoX)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
+- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
+- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
+- Add Preprocessed trace setup and VKs (#1150) (Sai)
+- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
+- ExtensionBuilder for SymbolicAirBuilder (#1161) (Linda Guiga)
+- Uni-stark: add unit tests for SymbolicExpression (#1169) (Thomas Coratger)
+- Uni stark: small touchups (#1163) (Thomas Coratger)
+- Clarify quotient degree vs quotient chunks naming (#1156) (Sai)
+- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
+- Feat: add `SubAirBuilder` module (#1172) (Robin Salen)
+- Doc: add intra-doc links (#1174) (Robin Salen)
+- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
+- Core: small touchups (#1186) (Thomas Coratger)
+- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
+
+### Authors
+- AJoX
+- Adrian Hamelink
+- AngusG
+- Daniel Lubarov
+- Gabriel Barreto
+- Himess
+- Linda Guiga
+- Merkel Tranjes
+- Ragnar
+- Robin Salen
+- Sai
+- Skylar Ray
+- Thomas Coratger
+- Zach Langley
+- o-k-d
+

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.4.0] - 2025-12-12
+### Merged PRs
+- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
+- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- GCD based inversion for 31 bit fields (#921) (AngusG)
+- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
+- More Clippy Complaints (#931) (AngusG)
+- Chore: remove useless bench_reverse_bits benchmark (#933) (Galoretka)
+- Packed Goldilocks Small Refactor (#946) (AngusG)
+- Make Assume unsafe and add a doc comment (#1005) (AngusG)
+- Compile Time asserts  (#1015) (AngusG)
+- Clippy: small step (#1102) (Thomas Coratger)
+- Clippy: add nursery (#1103) (Thomas Coratger)
+- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
+- Clippy: add match_bool (#1126) (Thomas Coratger)
+
+### Authors
+- AngusG
+- Galoretka
+- Himess
+- Thomas Coratger
+


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-util`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-field`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-matrix`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-air`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-dft`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-symmetric`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-mds`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-poseidon2`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-monty-31`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-challenger`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-baby-bear`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-mersenne-31`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-koala-bear`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-bn254`: 0.3.0 -> 0.4.0
* `p3-field-testing`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-goldilocks`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-poseidon`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-commit`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-uni-stark`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-lookup`: 0.3.0 -> 0.4.0
* `p3-batch-stark`: 0.3.0 -> 0.4.0
* `p3-interpolation`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-fri`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-circle`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-keccak`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-merkle-tree`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `p3-blake3`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-rescue`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-blake3-air`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-sha256`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-keccak-air`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-poseidon2-air`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-monolith`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `p3-multilinear-util`: 0.3.0 -> 0.4.0

### ⚠ `p3-util` breaking changes

```text
--- failure function_unsafe_added: pub fn became unsafe ---

Description:
A publicly-visible function became `unsafe`, so calling it now requires an `unsafe` block.
        ref: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#calling-an-unsafe-function-or-method
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_unsafe_added.ron

Failed in:
  function p3_util::assume in file /tmp/.tmpz0FpKk/Plonky3/util/src/lib.rs:244
```

### ⚠ `p3-field` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait p3_field::extension::BinomiallyExtendable gained BinomiallyExtendableAlgebra in file /tmp/.tmpz0FpKk/Plonky3/field/src/extension/mod.rs:22
  trait p3_field::PackedField gained DivAssign in file /tmp/.tmpz0FpKk/Plonky3/field/src/packed/packed_traits.rs:209
  trait p3_field::PackedField gained Sum in file /tmp/.tmpz0FpKk/Plonky3/field/src/packed/packed_traits.rs:209
  trait p3_field::PackedField gained Product in file /tmp/.tmpz0FpKk/Plonky3/field/src/packed/packed_traits.rs:209
  trait p3_field::Field gained DivAssign in file /tmp/.tmpz0FpKk/Plonky3/field/src/field.rs:750
  trait p3_field::Field gained Add in file /tmp/.tmpz0FpKk/Plonky3/field/src/field.rs:750
  trait p3_field::Field gained Sub in file /tmp/.tmpz0FpKk/Plonky3/field/src/field.rs:750
  trait p3_field::Field gained Mul in file /tmp/.tmpz0FpKk/Plonky3/field/src/field.rs:750

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_added.ron

Failed in:
  trait method p3_field::extension::HasFrobenius::pseudo_inv in file /tmp/.tmpz0FpKk/Plonky3/field/src/extension/mod.rs:105

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method frobenius_inv of trait HasFrobenius, previously in file /tmp/.tmpJmVF49/p3-field/src/extension/mod.rs:58
  method halve of trait Field, previously in file /tmp/.tmpJmVF49/p3-field/src/field.rs:775
  method div_2exp_u64 of trait Field, previously in file /tmp/.tmpJmVF49/p3-field/src/field.rs:791
```

### ⚠ `p3-dft` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Radix2Dit is no longer UnwindSafe, in /tmp/.tmpz0FpKk/Plonky3/dft/src/radix_2_dit.rs:25
  type Radix2DFTSmallBatch is no longer UnwindSafe, in /tmp/.tmpz0FpKk/Plonky3/dft/src/radix_2_small_batch.rs:36
  type Radix2DitParallel is no longer UnwindSafe, in /tmp/.tmpz0FpKk/Plonky3/dft/src/radix_2_dit_parallel.rs:30
```

### ⚠ `p3-poseidon2` breaking changes

```text
--- failure trait_allows_fewer_generic_type_params: trait now allows fewer generic type parameters ---

Description:
A trait now allows fewer generic type parameters than it used to. Uses of this trait that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_allows_fewer_generic_type_params.ron

Failed in:
  trait GenericPoseidon2LinearLayers allows 1 -> 0 generic types in /tmp/.tmpz0FpKk/Plonky3/poseidon2/src/generic.rs:32

--- failure trait_method_requires_different_generic_type_params: trait method now requires a different number of generic type parameters ---

Description:
A trait method now requires a different number of generic type parameters than it used to. Calls or implementations of this trait method using the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_requires_different_generic_type_params.ron

Failed in:
  GenericPoseidon2LinearLayers::internal_linear_layer (0 -> 1 generic types) in /tmp/.tmpz0FpKk/Plonky3/poseidon2/src/generic.rs:35
  GenericPoseidon2LinearLayers::external_linear_layer (0 -> 1 generic types) in /tmp/.tmpz0FpKk/Plonky3/poseidon2/src/generic.rs:39
```

### ⚠ `p3-monty-31` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type RecursiveDft is no longer UnwindSafe, in /tmp/.tmpz0FpKk/Plonky3/monty-31/src/dft/mod.rs:46

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method try_inverse of trait FieldParameters, previously in file /tmp/.tmpJmVF49/p3-monty-31/src/data_traits.rs:80

--- failure trait_method_requires_different_generic_type_params: trait method now requires a different number of generic type parameters ---

Description:
A trait method now requires a different number of generic type parameters than it used to. Calls or implementations of this trait method using the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_requires_different_generic_type_params.ron

Failed in:
  InternalLayerBaseParameters::internal_layer_mat_mul (0 -> 1 generic types) in /tmp/.tmpz0FpKk/Plonky3/monty-31/src/poseidon2.rs:23

--- failure trait_removed_associated_constant: trait's associated constant was removed ---

Description:
A public trait's associated constant was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_removed_associated_constant.ron

Failed in:
  associated constant InternalLayerBaseParameters::INTERNAL_DIAG_MONTY, previously at /tmp/.tmpJmVF49/p3-monty-31/src/poseidon2.rs:26

--- failure trait_removed_associated_type: trait's associated type was removed ---

Description:
A public trait's associated type was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_removed_associated_type.ron

Failed in:
  associated type InternalLayerBaseParameters::ArrayLike, previously at /tmp/.tmpJmVF49/p3-monty-31/src/poseidon2.rs:22
```

### ⚠ `p3-uni-stark` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProverConstraintFolder.preprocessed in /tmp/.tmpz0FpKk/Plonky3/uni-stark/src/folder.rs:20
  field VerifierConstraintFolder.preprocessed in /tmp/.tmpz0FpKk/Plonky3/uni-stark/src/folder.rs:49

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant VerificationError::OodEvaluationMismatch in /tmp/.tmpz0FpKk/Plonky3/uni-stark/src/verifier.rs:414

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant VerificationError:NextPointUnavailable in /tmp/.tmpz0FpKk/Plonky3/uni-stark/src/verifier.rs:422
  variant VerificationError:LookupError in /tmp/.tmpz0FpKk/Plonky3/uni-stark/src/verifier.rs:425

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function p3_uni_stark::get_log_quotient_degree, previously in file /tmp/.tmpJmVF49/p3-uni-stark/src/symbolic_builder.rs:15
```

### ⚠ `p3-fri` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FriParameters.commit_proof_of_work_bits in /tmp/.tmpz0FpKk/Plonky3/fri/src/config.rs:15
  field FriParameters.query_proof_of_work_bits in /tmp/.tmpz0FpKk/Plonky3/fri/src/config.rs:17
  field FriProof.commit_pow_witnesses in /tmp/.tmpz0FpKk/Plonky3/fri/src/proof.rs:14
  field FriProof.query_pow_witness in /tmp/.tmpz0FpKk/Plonky3/fri/src/proof.rs:17

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  p3_fri::verifier::verify_fri now takes 6 parameters instead of 5, in /tmp/.tmpz0FpKk/Plonky3/fri/src/verifier.rs:54
  p3_fri::prover::prove_fri now takes 7 parameters instead of 5, in /tmp/.tmpz0FpKk/Plonky3/fri/src/prover.rs:43

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types (e.g. via turbofish syntax) will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function verify_fri (5 -> 6 generic types) in /tmp/.tmpz0FpKk/Plonky3/fri/src/verifier.rs:54
  function prove_fri (5 -> 6 generic types) in /tmp/.tmpz0FpKk/Plonky3/fri/src/prover.rs:43

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field pow_witness of struct FriProof, previously in file /tmp/.tmpJmVF49/p3-fri/src/proof.rs:16
  field proof_of_work_bits of struct FriParameters, previously in file /tmp/.tmpJmVF49/p3-fri/src/config.rs:14
```

### ⚠ `p3-merkle-tree` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MerkleTreeError::RootMismatch 4 -> 5 in /tmp/.tmpz0FpKk/Plonky3/merkle-tree/src/mmcs.rs:100
  variant MerkleTreeError::EmptyBatch 5 -> 6 in /tmp/.tmpz0FpKk/Plonky3/merkle-tree/src/mmcs.rs:104

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant MerkleTreeError:IndexOutOfBounds in /tmp/.tmpz0FpKk/Plonky3/merkle-tree/src/mmcs.rs:91
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `p3-maybe-rayon`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore(maybe-rayon): replace deprecated repeatn with repeat_n (#1064) (Skylar Ray)
- Update lib.rs (#1091) (AJoX)
- Clippy: small step (#1102) (Thomas Coratger)
- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)

### Authors
- AJoX
- Skylar Ray
- Thomas Coratger
</blockquote>

## `p3-util`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- GCD based inversion for 31 bit fields (#921) (AngusG)
- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
- More Clippy Complaints (#931) (AngusG)
- Chore: remove useless bench_reverse_bits benchmark (#933) (Galoretka)
- Packed Goldilocks Small Refactor (#946) (AngusG)
- Make Assume unsafe and add a doc comment (#1005) (AngusG)
- Compile Time asserts  (#1015) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add match_bool (#1126) (Thomas Coratger)

### Authors
- AngusG
- Galoretka
- Himess
- Thomas Coratger
</blockquote>

## `p3-field`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- From_biguint method for Bn254 (#914) (AngusG)
- More Clippy Complaints (#931) (AngusG)
- Adding Macros to remove boilerplate impls (#943) (AngusG)
- Combining Interleave Code (#950) (AngusG)
- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
- Fast Octic inverse (#955) (AngusG)
- Fast Optic Square (#957) (AngusG)
- Fast Octic Multiplication (#956) (AngusG)
- Packing Trick for Field Extensions (#958) (AngusG)
- Refactor to packed add methods (#972) (AngusG)
- Speed up Extension Field Addition (#980) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move halve to ring (#969) (AngusG)
- Packed Sub Refactor (#979) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Speed Up Extension Field Subtraction (#988) (AngusG)
- Must Use (#996) (AngusG)
- Move Interleave into the Packed submodule (#997) (AngusG)
- Speed Up Base-Extension Multiplication (#998) (AngusG)
- Compile Time asserts  (#1015) (AngusG)
- Rename frobenius_inv -> pseudo_inv and fix doc (#1049) (Tom Wambsgans)
- Fix: Clarify NEON transmute conversions (#1073) (Skylar Ray)
- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
- Feat: revert `builder.assert_bool` to previous impl (#1191) (Zach Langley)

### Authors
- Adrian Hamelink
- AngusG
- Himess
- Skylar Ray
- Thomas Coratger
- Tom Wambsgans
- Zach Langley
</blockquote>

## `p3-matrix`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- From_biguint method for Bn254 (#914) (AngusG)
- More Clippy Complaints (#931) (AngusG)
- Chore: various small changes (#944) (Thomas Coratger)
- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
- Eq poly: implement batched eval_eq (#1051) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Matrix: make `HorizontallyTruncated` more generic (#1170) (Thomas Coratger)
- Matrix: add `pad_to_power_of_two_height` (#1185) (Thomas Coratger)

### Authors
- AngusG
- Thomas Coratger
</blockquote>

## `p3-air`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Air: more unit tests for air utils (#936) (Thomas Coratger)
- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
- Air: better doc for traits (#935) (Thomas Coratger)
- Chore: various small changes (#944) (Thomas Coratger)
- Weaken the trait bound of AirBuilder to allow `F` to be merely a Ring. (#977) (AngusG)
- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
- Integrate lookups to prover and verifier (#1165) (Linda Guiga)

### Authors
- AngusG
- Himess
- Linda Guiga
- Thomas Coratger
- o-k-d
</blockquote>

## `p3-dft`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- More Clippy Complaints (#931) (AngusG)
- Small refactor trying to clean up #897 (#900) (AngusG)
- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
- Remove Nightly Features (#932) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- Adrian Hamelink
- AngusG
- Himess
- Jeremi Do Dinh
- Sebastian
- Thomas Coratger
</blockquote>

## `p3-symmetric`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Hasher: add more documentation for `CryptographicHasher` trait (#922) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)

### Authors
- AngusG
- Himess
- Thomas Coratger
</blockquote>

## `p3-mds`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Refactor(mds): Eliminate code duplication in bowers_g_layer functions (#1098) (andrewshab)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)

### Authors
- Adrian Hamelink
- AngusG
- Himess
- Thomas Coratger
- andrewshab
</blockquote>

## `p3-poseidon2`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Porting BN254 to our own code base (#913) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Poseidon: make ExternalLayerConstants new const (#968) (Thomas Coratger)
- Chore: small touchups and poseidon external unit tests (#971) (Thomas Coratger)
- Remove Nightly Features (#932) (AngusG)
- Packed Sub Refactor (#979) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)

### Authors
- AngusG
- Himess
- Thomas Coratger
</blockquote>

## `p3-monty-31`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- From_biguint method for Bn254 (#914) (AngusG)
- GCD based inversion for 31 bit fields (#921) (AngusG)
- Fixing a pair of clippy complaints in AVX512 (#926) (AngusG)
- Monty31: small touchups for packing (#927) (Thomas Coratger)
- Packing: small touchups (#937) (Thomas Coratger)
- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
- Adding Macros to remove boilerplate impls (#943) (AngusG)
- Combining Interleave Code (#950) (AngusG)
- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
- Packing Trick for Field Extensions (#958) (AngusG)
- Chore: small touchups and poseidon external unit tests (#971) (Thomas Coratger)
- Refactor to packed add methods (#972) (AngusG)
- Speed up Extension Field Addition (#980) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move halve to ring (#969) (AngusG)
- Packed Sub Refactor (#979) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Speed Up Extension Field Subtraction (#988) (AngusG)
- Must Use (#996) (AngusG)
- Speed Up Base-Extension Multiplication (#998) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- Compile Time asserts  (#1015) (AngusG)
- Monty31: add halve for aarch64 neon (#1020) (Thomas Coratger)
- More Const Assert fixes (#1024) (AngusG)
- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
- Small Neon Refactor (#1037) (AngusG)
- Monty31: better Poseidon2 for aarch64 neon using `exp_small` (#1035) (Thomas Coratger)
- Monty 31: more efficient aarch64 neon `quartic_mul_packed` (#1060) (Thomas Coratger)
- Poseidon2 doc comment fixes (#1071) (AngusG)
- Monty-31: implement more efficient `dot_product_2` for neon (#1070) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Fixing a few clippy lints (#1115) (AngusG)
- Monty31: const assert in dot product (#1154) (Thomas Coratger)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)
- Core: small touchups (#1186) (Thomas Coratger)

### Authors
- Adrian Hamelink
- AngusG
- Himess
- Jeremi Do Dinh
- Thomas Coratger
</blockquote>

## `p3-challenger`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Add a comment about non-uniformity in `CanSampleBits` (#1026) (Tom Wambsgans)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
- Challenger: add unit tests for `observe_base_as_algebra_element` (#1155) (Thomas Coratger)
- Challenger: add `observe_algebra_elements` method (#1176) (Thomas Coratger)
- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- Himess
- Sebastian
- Thomas Coratger
- Tom Wambsgans
- Zach Langley
</blockquote>

## `p3-baby-bear`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- GCD based inversion for 31 bit fields (#921) (AngusG)
- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
- Packing Trick for Field Extensions (#958) (AngusG)
- Refactor to packed add methods (#972) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Speed Up Base-Extension Multiplication (#998) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
- Fix: remove unused alloc::format imports (#1066) (Skylar Ray)
- Monty 31: more efficient aarch64 neon `quartic_mul_packed` (#1060) (Thomas Coratger)
- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)
- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- AngusG
- Himess
- Jeremi Do Dinh
- Sebastian
- Skylar Ray
- Thomas Coratger
- andrewshab
</blockquote>

## `p3-mersenne-31`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- GCD based inversion for 31 bit fields (#921) (AngusG)
- Fixing a pair of clippy complaints in AVX512 (#926) (AngusG)
- More Clippy Complaints (#931) (AngusG)
- Packing: small touchups (#937) (Thomas Coratger)
- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
- Adding Macros to remove boilerplate impls (#943) (AngusG)
- Combining Interleave Code (#950) (AngusG)
- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
- Packing Trick for Field Extensions (#958) (AngusG)
- Refactor to packed add methods (#972) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move halve to ring (#969) (AngusG)
- Packed Sub Refactor (#979) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Must Use (#996) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- More Const Assert fixes (#1024) (AngusG)
- Perf: optimize ext_two_adic_generator with precomputed table (#1038) (Avory)
- Mersenne-31: Implement NEON-optimized halve for PackedMersenne31Neon (#1054) (VolodymyrBg)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Fixing a few clippy lints (#1115) (AngusG)
- Fix: Add bounds check to circle_two_adic_generator to prevent underflow (#1130) (Fibonacci747)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- AngusG
- Avory
- Fibonacci747
- Himess
- Sebastian
- Thomas Coratger
- VolodymyrBg
</blockquote>

## `p3-koala-bear`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- GCD based inversion for 31 bit fields (#921) (AngusG)
- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
- Fast Octic inverse (#955) (AngusG)
- Packing Trick for Field Extensions (#958) (AngusG)
- Refactor to packed add methods (#972) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- Koalabear: add default poseidon constants (#1008) (Thomas Coratger)
- Poseidon2: add Neon implementation for Monty31 (#1023) (Thomas Coratger)
- Fix: remove unused alloc::format imports (#1066) (Skylar Ray)
- Refactor: remove redundant clones in crypto modules (#1080) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- AngusG
- Himess
- Sebastian
- Skylar Ray
- Thomas Coratger
- andrewshab
</blockquote>

## `p3-bn254`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Porting BN254 to our own code base (#913) (AngusG)
- Interleaved Montgomery Multiplication (#915) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Custom halve impl for Bn254 (#919) (AngusG)
- From_biguint method for Bn254 (#914) (AngusG)
- Bn254 Binary Euclidean Inversion (#920) (AngusG)
- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
- Adding Macros to remove boilerplate impls (#943) (AngusG)
- Adding Degree 8 extensions for KoalaBear and BabyBear. (#954) (AngusG)
- Move halve to ring (#969) (AngusG)
- Must Use (#996) (AngusG)
- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)

### Authors
- AngusG
- Himess
- Skylar Ray
- Thomas Coratger
- andrewshab
</blockquote>

## `p3-field-testing`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Custom halve impl for Bn254 (#919) (AngusG)
- Adding custom mul/div_exp_2_u64 for the Goldilocks field. (#923) (AngusG)
- More Clippy Complaints (#931) (AngusG)
- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
- Move halve to ring (#969) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Speed Up Base-Extension Multiplication (#998) (AngusG)
- Monty31: add aarch64 neon custom `exp_5` and `exp_7` (#1033) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Feat: add thread safety to dft implementations (#999) (Jeremi Do Dinh)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Refactor: deduplicate field JSON serialization tests (#1162) (andrewshab)

### Authors
- Adrian Hamelink
- AngusG
- Himess
- Jeremi Do Dinh
- Thomas Coratger
- andrewshab
</blockquote>

## `p3-goldilocks`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Adding custom mul/div_exp_2_u64 for the Goldilocks field. (#923) (AngusG)
- Fast GCD Inverse for Goldilocks  (#925) (AngusG)
- Packing: small touchups (#937) (Thomas Coratger)
- Use `#[derive(...)]` for Debug and Default for packed fields. (#945) (AngusG)
- Adding Macros to remove boilerplate impls (#943) (AngusG)
- Packed Goldilocks Small Refactor (#946) (AngusG)
- Combining Interleave Code (#950) (AngusG)
- Add a macro for implying PackedValue for PackedFields (#949) (AngusG)
- Packing Trick for Field Extensions (#958) (AngusG)
- Remove Nightly Features (#932) (AngusG)
- Move halve to ring (#969) (AngusG)
- Move div_2_exp_u64 to ring (#970) (AngusG)
- Must Use (#996) (AngusG)
- Make Assume unsafe and add a doc comment (#1005) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- AngusG
- Himess
- Sebastian
- Thomas Coratger
</blockquote>

## `p3-poseidon`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)

### Authors
- Himess
- Thomas Coratger
</blockquote>

## `p3-commit`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Mmcs: better doc for `ExtensionMmcs` (#947) (Thomas Coratger)
- Optimize split_evals to reduce copying (#1043) (sashass1315)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)

### Authors
- Adrian Hamelink
- Himess
- Thomas Coratger
- o-k-d
- sashass1315
</blockquote>

## `p3-uni-stark`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Uni stark: small touchups on the verifier (#910) (Thomas Coratger)
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Fixed "attempt to subtract with overflow" issue in uni-stark (#934) (Gabriel Barreto)
- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
- Docs: Add comprehensive documentation to constraint folder implementation (#856) (Ragnar)
- Shrink some test sizes (#524) (Daniel Lubarov)
- Fixing error on main (#939) (AngusG)
- Chore: various small changes (#944) (Thomas Coratger)
- Remove Nightly Features (#932) (AngusG)
- Small visibility changes for recursion (#1046) (Linda Guiga)
- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
- Add modular lookups (local and global) with logup implementation (#1090) (Linda Guiga)
- Add multi-STARK prover and verifier (#1088) (Sai)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Update symbolic_builder.rs (#1106) (AJoX)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
- Add Preprocessed trace setup and VKs (#1150) (Sai)
- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
- ExtensionBuilder for SymbolicAirBuilder (#1161) (Linda Guiga)
- Uni-stark: add unit tests for SymbolicExpression (#1169) (Thomas Coratger)
- Uni stark: small touchups (#1163) (Thomas Coratger)
- Clarify quotient degree vs quotient chunks naming (#1156) (Sai)
- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
- Feat: add `SubAirBuilder` module (#1172) (Robin Salen)
- Doc: add intra-doc links (#1174) (Robin Salen)
- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
- Core: small touchups (#1186) (Thomas Coratger)
- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)

### Authors
- AJoX
- Adrian Hamelink
- AngusG
- Daniel Lubarov
- Gabriel Barreto
- Himess
- Linda Guiga
- Merkel Tranjes
- Ragnar
- Robin Salen
- Sai
- Skylar Ray
- Thomas Coratger
- Zach Langley
- o-k-d
</blockquote>

## `p3-lookup`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Add modular lookups (local and global) with logup implementation (#1090) (Linda Guiga)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
- ExtensionBuilder for SymbolicAirBuilder (#1161) (Linda Guiga)
- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
- Doc: add intra-doc links (#1174) (Robin Salen)
- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
- Core: small touchups (#1186) (Thomas Coratger)

### Authors
- Linda Guiga
- Robin Salen
- Thomas Coratger
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Rename multi-stark crate to batch-stark (#1122) (Sai)
- Add preprocessed/transparent columns to uni-stark (#1114) (o-k-d)
- Challenger: add `observe_base_as_algebra_element ` to `FieldChallenger` trait (#1152) (Thomas Coratger)
- Add preprocessed column support in batch-STARK  (#1151) (Sai)
- Update lookup traits and add folders with lookups (#1160) (Linda Guiga)
- Derive Clone for PreprocessedInstanceMeta (#1166) (Linda Guiga)
- Clarify quotient degree vs quotient chunks naming (#1156) (Sai)
- Doc: add intra-doc links (#1174) (Robin Salen)
- Integrate lookups to prover and verifier (#1165) (Linda Guiga)
- Core: small touchups (#1186) (Thomas Coratger)
- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)
- Implement uniform sampling of bits from field elements (#1050) (Sebastian)

### Authors
- Linda Guiga
- Robin Salen
- Sai
- Sebastian
- Thomas Coratger
- Zach Langley
- o-k-d
</blockquote>

## `p3-interpolation`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)

### Authors
- Adrian Hamelink
- Himess
- Skylar Ray
- Thomas Coratger
</blockquote>

## `p3-fri`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- More Clippy Complaints (#931) (AngusG)
- Shrink some test sizes (#524) (Daniel Lubarov)
- Update doc comment and some other comment fixes. (#959) (AngusG)
- Minor FRI refactor - make open input its own function (#961) (AngusG)
- Remove duplicated definition (#1031) (AngusG)
- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
- Challenger: use `observe_algebra_slice` when possible (#1187) (Thomas Coratger)
- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)

### Authors
- Adrian Hamelink
- AngusG
- Daniel Lubarov
- Himess
- Skylar Ray
- Thomas Coratger
- Zach Langley
</blockquote>

## `p3-circle`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Remove Nightly Features (#932) (AngusG)
- Docs: improve documentation for Circle STARKs deep quotient algorithms (#1079) (Adrian)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Circle: batch inverses in selectors_on_coset (#1068) (Forostovec)
- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)
- Challenger: use `observe_algebra_slice` when possible (#1187) (Thomas Coratger)
- Feat: add PoW phase for batching in FRI commit phase (#1164) (Zach Langley)

### Authors
- Adrian
- AngusG
- Forostovec
- Himess
- Thomas Coratger
- Zach Langley
</blockquote>

## `p3-keccak`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Remove Nightly Features (#932) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add nursery (#1103) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Fixing a few clippy lints (#1115) (AngusG)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)

### Authors
- AngusG
- Himess
- Thomas Coratger
</blockquote>

## `p3-merkle-tree`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Merkle tree: add documentation for MerkleTreeMmcs and errors (#908) (Thomas Coratger)
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Merkle tree: full documentation for first_digest_layer (#924) (Thomas Coratger)
- Merkle tree: very small doc touchup (#928) (Thomas Coratger)
- Merkle tree: add const assert (#1040) (Thomas Coratger)
- Doc: add better doc in air and fix TODO (#1061) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Add input size checks in MMCS (#1119) (Sai)
- Core: add error messages to error enums via thiserror (#1168) (Thomas Coratger)

### Authors
- AngusG
- Sai
- Thomas Coratger
</blockquote>

## `p3-blake3`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Clippy: small step (#1102) (Thomas Coratger)

### Authors
- Himess
- Thomas Coratger
</blockquote>

## `p3-rescue`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Possible different take on PR #973 (#978) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)

### Authors
- AngusG
- Himess
- Thomas Coratger
</blockquote>

## `p3-blake3-air`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)

### Authors
- Himess
- Linda Guiga
- Thomas Coratger
</blockquote>

## `p3-sha256`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Sha256: fix clippy warning (#1081) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)

### Authors
- Thomas Coratger
</blockquote>

## `p3-keccak-air`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
- Keccak air: better doc and some touchups (#942) (Thomas Coratger)
- Remove Nightly Features (#932) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
- Fix(keccak-air): align state indexing with Keccak specification (#1177) (Himess)

### Authors
- AngusG
- Himess
- Linda Guiga
- Merkel Tranjes
- Thomas Coratger
</blockquote>

## `p3-poseidon2-air`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- More Clippy Complaints (#931) (AngusG)
- Replace `Copy` with `Clone` in `AirBuilder`'s `Var` (#930) (Linda Guiga)
- Weaken the trait bound of AirBuilder to allow `F` to be merely a Ring. (#977) (AngusG)
- Generic Poseidon2 Simplifications (#987) (AngusG)
- Clippy: small step (#1102) (Thomas Coratger)
- Refactor: Replace &Vec<T> with &[T] in function parameters (#1111) (Merkel Tranjes)
- Make generate_trace_rows_for_perm public (#1159) (Alonso González)

### Authors
- Alonso González
- AngusG
- Himess
- Linda Guiga
- Merkel Tranjes
- Thomas Coratger
</blockquote>

## `p3-monolith`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)
- Chore: add descriptions to all sub-crate manifests (#906) (Himess)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)
- Clippy: add `needless_pass_by_value` (#1112) (Thomas Coratger)
- Allow users to impl either permute or permute_mut (#1175) (AngusG)

### Authors
- AngusG
- Himess
- Thomas Coratger
</blockquote>

## `p3-multilinear-util`

<blockquote>

## [0.4.0] - 2025-12-12

### Merged PRs
- Possible different take on PR #973 (#978) (AngusG)
- Multilinear utils: add multilinear point (#1011) (Thomas Coratger)
- Rm Multilinear Point (#1018) (AngusG)
- Fix(multilinear-util): use core::marker::PhantomData in no_std (#1063) (Skylar Ray)
- Eq poly: implement batched eval_eq (#1051) (Thomas Coratger)
- Multilinear utils: rm `eval_eq` (#1087) (Thomas Coratger)
- Clippy: small step (#1102) (Thomas Coratger)
- Clippy: add semicolon_if_nothing_returned (#1107) (Thomas Coratger)

### Authors
- AngusG
- Skylar Ray
- Thomas Coratger
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).