### PR TITLE
refactor(maybe-rayon): remove redundant prelude imports from serial module

### DIFF
--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -1,5 +1,4 @@
 use core::iter::{FlatMap, IntoIterator, Iterator};
-use core::marker::{Send, Sized, Sync};
 use core::ops::{Fn, FnOnce};
 use core::slice::{
     Chunks, ChunksExact, ChunksExactMut, ChunksMut, RChunks, RChunksExact, RChunksExactMut,


### PR DESCRIPTION
Remove unnecessary `use core::marker::{Send, Sized, Sync};` import from `serial.rs`.