### PR TITLE
Move Lookup-related Air to `batch-stark` and `lookup`

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -12,7 +12,6 @@ categories.workspace = true
 [dependencies]
 p3-field.workspace = true
 p3-matrix.workspace = true
-serde = { workspace = true, features = ["derive", "alloc"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,11 +1,8 @@
-use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::{Add, Mul, Sub};
 
 use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
-
-use crate::lookup::{Kind, Lookup, LookupEvaluator, LookupInput};
 
 /// Read access to a pair of trace rows (typically current and next).
 ///
@@ -221,87 +218,15 @@ pub trait BaseAir<F>: Sync {
 /// constraint will compute a particular value or it can be applied symbolically
 /// with each constraint computing a symbolic expression.
 pub trait Air<AB: AirBuilder>: BaseAir<AB::F> {
-    /// Update the number of auxiliary columns to account for a new lookup column,
-    /// and return its index (or indices).
-    ///
-    /// Default implementation returns an empty vector, indicating no lookup columns.
-    /// Override this method for AIRs that use lookups.
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        vec![]
-    }
-
-    /// Register all lookups for the current AIR and return them.
-    ///
-    /// Default implementation returns an empty vector, indicating no lookups.
-    /// Override this method for AIRs that use lookups.
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>>
-    where
-        AB: PermutationAirBuilder,
-    {
-        vec![]
-    }
-
-    /// Register a lookup to be used in this AIR.
-    /// This method can be used before proving or verifying, as the resulting
-    /// data is shared between the prover and the verifier.
-    fn register_lookup(&mut self, kind: Kind, lookup_inputs: &[LookupInput<AB::F>]) -> Lookup<AB::F>
-    where
-        AB: PermutationAirBuilder,
-    {
-        let (element_exprs, multiplicities_exprs) = lookup_inputs
-            .iter()
-            .map(|(elems, mult, dir)| {
-                let multiplicity = dir.multiplicity(mult.clone());
-                (elems.clone(), multiplicity)
-            })
-            .unzip();
-
-        Lookup {
-            kind,
-            element_exprs,
-            multiplicities_exprs,
-            columns: self.add_lookup_columns(),
-        }
-    }
-
     /// Evaluate all AIR constraints using the provided builder.
     ///
     /// The builder provides both the trace on which the constraints
     /// are evaluated on as well as the method of accumulating the
     /// constraint evaluations.
     ///
-    /// **Note**: Users do not need to specify lookup constraints evaluation in this method,
-    /// but instead only specify the AIR constraints and rely on `eval_with_lookups` to evaluate
-    /// both AIR and lookup constraints.
-    ///
     /// # Arguments
     /// - `builder`: Mutable reference to an `AirBuilder` for defining constraints.
     fn eval(&self, builder: &mut AB);
-
-    /// Evaluate all AIR and lookup constraints using the provided builder.
-    ///
-    /// The default implementation calls `eval` and then evaluates lookups if any are provided,
-    /// using the provided lookup evaluator.
-    /// Users typically don't need to override this method unless they need a custom behavior.
-    ///
-    /// # Arguments
-    /// - `builder`: Mutable reference to an `AirBuilder` for defining constraints.
-    /// - `lookups`: References to the lookups to be evaluated.
-    /// - `lookup_evaluator`: Reference to the lookup evaluator to be used for evaluation.
-    fn eval_with_lookups<LE: LookupEvaluator>(
-        &self,
-        builder: &mut AB,
-        lookups: &[Lookup<AB::F>],
-        lookup_evaluator: &LE,
-    ) where
-        AB: PermutationAirBuilder,
-    {
-        self.eval(builder);
-
-        if !lookups.is_empty() {
-            lookup_evaluator.eval_lookups(builder, lookups);
-        }
-    }
 }
 
 /// A builder which contains both a trace on which AIR constraints can be evaluated as well as a method of accumulating the AIR constraint evaluations.

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 
 mod air;
 mod check_constraints;
-pub mod lookup;
 pub mod symbolic;
 pub mod utils;
 mod virtual_column;

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 
 use p3_air::{Air, DebugConstraintBuilder};
 use p3_field::{ExtensionField, Field};
+use p3_lookup::AirWithLookups;
 use p3_lookup::lookup_traits::{Lookup, LookupGadget};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -16,6 +16,7 @@ use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpressionExt};
 use p3_challenger::FieldChallenger;
 use p3_commit::Pcs;
 use p3_field::{Algebra, BasedVectorSpace};
+use p3_lookup::LookupAir;
 use p3_lookup::lookup_traits::{Kind, Lookup, LookupGadget};
 use p3_matrix::Matrix;
 use p3_uni_stark::Val;
@@ -161,7 +162,7 @@ where
     pub fn from_instances<A>(config: &SC, instances: &[StarkInstance<'_, SC, A>]) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + Clone,
+        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + LookupAir<Val<SC>> + Clone,
     {
         let degrees: Vec<usize> = instances.iter().map(|i| i.trace.height()).collect();
         let log_ext_degrees: Vec<usize> = degrees
@@ -189,7 +190,7 @@ where
     ) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>,
+        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + LookupAir<Val<SC>>,
     {
         assert_eq!(
             airs.len(),

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -10,6 +10,7 @@ use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{
     Algebra, BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
 };
+use p3_lookup::AirWithLookups;
 use p3_lookup::folder::ProverConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::lookup_traits::{Kind, Lookup, LookupData, LookupGadget};
@@ -776,7 +777,7 @@ where
                 permutation_challenges: &packed_perm_challenges,
                 permutation_values: &permutation_vals_packed,
             };
-            A::eval_with_lookups(air, &mut folder, lookups, lookup_gadget);
+            air.eval_with_lookups(&mut folder, lookups, lookup_gadget);
 
             // quotient(x) = constraints(x) / Z_H(x)
             let quotient = folder.inner.finalize_constraints() * inv_vanishing;

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -5,6 +5,7 @@ use p3_air::symbolic::{
     AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
 };
 use p3_field::{Algebra, ExtensionField, Field};
+use p3_lookup::AirWithLookups;
 use p3_lookup::lookup_traits::{Kind, Lookup, LookupGadget};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
@@ -40,7 +41,7 @@ where
         ..layout
     };
     let mut builder = SymbolicAirBuilder::new(layout);
-    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_gadget);
+    air.eval_with_lookups(&mut builder, contexts, lookup_gadget);
     builder.constraint_layout()
 }
 
@@ -151,7 +152,7 @@ where
     let mut builder = SymbolicAirBuilder::new(layout);
 
     // Evaluate AIR and lookup constraints.
-    <A as Air<_>>::eval_with_lookups(air, &mut builder, contexts, lookup_gadget);
+    air.eval_with_lookups(&mut builder, contexts, lookup_gadget);
     let base_constraints = builder.base_constraints();
     let extension_constraints = builder.extension_constraints();
     (base_constraints, extension_constraints)

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -1,6 +1,6 @@
 use alloc::string::String;
-use alloc::vec;
 use alloc::vec::Vec;
+use alloc::{format, vec};
 use core::fmt::Debug;
 
 use hashbrown::HashMap;
@@ -9,9 +9,10 @@ use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, PrimeCharacteristicRing};
+use p3_lookup::AirWithLookups;
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::lookup_traits::{Lookup, LookupError, LookupGadget};
+use p3_lookup::lookup_traits::{Lookup, LookupGadget};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use p3_uni_stark::{VerificationError, VerifierConstraintFolder, recompose_quotient_from_chunks};
@@ -556,11 +557,7 @@ where
     for (name, all_expected_cumulative) in global_cumulative {
         lookup_gadget
             .verify_global_final_value(&all_expected_cumulative)
-            .map_err(|_| {
-                VerificationError::LookupError(LookupError::GlobalCumulativeMismatch(Some(
-                    name.clone(),
-                )))
-            })?;
+            .map_err(|e| VerificationError::LookupError(format!("{e:?}: {name}")))?;
     }
 
     Ok(())
