### PR TITLE
refactor(air): restore `Copy` bound on `AirBuilder::Var`

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -224,7 +224,7 @@ pub trait AirBuilder: Sized {
     ///
     /// Serves as the input type for an AIR constraint evaluation.
     type Var: Into<Self::Expr>
-        + Clone
+        + Copy
         + Send
         + Sync
         + Add<Self::F, Output = Self::Expr>

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -14,7 +14,7 @@ use crate::AirBuilder;
 pub fn pack_bits_le<R, Var, I>(iter: I) -> R
 where
     R: PrimeCharacteristicRing,
-    Var: Into<R> + Clone,
+    Var: Into<R>,
     I: DoubleEndedIterator<Item = Var>,
 {
     iter.rev()
@@ -119,8 +119,8 @@ pub fn add3<AB: AirBuilder>(
             .unwrap();
     let two_32 = two_16.square();
 
-    let acc_16 = a[0].clone() - b[0].clone() - c[0].clone() - d[0].clone();
-    let acc_32 = a[1].clone() - b[1].clone() - c[1].clone() - d[1].clone();
+    let acc_16 = a[0] - b[0] - c[0].clone() - d[0].clone();
+    let acc_32 = a[1] - b[1] - c[1].clone() - d[1].clone();
     let acc = acc_16.clone() + acc_32.mul_2exp_u64(16);
 
     builder.assert_zeros([
@@ -183,8 +183,8 @@ pub fn add2<AB: AirBuilder>(
             .unwrap();
     let two_32 = two_16.square();
 
-    let acc_16 = a[0].clone() - b[0].clone() - c[0].clone();
-    let acc_32 = a[1].clone() - b[1].clone() - c[1].clone();
+    let acc_16 = a[0] - b[0] - c[0].clone();
+    let acc_32 = a[1] - b[1] - c[1].clone();
     let acc = acc_16.clone() + acc_32.mul_2exp_u64(16);
 
     builder.assert_zeros([
@@ -207,26 +207,24 @@ pub fn xor_32_shift<AB: AirBuilder>(
     shift: usize,
 ) {
     // First we range check all elements of c.
-    builder.assert_bools(c.clone());
+    builder.assert_bools(*c);
 
     // Next we compute (b ^ (c << shift)) and pack the result into two 16-bit integers.
-    let xor_shift_c_0_16 = b[..16].iter().enumerate().map(|(i, elem)| {
-        (elem.clone())
-            .into()
-            .xor(&c[(32 + i - shift) % 32].clone().into())
-    });
+    let xor_shift_c_0_16 = b[..16]
+        .iter()
+        .enumerate()
+        .map(|(i, elem)| (*elem).into().xor(&c[(32 + i - shift) % 32].into()));
     let sum_0_16: AB::Expr = pack_bits_le(xor_shift_c_0_16);
 
-    let xor_shift_c_16_32 = b[16..].iter().enumerate().map(|(i, elem)| {
-        (elem.clone())
-            .into()
-            .xor(&c[(32 + (i + 16) - shift) % 32].clone().into())
-    });
+    let xor_shift_c_16_32 = b[16..]
+        .iter()
+        .enumerate()
+        .map(|(i, elem)| (*elem).into().xor(&c[(32 + (i + 16) - shift) % 32].into()));
     let sum_16_32: AB::Expr = pack_bits_le(xor_shift_c_16_32);
 
     // As both b and c have been range checked to be boolean, all the (b ^ (c << shift))
     // are also boolean and so this final check additionally has the effect of range checking a[0], a[1].
-    builder.assert_zeros([a[0].clone() - sum_0_16, a[1].clone() - sum_16_32]);
+    builder.assert_zeros([a[0] - sum_0_16, a[1] - sum_16_32]);
 }
 
 #[cfg(test)]

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -85,14 +85,14 @@ where
         let next: &FibRow<AB::Var> = (*next).borrow();
 
         let mut wf = builder.when_first_row();
-        wf.assert_eq(local.left.clone(), a0);
-        wf.assert_eq(local.right.clone(), b0);
+        wf.assert_eq(local.left, a0);
+        wf.assert_eq(local.right, b0);
 
         let mut wt = builder.when_transition();
-        wt.assert_eq(local.right.clone(), next.left.clone());
-        wt.assert_eq(local.left.clone() + local.right.clone(), next.right.clone());
+        wt.assert_eq(local.right, next.left);
+        wt.assert_eq(local.left + local.right, next.right);
 
-        builder.when_last_row().assert_eq(local.right.clone(), x);
+        builder.when_last_row().assert_eq(local.right, x);
     }
 }
 
@@ -171,17 +171,13 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
         let next = main.row_slice(1).unwrap();
         for i in 0..self.reps {
             let s = i * 3;
-            let a = local[s].clone();
-            let b = local[s + 1].clone();
-            let c = local[s + 2].clone();
-            builder.assert_eq(a.clone() * b.clone(), c);
+            let a = local[s];
+            let b = local[s + 1];
+            let c = local[s + 2];
+            builder.assert_eq(a * b, c);
 
-            builder
-                .when_transition()
-                .assert_eq(b.clone(), next[s].clone());
-            builder
-                .when_transition()
-                .assert_eq(a + b, next[s + 1].clone());
+            builder.when_transition().assert_eq(b, next[s]);
+            builder.when_transition().assert_eq(a + b, next[s + 1]);
         }
     }
 }
@@ -490,8 +486,8 @@ where
 
         // Enforce: main[0] = multiplier * preprocessed[0]
         builder.assert_eq(
-            local_main[0].clone(),
-            local_prep[0].clone() * AB::Expr::from_u64(self.multiplier),
+            local_main[0],
+            local_prep[0] * AB::Expr::from_u64(self.multiplier),
         );
     }
 }

--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -43,8 +43,8 @@ impl Blake3Air {
     ) {
         // We need to pack some bits together to verify the additions.
         // First we verify a' = a + b + m_{2i} mod 2^32
-        let b_0_16 = pack_bits_le(trace.b[..BITS_PER_LIMB].iter().cloned());
-        let b_16_32 = pack_bits_le(trace.b[BITS_PER_LIMB..].iter().cloned());
+        let b_0_16 = pack_bits_le(trace.b[..BITS_PER_LIMB].iter().copied());
+        let b_16_32 = pack_bits_le(trace.b[BITS_PER_LIMB..].iter().copied());
 
         add3(
             builder,
@@ -59,8 +59,8 @@ impl Blake3Air {
         xor_32_shift(builder, trace.a_prime, trace.d, trace.d_prime, 16);
 
         // Next we verify c' = c + d' mod 2^32
-        let d_prime_0_16 = pack_bits_le(trace.d_prime[..BITS_PER_LIMB].iter().cloned());
-        let d_prime_16_32 = pack_bits_le(trace.d_prime[BITS_PER_LIMB..].iter().cloned());
+        let d_prime_0_16 = pack_bits_le(trace.d_prime[..BITS_PER_LIMB].iter().copied());
+        let d_prime_16_32 = pack_bits_le(trace.d_prime[BITS_PER_LIMB..].iter().copied());
         add2(
             builder,
             trace.c_prime,
@@ -73,8 +73,8 @@ impl Blake3Air {
         xor_32_shift(builder, trace.c_prime, trace.b, trace.b_prime, 12);
 
         // Next we verify a'' = a' + b' + m_{2i + 1} mod 2^32
-        let b_prime_0_16 = pack_bits_le(trace.b_prime[..BITS_PER_LIMB].iter().cloned());
-        let b_prime_16_32 = pack_bits_le(trace.b_prime[BITS_PER_LIMB..].iter().cloned());
+        let b_prime_0_16 = pack_bits_le(trace.b_prime[..BITS_PER_LIMB].iter().copied());
+        let b_prime_16_32 = pack_bits_le(trace.b_prime[BITS_PER_LIMB..].iter().copied());
 
         add3(
             builder,
@@ -90,8 +90,8 @@ impl Blake3Air {
         xor_32_shift(builder, trace.a_output, trace.d_prime, trace.d_output, 8);
 
         // Next we verify c'' = c' + d'' mod 2^32
-        let d_output_0_16 = pack_bits_le(trace.d_output[..BITS_PER_LIMB].iter().cloned());
-        let d_output_16_32 = pack_bits_le(trace.d_output[BITS_PER_LIMB..].iter().cloned());
+        let d_output_0_16 = pack_bits_le(trace.d_output[..BITS_PER_LIMB].iter().copied());
+        let d_output_16_32 = pack_bits_le(trace.d_output[BITS_PER_LIMB..].iter().copied());
         add2(
             builder,
             trace.c_output,
@@ -108,7 +108,7 @@ impl Blake3Air {
 
     /// Given data for a full round, produce the data corresponding to a
     /// single application of the quarter round function on a column.
-    const fn full_round_to_column_quarter_round<'a, T: Clone, U>(
+    const fn full_round_to_column_quarter_round<'a, T: Copy, U>(
         &self,
         input: &'a Blake3State<T>,
         round_data: &'a FullRound<T>,
@@ -139,7 +139,7 @@ impl Blake3Air {
 
     /// Given data for a full round, produce the data corresponding to a
     /// single application of the quarter round function on a diagonal.
-    const fn full_round_to_diagonal_quarter_round<'a, T: Clone, U>(
+    const fn full_round_to_diagonal_quarter_round<'a, T: Copy, U>(
         &self,
         round_data: &'a FullRound<T>,
         m_vector: &'a [[U; 2]; 16],
@@ -243,10 +243,10 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         let local: &Blake3Cols<AB::Var> = (*local).borrow();
 
         let initial_row_3 = [
-            local.counter_low.clone(),
-            local.counter_hi.clone(),
-            local.block_len.clone(),
-            local.flags.clone(),
+            local.counter_low,
+            local.counter_hi,
+            local.block_len,
+            local.flags,
         ];
 
         // We start by checking that all the initialization inputs are boolean values.
@@ -257,8 +257,7 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
             .chain(local.chaining_values[1].iter())
             .chain(initial_row_3.iter())
             .for_each(|elem| {
-                elem.iter()
-                    .for_each(|bool| builder.assert_bool(bool.clone()));
+                elem.iter().for_each(|bool| builder.assert_bool(*bool));
             });
 
         // Next we ensure that the row0 and row2 for our initial state have been initialized correctly.
@@ -266,12 +265,12 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         // row0 should contain the packing of the first 4 chaining_values.
         local.chaining_values[0]
             .iter()
-            .zip(local.initial_row0.clone())
+            .zip(local.initial_row0)
             .for_each(|(bits, word)| {
-                let low_16 = pack_bits_le(bits[..BITS_PER_LIMB].iter().cloned());
-                let hi_16 = pack_bits_le(bits[BITS_PER_LIMB..].iter().cloned());
-                builder.assert_eq(low_16, word[0].clone());
-                builder.assert_eq(hi_16, word[1].clone());
+                let low_16 = pack_bits_le(bits[..BITS_PER_LIMB].iter().copied());
+                let hi_16 = pack_bits_le(bits[BITS_PER_LIMB..].iter().copied());
+                builder.assert_eq(low_16, word[0]);
+                builder.assert_eq(hi_16, word[1]);
             });
 
         // row2 should contain the first four constants in IV.
@@ -280,21 +279,21 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
             .iter()
             .zip(IV)
             .for_each(|(row_elem, constant)| {
-                builder.assert_eq(row_elem[0].clone(), AB::Expr::from_u16(constant[0]));
-                builder.assert_eq(row_elem[1].clone(), AB::Expr::from_u16(constant[1]));
+                builder.assert_eq(row_elem[0], AB::Expr::from_u16(constant[0]));
+                builder.assert_eq(row_elem[1], AB::Expr::from_u16(constant[1]));
             });
 
-        let mut m_values: [[AB::Expr; 2]; 16] = local.inputs.clone().map(|bits| {
+        let mut m_values: [[AB::Expr; 2]; 16] = local.inputs.map(|bits| {
             [
-                pack_bits_le(bits[..BITS_PER_LIMB].iter().cloned()),
-                pack_bits_le(bits[BITS_PER_LIMB..].iter().cloned()),
+                pack_bits_le(bits[..BITS_PER_LIMB].iter().copied()),
+                pack_bits_le(bits[BITS_PER_LIMB..].iter().copied()),
             ]
         });
 
         let initial_state = Blake3State {
-            row0: local.initial_row0.clone(),
-            row1: local.chaining_values[1].clone(),
-            row2: local.initial_row2.clone(),
+            row0: local.initial_row0,
+            row1: local.chaining_values[1],
+            row2: local.initial_row2,
             row3: initial_row_3,
         };
 
@@ -378,12 +377,12 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         local
             .final_round_helpers
             .iter()
-            .zip(local.full_rounds[6].state_output.row2.clone())
+            .zip(local.full_rounds[6].state_output.row2)
             .for_each(|(bits, word)| {
-                let low_16 = pack_bits_le(bits[..BITS_PER_LIMB].iter().cloned());
-                let hi_16 = pack_bits_le(bits[BITS_PER_LIMB..].iter().cloned());
-                builder.assert_eq(low_16, word[0].clone());
-                builder.assert_eq(hi_16, word[1].clone());
+                let low_16 = pack_bits_le(bits[..BITS_PER_LIMB].iter().copied());
+                let hi_16 = pack_bits_le(bits[BITS_PER_LIMB..].iter().copied());
+                builder.assert_eq(low_16, word[0]);
+                builder.assert_eq(hi_16, word[1]);
             });
         // Additionally, we need to ensure that both local.final_round_helpers and local.outputs[0] are boolean.
 
@@ -391,15 +390,15 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
             .final_round_helpers
             .iter()
             .chain(local.outputs[0].iter())
-            .for_each(|bits| bits.iter().for_each(|bit| builder.assert_bool(bit.clone())));
+            .for_each(|bits| bits.iter().for_each(|bit| builder.assert_bool(*bit)));
 
         // Finally we check the xor by xor'ing the output with final_round_helpers, packing the bits
         // and comparing with the words in local.full_rounds[6].state_output.row0.
 
         for (out_bits, left_words, right_bits) in izip!(
-            local.outputs[0].clone(),
-            local.full_rounds[6].state_output.row0.clone(),
-            local.final_round_helpers.clone()
+            local.outputs[0],
+            local.full_rounds[6].state_output.row0,
+            local.final_round_helpers
         ) {
             // We can reuse xor_32_shift with a shift of 0.
             // As a = b ^ c if and only if b = a ^ c we can perform our xor on the
@@ -411,9 +410,9 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         // This check also ensures that local.outputs[1] contains only boolean values.
 
         for (out_bits, left_bits, right_bits) in izip!(
-            local.outputs[1].clone(),
-            local.full_rounds[6].state_output.row1.clone(),
-            local.full_rounds[6].state_output.row3.clone()
+            local.outputs[1],
+            local.full_rounds[6].state_output.row1,
+            local.full_rounds[6].state_output.row3
         ) {
             for (out_bit, left_bit, right_bit) in izip!(out_bits, left_bits, right_bits) {
                 builder.assert_eq(out_bit, left_bit.into().xor(&right_bit.into()));
@@ -427,9 +426,9 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         // Hence we can directly check that the output is correct.
 
         for (out_bits, left_bits, right_bits) in izip!(
-            local.outputs[2].clone(),
-            local.chaining_values[0].clone(),
-            local.final_round_helpers.clone()
+            local.outputs[2],
+            local.chaining_values[0],
+            local.final_round_helpers
         ) {
             for (out_bit, left_bit, right_bit) in izip!(out_bits, left_bits, right_bits) {
                 builder.assert_eq(out_bit, left_bit.into().xor(&right_bit.into()));
@@ -440,9 +439,9 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
         // This check also ensures that local.outputs[3] contains only boolean values.
 
         for (out_bits, left_bits, right_bits) in izip!(
-            local.outputs[3].clone(),
-            local.chaining_values[1].clone(),
-            local.full_rounds[6].state_output.row3.clone()
+            local.outputs[3],
+            local.chaining_values[1],
+            local.full_rounds[6].state_output.row3
         ) {
             for (out_bit, left_bit, right_bit) in izip!(out_bits, left_bits, right_bits) {
                 builder.assert_eq(out_bit, left_bit.into().xor(&right_bit.into()));

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -48,17 +48,17 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         let local: &KeccakCols<AB::Var> = (*local).borrow();
         let next: &KeccakCols<AB::Var> = (*next).borrow();
 
-        let first_step = local.step_flags[0].clone();
-        let final_step = local.step_flags[NUM_ROUNDS_MIN_1].clone();
+        let first_step = local.step_flags[0];
+        let final_step = local.step_flags[NUM_ROUNDS_MIN_1];
         let not_final_step = AB::Expr::ONE - final_step;
 
         // If this is the first step, the input A must match the preimage.
         for y in 0..5 {
             for x in 0..5 {
                 builder
-                    .when(first_step.clone())
+                    .when(first_step)
                     .assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
-                        local.preimage[y][x][limb].clone() - local.a[y][x][limb].clone()
+                        local.preimage[y][x][limb] - local.a[y][x][limb]
                     }));
             }
         }
@@ -70,31 +70,31 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                     .when(not_final_step.clone())
                     .when_transition()
                     .assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
-                        local.preimage[y][x][limb].clone() - next.preimage[y][x][limb].clone()
+                        local.preimage[y][x][limb] - next.preimage[y][x][limb]
                     }));
             }
         }
 
         // The export flag must be 0 or 1.
-        builder.assert_bool(local.export.clone());
+        builder.assert_bool(local.export);
 
         // If this is not the final step, the export flag must be off.
         builder
             .when(not_final_step.clone())
-            .assert_zero(local.export.clone());
+            .assert_zero(local.export);
 
         // C'[x, z] = xor(C[x, z], C[x - 1, z], C[x + 1, z - 1]).
         // Note that if all entries of C are boolean, the arithmetic generalization
         // xor3 function only outputs 0, 1 and so this check also ensures that all
         // entries of C'[x, z] are boolean.
         for x in 0..5 {
-            builder.assert_bools(local.c[x].clone());
+            builder.assert_bools(local.c[x]);
             builder.assert_zeros::<64, _>(array::from_fn(|z| {
-                let xor = local.c[x][z].clone().into().xor3(
-                    &local.c[(x + 4) % 5][z].clone().into(),
-                    &local.c[(x + 1) % 5][(z + 63) % 64].clone().into(),
+                let xor = Into::<AB::Expr>::into(local.c[x][z]).xor3(
+                    &local.c[(x + 4) % 5][z].into(),
+                    &local.c[(x + 1) % 5][(z + 63) % 64].into(),
                 );
-                local.c_prime[x][z].clone() - xor
+                local.c_prime[x][z] - xor
             }));
         }
 
@@ -109,14 +109,12 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for y in 0..5 {
             for x in 0..5 {
                 let get_bit = |z: usize| {
-                    local.a_prime[y][x][z].clone().into().xor3(
-                        &local.c[x][z].clone().into(),
-                        &local.c_prime[x][z].clone().into(),
-                    )
+                    Into::<AB::Expr>::into(local.a_prime[y][x][z])
+                        .xor3(&local.c[x][z].into(), &local.c_prime[x][z].into())
                 };
 
                 // Check that all entries of A'[y][x] are boolean.
-                builder.assert_bools(local.a_prime[y][x].clone());
+                builder.assert_bools(local.a_prime[y][x]);
 
                 builder.assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
@@ -125,7 +123,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                             // Check to ensure all entries of A' are bools.
                             acc.double() + get_bit(z)
                         });
-                    computed_limb - local.a[y][x][limb].clone()
+                    computed_limb - local.a[y][x][limb]
                 }));
             }
         }
@@ -136,8 +134,8 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for x in 0..5 {
             let four = AB::Expr::TWO.double();
             builder.assert_zeros::<64, _>(array::from_fn(|z| {
-                let sum: AB::Expr = (0..5).map(|y| local.a_prime[y][x][z].clone().into()).sum();
-                let diff = sum - local.c_prime[x][z].clone();
+                let sum: AB::Expr = (0..5).map(|y| local.a_prime[y][x][z].into()).sum();
+                let diff = sum - local.c_prime[x][z];
                 diff.clone() * (diff.clone() - AB::Expr::TWO) * (diff - four.clone())
             }));
         }
@@ -158,33 +156,33 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                     let computed_limb = (limb * BITS_PER_LIMB..(limb + 1) * BITS_PER_LIMB)
                         .rev()
                         .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_bit(z));
-                    computed_limb - local.a_prime_prime[y][x][limb].clone()
+                    computed_limb - local.a_prime_prime[y][x][limb]
                 }));
             }
         }
 
         // A'''[0, 0] = A''[0, 0] XOR RC
         // Check to ensure the bits of A''[0, 0] are boolean.
-        builder.assert_bools(local.a_prime_prime_0_0_bits.clone());
+        builder.assert_bools(local.a_prime_prime_0_0_bits);
         builder.assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
             let computed_a_prime_prime_0_0_limb = (limb * BITS_PER_LIMB
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
                 .fold(AB::Expr::ZERO, |acc, z| {
-                    acc.double() + local.a_prime_prime_0_0_bits[z].clone()
+                    acc.double() + local.a_prime_prime_0_0_bits[z]
                 });
-            computed_a_prime_prime_0_0_limb - local.a_prime_prime[0][0][limb].clone()
+            computed_a_prime_prime_0_0_limb - local.a_prime_prime[0][0][limb]
         }));
 
         let get_xored_bit = |i| {
             let mut rc_bit_i = AB::Expr::ZERO;
             for r in 0..NUM_ROUNDS {
-                let this_round = local.step_flags[r].clone();
+                let this_round = local.step_flags[r];
                 let this_round_constant = AB::Expr::from_bool(rc_value_bit(r, i) != 0);
                 rc_bit_i += this_round * this_round_constant;
             }
 
-            rc_bit_i.xor(&local.a_prime_prime_0_0_bits[i].clone().into())
+            rc_bit_i.xor(&local.a_prime_prime_0_0_bits[i].into())
         };
 
         builder.assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
@@ -192,8 +190,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                 ..(limb + 1) * BITS_PER_LIMB)
                 .rev()
                 .fold(AB::Expr::ZERO, |acc, z| acc.double() + get_xored_bit(z));
