### PR TITLE
perf(monty-31/neon): specialized exp_4 skipping intermediate reduction

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -70,6 +70,7 @@ fn bench_packedfield(c: &mut Criterion) {
 
     const EXP_REPS: usize = 1000;
     benchmark_exp_const::<<F as Field>::Packing, 3, EXP_REPS>(c, &name);
+    benchmark_exp_const::<<F as Field>::Packing, 4, EXP_REPS>(c, &name);
     benchmark_exp_const::<<F as Field>::Packing, 5, EXP_REPS>(c, &name);
     benchmark_exp_const::<<F as Field>::Packing, 7, EXP_REPS>(c, &name);
 

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -556,59 +556,28 @@ fn cube<MPNeon: MontyParametersNeon>(val: int32x4_t) -> uint32x4_t {
     }
 }
 
-/// Raise packed field elements to the fourth power: x -> x^4.
-///
-/// # Overview
-///
-/// Chains two Montgomery squarings while keeping the intermediate
-/// x^2 in unreduced signed form (-P, P).
-///
-/// A normal square produces a fully reduced result in [0, P).
-/// That reduction costs 2 extra instructions (a compare and a
-/// fused multiply-subtract).
-/// Because Montgomery multiplication already accepts signed
-/// inputs in (-P, P), the intermediate x^2 can feed straight
-/// into the second squaring without that reduction.
-///
-/// # Data Flow
-///
-/// ```text
-///     val ──► x^2  (unreduced, in (-P, P))  ──► x^4  (canonical, in [0, P))
-///             │                                   │
-///             5 instr (no reduction)              7 instr (with reduction)
-/// ```
-///
-/// # Performance
-///
-/// ```text
-///     Naive  (two canonical squares):   2 x 7 = 14 instr,  ~28 cyc latency
-///     Here   (skip one reduction):      5 + 7 = 12 instr,  ~24 cyc latency
-///                                       ─────────────────
-///                                       saves 2 instr / 4 cyc
-/// ```
+/// Take the fourth power of the MontyField31 field elements.
 ///
 /// # Safety
-///
-/// - Inputs must be signed 32-bit integers in [-P, P].
-/// - Outputs are unsigned 32-bit integers in [0, P).
+/// Inputs must be signed 32-bit integers in the range [-P, P].
+/// Outputs will be a unsigned 32-bit integers in canonical form [0, ..., P).
 #[inline]
 #[must_use]
 fn exp_4<MPNeon: MontyParametersNeon>(val: int32x4_t) -> uint32x4_t {
+    // throughput: 3 cyc/vec (1.33 els/cyc)
+    // latency: 25 cyc
+
     unsafe {
-        // Precompute mu * val (mod 2^32).
-        // Reused by the first squaring since both operands are val.
         let mu_val = mulby_mu::<MPNeon>(val);
 
-        // x^2 — unreduced output in (-P, P).
-        // Skips the 2-instruction canonical reduction;
-        // The next Montgomery multiply accepts this range directly.
         let val_2 = mul_with_precomp::<MPNeon, false>(val, val, mu_val);
 
-        // Fresh precomputation for x^2 (new operand for the second squaring).
+        // val_2 replaces val as both operands, so mu must be recomputed.
         let mu_val_2 = mulby_mu::<MPNeon>(val_2);
 
-        // x^4 — canonical output in [0, P), safe to reinterpret as unsigned.
         let val_4 = mul_with_precomp::<MPNeon, true>(val_2, val_2, mu_val_2);
+
+        // Safe as mul_with_precomp::<MPNeon, true> returns integers in [0, P)
         aarch64::vreinterpretq_u32_s32(val_4)
     }
 }

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -268,7 +268,14 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for PackedMontyField31Neon<FP>
             1 => *self,
             2 => self.square(),
             3 => self.cube(),
