### PR TITLE
chore(field): Make `BinomialExtensionField::new` public

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -35,7 +35,8 @@ pub struct BinomialExtensionField<F, const D: usize, A = F> {
 }
 
 impl<F, A, const D: usize> BinomialExtensionField<F, D, A> {
-    pub(crate) const fn new(value: [A; D]) -> Self {
+    #[inline]
+    pub const fn new(value: [A; D]) -> Self {
         Self {
             value,
             _phantom: PhantomData,


### PR DESCRIPTION
In `miden-vm` we use the explicit `QuadFelt = BinomialExtensionField<Goldilocks, 2>`. Being able to call  `QuadFelt::new([v0, v1])` instead of `QuadFelt::from_basis_coefficients_slice(&[v0, v1]).unwrap()` would help a lot in terms of code readability. 