### PR TITLE
fix(uni-stark): make inferred quotient chunking trace-aware

### DIFF
--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -125,7 +125,7 @@ where
     // of quotient polynomials we will split Q(x) into. This is chosen to
     // always be a power of 2.
     let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, degree, config.is_zk());
 
     let num_quotient_chunks = 1 << (log_num_quotient_chunks + config.is_zk());
 

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -1,13 +1,24 @@
 //! STARK-specific quotient polynomial degree calculations.
 
+use alloc::vec::Vec;
+
 use p3_air::Air;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_max_constraint_degree_extension};
+use p3_air::symbolic::{
+    AirLayout, BaseEntry, BaseLeaf, ExtEntry, ExtLeaf, SymbolicAirBuilder, SymbolicExpr,
+    SymbolicExpression, SymbolicExpressionExt, get_all_symbolic_constraints,
+    get_max_constraint_degree_extension,
+};
 use p3_field::{ExtensionField, Field};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
 #[instrument(skip_all, level = "debug")]
-pub fn get_log_num_quotient_chunks<F, A>(air: &A, layout: AirLayout, is_zk: usize) -> usize
+pub fn get_log_num_quotient_chunks<F, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
@@ -20,8 +31,10 @@ where
 
         debug_assert!(
             {
-                let symbolic = get_log_quotient_degree_extension::<F, F, A>(air, layout, is_zk);
-                result >= symbolic
+                let hinted_degree = get_max_constraint_degree_extension::<F, F, A>(air, layout);
+                let symbolic =
+                    get_log_quotient_degree_extension::<F, F, A>(air, layout, trace_degree, is_zk);
+                degree_hint >= hinted_degree && result >= symbolic
             },
             "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
             degree_hint
@@ -30,7 +43,7 @@ where
         return result;
     }
 
-    get_log_quotient_degree_extension(air, layout, is_zk)
+    get_log_quotient_degree_extension(air, layout, trace_degree, is_zk)
 }
 
 #[instrument(
@@ -41,6 +54,7 @@ where
 pub fn get_log_quotient_degree_extension<F, EF, A>(
     air: &A,
     layout: AirLayout,
+    trace_degree: usize,
     is_zk: usize,
 ) -> usize
 where
@@ -56,24 +70,186 @@ where
 
         debug_assert!(
             {
-                let actual = get_max_constraint_degree_extension::<F, EF, A>(air, layout);
-                degree_hint >= actual
+                let hinted_degree = get_max_constraint_degree_extension::<F, EF, A>(air, layout);
+                let actual = get_log_quotient_degree_extension_symbolic::<F, EF, A>(
+                    air,
+                    layout,
+                    trace_degree,
+                    is_zk,
+                );
+                degree_hint >= hinted_degree && result >= actual
             },
-            "max_constraint_degree() hint {} is too small; symbolic evaluation found a larger degree",
+            "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
             degree_hint
         );
 
         return result;
     }
 
-    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
-    let constraint_degree =
-        (get_max_constraint_degree_extension::<F, EF, A>(air, layout) + is_zk).max(2);
+    get_log_quotient_degree_extension_symbolic(air, layout, trace_degree, is_zk)
+}
 
