### PR TITLE
monty31: use transmute in poseidon1 packing

### DIFF
--- a/monty-31/src/aarch64_neon/poseidon1.rs
+++ b/monty-31/src/aarch64_neon/poseidon1.rs
@@ -163,12 +163,12 @@ where
             }
 
             // PATH B (can overlap with S-box): partial dot product on s_hi.
-            let s_hi: &[PackedMontyField31Neon<FP>; 15] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer16<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31Neon<FP>; 15] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31Neon<FP>; 15] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer16::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31Neon<FP>; 15] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(&s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;
@@ -223,12 +223,12 @@ where
             }
 
             // PATH B (can overlap with S-box): partial dot product on s_hi.
-            let s_hi: &[PackedMontyField31Neon<FP>; 23] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer24<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31Neon<FP>; 23] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31Neon<FP>; 23] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer24::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31Neon<FP>; 23] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31Neon::<FP>::dot_product(&s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;

--- a/monty-31/src/x86_64_avx2/poseidon1.rs
+++ b/monty-31/src/x86_64_avx2/poseidon1.rs
@@ -162,12 +162,12 @@ where
             }
 
             // PATH B (can overlap with S-box): partial dot product on s_hi.
-            let s_hi: &[PackedMontyField31AVX2<FP>; 15] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer16<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31AVX2<FP>; 15] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31AVX2::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31AVX2<FP>; 15] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer16::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31AVX2<FP>; 15] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31AVX2::<FP>::dot_product(&s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;
@@ -222,12 +222,12 @@ where
             }
 
             // PATH B (can overlap with S-box): partial dot product on s_hi.
-            let s_hi: &[PackedMontyField31AVX2<FP>; 23] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer24<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31AVX2<FP>; 23] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31AVX2::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31AVX2<FP>; 23] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer24::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31AVX2<FP>; 23] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31AVX2::<FP>::dot_product(&s_hi, &first_row_hi);
 
             // SERIAL: complete s0 and rank-1 update.
             let s0_val = split.s0;

--- a/monty-31/src/x86_64_avx512/poseidon1.rs
+++ b/monty-31/src/x86_64_avx512/poseidon1.rs
@@ -156,12 +156,12 @@ where
                 split.s0 += self.packed_round_constants[r];
             }
 
-            let s_hi: &[PackedMontyField31AVX512<FP>; 15] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer16<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31AVX512<FP>; 15] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31AVX512::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31AVX512<FP>; 15] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer16::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31AVX512<FP>; 15] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31AVX512::<FP>::dot_product(&s_hi, &first_row_hi);
 
             let s0_val = split.s0;
             split.s0 = s0_val * first_row.s0 + partial_dot;
@@ -208,12 +208,12 @@ where
                 split.s0 += self.packed_round_constants[r];
             }
 
-            let s_hi: &[PackedMontyField31AVX512<FP>; 23] = unsafe { transmute(&split.s_hi) };
-            let first_row: &InternalLayer24<FP> =
-                unsafe { transmute(&self.packed_sparse_first_row[r]) };
-            let first_row_hi: &[PackedMontyField31AVX512<FP>; 23] =
-                unsafe { transmute(&first_row.s_hi) };
-            let partial_dot = PackedMontyField31AVX512::<FP>::dot_product(s_hi, first_row_hi);
+            let s_hi: [PackedMontyField31AVX512<FP>; 23] = unsafe { transmute(split.s_hi) };
+            let first_row =
+                InternalLayer24::from_packed_field_array(self.packed_sparse_first_row[r]);
+            let first_row_hi: [PackedMontyField31AVX512<FP>; 23] =
+                unsafe { transmute(first_row.s_hi) };
+            let partial_dot = PackedMontyField31AVX512::<FP>::dot_product(&s_hi, &first_row_hi);
 
             let s0_val = split.s0;
             split.s0 = s0_val * first_row.s0 + partial_dot;


### PR DESCRIPTION
@SyxtonPrime Related https://github.com/Plonky3/Plonky3/pull/1420#pullrequestreview-3956025703

Locally, I see a super small speedup, this is somehow in the noise threshold but each time I rerun, I still have something faster so maybe that is a slightly better solution here. Let me know, otherwise we can close:

```rust
Gnuplot not found, using plotters backend
Benchmarking poseidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 16>/16: Collecting 100 samples in estposeidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 16>/16
                        time:   [2.0089 µs 2.0114 µs 2.0150 µs]
                        change: [−3.2857% −1.5227% −0.3179%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking poseidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 24>/24: Collecting 100 samples in eposeidon-packed::<PackedMontyField31Neon<KoalaBearParameters>, 24>/24
                        time:   [3.2965 µs 3.2978 µs 3.2992 µs]
                        change: [−0.1603% −0.0166% +0.2095%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe
```