### PR TITLE
refactor: open to compute reduced openings using only packed alpha powers

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -605,7 +605,7 @@ where
                             let packed_opening = if chunk.len() == width {
                                 Challenge::ExtensionPacking::from_ext_slice(chunk)
                             } else {
-                                let mut padded = vec![Challenge::ZERO; width];
+                                let mut padded = Challenge::ZERO::zero_vec(width);
                                 padded[..chunk.len()].copy_from_slice(chunk);
                                 Challenge::ExtensionPacking::from_ext_slice(&padded)
                             };


### PR DESCRIPTION
Remove the pre-computed unpacked alpha_powers vector and compute reduced openings directly via packed SIMD multiplication over packed_alpha_powers.