### PR TITLE
batch-stark: avoid cloning generated_perm

### DIFF
--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -218,8 +218,6 @@ where
                     &mut lookup_data[i],
                     &challenges_per_instance[i],
                 );
-                permutation_commit_inputs
-                    .push((ext_domain, generated_perm.clone().flatten_to_base()));
 
                 #[cfg(debug_assertions)]
                 {
@@ -243,6 +241,9 @@ where
                         lookup_constraints_inputs,
                     );
                 }
+
+                // Consume the generated matrix directly; no extra clone before flattening.
+                permutation_commit_inputs.push((ext_domain, generated_perm.flatten_to_base()));
             }
         });
 


### PR DESCRIPTION
Remove the unnecessary `generated_perm.clone()` before `flatten_to_base`, and push permutation commit inputs by consuming `generated_perm` directly after the debug-only constraint checks.