### PR TITLE
bench: route Goldilocks packed benches via HashPackedGoldilocks

### DIFF
--- a/poseidon1/benches/poseidon1.rs
+++ b/poseidon1/benches/poseidon1.rs
@@ -4,8 +4,8 @@ use p3_baby_bear::{
     BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_24, BabyBear, MdsMatrixBabyBear, Poseidon1BabyBear,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_goldilocks::Goldilocks;
 use p3_goldilocks::poseidon1::{default_goldilocks_poseidon1_8, default_goldilocks_poseidon1_12};
+use p3_goldilocks::{Goldilocks, HashPackedGoldilocks};
 use p3_koala_bear::{
     KOALABEAR_POSEIDON_HALF_FULL_ROUNDS, KOALABEAR_POSEIDON_PARTIAL_ROUNDS_16,
     KOALABEAR_POSEIDON_PARTIAL_ROUNDS_24, KoalaBear, MdsMatrixKoalaBear, Poseidon1KoalaBear,
@@ -68,12 +68,12 @@ fn bench_poseidon1(c: &mut Criterion) {
     // Goldilocks width 8.
     let gl_8 = default_goldilocks_poseidon1_8();
     poseidon1_scalar::<Goldilocks, _, 8>(c, &gl_8);
-    poseidon1_packed::<Goldilocks, _, 8>(c, &gl_8);
+    poseidon1_goldilocks_packed::<_, 8>(c, &gl_8);
 
     // Goldilocks width 12.
     let gl_12 = default_goldilocks_poseidon1_12();
     poseidon1_scalar::<Goldilocks, _, 12>(c, &gl_12);
-    poseidon1_packed::<Goldilocks, _, 12>(c, &gl_12);
+    poseidon1_goldilocks_packed::<_, 12>(c, &gl_12);
 
     // Mersenne31 width 16.
     let m31_16 = default_mersenne31_poseidon1_16();
@@ -108,6 +108,24 @@ where
     let name = format!(
         "poseidon-packed::<{}, {}>",
         pretty_name::<F::Packing>(),
+        WIDTH
+    );
+    let id = BenchmarkId::new(name, WIDTH);
+    c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon.permute(input)));
+}
+
+/// Goldilocks packed benchmark target.
+///
+/// On aarch64 this is [`PackedGoldilocksNeon`] via [`HashPackedGoldilocks`],
+/// while on other targets it resolves to `<Goldilocks as Field>::Packing`.
+fn poseidon1_goldilocks_packed<Perm, const WIDTH: usize>(c: &mut Criterion, poseidon: &Perm)
+where
+    Perm: Permutation<[HashPackedGoldilocks; WIDTH]>,
+{
+    let input = [HashPackedGoldilocks::ZERO; WIDTH];
+    let name = format!(
+        "poseidon-packed::<{}, {}>",
+        pretty_name::<HashPackedGoldilocks>(),
         WIDTH
     );
     let id = BenchmarkId::new(name, WIDTH);

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -2,7 +2,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_bn254::{Bn254, Poseidon2Bn254};
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
+use p3_goldilocks::{HashPackedGoldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};
 use p3_symmetric::Permutation;
@@ -29,11 +29,11 @@ fn bench_poseidon12(c: &mut Criterion) {
     poseidon2::<Mersenne31, Poseidon2Mersenne31<24>, 24>(c, &poseidon2_m31_24);
 
     let poseidon2_gold_8 = Poseidon2Goldilocks::<8>::new_from_rng_128(&mut rng);
-    poseidon2::<Goldilocks, Poseidon2Goldilocks<8>, 8>(c, &poseidon2_gold_8);
+    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<8>, 8>(c, &poseidon2_gold_8);
     let poseidon2_gold_12 = Poseidon2Goldilocks::<12>::new_from_rng_128(&mut rng);
-    poseidon2::<Goldilocks, Poseidon2Goldilocks<12>, 12>(c, &poseidon2_gold_12);
+    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<12>, 12>(c, &poseidon2_gold_12);
     let poseidon2_gold_16 = Poseidon2Goldilocks::<16>::new_from_rng_128(&mut rng);
-    poseidon2::<Goldilocks, Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
+    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
 
     let poseidon2_bn254 = Poseidon2Bn254::<3>::new_from_rng(8, 22, &mut rng);
     poseidon2::<Bn254, Poseidon2Bn254<3>, 3>(c, &poseidon2_bn254);
@@ -46,6 +46,24 @@ where
 {
     let input = [F::Packing::ZERO; WIDTH];
     let name = format!("poseidon2::<{}, {}>", pretty_name::<F::Packing>(), WIDTH);
+    let id = BenchmarkId::new(name, WIDTH);
+    c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon2.permute(input)));
+}
+
+/// Goldilocks packed benchmark target.
+///
+/// On aarch64 this is [`PackedGoldilocksNeon`] via [`HashPackedGoldilocks`],
+/// while on other targets it resolves to `<Goldilocks as Field>::Packing`.
+fn poseidon2_goldilocks_packed<Perm, const WIDTH: usize>(c: &mut Criterion, poseidon2: &Perm)
+where
+    Perm: Permutation<[HashPackedGoldilocks; WIDTH]>,
+{
+    let input = [HashPackedGoldilocks::ZERO; WIDTH];
+    let name = format!(
+        "poseidon2::<{}, {}>",
+        pretty_name::<HashPackedGoldilocks>(),
+        WIDTH
+    );
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon2.permute(input)));
 }


### PR DESCRIPTION
Route Goldilocks Poseidon benches through HashPackedGoldilocks, ensuring aarch64 measures PackedGoldilocksNeon while other targets keep current packing.