### PR TITLE
fix: replace manual doubling with double()

### DIFF
--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -37,8 +37,8 @@ where
 {
     let t0 = x[0].clone() + x[1].clone();
     let t1 = x[2].clone() + x[3].clone();
-    let t2 = x[1].clone() + x[1].clone() + t1.clone();
-    let t3 = x[3].clone() + x[3].clone() + t0.clone();
+    let t2 = x[1].double() + t1.clone();
+    let t3 = x[3].double() + t0.clone();
     let t4 = t1.double().double() + t3.clone();
     let t5 = t0.double().double() + t2.clone();
     let t6 = t3 + t5.clone();


### PR DESCRIPTION
Replace x + x pattern with double() to remove 2 unnecessary clones and stay consistent with the rest of the codebase