### PR TITLE
fix: clap value for DftOptions::None

### DIFF
--- a/examples/src/parsers.rs
+++ b/examples/src/parsers.rs
@@ -137,7 +137,7 @@ impl ValueEnum for DftOptions {
                 1,
                 Some(vec![("smallbatchdft", 6), ("sb", 2)]),
             ),
-            Self::None => PossibleValue::new(""),
+            Self::None => PossibleValue::new("none"),
         })
     }
 }


### PR DESCRIPTION
Replace empty string with explicit "none" value for DftOptions::None.
Using an empty string as a clap value can lead to confusing CLI behavior and makes the option harder to use explicitly. This change provides a clear and consistent value.