-    // We bound the degree of the quotient polynomial by constraint_degree - 1,
-    // then choose the number of quotient chunks as the smallest power of two
-    // >= (constraint_degree - 1). This function returns log2(#chunks).
-    log2_ceil_usize(constraint_degree - 1)
+fn get_log_quotient_degree_extension_symbolic<F, EF, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
+{
+    let periodic_column_degrees = air
+        .periodic_columns()
+        .into_iter()
+        .map(|col| {
+            debug_assert!(
+                trace_degree.is_multiple_of(col.len()),
+                "periodic column period must divide the trace degree"
+            );
+            trace_degree - trace_degree / col.len()
+        })
+        .collect::<Vec<_>>();
+
+    let (base_constraints, extension_constraints) =
+        get_all_symbolic_constraints::<F, EF, _>(air, layout);
+
+    let base_degree = base_constraints
+        .iter()
+        .map(|constraint| {
+            symbolic_expression_degree(
+                constraint,
+                trace_degree,
+                is_zk,
+                periodic_column_degrees.as_slice(),
+            )
+        })
+        .max()
+        .unwrap_or(0);
+
+    let extension_degree = extension_constraints
+        .iter()
+        .map(|constraint| {
+            symbolic_expression_ext_degree(
+                constraint,
+                trace_degree,
+                is_zk,
+                periodic_column_degrees.as_slice(),
+            )
+        })
+        .max()
+        .unwrap_or(0);
+
+    let constraint_degree = base_degree.max(extension_degree);
+    log_chunks_from_constraint_degree(constraint_degree, trace_degree, is_zk)
+}
+
+fn symbolic_expression_degree<F: Field>(
+    expr: &SymbolicExpression<F>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    match expr {
+        SymbolicExpr::Leaf(leaf) => {
+            base_leaf_degree(leaf, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Add { x, y, .. } | SymbolicExpr::Sub { x, y, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees).max(
+                symbolic_expression_degree(y, trace_degree, is_zk, periodic_column_degrees),
+            )
+        }
+        SymbolicExpr::Neg { x, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Mul { x, y, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees)
+                + symbolic_expression_degree(y, trace_degree, is_zk, periodic_column_degrees)
+        }
+    }
+}
+
+fn base_leaf_degree<F: Field>(
+    leaf: &BaseLeaf<F>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    let extended_trace_degree = trace_degree << is_zk;
+    match leaf {
+        BaseLeaf::Variable(variable) => match variable.entry {
+            BaseEntry::Preprocessed { .. } | BaseEntry::Main { .. } => extended_trace_degree - 1,
+            BaseEntry::Periodic => periodic_column_degrees[variable.index],
+            BaseEntry::Public => 0,
+        },
+        BaseLeaf::IsFirstRow | BaseLeaf::IsLastRow => trace_degree - 1,
+        BaseLeaf::IsTransition => 1,
+        BaseLeaf::Constant(_) => 0,
+    }
+}
+
+fn symbolic_expression_ext_degree<F: Field, EF: ExtensionField<F>>(
+    expr: &SymbolicExpressionExt<F, EF>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    match expr {
+        SymbolicExpr::Leaf(leaf) => {
+            ext_leaf_degree(leaf, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Add { x, y, .. } | SymbolicExpr::Sub { x, y, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees).max(
+                symbolic_expression_ext_degree(y, trace_degree, is_zk, periodic_column_degrees),
+            )
+        }
+        SymbolicExpr::Neg { x, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Mul { x, y, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees)
+                + symbolic_expression_ext_degree(y, trace_degree, is_zk, periodic_column_degrees)
+        }
+    }
+}
+
+fn ext_leaf_degree<F: Field, EF: ExtensionField<F>>(
+    leaf: &ExtLeaf<F, EF>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    let extended_trace_degree = trace_degree << is_zk;
+    match leaf {
+        ExtLeaf::Base(expr) => {
+            symbolic_expression_degree(expr, trace_degree, is_zk, periodic_column_degrees)
+        }
+        ExtLeaf::ExtVariable(variable) => match variable.entry {
+            ExtEntry::Permutation { .. } => extended_trace_degree - 1,
+            ExtEntry::Challenge | ExtEntry::PermutationValue => 0,
+        },
+        ExtLeaf::ExtConstant(_) => 0,
+    }
+}
+
+fn log_chunks_from_constraint_degree(
+    constraint_degree: usize,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize {
+    if constraint_degree == 0 {
+        return 0;
+    }
+
+    let quotient_chunk_degree = trace_degree << is_zk;
+    let chunk_count = constraint_degree
+        .saturating_sub(trace_degree)
+        .saturating_add(1)
+        .div_ceil(quotient_chunk_degree)
+        .max(1);
+
+    log2_ceil_usize(chunk_count)
 }
 
 #[cfg(test)]
@@ -81,11 +257,14 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicVariable};
-    use p3_air::{AirBuilder, BaseAir, BaseEntry};
+    use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicVariable};
+    use p3_air::{AirBuilder, BaseAir, BaseEntry, PeriodicAirBuilder};
     use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
 
     use super::*;
+
+    const TRACE_DEGREE: usize = 1 << 6;
 
     #[derive(Debug)]
     struct MockAir {
@@ -112,6 +291,7 @@ mod tests {
             preprocessed_width,
             main_width: air.width(),
             num_public_values: air.num_public_values(),
+            num_periodic_columns: air.num_periodic_columns(),
             ..Default::default()
         }
     }
@@ -122,7 +302,7 @@ mod tests {
             constraints: vec![],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, 0);
     }
 
