### PR TITLE
feat: add `CanFinalizeDigest` trait for challenger transcript commitment

### DIFF
--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -7,7 +7,9 @@ use p3_field::{BasedVectorSpace, Field, PrimeField64};
 use p3_monty_31::{MontyField31, MontyParameters};
 use p3_symmetric::{CryptographicPermutation, Hash, MerkleCap};
 
-use crate::{CanObserve, CanSample, CanSampleBits, CanSampleUniformBits, FieldChallenger};
+use crate::{
+    CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, CanSampleUniformBits, FieldChallenger,
+};
 
 /// A generic duplex sponge challenger over a finite field, used for generating deterministic
 /// challenges from absorbed inputs.
@@ -400,6 +402,25 @@ where
         } else {
             self.sample_uniform_bits_with_strategy::<ErrorOnRejection>(bits)
         }
+    }
+}
+
+impl<F, P, const WIDTH: usize, const RATE: usize> CanFinalizeDigest
+    for DuplexChallenger<F, P, WIDTH, RATE>
+where
+    F: Copy,
+    P: CryptographicPermutation<[F; WIDTH]>,
+{
+    type Digest = [F; RATE];
+
+    fn finalize(mut self) -> [F; RATE] {
+        // Unconditionally duplex: absorb any pending input and permute.
+        //
+        // Note: sampling only pops from the output buffer without modifying
+        // sponge state, so it does not necessarily affect the digest (e.g.
+        // when the last observe already triggered auto-duplexing).
+        self.duplexing();
+        self.sponge_state[..RATE].try_into().unwrap()
     }
 }
 
@@ -807,5 +828,67 @@ mod tests {
         // After observing 8 EF2G elements (16 base field elements), duplexing should occur
         assert!(chal.input_buffer.is_empty());
         assert!(!chal.output_buffer.is_empty());
+    }
+
+    #[test]
+    fn test_finalize() {
+        let new_chal = || DuplexChallenger::<G, _, WIDTH, RATE>::new(TestPermutation {});
+
+        // Deterministic: same observations produce same digest.
+        let mut c1 = new_chal();
+        let mut c2 = new_chal();
+        for i in 0..5u8 {
+            c1.observe(G::from_u8(i));
+            c2.observe(G::from_u8(i));
+        }
+        assert_eq!(c1.finalize(), c2.finalize());
+
+        // Different observations produce different digests.
+        let mut c1 = new_chal();
+        let mut c2 = new_chal();
+        for i in 0..10u8 {
+            c1.observe(G::from_u8(i));
+            c2.observe(G::from_u8(i + 1));
+        }
+        assert_ne!(c1.finalize(), c2.finalize());
+    }
+
+    /// Document how sampling interacts with finalize.
+    ///
+    /// Sampling does not modify the sponge state — it only pops from the
+    /// output buffer. This means the digest only changes when a sample
+    /// triggers a new duplexing (because the output buffer was empty or
+    /// there was pending input). Within one "batch" of RATE outputs, all
+    /// sample counts produce the same digest.
+    #[test]
+    fn test_finalize_sample_interaction() {
+        let digest = |n_samples: usize| {
+            let mut c = DuplexChallenger::<G, _, WIDTH, RATE>::new(TestPermutation {});
+            for i in 0..5u8 {
+                c.observe(G::from_u8(i));
+            }
+            for _ in 0..n_samples {
+                let _: G = c.sample();
+            }
+            c.finalize()
+        };
+
+        // The first sample triggers duplexing (absorbs pending input),
+        // so finalize's duplexing is now an extra permutation on an
+        // already-duplexed state — different from the 0-sample case.
+        assert_ne!(digest(0), digest(1));
+
+        // Samples 1 through RATE all come from the same output batch.
+        // They don't trigger another duplexing, so the sponge state
+        // (and thus the digest) is identical.
+        assert_eq!(digest(1), digest(2));
+        assert_eq!(digest(1), digest(RATE));
+
+        // The (RATE+1)-th sample exhausts the output buffer and triggers
+        // a fresh duplexing, changing the sponge state again.
+        assert_ne!(digest(RATE), digest(RATE + 1));
+
+        // Within the second batch, the digest is again stable.
+        assert_eq!(digest(RATE + 1), digest(RATE + 2));
     }
 }

--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use p3_symmetric::CryptographicHasher;
 
-use crate::{CanObserve, CanSample};
+use crate::{CanFinalizeDigest, CanObserve, CanSample};
 
 /// A generic challenger that uses a cryptographic hash function to generate challenges.
 #[derive(Clone, Debug)]
@@ -84,6 +84,25 @@ where
         self.output_buffer
             .pop()
             .expect("Output buffer should be non-empty")