@@ -664,7 +661,7 @@ where
         permutation_values,
     };
     // Evaluate AIR and lookup constraints.
-    A::eval_with_lookups(air, &mut folder, lookups, lookup_gadget);
+    air.eval_with_lookups(&mut folder, lookups, lookup_gadget);
     let folded_constraints = folder.inner.accumulator;
 
     // Check that constraints(zeta) / Z_H(zeta) = quotient(zeta)

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -16,6 +16,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs, create_test_fri_params};
 use p3_keccak::Keccak256Hash;
+use p3_lookup::LookupAir;
 use p3_lookup::lookup_traits::{Direction, Kind, Lookup};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
@@ -177,6 +178,7 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
         }
     }
 }
+impl<F: Field> LookupAir<F> for MulAir {}
 
 // --- MulAirLookups structure for local and global lookups ---
 // This AIR is a `MulAir` that can register global lookups with `FibAirLookups`, as well as local lookups with a lookup column. Its inputs are the Fibonacci values.
@@ -226,19 +228,25 @@ where
     AB::Var: Debug,
     AB: AirBuilder + PermutationAirBuilder,
 {
+    fn eval(&self, builder: &mut AB) {
+        self.air.eval(builder);
+    }
+}
+
+impl<F: Field> LookupAir<F> for MulAirLookups {
     fn add_lookup_columns(&mut self) -> Vec<usize> {
         let new_idx = self.num_lookups;
         self.num_lookups += 1;
         vec![new_idx]
     }
 
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
         let mut lookups = Vec::new();
         self.num_lookups = 0;
 
         // Create symbolic air builder to access symbolic variables
-        let symbolic_air_builder = SymbolicAirBuilder::<AB::F>::new(AirLayout {
-            main_width: BaseAir::<AB::F>::width(self),
+        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
+            main_width: BaseAir::<F>::width(self),
             ..Default::default()
         });
         let symbolic_main = symbolic_air_builder.main();
@@ -261,18 +269,18 @@ where
                     // Lookup for 'a' against a permuted column.
                     (
                         vec![a.into()],
-                        SymbolicExpression::Leaf(BaseLeaf::Constant(AB::F::ONE)),
+                        SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
                         Direction::Receive,
                     ),
                     // Provide the range values (this would be done in the trace generation)
                     (
                         vec![lut.into()], // This represents the range values
-                        SymbolicExpression::Leaf(BaseLeaf::Constant(AB::F::ONE)),
+                        SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
                         Direction::Send,
                     ),
                 ];
 
