### PR TITLE
poseidon1: speedup monty-31 packed version

### DIFF
--- a/monty-31/src/aarch64_neon/poseidon.rs
+++ b/monty-31/src/aarch64_neon/poseidon.rs
@@ -5,6 +5,7 @@ use core::arch::aarch64::int32x4_t;
 use core::marker::PhantomData;
 use core::mem::transmute;
 
+use p3_field::PrimeCharacteristicRing;
 use p3_mds::karatsuba_convolution::{mds_circulant_karatsuba_16, mds_circulant_karatsuba_24};
 use p3_poseidon::external::{
     FullRoundConstants, FullRoundLayer, FullRoundLayerConstructor, mds_multiply,
@@ -164,10 +165,9 @@ where
             // PATH B (can overlap with S-box): partial dot product on s_hi.
             let s_hi: &[PackedMontyField31Neon<FP>; 15] = unsafe { transmute(&split.s_hi) };
             let first_row = &self.packed_sparse_first_row[r];
-            let mut partial_dot = s_hi[0] * first_row[1];
-            for j in 1..15 {
-                partial_dot += s_hi[j] * first_row[j + 1];
-            }
+            let first_row_hi: [PackedMontyField31Neon<FP>; 15] =
+                core::array::from_fn(|i| first_row[i + 1]);
+            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;
@@ -224,10 +224,9 @@ where
             // PATH B (can overlap with S-box): partial dot product on s_hi.
             let s_hi: &[PackedMontyField31Neon<FP>; 23] = unsafe { transmute(&split.s_hi) };
             let first_row = &self.packed_sparse_first_row[r];
-            let mut partial_dot = s_hi[0] * first_row[1];
-            for j in 1..23 {
-                partial_dot += s_hi[j] * first_row[j + 1];
-            }
+            let first_row_hi: [PackedMontyField31Neon<FP>; 23] =
+                core::array::from_fn(|i| first_row[i + 1]);
+            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;


### PR DESCRIPTION
Benchmarks after this PR when compared to main

```shell
    Gnuplot not found, using plotters backend
Benchmarking poseidon-scalar::<MontyField31<BabyBearParameters>, 16>/16: Collecting 100 samples in estimated 5.003poseidon-scalar::<MontyField31<BabyBearParameters>, 16>/16
                        time:   [1.4777 µs 1.4780 µs 1.4785 µs]
                        change: [−0.3883% −0.1930% −0.0535%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

Benchmarking poseidon-packed::<PackedMontyField31Neon<BabyBearParameters>, 16>/16: Collecting 100 samples in estimposeidon-packed::<PackedMontyField31Neon<BabyBearParameters>, 16>/16
                        time:   [2.0059 µs 2.0077 µs 2.0097 µs]
                        change: [−8.2084% −7.4848% −6.9184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking poseidon-scalar::<MontyField31<BabyBearParameters>, 24>/24: Collecting 100 samples in estimated 5.0poseidon-scalar::<MontyField31<BabyBearParameters>, 24>/24
                        time:   [3.9471 µs 3.9534 µs 3.9649 µs]
                        change: [−0.2819% +0.1218% +0.4617%] (p = 0.56 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking poseidon-packed::<PackedMontyField31Neon<BabyBearParameters>, 24>/24: Collecting 100 samples in estposeidon-packed::<PackedMontyField31Neon<BabyBearParameters>, 24>/24
                        time:   [3.4702 µs 3.4729 µs 3.4758 µs]
                        change: [−21.262% −18.080% −15.910%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking poseidon-scalar::<MontyField31<KoalaBearParameters>, 16>/16: Collecting 100 samples in estimated 5.poseidon-scalar::<MontyField31<KoalaBearParameters>, 16>/16
                        time:   [1.4449 µs 1.4470 µs 1.4504 µs]
                        change: [−1.8144% −0.9151% −0.3381%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

Benchmarking poseidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 16>/16: Collecting 100 samples in esposeidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 16>/16
                        time:   [2.0032 µs 2.0040 µs 2.0050 µs]
                        change: [−11.417% −11.233% −11.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking poseidon-scalar::<MontyField31<KoalaBearParameters>, 24>/24: Collecting 100 samples in estimated 5.poseidon-scalar::<MontyField31<KoalaBearParameters>, 24>/24
                        time:   [3.7015 µs 3.7041 µs 3.7068 µs]
                        change: [−0.2254% −0.0505% +0.2414%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

Benchmarking poseidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 24>/24: Collecting 100 samples in esposeidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 24>/24
                        time:   [3.3148 µs 3.3291 µs 3.3472 µs]
                        change: [−17.720% −17.448% −17.172%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```