### PR TITLE
test(keccak-air): add proptests for AIR constraints and trace generation

### DIFF
--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -35,6 +35,7 @@ p3-sha256 = { path = "../sha256" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }
 
+proptest.workspace = true
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -10,7 +10,7 @@ use rand::{RngExt, SeedableRng};
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
 use crate::constants::RC_BITS;
 use crate::round_flags::eval_round_flags;
-use crate::{BITS_PER_LIMB, NUM_ROUNDS, NUM_ROUNDS_MIN_1, U64_LIMBS, generate_trace_rows};
+use crate::{BITS_PER_LIMB, NUM_ROUNDS_MIN_1, U64_LIMBS, generate_trace_rows};
 
 /// Assumes the field size is at least 16 bits.
 #[derive(Debug)]
@@ -172,10 +172,9 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
 
         let get_xored_bit = |i| {
             let mut rc_bit_i = AB::Expr::ZERO;
-            for r in 0..NUM_ROUNDS {
-                let this_round = local.step_flags[r];
-                let this_round_constant = AB::Expr::from_bool(RC_BITS[r][i] != 0);
-                rc_bit_i += this_round * this_round_constant;
+            for (rc_bits_r, &step_flag) in RC_BITS.iter().zip(local.step_flags.iter()) {
+                let this_round_constant = AB::Expr::from_bool(rc_bits_r[i] != 0);
+                rc_bit_i += step_flag * this_round_constant;
             }
 
             rc_bit_i.xor(&AB::Expr::from(local.a_prime_prime_0_0_bits[i]))

--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -8,7 +8,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use crate::columns::{KeccakCols, NUM_KECCAK_COLS};
-use crate::constants::rc_value_bit;
+use crate::constants::RC_BITS;
 use crate::round_flags::eval_round_flags;
 use crate::{BITS_PER_LIMB, NUM_ROUNDS, NUM_ROUNDS_MIN_1, U64_LIMBS, generate_trace_rows};
 
@@ -174,11 +174,11 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
             let mut rc_bit_i = AB::Expr::ZERO;
             for r in 0..NUM_ROUNDS {
                 let this_round = local.step_flags[r];
-                let this_round_constant = AB::Expr::from_bool(rc_value_bit(r, i) != 0);
+                let this_round_constant = AB::Expr::from_bool(RC_BITS[r][i] != 0);
                 rc_bit_i += this_round * this_round_constant;
             }
 
-            rc_bit_i.xor(&local.a_prime_prime_0_0_bits[i].into())
+            rc_bit_i.xor(&AB::Expr::from(local.a_prime_prime_0_0_bits[i]))
         };
 
         builder.assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
@@ -199,6 +199,218 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
                         local.a_prime_prime_prime(y, x, limb) - next.a[y][x][limb]
                     }));
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_air::{check_all_constraints, check_constraints};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_goldilocks::Goldilocks;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::columns::KECCAK_COL_MAP;
+
+    type F = Goldilocks;
+
+    fn valid_trace(input: [u64; 25]) -> RowMajorMatrix<F> {
+        generate_trace_rows(vec![input], 0)
+    }
+
+    fn trace_val(trace: &mut RowMajorMatrix<F>, row: usize, col: usize) -> &mut F {
+        let w = trace.width;
+        &mut trace.values[row * w + col]
+    }
+
+    fn flip_bit(val: &mut F) {
+        *val = if *val == F::ZERO { F::ONE } else { F::ZERO };
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn prop_eval_satisfied_for_random_input(input in any::<[u64; 25]>()) {
+            let trace = valid_trace(input);
+            // Walk every row, evaluate all ~2 000 constraints.
+            check_constraints(&KeccakAir {}, &trace, &[]);
+        }
+
+        #[test]
+        fn prop_eval_satisfied_batch(
+            a in any::<[u64; 25]>(),
+            b in any::<[u64; 25]>(),
+        ) {
+            // Trace: rows [0..24) = perm(a), rows [24..48) = perm(b).
+            // Exercises the row-23 → row-24 boundary where the
+            // final-step flag must gate off the transition constraint.
+            let trace = generate_trace_rows::<F>(vec![a, b], 0);
+            check_constraints(&KeccakAir {}, &trace, &[]);
+        }
+    }
+
+    #[test]
+    fn test_corrupted_step_flag_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: swap step_flags[0] and step_flags[1] on row 0.
+        //
+        //     valid:   step_flags = [1, 0, 0, ..., 0]   (round 0 active)
+        //     corrupt: step_flags = [0, 1, 0, ..., 0]   (round 1 active)
+        //
+        // Violates the first-row constraint: step_flags[0] must be 1.
+        *trace_val(trace, 0, KECCAK_COL_MAP.step_flags[0]) = F::ZERO;
+        *trace_val(trace, 0, KECCAK_COL_MAP.step_flags[1]) = F::ONE;
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_preimage_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: change preimage[0][0][0] at row 1.
+        //
+        //     row 0: preimage[0][0][0] = 0x0000
+        //     row 1: preimage[0][0][0] = 0xBEEF  ← corrupt
+        //
+        // Violates: local.preimage == next.preimage (when not final step).
+        *trace_val(trace, 1, KECCAK_COL_MAP.preimage[0][0][0]) = F::from_u16(0xBEEF);
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_c_boolean_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: set C[0][0] = 2.
+        //
+        //     valid:   C[0][0] in {0, 1}
+        //     corrupt: C[0][0] = 2
+        //
+        // Violates: assert_bools(local.c[x]).
+        *trace_val(trace, 0, KECCAK_COL_MAP.c[0][0]) = F::TWO;
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_a_prime_bit_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: flip A'[0][0][0] (one theta-output bit).
+        //
+        // Breaks three constraints at once:
+        // - Boolean check on A'.
+        // - Limb reconstruction: sum of bits != stored limb.
+        // - Parity: sum(A'[x, 0..5, z]) not in {0, 2, 4}.
+        flip_bit(trace_val(trace, 0, KECCAK_COL_MAP.a_prime[0][0][0]));
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_a_prime_prime_limb_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: A''[0][0][0] += 1.
+        //
+        // The A' bits still reconstruct to the old chi result,
+        // but the stored limb is now old + 1 → mismatch.
+        *trace_val(trace, 0, KECCAK_COL_MAP.a_prime_prime[0][0][0]) += F::ONE;
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_a_prime_prime_0_0_bit_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: flip bit 0 of A''[0,0].
+        //
+        // The bit-decomposition no longer reconstructs to the
+        // stored A''[0][0] limb.
+        flip_bit(trace_val(
+            trace,
+            0,
+            KECCAK_COL_MAP.a_prime_prime_0_0_bits[0],
+        ));
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_a_prime_prime_prime_limb_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: A'''[0,0] limb 0 += 1.
+        //
+        // Breaks two constraints:
+        // - Iota: A'''[0,0] != A''[0,0] XOR RC.
+        // - Transition: A'''[0,0] != next row's A[0][0].
+        *trace_val(trace, 0, KECCAK_COL_MAP.a_prime_prime_prime_0_0_limbs[0]) += F::ONE;
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_round_output_to_next_input_detected() {
+        let trace = &mut valid_trace([0u64; 25]);
+
+        // Mutation: A[0][0][0] at row 1 += 1.
+        //
+        //     row 0 output: A'''[0][0][0] = V
+        //     row 1 input:  A[0][0][0]    = V + 1  ← corrupt
+        //
+        // Violates: A'''[y,x,limb] == next.a[y][x][limb].
+        *trace_val(trace, 1, KECCAK_COL_MAP.a[0][0][0]) += F::ONE;
+
+        let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(10));
+        assert!(!report.is_ok());
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(50))]
+
+        #[test]
+        fn prop_any_c_bit_corruption_detected(
+            input in any::<[u64; 25]>(),
+            x in 0..5usize,
+            z in 0..64usize,
+        ) {
+            // Flip C[x][z] at row 0.  5 × 64 = 320 bits total.
+            let trace = &mut valid_trace(input);
+            flip_bit(trace_val(trace, 0, KECCAK_COL_MAP.c[x][z]));
+
+            let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(5));
+            prop_assert!(!report.is_ok());
+        }
+
+        #[test]
+        fn prop_any_a_prime_bit_corruption_detected(
+            input in any::<[u64; 25]>(),
+            y in 0..5usize,
+            x in 0..5usize,
+            z in 0..64usize,
+        ) {
+            // Flip A'[y][x][z] at row 0.  5 × 5 × 64 = 1 600 bits total.
+            let trace = &mut valid_trace(input);
+            flip_bit(trace_val(trace, 0, KECCAK_COL_MAP.a_prime[y][x][z]));
+
+            let report = check_all_constraints(&KeccakAir {}, trace, &[], Some(5));
+            prop_assert!(!report.is_ok());
         }
     }
 }

