### PR TITLE
monty31: faster aarch64 neon `quintic_mul_packed`

### DIFF
--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -953,38 +953,48 @@ where
     unsafe {
         // Accumulate the full 64-bit sum C = Σ lhs_i ⋅ rhs_i (5 terms).
 
+        // Materialize all vectors once.
+        let lhs0 = lhs[0].into_vec();
+        let rhs0 = rhs[0].into_vec();
+        let lhs1 = lhs[1].into_vec();
+        let rhs1 = rhs[1].into_vec();
+        let lhs2 = lhs[2].into_vec();
+        let rhs2 = rhs[2].into_vec();
+        let lhs3 = lhs[3].into_vec();
+        let rhs3 = rhs[3].into_vec();
+        let lhs4 = lhs[4].into_vec();
+        let rhs4 = rhs[4].into_vec();
+
         // Low half (Lanes 0 & 1)
-        let mut sum_l = aarch64::vmull_u32(
-            aarch64::vget_low_u32(lhs[0].into_vec()),
-            aarch64::vget_low_u32(rhs[0].into_vec()),
+        let mut sum_l =
+            aarch64::vmull_u32(aarch64::vget_low_u32(lhs0), aarch64::vget_low_u32(rhs0));
+        sum_l = aarch64::vmlal_u32(
+            sum_l,
+            aarch64::vget_low_u32(lhs1),
+            aarch64::vget_low_u32(rhs1),
         );
         sum_l = aarch64::vmlal_u32(
             sum_l,
-            aarch64::vget_low_u32(lhs[1].into_vec()),
-            aarch64::vget_low_u32(rhs[1].into_vec()),
+            aarch64::vget_low_u32(lhs2),
+            aarch64::vget_low_u32(rhs2),
         );
         sum_l = aarch64::vmlal_u32(
             sum_l,
-            aarch64::vget_low_u32(lhs[2].into_vec()),
-            aarch64::vget_low_u32(rhs[2].into_vec()),
+            aarch64::vget_low_u32(lhs3),
+            aarch64::vget_low_u32(rhs3),
         );
         sum_l = aarch64::vmlal_u32(
             sum_l,
-            aarch64::vget_low_u32(lhs[3].into_vec()),
-            aarch64::vget_low_u32(rhs[3].into_vec()),
-        );
-        sum_l = aarch64::vmlal_u32(
-            sum_l,
-            aarch64::vget_low_u32(lhs[4].into_vec()),
-            aarch64::vget_low_u32(rhs[4].into_vec()),
+            aarch64::vget_low_u32(lhs4),
+            aarch64::vget_low_u32(rhs4),
         );
 
         // High half (Lanes 2 & 3)
-        let mut sum_h = aarch64::vmull_high_u32(lhs[0].into_vec(), rhs[0].into_vec());
-        sum_h = aarch64::vmlal_high_u32(sum_h, lhs[1].into_vec(), rhs[1].into_vec());
-        sum_h = aarch64::vmlal_high_u32(sum_h, lhs[2].into_vec(), rhs[2].into_vec());
-        sum_h = aarch64::vmlal_high_u32(sum_h, lhs[3].into_vec(), rhs[3].into_vec());
-        sum_h = aarch64::vmlal_high_u32(sum_h, lhs[4].into_vec(), rhs[4].into_vec());
+        let mut sum_h = aarch64::vmull_high_u32(lhs0, rhs0);
+        sum_h = aarch64::vmlal_high_u32(sum_h, lhs1, rhs1);
+        sum_h = aarch64::vmlal_high_u32(sum_h, lhs2, rhs2);
+        sum_h = aarch64::vmlal_high_u32(sum_h, lhs3, rhs3);
+        sum_h = aarch64::vmlal_high_u32(sum_h, lhs4, rhs4);
 
         // Split C into 32-bit halves per lane:
         // - c_lo = C mod 2^{32},


### PR DESCRIPTION
New benchmarks when compared to main branch

```shell
Gnuplot not found, using plotters backend
Benchmarking base_mul-throughput/100 BinomialExtensionField<BabyBear, 5>: Collecting 100 samples in estimated 5.00base_mul-throughput/100 BinomialExtensionField<BabyBear, 5>
                        time:   [983.31 ns 987.66 ns 996.01 ns]
                        change: [−0.2771% +0.6109% +2.0278%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking base_mul-latency/1000 BinomialExtensionField<BabyBear, 5>: Collecting 100 samples in estimated 5.0279base_mul-latency/1000 BinomialExtensionField<BabyBear, 5>
                        time:   [5.7739 µs 5.7978 µs 5.8438 µs]
                        change: [−0.2267% +0.1291% +0.7064%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

Benchmarking mul-throughput/100 BinomialExtensionField<BabyBear, 5>: Collecting 100 samples in estimated 5.0088 mul-throughput/100 BinomialExtensionField<BabyBear, 5>
                        time:   [4.7291 µs 4.7322 µs 4.7361 µs]
                        change: [−29.800% −29.317% −29.024%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking mul-latency/1000 BinomialExtensionField<BabyBear, 5>: Collecting 100 samples in estimated 5.0948 s mul-latency/1000 BinomialExtensionField<BabyBear, 5>
                        time:   [22.820 µs 22.838 µs 22.861 µs]
                        change: [+3.7555% +3.9968% +4.3032%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
```