### PR TITLE
feat(uni-stark): add runtime support for periodic columns

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -114,6 +114,16 @@ pub trait BaseAir<F>: Sync {
         None
     }
 
+    /// Return the number of periodic columns.
+    fn num_periodic_columns(&self) -> usize {
+        self.periodic_columns().len()
+    }
+
+    /// Return the periodic table data.
+    fn periodic_columns(&self) -> &[Vec<F>] {
+        &[]
+    }
+
     /// Which main trace columns have their next row accessed by this AIR's
     /// constraints.
     ///

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -6,7 +6,8 @@ use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::ViewPair;
 
 use crate::{
-    Air, AirBuilder, AirBuilderWithContext, ExtensionBuilder, PermutationAirBuilder, RowWindow,
+    Air, AirBuilder, AirBuilderWithContext, ExtensionBuilder, PeriodicAirBuilder,
+    PermutationAirBuilder, RowWindow,
 };
 
 /// A single constraint violation captured during debug evaluation.
@@ -54,6 +55,9 @@ pub struct DebugConstraintBuilder<'a, F: Field, EF: ExtensionField<F> = F> {
     /// Slice of public values made available to the AIR during evaluation.
     public_values: &'a [F],
 
+    /// Current-row periodic column values.
+    periodic_values: Vec<F>,
+
     /// Selector that equals one on the first row and zero elsewhere.
     is_first_row: F,
 
@@ -80,11 +84,13 @@ impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
     /// Permutation-related fields are set to `None` / empty so that the
     /// builder can still satisfy trait bounds that require extension-field
     /// support, but calling permutation accessors will panic.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         row_index: usize,
         main: ViewPair<'a, F>,
         preprocessed: ViewPair<'a, F>,
         public_values: &'a [F],
+        periodic_values: Vec<F>,
         is_first_row: F,
         is_last_row: F,
         is_transition: F,
@@ -99,6 +105,7 @@ impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
                 preprocessed.bottom.values,
             ),
             public_values,
+            periodic_values,
             is_first_row,
             is_last_row,
             is_transition,
@@ -121,6 +128,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
         main: ViewPair<'a, F>,
         preprocessed: ViewPair<'a, F>,
         public_values: &'a [F],
+        periodic_values: Vec<F>,
         is_first_row: F,
         is_last_row: F,
         is_transition: F,
@@ -138,6 +146,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
                 preprocessed.bottom.values,
             ),
             public_values,
+            periodic_values,
             is_first_row,
             is_last_row,
             is_transition,
@@ -225,6 +234,14 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilderWithContext for DebugConstraintB
     }
 }
 
+impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for DebugConstraintBuilder<'_, F, EF> {
+    type PeriodicVar = F;
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        &self.periodic_values
+    }
+}
+
 impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for DebugConstraintBuilder<'_, F, EF> {
     type EF = EF;
     type ExprEF = EF;
@@ -297,6 +314,11 @@ where
 
     for row_index in 0..height {
         let row_index_next = (row_index + 1) % height;
+        let periodic_values = air
+            .periodic_columns()
+            .iter()
+            .map(|col| col[row_index % col.len()])
+            .collect();
 
         // SAFETY: both indices are strictly less than `height`.
         let local = unsafe { main.row_slice_unchecked(row_index) };
@@ -335,6 +357,7 @@ where
             main_pair,
             preprocessed_pair,
             public_values,
+            periodic_values,
             F::from_bool(row_index == 0),
             F::from_bool(row_index == height - 1),
             F::from_bool(row_index != height - 1),
@@ -482,6 +505,7 @@ mod tests {
             main,
             ViewPair::new(empty_view, empty_view),
             &[],
+            vec![],
             BabyBear::ONE,  // is_first_row
             BabyBear::ONE,  // is_last_row (single row)
             BabyBear::ZERO, // is_transition

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -1,3 +1,4 @@
+use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::{Air, DebugConstraintBuilder};
@@ -102,6 +103,7 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
             main,
             preprocessed,
             public_values,
+            vec![],
             F::from_bool(row_index == 0),
             F::from_bool(row_index == height - 1),
             F::from_bool(row_index != height - 1),

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -759,6 +759,7 @@ where
                 main: main.as_view(),
                 preprocessed: preprocessed_view,
                 preprocessed_window: RowWindow::from_view(&preprocessed_view),
+                periodic_values: &[],
                 public_values,
                 is_first_row,
                 is_last_row,

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -644,6 +644,7 @@ where
         main,
         preprocessed,
         preprocessed_window,
+        periodic_values: &[],
         public_values,
         is_first_row: sels.is_first_row,
         is_last_row: sels.is_last_row,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::{Itertools, iterate};
-use p3_commit::{LagrangeSelectors, PolynomialSpace};
+use p3_commit::{EvaluatePolynomialAtPoint, LagrangeSelectors, PolynomialSpace};
 use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, batch_multiplicative_inverse};
 use p3_matrix::Matrix;
@@ -10,6 +10,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 use tracing::instrument;
 
+use crate::CircleEvaluations;
 use crate::point::Point;
 
 /// A twin-coset of the circle group on F. It has a power-of-two size and an arbitrary shift.
@@ -239,6 +240,20 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
             is_transition,
             inv_vanishing,
         }
