### PR TITLE
perf(dft): optimize `dft_layer` in `radix_2_small_batch`

### DIFF
--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -558,7 +558,7 @@ fn dft_layer<F: Field, B: Butterfly<F>>(vec: &mut [F], twiddles: &[B]) {
     );
 
     let block_size = size / num_blocks;
-    debug_assert!(block_size % 2 == 0, "Each block must split evenly");
+    debug_assert!(block_size.is_multiple_of(2), "Each block must split evenly");
     let half_block_size = block_size / 2;
 
     let base = vec.as_mut_ptr();


### PR DESCRIPTION
Replaced the iterator + closure loop with a raw pointer loop to cut extra bound checks & overhead
it's getting us 3–8% speedup
```fish
fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256...
                        time:   [5.7233 ms 5.7618 ms 5.8108 ms]
                        change: [−10.161% −8.5749% −7.0050%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #2
                        time:   [30.965 ms 31.400 ms 31.612 ms]
                        change: [−4.6788% −3.6923% −2.6120%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.8s or enable flat sampling.
fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #3
                        time:   [140.46 ms 140.85 ms 141.14 ms]
                        change: [−4.2485% −3.5295% −2.9230%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #4: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.3s.
fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #4
                        time:   [617.21 ms 618.17 ms 619.10 ms]
                        change: [−11.531% −7.6681% −5.1154%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #5: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 30.8s.
fft/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/ncols=256... #5
                        time:   [2.9604 s 2.9817 s 3.0037 s]
                        change: [−3.1402% −2.2584% −1.3414%] (p = 0.00 < 0.05)
                        Performance has improved.

fft_algebra/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/B...
                        time:   [260.63 µs 261.19 µs 262.08 µs]
                        change: [−2.8195% −2.4141% −2.0213%] (p = 0.00 < 0.05)
                        Performance has improved.
fft_algebra/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/B... #2
                        time:   [1.2414 ms 1.2450 ms 1.2476 ms]
                        change: [−2.1718% −1.5116% −0.9603%] (p = 0.00 < 0.05)
                        Change within noise threshold.
fft_algebra/MontyField31<BabyBearParameters>/Radix2DFTSmallBatch<MontyField31<BabyBearParameters>>/B... #3
                        time:   [5.8651 ms 5.9015 ms 5.9345 ms]
                        change: [−2.0633% −1.1870% −0.3433%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```