### PR TITLE
Permutation values

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -6,7 +6,7 @@ use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 
-use crate::lookup::{Kind, Lookup, LookupData, LookupEvaluator, LookupInput};
+use crate::lookup::{Kind, Lookup, LookupEvaluator, LookupInput};
 
 /// The underlying structure of an AIR.
 pub trait BaseAir<F>: Sync {
@@ -187,13 +187,11 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
     /// # Arguments
     /// - `builder`: Mutable reference to an `AirBuilder` for defining constraints.
     /// - `lookups`: References to the lookups to be evaluated.
-    /// - `lookup_data`: References to the lookup data to be used for evaluation.
     /// - `lookup_evaluator`: Reference to the lookup evaluator to be used for evaluation.
     fn eval_with_lookups<LE: LookupEvaluator>(
         &self,
         builder: &mut AB,
         lookups: &[Lookup<AB::F>],
-        lookup_data: &[LookupData<AB::ExprEF>],
         lookup_evaluator: &LE,
     ) where
         AB: PermutationAirBuilder,
@@ -201,7 +199,7 @@ pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
         self.eval(builder);
 
         if !lookups.is_empty() {
-            lookup_evaluator.eval_lookups(builder, lookups, lookup_data);
+            lookup_evaluator.eval_lookups(builder, lookups);
         }
     }
 }
@@ -417,11 +415,17 @@ pub trait PermutationAirBuilder: ExtensionBuilder {
     /// Randomness variable type used in permutation commitments.
     type RandomVar: Into<Self::ExprEF> + Copy;
 
+    /// Value type for expected cumulated values used in global lookup arguments.
+    type PermutationVar: Into<Self::ExprEF> + Clone;
+
     /// Return the matrix representing permutation registers.
     fn permutation(&self) -> Self::MP;
 
     /// Return the list of randomness values for permutation argument.
     fn permutation_randomness(&self) -> &[Self::RandomVar];
+
+    /// Return the expected cumulated values for global lookup arguments.
+    fn permutation_values(&self) -> &[Self::PermutationVar];
 }
 
 /// A wrapper around an [`AirBuilder`] that enforces constraints only when a specified condition is met.
@@ -511,12 +515,18 @@ impl<AB: PermutationAirBuilder> PermutationAirBuilder for FilteredAirBuilder<'_,
 
     type RandomVar = AB::RandomVar;
 
+    type PermutationVar = AB::PermutationVar;
+
     fn permutation(&self) -> Self::MP {
         self.inner.permutation()
     }
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
         self.inner.permutation_randomness()
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        self.inner.permutation_values()
     }
 }
 

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -67,6 +67,9 @@ pub struct DebugConstraintBuilder<'a, F: Field, EF: ExtensionField<F> = F> {
 
     /// Challenge values for the permutation argument, empty when unused.
     permutation_challenges: &'a [EF],
+
+    /// Expected cumulated values for global lookup arguments.
+    permutation_values: &'a [EF],
 }
 
 impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
@@ -96,6 +99,7 @@ impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
             is_transition,
             permutation: None,
             permutation_challenges: &[],
+            permutation_values: &[],
         }
     }
 }
@@ -116,6 +120,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
         is_transition: F,
         permutation: ViewPair<'a, EF>,
         permutation_challenges: &'a [EF],
+        permutation_values: &'a [EF],
     ) -> Self {
         Self {
             row_index,
@@ -129,6 +134,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
             is_transition,
             permutation: Some(permutation),
             permutation_challenges,
+            permutation_values,
         }
     }
 
@@ -243,6 +249,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> PermutationAirBuilder
 {
     type MP = VerticalPair<RowMajorMatrixView<'a, EF>, RowMajorMatrixView<'a, EF>>;
     type RandomVar = EF;
+    type PermutationVar = EF;
 
     /// # Panics
     ///
@@ -254,6 +261,10 @@ impl<'a, F: Field, EF: ExtensionField<F>> PermutationAirBuilder
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
         self.permutation_challenges
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        self.permutation_values
     }
 }
 