@@ -132,7 +312,7 @@ mod tests {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -146,7 +326,7 @@ mod tests {
             ],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -185,7 +365,7 @@ mod tests {
             width: 4,
             degree_hint: Some(3),
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
         assert_eq!(log_chunks, log2_ceil_usize(2));
     }
 
@@ -198,7 +378,7 @@ mod tests {
             width: 4,
             degree_hint: None,
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
         assert_eq!(log_chunks, 0);
     }
 
@@ -210,7 +390,7 @@ mod tests {
             width: 4,
             degree_hint: Some(1),
         };
-        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
 
         let air_no_hint = HintedMockAir {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
@@ -218,7 +398,7 @@ mod tests {
             degree_hint: None,
         };
         let without_hint =
-            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), 0);
+            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), TRACE_DEGREE, 0);
 
         assert_eq!(with_hint, without_hint);
     }
@@ -233,6 +413,74 @@ mod tests {
             width: 4,
             degree_hint: Some(0),
         };
-        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+    }
+
+    #[derive(Clone, Debug)]
+    struct PeriodicProductAir {
+        periods: Vec<usize>,
+    }
+
+    impl BaseAir<BabyBear> for PeriodicProductAir {
+        fn width(&self) -> usize {
+            0
+        }
+
+        fn num_periodic_columns(&self) -> usize {
+            self.periods.len()
+        }
+
+        fn periodic_columns(&self) -> Vec<Vec<BabyBear>> {
+            self.periods
+                .iter()
+                .enumerate()
+                .map(|(column_index, period)| {
+                    (0..*period)
+                        .map(|row| BabyBear::from_usize(column_index + row + 1))
+                        .collect()
+                })
+                .collect()
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<BabyBear>> for PeriodicProductAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<BabyBear>) {
+            let product = builder
+                .periodic_values()
+                .iter()
+                .copied()
+                .map(SymbolicExpression::from)
+                .reduce(|acc, value| acc * value)
+                .expect("test AIR must define at least one periodic column");
+            builder.assert_zero(product);
+        }
+    }
+
+    #[test]
+    fn test_period_2_columns_reduce_inferred_chunk_count() {
+        let air = PeriodicProductAir {
+            periods: vec![2, 2, 2, 2, 2],
+        };
+
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+
+        assert_eq!(
+            log_chunks, 1,
+            "five period-2 columns should need only 2 quotient chunks at trace degree 64"
+        );
+    }
+
+    #[test]
+    fn test_period_4_columns_reduce_inferred_chunk_count() {
+        let air = PeriodicProductAir {
+            periods: vec![4, 4, 4, 4, 4, 4],
+        };
+
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+
+        assert_eq!(
+            log_chunks, 2,
+            "six period-4 columns should need only 4 quotient chunks at trace degree 64"
+        );
     }
 }

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -29,14 +29,11 @@ where
         let constraint_degree = (degree_hint + is_zk).max(2);
         let result = log2_ceil_usize(constraint_degree - 1);
 
