### PR TITLE
fix(bn254): add Poseidon2 round-number constants and fix benchmark

### DIFF
--- a/bn254/src/lib.rs
+++ b/bn254/src/lib.rs
@@ -8,4 +8,7 @@ mod helpers;
 mod poseidon2;
 
 pub use bn254::*;
-pub use poseidon2::Poseidon2Bn254;
+pub use poseidon2::{
+    BN254_POSEIDON2_HALF_FULL_ROUNDS, BN254_POSEIDON2_PARTIAL_ROUNDS_3, BN254_S_BOX_DEGREE,
+    Poseidon2Bn254,
+};

--- a/bn254/src/poseidon2.rs
+++ b/bn254/src/poseidon2.rs
@@ -19,20 +19,30 @@ use crate::Bn254;
 /// satisfying `gcd(α, p - 1) = 1` is 5.
 pub const BN254_S_BOX_DEGREE: u64 = 5;
 
-/// Number of full rounds per half for BN254 Poseidon2 (`RF / 2`).
+/// Half the number of full rounds for BN254 Poseidon2.
 ///
-/// The total number of full rounds is `RF = 8` (4 beginning + 4 ending).
-/// Follows the Poseidon2 paper's security analysis with a +2 RF margin.
+/// Full rounds run at the beginning and at the end of the schedule.
+/// This constant is the per-side count, so the total is `R_F = 8`.
 ///
-/// Reference: <https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_bn256.rs>
+/// Of those 8 rounds:
+/// - 6 are required by the wide-trail differential bound,
+/// - 2 are kept as a statistical security margin.
+///
+/// # Reference
+///
+/// Poseidon2 paper, Table 1, instance `(n, t, d) = (256, 3, 5)`:
+/// <https://eprint.iacr.org/2023/323>.
 pub const BN254_POSEIDON2_HALF_FULL_ROUNDS: usize = 4;
 
-/// Number of partial rounds for BN254 Poseidon2 (width 3).
+/// Number of partial rounds for BN254 Poseidon2 at state width 3.
 ///
-/// Matches the reference implementation from the HorizenLabs Poseidon2 codebase
-/// for the BN256 scalar field at 128-bit security.
+/// Partial rounds apply the S-box to a single state element and carry
+/// most of the algebraic security of the permutation.
 ///
-/// Reference: <https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_bn256.rs>
+/// # Reference
+///
+/// Poseidon2 paper, Table 1, instance `(n, t, d) = (256, 3, 5)` at the
+/// 128-bit security level: <https://eprint.iacr.org/2023/323>.
 pub const BN254_POSEIDON2_PARTIAL_ROUNDS_3: usize = 56;
 
 /// An implementation of the Poseidon2 hash function for the Bn254Fr field.

--- a/bn254/src/poseidon2.rs
+++ b/bn254/src/poseidon2.rs
@@ -19,6 +19,22 @@ use crate::Bn254;
 /// satisfying `gcd(α, p - 1) = 1` is 5.
 pub const BN254_S_BOX_DEGREE: u64 = 5;
 
+/// Number of full rounds per half for BN254 Poseidon2 (`RF / 2`).
+///
+/// The total number of full rounds is `RF = 8` (4 beginning + 4 ending).
+/// Follows the Poseidon2 paper's security analysis with a +2 RF margin.
+///
+/// Reference: <https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_bn256.rs>
+pub const BN254_POSEIDON2_HALF_FULL_ROUNDS: usize = 4;
+
+/// Number of partial rounds for BN254 Poseidon2 (width 3).
+///
+/// Matches the reference implementation from the HorizenLabs Poseidon2 codebase
+/// for the BN256 scalar field at 128-bit security.
+///
+/// Reference: <https://github.com/HorizenLabs/poseidon2/blob/main/plain_implementations/src/poseidon2/poseidon2_instance_bn256.rs>
+pub const BN254_POSEIDON2_PARTIAL_ROUNDS_3: usize = 56;
+
 /// An implementation of the Poseidon2 hash function for the Bn254Fr field.
 ///
 /// It acts on arrays of the form `[Bn254Fr; WIDTH]`.
@@ -147,8 +163,8 @@ mod tests {
     #[test]
     fn test_poseidon2_bn254() {
         const WIDTH: usize = 3;
-        const ROUNDS_F: usize = 8;
-        const ROUNDS_P: usize = 56;
+        const ROUNDS_F: usize = 2 * BN254_POSEIDON2_HALF_FULL_ROUNDS;
+        const ROUNDS_P: usize = BN254_POSEIDON2_PARTIAL_ROUNDS_3;
 
         type F = Bn254;
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -1,6 +1,8 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_bn254::{Bn254, Poseidon2Bn254};
+use p3_bn254::{
+    BN254_POSEIDON2_HALF_FULL_ROUNDS, BN254_POSEIDON2_PARTIAL_ROUNDS_3, Bn254, Poseidon2Bn254,
+};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
@@ -35,7 +37,11 @@ fn bench_poseidon12(c: &mut Criterion) {
     let poseidon2_gold_16 = Poseidon2Goldilocks::<16>::new_from_rng_128(&mut rng);
     poseidon2::<Goldilocks, Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
 
-    let poseidon2_bn254 = Poseidon2Bn254::<3>::new_from_rng(8, 22, &mut rng);
+    let poseidon2_bn254 = Poseidon2Bn254::<3>::new_from_rng(
+        2 * BN254_POSEIDON2_HALF_FULL_ROUNDS,
+        BN254_POSEIDON2_PARTIAL_ROUNDS_3,
+        &mut rng,
+    );
     poseidon2::<Bn254, Poseidon2Bn254<3>, 3>(c, &poseidon2_bn254);
 }
 


### PR DESCRIPTION
Should supersede https://github.com/Plonky3/Plonky3/pull/1556

## Summary

- Add public `BN254_POSEIDON2_HALF_FULL_ROUNDS` and `BN254_POSEIDON2_PARTIAL_ROUNDS_3` constants to the `bn254` crate, matching the pattern already used by BabyBear, KoalaBear, Goldilocks, and Mersenne31
- Export `BN254_S_BOX_DEGREE` (was public but not re-exported from `lib.rs`)
- **Fix benchmark bug**: the Poseidon2 benchmark was using 22 partial rounds instead of the correct 56, producing misleading results
- Use the new constants in both the test and the benchmark to prevent future drift

## Test plan

- [x] `cargo check -p p3-bn254` passes
- [x] `cargo test -p p3-bn254 test_poseidon2_bn254` passes (validates constants match the zkhash reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)