### PR TITLE
fix(merkle-tree): make MerkleTreeHidingMmcs Sync

### DIFF
--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -35,6 +35,8 @@ use p3_util::log2_strict_usize;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
+const fn assert_sync<T: Sync>() {}
+
 const TWO_ADIC_FIXTURE: &str = "tests/fixtures/batch_stark_two_adic_v1.postcard";
 const CIRCLE_FIXTURE: &str = "tests/fixtures/batch_stark_circle_v1.postcard";
 
@@ -687,6 +689,10 @@ fn make_two_adic_compat_config(seed: u64) -> MyConfig {
 }
 
 fn make_config_zk(seed: u64) -> MyHidingConfig {
+    assert_sync::<HidingValMmcs>();
+    assert_sync::<HidingPcs>();
+    assert_sync::<MyHidingConfig>();
+
     let mut rng = SmallRng::seed_from_u64(seed);
     let perm = Perm::new_from_rng_128(&mut rng);
     let hash = MyHash::new(perm.clone());

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -31,11 +31,9 @@ use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
 use p3_uni_stark::{InvalidProofShapeError, StarkConfig};
-use p3_util::log2_strict_usize;
+use p3_util::{assert_clone, assert_send, assert_sync, log2_strict_usize};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-
-const fn assert_sync<T: Sync>() {}
 
 const TWO_ADIC_FIXTURE: &str = "tests/fixtures/batch_stark_two_adic_v1.postcard";
 const CIRCLE_FIXTURE: &str = "tests/fixtures/batch_stark_circle_v1.postcard";
@@ -689,7 +687,9 @@ fn make_two_adic_compat_config(seed: u64) -> MyConfig {
 }
 
 fn make_config_zk(seed: u64) -> MyHidingConfig {
+    assert_clone::<HidingValMmcs>();
     assert_sync::<HidingValMmcs>();
+    assert_send::<HidingPcs>();
     assert_sync::<HidingPcs>();
     assert_sync::<MyHidingConfig>();
 

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -20,6 +20,7 @@ p3-util.workspace = true
 itertools.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["alloc"] }
+spin.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use core::cell::RefCell;
 
 use itertools::Itertools;
 use p3_commit::{BatchOpening, BatchOpeningRef, Mmcs};
@@ -13,6 +12,7 @@ use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use spin::Mutex;
 
 use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 
@@ -35,7 +35,7 @@ use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 /// - `H`: the leaf hasher
 /// - `C`: the digest compression function
 /// - `R`: a random number generator for blinding leaves
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MerkleTreeHidingMmcs<
     P,
     PW,
@@ -47,7 +47,7 @@ pub struct MerkleTreeHidingMmcs<
     const SALT_ELEMS: usize,
 > {
     inner: MerkleTreeMmcs<P, PW, H, C, N, DIGEST_ELEMS>,
-    rng: RefCell<R>,
+    rng: Mutex<R>,
 }
 
 impl<P, PW, H, C, R, const N: usize, const DIGEST_ELEMS: usize, const SALT_ELEMS: usize>
@@ -66,12 +66,26 @@ impl<P, PW, H, C, R, const N: usize, const DIGEST_ELEMS: usize, const SALT_ELEMS
         let inner = MerkleTreeMmcs::new(hash, compress, cap_height);
         Self {
             inner,
-            rng: RefCell::new(rng),
+            rng: Mutex::new(rng),
         }
     }
 
     pub const fn cap_height(&self) -> usize {
         self.inner.cap_height()
+    }
+}
+
+impl<P, PW, H, C, R, const N: usize, const DIGEST_ELEMS: usize, const SALT_ELEMS: usize> Clone
+    for MerkleTreeHidingMmcs<P, PW, H, C, R, N, DIGEST_ELEMS, SALT_ELEMS>
+where
+    MerkleTreeMmcs<P, PW, H, C, N, DIGEST_ELEMS>: Clone,
+    R: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            rng: Mutex::new(self.rng.lock().clone()),
+        }
     }
 }
 
@@ -87,7 +101,7 @@ where
     C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
         + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
         + Sync,