-                let local_lookup = Air::<AB>::register_lookup(self, Kind::Local, &lookup_inputs);
+                let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
                 lookups.push(local_lookup);
             }
 
@@ -285,11 +293,11 @@ where
                 // Global lookup between MulAir inputs and FibAir inputs
                 let lookup_inputs = vec![(
                     vec![a.into(), b.into()],
-                    SymbolicExpression::Leaf(BaseLeaf::Constant(AB::F::ONE)),
+                    SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
                     Direction::Send, // MulAir sends data to the global lookup
                 )];
 
-                let global_lookup = Air::<AB>::register_lookup(
+                let global_lookup = LookupAir::register_lookup(
                     self,
                     Kind::Global(self.global_names[rep].clone()),
                     &lookup_inputs,
@@ -299,10 +307,6 @@ where
         }
 
         lookups
-    }
-
-    fn eval(&self, builder: &mut AB) {
-        self.air.eval(builder);
     }
 }
 
@@ -394,20 +398,26 @@ impl<F: Field> BaseAir<F> for FibAirLookups {
 }
 
 impl<AB: PermutationAirBuilder> Air<AB> for FibAirLookups {
+    fn eval(&self, builder: &mut AB) {
+        self.air.eval(builder);
+    }
+}
+
+impl<F: Field> LookupAir<F> for FibAirLookups {
     fn add_lookup_columns(&mut self) -> Vec<usize> {
         let new_idx = self.num_lookups;
         self.num_lookups += 1;
         vec![new_idx]
     }
 
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
         let mut lookups = Vec::new();
         self.num_lookups = 0;
 
         if self.is_global {
             // Create symbolic air builder to access symbolic variables
-            let symbolic_air_builder = SymbolicAirBuilder::<AB::F>::new(AirLayout {
-                main_width: BaseAir::<AB::F>::width(self),
+            let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
+                main_width: BaseAir::<F>::width(self),
                 num_public_values: 3,
                 ..Default::default()
             });
@@ -427,20 +437,16 @@ impl<AB: PermutationAirBuilder> Air<AB> for FibAirLookups {
             // Global lookup between FibAir inputs and MulAir inputs
             let lookup_inputs = vec![(
                 vec![left.into(), right.into()],
-                SymbolicExpression::Leaf(BaseLeaf::Constant(AB::F::from_u64(multiplicity))),
+                SymbolicExpression::Leaf(BaseLeaf::Constant(F::from_u64(multiplicity))),
                 Direction::Receive, // FibAir receives data from the global lookup
             )];
 
             let global_lookup =
-                Air::<AB>::register_lookup(self, Kind::Global(name), &lookup_inputs);
+                LookupAir::register_lookup(self, Kind::Global(name), &lookup_inputs);
             lookups.push(global_lookup);
         }
 
         lookups
-    }
-
-    fn eval(&self, builder: &mut AB) {
-        self.air.eval(builder);
     }
 }
 