--- a/keccak-air/src/constants.rs
+++ b/keccak-air/src/constants.rs
@@ -33,7 +33,7 @@ pub const RC: [u64; 24] = [
     0x8000000080008008,
 ];
 
-const RC_BITS: [[u8; 64]; 24] = [
+pub(crate) const RC_BITS: [[u8; 64]; 24] = [
     [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -156,6 +156,46 @@ const RC_BITS: [[u8; 64]; 24] = [
     ],
 ];
 
-pub(crate) const fn rc_value_bit(round: usize, bit_index: usize) -> u8 {
-    RC_BITS[round][bit_index]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rc_bits_consistent_with_rc() {
+        // The `RC_BITS` table is the bit-decomposition of the 24 round
+        // constants defined in FIPS 202 (Section 3.2.5, Algorithm 5).
+        //
+        // For each round r and bit position z:
+        //     RC_BITS[r][z] must equal bit z of RC[r]
+        //
+        // We also reconstruct each 64-bit constant from its bits
+        // and compare against the original — any single-bit typo
+        // in the 24 * 64 = 1536 entries would be caught.
+        for r in 0..24 {
+            let mut reconstructed = 0u64;
+            for z in 0..64 {
+                let bit = RC_BITS[r][z];
+
+                // Each entry must be 0 or 1.
+                assert!(bit <= 1, "RC_BITS[{r}][{z}] = {bit}, expected 0 or 1");
+
+                // Must match the corresponding bit in the u64 constant.
+                assert_eq!(
+                    bit,
+                    ((RC[r] >> z) & 1) as u8,
+                    "RC_BITS[{r}][{z}] disagrees with RC[{r}] = {:#018x}",
+                    RC[r]
+                );
+
+                reconstructed |= (bit as u64) << z;
+            }
+
+            // Full round-trip: bits → u64 must recover the original.
+            assert_eq!(
+                reconstructed, RC[r],
+                "Reconstructed RC[{r}] = {reconstructed:#018x}, expected {:#018x}",
+                RC[r]
+            );
+        }
+    }
 }

--- a/keccak-air/src/constants.rs
+++ b/keccak-air/src/constants.rs
@@ -171,11 +171,9 @@ mod tests {
         // We also reconstruct each 64-bit constant from its bits
         // and compare against the original — any single-bit typo
         // in the 24 * 64 = 1536 entries would be caught.
-        for r in 0..24 {
+        for (r, rc_bits_r) in RC_BITS.iter().enumerate() {
             let mut reconstructed = 0u64;
-            for z in 0..64 {
-                let bit = RC_BITS[r][z];
-
+            for (z, &bit) in rc_bits_r.iter().enumerate() {
                 // Each entry must be 0 or 1.
                 assert!(bit <= 1, "RC_BITS[{r}][{z}] = {bit}, expected 0 or 1");
 

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -146,9 +146,11 @@ fn generate_trace_row_for_round<F: PrimeField64>(
 mod tests {
     use alloc::vec;
 
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
     use p3_keccak::KeccakF;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
 
     use super::*;
 
@@ -324,6 +326,84 @@ mod tests {
                 "preimage[{}][{}] should equal input[{}]",
                 y, x, i_u64
             );
+        }
+    }
+
+    /// Reinterpret the flat trace buffer as typed column structs.
+    fn trace_to_rows<F: PrimeField64>(trace: &RowMajorMatrix<F>) -> &[KeccakCols<F>] {
+        let (prefix, rows, suffix) = unsafe { trace.values.align_to::<KeccakCols<F>>() };
+        assert!(prefix.is_empty(), "Alignment should match");
+        assert!(suffix.is_empty(), "Alignment should match");
+        rows
+    }
+
+    proptest! {
+        #[test]
+        fn prop_trace_output_matches_keccak_f(input in any::<[u64; 25]>()) {
+            let mut expected = input;
+            KeccakF.permute_mut(&mut expected);
+
+            let trace = generate_trace_rows::<Goldilocks>(vec![input], 0);
+            let rows = trace_to_rows(&trace);
+            let output = extract_output_from_trace(&rows[..NUM_ROUNDS]);
+            prop_assert_eq!(output, expected);
+        }
+
+        #[test]
+        fn prop_preimage_persists_across_rounds(input in any::<[u64; 25]>()) {
+            let trace = generate_trace_rows::<Goldilocks>(vec![input], 0);
+            let rows = trace_to_rows(&trace);
+
+            // Preimage must be identical in all 24 rows.
+            let first = rows[0].preimage;
+            for round in 1..NUM_ROUNDS {
+                prop_assert_eq!(rows[round].preimage, first,
+                    "preimage changed at round {}", round);
+            }
+        }
+
+        #[test]
+        fn prop_step_flags_rotation(input in any::<[u64; 25]>()) {
+            let trace = generate_trace_rows::<Goldilocks>(vec![input], 0);
+            let rows = trace_to_rows(&trace);
+
+            // Row r: step_flags[r] = 1, all others = 0.
+            //
+            //     round  0: [1, 0, 0, …, 0]
+            //     round  1: [0, 1, 0, …, 0]
+            //     round 23: [0, 0, 0, …, 1]
+            for round in 0..NUM_ROUNDS {
+                for flag in 0..NUM_ROUNDS {
+                    let expected = if flag == round { Goldilocks::ONE } else { Goldilocks::ZERO };
+                    prop_assert_eq!(rows[round].step_flags[flag], expected,
+                        "step_flags[{}] wrong at round {}", flag, round);
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(50))]
+
+        #[test]
+        fn prop_batch_matches_individual(
+            a in any::<[u64; 25]>(),
+            b in any::<[u64; 25]>(),
+        ) {
+            // Individual.
+            let trace_a = generate_trace_rows::<Goldilocks>(vec![a], 0);
+            let trace_b = generate_trace_rows::<Goldilocks>(vec![b], 0);
+            let out_a = extract_output_from_trace(&trace_to_rows(&trace_a)[..NUM_ROUNDS]);
+            let out_b = extract_output_from_trace(&trace_to_rows(&trace_b)[..NUM_ROUNDS]);
+
+            // Batch: rows [0..24) = perm(a), rows [24..48) = perm(b).
+            let batch = generate_trace_rows::<Goldilocks>(vec![a, b], 0);
+            let rows = trace_to_rows(&batch);
+            let batch_a = extract_output_from_trace(&rows[..NUM_ROUNDS]);
+            let batch_b = extract_output_from_trace(&rows[NUM_ROUNDS..2 * NUM_ROUNDS]);
+
+            prop_assert_eq!(out_a, batch_a);
+            prop_assert_eq!(out_b, batch_b);
         }
     }
 }

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -356,8 +356,8 @@ mod tests {
 
             // Preimage must be identical in all 24 rows.
             let first = rows[0].preimage;
-            for round in 1..NUM_ROUNDS {
-                prop_assert_eq!(rows[round].preimage, first,
+            for (round, row) in rows.iter().enumerate().take(NUM_ROUNDS).skip(1) {
+                prop_assert_eq!(row.preimage, first,
                     "preimage changed at round {}", round);
             }
         }
@@ -372,10 +372,10 @@ mod tests {
             //     round  0: [1, 0, 0, …, 0]
             //     round  1: [0, 1, 0, …, 0]
             //     round 23: [0, 0, 0, …, 1]
-            for round in 0..NUM_ROUNDS {
+            for (round, row) in rows.iter().enumerate().take(NUM_ROUNDS) {
                 for flag in 0..NUM_ROUNDS {
                     let expected = if flag == round { Goldilocks::ONE } else { Goldilocks::ZERO };
-                    prop_assert_eq!(rows[round].step_flags[flag], expected,
+                    prop_assert_eq!(row.step_flags[flag], expected,
                         "step_flags[{}] wrong at round {}", flag, round);
                 }
             }


### PR DESCRIPTION
## Summary

- Add property-based tests that verify all ~2000 AIR constraints are satisfied for random inputs — both single and batch traces. This was entirely missing before.
- Add 8 negative unit tests + 2 negative proptests that corrupt each column family and assert constraint rejection (soundness coverage).
- Add witness-level proptests: output vs reference permutation, preimage persistence, step flag rotation, batch vs individual equivalence.
- Add `RC_BITS` consistency test against the `RC` constants.
- Remove trivial `rc_value_bit` wrapper in favor of direct `RC_BITS[r][i]` access.
- Add `proptest` to dev-dependencies.

## Test plan

- [x] `cargo test -p p3-keccak-air` — 22 tests pass in ~1 s
- [x] `cargo check -p p3-keccak-air --examples` — examples still compile
- [x] No changes to existing test code (diff is purely additive for `generation.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)