### PR TITLE
chore(util): use explicit type in default calls for clarity

### DIFF
--- a/util/src/linear_map.rs
+++ b/util/src/linear_map.rs
@@ -21,14 +21,14 @@ pub struct LinearMap<K, V>(
 
 impl<K, V> Default for LinearMap<K, V> {
     fn default() -> Self {
-        Self(Default::default())
+        Self(Vec::default())
     }
 }
 
 impl<K: Eq, V> LinearMap<K, V> {
     /// Creates a new empty `LinearMap`.
     pub fn new() -> Self {
-        Default::default()
+        LinearMap::default()
     }
 
     /// Creates a new empty `LinearMap` with a pre-allocated capacity.


### PR DESCRIPTION
Replace `Default::default()` with explicit type calls (`Vec::default()` and `LinearMap::default()`) for improved code clarity.