+    }
+}
+
+impl<F: ComplexExtendable> EvaluatePolynomialAtPoint for CircleDomain<F> {
+    fn evaluate_polynomial_at<Ext: ExtensionField<F>>(&self, evals: &[F], point: Ext) -> Ext {
+        assert!(
+            self.is_standard(),
+            "evaluate_polynomial_at requires standard position"
+        );
+        assert_eq!(evals.len(), self.size());
+        let values = RowMajorMatrix::new(evals.to_vec(), 1);
+        let circle_evals = CircleEvaluations::from_natural_order(*self, values);
+        let circle_point = Point::from_projective_line(point);
+        circle_evals.evaluate_at_point(circle_point)[0]
     }
 }
 

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 p3-field.workspace = true
+p3-interpolation.workspace = true
 p3-matrix.workspace = true
 p3-util.workspace = true
 

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse};
+use p3_interpolation::interpolate_coset;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
@@ -127,6 +128,34 @@ pub trait PolynomialSpace: Copy {
     ///
     /// Note that these may not be normalized.
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>>;
+}
+
+/// Extension of [`PolynomialSpace`] for domains that support evaluating a polynomial
+/// (given by its evaluations over the domain) at an arbitrary point.
+pub trait EvaluatePolynomialAtPoint: PolynomialSpace {
+    /// Evaluate the polynomial defined by `evals` (evaluations over `self`) at `point`.
+    fn evaluate_polynomial_at<Ext: ExtensionField<Self::Val>>(
+        &self,
+        evals: &[Self::Val],
+        point: Ext,
+    ) -> Ext;
+
+    /// Evaluate a periodic column polynomial at `point`.
+    ///
+    /// `col` contains the period-length evaluations: row `i` of the full trace
+    /// gets value `col[i % col.len()]`. The default expands to trace size and
+    /// delegates to [`Self::evaluate_polynomial_at`]; domains with algebraic
+    /// structure can override for lower-cost evaluation.
+    fn evaluate_periodic_column_at<Ext: ExtensionField<Self::Val>>(
+        &self,
+        col: &[Self::Val],
+        point: Ext,
+    ) -> Ext {
+        let n = self.size();
+        let period = col.len();
+        let evals: Vec<Self::Val> = (0..n).map(|i| col[i % period]).collect();
+        self.evaluate_polynomial_at(&evals, point)
+    }
 }
 
 impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
@@ -289,5 +318,23 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
                 .take(coset.size())
                 .collect(),
         }
+    }
+}
+
+impl<Val: TwoAdicField> EvaluatePolynomialAtPoint for TwoAdicMultiplicativeCoset<Val> {
+    fn evaluate_polynomial_at<Ext: ExtensionField<Val>>(&self, evals: &[Val], point: Ext) -> Ext {
+        let evals_mat = RowMajorMatrix::new(evals.to_vec(), 1);
+        interpolate_coset(&evals_mat, self.shift(), point)[0]
+    }
+
+    fn evaluate_periodic_column_at<Ext: ExtensionField<Val>>(
+        &self,
+        col: &[Val],
+        point: Ext,
+    ) -> Ext {
+        let log_period = log2_strict_usize(col.len());
+        let folds = self.log_size() - log_period;
+        let sub_coset = Self::new(self.shift().exp_power_of_2(folds), log_period).unwrap();
+        sub_coset.evaluate_polynomial_at(col, point.exp_power_of_2(folds))
     }
 }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
