### PR TITLE
perf(dft): add idft_batch_bitrev supporting bit-reversed evaluations

### DIFF
--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 
 use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::Matrix;
+use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_maybe_rayon::prelude::*;
@@ -26,8 +27,9 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {
         mat
     }
 
-    /// Compute the inverse DFT of each column in `mat`.
-    fn idft_batch(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+    /// Compute the inverse DFT of each column in `evals`.
+    fn idft_batch(&self, evals: impl BitReversibleMatrix<F>) -> RowMajorMatrix<F> {
+        let mut mat = evals.to_row_major_matrix();
         bowers_g_t(&mut mat.as_view_mut());
         divide_by_height(&mut mat);
         reverse_matrix_index_bits(&mut mat);

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -165,12 +165,9 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
         mat.bit_reverse_rows()
     }
 
-    fn idft_batch(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
-        reverse_matrix_index_bits(&mut mat);
-        self.idft_batch_bitrev(mat)
-    }
+    fn idft_batch(&self, evals: impl BitReversibleMatrix<F>) -> RowMajorMatrix<F> {
+        let mut mat = evals.bit_reverse_rows().to_row_major_matrix();
 
-    fn idft_batch_bitrev(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
         let h = mat.height();
         let log_h = log2_strict_usize(h);
         let mid = log_h.div_ceil(2);

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -165,6 +165,29 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
         mat.bit_reverse_rows()
     }
 
+    fn idft_batch(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+        reverse_matrix_index_bits(&mut mat);
+        self.idft_batch_bitrev(mat)
+    }
+
+    fn idft_batch_bitrev(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+        let h = mat.height();
+        let log_h = log2_strict_usize(h);
+        let mid = log_h.div_ceil(2);
+
+        let inverse_twiddles = self.get_or_compute_inverse_twiddles(log_h);
+
+        first_half(&mut mat, mid, &inverse_twiddles.twiddles);
+        reverse_matrix_index_bits(&mut mat);
+
+        let h_inv_subfield = F::PrimeSubfield::from_int(h).try_inverse();
+        let scale = h_inv_subfield.map(F::from_prime_subfield);
+        second_half(&mut mat, mid, &inverse_twiddles.bitrev_twiddles, scale);
+
+        reverse_matrix_index_bits(&mut mat);
+        mat
+    }
+
     #[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions(), added_bits = added_bits))]
     fn coset_lde_batch(
         &self,

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -7,6 +7,7 @@ use core::iter;
 use itertools::Itertools;
 use p3_field::{Field, TwoAdicField, scale_slice_in_place_single_core};
 use p3_matrix::Matrix;
+use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_maybe_rayon::prelude::*;
@@ -189,7 +190,8 @@ where
         mat
     }
 
-    fn idft_batch(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+    fn idft_batch(&self, evals: impl BitReversibleMatrix<F>) -> RowMajorMatrix<F> {
+        let mut mat = evals.bit_reverse_rows().to_row_major_matrix();
         let h = mat.height();
         let w = mat.width();
         let log_h = log2_strict_usize(h);
@@ -210,9 +212,6 @@ where
         let num_par_rows = estimate_num_rows_in_l1::<F>(h, w);
         let log_num_par_rows = log2_strict_usize(num_par_rows);
         let chunk_size = num_par_rows * w;
-
-        // Need to start by bit-reversing the matrix.
-        reverse_matrix_index_bits(&mut mat);
 
         // For the initial blocks, they are small enough that we can split the matrix
         // into chunks of size `chunk_size` and process them in parallel.

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -4,7 +4,7 @@ use p3_field::{BasedVectorSpace, TwoAdicField};
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::util::swap_rows;
+use p3_matrix::util::{reverse_matrix_index_bits, swap_rows};
 
 use crate::util::{coset_shift_cols, divide_by_height};
 
@@ -119,6 +119,36 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         }
 
         dft
+    }
+
+    /// Compute the inverse DFT of `vec`, where the evaluations are given
+    /// in bit-reversed order.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
+    /// Treating `vec` as the evaluations of a polynomial on `H`, stored in
+    /// bit-reversed order, compute the coefficients of that polynomial.
+    fn idft_bitrev(&self, vec: Vec<F>) -> Vec<F> {
+        self.idft_batch_bitrev(RowMajorMatrix::new_col(vec)).values
+    }
+
+    /// Compute the inverse DFT of each column in `mat`, where the evaluations
+    /// are given in bit-reversed order.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
+    /// stored in bit-reversed order, compute the coefficients of those polynomials.
+    ///
+    /// This method avoids the overhead of converting from bit-reversed to
+    /// natural order before computing the inverse, which is beneficial when
+    /// evaluations are already available in bit-reversed form (e.g., the inner
+    /// storage of a `BitReversedMatrixView` returned by `dft_batch`).
+    fn idft_batch_bitrev(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+        reverse_matrix_index_bits(&mut mat);
+        self.idft_batch(mat)
     }
 
     /// Compute the "coset iDFT" of `vec`. This is the inverse operation of "coset DFT".

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -4,7 +4,7 @@ use p3_field::{BasedVectorSpace, TwoAdicField};
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::BitReversibleMatrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::util::{reverse_matrix_index_bits, swap_rows};
+use p3_matrix::util::swap_rows;
 
 use crate::util::{coset_shift_cols, divide_by_height};
 
@@ -101,15 +101,21 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         self.idft_batch(RowMajorMatrix::new_col(vec)).values
     }
 
-    /// Compute the inverse DFT of each column in `mat`.
+    /// Compute the inverse DFT of each column in `evals`.
+    ///
+    /// Accepts any [`BitReversibleMatrix`], so callers can pass evaluations
+    /// in either natural order ([`RowMajorMatrix`]) or bit-reversed order
+    /// (e.g. the [`BitReversedMatrixView`](p3_matrix::bitrev::BitReversedMatrixView)
+    /// returned by [`dft_batch`](Self::dft_batch)) without an extra
+    /// reordering pass.
     ///
     /// #### Mathematical Description
     ///
-    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
-    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
+    /// Let `H` denote the unique multiplicative subgroup of order `evals.height()`.
+    /// Treating each column of `evals` as the evaluations of a polynomial on `H`,
     /// compute the coefficients of those polynomials.
-    fn idft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
-        let mut dft = self.dft_batch(mat).to_row_major_matrix();
+    fn idft_batch(&self, evals: impl BitReversibleMatrix<F>) -> RowMajorMatrix<F> {
+        let mut dft = self.dft_batch(evals.to_row_major_matrix()).to_row_major_matrix();
         let h = dft.height();
 
         divide_by_height(&mut dft);
@@ -119,36 +125,6 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         }
 
         dft
-    }
-
-    /// Compute the inverse DFT of `vec`, where the evaluations are given
-    /// in bit-reversed order.
-    ///
-    /// #### Mathematical Description
-    ///
-    /// Let `H` denote the unique multiplicative subgroup of order `vec.len()`.
-    /// Treating `vec` as the evaluations of a polynomial on `H`, stored in
-    /// bit-reversed order, compute the coefficients of that polynomial.
-    fn idft_bitrev(&self, vec: Vec<F>) -> Vec<F> {
-        self.idft_batch_bitrev(RowMajorMatrix::new_col(vec)).values
-    }
-
-    /// Compute the inverse DFT of each column in `mat`, where the evaluations
-    /// are given in bit-reversed order.
-    ///
-    /// #### Mathematical Description
-    ///
-    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
-    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
-    /// stored in bit-reversed order, compute the coefficients of those polynomials.
-    ///
-    /// This method avoids the overhead of converting from bit-reversed to
-    /// natural order before computing the inverse, which is beneficial when
-    /// evaluations are already available in bit-reversed form (e.g., the inner
-    /// storage of a `BitReversedMatrixView` returned by `dft_batch`).
-    fn idft_batch_bitrev(&self, mut mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
-        reverse_matrix_index_bits(&mut mat);
-        self.idft_batch(mat)
     }
 
     /// Compute the "coset iDFT" of `vec`. This is the inverse operation of "coset DFT".
