### PR TITLE
chore(field): remove redundant #[allow(unused_imports)] attribute

### DIFF
--- a/field/src/packed/mod.rs
+++ b/field/src/packed/mod.rs
@@ -1,7 +1,6 @@
 pub mod interleaves;
 mod packed_traits;
 
-#[allow(unused_imports)]
 pub use interleaves::*; // Only used when vectorizations are available
 pub use packed_traits::*;
 


### PR DESCRIPTION
Removes unnecessary `#[allow(unused_imports)]` attribute from the packed field module.