### PR TITLE
fix(batch-stark): correct misleading degree_bits documentation

### DIFF
--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -32,9 +32,9 @@ pub struct PreprocessedInstanceMeta {
     pub matrix_index: usize,
     /// Width (number of columns) of the preprocessed trace.
     pub width: usize,
-    /// Log2 of the base trace degree for this instance's preprocessed trace.
+    /// Log2 of the extended trace degree for this instance's preprocessed trace.
     ///
-    /// This matches the log2 of the main trace degree (without ZK padding)
+    /// This matches the log2 of the main trace degree (with ZK padding)
     /// for that instance.
     pub degree_bits: usize,
 }

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -379,7 +379,7 @@ where
                     })
                 })?;
 
-            // Validate that the preprocessed data's base degree matches what we expect.
+            // Validate that the preprocessed data's extended degree matches what we expect.
             let ext_db = degree_bits[inst_idx];
 
             let meta = global.instances[inst_idx].as_ref().ok_or_else(|| {


### PR DESCRIPTION
Fix incorrect doc comments on `PreprocessedInstanceMeta::degree_bits` that stated it stores the base trace degree "without ZK padding", when it actually stores the extended degree (with ZK padding)
Fix matching comment in verifier that referred to "base degree" validation

## Context
The field `degree_bits` is assigned from `ext_db` (extended degree bits, with ZK padding) in `common.rs:243`, but the doc comment claimed it was the base degree without ZK padding. In ZK proof systems, this 1-bit difference means a 2x domain size discrepancy, which could mislead developers during secondary development.

The code itself is correct — both prover and verifier consistently use `ext_db`. Only the documentation was wrong.