### PR TITLE
perf: implement NEON vectorization for Poseidon2-Goldilocks

### DIFF
--- a/goldilocks/src/aarch64_neon/mod.rs
+++ b/goldilocks/src/aarch64_neon/mod.rs
@@ -1,0 +1,6 @@
+mod packing;
+mod poseidon2;
+mod poseidon2_asm;
+
+pub use packing::*;
+pub use poseidon2::*;

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -1,0 +1,401 @@
+use alloc::vec::Vec;
+use core::arch::aarch64::{
+    uint64x2_t, vaddq_u64, vandq_u64, vbicq_u64, vcgtq_s64, vdupq_n_u64, veorq_u64, vgetq_lane_u64,
+    vreinterpretq_s64_u64, vsetq_lane_u64, vshrq_n_u64, vsubq_u64,
+};
+use core::fmt::Debug;
+use core::iter::{Product, Sum};
+use core::mem::transmute;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use p3_field::exponentiation::exp_10540996611094048183;
+use p3_field::op_assign_macros::{
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field, impl_sum_prod_base_field,
+    ring_sum,
+};
+use p3_field::{
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
+};
+use p3_util::reconstitute_from_base;
+use rand::Rng;
+use rand::distr::{Distribution, StandardUniform};
+
+use crate::{Goldilocks, P};
+
+const WIDTH: usize = 2;
+
+/// Equal to `2^32 - 1 = 2^64 mod P`.
+const EPSILON: u64 = Goldilocks::ORDER_U64.wrapping_neg();
+
+/// Vectorized NEON implementation of `Goldilocks` arithmetic.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+#[must_use]
+pub struct PackedGoldilocksNeon(pub [Goldilocks; WIDTH]);
+
+impl PackedGoldilocksNeon {
+    #[inline]
+    #[must_use]
+    pub(crate) fn to_vector(self) -> uint64x2_t {
+        unsafe { transmute(self) }
+    }
+
+    #[inline]
+    pub(crate) fn from_vector(vector: uint64x2_t) -> Self {
+        unsafe { transmute(vector) }
+    }
+
+    #[inline]
+    const fn broadcast(value: Goldilocks) -> Self {
+        Self([value; WIDTH])
+    }
+}
+
+impl From<Goldilocks> for PackedGoldilocksNeon {
+    fn from(x: Goldilocks) -> Self {
+        Self::broadcast(x)
+    }
+}
+
+impl Add for PackedGoldilocksNeon {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self::from_vector(add(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl Sub for PackedGoldilocksNeon {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self::from_vector(sub(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl Neg for PackedGoldilocksNeon {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self::from_vector(neg(self.to_vector()))
+    }
+}
+
+impl Mul for PackedGoldilocksNeon {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self::from_vector(mul(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl_add_assign!(PackedGoldilocksNeon);
+impl_sub_assign!(PackedGoldilocksNeon);
+impl_mul_methods!(PackedGoldilocksNeon);
+ring_sum!(PackedGoldilocksNeon);
+impl_rng!(PackedGoldilocksNeon);
+
+impl PrimeCharacteristicRing for PackedGoldilocksNeon {
+    type PrimeSubfield = Goldilocks;
+
+    const ZERO: Self = Self::broadcast(Goldilocks::ZERO);
+    const ONE: Self = Self::broadcast(Goldilocks::ONE);
+    const TWO: Self = Self::broadcast(Goldilocks::TWO);
+    const NEG_ONE: Self = Self::broadcast(Goldilocks::NEG_ONE);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::from_vector(halve(self.to_vector()))
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        Self::from_vector(square(self.to_vector()))
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
+    }
+}
+
+impl InjectiveMonomial<7> for PackedGoldilocksNeon {}
+
+impl PermutationMonomial<7> for PackedGoldilocksNeon {
+    fn injective_exp_root_n(&self) -> Self {
+        exp_10540996611094048183(*self)
+    }
+}
+
+impl_add_base_field!(PackedGoldilocksNeon, Goldilocks);
+impl_sub_base_field!(PackedGoldilocksNeon, Goldilocks);
+impl_mul_base_field!(PackedGoldilocksNeon, Goldilocks);
+impl_div_methods!(PackedGoldilocksNeon, Goldilocks);
+impl_sum_prod_base_field!(PackedGoldilocksNeon, Goldilocks);
+
+impl Algebra<Goldilocks> for PackedGoldilocksNeon {}
+
+impl_packed_value!(PackedGoldilocksNeon, Goldilocks, WIDTH);
+
+unsafe impl PackedField for PackedGoldilocksNeon {
+    type Scalar = Goldilocks;
+}
+
+/// Interleave two 64-bit vectors at the element level.
+/// For block_len=1: [a0, a1] x [b0, b1] -> [a0, b0], [a1, b1]
+#[inline]
+pub fn interleave_u64(v0: uint64x2_t, v1: uint64x2_t) -> (uint64x2_t, uint64x2_t) {
+    unsafe {
+        let a0 = vgetq_lane_u64::<0>(v0);
+        let a1 = vgetq_lane_u64::<1>(v0);
+        let b0 = vgetq_lane_u64::<0>(v1);
+        let b1 = vgetq_lane_u64::<1>(v1);
+
+        // r0 = [a0, b0], r1 = [a1, b1]
+        let r0 = vsetq_lane_u64::<1>(b0, vsetq_lane_u64::<0>(a0, vdupq_n_u64(0)));
+        let r1 = vsetq_lane_u64::<1>(b1, vsetq_lane_u64::<0>(a1, vdupq_n_u64(0)));
+
+        (r0, r1)
+    }
+}
+
+unsafe impl PackedFieldPow2 for PackedGoldilocksNeon {
+    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
+        let (v0, v1) = (self.to_vector(), other.to_vector());
+        let (res0, res1) = match block_len {
+            1 => interleave_u64(v0, v1),
+            2 => (v0, v1),
+            _ => panic!("unsupported block length"),
+        };
+        (Self::from_vector(res0), Self::from_vector(res1))
+    }
+}
+
+// NEON arithmetic uses shifted representation (XOR with 2^63) for unsigned comparison.
+
+const SIGN_BIT: uint64x2_t = unsafe { transmute([i64::MIN as u64; WIDTH]) };
+const SHIFTED_FIELD_ORDER: uint64x2_t =
+    unsafe { transmute([Goldilocks::ORDER_U64 ^ (i64::MIN as u64); WIDTH]) };
+const EPSILON_VEC: uint64x2_t = unsafe { transmute([EPSILON; WIDTH]) };
+
+#[inline(always)]
+fn shift(x: uint64x2_t) -> uint64x2_t {
+    unsafe { veorq_u64(x, SIGN_BIT) }
+}
+
+#[inline(always)]
+unsafe fn canonicalize_s(x_s: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let x_s_signed = vreinterpretq_s64_u64(x_s);
+        let order_s_signed = vreinterpretq_s64_u64(SHIFTED_FIELD_ORDER);
+        let mask = vcgtq_s64(order_s_signed, x_s_signed);
+        let wrapback_amt = vbicq_u64(EPSILON_VEC, mask);
+        vaddq_u64(x_s, wrapback_amt)
+    }
+}
+
+#[inline(always)]
+unsafe fn add_no_double_overflow_64_64s_s(x: uint64x2_t, y_s: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let res_wrapped_s = vaddq_u64(x, y_s);
+        // After XOR shift, signed comparison correctly detects overflow.
+        // Overflow occurred iff y_s > res_wrapped_s (as signed, due to shift semantics)
+        let y_s_signed = vreinterpretq_s64_u64(y_s);
+        let res_s_signed = vreinterpretq_s64_u64(res_wrapped_s);
+        let mask = vcgtq_s64(y_s_signed, res_s_signed);
+        // wrapback_amt is EPSILON on overflow
+        let wrapback_amt = vshrq_n_u64::<32>(mask);
+        vaddq_u64(res_wrapped_s, wrapback_amt)
+    }
+}
+
+/// Goldilocks modular addition.
+#[inline]
+fn add(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let y_s = shift(y);
+        let res_s = add_no_double_overflow_64_64s_s(x, canonicalize_s(y_s));
+        shift(res_s)
+    }
+}
+
+/// Goldilocks modular subtraction.
+#[inline]
+fn sub(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let mut y_s = shift(y);
+        y_s = canonicalize_s(y_s);
+        let x_s = shift(x);
+        let y_s_signed = vreinterpretq_s64_u64(y_s);
+        let x_s_signed = vreinterpretq_s64_u64(x_s);
+        // -1 if underflow (y > x)
+        let mask = vcgtq_s64(y_s_signed, x_s_signed);
+        let wrapback_amt = vshrq_n_u64::<32>(mask);
+        let res_wrapped = vsubq_u64(x_s, y_s);
+        vsubq_u64(res_wrapped, wrapback_amt)
+    }
+}
+
+/// Goldilocks modular negation.
+#[inline]
+fn neg(y: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let y_s = shift(y);
+        vsubq_u64(SHIFTED_FIELD_ORDER, canonicalize_s(y_s))
+    }
+}
+
+/// Halve a vector of Goldilocks field elements.
+#[inline(always)]
+pub(crate) fn halve(input: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let one = vdupq_n_u64(1);
+        let zero = vdupq_n_u64(0);
+        let half = vdupq_n_u64(P.div_ceil(2));
+
+        let least_bit = vandq_u64(input, one);
+        let t = vshrq_n_u64::<1>(input);
+        // neg_least_bit is 0 or -1 (all bits 1)
+        let neg_least_bit = vsubq_u64(zero, least_bit);
+        let maybe_half = vandq_u64(half, neg_least_bit);
+        vaddq_u64(t, maybe_half)
+    }
+}
+
+/// Goldilocks modular multiplication using interleaved dual-lane ASM.
+#[inline]
+fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let x0 = vgetq_lane_u64::<0>(x);
+        let x1 = vgetq_lane_u64::<1>(x);
+        let y0 = vgetq_lane_u64::<0>(y);
+        let y1 = vgetq_lane_u64::<1>(y);
+
+        let (res_0, res_1) = mul_reduce_dual_asm(x0, y0, x1, y1);
+
+        transmute([res_0, res_1])
+    }
+}
+
+/// Interleaved dual-lane multiplication and reduction using scalar ASM.
+/// Uses shift-based EPSILON multiplication: hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+#[inline(always)]
+unsafe fn mul_reduce_dual_asm(a0: u64, b0: u64, a1: u64, b1: u64) -> (u64, u64) {
+    use core::arch::asm;
+    let result0: u64;
+    let result1: u64;
+
+    unsafe {
+        asm!(
+            // Compute both 128-bit products (interleaved for ILP)
+            "mul   {lo0}, {a0}, {b0}",
+            "mul   {lo1}, {a1}, {b1}",
+            "umulh {hi0}, {a0}, {b0}",
+            "umulh {hi1}, {a1}, {b1}",
+
+            // hi_hi = hi >> 32
+            "lsr   {hi_hi0}, {hi0}, #32",
+            "lsr   {hi_hi1}, {hi1}, #32",
+
+            // tmp = lo - hi_hi (with borrow handling)
+            "subs  {tmp0}, {lo0}, {hi_hi0}",
+            "csetm {adj0:w}, cc",
+            "subs  {tmp1}, {lo1}, {hi_hi1}",
+            "csetm {adj1:w}, cc",
+            "sub   {tmp0}, {tmp0}, {adj0}",
+            "sub   {tmp1}, {tmp1}, {adj1}",
+
+            // hi_lo = hi & EPSILON
+            "and   {hi_lo0}, {hi0}, {epsilon}",
+            "and   {hi_lo1}, {hi1}, {epsilon}",
+
+            // hi_lo_eps = (hi_lo << 32) - hi_lo (avoids multiply)
+            "lsl   {t0}, {hi_lo0}, #32",
+            "lsl   {t1}, {hi_lo1}, #32",
+            "sub   {hi_lo_eps0}, {t0}, {hi_lo0}",
+            "sub   {hi_lo_eps1}, {t1}, {hi_lo1}",
+
+            // result = tmp + hi_lo_eps (with overflow handling)
+            "adds  {result0}, {tmp0}, {hi_lo_eps0}",
+            "csetm {adj0:w}, cs",
+            "adds  {result1}, {tmp1}, {hi_lo_eps1}",
+            "csetm {adj1:w}, cs",
+            "add   {result0}, {result0}, {adj0}",
+            "add   {result1}, {result1}, {adj1}",
+
+            a0 = in(reg) a0,
+            b0 = in(reg) b0,
+            a1 = in(reg) a1,
+            b1 = in(reg) b1,
+            epsilon = in(reg) EPSILON,
+            lo0 = out(reg) _,
+            lo1 = out(reg) _,
+            hi0 = out(reg) _,
+            hi1 = out(reg) _,
+            hi_hi0 = out(reg) _,
+            hi_hi1 = out(reg) _,
+            tmp0 = out(reg) _,
+            tmp1 = out(reg) _,
+            hi_lo0 = out(reg) _,
+            hi_lo1 = out(reg) _,
+            t0 = out(reg) _,
+            t1 = out(reg) _,
+            hi_lo_eps0 = out(reg) _,
+            hi_lo_eps1 = out(reg) _,
+            adj0 = out(reg) _,
+            adj1 = out(reg) _,
+            result0 = out(reg) result0,
+            result1 = out(reg) result1,
+            options(pure, nomem, nostack),
+        );
+    }
+
+    (result0, result1)
+}
+
+/// Goldilocks modular square using interleaved dual-lane ASM.
+#[inline]
+fn square(x: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let x0 = vgetq_lane_u64::<0>(x);
+        let x1 = vgetq_lane_u64::<1>(x);
+
+        let (res_0, res_1) = mul_reduce_dual_asm(x0, x0, x1, x1);
+
+        transmute([res_0, res_1])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field_testing::test_packed_field;
+
+    use super::{Goldilocks, PackedGoldilocksNeon, WIDTH};
+
+    const SPECIAL_VALS: [Goldilocks; WIDTH] =
+        Goldilocks::new_array([0xFFFF_FFFF_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]);
+
+    const ZEROS: PackedGoldilocksNeon = PackedGoldilocksNeon(Goldilocks::new_array([
+        0x0000_0000_0000_0000,
+        0xFFFF_FFFF_0000_0001, // = P, canonicalizes to 0
+    ]));
+
+    const ONES: PackedGoldilocksNeon = PackedGoldilocksNeon(Goldilocks::new_array([
+        0x0000_0000_0000_0001,
+        0xFFFF_FFFF_0000_0002, // = P + 1, canonicalizes to 1
+    ]));
+
+    test_packed_field!(
+        crate::PackedGoldilocksNeon,
+        &[super::ZEROS],
+        &[super::ONES],
+        crate::PackedGoldilocksNeon(super::SPECIAL_VALS)
+    );
+}

