### PR TITLE
perf(rescue): remove unnecessary allocation in round constant generation

### DIFF
--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -101,10 +101,8 @@ where
             .into_iter()
             .map(|chunk| {
                 let integer = chunk
-                    .collect_vec()
-                    .iter()
                     .rev()
-                    .fold(0, |acc, &byte| (acc << 8) + *byte as u64);
+                    .fold(0u64, |acc, byte| (acc << 8) | (*byte as u64));
                 F::from_u64(integer)
             })
             .collect()


### PR DESCRIPTION
Eliminates an intermediate Vec allocation in the get_round_constants_rescue_prime method by operating directly on the iterator chain.