### PR TITLE
refactor(monty-31): remove redundant PartialEq trait bound

### DIFF
--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -7,8 +7,7 @@ use crate::MontyField31;
 
 /// MontyParameters contains the prime P along with constants needed to convert elements into and out of MONTY form.
 /// The MONTY constant is assumed to be a power of 2.
-pub trait MontyParameters:
-    Copy + Default + Debug + Eq + PartialEq + Sync + Send + Hash + 'static
+pub trait MontyParameters: Copy + Default + Debug + Eq + Sync + Send + Hash + 'static
 {
     // A 31-bit prime.
     const PRIME: u32;


### PR DESCRIPTION
Remove redundant `PartialEq` trait bound from `MontyParameters` trait definition.