### PR TITLE
fix(dft): reduce twiddle factor allocation in Radix2Dit

### DIFF
--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -52,7 +52,7 @@ impl<F: TwoAdicField> Radix2Dit<F> {
             .or_insert_with(|| {
                 let n = 1 << log_h;
                 let root = F::two_adic_generator(log_h);
-                Arc::from(root.powers().take(n).collect())
+                Arc::from(root.powers().take(n / 2).collect())
             })
             .clone()
     }


### PR DESCRIPTION
The twiddle factor cache in Radix2Dit was allocating n elements,  but only indices 0..n/2-1 are ever accessed in dit_layer. 
This is because ω^{n/2} = -1, so twiddles with indices >= n/2  are just negatives of the first half and are never used.

Changed allocation from n to n/2 elements, halving memory usage for the twiddle cache. This aligns with all other DFT implementations in the codebase (Radix2DitParallel, Radix2Bowers, Radix2DFTSmallBatch, Mersenne31ComplexRadix2Dit).