### PR TITLE
perf: reduce number of batch inversions in general FRI arity case

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -128,6 +128,7 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
         lagrange_interpolate_at(&xs, &evals, beta)
     }
 
+    #[instrument(skip_all)]
     fn fold_matrix<M: Matrix<EF>>(&self, beta: EF, log_arity: usize, m: M) -> Vec<EF> {
         if log_arity == 1 {
             // Optimized path for arity 2
@@ -165,42 +166,44 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
             //   Step 1 (beta):   fold pairs → g(s^2), g(-s^2) where g = f_e + beta*f_o
             //   Step 2 (beta^2): fold pair  → g(beta^2) = f(beta)
 
-            let mut data: Vec<EF> = Vec::with_capacity(m.width() * m.height());
-            for row in m.rows() {
-                data.extend(row);
-            }
+            let mut data = m.to_row_major_matrix().values;
 
             let initial_height = data.len() / 2;
             let g_inv = F::two_adic_generator(log2_strict_usize(initial_height) + 1).inverse();
-            let mut halve_inv_powers: Vec<F> = g_inv
+            let mut halve_inv_powers = g_inv
                 .shifted_powers(F::ONE.halve())
                 .collect_n(initial_height);
             reverse_slice_index_bits(&mut halve_inv_powers);
 
             let two = F::ONE + F::ONE;
             let mut current_beta = beta;
-            for step in 0..log_arity {
-                let height = data.len() / 2;
-                let step_halve_inv_powers = if step == 0 {
-                    halve_inv_powers[..height].to_vec()
-                } else {
-                    (0..height)
-                        .map(|j| two * halve_inv_powers[j << 1].square())
-                        .collect()
-                };
+            let mut next_data = EF::zero_vec(initial_height);
 
-                let mat = RowMajorMatrix::new(data, 2);
-                data = mat
-                    .par_rows()
-                    .zip(&step_halve_inv_powers)
-                    .map(|(mut row, halve_inv_power)| {
-                        let (lo, hi) = row.next_tuple().unwrap();
-                        (lo + hi).halve() + (lo - hi) * current_beta * *halve_inv_power
-                    })
-                    .collect();
+            for step in 0..log_arity {
+                let current_len = data.len();
+                let height = current_len / 2;
+                // Since j << 1 is always >= j, we never overwrite data we haven't read yet.
+                if step > 0 {
+                    for j in 0..height {
+                        halve_inv_powers[j] = two * halve_inv_powers[j << 1].square();
+                    }
+                }
+                next_data[..height]
+                    .par_iter_mut()
+                    .zip(data.par_chunks_exact(2))
+                    .zip(&halve_inv_powers[..height])
+                    .for_each(|((out, chunk), &halve_inv_power)| {
+                        // chunk is guaranteed to be size 2 by par_chunks_exact
+                        let lo = chunk[0];
+                        let hi = chunk[1];
+
+                        *out = (lo + hi).halve() + (lo - hi) * current_beta * halve_inv_power;
+                    });
                 current_beta = current_beta.square();
 
-                halve_inv_powers[..height].copy_from_slice(&step_halve_inv_powers);
+                // Swap buffers conceptually (just truncate data and copy back, or ping-pong).
+                data.truncate(height);
+                data.copy_from_slice(&next_data[..height]);
             }
 
             data


### PR DESCRIPTION
Current approach goes for higher arities as follows:
`fold_matrix` -> `fold_row` -> `lagrange_interpolate_at` -> `batch_multiplicative_inverse`
on every row.

We can instead leverage that a $2^k$-arity fold with challenge $\beta$ is equivalent to k sequential arity-2 folds with challenges $\beta, \beta^2, \cdots, \beta^k$.

This reduces the number of inversions to only 1 per step.

This yields about ~47%~ 56% speed-ups on `max_log_arity: 3` for the `fold_matrix` phases when running the following:
```bash
cargo run --example prove_prime_field_31 --release --features parallel -- --field koala-bear \
--objective poseidon-2-permutations --log-trace-length 17 --discrete-fourier-transform radix-2-dit-parallel \
--merkle-hash poseidon2
```