-            4 => self.square().square(),
+            4 => {
+                let val = self.to_signed_vector();
+                unsafe {
+                    // Safety: `exp_4` returns values in canonical form when given values in canonical form.
+                    let res = exp_4::<FP>(val);
+                    Self::from_vector(res)
+                }
+            }
             5 => {
                 let val = self.to_signed_vector();
                 unsafe {
@@ -546,6 +553,63 @@ fn cube<MPNeon: MontyParametersNeon>(val: int32x4_t) -> uint32x4_t {
 
         // Safe as mul_with_precomp::<MPNeon, true> returns integers in [0, P)
         aarch64::vreinterpretq_u32_s32(val_3)
+    }
+}
+
+/// Raise packed field elements to the fourth power: x -> x^4.
+///
+/// # Overview
+///
+/// Chains two Montgomery squarings while keeping the intermediate
+/// x^2 in unreduced signed form (-P, P).
+///
+/// A normal square produces a fully reduced result in [0, P).
+/// That reduction costs 2 extra instructions (a compare and a
+/// fused multiply-subtract).
+/// Because Montgomery multiplication already accepts signed
+/// inputs in (-P, P), the intermediate x^2 can feed straight
+/// into the second squaring without that reduction.
+///
+/// # Data Flow
+///
+/// ```text
+///     val ──► x^2  (unreduced, in (-P, P))  ──► x^4  (canonical, in [0, P))
+///             │                                   │
+///             5 instr (no reduction)              7 instr (with reduction)
+/// ```
+///
+/// # Performance
+///
+/// ```text
+///     Naive  (two canonical squares):   2 x 7 = 14 instr,  ~28 cyc latency
+///     Here   (skip one reduction):      5 + 7 = 12 instr,  ~24 cyc latency
+///                                       ─────────────────
+///                                       saves 2 instr / 4 cyc
+/// ```
+///
+/// # Safety
+///
+/// - Inputs must be signed 32-bit integers in [-P, P].
+/// - Outputs are unsigned 32-bit integers in [0, P).
+#[inline]
+#[must_use]
+fn exp_4<MPNeon: MontyParametersNeon>(val: int32x4_t) -> uint32x4_t {
+    unsafe {
+        // Precompute mu * val (mod 2^32).
+        // Reused by the first squaring since both operands are val.
+        let mu_val = mulby_mu::<MPNeon>(val);
+
+        // x^2 — unreduced output in (-P, P).
+        // Skips the 2-instruction canonical reduction;
+        // The next Montgomery multiply accepts this range directly.
+        let val_2 = mul_with_precomp::<MPNeon, false>(val, val, mu_val);
+
+        // Fresh precomputation for x^2 (new operand for the second squaring).
+        let mu_val_2 = mulby_mu::<MPNeon>(val_2);
+
+        // x^4 — canonical output in [0, P), safe to reinterpret as unsigned.
+        let val_4 = mul_with_precomp::<MPNeon, true>(val_2, val_2, mu_val_2);
+        aarch64::vreinterpretq_u32_s32(val_4)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a dedicated fourth-power function (`exp_4`) for packed NEON field elements that chains two Montgomery squarings while keeping the intermediate x^2 in unreduced signed form (-P, P).
- This avoids the 2-instruction canonical reduction (compare + fused multiply-subtract) between the two squarings, since Montgomery multiplication already accepts signed inputs in that range.
- Add an `exp_const<4>` benchmark case for packed BabyBear.

This follows the exact same pattern already used by `cube`, `exp_5`, and `exp_7`.

## Benchmark results (Apple Silicon, aarch64 NEON)

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `exp_const<4>/1000 PackedMontyField31Neon<BabyBearParameters>` | 1.63 µs | 1.53 µs | **-7.7%** |
| `exp_const<3>/1000` (regression check) | 1.32 µs | 1.32 µs | no change |
| `mul-throughput/100` (regression check) | 779 ns | 781 ns | no change |

## Test plan

- [x] `cargo test -p p3-baby-bear --lib` — 209 tests pass
- [x] `cargo test -p p3-koala-bear --lib` — 193 tests pass
- [x] `cargo test -p p3-monty-31 --lib` — 40 tests pass
- [x] No regressions on existing packed field benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)