### PR TITLE
air: simplify window access using matrix crate

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -2,108 +2,8 @@ use alloc::vec::Vec;
 use core::ops::{Add, Mul, Sub};
 
 use p3_field::{Algebra, Dup, ExtensionField, Field, PrimeCharacteristicRing};
-use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
-
-/// Read access to a pair of trace rows (typically current and next).
-///
-/// Implementors expose two flat slices that constraint evaluators use
-/// to express algebraic relations between rows.
-pub trait WindowAccess<T> {
-    /// Full slice of the current row.
-    fn current_slice(&self) -> &[T];
-
-    /// Full slice of the next row.
-    fn next_slice(&self) -> &[T];
-
-    /// Single element from the current row by index.
-    ///
-    /// Returns `None` if `i` is out of bounds.
-    #[inline]
-    fn current(&self, i: usize) -> Option<T>
-    where
-        T: Clone,
-    {
-        self.current_slice().get(i).cloned()
-    }
-
-    /// Single element from the next row by index.
-    ///
-    /// Returns `None` if `i` is out of bounds.
-    #[inline]
-    fn next(&self, i: usize) -> Option<T>
-    where
-        T: Clone,
-    {
-        self.next_slice().get(i).cloned()
-    }
-}
-
-/// A lightweight two-row window into a trace matrix.
-///
-/// Stores two `&[T]` slices — one for the current row and one for
-/// the next — without carrying any matrix metadata.  This is cheaper
-/// than a full `ViewPair` and is the concrete type used by most
-/// [`AirBuilder`] implementations for `type MainWindow` / `type PreprocessedWindow`.
-#[derive(Debug, Clone, Copy)]
-pub struct RowWindow<'a, T> {
-    /// The current row.
-    current: &'a [T],
-    /// The next row.
-    next: &'a [T],
-}
-
-impl<'a, T> RowWindow<'a, T> {
-    /// Create a window from a [`RowMajorMatrixView`] that has exactly
-    /// two rows. The first row becomes `current`, the second `next`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the view does not contain exactly `2 * width` elements.
-    #[inline]
-    pub fn from_view(view: &RowMajorMatrixView<'a, T>) -> Self {
-        let width = view.width;
-        assert_eq!(
-            view.values.len(),
-            2 * width,
-            "RowWindow::from_view: expected 2 rows (2*{width} elements), got {}",
-            view.values.len()
-        );
-        let (current, next) = view.values.split_at(width);
-        Self { current, next }
-    }
-
-    /// Create a window from two separate row slices.
-    ///
-    /// The caller is responsible for providing slices that represent
-    /// the intended (current, next) pair.
-    ///
-    /// # Panics
-    ///
-    /// Panics (in debug builds) if the slices have different lengths.
-    #[inline]
-    pub fn from_two_rows(current: &'a [T], next: &'a [T]) -> Self {
-        debug_assert_eq!(
-            current.len(),
-            next.len(),
-            "RowWindow::from_two_rows: row lengths differ ({} vs {})",
-            current.len(),
-            next.len()
-        );
-        Self { current, next }
-    }
-}
-
-impl<T> WindowAccess<T> for RowWindow<'_, T> {
-    #[inline]
-    fn current_slice(&self) -> &[T] {
-        self.current
-    }
-
-    #[inline]
-    fn next_slice(&self) -> &[T] {
-        self.next
-    }
-}
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
 
 /// The underlying structure of an AIR.
 pub trait BaseAir<F>: Sync {
@@ -261,10 +161,10 @@ pub trait AirBuilder: Sized {
         + Mul<Self::Expr, Output = Self::Expr>;
 
     /// Two-row window over the preprocessed trace columns.
-    type PreprocessedWindow: WindowAccess<Self::Var> + Clone;
+    type PreprocessedWindow: Matrix<Self::Var> + Clone;
 
     /// Two-row window over the main trace columns.
-    type MainWindow: WindowAccess<Self::Var> + Clone;
+    type MainWindow: Matrix<Self::Var> + Clone;
 
     /// Variable type for public values.
     type PublicVar: Into<Self::Expr> + Copy;
@@ -443,7 +343,7 @@ pub trait ExtensionBuilder: AirBuilder<F: Field> {
 /// Trait for builders supporting permutation arguments (e.g., for lookup constraints).
 pub trait PermutationAirBuilder: ExtensionBuilder {
     /// Two-row window over the permutation trace columns.
-    type MP: WindowAccess<Self::VarEF>;
+    type MP: Matrix<Self::VarEF>;
 
     /// Randomness variable type used in permutation commitments.
     type RandomVar: Into<Self::ExprEF> + Copy;

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -9,7 +9,7 @@ use p3_matrix::stack::ViewPair;
 
 use crate::{
     Air, AirBuilder, AirBuilderWithContext, ExtensionBuilder, Name, NamedAirBuilder,
-    NamedExtensionBuilder, NamespaceExt, PermutationAirBuilder, RowWindow,
+    NamedExtensionBuilder, NamespaceExt, PermutationAirBuilder,
 };
 
 /// A single constraint violation captured during debug evaluation.
@@ -120,9 +120,9 @@ pub struct DebugConstraintBuilder<'a, F: Field, EF: ExtensionField<F> = F> {
     /// Vertical pair giving access to the current and next witness rows.
     main: ViewPair<'a, F>,
 
-    /// Window over the current and next preprocessed rows.
-    /// When the AIR has no preprocessed trace this is a zero-width window.
-    preprocessed: RowWindow<'a, F>,
+    /// Vertical pair of the current and next preprocessed rows.
+    /// When the AIR has no preprocessed trace this is a zero-width pair.
+    preprocessed: ViewPair<'a, F>,
 
     /// Slice of public values made available to the AIR during evaluation.
     public_values: &'a [F],
@@ -153,7 +153,7 @@ impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
     /// Permutation-related fields are set to `None` / empty so that the
     /// builder can still satisfy trait bounds that require extension-field
     /// support, but calling permutation accessors will panic.
-    pub fn new(
+    pub const fn new(
         row_index: usize,
         main: ViewPair<'a, F>,
         preprocessed: ViewPair<'a, F>,
@@ -167,10 +167,7 @@ impl<'a, F: Field> DebugConstraintBuilder<'a, F> {
             constraint_index: 0,
             failures: Vec::new(),
             main,
-            preprocessed: RowWindow::from_two_rows(
-                preprocessed.top.values,
-                preprocessed.bottom.values,
-            ),
+            preprocessed,
             public_values,
             is_first_row,
             is_last_row,
@@ -188,7 +185,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
     /// Use this when the AIR declares lookup or permutation arguments
     /// that require access to the permutation trace and challenges.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_permutation(
+    pub const fn new_with_permutation(
         row_index: usize,
         main: ViewPair<'a, F>,
         preprocessed: ViewPair<'a, F>,
@@ -205,10 +202,7 @@ impl<'a, F: Field, EF: ExtensionField<F>> DebugConstraintBuilder<'a, F, EF> {
             constraint_index: 0,
             failures: Vec::new(),
             main,
-            preprocessed: RowWindow::from_two_rows(
-                preprocessed.top.values,
-                preprocessed.bottom.values,
-            ),
+            preprocessed,
             public_values,
             is_first_row,
             is_last_row,
@@ -243,12 +237,12 @@ where
     type F = F;
     type Expr = F;
     type Var = F;
-    type PreprocessedWindow = RowWindow<'a, F>;
-    type MainWindow = RowWindow<'a, F>;
+    type PreprocessedWindow = ViewPair<'a, F>;
+    type MainWindow = ViewPair<'a, F>;
     type PublicVar = F;
 
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
+        self.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
@@ -304,7 +298,7 @@ impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for DebugConstraintBuilde
 impl<'a, F: Field, EF: ExtensionField<F>> PermutationAirBuilder
     for DebugConstraintBuilder<'a, F, EF>
 {
-    type MP = RowWindow<'a, EF>;
+    type MP = ViewPair<'a, EF>;
     type RandomVar = EF;
     type PermutationVar = EF;
 
@@ -312,9 +306,8 @@ impl<'a, F: Field, EF: ExtensionField<F>> PermutationAirBuilder
     ///
     /// Panics when the builder was created without permutation data.
     fn permutation(&self) -> Self::MP {
-        let p = self.permutation
-            .expect("permutation() called on a builder created without permutation data; use new_with_permutation()");
-        RowWindow::from_two_rows(p.top.values, p.bottom.values)
+        self.permutation
+            .expect("permutation() called on a builder created without permutation data; use new_with_permutation()")
     }
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {
@@ -632,7 +625,7 @@ mod tests {
     use p3_field::PrimeCharacteristicRing;
 
     use super::*;
-    use crate::{BaseAir, WindowAccess};
+    use crate::BaseAir;
 
     /// Minimal AIR for testing transition and boundary constraints.
     ///
@@ -654,8 +647,8 @@ mod tests {
 
             // Transition constraint: next == current + 1 for every column.
             for col in 0..W {
-                let current = main.current(col).unwrap();
-                let next = main.next(col).unwrap();
+                let current = main.get(0, col).unwrap();
+                let next = main.get(1, col).unwrap();
                 builder.when_transition().assert_eq(next, current + F::ONE);
             }
 
@@ -663,7 +656,7 @@ mod tests {
             let public_values = builder.public_values;
             let mut when_last = builder.when(builder.is_last_row);
             for (i, &pv) in public_values.iter().enumerate().take(W) {
-                when_last.assert_eq(main.current(i).unwrap(), pv);
+                when_last.assert_eq(main.get(0, i).unwrap(), pv);
             }
         }
     }
@@ -775,7 +768,7 @@ mod tests {
         fn eval(&self, builder: &mut DebugConstraintBuilder<'_, F>) {
             let main = builder.main();
             for col in 0..W {
-                builder.assert_zero(main.current(col).unwrap());
+                builder.assert_zero(main.get(0, col).unwrap());
             }
         }
     }
@@ -886,9 +879,9 @@ mod tests {
         fn eval(&self, builder: &mut DebugConstraintBuilder<'_, F>) {
             let main = builder.main();
             // Constraint 0: unlabeled
-            builder.assert_zero(main.current(0).unwrap());
+            builder.assert_zero(main.get(0, 0).unwrap());
             // Constraint 1: labeled via NamedAirBuilder
-            builder.assert_zero_named(main.current(1).unwrap(), "col_1_must_be_zero");
+            builder.assert_zero_named(main.get(0, 1).unwrap(), "col_1_must_be_zero");
         }
     }
 
@@ -960,14 +953,14 @@ mod tests {
             let ns = "range_check";
 
             // Static namespace joined with static name.
-            builder.assert_zero_named(main.current(0).unwrap(), ns.join("limb_0"));
+            builder.assert_zero_named(main.get(0, 0).unwrap(), ns.join("limb_0"));
 
             // Namespace joined with a closure name.
             let i = 1;
-            builder.assert_zero_named(main.current(1).unwrap(), ns.name(|| format!("limb_{i}")));
+            builder.assert_zero_named(main.get(0, 1).unwrap(), ns.name(|| format!("limb_{i}")));
 
             // Plain closure name (not a namespace).
-            builder.assert_zero_named(main.current(2).unwrap(), || format!("col_{}", 2));
+            builder.assert_zero_named(main.get(0, 2).unwrap(), || format!("col_{}", 2));
         }
     }
 

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -1,9 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use core::borrow::Borrow;
 
 use p3_field::{Algebra, ExtensionField, Field};
-use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use tracing::instrument;
 
@@ -13,7 +11,7 @@ use crate::symbolic::expression_ext::SymbolicExpressionExt;
 use crate::symbolic::variable::{BaseEntry, ExtEntry, SymbolicVariableExt};
 use crate::{
     Air, AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
-    SymbolicExpression, SymbolicVariable, WindowAccess,
+    SymbolicExpression, SymbolicVariable,
 };
 
 /// Describes the shape of an AIR for symbolic constraint evaluation.
@@ -228,36 +226,6 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
 
     pub fn base_constraints(&self) -> Vec<SymbolicExpression<F>> {
         self.base_constraints.clone()
-    }
-}
-
-/// Implement `WindowAccess` for `RowMajorMatrix` treating it as a two-row window
-/// (first row = current, second row = next).
-///
-/// # Panics
-///
-/// Panics if the matrix does not have exactly 2 rows.
-impl<T: Clone + Send + Sync> WindowAccess<T> for RowMajorMatrix<T> {
-    fn current_slice(&self) -> &[T] {
-        assert_eq!(
-            self.height(),
-            2,
-            "WindowAccess for RowMajorMatrix requires exactly 2 rows, got {}",
-            self.height()
-        );
-        let values: &[T] = self.values.borrow();
-        &values[..self.width]
-    }
-
-    fn next_slice(&self) -> &[T] {
-        assert_eq!(
-            self.height(),
-            2,
-            "WindowAccess for RowMajorMatrix requires exactly 2 rows, got {}",
-            self.height()
-        );
-        let values: &[T] = self.values.borrow();
-        &values[self.width..]
     }
 }
 

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -1,10 +1,10 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use p3_air::Air;
 #[cfg(debug_assertions)]
 use p3_air::DebugConstraintBuilder;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpressionExt};
-use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{
@@ -758,7 +758,6 @@ where
             let inner_folder = ProverConstraintFolder {
                 main: main.as_view(),
                 preprocessed: preprocessed_view,
-                preprocessed_window: RowWindow::from_view(&preprocessed_view),
                 public_values,
                 is_first_row,
                 is_last_row,

--- a/batch-stark/src/verifier.rs
+++ b/batch-stark/src/verifier.rs
@@ -4,8 +4,8 @@ use alloc::{format, vec};
 use core::fmt::Debug;
 
 use hashbrown::HashMap;
+use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpressionExt};
-use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, PrimeCharacteristicRing};
@@ -699,12 +699,9 @@ where
         RowMajorMatrixView::new_row(preprocessed_next),
     );
 
-    let preprocessed_window =
-        RowWindow::from_two_rows(preprocessed.top.values, preprocessed.bottom.values);
     let inner_folder = VerifierConstraintFolder {
         main,
         preprocessed,
-        preprocessed_window,
         public_values,
         is_first_row: sels.is_first_row,
         is_last_row: sels.is_last_row,

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use core::slice::from_ref;
 
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
-use p3_air::{Air, AirBuilder, BaseAir, BaseLeaf, PermutationAirBuilder, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir, BaseLeaf, PermutationAirBuilder};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
 use p3_batch_stark::{
@@ -80,8 +80,10 @@ where
         let b0 = pis[1];
         let x = pis[2];
 
-        let local: &FibRow<AB::Var> = main.current_slice().borrow();
-        let next: &FibRow<AB::Var> = main.next_slice().borrow();
+        let local_row = main.row_slice(0).unwrap();
+        let local: &FibRow<AB::Var> = (*local_row).borrow();
+        let next_row = main.row_slice(1).unwrap();
+        let next: &FibRow<AB::Var> = (*next_row).borrow();
 
         let mut wf = builder.when_first_row();
         wf.assert_eq(local.left, a0);
@@ -166,8 +168,8 @@ impl<F> BaseAir<F> for MulAir {
 impl<AB: AirBuilder> Air<AB> for MulAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local = main.current_slice();
-        let next = main.next_slice();
+        let local = main.row_slice(0).unwrap();
+        let next = main.row_slice(1).unwrap();
         for i in 0..self.reps {
             let s = i * 3;
             let a = local[s];
@@ -252,7 +254,7 @@ impl<F: Field> LookupAir<F> for MulAirLookups {
             ..Default::default()
         });
         let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
+        let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
         let last_idx = symbolic_air_builder.main().width() - 1;
         let lut = symbolic_main_local[last_idx]; //  Extra column that corresponds to a permutation of 'a'
@@ -488,11 +490,11 @@ where
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local_main = main.current_slice();
+        let local_main = main.row_slice(0).unwrap();
 
         // Copy the preprocessed value so the immutable borrow on `builder`
         // is released before the mutable `assert_eq` call.
-        let prep_val = builder.preprocessed().current(0).unwrap();
+        let prep_val = builder.preprocessed().get(0, 0).unwrap();
 
         // Enforce: main[0] = multiplier * preprocessed[0]
         builder.assert_eq(
@@ -2257,7 +2259,7 @@ impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
             ..Default::default()
         });
         let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
+        let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
         let sender_col1 = symbolic_main_local[0]; // Column that sends values
         let sender_col2 = symbolic_main_local[1]; // Column that sends values

--- a/blake3-air/src/air.rs
+++ b/blake3-air/src/air.rs
@@ -4,8 +4,9 @@ use core::borrow::Borrow;
 
 use itertools::izip;
 use p3_air::utils::{add2, add3, pack_bits_le, xor_32_shift};
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField64};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -238,7 +239,8 @@ impl<AB: AirBuilder> Air<AB> for Blake3Air {
     #[inline]
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local: &Blake3Cols<AB::Var> = main.current_slice().borrow();
+        let current_row = main.row_slice(0).unwrap();
+        let local: &Blake3Cols<AB::Var> = (*current_row).borrow();
 
         let initial_row_3 = [
             local.counter_low,

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -1,8 +1,9 @@
 use core::array;
 use core::borrow::Borrow;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField64};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -40,8 +41,10 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         eval_round_flags(builder);
 
         let main = builder.main();
-        let local: &KeccakCols<AB::Var> = main.current_slice().borrow();
-        let next: &KeccakCols<AB::Var> = main.next_slice().borrow();
+        let current_row = main.row_slice(0).unwrap();
+        let local: &KeccakCols<AB::Var> = (*current_row).borrow();
+        let next_row = main.row_slice(1).unwrap();
+        let next: &KeccakCols<AB::Var> = (*next_row).borrow();
 
         let first_step = local.step_flags[0];
         let final_step = local.step_flags[NUM_ROUNDS_MIN_1];

--- a/keccak-air/src/round_flags.rs
+++ b/keccak-air/src/round_flags.rs
@@ -1,7 +1,8 @@
 use core::array;
 use core::borrow::Borrow;
 
-use p3_air::{AirBuilder, WindowAccess};
+use p3_air::AirBuilder;
+use p3_matrix::Matrix;
 
 use crate::columns::KeccakCols;
 use crate::{NUM_ROUNDS, NUM_ROUNDS_MIN_1};
@@ -22,9 +23,11 @@ pub(crate) fn eval_round_flags<AB: AirBuilder>(builder: &mut AB) {
     // Access the main trace matrix.
     let main = builder.main();
 
-    // Cast slices into typed Keccak column references.
-    let local: &KeccakCols<AB::Var> = main.current_slice().borrow();
-    let next: &KeccakCols<AB::Var> = main.next_slice().borrow();
+    // Cast rows into typed Keccak column references.
+    let current_row = main.row_slice(0).unwrap();
+    let local: &KeccakCols<AB::Var> = (*current_row).borrow();
+    let next_row = main.row_slice(1).unwrap();
+    let next: &KeccakCols<AB::Var> = (*next_row).borrow();
 
     // Initially, the first step flag should be 1 while the others should be 0.
     //

--- a/lookup/benches/logup.rs
+++ b/lookup/benches/logup.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
-use p3_air::{AirBuilder, BaseLeaf, WindowAccess};
+use p3_air::{AirBuilder, BaseLeaf};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
@@ -12,6 +12,7 @@ use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::TwoAdicFriPcs;
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::lookup_traits::{Direction, Kind, Lookup, LookupData, LookupGadget};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -47,7 +48,7 @@ fn build_lookups(num_lookups: usize, tuple_size: usize, trace_width: usize) -> V
         ..Default::default()
     });
     let symbolic_main = symbolic_builder.main();
-    let symbolic_main_local = symbolic_main.current_slice();
+    let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
     let cols_per_lookup = 2 * tuple_size + 1;
 

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -9,11 +9,11 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 
 use hashbrown::HashMap;
-use p3_air::{AirBuilder, PermutationAirBuilder, RowWindow};
+use p3_air::{AirBuilder, PermutationAirBuilder};
 use p3_field::Field;
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
-use p3_matrix::stack::VerticalPair;
+use p3_matrix::stack::{VerticalPair, ViewPair};
 
 use crate::lookup_traits::{Kind, Lookup, symbolic_to_expr};
 
@@ -174,10 +174,7 @@ fn accumulate_lookup<F: Field>(
 
         let builder = MiniLookupBuilder {
             main: main_rows,
-            preprocessed: RowWindow::from_two_rows(
-                preprocessed_rows.top.values,
-                preprocessed_rows.bottom.values,
-            ),
+            preprocessed: preprocessed_rows,
             public_values: instance.public_values,
             permutation_challenges: instance.permutation_challenges,
             row,
@@ -206,8 +203,8 @@ fn accumulate_lookup<F: Field>(
 }
 
 struct MiniLookupBuilder<'a, F: Field> {
-    main: VerticalPair<RowMajorMatrixView<'a, F>, RowMajorMatrixView<'a, F>>,
-    preprocessed: RowWindow<'a, F>,
+    main: ViewPair<'a, F>,
+    preprocessed: ViewPair<'a, F>,
     public_values: &'a [F],
     permutation_challenges: &'a [F],
     row: usize,
@@ -218,12 +215,12 @@ impl<'a, F: Field> AirBuilder for MiniLookupBuilder<'a, F> {
     type F = F;
     type Expr = F;
     type Var = F;
-    type PreprocessedWindow = RowWindow<'a, F>;
-    type MainWindow = RowWindow<'a, F>;
+    type PreprocessedWindow = ViewPair<'a, F>;
+    type MainWindow = ViewPair<'a, F>;
     type PublicVar = F;
 
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
+        self.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
@@ -259,14 +256,17 @@ impl<'a, F: Field> p3_air::ExtensionBuilder for MiniLookupBuilder<'a, F> {
 }
 
 impl<'a, F: Field> PermutationAirBuilder for MiniLookupBuilder<'a, F> {
-    type MP = RowWindow<'a, F>;
+    type MP = ViewPair<'a, F>;
     type RandomVar = F;
 
     type PermutationVar = F;
 
     fn permutation(&self) -> Self::MP {
-        // Empty slices; permutation columns are not needed for debug evals.
-        RowWindow::from_two_rows(&[], &[])
+        // Empty zero-width pair; permutation columns are not needed for debug evals.
+        ViewPair::new(
+            RowMajorMatrixView::new(&[], 0),
+            RowMajorMatrixView::new(&[], 0),
+        )
     }
 
     fn permutation_randomness(&self) -> &[Self::RandomVar] {

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -1,4 +1,4 @@
-use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, RowWindow};
+use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{
@@ -17,12 +17,12 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     type F = Val<SC>;
     type Expr = PackedVal<SC>;
     type Var = PackedVal<SC>;
-    type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
-    type MainWindow = RowWindow<'a, PackedVal<SC>>;
+    type PreprocessedWindow = RowMajorMatrixView<'a, PackedVal<SC>>;
+    type MainWindow = RowMajorMatrixView<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
 
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_view(&self.inner.main)
+        self.inner.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
@@ -78,12 +78,12 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
     for ProverConstraintFolderWithLookups<'a, SC>
 {
     type RandomVar = PackedChallenge<SC>;
-    type MP = RowWindow<'a, PackedChallenge<SC>>;
+    type MP = RowMajorMatrixView<'a, PackedChallenge<SC>>;
 
     type PermutationVar = PackedChallenge<SC>;
 
     fn permutation(&self) -> Self::MP {
-        RowWindow::from_view(&self.permutation)
+        self.permutation
     }
 
     fn permutation_randomness(&self) -> &[PackedChallenge<SC>] {
@@ -107,11 +107,11 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLook
     type Expr = SC::Challenge;
     type Var = SC::Challenge;
     type PublicVar = Val<SC>;
-    type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
-    type MainWindow = RowWindow<'a, SC::Challenge>;
+    type PreprocessedWindow = ViewPair<'a, SC::Challenge>;
+    type MainWindow = ViewPair<'a, SC::Challenge>;
 
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_two_rows(self.inner.main.top.values, self.inner.main.bottom.values)
+        self.inner.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
@@ -168,12 +168,12 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
     for VerifierConstraintFolderWithLookups<'a, SC>
 {
     type RandomVar = SC::Challenge;
-    type MP = RowWindow<'a, SC::Challenge>;
+    type MP = ViewPair<'a, SC::Challenge>;
 
     type PermutationVar = SC::Challenge;
 
     fn permutation(&self) -> Self::MP {
-        RowWindow::from_two_rows(self.permutation.top.values, self.permutation.bottom.values)
+        self.permutation
     }
 
     fn permutation_randomness(&self) -> &[SC::Challenge] {

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -20,7 +20,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::{ExtensionBuilder, PermutationAirBuilder, WindowAccess};
+use p3_air::{ExtensionBuilder, PermutationAirBuilder};
 use p3_field::{Field, PrimeCharacteristicRing, dot_product};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
@@ -211,14 +211,14 @@ impl LogUpGadget {
         let beta = permutation_challenges[self.num_challenges() * column + 1];
 
         assert!(
-            permutation.current_slice().len() > column,
+            permutation.width() > column,
             "Permutation trace has insufficient width"
         );
 
         // Read s[i] from the local row at the specified column.
-        let s_local = permutation.current(column).unwrap().into();
+        let s_local = permutation.get(0, column).unwrap().into();
         // Read s[i+1] from the next row (or a zero-padded view on the last row).
-        let s_next = permutation.next(column).unwrap().into();
+        let s_next = permutation.get(1, column).unwrap().into();
 
         // Anchor s[0] = 0 at the start.
         //

--- a/lookup/src/lookup_traits.rs
+++ b/lookup/src/lookup_traits.rs
@@ -1,8 +1,8 @@
 use p3_air::{
-    AirBuilder, BaseEntry, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, RowWindow,
-    SymbolicExpression, WindowAccess,
+    AirBuilder, BaseEntry, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, SymbolicExpression,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{StarkGenericConfig, Val};
@@ -43,7 +43,7 @@ pub trait LookupGadget: LookupEvaluator {
 /// A builder to generate the lookup traces, given the main trace, public values and permutation challenges.
 pub struct LookupTraceBuilder<'a, SC: StarkGenericConfig> {
     main: ViewPair<'a, Val<SC>>,
-    preprocessed: RowWindow<'a, Val<SC>>,
+    preprocessed: ViewPair<'a, Val<SC>>,
     public_values: &'a [Val<SC>],
     permutation_challenges: &'a [SC::Challenge],
     height: usize,
@@ -51,7 +51,7 @@ pub struct LookupTraceBuilder<'a, SC: StarkGenericConfig> {
 }
 
 impl<'a, SC: StarkGenericConfig> LookupTraceBuilder<'a, SC> {
-    pub fn new(
+    pub const fn new(
         main: ViewPair<'a, Val<SC>>,
         preprocessed: ViewPair<'a, Val<SC>>,
         public_values: &'a [Val<SC>],
@@ -61,10 +61,7 @@ impl<'a, SC: StarkGenericConfig> LookupTraceBuilder<'a, SC> {
     ) -> Self {
         Self {
             main,
-            preprocessed: RowWindow::from_two_rows(
-                preprocessed.top.values,
-                preprocessed.bottom.values,
-            ),
+            preprocessed,
             public_values,
             permutation_challenges,
             height,
@@ -77,13 +74,13 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
     type F = Val<SC>;
     type Expr = Val<SC>;
     type Var = Val<SC>;
-    type PreprocessedWindow = RowWindow<'a, Val<SC>>;
-    type MainWindow = RowWindow<'a, Val<SC>>;
+    type PreprocessedWindow = ViewPair<'a, Val<SC>>;
+    type MainWindow = ViewPair<'a, Val<SC>>;
     type PublicVar = Val<SC>;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
+        self.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
@@ -135,7 +132,7 @@ impl<SC: StarkGenericConfig> ExtensionBuilder for LookupTraceBuilder<'_, SC> {
 }
 
 impl<'a, SC: StarkGenericConfig> PermutationAirBuilder for LookupTraceBuilder<'a, SC> {
-    type MP = RowWindow<'a, SC::Challenge>;
+    type MP = ViewPair<'a, SC::Challenge>;
     type RandomVar = SC::Challenge;
 
     type PermutationVar = SC::Challenge;
@@ -166,8 +163,8 @@ where
                 BaseEntry::Main { offset } => {
                     let main = builder.main();
                     match offset {
-                        0 => main.current(v.index).unwrap().into(),
-                        1 => main.next(v.index).unwrap().into(),
+                        0 => main.get(0, v.index).unwrap().into(),
+                        1 => main.get(1, v.index).unwrap().into(),
                         _ => panic!("Cannot have expressions involving more than two rows."),
                     }
                 }
@@ -178,8 +175,8 @@ where
                 BaseEntry::Preprocessed { offset } => {
                     let prep = builder.preprocessed();
                     match offset {
-                        0 => prep.current(v.index).unwrap().into(),
-                        1 => prep.next(v.index).unwrap().into(),
+                        0 => prep.get(0, v.index).unwrap().into(),
+                        1 => prep.get(1, v.index).unwrap().into(),
                         _ => panic!("Cannot have expressions involving more than two rows."),
                     }
                 }

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -4,9 +4,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
-use p3_air::{
-    Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, WindowAccess,
-};
+use p3_air::{Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -301,7 +299,7 @@ impl LookupAir<F> for RangeCheckAir {
         });
 
         let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
+        let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
         // Perform each lookup independently using LookupContext
         (0..self.num_lookups)
@@ -536,7 +534,7 @@ fn test_symbolic_to_expr() {
 
     let main = builder.main();
 
-    let (local, next) = (main.current_slice(), main.next_slice());
+    let (local, next) = (main.row_slice(0).unwrap(), main.row_slice(1).unwrap());
 
     let mul = local[0] * next[1];
     let add = local[0] + next[1];
@@ -686,7 +684,7 @@ fn test_debug_util_detects_malformed_lookup() {
         main_width: 1,
         ..Default::default()
     });
-    let expr = builder.main().current(0).unwrap();
+    let expr = builder.main().get(0, 0).unwrap();
 
     // One local lookup with a single tuple; multiplicity is always +1,
     // so the total multiset count is non-zero.
@@ -1198,7 +1196,7 @@ impl LookupAir<F> for AddAir {
         });
 
         let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
+        let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
 
         // Extract columns for the lookup entries: [inp1, inp2, sum]
         let inp1 = symbolic_main_local[0];

--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -29,8 +29,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon1::external::mds_multiply;
 use rand::distr::{Distribution, StandardUniform};
@@ -258,7 +259,8 @@ impl<
     fn eval(&self, builder: &mut AB) {
         // Read the current row as a flat slice, then reinterpret as columns.
         let main = builder.main();
-        let local = main.current_slice().borrow();
+        let current_row = main.row_slice(0).unwrap();
+        let local = (*current_row).borrow();
 
         eval::<_, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>(
             self, builder, local,

--- a/poseidon1-air/src/vectorized.rs
+++ b/poseidon1-air/src/vectorized.rs
@@ -30,8 +30,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
@@ -292,6 +293,7 @@ impl<
         let main = builder.main();
 
         // Reinterpret as the vectorized column struct.
+        let current_row = main.row_slice(0).unwrap();
         let local: &VectorizedPoseidon1Cols<
             _,
             WIDTH,
@@ -300,7 +302,7 @@ impl<
             HALF_FULL_ROUNDS,
             PARTIAL_ROUNDS,
             VECTOR_LEN,
-        > = main.current_slice().borrow();
+        > = (*current_row).borrow();
 
         // Evaluate constraints independently for each permutation in the row.
         for perm in &local.cols {

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -3,8 +3,9 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::marker::PhantomData;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{Dup, PrimeCharacteristicRing, PrimeField};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use rand::distr::{Distribution, StandardUniform};
@@ -223,7 +224,8 @@ impl<
     #[inline]
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local = main.current_slice().borrow();
+        let current_row = main.row_slice(0).unwrap();
+        let local = (*current_row).borrow();
 
         eval::<_, _, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>(
             self, builder, local,

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -2,8 +2,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use rand::distr::StandardUniform;
@@ -263,6 +264,7 @@ impl<
     #[inline]
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
+        let current_row = main.row_slice(0).unwrap();
         let local: &VectorizedPoseidon2Cols<
             _,
             WIDTH,
@@ -271,7 +273,7 @@ impl<
             HALF_FULL_ROUNDS,
             PARTIAL_ROUNDS,
             VECTOR_LEN,
-        > = main.current_slice().borrow();
+        > = (*current_row).borrow();
         for perm in &local.cols {
             eval(&self.air, builder, perm);
         }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
+use p3_air::{AirBuilder, ExtensionBuilder};
 use p3_field::{Algebra, BasedVectorSpace};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
@@ -21,8 +21,6 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     /// The preprocessed columns as a [`RowMajorMatrixView`].
     /// Zero-width when the AIR has no preprocessed trace.
     pub preprocessed: RowMajorMatrixView<'a, PackedVal<SC>>,
-    /// Pre-built window over the preprocessed columns.
-    pub preprocessed_window: RowWindow<'a, PackedVal<SC>>,
     /// Public inputs to the [AIR](`p3_air::Air`) implementation.
     pub public_values: &'a [Val<SC>],
     /// Evaluations of the first-row selector polynomial.
@@ -60,8 +58,6 @@ pub struct VerifierConstraintFolder<'a, SC: StarkGenericConfig> {
     /// The preprocessed columns as a [`ViewPair`].
     /// Zero-width when the AIR has no preprocessed trace.
     pub preprocessed: ViewPair<'a, SC::Challenge>,
-    /// Pre-built window over the preprocessed columns.
-    pub preprocessed_window: RowWindow<'a, SC::Challenge>,
     /// Public values that are inputs to the computation
     pub public_values: &'a [Val<SC>],
     /// Evaluations of the first-row selector polynomial.
@@ -110,17 +106,17 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     type F = Val<SC>;
     type Expr = PackedVal<SC>;
     type Var = PackedVal<SC>;
-    type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
-    type MainWindow = RowWindow<'a, PackedVal<SC>>;
+    type PreprocessedWindow = RowMajorMatrixView<'a, PackedVal<SC>>;
+    type MainWindow = RowMajorMatrixView<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_view(&self.main)
+        self.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
-        &self.preprocessed_window
+        &self.preprocessed
     }
 
     #[inline]
@@ -176,16 +172,16 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     type F = Val<SC>;
     type Expr = SC::Challenge;
     type Var = SC::Challenge;
-    type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
-    type MainWindow = RowWindow<'a, SC::Challenge>;
+    type PreprocessedWindow = ViewPair<'a, SC::Challenge>;
+    type MainWindow = ViewPair<'a, SC::Challenge>;
     type PublicVar = Val<SC>;
 
     fn main(&self) -> Self::MainWindow {
-        RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
+        self.main
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {
-        &self.preprocessed_window
+        &self.preprocessed
     }
 
     fn is_first_row(&self) -> Self::Expr {

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -2,8 +2,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
+use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
-use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
@@ -462,7 +462,6 @@ where
             let mut folder = ProverConstraintFolder {
                 main: main.as_view(),
                 preprocessed: preprocessed_view,
-                preprocessed_window: RowWindow::from_view(&preprocessed_view),
                 public_values,
                 is_first_row,
                 is_last_row,

--- a/uni-stark/src/sub_builder.rs
+++ b/uni-stark/src/sub_builder.rs
@@ -1,41 +1,16 @@
 //! Helpers for restricting a builder to a subset of trace columns.
 //!
 //! The uni-STARK builders often need to enforce constraints that refer to only a slice of the main
-//! trace. [`SubSliced`] offers a cheap view over a subset of columns, and [`SubAirBuilder`] wires
-//! that view into any [`AirBuilder`] implementation so a sub-air can be evaluated independently
-//! without copying trace data.
+//! trace. [`SubAirBuilder`] wires a [`HorizontallyTruncated`] view into any [`AirBuilder`]
+//! implementation so a sub-air can be evaluated independently without copying trace data.
 
 // Code inspired by SP1 with additional modifications:
 // https://github.com/succinctlabs/sp1/blob/main/crates/stark/src/air/sub_builder.rs
 
-use core::marker::PhantomData;
 use core::ops::Range;
 
-use p3_air::{AirBuilder, BaseAir, WindowAccess};
-
-/// A column-restricted view over a trace window.
-///
-/// Wraps an inner window and exposes only the columns within
-/// the given range. Lets a sub-AIR see a contiguous subset
-/// of the parent trace without copying data.
-#[derive(Clone)]
-pub struct SubSliced<W, T> {
-    window: W,
-    range: Range<usize>,
-    _marker: PhantomData<T>,
-}
-
-impl<W: WindowAccess<T>, T> WindowAccess<T> for SubSliced<W, T> {
-    #[inline]
-    fn current_slice(&self) -> &[T] {
-        &self.window.current_slice()[self.range.clone()]
-    }
-
-    #[inline]
-    fn next_slice(&self) -> &[T] {
-        &self.window.next_slice()[self.range.clone()]
-    }
-}
+use p3_air::{AirBuilder, BaseAir};
+use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 
 /// Evaluates a sub-AIR against a restricted slice of the parent trace.
 ///
@@ -73,15 +48,12 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
     type Expr = AB::Expr;
     type Var = AB::Var;
     type PreprocessedWindow = AB::PreprocessedWindow;
-    type MainWindow = SubSliced<AB::MainWindow, AB::Var>;
+    type MainWindow = HorizontallyTruncated<AB::Var, AB::MainWindow>;
     type PublicVar = AB::PublicVar;
 
     fn main(&self) -> Self::MainWindow {
-        SubSliced {
-            window: self.inner.main(),
-            range: self.column_range.clone(),
-            _marker: PhantomData,
-        }
+        HorizontallyTruncated::new_with_range(self.inner.main(), self.column_range.clone())
+            .expect("SubAirBuilder: column range out of bounds for main trace")
     }
 
     fn preprocessed(&self) -> &Self::PreprocessedWindow {

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -4,8 +4,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
+use p3_air::Air;
 use p3_air::symbolic::SymbolicAirBuilder;
-use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
@@ -107,12 +107,9 @@ where
         ),
     };
 
-    let preprocessed_window =
-        RowWindow::from_two_rows(preprocessed.top.values, preprocessed.bottom.values);
     let mut folder = VerifierConstraintFolder {
         main,
         preprocessed,
-        preprocessed_window,
         public_values,
         is_first_row: sels.is_first_row,
         is_last_row: sels.is_last_row,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -1,6 +1,6 @@
 use core::borrow::Borrow;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;
@@ -10,6 +10,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs, create_test_fri_params};
 use p3_keccak::{Keccak256Hash, KeccakF};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
 use p3_mersenne_31::Mersenne31;
@@ -50,8 +51,10 @@ impl<AB: AirBuilder> Air<AB> for FibonacciAir {
         let b = pis[1];
         let x = pis[2];
 
-        let local: &FibonacciRow<AB::Var> = main.current_slice().borrow();
-        let next: &FibonacciRow<AB::Var> = main.next_slice().borrow();
+        let local_row = main.row_slice(0).unwrap();
+        let local: &FibonacciRow<AB::Var> = (*local_row).borrow();
+        let next_row = main.row_slice(1).unwrap();
+        let next: &FibonacciRow<AB::Var> = (*next_row).borrow();
 
         let mut when_first_row = builder.when_first_row();
 

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use itertools::Itertools;
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;
@@ -13,6 +13,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs, create_test_fri_params_zk};
 use p3_keccak::Keccak256Hash;
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
 use p3_mersenne_31::Mersenne31;
@@ -90,8 +91,8 @@ impl<F> BaseAir<F> for MulAir {
 impl<AB: AirBuilder> Air<AB> for MulAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let main_local = main.current_slice();
-        let main_next = main.next_slice();
+        let main_local = main.row_slice(0).unwrap();
+        let main_next = main.row_slice(1).unwrap();
 
         for i in 0..REPETITIONS {
             let start = i * 3;

--- a/uni-stark/tests/mul_fib_pair.rs
+++ b/uni-stark/tests/mul_fib_pair.rs
@@ -1,6 +1,6 @@
 use core::borrow::Borrow;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
@@ -8,6 +8,7 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeField64};
 use p3_fri::{HidingFriPcs, TwoAdicFriPcs, create_test_fri_params};
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -57,13 +58,18 @@ where
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local: &MulFibPairRow<AB::Var> = main.current_slice().borrow();
-        let next: &MulFibPairRow<AB::Var> = main.next_slice().borrow();
+        let local_row = main.row_slice(0).unwrap();
+        let local: &MulFibPairRow<AB::Var> = (*local_row).borrow();
+        let next_row = main.row_slice(1).unwrap();
+        let next: &MulFibPairRow<AB::Var> = (*next_row).borrow();
 
         // Copy the preprocessed values we need so the immutable borrow on
         // `builder` is released before the mutable `when_transition` call.
-        let prep: &PreprocessedRow<AB::Var> = builder.preprocessed().current_slice().borrow();
-        let (prod_coeff, sum_coeff) = (prep.prod_coeff, prep.sum_coeff);
+        let (prod_coeff, sum_coeff) = {
+            let prep_row = builder.preprocessed().row_slice(0).unwrap();
+            let prep: &PreprocessedRow<AB::Var> = (*prep_row).borrow();
+            (prep.prod_coeff, prep.sum_coeff)
+        };
 
         let mut when_transition = builder.when_transition();
 

--- a/uni-stark/tests/no_next_row.rs
+++ b/uni-stark/tests/no_next_row.rs
@@ -1,4 +1,4 @@
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
@@ -6,6 +6,7 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::TwoAdicFriPcs;
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -29,8 +30,8 @@ impl<F> BaseAir<F> for SquareAir {
 impl<AB: AirBuilder> Air<AB> for SquareAir {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let a = main.current(0).unwrap();
-        let b = main.current(1).unwrap();
+        let a = main.get(0, 0).unwrap();
+        let b = main.get(0, 1).unwrap();
         builder.assert_eq(a * a, b);
     }
 }

--- a/uni-stark/tests/rc_sub_builder.rs
+++ b/uni-stark/tests/rc_sub_builder.rs
@@ -11,13 +11,14 @@
 use core::marker::PhantomData;
 
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::testing::TrivialPcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::extension::BinomialExtensionField;
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_uni_stark::{StarkConfig, SubAirBuilder, prove, verify};
 use rand::SeedableRng;
@@ -43,8 +44,9 @@ where
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
 
-        let value = main.current(0).unwrap();
-        let bits = &main.current_slice()[1..];
+        let value = main.get(0, 0).unwrap();
+        let row = main.row_slice(0).unwrap();
+        let bits = &row[1..];
 
         let mut recomposed = AB::Expr::ZERO;
         for (i, bit) in bits.iter().enumerate() {
@@ -83,9 +85,9 @@ where
         // Evaluate the parent AIR
         let main = builder.main();
 
-        let accumulator = main.current(0).unwrap();
-        let range_value = main.current(1).unwrap();
-        let next_accumulator = main.next(0).unwrap();
+        let accumulator = main.get(0, 0).unwrap();
+        let range_value = main.get(0, 1).unwrap();
+        let next_accumulator = main.get(1, 0).unwrap();
 
         builder.when_first_row().assert_zero(accumulator);
         builder


### PR DESCRIPTION
We are loosing the `current` and `next` vocabulary but I feel like this simplifies the code a lot by fully reusing the matrix crate (before the behaviour was duplicated with the window access and I disliked it).