### PR TITLE
chore(uni-stark): remove redundant #[allow(unused)] from check_constraints

### DIFF
--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -16,7 +16,6 @@ use tracing::instrument;
 /// - `main`: The [`RowMajorMatrix`] containing witness rows.
 /// - `public_values`: Public values provided to the builder.
 #[instrument(skip_all)]
-#[allow(unused)]
 pub(crate) fn check_constraints<F, A>(air: &A, main: &RowMajorMatrix<F>, public_values: &[F])
 where
     F: Field,


### PR DESCRIPTION
Removes unnecessary #[allow(unused)] lint suppression from the check_constraints function in uni-stark/src/check_constraints.rs.