--- a/air/src/lookup/mod.rs
+++ b/air/src/lookup/mod.rs
@@ -156,46 +156,33 @@ pub trait LookupEvaluator {
     ) where
         AB: PermutationAirBuilder;
 
-    /// Evalutes the lookup constraints for all provided contexts.
+    /// Evaluates the lookup constraints for all provided contexts.
     ///
     /// For each context:
     /// - if it is a local lookup, evaluates it with `eval_local_lookup`.
-    /// - if it is a global lookup, evaluates it with `eval_global_update`, using the expected cumulated value from `lookup_data`.
-    fn eval_lookups<AB>(
-        &self,
-        builder: &mut AB,
-        contexts: &[Lookup<AB::F>],
-        // Assumed to be sorted by auxiliary_index.
-        lookup_data: &[LookupData<AB::ExprEF>],
-    ) where
+    /// - if it is a global lookup, evaluates it with `eval_global_update`, reading the expected
+    ///   cumulated value from the builder's `permutation_values()`.
+    fn eval_lookups<AB>(&self, builder: &mut AB, contexts: &[Lookup<AB::F>])
+    where
         AB: PermutationAirBuilder,
     {
-        let mut lookup_data_iter = lookup_data.iter();
+        let mut pv_idx = 0;
         for context in contexts.iter() {
             match &context.kind {
                 Kind::Local => {
                     self.eval_local_lookup(builder, context);
                 }
                 Kind::Global(_) => {
-                    // Find the expected cumulated value for this context.
-                    let LookupData {
-                        name: _,
-                        aux_idx,
-                        expected_cumulated,
-                    } = lookup_data_iter
-                        .next()
-                        .expect("Expected cumulated value missing");
-
-                    if *aux_idx != context.columns[0] {
-                        panic!("Expected cumulated values not sorted by auxiliary index");
-                    }
-                    self.eval_global_update(builder, context, expected_cumulated.clone());
+                    let expected = builder.permutation_values()[pv_idx].clone();
+                    pv_idx += 1;
+                    self.eval_global_update(builder, context, expected.into());
                 }
             }
         }
-        assert!(
-            lookup_data_iter.next().is_none(),
-            "Too many expected cumulated values provided"
+        assert_eq!(
+            pv_idx,
+            builder.permutation_values().len(),
+            "permutation values count mismatch"
         );
     }
 }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -17,15 +17,22 @@ use crate::{
 /// Describes the shape of an AIR for symbolic constraint evaluation.
 ///
 /// Bundles the various width/count parameters needed to construct a
-/// [`SymbolicAirBuilder`], replacing the 6-parameter signatures with a
-/// single value.
+/// [`SymbolicAirBuilder`].
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AirLayout {
+    /// Width of [`AirBuilder::preprocessed`].
     pub preprocessed_width: usize,
+    /// Width of [`AirBuilder::main`].
     pub main_width: usize,
+    /// Length of [`AirBuilder::public_values`].
     pub num_public_values: usize,
+    /// Width of [`PermutationAirBuilder::permutation`].
     pub permutation_width: usize,
+    /// Length of [`PermutationAirBuilder::permutation_randomness`].
     pub num_permutation_challenges: usize,
+    /// Length of [`PermutationAirBuilder::permutation_values`].
+    pub num_permutation_values: usize,
+    /// Length of [`PeriodicAirBuilder::periodic_values`].
     pub num_periodic_columns: usize,
 }
 
@@ -131,6 +138,7 @@ pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     base_constraints: Vec<SymbolicExpression<F>>,
     permutation: RowMajorMatrix<SymbolicVariableExt<F, EF>>,
     permutation_challenges: Vec<SymbolicVariableExt<F, EF>>,
+    permutation_values: Vec<SymbolicVariableExt<F, EF>>,
     extension_constraints: Vec<SymbolicExpressionExt<F, EF>>,
     constraint_types: Vec<ConstraintType>,
 }
@@ -143,6 +151,7 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
             num_public_values,
             permutation_width,
             num_permutation_challenges,
+            num_permutation_values,
             num_periodic_columns,
         } = layout;
         let prep_values = [0, 1]
