### PR TITLE
Guard Poseidon1 zero partial-round parameters

### DIFF
--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -34,16 +34,16 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
-use p3_field::{PrimeCharacteristicRing, PrimeField, dot_product};
+use p3_field::{dot_product, PrimeCharacteristicRing, PrimeField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon1::external::mds_multiply;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
-use crate::columns::{Poseidon1Cols, num_cols};
+use crate::columns::{num_cols, Poseidon1Cols};
 use crate::{
-    FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox, generate_trace_rows,
+    generate_trace_rows, FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox,
 };
 
 /// The Poseidon1 AIR.
@@ -90,13 +90,14 @@ pub struct Poseidon1Air<
 }
 
 impl<
-    F: PrimeCharacteristicRing,
-    const WIDTH: usize,
-    const SBOX_DEGREE: u64,
-    const SBOX_REGISTERS: usize,
-    const HALF_FULL_ROUNDS: usize,
-    const PARTIAL_ROUNDS: usize,
-> Clone for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+        F: PrimeCharacteristicRing,
+        const WIDTH: usize,
+        const SBOX_DEGREE: u64,
+        const SBOX_REGISTERS: usize,
+        const HALF_FULL_ROUNDS: usize,
+        const PARTIAL_ROUNDS: usize,
+    > Clone
+    for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     fn clone(&self) -> Self {
         Self {
@@ -107,13 +108,13 @@ impl<
 }
 
 impl<
-    F: PrimeCharacteristicRing,
-    const WIDTH: usize,
-    const SBOX_DEGREE: u64,
-    const SBOX_REGISTERS: usize,
-    const HALF_FULL_ROUNDS: usize,
-    const PARTIAL_ROUNDS: usize,
-> Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+        F: PrimeCharacteristicRing,
+        const WIDTH: usize,
+        const SBOX_DEGREE: u64,
+        const SBOX_REGISTERS: usize,
+        const HALF_FULL_ROUNDS: usize,
+        const PARTIAL_ROUNDS: usize,
+    > Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     /// Construct a `Poseidon1Air` from pre-computed round constants.
     ///
@@ -157,13 +158,13 @@ impl<
 }
 
 impl<
-    F: PrimeCharacteristicRing + Sync,
-    const WIDTH: usize,
-    const SBOX_DEGREE: u64,
-    const SBOX_REGISTERS: usize,
-    const HALF_FULL_ROUNDS: usize,
-    const PARTIAL_ROUNDS: usize,
-> BaseAir<F>
+        F: PrimeCharacteristicRing + Sync,
+        const WIDTH: usize,
+        const SBOX_DEGREE: u64,
+        const SBOX_REGISTERS: usize,
+        const HALF_FULL_ROUNDS: usize,
+        const PARTIAL_ROUNDS: usize,
+    > BaseAir<F>
     for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     /// Returns the number of trace columns (the AIR width).
@@ -209,6 +210,13 @@ pub(crate) fn eval<
         PARTIAL_ROUNDS,
     >,
 ) {
+    const {
+        assert!(
+            PARTIAL_ROUNDS > 0,
+            "Poseidon1Air requires PARTIAL_ROUNDS > 0"
+        );
+    }
+
     // Initialize the running state from the committed input columns.
     let mut state: [_; WIDTH] = local.inputs.map(|x| x.into());
 
@@ -272,13 +280,13 @@ pub(crate) fn eval<
 }
 
 impl<
-    AB: AirBuilder,
-    const WIDTH: usize,
-    const SBOX_DEGREE: u64,
-    const SBOX_REGISTERS: usize,
-    const HALF_FULL_ROUNDS: usize,
-    const PARTIAL_ROUNDS: usize,
-> Air<AB>
+        AB: AirBuilder,
+        const WIDTH: usize,
+        const SBOX_DEGREE: u64,
+        const SBOX_REGISTERS: usize,
+        const HALF_FULL_ROUNDS: usize,
+        const PARTIAL_ROUNDS: usize,
+    > Air<AB>
     for Poseidon1Air<AB::F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     #[inline]

--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -34,16 +34,16 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
-use p3_field::{dot_product, PrimeCharacteristicRing, PrimeField};
+use p3_field::{PrimeCharacteristicRing, PrimeField, dot_product};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon1::external::mds_multiply;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
-use crate::columns::{num_cols, Poseidon1Cols};
+use crate::columns::{Poseidon1Cols, num_cols};
 use crate::{
-    generate_trace_rows, FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox,
+    FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox, generate_trace_rows,
 };
 
 /// The Poseidon1 AIR.
@@ -90,14 +90,13 @@ pub struct Poseidon1Air<
 }
 
 impl<
