### PR TITLE
fix: dead code removal and twiddle table race condition

### DIFF
--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -122,6 +122,7 @@ impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
             })
             .collect::<Vec<_>>();
         // Helper closure to extend a table under its lock.
+        let have_minus_one = have - 1;
         let extend_table = |lock: &RwLock<Arc<[Vec<_>]>>, missing: &[Vec<_>]| {
             let mut w = lock.write();
             let current_len = w.len();
@@ -129,7 +130,7 @@ impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
             if (current_len + 1) < need {
                 let mut v = w.to_vec();
                 // Append only the portion needed in case another thread did a partial update.
-                let extend_from = current_len.saturating_sub(current_len);
+                let extend_from = current_len.saturating_sub(have_minus_one);
                 v.extend_from_slice(&missing[extend_from..]);
                 *w = v.into();
             }

--- a/poseidon2-air/src/columns.rs
+++ b/poseidon2-air/src/columns.rs
@@ -70,33 +70,6 @@ pub const fn num_cols<
     )
 }
 
-pub const fn make_col_map<
-    const WIDTH: usize,
-    const SBOX_DEGREE: u64,
-    const SBOX_REGISTERS: usize,
-    const HALF_FULL_ROUNDS: usize,
-    const PARTIAL_ROUNDS: usize,
->() -> Poseidon2Cols<usize, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS> {
-    todo!()
-    // let indices_arr = indices_arr::<
-    //     { num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>() },
-    // >();
-    // unsafe {
-    //     transmute::<
-    //         [usize;
-    //             num_cols::<WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>()],
-    //         Poseidon2Cols<
-    //             usize,
-    //             WIDTH,
-    //             SBOX_DEGREE,
-    //             SBOX_REGISTERS,
-    //             HALF_FULL_ROUNDS,
-    //             PARTIAL_ROUNDS,
-    //         >,
-    //     >(indices_arr)
-    // }
-}
-
 impl<
     T,
     const WIDTH: usize,

--- a/rescue/Cargo.toml
+++ b/rescue/Cargo.toml
@@ -15,7 +15,6 @@ p3-mds.workspace = true
 p3-symmetric.workspace = true
 p3-util.workspace = true
 
-itertools.workspace = true
 rand.workspace = true
 sha3.workspace = true
 

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -1,7 +1,6 @@
 use alloc::format;
 use alloc::vec::Vec;
 
-use itertools::Itertools;
 use p3_field::{Algebra, PermutationMonomial, PrimeField, PrimeField64};
 use p3_mds::MdsPermutation;
 use p3_symmetric::{CryptographicPermutation, Permutation};
@@ -96,15 +95,12 @@ where
         let byte_string = shake256_hash(seed_string.as_bytes(), num_bytes);
 
         byte_string
-            .iter()
             .chunks(bytes_per_constant)
-            .into_iter()
             .map(|chunk| {
                 let integer = chunk
-                    .collect_vec()
                     .iter()
                     .rev()
-                    .fold(0, |acc, &byte| (acc << 8) + *byte as u64);
+                    .fold(0, |acc, &byte| (acc << 8) + byte as u64);
                 F::from_u64(integer)
             })
             .collect()

--- a/uni-stark/src/preprocessed.rs
+++ b/uni-stark/src/preprocessed.rs
@@ -1,6 +1,5 @@
 use p3_air::Air;
 use p3_commit::Pcs;
-use p3_field::Field;
 use p3_matrix::Matrix;
 use tracing::debug_span;
 
@@ -52,7 +51,6 @@ pub fn setup_preprocessed<SC, A>(
 ) -> Option<(PreprocessedProverData<SC>, PreprocessedVerifierKey<SC>)>
 where
     SC: StarkGenericConfig,
-    Val<SC>: Field,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
 {
     let pcs = config.pcs();


### PR DESCRIPTION
- Fix race condition bug in monty-31 DFT twiddle table update: `current_len.saturating_sub(current_len)` was always 0, now correctly calculates offset when another thread partially updated the table
- Remove dead `make_col_map` function from poseidon2-air (contained only todo!() with commented-out code)
- Remove itertools dependency from rescue crate by using slice::chunks() instead of Iterator::chunks(), also removes intermediate Vec allocation
- Remove redundant `Val<SC>: Field` bound in uni-stark since PolynomialSpace::Val already requires Field
