### PR TITLE
feat(air): Minimum support for periodic columns

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -351,6 +351,15 @@ pub trait AirBuilder: Sized {
     }
 }
 
+/// Extension of [`AirBuilder`] for builders that supply periodic column values.
+pub trait PeriodicAirBuilder: AirBuilder {
+    /// Variable type for periodic column values.
+    type PeriodicVar: Into<Self::Expr> + Copy;
+
+    /// Periodic column values at the current row.
+    fn periodic_values(&self) -> &[Self::PeriodicVar];
+}
+
 /// Extension trait for builders that carry additional runtime context.
 ///
 /// Some AIRs need access to data that is only available at proving time,

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -10,7 +10,8 @@ use crate::symbolic::expression::BaseLeaf;
 use crate::symbolic::expression_ext::SymbolicExpressionExt;
 use crate::symbolic::variable::{BaseEntry, ExtEntry, SymbolicVariableExt};
 use crate::{
-    Air, AirBuilder, ExtensionBuilder, PermutationAirBuilder, SymbolicExpression, SymbolicVariable,
+    Air, AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
+    SymbolicExpression, SymbolicVariable,
 };
 
 #[instrument(skip_all, level = "debug")]
@@ -78,6 +79,7 @@ where
         air.num_public_values(),
         0,
         0,
+        0,
     );
     air.eval(&mut builder);
     builder.base_constraints()
@@ -105,6 +107,7 @@ where
         air.num_public_values(),
         permutation_width,
         num_permutation_challenges,
+        0,
     );
     air.eval(&mut builder);
     builder.extension_constraints()
@@ -135,6 +138,7 @@ where
         air.num_public_values(),
         permutation_width,
         num_permutation_challenges,
+        0,
     );
     air.eval(&mut builder);
     (builder.base_constraints(), builder.extension_constraints())
@@ -146,6 +150,7 @@ pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     preprocessed: RowMajorMatrix<SymbolicVariable<F>>,
     main: RowMajorMatrix<SymbolicVariable<F>>,
     public_values: Vec<SymbolicVariable<F>>,
+    periodic: Vec<SymbolicVariable<F>>,
     base_constraints: Vec<SymbolicExpression<F>>,
     permutation: RowMajorMatrix<SymbolicVariableExt<F, EF>>,
     permutation_challenges: Vec<SymbolicVariableExt<F, EF>>,
@@ -159,6 +164,7 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
         num_public_values: usize,
         permutation_width: usize,
         num_permutation_challenges: usize,
+        num_periodic_columns: usize,
     ) -> Self {
         let prep_values = [0, 1]
             .into_iter()
@@ -178,6 +184,9 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
         let public_values = (0..num_public_values)
             .map(move |index| SymbolicVariable::new(BaseEntry::Public, index))
             .collect();
+        let periodic = (0..num_periodic_columns)
+            .map(|index| SymbolicVariable::new(BaseEntry::Periodic, index))
+            .collect();
         let perm_values = [0, 1]
             .into_iter()
             .flat_map(|offset| {
@@ -194,6 +203,7 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
             preprocessed: RowMajorMatrix::new(prep_values, preprocessed_width),
             main: RowMajorMatrix::new(main_values, width),
             public_values,
+            periodic,
             base_constraints: vec![],
             permutation,
             permutation_challenges,
@@ -285,6 +295,14 @@ where
     }
 }
 
+impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for SymbolicAirBuilder<F, EF> {
+    type PeriodicVar = SymbolicVariable<F>;
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        &self.periodic
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
@@ -366,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_symbolic_air_builder_initialization() {
-        let builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0);
+        let builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0, 0);
 
         let expected_main = [
             SymbolicVariable::<BabyBear>::new(BaseEntry::Main { offset: 0 }, 0),
@@ -395,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_symbolic_air_builder_is_first_last_row() {
-        let builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0);
+        let builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0, 0);
 
         assert!(
             matches!(
@@ -416,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_symbolic_air_builder_assert_zero() {
-        let mut builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0);
+        let mut builder = SymbolicAirBuilder::<BabyBear>::new(2, 4, 3, 0, 0, 0);
         let expr = SymbolicExpression::Leaf(BaseLeaf::Constant(BabyBear::new(5)));
         builder.assert_zero(expr);
 

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -5,6 +5,7 @@ use core::marker::PhantomData;
 pub enum BaseEntry {
     Preprocessed { offset: usize },
     Main { offset: usize },
+    Periodic,
     Public,
 }
 
@@ -34,7 +35,12 @@ impl<F> SymbolicVariable<F> {
 
     pub const fn degree_multiple(&self) -> usize {
         match self.entry {
-            BaseEntry::Preprocessed { .. } | BaseEntry::Main { .. } => 1,
+            BaseEntry::Preprocessed { .. }
+            | BaseEntry::Main { .. }
+            // TODO: Periodic columns use degree 1 as an approximation. In Winterfell's model,
+            // a periodic column with period `p` over trace length `n` contributes degree `n/p - 1`.
+            // See: https://github.com/facebook/winterfell/blob/main/air/src/air/transition/degree.rs
+            | BaseEntry::Periodic => 1,
             BaseEntry::Public => 0,
         }
     }

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -144,6 +144,7 @@ where
         air.num_public_values(),
         num_aux_cols,
         num_challenges,
+        0,
     );
 
     // Evaluate AIR and lookup constraints.

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -242,7 +242,7 @@ where
 
         // Create symbolic air builder to access symbolic variables
         let symbolic_air_builder =
-            SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0);
+            SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0, 0);
         let symbolic_main = symbolic_air_builder.main();
         let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
@@ -409,7 +409,7 @@ impl<AB: PermutationAirBuilder> Air<AB> for FibAirLookups {
         if self.is_global {
             // Create symbolic air builder to access symbolic variables
             let symbolic_air_builder =
-                SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 3, 0, 0);
+                SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 3, 0, 0, 0);
             let symbolic_main = symbolic_air_builder.main();
             let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
@@ -2105,7 +2105,7 @@ where
 
         // Create symbolic air builder to access symbolic variables
         let symbolic_air_builder =
-            SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0);
+            SymbolicAirBuilder::<AB::F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0, 0);
         let symbolic_main = symbolic_air_builder.main();
         let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 

