### PR TITLE
air: add dag types for symbolic expression trees

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 hashbrown.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
+serde = { workspace = true, features = ["derive", "alloc"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/air/src/symbolic/dag.rs
+++ b/air/src/symbolic/dag.rs
@@ -3,6 +3,8 @@
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use serde::{Deserialize, Serialize};
+
 use super::SymbolicExpr;
 
 /// A single node in a flattened expression DAG.
@@ -14,7 +16,7 @@ use super::SymbolicExpr;
 ///
 /// All child indices must be strictly less than this node's
 /// own position in the containing vector.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SymbolicExprNode<A> {
     /// An atomic value: variable reference, field constant, or selector flag.
     Leaf(A),
@@ -69,18 +71,46 @@ pub enum SymbolicExprNode<A> {
 ///
 /// Every node at position `i` only references positions `< i`.
 /// A single forward pass is sufficient to evaluate or reconstruct the entire graph.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicExprDag<A> {
-    /// Nodes in dependency order (children always precede parents).
-    pub nodes: Vec<SymbolicExprNode<A>>,
-
-    /// Position of each constraint's root node inside the node vector.
-    ///
-    /// Preserves the input ordering from the slice passed to the constructor.
-    pub constraint_idx: Vec<usize>,
+    /// Topologically-sorted nodes (children always precede parents).
+    nodes: Vec<SymbolicExprNode<A>>,
+    /// Index of each constraint's root node in the node vector.
+    constraint_idx: Vec<usize>,
 }
 
 impl<A: Clone> SymbolicExprDag<A> {
+    /// Create a DAG from pre-built topologically-sorted nodes and constraint root indices.
+    pub(crate) const fn new(nodes: Vec<SymbolicExprNode<A>>, constraint_idx: Vec<usize>) -> Self {
+        Self {
+            nodes,
+            constraint_idx,
+        }
+    }
+
+    /// The topologically-sorted node slice.
+    #[inline]
+    #[must_use]
+    pub fn nodes(&self) -> &[SymbolicExprNode<A>] {
+        &self.nodes
+    }
+
+    /// Indices into the node slice for each constraint root.
+    ///
+    /// Preserves the input ordering from the slice passed to the constructor.
+    #[inline]
+    #[must_use]
+    pub fn constraint_idx(&self) -> &[usize] {
+        &self.constraint_idx
+    }
+
+    /// Total number of unique nodes in the DAG.
+    #[inline]
+    #[must_use]
+    pub const fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
     /// Rebuild expression trees from this DAG.
     ///
     /// Returns one tree per constraint root, in the same order as the original input slice.
@@ -95,13 +125,6 @@ impl<A: Clone> SymbolicExprDag<A> {
             .iter()
             .map(|&idx| all[idx].as_ref().clone())
             .collect()
-    }
-
-    /// Total number of unique nodes in the DAG.
-    #[inline]
-    #[must_use]
-    pub const fn node_count(&self) -> usize {
-        self.nodes.len()
     }
 
     /// Rebuild every node into a shared tree node.
@@ -199,9 +222,8 @@ mod tests {
     }
 
     /// Assert that every node at index `i` only references indices `< i`.
-    fn assert_topological_order<A>(dag: &SymbolicExprDag<A>) {
-        for (i, node) in dag.nodes.iter().enumerate() {
-            // Check that all child indices precede this node's position.
+    fn assert_topological_order<A: Clone>(dag: &SymbolicExprDag<A>) {
+        for (i, node) in dag.nodes().iter().enumerate() {
             let valid = match node {
                 SymbolicExprNode::Leaf(_) => true,
                 SymbolicExprNode::Add { left, right, .. }
@@ -318,7 +340,7 @@ mod tests {
 
         // The DAG should contain no nodes and no constraint roots.
         assert_eq!(dag.node_count(), 0);
-        assert!(dag.constraint_idx.is_empty());
+        assert!(dag.constraint_idx().is_empty());
         // Round-trip should also produce an empty list.
         assert!(dag.to_expressions().is_empty());
     }
@@ -337,8 +359,8 @@ mod tests {
         // The product node references the same index for both operands.
         assert_eq!(
             SymbolicExpr::flatten_to_dag(&[sq]),
-            SymbolicExprDag {
-                nodes: vec![
+            SymbolicExprDag::new(
+                vec![
                     SymbolicExprNode::Leaf(BaseLeaf::Variable(SymbolicVariable::new(
                         BaseEntry::Main { offset: 0 },
                         0,
@@ -356,8 +378,8 @@ mod tests {
                         degree_multiple: 2,
                     },
                 ],
-                constraint_idx: vec![3],
-            }
+                vec![3]
+            )
         );
     }
 
@@ -381,8 +403,8 @@ mod tests {
         // The shared product node at index 2 is referenced by both constraint roots.
         assert_eq!(
             dag,
-            SymbolicExprDag {
-                nodes: vec![
+            SymbolicExprDag::new(
+                vec![
                     SymbolicExprNode::Leaf(BaseLeaf::Variable(SymbolicVariable::new(
                         BaseEntry::Main { offset: 0 },
                         0,
@@ -412,8 +434,8 @@ mod tests {
                         degree_multiple: 2,
                     },
                 ],
-                constraint_idx: vec![4, 6],
-            }
+                vec![4, 6]
+            )
         );
     }
 
@@ -427,7 +449,8 @@ mod tests {
 
         // Different allocations must produce separate root nodes.
         assert_ne!(
-            dag.constraint_idx[0], dag.constraint_idx[1],
+            dag.constraint_idx()[0],
+            dag.constraint_idx()[1],
             "independent allocations must produce separate nodes"
         );
     }
@@ -516,9 +539,9 @@ mod tests {
             let dag = SymbolicExpr::flatten_to_dag(&[expr]);
 
             prop_assert_eq!(dag.node_count(), 1);
-            prop_assert_eq!(dag.constraint_idx.len(), 1);
+            prop_assert_eq!(dag.constraint_idx().len(), 1);
             // The sole constraint root must be node 0.
-            prop_assert_eq!(dag.constraint_idx[0], 0);
+            prop_assert_eq!(dag.constraint_idx()[0], 0);
         }
 
         #[test]
@@ -527,7 +550,7 @@ mod tests {
         ) {
             let dag = SymbolicExpr::flatten_to_dag(&exprs);
             // Number of root indices must equal the number of input expressions.
-            prop_assert_eq!(dag.constraint_idx.len(), exprs.len());
+            prop_assert_eq!(dag.constraint_idx().len(), exprs.len());
             // Round-trip must also produce the same count.
             prop_assert_eq!(dag.to_expressions().len(), exprs.len());
         }
@@ -536,7 +559,7 @@ mod tests {
         fn constraint_indices_in_bounds(expr in arb_expr(4)) {
             let dag = SymbolicExpr::flatten_to_dag(&[expr]);
             // Every root index must point to a valid node.
-            for &idx in &dag.constraint_idx {
+            for &idx in dag.constraint_idx() {
                 prop_assert!(idx < dag.node_count());
             }
         }

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -1,4 +1,5 @@
 use p3_field::{Algebra, ExtensionField, Field, InjectiveMonomial};
+use serde::{Deserialize, Serialize};
 
 use crate::symbolic::variable::SymbolicVariable;
 use crate::symbolic::{SymLeaf, SymbolicExpr};
@@ -7,7 +8,7 @@ use crate::symbolic::{SymLeaf, SymbolicExpr};
 ///
 /// These represent the atomic building blocks of AIR constraint expressions:
 /// trace column references, selectors, and field constants.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BaseLeaf<F> {
     /// A reference to a trace column or public input.
     Variable(SymbolicVariable<F>),

--- a/air/src/symbolic/mod.rs
+++ b/air/src/symbolic/mod.rs
@@ -192,101 +192,107 @@ impl<A: SymLeaf> SymbolicExpr<A> {
 impl<A: Clone> SymbolicExpr<A> {
     /// Flatten a slice of expression trees into a single DAG.
     ///
-    /// Subexpressions shared across constraints via pointer identity are deduplicated into a single node.
+    /// Subexpressions shared across constraints via pointer identity
+    /// are deduplicated into a single node.
     ///
-    /// The returned DAG maps each input constraint to its root node index.
+    /// Uses an iterative work stack to avoid stack overflow on deep
+    /// expression trees (e.g. from constraint folding).
     #[must_use]
     pub fn flatten_to_dag(constraints: &[Self]) -> SymbolicExprDag<A> {
-        // Map from raw pointer to node index for deduplication.
-        let mut cache: HashMap<*const Self, usize> = HashMap::new();
-        // Accumulator for topologically-sorted DAG nodes.
-        let mut nodes = Vec::new();
+        /// Work items for the iterative post-order traversal.
+        enum Task<'a, A> {
+            /// First visit: check cache, push children if not yet processed.
+            Enter(&'a SymbolicExpr<A>),
+            /// All children are done: look up their indices and emit this node.
+            Build(&'a SymbolicExpr<A>),
+        }
 
-        // Flatten each constraint tree, collecting the root index of each.
+        let mut cache: HashMap<*const Self, usize> = HashMap::new();
+        let mut nodes = Vec::new();
+        let mut stack: Vec<Task<'_, A>> = Vec::new();
+
         let constraint_idx = constraints
             .iter()
-            .map(|expr| expr.flatten_recursive(&mut cache, &mut nodes))
+            .map(|expr| {
+                stack.push(Task::Enter(expr));
+
+                while let Some(task) = stack.pop() {
+                    match task {
+                        Task::Enter(e) => {
+                            let ptr = e as *const Self;
+                            if cache.contains_key(&ptr) {
+                                continue;
+                            }
+                            match e {
+                                // Leaves have no children — emit immediately.
+                                Self::Leaf(a) => {
+                                    let idx = nodes.len();
+                                    nodes.push(SymbolicExprNode::Leaf(a.clone()));
+                                    cache.insert(ptr, idx);
+                                }
+                                // Binary ops: schedule Build after both children.
+                                Self::Add { x, y, .. }
+                                | Self::Sub { x, y, .. }
+                                | Self::Mul { x, y, .. } => {
+                                    stack.push(Task::Build(e));
+                                    stack.push(Task::Enter(y));
+                                    stack.push(Task::Enter(x));
+                                }
+                                // Unary op: schedule Build after the single child.
+                                Self::Neg { x, .. } => {
+                                    stack.push(Task::Build(e));
+                                    stack.push(Task::Enter(x));
+                                }
+                            }
+                        }
+                        Task::Build(e) => {
+                            let ptr = e as *const Self;
+                            let node = match e {
+                                Self::Leaf(_) => unreachable!(),
+                                Self::Add {
+                                    x,
+                                    y,
+                                    degree_multiple,
+                                } => SymbolicExprNode::Add {
+                                    left: cache[&(x.as_ref() as *const Self)],
+                                    right: cache[&(y.as_ref() as *const Self)],
+                                    degree_multiple: *degree_multiple,
+                                },
+                                Self::Sub {
+                                    x,
+                                    y,
+                                    degree_multiple,
+                                } => SymbolicExprNode::Sub {
+                                    left: cache[&(x.as_ref() as *const Self)],
+                                    right: cache[&(y.as_ref() as *const Self)],
+                                    degree_multiple: *degree_multiple,
+                                },
+                                Self::Neg { x, degree_multiple } => SymbolicExprNode::Neg {
+                                    idx: cache[&(x.as_ref() as *const Self)],
+                                    degree_multiple: *degree_multiple,
+                                },
+                                Self::Mul {
+                                    x,
+                                    y,
+                                    degree_multiple,
+                                } => SymbolicExprNode::Mul {
+                                    left: cache[&(x.as_ref() as *const Self)],
+                                    right: cache[&(y.as_ref() as *const Self)],
+                                    degree_multiple: *degree_multiple,
+                                },
+                            };
+                            let idx = nodes.len();
+                            nodes.push(node);
+                            cache.insert(ptr, idx);
+                        }
+                    }
+                }
+
+                cache[&(expr as *const Self)]
+            })
             .collect();
 
-        SymbolicExprDag {
-            nodes,
-            constraint_idx,
-        }
-    }
-
-    /// Recursively flatten this expression into topologically-sorted nodes,
-    /// deduplicating shared subexpressions by pointer identity.
-    ///
-    /// Returns the index of this expression's node in the output vector.
-    fn flatten_recursive(
-        &self,
-        cache: &mut HashMap<*const Self, usize>,
-        nodes: &mut Vec<SymbolicExprNode<A>>,
-    ) -> usize {
-        // Use the raw pointer as identity key for deduplication.
-        let ptr = self as *const Self;
-        // If this exact allocation was already flattened, return its index.
-        if let Some(&idx) = cache.get(&ptr) {
-            return idx;
-        }
-
-        // Recursively flatten children first (post-order), then build this node.
-        let node = match self {
-            Self::Leaf(a) => SymbolicExprNode::Leaf(a.clone()),
-            Self::Add {
-                x,
-                y,
-                degree_multiple,
-            } => {
-                // Flatten left and right operands, obtaining their DAG indices.
-                let left = x.flatten_recursive(cache, nodes);
-                let right = y.flatten_recursive(cache, nodes);
-                SymbolicExprNode::Add {
-                    left,
-                    right,
-                    degree_multiple: *degree_multiple,
-                }
-            }
-            Self::Sub {
-                x,
-                y,
-                degree_multiple,
-            } => {
-                let left = x.flatten_recursive(cache, nodes);
-                let right = y.flatten_recursive(cache, nodes);
-                SymbolicExprNode::Sub {
-                    left,
-                    right,
-                    degree_multiple: *degree_multiple,
-                }
-            }
-            Self::Neg { x, degree_multiple } => {
-                let idx = x.flatten_recursive(cache, nodes);
-                SymbolicExprNode::Neg {
-                    idx,
-                    degree_multiple: *degree_multiple,
-                }
-            }
-            Self::Mul {
-                x,
-                y,
-                degree_multiple,
-            } => {
-                let left = x.flatten_recursive(cache, nodes);
-                let right = y.flatten_recursive(cache, nodes);
-                SymbolicExprNode::Mul {
-                    left,
-                    right,
-                    degree_multiple: *degree_multiple,
-                }
-            }
-        };
-
-        // Append the new node and record its position in the cache.
-        let idx = nodes.len();
-        nodes.push(node);
-        cache.insert(ptr, idx);
-        idx
+        SymbolicExprDag::new(nodes, constraint_idx)
     }
 }
 

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -1,7 +1,9 @@
 use core::marker::PhantomData;
 
+use serde::{Deserialize, Serialize};
+
 /// Entry kinds for base-field trace columns and public inputs.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BaseEntry {
     Preprocessed { offset: usize },
     Main { offset: usize },
@@ -10,7 +12,7 @@ pub enum BaseEntry {
 }
 
 /// Entry kinds for extension-field columns (permutation trace, challenges, and permutation values).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ExtEntry {
     Permutation { offset: usize },
     Challenge,
@@ -18,7 +20,7 @@ pub enum ExtEntry {
 }
 
 /// A variable within the evaluation window for base-field columns.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicVariable<F> {
     pub entry: BaseEntry,
     pub index: usize,


### PR DESCRIPTION
Adds a flattened DAG representation for symbolic constraint expressions.
Converts `Arc`-based expression trees into a topologically-sorted `Vec<Node>` with index-based references.


Symbolic constraint trees in Plonky3 use `Arc<SymbolicExpr<A>>` for sub-expression sharing.
This works for build-time construction but has three limitations that the DAG addresses.

For me, the proposed approach here has several benefits (this is just a proposal, feel free to just close if you feel this will not be used or if this is not appropriate):

### 1. Serialization

`Arc` is a heap pointer with no meaningful on-disk representation.
The DAG replaces pointers with integer indices into a flat vector, making the entire structure trivially serializable.

OpenVM's stark-backend stores the DAG directly in `StarkVerifyingKey` for exactly this reason:
```
pub struct StarkVerifyingKey<Val, Com> {
    pub symbolic_constraints: SymbolicConstraintsDag<Val>,
    ...
}
```

### 2. Evaluation performance

Arc trees require pointer-chasing traversal -- each node dereferences a heap pointer to reach its children.
The CPU cannot predict these memory accesses.

The DAG enables single-pass linear evaluation:
```
let mut values = Vec::with_capacity(dag.nodes.len());
for node in &dag.nodes {
    let val = match node {
        Leaf(v) => evaluate_leaf(v),
        Add { left, right, .. } => values[*left] + values[*right],
        Mul { left, right, .. } => values[*left] * values[*right],
        ...
    };
    values.push(val);
}
```

This is cache-friendly (sequential memory), branch-predictor-friendly, and allocation-free.
OpenVM's prover evaluates constraints this way in its quotient computation hot path.

### 3. Subexpression deduplication

With Arc trees, sharing is implicit and invisible.
Two constraints referencing the same sub-expression via `Arc::clone` look identical to an observer.

The DAG makes sharing explicit and structural:
```
Node 0: Variable(is_add)
Node 5: Mul { left: 0, right: 3 }   // constraint 1
Node 8: Mul { left: 0, right: 7 }   // constraint 2 -- both reference node 0
```

This enables:
- Constraint complexity analysis (node count, max depth, reuse ratio) in a single O(n) pass
- Accurate memory estimation for prover allocation
- Comparing AIR constraint structures quantitatively