@@ -178,6 +187,9 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
         let permutation_challenges = (0..num_permutation_challenges)
             .map(|index| SymbolicVariableExt::new(ExtEntry::Challenge, index))
             .collect();
+        let permutation_values = (0..num_permutation_values)
+            .map(|index| SymbolicVariableExt::new(ExtEntry::PermutationValue, index))
+            .collect();
         Self {
             preprocessed: RowMajorMatrix::new(prep_values, preprocessed_width),
             main: RowMajorMatrix::new(main_values, main_width),
@@ -186,6 +198,7 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
             base_constraints: vec![],
             permutation,
             permutation_challenges,
+            permutation_values,
             extension_constraints: vec![],
             constraint_types: vec![],
         }
@@ -284,12 +297,18 @@ where
 
     type RandomVar = SymbolicVariableExt<F, EF>;
 
+    type PermutationVar = SymbolicVariableExt<F, EF>;
+
     fn permutation(&self) -> Self::MP {
         self.permutation.clone()
     }
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
         &self.permutation_challenges
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        &self.permutation_values
     }
 }
 
@@ -448,6 +467,7 @@ mod tests {
             num_public_values,
             permutation_width: 0,
             num_permutation_challenges: 0,
+            num_permutation_values: 0,
             num_periodic_columns,
         }
     }
@@ -466,6 +486,7 @@ mod tests {
             num_public_values,
             permutation_width,
             num_permutation_challenges,
+            num_permutation_values: 0,
             num_periodic_columns,
         }
     }

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -9,11 +9,12 @@ pub enum BaseEntry {
     Public,
 }
 
-/// Entry kinds for extension-field columns (permutation trace and challenges).
+/// Entry kinds for extension-field columns (permutation trace, challenges, and permutation values).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ExtEntry {
     Permutation { offset: usize },
     Challenge,
+    PermutationValue,
 }
 
 /// A variable within the evaluation window for base-field columns.
@@ -66,7 +67,7 @@ impl<F, EF> SymbolicVariableExt<F, EF> {
     pub const fn degree_multiple(&self) -> usize {
         match self.entry {
             ExtEntry::Permutation { .. } => 1,
-            ExtEntry::Challenge => 0,
+            ExtEntry::Challenge | ExtEntry::PermutationValue => 0,
         }
     }
 }

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use p3_air::{Air, DebugConstraintBuilder};
 use p3_field::{ExtensionField, Field};
-use p3_lookup::lookup_traits::{Lookup, LookupData, LookupGadget};
+use p3_lookup::lookup_traits::{Lookup, LookupGadget};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
@@ -10,10 +10,9 @@ use tracing::instrument;
 
 /// Type alias for the inputs to lookup constraint checking.
 /// - The first element is a slice of [`Lookup`] values (generic over a field `F`) representing the symbolic lookups to be performed.
-/// - The second element is a slice of [`LookupData`] values (generic over an extension field `EF`) representing the lookup data for global lookups.
-/// - The third element is a reference to the [`LookupGadget`] implementation.
+/// - The second element is a reference to the [`LookupGadget`] implementation.
 #[allow(unused)]
-type LookupConstraintsInputs<'a, F, EF, LG> = (&'a [Lookup<F>], &'a [LookupData<EF>], &'a LG);
+type LookupConstraintsInputs<'a, F, LG> = (&'a [Lookup<F>], &'a LG);
 
 /// Runs constraint checks using a given [AIR](`p3_air::Air`) implementation and trace matrix.
 ///
@@ -36,14 +35,16 @@ type LookupConstraintsInputs<'a, F, EF, LG> = (&'a [Lookup<F>], &'a [LookupData<
 ///     - the [`LookupGadget`] implementation.
 #[instrument(name = "check constraints", skip_all)]
 #[allow(unused)] // Do not remove, or this will trigger warnings in release mode.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn check_constraints<'b, F, EF, A, LG>(
     air: &A,
     main: &RowMajorMatrix<F>,
     preprocessed: &Option<RowMajorMatrix<F>>,
     permutation: &RowMajorMatrix<EF>,
     permutation_challenges: &[EF],
