### PR TITLE
refactor(air): move SymbolicAirBuilder from uni-stark to air crate

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
+tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -1,63 +1,14 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::{
+use p3_field::{ExtensionField, Field};
+use p3_matrix::dense::RowMajorMatrix;
+use tracing::instrument;
+
+use crate::{
     Air, AirBuilder, AirBuilderWithPublicValues, Entry, ExtensionBuilder, PermutationAirBuilder,
     SymbolicExpression, SymbolicVariable,
 };
-use p3_field::{ExtensionField, Field};
-use p3_matrix::dense::RowMajorMatrix;
-use p3_util::log2_ceil_usize;
-use tracing::instrument;
-
-#[instrument(skip_all, level = "debug")]
-pub fn get_log_num_quotient_chunks<F, A>(
-    air: &A,
-    preprocessed_width: usize,
-    num_public_values: usize,
-    is_zk: usize,
-) -> usize
-where
-    F: Field,
-    A: Air<SymbolicAirBuilder<F>>,
-{
-    get_log_quotient_degree_extension(air, preprocessed_width, num_public_values, 0, 0, is_zk)
-}
-
-#[instrument(
-    name = "infer log of base and extension constraint degree",
-    skip_all,
-    level = "debug"
-)]
-pub fn get_log_quotient_degree_extension<F, EF, A>(
-    air: &A,
-    preprocessed_width: usize,
-    num_public_values: usize,
-    permutation_width: usize,
-    num_permutation_challenges: usize,
-    is_zk: usize,
-) -> usize
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    A: Air<SymbolicAirBuilder<F, EF>>,
-{
-    assert!(is_zk <= 1, "is_zk must be either 0 or 1");
-    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
-    let constraint_degree = (get_max_constraint_degree_extension::<F, EF, A>(
-        air,
-        preprocessed_width,
-        num_public_values,
-        permutation_width,
-        num_permutation_challenges,
-    ) + is_zk)
-        .max(2);
-
-    // We bound the degree of the quotient polynomial by constraint_degree - 1,
-    // then choose the number of quotient chunks as the smallest power of two
-    // >= (constraint_degree - 1). This function returns log2(#chunks).
-    log2_ceil_usize(constraint_degree - 1)
-}
 
 #[instrument(skip_all, level = "debug")]
 pub fn get_max_constraint_degree<F, A>(
@@ -333,10 +284,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_air::BaseAir;
     use p3_baby_bear::BabyBear;
 
     use super::*;
+    use crate::BaseAir;
 
     #[derive(Debug)]
     struct MockAir {
@@ -356,40 +307,6 @@ mod tests {
                 builder.assert_zero(*constraint);
             }
         }
-    }
-
-    #[test]
-    fn test_get_log_num_quotient_chunks_no_constraints() {
-        let air = MockAir {
-            constraints: vec![],
-            width: 4,
-        };
-        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
-        assert_eq!(log_degree, 0);
-    }
-
-    #[test]
-    fn test_get_log_num_quotient_chunks_single_constraint() {
-        let air = MockAir {
-            constraints: vec![SymbolicVariable::new(Entry::Main { offset: 0 }, 0)],
-            width: 4,
-        };
-        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
-        assert_eq!(log_degree, log2_ceil_usize(1));
-    }
-
-    #[test]
-    fn test_get_log_num_quotient_chunks_multiple_constraints() {
-        let air = MockAir {
-            constraints: vec![
-                SymbolicVariable::new(Entry::Main { offset: 0 }, 0),
-                SymbolicVariable::new(Entry::Main { offset: 1 }, 1),
-                SymbolicVariable::new(Entry::Main { offset: 2 }, 2),
-            ],
-            width: 4,
-        };
-        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
-        assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
     #[test]

--- a/air/src/symbolic/mod.rs
+++ b/air/src/symbolic/mod.rs
@@ -1,7 +1,9 @@
 //! Symbolic expression types for AIR constraint representation.
 
+mod builder;
 mod expression;
 mod variable;
 
+pub use builder::*;
 pub use expression::SymbolicExpression;
 pub use variable::{Entry, SymbolicVariable};

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -12,12 +12,13 @@ use alloc::vec::Vec;
 
 use hashbrown::HashMap;
 use p3_air::Air;
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_challenger::FieldChallenger;
 use p3_commit::Pcs;
 use p3_field::BasedVectorSpace;
 use p3_lookup::lookup_traits::{Kind, Lookup, LookupGadget};
 use p3_matrix::Matrix;
-use p3_uni_stark::{SymbolicAirBuilder, SymbolicExpression, Val};
+use p3_uni_stark::Val;
 use p3_util::log2_strict_usize;
 
 use crate::config::{Challenge, Commitment, Domain, StarkGenericConfig as SGC};

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use p3_air::Air;
 #[cfg(debug_assertions)]
 use p3_air::DebugConstraintBuilder;
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
@@ -13,10 +14,7 @@ use p3_lookup::lookup_traits::{Kind, Lookup, LookupData, LookupGadget, lookup_da
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
-use p3_uni_stark::{
-    OpenedValues, PackedChallenge, PackedVal, ProverConstraintFolder, SymbolicAirBuilder,
-    SymbolicExpression,
-};
+use p3_uni_stark::{OpenedValues, PackedChallenge, PackedVal, ProverConstraintFolder};
 use p3_util::log2_strict_usize;
 use tracing::{debug_span, info_span, instrument};
 

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -1,9 +1,9 @@
 use alloc::vec::Vec;
 
 use p3_air::Air;
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_field::{ExtensionField, Field};
 use p3_lookup::lookup_traits::{Lookup, LookupData, LookupGadget};
-use p3_uni_stark::{SymbolicAirBuilder, SymbolicExpression};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -5,6 +5,7 @@ use core::fmt::Debug;
 
 use hashbrown::HashMap;
 use p3_air::Air;
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
@@ -15,10 +16,7 @@ use p3_lookup::lookup_traits::{
 };
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
-use p3_uni_stark::{
-    SymbolicAirBuilder, SymbolicExpression, VerificationError, VerifierConstraintFolder,
-    recompose_quotient_from_chunks,
-};
+use p3_uni_stark::{VerificationError, VerifierConstraintFolder, recompose_quotient_from_chunks};
 use p3_util::zip_eq::zip_eq;
 use tracing::{info_span, instrument};
 

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -3,6 +3,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::slice::from_ref;
 
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, PermutationAirBuilder};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
@@ -23,7 +24,7 @@ use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
-use p3_uni_stark::{StarkConfig, StarkGenericConfig, SymbolicAirBuilder, SymbolicExpression};
+use p3_uni_stark::{StarkConfig, StarkGenericConfig};
 use p3_util::log2_strict_usize;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;

--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -1,3 +1,4 @@
+use p3_air::symbolic::SymbolicAirBuilder;
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_blake3_air::Blake3Air;
 use p3_challenger::FieldChallenger;
@@ -8,8 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use p3_poseidon2_air::{Poseidon2Air, VectorizedPoseidon2Air};
 use p3_uni_stark::{
-    DebugConstraintBuilder, ProverConstraintFolder, StarkGenericConfig, SymbolicAirBuilder,
-    VerifierConstraintFolder,
+    DebugConstraintBuilder, ProverConstraintFolder, StarkGenericConfig, VerifierConstraintFolder,
 };
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -4,14 +4,14 @@ use p3_air::lookup::LookupEvaluator;
 /// Public re-exports of lookup types.
 pub use p3_air::lookup::{Direction, Kind, Lookup, LookupData, LookupError, LookupInput};
 use p3_air::{
-    AirBuilder, AirBuilderWithPublicValues, ExtensionBuilder, PermutationAirBuilder,
+    AirBuilder, AirBuilderWithPublicValues, Entry, ExtensionBuilder, PermutationAirBuilder,
     SymbolicExpression,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::ViewPair;
-use p3_uni_stark::{Entry, StarkGenericConfig, Val};
+use p3_uni_stark::{StarkGenericConfig, Val};
 use tracing::warn;
 
 /// Converts `LookupData<F>` to `LookupData<SymbolicExpression<F>>`.

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -4,6 +4,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::lookup::LookupEvaluator;
+use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{
     Air, AirBuilder, AirBuilderWithPublicValues, BaseAir, ExtensionBuilder, PermutationAirBuilder,
 };
@@ -12,7 +13,6 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_uni_stark::{SymbolicAirBuilder, SymbolicExpression};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
@@ -515,8 +515,8 @@ impl LookupTraceBuilder {
 #[test]
 fn test_symbolic_to_expr() {
     use p3_air::AirBuilder;
+    use p3_air::symbolic::SymbolicAirBuilder;
     use p3_field::PrimeCharacteristicRing;
-    use p3_uni_stark::SymbolicAirBuilder;
 
     let mut builder = SymbolicAirBuilder::<F>::new(0, 2, 0, 0, 0);
 

--- a/uni-stark/src/lib.rs
+++ b/uni-stark/src/lib.rs
@@ -11,17 +11,16 @@ mod preprocessed;
 mod proof;
 mod prover;
 mod sub_builder;
-mod symbolic_builder;
+mod symbolic;
 mod verifier;
 
 pub use check_constraints::*;
 pub use config::*;
 pub use folder::*;
-// Public re-exports from p3-air.
 pub use p3_air::symbolic::*;
 pub use preprocessed::*;
 pub use proof::*;
 pub use prover::*;
 pub use sub_builder::*;
-pub use symbolic_builder::*;
+pub use symbolic::*;
 pub use verifier::*;

--- a/uni-stark/src/preprocessed.rs
+++ b/uni-stark/src/preprocessed.rs
@@ -1,9 +1,10 @@
 use p3_air::Air;
+use p3_air::symbolic::SymbolicAirBuilder;
 use p3_commit::Pcs;
 use p3_matrix::Matrix;
 use tracing::debug_span;
 
-use crate::{ProverConstraintFolder, StarkGenericConfig, SymbolicAirBuilder, Val};
+use crate::{ProverConstraintFolder, StarkGenericConfig, Val};
 
 /// Prover-side reusable data for preprocessed columns.
 ///

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_air::Air;
+use p3_air::symbolic::{SymbolicAirBuilder, get_symbolic_constraints};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
@@ -14,8 +15,7 @@ use tracing::{debug_span, info_span, instrument};
 
 use crate::{
     Commitments, Domain, OpenedValues, PackedChallenge, PackedVal, PreprocessedProverData, Proof,
-    ProverConstraintFolder, StarkGenericConfig, SymbolicAirBuilder, Val,
-    get_log_num_quotient_chunks, get_symbolic_constraints,
+    ProverConstraintFolder, StarkGenericConfig, Val, get_log_num_quotient_chunks,
 };
 
 #[instrument(skip_all)]

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -1,0 +1,122 @@
+//! STARK-specific quotient polynomial degree calculations.
+
+use p3_air::Air;
+use p3_air::symbolic::SymbolicAirBuilder;
+use p3_field::{ExtensionField, Field};
+use p3_util::log2_ceil_usize;
+use tracing::instrument;
+
+#[instrument(skip_all, level = "debug")]
+pub fn get_log_num_quotient_chunks<F, A>(
+    air: &A,
+    preprocessed_width: usize,
+    num_public_values: usize,
+    is_zk: usize,
+) -> usize
+where
+    F: Field,
+    A: Air<SymbolicAirBuilder<F>>,
+{
+    get_log_quotient_degree_extension(air, preprocessed_width, num_public_values, 0, 0, is_zk)
+}
+
+#[instrument(
+    name = "infer log of base and extension constraint degree",
+    skip_all,
+    level = "debug"
+)]
+pub fn get_log_quotient_degree_extension<F, EF, A>(
+    air: &A,
+    preprocessed_width: usize,
+    num_public_values: usize,
+    permutation_width: usize,
+    num_permutation_challenges: usize,
+    is_zk: usize,
+) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
+{
+    assert!(is_zk <= 1, "is_zk must be either 0 or 1");
+    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
+    let constraint_degree = (p3_air::symbolic::get_max_constraint_degree_extension::<F, EF, A>(
+        air,
+        preprocessed_width,
+        num_public_values,
+        permutation_width,
+        num_permutation_challenges,
+    ) + is_zk)
+        .max(2);
+
+    // We bound the degree of the quotient polynomial by constraint_degree - 1,
+    // then choose the number of quotient chunks as the smallest power of two
+    // >= (constraint_degree - 1). This function returns log2(#chunks).
+    log2_ceil_usize(constraint_degree - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_air::symbolic::{SymbolicAirBuilder, SymbolicVariable};
+    use p3_air::{AirBuilder, BaseAir, Entry};
+    use p3_baby_bear::BabyBear;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockAir {
+        constraints: Vec<SymbolicVariable<BabyBear>>,
+        width: usize,
+    }
+
+    impl BaseAir<BabyBear> for MockAir {
+        fn width(&self) -> usize {
+            self.width
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<BabyBear>> for MockAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<BabyBear>) {
+            for constraint in &self.constraints {
+                builder.assert_zero(*constraint);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_log_num_quotient_chunks_no_constraints() {
+        let air = MockAir {
+            constraints: vec![],
+            width: 4,
+        };
+        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
+        assert_eq!(log_degree, 0);
+    }
+
+    #[test]
+    fn test_get_log_num_quotient_chunks_single_constraint() {
+        let air = MockAir {
+            constraints: vec![SymbolicVariable::new(Entry::Main { offset: 0 }, 0)],
+            width: 4,
+        };
+        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
+        assert_eq!(log_degree, log2_ceil_usize(1));
+    }
+
+    #[test]
+    fn test_get_log_num_quotient_chunks_multiple_constraints() {
+        let air = MockAir {
+            constraints: vec![
+                SymbolicVariable::new(Entry::Main { offset: 0 }, 0),
+                SymbolicVariable::new(Entry::Main { offset: 1 }, 1),
+                SymbolicVariable::new(Entry::Main { offset: 2 }, 2),
+            ],
+            width: 4,
+        };
+        let log_degree = get_log_num_quotient_chunks(&air, 3, 2, 0);
+        assert_eq!(log_degree, log2_ceil_usize(1));
+    }
+}

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -6,6 +6,7 @@ use alloc::{format, vec};
 use itertools::Itertools;
 use p3_air::Air;
 use p3_air::lookup::LookupError;
+use p3_air::symbolic::SymbolicAirBuilder;
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
@@ -15,7 +16,7 @@ use p3_util::zip_eq::zip_eq;
 use thiserror::Error;
 use tracing::instrument;
 
-use crate::symbolic_builder::{SymbolicAirBuilder, get_log_num_quotient_chunks};
+use crate::symbolic::get_log_num_quotient_chunks;
 use crate::{
     Domain, PcsError, PreprocessedVerifierKey, Proof, StarkGenericConfig, Val,
     VerifierConstraintFolder,

--- a/uni-stark/tests/rc_sub_builder.rs
+++ b/uni-stark/tests/rc_sub_builder.rs
@@ -10,6 +10,7 @@
 
 use core::marker::PhantomData;
 
+use p3_air::symbolic::SymbolicAirBuilder;
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
@@ -19,7 +20,7 @@ use p3_field::PrimeCharacteristicRing;
 use p3_field::extension::BinomialExtensionField;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_uni_stark::{StarkConfig, SubAirBuilder, SymbolicAirBuilder, prove, verify};
+use p3_uni_stark::{StarkConfig, SubAirBuilder, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 


### PR DESCRIPTION
Move the core `SymbolicAirBuilder` struct and constraint evaluation functions to `p3_air::symbolic`. This enables other crates to use symbolic constraint analysis without depending on uni-stark.

STARK-specific quotient degree calculations (`get_log_num_quotient_chunks`, `get_log_quotient_degree_extension`) remain in uni-stark.

Note: this cherry picks the commit from #1251 to make the latter focused on periodic columns.