### PR TITLE
fix: race condition in update_twiddles skipping inv_twiddles update

### DIFF
--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -82,7 +82,8 @@ impl<F: TwoAdicField> Radix2DFTSmallBatch<F> {
         // need it to be larger, which is wasteful.
 
         // roots_of_unity_table(fft_len) returns a vector of twiddles of length log_2(fft_len).
-        let curr_max_fft_len = 1 << self.twiddles.read().len();
+        let curr_max_fft_len =
+            (1 << self.twiddles.read().len()).min(1 << self.inv_twiddles.read().len());
         if fft_len > curr_max_fft_len {
             let mut new_twiddles = self.roots_of_unity_table(fft_len);
             let mut new_inv_twiddles: Vec<Vec<F>> = new_twiddles

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -878,64 +878,6 @@ fn zip_par_iter_vec<I: IndexedParallelIterator>(
         .collect::<Vec<_>>()
 }
 
-#[cfg(test)]
-mod tests {
-    extern crate std;
-
-    use alloc::sync::Arc;
-    use alloc::vec;
-
-    use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
-    use p3_matrix::dense::RowMajorMatrix;
-
-    use super::*;
-
-    /// Test that concurrent dft_batch and idft_batch calls with increasing sizes
-    /// don't panic due to inconsistent twiddle/inv_twiddle table sizes.
-    #[test]
-    fn test_concurrent_dft_and_idft_no_panic() {
-        let dft = Arc::new(Radix2DFTSmallBatch::<BabyBear>::default());
-
-        // Spawn threads that do dft and idft with different sizes concurrently.
-        let handles: Vec<_> = (1..=6)
-            .flat_map(|log_n| {
-                let dft_fwd = Arc::clone(&dft);
-                let dft_inv = Arc::clone(&dft);
-                let n = 1 << log_n;
-
-                let h1 = std::thread::spawn(move || {
-                    let mat = RowMajorMatrix::new(vec![BabyBear::ONE; n * 2], 2);
-                    dft_fwd.dft_batch(mat);
-                });
-                let h2 = std::thread::spawn(move || {
-                    let mat = RowMajorMatrix::new(vec![BabyBear::ONE; n * 2], 2);
-                    dft_inv.idft_batch(mat);
-                });
-                [h1, h2]
-            })
-            .collect();
-
-        for h in handles {
-            h.join().expect("thread panicked");
-        }
-    }
-
-    /// Test that after update_twiddles, both dft_batch and idft_batch work
-    /// for the same size without panic.
-    #[test]
-    fn test_update_twiddles_both_tables_consistent() {
-        let dft = Radix2DFTSmallBatch::<BabyBear>::default();
-
-        for log_n in 1..=8 {
-            let n = 1 << log_n;
-            let mat = RowMajorMatrix::new(vec![BabyBear::TWO; n], 1);
-            let forward = dft.dft_batch(mat.clone());
-            // This would panic if inv_twiddles was not updated.
-            let _inverse = dft.idft_batch(forward.to_row_major_matrix());
-        }
-    }
-}
 
 trait MultiLayerButterfly<F: Field, B: Butterfly<F>>: Copy + Send + Sync {
     fn apply_2_layers(

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -878,6 +878,65 @@ fn zip_par_iter_vec<I: IndexedParallelIterator>(
         .collect::<Vec<_>>()
 }
 
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::sync::Arc;
+    use alloc::vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_matrix::dense::RowMajorMatrix;
+
+    use super::*;
+
+    /// Test that concurrent dft_batch and idft_batch calls with increasing sizes
+    /// don't panic due to inconsistent twiddle/inv_twiddle table sizes.
+    #[test]
+    fn test_concurrent_dft_and_idft_no_panic() {
+        let dft = Arc::new(Radix2DFTSmallBatch::<BabyBear>::default());
+
+        // Spawn threads that do dft and idft with different sizes concurrently.
+        let handles: Vec<_> = (1..=6)
+            .flat_map(|log_n| {
+                let dft_fwd = Arc::clone(&dft);
+                let dft_inv = Arc::clone(&dft);
+                let n = 1 << log_n;
+
+                let h1 = std::thread::spawn(move || {
+                    let mat = RowMajorMatrix::new(vec![BabyBear::ONE; n * 2], 2);
+                    dft_fwd.dft_batch(mat);
+                });
+                let h2 = std::thread::spawn(move || {
+                    let mat = RowMajorMatrix::new(vec![BabyBear::ONE; n * 2], 2);
+                    dft_inv.idft_batch(mat);
+                });
+                [h1, h2]
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+    }
+
+    /// Test that after update_twiddles, both dft_batch and idft_batch work
+    /// for the same size without panic.
+    #[test]
+    fn test_update_twiddles_both_tables_consistent() {
+        let dft = Radix2DFTSmallBatch::<BabyBear>::default();
+
+        for log_n in 1..=8 {
+            let n = 1 << log_n;
+            let mat = RowMajorMatrix::new(vec![BabyBear::TWO; n], 1);
+            let forward = dft.dft_batch(mat.clone());
+            // This would panic if inv_twiddles was not updated.
+            let _inverse = dft.idft_batch(forward.to_row_major_matrix());
+        }
+    }
+}
+
 trait MultiLayerButterfly<F: Field, B: Butterfly<F>>: Copy + Send + Sync {
     fn apply_2_layers(
         &self,


### PR DESCRIPTION
The outer check in update_twiddles only reads twiddles.len() to decide whether to skip the update, but twiddles and inv_twiddles are written under separate locks. A concurrent thread could see the updated twiddles and skip the function entirely, leaving inv_twiddles at the old size — causing a panic in idft_batch. Fixed by checking the min of both table lengths.