+    permutation_values: &[EF],
     public_values: &[F],
-    lookup_constraints_inputs: LookupConstraintsInputs<'b, F, EF, LG>,
+    lookup_constraints_inputs: LookupConstraintsInputs<'b, F, LG>,
 ) where
     F: Field,
     EF: ExtensionField<F>,
@@ -52,7 +53,7 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
 {
     let height = main.height();
 
-    let (lookups, lookup_data, lookup_gadget) = lookup_constraints_inputs;
+    let (lookups, lookup_gadget) = lookup_constraints_inputs;
 
     for row_index in 0..height {
         let row_index_next = (row_index + 1) % height;
@@ -105,9 +106,10 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
             F::from_bool(row_index != height - 1),
             permutation,
             permutation_challenges,
+            permutation_values,
         );
 
-        air.eval_with_lookups(&mut builder, lookups, lookup_data, lookup_gadget);
+        air.eval_with_lookups(&mut builder, lookups, lookup_gadget);
 
         // Stop at the first failing row and report all violations at once.
         if builder.has_failures() {

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -25,7 +25,6 @@ use crate::config::{Challenge, Domain, StarkGenericConfig as SGC, Val, observe_i
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof, OpenedValuesWithLookups};
 use crate::symbolic::{
     get_constraint_layout, get_log_num_quotient_chunks, get_symbolic_constraints,
-    lookup_data_to_ext_expr,
 };
 
 #[derive(Debug)]
@@ -149,7 +148,6 @@ where
                         air,
                         layout,
                         &all_lookups[i],
-                        &lookup_data_to_ext_expr(&lookup_data[i]),
                         config.is_zk(),
                         &lookup_gadget,
                     )
@@ -228,17 +226,18 @@ where
 
                     let preprocessed_trace = inst.air.preprocessed_trace();
 
-                    let lookup_constraints_inputs = (
-                        all_lookups[i].as_slice(),
-                        lookup_data[i].as_slice(),
-                        &lookup_gadget,
-                    );
+                    let perm_vals: Vec<SC::Challenge> = lookup_data[i]
+                        .iter()
+                        .map(|ld| ld.expected_cumulated)
+                        .collect();
+                    let lookup_constraints_inputs = (all_lookups[i].as_slice(), &lookup_gadget);
                     check_constraints(
                         inst.air,
                         &inst.trace,
                         &preprocessed_trace,
                         &generated_perm,
                         &challenges_per_instance[i],
+                        &perm_vals,
                         &inst.public_values,
                         lookup_constraints_inputs,
                     );
@@ -315,27 +314,15 @@ where
         // In debug builds, cross-check the static hint against symbolic evaluation.
         debug_assert!(
             airs[i].num_constraints().is_none_or(|n| {
-                n == get_symbolic_constraints(
-                    airs[i],
-                    sym_layout,
-                    &all_lookups[i],
-                    &lookup_data_to_ext_expr(&lookup_data[i]),
-                    &lookup_gadget,
-                )
-                .0
-                .len()
+                n == get_symbolic_constraints(airs[i], sym_layout, &all_lookups[i], &lookup_gadget)
+                    .0
+                    .len()
             }),
             "num_constraints() = {} but symbolic evaluation found {} base constraints",
             airs[i].num_constraints().unwrap(),
-            get_symbolic_constraints(
-                airs[i],
-                sym_layout,
-                &all_lookups[i],
-                &lookup_data_to_ext_expr(&lookup_data[i]),
-                &lookup_gadget,
-            )
-            .0
-            .len(),
+            get_symbolic_constraints(airs[i], sym_layout, &all_lookups[i], &lookup_gadget,)
+                .0
+                .len(),
         );
 
         // Get evaluations on quotient domain from the main commitment.
@@ -370,6 +357,10 @@ where
             });
 
         // Compute quotient(x) = constraints(x)/Z_H(x) over quotient_domain, as extension values.