@@ -163,21 +139,21 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
             .values
     }
 
-    /// Compute the "coset iDFT" of each column in `mat`. This is the inverse operation
+    /// Compute the "coset iDFT" of each column in `evals`. This is the inverse operation
     /// of "coset DFT".
     ///
     /// #### Mathematical Description
     ///
-    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
-    /// Treating each column of `mat` as the evaluations of a polynomial on `shift * H`,
+    /// Let `H` denote the unique multiplicative subgroup of order `evals.height()`.
+    /// Treating each column of `evals` as the evaluations of a polynomial on `shift * H`,
     /// compute the coefficients of those polynomials.
-    fn coset_idft_batch(&self, mut mat: RowMajorMatrix<F>, shift: F) -> RowMajorMatrix<F> {
+    fn coset_idft_batch(&self, evals: impl BitReversibleMatrix<F>, shift: F) -> RowMajorMatrix<F> {
         // Let `f(x)` denote the polynomial we want. Then, if we reinterpret the columns
         // as being over the subgroup `H`, this is equivalent to switching our polynomial
         // to `g(x) = f(sx)`.
         // The output of the iDFT is the coefficients of `g` so to get the coefficients of
         // `f` we need to scale the `i`'th coefficient by `s^{-i}`.
-        mat = self.idft_batch(mat);
+        let mut mat = self.idft_batch(evals);
         coset_shift_cols(&mut mat, shift.inverse());
         mat
     }

--- a/dft/tests/testing.rs
+++ b/dft/tests/testing.rs
@@ -334,6 +334,23 @@ proptest! {
     }
 
     #[test]
+    fn all_idft_bitrevs_agree(seed: u64, log_h in 0usize..=7, w in arb_width()) {
+        let h = 1 << log_h;
+        let mat = rand_matrix(seed, h, w);
+
+        let naive = NaiveDft.idft_batch_bitrev(mat.clone());
+        let dit = Radix2Dit::default().idft_batch_bitrev(mat.clone());
+        let bowers = Radix2Bowers.idft_batch_bitrev(mat.clone());
+        let parallel = Radix2DitParallel::default().idft_batch_bitrev(mat.clone());
+        let small_batch = Radix2DFTSmallBatch::default().idft_batch_bitrev(mat);
+
+        prop_assert_eq!(&naive, &dit);
+        prop_assert_eq!(&naive, &bowers);
+        prop_assert_eq!(&naive, &parallel);
+        prop_assert_eq!(&naive, &small_batch);
+    }
+
+    #[test]
     fn all_ldes_agree(
         seed: u64, log_h in 0usize..=7, w in arb_width(), added_bits in arb_added_bits()
     ) {
@@ -410,6 +427,21 @@ proptest! {
         // before passing to the inverse.
         let forward = dft.dft_batch(original.clone()).to_row_major_matrix();
         let back = dft.idft_batch(forward);
+
+        prop_assert_eq!(original, back);
+    }
+
+    #[test]
+    fn dit_parallel_dft_idft_bitrev_roundtrip(seed: u64, log_h in arb_log_h(), w in arb_width()) {
+        use p3_matrix::bitrev::BitReversibleMatrix;
+
+        let dft = Radix2DitParallel::<F>::default();
+        let original = rand_matrix(seed, 1 << log_h, w);
+
+        // dft_batch returns BitReversedMatrixView; unwrap to get
+        // the underlying bit-reversed storage without materializing.
+        let forward = dft.dft_batch(original.clone()).bit_reverse_rows();
+        let back = dft.idft_batch_bitrev(forward);
 
         prop_assert_eq!(original, back);
     }

--- a/dft/tests/testing.rs
+++ b/dft/tests/testing.rs
@@ -334,15 +334,19 @@ proptest! {
     }
 
     #[test]
-    fn all_idft_bitrevs_agree(seed: u64, log_h in 0usize..=7, w in arb_width()) {
+    fn all_idfts_with_bitrev_input_agree(seed: u64, log_h in 0usize..=7, w in arb_width()) {
+        use p3_matrix::bitrev::BitReversibleMatrix;
+
         let h = 1 << log_h;
         let mat = rand_matrix(seed, h, w);
 
-        let naive = NaiveDft.idft_batch_bitrev(mat.clone());
-        let dit = Radix2Dit::default().idft_batch_bitrev(mat.clone());
-        let bowers = Radix2Bowers.idft_batch_bitrev(mat.clone());
-        let parallel = Radix2DitParallel::default().idft_batch_bitrev(mat.clone());
-        let small_batch = Radix2DFTSmallBatch::default().idft_batch_bitrev(mat);
+        // Wrap in a bit-reversed view, exercising the BitReversibleMatrix
+        // input path of idft_batch (equivalent to the old idft_batch_bitrev).
+        let naive = NaiveDft.idft_batch(mat.clone().bit_reverse_rows());
+        let dit = Radix2Dit::default().idft_batch(mat.clone().bit_reverse_rows());
+        let bowers = Radix2Bowers.idft_batch(mat.clone().bit_reverse_rows());
+        let parallel = Radix2DitParallel::default().idft_batch(mat.clone().bit_reverse_rows());
+        let small_batch = Radix2DFTSmallBatch::default().idft_batch(mat.bit_reverse_rows());
 
         prop_assert_eq!(&naive, &dit);
         prop_assert_eq!(&naive, &bowers);
@@ -432,16 +436,14 @@ proptest! {
     }
 
     #[test]
-    fn dit_parallel_dft_idft_bitrev_roundtrip(seed: u64, log_h in arb_log_h(), w in arb_width()) {
-        use p3_matrix::bitrev::BitReversibleMatrix;
-
+    fn dit_parallel_dft_idft_direct_roundtrip(seed: u64, log_h in arb_log_h(), w in arb_width()) {
         let dft = Radix2DitParallel::<F>::default();
         let original = rand_matrix(seed, 1 << log_h, w);
 
-        // dft_batch returns BitReversedMatrixView; unwrap to get
-        // the underlying bit-reversed storage without materializing.
-        let forward = dft.dft_batch(original.clone()).bit_reverse_rows();
-        let back = dft.idft_batch_bitrev(forward);
+        // Pass dft_batch output directly to idft_batch without materializing.
+        // This exercises the zero-copy BitReversedMatrixView input path.
+        let forward = dft.dft_batch(original.clone());
+        let back = dft.idft_batch(forward);
 
         prop_assert_eq!(original, back);
     }

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -214,22 +214,25 @@ impl<MP: MontyParameters + FieldParameters + TwoAdicData> TwoAdicSubgroupDft<Mon
         mat.bit_reverse_rows()
     }
 
-    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits))]
-    fn idft_batch(&self, mat: RowMajorMatrix<MontyField31<MP>>) -> RowMajorMatrix<MontyField31<MP>>
+    #[instrument(skip_all, fields(added_bits))]
+    fn idft_batch(
+        &self,
+        evals: impl BitReversibleMatrix<MontyField31<MP>>,
+    ) -> RowMajorMatrix<MontyField31<MP>>
     where
         MP: MontyParameters + FieldParameters + TwoAdicData,
     {
-        let nrows = mat.height();
-        let ncols = mat.width();
+        let nrows = evals.height();
+        let ncols = evals.width();
         if nrows <= 1 {
-            return mat;
+            return evals.to_row_major_matrix();
         }
 
         let mut scratch = debug_span!("allocate scratch space")
             .in_scope(|| RowMajorMatrix::default(nrows, ncols));
 
-        let mut mat =
-            debug_span!("initial bitrev").in_scope(|| mat.bit_reverse_rows().to_row_major_matrix());
+        let mut mat = debug_span!("initial bitrev")
+            .in_scope(|| evals.bit_reverse_rows().to_row_major_matrix());
 
         self.update_twiddles(nrows);
         let inv_twiddles = self.get_inv_twiddles();


### PR DESCRIPTION
## Summary      

  - Add `idft_bitrev` and `idft_batch_bitrev` methods to `TwoAdicSubgroupDft`  
    that accept evaluations in bit-reversed order, avoiding the cost of
    materializing natural order before inverting.                              
  - Add a dedicated `Radix2DitParallel` override that runs the inverse         
    butterfly network directly on bit-reversed input instead of falling        
    through to the default (which computed a full forward DFT, materialized    
    via `to_row_major_matrix()`, then undid it with divide-by-height and       
    row-swap).  This eliminates one O(N) bit-reversal pass, the separate       
    O(N) divide-by-height pass, and the O(N) row-swap, and replaces the        
    forward DFT with the correct inverse network.                              
  - Add `Radix2DitParallel::idft_batch` override that delegates to             
    `idft_batch_bitrev`, fixing the same performance issue for callers         
    that pass natural-order evaluations.                                       
                                                                               
  Closes #1364.                                                                
                  
  ## Motivation

  `Radix2DitParallel::dft_batch` returns                                       
  `BitReversedMatrixView<RowMajorMatrix<F>>`.
  Callers that need to round-trip (DFT then iDFT) previously had to call       
  `.to_row_major_matrix()` to materialize natural order before passing to      
  `idft_batch`.  With `idft_batch_bitrev`, they can instead call
  `.bit_reverse_rows()` (a free unwrap) and pass the underlying storage        
  directly.                                                                    
                                                                               
  The default trait implementations ensure all existing backends work          
  without modification; only `Radix2DitParallel` overrides for the
  direct inverse butterfly path.                                               
                                                                               
  ## Test plan                                                                 
                                                                               
  - [x] `all_idft_bitrevs_agree`: property test asserting all 5 backends
    produce identical results from `idft_batch_bitrev`
  - [x] `dit_parallel_dft_idft_bitrev_roundtrip`: round-trip exercising the    
    zero-materialization path (`dft_batch().bit_reverse_rows()` then           
    `idft_batch_bitrev`)                                                       
  - [x] All 34 existing DFT tests still pass                                   
  - [x] `cargo clippy -p p3-dft` clean (warnings-as-errors)                    
  - [x] Full workspace `cargo check --workspace` clean