### PR TITLE
feat(merkle-tree): add Merkle path pruning for compact multi-opening proofs

### DIFF
--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -9,6 +9,6 @@ mod pruning;
 
 pub use hiding_mmcs::*;
 pub use merkle_tree::MerkleTree;
-pub use mmcs::{MerkleTreeError, MerkleTreeMmcs};
+pub use mmcs::{MerkleTreeError, MerkleTreeMmcs, PrunedBatchOpening};
 pub use p3_symmetric::MerkleCap;
-pub use pruning::*;
+pub use pruning::{PrunedMerklePaths, PrunedPath};

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -5,8 +5,10 @@ extern crate alloc;
 mod hiding_mmcs;
 mod merkle_tree;
 mod mmcs;
+mod pruning;
 
 pub use hiding_mmcs::*;
 pub use merkle_tree::MerkleTree;
 pub use mmcs::{MerkleTreeError, MerkleTreeMmcs};
 pub use p3_symmetric::MerkleCap;
+pub use pruning::*;

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -36,6 +36,7 @@ use crate::MerkleTreeError::{
     CapMismatch, EmptyBatch, IncompatibleHeights, IndexOutOfBounds, WrongBatchSize, WrongHeight,
 };
 use crate::merkle_tree::{padded_len, select_arity_step};
+use crate::pruning::{MerkleAuthPath, prune_paths, restore_paths};
 use crate::{MerkleCap, MerkleTree};
 
 /// A Merkle Tree-based commitment scheme for multiple matrices of potentially differing heights.
@@ -272,6 +273,252 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
     pub const fn cap_height(&self) -> usize {
         self.cap_height
     }
+
+    /// Opens multiple leaf indices at once and returns a pruned proof.
+    ///
+    /// Equivalent to opening each index individually and then pruning the
+    /// resulting authentication paths, but avoids redundant allocations.
+    ///
+    /// The returned value contains:
+    /// - The opened matrix rows for each query (in input order).
+    /// - A compact pruned proof with shared siblings deduplicated.
+    ///
+    /// Use the pruned-verification method on the verifier side.
+    pub fn open_batch_pruned<M: Matrix<P::Value>>(
+        &self,
+        indices: &[usize],
+        prover_data: &MerkleTree<P::Value, PW::Value, M, N, DIGEST_ELEMS>,
+    ) -> PrunedBatchOpening<P::Value, PW::Value, DIGEST_ELEMS>
+    where
+        P: PackedValue,
+        PW: PackedValue,
+        H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
+            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
+            + Sync,
+        C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
+            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
+            + Sync,
+        PW::Value: Eq + Clone,
+        [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
+    {
+        // Phase 1: Derive tree geometry from the committed data.
+        //
+        // The tree has multiple digest layers. The "cap" is a configurable
+        // number of layers cut from the top — the commitment is those top
+        // digests rather than just the single root.
+        // The proof only needs to cover levels below the cap.
+        //
+        //   Example: 5 digest layers, cap_height = 1
+        //     layers:          [0] [1] [2] [3] [4]
+        //     cap covers:                      [4]   (1 layer from the top)
+        //     proof covers:    [0] [1] [2] [3]       (4 proof levels)
+        let max_height = self.get_max_height(prover_data);
+        let num_layers = prover_data.digest_layers.len();
+        let effective_cap_height = self.cap_height.min(num_layers.saturating_sub(1));
+        let proof_levels = num_layers
+            .saturating_sub(1)
+            .saturating_sub(effective_cap_height);
+        // Used to compute the bit-shift from global leaf index to a shorter
+        // matrix's row index. Smaller matrices have fewer rows, so their
+        // row index is the global index right-shifted by the height difference.
+        let log_max_height = log2_ceil_usize(max_height);
+
+        // Phase 2: Build the shift schedule for the pruning algorithm.
+        //
+        // The arity schedule stores the branching factor at each level
+        // (2 for binary, 4 for quad, etc.). The pruning LCA computation
+        // needs log_2(arity) at each level so it can use bit-shifts instead
+        // of integer division. trailing_zeros gives log_2 for powers of two.
+        let shift_schedule: Vec<u32> = prover_data.arity_schedule[..proof_levels]
+            .iter()
+            .map(|&step| step.trailing_zeros())
+            .collect();
+
+        // Pre-compute the exact total number of sibling digests in a full
+        // (unpruned) proof. At each level, the sibling count is arity - 1
+        // (one child is ours, the rest are siblings).
+        // This lets us allocate the flat sibling buffer exactly once per
+        // query with no dynamic resizing.
+        //
+        //   Example: 3 binary levels → 1 + 1 + 1 = 3 siblings total
+        //   Example: 2 quad levels   → 3 + 3     = 6 siblings total
+        let expected_siblings: usize = prover_data.arity_schedule[..proof_levels]
+            .iter()
+            .map(|&step| step - 1)
+            .sum();
+
+        // Phase 3: For each queried leaf index, collect its opened rows
+        // and full authentication path.
+        //
+        // Each query is independent: it reads one row from each committed
+        // matrix (at the appropriate bit-shifted index) and walks down the
+        // digest layers to collect all sibling digests.
+        //
+        // The result is unzipped into two parallel vectors:
+        //   - one with the opened matrix rows (for the verifier)
+        //   - one with the flat sibling arrays (for pruning)
+        let (all_opened_values, auth_paths): (Vec<_>, Vec<_>) = indices
+            .iter()
+            .map(|&index| {
+                assert!(
+                    index < max_height,
+                    "index {index} out of bounds for height {max_height}"
+                );
+
+                // Gather the row from each committed matrix at this leaf index.
+                //
+                // Shorter matrices cover fewer rows. The bit-shift
+                // (log_max_height - log_height) maps the global leaf index
+                // down to the row index in that shorter matrix.
+                //
+                //   Example: max_height = 32 (5 bits), matrix height = 8 (3 bits)
+                //     bits_reduced = 5 - 3 = 2
+                //     leaf index 20 → row 20 >> 2 = 5
+                let openings: Vec<Vec<P::Value>> = prover_data
+                    .leaves
+                    .iter()
+                    .map(|matrix| {
+                        let log2_height = log2_ceil_usize(matrix.height());
+                        let bits_reduced = log_max_height - log2_height;
+                        let reduced_index = index >> bits_reduced;
+                        matrix.row(reduced_index).unwrap().into_iter().collect()
+                    })
+                    .collect();
+
+                // Walk up the digest layers collecting sibling digests.
+                //
+                // At each level, the queried leaf belongs to a group of
+                // `step` children under one parent. We emit all children
+                // in that group except the queried one — those are the
+                // siblings the verifier needs to recompute the parent hash.
+                //
+                //   Example (binary, step = 2):
+                //     group = [child_0, child_1], queried = child_0
+                //     → emit child_1 (1 sibling)
+                //
+                //   Example (4-ary, step = 4):
+                //     group = [c0, c1, c2, c3], queried = c2
+                //     → emit c0, c1, c3 (3 siblings)
+                //
+                // After collecting siblings at this level, divide the index
+                // by the step to move up to the parent level.
+                let mut siblings = Vec::with_capacity(expected_siblings);
+                let mut idx = index;
+                for layer_idx in 0..proof_levels {
+                    let step = prover_data.arity_schedule[layer_idx];
+                    // Start of the N-child group containing this index.
+                    let group_start = (idx / step) * step;
+                    // Position of the queried child within the group.
+                    let pos_in_group = idx % step;
+                    // Emit every child in the group except the queried one.
+                    for k in 0..step {
+                        if k != pos_in_group {
+                            siblings.push(prover_data.digest_layers[layer_idx][group_start + k]);
+                        }
+                    }
+                    // Move to the parent index for the next level.
+                    idx /= step;
+                }
+
+                (
+                    openings,
+                    MerkleAuthPath {
+                        leaf_index: index,
+                        siblings,
+                    },
+                )
+            })
+            .unzip();
+
+        // Phase 4: Prune the authentication paths.
+        //
+        // This sorts paths by leaf index, deduplicates, computes the LCA
+        // between each consecutive pair, and strips the shared upper siblings.
+        // The result is a compact proof that can be restored on the verifier
+        // side with zero information loss.
+        let pruned = prune_paths(proof_levels, &shift_schedule, &auth_paths);
+
+        PrunedBatchOpening {
+            opened_values: all_opened_values,
+            pruned_proof: pruned,
+        }
+    }
+
+    /// Verifies a pruned batch opening against the commitment.
+    ///
+    /// Restores full authentication paths from the pruned proof, then verifies
+    /// each one individually using the standard single-index verification logic.
+    ///
+    /// Takes the opening **by value** to avoid deep-cloning the three-level
+    /// nested opened-values structure on return.
+    ///
+    /// # Returns
+    ///
+    /// On success, the opened matrix rows for each query (moved, not cloned).
+    /// On failure, a verification error.
+    pub fn verify_batch_pruned(
+        &self,
+        commit: &<Self as Mmcs<P::Value>>::Commitment,
+        dimensions: &[Dimensions],
+        pruned_opening: PrunedBatchOpening<P::Value, PW::Value, DIGEST_ELEMS>,
+    ) -> Result<Vec<Vec<Vec<P::Value>>>, MerkleTreeError>
+    where
+        P: PackedValue,
+        PW: PackedValue,
+        H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
+            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
+            + Sync,
+        C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
+            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
+            + Sync,
+        PW::Value: Eq + Clone,
+        [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
+    {
+        // Phase 1: Restore the full (unpruned) authentication paths from
+        // the compact representation. This copies shared upper siblings
+        // from each predecessor in a single forward pass.
+        let restored =
+            restore_paths(&pruned_opening.pruned_proof).ok_or(MerkleTreeError::WrongHeight {
+                expected_proof_len: 0,
+                num_siblings: 0,
+            })?;
+
+        // The number of restored paths must match the number of query openings.
+        if restored.len() != pruned_opening.opened_values.len() {
+            return Err(WrongBatchSize);
+        }
+
+        // Phase 2: Verify each restored path individually against the commitment.
+        //
+        // Each path's flat sibling buffer is borrowed directly — no cloning.
+        // The standard single-index verification hashes the opened values,
+        // replays the arity schedule, and checks the result against the cap.
+        for (auth_path, opened) in restored.iter().zip(&pruned_opening.opened_values) {
+            let batch_ref = BatchOpeningRef::new(opened.as_slice(), &auth_path.siblings);
+            self.verify_batch(commit, dimensions, auth_path.leaf_index, batch_ref)?;
+        }
+
+        // Move the opened values out of the consumed struct — zero-copy return.
+        Ok(pruned_opening.opened_values)
+    }
+}
+
+/// A batch opening with pruned Merkle authentication paths.
+///
+/// The pruned equivalent of opening multiple indices individually.
+/// Shared sibling digests between queries are removed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize, [D; DIGEST_ELEMS]: Serialize"))]
+#[serde(bound(
+    deserialize = "T: serde::de::DeserializeOwned, [D; DIGEST_ELEMS]: serde::de::DeserializeOwned"
+))]
+pub struct PrunedBatchOpening<T, D, const DIGEST_ELEMS: usize> {
+    /// Opened matrix rows for each query, in original input order.
+    /// Outer index = query, middle index = matrix, inner = row elements.
+    pub opened_values: Vec<Vec<Vec<T>>>,
+
+    /// Compact authentication paths with redundant siblings removed.
+    pub pruned_proof: crate::pruning::PrunedMerklePaths<D, DIGEST_ELEMS>,
 }
 
 impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize> Mmcs<P::Value>
@@ -554,7 +801,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use alloc::vec::Vec;
+    use alloc::{format, vec};
 
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -565,6 +813,7 @@ mod tests {
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
+    use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -1537,6 +1786,317 @@ mod tests {
                     prop_assert_eq!(&opened_values[0], &expected);
                 }
             }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Pruned opening integration tests