+        let perm_vals: Vec<SC::Challenge> = lookup_data[i]
+            .iter()
+            .map(|ld| ld.expected_cumulated)
+            .collect();
         let q_values = quotient_values::<SC, A, _, LogUpGadget>(
             airs[i],
             &pub_vals[i],
@@ -379,7 +370,7 @@ where
             &trace_on_quotient_domain,
             permutation_on_quotient_domain.as_ref(),
             &all_lookups[i],
-            &lookup_data[i],
+            &perm_vals,
             &lookup_gadget,
             &challenges_per_instance[i],
             preprocessed_on_quotient_domain.as_ref(),
@@ -653,7 +644,7 @@ pub fn quotient_values<SC, A, Mat, LG>(
     trace_on_quotient_domain: &Mat,
     opt_permutation_on_quotient_domain: Option<&Mat>,
     lookups: &[Lookup<Val<SC>>],
-    lookup_data: &[LookupData<SC::Challenge>],
+    permutation_vals: &[SC::Challenge],
     lookup_gadget: &LG,
     permutation_challenges: &[SC::Challenge],
     preprocessed_on_quotient_domain: Option<&Mat>,
@@ -693,13 +684,7 @@ where
         pad(&mut sels.inv_vanishing);
     }
 
-    let constraint_layout = get_constraint_layout(
-        air,
-        layout,
-        lookups,
-        &lookup_data_to_ext_expr(lookup_data),
-        lookup_gadget,
-    );
+    let constraint_layout = get_constraint_layout(air, layout, lookups, lookup_gadget);
     let (base_alpha_powers, ext_alpha_powers) = constraint_layout.decompose_alpha(alpha);
 
     // Precompute per-instance data used by the hot inner loop to avoid repeated allocations.
@@ -707,18 +692,10 @@ where
         .iter()
         .map(|&p_c| PackedChallenge::<SC>::from(p_c))
         .collect();
-    let lookup_data_packed: Vec<LookupData<PackedChallenge<SC>>> = if lookups.is_empty() {
-        Vec::new()
-    } else {
-        lookup_data
-            .iter()
-            .map(|ld| LookupData {
-                name: ld.name.clone(),
-                aux_idx: ld.aux_idx,
-                expected_cumulated: ld.expected_cumulated.into(),
-            })
-            .collect()
-    };
+    let permutation_vals_packed: Vec<PackedChallenge<SC>> = permutation_vals
+        .iter()
+        .map(|&v| PackedChallenge::<SC>::from(v))
+        .collect();
 
     (0..quotient_size)
         .into_par_iter()
@@ -795,14 +772,9 @@ where
                 inner: inner_folder,
                 permutation: permutation.as_view(),
                 permutation_challenges: &packed_perm_challenges,
+                permutation_values: &permutation_vals_packed,
             };
-            A::eval_with_lookups(
-                air,
-                &mut folder,
-                lookups,
-                &lookup_data_packed,
-                lookup_gadget,
-            );
+            A::eval_with_lookups(air, &mut folder, lookups, lookup_gadget);
 
             // quotient(x) = constraints(x) / Z_H(x)
             let quotient = folder.inner.finalize_constraints() * inv_vanishing;

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -1,11 +1,11 @@
 use alloc::vec::Vec;
 
+use p3_air::Air;
 use p3_air::symbolic::{
     AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
 };
-use p3_air::{Air, ExtLeaf, SymbolicExpr};
 use p3_field::{Algebra, ExtensionField, Field};
-use p3_lookup::lookup_traits::{Lookup, LookupData, LookupGadget};
+use p3_lookup::lookup_traits::{Kind, Lookup, LookupGadget};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
@@ -18,7 +18,6 @@ pub fn get_constraint_layout<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
     contexts: &[Lookup<F>],
-    lookup_data: &[LookupData<SymbolicExpressionExt<F, EF>>],
     lookup_gadget: &LG,
 ) -> ConstraintLayout
 where
