### PR TITLE
refactor: split `AirBuilder::M` into `MainWindow` and `PreprocessedWindow`

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -43,7 +43,7 @@ pub trait WindowAccess<T> {
 /// Stores two `&[T]` slices — one for the current row and one for
 /// the next — without carrying any matrix metadata.  This is cheaper
 /// than a full `ViewPair` and is the concrete type used by most
-/// [`AirBuilder`] implementations for `type M`.
+/// [`AirBuilder`] implementations for `type MainWindow` / `type PreprocessedWindow`.
 #[derive(Debug, Clone, Copy)]
 pub struct RowWindow<'a, T> {
     /// The current row.
@@ -260,19 +260,22 @@ pub trait AirBuilder: Sized {
         + Mul<Self::Var, Output = Self::Expr>
         + Mul<Self::Expr, Output = Self::Expr>;
 
+    /// Two-row window over the preprocessed trace columns.
+    type PreprocessedWindow: WindowAccess<Self::Var> + Clone;
+
     /// Two-row window over the main trace columns.
-    type M: WindowAccess<Self::Var> + Clone;
+    type MainWindow: WindowAccess<Self::Var> + Clone;
 
     /// Variable type for public values.
     type PublicVar: Into<Self::Expr> + Copy;
 
     /// Return the current and next row slices of the main (primary) trace.
-    fn main(&self) -> Self::M;
+    fn main(&self) -> Self::MainWindow;
 
     /// Return the preprocessed registers as a two-row window.
     ///
     /// When no preprocessed columns exist, this returns a zero-width window.
-    fn preprocessed(&self) -> &Self::M;
+    fn preprocessed(&self) -> &Self::PreprocessedWindow;
 
     /// Expression evaluating to 1 on the first row, 0 elsewhere.
     fn is_first_row(&self) -> Self::Expr;
@@ -485,19 +488,16 @@ impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
     type F = AB::F;
     type Expr = AB::Expr;
     type Var = AB::Var;
-    type M = AB::M;
+    type PreprocessedWindow = AB::PreprocessedWindow;
+    type MainWindow = AB::MainWindow;
     type PublicVar = AB::PublicVar;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         self.inner.main()
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         self.inner.preprocessed()
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.inner.public_values()
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -518,6 +518,10 @@ impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.inner.assert_zero(self.condition() * x.into());
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.inner.public_values()
     }
 }
 

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -171,19 +171,16 @@ where
     type F = F;
     type Expr = F;
     type Var = F;
-    type M = RowWindow<'a, F>;
+    type PreprocessedWindow = RowWindow<'a, F>;
+    type MainWindow = RowWindow<'a, F>;
     type PublicVar = F;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.public_values
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -212,6 +209,10 @@ where
             });
         }
         self.constraint_index += 1;
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
     }
 }
 

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -265,19 +265,16 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
     type F = F;
     type Expr = SymbolicExpression<F>;
     type Var = SymbolicVariable<F>;
-    type M = RowMajorMatrix<Self::Var>;
+    type PreprocessedWindow = RowMajorMatrix<Self::Var>;
+    type MainWindow = RowMajorMatrix<Self::Var>;
     type PublicVar = SymbolicVariable<F>;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         self.main.clone()
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        &self.public_values
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -301,6 +298,10 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.base_constraints.push(x.into());
         self.constraint_types.push(ConstraintType::Base);
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        &self.public_values
     }
 }
 

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -218,19 +218,16 @@ impl<'a, F: Field> AirBuilder for MiniLookupBuilder<'a, F> {
     type F = F;
     type Expr = F;
     type Var = F;
+    type PreprocessedWindow = RowWindow<'a, F>;
+    type MainWindow = RowWindow<'a, F>;
     type PublicVar = F;
-    type M = RowWindow<'a, F>;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.public_values
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -247,6 +244,10 @@ impl<'a, F: Field> AirBuilder for MiniLookupBuilder<'a, F> {
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, _x: I) {}
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
+    }
 }
 
 impl<'a, F: Field> p3_air::ExtensionBuilder for MiniLookupBuilder<'a, F> {

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -17,20 +17,16 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     type F = Val<SC>;
     type Expr = PackedVal<SC>;
     type Var = PackedVal<SC>;
+    type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
+    type MainWindow = RowWindow<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
-    type M = RowWindow<'a, PackedVal<SC>>;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_view(&self.inner.main)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         self.inner.preprocessed()
-    }
-
-    #[inline]
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.inner.public_values
     }
 
     #[inline]
@@ -57,6 +53,11 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     #[inline]
     fn assert_zeros<const N: usize, I: Into<Self::Expr>>(&mut self, array: [I; N]) {
         self.inner.assert_zeros(array);
+    }
+
+    #[inline]
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.inner.public_values
     }
 }
 
@@ -106,13 +107,14 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLook
     type Expr = SC::Challenge;
     type Var = SC::Challenge;
     type PublicVar = Val<SC>;
-    type M = RowWindow<'a, SC::Challenge>;
+    type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
+    type MainWindow = RowWindow<'a, SC::Challenge>;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.inner.main.top.values, self.inner.main.bottom.values)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         self.inner.preprocessed()
     }
 

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -77,21 +77,17 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
     type F = Val<SC>;
     type Expr = Val<SC>;
     type Var = Val<SC>;
