### PR TITLE
fix: remove undefined WIDTH const in `interleave` module for avx512

### DIFF
--- a/field/src/packed/interleaves.rs
+++ b/field/src/packed/interleaves.rs
@@ -174,7 +174,7 @@ pub mod interleave {
     fn interleave1_antidiagonal(x: __m512i, y: __m512i) -> __m512i {
         const INTERLEAVE1_INDICES: __m512i = unsafe {
             // Safety: `[u32; 16]` is trivially transmutable to `__m512i`.
-            transmute::<[u32; WIDTH], _>([
+            transmute::<[u32; 16], _>([
                 0x01, 0x10, 0x03, 0x12, 0x05, 0x14, 0x07, 0x16, 0x09, 0x18, 0x0b, 0x1a, 0x0d, 0x1c,
                 0x0f, 0x1e,
             ])


### PR DESCRIPTION
closes #1198 