### PR TITLE
 chore(lookup): move rand to dev-dependencies, remove unused serde

### DIFF
--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -14,14 +14,13 @@ p3-air = { workspace = true }
 p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 p3-uni-stark = { workspace = true }
-rand = { workspace = true }
-serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
+rand = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
`rand` is only used in tests.rs (behind #[cfg(test)]), moved to [dev-dependencies]
`serde` was declared but never used anywhere in the crate, removed