### PR TITLE
fix: update outdated docs in batch-stark and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Fields:
   - [x] NEON
 - [x] Goldilocks
   - [x] ~128 bit extension field
+- [x] BN254 (scalar field)
 
 Generalized vector commitment schemes
 - [x] generalized Merkle tree
@@ -58,6 +59,7 @@ Hashes
   - [ ] modifications to tune BLAKE3 for hashing small leaves
 - [x] Keccak-256
 - [x] Monolith
+- [x] SHA-256
 
 
 ## Benchmarks

--- a/batch-stark/src/lib.rs
+++ b/batch-stark/src/lib.rs
@@ -1,17 +1,22 @@
 //! Batch-STARK proving and verification.
 //!
 //! ```ignore
-//! use p3_batch_stark::{prove_batch, verify_batch, CommonData, StarkInstance};
+//! use p3_batch_stark::{
+//!     prove_batch_no_lookups, verify_batch_no_lookups, CommonData, StarkInstance,
+//! };
 //!
 //! let instances = vec![
-//!     StarkInstance { air: &air1, trace: trace1, public_values: pv1 },
-//!     StarkInstance { air: &air2, trace: trace2, public_values: pv2 },
+//!     StarkInstance { air: &air1, trace: trace1, public_values: pv1, lookups: vec![] },
+//!     StarkInstance { air: &air2, trace: trace2, public_values: pv2, lookups: vec![] },
 //! ];
 //!
 //! let common = CommonData::from_instances(&config, &instances);
-//! let proof = prove_batch(&config, instances, &common);
-//! verify_batch(&config, &[air1, air2], &proof, &[pv1, pv2], &common)?;
+//! let proof = prove_batch_no_lookups(&config, &instances, &common);
+//! verify_batch_no_lookups(&config, &[air1, air2], &proof, &[pv1, pv2], &common)?;
 //! ```
+//!
+//! For advanced usage with lookups, use [`prove_batch`] and [`verify_batch`] directly
+//! with a [`LookupGadget`](p3_lookup::lookup_traits::LookupGadget) implementation.
 
 #![no_std]
 
@@ -34,5 +39,5 @@ pub use config::{
 };
 pub use p3_uni_stark::{OpenedValues, VerificationError};
 pub use proof::{BatchCommitments, BatchOpenedValues, BatchProof};
-pub use prover::{StarkInstance, prove_batch};
-pub use verifier::verify_batch;
+pub use prover::{StarkInstance, prove_batch, prove_batch_no_lookups};
+pub use verifier::{verify_batch, verify_batch_no_lookups};


### PR DESCRIPTION
Fixed outdated doc example in batch-stark - StarkInstance now has 4 fields and the API changed to support lookups. Updated example to use the no-lookups variants. Also added missing SHA-256 and BN254 to README status.