### PR TITLE
use same numbers of rounds in Poseidon1 / Poseidon2

### DIFF
--- a/poseidon/benches/poseidon.rs
+++ b/poseidon/benches/poseidon.rs
@@ -41,7 +41,7 @@ where
 
     // TODO: Should be calculated for the particular field, width and ALPHA.
     let half_num_full_rounds = 4;
-    let num_partial_rounds = 22;
+    let num_partial_rounds = 20;
 
     type External<F, Mds, const W: usize> = PoseidonExternalLayerGeneric<F, Mds, W>;
     type Internal<F, const W: usize> = PoseidonInternalLayerGeneric<F, W>;
@@ -73,7 +73,7 @@ where
     let mut rng = SmallRng::seed_from_u64(1);
 
     let half_num_full_rounds = 4;
-    let num_partial_rounds = 22;
+    let num_partial_rounds = 20;
 
     type External<F, Mds, const W: usize> = PoseidonExternalLayerGeneric<F, Mds, W>;
     type Internal<F, Mds, const W: usize> = PoseidonInternalLayerTextbook<F, Mds, W>;


### PR DESCRIPTION
Fixing the numbers of rounds of Poseidon1 in the benchmarks. Justification: "the number of rounds is the same as in Poseidonπ", beginning of seection 6 (p. 14) of the [Poseidon2 paper](https://eprint.iacr.org/2023/323.pdf).

I could also rename [poseidon2_round_numbers_128](https://github.com/Plonky3/Plonky3/blob/82774b23b90a5e6e87562adb85a0f89c2ee6f066/poseidon2/src/round_numbers.rs#L34) to "poseidon_round_numbers_128", and move it in the poseidon (1) crate, and add a comment saying it's also valid for poseidon2 ? what do you think