### PR TITLE
feat: make `HidingFriPcs` `Sync`

### DIFF
--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -22,6 +22,7 @@ p3-util.workspace = true
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
+spin.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use core::cell::RefCell;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
@@ -15,6 +14,7 @@ use p3_matrix::row_index_mapped::RowIndexMappedView;
 use p3_util::zip_eq::zip_eq;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
+use spin::Mutex;
 use tracing::{info_span, instrument};
 
 use crate::verifier::FriError;
@@ -22,15 +22,32 @@ use crate::{FriParameters, FriProof, TwoAdicFriPcs};
 
 /// A hiding FRI PCS. Both MMCSs must also be hiding; this is not enforced at compile time so it's
 /// the user's responsibility to configure.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
     inner: TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>,
     num_random_codewords: usize,
-    rng: RefCell<R>,
+    rng: Mutex<R>,
+}
+
+impl<Val, Dft, InputMmcs, FriMmcs, R> Clone for HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R>
+where
+    Val: Clone,
+    Dft: Clone,
+    InputMmcs: Clone,
+    FriMmcs: Clone,
+    R: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            num_random_codewords: self.num_random_codewords,
+            rng: Mutex::new(self.rng.lock().clone()),
+        }
+    }
 }
 
 impl<Val, Dft, InputMmcs, FriMmcs, R> HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
-    pub fn new(
+    pub const fn new(
         dft: Dft,
         mmcs: InputMmcs,
         params: FriParameters<FriMmcs>,
@@ -41,7 +58,7 @@ impl<Val, Dft, InputMmcs, FriMmcs, R> HidingFriPcs<Val, Dft, InputMmcs, FriMmcs,
         Self {
             inner,
             num_random_codewords,
-            rng: rng.into(),
+            rng: Mutex::new(rng),
         }
     }
 }
@@ -96,7 +113,7 @@ where
                         let mut random_evaluation = add_random_cols(
                             &mat,
                             mat_width + 2 * self.num_random_codewords,
-                            &mut *self.rng.borrow_mut(),
+                            &mut *self.rng.lock(),
                         );
                         random_evaluation.width = mat_width + self.num_random_codewords;
 
@@ -156,7 +173,7 @@ where
             .map(|i| cis[i] * last_chunk_ci_inv)
             .collect_vec();
 
-        let mut rng = self.rng.borrow_mut();
+        let mut rng = self.rng.lock();
         let randomized_evaluations: Vec<RowMajorMatrix<Val>> = evaluations
             .into_iter()
             .map(|mat| add_random_cols(&mat, self.num_random_codewords, &mut *rng))
@@ -382,7 +399,7 @@ where
             .into_iter()
             .map(|domain| {
                 let m = DenseMatrix::rand(
-                    &mut *self.rng.borrow_mut(),
+                    &mut *self.rng.lock(),
                     domain.size(),
                     self.num_random_codewords + Challenge::DIMENSION,
                 );


### PR DESCRIPTION
Current `HidingFriPcs` uses `RefCell` for its internal `Rng` which isn't `Sync` compatible.
I'm suggesting to switch to a `Mutex` instead (from `spin` to remain `no-std`) so that it can be made `Sync`.

This is needed for dynamic AIR verification in recursion with ZK.