### PR TITLE
fix: check absolute error in log2_no_std test

### DIFF
--- a/rescue/src/util.rs
+++ b/rescue/src/util.rs
@@ -111,7 +111,8 @@ mod test {
             7.409391, 7.491853, 7.569856, 7.643856,
         ];
         for (&x, y) in inputs.iter().zip(expected) {
-            assert!((log2_no_std(x) - y) < TOLERANCE);
+            let diff = log2_no_std(x) - y;
+            assert!(diff.abs() < TOLERANCE);
         }
     }
 }


### PR DESCRIPTION
The test previously asserted only that log2_no_std(x) - expected < TOLERANCE, which made it effectively one-sided: large negative errors (underestimation) would still pass. So now switches the condition to use the absolute difference, ensuring we bound both overestimation and underestimation by the intended tolerance.