### PR TITLE
test: add tests for CosetMds with multiple sizes and properties

### DIFF
--- a/mds/src/coset_mds.rs
+++ b/mds/src/coset_mds.rs
@@ -161,7 +161,7 @@ mod tests {
 
         // Ensure inputs are different
         if input1 == input2 {
-            input2[0] = input2[0] + F::ONE;
+            input2[0] += F::ONE;
         }
 
         let mds = CosetMds::default();


### PR DESCRIPTION
## Problem

The `CosetMds` implementation had only a single test case with a fixed size of N=8, which provided limited coverage. This left the code untested for other common sizes (4, 16, 32) and lacked verification of basic permutation properties.

## Solution

Added parameterized tests covering sizes 4, 8, 16, and 32 by extracting the existing test logic into a reusable function. Also added two property tests: one to verify the permutation is non-identity and produces different outputs, and another to ensure different inputs produce different outputs.