### PR TITLE
Add property tests for x86 Poseidon2 width-32

### DIFF
--- a/baby-bear/src/x86_64_avx2/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon2.rs
@@ -175,7 +175,9 @@ impl InternalLayerParametersAVX2<BabyBearParameters, 32> for BabyBearInternalLay
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -184,6 +186,11 @@ mod tests {
     type F = BabyBear;
     type Perm16 = Poseidon2BabyBear<16>;
     type Perm24 = Poseidon2BabyBear<24>;
+    type Perm32 = Poseidon2BabyBear<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -227,16 +234,20 @@ mod tests {
         assert_eq!(avx2_output, expected);
     }
 
-    #[test]
-    fn test_avx2_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
-        let poseidon2 = Poseidon2BabyBear::<32>::new_from_rng_128(&mut rng);
-        let input: [F; 32] = rng.random();
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
-        let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
-        poseidon2.permute_mut(&mut avx2_input);
-        let avx2_output = avx2_input.map(|x| x.0[0]);
-        assert_eq!(avx2_output, expected);
+    proptest! {
+        #[test]
+        fn prop_avx2_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
+
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
+
+            let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
+            poseidon2.permute_mut(&mut avx2_input);
+            let avx2_output = avx2_input.map(|x| x.0[0]);
+
+            prop_assert_eq!(avx2_output, expected);
+        }
     }
 }

--- a/baby-bear/src/x86_64_avx512/poseidon2.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon2.rs
@@ -192,7 +192,9 @@ impl InternalLayerParametersAVX512<BabyBearParameters, 32> for BabyBearInternalL
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -201,6 +203,11 @@ mod tests {
     type F = BabyBear;
     type Perm16 = Poseidon2BabyBear<16>;
     type Perm24 = Poseidon2BabyBear<24>;
+    type Perm32 = Poseidon2BabyBear<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -244,16 +251,20 @@ mod tests {
         assert_eq!(avx512_output, expected);
     }
 
-    #[test]
-    fn test_avx512_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
-        let poseidon2 = Poseidon2BabyBear::<32>::new_from_rng_128(&mut rng);
-        let input: [F; 32] = rng.random();
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
-        let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
-        poseidon2.permute_mut(&mut avx512_input);
-        let avx512_output = avx512_input.map(|x| x.0[0]);
-        assert_eq!(avx512_output, expected);
+    proptest! {
+        #[test]
+        fn prop_avx512_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
+
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
+
+            let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
+            poseidon2.permute_mut(&mut avx512_input);
+            let avx512_output = avx512_input.map(|x| x.0[0]);
+
+            prop_assert_eq!(avx512_output, expected);
+        }
     }
 }

--- a/koala-bear/src/x86_64_avx2/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon2.rs
@@ -311,7 +311,9 @@ impl InternalLayerParametersAVX2<KoalaBearParameters, 32> for KoalaBearInternalL
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -320,6 +322,11 @@ mod tests {
     type F = KoalaBear;
     type Perm16 = Poseidon2KoalaBear<16>;
     type Perm24 = Poseidon2KoalaBear<24>;
+    type Perm32 = Poseidon2KoalaBear<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -363,24 +370,24 @@ mod tests {
         assert_eq!(avx2_output, expected);
     }
 
-    /// Test that the output is the same as the scalar version on a random input.
-    #[test]
-    fn test_avx2_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
+    // Test that the output is the same as the scalar version on random width-32 inputs.
+    proptest! {
+        #[test]
+        fn prop_avx2_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
 
-        // Our Poseidon2 implementation.
-        let poseidon2 = Poseidon2KoalaBear::<32>::new_from_rng_128(&mut rng);
+            // Our Poseidon2 implementation.
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
 
-        let input: [F; 32] = rng.random();
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
 
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
+            let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
+            poseidon2.permute_mut(&mut avx2_input);
 
-        let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
-        poseidon2.permute_mut(&mut avx2_input);
+            let avx2_output = avx2_input.map(|x| x.0[0]);
 
-        let avx2_output = avx2_input.map(|x| x.0[0]);
-
-        assert_eq!(avx2_output, expected);
+            prop_assert_eq!(avx2_output, expected);
+        }
     }
 }