-        F: PrimeCharacteristicRing,
-        const WIDTH: usize,
-        const SBOX_DEGREE: u64,
-        const SBOX_REGISTERS: usize,
-        const HALF_FULL_ROUNDS: usize,
-        const PARTIAL_ROUNDS: usize,
-    > Clone
-    for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+    F: PrimeCharacteristicRing,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> Clone for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     fn clone(&self) -> Self {
         Self {
@@ -108,13 +107,13 @@ impl<
 }
 
 impl<
-        F: PrimeCharacteristicRing,
-        const WIDTH: usize,
-        const SBOX_DEGREE: u64,
-        const SBOX_REGISTERS: usize,
-        const HALF_FULL_ROUNDS: usize,
-        const PARTIAL_ROUNDS: usize,
-    > Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
+    F: PrimeCharacteristicRing,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     /// Construct a `Poseidon1Air` from pre-computed round constants.
     ///
@@ -158,13 +157,13 @@ impl<
 }
 
 impl<
-        F: PrimeCharacteristicRing + Sync,
-        const WIDTH: usize,
-        const SBOX_DEGREE: u64,
-        const SBOX_REGISTERS: usize,
-        const HALF_FULL_ROUNDS: usize,
-        const PARTIAL_ROUNDS: usize,
-    > BaseAir<F>
+    F: PrimeCharacteristicRing + Sync,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> BaseAir<F>
     for Poseidon1Air<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     /// Returns the number of trace columns (the AIR width).
@@ -280,13 +279,13 @@ pub(crate) fn eval<
 }
 
 impl<
-        AB: AirBuilder,
-        const WIDTH: usize,
-        const SBOX_DEGREE: u64,
-        const SBOX_REGISTERS: usize,
-        const HALF_FULL_ROUNDS: usize,
-        const PARTIAL_ROUNDS: usize,
-    > Air<AB>
+    AB: AirBuilder,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+> Air<AB>
     for Poseidon1Air<AB::F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>
 {
     #[inline]

--- a/poseidon1/src/internal.rs
+++ b/poseidon1/src/internal.rs
@@ -264,7 +264,7 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
 
-    use super::{partial_permute_state, PartialRoundConstants};
+    use super::{PartialRoundConstants, partial_permute_state};
 
     type F = BabyBear;
 

--- a/poseidon1/src/internal.rs
+++ b/poseidon1/src/internal.rs
@@ -189,11 +189,28 @@ pub fn partial_permute_state<
     // Apply the dense transition matrix m_i (once).
     mds_multiply(state, &constants.m_i);
 
-    let rounds_p = constants.sparse_first_row.len();
+    let (last_sparse_first_row, sparse_first_rows) = constants
+        .sparse_first_row
+        .split_last()
+        .expect("Poseidon1 partial rounds require rounds_p > 0");
+    let (last_v, vs) = constants
+        .v
+        .split_last()
+        .expect("Poseidon1 partial rounds require rounds_p > 0");
+    assert_eq!(
+        sparse_first_rows.len(),
+        vs.len(),
+        "Poseidon1 partial round constants are inconsistent"
+    );
+    assert_eq!(
+        constants.round_constants.len(),
+        sparse_first_rows.len(),
+        "Poseidon1 scalar partial round constants must have length rounds_p - 1"
+    );
 
     // Partial rounds 0..RP-2: S-box + scalar RC + sparse matmul.
     // The last round is handled separately to avoid a branch per iteration.
-    for r in 0..rounds_p - 1 {
+    for r in 0..sparse_first_rows.len() {
         // S-box on state[0] only.
         state[0] = state[0].injective_exp_n();
 
@@ -201,16 +218,12 @@ pub fn partial_permute_state<
         state[0] += constants.round_constants[r];
 
         // Sparse matrix multiply.
-        cheap_matmul(state, &constants.sparse_first_row[r], &constants.v[r]);
+        cheap_matmul(state, &sparse_first_rows[r], &vs[r]);
     }
 
     // Last partial round: S-box + sparse matmul (no round constant).
     state[0] = state[0].injective_exp_n();
-    cheap_matmul(
-        state,
-        &constants.sparse_first_row[rounds_p - 1],
-        &constants.v[rounds_p - 1],
-    );
+    cheap_matmul(state, last_sparse_first_row, last_v);
 }
 
 /// Textbook partial round permutation with forward-substituted scalar constants.
@@ -241,5 +254,51 @@ pub fn textbook_partial_permute_state<
     }
     for (s, &r) in state.iter_mut().zip(constants.textbook_residual.iter()) {
         *s += r;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+
+    use super::{partial_permute_state, PartialRoundConstants};
+
+    type F = BabyBear;
+
+    #[test]
+    #[should_panic(expected = "Poseidon1 partial rounds require rounds_p > 0")]
+    fn test_partial_permute_state_rejects_zero_partial_rounds() {
+        let constants = PartialRoundConstants {
+            first_round_constants: [F::ZERO; 4],
+            m_i: [[F::ZERO; 4]; 4],
+            sparse_first_row: vec![],
+            v: vec![],
+            round_constants: vec![],
+            textbook_scalar_constants: vec![],
+            textbook_residual: [F::ZERO; 4],
+        };
+        let mut state = [F::ZERO; 4];
+        partial_permute_state::<F, F, 4, 7>(&mut state, &constants);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Poseidon1 scalar partial round constants must have length rounds_p - 1"
+    )]
+    fn test_partial_permute_state_rejects_mismatched_scalar_constants() {
+        let constants = PartialRoundConstants {
+            first_round_constants: [F::ZERO; 4],
+            m_i: [[F::ZERO; 4]; 4],
+            sparse_first_row: vec![[F::ONE; 4], [F::ONE; 4]],
+            v: vec![[F::ZERO; 4], [F::ZERO; 4]],
+            round_constants: vec![],
+            textbook_scalar_constants: vec![],
+            textbook_residual: [F::ZERO; 4],
+        };
+        let mut state = [F::ZERO; 4];
+        partial_permute_state::<F, F, 4, 7>(&mut state, &constants);
     }
 }

