### PR TITLE
feat: remove `ProverData` from `CommonData`

### DIFF
--- a/batch-stark/src/lib.rs
+++ b/batch-stark/src/lib.rs
@@ -1,16 +1,17 @@
 //! Batch-STARK proving and verification.
 //!
 //! ```ignore
-//! use p3_batch_stark::{prove_batch_no_lookups, verify_batch_no_lookups, CommonData, StarkInstance};
+//! use p3_batch_stark::{prove_batch, verify_batch, ProverData, StarkInstance};
 //!
 //! let instances = vec![
 //!     StarkInstance { air: &air1, trace: trace1, public_values: pv1, lookups: vec![] },
-//!     StarkInstance { air: &air2, trace: trace2, public_values: pv2: lookups: vec![] },
+//!     StarkInstance { air: &air2, trace: trace2, public_values: pv2, lookups: vec![] },
 //! ];
 //!
-//! let common = CommonData::from_instances(&config, &instances);
-//! let proof = prove_batch_no_lookups(&config, instances, &common);
-//! verify_batch_no_lookups(&config, &[air1, air2], &proof, &[pv1, pv2], &common)?;
+//! let prover_data = ProverData::from_instances(&config, &instances);
+//! let common = &prover_data.common;
+//! let proof = prove_batch(&config, &instances, &prover_data);
+//! verify_batch(&config, &[air1, air2], &proof, &[pv1, pv2], common)?;
 //! ```
 
 #![no_std]
@@ -29,7 +30,7 @@ pub mod verifier;
 // Re-export main types and functions for convenience
 #[cfg(debug_assertions)]
 pub use check_constraints::*;
-pub use common::{CommonData, get_perm_challenges};
+pub use common::{CommonData, ProverData, ProverOnlyData, get_perm_challenges};
 pub use config::{
     Challenge, Commitment, Domain, PackedChallenge, PackedVal, PcsError, PcsProof,
     StarkGenericConfig, Val,


### PR DESCRIPTION
closes #1248 

@LindaGuiga I've tweaked the suggested approach, I assume you meant to have `ProverOnlyData` to be the struct embedded into `ProverData`, and not the opposite 🙂 