### PR TITLE
fix(matrix): correct idx initialization in `FlatMatrixView::row_subseq_unchecked`

### DIFF
--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -88,7 +88,7 @@ where
                     .row_subseq_unchecked(r, inner_start, self.0.width())
                     .into_iter()
                     .peekable(),
-                idx: start,
+                idx: start % EF::DIMENSION,
                 _phantom: PhantomData,
             }
             .take(len)
@@ -324,5 +324,21 @@ mod tests {
 
         // Iterator should now be exhausted
         assert_eq!(row_iter.next(), None);
+    }
+
+    #[test]
+    fn test_row_subseq_start_ge_dimension() {
+        let ef = |offset| EF::from_basis_coefficients_fn(|i| F::from_u8(i as u8 + offset));
+        let values = vec![ef(10), ef(20), ef(30)];
+        let matrix = RowMajorMatrix::new(values, 3);
+        let flat = FlatMatrixView::<F, EF, _>::new(matrix);
+
+        unsafe {
+            let result: Vec<_> = flat.row_subseq_unchecked(0, 2, 5).into_iter().collect();
+            assert_eq!(result, [20, 21, 30].map(F::from_u8).to_vec());
+
+            let result: Vec<_> = flat.row_subseq_unchecked(0, 3, 6).into_iter().collect();
+            assert_eq!(result, [21, 30, 31].map(F::from_u8).to_vec());
+        }
     }
 }


### PR DESCRIPTION
`FlatIter.idx` tracks position within current EF element (valid range: 0 to DIMENSION-1).

When `start >= DIMENSION`, passing `idx: start` caused out-of-bounds access in [as_basis_coefficients_slice()[idx]] https://github.com/Plonky3/Plonky3/blob/4927bceb59c2fe831f6229f9670ebc3f3b534b55/field/src/field.rs#L554-L557 For example, with start=3 and DIMENSION=2,
code tried to access slice[3] on a 2-element array.

Fix: use `start % EF::DIMENSION` instead of `start`.

Existing tests passed because they only used start=1 < DIMENSION=2.
Added regression test with start >= DIMENSION.