--- a/koala-bear/src/x86_64_avx512/poseidon2.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon2.rs
@@ -240,7 +240,9 @@ impl InternalLayerParametersAVX512<KoalaBearParameters, 32> for KoalaBearInterna
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -249,6 +251,11 @@ mod tests {
     type F = KoalaBear;
     type Perm16 = Poseidon2KoalaBear<16>;
     type Perm24 = Poseidon2KoalaBear<24>;
+    type Perm32 = Poseidon2KoalaBear<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input.
     #[test]
@@ -292,24 +299,24 @@ mod tests {
         assert_eq!(avx512_output, expected);
     }
 
-    /// Test that the output is the same as the scalar version on a random input.
-    #[test]
-    fn test_avx512_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
+    // Test that the output is the same as the scalar version on random width-32 inputs.
+    proptest! {
+        #[test]
+        fn prop_avx512_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
 
-        // Our Poseidon2 implementation.
-        let poseidon2 = Poseidon2KoalaBear::<32>::new_from_rng_128(&mut rng);
+            // Our Poseidon2 implementation.
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
 
-        let input: [F; 32] = rng.random();
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
 
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
+            let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
+            poseidon2.permute_mut(&mut avx512_input);
 
-        let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
-        poseidon2.permute_mut(&mut avx512_input);
+            let avx512_output = avx512_input.map(|x| x.0[0]);
 
-        let avx512_output = avx512_input.map(|x| x.0[0]);
-
-        assert_eq!(avx512_output, expected);
+            prop_assert_eq!(avx512_output, expected);
+        }
     }
 }

--- a/mersenne-31/src/x86_64_avx2/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon2.rs
@@ -369,7 +369,9 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX2, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -380,6 +382,10 @@ mod tests {
     type Perm16 = Poseidon2Mersenne31<16>;
     type Perm24 = Poseidon2Mersenne31<24>;
     type Perm32 = Poseidon2Mersenne31<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input of length 16.
     #[test]
@@ -423,16 +429,20 @@ mod tests {
         assert_eq!(avx2_output, expected);
     }
 
-    #[test]
-    fn test_avx2_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
-        let poseidon2 = Perm32::new_from_rng_128(&mut rng);
-        let input: [F; 32] = rng.random();
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
-        let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
-        poseidon2.permute_mut(&mut avx2_input);
-        let avx2_output = avx2_input.map(|x| x.0[0]);
-        assert_eq!(avx2_output, expected);
+    proptest! {
+        #[test]
+        fn prop_avx2_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
+
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
+
+            let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
+            poseidon2.permute_mut(&mut avx2_input);
+            let avx2_output = avx2_input.map(|x| x.0[0]);
+
+            prop_assert_eq!(avx2_output, expected);
+        }
     }
 }

--- a/mersenne-31/src/x86_64_avx512/poseidon2.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon2.rs
@@ -315,7 +315,9 @@ impl<const WIDTH: usize> ExternalLayer<PackedMersenne31AVX512, WIDTH, 5>
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -326,6 +328,10 @@ mod tests {
     type Perm16 = Poseidon2Mersenne31<16>;
     type Perm24 = Poseidon2Mersenne31<24>;
     type Perm32 = Poseidon2Mersenne31<32>;
+
+    fn arb_f() -> impl Strategy<Value = F> {
+        prop::num::u32::ANY.prop_map(F::from_u32)
+    }
 
     /// Test that the output is the same as the scalar version on a random input of length 16.
     #[test]
@@ -369,16 +375,20 @@ mod tests {
         assert_eq!(avx512_output, expected);
     }
 
-    #[test]
-    fn test_avx512_poseidon2_width_32() {
-        let mut rng = SmallRng::seed_from_u64(1);
-        let poseidon2 = Perm32::new_from_rng_128(&mut rng);
-        let input: [F; 32] = rng.random();
-        let mut expected = input;
-        poseidon2.permute_mut(&mut expected);
-        let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
-        poseidon2.permute_mut(&mut avx512_input);
-        let avx512_output = avx512_input.map(|x| x.0[0]);
-        assert_eq!(avx512_output, expected);
+    proptest! {
+        #[test]
+        fn prop_avx512_poseidon2_width_32(input in prop::array::uniform32(arb_f())) {
+            let mut rng = SmallRng::seed_from_u64(1);
+            let poseidon2 = Perm32::new_from_rng_128(&mut rng);
+
+            let mut expected = input;
+            poseidon2.permute_mut(&mut expected);
+
+            let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
+            poseidon2.permute_mut(&mut avx512_input);
+            let avx512_output = avx512_input.map(|x| x.0[0]);
+
+            prop_assert_eq!(avx512_output, expected);
+        }
     }
 }


### PR DESCRIPTION
This replaces single-sample width-32 x86 Poseidon2 checks with property-based scalar-vs-SIMD equivalence tests, aligning x86 coverage with existing NEON proptests and improving regression detection for handwritten SIMD paths. 