+    // ----------------------------------------------------------------
+
+    fn make_binary_mmcs(seed: u64) -> MyMmcs {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        MyMmcs::new(hash, compress, 0)
+    }
+
+    fn make_4ary_mmcs_pruning(seed: u64) -> MyMmcs4 {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let perm16 = Perm::new_from_rng_128(&mut rng);
+        let perm32 = PermWide::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm16);
+        let compress = MyCompress4::new(perm32);
+        MyMmcs4::new(hash, compress, 0)
+    }
+
+    #[test]
+    fn pruned_opening_matches_individual_binary() {
+        let seed = 42u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 32, 4);
+        let dims = vec![mat.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        let indices: Vec<usize> = vec![0, 5, 7, 12, 15, 20, 31];
+
+        // Open individually.
+        let individual_openings: Vec<_> = indices
+            .iter()
+            .map(|&i| mmcs.open_batch(i, &prover_data))
+            .collect();
+
+        // Open pruned.
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        // Check opened values match.
+        for (i, individual) in individual_openings.iter().enumerate() {
+            assert_eq!(
+                pruned_opening.opened_values[i], individual.opened_values,
+                "opened values mismatch at query {i}"
+            );
+        }
+
+        // Verify pruned opening (consumed by value — zero deep-clone).
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(result.is_ok(), "pruned verification should succeed");
+    }
+
+    #[test]
+    fn pruned_opening_4ary_roundtrip() {
+        let seed = 99u64;
+        let mmcs = make_4ary_mmcs_pruning(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 64, 8);
+        let dims = vec![mat.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        let indices: Vec<usize> = vec![0, 1, 10, 20, 30, 40, 50, 63];
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(result.is_ok(), "4-ary pruned verification should succeed");
+    }
+
+    #[test]
+    fn pruned_opening_rejects_tampered_proof() {
+        let seed = 77u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 16, 4);
+        let dims = vec![mat.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        let indices: Vec<usize> = vec![0, 3, 7, 15];
+        let mut pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        // Tamper with a sibling digest in the first path.
+        if let Some(first_path) = pruned_opening.pruned_proof.paths.first_mut()
+            && let Some(sibling) = first_path.siblings.first_mut()
+        {
+            sibling[0] = F::from_u32(999999);
+        }
+
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(result.is_err(), "tampered proof should fail verification");
+    }
+
+    #[test]
+    fn pruned_proof_is_smaller_than_individual() {
+        let seed = 55u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 256, 4);
+        let (_, prover_data) = mmcs.commit(vec![mat]);
+
+        let indices: Vec<usize> = vec![0, 1, 2, 3, 10, 11, 100, 101, 200, 201, 254, 255];
+
+        // Count total siblings in individual proofs.
+        let individual_total: usize = indices
+            .iter()
+            .map(|&i| mmcs.open_batch(i, &prover_data).opening_proof.len())
+            .sum();
+
+        // Count total siblings in pruned proof.
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+        let pruned_total: usize = pruned_opening
+            .pruned_proof
+            .paths
+            .iter()
+            .map(|p| p.siblings.len())
+            .sum();
+
+        assert!(
+            pruned_total < individual_total,
+            "pruned {pruned_total} should be < individual {individual_total}"
+        );
+    }
+
+    #[test]
+    fn pruned_opening_with_duplicate_indices() {
+        let seed = 33u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 16, 4);
+        let dims = vec![mat.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        // Duplicate index 5.
+        let indices: Vec<usize> = vec![5, 10, 5];
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        // Should have 3 entries in opened_values (preserving duplicates).
+        assert_eq!(pruned_opening.opened_values.len(), 3);
+        assert_eq!(
+            pruned_opening.opened_values[0], pruned_opening.opened_values[2],
+            "duplicate queries should have identical values"
+        );
+
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn pruned_opening_mixed_heights() {
+        let seed = 44u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat1 = RowMajorMatrix::<F>::rand(&mut rng, 32, 4);
+        let mat2 = RowMajorMatrix::<F>::rand(&mut rng, 8, 6);
+        let dims = vec![mat1.dimensions(), mat2.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat1, mat2]);
+
+        let indices: Vec<usize> = vec![0, 7, 15, 31];
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(
+            result.is_ok(),
+            "mixed-height pruned verification should succeed"
+        );
+    }
+
+    // Pruned-opening proptests
+
+    proptest! {
+        #[test]
+        fn proptest_pruned_binary_roundtrip(
+            height in 2..128usize,
+            width in 1..16usize,
+            seed in 0u64..=u64::MAX,
+            num_queries in 1..20usize,
+        ) {
+            // Invariant: pruned opening must produce the same opened values
+            // and pass verification identically to individual openings.
+            //
+            // Fixture state: random binary tree (height x width) committed
+            // with a seeded Poseidon2 permutation.
+
+            // Build a binary MMCS and commit a random matrix.
+            let mmcs = make_binary_mmcs(seed);
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mat = RowMajorMatrix::<F>::rand(&mut rng, height, width);
+            let dims = vec![mat.dimensions()];
+            let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+            // Deterministic pseudo-random query indices (mod height).
+            // Uses a large prime stride (7919) to spread queries across the tree.
+            let indices: Vec<usize> = (0..num_queries)
+                .map(|i| (seed as usize).wrapping_add(i * 7919) % height)
+                .collect();
+
+            // Reference: open each index individually (standard unpruned path).
+            let individual: Vec<_> = indices
+                .iter()
+                .map(|&i| mmcs.open_batch(i, &prover_data))
+                .collect();
+
+            // Test subject: open all indices at once via pruning.
+            let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+            // Check: opened values must be identical for every query.
+            for (i, ind) in individual.iter().enumerate() {
+                prop_assert_eq!(
+                    &pruned_opening.opened_values[i],
+                    &ind.opened_values,
+                );
+            }
+
+            // Check: the pruned proof must verify against the commitment.
+            mmcs.verify_batch_pruned(&commit, &dims, pruned_opening)
+                .map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+        }
+
+        #[test]
+        fn proptest_pruned_4ary_roundtrip(
+            height in 2..128usize,
+            width in 1..16usize,
+            seed in 0u64..=u64::MAX,
+            num_queries in 1..20usize,
+        ) {
+            // Same invariant as the binary test, but for 4-ary compression.
+            // The arity schedule may include both 4-ary and binary bridge
+            // steps depending on the matrix height.
+
+            let mmcs = make_4ary_mmcs_pruning(seed);
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mat = RowMajorMatrix::<F>::rand(&mut rng, height, width);
+            let dims = vec![mat.dimensions()];
+            let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+            let indices: Vec<usize> = (0..num_queries)
+                .map(|i| (seed as usize).wrapping_add(i * 7919) % height)
+                .collect();
+
+            // Reference: individual openings.
+            let individual: Vec<_> = indices
+                .iter()
+                .map(|&i| mmcs.open_batch(i, &prover_data))
+                .collect();
+
+            // Test subject: pruned opening.
+            let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+            // Check: identical opened values.
+            for (i, ind) in individual.iter().enumerate() {
+                prop_assert_eq!(
+                    &pruned_opening.opened_values[i],
+                    &ind.opened_values,
+                );
+            }
+
+            // Check: pruned proof verifies.
+            mmcs.verify_batch_pruned(&commit, &dims, pruned_opening)
+                .map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+        }
+
+        #[test]
+        fn proptest_pruned_proof_size_leq_individual(
+            height in 2..256usize,
+            seed in 0u64..=u64::MAX,
+            num_queries in 2..30usize,
+        ) {
+            // Invariant: the pruned proof must never contain more sibling
+            // digests than the sum of all individual proofs.
+            //
+            // This should hold for any query pattern — clustered queries
+            // save more, spread queries save less, but never go negative.
+
+            let mmcs = make_binary_mmcs(seed);
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mat = RowMajorMatrix::<F>::rand(&mut rng, height, 4);
+            let (_, prover_data) = mmcs.commit(vec![mat]);
+
+            let indices: Vec<usize> = (0..num_queries)
+                .map(|i| (seed as usize).wrapping_add(i * 7919) % height)
+                .collect();
+
+            // Sum of individual proof sizes (unpruned baseline).
+            let individual_total: usize = indices
+                .iter()
+                .map(|&i| mmcs.open_batch(i, &prover_data).opening_proof.len())
+                .sum();
+
+            // Pruned proof total.
+            let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+            let pruned_total: usize = pruned_opening
+                .pruned_proof
+                .paths
+                .iter()
+                .map(|p| p.siblings.len())
+                .sum();
+
+            prop_assert!(
+                pruned_total <= individual_total,
+                "pruned {} > individual {}", pruned_total, individual_total
+            );
         }
     }
 }

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -33,7 +33,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::MerkleTreeError::{
-    CapMismatch, EmptyBatch, IncompatibleHeights, IndexOutOfBounds, WrongBatchSize, WrongHeight,
+    CapMismatch, EmptyBatch, IncompatibleHeights, IndexOutOfBounds, MalformedPrunedProof,
+    WrongBatchSize, WrongHeight,
 };
 use crate::merkle_tree::{padded_len, select_arity_step};
 use crate::pruning::{MerkleAuthPath, prune_paths, restore_paths};
@@ -122,6 +123,10 @@ pub enum MerkleTreeError {
         /// The actual tree depth.
         tree_depth: usize,
     },
+
+    /// A pruned batch opening could not be restored (malformed proof).
+    #[error("malformed pruned proof: cannot restore full authentication paths")]
+    MalformedPrunedProof,
 }
 
 /// The arity schedule and query positions for a given Merkle path.
@@ -293,11 +298,9 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         P: PackedValue,
         PW: PackedValue,
         H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
-            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
-            + Sync,
+            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>,
         C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
