### PR TITLE
chore(field): revert making `BinomialExtensionField::new` public and replace with `From<[A; D]>`

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -55,6 +55,12 @@ impl<F: Field, A: Algebra<F>, const D: usize> From<A> for BinomialExtensionField
     }
 }
 
+impl<F: Field, A: Algebra<F>, const D: usize> From<[A; D]> for BinomialExtensionField<F, D, A> {
+    fn from(x: [A; D]) -> Self {
+        Self::new(x)
+    }
+}
+
 impl<F: BinomiallyExtendable<D>, const D: usize> Packable for BinomialExtensionField<F, D> {}
 
 impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace<A>


### PR DESCRIPTION
This PR reverts https://github.com/Plonky3/Plonky3/pull/1209 and instead implements the desired behavior using the `From` trait. 