+    }
+}
+
+impl<T, H, const OUT_LEN: usize> CanFinalizeDigest for HashChallenger<T, H, OUT_LEN>
+where
+    T: Clone,
+    H: CryptographicHasher<T, [T; OUT_LEN]>,
+{
+    type Digest = [T; OUT_LEN];
+
+    fn finalize(mut self) -> [T; OUT_LEN] {
+        // Unconditionally flush: hash the input buffer and produce the
+        // digest from the resulting output.
+        //
+        // Note: unlike sponge-based challengers, observe never auto-flushes
+        // here, so the first sample always changes the chaining values and
+        // thus the digest.
+        self.flush();
+        core::array::from_fn(|i| self.output_buffer[i].clone())
     }
 }
 
@@ -318,6 +337,61 @@ mod tests {
 
         // Check that the output buffer is now one element shorter
         assert_eq!(hash_challenger.output_buffer, vec![F::from_u8(42)]);
+    }
+
+    #[test]
+    fn test_finalize() {
+        let new_chal = || HashChallenger::new(vec![F::from_u8(1), F::from_u8(2)], TestHasher {});
+
+        // Deterministic: same observations produce same digest.
+        let mut h1 = new_chal();
+        let mut h2 = new_chal();
+        h1.observe(F::from_u8(42));
+        h2.observe(F::from_u8(42));
+        assert_eq!(h1.finalize(), h2.finalize());
+
+        // Different observations produce different digests.
+        let mut h1 = new_chal();
+        let mut h2 = new_chal();
+        h1.observe(F::from_u8(1));
+        h2.observe(F::from_u8(2));
+        assert_ne!(h1.finalize(), h2.finalize());
+    }
+
+    /// Document how sampling interacts with finalize.
+    ///
+    /// Sampling pops from the output buffer. When the buffer is exhausted,
+    /// the next sample triggers a flush (hash), which changes the chaining
+    /// values in the input buffer. Finalize always flushes, so the digest
+    /// changes whenever a sample triggered a flush — i.e. every OUT_LEN
+    /// samples.
+    #[test]
+    fn test_finalize_sample_interaction() {
+        let digest = |n_samples: usize| {
+            let mut c = HashChallenger::new(vec![F::from_u8(1), F::from_u8(2)], TestHasher {});
+            c.observe(F::from_u8(42));
+            for _ in 0..n_samples {
+                let _: F = c.sample();
+            }
+            c.finalize()
+        };
+
+        // The first sample triggers a flush (output buffer was empty after
+        // observe), changing the chaining values. Finalize's flush then
+        // hashes different input than the 0-sample case.
+        assert_ne!(digest(0), digest(1));
+
+        // Samples 1 through OUT_LEN come from the same flush output.
+        // They don't trigger another flush, so the chaining values
+        // (and thus the digest) are identical.
+        assert_eq!(digest(1), digest(OUT_LEN));
+
+        // The (OUT_LEN+1)-th sample exhausts the output buffer and
+        // triggers a fresh flush, changing the chaining values again.
+        assert_ne!(digest(OUT_LEN), digest(OUT_LEN + 1));
+
+        // Within the second batch, the digest is again stable.
+        assert_eq!(digest(OUT_LEN + 1), digest(2 * OUT_LEN));
     }
 
     #[test]

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -208,3 +208,22 @@ where
         (*self).sample_uniform_bits::<RESAMPLE>(bits)
     }
 }
+
+/// Extract a binding commitment to the full transcript state.
+///
+/// Consumes the challenger, producing a digest that commits to all
+/// previously observed values.
+///
+/// ## Contract
+///
+/// Implementations must satisfy the following properties:
+///
+/// - **Determinism**: identical sequences of observations and samples produce identical digests.
+/// - **Observation sensitivity**: different observed values produce different digests.
+pub trait CanFinalizeDigest {
+    /// The type of digest produced by finalization.
+    type Digest;
+
+    /// Finalize the transcript and produce a binding digest.
+    fn finalize(self) -> Self::Digest;
+}

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use p3_field::{BasedVectorSpace, Field, PrimeField, PrimeField32, reduce_32, split_32};
 use p3_symmetric::{CryptographicPermutation, Hash, MerkleCap};
 
-use crate::{CanObserve, CanSample, CanSampleBits, FieldChallenger};
+use crate::{CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, FieldChallenger};
 
 /// A challenger that operates natively on PF but produces challenges of F: PrimeField32.
 ///
@@ -227,6 +227,26 @@ where
     }
 }
 
