### PR TITLE
perf(dft): precompute twiddle*scale in ScaledDitButterfly (exp-6)

### DIFF
--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -191,21 +191,48 @@ impl<F: Field> Butterfly<F> for DitButterfly<F> {
 ///   output_1 = (x1 + x2 * twiddle) * scale
 ///   output_2 = (x1 - x2 * twiddle) * scale
 /// ```
+/// which is equivalent to:
+/// ```text
+///   output_1 = x1 * scale + x2 * (twiddle * scale)
+///   output_2 = x1 * scale - x2 * (twiddle * scale)
+/// ```
+///
 /// This is used to merge a uniform scaling step (e.g., 1/N normalization in inverse DFT)
 /// into a butterfly pass, avoiding a separate memory pass over the data.
+///
+/// The struct stores `scale` and `twiddle_times_scale = twiddle * scale` so that the
+/// `apply` method only needs 2 multiplications instead of 3.
 #[derive(Copy, Clone)]
 pub struct ScaledDitButterfly<F> {
     pub twiddle: F,
     pub scale: F,
+    /// Precomputed product `twiddle * scale` to reduce multiplications in the hot loop.
+    pub twiddle_times_scale: F,
+}
+
+impl<F: Field> ScaledDitButterfly<F> {
+    /// Construct a `ScaledDitButterfly`, precomputing `twiddle * scale`.
+    #[inline]
+    pub fn new(twiddle: F, scale: F) -> Self {
+        Self {
+            twiddle,
+            scale,
+            twiddle_times_scale: twiddle * scale,
+        }
+    }
 }
 
 impl<F: Field> Butterfly<F> for ScaledDitButterfly<F> {
     #[inline]
     fn apply<PF: PackedField<Scalar = F>>(&self, x_1: PF, x_2: PF) -> (PF, PF) {
-        let x_2_twiddle = x_2 * self.twiddle;
-        let sum = (x_1 + x_2_twiddle) * self.scale;
-        let diff = (x_1 - x_2_twiddle) * self.scale;
-        (sum, diff)
+        // 2 multiplications instead of 3:
+        //   x1_s   = x1 * scale
+        //   x2_ts  = x2 * (twiddle * scale)   [precomputed]
+        //   out1   = x1_s + x2_ts
+        //   out2   = x1_s - x2_ts
+        let x_1_scale = x_1 * self.scale;
+        let x_2_twiddle_scale = x_2 * self.twiddle_times_scale;
+        (x_1_scale + x_2_twiddle_scale, x_1_scale - x_2_twiddle_scale)
     }
 }
 

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -542,6 +542,9 @@ fn dit_layer_oop<'a, F: Field>(
 ///
 /// This avoids an extra memory pass when scaling is required (e.g., 1/N in inverse DFT).
 /// When `scale` is `None`, this is identical to `dit_layer_rev`.
+///
+/// When `scale` is `Some(s)`, uses `ScaledDitButterfly::new(twiddle, s)` which precomputes
+/// `twiddle * scale` once per block, reducing multiplications in the hot loop from 3 to 2.
 fn dit_layer_rev_scaled<F: Field>(
     submat: &mut RowMajorMatrixViewMut<'_, F>,
     log_h: usize,
@@ -578,8 +581,8 @@ fn dit_layer_rev_scaled<F: Field>(
         }
         Some(s) => {
             // Fold scaling into the butterfly to avoid a separate memory pass.
-            // ScaledDitButterfly computes: (scale*(x1 + x2*twiddle), scale*(x1 - x2*twiddle))
-            // which equals: scale first, then butterfly — same result.
+            // ScaledDitButterfly::new precomputes twiddle * scale once per block,
+            // so the hot loop only needs 2 multiplications instead of 3.
             let blocks_and_twiddles = submat
                 .values
                 .chunks_mut(block_size * width)
@@ -587,12 +590,12 @@ fn dit_layer_rev_scaled<F: Field>(
             if backwards {
                 for (block, twiddle) in blocks_and_twiddles.rev() {
                     let (lo, hi) = block.split_at_mut(half_block_size * width);
-                    ScaledDitButterfly { twiddle, scale: s }.apply_to_rows(lo, hi);
+                    ScaledDitButterfly::new(twiddle, s).apply_to_rows(lo, hi);
                 }
             } else {
                 for (block, twiddle) in blocks_and_twiddles {
                     let (lo, hi) = block.split_at_mut(half_block_size * width);
-                    ScaledDitButterfly { twiddle, scale: s }.apply_to_rows(lo, hi);
+                    ScaledDitButterfly::new(twiddle, s).apply_to_rows(lo, hi);
                 }
             }
         }


### PR DESCRIPTION
> **This is part of a series of 6 incremental DFT butterfly optimizations.** Each builds on the previous. Please review in order: #1486 → this PR → ...
>
> **Incremental diff (only this PR's changes):** https://github.com/Barnadrot/Plonky3/compare/perf/dft-exp-001...perf/dft-exp-006

## Summary

**Target bottleneck:** `ScaledDitButterfly::apply` (introduced in #1486) computed `x2 * twiddle` then `(x1 ± result) * scale` — 3 field multiplications per element pair in the inverse DFT's first butterfly layer.

**Fix:** Add `ScaledDitButterfly::new(twiddle, scale)` which precomputes `twiddle_times_scale = twiddle * scale` once per block. The hot loop is restructured as:
```
x1_s  = x1 * scale
x2_ts = x2 * (twiddle * scale)   // precomputed
out1  = x1_s + x2_ts
out2  = x1_s - x2_ts
```
Reducing from 3 multiplications to 2 per element pair.

## Performance

**Benchmark:** `coset_lde/BabyBear/Radix2DitParallel/ncols=256/1048576`

```
RAYON_NUM_THREADS=8 cargo bench -p p3-dft --features p3-dft/parallel --bench fft \
  -- "coset_lde/BabyBear/Radix2DitParallel/ncols=256/1048576"
```

**Machine:** AMD EPYC-Milan, 4 cores / 8 threads (2.0 GHz), Linux 6.8.0

| | Time |
|---|---|
| Before (after #1486) | 2724.4 ms |
| After | 2698.2 ms |
| Improvement | ~0.96% |