### PR TITLE
refactor(air): remove unused code and dependencies

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
-tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/air/src/lookup/mod.rs
+++ b/air/src/lookup/mod.rs
@@ -48,7 +48,7 @@ impl Direction {
 
 /// Data required for global lookup arguments in a multi-STARK proof.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct LookupData<F: Clone> {
+pub struct LookupData<F> {
     /// Name of the global lookup interaction.
     pub name: String,
     /// Index of the auxiliary column (if there are multiple auxiliary columns, this is the first one)

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -27,7 +27,7 @@ where
 ///
 /// Verifies at debug time that all inputs are boolean.
 #[inline(always)]
-pub fn checked_xor<F: Field, const N: usize>(xs: &[F]) -> F {
+pub fn checked_xor<F: Field>(xs: &[F]) -> F {
     xs.iter().fold(F::ZERO, |acc, x| {
         debug_assert!(x.is_zero() || x.is_one());
         acc.xor(x)
@@ -266,22 +266,22 @@ mod tests {
     fn test_checked_xor_multiple_cases() {
         // Input: [1, 0, 1] => XOR(1 ^ 0 ^ 1) = 0
         let bits = vec![F::ONE, F::ZERO, F::ONE];
-        let result = checked_xor::<F, 3>(&bits);
+        let result = checked_xor::<F>(&bits);
         assert_eq!(result, F::ZERO);
 
         // [1, 1, 1] => XOR = 1 ^ 1 ^ 1 = 1
         let bits = vec![F::ONE, F::ONE, F::ONE];
-        let result = checked_xor::<F, 3>(&bits);
+        let result = checked_xor::<F>(&bits);
         assert_eq!(result, F::ONE);
 
         // [0, 0, 0] => XOR = 0
         let bits = vec![F::ZERO, F::ZERO, F::ZERO];
-        let result = checked_xor::<F, 3>(&bits);
+        let result = checked_xor::<F>(&bits);
         assert_eq!(result, F::ZERO);
 
         // [1, 0, 1, 0] => XOR = 1 ^ 0 ^ 1 ^ 0 = 0
         let bits = vec![F::ONE, F::ZERO, F::ONE, F::ZERO];
-        let result = checked_xor::<F, 4>(&bits);
+        let result = checked_xor::<F>(&bits);
         assert_eq!(result, F::ZERO);
     }
 


### PR DESCRIPTION
Remove dead code from air crate: unused const generic N in checked_xor, redundant Clone bound on LookupData, unused tracing dependency.