--- a/poseidon1/src/utils.rs
+++ b/poseidon1/src/utils.rs
@@ -69,7 +69,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{Field, dot_product};
+use p3_field::{dot_product, Field};
 
 /// Expand a circulant matrix from its first column into a dense NxN matrix.
 ///
@@ -326,14 +326,16 @@ fn equivalent_round_constants<F: Field, const N: usize>(
     partial_rc: &[[F; N]],
     mds_inv: &[[F; N]; N],
 ) -> ([F; N], Vec<F>) {
-    let rounds_p = partial_rc.len();
-    let mut opt_partial_rc = F::zero_vec(rounds_p);
+    let (last_rc, prefix_rc) = partial_rc
+        .split_last()
+        .expect("Poseidon1 optimized constants require rounds_p > 0");
+    let mut opt_partial_rc = F::zero_vec(partial_rc.len());
 
     // Start with the last partial round's full constant vector.
-    let mut tmp = partial_rc[rounds_p - 1];
+    let mut tmp = *last_rc;
 
     // Process rounds in reverse: from second-to-last down to first.
-    for i in (0..rounds_p - 1).rev() {
+    for (i, rc) in prefix_rc.iter().enumerate().rev() {
         // Push the accumulated constants backward through M^{-1}.
         let inv_cip = matrix_vec_mul(mds_inv, &tmp);
 
@@ -341,7 +343,7 @@ fn equivalent_round_constants<F: Field, const N: usize>(
         opt_partial_rc[i + 1] = inv_cip[0];
 
         // Load round i's constants and add the remaining backward-substituted values.
-        tmp = partial_rc[i];
+        tmp = *rc;
         for j in 1..N {
             tmp[j] += inv_cip[j];
         }
@@ -421,6 +423,16 @@ pub fn compute_optimized_constants<F: Field, const N: usize>(
     rounds_p: usize,
     partial_rc: &[[F; N]],
 ) -> ([F; N], Vec<F>, [[F; N]; N], Vec<[F; N]>, Vec<[F; N]>) {
+    assert!(
+        rounds_p > 0,
+        "Poseidon1 optimized constants require rounds_p > 0"
+    );
+    assert_eq!(
+        partial_rc.len(),
+        rounds_p,
+        "Poseidon1 partial round constants length must match rounds_p"
+    );
+
     let mds_inv = matrix_inverse(mds);
     let (first_round_constants, opt_partial_rc) = equivalent_round_constants(partial_rc, &mds_inv);
     let (m_i, sparse_v, sparse_w_hat) = compute_equivalent_matrices(mds, rounds_p);
@@ -577,5 +589,25 @@ mod tests {
             textbook_state, scalar_state,
             "Textbook and textbook+scalar partial rounds should match"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "Poseidon1 optimized constants require rounds_p > 0")]
+    fn test_compute_optimized_constants_rejects_zero_partial_rounds() {
+        let mut rng = SmallRng::seed_from_u64(7);
+        let mds: [[F; 4]; 4] = rng.random();
+        let partial_rc = vec![];
+
+        let _ = compute_optimized_constants::<F, 4>(&mds, 0, &partial_rc);
+    }
+
+    #[test]
+    #[should_panic(expected = "Poseidon1 partial round constants length must match rounds_p")]
+    fn test_compute_optimized_constants_rejects_mismatched_partial_constants_len() {
+        let mut rng = SmallRng::seed_from_u64(8);
+        let mds: [[F; 4]; 4] = rng.random();
+        let partial_rc = vec![];
+
+        let _ = compute_optimized_constants::<F, 4>(&mds, 1, &partial_rc);
     }
 }

--- a/poseidon1/src/utils.rs
+++ b/poseidon1/src/utils.rs
@@ -69,7 +69,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_field::{dot_product, Field};
+use p3_field::{Field, dot_product};
 
 /// Expand a circulant matrix from its first column into a dense NxN matrix.
 ///


### PR DESCRIPTION
This hardens the Poseidon1 sparse partial-round paths against invalid parameter sets and malformed precomputed constants.

All in-tree Poseidon1 parameter sets currently used have non-zero partial-round counts, so this does not change behavior for existing configurations. The issue is that the public construction paths still accept `rounds_p = 0` or inconsistent partial-round constant shapes, which currently fall through to implicit `RP - 1` underflow or tail-indexing assumptions.

This change turns those cases into explicit fail-fast checks in the AIR, optimized constant generation, and sparse partial-round execution, while leaving valid parameter behavior unchanged. It also adds focused regression tests for the new boundary checks.