### PR TITLE
feat: add `Clone` to `StarkConfig` and `StarkGenericConfig`

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -28,7 +28,7 @@ use crate::prover::prove;
 use crate::verifier::verify;
 use crate::{CfftPerm, CfftPermutable, CircleEvaluations, CircleFriProof, cfft_permute_index};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CirclePcs<Val: Field, InputMmcs, FriMmcs> {
     pub mmcs: InputMmcs,
     pub fri_params: FriParameters<FriMmcs>,

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{OpenedValues, Pcs, PolynomialSpace};
 
 /// A trivial PCS: its commitment is simply the coefficients of each poly.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TrivialPcs<Val: TwoAdicField, Dft: TwoAdicSubgroupDft<Val>> {
     pub dft: Dft,
     // degree bound

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -5,7 +5,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
 
 /// A set of parameters defining a specific instance of the FRI protocol.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FriParameters<M> {
     pub log_blowup: usize,
     // TODO: This parameter and FRI early stopping are not yet implemented in `CirclePcs`.

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -22,7 +22,7 @@ use crate::{FriParameters, FriProof, TwoAdicFriPcs};
 
 /// A hiding FRI PCS. Both MMCSs must also be hiding; this is not enforced at compile time so it's
 /// the user's responsibility to configure.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
     inner: TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>,
     num_random_codewords: usize,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -44,7 +44,7 @@ use crate::{FriFoldingStrategy, FriParameters, FriProof, prover};
 /// `gH` where `|H| >= 2 * deg(f)`. A value `f(z)` is opened by using a FRI
 /// proof to show that the evaluations of `(f(x) - f(z))/(x - z)` over
 /// `gH` are low degree.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
     pub(crate) dft: Dft,
     pub(crate) mmcs: InputMmcs,

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -21,7 +21,7 @@ pub type PackedVal<SC> = <Val<SC> as Field>::Packing;
 pub type PackedChallenge<SC> =
     <<SC as StarkGenericConfig>::Challenge as ExtensionField<Val<SC>>>::ExtensionPacking;
 
-pub trait StarkGenericConfig {
+pub trait StarkGenericConfig: Clone {
     /// The [`Pcs`] implementation used to commit to trace polynomials.
     type Pcs: Pcs<Self::Challenge, Self::Challenger>;
 
@@ -45,7 +45,7 @@ pub trait StarkGenericConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StarkConfig<Pcs, Challenge, Challenger> {
     /// The [`Pcs`] used to commit polynomials and produce opening proofs.
     pcs: Pcs,
@@ -54,7 +54,7 @@ pub struct StarkConfig<Pcs, Challenge, Challenger> {
     _phantom: PhantomData<Challenge>,
 }
 
-impl<Pcs, Challenge, Challenger> StarkConfig<Pcs, Challenge, Challenger> {
+impl<Pcs: Clone, Challenge: Clone, Challenger: Clone> StarkConfig<Pcs, Challenge, Challenger> {
     pub const fn new(pcs: Pcs, challenger: Challenger) -> Self {
         Self {
             pcs,
@@ -66,8 +66,8 @@ impl<Pcs, Challenge, Challenger> StarkConfig<Pcs, Challenge, Challenger> {
 
 impl<Pcs, Challenge, Challenger> StarkGenericConfig for StarkConfig<Pcs, Challenge, Challenger>
 where
-    Challenge: ExtensionField<<Pcs::Domain as PolynomialSpace>::Val>,
-    Pcs: p3_commit::Pcs<Challenge, Challenger>,
+    Challenge: ExtensionField<<Pcs::Domain as PolynomialSpace>::Val> + Clone,
+    Pcs: p3_commit::Pcs<Challenge, Challenger> + Clone,
     Challenger: FieldChallenger<<Pcs::Domain as PolynomialSpace>::Val>
         + CanObserve<Pcs::Commitment>
         + CanSample<Challenge>


### PR DESCRIPTION
Convenient to have, and I cannot foresee a situation where downstream users would not be able to add `Clone` to their own `StarkGenericConfig` implementation.