### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,45 +96,45 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.4.0" }
-p3-baby-bear = { path = "baby-bear", version = "0.4.0" }
-p3-blake3 = { path = "blake3", version = "0.4.0" }
-p3-blake3-air = { path = "blake3-air", version = "0.4.0" }
-p3-bn254 = { path = "bn254", version = "0.4.0" }
-p3-challenger = { path = "challenger", version = "0.4.0" }
-p3-circle = { path = "circle", version = "0.4.0" }
-p3-commit = { path = "commit", version = "0.4.0" }
-p3-dft = { path = "dft", version = "0.4.0" }
+p3-air = { path = "air", version = "0.4.1" }
+p3-baby-bear = { path = "baby-bear", version = "0.4.1" }
+p3-blake3 = { path = "blake3", version = "0.4.1" }
+p3-blake3-air = { path = "blake3-air", version = "0.4.1" }
+p3-bn254 = { path = "bn254", version = "0.4.1" }
+p3-challenger = { path = "challenger", version = "0.4.1" }
+p3-circle = { path = "circle", version = "0.4.1" }
+p3-commit = { path = "commit", version = "0.4.1" }
+p3-dft = { path = "dft", version = "0.4.1" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.4.0" }
-p3-field-testing = { path = "field-testing", version = "0.4.0" }
-p3-fri = { path = "fri", version = "0.4.0" }
-p3-goldilocks = { path = "goldilocks", version = "0.4.0" }
-p3-interpolation = { path = "interpolation", version = "0.4.0" }
-p3-keccak = { path = "keccak", version = "0.4.0" }
-p3-keccak-air = { path = "keccak-air", version = "0.4.0" }
-p3-koala-bear = { path = "koala-bear", version = "0.4.0" }
-p3-lookup = { path = "lookup", version = "0.4.0" }
-p3-matrix = { path = "matrix", version = "0.4.0" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.4.0" }
-p3-mds = { path = "mds", version = "0.4.0" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.4.0" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.4.0" }
-p3-monty-31 = { path = "monty-31", version = "0.4.0" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.4.0" }
-p3-poseidon = { path = "poseidon", version = "0.4.0" }
-p3-poseidon2 = { path = "poseidon2", version = "0.4.0" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.4.0" }
-p3-rescue = { path = "rescue", version = "0.4.0" }
-p3-sha256 = { path = "sha256", version = "0.4.0" }
-p3-symmetric = { path = "symmetric", version = "0.4.0" }
-p3-uni-stark = { path = "uni-stark", version = "0.4.0" }
-p3-util = { path = "util", version = "0.4.0" }
+p3-field = { path = "field", version = "0.4.1" }
+p3-field-testing = { path = "field-testing", version = "0.4.1" }
+p3-fri = { path = "fri", version = "0.4.1" }
+p3-goldilocks = { path = "goldilocks", version = "0.4.1" }
+p3-interpolation = { path = "interpolation", version = "0.4.1" }
+p3-keccak = { path = "keccak", version = "0.4.1" }
+p3-keccak-air = { path = "keccak-air", version = "0.4.1" }
+p3-koala-bear = { path = "koala-bear", version = "0.4.1" }
+p3-lookup = { path = "lookup", version = "0.4.1" }
+p3-matrix = { path = "matrix", version = "0.4.1" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.4.1" }
+p3-mds = { path = "mds", version = "0.4.1" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.4.1" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.4.1" }
+p3-monty-31 = { path = "monty-31", version = "0.4.1" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.4.1" }
+p3-poseidon = { path = "poseidon", version = "0.4.1" }
+p3-poseidon2 = { path = "poseidon2", version = "0.4.1" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.4.1" }
+p3-rescue = { path = "rescue", version = "0.4.1" }
+p3-sha256 = { path = "sha256", version = "0.4.1" }
+p3-symmetric = { path = "symmetric", version = "0.4.1" }
+p3-uni-stark = { path = "uni-stark", version = "0.4.1" }
+p3-util = { path = "util", version = "0.4.1" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Rename multi-stark crate to batch-stark (#1122) (Sai)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Porting BN254 to our own code base (#913) (AngusG)

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+### Merged PRs
+- fix: remove undefined WIDTH const in interleave module (#1199) (Robin Salen)
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
@@ -44,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adrian Hamelink
 - AngusG
 - Himess
+- Robin Salen
 - Skylar Ray
 - Thomas Coratger
 - Tom Wambsgans

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Add modular lookups (local and global) with logup implementation (#1090) (Linda Guiga)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore(maybe-rayon): replace deprecated repeatn with repeat_n (#1064) (Skylar Ray)

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Merkle tree: add documentation for MerkleTreeMmcs and errors (#908) (Thomas Coratger)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+### Merged PRs
+- mersenne 31: optimize Poseidon2 for aarch64 Neon (#1196) (Thomas Coratger)
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Possible different take on PR #973 (#978) (AngusG)

--- a/poseidon/CHANGELOG.md
+++ b/poseidon/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Porting BN254 to our own code base (#913) (AngusG)

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Sha256: fix clippy warning (#1081) (Thomas Coratger)

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2025-12-18
+_No changes_
+
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
 - Clippy wants us to put things inside of fmt now instead of just extra arguments... (#916) (AngusG)


### PR DESCRIPTION
supersedes #1204

manually bypassing some `release-plz` limitations