### PR TITLE
perf(util): Remove redundant clone in reverse_slice_index_bits test

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -896,7 +896,7 @@ mod tests {
                 rand_list.resize_with(length, || rng.random());
                 let expect = reverse_index_bits_naive(&rand_list);
 
-                let mut actual = rand_list.clone();
+                let mut actual = rand_list;
                 reverse_slice_index_bits(&mut actual);
 
                 assert_eq!(actual, expect);


### PR DESCRIPTION
Remove unnecessary .clone() call in test_reverse_slice_index_bits_random by moving the vector instead of cloning it.