### PR TITLE
field: relax redundant bounds in From<[A; D]> for BinomialExtensionField

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -80,9 +80,13 @@ impl<F: Field, A: Algebra<F>, const D: usize> From<A> for BinomialExtensionField
     }
 }
 
-impl<F: Field, A: Algebra<F>, const D: usize> From<[A; D]> for BinomialExtensionField<F, D, A> {
+impl<F, A, const D: usize> From<[A; D]> for BinomialExtensionField<F, D, A> {
+    #[inline]
     fn from(x: [A; D]) -> Self {
-        Self::new(x)
+        Self {
+            value: x,
+            _phantom: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Removes unnecessary Field and Algebra bounds from From<[A; D]> for
BinomialExtensionField. No functional changes.
