### PR TITLE
matrix: implement BitReversibleMatrix for wrapper types

### DIFF
--- a/matrix/src/bitrev.rs
+++ b/matrix/src/bitrev.rs
@@ -81,10 +81,10 @@ impl RowIndexMap for BitReversalPerm {
 /// to a `DenseMatrix`.
 pub type BitReversedMatrixView<Inner> = RowIndexMappedView<BitReversalPerm, Inner>;
 
-impl<T: Clone + Send + Sync, S: DenseStorage<T>> BitReversibleMatrix<T>
-    for BitReversedMatrixView<DenseMatrix<T, S>>
+impl<T: Clone + Send + Sync, Inner: BitReversibleMatrix<T>> BitReversibleMatrix<T>
+    for BitReversedMatrixView<Inner>
 {
-    type BitRev = DenseMatrix<T, S>;
+    type BitRev = Inner;
 
     fn bit_reverse_rows(self) -> Self::BitRev {
         self.inner

--- a/matrix/src/extension.rs
+++ b/matrix/src/extension.rs
@@ -6,6 +6,7 @@ use core::ops::Deref;
 use p3_field::{ExtensionField, Field};
 
 use crate::Matrix;
+use crate::bitrev::BitReversibleMatrix;
 
 /// A view that flattens a matrix of extension field elements into a matrix of base field elements.
 ///
@@ -129,6 +130,19 @@ where
         let value = self.inner.peek()?.as_basis_coefficients_slice()[self.idx];
         self.idx += 1;
         Some(value)
+    }
+}
+
+impl<F, EF, Inner> BitReversibleMatrix<F> for FlatMatrixView<F, EF, Inner>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Inner: BitReversibleMatrix<EF>,
+{
+    type BitRev = FlatMatrixView<F, EF, Inner::BitRev>;
+
+    fn bit_reverse_rows(self) -> Self::BitRev {
+        FlatMatrixView::new(self.0.bit_reverse_rows())
     }
 }
 

--- a/matrix/src/horizontally_truncated.rs
+++ b/matrix/src/horizontally_truncated.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 use core::ops::Range;
 
 use crate::Matrix;
+use crate::bitrev::BitReversibleMatrix;
 
 /// A matrix wrapper that exposes a contiguous range of columns from an inner matrix.
 ///
@@ -122,6 +123,20 @@ where
                 self.column_range.start + start,
                 self.column_range.start + end,
             )
+        }
+    }
+}
+
+impl<T: Clone + Send + Sync, Inner: BitReversibleMatrix<T>> BitReversibleMatrix<T>
+    for HorizontallyTruncated<T, Inner>
+{
+    type BitRev = HorizontallyTruncated<T, Inner::BitRev>;
+
+    fn bit_reverse_rows(self) -> Self::BitRev {
+        HorizontallyTruncated {
+            inner: self.inner.bit_reverse_rows(),
+            column_range: self.column_range,
+            _phantom: PhantomData,
         }
     }
 }

--- a/matrix/src/stack.rs
+++ b/matrix/src/stack.rs
@@ -1,6 +1,7 @@
 use core::ops::Deref;
 
 use crate::Matrix;
+use crate::bitrev::BitReversibleMatrix;
 use crate::dense::RowMajorMatrixView;
 
 /// A type alias representing a vertical composition of two row-major matrix views.
@@ -242,6 +243,19 @@ where
         match self {
             Self::Left(l) => l,
             Self::Right(r) => r,
+        }
+    }
+}
+
+impl<T: Clone + Send + Sync, Left: BitReversibleMatrix<T>, Right: BitReversibleMatrix<T>>
+    BitReversibleMatrix<T> for HorizontalPair<Left, Right>
+{
+    type BitRev = HorizontalPair<Left::BitRev, Right::BitRev>;
+
+    fn bit_reverse_rows(self) -> Self::BitRev {
+        HorizontalPair {
+            left: self.left.bit_reverse_rows(),
+            right: self.right.bit_reverse_rows(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Allow bit-reversal to pass through matrix wrappers that preserve row structure, avoiding the need to unwrap and re-wrap manually
- Generalize the `BitReversibleMatrix` impl for `BitReversedMatrixView` from `DenseMatrix`-only to any `Inner: BitReversibleMatrix`
- Implement `BitReversibleMatrix` for `FlatMatrixView`, `HorizontalPair`, and `HorizontallyTruncated` by delegating to the inner matrix's bit-reversal

## Test plan
- [x] `cargo test -p p3-matrix` — all 114 tests pass
- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo +stable clippy -p p3-matrix --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)