### PR TITLE
chore(keccak): clarify fallback docs and rename state var

### DIFF
--- a/keccak/src/fallback.rs
+++ b/keccak/src/fallback.rs
@@ -1,5 +1,5 @@
-//! This module should be included only when none of the more target-specific implementations are
-//! available. It fills in a few things based on a pure Rust implementation of Keccak.
+//! This module should be included only when no target-specific implementations are available.
+//! It provides a fallback implementation based on pure Rust Keccak.
 
 use core::mem::transmute;
 
@@ -10,9 +10,9 @@ use crate::KeccakF;
 pub const VECTOR_LEN: usize = 1;
 
 impl Permutation<[[u64; VECTOR_LEN]; 25]> for KeccakF {
-    fn permute_mut(&self, input: &mut [[u64; VECTOR_LEN]; 25]) {
-        let input: &mut [u64; 25] = unsafe { transmute(input) };
-        self.permute_mut(input);
+    fn permute_mut(&self, state: &mut [[u64; VECTOR_LEN]; 25]) {
+        let state: &mut [u64; 25] = unsafe { transmute(state) };
+        self.permute_mut(state);
     }
 }
 


### PR DESCRIPTION
Small cleanup to improve readability of the Keccak fallback implementation.
- Clarify module-level documentation
- Avoid variable shadowing in permute_mut