### PR TITLE
fix: remove unnecessary clone of opening points

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -426,8 +426,7 @@ where
 
         // Contained in each `Self::ProverData` is a list of matrices which have been committed to.
         // We extract those matrices to be able to refer to them directly.
-        let commitment_data_with_opening_pts = commitment_data_with_opening_points;
-        let mats_and_points = commitment_data_with_opening_pts
+        let mats_and_points = commitment_data_with_opening_points
             .iter()
             .map(|(data, points)| {
                 let mats = self
@@ -638,7 +637,7 @@ where
             fri_input,
             challenger,
             log_global_max_height,
-            &commitment_data_with_opening_pts,
+            &commitment_data_with_opening_points,
             &self.mmcs,
         );
 


### PR DESCRIPTION
- The original code did .iter().map(|(data, points)| (*data, points.clone())).collect() on an already-owned Vec with the exact same target type — effectively a deep copy that produces an identical value
- Replaced with a simple variable rebind since the input is not used afterward