### PR TITLE
perf(field): Remove redundant allocation in BasedVectorSpace::flatten_to_base

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -511,7 +511,7 @@ pub trait BasedVectorSpace<F: PrimeCharacteristicRing>: Sized {
     #[inline]
     fn flatten_to_base(vec: Vec<Self>) -> Vec<F> {
         vec.into_iter()
-            .flat_map(|x| x.as_basis_coefficients_slice().to_vec())
+            .flat_map(|x| x.as_basis_coefficients_slice().iter().cloned())
             .collect()
     }
 


### PR DESCRIPTION
Eliminates unnecessary intermediate Vec allocation in flatten_to_base by directly iterating over coefficient slices.