### PR TITLE
uni stark: rely on default `assert_zeros_ext` for `ProverConstraintFolder`

### DIFF
--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -174,15 +174,6 @@ impl<SC: StarkGenericConfig> ExtensionBuilder for ProverConstraintFolder<'_, SC>
         self.ext_constraints.push(x.into());
         self.constraint_index += 1;
     }
-
-    fn assert_zeros_ext<const N: usize, I>(&mut self, array: [I; N])
-    where
-        I: Into<Self::ExprEF>,
-    {
-        self.ext_constraints
-            .extend(array.into_iter().map(Into::into));
-        self.constraint_index += N;
-    }
 }
 
 impl<SC: StarkGenericConfig> PeriodicAirBuilder for ProverConstraintFolder<'_, SC> {


### PR DESCRIPTION
@Nashtare For some reason, I forgot to validate my comment on https://github.com/Plonky3/Plonky3/pull/1493 about this in the review :) 