### PR TITLE
Rename `RngElt` to `RingElement` for clarity

### DIFF
--- a/mds/src/karatsuba_convolution.rs
+++ b/mds/src/karatsuba_convolution.rs
@@ -46,8 +46,8 @@
 
 use core::ops::{Add, AddAssign, Neg, ShrAssign, Sub, SubAssign};
 
-/// Elements of a ring supporting the arithmetic operations needed by `Convolve`.
-pub trait RingElement:
+/// This trait collects the operations needed by `Convolve` below.
+pub trait ConvolutionScalar:
     Add<Output = Self>
     + AddAssign
     + Copy
@@ -59,8 +59,8 @@ pub trait RingElement:
 {
 }
 
-impl RingElement for i64 {}
-impl RingElement for i128 {}
+impl ConvolutionScalar for i64 {}
+impl ConvolutionScalar for i128 {}
 
 /// Template function to perform convolution of vectors.
 ///
@@ -88,7 +88,7 @@ impl RingElement for i128 {}
 /// with a shift, which on most architectures has better throughput
 /// and latency, and is issued on different ports (1*p06) to
 /// multiplication (1*p1).
-pub trait Convolve<F, T: RingElement, U: RingElement, V: RingElement> {
+pub trait Convolve<F, T: ConvolutionScalar, U: ConvolutionScalar, V: ConvolutionScalar> {
     /// Given an input element, retrieve the corresponding internal
     /// element that will be used in calculations.
     fn read(input: F) -> T;
@@ -238,9 +238,9 @@ fn conv_n_recursive<const N: usize, const HALF_N: usize, T, U, V, C, NC>(
     inner_conv: C,
     inner_negacyclic_conv: NC,
 ) where
-    T: RingElement,
-    U: RingElement,
-    V: RingElement,
+    T: ConvolutionScalar,
+    U: ConvolutionScalar,
+    V: ConvolutionScalar,
     C: Fn([T; HALF_N], [U; HALF_N], &mut [V]),
     NC: Fn([T; HALF_N], [U; HALF_N], &mut [V]),
 {
@@ -289,9 +289,9 @@ fn negacyclic_conv_n_recursive<const N: usize, const HALF_N: usize, T, U, V, NC>
     output: &mut [V],
     inner_negacyclic_conv: NC,
 ) where
-    T: RingElement,
-    U: RingElement,
-    V: RingElement,
+    T: ConvolutionScalar,
+    U: ConvolutionScalar,
+    V: ConvolutionScalar,
     NC: Fn([T; HALF_N], [U; HALF_N], &mut [V]),
 {
     debug_assert_eq!(2 * HALF_N, N);


### PR DESCRIPTION
Renames the trait `RngElt` to `RingElement` to improve code clarity and avoid ambiguity. The trait defines operations characteristic of ring elements (addition, subtraction, negation) used in Karatsuba-style convolution computations.

## Summary

- Renamed `RngElt` trait to `RingElement`
- Removed TODO comment requesting a better name