+        // Keep the hint-path assertion cheap: full symbolic quotient inference is too
+        // expensive for hot debug test paths like prove/verify end-to-end runs.
         debug_assert!(
-            {
-                let hinted_degree = get_max_constraint_degree_extension::<F, F, A>(air, layout);
-                let symbolic =
-                    get_log_quotient_degree_extension::<F, F, A>(air, layout, trace_degree, is_zk);
-                degree_hint >= hinted_degree && result >= symbolic
-            },
-            "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
+            degree_hint >= get_max_constraint_degree_extension::<F, F, A>(air, layout),
+            "max_constraint_degree() hint {} is too small",
             degree_hint
         );
 
@@ -68,18 +65,11 @@ where
         let constraint_degree = (degree_hint + is_zk).max(2);
         let result = log2_ceil_usize(constraint_degree - 1);
 
+        // Keep the hint-path assertion cheap: full symbolic quotient inference is too
+        // expensive for hot debug test paths like prove/verify end-to-end runs.
         debug_assert!(
-            {
-                let hinted_degree = get_max_constraint_degree_extension::<F, EF, A>(air, layout);
-                let actual = get_log_quotient_degree_extension_symbolic::<F, EF, A>(
-                    air,
-                    layout,
-                    trace_degree,
-                    is_zk,
-                );
-                degree_hint >= hinted_degree && result >= actual
-            },
-            "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
+            degree_hint >= get_max_constraint_degree_extension::<F, EF, A>(air, layout),
+            "max_constraint_degree() hint {} is too small",
             degree_hint
         );
 

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -285,8 +285,12 @@ where
         num_periodic_columns: air.num_periodic_columns(),
         ..Default::default()
     };
-    let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+    let log_num_quotient_chunks = get_log_num_quotient_chunks::<Val<SC>, A>(
+        air,
+        layout,
+        degree >> config.is_zk(),
+        config.is_zk(),
+    );
     let (_, num_quotient_chunks) = checked_log_size_sum(log_num_quotient_chunks, config.is_zk())
         .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
             air: None,


### PR DESCRIPTION

## Summary

Fixes #1382.

This keeps the existing symbolic-expression API and the current `max_constraint_degree()` hint contract unchanged, but tightens the inferred no-hint quotient-degree / quotient-chunk path in `uni-stark`.

In particular, the new inference path stops pretending that:

- `is_transition` is degree-`0`
- periodic columns always behave like full trace-degree leaves

Instead, it derives the inferred quotient degree from the actual symbolic constraints together with the trace degree and periodic periods.

## What changes

- thread the original trace degree into quotient-chunk inference in both:
  - prover
  - verifier
- add a local trace-aware symbolic degree walker in `uni-stark`
- treat `is_transition` as linear for quotient-degree purposes
- use periodic-column degree `n - n/p`
- keep explicit `max_constraint_degree()` hints on their existing compatibility path
- add targeted regression tests that cross a quotient-chunk bucket boundary:
  - five period-`2` columns at trace degree `64`
  - six period-`4` columns at trace degree `64`

## Why this stays narrow

I intentionally did not try to redesign `p3-air`'s symbolic degree API in this PR.

This patch keeps the v1 boundary inside `uni-stark`:

- no repo-wide symbolic-expression rewrite
- no change to the AIR authoring surface
- no reinterpretation of existing `max_constraint_degree()` hints
- only the inferred no-hint quotient-degree / chunk estimation gets tighter

That seems like the smallest change that fixes the over-conservative periodic-column path while also accounting for the linear `is_transition` selector.

## Validation

- `cargo test -p p3-uni-stark -- --nocapture`
- `cargo test -p p3-air -- --nocapture`
- `cargo test -p p3-commit -- --nocapture`
- `cargo test -p p3-circle periodic -- --nocapture`
- `cargo test -p p3-fri periodic -- --nocapture`
- `git diff --check`

## Notes

- During the first broad local validation pass, I did hit one real bug in an earlier version of this patch:
  - verifier-side chunk inference was accidentally being fed the proof's extended degree instead of the original trace degree
- This version fixes that and reruns the full `p3-uni-stark` suite plus adjacent sanity checks.
- I also intentionally left explicit `max_constraint_degree()` hints alone here; if maintainers want those hints themselves to become trace-aware, that feels like a larger follow-up discussion than this v1.
