### PR TITLE
fix(verifier): tighten input shape validation

### DIFF
--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -65,6 +65,11 @@ where
         || airs.len() != public_values.len()
         || airs.len() != degree_bits.len()
         || airs.len() != global_lookup_data.len()
+        || airs.len() != all_lookups.len()
+        || common
+            .preprocessed
+            .as_ref()
+            .is_some_and(|global| global.instances.len() != airs.len())
     {
         return Err(InvalidProofShapeError::InstanceCountMismatch.into());
     }
@@ -125,8 +130,18 @@ where
 
     for (i, air) in airs.iter().enumerate() {
         let air_width = A::width(air);
+        let expected_public_values_len = air.num_public_values();
+        let got_public_values_len = public_values[i].len();
         let inst_opened_vals = &opened_values.instances[i];
         let inst_base_opened_vals = &inst_opened_vals.base_opened_values;
+
+        if got_public_values_len != expected_public_values_len {
+            return Err(InvalidProofShapeError::PublicValuesLengthMismatch {
+                expected: expected_public_values_len,
+                got: got_public_values_len,
+            }
+            .into());
+        }
 
         // Validate trace widths match the AIR
         if inst_base_opened_vals.trace_local.len() != air_width {

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -934,6 +934,37 @@ fn test_invalid_public_values_rejected() -> Result<(), Box<dyn std::error::Error
 }
 
 #[test]
+fn test_short_public_values_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let config = make_config(7);
+
+    let (air_fib, trace, fib_pis) = create_fib_instance(4);
+    let instances = vec![StarkInstance {
+        air: &air_fib,
+        trace: &trace,
+        public_values: fib_pis,
+        lookups: vec![],
+    }];
+    let prover_data = ProverData::from_instances(&config, &instances);
+    let common = &prover_data.common;
+    let proof = prove_batch(&config, &instances, &prover_data);
+
+    let airs = vec![air_fib];
+    let short_pvs = vec![vec![Val::from_u64(0), Val::from_u64(1)]];
+    let err = verify_batch(&config, &airs, &proof, &short_pvs, common)
+        .expect_err("Should reject short public values");
+    match err {
+        VerificationError::InvalidProofShape(
+            InvalidProofShapeError::PublicValuesLengthMismatch { expected, got },
+        ) => {
+            assert_eq!(expected, 3);
+            assert_eq!(got, 2);
+        }
+        _ => panic!("unexpected error: {err:?}"),
+    }
+    Ok::<_, Box<dyn std::error::Error>>(())
+}
+
+#[test]
 fn test_different_widths() -> Result<(), impl Debug> {
     let config = make_config(4242);
 

--- a/uni-stark/src/error.rs
+++ b/uni-stark/src/error.rs
@@ -70,6 +70,9 @@ pub enum InvalidProofShapeError {
     /// Preprocessed metadata missing or mismatched.
     #[error("air {air}: preprocessed metadata mismatch")]
     PreprocessedMetadataMismatch { air: usize },
+    /// Public values length doesn't match what the AIR expects.
+    #[error("public values length mismatch: expected {expected}, got {got}")]
+    PublicValuesLengthMismatch { expected: usize, got: usize },
     /// Lookup commitment presence doesn't match lookup configuration.
     #[error("lookup commitment presence does not match lookup configuration")]
     LookupCommitmentMismatch,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -283,6 +283,15 @@ where
     }
 
     let air_width = A::width(air);
+    let expected_public_values_len = air.num_public_values();
+    if public_values.len() != expected_public_values_len {
+        return Err(InvalidProofShapeError::PublicValuesLengthMismatch {
+            expected: expected_public_values_len,
+            got: public_values.len(),
+        }
+        .into());
+    }
+
     let main_next = !air.main_next_row_columns().is_empty();
     let pre_next = !air.preprocessed_next_row_columns().is_empty();
     let trace_next_ok = if main_next {

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -16,7 +16,7 @@ use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
-use p3_uni_stark::{StarkConfig, prove, verify};
+use p3_uni_stark::{InvalidProofShapeError, StarkConfig, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
@@ -291,6 +291,27 @@ fn test_one_row_trace() {
 #[test]
 fn test_public_value() {
     test_public_value_impl(1 << 3, 21, 2);
+}
+
+#[test]
+fn test_short_public_values_rejected() {
+    let trace = generate_trace_rows::<Val>(0, 1, 1 << 3);
+    let config = make_two_adic_config(2);
+    let pis = vec![BabyBear::ZERO, BabyBear::ONE, BabyBear::from_u64(21)];
+
+    let proof = prove(&config, &FibonacciAir {}, trace, &pis);
+    let short_pis = vec![BabyBear::ZERO, BabyBear::ONE];
+    let err = verify(&config, &FibonacciAir {}, &proof, &short_pis)
+        .expect_err("verification should reject short public values");
+    match err {
+        p3_uni_stark::VerificationError::InvalidProofShape(
+            InvalidProofShapeError::PublicValuesLengthMismatch { expected, got },
+        ) => {
+            assert_eq!(expected, 3);
+            assert_eq!(got, 2);
+        }
+        _ => panic!("unexpected error: {err:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
  Add explicit verifier-side checks for malformed public input and batch  metadata shapes, returning proof-shape errors instead of reaching unchecked indexing paths. 