### PR TITLE
monty 31: faster forward dft

### DIFF
--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -115,33 +115,11 @@ impl<PMP: PackedMontyParameters> PackedMontyField31Neon<PMP> {
         Self([value; WIDTH])
     }
 
-    /// Fused DIF (decimation-in-frequency) butterfly for forward FFT.
+    /// Fused DIF butterfly for forward FFT: computes `(x + y, (x - y) * roots)`.
     ///
-    /// Computes `(x + y, (x - y) * roots)` with one fewer modular reduction
-    /// than the naive `Sub` + `Mul` approach.
-    ///
-    /// # Why this is faster
-    ///
-    /// The naive butterfly computes `x - y` via `mod_sub`, which produces a
-    /// canonical result in `[0, P)` using 3 NEON ops:
-    ///
-    /// ```text
-    ///     sub   diff, x, y          // diff in (-P, P) as signed
-    ///     add   tmp, diff, P        // tmp  in (0, 2P)
-    ///     umin  diff, diff, tmp     // diff in [0, P)   ← canonical
-    /// ```
-    ///
-    /// But Montgomery multiplication (`mul`) accepts signed inputs in `(-P, P)`.
-    /// The raw `vsubq_u32(x, y)` already lies in that range when reinterpreted
-    /// as `i32`, so the `add` + `umin` reduction is unnecessary.
-    ///
-    /// ```text
-    ///     Standard path:  mod_sub (3 ops) + mul (7 ops) = 10 ops
-    ///     Fused path:     raw sub (1 op)  + mul (7 ops) =  8 ops   ← 2 fewer
-    /// ```
-    ///
-    /// The `x + y` half still needs full `mod_add` (3 ops) since its result
-    /// feeds into subsequent butterflies that expect canonical `[0, P)` inputs.
+    /// Saves 2 NEON ops per butterfly by skipping the modular reduction on
+    /// `x - y`. The raw `vsubq_u32(x, y)` lies in `(-P, P)` as signed,
+    /// which is already a valid input for Montgomery multiplication.
     #[inline(always)]
     pub(crate) fn forward_butterfly(self, y: Self, roots: Self) -> (Self, Self) {
         unsafe {

--- a/monty-31/src/dft/forward.rs
+++ b/monty-31/src/dft/forward.rs
@@ -69,23 +69,15 @@ fn forward_butterfly<T: PrimeCharacteristicRing + Copy>(x: T, y: T, roots: T) ->
 
 /// Architecture-dispatched DIF butterfly for packed `MontyField31` vectors.
 ///
-/// # DIF Butterfly
-///
-/// The decimation-in-frequency (DIF) butterfly computes:
-///
-/// ```text
-///     (x, y)  →  (x + y,  (x - y) · ω)
-/// ```
-///
-/// where `ω` is a twiddle factor (root of unity).
-///
-/// # aarch64 Optimization
+/// The DIF butterfly computes `(x + y, (x - y) · ω)` where `ω` is a twiddle factor.
 ///
 /// On aarch64, this delegates to `PackedMontyField31Neon::forward_butterfly`,
-/// which fuses the subtraction and multiplication to skip an unnecessary
-/// modular reduction. See that method's documentation for the full rationale.
+/// which fuses the subtraction and multiplication to skip the modular reduction
+/// on `x - y`. See that method's documentation for the full rationale.
 ///
 /// On other architectures, this falls back to the generic `forward_butterfly`.
+///
+/// TODO: apply the same fused sub+mul optimization for AVX2/AVX-512 backends.
 #[inline(always)]
 fn monty_forward_butterfly<MP: FieldParameters + TwoAdicData>(
     x: <MontyField31<MP> as Field>::Packing,


### PR DESCRIPTION
A subset of the benchmarks just to show the improvements:

```shell
Gnuplot not found, using plotters backend
Benchmarking fft/MontyField31<BabyBearParameters>/RecursiveDft<Benchmarking fft/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/16384: Warming up fBenchmarking fft/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/16384: Collecting 1Benchmarking fft/MontyField31<BabyBearParameters>/RecursiveDft<fft/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/16384
                        time:   [15.871 ms 15.898 ms 15.930 ms]
                        change: [−8.6921% −8.3634% −8.0633%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild

Benchmarking coset_lde/MontyField31<BabyBearParameters>/RecursiBenchmarking coset_lde/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/...: Warming Benchmarking coset_lde/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/...: CollectiBenchmarking coset_lde/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/...: Analyzincoset_lde/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/ncols=256/...
                        time:   [47.052 ms 50.656 ms 54.867 ms]
                        change: [−5.1038% −0.5556% +5.0829%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe

Benchmarking fft_algebra/MontyField31<BabyBearParameters>/RecurBenchmarking fft_algebra/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/Binomial... #3: WarmiBenchmarking fft_algebra/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/Binomial... #3: ColleBenchmarking fft_algebra/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/Binomial... #3: Analyfft_algebra/MontyField31<BabyBearParameters>/RecursiveDft<MontyField31<BabyBearParameters>>/Binomial... #3
                        time:   [17.120 ms 17.289 ms 17.662 ms]
                        change: [−9.5981% −8.2932% −6.4359%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```