### PR TITLE
field: batch invert packed quintic divisors

### DIFF
--- a/field/src/extension/packed_quintic_extension.rs
+++ b/field/src/extension/packed_quintic_extension.rs
@@ -608,7 +608,10 @@ where
     #[allow(clippy::suspicious_arithmetic_impl)]
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        let rhs_inv = Self::from_fn(|i| rhs.as_slice()[i].inverse());
+        let mut rhs_inv = Self::broadcast(QuinticTrinomialExtensionField::<F>::ZERO);
+        crate::batch_multiplicative_inverse_general(rhs.as_slice(), rhs_inv.as_slice_mut(), |x| {
+            x.inverse()
+        });
         self * rhs_inv
     }
 }


### PR DESCRIPTION
Use batch inverse in packed quintic division.

`PackedQuinticTrinomialExtensionField::div` used to call `inverse()` lane-by-lane (`WIDTH` times). This switches to `batch_multiplicative_inverse_general`, so we do one batched inversion flow instead.

AVX2:

<img width="1118" height="268" alt="image" src="https://github.com/user-attachments/assets/0446ae65-d0cb-4b5b-828a-bb2145f11221" />