+impl<F, PF, P, const WIDTH: usize, const RATE: usize> CanFinalizeDigest
+    for MultiField32Challenger<F, PF, P, WIDTH, RATE>
+where
+    F: PrimeField32,
+    PF: PrimeField,
+    P: CryptographicPermutation<[PF; WIDTH]>,
+{
+    type Digest = [PF; RATE];
+
+    fn finalize(mut self) -> [PF; RATE] {
+        // Unconditionally duplex: absorb any pending input and permute.
+        //
+        // Note: sampling only pops from the output buffer without modifying
+        // sponge state, so it does not necessarily affect the digest (e.g.
+        // when the last observe already triggered auto-duplexing).
+        self.duplexing();
+        self.sponge_state[..RATE].try_into().unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use p3_baby_bear::BabyBear;
@@ -255,6 +275,22 @@ mod tests {
 
     impl CryptographicPermutation<[PF; WIDTH]> for TestPermutation {}
 
+    /// A permutation where each output depends on all inputs, suitable for
+    /// tests that need to detect state changes (e.g. finalize).
+    #[derive(Clone)]
+    struct MixingPermutation;
+
+    impl Permutation<[PF; WIDTH]> for MixingPermutation {
+        fn permute_mut(&self, input: &mut [PF; WIDTH]) {
+            let sum: PF = input.iter().copied().sum();
+            for (i, val) in input.iter_mut().enumerate() {
+                *val = sum + PF::from_u8((i + 1) as u8);
+            }
+        }
+    }
+
+    impl CryptographicPermutation<[PF; WIDTH]> for MixingPermutation {}
+
     #[test]
     fn test_output_buffer_excludes_capacity() {
         let permutation = TestPermutation;
@@ -279,6 +315,73 @@ mod tests {
             expected_output_size,
             incorrect_output_size
         );
+    }
+
+    #[test]
+    fn test_finalize() {
+        let new_chal =
+            || MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+
+        // Deterministic: same observations produce same digest.
+        let mut c1 = new_chal();
+        let mut c2 = new_chal();
+        for i in 0..5u8 {
+            c1.observe(F::from_u8(i));
+            c2.observe(F::from_u8(i));
+        }
+        assert_eq!(c1.finalize(), c2.finalize());
+
+        // Different observations produce different digests.
+        let mut c1 = new_chal();
+        let mut c2 = new_chal();
+        for i in 0..5u8 {
+            c1.observe(F::from_u8(i));
+            c2.observe(F::from_u8(i + 1));
+        }
+        assert_ne!(c1.finalize(), c2.finalize());
+    }
+
+    /// Document how sampling interacts with finalize.
+    ///
+    /// Same principle as DuplexChallenger: sampling only pops from the
+    /// output buffer without modifying sponge state. The digest changes
+    /// when a sample triggers a new duplexing. Each duplexing produces
+    /// `num_f_elms * RATE` output elements (here 1 * 4 = 4 BabyBear
+    /// elements for Goldilocks/BabyBear), so the digest is stable within
+    /// each batch of that many samples.
+    #[test]
+    fn test_finalize_sample_interaction() {
+        let batch_size = {
+            let c =
+                MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+            c.num_f_elms * RATE
+        };
+
+        let digest = |n_samples: usize| {
+            let mut c =
+                MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+            for i in 0..3u8 {
+                c.observe(F::from_u8(i));
+            }
+            for _ in 0..n_samples {
+                let _: F = c.sample();
+            }
+            c.finalize()
+        };
+
+        // The first sample triggers duplexing (absorbs pending input),
+        // so finalize's duplexing is an extra permutation — different digest.
+        assert_ne!(digest(0), digest(1));
+
+        // Samples within the same batch don't trigger another duplexing.
+        assert_eq!(digest(1), digest(2));
+        assert_eq!(digest(1), digest(batch_size));
+
+        // Exhausting the output buffer triggers a fresh duplexing.
+        assert_ne!(digest(batch_size), digest(batch_size + 1));
+
+        // Stable within the second batch.
+        assert_eq!(digest(batch_size + 1), digest(batch_size + 2));
     }
 
     #[test]

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -8,7 +8,8 @@ use p3_util::log2_ceil_u64;
 use tracing::instrument;
 
 use crate::{
-    CanObserve, CanSample, CanSampleBits, FieldChallenger, GrindingChallenger, HashChallenger,
+    CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, FieldChallenger, GrindingChallenger,
+    HashChallenger,
 };
 
 /// Given a challenger that can observe and sample bytes, produces a challenger that is able to
@@ -354,4 +355,26 @@ where
     F: PrimeField64,
     Inner: CanSample<u8> + CanObserve<u8> + Clone + Send + Sync,
 {
+}
+
+impl<F, Inner> CanFinalizeDigest for SerializingChallenger32<F, Inner>
+where
+    Inner: CanFinalizeDigest,
+{
+    type Digest = Inner::Digest;
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize()
+    }
+}
+
+impl<F, Inner> CanFinalizeDigest for SerializingChallenger64<F, Inner>
+where
+    Inner: CanFinalizeDigest,
+{
+    type Digest = Inner::Digest;
+
+    fn finalize(self) -> Self::Digest {
+        self.inner.finalize()
+    }
 }


### PR DESCRIPTION
Add a `CanFinalizeDigest` trait that consumes a challenger and produces a binding digest of all previously observed values. Implementations unconditionally apply one final state transition (duplexing or flush) before extracting the digest.

This is useful for producing a binding commitment to the entire proof.

Implemented for all challenger types:
- DuplexChallenger: duplexes and returns the rate portion of the sponge
- MultiField32Challenger: same sponge-based approach over the larger field
- HashChallenger: flushes (hashes) the input buffer and returns the output
- SerializingChallenger32/64: delegates to the inner challenger