### PR TITLE
perf(challenger): eliminate redundant allocation in HashChallenger::flush

### DIFF
--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -39,9 +39,9 @@ where
 
         // Reuse the existing buffer and avoid allocating a second Vec.
         self.output_buffer.clear();
+        self.input_buffer.extend_from_slice(&output)
         self.output_buffer.extend(output);
         // Chain the hash output into the transcript.
-        self.input_buffer.extend_from_slice(&output);
     }
 }
 


### PR DESCRIPTION
Remove unnecessary vector allocation in `HashChallenger::flush()` method by reusing existing buffers.