@@ -30,37 +29,25 @@ where
 {
     let num_aux_cols = contexts.len() * lookup_gadget.num_aux_cols();
     let num_challenges = contexts.len() * lookup_gadget.num_challenges();
+    let num_permutation_values = contexts
+        .iter()
+        .filter(|c| matches!(&c.kind, Kind::Global(_)))
+        .count();
     let layout = AirLayout {
         permutation_width: num_aux_cols,
         num_permutation_challenges: num_challenges,
+        num_permutation_values,
         ..layout
     };
     let mut builder = SymbolicAirBuilder::new(layout);
-    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_data, lookup_gadget);
+    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_gadget);
     builder.constraint_layout()
-}
-
-/// Converts `LookupData<EF>` to `LookupData<SymbolicExpressionExt<F, EF>>`.
-pub fn lookup_data_to_ext_expr<F, EF: Clone>(
-    lookup_data: &[LookupData<EF>],
-) -> Vec<LookupData<SymbolicExpressionExt<F, EF>>> {
-    lookup_data
-        .iter()
-        .map(|data| LookupData {
-            name: data.name.clone(),
-            aux_idx: data.aux_idx,
-            expected_cumulated: SymbolicExpr::Leaf(ExtLeaf::ExtConstant(
-                data.expected_cumulated.clone(),
-            )),
-        })
-        .collect()
 }
 
 pub fn get_log_num_quotient_chunks<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
     contexts: &[Lookup<F>],
-    lookup_data: &[LookupData<SymbolicExpressionExt<F, EF>>],
     is_zk: usize,
     lookup_gadget: &LG,
 ) -> usize
@@ -85,8 +72,7 @@ where
 
         debug_assert!(
             {
-                let actual =
-                    get_max_constraint_degree(air, layout, contexts, lookup_data, lookup_gadget);
+                let actual = get_max_constraint_degree(air, layout, contexts, lookup_gadget);
                 max_degree >= actual
             },
             "max_constraint_degree() hint {} with lookup degree {} is too small; \
@@ -100,8 +86,7 @@ where
 
     // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
     let constraint_degree =
-        (get_max_constraint_degree(air, layout, contexts, lookup_data, lookup_gadget) + is_zk)
-            .max(2);
+        (get_max_constraint_degree(air, layout, contexts, lookup_gadget) + is_zk).max(2);
 
     // The quotient's actual degree is approximately (max_constraint_degree - 1) n,
     // where subtracting 1 comes from division by the vanishing polynomial.
@@ -114,7 +99,6 @@ pub fn get_max_constraint_degree<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
     contexts: &[Lookup<F>],
-    lookup_data: &[LookupData<SymbolicExpressionExt<F, EF>>],
     lookup_gadget: &LG,
 ) -> usize
 where
@@ -124,8 +108,7 @@ where
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupGadget,
 {
-    let (base, extension) =
-        get_symbolic_constraints(air, layout, contexts, lookup_data, lookup_gadget);
+    let (base, extension) = get_symbolic_constraints(air, layout, contexts, lookup_gadget);
     let base_degree = base.iter().map(|c| c.degree_multiple()).max().unwrap_or(0);
     let extension_degree = extension
         .iter()
@@ -140,7 +123,6 @@ pub fn get_symbolic_constraints<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
     contexts: &[Lookup<F>],
-    lookup_data: &[LookupData<SymbolicExpressionExt<F, EF>>],
     lookup_gadget: &LG,
 ) -> (
     Vec<SymbolicExpression<F>>,
@@ -156,15 +138,20 @@ where
     let num_lookups = contexts.len();
     let num_aux_cols = num_lookups * lookup_gadget.num_aux_cols();
     let num_challenges = num_lookups * lookup_gadget.num_challenges();
+    let num_permutation_values = contexts
+        .iter()
+        .filter(|c| matches!(&c.kind, Kind::Global(_)))
+        .count();
     let layout = AirLayout {
         permutation_width: num_aux_cols,
         num_permutation_challenges: num_challenges,
+        num_permutation_values,
         ..layout
     };
     let mut builder = SymbolicAirBuilder::new(layout);
 
     // Evaluate AIR and lookup constraints.
-    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_data, lookup_gadget);
+    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_gadget);
     let base_constraints = builder.base_constraints();
     let extension_constraints = builder.extension_constraints();
     (base_constraints, extension_constraints)

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -11,7 +11,7 @@ use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, PrimeCharacteristicRing};
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::lookup_traits::{Lookup, LookupData, LookupError, LookupGadget};
+use p3_lookup::lookup_traits::{Lookup, LookupError, LookupGadget};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use p3_uni_stark::{VerificationError, VerifierConstraintFolder, recompose_quotient_from_chunks};
@@ -23,7 +23,7 @@ use crate::config::{
     Challenge, Domain, PcsError, StarkGenericConfig as SGC, Val, observe_instance_binding,
 };
 use crate::proof::BatchProof;
