### PR TITLE
Clarify selector semantics

### DIFF
--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -2140,7 +2140,7 @@ impl SingleTableLocalLookupAir {
 
 impl<F> BaseAir<F> for SingleTableLocalLookupAir {
     fn width(&self) -> usize {
-        7 // 7 columns: 3 sender columns (1 for each selector type), lookup table, 3 multiplicty columns (1 for each selector type)
+        7 // 7 columns: 3 sender columns (1 for each selector type), lookup table, 3 multiplicity columns (1 for each selector type)
     }
 }
 
@@ -2181,17 +2181,15 @@ impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
         let mul2 = symbolic_main_local[5]; // Multiplicity column for second selector
         let mul3 = symbolic_main_local[6]; // Multiplicity column for third selector
 
-        // Local lookup: sender column looks up into lookup table column
-        // Sender: send is_transition * sender_col
-        // Receiver: receive lookup_table_col with multiplicity 1
+        // Local lookup: sender column looks up into lookup table column.
         let lookup_inputs1 = vec![
-            // Sender: send values from sender column with `is_first_row` multiplicity
+            // Read values from the sender column with `is_first_row` multiplicity.
             (
                 vec![sender_col1.into()],
                 symbolic_air_builder.is_first_row(),
                 Direction::Receive,
             ),
-            // Receiver: receive values in lookup table column with multiplicity 1 * `is_first_row` multiplicity.
+            // Provide values from the lookup table with `is_first_row * mul1` multiplicity.
             // Note that we need to multiply by `is_first_row` here because the Lagrange selectors are not normalized.
             (
                 vec![lookup_table_col.into()],
@@ -2201,13 +2199,13 @@ impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
         ];
 
         let lookup_inputs2 = vec![
-            // Sender: send values from sender column with `is_last_row` multiplicity
+            // Read values from the sender column with `is_transition` multiplicity.
             (
                 vec![sender_col2.into()],
                 symbolic_air_builder.is_transition(),
                 Direction::Receive,
             ),
-            // Receiver: receive values in lookup table column with multiplicity 1 * `is_transition` multiplicity.
+            // Provide values from the lookup table with `is_transition * mul2` multiplicity.
             // Note that we need to multiply by `is_transition` here because the Lagrange selectors are not normalized.
             (
                 vec![lookup_table_col.into()],
@@ -2217,13 +2215,13 @@ impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
         ];
 
         let lookup_inputs3 = vec![
-            // Sender: send values from sender column with `is_transition` multiplicity
+            // Read values from the sender column with `is_last_row` multiplicity.
             (
                 vec![sender_col3.into()],
                 symbolic_air_builder.is_last_row(),
                 Direction::Receive,
             ),
-            // Receiver: receive values in lookup table column with multiplicity 1 * `is_last_row` multiplicity.
+            // Provide values from the lookup table with `is_last_row * mul3` multiplicity.
             // Note that we need to multiply by `is_last_row` here because the Lagrange selectors are not normalized.
             (
                 vec![lookup_table_col.into()],
@@ -2255,8 +2253,8 @@ fn single_table_local_lookup_trace<F: Field>(height: usize) -> RowMajorMatrix<F>
     // Column 2: all rows are 11 except last row which is 0
     // Column 3: Lookup table column: values 7 to 0
     // Column 4: (mult1) 1 at row 0, 0 elsewhere
-    // Column 5: (mult1): 1 everywhere except last row, which is 0
-    // Column 6: (mult2): 1 at last row, 0 elsewhere
+    // Column 5: (mult2) 1 everywhere except last row, which is 0
+    // Column 6: (mult3) 1 at last row, 0 elsewhere
     for i in 0..height {
         // Sender columns:
         // Column 0
@@ -2283,7 +2281,7 @@ fn single_table_local_lookup_trace<F: Field>(height: usize) -> RowMajorMatrix<F>
 }
 
 /// Test with a single table doing local lookup between its two columns.
-/// The goal of this test is to check that the use of (non-normalized) Lagrange selectors does not cause isssues.
+/// The goal of this test is to check that the use of (non-normalized) Lagrange selectors does not cause issues.
 #[test]
 fn test_single_table_local_lookup() -> Result<(), impl Debug> {
     let config = make_config(2029);

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -30,7 +30,7 @@ pub enum Kind {
     Global(String),
 }
 
-/// Indicates the direction of data flow in a global lookup.
+/// Indicates the direction of data flow in a lookup interaction.
 #[derive(Clone, Copy)]
 pub enum Direction {
     /// Indicates that elements are being sent (contributed) to the lookup.
@@ -72,7 +72,7 @@ pub struct LookupData<F> {
 /// use p3_lookup::{LookupInput, Direction};
 /// use p3_air::SymbolicExpression;
 ///
-/// let lookup_input: LookupInput<SymbolicExpression<F>> = (
+/// let lookup_input: LookupInput<F> = (
 ///     vec![SymbolicExpression::Constant(F::ONE)],
 ///     SymbolicExpression::Constant(F::ONE),
 ///     Direction::Send
@@ -90,8 +90,8 @@ pub struct Lookup<F: Field> {
     /// actually represents a tuple of elements that are bundled together to make one lookup.
     pub element_exprs: Vec<Vec<SymbolicExpression<F>>>,
     /// Multiplicities for the elements.
-    /// Note that Lagrange selectors may not be normalized, and so cannot be used as proper
-    /// filters in the multiplicities.
+    /// Note that Lagrange selectors may not be normalized, so they cannot be used as proper
+    /// boolean filters in the multiplicities.
     pub multiplicities_exprs: Vec<SymbolicExpression<F>>,
     /// The column index in the permutation trace for this lookup's running sum
     pub columns: Vec<usize>,

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -79,11 +79,14 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub preprocessed_window: RowWindow<'a, PackedVal<SC>>,
     /// Public inputs to the [AIR](`p3_air::Air`) implementation.
     pub public_values: &'a [Val<SC>],
-    /// Evaluations of the Selector polynomial for the first row of the trace
+    /// Evaluations of the first-row selector polynomial.
+    /// Non-zero only on the first trace row.
     pub is_first_row: PackedVal<SC>,
-    /// Evaluations of the Selector polynomial for the last row of the trace
+    /// Evaluations of the last-row selector polynomial.
+    /// Non-zero only on the last trace row.
     pub is_last_row: PackedVal<SC>,
-    /// Evaluations of the Selector polynomial for rows where transition constraints should be applied
+    /// Evaluations of the transition selector polynomial.
+    /// Zero only on the last trace row.
     pub is_transition: PackedVal<SC>,
     /// Base-field alpha powers, reordered to match base constraint emission order.
     /// `base_alpha_powers[d][j]` = d-th basis coefficient of alpha power for j-th base constraint.
@@ -115,11 +118,14 @@ pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     pub preprocessed_window: RowWindow<'a, SC::Challenge>,
     /// Public values that are inputs to the computation
     pub public_values: &'a [Val<SC>],
-    /// Evaluations of the Selector polynomial for the first row of the trace
+    /// Evaluations of the first-row selector polynomial.
+    /// Non-zero only on the first trace row.
     pub is_first_row: SC::Challenge,
-    /// Evaluations of the Selector polynomial for the last row of the trace
+    /// Evaluations of the last-row selector polynomial.
+    /// Non-zero only on the last trace row.
     pub is_last_row: SC::Challenge,
-    /// Evaluations of the Selector polynomial for rows where transition constraints should be applied
+    /// Evaluations of the transition selector polynomial.
+    /// Zero only on the last trace row.
     pub is_transition: SC::Challenge,
     /// Single challenge value used for constraint combination
     pub alpha: SC::Challenge,

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -97,15 +97,15 @@ where
     //
     // When we convert to working with polynomials, the `X_i`'s and `Y_i`'s will be replaced by the
     // degree `N - 1` polynomials `T_i(x)` and `T_i(hx)` respectively. The selector polynomials are
-    //  a little more complicated however.
+    // a little more complicated, however.
     //
-    // In our our case, the selector polynomials are `S_1(x) = is_first_row`, `S_2(x) = is_last_row`
+    // In our case, the selector polynomials are `S_1(x) = is_first_row`, `S_2(x) = is_last_row`
     // and `S_3(x) = is_transition`. Both `S_1(x)` and `S_2(x)` are polynomials of degree `N - 1`
-    // as they must be non zero only at a single location in the initial domain. However, `is_transition`
-    // is a polynomial of degree `1` as it simply need to be `0` on the last row.
+    // as they must be non-zero only at a single location in the initial domain. However,
+    // `is_transition` is a polynomial of degree `1` as it simply needs to be `0` on the last row.
     //
     // The constraint degree (`deg(C)`) is the linear factor of `N` in the constraint polynomial. In other
-    // words, it is roughly the total degree of `C` however, we treat `Z_3` as a constant term which does
+    // words, it is roughly the total degree of `C`; however, we treat `Z_3` as a constant term which does
     // not contribute to the degree.
     //
     // E.g. `C_j = Z_1 * (X_1^3 - X_2 * X_3 * X_4)` would have degree `4`.

--- a/uni-stark/src/sub_builder.rs
+++ b/uni-stark/src/sub_builder.rs
@@ -5,7 +5,7 @@
 //! that view into any [`AirBuilder`] implementation so a sub-air can be evaluated independently
 //! without copying trace data.
 
-// Code inpsired from SP1 with additional modifications:
+// Code inspired by SP1 with additional modifications:
 // https://github.com/succinctlabs/sp1/blob/main/crates/stark/src/air/sub_builder.rs
 
 use core::marker::PhantomData;


### PR DESCRIPTION
  This fixes a few docs and test comments that currently contradict the implementation: selectors are not guaranteed to be normalized, and the local lookup example had row-selector comments swapped. The change is docs-only, aligns `lookup` and `uni-stark` with the selector semantics already used in `p3-air`, and the affected tests and package checks pass.     