### PR TITLE
refactor(p3-field): gate interleaves re-export with SIMD target cfg

### DIFF
--- a/field/src/packed/mod.rs
+++ b/field/src/packed/mod.rs
@@ -1,7 +1,11 @@
 pub mod interleaves;
 mod packed_traits;
 
-#[allow(unused_imports)]
+#[cfg(any(
+    all(target_arch = "aarch64", target_feature = "neon"),
+    all(target_arch = "x86_64", target_feature = "avx2",),
+    all(target_arch = "x86_64", target_feature = "avx512f"),
+))]
 pub use interleaves::*; // Only used when vectorizations are available
 pub use packed_traits::*;
 


### PR DESCRIPTION
The `interleaves` module was unconditionally re-exported in `packed/mod.rs`, even when SIMD targets (AVX2/AVX512/NEON) were not available. This caused clippy to emit an `unused_imports` warning on non-SIMD builds since the re-exported items were never actually used.