### PR TITLE
fix(bn254): use subtraction instead of multiplication for negation

### DIFF
--- a/bn254/src/bn254.rs
+++ b/bn254/src/bn254.rs
@@ -467,7 +467,7 @@ impl Neg for Bn254 {
 
     #[inline]
     fn neg(self) -> Self::Output {
-        self * Self::NEG_ONE
+        Self::ZERO - self
     }
 }
 


### PR DESCRIPTION
The `Neg` implementation for `Bn254` was using multiplication by `NEG_ONE`, which is significantly slower than simple subtraction. 
Replaced `self * Self::NEG_ONE` with `Self::ZERO - self` to match the approach used by other field implementations (Goldilocks, MontyField31).

bench results: 
<img width="980" height="268" alt="image" src="https://github.com/user-attachments/assets/c231e6a9-e2d3-43fc-826a-69606220f8b1" />
<img width="967" height="260" alt="image" src="https://github.com/user-attachments/assets/ceeb8de6-ec52-4fd2-8699-467cfaa0b66b" />