-            computed_a_prime_prime_prime_0_0_limb
-                - local.a_prime_prime_prime_0_0_limbs[limb].clone()
+            computed_a_prime_prime_prime_0_0_limb - local.a_prime_prime_prime_0_0_limbs[limb]
         }));
 
         // Enforce that this round's output equals the next round's input.
@@ -203,7 +200,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                     .when_transition()
                     .when(not_final_step.clone())
                     .assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
-                        local.a_prime_prime_prime(y, x, limb) - next.a[y][x][limb].clone()
+                        local.a_prime_prime_prime(y, x, limb) - next.a[y][x][limb]
                     }));
             }
         }

--- a/keccak-air/src/columns.rs
+++ b/keccak-air/src/columns.rs
@@ -60,7 +60,7 @@ pub struct KeccakCols<T> {
     pub a_prime_prime_prime_0_0_limbs: [T; U64_LIMBS],
 }
 
-impl<T: Clone> KeccakCols<T> {
+impl<T: Copy> KeccakCols<T> {
     pub fn b(&self, x: usize, y: usize, z: usize) -> T {
         debug_assert!(x < 5);
         debug_assert!(y < 5);
@@ -75,7 +75,7 @@ impl<T: Clone> KeccakCols<T> {
         let a = (x + 3 * y) % 5;
         let b = x;
         let rot = R[a][b] as usize;
-        self.a_prime[b][a][(z + 64 - rot) % 64].clone()
+        self.a_prime[b][a][(z + 64 - rot) % 64]
     }
 
     pub fn a_prime_prime_prime(&self, y: usize, x: usize, limb: usize) -> T {
@@ -84,9 +84,9 @@ impl<T: Clone> KeccakCols<T> {
         debug_assert!(limb < U64_LIMBS);
 
         if y == 0 && x == 0 {
-            self.a_prime_prime_prime_0_0_limbs[limb].clone()
+            self.a_prime_prime_prime_0_0_limbs[limb]
         } else {
-            self.a_prime_prime[y][x][limb].clone()
+            self.a_prime_prime[y][x][limb]
         }
     }
 }

--- a/keccak-air/src/round_flags.rs
+++ b/keccak-air/src/round_flags.rs
@@ -36,13 +36,11 @@ pub(crate) fn eval_round_flags<AB: AirBuilder>(builder: &mut AB) {
     // Initially, the first step flag should be 1 while the others should be 0.
     //
     // Constraint: In the first row, the first flag is 1.
-    builder
-        .when_first_row()
-        .assert_one(local.step_flags[0].clone());
+    builder.when_first_row().assert_one(local.step_flags[0]);
     // Constraint: In the first row, all other flags are 0.
     builder
         .when_first_row()
-        .assert_zeros::<NUM_ROUNDS_MIN_1, _>(try_clone_array(&local.step_flags[1..]));
+        .assert_zeros::<NUM_ROUNDS_MIN_1, _>(try_copy_array(&local.step_flags[1..]));
 
     // Constraint: In all transitions, flags rotate forward.
     //
@@ -52,27 +50,16 @@ pub(crate) fn eval_round_flags<AB: AirBuilder>(builder: &mut AB) {
     builder
         .when_transition()
         .assert_zeros::<NUM_ROUNDS, _>(array::from_fn(|i| {
-            local.step_flags[i].clone() - next.step_flags[(i + 1) % NUM_ROUNDS].clone()
+            local.step_flags[i] - next.step_flags[(i + 1) % NUM_ROUNDS]
         }));
 }
 
-/// Clone a slice into an array of fixed length N by element-wise cloning.
+/// Copy a slice into an array of fixed length N.
 ///
 /// # Panics
 ///
 /// Panics if the input slice length does not match N.
-///
-/// # Arguments
-///
-/// - `slice`: The input slice to copy.
-///
-/// # Returns
-///
-/// - `[T; N]`: The cloned array.
-fn try_clone_array<T: Clone, const N: usize>(slice: &[T]) -> [T; N] {
-    // Check at runtime that the length is correct (should always hold).
+fn try_copy_array<T: Copy, const N: usize>(slice: &[T]) -> [T; N] {
     assert!(slice.len() == N, "Incorrect length");
-
-    // Clone each element into a new array.
-    array::from_fn(|i| slice[i].clone())
+    array::from_fn(|i| slice[i])
 }

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -172,8 +172,8 @@ where
     match expr {
         SymbolicExpression::Variable(v) => match v.entry {
             Entry::Main { offset } => match offset {
-                0 => builder.main().row_slice(0).unwrap()[v.index].clone().into(),
-                1 => builder.main().row_slice(1).unwrap()[v.index].clone().into(),
+                0 => builder.main().row_slice(0).unwrap()[v.index].into(),
+                1 => builder.main().row_slice(1).unwrap()[v.index].into(),
                 _ => panic!("Cannot have expressions involving more than two rows."),
             },
             Entry::Public => builder.public_values()[v.index].into(),
@@ -183,14 +183,12 @@ where
                     .expect("Missing preprocessed columns")
                     .row_slice(0)
                     .unwrap()[v.index]
-                    .clone()
                     .into(),
                 1 => builder
                     .preprocessed()
                     .expect("Missing preprocessed columns")
                     .row_slice(1)
                     .unwrap()[v.index]
-                    .clone()
                     .into(),
                 _ => panic!("Cannot have expressions involving more than two rows."),
             },

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -170,7 +170,7 @@ pub(crate) fn eval<
         PARTIAL_ROUNDS,
     >,
 ) {
-    let mut state: [_; WIDTH] = local.inputs.clone().map(|x| x.into());
+    let mut state: [_; WIDTH] = local.inputs.map(|x| x.into());
 
     LinearLayers::external_linear_layer(&mut state);
 
@@ -252,8 +252,8 @@ fn eval_full_round<
     }
     LinearLayers::external_linear_layer(state);
     for (state_i, post_i) in state.iter_mut().zip(&full_round.post) {
-        builder.assert_eq(state_i.clone(), post_i.clone());
-        *state_i = post_i.clone().into();
+        builder.assert_eq(state_i.clone(), *post_i);
+        *state_i = (*post_i).into();
     }
 }
 
@@ -273,8 +273,8 @@ fn eval_partial_round<
     state[0] += round_constant.clone();
     eval_sbox(&partial_round.sbox, &mut state[0], builder);
 
-    builder.assert_eq(state[0].clone(), partial_round.post_sbox.clone());
-    state[0] = partial_round.post_sbox.clone().into();
+    builder.assert_eq(state[0].clone(), partial_round.post_sbox);
+    state[0] = partial_round.post_sbox.into();
 
     LinearLayers::internal_linear_layer(state);
 }
@@ -299,19 +299,19 @@ fn eval_sbox<AB, const DEGREE: u64, const REGISTERS: usize>(
         (5, 0) => x.exp_const_u64::<5>(),
         (7, 0) => x.exp_const_u64::<7>(),
         (5, 1) => {
-            let committed_x3 = sbox.0[0].clone().into();
+            let committed_x3: AB::Expr = sbox.0[0].into();
             let x2 = x.square();
             builder.assert_eq(committed_x3.clone(), x2.clone() * x.clone());
             committed_x3 * x2
         }
         (7, 1) => {
-            let committed_x3 = sbox.0[0].clone().into();
+            let committed_x3: AB::Expr = sbox.0[0].into();
             builder.assert_eq(committed_x3.clone(), x.cube());
             committed_x3.square() * x.clone()
         }
         (11, 2) => {
-            let committed_x3 = sbox.0[0].clone().into();
-            let committed_x9 = sbox.0[1].clone().into();
+            let committed_x3: AB::Expr = sbox.0[0].into();
+            let committed_x9: AB::Expr = sbox.0[1].into();
             let x2 = x.square();
             builder.assert_eq(committed_x3.clone(), x2.clone() * x.clone());
             builder.assert_eq(committed_x9.clone(), committed_x3.cube());

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -60,18 +60,18 @@ impl<AB: AirBuilder> Air<AB> for FibonacciAir {
 
         let mut when_first_row = builder.when_first_row();
 
-        when_first_row.assert_eq(local.left.clone(), a);
-        when_first_row.assert_eq(local.right.clone(), b);
+        when_first_row.assert_eq(local.left, a);
+        when_first_row.assert_eq(local.right, b);
 
         let mut when_transition = builder.when_transition();
 
         // a' <- b
-        when_transition.assert_eq(local.right.clone(), next.left.clone());
+        when_transition.assert_eq(local.right, next.left);
 
         // b' <- a + b
-        when_transition.assert_eq(local.left.clone() + local.right.clone(), next.right.clone());
+        when_transition.assert_eq(local.left + local.right, next.right);
 
-        builder.when_last_row().assert_eq(local.right.clone(), x);
+        builder.when_last_row().assert_eq(local.right, x);
     }
 }
 

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -96,17 +96,15 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
 
         for i in 0..REPETITIONS {
             let start = i * 3;
-            let a = main_local[start].clone();
-            let b = main_local[start + 1].clone();
-            let c = main_local[start + 2].clone();
-            builder.assert_zero(a.clone().into().exp_u64(self.degree - 1) * b.clone() - c);
+            let a = main_local[start];
+            let b = main_local[start + 1];
+            let c = main_local[start + 2];
+            builder.assert_zero(a.into().exp_u64(self.degree - 1) * b - c);
             if self.uses_boundary_constraints {
-                builder
-                    .when_first_row()
-                    .assert_eq(a.clone() * a.clone() + AB::Expr::ONE, b);
+                builder.when_first_row().assert_eq(a * a + AB::Expr::ONE, b);
             }
             if self.uses_transition_constraints {
-                let next_a = main_next[start].clone();
+                let next_a = main_next[start];
                 builder
                     .when_transition()
                     .assert_eq(a + AB::Expr::from_u8(REPETITIONS as u8), next_a);

--- a/uni-stark/tests/mul_fib_pair.rs
+++ b/uni-stark/tests/mul_fib_pair.rs
@@ -71,12 +71,12 @@ where
         let mut when_transition = builder.when_transition();
 
         // a' <- b
-        when_transition.assert_eq(local.b.clone(), next.a.clone());
+        when_transition.assert_eq(local.b, next.a);
 
         // b' <- prod_coeff * a * b + sum_coeff * (a + b)
-        let prod_term = prep.prod_coeff.clone() * local.a.clone() * local.b.clone();
-        let sum_term = prep.sum_coeff.clone() * (local.a.clone() + local.b.clone());
-        when_transition.assert_eq(prod_term + sum_term, next.b.clone());
+        let prod_term = prep.prod_coeff * local.a * local.b;
+        let sum_term = prep.sum_coeff * (local.a + local.b);
+        when_transition.assert_eq(prod_term + sum_term, next.b);
     }
 }
 

--- a/uni-stark/tests/no_next_row.rs
+++ b/uni-stark/tests/no_next_row.rs
@@ -31,9 +31,9 @@ impl<AB: AirBuilder> Air<AB> for SquareAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let local = main.row_slice(0).expect("Matrix is empty?");
-        let a = local[0].clone();
-        let b = local[1].clone();
-        builder.assert_eq(a.clone() * a, b);
+        let a = local[0];
+        let b = local[1];
+        builder.assert_eq(a * a, b);
     }
 }
 

--- a/uni-stark/tests/rc_sub_builder.rs
+++ b/uni-stark/tests/rc_sub_builder.rs
@@ -45,14 +45,14 @@ where
         let main = builder.main();
         let local = main.row_slice(0).expect("matrix should have a local row");
 
-        let value = local[0].clone();
+        let value = local[0];
         let bits = &local[1..];
 
         let mut recomposed = AB::Expr::ZERO;
         for (i, bit) in bits.iter().enumerate() {
             let weight = BabyBear::from_u32(1 << i);
-            recomposed += bit.clone() * weight;
-            builder.assert_zero(bit.clone() * (bit.clone() - AB::Expr::ONE));
+            recomposed += *bit * weight;
+            builder.assert_zero(*bit * (*bit - AB::Expr::ONE));
         }
 
         builder.assert_zero(value - recomposed);
@@ -87,11 +87,11 @@ where
         let local = main.row_slice(0).expect("matrix should have a local row");
         let next = main.row_slice(1).expect("matrix only has 1 row?");
 
-        let accumulator = local[0].clone();
-        let range_value = local[1].clone();
-        let next_accumulator = next[0].clone();
+        let accumulator = local[0];
+        let range_value = local[1];
+        let next_accumulator = next[0];
 
-        builder.when_first_row().assert_zero(accumulator.clone());
+        builder.when_first_row().assert_zero(accumulator);
         builder
             .when_transition()
             .assert_eq(next_accumulator, accumulator + range_value);


### PR DESCRIPTION
Fixes #1366. Happy to close if it turns out `Clone` was necessary.
