### PR TITLE
feat: include lookups in `max_degree` hint

### DIFF
--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -349,7 +349,7 @@ impl LookupGadget for LogUpGadget {
     ///
     /// The constraint degree is then:
     /// `1 + max(deg(numerator), deg(common_denominator))`
-    fn constraint_degree<F: Field>(&self, context: Lookup<F>) -> usize {
+    fn constraint_degree<F: Field>(&self, context: &Lookup<F>) -> usize {
         assert!(context.multiplicities_exprs.len() == context.element_exprs.len());
 
         let n = context.multiplicities_exprs.len();

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -56,7 +56,7 @@ pub trait LookupGadget: LookupEvaluator {
     ) -> Result<(), LookupError>;
 
     /// Computes the polynomial degree of a lookup transition constraint.
-    fn constraint_degree<F: Field>(&self, context: Lookup<F>) -> usize;
+    fn constraint_degree<F: Field>(&self, context: &Lookup<F>) -> usize;
 }
 
 /// A builder to generate the lookup traces, given the main trace, public values and permutation challenges.

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -76,14 +76,14 @@ fn test_constraint_degree_calculation() {
     // - each multiplicity has degree 1
     // - so the total degree should be 3 (1 + (1 + 1)).
     let lookup_deg_3 = create_dummy_lookup(&[1, 1], &[vec![1], vec![1]], &[1, 1]);
-    assert_eq!(gadget.constraint_degree(lookup_deg_3), 3);
+    assert_eq!(gadget.constraint_degree(&lookup_deg_3), 3);
 
     // We have two lookup elements (each element is a single column):
     // - each element has degree 1
     // - each multiplicity has degree 3
     // - so the total degree should be 4 (3 + 1).
     let lookup_degree_4 = create_dummy_lookup(&[1, 1], &[vec![1], vec![1]], &[3, 3]);
-    assert_eq!(gadget.constraint_degree(lookup_degree_4), 4);
+    assert_eq!(gadget.constraint_degree(&lookup_degree_4), 4);
 
     // We have two lookup elements (each element is a single column):
     // - one element has degree 2
@@ -91,7 +91,7 @@ fn test_constraint_degree_calculation() {
     // - each multiplicity has degree 1
     // - so the total degree should be 6 (3 + 3).
     let lookup_degree_6 = create_dummy_lookup(&[1, 1], &[vec![2], vec![3]], &[1, 1]);
-    assert_eq!(gadget.constraint_degree(lookup_degree_6), 6);
+    assert_eq!(gadget.constraint_degree(&lookup_degree_6), 6);
 
     // We have two lookup elements:
     // - first element is a tuple of 5 columns
@@ -104,7 +104,7 @@ fn test_constraint_degree_calculation() {
     let degrees1 = vec![1, 3, 0, 0, 0]; // First element of degree 3.
     let degrees2 = vec![0, 1, 0, 2, 0, 1]; // Second element of degree 2.
     let lookup_degree_7 = create_dummy_lookup(&[5, 6], &[degrees1, degrees2], &[5, 2]);
-    assert_eq!(gadget.constraint_degree(lookup_degree_7), 7);
+    assert_eq!(gadget.constraint_degree(&lookup_degree_7), 7);
 }
 
 /// A mock `AirBuilder` for testing purposes that simulates constraint evaluation.


### PR DESCRIPTION
@tcoratger I think we can extend your idea in #1331 to allow hints in AIRs with lookups, this would still save the full symbolic evaluation and be useful to a wider range of cases.
Let me know what you think! 