+use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, RowWindow};
 use p3_field::{Algebra, BasedVectorSpace, PackedField, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
@@ -77,6 +77,8 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub preprocessed: RowMajorMatrixView<'a, PackedVal<SC>>,
     /// Pre-built window over the preprocessed columns.
     pub preprocessed_window: RowWindow<'a, PackedVal<SC>>,
+    /// Periodic column values at the current packed row.
+    pub periodic_values: &'a [PackedVal<SC>],
     /// Public inputs to the [AIR](`p3_air::Air`) implementation.
     pub public_values: &'a [Val<SC>],
     /// Evaluations of the Selector polynomial for the first row of the trace
@@ -113,6 +115,8 @@ pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     pub preprocessed: ViewPair<'a, SC::Challenge>,
     /// Pre-built window over the preprocessed columns.
     pub preprocessed_window: RowWindow<'a, SC::Challenge>,
+    /// Periodic column values at the opened point.
+    pub periodic_values: &'a [SC::Challenge],
     /// Public values that are inputs to the computation
     pub public_values: &'a [Val<SC>],
     /// Evaluations of the Selector polynomial for the first row of the trace
@@ -218,6 +222,14 @@ impl<SC: StarkGenericConfig> ExtensionBuilder for ProverConstraintFolder<'_, SC>
     }
 }
 
+impl<SC: StarkGenericConfig> PeriodicAirBuilder for ProverConstraintFolder<'_, SC> {
+    type PeriodicVar = PackedVal<SC>;
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_values
+    }
+}
+
 impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC> {
     type F = Val<SC>;
     type Expr = SC::Challenge;
@@ -254,5 +266,13 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
 
     fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values
+    }
+}
+
+impl<SC: StarkGenericConfig> PeriodicAirBuilder for VerifierConstraintFolder<'_, SC> {
+    type PeriodicVar = SC::Challenge;
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_values
     }
 }

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{EvaluatePolynomialAtPoint, Pcs, PolynomialSpace};
 use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
@@ -34,6 +34,7 @@ pub fn prove_with_preprocessed<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
 {
     #[cfg(debug_assertions)]
@@ -78,6 +79,7 @@ where
         preprocessed_width,
         main_width: air.width(),
         num_public_values: air.num_public_values(),
+        num_periodic_columns: air.num_periodic_columns(),
         ..Default::default()
     };
 
