### PR TITLE
chore: bump deps pre-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,29 +62,29 @@ transmute_undefined_repr = "allow"
 cognitive_complexity = "allow"
 
 [workspace.dependencies]
-blake3 = { version = "1.5", default-features = false }
-clap = { version = "4.5.23", features = ["derive"] }
+blake3 = { version = "1.8", default-features = false }
+clap = { version = "4.5.60", features = ["derive"] }
 criterion = "0.8"
-hashbrown = "0.16.0"
-hex-literal = "1.0.0"
+hashbrown = "0.16.1"
+hex-literal = "1.1.0"
 itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
-num-bigint = { version = "0.4.3", default-features = false }
+num-bigint = { version = "0.4.6", default-features = false }
 paste = "1.0.15"
-postcard = { version = "1.0.0", default-features = false }
-proptest = "1.8"
+postcard = { version = "1.1.3", default-features = false }
+proptest = "1.10"
 rand = { version = "0.10.0", default-features = false }
 rand_xoshiro = "0.8.0"
 rayon = "1.11.0"
 serde = { version = "1.0", default-features = false }
-serde_json = "1.0.113"
-sha2 = { version = "0.10.8", default-features = false }
+serde_json = "1.0.149"
+sha2 = { version = "0.10.9", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 spin = "0.10.0"
 thiserror = { version = "2.0", default-features = false }
 tiny-keccak = "2.0.2"
-tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
-tracing-forest = "0.3.0"
-tracing-subscriber = { version = "0.3.17", default-features = false, features = ["alloc"] }
+tracing = { version = "0.1.44", default-features = false, features = ["attributes"] }
+tracing-forest = "0.3.1"
+tracing-subscriber = { version = "0.3.22", default-features = false, features = ["alloc"] }
 transpose = "0.2.3"
 
 # Local dependencies


### PR DESCRIPTION
Just ran `cargo upgrade --incompatible`.