--- a/goldilocks/src/aarch64_neon/poseidon2.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2.rs
@@ -1,0 +1,396 @@
+//! Optimized Poseidon2 for Goldilocks on aarch64.
+//!
+//! Uses ARM inline assembly with latency hiding via interleaved S-box/MDS computation.
+//! Fully unrolled internal rounds for W8, W12, W16.
+//!
+//! For packed operations, lanes are extracted to scalar, processed with interleaved
+//! dual-lane ASM, then repacked. This is faster than using PackedGoldilocksNeon
+//! arithmetic directly because the scalar `add_asm` avoids the modular reduction
+//! overhead present in NEON addition.
+
+use alloc::vec::Vec;
+
+use p3_poseidon2::{
+    ExternalLayer, ExternalLayerConstants, ExternalLayerConstructor, InternalLayer,
+    InternalLayerConstructor,
+};
+
+use super::packing::PackedGoldilocksNeon;
+use super::poseidon2_asm::{
+    external_initial_permute_state_asm, external_terminal_permute_state_asm,
+    internal_permute_state_asm, internal_permute_state_asm_w8, internal_permute_state_asm_w12,
+    internal_permute_state_asm_w16, internal_round_dual_asm_w8, internal_round_dual_asm_w16,
+};
+use crate::{
+    Goldilocks, MATRIX_DIAG_8_GOLDILOCKS, MATRIX_DIAG_12_GOLDILOCKS, MATRIX_DIAG_16_GOLDILOCKS,
+    MATRIX_DIAG_20_GOLDILOCKS,
+};
+
+/// Degree of the chosen permutation polynomial for Goldilocks.
+const GOLDILOCKS_S_BOX_DEGREE: u64 = 7;
+
+/// ASM-optimized internal layer with latency-hiding S-box/MDS interleaving.
+#[derive(Debug, Clone, Default)]
+pub struct Poseidon2InternalLayerGoldilocksAsm {
+    internal_constants: Vec<Goldilocks>,
+}
+
+impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocksAsm {
+    fn new_from_constants(internal_constants: Vec<Goldilocks>) -> Self {
+        Self { internal_constants }
+    }
+}
+
+impl InternalLayer<Goldilocks, 8, GOLDILOCKS_S_BOX_DEGREE> for Poseidon2InternalLayerGoldilocksAsm {
+    fn permute_state(&self, state: &mut [Goldilocks; 8]) {
+        internal_permute_state_asm_w8(state, MATRIX_DIAG_8_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<Goldilocks, 12, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 12]) {
+        internal_permute_state_asm_w12(state, MATRIX_DIAG_12_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<Goldilocks, 16, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 16]) {
+        internal_permute_state_asm_w16(state, MATRIX_DIAG_16_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<Goldilocks, 20, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 20]) {
+        internal_permute_state_asm(state, MATRIX_DIAG_20_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+/// ASM-optimized external layer with pipelined S-box computation.
+#[derive(Clone)]
+pub struct Poseidon2ExternalLayerGoldilocksAsm<const WIDTH: usize> {
+    external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
+}
+
+impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
+    for Poseidon2ExternalLayerGoldilocksAsm<WIDTH>
+{
+    fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
+        Self { external_constants }
+    }
+}
+
+impl<const WIDTH: usize> ExternalLayer<Goldilocks, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2ExternalLayerGoldilocksAsm<WIDTH>
+{
+    fn permute_state_initial(&self, state: &mut [Goldilocks; WIDTH]) {
+        external_initial_permute_state_asm(state, self.external_constants.get_initial_constants());
+    }
+
+    fn permute_state_terminal(&self, state: &mut [Goldilocks; WIDTH]) {
+        external_terminal_permute_state_asm(
+            state,
+            self.external_constants.get_terminal_constants(),
+        );
+    }
+}
+
+/// Type alias for scalar ASM-optimized Poseidon2.
+pub type Poseidon2GoldilocksAsm<const WIDTH: usize> = p3_poseidon2::Poseidon2<
+    Goldilocks,
+    Poseidon2ExternalLayerGoldilocksAsm<WIDTH>,
+    Poseidon2InternalLayerGoldilocksAsm,
+    WIDTH,
+    GOLDILOCKS_S_BOX_DEGREE,
+>;
+
+use super::poseidon2_asm::{
+    external_round_dual_asm, internal_round_dual_asm, internal_round_dual_asm_w12,
+    mds_light_permutation_asm,
+};
+
+fn internal_permute_packed_asm<const WIDTH: usize>(
+    state: &mut [PackedGoldilocksNeon; WIDTH],
+    diag: [Goldilocks; WIDTH],
+    internal_constants: &[Goldilocks],
+) {
+    // Extract lanes - keep as raw u64 arrays for ASM
+    let mut lane0: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[1].value);
+    let diag_raw: [u64; WIDTH] = core::array::from_fn(|i| diag[i].value);
+
+    // Process all internal rounds with true interleaved dual-lane execution
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_dual_asm(&mut lane0, &mut lane1, &diag_raw, rc.value);
+        }
+    }
+
+    // Pack results back
+    for i in 0..WIDTH {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+/// Specialized W8 version using fully unrolled internal round.
+fn internal_permute_packed_asm_w8(
+    state: &mut [PackedGoldilocksNeon; 8],
+    diag: [Goldilocks; 8],
+    internal_constants: &[Goldilocks],
+) {
+    let mut lane0: [u64; 8] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; 8] = core::array::from_fn(|i| state[i].0[1].value);
+    let diag_raw: [u64; 8] = core::array::from_fn(|i| diag[i].value);
+
+    // Use the fully unrolled W8 internal round
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_dual_asm_w8(&mut lane0, &mut lane1, &diag_raw, rc.value);
+        }
+    }
+
+    for i in 0..8 {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+/// Specialized W12 version using fully unrolled internal round.
+fn internal_permute_packed_asm_w12(
+    state: &mut [PackedGoldilocksNeon; 12],
+    diag: [Goldilocks; 12],
+    internal_constants: &[Goldilocks],
+) {
+    let mut lane0: [u64; 12] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; 12] = core::array::from_fn(|i| state[i].0[1].value);
+    let diag_raw: [u64; 12] = core::array::from_fn(|i| diag[i].value);
+
+    // Use the fully unrolled W12 internal round
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_dual_asm_w12(&mut lane0, &mut lane1, &diag_raw, rc.value);
+        }
+    }
+
+    for i in 0..12 {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+/// Specialized W16 version using fully unrolled internal round.
+fn internal_permute_packed_asm_w16(
+    state: &mut [PackedGoldilocksNeon; 16],
+    diag: [Goldilocks; 16],
+    internal_constants: &[Goldilocks],
+) {
+    let mut lane0: [u64; 16] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; 16] = core::array::from_fn(|i| state[i].0[1].value);
+    let diag_raw: [u64; 16] = core::array::from_fn(|i| diag[i].value);
+
+    // Use the fully unrolled W16 internal round
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_dual_asm_w16(&mut lane0, &mut lane1, &diag_raw, rc.value);
+        }
+    }
+
+    for i in 0..16 {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+/// Run external initial permutation on packed state with true interleaved execution.
+fn external_initial_permute_packed_asm<const WIDTH: usize>(
+    state: &mut [PackedGoldilocksNeon; WIDTH],
+    initial_constants: &[[Goldilocks; WIDTH]],
+) {
+    let mut lane0: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[1].value);
+
+    // Initial MDS (sequential - MDS is mostly additions)
+    unsafe {
+        mds_light_permutation_asm(&mut lane0);
+        mds_light_permutation_asm(&mut lane1);
+    }
+
+    // External rounds with true interleaved dual-lane execution
+    for rc in initial_constants {
+        let rc_raw: [u64; WIDTH] = core::array::from_fn(|i| rc[i].value);
+        unsafe {
+            external_round_dual_asm(&mut lane0, &mut lane1, &rc_raw);
+        }
+    }
+
+    for i in 0..WIDTH {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+/// Run external terminal permutation on packed state with true interleaved execution.
+fn external_terminal_permute_packed_asm<const WIDTH: usize>(
+    state: &mut [PackedGoldilocksNeon; WIDTH],
+    terminal_constants: &[[Goldilocks; WIDTH]],
+) {
+    let mut lane0: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[0].value);
+    let mut lane1: [u64; WIDTH] = core::array::from_fn(|i| state[i].0[1].value);
+
+    // External rounds with true interleaved dual-lane execution
+    for rc in terminal_constants {
+        let rc_raw: [u64; WIDTH] = core::array::from_fn(|i| rc[i].value);
+        unsafe {
+            external_round_dual_asm(&mut lane0, &mut lane1, &rc_raw);
+        }
+    }
+
+    for i in 0..WIDTH {
+        state[i] = PackedGoldilocksNeon([Goldilocks::new(lane0[i]), Goldilocks::new(lane1[i])]);
+    }
+}
+
+// Internal layer implementations for PackedGoldilocksNeon
+
+impl InternalLayer<PackedGoldilocksNeon, 8, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksNeon; 8]) {
+        internal_permute_packed_asm_w8(state, MATRIX_DIAG_8_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<PackedGoldilocksNeon, 12, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksNeon; 12]) {
+        internal_permute_packed_asm_w12(state, MATRIX_DIAG_12_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<PackedGoldilocksNeon, 16, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksNeon; 16]) {
+        internal_permute_packed_asm_w16(state, MATRIX_DIAG_16_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+impl InternalLayer<PackedGoldilocksNeon, 20, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksAsm
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksNeon; 20]) {
+        internal_permute_packed_asm(state, MATRIX_DIAG_20_GOLDILOCKS, &self.internal_constants);
+    }
+}
+
+// External layer implementations for PackedGoldilocksNeon
+
+impl<const WIDTH: usize> ExternalLayer<PackedGoldilocksNeon, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2ExternalLayerGoldilocksAsm<WIDTH>
+{
+    fn permute_state_initial(&self, state: &mut [PackedGoldilocksNeon; WIDTH]) {
+        external_initial_permute_packed_asm(state, self.external_constants.get_initial_constants());
+    }
+
+    fn permute_state_terminal(&self, state: &mut [PackedGoldilocksNeon; WIDTH]) {
+        external_terminal_permute_packed_asm(
+            state,
+            self.external_constants.get_terminal_constants(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field::{PrimeCharacteristicRing, PrimeField64};
+    use p3_poseidon2::{ExternalLayerConstants, InternalLayer, Poseidon2};
+    use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use super::*;
+    use crate::{Poseidon2ExternalLayerGoldilocks, Poseidon2InternalLayerGoldilocks};
+
+    type F = Goldilocks;
+
+    // Test that fully ASM-optimized implementation matches generic scalar
+    fn test_asm_matches_generic<const WIDTH: usize>()
+    where
+        Poseidon2InternalLayerGoldilocks: InternalLayer<F, WIDTH, GOLDILOCKS_S_BOX_DEGREE>,
+        Poseidon2InternalLayerGoldilocksAsm: InternalLayer<F, WIDTH, GOLDILOCKS_S_BOX_DEGREE>,
+        Poseidon2ExternalLayerGoldilocksAsm<WIDTH>:
+            ExternalLayer<Goldilocks, WIDTH, GOLDILOCKS_S_BOX_DEGREE>,
+    {
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        let external_constants =
+            ExternalLayerConstants::<Goldilocks, WIDTH>::new_from_rng(4, &mut rng);
+        let internal_constants: Vec<Goldilocks> =
+            (0..22).map(|_| F::from_u64(rng.random())).collect();
+
+        // Generic scalar implementation
+        let generic_poseidon2: Poseidon2<
+            Goldilocks,
+            Poseidon2ExternalLayerGoldilocks<WIDTH>,
+            Poseidon2InternalLayerGoldilocks,
+            WIDTH,
+            GOLDILOCKS_S_BOX_DEGREE,
+        > = Poseidon2::new(external_constants.clone(), internal_constants.clone());
+
+        // Fully ASM-optimized implementation
+        let asm_poseidon2: Poseidon2GoldilocksAsm<WIDTH> =
+            Poseidon2::new(external_constants, internal_constants);
+
+        // Test with zeros
+        let mut generic_input = [F::ZERO; WIDTH];
+        let mut asm_input = [F::ZERO; WIDTH];
+
+        generic_poseidon2.permute_mut(&mut generic_input);
+        asm_poseidon2.permute_mut(&mut asm_input);
+
+        for i in 0..WIDTH {
+            assert_eq!(
+                asm_input[i].as_canonical_u64(),
+                generic_input[i].as_canonical_u64(),
+                "ASM mismatch at index {i} for zero input"
+            );
+        }
+
+        // Test with random input
+        let mut generic_input: [F; WIDTH] = core::array::from_fn(|_| F::from_u64(rng.random()));
+        let mut asm_input = generic_input;
+
+        generic_poseidon2.permute_mut(&mut generic_input);
+        asm_poseidon2.permute_mut(&mut asm_input);
+
+        for i in 0..WIDTH {
+            assert_eq!(
+                asm_input[i].as_canonical_u64(),
+                generic_input[i].as_canonical_u64(),
+                "ASM mismatch at index {i} for random input"
+            );
+        }
+    }
+
+    #[test]
+    fn test_asm_matches_generic_width_8() {
+        test_asm_matches_generic::<8>();
+    }
+
+    #[test]
+    fn test_asm_matches_generic_width_12() {
+        test_asm_matches_generic::<12>();
+    }
+
+    #[test]
+    fn test_asm_matches_generic_width_16() {
+        test_asm_matches_generic::<16>();
+    }
+
+    #[test]
+    fn test_asm_matches_generic_width_20() {
+        test_asm_matches_generic::<20>();
+    }
+}

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -1,0 +1,1369 @@
+//! ARM assembly primitives for Poseidon2 on Goldilocks.
+//!
+//! Latency hiding: ARM mul/umulh have ~4-5 cycle latency. By interleaving
+//! S-box computation with MDS operations, we hide much of this latency.
+
+use core::arch::asm;
+
+use crate::{Goldilocks, P};
+
+const EPSILON: u64 = P.wrapping_neg(); // 2^32 - 1
+
+/// Multiply two Goldilocks elements using inline assembly.
+/// Returns the product reduced modulo P.
+#[inline(always)]
+unsafe fn mul_asm(a: u64, b: u64) -> u64 {
+    let _lo: u64;
+    let _hi: u64;
+    let _t0: u64;
+    let _t1: u64;
+    let _t2: u64;
+    let result: u64;
+
+    // SAFETY: Inline assembly performs Goldilocks multiplication with proper reduction
+    unsafe {
+        asm!(
+            // Compute 128-bit product: hi:lo = a * b
+            "mul   {lo}, {a}, {b}",
+            "umulh {hi}, {a}, {b}",
+
+            // Reduce: result = lo - hi_hi + hi_lo * EPSILON
+            // where hi = hi_hi * 2^32 + hi_lo
+
+            // t0 = lo - (hi >> 32), with borrow detection
+            "lsr   {t0}, {hi}, #32",          // t0 = hi >> 32
+            "subs  {t1}, {lo}, {t0}",         // t1 = lo - t0, set flags
+            "csetm {t2:w}, cc",               // t2 = -1 if borrow, 0 otherwise
+            "sub   {t1}, {t1}, {t2}",         // Adjust for borrow (subtract EPSILON)
+
+            // t0 = (hi & EPSILON) * EPSILON
+            "and   {t0}, {hi}, {epsilon}",    // t0 = hi & EPSILON
+            "mul   {t0}, {t0}, {epsilon}",    // t0 = t0 * EPSILON
+
+            // result = t1 + t0, with overflow detection
+            "adds  {result}, {t1}, {t0}",     // result = t1 + t0, set flags
+            "csetm {t2:w}, cs",               // t2 = -1 if carry, 0 otherwise
+            "add   {result}, {result}, {t2}", // Add EPSILON on overflow
+
+            a = in(reg) a,
+            b = in(reg) b,
+            epsilon = in(reg) EPSILON,
+            lo = out(reg) _lo,
+            hi = out(reg) _hi,
+            t0 = out(reg) _t0,
+            t1 = out(reg) _t1,
+            t2 = out(reg) _t2,
+            result = out(reg) result,
+            options(pure, nomem, nostack),
+        );
+    }
+
+    result
+}
+
+/// Add two Goldilocks elements with overflow handling using inline assembly.
+#[inline(always)]
+unsafe fn add_asm(a: u64, b: u64) -> u64 {
+    let result: u64;
+    let _adj: u64;
+
+    // SAFETY: Inline assembly performs Goldilocks addition with overflow handling
+    unsafe {
+        asm!(
+            "adds  {result}, {a}, {b}",
+            "csetm {adj:w}, cs",
+            "add   {result}, {result}, {adj}",
+            a = in(reg) a,
+            b = in(reg) b,
+            result = out(reg) result,
+            adj = out(reg) _adj,
+            options(pure, nomem, nostack),
+        );
+    }
+
+    result
+}
+
+/// Optimized internal round that interleaves S-box with MDS.
+///
+/// The internal MDS for Poseidon2 is:
+///   sum = state[0] + state[1] + ... + state[WIDTH-1]
+///   state[i] = state[i] * diag[i] + sum
+///
+/// We interleave this with the S-box computation (x^7 = x * x^2 * x^4) to hide
+/// multiplication latency.
+#[inline(always)]
+#[allow(clippy::needless_range_loop)]
+pub unsafe fn internal_round_asm<const WIDTH: usize>(
+    state: &mut [u64; WIDTH],
+    diag: &[u64; WIDTH],
+    rc: u64,
+) {
+    unsafe {
+        // Add round constant to state[0]
+        let s0 = add_asm(state[0], rc);
+
+        // Start S-box computation - compute s0^2
+        let s0_2 = mul_asm(s0, s0);
+
+        // While s0^2 is computing, start summing state[1..WIDTH]
+        // This can execute in parallel with the multiplication
+        let mut sum_hi: u64 = 0;
+        for i in 1..WIDTH {
+            sum_hi = add_asm(sum_hi, state[i]);
+        }
+
+        // Continue S-box - compute s0^3 and s0^4
+        let s0_3 = mul_asm(s0_2, s0);
+        let s0_4 = mul_asm(s0_2, s0_2);
+
+        // While s0^3 and s0^4 are computing, start diagonal multiplies
+        // for state[1..WIDTH]. Store results temporarily.
+        let mut diag_muls: [u64; WIDTH] = [0; WIDTH];
+        for i in 1..WIDTH {
+            diag_muls[i] = mul_asm(state[i], diag[i]);
+        }
+
+        // Finish S-box - compute s0^7
+        let s0_7 = mul_asm(s0_3, s0_4);
+
+        // Complete the sum with s0^7
+        let sum = add_asm(sum_hi, s0_7);
+
+        // Compute state[0] = s0^7 * diag[0] + sum
+        let s0_diag = mul_asm(s0_7, diag[0]);
+        state[0] = add_asm(s0_diag, sum);
+
+        // Finalize state[1..WIDTH] = diag_muls[i] + sum
+        for i in 1..WIDTH {
+            state[i] = add_asm(diag_muls[i], sum);
+        }
+    }
+}
+
+/// Interleaved dual-lane internal round for better ILP.
+/// Processes two independent states simultaneously, interleaving operations to hide latency.
+#[inline(always)]
+pub unsafe fn internal_round_dual_asm<const WIDTH: usize>(
+    state0: &mut [u64; WIDTH],
+    state1: &mut [u64; WIDTH],
+    diag: &[u64; WIDTH],
+    rc: u64,
+) {
+    unsafe {
+        // Add round constant to state[0] for both lanes
+        let s0_a = add_asm(state0[0], rc);
+        let s0_b = add_asm(state1[0], rc);
+
+        // Start S-box - compute s0^2 for both lanes (independent muls)
+        let s0_2_a = mul_asm(s0_a, s0_a);
+        let s0_2_b = mul_asm(s0_b, s0_b);
+
+        // While s0^2 is computing, sum state[1..WIDTH] for both lanes
+        let mut sum_hi_a: u64 = 0;
+        let mut sum_hi_b: u64 = 0;
+        for i in 1..WIDTH {
+            sum_hi_a = add_asm(sum_hi_a, state0[i]);
+            sum_hi_b = add_asm(sum_hi_b, state1[i]);
+        }
+
+        // Continue S-box - compute s0^3 and s0^4 for both lanes (interleaved)
+        let s0_3_a = mul_asm(s0_2_a, s0_a);
+        let s0_3_b = mul_asm(s0_2_b, s0_b);
+        let s0_4_a = mul_asm(s0_2_a, s0_2_a);
+        let s0_4_b = mul_asm(s0_2_b, s0_2_b);
+
+        // Start diagonal multiplies for both lanes (interleaved)
+        let mut diag_muls_a: [u64; WIDTH] = [0; WIDTH];
+        let mut diag_muls_b: [u64; WIDTH] = [0; WIDTH];
+        for i in 1..WIDTH {
+            diag_muls_a[i] = mul_asm(state0[i], diag[i]);
+            diag_muls_b[i] = mul_asm(state1[i], diag[i]);
+        }
+
+        // Finish S-box - compute s0^7 for both lanes
+        let s0_7_a = mul_asm(s0_3_a, s0_4_a);
+        let s0_7_b = mul_asm(s0_3_b, s0_4_b);
+
+        // Complete the sums
+        let sum_a = add_asm(sum_hi_a, s0_7_a);
+        let sum_b = add_asm(sum_hi_b, s0_7_b);
+
+        // Compute state[0] = s0^7 * diag[0] + sum for both lanes
+        let s0_diag_a = mul_asm(s0_7_a, diag[0]);
+        let s0_diag_b = mul_asm(s0_7_b, diag[0]);
+        state0[0] = add_asm(s0_diag_a, sum_a);
+        state1[0] = add_asm(s0_diag_b, sum_b);
+
+        // Finalize state[1..WIDTH] for both lanes
+        for i in 1..WIDTH {
+            state0[i] = add_asm(diag_muls_a[i], sum_a);
+            state1[i] = add_asm(diag_muls_b[i], sum_b);
+        }
+    }
+}
+
+/// Fully unrolled dual-lane internal round for WIDTH=12.
+/// Hand-unrolled for maximum performance on the most common width.
+#[inline(always)]
+pub unsafe fn internal_round_dual_asm_w12(
+    state0: &mut [u64; 12],
+    state1: &mut [u64; 12],
+    diag: &[u64; 12],
+    rc: u64,
+) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0_a = add_asm(state0[0], rc);
+        let s0_b = add_asm(state1[0], rc);
+
+        let s0_2_a = mul_asm(s0_a, s0_a);
+        let s0_2_b = mul_asm(s0_b, s0_b);
+
+        // Unrolled sum computation - interleaved between lanes
+        let sum1_a = add_asm(state0[1], state0[2]);
+        let sum1_b = add_asm(state1[1], state1[2]);
+        let sum2_a = add_asm(state0[3], state0[4]);
+        let sum2_b = add_asm(state1[3], state1[4]);
+        let sum3_a = add_asm(state0[5], state0[6]);
+        let sum3_b = add_asm(state1[5], state1[6]);
+        let sum4_a = add_asm(state0[7], state0[8]);
+        let sum4_b = add_asm(state1[7], state1[8]);
+        let sum5_a = add_asm(state0[9], state0[10]);
+        let sum5_b = add_asm(state1[9], state1[10]);
+
+        // Continue S-box
+        let s0_3_a = mul_asm(s0_2_a, s0_a);
+        let s0_3_b = mul_asm(s0_2_b, s0_b);
+        let s0_4_a = mul_asm(s0_2_a, s0_2_a);
+        let s0_4_b = mul_asm(s0_2_b, s0_2_b);
+
+        // Combine partial sums
+        let sum12_a = add_asm(sum1_a, sum2_a);
+        let sum12_b = add_asm(sum1_b, sum2_b);
+        let sum34_a = add_asm(sum3_a, sum4_a);
+        let sum34_b = add_asm(sum3_b, sum4_b);
+        let sum511_a = add_asm(sum5_a, state0[11]);
+        let sum511_b = add_asm(sum5_b, state1[11]);
+
+        // Diagonal multiplies - unrolled and interleaved
+        let d1_a = mul_asm(state0[1], diag[1]);
+        let d1_b = mul_asm(state1[1], diag[1]);
+        let d2_a = mul_asm(state0[2], diag[2]);
+        let d2_b = mul_asm(state1[2], diag[2]);
+        let d3_a = mul_asm(state0[3], diag[3]);
+        let d3_b = mul_asm(state1[3], diag[3]);
+        let d4_a = mul_asm(state0[4], diag[4]);
+        let d4_b = mul_asm(state1[4], diag[4]);
+        let d5_a = mul_asm(state0[5], diag[5]);
+        let d5_b = mul_asm(state1[5], diag[5]);
+        let d6_a = mul_asm(state0[6], diag[6]);
+        let d6_b = mul_asm(state1[6], diag[6]);
+
+        // More partial sum combining
+        let sum1234_a = add_asm(sum12_a, sum34_a);
+        let sum1234_b = add_asm(sum12_b, sum34_b);
+        let sum_hi_a = add_asm(sum1234_a, sum511_a);
+        let sum_hi_b = add_asm(sum1234_b, sum511_b);
+
+        // More diagonal multiplies
+        let d7_a = mul_asm(state0[7], diag[7]);
+        let d7_b = mul_asm(state1[7], diag[7]);
+        let d8_a = mul_asm(state0[8], diag[8]);
+        let d8_b = mul_asm(state1[8], diag[8]);
+        let d9_a = mul_asm(state0[9], diag[9]);
+        let d9_b = mul_asm(state1[9], diag[9]);
+        let d10_a = mul_asm(state0[10], diag[10]);
+        let d10_b = mul_asm(state1[10], diag[10]);
+        let d11_a = mul_asm(state0[11], diag[11]);
+        let d11_b = mul_asm(state1[11], diag[11]);
+
+        // Finish S-box
+        let s0_7_a = mul_asm(s0_3_a, s0_4_a);
+        let s0_7_b = mul_asm(s0_3_b, s0_4_b);
+
+        // Complete sum
+        let sum_a = add_asm(sum_hi_a, s0_7_a);
+        let sum_b = add_asm(sum_hi_b, s0_7_b);
+
+        // Compute state[0]
+        let s0_diag_a = mul_asm(s0_7_a, diag[0]);
+        let s0_diag_b = mul_asm(s0_7_b, diag[0]);
+        state0[0] = add_asm(s0_diag_a, sum_a);
+        state1[0] = add_asm(s0_diag_b, sum_b);
+
+        // Finalize all other states - unrolled
+        state0[1] = add_asm(d1_a, sum_a);
+        state1[1] = add_asm(d1_b, sum_b);
+        state0[2] = add_asm(d2_a, sum_a);
+        state1[2] = add_asm(d2_b, sum_b);
+        state0[3] = add_asm(d3_a, sum_a);
+        state1[3] = add_asm(d3_b, sum_b);
+        state0[4] = add_asm(d4_a, sum_a);
+        state1[4] = add_asm(d4_b, sum_b);
+        state0[5] = add_asm(d5_a, sum_a);
+        state1[5] = add_asm(d5_b, sum_b);
+        state0[6] = add_asm(d6_a, sum_a);
+        state1[6] = add_asm(d6_b, sum_b);
+        state0[7] = add_asm(d7_a, sum_a);
+        state1[7] = add_asm(d7_b, sum_b);
+        state0[8] = add_asm(d8_a, sum_a);
+        state1[8] = add_asm(d8_b, sum_b);
+        state0[9] = add_asm(d9_a, sum_a);
+        state1[9] = add_asm(d9_b, sum_b);
+        state0[10] = add_asm(d10_a, sum_a);
+        state1[10] = add_asm(d10_b, sum_b);
+        state0[11] = add_asm(d11_a, sum_a);
+        state1[11] = add_asm(d11_b, sum_b);
+    }
+}
+
+/// Run all internal rounds with the optimized assembly implementation.
+#[inline]
+pub fn internal_permute_state_asm<const WIDTH: usize>(
+    state: &mut [Goldilocks; WIDTH],
+    diag: [Goldilocks; WIDTH],
+    internal_constants: &[Goldilocks],
+) {
+    // Convert to raw u64 arrays for assembly processing
+    let state_raw: &mut [u64; WIDTH] =
+        unsafe { &mut *(state as *mut [Goldilocks; WIDTH] as *mut [u64; WIDTH]) };
+    let diag_raw: [u64; WIDTH] = unsafe { core::mem::transmute_copy(&diag) };
+
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_asm(state_raw, &diag_raw, rc.value);
+        }
+    }
+}
+
+/// Fully unrolled internal round for WIDTH=12 (scalar version).
+#[inline(always)]
+pub unsafe fn internal_round_asm_w12(state: &mut [u64; 12], diag: &[u64; 12], rc: u64) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0 = add_asm(state[0], rc);
+        let s0_2 = mul_asm(s0, s0);
+
+        // Unrolled sum computation with tree reduction
+        let sum1 = add_asm(state[1], state[2]);
+        let sum2 = add_asm(state[3], state[4]);
+        let sum3 = add_asm(state[5], state[6]);
+        let sum4 = add_asm(state[7], state[8]);
+        let sum5 = add_asm(state[9], state[10]);
+
+        let s0_3 = mul_asm(s0_2, s0);
+        let s0_4 = mul_asm(s0_2, s0_2);
+
+        let sum12 = add_asm(sum1, sum2);
+        let sum34 = add_asm(sum3, sum4);
+        let sum511 = add_asm(sum5, state[11]);
+
+        // Diagonal multiplies - fully unrolled
+        let d1 = mul_asm(state[1], diag[1]);
+        let d2 = mul_asm(state[2], diag[2]);
+        let d3 = mul_asm(state[3], diag[3]);
+        let d4 = mul_asm(state[4], diag[4]);
+        let d5 = mul_asm(state[5], diag[5]);
+        let d6 = mul_asm(state[6], diag[6]);
+
+        let sum1234 = add_asm(sum12, sum34);
+        let sum_hi = add_asm(sum1234, sum511);
+
+        let d7 = mul_asm(state[7], diag[7]);
+        let d8 = mul_asm(state[8], diag[8]);
+        let d9 = mul_asm(state[9], diag[9]);
+        let d10 = mul_asm(state[10], diag[10]);
+        let d11 = mul_asm(state[11], diag[11]);
+
+        // Finish S-box
+        let s0_7 = mul_asm(s0_3, s0_4);
+        let sum = add_asm(sum_hi, s0_7);
+
+        // Compute state[0]
+        let s0_diag = mul_asm(s0_7, diag[0]);
+        state[0] = add_asm(s0_diag, sum);
+
+        // Finalize all other states - unrolled
+        state[1] = add_asm(d1, sum);
+        state[2] = add_asm(d2, sum);
+        state[3] = add_asm(d3, sum);
+        state[4] = add_asm(d4, sum);
+        state[5] = add_asm(d5, sum);
+        state[6] = add_asm(d6, sum);
+        state[7] = add_asm(d7, sum);
+        state[8] = add_asm(d8, sum);
+        state[9] = add_asm(d9, sum);
+        state[10] = add_asm(d10, sum);
+        state[11] = add_asm(d11, sum);
+    }
+}
+
+/// Fully unrolled internal round for WIDTH=8 (scalar version).
+#[inline(always)]
+pub unsafe fn internal_round_asm_w8(state: &mut [u64; 8], diag: &[u64; 8], rc: u64) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0 = add_asm(state[0], rc);
+        let s0_2 = mul_asm(s0, s0);
+
+        // Unrolled sum computation with tree reduction
+        let sum1 = add_asm(state[1], state[2]);
+        let sum2 = add_asm(state[3], state[4]);
+        let sum3 = add_asm(state[5], state[6]);
+
+        let s0_3 = mul_asm(s0_2, s0);
+        let s0_4 = mul_asm(s0_2, s0_2);
+
+        let sum12 = add_asm(sum1, sum2);
+        let sum37 = add_asm(sum3, state[7]);
+
+        // Diagonal multiplies - fully unrolled
+        let d1 = mul_asm(state[1], diag[1]);
+        let d2 = mul_asm(state[2], diag[2]);
+        let d3 = mul_asm(state[3], diag[3]);
+        let d4 = mul_asm(state[4], diag[4]);
+
+        let sum_hi = add_asm(sum12, sum37);
+
+        let d5 = mul_asm(state[5], diag[5]);
+        let d6 = mul_asm(state[6], diag[6]);
+        let d7 = mul_asm(state[7], diag[7]);
+
+        // Finish S-box
+        let s0_7 = mul_asm(s0_3, s0_4);
+        let sum = add_asm(sum_hi, s0_7);
+
+        // Compute state[0]
+        let s0_diag = mul_asm(s0_7, diag[0]);
+        state[0] = add_asm(s0_diag, sum);
+
+        // Finalize all other states - unrolled
+        state[1] = add_asm(d1, sum);
+        state[2] = add_asm(d2, sum);
+        state[3] = add_asm(d3, sum);
+        state[4] = add_asm(d4, sum);
+        state[5] = add_asm(d5, sum);
+        state[6] = add_asm(d6, sum);
+        state[7] = add_asm(d7, sum);
+    }
+}
+
+/// Fully unrolled dual-lane internal round for WIDTH=8.
+#[inline(always)]
+pub unsafe fn internal_round_dual_asm_w8(
+    state0: &mut [u64; 8],
+    state1: &mut [u64; 8],
+    diag: &[u64; 8],
+    rc: u64,
+) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0_a = add_asm(state0[0], rc);
+        let s0_b = add_asm(state1[0], rc);
+
+        let s0_2_a = mul_asm(s0_a, s0_a);
+        let s0_2_b = mul_asm(s0_b, s0_b);
+
+        // Unrolled sum computation - interleaved between lanes
+        let sum1_a = add_asm(state0[1], state0[2]);
+        let sum1_b = add_asm(state1[1], state1[2]);
+        let sum2_a = add_asm(state0[3], state0[4]);
+        let sum2_b = add_asm(state1[3], state1[4]);
+        let sum3_a = add_asm(state0[5], state0[6]);
+        let sum3_b = add_asm(state1[5], state1[6]);
+
+        // Continue S-box
+        let s0_3_a = mul_asm(s0_2_a, s0_a);
+        let s0_3_b = mul_asm(s0_2_b, s0_b);
+        let s0_4_a = mul_asm(s0_2_a, s0_2_a);
+        let s0_4_b = mul_asm(s0_2_b, s0_2_b);
+
+        // Combine partial sums
+        let sum12_a = add_asm(sum1_a, sum2_a);
+        let sum12_b = add_asm(sum1_b, sum2_b);
+        let sum37_a = add_asm(sum3_a, state0[7]);
+        let sum37_b = add_asm(sum3_b, state1[7]);
+
+        // Diagonal multiplies - unrolled and interleaved
+        let d1_a = mul_asm(state0[1], diag[1]);
+        let d1_b = mul_asm(state1[1], diag[1]);
+        let d2_a = mul_asm(state0[2], diag[2]);
+        let d2_b = mul_asm(state1[2], diag[2]);
+        let d3_a = mul_asm(state0[3], diag[3]);
+        let d3_b = mul_asm(state1[3], diag[3]);
+        let d4_a = mul_asm(state0[4], diag[4]);
+        let d4_b = mul_asm(state1[4], diag[4]);
+
+        let sum_hi_a = add_asm(sum12_a, sum37_a);
+        let sum_hi_b = add_asm(sum12_b, sum37_b);
+
+        let d5_a = mul_asm(state0[5], diag[5]);
+        let d5_b = mul_asm(state1[5], diag[5]);
+        let d6_a = mul_asm(state0[6], diag[6]);
+        let d6_b = mul_asm(state1[6], diag[6]);
+        let d7_a = mul_asm(state0[7], diag[7]);
+        let d7_b = mul_asm(state1[7], diag[7]);
+
+        // Finish S-box
+        let s0_7_a = mul_asm(s0_3_a, s0_4_a);
+        let s0_7_b = mul_asm(s0_3_b, s0_4_b);
+
+        // Complete sum
+        let sum_a = add_asm(sum_hi_a, s0_7_a);
+        let sum_b = add_asm(sum_hi_b, s0_7_b);
+
+        // Compute state[0]
+        let s0_diag_a = mul_asm(s0_7_a, diag[0]);
+        let s0_diag_b = mul_asm(s0_7_b, diag[0]);
+        state0[0] = add_asm(s0_diag_a, sum_a);
+        state1[0] = add_asm(s0_diag_b, sum_b);
+
+        // Finalize all other states - unrolled
+        state0[1] = add_asm(d1_a, sum_a);
+        state1[1] = add_asm(d1_b, sum_b);
+        state0[2] = add_asm(d2_a, sum_a);
+        state1[2] = add_asm(d2_b, sum_b);
+        state0[3] = add_asm(d3_a, sum_a);
+        state1[3] = add_asm(d3_b, sum_b);
+        state0[4] = add_asm(d4_a, sum_a);
+        state1[4] = add_asm(d4_b, sum_b);
+        state0[5] = add_asm(d5_a, sum_a);
+        state1[5] = add_asm(d5_b, sum_b);
+        state0[6] = add_asm(d6_a, sum_a);
+        state1[6] = add_asm(d6_b, sum_b);
+        state0[7] = add_asm(d7_a, sum_a);
+        state1[7] = add_asm(d7_b, sum_b);
+    }
+}
+
+/// Specialized W8 internal permute using fully unrolled rounds.
+#[inline]
+pub fn internal_permute_state_asm_w8(
+    state: &mut [Goldilocks; 8],
+    diag: [Goldilocks; 8],
+    internal_constants: &[Goldilocks],
+) {
+    let state_raw: &mut [u64; 8] =
+        unsafe { &mut *(state as *mut [Goldilocks; 8] as *mut [u64; 8]) };
+    let diag_raw: [u64; 8] = unsafe { core::mem::transmute_copy(&diag) };
+
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_asm_w8(state_raw, &diag_raw, rc.value);
+        }
+    }
+}
+
+/// Specialized W12 internal permute using fully unrolled rounds.
+#[inline]
+pub fn internal_permute_state_asm_w12(
+    state: &mut [Goldilocks; 12],
+    diag: [Goldilocks; 12],
+    internal_constants: &[Goldilocks],
+) {
+    let state_raw: &mut [u64; 12] =
+        unsafe { &mut *(state as *mut [Goldilocks; 12] as *mut [u64; 12]) };
+    let diag_raw: [u64; 12] = unsafe { core::mem::transmute_copy(&diag) };
+
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_asm_w12(state_raw, &diag_raw, rc.value);
+        }
+    }
+}
+
+/// Fully unrolled internal round for WIDTH=16 (scalar version).
+#[inline(always)]
+pub unsafe fn internal_round_asm_w16(state: &mut [u64; 16], diag: &[u64; 16], rc: u64) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0 = add_asm(state[0], rc);
+        let s0_2 = mul_asm(s0, s0);
+
+        // Unrolled sum computation with tree reduction
+        let sum1 = add_asm(state[1], state[2]);
+        let sum2 = add_asm(state[3], state[4]);
+        let sum3 = add_asm(state[5], state[6]);
+        let sum4 = add_asm(state[7], state[8]);
+        let sum5 = add_asm(state[9], state[10]);
+        let sum6 = add_asm(state[11], state[12]);
+        let sum7 = add_asm(state[13], state[14]);
+
+        let s0_3 = mul_asm(s0_2, s0);
+        let s0_4 = mul_asm(s0_2, s0_2);
+
+        let sum12 = add_asm(sum1, sum2);
+        let sum34 = add_asm(sum3, sum4);
+        let sum56 = add_asm(sum5, sum6);
+        let sum715 = add_asm(sum7, state[15]);
+
+        // Diagonal multiplies - fully unrolled (first batch)
+        let d1 = mul_asm(state[1], diag[1]);
+        let d2 = mul_asm(state[2], diag[2]);
+        let d3 = mul_asm(state[3], diag[3]);
+        let d4 = mul_asm(state[4], diag[4]);
+        let d5 = mul_asm(state[5], diag[5]);
+        let d6 = mul_asm(state[6], diag[6]);
+        let d7 = mul_asm(state[7], diag[7]);
+        let d8 = mul_asm(state[8], diag[8]);
+
+        let sum1234 = add_asm(sum12, sum34);
+        let sum56715 = add_asm(sum56, sum715);
+        let sum_hi = add_asm(sum1234, sum56715);
+
+        // Diagonal multiplies - second batch
+        let d9 = mul_asm(state[9], diag[9]);
+        let d10 = mul_asm(state[10], diag[10]);
+        let d11 = mul_asm(state[11], diag[11]);
+        let d12 = mul_asm(state[12], diag[12]);
+        let d13 = mul_asm(state[13], diag[13]);
+        let d14 = mul_asm(state[14], diag[14]);
+        let d15 = mul_asm(state[15], diag[15]);
+
+        // Finish S-box
+        let s0_7 = mul_asm(s0_3, s0_4);
+        let sum = add_asm(sum_hi, s0_7);
+
+        // Compute state[0]
+        let s0_diag = mul_asm(s0_7, diag[0]);
+        state[0] = add_asm(s0_diag, sum);
+
+        // Finalize all other states - unrolled
+        state[1] = add_asm(d1, sum);
+        state[2] = add_asm(d2, sum);
+        state[3] = add_asm(d3, sum);
+        state[4] = add_asm(d4, sum);
+        state[5] = add_asm(d5, sum);
+        state[6] = add_asm(d6, sum);
+        state[7] = add_asm(d7, sum);
+        state[8] = add_asm(d8, sum);
+        state[9] = add_asm(d9, sum);
+        state[10] = add_asm(d10, sum);
+        state[11] = add_asm(d11, sum);
+        state[12] = add_asm(d12, sum);
+        state[13] = add_asm(d13, sum);
+        state[14] = add_asm(d14, sum);
+        state[15] = add_asm(d15, sum);
+    }
+}
+
+/// Fully unrolled dual-lane internal round for WIDTH=16.
+#[inline(always)]
+pub unsafe fn internal_round_dual_asm_w16(
+    state0: &mut [u64; 16],
+    state1: &mut [u64; 16],
+    diag: &[u64; 16],
+    rc: u64,
+) {
+    unsafe {
+        // Add round constant and start S-box
+        let s0_a = add_asm(state0[0], rc);
+        let s0_b = add_asm(state1[0], rc);
+
+        let s0_2_a = mul_asm(s0_a, s0_a);
+        let s0_2_b = mul_asm(s0_b, s0_b);
+
+        // Unrolled sum computation - interleaved between lanes
+        let sum1_a = add_asm(state0[1], state0[2]);
+        let sum1_b = add_asm(state1[1], state1[2]);
+        let sum2_a = add_asm(state0[3], state0[4]);
+        let sum2_b = add_asm(state1[3], state1[4]);
+        let sum3_a = add_asm(state0[5], state0[6]);
+        let sum3_b = add_asm(state1[5], state1[6]);
+        let sum4_a = add_asm(state0[7], state0[8]);
+        let sum4_b = add_asm(state1[7], state1[8]);
+        let sum5_a = add_asm(state0[9], state0[10]);
+        let sum5_b = add_asm(state1[9], state1[10]);
+        let sum6_a = add_asm(state0[11], state0[12]);
+        let sum6_b = add_asm(state1[11], state1[12]);
+        let sum7_a = add_asm(state0[13], state0[14]);
+        let sum7_b = add_asm(state1[13], state1[14]);
+
+        // Continue S-box
+        let s0_3_a = mul_asm(s0_2_a, s0_a);
+        let s0_3_b = mul_asm(s0_2_b, s0_b);
+        let s0_4_a = mul_asm(s0_2_a, s0_2_a);
+        let s0_4_b = mul_asm(s0_2_b, s0_2_b);
+
+        // Combine partial sums
+        let sum12_a = add_asm(sum1_a, sum2_a);
+        let sum12_b = add_asm(sum1_b, sum2_b);
+        let sum34_a = add_asm(sum3_a, sum4_a);
+        let sum34_b = add_asm(sum3_b, sum4_b);
+        let sum56_a = add_asm(sum5_a, sum6_a);
+        let sum56_b = add_asm(sum5_b, sum6_b);
+        let sum715_a = add_asm(sum7_a, state0[15]);
+        let sum715_b = add_asm(sum7_b, state1[15]);
+
+        // Diagonal multiplies - first batch, interleaved
+        let d1_a = mul_asm(state0[1], diag[1]);
+        let d1_b = mul_asm(state1[1], diag[1]);
+        let d2_a = mul_asm(state0[2], diag[2]);
+        let d2_b = mul_asm(state1[2], diag[2]);
+        let d3_a = mul_asm(state0[3], diag[3]);
+        let d3_b = mul_asm(state1[3], diag[3]);
+        let d4_a = mul_asm(state0[4], diag[4]);
+        let d4_b = mul_asm(state1[4], diag[4]);
+        let d5_a = mul_asm(state0[5], diag[5]);
+        let d5_b = mul_asm(state1[5], diag[5]);
+        let d6_a = mul_asm(state0[6], diag[6]);
+        let d6_b = mul_asm(state1[6], diag[6]);
+        let d7_a = mul_asm(state0[7], diag[7]);
+        let d7_b = mul_asm(state1[7], diag[7]);
+        let d8_a = mul_asm(state0[8], diag[8]);
+        let d8_b = mul_asm(state1[8], diag[8]);
+
+        // More partial sum combining
+        let sum1234_a = add_asm(sum12_a, sum34_a);
+        let sum1234_b = add_asm(sum12_b, sum34_b);
+        let sum56715_a = add_asm(sum56_a, sum715_a);
+        let sum56715_b = add_asm(sum56_b, sum715_b);
+        let sum_hi_a = add_asm(sum1234_a, sum56715_a);
+        let sum_hi_b = add_asm(sum1234_b, sum56715_b);
+
+        // Diagonal multiplies - second batch
+        let d9_a = mul_asm(state0[9], diag[9]);
+        let d9_b = mul_asm(state1[9], diag[9]);
+        let d10_a = mul_asm(state0[10], diag[10]);
+        let d10_b = mul_asm(state1[10], diag[10]);
+        let d11_a = mul_asm(state0[11], diag[11]);
+        let d11_b = mul_asm(state1[11], diag[11]);
+        let d12_a = mul_asm(state0[12], diag[12]);
+        let d12_b = mul_asm(state1[12], diag[12]);
+        let d13_a = mul_asm(state0[13], diag[13]);
+        let d13_b = mul_asm(state1[13], diag[13]);
+        let d14_a = mul_asm(state0[14], diag[14]);
+        let d14_b = mul_asm(state1[14], diag[14]);
+        let d15_a = mul_asm(state0[15], diag[15]);
+        let d15_b = mul_asm(state1[15], diag[15]);
+
+        // Finish S-box
+        let s0_7_a = mul_asm(s0_3_a, s0_4_a);
+        let s0_7_b = mul_asm(s0_3_b, s0_4_b);
+
+        // Complete sum
+        let sum_a = add_asm(sum_hi_a, s0_7_a);
+        let sum_b = add_asm(sum_hi_b, s0_7_b);
+
+        // Compute state[0]
+        let s0_diag_a = mul_asm(s0_7_a, diag[0]);
+        let s0_diag_b = mul_asm(s0_7_b, diag[0]);
+        state0[0] = add_asm(s0_diag_a, sum_a);
+        state1[0] = add_asm(s0_diag_b, sum_b);
+
+        // Finalize all other states - unrolled
+        state0[1] = add_asm(d1_a, sum_a);
+        state1[1] = add_asm(d1_b, sum_b);
+        state0[2] = add_asm(d2_a, sum_a);
+        state1[2] = add_asm(d2_b, sum_b);
+        state0[3] = add_asm(d3_a, sum_a);
+        state1[3] = add_asm(d3_b, sum_b);
+        state0[4] = add_asm(d4_a, sum_a);
+        state1[4] = add_asm(d4_b, sum_b);
+        state0[5] = add_asm(d5_a, sum_a);
+        state1[5] = add_asm(d5_b, sum_b);
+        state0[6] = add_asm(d6_a, sum_a);
+        state1[6] = add_asm(d6_b, sum_b);
+        state0[7] = add_asm(d7_a, sum_a);
+        state1[7] = add_asm(d7_b, sum_b);
+        state0[8] = add_asm(d8_a, sum_a);
+        state1[8] = add_asm(d8_b, sum_b);
+        state0[9] = add_asm(d9_a, sum_a);
+        state1[9] = add_asm(d9_b, sum_b);
+        state0[10] = add_asm(d10_a, sum_a);
+        state1[10] = add_asm(d10_b, sum_b);
+        state0[11] = add_asm(d11_a, sum_a);
+        state1[11] = add_asm(d11_b, sum_b);
+        state0[12] = add_asm(d12_a, sum_a);
+        state1[12] = add_asm(d12_b, sum_b);
+        state0[13] = add_asm(d13_a, sum_a);
+        state1[13] = add_asm(d13_b, sum_b);
+        state0[14] = add_asm(d14_a, sum_a);
+        state1[14] = add_asm(d14_b, sum_b);
+        state0[15] = add_asm(d15_a, sum_a);
+        state1[15] = add_asm(d15_b, sum_b);
+    }
+}
+
+/// Specialized W16 internal permute using fully unrolled rounds.
+#[inline]
+pub fn internal_permute_state_asm_w16(
+    state: &mut [Goldilocks; 16],
+    diag: [Goldilocks; 16],
+    internal_constants: &[Goldilocks],
+) {
+    let state_raw: &mut [u64; 16] =
+        unsafe { &mut *(state as *mut [Goldilocks; 16] as *mut [u64; 16]) };
+    let diag_raw: [u64; 16] = unsafe { core::mem::transmute_copy(&diag) };
+
+    for &rc in internal_constants {
+        unsafe {
+            internal_round_asm_w16(state_raw, &diag_raw, rc.value);
+        }
+    }
+}
+
+// External layer: S-box on all elements, then MDS. Pipelined for latency hiding.
+
+/// Double a Goldilocks element.
+#[inline(always)]
+unsafe fn double_asm(a: u64) -> u64 {
+    // SAFETY: add_asm is safe with valid Goldilocks field elements
+    unsafe { add_asm(a, a) }
+}
+
+/// 4x4 circulant MDS with coefficients [2,3,1,1].
+#[inline(always)]
+unsafe fn apply_mat4_asm(x: &mut [u64; 4]) {
+    unsafe {
+        let t01 = add_asm(x[0], x[1]);
+        let t23 = add_asm(x[2], x[3]);
+        let t0123 = add_asm(t01, t23);
+        let t01123 = add_asm(t0123, x[1]);
+        let t01233 = add_asm(t0123, x[3]);
+
+        let y3 = add_asm(t01233, double_asm(x[0]));
+        let y1 = add_asm(t01123, double_asm(x[2]));
+        let y0 = add_asm(t01123, t01);
+        let y2 = add_asm(t01233, t23);
+
+        x[0] = y0;
+        x[1] = y1;
+        x[2] = y2;
+        x[3] = y3;
+    }
+}
+
+/// Poseidon2 MDS light permutation: 4x4 blocks + outer sums.
+#[inline(always)]
+pub unsafe fn mds_light_permutation_asm<const WIDTH: usize>(state: &mut [u64; WIDTH]) {
+    unsafe {
+        // Apply M_4 to each consecutive four elements
+        let mut i = 0;
+        while i < WIDTH {
+            let chunk: &mut [u64; 4] = (&mut state[i..i + 4]).try_into().unwrap();
+            apply_mat4_asm(chunk);
+            i += 4;
+        }
+
+        // Compute the four sums of every 4th element
+        let mut sums = [0u64; 4];
+        for j in (0..WIDTH).step_by(4) {
+            sums[0] = add_asm(sums[0], state[j]);
+            sums[1] = add_asm(sums[1], state[j + 1]);
+            sums[2] = add_asm(sums[2], state[j + 2]);
+            sums[3] = add_asm(sums[3], state[j + 3]);
+        }
+
+        // Add sums back to state
+        for (i, elem) in state.iter_mut().enumerate() {
+            *elem = add_asm(*elem, sums[i % 4]);
+        }
+    }
+}
+
+/// Pipelined S-box computation for all elements.
+/// Computes x^7 for all elements by interleaving stages to hide latency.
+#[inline(always)]
+pub unsafe fn sbox_layer_asm<const WIDTH: usize>(state: &mut [u64; WIDTH]) {
+    unsafe {
+        // Stage 1: Compute all x^2 values
+        let mut x2 = [0u64; WIDTH];
+        for i in 0..WIDTH {
+            x2[i] = mul_asm(state[i], state[i]);
+        }
+
+        // Stage 2: Compute x^3 and x^4 values interleaved
+        // x^3 = x^2 * x, x^4 = x^2 * x^2
+        let mut x3 = [0u64; WIDTH];
+        let mut x4 = [0u64; WIDTH];
+        for i in 0..WIDTH {
+            x3[i] = mul_asm(x2[i], state[i]);
+            x4[i] = mul_asm(x2[i], x2[i]);
+        }
+
+        // Stage 3: Compute x^7 = x^3 * x^4
+        for i in 0..WIDTH {
+            state[i] = mul_asm(x3[i], x4[i]);
+        }
+    }
+}
+
+/// Optimized external round: add RC, S-box, MDS.
+#[inline(always)]
+pub unsafe fn external_round_asm<const WIDTH: usize>(state: &mut [u64; WIDTH], rc: &[u64; WIDTH]) {
+    unsafe {
+        // Add round constants
+        for i in 0..WIDTH {
+            state[i] = add_asm(state[i], rc[i]);
+        }
+
+        // Apply S-box (x^7) to all elements
+        sbox_layer_asm(state);
+
+        // Apply MDS light permutation
+        mds_light_permutation_asm(state);
+    }
+}
+
+/// Interleaved dual-lane S-box layer for better ILP.
+#[inline(always)]
+pub unsafe fn sbox_layer_dual_asm<const WIDTH: usize>(
+    state0: &mut [u64; WIDTH],
+    state1: &mut [u64; WIDTH],
+) {
+    unsafe {
+        // Stage 1: Compute all x^2 values for both lanes (interleaved)
+        let mut x2_a = [0u64; WIDTH];
+        let mut x2_b = [0u64; WIDTH];
+        for i in 0..WIDTH {
+            x2_a[i] = mul_asm(state0[i], state0[i]);
+            x2_b[i] = mul_asm(state1[i], state1[i]);
+        }
+
+        // Stage 2: Compute x^3 and x^4 for both lanes (interleaved)
+        let mut x3_a = [0u64; WIDTH];
+        let mut x3_b = [0u64; WIDTH];
+        let mut x4_a = [0u64; WIDTH];
+        let mut x4_b = [0u64; WIDTH];
+        for i in 0..WIDTH {
+            x3_a[i] = mul_asm(x2_a[i], state0[i]);
+            x3_b[i] = mul_asm(x2_b[i], state1[i]);
+            x4_a[i] = mul_asm(x2_a[i], x2_a[i]);
+            x4_b[i] = mul_asm(x2_b[i], x2_b[i]);
+        }
+
+        // Stage 3: Compute x^7 = x^3 * x^4 for both lanes
+        for i in 0..WIDTH {
+            state0[i] = mul_asm(x3_a[i], x4_a[i]);
+            state1[i] = mul_asm(x3_b[i], x4_b[i]);
+        }
+    }
+}
+
+/// Interleaved dual-lane external round for better ILP.
+#[inline(always)]
+pub unsafe fn external_round_dual_asm<const WIDTH: usize>(
+    state0: &mut [u64; WIDTH],
+    state1: &mut [u64; WIDTH],
+    rc: &[u64; WIDTH],
+) {
+    unsafe {
+        // Add round constants (interleaved)
+        for i in 0..WIDTH {
+            state0[i] = add_asm(state0[i], rc[i]);
+            state1[i] = add_asm(state1[i], rc[i]);
+        }
+
+        // Apply S-box (interleaved dual-lane)
+        sbox_layer_dual_asm(state0, state1);
+
+        // Apply MDS (sequential - MDS is mostly additions which are fast)
+        mds_light_permutation_asm(state0);
+        mds_light_permutation_asm(state1);
+    }
+}
+
+/// Run initial external rounds with ASM optimization.
+#[inline]
+pub fn external_initial_permute_state_asm<const WIDTH: usize>(
+    state: &mut [Goldilocks; WIDTH],
+    initial_constants: &[[Goldilocks; WIDTH]],
+) {
+    let state_raw: &mut [u64; WIDTH] =
+        unsafe { &mut *(state as *mut [Goldilocks; WIDTH] as *mut [u64; WIDTH]) };
+
+    // Initial MDS before rounds
+    unsafe {
+        mds_light_permutation_asm(state_raw);
+    }
+
+    // Run initial rounds
+    for rc in initial_constants {
+        let rc_raw: [u64; WIDTH] = unsafe { core::mem::transmute_copy(rc) };
+        unsafe {
+            external_round_asm(state_raw, &rc_raw);
+        }
+    }
+}
+
+/// Run terminal external rounds with ASM optimization.
+#[inline]
+pub fn external_terminal_permute_state_asm<const WIDTH: usize>(
+    state: &mut [Goldilocks; WIDTH],
+    terminal_constants: &[[Goldilocks; WIDTH]],
+) {
+    let state_raw: &mut [u64; WIDTH] =
+        unsafe { &mut *(state as *mut [Goldilocks; WIDTH] as *mut [u64; WIDTH]) };
+
+    for rc in terminal_constants {
+        let rc_raw: [u64; WIDTH] = unsafe { core::mem::transmute_copy(rc) };
+        unsafe {
+            external_round_asm(state_raw, &rc_raw);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field::PrimeField64;
+    use p3_poseidon2::matmul_internal;
+
+    use super::*;
+    use crate::{
+        MATRIX_DIAG_8_GOLDILOCKS, MATRIX_DIAG_12_GOLDILOCKS, MATRIX_DIAG_16_GOLDILOCKS,
+        MATRIX_DIAG_20_GOLDILOCKS,
+    };
+
+    fn test_internal_round_matches<const WIDTH: usize>(diag: [Goldilocks; WIDTH]) {
+        let mut rng_state = 12345u64;
+        let mut next_rand = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            rng_state
+        };
+
+        // Generate random state
+        let mut state_asm: [Goldilocks; WIDTH] =
+            core::array::from_fn(|_| Goldilocks::new(next_rand()));
+        let mut state_generic = state_asm;
+
+        // Generate random internal constants
+        let internal_constants: [Goldilocks; 22] =
+            core::array::from_fn(|_| Goldilocks::new(next_rand()));
+
+        // Run ASM version
+        internal_permute_state_asm(&mut state_asm, diag, &internal_constants);
+
+        // Run generic version - manually implement the internal permute
+        for &rc in internal_constants.iter() {
+            // Add round constant and apply S-box to state[0]
+            state_generic[0] += rc;
+            let s = state_generic[0];
+            let s2 = s * s;
+            let s3 = s2 * s;
+            let s4 = s2 * s2;
+            state_generic[0] = s3 * s4; // s^7
+
+            // Apply internal MDS: sum + diagonal multiply
+            matmul_internal(&mut state_generic, diag);
+        }
+
+        // Compare results
+        for i in 0..WIDTH {
+            assert_eq!(
+                state_asm[i].as_canonical_u64(),
+                state_generic[i].as_canonical_u64(),
+                "Mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_internal_round_width_8() {
+        test_internal_round_matches(MATRIX_DIAG_8_GOLDILOCKS);
+    }
+
+    #[test]
+    fn test_internal_round_width_12() {
+        test_internal_round_matches(MATRIX_DIAG_12_GOLDILOCKS);
+    }
+
+    #[test]
+    fn test_internal_round_width_16() {
+        test_internal_round_matches(MATRIX_DIAG_16_GOLDILOCKS);
+    }
+
+    #[test]
+    fn test_internal_round_width_20() {
+        test_internal_round_matches(MATRIX_DIAG_20_GOLDILOCKS);
+    }
+
+    #[test]
+    fn test_add_asm() {
+        // Test addition against the standard implementation
+        let test_cases: [(u64, u64); 8] = [
+            (0, 0),
+            (1, 1),
+            (P - 1, 1),         // Should wrap to 0
+            (P - 1, P - 1),     // Should wrap
+            (P / 2, P / 2),     // No wrap
+            (P / 2, P / 2 + 1), // Just wraps
+            (0xFFFFFFFF00000000, 0xFFFFFFFF00000000),
+            (0x123456789ABCDEF0, 0xFEDCBA9876543210),
+        ];
+
+        for (a, b) in test_cases {
+            let expected = (Goldilocks::new(a) + Goldilocks::new(b)).as_canonical_u64();
+            let result = unsafe { add_asm(a, b) };
+            let result_canonical = Goldilocks::new(result).as_canonical_u64();
+            assert_eq!(
+                result_canonical, expected,
+                "add_asm({a:#x}, {b:#x}) = {result:#x}, expected {expected:#x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mul_asm() {
+        // Test multiplication against the standard implementation
+        let test_cases: [(u64, u64); 8] = [
+            (0, 0),
+            (1, 1),
+            (P - 1, P - 1),
+            (P - 1, 2), // Near-max times small
+            (2, P - 1), // Commutative check
+            (0x123456789ABCDEF0, 0xFEDCBA9876543210),
+            (0xFFFFFFFF00000000, 0xFFFFFFFF00000000),
+            (EPSILON, EPSILON), // Edge case with epsilon
+        ];
+
+        for (a, b) in test_cases {
+            let expected = (Goldilocks::new(a) * Goldilocks::new(b)).as_canonical_u64();
+            let result = unsafe { mul_asm(a, b) };
+            let result_canonical = Goldilocks::new(result).as_canonical_u64();
+            assert_eq!(
+                result_canonical, expected,
+                "mul_asm({a:#x}, {b:#x}) = {result:#x}, expected {expected:#x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mul_asm_random() {
+        // Test with many random values
+        let mut rng_state = 0xDEADBEEFCAFEBABEu64;
+        let mut next_rand = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            rng_state
+        };
+
+        for _ in 0..1000 {
+            let a = next_rand();
+            let b = next_rand();
+            let expected = (Goldilocks::new(a) * Goldilocks::new(b)).as_canonical_u64();
+            let result = unsafe { mul_asm(a, b) };
+            let result_canonical = Goldilocks::new(result).as_canonical_u64();
+            assert_eq!(
+                result_canonical, expected,
+                "mul_asm({a:#x}, {b:#x}) = {result:#x}, expected {expected:#x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sbox_layer() {
+        let mut rng_state = 98765u64;
+        let mut next_rand = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            rng_state
+        };
+
+        // Test S-box layer against generic implementation
+        let mut state_asm: [Goldilocks; 8] = core::array::from_fn(|_| Goldilocks::new(next_rand()));
+        let state_generic = state_asm;
+
+        // Convert to raw and apply ASM S-box
+        let state_raw: &mut [u64; 8] =
+            unsafe { &mut *(&mut state_asm as *mut [Goldilocks; 8] as *mut [u64; 8]) };
+        unsafe {
+            sbox_layer_asm(state_raw);
+        }
+
+        // Compute expected results
+        for i in 0..8 {
+            let x = state_generic[i];
+            let x2 = x * x;
+            let x3 = x2 * x;
+            let x4 = x2 * x2;
+            let x7 = x3 * x4;
+            assert_eq!(
+                state_asm[i].as_canonical_u64(),
+                x7.as_canonical_u64(),
+                "S-box mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mds_light_permutation() {
+        use p3_poseidon2::{MDSMat4, mds_light_permutation};
+
+        let mut rng_state = 54321u64;
+        let mut next_rand = || {
+            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            rng_state
+        };
+
+        // Test MDS against generic implementation
+        let mut state_asm: [Goldilocks; 12] =
+            core::array::from_fn(|_| Goldilocks::new(next_rand()));
+        let mut state_generic = state_asm;
+
+        // Apply ASM MDS
+        let state_raw: &mut [u64; 12] =
+            unsafe { &mut *(&mut state_asm as *mut [Goldilocks; 12] as *mut [u64; 12]) };
+        unsafe {
+            mds_light_permutation_asm(state_raw);
+        }
+
+        // Apply generic MDS
+        mds_light_permutation(&mut state_generic, &MDSMat4);
+
+        // Compare results
+        for i in 0..12 {
+            assert_eq!(
+                state_asm[i].as_canonical_u64(),
+                state_generic[i].as_canonical_u64(),
+                "MDS mismatch at index {i}"
+            );
+        }
+    }
+
+    // ===================== Boundary Value Tests =====================
+    // Test edge cases that stress reduction logic and overflow handling
+
+    const P_MINUS_1: u64 = P - 1;
+    const TWO_POW_32: u64 = 0x1_0000_0000;
+
+    /// Boundary values for arithmetic tests
+    const BOUNDARY_VALS: [u64; 8] = [
+        0,
+        1,
+        P_MINUS_1,
+        EPSILON,
+        TWO_POW_32,
+        TWO_POW_32 - 1,
+        0x8000_0000_0000_0000,
+        0x123456789ABCDEF0,
+    ];
+
+    fn check_binary_op<F>(op_name: &str, asm_op: F)
+    where
+        F: Fn(u64, u64) -> u64,
+    {
+        for &a in &BOUNDARY_VALS {
+            for &b in &BOUNDARY_VALS {
+                let expected = match op_name {
+                    "add" => (Goldilocks::new(a) + Goldilocks::new(b)).as_canonical_u64(),
+                    "mul" => (Goldilocks::new(a) * Goldilocks::new(b)).as_canonical_u64(),
+                    _ => panic!("unknown op"),
+                };
+                let result = Goldilocks::new(asm_op(a, b)).as_canonical_u64();
+                assert_eq!(result, expected, "{op_name}({a:#x}, {b:#x}) mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn test_arithmetic_boundary_values() {
+        // Test add_asm and mul_asm with all boundary value combinations
+        check_binary_op("add", |a, b| unsafe { add_asm(a, b) });
+        check_binary_op("mul", |a, b| unsafe { mul_asm(a, b) });
+
+        // Verify key identities
+        assert_eq!(
+            Goldilocks::new(unsafe { mul_asm(P_MINUS_1, P_MINUS_1) }).as_canonical_u64(),
+            1,
+            "(-1)^2 should equal 1"
+        );
+    }
+
+    #[test]
+    fn test_sbox_mds_boundary_values() {
+        use p3_poseidon2::{MDSMat4, mds_light_permutation};
+
+        // Test S-box with boundary values
+        for &val in &BOUNDARY_VALS {
+            let g = Goldilocks::new(val);
+            let expected = {
+                let x2 = g * g;
+                let x4 = x2 * x2;
+                x2 * x4 * g
+            };
+
+            let mut state: [u64; 8] = [val, 1, 1, 1, 1, 1, 1, 1];
+            unsafe {
+                sbox_layer_asm(&mut state);
+            }
+
+            assert_eq!(
+                Goldilocks::new(state[0]).as_canonical_u64(),
+                expected.as_canonical_u64(),
+                "sbox({val:#x}) mismatch"
+            );
+        }
+
+        // Test MDS with mixed boundary patterns
+        let mds_vals: [u64; 4] = [0, 1, EPSILON, TWO_POW_32];
+        for &v0 in &mds_vals {
+            for &v1 in &mds_vals {
+                let mut state_generic: [Goldilocks; 8] =
+                    core::array::from_fn(|i| Goldilocks::new(if i % 2 == 0 { v0 } else { v1 }));
+                let mut state_raw: [u64; 8] =
+                    core::array::from_fn(|i| state_generic[i].as_canonical_u64());
+
+                unsafe {
+                    mds_light_permutation_asm(&mut state_raw);
+                }
+                mds_light_permutation(&mut state_generic, &MDSMat4);
+
+                for i in 0..8 {
+                    assert_eq!(
+                        Goldilocks::new(state_raw[i]).as_canonical_u64(),
+                        state_generic[i].as_canonical_u64(),
+                        "MDS v0={v0:#x} v1={v1:#x} mismatch at {i}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_internal_round_correctness() {
+        // Verify internal round formula: s0=state[0]+rc, s0_7=s0^7,
+        // sum=s0_7+sum(state[1..]), state[i]=state[i]*diag[i]+sum
+        let diag: [u64; 8] = [
+            0xc3b6c08e23ba9300,
+            0xd84b5de94a324fb6,
+            0x0d0c371c5b35b84f,
+            0x7964f570a8f648d,
+            0x5daf18bbd996604b,
+            0x6743bc47b9595257,
+            0x5528b9362c59bb70,
+            0xac45e25b7127b68b,
+        ];
+        let rc = 0x123456789ABCDEF0u64;
+
+        let mut state: [u64; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let orig = state;
+
+        // Compute reference
+        let s0 = Goldilocks::new(orig[0]) + Goldilocks::new(rc);
+        let s0_7 = {
+            let x2 = s0 * s0;
+            let x4 = x2 * x2;
+            x2 * x4 * s0
+        };
+        let sum_hi: Goldilocks = orig[1..].iter().map(|&x| Goldilocks::new(x)).sum();
+        let sum = sum_hi + s0_7;
+
+        let mut expected: [Goldilocks; 8] = core::array::from_fn(|i| Goldilocks::new(orig[i]));
+        expected[0] = s0_7 * Goldilocks::new(diag[0]) + sum;
+        for i in 1..8 {
+            expected[i] = Goldilocks::new(orig[i]) * Goldilocks::new(diag[i]) + sum;
+        }
+
+        unsafe {
+            internal_round_asm_w8(&mut state, &diag, rc);
+        }
+
+        for i in 0..8 {
+            assert_eq!(
+                Goldilocks::new(state[i]).as_canonical_u64(),
+                expected[i].as_canonical_u64(),
+                "internal_round mismatch at {i}"
+            );
+        }
+    }
+}

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -333,8 +333,6 @@ impl RawDataSerializable for Goldilocks {
 }
 
 impl Field for Goldilocks {
-    // TODO: Add cfg-guarded Packing for NEON
-
     #[cfg(all(
         target_arch = "x86_64",
         target_feature = "avx2",
@@ -344,6 +342,10 @@ impl Field for Goldilocks {
 
     #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedGoldilocksAVX512;
+
+    #[cfg(target_arch = "aarch64")]
+    type Packing = crate::PackedGoldilocksNeon;
+
     #[cfg(not(any(
         all(
             target_arch = "x86_64",
@@ -351,6 +353,7 @@ impl Field for Goldilocks {
             not(target_feature = "avx512f")
         ),
         all(target_arch = "x86_64", target_feature = "avx512f"),
+        target_arch = "aarch64",
     )))]
     type Packing = Self;
 

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -13,6 +13,12 @@ pub use goldilocks::*;
 pub use mds::*;
 pub use poseidon2::*;
 
+#[cfg(target_arch = "aarch64")]
+mod aarch64_neon;
+
+#[cfg(target_arch = "aarch64")]
+pub use aarch64_neon::*;
+
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "avx2",

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -27,8 +27,19 @@ const GOLDILOCKS_S_BOX_DEGREE: u64 = 7;
 /// An implementation of the Poseidon2 hash function for the Goldilocks field.
 ///
 /// It acts on arrays of the form `[Goldilocks; WIDTH]`.
-/// Currently the internal layers are unoptimized. These could be sped up in a similar way to
-/// how it was done for Monty31 fields.
+#[cfg(target_arch = "aarch64")]
+pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
+    Goldilocks,
+    crate::Poseidon2ExternalLayerGoldilocksAsm<WIDTH>,
+    crate::Poseidon2InternalLayerGoldilocksAsm,
+    WIDTH,
+    GOLDILOCKS_S_BOX_DEGREE,
+>;
+
+/// An implementation of the Poseidon2 hash function for the Goldilocks field.
+///
+/// It acts on arrays of the form `[Goldilocks; WIDTH]`.
+#[cfg(not(target_arch = "aarch64"))]
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
     Goldilocks,
     Poseidon2ExternalLayerGoldilocks<WIDTH>,


### PR DESCRIPTION
Implement NEON vectorization to speed up Poseidon2 for Goldilocks.

A lot came from adapting the plonky2 code (originally for Poseidon). Typically, some operations are kept in scalar (with interleaving) as the overhead of NEON packing was too high.

In terms of performance, on my M4 pro 16 cores, I am getting for the keccak-air example:

- single -threaded (`cargo run --release --example prove_goldilocks_poseidon2`): **~24.74% reduction**
- multi-threaded (`cargo run --release --example prove_goldilocks_poseidon2 --features parallel`): **~23.85% reduction**

The commitment phase itself is reduced by close to 30% (most of the prover time for Keccak).

@adr1anh There isn't much difference since last time, I couldn't get to push performances further with the last few things I tried.

@tcoratger I believe you're on Apple silicon too, would you mind having a look whenever you have some time? 🙏🏼 