@@ -493,6 +499,7 @@ where
         );
     }
 }
+impl<F: Field> LookupAir<F> for PreprocessedMulAir {}
 
 fn preprocessed_mul_trace<F: Field>(rows: usize, multiplier: u64) -> RowMajorMatrix<F> {
     assert!(rows.is_power_of_two());
@@ -697,24 +704,26 @@ impl<AB: PermutationAirBuilder> Air<AB> for DemoAirWithLookups
 where
     AB::Var: Debug,
 {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        match self {
-            Self::FibLookups(a) => <FibAirLookups as Air<AB>>::add_lookup_columns(a),
-            Self::MulLookups(a) => <MulAirLookups as Air<AB>>::add_lookup_columns(a),
-        }
-    }
-
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
-        match self {
-            Self::FibLookups(a) => <FibAirLookups as Air<AB>>::get_lookups(a),
-            Self::MulLookups(a) => <MulAirLookups as Air<AB>>::get_lookups(a),
-        }
-    }
-
     fn eval(&self, builder: &mut AB) {
         match self {
             Self::FibLookups(a) => <FibAirLookups as Air<AB>>::eval(a, builder),
             Self::MulLookups(a) => <MulAirLookups as Air<AB>>::eval(a, builder),
+        }
+    }
+}
+
+impl<F: Field> LookupAir<F> for DemoAirWithLookups {
+    fn add_lookup_columns(&mut self) -> Vec<usize> {
+        match self {
+            Self::FibLookups(a) => LookupAir::<F>::add_lookup_columns(a),
+            Self::MulLookups(a) => LookupAir::<F>::add_lookup_columns(a),
+        }
+    }
+
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
+        match self {
+            Self::FibLookups(a) => LookupAir::<F>::get_lookups(a),
+            Self::MulLookups(a) => LookupAir::<F>::get_lookups(a),
         }
     }
 }
@@ -732,6 +741,7 @@ where
         }
     }
 }
+impl<F: PrimeField64> LookupAir<F> for DemoAir {}
 
 /// Creates a Fibonacci instance with specified log height.
 fn create_fib_instance(log_height: usize) -> (DemoAir, RowMajorMatrix<Val>, Vec<Val>) {
@@ -2105,19 +2115,25 @@ where
     AB::Var: Debug,
     AB: AirBuilder + PermutationAirBuilder,
 {
+    fn eval(&self, _builder: &mut AB) {
+        // No additional constraints needed for this simple table
+    }
+}
+
+impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
     fn add_lookup_columns(&mut self) -> Vec<usize> {
         let new_idx = self.num_lookups;
         self.num_lookups += 1;
         vec![new_idx]
     }
 
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
         let mut lookups = Vec::new();
         self.num_lookups = 0;
 
         // Create symbolic air builder to access symbolic variables
-        let symbolic_air_builder = SymbolicAirBuilder::<AB::F>::new(AirLayout {
-            main_width: BaseAir::<AB::F>::width(self),
+        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
+            main_width: BaseAir::<F>::width(self),
             ..Default::default()
         });
         let symbolic_main = symbolic_air_builder.main();
@@ -2185,15 +2201,11 @@ where
         let all_lookup_inputs = vec![lookup_inputs1, lookup_inputs2, lookup_inputs3];
 
         for lookup_inputs in all_lookup_inputs {
-            let local_lookup = Air::<AB>::register_lookup(self, Kind::Local, &lookup_inputs);
+            let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
             lookups.push(local_lookup);
         }
 
         lookups
-    }
-
-    fn eval(&self, _builder: &mut AB) {
-        // No additional constraints needed for this simple table
     }
 }
 

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -15,6 +15,7 @@ p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
 p3-uni-stark = { workspace = true }