-use crate::symbolic::{get_log_num_quotient_chunks, lookup_data_to_ext_expr};
+use crate::symbolic::get_log_num_quotient_chunks;
 
 #[instrument(skip_all)]
 pub fn verify_batch<SC, A>(
@@ -109,7 +109,6 @@ where
                     air,
                     layout,
                     &all_lookups[i],
-                    &lookup_data_to_ext_expr(&global_lookup_data[i]),
                     config.is_zk(),
                     &lookup_gadget,
                 )
@@ -508,6 +507,10 @@ where
                 &pre_next_zeros
             }
         };
+        let perm_vals: Vec<SC::Challenge> = global_lookup_data[i]
+            .iter()
+            .map(|ld| ld.expected_cumulated)
+            .collect();
         let verifier_data = VerifierData {
             trace_local: &opened_values.instances[i].base_opened_values.trace_local,
             trace_next: trace_next_ref,
@@ -520,7 +523,7 @@ where
             permutation_local: &perm_local_ext,
             permutation_next: &perm_next_ext,
             permutation_challenges: &challenges_per_instance[i],
-            lookup_data: &proof.global_lookup_data[i],
+            permutation_values: &perm_vals,
             lookups: &all_lookups[i],
             public_values: &public_values[i],
             trace_domain: init_trace_domain,
@@ -583,8 +586,8 @@ pub struct VerifierData<'a, SC: SGC> {
     permutation_next: &'a [SC::Challenge],
     // Challenges used for the lookup argument
     permutation_challenges: &'a [SC::Challenge],
-    // Lookup data needed for global lookup verification
-    lookup_data: &'a [LookupData<SC::Challenge>],
+    // Expected cumulated values for global lookup arguments
+    permutation_values: &'a [SC::Challenge],
     // Lookup contexts for this instance
     lookups: &'a [Lookup<Val<SC>>],
     // Public values for this instance
@@ -617,7 +620,7 @@ where
         permutation_local,
         permutation_next,
         permutation_challenges,
-        lookup_data,
+        permutation_values,
         lookups,
         public_values,
         trace_domain,
@@ -655,9 +658,10 @@ where
             RowMajorMatrixView::new_row(permutation_next),
         ),
         permutation_challenges,
+        permutation_values,
     };
     // Evaluate AIR and lookup constraints.
-    A::eval_with_lookups(air, &mut folder, lookups, lookup_data, lookup_gadget);
+    A::eval_with_lookups(air, &mut folder, lookups, lookup_gadget);
     let folded_constraints = folder.inner.accumulator;
 
     // Check that constraints(zeta) / Z_H(zeta) = quotient(zeta)

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -262,6 +262,8 @@ impl<'a, F: Field> PermutationAirBuilder for MiniLookupBuilder<'a, F> {
 
     type RandomVar = F;
 
+    type PermutationVar = F;
+
     fn permutation(&self) -> Self::MP {
         // Empty 0-width view; permutation columns are not needed for debug evals.
         VerticalPair::new(
@@ -272,5 +274,9 @@ impl<'a, F: Field> PermutationAirBuilder for MiniLookupBuilder<'a, F> {
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
         self.permutation_challenges
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        &[]
     }
 }

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -10,6 +10,7 @@ pub struct ProverConstraintFolderWithLookups<'a, SC: StarkGenericConfig> {
     pub inner: ProverConstraintFolder<'a, SC>,
     pub permutation: RowMajorMatrixView<'a, PackedChallenge<SC>>,
     pub permutation_challenges: &'a [PackedChallenge<SC>],
+    pub permutation_values: &'a [PackedChallenge<SC>],
 }
 
 impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookups<'a, SC> {
@@ -85,6 +86,9 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
     type MP = RowMajorMatrixView<'a, PackedChallenge<SC>>;
 
     type RandomVar = PackedChallenge<SC>;
+
+    type PermutationVar = PackedChallenge<SC>;
+
     fn permutation(&self) -> RowMajorMatrixView<'a, PackedChallenge<SC>> {
         self.permutation
     }
