### PR TITLE
feat: use compile-time asserts for const generic parameters

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -57,7 +57,7 @@ impl<F: Copy, const D: usize> BinomialExtensionField<F, D, F> {
     /// Panics if `N == 0`.
     #[inline]
     pub const fn new_array<const N: usize>(input: [[F; D]; N]) -> [Self; N] {
-        assert!(N > 0);
+        const { assert!(N > 0) }
         let mut output = [Self::new(input[0]); N];
         let mut i = 1;
         while i < N {

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -37,9 +37,11 @@ where
     pub const NUM_BARS: usize = 8;
 
     pub fn new(mds: Mds) -> Self {
-        assert!(WIDTH >= 8);
-        assert!(WIDTH <= 24);
-        assert_eq!(WIDTH % 4, 0);
+        const {
+            assert!(WIDTH >= 8);
+            assert!(WIDTH <= 24);
+            assert!(WIDTH.is_multiple_of(4));
+        }
 
         let round_constants = Self::instantiate_round_constants();
         let lookup1 = Self::instantiate_lookup1();

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -33,7 +33,7 @@ where
     InnerP: CryptographicPermutation<[T; WIDTH]>,
 {
     fn compress(&self, input: [[T; CHUNK]; N]) -> [T; CHUNK] {
-        debug_assert!(CHUNK * N <= WIDTH);
+        const { assert!(CHUNK * N <= WIDTH) }
         let mut pre = [T::default(); WIDTH];
         for i in 0..N {
             pre[i * CHUNK..(i + 1) * CHUNK].copy_from_slice(&input[i]);


### PR DESCRIPTION
I scanned the entire codebase looking for compile-time assert opportunities. Most places either already use `const { }` blocks (monty-31, mersenne-31, util, field/packed, etc.) or cannot be converted because they depend on runtime values. 
These 3 files are the remaining ones that could benefit from this change.

Part of #1014