@@ -389,6 +391,7 @@ pub fn prove<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
 {
     prove_with_preprocessed::<SC, A>(config, air, trace, public_values, None)
@@ -409,6 +412,7 @@ pub fn quotient_values<SC, A, Mat>(
 ) -> Vec<SC::Challenge>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
     Mat: Matrix<Val<SC>> + Sync,
 {
@@ -431,6 +435,32 @@ where
 
     let constraint_layout = get_constraint_layout(air, layout);
     let (base_alpha_powers, ext_alpha_powers) = constraint_layout.decompose_alpha(alpha);
+    let periodic_cols = air.periodic_columns();
+    let periodic_on_quotient: Vec<Vec<Val<SC>>> = if periodic_cols.is_empty() {
+        vec![]
+    } else {
+        let quotient_points: Vec<Val<SC>> = {
+            let mut point = quotient_domain.first_point();
+            (0..quotient_size)
+                .map(|_| {
+                    let out = point;
+                    point = quotient_domain
+                        .next_point(point)
+                        .expect("quotient domain must support next_point");
+                    out
+                })
+                .collect()
+        };
+        periodic_cols
+            .iter()
+            .map(|col| {
+                quotient_points
+                    .iter()
+                    .map(|&point| trace_domain.evaluate_periodic_column_at(col, point))
+                    .collect()
+            })
+            .collect()
+    };
 
     (0..quotient_size)
         .into_par_iter()
@@ -459,10 +489,20 @@ where
             let preprocessed_view = preprocessed
                 .as_ref()
                 .map_or_else(|| RowMajorMatrixView::new(&[], 0), |m| m.as_view());
+            let periodic_values: Vec<PackedVal<SC>> = periodic_on_quotient
+                .iter()
+                .map(|col_evals| {
+                    let slice: Vec<Val<SC>> = (i_start..i_start + PackedVal::<SC>::WIDTH)
+                        .map(|i| col_evals.get(i).cloned().unwrap_or_default())
+                        .collect();
+                    *PackedVal::<SC>::from_slice(&slice)
+                })
+                .collect();
             let mut folder = ProverConstraintFolder {
                 main: main.as_view(),
                 preprocessed: preprocessed_view,
                 preprocessed_window: RowWindow::from_view(&preprocessed_view),
+                periodic_values: &periodic_values,
                 public_values,
                 is_first_row,
                 is_last_row,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use p3_air::symbolic::SymbolicAirBuilder;
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{EvaluatePolynomialAtPoint, Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
@@ -87,6 +87,7 @@ pub fn verify_constraints<SC, A, PcsErr>(
 ) -> Result<(), VerificationError<PcsErr>>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: for<'a> Air<VerifierConstraintFolder<'a, SC>>,
     PcsErr: core::fmt::Debug,
 {
@@ -110,10 +111,16 @@ where
 
     let preprocessed_window =
         RowWindow::from_two_rows(preprocessed.top.values, preprocessed.bottom.values);
+    let periodic_values: Vec<SC::Challenge> = air
+        .periodic_columns()
+        .iter()
+        .map(|col| trace_domain.evaluate_periodic_column_at(col, zeta))
+        .collect();
     let mut folder = VerifierConstraintFolder {
         main,
         preprocessed,
         preprocessed_window,
+        periodic_values: &periodic_values,
         public_values,
         is_first_row: sels.is_first_row,
         is_last_row: sels.is_last_row,
@@ -206,6 +213,7 @@ pub fn verify<SC, A>(
 ) -> Result<(), VerificationError<PcsError<SC>>>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<VerifierConstraintFolder<'a, SC>>,
 {
     verify_with_preprocessed(config, air, proof, public_values, None)
@@ -221,6 +229,7 @@ pub fn verify_with_preprocessed<SC, A>(
 ) -> Result<(), VerificationError<PcsError<SC>>>
 where
     SC: StarkGenericConfig,
+    Domain<SC>: EvaluatePolynomialAtPoint,
     A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<VerifierConstraintFolder<'a, SC>>,
 {
     let Proof {
@@ -249,6 +258,7 @@ where
         preprocessed_width,
         main_width: air.width(),
         num_public_values: air.num_public_values(),
+        num_periodic_columns: air.num_periodic_columns(),
         ..Default::default()
     };
     let log_num_quotient_chunks =

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -6,8 +6,8 @@ use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;
-use p3_commit::ExtensionMmcs;
 use p3_commit::testing::TrivialPcs;
+use p3_commit::{EvaluatePolynomialAtPoint, ExtensionMmcs};
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -19,7 +19,7 @@ use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
-use p3_uni_stark::{StarkConfig, StarkGenericConfig, Val, prove, verify};
+use p3_uni_stark::{Domain, StarkConfig, StarkGenericConfig, Val, prove, verify};
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -121,6 +121,7 @@ fn do_test<SC: StarkGenericConfig>(
 where
     SC::Challenger: Clone,
     StandardUniform: Distribution<Val<SC>>,
+    Domain<SC>: EvaluatePolynomialAtPoint,
 {
     let trace = air.random_valid_trace(log_height, true);
 

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -1,0 +1,215 @@
+use core::fmt::Debug;
+use core::marker::PhantomData;
+
+use p3_air::{Air, AirBuilder, BaseAir, PeriodicAirBuilder, WindowAccess};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
+use p3_circle::CirclePcs;
+use p3_commit::testing::TrivialPcs;
+use p3_commit::{EvaluatePolynomialAtPoint, ExtensionMmcs};
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing};
+use p3_fri::{FriParameters, TwoAdicFriPcs};
+use p3_keccak::Keccak256Hash;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_mersenne_31::Mersenne31;
+use p3_symmetric::{
+    CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
+};
+use p3_uni_stark::{Domain, StarkConfig, StarkGenericConfig, Val, prove, verify};
+use rand::SeedableRng;
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
+
+const WIDTH: usize = 2;
+
+#[derive(Clone, Debug)]
+struct PeriodicAir<F> {
+    periodic: Vec<Vec<F>>,
+}
+
+impl<F: Field + PrimeCharacteristicRing> Default for PeriodicAir<F> {
+    fn default() -> Self {
+        Self {
+            periodic: vec![
+                vec![F::ONE, F::TWO],
+                vec![
+                    F::from_u64(10),
+                    F::from_u64(20),
+                    F::from_u64(30),
+                    F::from_u64(40),
+                ],
+            ],
+        }
+    }
+}
+
+impl<F: Field> PeriodicAir<F> {
+    fn valid_trace(&self, rows: usize) -> RowMajorMatrix<F> {
+        let periodic = &self.periodic;
+        let mut values = F::zero_vec(rows * WIDTH);
+        for (i, row) in values.chunks_exact_mut(WIDTH).enumerate() {
+            row[0] = periodic[0][i % periodic[0].len()];
+            row[1] = periodic[1][i % periodic[1].len()];
+        }
+        RowMajorMatrix::new(values, WIDTH)
+    }
+}
+
+impl<F: Field> BaseAir<F> for PeriodicAir<F> {
+    fn width(&self) -> usize {
+        WIDTH
+    }
+
+    fn num_periodic_columns(&self) -> usize {
+        self.periodic.len()
+    }
+
+    fn periodic_columns(&self) -> &[Vec<F>] {
+        &self.periodic
+    }
+}
+
+impl<AB> Air<AB> for PeriodicAir<AB::F>
+where
+    AB: AirBuilder + PeriodicAirBuilder,
+    AB::F: Field,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let p0 = builder.periodic_values()[0].into();
+        let p1 = builder.periodic_values()[1].into();
+        builder.assert_eq(main.current(0).unwrap(), p0);
+        builder.assert_eq(main.current(1).unwrap(), p1);
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn do_test<SC>(config: SC, air: PeriodicAir<Val<SC>>, rows: usize) -> Result<(), impl Debug>
+where
+    SC: StarkGenericConfig,
+    SC::Challenger: Clone,
+    StandardUniform: Distribution<Val<SC>>,
+    Domain<SC>: EvaluatePolynomialAtPoint,
+{
+    let trace = air.valid_trace(rows);
+    let proof = prove(&config, &air, trace, &[]);
+
+    let serialized_proof = postcard::to_allocvec(&proof).expect("unable to serialize proof");
+    let deserialized_proof =
+        postcard::from_bytes(&serialized_proof).expect("unable to deserialize proof");
+
+    verify(&config, &air, &deserialized_proof, &[])
+}
+
+fn do_test_bb_trivial(log_n: usize) -> Result<(), impl Debug> {
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type Dft = Radix2DitParallel<Val>;
+    type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+    type Pcs = TrivialPcs<Val, Dft>;
+    type Config = StarkConfig<Pcs, Challenge, Challenger>;
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let pcs = Pcs {
+        dft: Dft::default(),
+        log_n,
+        _phantom: PhantomData,
+    };
+    let challenger = Challenger::new(perm);
+    let config = Config::new(pcs, challenger);
+
+    do_test(config, PeriodicAir::<Val>::default(), 1 << log_n)
+}
+
+fn do_test_bb_twoadic(log_blowup: usize, log_n: usize) -> Result<(), impl Debug> {
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    type Dft = Radix2DitParallel<Val>;
+    type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+    type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    type Config = StarkConfig<Pcs, Challenge, Challenger>;
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let fri_params = FriParameters {
+        log_blowup,
+        log_final_poly_len: 3,
+        max_log_arity: 2,
+        num_queries: 40,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 8,
+        mmcs: challenge_mmcs,
+    };
+    let pcs = Pcs::new(Dft::default(), val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    let config = Config::new(pcs, challenger);
+
+    do_test(config, PeriodicAir::<Val>::default(), 1 << log_n)
+}
+
+fn do_test_m31_circle(log_blowup: usize, log_n: usize) -> Result<(), impl Debug> {
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Val, 3>;
+    type ByteHash = Keccak256Hash;
+    type FieldHash = SerializingHasher<ByteHash>;
+    type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
+    type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 2, 32>;
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    type Config = StarkConfig<Pcs, Challenge, Challenger>;
+
+    let byte_hash = ByteHash {};
+    let field_hash = FieldHash::new(byte_hash);
+    let compress = MyCompress::new(byte_hash);
+    let val_mmcs = ValMmcs::new(field_hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let fri_params = FriParameters {
+        log_blowup,
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 40,
+        commit_proof_of_work_bits: 0,
+        query_proof_of_work_bits: 8,
+        mmcs: challenge_mmcs,
+    };
+    let pcs = Pcs {
+        mmcs: val_mmcs,
+        fri_params,
+        _phantom: PhantomData,
+    };
+    let challenger = Challenger::from_hasher(vec![], byte_hash);
+    let config = Config::new(pcs, challenger);
+
+    do_test(config, PeriodicAir::<Val>::default(), 1 << log_n)
+}
+
+#[test]
+fn prove_bb_trivial() -> Result<(), impl Debug> {
+    do_test_bb_trivial(8)
+}
+
+#[test]
+fn prove_bb_twoadic() -> Result<(), impl Debug> {
+    do_test_bb_twoadic(1, 6)
+}
+
+#[test]
+fn prove_m31_circle() -> Result<(), impl Debug> {
+    do_test_m31_circle(1, 6)
+}


### PR DESCRIPTION
Add runtime periodic-column evaluation across the shared AIR and domain layers for uni-stark, and cover the new behavior with focused uni-stark tests.