### PR TITLE
monolith: avoid unnecessary array clone in `bricks()`

### DIFF
--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -3,7 +3,6 @@
 
 extern crate alloc;
 
-use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 
 use p3_field::integers::QuotientMap;
@@ -140,8 +139,10 @@ where
     #[inline]
     pub fn bricks(state: &mut [Mersenne31; WIDTH]) {
         // Feistel Type-3
-        for (x, x_mut) in state.to_owned().iter().zip(state.iter_mut().skip(1)) {
-            *x_mut += x.square();
+        // Reverse iteration so state[i] is still unmodified when read,
+        // avoiding a full array clone.
+        for i in (0..WIDTH - 1).rev() {
+            state[i + 1] += state[i].square();
         }
     }
 


### PR DESCRIPTION
Before: `bricks()` called `state.to_owned()` to clone the entire `[Mersenne31; WIDTH]` array every invocation, just to read original values while mutating in the Feistel Type-3 loop.

After: reversed the iteration order so `state[i]` is always read before it could be written by a later step. same semantics, no clone needed. also removed the now-unused `alloc::borrow::ToOwned` import.