+serde = { workspace = true, features = ["derive", "alloc"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -10,3 +10,6 @@ pub mod logup;
 pub mod lookup_traits;
 #[cfg(test)]
 mod tests;
+mod types;
+
+pub use types::*;

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -20,7 +20,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::lookup::{LookupError, LookupEvaluator};
 use p3_air::{ExtensionBuilder, PermutationAirBuilder, WindowAccess};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
@@ -33,6 +32,7 @@ use tracing::instrument;
 use crate::lookup_traits::{
     Kind, Lookup, LookupData, LookupGadget, LookupTraceBuilder, symbolic_to_expr,
 };
+use crate::types::{LookupError, LookupEvaluator};
 
 /// Core LogUp gadget implementing lookup arguments via logarithmic derivatives.
 ///

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -1,6 +1,3 @@
-use p3_air::lookup::LookupEvaluator;
-/// Public re-exports of lookup types.
-pub use p3_air::lookup::{Direction, Kind, Lookup, LookupData, LookupError, LookupInput};
 use p3_air::{
     AirBuilder, BaseEntry, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, RowWindow,
     SymbolicExpression, WindowAccess,
@@ -10,6 +7,10 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{StarkGenericConfig, Val};
 use tracing::warn;
+
+pub use crate::types::{
+    Direction, Kind, Lookup, LookupData, LookupError, LookupEvaluator, LookupInput,
+};
 
 /// A trait for lookup argument.
 pub trait LookupGadget: LookupEvaluator {

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -3,7 +3,6 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::lookup::LookupEvaluator;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{
     Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, WindowAccess,
@@ -18,6 +17,7 @@ use rand::{RngExt, SeedableRng};
 
 use crate::logup::LogUpGadget;
 use crate::lookup_traits::{Direction, Kind, Lookup, LookupGadget, symbolic_to_expr};
+use crate::types::{LookupAir, LookupEvaluator};
 
 /// Base field type for the test
 type F = BabyBear;
@@ -280,6 +280,12 @@ where
     AB::ExprEF: From<AB::Var> + From<F>,
     F: Copy + Into<AB::ExprEF>,
 {
+    fn eval(&self, _builder: &mut AB) {
+        // There are no constraints, only lookups for the range checks.
+    }
+}
+
+impl LookupAir<F> for RangeCheckAir {
     fn add_lookup_columns(&mut self) -> Vec<usize> {
         let new_idx = self.cur_num_lookups;
         self.cur_num_lookups += 1;
@@ -287,9 +293,9 @@ where
         vec![new_idx]
     }
 
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
         let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<AB::F>::width(self),
+            main_width: BaseAir::<F>::width(self),
             ..Default::default()
         });
 
@@ -319,13 +325,9 @@ where
                 ];
 
                 // Register the local lookup.
-                Air::<AB>::register_lookup(self, Kind::Local, &lookup_inputs)
+                LookupAir::register_lookup(self, Kind::Local, &lookup_inputs)
             })
             .collect::<Vec<_>>()
-    }
-
-    fn eval(&self, _builder: &mut AB) {
-        // There are no constraints, only lookups for the range checks.
     }
 }
 
@@ -643,7 +645,7 @@ fn test_range_check_end_to_end_valid() {
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, challenges.to_vec());
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Check that the lookup was created correctly.
     assert_eq!(lookups.len(), 1, "Should have one lookup defined");
@@ -759,7 +761,7 @@ fn test_range_check_end_to_end_invalid() {
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, vec![alpha, beta]);
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Evaluate constraints.
     //
