### PR TITLE
chore(lookup): move `rand` to dev-dependencies

### DIFF
--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -14,7 +14,6 @@ p3-air = { workspace = true }
 p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 p3-uni-stark = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -22,6 +21,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
+rand = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
Move rand dependency from [dependencies] to [dev-dependencies] in the p3-lookup crate, as it is only used in test code.