### PR TITLE
perf(uni-stark): only open preprocessed at zeta_next when needed

### DIFF
--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -302,6 +302,7 @@ where
 
     let is_random = opt_r_data.is_some();
     let main_next = !air.main_next_row_columns().is_empty();
+    let pre_next = !air.preprocessed_next_row_columns().is_empty();
     let (opened_values, opening_proof) = info_span!("open").in_scope(|| {
         let round0 = opt_r_data.as_ref().map(|r_data| (r_data, vec![vec![zeta]]));
         let round1_points = if main_next {
@@ -311,7 +312,14 @@ where
         };
         let round1 = (&trace_data, vec![round1_points]);
         let round2 = (&quotient_data, vec![vec![zeta]; num_quotient_chunks]); // open every chunk at zeta
-        let round3 = preprocessed_data_ref.map(|data| (data, vec![vec![zeta, zeta_next]]));
+        let round3 = preprocessed_data_ref.map(|data| {
+            let pre_points = if pre_next {
+                vec![zeta, zeta_next]
+            } else {
+                vec![zeta]
+            };
+            (data, vec![pre_points])
+        });
 
         let rounds = round0
             .into_iter()
@@ -339,10 +347,13 @@ where
         None
     };
     let (preprocessed_local, preprocessed_next) = if preprocessed_width > 0 {
-        (
-            Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][0].clone()),
-            Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][1].clone()),
-        )
+        let local = Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][0].clone());
+        let next = if pre_next {
+            Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][1].clone())
+        } else {
+            None
+        };
+        (local, next)
     } else {
         (None, None)
     };

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -161,7 +161,12 @@ where
         .preprocessed_next
         .as_ref()
         .map_or(0, |v| v.len());
-    if preprocessed_width != preprocessed_local_len || preprocessed_width != preprocessed_next_len {
+    let expected_next_len = if !air.preprocessed_next_row_columns().is_empty() {
+        preprocessed_width
+    } else {
+        0
+    };
+    if preprocessed_width != preprocessed_local_len || expected_next_len != preprocessed_next_len {
         // Verifier expects preprocessed trace while proof does not have it, or vice versa
         return Err(VerificationError::InvalidProofShape);
     }
@@ -259,6 +264,7 @@ where
 
     let air_width = A::width(air);
     let main_next = !air.main_next_row_columns().is_empty();
+    let pre_next = !air.preprocessed_next_row_columns().is_empty();
     let trace_next_ok = if main_next {
         opened_values
             .trace_next
@@ -362,15 +368,13 @@ where
 
     // Add preprocessed commitment verification if present
     if preprocessed_width > 0 {
+        let mut pre_points = vec![(zeta, opened_values.preprocessed_local.clone().unwrap())];
+        if pre_next {
+            pre_points.push((zeta_next, opened_values.preprocessed_next.clone().unwrap()));
+        }
         coms_to_verify.push((
             preprocessed_commit.unwrap(),
-            vec![(
-                trace_domain,
-                vec![
-                    (zeta, opened_values.preprocessed_local.clone().unwrap()),
-                    (zeta_next, opened_values.preprocessed_next.clone().unwrap()),
-                ],
-            )],
+            vec![(trace_domain, pre_points)],
         ));
     }
 
@@ -391,12 +395,21 @@ where
             &zeros
         }
     };
+    let pre_next_zeros;
+    let preprocessed_next_for_verify = match &opened_values.preprocessed_next {
+        Some(v) => Some(v.as_slice()),
+        None if preprocessed_width > 0 => {
+            pre_next_zeros = vec![SC::Challenge::ZERO; preprocessed_width];
+            Some(pre_next_zeros.as_slice())
+        }
+        None => None,
+    };
     verify_constraints::<SC, A, PcsError<SC>>(
         air,
         &opened_values.trace_local,
         trace_next_slice,
         opened_values.preprocessed_local.as_deref(),
-        opened_values.preprocessed_next.as_deref(),
+        preprocessed_next_for_verify,
         public_values,
         init_trace_domain,
         zeta,


### PR DESCRIPTION
PR #1317 added `preprocessed_uses_next_row()` and wired it up in batch-stark, but uni-stark was missed. This applies the same conditional logic so we skip the unnecessary opening at zeta_next for preprocessed columns when the AIR doesn't access the next preprocessed row.