### PR TITLE
perf(interpolation): optimize barycentric weights via algebraic identity

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -32,7 +32,7 @@ use p3_field::{
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::{BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixCow};
-use p3_matrix::interpolation::Interpolate;
+use p3_matrix::interpolation::{Interpolate, compute_adjusted_weights};
 use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
@@ -491,6 +491,13 @@ where
         // for that point, and precompute 1/(z - X) for the largest subgroup (in bitrev order).
         let inv_denoms = compute_inverse_denominators(&mats_and_points, &coset);
 
+        // Precompute adjusted barycentric weights once per opening point.
+        // adjusted[i] = 1/(z - x_i) - 1/z, reused across all matrices opened at z.
+        let adjusted_weights: LinearMap<Challenge, Vec<Challenge>> = inv_denoms
+            .iter()
+            .map(|(point, denoms)| (*point, compute_adjusted_weights(*point, denoms)))
+            .collect();
+
         // Evaluate coset representations and write openings to the challenger
         let all_opened_values = mats_and_points
             .iter()
@@ -510,7 +517,6 @@ where
 
                         // `subgroup` and `mat` are both in bit-reversed order, so we can truncate.
                         let (low_coset, _) = mat.split_rows(h);
-                        let coset_h = &coset[..h];
 
                         points_for_mat
                             .iter()
@@ -524,15 +530,13 @@ where
                                     "compute opened values with Lagrange interpolation"
                                 )
                                 .in_scope(|| {
-                                    // Get the relevant inverse denominators for this point and use these to
-                                    // interpolate to get the evaluation of each polynomial in the matrix
-                                    // at the desired point.
-                                    let inv_denoms = &inv_denoms.get(&point).unwrap()[..h];
-                                    low_coset.interpolate_coset_with_precomputation(
+                                    // Slice the precomputed adjusted weights to match this matrix's height.
+                                    // Zero-allocation hot path: straight to the SIMD dot product.
+                                    let adj = &adjusted_weights.get(&point).unwrap()[..h];
+                                    low_coset.interpolate_coset_with_adjusted_weights(
                                         Val::GENERATOR,
                                         point,
-                                        coset_h,
-                                        inv_denoms,
+                                        adj,
                                     )
                                 });
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -533,7 +533,7 @@ where
                                     // Slice the precomputed adjusted weights to match this matrix's height.
                                     // Zero-allocation hot path: straight to the SIMD dot product.
                                     let adj = &adjusted_weights.get(&point).unwrap()[..h];
-                                    low_coset.interpolate_coset_with_adjusted_weights(
+                                    low_coset.interpolate_coset_with_precomputation(
                                         Val::GENERATOR,
                                         point,
                                         adj,

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -10,22 +10,22 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+
+itertools.workspace = true
 p3-field.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
-
-itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 
 [dev-dependencies]
+
+criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 proptest.workspace = true
-
-criterion.workspace = true
 
 [[bench]]
 name = "transpose_benchmark"
@@ -35,6 +35,11 @@ harness = false
 [[bench]]
 name = "columnwise_dot_product"
 path = "benches/columnwise_dot_product.rs"
+harness = false
+
+[[bench]]
+name = "interpolation"
+path = "benches/interpolation.rs"
 harness = false
 
 [lints]

--- a/matrix/benches/interpolation.rs
+++ b/matrix/benches/interpolation.rs
@@ -1,0 +1,118 @@
+//! Benchmarks for barycentric Lagrange interpolation over two-adic cosets.
+//!
+//! Measures three interpolation tiers at increasing matrix sizes:
+//!
+//! ```text
+//!   Tier 1 (full)        — builds coset + batch-inverts + evaluates.
+//!   Tier 2 (precomputed) — caller supplies 1/(z - x_i), internally adjusts.
+//!   Tier 3 (adjusted)    — caller supplies adjusted weights, zero inner alloc.
+//! ```
+//!
+//! Tier 3 is the FRI PCS prover hot path.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::interpolation::{Interpolate, compute_adjusted_weights};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 4>;
+
+// Narrow  → per-element weight work dominates.
+// Balanced → weights and dot product share the cost.
+// Wide    → SIMD dot product dominates, weight cost is noise.
+const CONFIGS: &[(usize, usize)] = &[(10, 1), (14, 16), (18, 128)];
+
+fn interpolate_coset(c: &mut Criterion) {
+    // Tier 1: full end-to-end.
+    // Timed: coset enumeration + batch inversion + evaluation.
+    let mut group = c.benchmark_group("interpolate_coset");
+    group.sample_size(20);
+
+    let shift = F::GENERATOR;
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let m = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let point = EF::from_u32(123456789);
+
+        let param = format!("2^{log_rows}x{width}");
+        group.bench_with_input(BenchmarkId::new("full", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset(shift, point));
+        });
+    }
+
+    group.finish();
+}
+
+fn interpolate_coset_with_precomputation(c: &mut Criterion) {
+    // Tier 2: inverse denominators precomputed by the caller.
+    // Timed: weight adjustment + dot product + scaling.
+    let mut group = c.benchmark_group("interpolate_coset_with_precomputation");
+    group.sample_size(20);
+
+    let shift = F::GENERATOR;
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let m = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let point = EF::from_u32(123456789);
+
+        // Setup (not timed): build coset and 1/(z - x_i) via batch inversion.
+        let subgroup_gen = F::two_adic_generator(log_rows);
+        let coset: Vec<F> = subgroup_gen.shifted_powers(shift).collect_n(rows);
+        let diffs: Vec<EF> = coset.iter().map(|&g| point - g).collect();
+        let diff_invs = batch_multiplicative_inverse(&diffs);
+
+        let param = format!("2^{log_rows}x{width}");
+        group.bench_with_input(BenchmarkId::new("precomputed", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset_with_precomputation(shift, point, &coset, &diff_invs));
+        });
+    }
+
+    group.finish();
+}
+
+fn interpolate_coset_with_adjusted_weights(c: &mut Criterion) {
+    // Tier 3: adjusted weights precomputed by the caller.
+    // Timed: dot product + scaling only (zero inner allocation).
+    let mut group = c.benchmark_group("interpolate_coset_with_adjusted_weights");
+    group.sample_size(20);
+
+    let shift = F::GENERATOR;
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let m = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let point = EF::from_u32(123456789);
+
+        // Setup (not timed): build coset, batch-invert, subtract z^{-1}.
+        let subgroup_gen = F::two_adic_generator(log_rows);
+        let coset: Vec<F> = subgroup_gen.shifted_powers(shift).collect_n(rows);
+        let diffs: Vec<EF> = coset.iter().map(|&g| point - g).collect();
+        let diff_invs = batch_multiplicative_inverse(&diffs);
+        let adjusted = compute_adjusted_weights(point, &diff_invs);
+
+        let param = format!("2^{log_rows}x{width}");
+        group.bench_with_input(BenchmarkId::new("adjusted", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset_with_adjusted_weights(shift, point, &adjusted));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    interpolate_coset,
+    interpolate_coset_with_precomputation,
+    interpolate_coset_with_adjusted_weights
+);
+criterion_main!(benches);

--- a/matrix/benches/interpolation.rs
+++ b/matrix/benches/interpolation.rs
@@ -1,14 +1,4 @@
 //! Benchmarks for barycentric Lagrange interpolation over two-adic cosets.
-//!
-//! Measures three interpolation tiers at increasing matrix sizes:
-//!
-//! ```text
-//!   Tier 1 (full)        — builds coset + batch-inverts + evaluates.
-//!   Tier 2 (precomputed) — caller supplies 1/(z - x_i), internally adjusts.
-//!   Tier 3 (adjusted)    — caller supplies adjusted weights, zero inner alloc.
-//! ```
-//!
-//! Tier 3 is the FRI PCS prover hot path.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
@@ -22,10 +12,21 @@ use rand::rngs::SmallRng;
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
 
-// Narrow  → per-element weight work dominates.
-// Balanced → weights and dot product share the cost.
-// Wide    → SIMD dot product dominates, weight cost is noise.
-const CONFIGS: &[(usize, usize)] = &[(10, 1), (14, 16), (18, 128)];
+// Cover all four corners (tall/short) × (narrow/wide) plus a balanced midpoint.
+//
+// This way, each shape's bottleneck can be observed independently:
+//   tall narrow    → per-element weight work dominates
+//   short wide     → SIMD dot product dominates
+//   tall wide      → both axes large, stresses the full pipeline
+//   short narrow   → both axes small, baseline
+//   balanced       → weights and dot product share the cost
+const CONFIGS: &[(usize, usize)] = &[
+    (10, 1),   // short, narrow
+    (10, 128), // short, wide
+    (18, 1),   // tall, narrow
+    (18, 128), // tall, wide
+    (14, 16),  // balanced
+];
 
 fn interpolate_coset(c: &mut Criterion) {
     // Tier 1: full end-to-end.
@@ -51,38 +52,9 @@ fn interpolate_coset(c: &mut Criterion) {
 }
 
 fn interpolate_coset_with_precomputation(c: &mut Criterion) {
-    // Tier 2: inverse denominators precomputed by the caller.
-    // Timed: weight adjustment + dot product + scaling.
-    let mut group = c.benchmark_group("interpolate_coset_with_precomputation");
-    group.sample_size(20);
-
-    let shift = F::GENERATOR;
-
-    for &(log_rows, width) in CONFIGS {
-        let rows = 1usize << log_rows;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let m = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
-        let point = EF::from_u32(123456789);
-
-        // Setup (not timed): build coset and 1/(z - x_i) via batch inversion.
-        let subgroup_gen = F::two_adic_generator(log_rows);
-        let coset: Vec<F> = subgroup_gen.shifted_powers(shift).collect_n(rows);
-        let diffs: Vec<EF> = coset.iter().map(|&g| point - g).collect();
-        let diff_invs = batch_multiplicative_inverse(&diffs);
-
-        let param = format!("2^{log_rows}x{width}");
-        group.bench_with_input(BenchmarkId::new("precomputed", &param), &(), |b, _| {
-            b.iter(|| m.interpolate_coset_with_precomputation(shift, point, &coset, &diff_invs));
-        });
-    }
-
-    group.finish();
-}
-
-fn interpolate_coset_with_adjusted_weights(c: &mut Criterion) {
-    // Tier 3: adjusted weights precomputed by the caller.
+    // Tier 2: adjusted weights precomputed by the caller.
     // Timed: dot product + scaling only (zero inner allocation).
-    let mut group = c.benchmark_group("interpolate_coset_with_adjusted_weights");
+    let mut group = c.benchmark_group("interpolate_coset_with_precomputation");
     group.sample_size(20);
 
     let shift = F::GENERATOR;
@@ -101,8 +73,8 @@ fn interpolate_coset_with_adjusted_weights(c: &mut Criterion) {
         let adjusted = compute_adjusted_weights(point, &diff_invs);
 
         let param = format!("2^{log_rows}x{width}");
-        group.bench_with_input(BenchmarkId::new("adjusted", &param), &(), |b, _| {
-            b.iter(|| m.interpolate_coset_with_adjusted_weights(shift, point, &adjusted));
+        group.bench_with_input(BenchmarkId::new("precomputed", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset_with_precomputation(shift, point, &adjusted));
         });
     }
 
@@ -113,6 +85,5 @@ criterion_group!(
     benches,
     interpolate_coset,
     interpolate_coset_with_precomputation,
-    interpolate_coset_with_adjusted_weights
 );
 criterion_main!(benches);

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -154,6 +154,38 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
     /// - log_2(N) extension-field squarings (for z^N).
     /// - log_2(N) base-field squarings (for g^N).
     /// - One SIMD-parallel column-wise dot product over the full matrix.
+    /// Given evaluations of a batch of polynomials over the given coset of the canonical
+    /// power-of-two subgroup, evaluate the polynomials at `point`.
+    ///
+    /// This method takes the precomputed `adjusted_weights` and should
+    /// be preferred over [`interpolate_coset`](Interpolate::interpolate_coset) when repeatedly
+    /// called with the same subgroup and/or point.
+    ///
+    /// # Overview
+    ///
+    /// Each adjusted weight encodes the identity:
+    ///
+    /// ```text
+    ///   g*h^i / (z - g*h^i)  =  z * adjusted_i
+    /// ```
+    ///
+    /// so the full barycentric formula becomes:
+    ///
+    /// ```text
+    ///   f(z)  =  z * (z^N - g^N) / (N * g^N)  *  sum_i  adjusted_i * f(g*h^i)
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// - The evaluation point must not lie in the coset.
+    /// - Each weight must equal 1/(z - x_i) - 1/z for the corresponding coset element.
+    ///
+    /// # Performance
+    ///
+    /// - One base-field inversion (for N * g^N).
+    /// - log_2(N) extension-field squarings (for z^N).
+    /// - log_2(N) base-field squarings (for g^N).
+    /// - One SIMD-parallel column-wise dot product over the full matrix.
     /// - No heap allocation except the result vector.
     fn interpolate_coset_with_adjusted_weights<EF: ExtensionField<F>>(
         &self,

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -5,16 +5,28 @@
 //!
 //! # Mathematical background
 //!
-//! Given evaluations of a polynomial f over a coset g * H of size N = 2^k,
-//! the barycentric formula recovers f(z) for any z outside the coset:
+//! Slight variation of this approach: <https://hackmd.io/@vbuterin/barycentric_evaluation>.
 //!
+//! We start with the evaluations of a polynomial `f` over a coset `gH` of size `N`
+//! and want to compute `f(z)`.
+//!
+//! Observe that `z^N - g^N` is equal to `0` at all points in the coset.
+//! Thus `(z^N - g^N)/(z - gh^i)` is equal to `0` at all points except for `gh^i`
+//! where it is equal to:
 //! ```text
-//!   f(z) = (z^N - g^N) / (N * g^N)  *  sum_i  g*h^i / (z - g*h^i)  *  f(g*h^i)
-//!         = z * (z^N - g^N) / (N * g^N)  * sum_i (1/(z - g*h^i) - 1/z) * f(g*h^i)
+//!   N * (gh^i)^{N - 1} = N * g^N * (gh^i)^{-1}.
+//! ```
+//!
+//! Hence `L_i(z) = h^i * (z^N - g^N)/(N * g^{N - 1} * (z - gh^i))` will be equal
+//! to `1` at `gh^i` and `0` at all other points in the coset. This means that we
+//! can compute `f(z)` as:
+//! ```text
+//!   sum_i L_i(z) f(gh^i) = (z^N - g^N)/(N * g^N) * sum_i gh^i/(z - gh^i) * f(gh^i)
+//!                        = z * (z^N - g^N)/(N * g^N) * sum_i (1/(z - gh^i) - 1/z) * f(gh^i).
 //! ```
 //!
 //! This second equality lets us trade off N extension-by-base multiplications for
-//! A single extension-by-extension multiplication, an extension inversion and N
+//! a single extension-by-extension multiplication, an extension inversion and N
 //! extension-by-extension subtractions. For large N this is worth it.
 //!
 //! Thus we define the **adjusted weights** to be `(1/(z - g*h^i) - 1/z)` and work with
@@ -94,37 +106,17 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
 
         // Convert to adjusted weights and delegate to the zero-allocation hot path.
         let adjusted = compute_adjusted_weights(point, &diff_invs);
-        self.interpolate_coset_with_adjusted_weights(shift, point, &adjusted)
-    }
-
-    /// Evaluate a batch of polynomials using precomputed inverse denominators.
-    ///
-    /// Accepts 1/(z - x_i) values computed by the caller. Converts them to
-    /// adjusted weights internally, then delegates to the zero-allocation path.
-    ///
-    /// Prefer the adjusted-weights variant when the same denominators are reused
-    /// across multiple matrices — it avoids re-subtracting z^{-1} on every call.
-    ///
-    /// # Safety
-    ///
-    /// - The evaluation point must not lie in the coset.
-    /// - Coset and inverse-denominator slices must be consistent with row ordering.
-    fn interpolate_coset_with_precomputation<EF: ExtensionField<F>>(
-        &self,
-        shift: F,
-        point: EF,
-        coset: &[F],
-        diff_invs: &[EF],
-    ) -> Vec<EF> {
-        debug_assert_eq!(coset.len(), diff_invs.len());
-        debug_assert_eq!(coset.len(), self.height());
-
-        // Convert 1/(z - x_i) to adjusted form and delegate.
-        let adjusted = compute_adjusted_weights(point, diff_invs);
-        self.interpolate_coset_with_adjusted_weights(shift, point, &adjusted)
+        self.interpolate_coset_with_precomputation(shift, point, &adjusted)
     }
 
     /// Fastest interpolation path — zero allocation beyond the result vector.
+    ///
+    /// Given evaluations of a batch of polynomials over the given coset of the canonical
+    /// power-of-two subgroup, evaluate the polynomials at `point`.
+    ///
+    /// This method takes the precomputed `adjusted_weights` and should
+    /// be preferred over [`interpolate_coset`](Interpolate::interpolate_coset) when repeatedly
+    /// called with the same subgroup and/or point.
     ///
     /// # Overview
     ///
@@ -154,40 +146,8 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
     /// - log_2(N) extension-field squarings (for z^N).
     /// - log_2(N) base-field squarings (for g^N).
     /// - One SIMD-parallel column-wise dot product over the full matrix.
-    /// Given evaluations of a batch of polynomials over the given coset of the canonical
-    /// power-of-two subgroup, evaluate the polynomials at `point`.
-    ///
-    /// This method takes the precomputed `adjusted_weights` and should
-    /// be preferred over [`interpolate_coset`](Interpolate::interpolate_coset) when repeatedly
-    /// called with the same subgroup and/or point.
-    ///
-    /// # Overview
-    ///
-    /// Each adjusted weight encodes the identity:
-    ///
-    /// ```text
-    ///   g*h^i / (z - g*h^i)  =  z * adjusted_i
-    /// ```
-    ///
-    /// so the full barycentric formula becomes:
-    ///
-    /// ```text
-    ///   f(z)  =  z * (z^N - g^N) / (N * g^N)  *  sum_i  adjusted_i * f(g*h^i)
-    /// ```
-    ///
-    /// # Safety
-    ///
-    /// - The evaluation point must not lie in the coset.
-    /// - Each weight must equal 1/(z - x_i) - 1/z for the corresponding coset element.
-    ///
-    /// # Performance
-    ///
-    /// - One base-field inversion (for N * g^N).
-    /// - log_2(N) extension-field squarings (for z^N).
-    /// - log_2(N) base-field squarings (for g^N).
-    /// - One SIMD-parallel column-wise dot product over the full matrix.
     /// - No heap allocation except the result vector.
-    fn interpolate_coset_with_adjusted_weights<EF: ExtensionField<F>>(
+    fn interpolate_coset_with_precomputation<EF: ExtensionField<F>>(
         &self,
         shift: F,
         point: EF,
@@ -237,27 +197,31 @@ mod tests {
     use p3_util::log2_strict_usize;
     use proptest::prelude::*;
 
-    use super::Interpolate;
+    use super::{Interpolate, compute_adjusted_weights};
     use crate::dense::RowMajorMatrix;
 
     type F = BabyBear;
     type EF4 = BinomialExtensionField<BabyBear, 4>;
 
+    /// Evaluate a polynomial (given by coefficients) at a point using Horner's method.
+    ///
+    /// Horner's method: `f(z) = c_0 + z*(c_1 + z*(c_2 + ...))`.
+    /// Processes coefficients from highest degree down to constant term.
     fn eval_poly<EF: ExtensionField<F>>(coeffs: &[F], point: EF) -> EF {
-        // Horner's method: fold from the highest-degree coefficient down.
-        // f(z) = c_0 + z * (c_1 + z * (c_2 + ...))
         coeffs
             .iter()
             .rev()
             .fold(EF::ZERO, |acc, &c| acc * point + c)
     }
 
+    /// Evaluate a polynomial at all points of a coset, returning the evaluations.
     fn eval_poly_on_coset<EF: ExtensionField<F>>(coeffs: &[F], shift: F, log_n: usize) -> Vec<EF> {
         let n = 1 << log_n;
+        // Build the coset {shift * h^0, shift * h^1, ..., shift * h^{n-1}}.
         let subgroup_gen = F::two_adic_generator(log_n);
         (0..n)
             .map(|i| {
-                // Coset element at index i: shift * generator^i.
+                // Coset element: shift * subgroup_gen^i.
                 let coset_elem = shift * subgroup_gen.exp_u64(i as u64);
                 eval_poly(coeffs, EF::from(coset_elem))
             })
@@ -266,59 +230,65 @@ mod tests {
 
     #[test]
     fn test_interpolate_subgroup() {
-        // Invariant: interpolating f(x) = x^2 + 2x + 3 at z = 100
-        // must recover f(100) = 10203.
-        //
-        // Fixture: 8 precomputed evaluations over the canonical subgroup.
+        // Polynomial: f(x) = x^2 + 2x + 3, evaluated over the 8-point two-adic subgroup.
+        // Known answer: f(100) = 10000 + 200 + 3 = 10203.
+
+        // Pre-computed evaluations of f over the canonical 8-point subgroup {h^0, ..., h^7}.
         let evals = [
             6, 886605102, 1443543107, 708307799, 2, 556938009, 569722818, 1874680944,
         ]
         .map(F::from_u32);
 
-        // One polynomial (1 column), 8 evaluation points (8 rows).
+        // Single column matrix: one polynomial, 8 evaluation rows.
         let evals_mat = RowMajorMatrix::new(evals.to_vec(), 1);
 
-        // z = 100 lies outside the subgroup.
+        // Interpolate at z = 100, which lies outside the subgroup.
         let point = F::from_u16(100);
         let result = evals_mat.interpolate_subgroup(point);
 
-        // 100^2 + 2*100 + 3 = 10203.
+        // Verify the known answer: f(100) = 10203.
         assert_eq!(result, vec![F::from_u16(10203)]);
     }
 
     #[test]
     fn test_interpolate_coset() {
-        // Invariant: both the full path and the precomputation path must
-        // agree on f(100) = 10203 for f(x) = x^2 + 2x + 3.
-        //
-        // Fixture: 8-point coset shifted by the field's multiplicative generator.
+        // Polynomial: f(x) = x^2 + 2x + 3, evaluated over an 8-point coset shifted
+        // by the field generator. Known answer: f(100) = 10203.
+
+        // Coset shift: the multiplicative generator of the field.
         let shift = F::GENERATOR;
 
+        // Pre-computed evaluations of f over the coset {shift * h^0, ..., shift * h^7}.
         let evals = [
             1026, 129027310, 457985035, 994890337, 902, 1988942953, 1555278970, 913671254,
         ]
         .map(F::from_u32);
 
+        // Single column matrix: one polynomial, 8 rows.
         let evals_mat = RowMajorMatrix::new(evals.to_vec(), 1);
 
-        // Part 1: full path (builds coset + batch-inverts internally).
+        // Part 1: test the standard coset interpolation path.
         let point = F::from_u16(100);
         let result = evals_mat.interpolate_coset(shift, point);
         assert_eq!(result, vec![F::from_u16(10203)]);
 
-        // Part 2: precomputation path (caller provides coset + inverse denominators).
+        // Part 2: test the precomputation path, which should give the same result.
+        // Manually build the coset elements and adjusted weights.
         let n = evals.len();
         let k = log2_strict_usize(n);
 
-        // Build the 8-element coset manually.
+        // Coset elements: {shift * h^0, shift * h^1, ..., shift * h^{N-1}}.
         let coset = F::two_adic_generator(k).shifted_powers(shift).collect_n(n);
 
-        // Compute 1/(z - x_i) via batch inversion.
+        // Inverse denominators: 1/(z - coset_i) for each coset element.
         let denom: Vec<_> = coset.iter().map(|&w| point - w).collect();
         let denom = batch_multiplicative_inverse(&denom);
 
-        // Both paths must be bit-identical.
-        let result = evals_mat.interpolate_coset_with_precomputation(shift, point, &coset, &denom);
+        // Adjusted weights: 1/(z - coset_i) - 1/z.
+        let adjusted = compute_adjusted_weights(point, &denom);
+
+        // The precomputation variant must produce the same result.
+        let result = evals_mat.interpolate_coset_with_precomputation(shift, point, &adjusted);
         assert_eq!(result, vec![F::from_u16(10203)]);
     }
 
@@ -362,19 +332,16 @@ mod tests {
 
     #[test]
     fn test_interpolate_coset_multiple_polynomials() {
-        // Invariant: batch interpolation of K polynomials via a K-column matrix
-        // must agree with interpolating each polynomial individually.
+        // Verify batch interpolation: two polynomials evaluated over the same coset
+        // are interpolated simultaneously using a 2-column matrix.
         //
-        // Fixture: two polynomials over an 8-point coset.
+        //     f_1(x) = x^2 + 2x + 3
+        //     f_2(x) = 4x^2 + 5x + 6
         //
-        //   f_1(x) = x^2 + 2x + 3
-        //   f_2(x) = 4x^2 + 5x + 6
-        //
-        //   Matrix layout (8 rows x 2 columns):
-        //
-        //     row i = [ f_1(coset_i),  f_2(coset_i) ]
+        //     Matrix layout (8 rows x 2 columns):
+        //         row i = [ f_1(coset[i]), f_2(coset[i]) ]
 
-        // 8-point coset shifted by the quartic extension generator.
+        // Build the 8-point coset shifted by the extension field generator.
         let shift = EF4::GENERATOR;
         let coset = EF4::two_adic_generator(3)
             .shifted_powers(shift)
@@ -383,82 +350,94 @@ mod tests {
         let f1 = |x: EF4| x * x + x * F::TWO + F::from_u32(3);
         let f2 = |x: EF4| x * x * F::from_u32(4) + x * F::from_u32(5) + F::from_u32(6);
 
-        // Interleave: [f1(c_0), f2(c_0), f1(c_1), f2(c_1), ...].
+        // Interleave evaluations: [f1(c0), f2(c0), f1(c1), f2(c1), ...].
         let evals: Vec<_> = coset.iter().flat_map(|&x| vec![f1(x), f2(x)]).collect();
+
+        // Two-column matrix: each column is one polynomial's evaluations.
         let evals_mat = RowMajorMatrix::new(evals, 2);
 
-        // Interpolate both columns at z = 77.
+        // Interpolate both polynomials at z = 77.
         let point = EF4::from_u32(77);
         let result = evals_mat.interpolate_coset(shift, point);
 
-        // Each column must match direct evaluation.
-        assert_eq!(result[0], f1(point));
-        assert_eq!(result[1], f2(point));
+        // Compare against direct evaluation of each polynomial at the same point.
+        let expected_f1 = f1(point);
+        let expected_f2 = f2(point);
+
+        assert_eq!(result[0], expected_f1);
+        assert_eq!(result[1], expected_f2);
     }
 
     #[test]
     fn test_interpolate_subgroup_multiple_columns() {
-        // Invariant: the subgroup path (shift = 1) must produce the same
-        // results as the coset path for multi-column matrices.
+        // Same as the coset multi-polynomial test, but over the canonical subgroup
+        // (shift = 1). Verifies that the subgroup path correctly delegates to
+        // the coset path and produces identical results.
         //
-        //   f_1(x) = x^2 + 2x + 3
-        //   f_2(x) = 4x^2 + 5x + 6
+        //     f_1(x) = x^2 + 2x + 3
+        //     f_2(x) = 4x^2 + 5x + 6
 
         let f1 = |x: EF4| x * x + x * F::TWO + F::from_u32(3);
         let f2 = |x: EF4| x * x * F::from_u32(4) + x * F::from_u32(5) + F::from_u32(6);
 
-        // Canonical 8-point subgroup.
+        // Evaluation domain: the canonical 2^3 = 8-point subgroup {h^0, ..., h^7}.
         let subgroup_iter = EF4::two_adic_generator(3).powers().take(8);
 
-        // Interleaved evaluations => 8 rows x 2 columns.
+        // Evaluate both polynomials on the subgroup, interleaved.
         let evals: Vec<_> = subgroup_iter.flat_map(|x| vec![f1(x), f2(x)]).collect();
+
+        // 8 rows x 2 columns: column 0 holds f_1 evaluations, column 1 holds f_2.
         let evals_mat = RowMajorMatrix::new(evals, 2);
 
-        // z = 77 lies outside the subgroup.
+        // Interpolate at z = 77, which lies outside the subgroup.
         let point = EF4::from_u32(77);
         let result = evals_mat.interpolate_subgroup(point);
 
-        assert_eq!(result, vec![f1(point), f2(point)]);
+        // Compare against direct evaluation of each polynomial.
+        let expected_f1 = f1(point);
+        let expected_f2 = f2(point);
+
+        assert_eq!(result, vec![expected_f1, expected_f2]);
     }
 
     proptest! {
+        // Correctness: subgroup round-trip
         #[test]
         fn prop_roundtrip_subgroup(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: evaluate f on the canonical subgroup, interpolate at z,
-            // and the result must equal direct Horner evaluation of f at z.
+            // Invariant: evaluate f on 2^log_n-subgroup, interpolate at z → must equal f(z).
             //
-            //   coeffs -> eval on {h^0, ..., h^{N-1}} -> interpolate at z
-            //   coeffs -> Horner at z
-            //   Both must agree.
+            //     coeffs  →  eval on {h^0, ..., h^{N-1}}  →  interpolate at z
+            //     coeffs  →  Horner at z
+            //     Both must agree.
 
             // Truncate to degree < N so the polynomial is uniquely determined.
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
 
-            // Evaluate on the canonical subgroup (shift = 1).
+            // Evaluate on canonical subgroup (shift = 1).
             let evals: Vec<F> = eval_poly_on_coset(&coeffs, F::ONE, log_n);
             let evals_mat = RowMajorMatrix::new(evals, 1);
 
             let point = EF4::from_u32(point_raw);
 
+            // Compare interpolation against direct Horner evaluation.
             let result = evals_mat.interpolate_subgroup(point);
             let expected = eval_poly(&coeffs, point);
             prop_assert_eq!(result[0], expected);
         }
 
+        // Correctness: coset round-trip (shift = GENERATOR)
         #[test]
         fn prop_roundtrip_coset(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: same round-trip as above, but over a shifted coset
-            // with shift = multiplicative generator.
-
+            // Same round-trip as above, but over a shifted coset {g*h^i}.
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let shift = F::GENERATOR;
@@ -472,15 +451,18 @@ mod tests {
             prop_assert_eq!(result[0], expected);
         }
 
+        // Path equivalence: standard vs precomputation
         #[test]
         fn prop_precomputation_equivalence(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: the full path and the precomputation path must be
-            // bit-identical — they compute the same barycentric formula.
-
+            // Invariant: both code paths compute the same barycentric formula.
+            //
+            //     interpolate_coset                     (builds coset + adjusted weights internally)
+            //     interpolate_coset_with_precomputation (caller provides adjusted weights)
+            //     → must be bit-identical.
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let shift = F::GENERATOR;
@@ -489,34 +471,33 @@ mod tests {
             let evals_mat = RowMajorMatrix::new(evals, 1);
             let point = EF4::from_u32(point_raw);
 
-            // Full path (builds everything internally).
+            // Standard path.
             let result_standard = evals_mat.interpolate_coset(shift, point);
 
-            // Manual precomputation path (caller builds coset + inverse denoms).
+            // Manual precomputation path.
             let subgroup_gen = F::two_adic_generator(log_n);
             let coset: Vec<F> =
                 (0..n).map(|i| shift * subgroup_gen.exp_u64(i as u64)).collect();
             let diffs: Vec<EF4> = coset.iter().map(|&c| point - c).collect();
             let diff_invs = batch_multiplicative_inverse(&diffs);
+            let adjusted = compute_adjusted_weights(point, &diff_invs);
             let result_precomp = evals_mat
-                .interpolate_coset_with_precomputation(shift, point, &coset, &diff_invs);
+                .interpolate_coset_with_precomputation(shift, point, &adjusted);
 
             prop_assert_eq!(result_standard, result_precomp);
         }
 
+        // Constant polynomial: f(x) = c → interpolation at any z must return c.
         #[test]
         fn prop_constant_polynomial(
             log_n in 1usize..=4,
             c_raw in 0u32..2013265921u32,
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: a constant polynomial evaluates to the same value
-            // everywhere. Interpolation at any external point must recover it.
-
             let n = 1usize << log_n;
             let c = F::from_u32(c_raw);
 
-            // N identical evaluations => degree-0 polynomial.
+            // N identical evaluations → constant polynomial.
             let evals = vec![c; n];
             let evals_mat = RowMajorMatrix::new(evals, 1);
             let point = EF4::from_u32(point_raw);
@@ -525,6 +506,7 @@ mod tests {
             prop_assert_eq!(result[0], EF4::from(c));
         }
 
+        // Linearity: interp(a*f + b*g) == a*interp(f) + b*interp(g)
         #[test]
         fn prop_linearity(
             log_n in 1usize..=3,
@@ -534,16 +516,14 @@ mod tests {
             b_raw in 0u32..2013265921u32,
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: barycentric interpolation is linear.
-            //   interp(a*f + b*g, z) == a * interp(f, z) + b * interp(g, z)
-
+            // Invariant: barycentric interpolation is linear over the evaluation column.
             let n = 1usize << log_n;
             let f_coeffs: Vec<F> = f_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let g_coeffs: Vec<F> = g_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let a = F::from_u32(a_raw);
             let b = F::from_u32(b_raw);
 
-            // Evaluate f, g, and the linear combination on the canonical subgroup.
+            // Evaluate f, g, and (a*f + b*g) on the canonical subgroup.
             let f_evals: Vec<F> = eval_poly_on_coset(&f_coeffs, F::ONE, log_n);
             let g_evals: Vec<F> = eval_poly_on_coset(&g_coeffs, F::ONE, log_n);
             let combined_evals: Vec<F> = f_evals
@@ -566,6 +546,7 @@ mod tests {
             prop_assert_eq!(interp_combined, expected);
         }
 
+        // Batch equivalence: 2-column matrix vs two 1-column matrices
         #[test]
         fn prop_batch_equals_individual(
             log_n in 1usize..=3,
@@ -573,15 +554,12 @@ mod tests {
             g_raw in prop::collection::vec(0u32..2013265921, 1..=8),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: a multi-column matrix must produce the same results
-            // as interpolating each column individually.
+            // Invariant: batch[col_j] == individual[col_j] for all j.
             //
-            //   batch (N x 2):  [ f(c_0)  g(c_0) ]  -> interpolate -> [ f(z), g(z) ]
-            //                   [ f(c_1)  g(c_1) ]
-            //                   ...
-            //
-            //   single (N x 1) each  -> interpolate -> f(z), g(z)
-
+            //     batch_mat (N×2):       [f(c_0) g(c_0)]     → interpolate → [f(z), g(z)]
+            //                            [f(c_1) g(c_1)]
+            //                            ...
+            //     f_mat (N×1), g_mat (N×1) → interpolate each → f(z), g(z)
             let n = 1usize << log_n;
             let f_coeffs: Vec<F> = f_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let g_coeffs: Vec<F> = g_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
@@ -590,7 +568,7 @@ mod tests {
             let f_evals: Vec<F> = eval_poly_on_coset(&f_coeffs, shift, log_n);
             let g_evals: Vec<F> = eval_poly_on_coset(&g_coeffs, shift, log_n);
 
-            // Interleave into a 2-column batch matrix.
+            // Interleave into 2-column batch matrix.
             let batch_evals: Vec<F> = f_evals
                 .iter()
                 .zip(&g_evals)

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -1,71 +1,118 @@
-//! Lagrange interpolation over two-adic cosets.
+//! Barycentric Lagrange interpolation over two-adic cosets.
+//!
+//! Evaluates polynomials at out-of-domain points given their evaluations
+//! over a power-of-two multiplicative coset.
+//!
+//! # Mathematical background
+//!
+//! Given evaluations of a polynomial f over a coset g * H of size N = 2^k,
+//! the barycentric formula recovers f(z) for any z outside the coset:
+//!
+//! ```text
+//!   f(z) = (z^N - g^N) / (N * g^N)  *  sum_i  g*h^i / (z - g*h^i)  *  f(g*h^i)
+//! ```
+//!
+//! The per-element weight g*h^i / (z - g*h^i) normally requires N
+//! extension-by-base multiplications. An algebraic identity eliminates them:
+//!
+//! ```text
+//!   g*h^i / (z - g*h^i)  =  z * ( 1/(z - g*h^i) - 1/z )
+//! ```
+//!
+//! So we define **adjusted weights** as the parenthesized difference, absorb the
+//! extra factor of z into the global scalar, and feed the adjusted weights
+//! straight into the SIMD-optimized dot product — zero per-element coset work.
 
 use alloc::vec::Vec;
 
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
-    ExtensionField, TwoAdicField, batch_multiplicative_inverse, scale_slice_in_place_single_core,
+    ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse,
+    scale_slice_in_place_single_core,
 };
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
 use crate::Matrix;
 
-/// Extension trait that adds Lagrange interpolation over two-adic cosets to any [`Matrix`].
+/// Subtract z^{-1} from each inverse denominator to produce adjusted barycentric weights.
 ///
-/// This is automatically implemented for every `M: Matrix<F>` where `F: TwoAdicField`.
-/// So there is nothing to implement manually — just import the trait.
+/// # Overview
+///
+/// Converts raw 1/(z - x_i) values into the form needed by the
+/// zero-allocation interpolation path.
+///
+/// Intended to be called once per opening point z, then reused across
+/// every matrix opened at that point.
+///
+/// # Performance
+///
+/// One extension-field inversion + N parallel extension-field subtractions.
+pub fn compute_adjusted_weights<EF: Field>(point: EF, diff_invs: &[EF]) -> Vec<EF> {
+    // Single inversion of z, amortised over all N weights.
+    let point_inv = point.inverse();
+    // Subtract z^{-1} from each 1/(z - x_i) in parallel.
+    diff_invs.par_iter().map(|&d| d - point_inv).collect()
+}
+
+/// Barycentric Lagrange interpolation over two-adic cosets.
+///
+/// Blanket-implemented for every matrix over a two-adic field.
+/// Import the trait, then call the methods directly on any matrix.
 pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
-    /// Given evaluations of a batch of polynomials over the canonical power-of-two subgroup,
-    /// evaluate the polynomials at `point`.
+    /// Evaluate a batch of polynomials at a point outside the canonical subgroup.
     ///
-    /// The canonical subgroup is the coset with shift = 1, so this delegates directly
-    /// to the coset interpolation method.
+    /// Convenience wrapper that uses shift = 1.
     ///
-    /// This assumes the point is not in the subgroup, otherwise the behavior is undefined.
+    /// # Safety
+    ///
+    /// The evaluation point must not lie in the subgroup.
     fn interpolate_subgroup<EF: ExtensionField<F>>(&self, point: EF) -> Vec<EF> {
-        // The canonical subgroup is the coset g*H with g = 1.
+        // Canonical subgroup has unit shift.
         self.interpolate_coset(F::ONE, point)
     }
 
-    /// Given evaluations of a batch of polynomials over the given coset of the canonical
-    /// power-of-two subgroup, evaluate the polynomials at `point`.
+    /// Evaluate a batch of polynomials at a point outside a shifted coset.
     ///
-    /// This assumes the point is not in the coset, otherwise the behavior is undefined.
+    /// Builds the coset, batch-inverts the denominators, converts to adjusted
+    /// weights, and evaluates — all in one call.
     ///
-    /// The evaluations must be given in standard (not bit-reversed) order.
+    /// Evaluations must be in standard (not bit-reversed) order.
+    ///
+    /// # Safety
+    ///
+    /// The evaluation point must not lie in the coset.
     fn interpolate_coset<EF: ExtensionField<F>>(&self, shift: F, point: EF) -> Vec<EF> {
-        // The matrix height equals the coset size N = 2^log_height.
         let log_height = log2_strict_usize(self.height());
 
-        // Build the coset elements: {shift * h^0, shift * h^1, ..., shift * h^{N-1}}
-        // where h is the 2-adic generator of order N.
-        let coset = TwoAdicMultiplicativeCoset::new(shift, log_height)
+        // Materialise the coset so the diff computation can use parallel iteration.
+        let coset: Vec<F> = TwoAdicMultiplicativeCoset::new(shift, log_height)
             .unwrap()
             .iter()
             .collect();
 
-        // Compute the difference (point - coset_element) for each coset element,
-        // then batch-invert to get 1/(z - g*h^i) in a single Montgomery inversion.
-        let diffs: Vec<_> = coset.par_iter().map(|&g| point - g).collect();
+        // Compute z - x_i in parallel, then batch-invert in one shot
+        // (Montgomery's trick: single field inversion + O(N) multiplications).
+        let diffs: Vec<EF> = coset.par_iter().map(|&g| point - g).collect();
         let diff_invs = batch_multiplicative_inverse(&diffs);
 
-        // Delegate to the precomputation variant with the coset and inverses we just built.
-        self.interpolate_coset_with_precomputation(shift, point, &coset, &diff_invs)
+        // Convert to adjusted weights and delegate to the zero-allocation hot path.
+        let adjusted = compute_adjusted_weights(point, &diff_invs);
+        self.interpolate_coset_with_adjusted_weights(shift, point, &adjusted)
     }
 
-    /// Given evaluations of a batch of polynomials over the given coset of the canonical
-    /// power-of-two subgroup, evaluate the polynomials at `point`.
+    /// Evaluate a batch of polynomials using precomputed inverse denominators.
     ///
-    /// This assumes the point is not in the coset, otherwise the behavior is undefined.
+    /// Accepts 1/(z - x_i) values computed by the caller. Converts them to
+    /// adjusted weights internally, then delegates to the zero-allocation path.
     ///
-    /// This method takes the precomputed `coset` points and `diff_invs` (the inverses of the
-    /// differences between the evaluation point and each shifted subgroup element), and should
-    /// be preferred over [`interpolate_coset`](Interpolate::interpolate_coset) when repeatedly
-    /// called with the same subgroup and/or point.
+    /// Prefer the adjusted-weights variant when the same denominators are reused
+    /// across multiple matrices — it avoids re-subtracting z^{-1} on every call.
     ///
-    /// Unlike `interpolate_coset`, the parameters `coset` and `diff_invs` may use any indexing
-    /// scheme, as long as they are consistent with the row ordering of `self`.
+    /// # Safety
+    ///
+    /// - The evaluation point must not lie in the coset.
+    /// - Coset and inverse-denominator slices must be consistent with row ordering.
     fn interpolate_coset_with_precomputation<EF: ExtensionField<F>>(
         &self,
         shift: F,
@@ -73,69 +120,75 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
         coset: &[F],
         diff_invs: &[EF],
     ) -> Vec<EF> {
-        // Slight variation of this approach: https://hackmd.io/@vbuterin/barycentric_evaluation
         debug_assert_eq!(coset.len(), diff_invs.len());
         debug_assert_eq!(coset.len(), self.height());
 
-        // We start with the evaluations of a polynomial `f` over a coset `gH` of size `N`
-        // and want to compute `f(z)`.
-        //
-        // Observe that `z^N - g^N` is equal to `0` at all points in the coset.
-        // Thus `(z^N - g^N)/(z - gh^i)` is equal to `0` at all points except for `gh^i`
-        // where it is equal to:
-        //          `N * (gh^i)^{N - 1} = N * g^N * (gh^i)^{-1}.`
-        //
-        // Hence `L_i(z) = h^i * (z^N - g^N)/(N * g^{N - 1} * (z - gh^i))` will be equal
-        // to `1` at `gh^i` and `0` at all other points in the coset. This means that we
-        // can compute `f(z)` as:
-        //   `\sum_i L_i(z) f(gh^i) = (z^N - g^N)/(N * g^N) * \sum_i gh^i/(z - gh^i) f(gh^i).`
+        // Convert 1/(z - x_i) to adjusted form and delegate.
+        let adjusted = compute_adjusted_weights(point, diff_invs);
+        self.interpolate_coset_with_adjusted_weights(shift, point, &adjusted)
+    }
 
-        // TODO: It might be possible to speed this up by refactoring the code to instead compute:
-        //          `((z/g)^N - 1)/N * \sum_i 1/(z/(gh^i) - 1) f(gh^i).`
-        // This would remove the need for the multiplications and collections in `col_scale` and
-        // let us remove one of the `exp_power_of_2` calls (which are somewhat expensive as they
-        // are over the extension field). We could also remove the .inverse() in scale_vec.
+    /// Fastest interpolation path — zero allocation beyond the result vector.
+    ///
+    /// # Overview
+    ///
+    /// Each adjusted weight encodes the identity:
+    ///
+    /// ```text
+    ///   g*h^i / (z - g*h^i)  =  z * adjusted_i
+    /// ```
+    ///
+    /// so the full barycentric formula becomes:
+    ///
+    /// ```text
+    ///   f(z)  =  z * (z^N - g^N) / (N * g^N)  *  sum_i  adjusted_i * f(g*h^i)
+    /// ```
+    ///
+    /// The inner sum is a single SIMD-optimized column-wise dot product.
+    /// The outer scalar is computed with one base-field inversion.
+    ///
+    /// # Safety
+    ///
+    /// - The evaluation point must not lie in the coset.
+    /// - Each weight must equal 1/(z - x_i) - 1/z for the corresponding coset element.
+    ///
+    /// # Performance
+    ///
+    /// - One base-field inversion (for N * g^N).
+    /// - log_2(N) extension-field squarings (for z^N).
+    /// - log_2(N) base-field squarings (for g^N).
+    /// - One SIMD-parallel column-wise dot product over the full matrix.
+    /// - No heap allocation except the result vector.
+    fn interpolate_coset_with_adjusted_weights<EF: ExtensionField<F>>(
+        &self,
+        shift: F,
+        point: EF,
+        adjusted_weights: &[EF],
+    ) -> Vec<EF> {
+        debug_assert_eq!(adjusted_weights.len(), self.height());
 
-        // N = 2^log_height is the coset size.
         let log_height = log2_strict_usize(self.height());
 
-        // Phase 1: Build the per-element barycentric weights.
+        // Phase 1: Global scaling factor
         //
-        // For each coset element g*h^i, compute the weight:
-        //     w_i = g*h^i / (z - g*h^i)
+        //   s = z * (z^N - g^N) / (N * g^N)
         //
-        // These are the numerator terms in the barycentric Lagrange formula.
-        let col_scale: Vec<_> = coset
-            .par_iter()
-            .zip(diff_invs)
-            .map(|(&sg, &diff_inv)| diff_inv * sg)
-            .collect();
+        // z^N via extension-field repeated squaring (expensive).
+        let z_pow_n = point.exp_power_of_2(log_height);
+        // g^N via base-field repeated squaring (cheap — single-word ops).
+        let g_pow_n = shift.exp_power_of_2(log_height);
+        // Combine denominator N * g^N and invert once (only base-field inversion).
+        let denom_inv = g_pow_n.mul_2exp_u64(log_height as u64).inverse();
+        // Assemble: z * (z^N - g^N) * 1/(N * g^N).
+        let scaling_factor = point * (z_pow_n - g_pow_n) * denom_inv;
 
-        // Phase 2: Compute the global scaling factor.
+        // Phase 2: Weighted column sums via the SIMD-optimized dot product.
         //
-        // The barycentric formula gives:
-        //     f(z) = Z_{gH}(z) / (N * g^N) * \sum_i w_i * f(g*h^i)
-        //
-        // where Z_{gH}(z) = z^N - g^N is the vanishing polynomial of the coset.
+        // Computes M^T * adjusted_weights, yielding one extension-field
+        // result per column (polynomial).
+        let mut evals = self.columnwise_dot_product(adjusted_weights);
 
-        // Raise point and shift to the N-th power.
-        let point_pow_height = point.exp_power_of_2(log_height);
-        let shift_pow_height = shift.exp_power_of_2(log_height);
-
-        // Vanishing polynomial evaluated at z: Z_{gH}(z) = z^N - g^N.
-        let vanishing_polynomial = point_pow_height - shift_pow_height;
-
-        // Compute the Denominator: N * g^N.
-        let denominator = shift_pow_height.mul_2exp_u64(log_height as u64);
-
-        // Global scaling factor: s = Z_{gH}(z) / (N * g^N).
-        let scaling_factor = vanishing_polynomial * denominator.inverse();
-
-        // Phase 3: Evaluate all column polynomials at once.
-        //
-        // M^T * col_scale computes \sum_i w_i * f_j(g*h^i) for each column j.
-        // Then multiply each result by the global scaling factor s.
-        let mut evals = self.columnwise_dot_product(&col_scale);
+        // Phase 3: Apply the global scalar to every column result.
         scale_slice_in_place_single_core(&mut evals, scaling_factor);
         evals
     }
@@ -162,24 +215,21 @@ mod tests {
     type F = BabyBear;
     type EF4 = BinomialExtensionField<BabyBear, 4>;
 
-    /// Evaluate a polynomial (given by coefficients) at a point using Horner's method.
     fn eval_poly<EF: ExtensionField<F>>(coeffs: &[F], point: EF) -> EF {
-        // Horner's method: f(z) = c_0 + z*(c_1 + z*(c_2 + ...))
-        // Process coefficients from highest degree down to constant term.
+        // Horner's method: fold from the highest-degree coefficient down.
+        // f(z) = c_0 + z * (c_1 + z * (c_2 + ...))
         coeffs
             .iter()
             .rev()
             .fold(EF::ZERO, |acc, &c| acc * point + c)
     }
 
-    /// Evaluate a polynomial at all points of a coset, returning the evaluations.
     fn eval_poly_on_coset<EF: ExtensionField<F>>(coeffs: &[F], shift: F, log_n: usize) -> Vec<EF> {
         let n = 1 << log_n;
-        // Build the coset {shift * h^0, shift * h^1, ..., shift * h^{n-1}}.
         let subgroup_gen = F::two_adic_generator(log_n);
         (0..n)
             .map(|i| {
-                // Coset element: shift * subgroup_gen^i.
+                // Coset element at index i: shift * generator^i.
                 let coset_elem = shift * subgroup_gen.exp_u64(i as u64);
                 eval_poly(coeffs, EF::from(coset_elem))
             })
@@ -188,120 +238,115 @@ mod tests {
 
     #[test]
     fn test_interpolate_subgroup() {
-        // Polynomial: f(x) = x^2 + 2x + 3, evaluated over the 8-point two-adic subgroup.
-        // Known answer: f(100) = 10000 + 200 + 3 = 10203.
-
-        // Pre-computed evaluations of f over the canonical 8-point subgroup {h^0, ..., h^7}.
+        // Invariant: interpolating f(x) = x^2 + 2x + 3 at z = 100
+        // must recover f(100) = 10203.
+        //
+        // Fixture: 8 precomputed evaluations over the canonical subgroup.
         let evals = [
             6, 886605102, 1443543107, 708307799, 2, 556938009, 569722818, 1874680944,
         ]
         .map(F::from_u32);
 
-        // Single column matrix: one polynomial, 8 evaluation rows.
+        // One polynomial (1 column), 8 evaluation points (8 rows).
         let evals_mat = RowMajorMatrix::new(evals.to_vec(), 1);
 
-        // Interpolate at z = 100, which lies outside the subgroup.
+        // z = 100 lies outside the subgroup.
         let point = F::from_u16(100);
         let result = evals_mat.interpolate_subgroup(point);
 
-        // Verify the known answer: f(100) = 10203.
+        // 100^2 + 2*100 + 3 = 10203.
         assert_eq!(result, vec![F::from_u16(10203)]);
     }
 
     #[test]
     fn test_interpolate_coset() {
-        // Polynomial: f(x) = x^2 + 2x + 3, evaluated over an 8-point coset shifted
-        // by the field generator. Known answer: f(100) = 10203.
-
-        // Coset shift: the multiplicative generator of the field.
+        // Invariant: both the full path and the precomputation path must
+        // agree on f(100) = 10203 for f(x) = x^2 + 2x + 3.
+        //
+        // Fixture: 8-point coset shifted by the field's multiplicative generator.
         let shift = F::GENERATOR;
 
-        // Pre-computed evaluations of f over the coset {shift * h^0, ..., shift * h^7}.
         let evals = [
             1026, 129027310, 457985035, 994890337, 902, 1988942953, 1555278970, 913671254,
         ]
         .map(F::from_u32);
 
-        // Single column matrix: one polynomial, 8 rows.
         let evals_mat = RowMajorMatrix::new(evals.to_vec(), 1);
 
-        // Part 1: test the standard coset interpolation path.
+        // Part 1: full path (builds coset + batch-inverts internally).
         let point = F::from_u16(100);
         let result = evals_mat.interpolate_coset(shift, point);
         assert_eq!(result, vec![F::from_u16(10203)]);
 
-        // Part 2: test the precomputation path, which should give the same result.
-        // Manually build the coset elements and inverse denominators.
+        // Part 2: precomputation path (caller provides coset + inverse denominators).
         let n = evals.len();
         let k = log2_strict_usize(n);
 
-        // Coset elements: {shift * h^0, shift * h^1, ..., shift * h^{N-1}}.
+        // Build the 8-element coset manually.
         let coset = F::two_adic_generator(k).shifted_powers(shift).collect_n(n);
 
-        // Inverse denominators: 1/(z - coset_i) for each coset element.
+        // Compute 1/(z - x_i) via batch inversion.
         let denom: Vec<_> = coset.iter().map(|&w| point - w).collect();
         let denom = batch_multiplicative_inverse(&denom);
 
-        // The precomputation variant must produce the same result.
+        // Both paths must be bit-identical.
         let result = evals_mat.interpolate_coset_with_precomputation(shift, point, &coset, &denom);
         assert_eq!(result, vec![F::from_u16(10203)]);
     }
 
     #[test]
     fn test_interpolate_coset_single_point_identity() {
-        // Invariant: a constant polynomial f(x) = c evaluates to c everywhere,
-        // so interpolation at any external point must recover exactly c.
-
-        // Constant polynomial: all 8 evaluations are the same value.
+        // Invariant: a constant polynomial f(x) = c evaluates to c everywhere.
+        // Interpolation at any external point must recover exactly c.
         let c = F::from_u32(42);
+
+        // 8 identical evaluations => constant polynomial of degree 0.
         let evals = vec![c; 8];
         let evals_mat = RowMajorMatrix::new(evals, 1);
 
-        // Shifted coset and an arbitrary external evaluation point.
         let shift = F::GENERATOR;
         let point = F::from_u16(1337);
 
-        // Interpolation must recover the constant exactly.
         let result = evals_mat.interpolate_coset(shift, point);
         assert_eq!(result, vec![c]);
     }
 
     #[test]
     fn test_interpolate_subgroup_degree_3_correctness() {
-        // Verify that a degree-3 polynomial over a degree-4 extension field
-        // is correctly interpolated from exactly 2^2 = 4 subgroup points.
-        // A degree-3 polynomial requires exactly 4 evaluation points.
+        // Invariant: a degree-3 polynomial over a quartic extension field is
+        // uniquely determined by 4 = 2^2 evaluation points.
+        // Interpolation must match direct evaluation.
 
-        // f(x) = x^3 + 2*x^2 + 3*x + 4, defined over the quartic extension.
+        // f(x) = x^3 + 2*x^2 + 3*x + 4
         let poly = |x: EF4| x * x * x + x * x * F::TWO + x * F::from_u32(3) + F::from_u32(4);
 
-        // Evaluate f at the 4 elements of the canonical 2^2-subgroup.
+        // Evaluate at the 4 elements of the canonical 2^2-subgroup.
         let subgroup = EF4::two_adic_generator(2).powers().collect_n(4);
         let evals: Vec<_> = subgroup.iter().map(|&x| poly(x)).collect();
-
-        // Single column matrix: one polynomial, 4 evaluation rows.
         let evals_mat = RowMajorMatrix::new(evals, 1);
 
-        // Interpolate at z = 5 and compare against direct evaluation.
+        // Interpolate at z = 5 and compare against direct Horner evaluation.
         let point = EF4::from_u16(5);
         let result = evals_mat.interpolate_subgroup(point);
         let expected = poly(point);
-
         assert_eq!(result[0], expected);
     }
 
     #[test]
     fn test_interpolate_coset_multiple_polynomials() {
-        // Verify batch interpolation: two polynomials evaluated over the same coset
-        // are interpolated simultaneously using a 2-column matrix.
+        // Invariant: batch interpolation of K polynomials via a K-column matrix
+        // must agree with interpolating each polynomial individually.
         //
-        //     f_1(x) = x^2 + 2x + 3
-        //     f_2(x) = 4x^2 + 5x + 6
+        // Fixture: two polynomials over an 8-point coset.
         //
-        //     Matrix layout (8 rows x 2 columns):
-        //         row i = [ f_1(coset[i]), f_2(coset[i]) ]
+        //   f_1(x) = x^2 + 2x + 3
+        //   f_2(x) = 4x^2 + 5x + 6
+        //
+        //   Matrix layout (8 rows x 2 columns):
+        //
+        //     row i = [ f_1(coset_i),  f_2(coset_i) ]
 
-        // Build the 8-point coset shifted by the extension field generator.
+        // 8-point coset shifted by the quartic extension generator.
         let shift = EF4::GENERATOR;
         let coset = EF4::two_adic_generator(3)
             .shifted_powers(shift)
@@ -310,94 +355,82 @@ mod tests {
         let f1 = |x: EF4| x * x + x * F::TWO + F::from_u32(3);
         let f2 = |x: EF4| x * x * F::from_u32(4) + x * F::from_u32(5) + F::from_u32(6);
 
-        // Interleave evaluations: [f1(c0), f2(c0), f1(c1), f2(c1), ...].
+        // Interleave: [f1(c_0), f2(c_0), f1(c_1), f2(c_1), ...].
         let evals: Vec<_> = coset.iter().flat_map(|&x| vec![f1(x), f2(x)]).collect();
-
-        // Two-column matrix: each column is one polynomial's evaluations.
         let evals_mat = RowMajorMatrix::new(evals, 2);
 
-        // Interpolate both polynomials at z = 77.
+        // Interpolate both columns at z = 77.
         let point = EF4::from_u32(77);
         let result = evals_mat.interpolate_coset(shift, point);
 
-        // Compare against direct evaluation of each polynomial at the same point.
-        let expected_f1 = f1(point);
-        let expected_f2 = f2(point);
-
-        assert_eq!(result[0], expected_f1);
-        assert_eq!(result[1], expected_f2);
+        // Each column must match direct evaluation.
+        assert_eq!(result[0], f1(point));
+        assert_eq!(result[1], f2(point));
     }
 
     #[test]
     fn test_interpolate_subgroup_multiple_columns() {
-        // Same as the coset multi-polynomial test, but over the canonical subgroup
-        // (shift = 1). Verifies that the subgroup path correctly delegates to
-        // the coset path and produces identical results.
+        // Invariant: the subgroup path (shift = 1) must produce the same
+        // results as the coset path for multi-column matrices.
         //
-        //     f_1(x) = x^2 + 2x + 3
-        //     f_2(x) = 4x^2 + 5x + 6
+        //   f_1(x) = x^2 + 2x + 3
+        //   f_2(x) = 4x^2 + 5x + 6
 
         let f1 = |x: EF4| x * x + x * F::TWO + F::from_u32(3);
         let f2 = |x: EF4| x * x * F::from_u32(4) + x * F::from_u32(5) + F::from_u32(6);
 
-        // Evaluation domain: the canonical 2^3 = 8-point subgroup {h^0, ..., h^7}.
+        // Canonical 8-point subgroup.
         let subgroup_iter = EF4::two_adic_generator(3).powers().take(8);
 
-        // Evaluate both polynomials on the subgroup, interleaved.
+        // Interleaved evaluations => 8 rows x 2 columns.
         let evals: Vec<_> = subgroup_iter.flat_map(|x| vec![f1(x), f2(x)]).collect();
-
-        // 8 rows x 2 columns: column 0 holds f_1 evaluations, column 1 holds f_2.
         let evals_mat = RowMajorMatrix::new(evals, 2);
 
-        // Interpolate at z = 77, which lies outside the subgroup.
+        // z = 77 lies outside the subgroup.
         let point = EF4::from_u32(77);
         let result = evals_mat.interpolate_subgroup(point);
 
-        // Compare against direct evaluation of each polynomial.
-        let expected_f1 = f1(point);
-        let expected_f2 = f2(point);
-
-        assert_eq!(result, vec![expected_f1, expected_f2]);
+        assert_eq!(result, vec![f1(point), f2(point)]);
     }
 
     proptest! {
-        // Correctness: subgroup round-trip
         #[test]
         fn prop_roundtrip_subgroup(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: evaluate f on 2^log_n-subgroup, interpolate at z → must equal f(z).
+            // Invariant: evaluate f on the canonical subgroup, interpolate at z,
+            // and the result must equal direct Horner evaluation of f at z.
             //
-            //     coeffs  →  eval on {h^0, ..., h^{N-1}}  →  interpolate at z
-            //     coeffs  →  Horner at z
-            //     Both must agree.
+            //   coeffs -> eval on {h^0, ..., h^{N-1}} -> interpolate at z
+            //   coeffs -> Horner at z
+            //   Both must agree.
 
             // Truncate to degree < N so the polynomial is uniquely determined.
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
 
-            // Evaluate on canonical subgroup (shift = 1).
+            // Evaluate on the canonical subgroup (shift = 1).
             let evals: Vec<F> = eval_poly_on_coset(&coeffs, F::ONE, log_n);
             let evals_mat = RowMajorMatrix::new(evals, 1);
 
             let point = EF4::from_u32(point_raw);
 
-            // Compare interpolation against direct Horner evaluation.
             let result = evals_mat.interpolate_subgroup(point);
             let expected = eval_poly(&coeffs, point);
             prop_assert_eq!(result[0], expected);
         }
 
-        // Correctness: coset round-trip (shift = GENERATOR)
         #[test]
         fn prop_roundtrip_coset(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Same round-trip as above, but over a shifted coset {g*h^i}.
+            // Invariant: same round-trip as above, but over a shifted coset
+            // with shift = multiplicative generator.
+
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let shift = F::GENERATOR;
@@ -411,18 +444,15 @@ mod tests {
             prop_assert_eq!(result[0], expected);
         }
 
-        // Path equivalence: standard vs precomputation
         #[test]
         fn prop_precomputation_equivalence(
             log_n in 1usize..=4,
             coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=16),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: both code paths compute the same barycentric formula.
-            //
-            //     interpolate_coset           (builds coset + inverses internally)
-            //     interpolate_coset_with_precomputation (caller provides them)
-            //     → must be bit-identical.
+            // Invariant: the full path and the precomputation path must be
+            // bit-identical — they compute the same barycentric formula.
+
             let n = 1usize << log_n;
             let coeffs: Vec<F> = coeffs_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let shift = F::GENERATOR;
@@ -431,10 +461,10 @@ mod tests {
             let evals_mat = RowMajorMatrix::new(evals, 1);
             let point = EF4::from_u32(point_raw);
 
-            // Standard path.
+            // Full path (builds everything internally).
             let result_standard = evals_mat.interpolate_coset(shift, point);
 
-            // Manual precomputation path.
+            // Manual precomputation path (caller builds coset + inverse denoms).
             let subgroup_gen = F::two_adic_generator(log_n);
             let coset: Vec<F> =
                 (0..n).map(|i| shift * subgroup_gen.exp_u64(i as u64)).collect();
@@ -446,17 +476,19 @@ mod tests {
             prop_assert_eq!(result_standard, result_precomp);
         }
 
-        // Constant polynomial: f(x) = c → interpolation at any z must return c.
         #[test]
         fn prop_constant_polynomial(
             log_n in 1usize..=4,
             c_raw in 0u32..2013265921u32,
             point_raw in 1u32..2013265921u32,
         ) {
+            // Invariant: a constant polynomial evaluates to the same value
+            // everywhere. Interpolation at any external point must recover it.
+
             let n = 1usize << log_n;
             let c = F::from_u32(c_raw);
 
-            // N identical evaluations → constant polynomial.
+            // N identical evaluations => degree-0 polynomial.
             let evals = vec![c; n];
             let evals_mat = RowMajorMatrix::new(evals, 1);
             let point = EF4::from_u32(point_raw);
@@ -465,7 +497,6 @@ mod tests {
             prop_assert_eq!(result[0], EF4::from(c));
         }
 
-        // Linearity: interp(a*f + b*g) == a*interp(f) + b*interp(g)
         #[test]
         fn prop_linearity(
             log_n in 1usize..=3,
@@ -475,14 +506,16 @@ mod tests {
             b_raw in 0u32..2013265921u32,
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: barycentric interpolation is linear over the evaluation column.
+            // Invariant: barycentric interpolation is linear.
+            //   interp(a*f + b*g, z) == a * interp(f, z) + b * interp(g, z)
+
             let n = 1usize << log_n;
             let f_coeffs: Vec<F> = f_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let g_coeffs: Vec<F> = g_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let a = F::from_u32(a_raw);
             let b = F::from_u32(b_raw);
 
-            // Evaluate f, g, and (a*f + b*g) on the canonical subgroup.
+            // Evaluate f, g, and the linear combination on the canonical subgroup.
             let f_evals: Vec<F> = eval_poly_on_coset(&f_coeffs, F::ONE, log_n);
             let g_evals: Vec<F> = eval_poly_on_coset(&g_coeffs, F::ONE, log_n);
             let combined_evals: Vec<F> = f_evals
@@ -505,7 +538,6 @@ mod tests {
             prop_assert_eq!(interp_combined, expected);
         }
 
-        // Batch equivalence: 2-column matrix vs two 1-column matrices
         #[test]
         fn prop_batch_equals_individual(
             log_n in 1usize..=3,
@@ -513,12 +545,15 @@ mod tests {
             g_raw in prop::collection::vec(0u32..2013265921, 1..=8),
             point_raw in 1u32..2013265921u32,
         ) {
-            // Invariant: batch[col_j] == individual[col_j] for all j.
+            // Invariant: a multi-column matrix must produce the same results
+            // as interpolating each column individually.
             //
-            //     batch_mat (N×2):       [f(c_0) g(c_0)]     → interpolate → [f(z), g(z)]
-            //                            [f(c_1) g(c_1)]
-            //                            ...
-            //     f_mat (N×1), g_mat (N×1) → interpolate each → f(z), g(z)
+            //   batch (N x 2):  [ f(c_0)  g(c_0) ]  -> interpolate -> [ f(z), g(z) ]
+            //                   [ f(c_1)  g(c_1) ]
+            //                   ...
+            //
+            //   single (N x 1) each  -> interpolate -> f(z), g(z)
+
             let n = 1usize << log_n;
             let f_coeffs: Vec<F> = f_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
             let g_coeffs: Vec<F> = g_raw.iter().take(n).map(|&v| F::from_u32(v)).collect();
@@ -527,7 +562,7 @@ mod tests {
             let f_evals: Vec<F> = eval_poly_on_coset(&f_coeffs, shift, log_n);
             let g_evals: Vec<F> = eval_poly_on_coset(&g_coeffs, shift, log_n);
 
-            // Interleave into 2-column batch matrix.
+            // Interleave into a 2-column batch matrix.
             let batch_evals: Vec<F> = f_evals
                 .iter()
                 .zip(&g_evals)

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -10,19 +10,15 @@
 //!
 //! ```text
 //!   f(z) = (z^N - g^N) / (N * g^N)  *  sum_i  g*h^i / (z - g*h^i)  *  f(g*h^i)
+//!         = z * (z^N - g^N) / (N * g^N)  * sum_i (1/(z - g*h^i) - 1/z) * f(g*h^i)
 //! ```
 //!
-//! The per-element weight g*h^i / (z - g*h^i) normally requires N
-//! extension-by-base multiplications. An algebraic identity eliminates them:
+//! This second equality lets us trade off N extension-by-base multiplications for
+//! A single extension-by-extension multiplication, an extension inversion and N
+//! extension-by-extension subtractions. For large N this is worth it.
 //!
-//! ```text
-//!   g*h^i / (z - g*h^i)  =  z * ( 1/(z - g*h^i) - 1/z )
-//! ```
-//!
-//! So we define **adjusted weights** as the parenthesized difference, absorb the
-//! extra factor of z into the global scalar, and feed the adjusted weights
-//! straight into the SIMD-optimized dot product — zero per-element coset work.
-
+//! Thus we define the **adjusted weights** to be `(1/(z - g*h^i) - 1/z)` and work with
+//! these instead.
 use alloc::vec::Vec;
 
 use p3_field::coset::TwoAdicMultiplicativeCoset;


### PR DESCRIPTION
@SyxtonPrime What do you think about the following? I think that you have left a TODO in the interpolation function couple months ago (maybe was not you, not sure). I think this PR improves the situation a bit. This is not magical but couple percents better than before.

## Summary

- Replace N extension-by-base multiplications in barycentric weight computation with 1 extension inversion + N extension subtractions, using the identity `g*h^i/(z - g*h^i) = z * (1/(z - g*h^i) - 1/z)`.
- Add `interpolate_coset_with_adjusted_weights` as a zero-allocation hot path for the FRI PCS prover.
- Add `compute_adjusted_weights` public helper to convert inverse denominators once per opening point.
- Update the FRI PCS opening path to precompute adjusted weights per point and reuse across all matrices.
- Compute the scaling factor with a single base-field inversion (combine `N * g^N` into one denominator).
- Add interpolation benchmarks covering three tiers (full, precomputed, adjusted) at three matrix sizes.

## Benchmark results (BabyBear + degree-4 extension, same machine, back-to-back)

### `interpolate_coset` — full end-to-end

| Config | Before (main) | After | Speedup |
|---|---|---|---|
| 2^10 x 1 | 28.40 µs | 26.07 µs | **1.09x (8.2%)** |
| 2^14 x 16 | 622.6 µs | 583.6 µs | **1.07x (6.3%)** |
| 2^18 x 128 | 38.88 ms | 37.97 ms | **1.02x (2.3%)** |

### `interpolate_coset_with_precomputation` — caller provides inverse denominators

| Config | Before (main) | After | Speedup |
|---|---|---|---|
| 2^10 x 1 | 7.560 µs | 7.250 µs | **1.04x (4.1%)** |
| 2^14 x 16 | 286.9 µs | 280.4 µs | **1.02x (2.3%)** |
| 2^18 x 128 | 33.48 ms | 33.12 ms | **1.01x (1.1%)** |

### `interpolate_coset_with_adjusted_weights` — zero-allocation FRI PCS hot path (new)

| Config | vs main `_with_precomputation` | Speedup |
|---|---|---|
| 2^10 x 1 | 7.560 µs → 6.637 µs | **1.14x (12.2%)** |
| 2^14 x 16 | 286.9 µs → 274.4 µs | **1.05x (4.4%)** |
| 2^18 x 128 | 33.48 ms → 33.16 ms | **1.01x (1.0%)** |

## Test plan

- [x] All 12 matrix interpolation tests pass (unit + property-based)
- [x] All 26 FRI PCS tests pass
- [x] `cargo fmt`, `cargo clippy`, `cargo sort` clean
- [x] Benchmarks run and show consistent improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)