@@ -92,12 +96,17 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
     fn permutation_randomness(&self) -> &[PackedChallenge<SC>] {
         self.permutation_challenges
     }
+
+    fn permutation_values(&self) -> &[PackedChallenge<SC>] {
+        self.permutation_values
+    }
 }
 
 pub struct VerifierConstraintFolderWithLookups<'a, SC: StarkGenericConfig> {
     pub inner: VerifierConstraintFolder<'a, SC>,
     pub permutation: ViewPair<'a, SC::Challenge>,
     pub permutation_challenges: &'a [SC::Challenge],
+    pub permutation_values: &'a [SC::Challenge],
 }
 
 impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLookups<'a, SC> {
@@ -175,11 +184,17 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
 
     type RandomVar = SC::Challenge;
 
+    type PermutationVar = SC::Challenge;
+
     fn permutation(&self) -> ViewPair<'a, SC::Challenge> {
         self.permutation
     }
 
     fn permutation_randomness(&self) -> &[SC::Challenge] {
         self.permutation_challenges
+    }
+
+    fn permutation_values(&self) -> &[SC::Challenge] {
+        self.permutation_values
     }
 }

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -1,5 +1,3 @@
-use alloc::vec::Vec;
-
 use p3_air::lookup::LookupEvaluator;
 /// Public re-exports of lookup types.
 pub use p3_air::lookup::{Direction, Kind, Lookup, LookupData, LookupError, LookupInput};
@@ -12,24 +10,6 @@ use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{StarkGenericConfig, Val};
 use tracing::warn;
-
-/// Converts `LookupData<F>` to `LookupData<SymbolicExpression<F>>`.
-pub fn lookup_data_to_expr<F: Clone>(
-    lookup_data: &[LookupData<F>],
-) -> Vec<LookupData<SymbolicExpression<F>>> {
-    lookup_data
-        .iter()
-        .map(|data| {
-            let expected =
-                SymbolicExpression::Leaf(BaseLeaf::Constant(data.expected_cumulated.clone()));
-            LookupData {
-                name: data.name.clone(),
-                aux_idx: data.aux_idx,
-                expected_cumulated: expected,
-            }
-        })
-        .collect()
-}
 
 /// A trait for lookup argument.
 pub trait LookupGadget: LookupEvaluator {
@@ -156,12 +136,19 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder for LookupTraceBuilder<'a
     type MP = RowMajorMatrixView<'a, SC::Challenge>;
 
     type RandomVar = SC::Challenge;
+
+    type PermutationVar = SC::Challenge;
+
     fn permutation(&self) -> RowMajorMatrixView<'a, SC::Challenge> {
         panic!("we should not be accessing the permutation matrix while building it");
     }
 
     fn permutation_randomness(&self) -> &[SC::Challenge] {
         self.permutation_challenges
+    }
+
+    fn permutation_values(&self) -> &[SC::Challenge] {
+        &[]
     }
 }
 

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -226,6 +226,7 @@ impl ExtensionBuilder for MockAirBuilder {
 impl PermutationAirBuilder for MockAirBuilder {
     type MP = RowMajorMatrix<EF>;
     type RandomVar = EF;
+    type PermutationVar = EF;
 
     fn permutation(&self) -> Self::MP {
         self.window(&self.permutation)
@@ -233,6 +234,10 @@ impl PermutationAirBuilder for MockAirBuilder {
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
         &self.challenges
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        &[]
     }
 }
 


### PR DESCRIPTION
Builds on top #1390 

Adds the ability to access permutation values (such as cumulative logUp sums) in the AirBuilder. 