### PR TITLE
chore: visibility change for BatchTranscript

### DIFF
--- a/batch-stark/src/lib.rs
+++ b/batch-stark/src/lib.rs
@@ -37,4 +37,5 @@ pub use config::{
 pub use p3_uni_stark::{OpenedValues, VerificationError};
 pub use proof::{BatchCommitments, BatchOpenedValues, BatchProof};
 pub use prover::{StarkInstance, prove_batch};
+pub use transcript::BatchTranscript;
 pub use verifier::verify_batch;

--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -11,9 +11,9 @@ use crate::common::GlobalPreprocessed;
 use crate::config::{Challenge, Commitment, StarkGenericConfig as SGC, Val};
 
 /// Wrapper around a Fiat-Shamir challenger.
-pub(crate) struct BatchTranscript<SC: SGC> {
+pub struct BatchTranscript<SC: SGC> {
     /// The underlying challenger.
-    pub(crate) challenger: SC::Challenger,
+    pub challenger: SC::Challenger,
 }
 
 impl<SC: SGC> BatchTranscript<SC> {


### PR DESCRIPTION
Make `BatchTranscript` pub and re-export it.