-            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
-            + Sync,
+            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>,
         PW::Value: Eq + Clone,
         [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     {
@@ -312,7 +315,12 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         //     layers:          [0] [1] [2] [3] [4]
         //     cap covers:                      [4]   (1 layer from the top)
         //     proof covers:    [0] [1] [2] [3]       (4 proof levels)
-        let max_height = self.get_max_height(prover_data);
+        let max_height = prover_data
+            .leaves
+            .iter()
+            .map(|m| m.height())
+            .max()
+            .expect("No committed matrices?");
         let num_layers = prover_data.digest_layers.len();
         let effective_cap_height = self.cap_height.min(num_layers.saturating_sub(1));
         let proof_levels = num_layers
@@ -478,10 +486,7 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // the compact representation. This copies shared upper siblings
         // from each predecessor in a single forward pass.
         let restored =
-            restore_paths(&pruned_opening.pruned_proof).ok_or(MerkleTreeError::WrongHeight {
-                expected_proof_len: 0,
-                num_siblings: 0,
-            })?;
+            restore_paths(&pruned_opening.pruned_proof).ok_or(MalformedPrunedProof)?;
 
         // The number of restored paths must match the number of query openings.
         if restored.len() != pruned_opening.opened_values.len() {
@@ -493,6 +498,10 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // Each path's flat sibling buffer is borrowed directly — no cloning.
         // The standard single-index verification hashes the opened values,
         // replays the arity schedule, and checks the result against the cap.
+        //
+        // TODO: amortize verifier cost across paths the same way the proof
+        // is amortized — shared upper-level compressions are recomputed once
+        // per path instead of once per shared subtree.
         for (auth_path, opened) in restored.iter().zip(&pruned_opening.opened_values) {
             let batch_ref = BatchOpeningRef::new(opened.as_slice(), &auth_path.siblings);
             self.verify_batch(commit, dimensions, auth_path.leaf_index, batch_ref)?;
@@ -1960,6 +1969,29 @@ mod tests {
         assert!(
             result.is_ok(),
             "mixed-height pruned verification should succeed"
+        );
+    }
+
+    #[test]
+    fn pruned_opening_4ary_mixed_heights() {
+        // 4-ary MMCS with matrices at heights that don't align to the same
+        // power of 4 — the schedule mixes 4-ary steps with binary bridges.
+        let seed = 88u64;
+        let mmcs = make_4ary_mmcs_pruning(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat1 = RowMajorMatrix::<F>::rand(&mut rng, 64, 4);
+        let mat2 = RowMajorMatrix::<F>::rand(&mut rng, 8, 6);
+        let dims = vec![mat1.dimensions(), mat2.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat1, mat2]);
+
+        let indices: Vec<usize> = vec![0, 5, 17, 33, 50, 63];
+        let pruned_opening = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        let result = mmcs.verify_batch_pruned(&commit, &dims, pruned_opening);
+        assert!(
+            result.is_ok(),
+            "4-ary mixed-height pruned verification should succeed"
         );
     }
 

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -485,8 +485,7 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // Phase 1: Restore the full (unpruned) authentication paths from
         // the compact representation. This copies shared upper siblings
         // from each predecessor in a single forward pass.
-        let restored =
-            restore_paths(&pruned_opening.pruned_proof).ok_or(MalformedPrunedProof)?;
+        let restored = restore_paths(&pruned_opening.pruned_proof).ok_or(MalformedPrunedProof)?;
 
         // The number of restored paths must match the number of query openings.
         if restored.len() != pruned_opening.opened_values.len() {

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -255,6 +255,126 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         })
     }
 
+    /// Per-level compression arity for an unpruned proof, derived without hashing.
+    ///
+    /// One entry per proof level, each either `N` or `2`.
+    ///
+    /// # Returns
+    ///
+    /// - One entry per proof level, from leaves up to just above the cap.
+    /// - Cap layers are excluded — the proof never traverses them.
+    ///
+    /// # Trust model
+    ///
+    /// - Built from verifier-known dimensions and cap height only.
+    /// - Nothing is read from the proof.
+    /// - Safe to feed into pruned-path restoration: a malicious proof cannot
+    ///   inflate the verifier's allocation budget.
+    pub fn proof_arity_schedule(
+        &self,
+        dimensions: &[Dimensions],
+    ) -> Result<Vec<usize>, MerkleTreeError>
+    where
+        P: PackedValue,
+        PW: PackedValue,
+    {
+        // No commitments → no tree → no schedule.
+        if dimensions.is_empty() {
+            return Err(EmptyBatch);
+        }
+
+        // Phase 1: order matrices tallest-first so the walk can peek ahead
+        // and consume each one at its injection layer.
+        let mut heights_tallest_first = dimensions
+            .iter()
+            .enumerate()
+            .sorted_by_key(|(_, dims)| Reverse(dims.height))
+            .peekable();
+
+        // Heights sharing the same next-power-of-two must match exactly.
+        //
+        //     [8, 5]   → both round to 8, differ → reject
+        //     [8, 8]   → identical at the same slot → OK
+        //     [8, 4]   → distinct slots → OK
+        if !heights_tallest_first
+            .clone()
+            .map(|(_, dims)| dims.height)
+            .tuple_windows()
+            .all(|(curr, next)| {
+                curr == next || curr.next_power_of_two() != next.next_power_of_two()
+            })
+        {
+            return Err(IncompatibleHeights);
+        }
+
+        // Phase 2: walk from leaves toward the root.
+        //
+        // Seed length is `padded_len(max_height, N)` — same padding the
+        // prover uses to round the leaf layer up to a full N-ary group.
+        let (max_height, mut curr_height_padded) = match heights_tallest_first.peek() {
+            Some((_, dims)) => {
+                let max_height = dims.height;
+                let curr_height_padded = padded_len(max_height, N);
+                (max_height, curr_height_padded)
+            }
+            None => return Err(EmptyBatch),
+        };
+
+        let leaf_height_npt = max_height.next_power_of_two();
+
+        // Drop matrices already hashed into the leaf layer.
+        //
+        // Only shorter ones still need an injection slot.
+        heights_tallest_first
+            .peeking_take_while(|(_, dims)| dims.height.next_power_of_two() == leaf_height_npt)
+            .for_each(|_| {});
+
+        // One schedule entry per non-root layer.
+        //
+        //     layer_len:  L_0 → L_1 → L_2 → ... → 1   (root)
+        //     step:        s_0   s_1   s_2  ...
+        //     schedule  = [s_0,  s_1,  s_2,  ...]
+        let mut schedule = Vec::new();
+        while curr_height_padded > 1 {
+            // Arity at this layer:
+            //   N → full N-ary compression
+            //   2 → binary bridge inserted to land on the next injection point
+            let step = select_arity_step::<N>(
+                curr_height_padded,
+                leaf_height_npt,
+                heights_tallest_first.clone().map(|(_, dims)| dims.height),
+            );
+            schedule.push(step);
+
+            // - Shrink by `step`,
+            // - Re-pad so the next layer can form complete N-ary groups for the compression after it.
+            let logical_next = curr_height_padded / step;
+            curr_height_padded = padded_len(logical_next, N);
+
+            // - Inject any matrix whose rounded height matches the next layer's pre-pad width,
+            // - Consume it so it stops driving arity below.
+            let logical_next_npt = logical_next.next_power_of_two();
+            let next_height = heights_tallest_first
+                .peek()
+                .map(|(_, dims)| dims.height)
+                .filter(|h| h.next_power_of_two() == logical_next_npt);
+            if let Some(next_height) = next_height {
+                heights_tallest_first
+                    .peeking_take_while(|(_, dims)| dims.height == next_height)
+                    .for_each(|_| {});
+            }
+        }
+
+        // Phase 3: strip the top `cap_height` entries
+        //
+        // Those layers live inside the verifier's cap, not in the proof.
+        let total_levels = schedule.len();
+        let effective_cap_height = self.cap_height.min(total_levels);
+        schedule.truncate(total_levels - effective_cap_height);
+
+        Ok(schedule)
+    }
+
     /// Create a new `MerkleTreeMmcs` with the given hash and compression functions.
     ///
     /// # Arguments
@@ -482,17 +602,29 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         PW::Value: Eq + Clone,
         [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     {
-        // Phase 1: Restore the full (unpruned) authentication paths from
+        // Phase 1: Derive the expected full-path sibling count from the
+        // verifier-known dimensions, *not* from the proof.
+        //
+        // Each schedule entry contributes `step - 1` siblings: one of the
+        // step children is the queried node itself, the rest are siblings.
+        //
+        //   schedule = [4, 2]   → 3 + 1 = 4 expected siblings
+        //   schedule = [2, 2, 2] → 1 + 1 + 1 = 3 expected siblings
+        let proof_arity = self.proof_arity_schedule(dimensions)?;
+        let full_sibling_count: usize = proof_arity.iter().map(|step| step - 1).sum();
+
+        // Phase 2: Restore the full (unpruned) authentication paths from
         // the compact representation. This copies shared upper siblings
         // from each predecessor in a single forward pass.
-        let restored = restore_paths(&pruned_opening.pruned_proof).ok_or(MalformedPrunedProof)?;
+        let restored = restore_paths(&pruned_opening.pruned_proof, full_sibling_count)
+            .ok_or(MalformedPrunedProof)?;
 
         // The number of restored paths must match the number of query openings.
         if restored.len() != pruned_opening.opened_values.len() {
             return Err(WrongBatchSize);
         }
 
-        // Phase 2: Verify each restored path individually against the commitment.
+        // Phase 3: Verify each restored path individually against the commitment.
         //
         // Each path's flat sibling buffer is borrowed directly — no cloning.
         // The standard single-index verification hashes the opened values,

--- a/merkle-tree/src/pruning.rs
+++ b/merkle-tree/src/pruning.rs
@@ -59,7 +59,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
 #[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
-pub struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
+pub(crate) struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
     /// Index of this leaf in the tree (0-based).
     pub leaf_index: usize,
 
@@ -68,25 +68,6 @@ pub struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
     /// The count at each level is 2^shift - 1, where shift is the log_2
     /// of the compression arity at that level.
     pub siblings: Vec<[D; DIGEST_ELEMS]>,
-}
-
-impl<D: Clone, const DIGEST_ELEMS: usize> MerkleAuthPath<D, DIGEST_ELEMS> {
-    /// Returns the slice of siblings at a given tree level.
-    ///
-    /// The shift schedule describes log_2(arity) at each level.
-    /// This computes the flat-buffer offset and element count on the fly.
-    #[inline]
-    pub fn level_siblings(&self, level: usize, shift_schedule: &[u32]) -> &[[D; DIGEST_ELEMS]] {
-        // Compute where this level's siblings begin in the flat buffer
-        // and how many elements it spans.
-        //
-        //   Example: shift_schedule = [1, 2, 1] (binary, 4-ary, binary)
-        //     level 0 → offset 0, count 1   (1 binary sibling)
-        //     level 1 → offset 1, count 3   (3 quad siblings)
-        //     level 2 → offset 4, count 1   (1 binary sibling)
-        let (start, count) = level_offset_and_count(level, shift_schedule);
-        &self.siblings[start..start + count]
-    }
 }
 
 /// Compact representation of multiple Merkle authentication paths with
@@ -132,36 +113,8 @@ pub struct PrunedMerklePaths<D, const DIGEST_ELEMS: usize> {
 pub struct PrunedPath<D, const DIGEST_ELEMS: usize> {
     /// Leaf index in the original tree.
     pub leaf_index: usize,
-    /// How many complete levels are stored in the sibling buffer.
-    pub num_levels_stored: usize,
     /// Flat sibling digests for the first few levels only (below LCA).
     pub siblings: Vec<[D; DIGEST_ELEMS]>,
-}
-
-/// Computes the flat-buffer offset and element count for a given level.
-///
-/// Each level contributes 2^shift - 1 siblings.
-/// The offset is the sum of all preceding levels' counts.
-///
-/// # Returns
-///
-/// (byte offset into the flat sibling buffer, number of siblings at this level).
-#[inline]
-fn level_offset_and_count(level: usize, shift_schedule: &[u32]) -> (usize, usize) {
-    // Sum the sibling counts for all levels before the target.
-    // Each level contributes 2^shift - 1 siblings (arity minus the queried child).
-    //
-    //   Example: shift_schedule = [1, 2, 1], target level = 2
-    //     level 0: 2^1 - 1 = 1 sibling  → offset += 1
-    //     level 1: 2^2 - 1 = 3 siblings → offset += 3
-    //     → start offset = 4
-    let mut offset = 0;
-    for &shift in &shift_schedule[..level] {
-        offset += (1usize << shift) - 1;
-    }
-    // Sibling count at the target level.
-    let count = (1usize << shift_schedule[level]) - 1;
-    (offset, count)
 }
 
 /// Total number of sibling digests for the first few levels.
@@ -241,7 +194,7 @@ fn first_shared_level_generic(a: usize, b: usize, shift_schedule: &[u32]) -> usi
 /// - Binary trees: O(1) LCA via bitwise XOR (checked once, hoisted).
 /// - N-ary trees: O(h) LCA via shift loop per consecutive pair.
 /// - Sorting: lightweight u32 index array, not the full path structs.
-pub fn prune_paths<D, const DIGEST_ELEMS: usize>(
+pub(crate) fn prune_paths<D, const DIGEST_ELEMS: usize>(
     num_levels: usize,
     shift_schedule: &[u32],
     paths: &[MerkleAuthPath<D, DIGEST_ELEMS>],
@@ -340,7 +293,6 @@ where
 
         pruned_paths.push(PrunedPath {
             leaf_index: path.leaf_index,
-            num_levels_stored: keep,
             // Slice the flat buffer up to the computed boundary.
             siblings: path.siblings[..sibling_count].to_vec(),
         });
@@ -369,7 +321,7 @@ where
 ///
 /// Returns `None` if the number of levels is 64 or more (DoS prevention,
 /// since 2^64 leaves would require unbounded allocations).
-pub fn restore_paths<D, const DIGEST_ELEMS: usize>(
+pub(crate) fn restore_paths<D, const DIGEST_ELEMS: usize>(
     pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
 ) -> Option<Vec<MerkleAuthPath<D, DIGEST_ELEMS>>>
 where
@@ -378,16 +330,26 @@ where
     let num_levels = pruned.num_levels;
     let n = pruned.paths.len();
 
+    // Reject trees deeper than 63 levels to prevent unbounded allocations.
+    // A depth-64 tree would have 2^64 leaves — clearly a DoS attempt.
+    //
+    // TODO: tighten this. 32-bit `usize` targets need depth < 32, and even
+    // on 64-bit, common field 2-adicities mean realistic proofs stay well
+    // below 32 levels — anything past that is suspicious.
+    if num_levels >= 64 {
+        return None;
+    }
+
+    // The shift schedule must cover every level claimed by the proof.
+    // A shorter schedule would slice-index past the end below.
+    if pruned.shift_schedule.len() != num_levels {
+        return None;
+    }
+
     // Compute how many sibling digests a complete (unpruned) path contains.
     //
     //   Example: shift_schedule = [1, 2, 1] → 1 + 3 + 1 = 5 siblings total
     let full_sibling_count = total_siblings_for_levels(num_levels, &pruned.shift_schedule);
-
-    // Reject trees deeper than 63 levels to prevent unbounded allocations.
-    // A depth-64 tree would have 2^64 leaves — clearly a DoS attempt.
-    if num_levels >= 64 {
-        return None;
-    }
 
     // Zero paths with zero queries is valid (empty proof).
     // Zero paths with nonzero queries is malformed.
@@ -447,20 +409,6 @@ where
         .collect()
 }
 
-// Metrics
-
-/// Total number of individual sibling digests across all pruned paths.
-///
-/// Compare against the unpruned total (paths * full sibling count)
-/// to measure the compression ratio.
-pub fn pruned_sibling_count<D, const DIGEST_ELEMS: usize>(
-    pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
-) -> usize {
-    // Sum the flat sibling buffer lengths across all pruned paths.
-    // Compare this against (num_paths * full_sibling_count) for compression ratio.
-    pruned.paths.iter().map(|p| p.siblings.len()).sum()
-}
-
 // Tests
 
 #[cfg(test)]
@@ -471,6 +419,16 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
+
+    /// Total number of individual sibling digests across all pruned paths.
+    ///
+    /// Compare against the unpruned total (paths * full sibling count)
+    /// to measure the compression ratio.
+    fn pruned_sibling_count<D, const DIGEST_ELEMS: usize>(
+        pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
+    ) -> usize {
+        pruned.paths.iter().map(|p| p.siblings.len()).sum()
+    }
 
     fn binary_shifts(h: usize) -> Vec<u32> {
         // All levels binary (arity 2 → shift 1).
@@ -627,43 +585,6 @@ mod tests {
         }
     }
 
-    // Level offset tests
-
-    #[test]
-    fn test_level_offset_binary() {
-        // Binary tree: 1 sibling per level.
-        //   level 0 → offset 0, count 1
-        //   level 1 → offset 1, count 1
-        //   level 2 → offset 2, count 1
-        //   level 3 → offset 3, count 1
-        let s = binary_shifts(4);
-        assert_eq!(level_offset_and_count(0, &s), (0, 1));
-        assert_eq!(level_offset_and_count(1, &s), (1, 1));
-        assert_eq!(level_offset_and_count(2, &s), (2, 1));
-        assert_eq!(level_offset_and_count(3, &s), (3, 1));
-    }
-
-    #[test]
-    fn test_level_offset_4ary() {
-        // 4-ary tree: 3 siblings per level.
-        //   level 0 → offset 0, count 3
-        //   level 1 → offset 3, count 3
-        //   level 2 → offset 6, count 3
-        let s = quad_shifts(3);
-        assert_eq!(level_offset_and_count(0, &s), (0, 3));
-        assert_eq!(level_offset_and_count(1, &s), (3, 3));
-        assert_eq!(level_offset_and_count(2, &s), (6, 3));
-    }
-
-    #[test]
-    fn test_level_offset_mixed() {
-        // Mixed arity: binary (1), 4-ary (3), binary (1) → offsets 0, 1, 4.
-        let s = vec![1u32, 2, 1];
-        assert_eq!(level_offset_and_count(0, &s), (0, 1));
-        assert_eq!(level_offset_and_count(1, &s), (1, 3));
-        assert_eq!(level_offset_and_count(2, &s), (4, 1));
-    }
-
     // Total siblings tests
 
     #[test]
@@ -702,32 +623,6 @@ mod tests {
         assert_eq!(total_siblings_for_levels(3, &s), 11);
     }
 
-    #[test]
-    fn test_total_siblings_consistent_with_level_offsets() {
-        // The total for n levels must equal the offset of level n
-        // (i.e., one past the last element of level n-1).
-        // Verify this identity for several schedules.
-        for schedule in [
-            vec![1u32, 1, 1, 1],
-            vec![2, 2, 2],
-            vec![1, 2, 1, 3],
-            vec![3, 1, 2],
-        ] {
-            for n in 0..schedule.len() {
-                let total = total_siblings_for_levels(n, &schedule);
-                if n > 0 {
-                    // offset(n) should equal total_siblings(n) because
-                    // both are the sum of counts for levels 0..n.
-                    let (offset_n, _) = level_offset_and_count(n, &schedule);
-                    assert_eq!(
-                        total, offset_n,
-                        "schedule={schedule:?}, n={n}: total={total}, offset={offset_n}"
-                    );
-                }
-            }
-        }
-    }
-
     // Pruning tests
 
     #[test]
@@ -740,11 +635,10 @@ mod tests {
     #[test]
     fn test_prune_single_path() {
         // A single path has no predecessor to share with → all levels kept.
+        // Binary: 1 sibling per level × 3 levels = 3 total.
         let path = mock_path::<2>(5, 3);
         let pruned = prune_paths(3, &binary_shifts(3), &[path]);
         assert_eq!(pruned.paths.len(), 1);
-        assert_eq!(pruned.paths[0].num_levels_stored, 3);
-        // Binary: 1 sibling per level × 3 levels = 3 total.
         assert_eq!(pruned.paths[0].siblings.len(), 3);
     }
 
@@ -754,22 +648,22 @@ mod tests {
         // First path: all 3 levels. Second path: only level 0.
         let paths = [mock_path::<2>(4, 3), mock_path::<2>(5, 3)];
         let pruned = prune_paths(3, &binary_shifts(3), &paths);
-        assert_eq!(pruned.paths[0].num_levels_stored, 3);
-        assert_eq!(pruned.paths[1].num_levels_stored, 1);
+        assert_eq!(pruned.paths[0].siblings.len(), 3);
+        assert_eq!(pruned.paths[1].siblings.len(), 1);
     }
 
     #[test]
     fn test_prune_all_leaves_binary_height3() {
         // All 8 leaves in a height-3 binary tree.
         //
-        // Expected level counts per sorted path:
+        // Expected sibling counts per sorted path (1 sibling per binary level):
         //   [3, 1, 2, 1, 3, 1, 2, 1]
         //
         // Total pruned siblings: 14 vs unpruned 8 * 3 = 24.
         let h = 3;
         let paths: Vec<_> = (0..8).map(|i| mock_path::<2>(i, h)).collect();
         let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let counts: Vec<usize> = pruned.paths.iter().map(|p| p.num_levels_stored).collect();
+        let counts: Vec<usize> = pruned.paths.iter().map(|p| p.siblings.len()).collect();
         assert_eq!(counts, vec![3, 1, 2, 1, 3, 1, 2, 1]);
         assert_eq!(pruned_sibling_count(&pruned), 14);
     }
@@ -777,14 +671,14 @@ mod tests {
     #[test]
     fn test_prune_4ary_adjacent() {
         // Leaves 0-3 are siblings in a 4-ary tree → all share level 1.
-        // First path: both levels. Remaining paths: only level 0.
+        // First path: both levels (6 siblings). Remaining paths: only level 0 (3 siblings).
         let s = quad_shifts(2);
         let paths: Vec<_> = (0..4).map(|i| realistic_quad_path::<2>(i, 2)).collect();
         let pruned = prune_paths(2, &s, &paths);
-        assert_eq!(pruned.paths[0].num_levels_stored, 2);
-        assert_eq!(pruned.paths[1].num_levels_stored, 1);
-        assert_eq!(pruned.paths[2].num_levels_stored, 1);
-        assert_eq!(pruned.paths[3].num_levels_stored, 1);
+        assert_eq!(pruned.paths[0].siblings.len(), 6);
+        assert_eq!(pruned.paths[1].siblings.len(), 3);
+        assert_eq!(pruned.paths[2].siblings.len(), 3);
+        assert_eq!(pruned.paths[3].siblings.len(), 3);
     }
 
     #[test]
@@ -895,6 +789,21 @@ mod tests {
         assert_eq!(restored, paths);
     }
 
+    #[test]
+    fn test_roundtrip_mixed_arity() {
+        // Mixed schedule [1, 2, 1] (binary, 4-ary, binary) → 16 leaves.
+        // Exercises both the LCA loop and the per-level sibling counts.
+        let shifts = vec![1u32, 2, 1];
+        let indices = [0, 1, 4, 7, 8, 11, 15];
+        let paths: Vec<_> = indices
+            .iter()
+            .map(|&i| realistic_nary_path::<2>(i, &shifts))
+            .collect();
+        let pruned = prune_paths(shifts.len(), &shifts, &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored, paths);
+    }
+
     // Error / bounds tests
 
     #[test]
@@ -906,7 +815,6 @@ mod tests {
             original_order: vec![0],
             paths: vec![PrunedPath {
                 leaf_index: 0,
-                num_levels_stored: 0,
                 siblings: vec![],
             }],
         };
@@ -935,7 +843,6 @@ mod tests {
             original_order: vec![0],
             paths: vec![PrunedPath {
                 leaf_index: 0,
-                num_levels_stored: 1,
                 siblings: vec![[0; 2]],
             }],
         };

--- a/merkle-tree/src/pruning.rs
+++ b/merkle-tree/src/pruning.rs
@@ -1,0 +1,1118 @@
+//! Merkle path pruning: compact multi-opening proofs via shared-ancestor deduplication.
+//!
+//! # Problem
+//!
+//! When a STARK prover opens k leaf indices in a Merkle tree of height h,
+//! each opening produces h levels of sibling digests for verification — a total of k * h digest-levels.
+//!
+//! Many of these are **redundant**: leaves that are close in the tree share
+//! ancestors, and their authentication paths overlap above the Lowest Common Ancestor (LCA).
+//!
+//! # Solution
+//!
+//! This module eliminates redundant sibling digests by exploiting tree structure:
+//!
+//! 1. Sort all opened paths by leaf index.
+//! 2. For each consecutive pair, compute their LCA level using the per-level
+//!    arity (stored as log_2 shifts).
+//! 3. Each path only emits siblings **below** its LCA with the previous path.
+//! 4. During restoration, siblings above the LCA are copied from the previous path.
+//!
+//! # Visual example (binary tree)
+//!
+//! Height-3 tree with 8 leaves, opening leaves 1, 2, and 5:
+//!
+//! ```text
+//!                         [root]                      Level 3
+//!                       /        \
+//!                    [A]          [B]                 Level 2
+//!                   /   \        /   \
+//!                 [C]   [D]    [E]   [F]              Level 1
+//!                 / \   / \    / \   / \
+//!                0   1 2   3  4   5 6   7             Level 0 (leaves)
+//!                    ^ ^          ^
+//!                    opened leaves
+//! ```
+//!
+//! **Without pruning** (3 paths x 3 levels = 9 sibling digests):
+//! - Leaf 1: siblings `[0, D, B]`       (3 digests)
+//! - Leaf 2: siblings `[3, C, B]`       (3 digests)
+//! - Leaf 5: siblings `[4, F, A]`       (3 digests)
+//!
+//! **With pruning** (only 7 sibling digests):
+//! - Leaf 1: siblings `[0, D, B]`       (3 digests — first path, no sharing)
+//! - Leaf 2: siblings `[3, C]`          (2 digests — LCA at level 2, share level 2)
+//! - Leaf 5: siblings `[4, F, A]`       (3 digests — LCA at root, no sharing)
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// A full (unpruned) Merkle authentication path for a single leaf.
+///
+/// All sibling digests are stored in a **single contiguous allocation**.
+///
+/// The number of siblings at each tree level depends on the compression
+/// arity at that level: 2^shift - 1 digests per level.
+/// Level boundaries can be recovered from the per-level shift schedule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
+#[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
+pub struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
+    /// Index of this leaf in the tree (0-based).
+    pub leaf_index: usize,
+
+    /// All sibling digests concatenated: level 0 first, then level 1, etc.
+    ///
+    /// The count at each level is 2^shift - 1, where shift is the log_2
+    /// of the compression arity at that level.
+    pub siblings: Vec<[D; DIGEST_ELEMS]>,
+}
+
+impl<D: Clone, const DIGEST_ELEMS: usize> MerkleAuthPath<D, DIGEST_ELEMS> {
+    /// Returns the slice of siblings at a given tree level.
+    ///
+    /// The shift schedule describes log_2(arity) at each level.
+    /// This computes the flat-buffer offset and element count on the fly.
+    #[inline]
+    pub fn level_siblings(&self, level: usize, shift_schedule: &[u32]) -> &[[D; DIGEST_ELEMS]] {
+        // Compute where this level's siblings begin in the flat buffer
+        // and how many elements it spans.
+        //
+        //   Example: shift_schedule = [1, 2, 1] (binary, 4-ary, binary)
+        //     level 0 → offset 0, count 1   (1 binary sibling)
+        //     level 1 → offset 1, count 3   (3 quad siblings)
+        //     level 2 → offset 4, count 1   (1 binary sibling)
+        let (start, count) = level_offset_and_count(level, shift_schedule);
+        &self.siblings[start..start + count]
+    }
+}
+
+/// Compact representation of multiple Merkle authentication paths with
+/// redundant sibling digests removed.
+///
+/// Paths are sorted by leaf index and deduplicated.
+///
+/// Each path stores only the siblings below its LCA with the previous path;
+/// the rest are reconstructed during restoration by copying from that previous path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
+#[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
+pub struct PrunedMerklePaths<D, const DIGEST_ELEMS: usize> {
+    /// Number of levels in the original (unpruned) proof.
+    pub num_levels: usize,
+
+    /// log_2(arity) at each tree level.
+    ///
+    /// A value of 1 means binary (2-to-1 compression), 2 means 4-ary, etc.
+    ///
+    /// Stored in the proof so the verifier can reconstruct level boundaries
+    /// and recompute the LCA during restoration.
+    pub shift_schedule: Vec<u32>,
+
+    /// Permutation mapping original input order to sorted/deduplicated index.
+    ///
+    /// Entry i holds the index into the sorted path array for the i-th
+    /// original query.
+    pub original_order: Vec<u32>,
+
+    /// Pruned authentication paths, sorted by leaf index.
+    pub paths: Vec<PrunedPath<D, DIGEST_ELEMS>>,
+}
+
+/// A single pruned Merkle authentication path.
+///
+/// Contains only the siblings below this path's LCA with the previous sorted path.
+///
+/// Siblings at and above the LCA are shared with the neighbor and omitted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
+#[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
+pub struct PrunedPath<D, const DIGEST_ELEMS: usize> {
+    /// Leaf index in the original tree.
+    pub leaf_index: usize,
+    /// How many complete levels are stored in the sibling buffer.
+    pub num_levels_stored: usize,
+    /// Flat sibling digests for the first few levels only (below LCA).
+    pub siblings: Vec<[D; DIGEST_ELEMS]>,
+}
+
+/// Computes the flat-buffer offset and element count for a given level.
+///
+/// Each level contributes 2^shift - 1 siblings.
+/// The offset is the sum of all preceding levels' counts.
+///
+/// # Returns
+///
+/// (byte offset into the flat sibling buffer, number of siblings at this level).
+#[inline]
+fn level_offset_and_count(level: usize, shift_schedule: &[u32]) -> (usize, usize) {
+    // Sum the sibling counts for all levels before the target.
+    // Each level contributes 2^shift - 1 siblings (arity minus the queried child).
+    //
+    //   Example: shift_schedule = [1, 2, 1], target level = 2
+    //     level 0: 2^1 - 1 = 1 sibling  → offset += 1
+    //     level 1: 2^2 - 1 = 3 siblings → offset += 3
+    //     → start offset = 4
+    let mut offset = 0;
+    for &shift in &shift_schedule[..level] {
+        offset += (1usize << shift) - 1;
+    }
+    // Sibling count at the target level.
+    let count = (1usize << shift_schedule[level]) - 1;
+    (offset, count)
+}
+
+/// Total number of sibling digests for the first few levels.
+#[inline]
+fn total_siblings_for_levels(num_levels: usize, shift_schedule: &[u32]) -> usize {
+    // Sum 2^shift - 1 for each of the first few levels.
+    //
+    //   Example: shift_schedule = [1, 2, 1], num_levels = 2
+    //     level 0: 2^1 - 1 = 1
+    //     level 1: 2^2 - 1 = 3
+    //     → total = 4
+    shift_schedule[..num_levels]
+        .iter()
+        .map(|&s| (1usize << s) - 1)
+        .sum()
+}
+
+/// O(1) LCA for purely binary trees.
+///
+/// XOR the two leaf indices and count the bit-width of the result.
+/// The highest differing bit position is exactly the tree level where
+/// the two paths diverge.
+///
+/// For identical leaves, returns 1 (they share the parent at level 1).
+///
+/// # Returns
+///
+/// The smallest level at which both leaves share the same ancestor,
+/// clamped to the total number of levels.
+#[inline]
+fn first_shared_level_binary(a: usize, b: usize, num_levels: usize) -> usize {
+    let xor = a ^ b;
+    if xor == 0 {
+        // Same leaf — they trivially share the same parent.
+        return 1;
+    }
+    // Bit-width of the XOR = position of the highest differing bit + 1.
+    let level = (usize::BITS - xor.leading_zeros()) as usize;
+    level.min(num_levels)
+}
+
+/// Generic LCA via per-level shift loop.
+///
+/// Right-shifts both indices by the arity at each level.
+/// The first level where they become equal is the LCA.
+///
+/// For binary trees the caller should use the O(1) fast path instead;
+/// that check must be hoisted outside hot loops.
+#[inline]
+fn first_shared_level_generic(a: usize, b: usize, shift_schedule: &[u32]) -> usize {
+    let mut a_idx = a;
+    let mut b_idx = b;
+    for (level, &shift) in shift_schedule.iter().enumerate() {
+        // Divide both indices by the arity at this level (via shift).
+        a_idx >>= shift;
+        b_idx >>= shift;
+        // If both land in the same group, they share this ancestor.
+        if a_idx == b_idx {
+            return level + 1;
+        }
+    }
+    // No convergence within the schedule — share only the root.
+    shift_schedule.len()
+}
+
+/// Eliminates redundant sibling levels shared between adjacent sorted paths.
+///
+/// # Algorithm
+///
+/// 1. Sort a lightweight index array by leaf index (avoids moving large structs).
+/// 2. Deduplicate consecutive entries with the same leaf index.
+/// 3. For each path, compute the first shared level with the previous path
+///    and emit only the siblings below that level.
+///
+/// # Performance
+///
+/// - Binary trees: O(1) LCA via bitwise XOR (checked once, hoisted).
+/// - N-ary trees: O(h) LCA via shift loop per consecutive pair.
+/// - Sorting: lightweight u32 index array, not the full path structs.
+pub fn prune_paths<D, const DIGEST_ELEMS: usize>(
+    num_levels: usize,
+    shift_schedule: &[u32],
+    paths: &[MerkleAuthPath<D, DIGEST_ELEMS>],
+) -> PrunedMerklePaths<D, DIGEST_ELEMS>
+where
+    D: Clone + PartialEq,
+{
+    debug_assert_eq!(shift_schedule.len(), num_levels);
+
+    // Empty input → empty output.
+    if paths.is_empty() {
+        return PrunedMerklePaths {
+            num_levels,
+            shift_schedule: shift_schedule.to_vec(),
+            original_order: vec![],
+            paths: vec![],
+        };
+    }
+
+    // Phase 1: Sort by leaf index.
+    //
+    // We sort a lightweight u32 index array instead of moving the full
+    // auth-path structs (which can be hundreds of bytes each).
+    // This keeps the sort entirely within L1 cache.
+    let mut order: Vec<u32> = (0..paths.len() as u32).collect();
+    order.sort_unstable_by_key(|&i| paths[i as usize].leaf_index);
+
+    // Phase 2: Deduplicate consecutive entries with the same leaf index.
+    //
+    // When the same leaf is queried multiple times, we store it once
+    // in the pruned output and record which original queries map to it.
+    //
+    //   Example: input queries [5, 1, 3, 1]
+    //     sorted order:    [1, 1, 3, 5]
+    //     after dedup:     [1, 3, 5]       (3 unique paths)
+    //     original_order:  [2, 0, 1, 0]    (query 0→slot 2, query 1→slot 0, ...)
+    let mut original_order = vec![0u32; paths.len()];
+    let mut deduped_indices: Vec<u32> = Vec::with_capacity(paths.len());
+
+    for &sorted_idx in &order {
+        let leaf = paths[sorted_idx as usize].leaf_index;
+        // Start a new deduped entry only when the leaf differs from the last one.
+        if deduped_indices
+            .last()
+            .is_none_or(|&prev| paths[prev as usize].leaf_index != leaf)
+        {
+            deduped_indices.push(sorted_idx);
+        }
+        // Record which deduped slot this original query maps to.
+        original_order[sorted_idx as usize] = (deduped_indices.len() - 1) as u32;
+    }
+
+    // Phase 3: Build pruned paths.
+    //
+    // For each unique leaf (in sorted order), compute how many levels
+    // of siblings to keep. The first path keeps everything. Subsequent
+    // paths keep only the levels below their LCA with the predecessor —
+    // the rest are identical and will be copied during restoration.
+    //
+    //   Example: height-3 binary tree, sorted leaves [0, 1, 4]
+    //     path 0 (leaf 0): first → keep all 3 levels
+    //     path 1 (leaf 1): LCA with leaf 0 at level 1 → keep 1 level
+    //     path 2 (leaf 4): LCA with leaf 1 at level 3 → keep 3 levels
+    let n = deduped_indices.len();
+    let mut pruned_paths = Vec::with_capacity(n);
+
+    // Hoist the binary-tree check: O(h) once, not O(h) per pair.
+    // When all shifts are 1, the O(1) XOR fast path applies.
+    let is_purely_binary = shift_schedule.iter().all(|&s| s == 1);
+
+    for j in 0..n {
+        let path = &paths[deduped_indices[j] as usize];
+
+        // First path: keep all levels (no predecessor to share with).
+        // Later paths: keep only levels below the LCA with the predecessor.
+        let keep_levels = if j == 0 {
+            num_levels
+        } else {
+            let prev_leaf = paths[deduped_indices[j - 1] as usize].leaf_index;
+            if is_purely_binary {
+                // O(1): XOR the two leaf indices, count bit-width.
+                first_shared_level_binary(prev_leaf, path.leaf_index, num_levels)
+            } else {
+                // O(h): right-shift both indices level by level until they match.
+                first_shared_level_generic(prev_leaf, path.leaf_index, shift_schedule)
+            }
+        };
+
+        // Clamp to the actual number of levels (safety guard).
+        let keep = keep_levels.min(num_levels);
+        // Convert level count → flat-buffer element count.
+        //
+        //   Example: keep = 2, shift_schedule = [1, 2, 1]
+        //     level 0: 1 sibling, level 1: 3 siblings → 4 elements total
+        let sibling_count = total_siblings_for_levels(keep, shift_schedule);
+
+        pruned_paths.push(PrunedPath {
+            leaf_index: path.leaf_index,
+            num_levels_stored: keep,
+            // Slice the flat buffer up to the computed boundary.
+            siblings: path.siblings[..sibling_count].to_vec(),
+        });
+    }
+
+    PrunedMerklePaths {
+        num_levels,
+        shift_schedule: shift_schedule.to_vec(),
+        original_order,
+        paths: pruned_paths,
+    }
+}
+
+/// Restores full Merkle authentication paths from a pruned representation.
+///
+/// Processes paths in sorted order.
+/// Each path takes its own stored siblings (below LCA) and copies the
+/// remaining siblings (at and above LCA) from the previous restored path.
+///
+/// # Returns
+///
+/// Full authentication paths in the **original input order**, or
+/// `None` if the proof data is malformed.
+///
+/// # Safety
+///
+/// Returns `None` if the number of levels is 64 or more (DoS prevention,
+/// since 2^64 leaves would require unbounded allocations).
+pub fn restore_paths<D, const DIGEST_ELEMS: usize>(
+    pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
+) -> Option<Vec<MerkleAuthPath<D, DIGEST_ELEMS>>>
+where
+    D: Clone + Default,
+{
+    let num_levels = pruned.num_levels;
+    let n = pruned.paths.len();
+
+    // Compute how many sibling digests a complete (unpruned) path contains.
+    //
+    //   Example: shift_schedule = [1, 2, 1] → 1 + 3 + 1 = 5 siblings total
+    let full_sibling_count = total_siblings_for_levels(num_levels, &pruned.shift_schedule);
+
+    // Reject trees deeper than 63 levels to prevent unbounded allocations.
+    // A depth-64 tree would have 2^64 leaves — clearly a DoS attempt.
+    if num_levels >= 64 {
+        return None;
+    }
+
+    // Zero paths with zero queries is valid (empty proof).
+    // Zero paths with nonzero queries is malformed.
+    if n == 0 {
+        return if pruned.original_order.is_empty() {
+            Some(vec![])
+        } else {
+            None
+        };
+    }
+
+    let mut restored: Vec<MerkleAuthPath<D, DIGEST_ELEMS>> = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let pruned_path = &pruned.paths[i];
+        let kept_siblings = pruned_path.siblings.len();
+
+        // Allocate the full-size buffer once (no resizing).
+        let mut siblings = Vec::with_capacity(full_sibling_count);
+
+        // Lower portion: the unique siblings this path stored (below LCA).
+        // These differ from the predecessor and were kept during pruning.
+        siblings.extend_from_slice(&pruned_path.siblings);
+
+        // Upper portion: shared siblings copied from the previous path.
+        // Both paths traverse the same nodes above the LCA, so their
+        // siblings there are identical — just memcpy the tail.
+        //
+        //   Example: full = 5 siblings, this path stored 2
+        //     this path's buffer:  [s0, s1, ?, ?, ?]
+        //     previous path:       [_, _, s2, s3, s4]   (shared above LCA)
+        //     after copy:          [s0, s1, s2, s3, s4]
+        if let Some(prev) = restored.last()
+            && kept_siblings < full_sibling_count
+        {
+            siblings.extend_from_slice(&prev.siblings[kept_siblings..]);
+        }
+
+        // Sanity check: restored path must be exactly the right size.
+        // If not, the pruned proof is malformed.
+        if siblings.len() != full_sibling_count {
+            return None;
+        }
+
+        restored.push(MerkleAuthPath {
+            leaf_index: pruned_path.leaf_index,
+            siblings,
+        });
+    }
+
+    // Reorder from sorted/deduped order back to the caller's original query
+    // order. Each entry in the order mapping points to the deduped path slot.
+    pruned
+        .original_order
+        .iter()
+        .map(|&idx| restored.get(idx as usize).cloned())
+        .collect()
+}
+
+// Metrics
+
+/// Total number of individual sibling digests across all pruned paths.
+///
+/// Compare against the unpruned total (paths * full sibling count)
+/// to measure the compression ratio.
+pub fn pruned_sibling_count<D, const DIGEST_ELEMS: usize>(
+    pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
+) -> usize {
+    // Sum the flat sibling buffer lengths across all pruned paths.
+    // Compare this against (num_paths * full_sibling_count) for compression ratio.
+    pruned.paths.iter().map(|p| p.siblings.len()).sum()
+}
+
+// Tests
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn binary_shifts(h: usize) -> Vec<u32> {
+        // All levels binary (arity 2 → shift 1).
+        vec![1; h]
+    }
+
+    fn quad_shifts(h: usize) -> Vec<u32> {
+        // All levels 4-ary (arity 4 → shift 2).
+        vec![2; h]
+    }
+
+    fn mock_path<const DE: usize>(leaf_index: usize, h: usize) -> MerkleAuthPath<u32, DE> {
+        // Deterministic siblings: value encodes (leaf_index, level) for easy debugging.
+        MerkleAuthPath {
+            leaf_index,
+            siblings: (0..h)
+                .map(|lvl| [(leaf_index * 100 + lvl) as u32; DE])
+                .collect(),
+        }
+    }
+
+    fn realistic_binary_path<const DE: usize>(
+        leaf_index: usize,
+        h: usize,
+    ) -> MerkleAuthPath<u32, DE> {
+        // Binary tree mock where siblings above the LCA are structurally
+        // identical for leaves sharing that ancestor.
+        // Sibling at level l = the "other child" index at that level.
+        MerkleAuthPath {
+            leaf_index,
+            siblings: (0..h)
+                .map(|lvl| [((leaf_index >> lvl) ^ 1) as u32; DE])
+                .collect(),
+        }
+    }
+
+    fn realistic_quad_path<const DE: usize>(
+        leaf_index: usize,
+        num_levels: usize,
+    ) -> MerkleAuthPath<u32, DE> {
+        // 4-ary tree mock: 3 siblings per level, shared above LCA.
+        // Group index at each level determines the sibling values.
+        let mut siblings = Vec::new();
+        for lvl in 0..num_levels {
+            let group_idx = leaf_index / 4usize.pow(lvl as u32 + 1);
+            for s in 0..3u32 {
+                siblings.push([(group_idx * 100 + lvl * 10 + s as usize) as u32; DE]);
+            }
+        }
+        MerkleAuthPath {
+            leaf_index,
+            siblings,
+        }
+    }
+
+    // LCA tests
+
+    #[test]
+    fn test_lca_binary_fast_path() {
+        // Binary tree, height 3 (8 leaves).
+        //
+        //          [root]            Level 3
+        //        /        \
+        //     [A]          [B]       Level 2
+        //    /   \        /   \
+        //  [C]   [D]    [E]   [F]    Level 1
+        //  / \   / \    / \   / \
+        // 0   1 2   3  4   5 6   7   Level 0
+
+        // Adjacent siblings share at level 1.
+        assert_eq!(first_shared_level_binary(0, 1, 3), 1);
+        assert_eq!(first_shared_level_binary(4, 5, 3), 1);
+
+        // Leaves in the same quadrant share at level 2.
+        assert_eq!(first_shared_level_binary(0, 3, 3), 2);
+        assert_eq!(first_shared_level_binary(4, 6, 3), 2);
+
+        // Leaves in opposite halves share only at the root.
+        assert_eq!(first_shared_level_binary(0, 7, 3), 3);
+
+        // Same leaf: trivially share at level 1.
+        assert_eq!(first_shared_level_binary(5, 5, 3), 1);
+    }
+
+    #[test]
+    fn test_lca_generic_binary() {
+        // Generic loop path must produce identical results for binary trees.
+        let s = binary_shifts(3);
+        assert_eq!(first_shared_level_generic(0, 1, &s), 1);
+        assert_eq!(first_shared_level_generic(0, 3, &s), 2);
+        assert_eq!(first_shared_level_generic(0, 7, &s), 3);
+        assert_eq!(first_shared_level_generic(4, 5, &s), 1);
+    }
+
+    #[test]
+    fn test_lca_4ary() {
+        // 4-ary tree, height 3 (64 leaves).
+        // Leaves 0-3 share the same parent → LCA at level 1.
+        let s = quad_shifts(3);
+        assert_eq!(first_shared_level_generic(0, 1, &s), 1);
+        assert_eq!(first_shared_level_generic(0, 3, &s), 1);
+
+        // Leaves 0 and 4 are in different level-0 groups, share at level 2.
+        assert_eq!(first_shared_level_generic(0, 4, &s), 2);
+        assert_eq!(first_shared_level_generic(0, 15, &s), 2);
+
+        // Leaves in different top quadrants share at level 3 (root).
+        assert_eq!(first_shared_level_generic(0, 16, &s), 3);
+        assert_eq!(first_shared_level_generic(0, 63, &s), 3);
+    }
+
+    #[test]
+    fn test_lca_mixed_schedule() {
+        // Mixed arity: 4-ary, binary, 4-ary → 4 * 2 * 4 = 32 leaves.
+        let s = vec![2u32, 1, 2];
+
+        // Leaves 0 and 3 are in the same 4-group at level 0.
+        assert_eq!(first_shared_level_generic(0, 3, &s), 1);
+
+        // Leaves 0 and 4 span different 4-groups but the same binary parent.
+        assert_eq!(first_shared_level_generic(0, 4, &s), 2);
+
+        // Leaves 0 and 8 span different top-level groups.
+        assert_eq!(first_shared_level_generic(0, 8, &s), 3);
+    }
+
+    #[test]
+    fn test_lca_symmetry() {
+        // LCA must be symmetric: swapping the two leaves must not change the result.
+        let s = vec![2u32, 1, 2];
+        for a in 0..32 {
+            for b in 0..32 {
+                assert_eq!(
+                    first_shared_level_generic(a, b, &s),
+                    first_shared_level_generic(b, a, &s)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_binary_fast_path_matches_generic() {
+        // The O(1) binary fast path must produce identical results to the
+        // generic O(h) loop for all pairs in a binary tree.
+        let s = binary_shifts(5);
+        for a in 0..32 {
+            for b in 0..32 {
+                assert_eq!(
+                    first_shared_level_generic(a, b, &s),
+                    first_shared_level_binary(a, b, 5),
+                    "mismatch for a={a}, b={b}"
+                );
+            }
+        }
+    }
+
+    // Level offset tests
+
+    #[test]
+    fn test_level_offset_binary() {
+        // Binary tree: 1 sibling per level.
+        //   level 0 → offset 0, count 1
+        //   level 1 → offset 1, count 1
+        //   level 2 → offset 2, count 1
+        //   level 3 → offset 3, count 1
+        let s = binary_shifts(4);
+        assert_eq!(level_offset_and_count(0, &s), (0, 1));
+        assert_eq!(level_offset_and_count(1, &s), (1, 1));
+        assert_eq!(level_offset_and_count(2, &s), (2, 1));
+        assert_eq!(level_offset_and_count(3, &s), (3, 1));
+    }
+
+    #[test]
+    fn test_level_offset_4ary() {
+        // 4-ary tree: 3 siblings per level.
+        //   level 0 → offset 0, count 3
+        //   level 1 → offset 3, count 3
+        //   level 2 → offset 6, count 3
+        let s = quad_shifts(3);
+        assert_eq!(level_offset_and_count(0, &s), (0, 3));
+        assert_eq!(level_offset_and_count(1, &s), (3, 3));
+        assert_eq!(level_offset_and_count(2, &s), (6, 3));
+    }
+
+    #[test]
+    fn test_level_offset_mixed() {
+        // Mixed arity: binary (1), 4-ary (3), binary (1) → offsets 0, 1, 4.
+        let s = vec![1u32, 2, 1];
+        assert_eq!(level_offset_and_count(0, &s), (0, 1));
+        assert_eq!(level_offset_and_count(1, &s), (1, 3));
+        assert_eq!(level_offset_and_count(2, &s), (4, 1));
+    }
+
+    // Total siblings tests
+
+    #[test]
+    fn test_total_siblings_binary() {
+        // Binary tree: 1 sibling per level.
+        //   1 level  → 1
+        //   3 levels → 1 + 1 + 1 = 3
+        //   5 levels → 5
+        let s = binary_shifts(5);
+        assert_eq!(total_siblings_for_levels(0, &s), 0);
+        assert_eq!(total_siblings_for_levels(1, &s), 1);
+        assert_eq!(total_siblings_for_levels(3, &s), 3);
+        assert_eq!(total_siblings_for_levels(5, &s), 5);
+    }
+
+    #[test]
+    fn test_total_siblings_4ary() {
+        // 4-ary tree: 3 siblings per level.
+        //   1 level  → 3
+        //   2 levels → 3 + 3 = 6
+        //   3 levels → 9
+        let s = quad_shifts(3);
+        assert_eq!(total_siblings_for_levels(0, &s), 0);
+        assert_eq!(total_siblings_for_levels(1, &s), 3);
+        assert_eq!(total_siblings_for_levels(2, &s), 6);
+        assert_eq!(total_siblings_for_levels(3, &s), 9);
+    }
+
+    #[test]
+    fn test_total_siblings_mixed() {
+        // Mixed: binary (1), 4-ary (3), 8-ary (7) → cumulative 1, 4, 11.
+        let s = vec![1u32, 2, 3];
+        assert_eq!(total_siblings_for_levels(0, &s), 0);
+        assert_eq!(total_siblings_for_levels(1, &s), 1);
+        assert_eq!(total_siblings_for_levels(2, &s), 4);
+        assert_eq!(total_siblings_for_levels(3, &s), 11);
+    }
+
+    #[test]
+    fn test_total_siblings_consistent_with_level_offsets() {
+        // The total for n levels must equal the offset of level n
+        // (i.e., one past the last element of level n-1).
+        // Verify this identity for several schedules.
+        for schedule in [
+            vec![1u32, 1, 1, 1],
+            vec![2, 2, 2],
+            vec![1, 2, 1, 3],
+            vec![3, 1, 2],
+        ] {
+            for n in 0..schedule.len() {
+                let total = total_siblings_for_levels(n, &schedule);
+                if n > 0 {
+                    // offset(n) should equal total_siblings(n) because
+                    // both are the sum of counts for levels 0..n.
+                    let (offset_n, _) = level_offset_and_count(n, &schedule);
+                    assert_eq!(
+                        total, offset_n,
+                        "schedule={schedule:?}, n={n}: total={total}, offset={offset_n}"
+                    );
+                }
+            }
+        }
+    }
+
+    // Pruning tests
+
+    #[test]
+    fn test_prune_empty() {
+        // No paths → empty pruned output.
+        let pruned = prune_paths::<u32, 2>(3, &binary_shifts(3), &[]);
+        assert!(pruned.paths.is_empty());
+    }
+
+    #[test]
+    fn test_prune_single_path() {
+        // A single path has no predecessor to share with → all levels kept.
+        let path = mock_path::<2>(5, 3);
+        let pruned = prune_paths(3, &binary_shifts(3), &[path]);
+        assert_eq!(pruned.paths.len(), 1);
+        assert_eq!(pruned.paths[0].num_levels_stored, 3);
+        // Binary: 1 sibling per level × 3 levels = 3 total.
+        assert_eq!(pruned.paths[0].siblings.len(), 3);
+    }
+
+    #[test]
+    fn test_prune_adjacent_binary() {
+        // Leaves 4 and 5 are binary siblings → LCA at level 1.
+        // First path: all 3 levels. Second path: only level 0.
+        let paths = [mock_path::<2>(4, 3), mock_path::<2>(5, 3)];
+        let pruned = prune_paths(3, &binary_shifts(3), &paths);
+        assert_eq!(pruned.paths[0].num_levels_stored, 3);
+        assert_eq!(pruned.paths[1].num_levels_stored, 1);
+    }
+
+    #[test]
+    fn test_prune_all_leaves_binary_height3() {
+        // All 8 leaves in a height-3 binary tree.
+        //
+        // Expected level counts per sorted path:
+        //   [3, 1, 2, 1, 3, 1, 2, 1]
+        //
+        // Total pruned siblings: 14 vs unpruned 8 * 3 = 24.
+        let h = 3;
+        let paths: Vec<_> = (0..8).map(|i| mock_path::<2>(i, h)).collect();
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let counts: Vec<usize> = pruned.paths.iter().map(|p| p.num_levels_stored).collect();
+        assert_eq!(counts, vec![3, 1, 2, 1, 3, 1, 2, 1]);
+        assert_eq!(pruned_sibling_count(&pruned), 14);
+    }
+
+    #[test]
+    fn test_prune_4ary_adjacent() {
+        // Leaves 0-3 are siblings in a 4-ary tree → all share level 1.
+        // First path: both levels. Remaining paths: only level 0.
+        let s = quad_shifts(2);
+        let paths: Vec<_> = (0..4).map(|i| realistic_quad_path::<2>(i, 2)).collect();
+        let pruned = prune_paths(2, &s, &paths);
+        assert_eq!(pruned.paths[0].num_levels_stored, 2);
+        assert_eq!(pruned.paths[1].num_levels_stored, 1);
+        assert_eq!(pruned.paths[2].num_levels_stored, 1);
+        assert_eq!(pruned.paths[3].num_levels_stored, 1);
+    }
+
+    #[test]
+    fn test_prune_duplicate_indices() {
+        // Two queries for the same leaf → deduplicated to one path.
+        // Both original queries map to the same deduped slot.
+        let paths = [mock_path::<2>(3, 3), mock_path::<2>(3, 3)];
+        let pruned = prune_paths(3, &binary_shifts(3), &paths);
+        assert_eq!(pruned.paths.len(), 1);
+        assert_eq!(pruned.original_order, vec![0, 0]);
+    }
+
+    #[test]
+    fn test_original_order_preservation() {
+        // Input order [5, 1, 3] → sorted [1, 3, 5] at indices [0, 1, 2].
+        // Original query 0 (leaf 5) maps to sorted index 2, etc.
+        let paths = [
+            mock_path::<2>(5, 3),
+            mock_path::<2>(1, 3),
+            mock_path::<2>(3, 3),
+        ];
+        let pruned = prune_paths(3, &binary_shifts(3), &paths);
+        assert_eq!(pruned.original_order, vec![2, 0, 1]);
+    }
+
+    #[test]
+    fn test_proof_size_smaller_for_overlapping() {
+        // Clustered leaves must produce a strictly smaller pruned proof.
+        let h = 5;
+        let paths: Vec<_> = [2, 3, 6, 7].iter().map(|&i| mock_path::<2>(i, h)).collect();
+        let unpruned: usize = paths.iter().map(|p| p.siblings.len()).sum();
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        assert!(pruned_sibling_count(&pruned) < unpruned);
+    }
+
+    // Roundtrip tests
+
+    #[test]
+    fn test_roundtrip_single() {
+        // Single path: prune → restore must be identity.
+        let h = 4;
+        let paths = [realistic_binary_path::<2>(3, h)];
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored, paths);
+    }
+
+    #[test]
+    fn test_roundtrip_binary_all_leaves() {
+        // All 8 leaves in a height-3 binary tree: full roundtrip.
+        let h = 3;
+        let paths: Vec<_> = (0..8).map(|i| realistic_binary_path::<2>(i, h)).collect();
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored, paths);
+    }
+
+    #[test]
+    fn test_roundtrip_unordered() {
+        // Unsorted input [5, 1, 3] must be restored in the original order.
+        let h = 3;
+        let paths = [
+            realistic_binary_path::<2>(5, h),
+            realistic_binary_path::<2>(1, h),
+            realistic_binary_path::<2>(3, h),
+        ];
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored.as_slice(), &paths);
+    }
+
+    #[test]
+    fn test_roundtrip_duplicates() {
+        // Duplicate queries must roundtrip correctly.
+        // Both copies must match their respective originals.
+        let h = 3;
+        let paths = [
+            realistic_binary_path::<2>(2, h),
+            realistic_binary_path::<2>(5, h),
+            realistic_binary_path::<2>(2, h),
+        ];
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored.as_slice(), &paths);
+    }
+
+    #[test]
+    fn test_roundtrip_4ary() {
+        // All 16 leaves of a 2-level 4-ary tree.
+        let s = quad_shifts(2);
+        let paths: Vec<_> = (0..16).map(|i| realistic_quad_path::<2>(i, 2)).collect();
+        let pruned = prune_paths(2, &s, &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored, paths);
+    }
+
+    #[test]
+    fn test_roundtrip_height5() {
+        // Sparse query set across a height-5 binary tree.
+        let h = 5;
+        let indices = [0, 3, 7, 12, 15, 16, 20, 31];
+        let paths: Vec<_> = indices
+            .iter()
+            .map(|&i| realistic_binary_path::<4>(i, h))
+            .collect();
+        let pruned = prune_paths(h, &binary_shifts(h), &paths);
+        let restored = restore_paths(&pruned).unwrap();
+        assert_eq!(restored, paths);
+    }
+
+    // Error / bounds tests
+
+    #[test]
+    fn test_restore_rejects_large_num_levels() {
+        // 64 levels would require 2^64 leaves — reject to prevent DoS.
+        let pruned = PrunedMerklePaths::<u32, 2> {
+            num_levels: 64,
+            shift_schedule: vec![1; 64],
+            original_order: vec![0],
+            paths: vec![PrunedPath {
+                leaf_index: 0,
+                num_levels_stored: 0,
+                siblings: vec![],
+            }],
+        };
+        assert!(restore_paths(&pruned).is_none());
+    }
+
+    #[test]
+    fn test_restore_empty() {
+        // Zero paths with zero queries → valid empty result.
+        let pruned = PrunedMerklePaths::<u32, 2> {
+            num_levels: 3,
+            shift_schedule: vec![1, 1, 1],
+            original_order: vec![],
+            paths: vec![],
+        };
+        assert!(restore_paths(&pruned).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_restore_rejects_inconsistent_siblings() {
+        // First path stores only 1 level of siblings but the tree has 3 levels.
+        // With no predecessor to copy from, restoration must fail.
+        let pruned = PrunedMerklePaths::<u32, 2> {
+            num_levels: 3,
+            shift_schedule: vec![1, 1, 1],
+            original_order: vec![0],
+            paths: vec![PrunedPath {
+                leaf_index: 0,
+                num_levels_stored: 1,
+                siblings: vec![[0; 2]],
+            }],
+        };
+        assert!(restore_paths(&pruned).is_none());
+    }
+
+    // Size analysis
+
+    #[test]
+    fn test_pruned_size_leq_original() {
+        // Invariant: pruning must never increase the total sibling count.
+        for h in 2..6 {
+            let n_leaves = 1 << h;
+            for subset in 1..=n_leaves.min(16) {
+                let paths: Vec<_> = (0..subset).map(|i| mock_path::<2>(i, h)).collect();
+                let unpruned: usize = paths.iter().map(|p| p.siblings.len()).sum();
+                let pruned = prune_paths(h, &binary_shifts(h), &paths);
+                assert!(pruned_sibling_count(&pruned) <= unpruned);
+            }
+        }
+    }
+
+    // Proptests
+
+    fn binary_tree_queries() -> impl Strategy<Value = (usize, Vec<usize>)> {
+        // Random binary tree: height 1..10, up to 32 random leaf queries.
+        (1..10usize).prop_flat_map(|h| {
+            let n_leaves = 1usize << h;
+            let indices = proptest::collection::vec(0..n_leaves, 1..=n_leaves.min(32));
+            (Just(h), indices)
+        })
+    }
+
+    fn quad_tree_queries() -> impl Strategy<Value = (usize, Vec<usize>)> {
+        // Random 4-ary tree: height 1..5, up to 32 random leaf queries.
+        (1..5usize).prop_flat_map(|h| {
+            let n_leaves = 4usize.pow(h as u32);
+            let indices = proptest::collection::vec(0..n_leaves, 1..=n_leaves.min(32));
+            (Just(h), indices)
+        })
+    }
+
+    /// Build a realistic mock path for any power-of-two arity schedule.
+    ///
+    /// For each level, generates (2^shift - 1) siblings whose values are
+    /// determined by the ancestor group index at that level. This means
+    /// leaves sharing an ancestor will have identical siblings above the LCA.
+    fn realistic_nary_path<const DE: usize>(
+        leaf_index: usize,
+        shift_schedule: &[u32],
+    ) -> MerkleAuthPath<u32, DE> {
+        let mut siblings = Vec::new();
+        let mut group_size = 1usize;
+        for &shift in shift_schedule {
+            // The arity at this level.
+            let arity = 1usize << shift;
+            // Group size below this level (product of all arities so far + this one).
+            group_size *= arity;
+            // Which group does this leaf belong to at this level?
+            let group_idx = leaf_index / group_size;
+            // Generate (arity - 1) sibling digests for this level.
+            for s in 0..(arity - 1) {
+                siblings.push([(group_idx * 1000 + s) as u32; DE]);
+            }
+        }
+        MerkleAuthPath {
+            leaf_index,
+            siblings,
+        }
+    }
+
+    /// Strategy for a tree with random per-level arities (2, 4, 8, or 16).
+    /// Returns the shift schedule, total leaf count, and random query indices.
+    fn mixed_arity_tree_queries() -> impl Strategy<Value = (Vec<u32>, usize, Vec<usize>)> {
+        // 1..6 levels, each with a random power-of-two arity (shift 1..=4).
+        proptest::collection::vec(1..=4u32, 1..6).prop_flat_map(|shifts| {
+            // Total leaves = product of arities = 2^(sum of shifts).
+            let total_shift: u32 = shifts.iter().sum();
+            // Cap at 2^16 = 65536 leaves to keep tests fast.
+            if total_shift > 16 {
+                // Truncate the schedule to stay within bounds.
+                let mut cumulative = 0u32;
+                let truncated: Vec<u32> = shifts
+                    .into_iter()
+                    .take_while(|&s| {
+                        cumulative += s;
+                        cumulative <= 16
+                    })
+                    .collect();
+                let n_leaves = 1usize << truncated.iter().sum::<u32>();
+                let indices = proptest::collection::vec(0..n_leaves, 1..=n_leaves.min(32));
+                (Just(truncated), Just(n_leaves), indices)
+            } else {
+                let n_leaves = 1usize << total_shift;
+                let indices = proptest::collection::vec(0..n_leaves, 1..=n_leaves.min(32));
+                (Just(shifts), Just(n_leaves), indices)
+            }
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_binary_roundtrip((h, indices) in binary_tree_queries()) {
+            // Prune → restore must recover the exact original paths.
+            let s = binary_shifts(h);
+            let paths: Vec<_> = indices.iter().map(|&i| realistic_binary_path::<2>(i, h)).collect();
+            let pruned = prune_paths(h, &s, &paths);
+            let restored = restore_paths(&pruned).unwrap();
+            prop_assert_eq!(&restored, &paths);
+        }
+
+        #[test]
+        fn proptest_quad_roundtrip((h, indices) in quad_tree_queries()) {
+            // Same roundtrip invariant for 4-ary trees.
+            let s = quad_shifts(h);
+            let paths: Vec<_> = indices.iter().map(|&i| realistic_quad_path::<2>(i, h)).collect();
+            let pruned = prune_paths(h, &s, &paths);
+            let restored = restore_paths(&pruned).unwrap();
+            prop_assert_eq!(&restored, &paths);
+        }
+
+        #[test]
+        fn proptest_pruned_size_leq_original((h, indices) in binary_tree_queries()) {
+            // Pruning must never increase total sibling count.
+            let s = binary_shifts(h);
+            let paths: Vec<_> = indices.iter().map(|&i| mock_path::<2>(i, h)).collect();
+            let unpruned: usize = paths.iter().map(|p| p.siblings.len()).sum();
+            let pruned = prune_paths(h, &s, &paths);
+            prop_assert!(pruned_sibling_count(&pruned) <= unpruned);
+        }
+
+        #[test]
+        fn proptest_binary_fast_path_matches_generic(a in 0..1024usize, b in 0..1024usize) {
+            // The O(1) binary fast path must match the O(h) generic loop.
+            let h = 10;
+            let s = binary_shifts(h);
+            prop_assert_eq!(
+                first_shared_level_generic(a, b, &s),
+                first_shared_level_binary(a, b, h)
+            );
+        }
+
+        #[test]
+        fn proptest_dedup_preserves_identity((h, mut indices) in binary_tree_queries()) {
+            // Duplicating every query must produce identical restored paths
+            // for the original and duplicated halves.
+            let original_len = indices.len();
+            indices.extend_from_slice(&indices.clone());
+            let s = binary_shifts(h);
+            let paths: Vec<_> = indices.iter().map(|&i| realistic_binary_path::<2>(i, h)).collect();
+            let pruned = prune_paths(h, &s, &paths);
+            let restored = restore_paths(&pruned).unwrap();
+            prop_assert_eq!(restored.len(), original_len * 2);
+            for i in 0..original_len {
+                prop_assert_eq!(&restored[i], &restored[i + original_len]);
+            }
+        }
+
+        #[test]
+        fn proptest_mixed_arity_roundtrip((shifts, _n_leaves, indices) in mixed_arity_tree_queries()) {
+            // Roundtrip with random per-level arities (2, 4, 8, or 16).
+            // Covers mixed schedules like [1, 3, 2] (binary, 8-ary, 4-ary).
+            let h = shifts.len();
+            let paths: Vec<_> = indices.iter().map(|&i| realistic_nary_path::<2>(i, &shifts)).collect();
+            let pruned = prune_paths(h, &shifts, &paths);
+            let restored = restore_paths(&pruned).unwrap();
+            prop_assert_eq!(&restored, &paths);
+        }
+
+        #[test]
+        fn proptest_mixed_arity_size_leq_original((shifts, _n_leaves, indices) in mixed_arity_tree_queries()) {
+            // Pruning must never increase sibling count, regardless of arity.
+            let h = shifts.len();
+            let paths: Vec<_> = indices.iter().map(|&i| realistic_nary_path::<2>(i, &shifts)).collect();
+            let unpruned: usize = paths.iter().map(|p| p.siblings.len()).sum();
+            let pruned = prune_paths(h, &shifts, &paths);
+            prop_assert!(pruned_sibling_count(&pruned) <= unpruned);
+        }
+    }
+}

--- a/merkle-tree/src/pruning.rs
+++ b/merkle-tree/src/pruning.rs
@@ -77,21 +77,17 @@ pub(crate) struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
 ///
 /// Each path stores only the siblings below its LCA with the previous path;
 /// the rest are reconstructed during restoration by copying from that previous path.
+///
+/// # Wire format
+///
+/// - Tree depth and per-level arity are not stored.
+/// - The verifier rederives both from the committed matrix dimensions.
+/// - Doing so shrinks the proof and removes a DoS surface where a malicious
+///   schedule could dictate per-level sibling counts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
 #[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
 pub struct PrunedMerklePaths<D, const DIGEST_ELEMS: usize> {
-    /// Number of levels in the original (unpruned) proof.
-    pub num_levels: usize,
-
-    /// log_2(arity) at each tree level.
-    ///
-    /// A value of 1 means binary (2-to-1 compression), 2 means 4-ary, etc.
-    ///
-    /// Stored in the proof so the verifier can reconstruct level boundaries
-    /// and recompute the LCA during restoration.
-    pub shift_schedule: Vec<u32>,
-
     /// Permutation mapping original input order to sorted/deduplicated index.
     ///
     /// Entry i holds the index into the sorted path array for the i-th
@@ -207,8 +203,6 @@ where
     // Empty input → empty output.
     if paths.is_empty() {
         return PrunedMerklePaths {
-            num_levels,
-            shift_schedule: shift_schedule.to_vec(),
             original_order: vec![],
             paths: vec![],
         };
@@ -299,8 +293,6 @@ where
     }
 
     PrunedMerklePaths {
-        num_levels,
-        shift_schedule: shift_schedule.to_vec(),
         original_order,
         paths: pruned_paths,
     }
@@ -312,44 +304,23 @@ where
 /// Each path takes its own stored siblings (below LCA) and copies the
 /// remaining siblings (at and above LCA) from the previous restored path.
 ///
+/// # Trust model
+///
+/// - The full-sibling count is supplied by the caller, never read from the proof.
+/// - A malicious prover cannot use it to inflate per-path allocations.
+///
 /// # Returns
 ///
-/// Full authentication paths in the **original input order**, or
-/// `None` if the proof data is malformed.
-///
-/// # Safety
-///
-/// Returns `None` if the number of levels is 64 or more (DoS prevention,
-/// since 2^64 leaves would require unbounded allocations).
+/// - Full authentication paths in the **original input order**.
+/// - `None` if the proof data is malformed.
 pub(crate) fn restore_paths<D, const DIGEST_ELEMS: usize>(
     pruned: &PrunedMerklePaths<D, DIGEST_ELEMS>,
+    full_sibling_count: usize,
 ) -> Option<Vec<MerkleAuthPath<D, DIGEST_ELEMS>>>
 where
     D: Clone + Default,
 {
-    let num_levels = pruned.num_levels;
     let n = pruned.paths.len();
-
-    // Reject trees deeper than 63 levels to prevent unbounded allocations.
-    // A depth-64 tree would have 2^64 leaves — clearly a DoS attempt.
-    //
-    // TODO: tighten this. 32-bit `usize` targets need depth < 32, and even
-    // on 64-bit, common field 2-adicities mean realistic proofs stay well
-    // below 32 levels — anything past that is suspicious.
-    if num_levels >= 64 {
-        return None;
-    }
-
-    // The shift schedule must cover every level claimed by the proof.
-    // A shorter schedule would slice-index past the end below.
-    if pruned.shift_schedule.len() != num_levels {
-        return None;
-    }
-
-    // Compute how many sibling digests a complete (unpruned) path contains.
-    //
-    //   Example: shift_schedule = [1, 2, 1] → 1 + 3 + 1 = 5 siblings total
-    let full_sibling_count = total_siblings_for_levels(num_levels, &pruned.shift_schedule);
 
     // Zero paths with zero queries is valid (empty proof).
     // Zero paths with nonzero queries is malformed.
@@ -720,9 +691,11 @@ mod tests {
     fn test_roundtrip_single() {
         // Single path: prune → restore must be identity.
         let h = 4;
+        let s = binary_shifts(h);
+        let full = total_siblings_for_levels(h, &s);
         let paths = [realistic_binary_path::<2>(3, h)];
-        let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let pruned = prune_paths(h, &s, &paths);
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored, paths);
     }
 
@@ -730,9 +703,11 @@ mod tests {
     fn test_roundtrip_binary_all_leaves() {
         // All 8 leaves in a height-3 binary tree: full roundtrip.
         let h = 3;
+        let s = binary_shifts(h);
+        let full = total_siblings_for_levels(h, &s);
         let paths: Vec<_> = (0..8).map(|i| realistic_binary_path::<2>(i, h)).collect();
-        let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let pruned = prune_paths(h, &s, &paths);
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored, paths);
     }
 
@@ -740,13 +715,15 @@ mod tests {
     fn test_roundtrip_unordered() {
         // Unsorted input [5, 1, 3] must be restored in the original order.
         let h = 3;
+        let s = binary_shifts(h);
+        let full = total_siblings_for_levels(h, &s);
         let paths = [
             realistic_binary_path::<2>(5, h),
             realistic_binary_path::<2>(1, h),
             realistic_binary_path::<2>(3, h),
         ];
-        let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let pruned = prune_paths(h, &s, &paths);
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored.as_slice(), &paths);
     }
 
@@ -755,13 +732,15 @@ mod tests {
         // Duplicate queries must roundtrip correctly.
         // Both copies must match their respective originals.
         let h = 3;
+        let s = binary_shifts(h);
+        let full = total_siblings_for_levels(h, &s);
         let paths = [
             realistic_binary_path::<2>(2, h),
             realistic_binary_path::<2>(5, h),
             realistic_binary_path::<2>(2, h),
         ];
-        let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let pruned = prune_paths(h, &s, &paths);
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored.as_slice(), &paths);
     }
 
@@ -769,9 +748,10 @@ mod tests {
     fn test_roundtrip_4ary() {
         // All 16 leaves of a 2-level 4-ary tree.
         let s = quad_shifts(2);
+        let full = total_siblings_for_levels(2, &s);
         let paths: Vec<_> = (0..16).map(|i| realistic_quad_path::<2>(i, 2)).collect();
         let pruned = prune_paths(2, &s, &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored, paths);
     }
 
@@ -779,13 +759,15 @@ mod tests {
     fn test_roundtrip_height5() {
         // Sparse query set across a height-5 binary tree.
         let h = 5;
+        let s = binary_shifts(h);
+        let full = total_siblings_for_levels(h, &s);
         let indices = [0, 3, 7, 12, 15, 16, 20, 31];
         let paths: Vec<_> = indices
             .iter()
             .map(|&i| realistic_binary_path::<4>(i, h))
             .collect();
-        let pruned = prune_paths(h, &binary_shifts(h), &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let pruned = prune_paths(h, &s, &paths);
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored, paths);
     }
 
@@ -794,59 +776,67 @@ mod tests {
         // Mixed schedule [1, 2, 1] (binary, 4-ary, binary) → 16 leaves.
         // Exercises both the LCA loop and the per-level sibling counts.
         let shifts = vec![1u32, 2, 1];
+        let full = total_siblings_for_levels(shifts.len(), &shifts);
         let indices = [0, 1, 4, 7, 8, 11, 15];
         let paths: Vec<_> = indices
             .iter()
             .map(|&i| realistic_nary_path::<2>(i, &shifts))
             .collect();
         let pruned = prune_paths(shifts.len(), &shifts, &paths);
-        let restored = restore_paths(&pruned).unwrap();
+        let restored = restore_paths(&pruned, full).unwrap();
         assert_eq!(restored, paths);
     }
 
     // Error / bounds tests
 
     #[test]
-    fn test_restore_rejects_large_num_levels() {
-        // 64 levels would require 2^64 leaves — reject to prevent DoS.
-        let pruned = PrunedMerklePaths::<u32, 2> {
-            num_levels: 64,
-            shift_schedule: vec![1; 64],
-            original_order: vec![0],
-            paths: vec![PrunedPath {
-                leaf_index: 0,
-                siblings: vec![],
-            }],
-        };
-        assert!(restore_paths(&pruned).is_none());
-    }
-
-    #[test]
     fn test_restore_empty() {
-        // Zero paths with zero queries → valid empty result.
+        // Zero paths with zero queries → valid empty result, regardless of the
+        // sibling count the verifier expected.
         let pruned = PrunedMerklePaths::<u32, 2> {
-            num_levels: 3,
-            shift_schedule: vec![1, 1, 1],
             original_order: vec![],
             paths: vec![],
         };
-        assert!(restore_paths(&pruned).unwrap().is_empty());
+        assert!(restore_paths(&pruned, 3).unwrap().is_empty());
     }
 
     #[test]
     fn test_restore_rejects_inconsistent_siblings() {
-        // First path stores only 1 level of siblings but the tree has 3 levels.
+        // First path stores only 1 level of siblings but the verifier expects 3.
         // With no predecessor to copy from, restoration must fail.
         let pruned = PrunedMerklePaths::<u32, 2> {
-            num_levels: 3,
-            shift_schedule: vec![1, 1, 1],
             original_order: vec![0],
             paths: vec![PrunedPath {
                 leaf_index: 0,
                 siblings: vec![[0; 2]],
             }],
         };
-        assert!(restore_paths(&pruned).is_none());
+        assert!(restore_paths(&pruned, 3).is_none());
+    }
+
+    #[test]
+    fn test_restore_rejects_oversized_first_path() {
+        // Invariant: the first path's stored siblings must equal the
+        // verifier-derived full count. Anything bigger is malformed.
+        //
+        // Fixture state: verifier expects 3 siblings per full path.
+        //
+        // Mutation: first path stores 10 siblings (forged).
+        //
+        //     stored:    [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9]   (len 10)
+        //     expected:  [s0, s1, s2]                               (len 3)
+        //     → 10 != 3 → reject
+        //
+        // Why this matters: trusting the prover-supplied length would let
+        // a malicious proof inflate per-path allocations arbitrarily.
+        let pruned = PrunedMerklePaths::<u32, 2> {
+            original_order: vec![0],
+            paths: vec![PrunedPath {
+                leaf_index: 0,
+                siblings: vec![[0; 2]; 10],
+            }],
+        };
+        assert!(restore_paths(&pruned, 3).is_none());
     }
 
     // Size analysis
@@ -948,9 +938,10 @@ mod tests {
         fn proptest_binary_roundtrip((h, indices) in binary_tree_queries()) {
             // Prune → restore must recover the exact original paths.
             let s = binary_shifts(h);
+            let full = total_siblings_for_levels(h, &s);
             let paths: Vec<_> = indices.iter().map(|&i| realistic_binary_path::<2>(i, h)).collect();
             let pruned = prune_paths(h, &s, &paths);
-            let restored = restore_paths(&pruned).unwrap();
+            let restored = restore_paths(&pruned, full).unwrap();
             prop_assert_eq!(&restored, &paths);
         }
 
@@ -958,9 +949,10 @@ mod tests {
         fn proptest_quad_roundtrip((h, indices) in quad_tree_queries()) {
             // Same roundtrip invariant for 4-ary trees.
             let s = quad_shifts(h);
+            let full = total_siblings_for_levels(h, &s);
             let paths: Vec<_> = indices.iter().map(|&i| realistic_quad_path::<2>(i, h)).collect();
             let pruned = prune_paths(h, &s, &paths);
-            let restored = restore_paths(&pruned).unwrap();
+            let restored = restore_paths(&pruned, full).unwrap();
             prop_assert_eq!(&restored, &paths);
         }
 
@@ -992,9 +984,10 @@ mod tests {
             let original_len = indices.len();
             indices.extend_from_slice(&indices.clone());
             let s = binary_shifts(h);
+            let full = total_siblings_for_levels(h, &s);
             let paths: Vec<_> = indices.iter().map(|&i| realistic_binary_path::<2>(i, h)).collect();
             let pruned = prune_paths(h, &s, &paths);
-            let restored = restore_paths(&pruned).unwrap();
+            let restored = restore_paths(&pruned, full).unwrap();
             prop_assert_eq!(restored.len(), original_len * 2);
             for i in 0..original_len {
                 prop_assert_eq!(&restored[i], &restored[i + original_len]);
@@ -1006,9 +999,10 @@ mod tests {
             // Roundtrip with random per-level arities (2, 4, 8, or 16).
             // Covers mixed schedules like [1, 3, 2] (binary, 8-ary, 4-ary).
             let h = shifts.len();
+            let full = total_siblings_for_levels(h, &shifts);
             let paths: Vec<_> = indices.iter().map(|&i| realistic_nary_path::<2>(i, &shifts)).collect();
             let pruned = prune_paths(h, &shifts, &paths);
-            let restored = restore_paths(&pruned).unwrap();
+            let restored = restore_paths(&pruned, full).unwrap();
             prop_assert_eq!(&restored, &paths);
         }
 


### PR DESCRIPTION
Useful in context like leanVM, see https://github.com/leanEthereum/leanMultisig/blob/a03c1da911f9a3acfa1f5e8f71d6cdcc600104cc/crates/backend/fiat-shamir/src/merkle_pruning.rs

## Summary

- Adds a `pruning` module to `p3-merkle-tree` that deduplicates redundant sibling digests when opening multiple leaves in the same Merkle tree
- Sorts paths by leaf index, computes the Lowest Common Ancestor (LCA) between consecutive pairs, and strips shared upper siblings
- Adds `open_batch_pruned()` and `verify_batch_pruned()` methods on `MerkleTreeMmcs` for end-to-end usage
- Typical proof size reduction: **30-40%** for FRI parameters (80 queries, height 20)

## Performance design

- **Flat contiguous memory**: single `Vec` per path, no nested `Vec<Vec>` — cache-friendly `memcpy` during restoration
- **O(1) binary LCA**: XOR + leading_zeros, with the binary-tree check hoisted outside the hot loop
- **O(h) N-ary LCA**: bitwise shifts instead of integer division
- **Index-only sorting**: sort lightweight `u32` array, not full path structs
- **Zero-copy verification**: siblings borrowed directly, opening consumed by value (no deep clone)
- **Pre-allocated buffers**: exact sibling capacity computed upfront, zero resizing

## Test plan

- [x] 36 unit tests in `pruning.rs`: LCA, level offsets, total siblings, pruning, roundtrip (binary + 4-ary + mixed), error bounds, size analysis
- [x] 6 integration tests in `mmcs.rs`: binary roundtrip, 4-ary roundtrip, tampered proof rejection, size comparison, duplicate handling, mixed matrix heights
- [x] 5 proptest strategies: binary roundtrip, quad roundtrip, pruned size <= original, fast-path matches generic, dedup preserves identity
- [x] All 81 tests pass, zero clippy warnings, zero fmt diff
- [x] All 39 pre-existing merkle-tree tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)