--- a/lookup/benches/logup.rs
+++ b/lookup/benches/logup.rs
@@ -42,7 +42,7 @@ fn random_main_trace(height: usize, width: usize, rng: &mut SmallRng) -> RowMajo
 
 /// Build symbolic lookup contexts similar to RangeCheckAir pattern.
 fn build_lookups(num_lookups: usize, tuple_size: usize, trace_width: usize) -> Vec<Lookup<F>> {
-    let symbolic_builder = SymbolicAirBuilder::<F>::new(0, trace_width, 0, 0, 0);
+    let symbolic_builder = SymbolicAirBuilder::<F>::new(0, trace_width, 0, 0, 0, 0);
     let symbolic_main = symbolic_builder.main();
     let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -180,6 +180,9 @@ where
                     1 => builder.main().row_slice(1).unwrap()[v.index].into(),
                     _ => panic!("Cannot have expressions involving more than two rows."),
                 },
+                BaseEntry::Periodic => {
+                    panic!("Periodic columns are not supported in lookup resolution")
+                }
                 BaseEntry::Public => builder.public_values()[v.index].into(),
                 BaseEntry::Preprocessed { offset } => match offset {
                     0 => builder

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -275,7 +275,7 @@ where
 
     fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
         let symbolic_air_builder =
-            SymbolicAirBuilder::<F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0);
+            SymbolicAirBuilder::<F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0, 0);
 
         let symbolic_main = symbolic_air_builder.main();
         let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
@@ -510,7 +510,7 @@ fn test_symbolic_to_expr() {
     use p3_air::symbolic::SymbolicAirBuilder;
     use p3_field::PrimeCharacteristicRing;
 
-    let mut builder = SymbolicAirBuilder::<F>::new(0, 2, 0, 0, 0);
+    let mut builder = SymbolicAirBuilder::<F>::new(0, 2, 0, 0, 0, 0);
 
     let main = builder.main();
 
@@ -660,7 +660,7 @@ fn test_debug_util_detects_malformed_lookup() {
     let main_values = vec![F::from_u32(3), F::from_u32(4)];
     let main_trace = RowMajorMatrix::new(main_values, 1);
 
-    let builder = SymbolicAirBuilder::<F>::new(0, 1, 0, 0, 0);
+    let builder = SymbolicAirBuilder::<F>::new(0, 1, 0, 0, 0, 0);
     let expr = builder.main().row_slice(0).unwrap()[0];
 
     // One local lookup with a single tuple; multiplicity is always +1,
@@ -1162,7 +1162,7 @@ where
 
     fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
         let symbolic_air_builder =
-            SymbolicAirBuilder::<F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0);
+            SymbolicAirBuilder::<F>::new(0, BaseAir::<AB::F>::width(self), 0, 0, 0, 0);
 
         let symbolic_main = symbolic_air_builder.main();
         let symbolic_main_local = symbolic_main.row_slice(0).unwrap();

--- a/uni-stark/tests/rc_sub_builder.rs
+++ b/uni-stark/tests/rc_sub_builder.rs
@@ -126,7 +126,7 @@ impl RangeCheckAir {
 #[test]
 fn range_checked_sub_builder() {
     let air = RangeCheckAir;
-    let mut builder = SymbolicAirBuilder::<BabyBear>::new(0, TRACE_WIDTH, 0, 0, 0);
+    let mut builder = SymbolicAirBuilder::<BabyBear>::new(0, TRACE_WIDTH, 0, 0, 0, 0);
     air.eval(&mut builder);
 
     let constraints = builder.base_constraints();


### PR DESCRIPTION
This PR includes the minimum amount of changes required in the SymbolicAir to allow downstream implementers to support periodic columns. Eventually, we should add support for the existing STARKs. See https://github.com/0xMiden/Plonky3/pull/44.