### PR TITLE
perf: pre-allocate Vecs with known sizes in hot paths

### DIFF
--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -249,8 +249,9 @@ where
     let alpha: Challenge<SC> = challenger.sample_algebra_element();
 
     // Build per-instance quotient domains and values, and split into chunks.
-    let mut quotient_chunk_domains: Vec<Domain<SC>> = Vec::new();
-    let mut quotient_chunk_mats: Vec<RowMajorMatrix<Val<SC>>> = Vec::new();
+    let total_chunks: usize = num_quotient_chunks.iter().sum();
+    let mut quotient_chunk_domains: Vec<Domain<SC>> = Vec::with_capacity(total_chunks);
+    let mut quotient_chunk_mats: Vec<RowMajorMatrix<Val<SC>>> = Vec::with_capacity(total_chunks);
     // Track ranges so we can map openings back to instances.
     let mut quotient_chunk_ranges: Vec<(usize, usize)> = Vec::with_capacity(n_instances);
 

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -302,7 +302,8 @@ where
         .collect::<Vec<_>>();
 
     // Build the per-matrix openings for the aggregated quotient commitment.
-    let mut qc_round = Vec::new();
+    let total_qc_chunks: usize = num_quotient_chunks.iter().sum();
+    let mut qc_round = Vec::with_capacity(total_qc_chunks);
     for (i, domains) in randomized_quotient_chunks_domains.iter().enumerate() {
         let inst_qcs = &opened_values.instances[i]
             .base_opened_values
@@ -323,7 +324,7 @@ where
     // Preprocessed rounds: a single global commitment with one matrix per
     // instance that has preprocessed columns.
     if let Some(global) = &common.preprocessed {
-        let mut pre_round = Vec::new();
+        let mut pre_round = Vec::with_capacity(global.matrix_to_instance.len());
 
         for (matrix_index, &inst_idx) in global.matrix_to_instance.iter().enumerate() {
             let pre_w = preprocessed_widths[inst_idx];
@@ -370,7 +371,7 @@ where
 
     if is_lookup {
         let permutation_commit = commitments.permutation.clone().unwrap();
-        let mut permutation_round = Vec::new();
+        let mut permutation_round = Vec::with_capacity(ext_trace_domains.len());
         for (i, (ext_dom, inst_opened_vals)) in ext_trace_domains
             .iter()
             .zip(opened_values.instances.iter())

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -290,8 +290,9 @@ where
         // Iterate over our reduced columns and extract lambda - the multiple of the vanishing polynomial
         // which may appear in the reduced quotient due to CFFT dimension gap.
 
-        let mut lambdas = vec![];
-        let mut log_heights = vec![];
+        let num_reduced = reduced_openings.len();
+        let mut lambdas = Vec::with_capacity(num_reduced);
+        let mut log_heights = Vec::with_capacity(num_reduced);
         let first_layer_mats: Vec<RowMajorMatrix<Challenge>> = reduced_openings
             .into_iter()
             .map(|(log_height, (_, mut ro))| {

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 use core::iter;
 
@@ -170,9 +169,10 @@ where
 {
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();
-    let mut commits = vec![];
-    let mut data = vec![];
-    let mut pow_witnesses = vec![];
+    let num_rounds = log2_strict_usize(folded.len() / (params.blowup() * params.final_poly_len()));
+    let mut commits = Vec::with_capacity(num_rounds);
+    let mut data = Vec::with_capacity(num_rounds);
+    let mut pow_witnesses = Vec::with_capacity(num_rounds);
 
     while folded.len() > params.blowup() * params.final_poly_len() {
         // As folded is in bit reversed order, it looks like:


### PR DESCRIPTION
Pre-allocate vectors in FRI commit phase, batch-stark prover/verifier, and circle PCS where the final size is computable before the loop. Eliminates unnecessary reallocations during proving.