### PR TITLE
chore(challenger): Remove unused PackedValue import

### DIFF
--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -1,4 +1,4 @@
-use p3_field::{Field, PackedValue, PrimeField, PrimeField32, PrimeField64};
+use p3_field::{Field, PrimeField32, PrimeField64};
 use p3_maybe_rayon::prelude::*;
 use p3_symmetric::CryptographicPermutation;
 use tracing::instrument;


### PR DESCRIPTION
Removes the unused `PackedValue` import from `grinding_challenger.rs` to clean up dependencies and eliminate potential compiler warnings.