### PR TITLE
Type Circle FRI Shape Errors

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -591,6 +591,7 @@ mod tests {
     use p3_challenger::{HashChallenger, SerializingChallenger32};
     use p3_commit::ExtensionMmcs;
     use p3_field::extension::BinomialExtensionField;
+    use p3_fri::verifier::FriError;
     use p3_fri::FriParameters;
     use p3_keccak::Keccak256Hash;
     use p3_merkle_tree::MerkleTreeMmcs;
@@ -601,85 +602,181 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn circle_pcs() {
-        // Very simple pcs test. More rigorous tests in p3_fri/tests/pcs.
+    type Val = Mersenne31;
+    type Challenge = BinomialExtensionField<Mersenne31, 3>;
+    type ByteHash = Keccak256Hash;
+    type FieldHash = SerializingHasher<ByteHash>;
+    type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
+    type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 2, 32>;
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
+    type TestPcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+    type TestError = FriError<
+        <ChallengeMmcs as Mmcs<Challenge>>::Error,
+        InputError<<ValMmcs as Mmcs<Val>>::Error, <ChallengeMmcs as Mmcs<Challenge>>::Error>,
+    >;
 
+    /// Shared test fixture: builds a valid PCS commitment, opening, and proof.
+    #[allow(clippy::type_complexity)]
+    fn setup_valid_proof() -> (
+        TestPcs,
+        ByteHash,
+        <ValMmcs as Mmcs<Val>>::Commitment,
+        CircleDomain<Val>,
+        Challenge,
+        Vec<Vec<Vec<Vec<Challenge>>>>,
+        CirclePcsProof<Val, Challenge, ValMmcs, ChallengeMmcs, Val>,
+    ) {
         let mut rng = SmallRng::seed_from_u64(0);
 
-        type Val = Mersenne31;
-        type Challenge = BinomialExtensionField<Mersenne31, 3>;
-
-        type ByteHash = Keccak256Hash;
-        type FieldHash = SerializingHasher<ByteHash>;
         let byte_hash = ByteHash {};
         let field_hash = FieldHash::new(byte_hash);
-
-        type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;
         let compress = MyCompress::new(byte_hash);
-
-        type ValMmcs = MerkleTreeMmcs<Val, u8, FieldHash, MyCompress, 2, 32>;
         let val_mmcs = ValMmcs::new(field_hash, compress, 0);
-
-        type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
         let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-
-        type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
-
         let fri_params = FriParameters::new_testing(challenge_mmcs, 0);
 
-        type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
-        let pcs = Pcs {
+        let pcs = TestPcs {
             mmcs: val_mmcs,
             fri_params,
             _phantom: PhantomData,
         };
 
         let log_n = 10;
-
-        let d = <Pcs as p3_commit::Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+        let d = <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
             &pcs,
             1 << log_n,
         );
 
         let evals = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
-
         let (comm, data) =
-            <Pcs as p3_commit::Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
-
+            <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
         let zeta: Challenge = rng.random();
 
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         let (values, proof) = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
 
+        (pcs, byte_hash, comm, d, zeta, values, proof)
+    }
+
+    /// Attempts to verify `proof` with the given PCS setup, returning the
+    /// verification result.
+    fn try_verify(
+        pcs: &TestPcs,
+        byte_hash: ByteHash,
+        comm: &<ValMmcs as Mmcs<Val>>::Commitment,
+        d: CircleDomain<Val>,
+        zeta: Challenge,
+        values: &[Vec<Vec<Vec<Challenge>>>],
+        proof: &CirclePcsProof<Val, Challenge, ValMmcs, ChallengeMmcs, Val>,
+    ) -> Result<(), TestError> {
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         pcs.verify(
-            vec![(
-                comm.clone(),
-                vec![(d, vec![(zeta, values[0][0][0].clone())])],
-            )],
-            &proof,
+            vec![(comm.clone(), vec![(d, vec![(zeta, values[0][0][0].clone())])])],
+            proof,
             &mut chal,
         )
-        .expect("verify err");
+    }
 
-        let mut malformed_proof = proof.clone();
-        malformed_proof.fri_proof.query_proofs.pop();
+    #[test]
+    fn circle_pcs() {
+        // Very simple pcs test. More rigorous tests in p3_fri/tests/pcs.
+        let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
 
-        let mut chal = Challenger::from_hasher(vec![], byte_hash);
-        let err = pcs
-            .verify(
-                vec![(comm, vec![(d, vec![(zeta, values[0][0][0].clone())])])],
-                &malformed_proof,
-                &mut chal,
-            )
-            .expect_err("expected query proof count mismatch");
+        try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof).expect("verify err");
+    }
 
-        assert!(matches!(
-            err,
-            FriError::QueryProofCountMismatch { expected, got }
-                if expected == pcs.fri_params.num_queries
-                    && got + 1 == pcs.fri_params.num_queries
-        ));
+    #[test]
+    fn reject_query_proof_count_mismatch() {
+        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        proof.fri_proof.query_proofs.pop();
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected QueryProofCountMismatch");
+
+        let FriError::QueryProofCountMismatch { expected, got } = err else {
+            panic!("expected QueryProofCountMismatch, got {err:?}");
+        };
+        assert_eq!(expected, pcs.fri_params.num_queries);
+        assert_eq!(got, pcs.fri_params.num_queries - 1);
+    }
+
+    #[test]
+    fn reject_query_commit_phase_openings_count_mismatch() {
+        let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
+
+        let mut bad = proof.clone();
+        bad.fri_proof.query_proofs[0].commit_phase_openings.pop();
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &bad)
+            .expect_err("expected QueryCommitPhaseOpeningsCountMismatch");
+
+        let FriError::QueryCommitPhaseOpeningsCountMismatch {
+            query,
+            expected,
+            got,
+        } = err
+        else {
+            panic!("expected QueryCommitPhaseOpeningsCountMismatch, got {err:?}");
+        };
+        assert_eq!(query, 0);
+        assert_eq!(expected, proof.fri_proof.commit_phase_commits.len());
+        assert_eq!(got, expected - 1);
+    }
+
+    #[test]
+    fn reject_sibling_values_length_mismatch() {
+        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        proof.fri_proof.query_proofs[0].commit_phase_openings[0]
+            .sibling_values
+            .pop();
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected SiblingValuesLengthMismatch");
+
+        let FriError::SiblingValuesLengthMismatch {
+            round,
+            expected,
+            got,
+        } = err
+        else {
+            panic!("expected SiblingValuesLengthMismatch, got {err:?}");
+        };
+        assert_eq!(round, 0);
+        assert_eq!(
+            got + 1,
+            expected,
+            "popping one sibling should yield got = expected - 1"
+        );
+    }
+
+    // NOTE: `FinalFoldHeightMismatch` and `UnconsumedReducedOpenings` cannot be
+    // triggered through the PCS layer because MMCS commitment verification or
+    // input-proof checks fail first for any mutation that would reach those
+    // code paths. They are tested implicitly through the circle verifier's
+    // internal logic and protect against a malicious prover bypassing MMCS.
+
+    #[test]
+    fn reject_query_log_arities_mismatch() {
+        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        // Only possible when there are at least 2 query proofs.
+        if proof.fri_proof.query_proofs.len() < 2 {
+            return;
+        }
+
+        // Corrupt the log_arity of the first opening in the second query proof.
+        let original = proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity;
+        proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity = original + 1;
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected QueryLogAritiesMismatch");
+
+        let FriError::QueryLogAritiesMismatch { query, .. } = err else {
+            panic!("expected QueryLogAritiesMismatch, got {err:?}");
+        };
+        assert_eq!(query, 1);
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -654,10 +654,32 @@ mod tests {
 
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         pcs.verify(
-            vec![(comm, vec![(d, vec![(zeta, values[0][0][0].clone())])])],
+            vec![(
+                comm.clone(),
+                vec![(d, vec![(zeta, values[0][0][0].clone())])],
+            )],
             &proof,
             &mut chal,
         )
         .expect("verify err");
+
+        let mut malformed_proof = proof.clone();
+        malformed_proof.fri_proof.query_proofs.pop();
+
+        let mut chal = Challenger::from_hasher(vec![], byte_hash);
+        let err = pcs
+            .verify(
+                vec![(comm, vec![(d, vec![(zeta, values[0][0][0].clone())])])],
+                &malformed_proof,
+                &mut chal,
+            )
+            .expect_err("expected query proof count mismatch");
+
+        assert!(matches!(
+            err,
+            FriError::QueryProofCountMismatch { expected, got }
+                if expected == pcs.fri_params.num_queries
+                    && got + 1 == pcs.fri_params.num_queries
+        ));
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -777,11 +777,19 @@ mod tests {
         // the remaining one).
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
 
+        // Capture the original sibling count and arity before mutating.
+        let log_arity =
+            proof.fri_proof.query_proofs[0].commit_phase_openings[0].log_arity as usize;
+        let arity = 1usize << log_arity;
+        let original_sibling_count =
+            proof.fri_proof.query_proofs[0].commit_phase_openings[0].sibling_values.len();
+
         // Mutation: remove one sibling value from query 0, round 0.
         //
-        //     before: sibling_values = [s_0, ..., s_{k-2}]   (k - 1 elements)
-        //     after:  sibling_values = [s_0, ..., s_{k-3}]   (k - 2 elements)
-        //     → expected k - 1, got k - 2 → error at round 0
+        //     arity = 2^{log_arity}, expected siblings = arity - 1
+        //     before: sibling_values = [s_0, ..., s_{arity-2}]   (arity - 1 elements)
+        //     after:  sibling_values = [s_0, ..., s_{arity-3}]   (arity - 2 elements)
+        //     → expected arity - 1, got arity - 2 → error at round 0
         proof.fri_proof.query_proofs[0].commit_phase_openings[0]
             .sibling_values
             .pop();
@@ -799,12 +807,10 @@ mod tests {
         };
         // Error must identify round 0 as the offender.
         assert_eq!(round, 0);
-        // One sibling was removed, so got should be exactly one less.
-        assert_eq!(
-            got + 1,
-            expected,
-            "popping one sibling should yield got = expected - 1"
-        );
+        // The verifier expects (arity - 1) siblings per folding group.
+        assert_eq!(expected, arity - 1);
+        // We popped one, so one fewer than the original count.
+        assert_eq!(got, original_sibling_count - 1);
     }
 
     // Two error variants cannot be triggered through the PCS verification
@@ -836,6 +842,13 @@ mod tests {
             return;
         }
 
+        // Capture the reference arity schedule from query 0 before mutating.
+        let reference_arities: Vec<usize> = proof.fri_proof.query_proofs[0]
+            .commit_phase_openings
+            .iter()
+            .map(|o| o.log_arity as usize)
+            .collect();
+
         // Mutation: bump the log_arity of query 1's first round by 1.
         //
         //     query 0 arities: [a_0, a_1, ..., a_{n-1}]       (reference)
@@ -844,13 +857,26 @@ mod tests {
         let original = proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity;
         proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity = original + 1;
 
+        // Build the expected corrupted schedule for query 1.
+        let mut corrupted_arities = reference_arities.clone();
+        corrupted_arities[0] = original as usize + 1;
+
         let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
             .expect_err("expected QueryLogAritiesMismatch");
 
-        let FriError::QueryLogAritiesMismatch { query, .. } = err else {
+        let FriError::QueryLogAritiesMismatch {
+            query,
+            expected,
+            got,
+        } = err
+        else {
             panic!("expected QueryLogAritiesMismatch, got {err:?}");
         };
         // Error must identify query 1 (the first one compared against the reference).
         assert_eq!(query, 1);
+        // The expected schedule is query 0's (the reference).
+        assert_eq!(expected, reference_arities);
+        // The got schedule is query 1's corrupted version.
+        assert_eq!(got, corrupted_arities);
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -616,7 +616,17 @@ mod tests {
         InputError<<ValMmcs as Mmcs<Val>>::Error, <ChallengeMmcs as Mmcs<Challenge>>::Error>,
     >;
 
-    /// Shared test fixture: builds a valid PCS commitment, opening, and proof.
+    /// Build a valid Circle PCS proof for a random single-column trace.
+    ///
+    /// Returns all the pieces needed to verify (or re-verify after mutation):
+    /// the PCS instance, hasher seed, commitment, domain, evaluation point,
+    /// opened values, and the proof itself.
+    ///
+    /// # Fixture parameters
+    ///
+    /// - Trace: 2^{10} = 1024 rows, 1 column of random field elements.
+    /// - FRI: testing parameters with log_blowup = 2, log_final_poly_len = 0.
+    /// - Hash: Keccak-256 with a binary Merkle tree.
     #[allow(clippy::type_complexity)]
     fn setup_valid_proof() -> (
         TestPcs,
@@ -629,11 +639,16 @@ mod tests {
     ) {
         let mut rng = SmallRng::seed_from_u64(0);
 
+        // Build the hash stack: field hasher → compression → Merkle tree.
         let byte_hash = ByteHash {};
         let field_hash = FieldHash::new(byte_hash);
         let compress = MyCompress::new(byte_hash);
         let val_mmcs = ValMmcs::new(field_hash, compress, 0);
+
+        // Wrap the value-domain Merkle tree for extension-field leaves.
         let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+        // Minimal FRI parameters for fast test execution.
         let fri_params = FriParameters::new_testing(challenge_mmcs, 0);
 
         let pcs = TestPcs {
@@ -642,6 +657,7 @@ mod tests {
             _phantom: PhantomData,
         };
 
+        // Generate a random trace on a circle domain of size 2^{10}.
         let log_n = 10;
         let d = <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
             &pcs,
@@ -649,18 +665,26 @@ mod tests {
         );
 
         let evals = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
+
+        // Commit to the trace and produce the Merkle root.
         let (comm, data) =
             <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
+
+        // Random evaluation point in the extension field.
         let zeta: Challenge = rng.random();
 
+        // Generate the opening proof at the chosen evaluation point.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         let (values, proof) = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
 
         (pcs, byte_hash, comm, d, zeta, values, proof)
     }
 
-    /// Attempts to verify `proof` with the given PCS setup, returning the
-    /// verification result.
+    /// Run the PCS verifier with the given proof and return the result.
+    ///
+    /// This is a thin wrapper that reconstructs a fresh challenger and
+    /// calls the verification routine. Tests use it to verify both valid
+    /// proofs and intentionally malformed ones.
     fn try_verify(
         pcs: &TestPcs,
         byte_hash: ByteHash,
@@ -670,6 +694,8 @@ mod tests {
         values: &[Vec<Vec<Vec<Challenge>>>],
         proof: &CirclePcsProof<Val, Challenge, ValMmcs, ChallengeMmcs, Val>,
     ) -> Result<(), TestError> {
+        // Build a fresh challenger from the same seed so the transcript
+        // replays identically to what the prover produced.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         pcs.verify(
             vec![(comm.clone(), vec![(d, vec![(zeta, values[0][0][0].clone())])])],
@@ -680,21 +706,28 @@ mod tests {
 
     #[test]
     fn circle_pcs() {
-        // Very simple pcs test. More rigorous tests in p3_fri/tests/pcs.
+        // Smoke test: an honestly generated proof must verify successfully.
         let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
-
         try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof).expect("verify err");
     }
 
     #[test]
     fn reject_query_proof_count_mismatch() {
+        // Invariant: the proof must contain exactly num_queries query proofs.
+        // The verifier rejects if the count is wrong.
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
 
+        // Mutation: remove one query proof so the count falls short.
+        //
+        //     before: query_proofs = [q_0, q_1, ..., q_{n-1}]   (n = num_queries)
+        //     after:  query_proofs = [q_0, q_1, ..., q_{n-2}]   (n - 1)
+        //     → expected n, got n - 1 → error
         proof.fri_proof.query_proofs.pop();
 
         let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
             .expect_err("expected QueryProofCountMismatch");
 
+        // Destructure for precise field assertions (better diagnostics than matches!).
         let FriError::QueryProofCountMismatch { expected, got } = err else {
             panic!("expected QueryProofCountMismatch, got {err:?}");
         };
@@ -704,9 +737,20 @@ mod tests {
 
     #[test]
     fn reject_query_commit_phase_openings_count_mismatch() {
+        // Invariant: each query proof must carry exactly one opening per
+        // commit-phase round. If a query has fewer (or more) openings than
+        // there are commitments, the proof shape is invalid.
         let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
 
+        // We need the original proof to assert against its commitment count,
+        // so clone before mutating.
         let mut bad = proof.clone();
+
+        // Mutation: remove the last opening from query 0.
+        //
+        //     commit_phase_commits:                [c_0, ..., c_{n-1}]   (n rounds)
+        //     query 0 commit_phase_openings:       [o_0, ..., o_{n-2}]   (n - 1 after pop)
+        //     → n != n - 1 → error on query 0
         bad.fri_proof.query_proofs[0].commit_phase_openings.pop();
 
         let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &bad)
@@ -720,6 +764,7 @@ mod tests {
         else {
             panic!("expected QueryCommitPhaseOpeningsCountMismatch, got {err:?}");
         };
+        // Error must identify query 0 as the offender.
         assert_eq!(query, 0);
         assert_eq!(expected, proof.fri_proof.commit_phase_commits.len());
         assert_eq!(got, expected - 1);
@@ -727,8 +772,16 @@ mod tests {
 
     #[test]
     fn reject_sibling_values_length_mismatch() {
+        // Invariant: in each folding round with arity k, the prover must
+        // supply exactly k - 1 sibling values (the queried evaluation is
+        // the remaining one).
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
 
+        // Mutation: remove one sibling value from query 0, round 0.
+        //
+        //     before: sibling_values = [s_0, ..., s_{k-2}]   (k - 1 elements)
+        //     after:  sibling_values = [s_0, ..., s_{k-3}]   (k - 2 elements)
+        //     → expected k - 1, got k - 2 → error at round 0
         proof.fri_proof.query_proofs[0].commit_phase_openings[0]
             .sibling_values
             .pop();
@@ -744,7 +797,9 @@ mod tests {
         else {
             panic!("expected SiblingValuesLengthMismatch, got {err:?}");
         };
+        // Error must identify round 0 as the offender.
         assert_eq!(round, 0);
+        // One sibling was removed, so got should be exactly one less.
         assert_eq!(
             got + 1,
             expected,
@@ -752,22 +807,40 @@ mod tests {
         );
     }
 
-    // NOTE: `FinalFoldHeightMismatch` and `UnconsumedReducedOpenings` cannot be
-    // triggered through the PCS layer because MMCS commitment verification or
-    // input-proof checks fail first for any mutation that would reach those
-    // code paths. They are tested implicitly through the circle verifier's
-    // internal logic and protect against a malicious prover bypassing MMCS.
+    // Two error variants cannot be triggered through the PCS verification
+    // layer because Merkle commitment checks or input-proof validation
+    // fail first for any proof mutation that would reach those code paths:
+    //
+    // - Final fold height mismatch: requires the total folding to stop at
+    //   the wrong domain size, but altering round counts also invalidates
+    //   Merkle proofs.
+    // - Unconsumed reduced openings: requires leftover polynomial data
+    //   after folding completes, but input-proof checks reject the shape
+    //   before the folding loop runs.
+    //
+    // Both are reachable by a malicious prover who crafts openings that
+    // pass Merkle checks but have wrong structure — they serve as defense
+    // in depth in the low-level verifier.
 
     #[test]
     fn reject_query_log_arities_mismatch() {
+        // Invariant: all query proofs must use the same per-round folding
+        // arity schedule. The verifier takes the first query proof's
+        // schedule as a reference and rejects any that differ.
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
 
-        // Only possible when there are at least 2 query proofs.
+        // This check compares query 1 against query 0, so we need at least
+        // two query proofs. With testing parameters this is always true, but
+        // guard defensively.
         if proof.fri_proof.query_proofs.len() < 2 {
             return;
         }
 
-        // Corrupt the log_arity of the first opening in the second query proof.
+        // Mutation: bump the log_arity of query 1's first round by 1.
+        //
+        //     query 0 arities: [a_0, a_1, ..., a_{n-1}]       (reference)
+        //     query 1 arities: [a_0 + 1, a_1, ..., a_{n-1}]   (corrupted)
+        //     → schedules differ → error on query 1
         let original = proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity;
         proof.fri_proof.query_proofs[1].commit_phase_openings[0].log_arity = original + 1;
 
@@ -777,6 +850,7 @@ mod tests {
         let FriError::QueryLogAritiesMismatch { query, .. } = err else {
             panic!("expected QueryLogAritiesMismatch, got {err:?}");
         };
+        // Error must identify query 1 (the first one compared against the reference).
         assert_eq!(query, 1);
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -591,8 +591,8 @@ mod tests {
     use p3_challenger::{HashChallenger, SerializingChallenger32};
     use p3_commit::ExtensionMmcs;
     use p3_field::extension::BinomialExtensionField;
-    use p3_fri::verifier::FriError;
     use p3_fri::FriParameters;
+    use p3_fri::verifier::FriError;
     use p3_keccak::Keccak256Hash;
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_mersenne_31::Mersenne31;
@@ -659,16 +659,13 @@ mod tests {
 
         // Generate a random trace on a circle domain of size 2^{10}.
         let log_n = 10;
-        let d = <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
-            &pcs,
-            1 << log_n,
-        );
+        let d =
+            <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_n);
 
         let evals = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
 
         // Commit to the trace and produce the Merkle root.
-        let (comm, data) =
-            <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
+        let (comm, data) = <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
 
         // Random evaluation point in the extension field.
         let zeta: Challenge = rng.random();
@@ -698,7 +695,10 @@ mod tests {
         // replays identically to what the prover produced.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         pcs.verify(
-            vec![(comm.clone(), vec![(d, vec![(zeta, values[0][0][0].clone())])])],
+            vec![(
+                comm.clone(),
+                vec![(d, vec![(zeta, values[0][0][0].clone())])],
+            )],
             proof,
             &mut chal,
         )
@@ -778,11 +778,11 @@ mod tests {
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
 
         // Capture the original sibling count and arity before mutating.
-        let log_arity =
-            proof.fri_proof.query_proofs[0].commit_phase_openings[0].log_arity as usize;
+        let log_arity = proof.fri_proof.query_proofs[0].commit_phase_openings[0].log_arity as usize;
         let arity = 1usize << log_arity;
-        let original_sibling_count =
-            proof.fri_proof.query_proofs[0].commit_phase_openings[0].sibling_values.len();
+        let original_sibling_count = proof.fri_proof.query_proofs[0].commit_phase_openings[0]
+            .sibling_values
+            .len();
 
         // Mutation: remove one sibling value from query 0, round 0.
         //

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -28,18 +28,36 @@ where
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     Folding: FriFoldingStrategy<Val, Challenge>,
 {
+    // Phase 1: Derive folding challenges
+    //
+    // In Circle-FRI, the verifier must produce one random challenge (beta)
+    // per commit-phase round. Each commitment is observed into the Fiat-Shamir
+    // transcript, then a challenge is sampled.
+    // This yields exactly as many betas as there are commit-phase rounds.
     let betas: Vec<Challenge> = proof
         .commit_phase_commits
         .iter()
         .map(|comm| {
+            // Absorb this round's commitment into the transcript.
             challenger.observe(comm.clone());
+            // Squeeze a field-extension element to use as the folding challenge.
             challenger.sample_algebra_element()
         })
         .collect();
 
-    // Observe the claimed final polynomial.
+    // Absorb the prover's claimed constant polynomial into the transcript.
+    // After all folding rounds, the result should reduce to this constant.
     challenger.observe_algebra_element(proof.final_poly);
 
+    // Phase 2: Structural shape checks
+    //
+    // Before doing any expensive cryptographic work, validate that the proof
+    // has the right shape. A malicious prover could submit too few (or too
+    // many) query proofs, mismatched opening counts, or inconsistent arity
+    // schedules. Catching these early avoids wasted work and gives precise
+    // error variants.
+
+    // The number of query proofs must match the security parameter.
     if proof.query_proofs.len() != params.num_queries {
         return Err(FriError::QueryProofCountMismatch {
             expected: params.num_queries,
@@ -47,12 +65,18 @@ where
         });
     }
 
-    // Check PoW.
+    // Verify proof-of-work: a grinding witness that the prover must compute
+    // to raise the cost of brute-forcing query positions.
     if !challenger.check_witness(params.query_proof_of_work_bits, proof.pow_witness) {
         return Err(FriError::InvalidPowWitness);
     }
 
-    // Validate that all query proofs have the same number of commit phase openings
+    // Each query proof must carry exactly one opening per commit-phase round.
+    //
+    //     commit_phase_commits:       [c_0, c_1, ..., c_{n-1}]   (n rounds)
+    //     qp.commit_phase_openings:   [o_0, o_1, ..., o_{n-1}]   (must also be n)
+    //
+    // A mismatch means the prover omitted or duplicated round data.
     let expected_rounds = proof.commit_phase_commits.len();
     for (query, qp) in proof.query_proofs.iter().enumerate() {
         let got_rounds = qp.commit_phase_openings.len();
@@ -65,8 +89,11 @@ where
         }
     }
 
-    // Extract the per-round folding arities from the first query proof and ensure all
-    // query proofs use the same schedule (mirrors the standard FRI verifier check).
+    // In variable-arity FRI, each round folds by 2^{log_arity_i} points.
+    // All query proofs must agree on the per-round arity schedule, otherwise
+    // different queries would fold through incompatible domain decompositions.
+    //
+    // We take the first query proof's schedule as the reference:
     let log_arities: Vec<usize> = proof
         .query_proofs
         .first()
@@ -78,6 +105,7 @@ where
         })
         .unwrap_or_default();
 
+    // Compare every subsequent query proof against the reference schedule.
     for (query, qp) in proof.query_proofs.iter().enumerate().skip(1) {
         let got_log_arities: Vec<usize> = qp
             .commit_phase_openings
@@ -93,30 +121,44 @@ where
         }
     }
 
-    // With variable arity, compute log_max_height by summing all log_arities.
+    // Phase 3: Query verification
+    //
+    // The initial evaluation domain has size 2^{log_max_height}, where
+    // log_max_height = sum(log_arities) + log_blowup.
+    // Each folding round reduces the domain by 2^{log_arity_i}, so after
+    // all rounds the domain shrinks to 2^{log_blowup} (the blowup factor).
     let total_log_reduction: usize = log_arities.iter().sum();
     let log_max_height = total_log_reduction + params.log_blowup;
 
     for qp in &proof.query_proofs {
+        // Sample a random query index uniformly from the initial domain.
         let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
+
+        // Open the input polynomials at this query index.
+        // Returns (log_height, evaluation) pairs sorted by height descending.
         let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
 
+        // Sanity check: reduced openings must arrive in strictly descending
+        // height order so they are folded in at the correct domain sizes.
         debug_assert!(
             ro.iter().tuple_windows().all(|((l, _), (r, _))| l > r),
             "reduced openings sorted by height descending"
         );
 
-        // betas.len() == commit_phase_commits.len() by construction (lines 31–38).
-        // commit_phase_openings.len() == commit_phase_commits.len() by the check above (lines 56–66).
+        // Zip the challenges, commitments, and openings together for folding.
+        //
+        // Invariant: all three iterators have the same length here.
+        // - The challenges are derived from the commitments (one per round).
+        // - The openings count was validated to match the commitment count.
+        // Plain zip is safe; it cannot silently truncate.
         let fold_data_iter = betas
             .iter()
             .zip(proof.commit_phase_commits.iter())
             .zip(qp.commit_phase_openings.iter());
 
-        // Starting at the evaluation at `index` of the initial domain,
-        // perform fri folds until the domain size reaches the final domain size.
-        // Check after each fold that the group of sibling evaluations at the current
-        // node match the commitment.
+        // Walk the FRI folding chain: at each round, verify the Merkle
+        // opening against the commitment, then fold the sibling evaluations
+        // using the challenge beta to produce the next-round evaluation.
         let folded_eval = verify_query(
             folding,
             params,
@@ -126,8 +168,8 @@ where
             log_max_height,
         )?;
 
-        // As we fold until the polynomial is constant, proof.final_poly should be a constant value and
-        // we do not need to do any polynomial evaluations.
+        // After all rounds, the polynomial has been folded to a constant.
+        // That constant must equal the prover's claimed final polynomial.
         if folded_eval != proof.final_poly {
             return Err(FriError::FinalPolyMismatch);
         }
@@ -136,24 +178,45 @@ where
     Ok(())
 }
 
+/// One round's worth of data needed to verify a Circle-FRI fold.
+///
+/// Groups together:
+/// - The random folding challenge for this round.
+/// - The Merkle commitment to the evaluations on this round's domain.
+/// - The prover-supplied sibling values and Merkle opening proof.
 type CommitStep<'a, F, M> = (
     (
-        &'a F, // The challenge point beta used for the next fold of Circle-FRI evaluations.
-        &'a <M as Mmcs<F>>::Commitment, // A commitment to the Circle-FRI evaluations on the current domain.
+        &'a F,
+        &'a <M as Mmcs<F>>::Commitment,
     ),
-    &'a CircleCommitPhaseProofStep<F, M>, // The siblings and opening proof for the current Circle-FRI node.
+    &'a CircleCommitPhaseProofStep<F, M>,
 );
 
-/// Verifies a single query chain in the Circle-FRI proof.
+/// Verify one query chain in the Circle-FRI proof.
 ///
-/// Given an initial `index` corresponding to a point in the initial domain
-/// and a series of `reduced_openings` corresponding to evaluations of
-/// polynomials to be added in at specific domain sizes, perform the standard
-/// sequence of Circle-FRI folds, checking at each step that the group of sibling evaluations
-/// match the commitment.
+/// Starting from a leaf in the initial evaluation domain, this walks
+/// up the folding tree one round at a time:
 ///
-/// With variable arity, each round may fold by a different factor determined by the
-/// `log_arity` field in the opening.
+/// ```text
+///     domain size:  2^{log_max_height}  →  ...  →  2^{log_blowup}
+///     round:              0                           last
+/// ```
+///
+/// At each round:
+/// - Roll in any reduced openings whose height matches the current domain.
+/// - Reconstruct the full sibling group from the queried evaluation
+///   plus the (arity - 1) sibling values provided by the prover.
+/// - Verify the Merkle opening against the round commitment.
+/// - Fold the sibling group with the challenge beta to produce the
+///   parent evaluation for the next round.
+///
+/// With variable arity, each round may fold by a different factor
+/// (2^{log_arity_i} siblings per group).
+///
+/// # Returns
+///
+/// The final folded evaluation, which the caller checks against
+/// the prover's claimed constant.
 fn verify_query<'a, Folding, F, EF, M>(
     folding: &Folding,
     params: &FriParameters<M>,
@@ -168,19 +231,29 @@ where
     M: Mmcs<EF> + 'a,
     Folding: FriFoldingStrategy<F, EF>,
 {
+    // Running accumulator: starts at zero and accumulates reduced openings
+    // and folding results as we walk up the tree.
     let mut folded_eval = EF::ZERO;
+
+    // Reduced openings arrive sorted by height descending.
+    // We consume them as the current domain height matches.
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
-    // Track the current log_height as we fold down
+    // Current domain size is 2^{log_current_height}; decreases each round.
     let mut log_current_height = log_max_height;
 
-    // We start with evaluations over a domain of size (1 << log_max_height). We fold
-    // using FRI until the domain size reaches (1 << log_blowup).
     for (round, ((&beta, comm), opening)) in steps.enumerate() {
+        // This round folds 2^{log_arity} siblings into one parent.
         let log_arity = opening.log_arity as usize;
         let arity = 1 << log_arity;
 
-        // Validate that sibling_values has the expected length (arity - 1)
+        // Shape check: the prover must supply exactly (arity - 1) siblings.
+        // The queried evaluation itself is the remaining one, so the full
+        // group has arity elements total.
+        //
+        //     sibling_values: [s_0, s_1, ..., s_{arity-2}]   (arity - 1 elements)
+        //     queried value:  folded_eval                     (1 element)
+        //     full group:     arity elements
         if opening.sibling_values.len() != arity - 1 {
             return Err(FriError::SiblingValuesLengthMismatch {
                 round,
@@ -189,16 +262,24 @@ where
             });
         }
 
-        // If there are new polynomials to roll in at this height, do so.
+        // If there are input polynomials evaluated at this domain height,
+        // add their contribution before folding. This is the "roll-in" step
+        // that combines multiple polynomials into the FRI batch.
         if let Some((_, ro)) = ro_iter.next_if(|(lh, _)| *lh == log_current_height) {
             folded_eval += ro;
         }
 
-        // Reconstruct the full evaluation row from self + siblings
+        // Reconstruct the full evaluation group for this node.
+        // The queried index within the group tells us where our value sits;
+        // the prover's sibling values fill the remaining positions.
+        //
+        //     arity = 4, index_in_group = 1:
+        //     evals = [sibling_0, folded_eval, sibling_1, sibling_2]
         let index_in_group = index % arity;
         let mut evals = vec![EF::ZERO; arity];
         evals[index_in_group] = folded_eval;
 
+        // Fill in siblings at every position except the queried one.
         let mut sibling_idx = 0;
         #[allow(clippy::needless_range_loop)]
         for j in 0..arity {
@@ -208,18 +289,21 @@ where
             }
         }
 
-        // Compute the new height after folding
+        // After folding, the domain halves (or shrinks by 2^{log_arity}).
         let log_folded_height = log_current_height - log_arity;
 
+        // Dimensions for the MMCS verification: one matrix of width = arity
+        // at the folded height. This tells the Merkle tree the expected shape.
         let dims = &[Dimensions {
             width: arity,
             height: 1 << log_folded_height,
         }];
 
-        // Replace index with the index of the parent fri node.
+        // Move from the leaf index to its parent in the folding tree.
         index >>= log_arity;
 
-        // Verify the commitment to the evaluations of the sibling nodes.
+        // Verify the Merkle opening: the sibling evaluations the prover
+        // gave us must be consistent with the round commitment.
         params
             .mmcs
             .verify_batch(
@@ -230,15 +314,17 @@ where
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
-        // Fold the group of evaluations of sibling nodes into the evaluation of the parent fri node.
+        // Fold the full sibling group down to a single evaluation using
+        // the random challenge beta. This is the core FRI step.
         folded_eval =
             folding.fold_row(index, log_folded_height, log_arity, beta, evals.into_iter());
 
-        // Update current height
+        // Advance to the next (smaller) domain.
         log_current_height = log_folded_height;
     }
 
-    // Verify we reached the expected final height
+    // After all rounds, we should have folded down to 2^{log_blowup}.
+    // If not, the proof has the wrong number of rounds for the domain size.
     if log_current_height != params.log_blowup {
         return Err(FriError::FinalFoldHeightMismatch {
             expected: params.log_blowup,
@@ -246,7 +332,9 @@ where
         });
     }
 
-    // If ro_iter is not empty, we failed to fold in some polynomial evaluations.
+    // All input polynomial evaluations should have been consumed during
+    // folding. Leftovers mean the proof contains data for heights that
+    // were never reached.
     if let Some((next_log_height, _)) = ro_iter.next() {
         return Err(FriError::UnconsumedReducedOpenings {
             next_log_height,
@@ -254,7 +342,5 @@ where
         });
     }
 
-    // If we reached this point, we have verified that, starting at the initial index,
-    // the chain of folds has produced folded_eval.
     Ok(folded_eval)
 }

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -65,20 +65,39 @@ where
         }
     }
 
-    // With variable arity, compute log_max_height by summing all log_arities
-    let total_log_reduction: usize = proof
+    // Extract the per-round folding arities from the first query proof and ensure all
+    // query proofs use the same schedule (mirrors the standard FRI verifier check).
+    let log_arities: Vec<usize> = proof
         .query_proofs
         .first()
         .map(|qp| {
             qp.commit_phase_openings
                 .iter()
                 .map(|o| o.log_arity as usize)
-                .sum()
+                .collect()
         })
-        .unwrap_or(0);
+        .unwrap_or_default();
+
+    for (query, qp) in proof.query_proofs.iter().enumerate().skip(1) {
+        let got_log_arities: Vec<usize> = qp
+            .commit_phase_openings
+            .iter()
+            .map(|o| o.log_arity as usize)
+            .collect();
+        if got_log_arities != log_arities {
+            return Err(FriError::QueryLogAritiesMismatch {
+                query,
+                expected: log_arities,
+                got: got_log_arities,
+            });
+        }
+    }
+
+    // With variable arity, compute log_max_height by summing all log_arities.
+    let total_log_reduction: usize = log_arities.iter().sum();
     let log_max_height = total_log_reduction + params.log_blowup;
 
-    for (query, qp) in proof.query_proofs.iter().enumerate() {
+    for qp in &proof.query_proofs {
         let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
         let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
 
@@ -87,14 +106,8 @@ where
             "reduced openings sorted by height descending"
         );
 
-        if qp.commit_phase_openings.len() != proof.commit_phase_commits.len() {
-            return Err(FriError::QueryCommitPhaseDataCountMismatch {
-                query,
-                expected: proof.commit_phase_commits.len(),
-                got: qp.commit_phase_openings.len(),
-            });
-        }
-
+        // betas.len() == commit_phase_commits.len() by construction (lines 31–38).
+        // commit_phase_openings.len() == commit_phase_commits.len() by the check above (lines 56–66).
         let fold_data_iter = betas
             .iter()
             .zip(proof.commit_phase_commits.iter())

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -185,10 +185,7 @@ where
 /// - The Merkle commitment to the evaluations on this round's domain.
 /// - The prover-supplied sibling values and Merkle opening proof.
 type CommitStep<'a, F, M> = (
-    (
-        &'a F,
-        &'a <M as Mmcs<F>>::Commitment,
-    ),
+    (&'a F, &'a <M as Mmcs<F>>::Commitment),
     &'a CircleCommitPhaseProofStep<F, M>,
 );
 

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -8,7 +8,6 @@ use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriFoldingStrategy, FriParameters};
 use p3_matrix::Dimensions;
-use p3_util::zip_eq::zip_eq;
 
 use crate::{CircleCommitPhaseProofStep, CircleFriProof};
 
@@ -42,7 +41,10 @@ where
     challenger.observe_algebra_element(proof.final_poly);
 
     if proof.query_proofs.len() != params.num_queries {
-        return Err(FriError::InvalidProofShape);
+        return Err(FriError::QueryProofCountMismatch {
+            expected: params.num_queries,
+            got: proof.query_proofs.len(),
+        });
     }
 
     // Check PoW.
@@ -51,12 +53,16 @@ where
     }
 
     // Validate that all query proofs have the same number of commit phase openings
-    if !proof
-        .query_proofs
-        .iter()
-        .all(|qp| qp.commit_phase_openings.len() == proof.commit_phase_commits.len())
-    {
-        return Err(FriError::InvalidProofShape);
+    let expected_rounds = proof.commit_phase_commits.len();
+    for (query, qp) in proof.query_proofs.iter().enumerate() {
+        let got_rounds = qp.commit_phase_openings.len();
+        if got_rounds != expected_rounds {
+            return Err(FriError::QueryCommitPhaseOpeningsCountMismatch {
+                query,
+                expected: expected_rounds,
+                got: got_rounds,
+            });
+        }
     }
 
     // With variable arity, compute log_max_height by summing all log_arities
@@ -72,7 +78,7 @@ where
         .unwrap_or(0);
     let log_max_height = total_log_reduction + params.log_blowup;
 
-    for qp in &proof.query_proofs {
+    for (query, qp) in proof.query_proofs.iter().enumerate() {
         let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
         let ro = open_input(index, &qp.input_proof).map_err(FriError::InputError)?;
 
@@ -80,6 +86,19 @@ where
             ro.iter().tuple_windows().all(|((l, _), (r, _))| l > r),
             "reduced openings sorted by height descending"
         );
+
+        if qp.commit_phase_openings.len() != proof.commit_phase_commits.len() {
+            return Err(FriError::QueryCommitPhaseDataCountMismatch {
+                query,
+                expected: proof.commit_phase_commits.len(),
+                got: qp.commit_phase_openings.len(),
+            });
+        }
+
+        let fold_data_iter = betas
+            .iter()
+            .zip(proof.commit_phase_commits.iter())
+            .zip(qp.commit_phase_openings.iter());
 
         // Starting at the evaluation at `index` of the initial domain,
         // perform fri folds until the domain size reaches the final domain size.
@@ -89,15 +108,7 @@ where
             folding,
             params,
             index >> folding.extra_query_index_bits(),
-            zip_eq(
-                zip_eq(
-                    &betas,
-                    &proof.commit_phase_commits,
-                    FriError::InvalidProofShape,
-                )?,
-                &qp.commit_phase_openings,
-                FriError::InvalidProofShape,
-            )?,
+            fold_data_iter,
             ro,
             log_max_height,
         )?;
@@ -152,13 +163,17 @@ where
 
     // We start with evaluations over a domain of size (1 << log_max_height). We fold
     // using FRI until the domain size reaches (1 << log_blowup).
-    for ((&beta, comm), opening) in steps {
+    for (round, ((&beta, comm), opening)) in steps.enumerate() {
         let log_arity = opening.log_arity as usize;
         let arity = 1 << log_arity;
 
         // Validate that sibling_values has the expected length (arity - 1)
         if opening.sibling_values.len() != arity - 1 {
-            return Err(FriError::InvalidProofShape);
+            return Err(FriError::SiblingValuesLengthMismatch {
+                round,
+                expected: arity - 1,
+                got: opening.sibling_values.len(),
+            });
         }
 
         // If there are new polynomials to roll in at this height, do so.
@@ -212,12 +227,18 @@ where
 
     // Verify we reached the expected final height
     if log_current_height != params.log_blowup {
-        return Err(FriError::InvalidProofShape);
+        return Err(FriError::FinalFoldHeightMismatch {
+            expected: params.log_blowup,
+            got: log_current_height,
+        });
     }
 
     // If ro_iter is not empty, we failed to fold in some polynomial evaluations.
-    if ro_iter.next().is_some() {
-        return Err(FriError::InvalidProofShape);
+    if let Some((next_log_height, _)) = ro_iter.next() {
+        return Err(FriError::UnconsumedReducedOpenings {
+            next_log_height,
+            remaining: 1 + ro_iter.count(),
+        });
     }
 
     // If we reached this point, we have verified that, starting at the initial index,


### PR DESCRIPTION
  This PR replaces opaque `InvalidProofShape` failures in the Circle FRI verifier with specific `FriError` variants, so malformed proofs now fail with precise and debuggable reasons. It also adds a negative regression test in `circle_pcs` that removes one query proof and asserts `QueryProofCountMismatch`, confirming the new shape checks are actually enforced. Validation evidence: `cargo test -p p3-circle --lib` passed (20/20 tests).  