### PR TITLE
field: rm unused `packed_linear_combination`

### DIFF
--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -366,7 +366,7 @@ enum ConstraintType {
 ///
 /// When alpha powers are pre-computed in global order `[α^{N−1}, …, α⁰]`,
 /// the layout tells us which powers correspond to base-field constraints (for
-/// `packed_linear_combination`) and which to extension-field constraints.
+/// `batched_linear_combination`) and which to extension-field constraints.
 #[derive(Debug, Default)]
 pub struct ConstraintLayout {
     /// Global indices of base-field constraints, in emission order.
@@ -385,7 +385,7 @@ impl ConstraintLayout {
     ///
     /// Returns `(base_alpha_powers, ext_alpha_powers)` where:
     /// - `base_alpha_powers[d][j]` = d-th basis coefficient of the alpha power for
-    ///   the j-th base constraint (transposed + reordered for `packed_linear_combination`)
+    ///   the j-th base constraint (transposed + reordered for `batched_linear_combination`)
     /// - `ext_alpha_powers[j]` = full EF alpha power for the j-th extension constraint
     ///
     /// Constraints are emitted in one global order and folded into a single random
@@ -400,7 +400,7 @@ impl ConstraintLayout {
     /// throughput, while extension constraints must stay in the extension field. This
     /// method splits the precomputed powers accordingly, and also transposes EF powers
     /// into their base-field coordinates so the base-field path can use
-    /// `packed_linear_combination` without repeated cross-field conversions.
+    /// `batched_linear_combination` without repeated cross-field conversions.
     pub fn decompose_alpha<F: Field, EF: ExtensionField<F>>(
         &self,
         alpha: EF,

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -90,56 +90,6 @@ where
     }
 }
 
-pub fn test_packed_linear_combination<PF: PackedField + Eq>()
-where
-    StandardUniform: Distribution<PF> + Distribution<PF::Scalar>,
-{
-    let mut rng = SmallRng::seed_from_u64(1);
-    let u: [PF::Scalar; 64] = rng.random();
-    let v: [PF; 64] = rng.random();
-
-    let mut dot = PF::ZERO;
-    assert_eq!(dot, PF::packed_linear_combination::<0>(&u[..0], &v[..0]));
-    dot += v[0] * u[0];
-    assert_eq!(dot, PF::packed_linear_combination::<1>(&u[..1], &v[..1]));
-    dot += v[1] * u[1];
-    assert_eq!(dot, PF::packed_linear_combination::<2>(&u[..2], &v[..2]));
-    dot += v[2] * u[2];
-    assert_eq!(dot, PF::packed_linear_combination::<3>(&u[..3], &v[..3]));
-    dot += v[3] * u[3];
-    assert_eq!(dot, PF::packed_linear_combination::<4>(&u[..4], &v[..4]));
-    dot += v[4] * u[4];
-    assert_eq!(dot, PF::packed_linear_combination::<5>(&u[..5], &v[..5]));
-    dot += v[5] * u[5];
-    assert_eq!(dot, PF::packed_linear_combination::<6>(&u[..6], &v[..6]));
-    dot += v[6] * u[6];
-    assert_eq!(dot, PF::packed_linear_combination::<7>(&u[..7], &v[..7]));
-    dot += v[7] * u[7];
-    assert_eq!(dot, PF::packed_linear_combination::<8>(&u[..8], &v[..8]));
-    dot += v[8] * u[8];
-    assert_eq!(dot, PF::packed_linear_combination::<9>(&u[..9], &v[..9]));
-    dot += v[9] * u[9];
-    assert_eq!(dot, PF::packed_linear_combination::<10>(&u[..10], &v[..10]));
-    dot += v[10] * u[10];
-    assert_eq!(dot, PF::packed_linear_combination::<11>(&u[..11], &v[..11]));
-    dot += v[11] * u[11];
-    assert_eq!(dot, PF::packed_linear_combination::<12>(&u[..12], &v[..12]));
-    dot += v[12] * u[12];
-    assert_eq!(dot, PF::packed_linear_combination::<13>(&u[..13], &v[..13]));
-    dot += v[13] * u[13];
-    assert_eq!(dot, PF::packed_linear_combination::<14>(&u[..14], &v[..14]));
-    dot += v[14] * u[14];
-    assert_eq!(dot, PF::packed_linear_combination::<15>(&u[..15], &v[..15]));
-    dot += v[15] * u[15];
-    assert_eq!(dot, PF::packed_linear_combination::<16>(&u[..16], &v[..16]));
-
-    let dot_64: PF = u
-        .iter()
-        .zip(v.iter())
-        .fold(PF::ZERO, |acc, (&lhs, &rhs)| acc + (rhs * lhs));
-    assert_eq!(dot_64, PF::packed_linear_combination::<64>(&u, &v));
-}
-
 pub fn test_packed_mixed_dot_product<PF: PackedField + Eq>()
 where
     StandardUniform: Distribution<PF> + Distribution<PF::Scalar>,
@@ -639,10 +589,6 @@ macro_rules! test_packed_field {
             #[test]
             fn test_interleaves() {
                 $crate::test_interleaves::<$packedfield>();
-            }
-            #[test]
-            fn test_packed_linear_combination() {
-                $crate::test_packed_linear_combination::<$packedfield>();
             }
             #[test]
             fn test_packed_mixed_dot_product() {

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -308,20 +308,6 @@ pub unsafe trait PackedField: Algebra<Self::Scalar>
         }
     }
 
-    /// Compute a linear combination of a slice of base field elements and
-    /// a slice of packed field elements. The slices must have equal length
-    /// and it must be a compile time constant.
-    ///
-    /// # Panics
-    ///
-    /// May panic if the length of either slice is not equal to `N`.
-    #[must_use]
-    fn packed_linear_combination<const N: usize>(coeffs: &[Self::Scalar], vecs: &[Self]) -> Self {
-        assert_eq!(coeffs.len(), N);
-        assert_eq!(vecs.len(), N);
-        let combined: [Self; N] = array::from_fn(|i| vecs[i] * coeffs[i]);
-        Self::sum_array::<N>(&combined)
-    }
 }
 
 /// # Safety

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -640,11 +640,6 @@ impl_packed_value!(
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31Neon<FP> {
     type Scalar = MontyField31<FP>;
-
-    #[inline]
-    fn packed_linear_combination<const N: usize>(coeffs: &[Self::Scalar], vecs: &[Self]) -> Self {
-        general_dot_product::<_, _, _, N>(coeffs, vecs)
-    }
 }
 
 impl_packed_field_pow_2!(

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -1001,11 +1001,6 @@ impl_packed_value!(
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX2<FP> {
     type Scalar = MontyField31<FP>;
-
-    #[inline]
-    fn packed_linear_combination<const N: usize>(coeffs: &[Self::Scalar], vecs: &[Self]) -> Self {
-        general_dot_product::<_, _, _, N>(coeffs, vecs)
-    }
 }
 
 impl_packed_field_pow_2!(

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -1265,11 +1265,6 @@ impl_packed_value!(
 
 unsafe impl<FP: FieldParameters> PackedField for PackedMontyField31AVX512<FP> {
     type Scalar = MontyField31<FP>;
-
-    #[inline]
-    fn packed_linear_combination<const N: usize>(coeffs: &[Self::Scalar], vecs: &[Self]) -> Self {
-        general_dot_product::<_, _, _, N>(coeffs, vecs)
-    }
 }
 
 impl_packed_field_pow_2!(

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -13,7 +13,7 @@ use crate::{PackedChallenge, PackedVal, StarkGenericConfig, Val};
 ///
 /// Collects constraints during `air.eval()` into separate base/ext vectors, then
 /// combines them in [`Self::finalize_constraints`] using decomposed alpha powers and
-/// `packed_linear_combination` for efficient SIMD accumulation.
+/// `batched_linear_combination` for efficient SIMD accumulation.
 #[derive(Debug)]
 pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     /// The [`RowMajorMatrixView`] containing rows on which the constraint polynomial is evaluated.


### PR DESCRIPTION
@adr1anh After https://github.com/Plonky3/Plonky3/pull/1451, I think this is now unused and useless.