### PR TITLE
chore(rescue): remove outdated dead_code allowance

### DIFF
--- a/rescue/src/lib.rs
+++ b/rescue/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // TODO: remove when we settle on implementation details and publicly export
 #![no_std]
 
 extern crate alloc;


### PR DESCRIPTION
Removes the crate-level `#![allow(dead_code)]` attribute from `p3-rescue`.