-    R: Rng + Clone,
+    R: Rng + Clone + Send,
     PW::Value: Eq + Clone,
     [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     StandardUniform: Distribution<P::Value>,
@@ -108,11 +122,11 @@ where
         &self,
         inputs: Vec<M>,
     ) -> (Self::Commitment, Self::ProverData<M>) {
+        let mut rng = self.rng.lock();
         let salted_inputs = inputs
             .into_iter()
             .map(|mat| {
-                let salts =
-                    RowMajorMatrix::rand(&mut *self.rng.borrow_mut(), mat.height(), SALT_ELEMS);
+                let salts = RowMajorMatrix::rand(&mut *rng, mat.height(), SALT_ELEMS);
                 HorizontalPair::new(mat, salts)
             })
             .collect();
@@ -181,6 +195,8 @@ mod tests {
     use super::MerkleTreeHidingMmcs;
     use crate::MerkleTreeError;
 
+    const fn assert_sync<T: Sync>() {}
+
     type F = BabyBear;
     const SALT_ELEMS: usize = 4;
 
@@ -230,5 +246,10 @@ mod tests {
         let (commit, prover_data) = mmcs.commit(mats);
         let batch_proof = mmcs.open_batch(17, &prover_data);
         mmcs.verify_batch(&commit, &dims, 17, (&batch_proof).into())
+    }
+
+    #[test]
+    fn hiding_mmcs_is_sync() {
+        assert_sync::<MyMmcs>();
     }
 }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -189,13 +189,12 @@ mod tests {
     use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use p3_util::assert_sync;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
     use super::MerkleTreeHidingMmcs;
     use crate::MerkleTreeError;
-
-    const fn assert_sync<T: Sync>() {}
 
     type F = BabyBear;
     const SALT_ELEMS: usize = 4;

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -20,6 +20,8 @@ use p3_uni_stark::{InvalidProofShapeError, StarkConfig, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
+const fn assert_sync<T: Sync>() {}
+
 /// For testing the public values feature
 pub struct FibonacciAir {}
 
@@ -172,6 +174,10 @@ type ZkHidingPcs = HidingFriPcs<Val, Dft, ZkValHidingMmcs, ZkChallengeHidingMmcs
 type ZkConfig = StarkConfig<ZkHidingPcs, Challenge, ZkChallenger>;
 
 fn make_zk_config() -> ZkConfig {
+    assert_sync::<ZkValHidingMmcs>();
+    assert_sync::<ZkHidingPcs>();
+    assert_sync::<ZkConfig>();
+
     let byte_hash = ZkByteHash {};
     let u64_hash = ZkU64Hash::new(KeccakF {});
     let field_hash = ZkFieldHash::new(u64_hash);

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -17,10 +17,9 @@ use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
 use p3_uni_stark::{InvalidProofShapeError, StarkConfig, prove, verify};
+use p3_util::assert_sync;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-
-const fn assert_sync<T: Sync>() {}
 
 /// For testing the public values feature
 pub struct FibonacciAir {}

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -20,6 +20,8 @@ use p3_uni_stark::{StarkConfig, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
+const fn assert_sync<T: Sync>() {}
+
 #[derive(Clone)]
 struct PeriodicAir<F> {
     periodic: Vec<Vec<F>>,
@@ -141,6 +143,10 @@ fn periodic_air_two_adic_zk_prove_verify() -> Result<(), impl Debug> {
     type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
     type Config = StarkConfig<Pcs, Challenge, Challenger>;
+
+    assert_sync::<ValMmcs>();
+    assert_sync::<Pcs>();
+    assert_sync::<Config>();
 
     let mut rng = SmallRng::seed_from_u64(1);
     let perm = Perm::new_from_rng_128(&mut rng);

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -17,10 +17,9 @@ use p3_symmetric::{
     CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
 };
 use p3_uni_stark::{StarkConfig, prove, verify};
+use p3_util::assert_sync;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-
-const fn assert_sync<T: Sync>() {}
 
 #[derive(Clone)]
 struct PeriodicAir<F> {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -170,6 +170,15 @@ pub const fn indices_arr<const N: usize>() -> [usize; N] {
     indices_arr
 }
 
+/// Statically asserts that `T` implements [`Clone`].
+pub const fn assert_clone<T: Clone>() {}
+
+/// Statically asserts that `T` implements [`Send`].
+pub const fn assert_send<T: Send>() {}
+
+/// Statically asserts that `T` implements [`Sync`].
+pub const fn assert_sync<T: Sync>() {}
+
 #[inline]
 pub const fn reverse_bits(x: usize, n: usize) -> usize {
     // Assert that n is a power of 2


### PR DESCRIPTION
Current `MerkleTreeHidingMmcs` stores its internal `Rng` in a `RefCell`, which keeps the hiding MMCS `!Sync` even when it is used as the input MMCS inside `HidingFriPcs`.

This switches the RNG storage to `spin::Mutex` so the hiding commitment chain can be `Sync` end to end while staying `no_std` compatible. It preserves clone semantics by cloning the locked RNG state, adds a `Sync` regression test for `MerkleTreeHidingMmcs`, and adds compile-time `Sync` assertions in the existing ZK configs that compose it through `HidingFriPcs`.