### PR TITLE
chore: release v0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,46 +89,46 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.5.1" }
-p3-baby-bear = { path = "baby-bear", version = "0.5.1" }
-p3-blake3 = { path = "blake3", version = "0.5.1" }
-p3-blake3-air = { path = "blake3-air", version = "0.5.1" }
-p3-bn254 = { path = "bn254", version = "0.5.1" }
-p3-challenger = { path = "challenger", version = "0.5.1" }
-p3-circle = { path = "circle", version = "0.5.1" }
-p3-commit = { path = "commit", version = "0.5.1" }
-p3-dft = { path = "dft", version = "0.5.1" }
+p3-air = { path = "air", version = "0.5.2" }
+p3-baby-bear = { path = "baby-bear", version = "0.5.2" }
+p3-blake3 = { path = "blake3", version = "0.5.2" }
+p3-blake3-air = { path = "blake3-air", version = "0.5.2" }
+p3-bn254 = { path = "bn254", version = "0.5.2" }
+p3-challenger = { path = "challenger", version = "0.5.2" }
+p3-circle = { path = "circle", version = "0.5.2" }
+p3-commit = { path = "commit", version = "0.5.2" }
+p3-dft = { path = "dft", version = "0.5.2" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.5.1" }
-p3-field-testing = { path = "field-testing", version = "0.5.1" }
-p3-fri = { path = "fri", version = "0.5.1" }
-p3-goldilocks = { path = "goldilocks", version = "0.5.1" }
-p3-interpolation = { path = "interpolation", version = "0.5.1" }
-p3-keccak = { path = "keccak", version = "0.5.1" }
-p3-keccak-air = { path = "keccak-air", version = "0.5.1" }
-p3-koala-bear = { path = "koala-bear", version = "0.5.1" }
-p3-lookup = { path = "lookup", version = "0.5.1" }
-p3-matrix = { path = "matrix", version = "0.5.1" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.5.1" }
-p3-mds = { path = "mds", version = "0.5.1" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.5.1" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.5.1" }
-p3-monty-31 = { path = "monty-31", version = "0.5.1" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.5.1" }
-p3-poseidon1 = { path = "poseidon1", version = "0.5.1" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.5.1" }
-p3-poseidon2 = { path = "poseidon2", version = "0.5.1" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.5.1" }
-p3-rescue = { path = "rescue", version = "0.5.1" }
-p3-sha256 = { path = "sha256", version = "0.5.1" }
-p3-symmetric = { path = "symmetric", version = "0.5.1" }
-p3-uni-stark = { path = "uni-stark", version = "0.5.1" }
-p3-util = { path = "util", version = "0.5.1" }
+p3-field = { path = "field", version = "0.5.2" }
+p3-field-testing = { path = "field-testing", version = "0.5.2" }
+p3-fri = { path = "fri", version = "0.5.2" }
+p3-goldilocks = { path = "goldilocks", version = "0.5.2" }
+p3-interpolation = { path = "interpolation", version = "0.5.2" }
+p3-keccak = { path = "keccak", version = "0.5.2" }
+p3-keccak-air = { path = "keccak-air", version = "0.5.2" }
+p3-koala-bear = { path = "koala-bear", version = "0.5.2" }
+p3-lookup = { path = "lookup", version = "0.5.2" }
+p3-matrix = { path = "matrix", version = "0.5.2" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.5.2" }
+p3-mds = { path = "mds", version = "0.5.2" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.5.2" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.5.2" }
+p3-monty-31 = { path = "monty-31", version = "0.5.2" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.5.2" }
+p3-poseidon1 = { path = "poseidon1", version = "0.5.2" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.5.2" }
+p3-poseidon2 = { path = "poseidon2", version = "0.5.2" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.5.2" }
+p3-rescue = { path = "rescue", version = "0.5.2" }
+p3-sha256 = { path = "sha256", version = "0.5.2" }
+p3-symmetric = { path = "symmetric", version = "0.5.2" }
+p3-uni-stark = { path = "uni-stark", version = "0.5.2" }
+p3-util = { path = "util", version = "0.5.2" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf(batch-stark): avoid cloning generated_perm (#1473)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ## [0.4.2] - 2026-01-05

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Field: reinforcement of tests with edge cases and proptests (#1435)
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix overflow dot_product_5 neon (#1429)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix div2_asm goldilocks neon (#1430)

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ## [0.4.2] - 2026-01-05

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix overflow dot_product_5 neon (#1429)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Logup: better memory allocation (#1455)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Mds: small improvements and more testing (#1459)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Mds: small improvements and more testing (#1459)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ## [0.4.2] - 2026-01-05

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Poseidon1: speedup monty-31 packed version on avx (#1420)
+- Monty31: use transmute in poseidon1 packing (#1446)
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Monty31: faster aarch64 neon `quintic_mul_packed` (#1422)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Uni stark: rm useless `check_constraints.rs` file (#1471)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.5.1 -> 0.5.2
* `p3-util`: 0.5.1 -> 0.5.2
* `p3-field`: 0.5.1 -> 0.5.2
* `p3-matrix`: 0.5.1 -> 0.5.2
* `p3-air`: 0.5.1 -> 0.5.2
* `p3-dft`: 0.5.1 -> 0.5.2
* `p3-symmetric`: 0.5.1 -> 0.5.2
* `p3-mds`: 0.5.1 -> 0.5.2
* `p3-poseidon1`: 0.5.1 -> 0.5.2
* `p3-poseidon2`: 0.5.1 -> 0.5.2
* `p3-monty-31`: 0.5.1 -> 0.5.2
* `p3-challenger`: 0.5.1 -> 0.5.2
* `p3-baby-bear`: 0.5.1 -> 0.5.2
* `p3-goldilocks`: 0.5.1 -> 0.5.2
* `p3-koala-bear`: 0.5.1 -> 0.5.2
* `p3-mersenne-31`: 0.5.1 -> 0.5.2
* `p3-bn254`: 0.5.1 -> 0.5.2
* `p3-field-testing`: 0.5.1 -> 0.5.2
* `p3-commit`: 0.5.1 -> 0.5.2
* `p3-uni-stark`: 0.5.1 -> 0.5.2
* `p3-lookup`: 0.5.1 -> 0.5.2
* `p3-batch-stark`: 0.5.1 -> 0.5.2
* `p3-interpolation`: 0.5.1 -> 0.5.2
* `p3-fri`: 0.5.1 -> 0.5.2
* `p3-circle`: 0.5.1 -> 0.5.2
* `p3-keccak`: 0.5.1 -> 0.5.2
* `p3-merkle-tree`: 0.5.1 -> 0.5.2
* `p3-blake3`: 0.5.1 -> 0.5.2
* `p3-rescue`: 0.5.1 -> 0.5.2
* `p3-blake3-air`: 0.5.1 -> 0.5.2
* `p3-sha256`: 0.5.1 -> 0.5.2
* `p3-keccak-air`: 0.5.1 -> 0.5.2
* `p3-poseidon2-air`: 0.5.1 -> 0.5.2
* `p3-monolith`: 0.5.1 -> 0.5.2
* `p3-multilinear-util`: 0.5.1 -> 0.5.2
* `p3-poseidon1-air`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>



## `p3-field`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>


## `p3-air`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>



## `p3-mds`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Mds: small improvements and more testing (#1459)
</blockquote>


## `p3-poseidon2`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>

## `p3-monty-31`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Poseidon1: speedup monty-31 packed version on avx (#1420)
- Monty31: use transmute in poseidon1 packing (#1446)
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>

## `p3-challenger`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
</blockquote>

## `p3-baby-bear`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>

## `p3-goldilocks`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>

## `p3-koala-bear`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Perf: abstract away Copy vs Clone (#1463)
- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
</blockquote>

## `p3-mersenne-31`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Mds: small improvements and more testing (#1459)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>


## `p3-field-testing`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Field: reinforcement of tests with edge cases and proptests (#1435)
- Make batched_linear_combination chunk size per-impl tunable (#1451)
</blockquote>


## `p3-uni-stark`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Make batched_linear_combination chunk size per-impl tunable (#1451)
- Uni stark: rm useless `check_constraints.rs` file (#1471)
</blockquote>

## `p3-lookup`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Logup: better memory allocation (#1455)
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Perf(batch-stark): avoid cloning generated_perm (#1473)
</blockquote>











## `p3-poseidon2-air`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>


## `p3-multilinear-util`

<blockquote>

## [0.5.2] - 2026-03-27

### Merged PRs
- Perf: abstract away Copy vs Clone (#1463)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).