@@ -826,7 +828,7 @@ fn test_inconsistent_witness_fails_transition() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Evaluate the constraints.
     for i in 0..builder.height {
@@ -882,7 +884,7 @@ fn test_zero_multiplicity_is_not_counted() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // The initial boundary constraint will fail on row 0 since s[0] is incorrect.
     //
@@ -906,7 +908,7 @@ fn test_empty_lookup_is_valid() {
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, vec![alpha]);
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // This should not panic, as there are no rows to evaluate.
     for i in 0..builder.height {
@@ -995,7 +997,7 @@ fn test_nontrivial_permutation() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Evaluate constraints for every row
     for i in 0..builder.height {
@@ -1110,7 +1112,7 @@ fn test_multiple_lookups_different_columns() {
 
     // Register lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <RangeCheckAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Check that the lookup was created correctly.
     assert_eq!(lookups.len(), 2, "Should have two lookups defined");
@@ -1175,6 +1177,12 @@ where
     AB::ExprEF: From<AB::Var> + From<F>,
     F: Copy + Into<AB::ExprEF>,
 {
+    fn eval(&self, _builder: &mut AB) {
+        // No constraints, only lookups
+    }
+}
+
+impl LookupAir<F> for AddAir {
     fn add_lookup_columns(&mut self) -> Vec<usize> {
         let new_idx = self.num_lookups;
         self.num_lookups += 1;
@@ -1182,16 +1190,16 @@ where
         vec![new_idx]
     }
 
-    fn get_lookups(&mut self) -> Vec<Lookup<AB::F>> {
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
         let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<AB::F>::width(self),
+            main_width: BaseAir::<F>::width(self),
             ..Default::default()
         });
 
         let symbolic_main = symbolic_air_builder.main();
         let symbolic_main_local = symbolic_main.current_slice();
 
-        // Extract columns for thelookup entries: [inp1, inp2, sum]
+        // Extract columns for the lookup entries: [inp1, inp2, sum]
         let inp1 = symbolic_main_local[0];
         let inp2 = symbolic_main_local[1];
         let sum = symbolic_main_local[2];
@@ -1213,7 +1221,7 @@ where
             (b_elements.clone(), b_multiplicities, Direction::Send),
         ];
 
-        let local_lookup = Air::<AB>::register_lookup(self, Kind::Local, &lookup_inputs);
+        let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
 
         // also need is_send
         let (is_global, direction) = self.with_global;
@@ -1224,16 +1232,12 @@ where
                 direction,
             )];
             let global_lookup =
-                Air::<AB>::register_lookup(self, Kind::Global("LUT".to_string()), &lookup_inputs);
+                LookupAir::register_lookup(self, Kind::Global("LUT".to_string()), &lookup_inputs);
             // Return the local and global lookups.
             return vec![local_lookup, global_lookup];
         }
         // Return the local lookup.
         vec![local_lookup]
-    }
-
-    fn eval(&self, _builder: &mut AB) {
-        // No constraints, only lookups
     }
 }
 
