### PR TITLE
test(poseidon1): validate all SIMD lanes against scalar outputs

### DIFF
--- a/baby-bear/src/aarch64_neon/poseidon1.rs
+++ b/baby-bear/src/aarch64_neon/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearNeon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedBabyBearNeon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearNeon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedBabyBearNeon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/baby-bear/src/x86_64_avx2/poseidon1.rs
+++ b/baby-bear/src/x86_64_avx2/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearAVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearAVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedBabyBearAVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/baby-bear/src/x86_64_avx512/poseidon1.rs
+++ b/baby-bear/src/x86_64_avx512/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearAVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_babybear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedBabyBearAVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedBabyBearAVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/koala-bear/src/aarch64_neon/poseidon1.rs
+++ b/koala-bear/src/aarch64_neon/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearNeon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedKoalaBearNeon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearNeon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedKoalaBearNeon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/koala-bear/src/x86_64_avx2/poseidon1.rs
+++ b/koala-bear/src/x86_64_avx2/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearAVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearAVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedKoalaBearAVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/koala-bear/src/x86_64_avx512/poseidon1.rs
+++ b/koala-bear/src/x86_64_avx512/poseidon1.rs
@@ -27,14 +27,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearAVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -43,14 +51,22 @@ mod tests {
         ) {
             let perm = default_koalabear_poseidon1_24();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedKoalaBearAVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedKoalaBearAVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/mersenne-31/src/aarch64_neon/poseidon1.rs
+++ b/mersenne-31/src/aarch64_neon/poseidon1.rs
@@ -226,14 +226,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31Neon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedMersenne31Neon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -242,14 +250,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_32();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31Neon::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut neon_input = input.map(Into::<PackedMersenne31Neon>::into);
-            perm.permute_mut(&mut neon_input);
-            let neon_output = neon_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(neon_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/mersenne-31/src/x86_64_avx2/poseidon1.rs
+++ b/mersenne-31/src/x86_64_avx2/poseidon1.rs
@@ -205,9 +205,11 @@ mod tests {
 
         let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
         perm.permute_mut(&mut avx2_input);
-        let avx2_output = avx2_input.map(|x| x.0[0]);
 
-        assert_eq!(avx2_output, expected);
+        for lane in 0..avx2_input[0].0.len() {
+            let avx2_output = avx2_input.map(|x| x.0[lane]);
+            assert_eq!(avx2_output, expected, "lane {} mismatch", lane);
+        }
     }
 
     /// Known-answer test for width 32 through the AVX2 packed path.
@@ -230,9 +232,11 @@ mod tests {
 
         let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
         perm.permute_mut(&mut avx2_input);
-        let avx2_output = avx2_input.map(|x| x.0[0]);
 
-        assert_eq!(avx2_output, expected);
+        for lane in 0..avx2_input[0].0.len() {
+            let avx2_output = avx2_input.map(|x| x.0[lane]);
+            assert_eq!(avx2_output, expected, "lane {} mismatch", lane);
+        }
     }
 
     fn arb_f() -> impl Strategy<Value = F> {
@@ -246,14 +250,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31AVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -262,14 +274,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_32();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31AVX2::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx2_input = input.map(Into::<PackedMersenne31AVX2>::into);
-            perm.permute_mut(&mut avx2_input);
-            let avx2_output = avx2_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx2_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }

--- a/mersenne-31/src/x86_64_avx512/poseidon1.rs
+++ b/mersenne-31/src/x86_64_avx512/poseidon1.rs
@@ -205,9 +205,11 @@ mod tests {
 
         let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
         perm.permute_mut(&mut avx512_input);
-        let avx512_output = avx512_input.map(|x| x.0[0]);
 
-        assert_eq!(avx512_output, expected);
+        for lane in 0..avx512_input[0].0.len() {
+            let avx512_output = avx512_input.map(|x| x.0[lane]);
+            assert_eq!(avx512_output, expected, "lane {} mismatch", lane);
+        }
     }
 
     /// Known-answer test for width 32 through the AVX512 packed path.
@@ -230,9 +232,11 @@ mod tests {
 
         let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
         perm.permute_mut(&mut avx512_input);
-        let avx512_output = avx512_input.map(|x| x.0[0]);
 
-        assert_eq!(avx512_output, expected);
+        for lane in 0..avx512_input[0].0.len() {
+            let avx512_output = avx512_input.map(|x| x.0[lane]);
+            assert_eq!(avx512_output, expected, "lane {} mismatch", lane);
+        }
     }
 
     fn arb_f() -> impl Strategy<Value = F> {
@@ -246,14 +250,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_16();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31AVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
 
         #[test]
@@ -262,14 +274,22 @@ mod tests {
         ) {
             let perm = default_mersenne31_poseidon1_32();
 
-            let mut expected = input;
-            perm.permute_mut(&mut expected);
+            let mut packed_input = core::array::from_fn(|i| {
+                let mut packed = PackedMersenne31AVX512::ZERO;
+                for lane in 0..packed.0.len() {
+                    packed.0[lane] = input[i] + F::from_u32((lane + 1) as u32);
+                }
+                packed
+            });
+            perm.permute_mut(&mut packed_input);
 
-            let mut avx512_input = input.map(Into::<PackedMersenne31AVX512>::into);
-            perm.permute_mut(&mut avx512_input);
-            let avx512_output = avx512_input.map(|x| x.0[0]);
+            for lane in 0..packed_input[0].0.len() {
+                let mut expected = input.map(|x| x + F::from_u32((lane + 1) as u32));
+                perm.permute_mut(&mut expected);
+                let packed_output = packed_input.map(|x| x.0[lane]);
 
-            prop_assert_eq!(avx512_output, expected);
+                prop_assert_eq!(packed_output, expected, "lane {} mismatch", lane);
+            }
         }
     }
 }


### PR DESCRIPTION
These Poseidon1 SIMD tests now use lane-distinct inputs and assert every lane against scalar baselines, closing lane0-only blind spots without changing production code.