### PR TITLE
chore(p3-lookup): remove unused dependencies

### DIFF
--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -10,14 +10,11 @@ categories.workspace = true
 
 [dependencies]
 hashbrown = { workspace = true }
-itertools.workspace = true
 p3-air = { workspace = true }
 p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-uni-stark = { workspace = true }
-serde = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Removed three dependencies from `p3-lookup` that are declared in `[dependencies]` but never referenced in any source file