### PR TITLE
fix: avoid unnecessary clone of quotient chunk matrices in batch-stark prover

### DIFF
--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -396,10 +396,7 @@ where
         let chunk_mats = quotient_domain.split_evals(n_chunks, q_flat);
         let chunk_domains = quotient_domain.split_domains(n_chunks);
 
-        let evals = chunk_domains
-            .iter()
-            .zip(chunk_mats)
-            .map(|(d, m)| (*d, m));
+        let evals = chunk_domains.iter().zip(chunk_mats).map(|(d, m)| (*d, m));
         let ldes = pcs.get_quotient_ldes(evals, n_chunks);
 
         let start = quotient_chunk_domains.len();


### PR DESCRIPTION
Move quotient chunk matrices into get_quotient_ldes instead of cloning them. chunk_mats is not used after this call, making each clone a pure waste - alloc, memcpy, and immediate drop