+    type PreprocessedWindow = RowWindow<'a, Val<SC>>;
+    type MainWindow = RowWindow<'a, Val<SC>>;
     type PublicVar = Val<SC>;
-    type M = RowWindow<'a, Val<SC>>;
 
     #[inline]
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed
-    }
-
-    #[inline]
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.public_values
     }
 
     #[inline]
@@ -120,6 +116,11 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
         for item in array {
             assert!(item.into() == Self::F::ZERO);
         }
+    }
+
+    #[inline]
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
     }
 }
 

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -170,14 +170,15 @@ impl AirBuilder for MockAirBuilder {
     type F = F;
     type Expr = F;
     type Var = F;
-    type M = RowMajorMatrix<F>;
+    type PreprocessedWindow = RowMajorMatrix<F>;
+    type MainWindow = RowMajorMatrix<F>;
     type PublicVar = F;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         self.window(&self.main)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed
     }
 

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -156,21 +156,17 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     type F = Val<SC>;
     type Expr = PackedVal<SC>;
     type Var = PackedVal<SC>;
+    type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
+    type MainWindow = RowWindow<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
-    type M = RowWindow<'a, PackedVal<SC>>;
 
     #[inline]
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_view(&self.main)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed_window
-    }
-
-    #[inline]
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.public_values
     }
 
     #[inline]
@@ -201,6 +197,11 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
         self.base_constraints.extend(expr_array);
         self.constraint_index += N;
     }
+
+    #[inline]
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
+    }
 }
 
 impl<SC: StarkGenericConfig> ExtensionBuilder for ProverConstraintFolder<'_, SC> {
@@ -221,19 +222,16 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     type F = Val<SC>;
     type Expr = SC::Challenge;
     type Var = SC::Challenge;
+    type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
+    type MainWindow = RowWindow<'a, SC::Challenge>;
     type PublicVar = Val<SC>;
-    type M = RowWindow<'a, SC::Challenge>;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
     }
 
-    fn preprocessed(&self) -> &Self::M {
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
         &self.preprocessed_window
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.public_values
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -252,5 +250,9 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.accumulator *= self.alpha;
         self.accumulator += x.into();
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
     }
 }

--- a/uni-stark/src/sub_builder.rs
+++ b/uni-stark/src/sub_builder.rs
@@ -49,9 +49,6 @@ pub struct SubAirBuilder<'a, AB: AirBuilder, SubAir: BaseAir<AB::F>, T> {
     /// Column range (in the parent trace) that the sub-AIR is allowed to see.
     column_range: Range<usize>,
 
-    /// Cached zero-width preprocessed window returned by reference.
-    preprocessed: SubSliced<AB::M, AB::Var>,
-
     /// Marker for the sub-AIR and witness type.
     _phantom: core::marker::PhantomData<(SubAir, T)>,
 }
@@ -61,16 +58,10 @@ impl<'a, AB: AirBuilder, SubAir: BaseAir<AB::F>, T> SubAirBuilder<'a, AB, SubAir
     ///
     /// The range must lie entirely inside the parent trace width.
     #[must_use]
-    pub fn new(inner: &'a mut AB, column_range: Range<usize>) -> Self {
-        let preprocessed = SubSliced {
-            window: inner.preprocessed().clone(),
-            range: 0..0,
-            _marker: PhantomData,
-        };
+    pub const fn new(inner: &'a mut AB, column_range: Range<usize>) -> Self {
         Self {
             inner,
             column_range,
-            preprocessed,
             _phantom: core::marker::PhantomData,
         }
     }
@@ -81,10 +72,11 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
     type F = AB::F;
     type Expr = AB::Expr;
     type Var = AB::Var;
-    type M = SubSliced<AB::M, AB::Var>;
+    type PreprocessedWindow = AB::PreprocessedWindow;
+    type MainWindow = SubSliced<AB::MainWindow, AB::Var>;
     type PublicVar = AB::PublicVar;
 
-    fn main(&self) -> Self::M {
+    fn main(&self) -> Self::MainWindow {
         SubSliced {
             window: self.inner.main(),
             range: self.column_range.clone(),
@@ -92,12 +84,8 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
         }
     }
 
-    fn preprocessed(&self) -> &Self::M {
-        &self.preprocessed
-    }
-
-    fn public_values(&self) -> &[Self::PublicVar] {
-        self.inner.public_values()
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
+        self.inner.preprocessed()
     }
 
     fn is_first_row(&self) -> Self::Expr {
@@ -115,5 +103,9 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.inner.assert_zero(x.into());
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.inner.public_values()
     }
 }


### PR DESCRIPTION
_Note: This is not strictly required for the next release. It's a little QoL which makes it easier for Miden to maintain preprocess-less Air's._

Replace the single associated type `M` with two separate types so that downstream users can supply different concrete window types for main and preprocessed traces.

This also simplifies `SubAirBuilder`: it no longer wraps the preprocessed window in a `SubSliced` with a dummy `0..0` range and instead delegates directly to the parent builder.