### PR TITLE
refactor(verifier): remove unused MissingInput variant

### DIFF
--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -33,8 +33,6 @@ where
     FinalPolyMismatch,
     #[error("invalid proof-of-work witness")]
     InvalidPowWitness,
-    #[error("missing input: required input is not present")]
-    MissingInput,
 }
 
 /// A chain of FRI input openings allowing a verifier to check a sequence of


### PR DESCRIPTION
Remove the unused `FriError::MissingInput` variant, align the public error enum with the verifier's actual `InvalidProofShape` behavior.