@@ -1283,7 +1287,7 @@ fn test_tuple_lookup() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = <AddAir as Air<MockAirBuilder>>::get_lookups(&mut air);
+    let lookups = LookupAir::get_lookups(&mut air);
 
     // Evaluate the constraints for every row.
     for i in 0..builder.height {
@@ -1420,8 +1424,8 @@ fn test_global_lookup() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups1 = <AddAir as Air<MockAirBuilder>>::get_lookups(&mut air1);
-    let lookups2 = <AddAir as Air<MockAirBuilder>>::get_lookups(&mut air2);
+    let lookups1 = LookupAir::get_lookups(&mut air1);
+    let lookups2 = LookupAir::get_lookups(&mut air2);
 
     assert_eq!(
         builder1.height, builder2.height,

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -1,13 +1,16 @@
-//! Lookup Arguments for STARKs
+//! Core lookup types and traits.
+//!
+//! These types define the data structures for lookup arguments in STARKs.
+//! They were previously in `p3-air` but live here to keep the `Air` trait
+//! free of lookup concerns.
 
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::ops::Neg;
 
+use p3_air::{Air, PermutationAirBuilder, SymbolicExpression};
 use p3_field::Field;
 use serde::{Deserialize, Serialize};
-
-use crate::{PermutationAirBuilder, SymbolicExpression};
 
 /// Defines errors that can occur during lookup verification.
 #[derive(Debug)]
@@ -66,7 +69,7 @@ pub struct LookupData<F> {
 ///
 /// # Example
 /// ```ignored
-/// use p3_air::lookup::{LookupInput, Direction};
+/// use p3_lookup::{LookupInput, Direction};
 /// use p3_air::SymbolicExpression;
 ///
 /// let lookup_input: LookupInput<SymbolicExpression<F>> = (
@@ -77,8 +80,8 @@ pub struct LookupData<F> {
 /// ```
 pub type LookupInput<F> = (Vec<SymbolicExpression<F>>, SymbolicExpression<F>, Direction);
 
-/// A structure that holds the lookup data necessary to generate lookup contexts
-/// via [`LookupTraceBuilder`]. It is shared between the prover and the verifier.
+/// A structure that holds the lookup data necessary to generate lookup contexts.
+/// It is shared between the prover and the verifier.
 #[derive(Clone, Debug)]
 pub struct Lookup<F: Field> {
     /// Type of lookup: local or global
@@ -117,7 +120,6 @@ impl<F: Field> Lookup<F> {
 }
 
 /// Trait for evaluating lookup constraints.
-/// This is the core interface needed by [`Air::eval_with_lookups`](crate::Air::eval_with_lookups).
 pub trait LookupEvaluator {
     /// Returns the number of auxiliary columns needed by this lookup protocol.
     ///
@@ -186,3 +188,74 @@ pub trait LookupEvaluator {
         );
     }
 }
+
+/// Extension trait for AIRs that use lookups.
+///
+/// This decouples lookup definition from the core [`Air`] trait, so AIRs
+/// that don't use lookups don't need to know about lookup types at all.
+pub trait LookupAir<F: Field> {
+    /// Allocate auxiliary columns for a new lookup and return their indices.
+    ///
+    /// Default implementation returns an empty vector, indicating no lookup columns.
+    fn add_lookup_columns(&mut self) -> Vec<usize> {
+        Vec::new()
+    }
+
+    /// Return all lookups registered by this AIR.
+    ///
+    /// Default implementation returns an empty vector, indicating no lookups.
+    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
+        Vec::new()
+    }
+
+    /// Register a lookup to be used in this AIR.
+    ///
+    /// This is a convenience method that constructs a [`Lookup`] from inputs
+    /// and allocates auxiliary columns via [`add_lookup_columns`](Self::add_lookup_columns).
+    fn register_lookup(&mut self, kind: Kind, lookup_inputs: &[LookupInput<F>]) -> Lookup<F> {
+        let (element_exprs, multiplicities_exprs) = lookup_inputs
+            .iter()
+            .map(|(elems, mult, dir)| {
+                let multiplicity = dir.multiplicity(mult.clone());
+                (elems.clone(), multiplicity)
+            })
+            .unzip();
+
+        Lookup {
+            kind,
+            element_exprs,
+            multiplicities_exprs,
+            columns: self.add_lookup_columns(),
+        }
+    }
+}
+
+/// Extension of [`Air`] that adds lookup constraint evaluation.
+///
+/// This trait is blanket-implemented for every type that implements [`Air`],
+/// so any AIR automatically supports `eval_with_lookups`. It lives in
+/// `p3-lookup` (rather than `p3-air`) to keep the core `Air` trait free of
+/// lookup concerns.
+pub trait AirWithLookups<AB: PermutationAirBuilder>: Air<AB> {
+    /// Evaluate both AIR constraints and lookup constraints.
+    ///
+    /// First evaluates the core AIR constraints via [`Air::eval`], then
+    /// evaluates any lookup constraints via the provided [`LookupEvaluator`].
+    ///
+    /// For AIRs without lookups, pass an empty `lookups` slice and the
+    /// evaluator will be skipped entirely.
+    fn eval_with_lookups(
+        &self,
+        builder: &mut AB,
+        lookups: &[Lookup<AB::F>],
+        lookup_evaluator: &impl LookupEvaluator,
+    ) {
+        self.eval(builder);
+
+        if !lookups.is_empty() {
+            lookup_evaluator.eval_lookups(builder, lookups);
+        }
+    }
+}
+
+impl<AB: PermutationAirBuilder, A: Air<AB>> AirWithLookups<AB> for A {}

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -1,10 +1,10 @@
 //! See [`crate::prover`] for an overview of the protocol and a more detailed soundness analysis.
 
+use alloc::string::String;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
 use itertools::Itertools;
-use p3_air::lookup::LookupError;
 use p3_air::symbolic::SymbolicAirBuilder;
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
@@ -455,6 +455,6 @@ where
     )]
     NextPointUnavailable,
     /// Lookup related error
-    #[error("lookup error: {0:?}")]
-    LookupError(LookupError),
+    #[error("lookup error: {0}")]
+    LookupError(String),
 }


### PR DESCRIPTION
Built on top of https://github.com/Plonky3/Plonky3/pull/1391

The current lookup abstraction is tightly linked to the Air and is inherently dependent on the batch-stark's lookup implementation. This PR moves them to the relevant crates.