### PR TITLE
feat: bus-based cross-AIR interactions and lookup crate redesign

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -15,6 +15,16 @@ pub trait BaseAir<F>: Sync {
         None
     }
 
+    /// Width of the preprocessed trace, in columns.
+    ///
+    /// Defaults to `0`, matching the default [`Self::preprocessed_trace`] of
+    /// `None`. Implementors that override [`Self::preprocessed_trace`] **must**
+    /// also override this method to return a matching width — callers use this
+    /// to size symbolic builders without materializing the preprocessed matrix.
+    fn preprocessed_width(&self) -> usize {
+        0
+    }
+
     /// Return the number of periodic columns.
     ///
     /// Override when this AIR uses periodic columns; see [`Self::periodic_columns`].
@@ -123,9 +133,7 @@ pub trait BaseAir<F>: Sync {
     /// access an offset-1 preprocessed entry) can override this to return an
     /// empty vector to allow the prover and verifier to open only at `zeta`.
     fn preprocessed_next_row_columns(&self) -> Vec<usize> {
-        self.preprocessed_trace()
-            .map(|t| (0..t.width).collect())
-            .unwrap_or_default()
+        (0..self.preprocessed_width()).collect()
     }
 
     /// Optional hint for the number of constraints in this AIR.

--- a/air/src/builder.rs
+++ b/air/src/builder.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::ops::{Add, Mul, Sub};
 
 use p3_field::{Algebra, Dup, ExtensionField, Field, PrimeCharacteristicRing};
@@ -173,6 +174,45 @@ pub trait AirBuilder: Sized {
     /// into a single assert_bools call will improve performance.
     fn assert_bool<I: Into<Self::Expr>>(&mut self, x: I) {
         self.assert_zero(x.into().bool_check());
+    }
+
+    /// Record a **global** (cross-AIR) interaction on the named bus.
+    ///
+    /// - `bus_name` — shared identifier across AIRs on the same bus.
+    /// - `fields` — message elements.
+    /// - `count` — signed multiplicity (+ = send, - = receive).
+    /// - `count_weight` — soundness weight (`1` for queries, `0` for table entries).
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        _bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        _count: impl Into<Self::Expr>,
+        _count_weight: u32,
+    ) {
+        // Default: no-op.
+        fields.into_iter().for_each(drop);
+    }
+
+    /// Record a **local** (intra-AIR) lookup — both sides in one call.
+    ///
+    /// Bundles multiple `(fields, count)` pairs into a single running sum
+    /// that must return to zero. No cross-AIR communication.
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        // Default: no-op.
+        tuples.into_iter().for_each(drop);
+    }
+
+    /// Number of global (cross-AIR) interactions recorded so far.
+    fn num_global_interactions(&self) -> usize {
+        0
+    }
+
+    /// Number of local (intra-AIR) interactions recorded so far.
+    fn num_local_interactions(&self) -> usize {
+        0
     }
 }
 

--- a/air/src/builder.rs
+++ b/air/src/builder.rs
@@ -1,4 +1,3 @@
-use alloc::vec::Vec;
 use core::ops::{Add, Mul, Sub};
 
 use p3_field::{Algebra, Dup, ExtensionField, Field, PrimeCharacteristicRing};
@@ -174,45 +173,6 @@ pub trait AirBuilder: Sized {
     /// into a single assert_bools call will improve performance.
     fn assert_bool<I: Into<Self::Expr>>(&mut self, x: I) {
         self.assert_zero(x.into().bool_check());
-    }
-
-    /// Record a **global** (cross-AIR) interaction on the named bus.
-    ///
-    /// - `bus_name` — shared identifier across AIRs on the same bus.
-    /// - `fields` — message elements.
-    /// - `count` — signed multiplicity (+ = send, - = receive).
-    /// - `count_weight` — soundness weight (`1` for queries, `0` for table entries).
-    fn push_interaction<E: Into<Self::Expr>>(
-        &mut self,
-        _bus_name: &str,
-        fields: impl IntoIterator<Item = E>,
-        _count: impl Into<Self::Expr>,
-        _count_weight: u32,
-    ) {
-        // Default: no-op.
-        fields.into_iter().for_each(drop);
-    }
-
-    /// Record a **local** (intra-AIR) lookup — both sides in one call.
-    ///
-    /// Bundles multiple `(fields, count)` pairs into a single running sum
-    /// that must return to zero. No cross-AIR communication.
-    fn push_local_interaction(
-        &mut self,
-        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
-    ) {
-        // Default: no-op.
-        tuples.into_iter().for_each(drop);
-    }
-
-    /// Number of global (cross-AIR) interactions recorded so far.
-    fn num_global_interactions(&self) -> usize {
-        0
-    }
-
-    /// Number of local (intra-AIR) interactions recorded so far.
-    fn num_local_interactions(&self) -> usize {
-        0
     }
 }
 

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -1082,5 +1082,4 @@ mod tests {
             assert_eq!(val, EF::ONE);
         }
     }
-
 }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -1,4 +1,3 @@
-use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -144,49 +143,7 @@ where
     (builder.base_constraints(), builder.extension_constraints())
 }
 
-/// A cross-AIR interaction recorded during symbolic evaluation.
-///
-/// ```text
-///     bus_name:     "memory"          fields:       [addr, value]
-///     count:        is_active         count_weight: 1
-/// ```
-#[derive(Clone, Debug)]
-pub struct SymbolicInteraction<F> {
-    /// Bus identifier.
-    ///
-    /// AIRs sharing the same name form one logical channel.
-    pub bus_name: String,
-
-    /// Message elements (symbolic expressions evaluated per trace row).
-    pub fields: Vec<SymbolicExpression<F>>,
-
-    /// Signed multiplicity (positive = send, negative = receive).
-    pub count: SymbolicExpression<F>,
-
-    /// Soundness weight for the trace height constraint:
-    /// `∑ weight_i × height_i < p`.
-    ///
-    /// Typically:
-    /// - `1` for queries,
-    /// - `0` for table entries.
-    pub count_weight: u32,
-}
-
-/// An intra-AIR lookup recorded during symbolic evaluation.
-///
-/// Bundles multiple (fields, count) tuples into a single running sum
-/// that must return to zero. No cross-AIR communication.
-///
-/// ```text
-///     tuples: [(query_fields, +1), (table_fields, -mult)]
-/// ```
-#[derive(Clone, Debug)]
-pub struct SymbolicLocalInteraction<F> {
-    /// Each tuple: `(message_fields, signed_count)`.
-    pub tuples: Vec<(Vec<SymbolicExpression<F>>, SymbolicExpression<F>)>,
-}
-
-/// Symbolic AIR builder that records constraints and interactions.
+/// Symbolic AIR builder that records constraints.
 #[derive(Debug)]
 pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     preprocessed: RowMajorMatrix<SymbolicVariable<F>>,
@@ -199,10 +156,6 @@ pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     permutation_values: Vec<SymbolicVariableExt<F, EF>>,
     extension_constraints: Vec<SymbolicExpressionExt<F, EF>>,
     constraint_types: Vec<ConstraintType>,
-    /// Global interactions.
-    global_interactions: Vec<SymbolicInteraction<F>>,
-    /// Local interactions.
-    local_interactions: Vec<SymbolicLocalInteraction<F>>,
 }
 
 impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
@@ -263,8 +216,6 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
             permutation_values,
             extension_constraints: vec![],
             constraint_types: vec![],
-            global_interactions: vec![],
-            local_interactions: vec![],
         }
     }
 
@@ -290,21 +241,6 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
 
     pub fn base_constraints(&self) -> Vec<SymbolicExpression<F>> {
         self.base_constraints.clone()
-    }
-
-    /// Global (cross-AIR) interactions recorded.
-    pub fn global_interactions(&self) -> &[SymbolicInteraction<F>] {
-        &self.global_interactions
-    }
-
-    /// Number of global (cross-AIR) interactions recorded.
-    pub const fn num_global_interactions(&self) -> usize {
-        self.global_interactions.len()
-    }
-
-    /// Local (intra-AIR) interactions recorded.
-    pub fn local_interactions(&self) -> &[SymbolicLocalInteraction<F>] {
-        &self.local_interactions
     }
 }
 
@@ -379,38 +315,6 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
 
     fn public_values(&self) -> &[Self::PublicVar] {
         &self.public_values
-    }
-
-    fn push_interaction<E: Into<Self::Expr>>(
-        &mut self,
-        bus_name: &str,
-        fields: impl IntoIterator<Item = E>,
-        count: impl Into<Self::Expr>,
-        count_weight: u32,
-    ) {
-        self.global_interactions.push(SymbolicInteraction {
-            bus_name: String::from(bus_name),
-            fields: fields.into_iter().map(Into::into).collect(),
-            count: count.into(),
-            count_weight,
-        });
-    }
-
-    fn push_local_interaction(
-        &mut self,
-        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
-    ) {
-        self.local_interactions.push(SymbolicLocalInteraction {
-            tuples: tuples.into_iter().collect(),
-        });
-    }
-
-    fn num_global_interactions(&self) -> usize {
-        self.global_interactions.len()
-    }
-
-    fn num_local_interactions(&self) -> usize {
-        self.local_interactions.len()
     }
 }
 
@@ -1179,76 +1083,4 @@ mod tests {
         }
     }
 
-    /// An AIR that pushes interactions via `AirBuilder`.
-    #[derive(Debug)]
-    struct InteractingAir;
-
-    impl BaseAir<F> for InteractingAir {
-        fn width(&self) -> usize {
-            3
-        }
-    }
-
-    impl Air<SymbolicAirBuilder<F>> for InteractingAir {
-        fn eval(&self, builder: &mut SymbolicAirBuilder<F>) {
-            let main = builder.main();
-            let a = main.current_slice()[0];
-            let b = main.current_slice()[1];
-            let m = main.current_slice()[2];
-
-            // Normal constraint.
-            builder.assert_zero(a - b);
-
-            // Two interactions on different buses.
-            let a_expr: SymbolicExpression<F> = a.into();
-            let b_expr: SymbolicExpression<F> = b.into();
-            let m_expr: SymbolicExpression<F> = m.into();
-            builder.push_interaction("memory", [a_expr.clone(), b_expr], m_expr.clone(), 1);
-            builder.push_interaction("range", [a_expr], m_expr, 1);
-        }
-    }
-
-    #[test]
-    fn symbolic_builder_records_interactions() {
-        let layout = AirLayout {
-            main_width: 3,
-            ..Default::default()
-        };
-        let mut builder = SymbolicAirBuilder::<F>::new(layout);
-        InteractingAir.eval(&mut builder);
-
-        // One normal constraint.
-        assert_eq!(builder.base_constraints().len(), 1);
-
-        // Two interactions recorded.
-        let interactions = builder.global_interactions();
-        assert_eq!(interactions.len(), 2);
-
-        assert_eq!(interactions[0].bus_name, "memory");
-        assert_eq!(interactions[0].fields.len(), 2);
-        assert_eq!(interactions[0].count_weight, 1);
-
-        assert_eq!(interactions[1].bus_name, "range");
-        assert_eq!(interactions[1].fields.len(), 1);
-        assert_eq!(interactions[1].count_weight, 1);
-    }
-
-    #[test]
-    fn symbolic_builder_no_interactions_by_default() {
-        let layout = AirLayout {
-            main_width: 2,
-            ..Default::default()
-        };
-        let mut builder = SymbolicAirBuilder::<F>::new(layout);
-
-        // A plain AIR with no interactions.
-        let mock = MockAir {
-            constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
-            width: 2,
-        };
-        mock.eval(&mut builder);
-
-        assert_eq!(builder.global_interactions().len(), 0);
-        assert_eq!(builder.base_constraints().len(), 1);
-    }
 }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -12,7 +13,7 @@ use crate::symbolic::expression::BaseLeaf;
 use crate::symbolic::expression_ext::SymbolicExpressionExt;
 use crate::symbolic::variable::{BaseEntry, ExtEntry, SymbolicVariableExt};
 use crate::{
-    Air, AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
+    Air, AirBuilder, BaseAir, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
     SymbolicExpression, SymbolicVariable, WindowAccess,
 };
 
@@ -36,6 +37,19 @@ pub struct AirLayout {
     pub num_permutation_values: usize,
     /// Length of [`PeriodicAirBuilder::periodic_values`].
     pub num_periodic_columns: usize,
+}
+
+impl AirLayout {
+    /// Derive layout from an AIR's metadata.
+    pub fn from_air<F: Clone + Send + Sync>(air: &impl BaseAir<F>) -> Self {
+        Self {
+            preprocessed_width: air.preprocessed_trace().as_ref().map_or(0, |t| t.width()),
+            main_width: air.width(),
+            num_public_values: air.num_public_values(),
+            num_periodic_columns: air.num_periodic_columns(),
+            ..Default::default()
+        }
+    }
 }
 
 #[instrument(skip_all, level = "debug")]
@@ -130,7 +144,49 @@ where
     (builder.base_constraints(), builder.extension_constraints())
 }
 
-/// An [`AirBuilder`] for evaluating constraints symbolically, and recording them for later use.
+/// A cross-AIR interaction recorded during symbolic evaluation.
+///
+/// ```text
+///     bus_name:     "memory"          fields:       [addr, value]
+///     count:        is_active         count_weight: 1
+/// ```
+#[derive(Clone, Debug)]
+pub struct SymbolicInteraction<F> {
+    /// Bus identifier.
+    ///
+    /// AIRs sharing the same name form one logical channel.
+    pub bus_name: String,
+
+    /// Message elements (symbolic expressions evaluated per trace row).
+    pub fields: Vec<SymbolicExpression<F>>,
+
+    /// Signed multiplicity (positive = send, negative = receive).
+    pub count: SymbolicExpression<F>,
+
+    /// Soundness weight for the trace height constraint:
+    /// `∑ weight_i × height_i < p`.
+    ///
+    /// Typically:
+    /// - `1` for queries,
+    /// - `0` for table entries.
+    pub count_weight: u32,
+}
+
+/// An intra-AIR lookup recorded during symbolic evaluation.
+///
+/// Bundles multiple (fields, count) tuples into a single running sum
+/// that must return to zero. No cross-AIR communication.
+///
+/// ```text
+///     tuples: [(query_fields, +1), (table_fields, -mult)]
+/// ```
+#[derive(Clone, Debug)]
+pub struct SymbolicLocalInteraction<F> {
+    /// Each tuple: `(message_fields, signed_count)`.
+    pub tuples: Vec<(Vec<SymbolicExpression<F>>, SymbolicExpression<F>)>,
+}
+
+/// Symbolic AIR builder that records constraints and interactions.
 #[derive(Debug)]
 pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     preprocessed: RowMajorMatrix<SymbolicVariable<F>>,
@@ -143,6 +199,10 @@ pub struct SymbolicAirBuilder<F: Field, EF: ExtensionField<F> = F> {
     permutation_values: Vec<SymbolicVariableExt<F, EF>>,
     extension_constraints: Vec<SymbolicExpressionExt<F, EF>>,
     constraint_types: Vec<ConstraintType>,
+    /// Global interactions.
+    global_interactions: Vec<SymbolicInteraction<F>>,
+    /// Local interactions.
+    local_interactions: Vec<SymbolicLocalInteraction<F>>,
 }
 
 impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
@@ -203,6 +263,8 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
             permutation_values,
             extension_constraints: vec![],
             constraint_types: vec![],
+            global_interactions: vec![],
+            local_interactions: vec![],
         }
     }
 
@@ -228,6 +290,21 @@ impl<F: Field, EF: ExtensionField<F>> SymbolicAirBuilder<F, EF> {
 
     pub fn base_constraints(&self) -> Vec<SymbolicExpression<F>> {
         self.base_constraints.clone()
+    }
+
+    /// Global (cross-AIR) interactions recorded.
+    pub fn global_interactions(&self) -> &[SymbolicInteraction<F>] {
+        &self.global_interactions
+    }
+
+    /// Number of global (cross-AIR) interactions recorded.
+    pub const fn num_global_interactions(&self) -> usize {
+        self.global_interactions.len()
+    }
+
+    /// Local (intra-AIR) interactions recorded.
+    pub fn local_interactions(&self) -> &[SymbolicLocalInteraction<F>] {
+        &self.local_interactions
     }
 }
 
@@ -302,6 +379,38 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
 
     fn public_values(&self) -> &[Self::PublicVar] {
         &self.public_values
+    }
+
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        count: impl Into<Self::Expr>,
+        count_weight: u32,
+    ) {
+        self.global_interactions.push(SymbolicInteraction {
+            bus_name: String::from(bus_name),
+            fields: fields.into_iter().map(Into::into).collect(),
+            count: count.into(),
+            count_weight,
+        });
+    }
+
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        self.local_interactions.push(SymbolicLocalInteraction {
+            tuples: tuples.into_iter().collect(),
+        });
+    }
+
+    fn num_global_interactions(&self) -> usize {
+        self.global_interactions.len()
+    }
+
+    fn num_local_interactions(&self) -> usize {
+        self.local_interactions.len()
     }
 }
 
@@ -1068,5 +1177,78 @@ mod tests {
         for &val in &ext {
             assert_eq!(val, EF::ONE);
         }
+    }
+
+    /// An AIR that pushes interactions via `AirBuilder`.
+    #[derive(Debug)]
+    struct InteractingAir;
+
+    impl BaseAir<F> for InteractingAir {
+        fn width(&self) -> usize {
+            3
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<F>> for InteractingAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<F>) {
+            let main = builder.main();
+            let a = main.current_slice()[0];
+            let b = main.current_slice()[1];
+            let m = main.current_slice()[2];
+
+            // Normal constraint.
+            builder.assert_zero(a - b);
+
+            // Two interactions on different buses.
+            let a_expr: SymbolicExpression<F> = a.into();
+            let b_expr: SymbolicExpression<F> = b.into();
+            let m_expr: SymbolicExpression<F> = m.into();
+            builder.push_interaction("memory", [a_expr.clone(), b_expr], m_expr.clone(), 1);
+            builder.push_interaction("range", [a_expr], m_expr, 1);
+        }
+    }
+
+    #[test]
+    fn symbolic_builder_records_interactions() {
+        let layout = AirLayout {
+            main_width: 3,
+            ..Default::default()
+        };
+        let mut builder = SymbolicAirBuilder::<F>::new(layout);
+        InteractingAir.eval(&mut builder);
+
+        // One normal constraint.
+        assert_eq!(builder.base_constraints().len(), 1);
+
+        // Two interactions recorded.
+        let interactions = builder.global_interactions();
+        assert_eq!(interactions.len(), 2);
+
+        assert_eq!(interactions[0].bus_name, "memory");
+        assert_eq!(interactions[0].fields.len(), 2);
+        assert_eq!(interactions[0].count_weight, 1);
+
+        assert_eq!(interactions[1].bus_name, "range");
+        assert_eq!(interactions[1].fields.len(), 1);
+        assert_eq!(interactions[1].count_weight, 1);
+    }
+
+    #[test]
+    fn symbolic_builder_no_interactions_by_default() {
+        let layout = AirLayout {
+            main_width: 2,
+            ..Default::default()
+        };
+        let mut builder = SymbolicAirBuilder::<F>::new(layout);
+
+        // A plain AIR with no interactions.
+        let mock = MockAir {
+            constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
+            width: 2,
+        };
+        mock.eval(&mut builder);
+
+        assert_eq!(builder.global_interactions().len(), 0);
+        assert_eq!(builder.base_constraints().len(), 1);
     }
 }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -42,7 +42,7 @@ impl AirLayout {
     /// Derive layout from an AIR's metadata.
     pub fn from_air<F: Clone + Send + Sync>(air: &impl BaseAir<F>) -> Self {
         Self {
-            preprocessed_width: air.preprocessed_trace().as_ref().map_or(0, |t| t.width()),
+            preprocessed_width: air.preprocessed_width(),
             main_width: air.width(),
             num_public_values: air.num_public_values(),
             num_periodic_columns: air.num_periodic_columns(),

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -1,7 +1,8 @@
 use p3_field::{Algebra, ExtensionField, Field, InjectiveMonomial};
 
-use crate::symbolic::variable::SymbolicVariable;
+use crate::symbolic::variable::{BaseEntry, SymbolicVariable};
 use crate::symbolic::{SymLeaf, SymbolicExpr};
+use crate::{AirBuilder, WindowAccess};
 
 /// Leaf nodes for base-field symbolic expressions.
 ///
@@ -73,6 +74,56 @@ impl<F: Field, EF: ExtensionField<F>> From<F> for SymbolicExpression<EF> {
     }
 }
 
+impl<F: Field> SymbolicExpression<F> {
+    /// Evaluate this symbolic expression against a concrete [`AirBuilder`].
+    ///
+    /// Leaves resolve from the builder's trace windows, public values,
+    /// and selectors. Arithmetic nodes recurse into children.
+    ///
+    /// # Panics
+    ///
+    /// Panics on periodic columns and row offsets beyond 1.
+    pub fn resolve<AB>(&self, builder: &AB) -> AB::Expr
+    where
+        AB: AirBuilder<F = F>,
+    {
+        match self {
+            Self::Leaf(leaf) => match leaf {
+                BaseLeaf::Variable(v) => match v.entry {
+                    BaseEntry::Main { offset } => {
+                        let main = builder.main();
+                        match offset {
+                            0 => main.current(v.index).unwrap().into(),
+                            1 => main.next(v.index).unwrap().into(),
+                            _ => panic!("expressions cannot span more than two rows"),
+                        }
+                    }
+                    BaseEntry::Preprocessed { offset } => {
+                        let prep = builder.preprocessed();
+                        match offset {
+                            0 => prep.current(v.index).unwrap().into(),
+                            1 => prep.next(v.index).unwrap().into(),
+                            _ => panic!("expressions cannot span more than two rows"),
+                        }
+                    }
+                    BaseEntry::Public => builder.public_values()[v.index].into(),
+                    BaseEntry::Periodic => {
+                        panic!("periodic columns cannot be resolved in this context")
+                    }
+                },
+                BaseLeaf::IsFirstRow => builder.is_first_row(),
+                BaseLeaf::IsLastRow => builder.is_last_row(),
+                BaseLeaf::IsTransition => builder.is_transition_window(2),
+                BaseLeaf::Constant(c) => AB::Expr::from(*c),
+            },
+            Self::Add { x, y, .. } => x.resolve(builder) + y.resolve(builder),
+            Self::Sub { x, y, .. } => x.resolve(builder) - y.resolve(builder),
+            Self::Neg { x, .. } => -x.resolve(builder),
+            Self::Mul { x, y, .. } => x.resolve(builder) * y.resolve(builder),
+        }
+    }
+}
+
 impl<F: Field> Algebra<F> for SymbolicExpression<F> {}
 
 impl<F: Field> Algebra<SymbolicVariable<F>> for SymbolicExpression<F> {}
@@ -89,6 +140,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
+    use p3_matrix::dense::RowMajorMatrix;
 
     use super::*;
     use crate::symbolic::BaseEntry;
@@ -725,5 +777,156 @@ mod tests {
         // x * 0 should have degree 0 (constant).
         let result = var * zero;
         assert_eq!(result.degree_multiple(), 0);
+    }
+
+    /// Two-row trace builder.
+    struct ResolveTestBuilder {
+        main: RowMajorMatrix<BabyBear>,
+        public_values: Vec<BabyBear>,
+        is_first: BabyBear,
+        is_last: BabyBear,
+        is_transition: BabyBear,
+    }
+
+    impl AirBuilder for ResolveTestBuilder {
+        type F = BabyBear;
+        type Expr = BabyBear;
+        type Var = BabyBear;
+        type PreprocessedWindow = RowMajorMatrix<BabyBear>;
+        type MainWindow = RowMajorMatrix<BabyBear>;
+        type PublicVar = BabyBear;
+
+        fn main(&self) -> Self::MainWindow {
+            self.main.clone()
+        }
+
+        fn preprocessed(&self) -> &Self::PreprocessedWindow {
+            unimplemented!("no preprocessed columns in test builder")
+        }
+
+        fn is_first_row(&self) -> Self::Expr {
+            self.is_first
+        }
+
+        fn is_last_row(&self) -> Self::Expr {
+            self.is_last
+        }
+
+        fn is_transition_window(&self, _: usize) -> Self::Expr {
+            self.is_transition
+        }
+
+        fn assert_zero<I: Into<Self::Expr>>(&mut self, _: I) {}
+
+        fn public_values(&self) -> &[Self::PublicVar] {
+            &self.public_values
+        }
+    }
+
+    /// 2-row × 2-column trace:
+    ///
+    /// ```text
+    ///     row 0 (current): [10, 20]
+    ///     row 1 (next):    [30, 40]
+    /// ```
+    fn test_builder() -> ResolveTestBuilder {
+        ResolveTestBuilder {
+            main: RowMajorMatrix::new(
+                vec![
+                    BabyBear::new(10),
+                    BabyBear::new(20), // current row
+                    BabyBear::new(30),
+                    BabyBear::new(40), // next row
+                ],
+                2, // width
+            ),
+            public_values: vec![BabyBear::new(99)],
+            is_first: BabyBear::ONE,
+            is_last: BabyBear::ZERO,
+            is_transition: BabyBear::ONE,
+        }
+    }
+
+    #[test]
+    fn resolve_main_current_row() {
+        let b = test_builder();
+        // Main column 0, offset 0 → current row value 10.
+        let expr =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0));
+        assert_eq!(expr.resolve(&b), BabyBear::new(10));
+    }
+
+    #[test]
+    fn resolve_main_next_row() {
+        let b = test_builder();
+        // Main column 1, offset 1 → next row value 40.
+        let expr =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 1 }, 1));
+        assert_eq!(expr.resolve(&b), BabyBear::new(40));
+    }
+
+    #[test]
+    fn resolve_public_value() {
+        let b = test_builder();
+        // Public value at index 0 → 99.
+        let expr = SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Public, 0));
+        assert_eq!(expr.resolve(&b), BabyBear::new(99));
+    }
+
+    #[test]
+    fn resolve_constant() {
+        let b = test_builder();
+        let expr = SymbolicExpression::<BabyBear>::from(BabyBear::new(42));
+        assert_eq!(expr.resolve(&b), BabyBear::new(42));
+    }
+
+    #[test]
+    fn resolve_selectors() {
+        let b = test_builder();
+
+        let first = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsFirstRow);
+        assert_eq!(first.resolve(&b), BabyBear::ONE, "is_first_row = 1");
+
+        let last = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsLastRow);
+        assert_eq!(last.resolve(&b), BabyBear::ZERO, "is_last_row = 0");
+
+        let trans = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
+        assert_eq!(trans.resolve(&b), BabyBear::ONE, "is_transition = 1");
+    }
+
+    #[test]
+    fn resolve_arithmetic() {
+        let b = test_builder();
+
+        // col0_curr = 10, col1_curr = 20.
+        let col0 =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0));
+        let col1 =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 1));
+
+        // 10 + 20 = 30.
+        let add = col0.clone() + col1.clone();
+        assert_eq!(add.resolve(&b), BabyBear::new(30));
+
+        // 10 - 20 = -10 (mod p).
+        let sub = col0.clone() - col1.clone();
+        assert_eq!(sub.resolve(&b), BabyBear::new(10) - BabyBear::new(20));
+
+        // 10 * 20 = 200.
+        let mul = col0.clone() * col1;
+        assert_eq!(mul.resolve(&b), BabyBear::new(200));
+
+        // -10 (mod p).
+        let neg = -col0;
+        assert_eq!(neg.resolve(&b), -BabyBear::new(10));
+    }
+
+    #[test]
+    #[should_panic(expected = "periodic columns cannot be resolved")]
+    fn resolve_periodic_panics() {
+        let b = test_builder();
+        let expr =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 0));
+        let _ = expr.resolve(&b);
     }
 }

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -93,16 +93,28 @@ impl<F: Field> SymbolicExpression<F> {
                     BaseEntry::Main { offset } => {
                         let main = builder.main();
                         match offset {
-                            0 => main.current(v.index).unwrap().into(),
-                            1 => main.next(v.index).unwrap().into(),
+                            0 => main
+                                .current(v.index)
+                                .expect("main column index out of bounds")
+                                .into(),
+                            1 => main
+                                .next(v.index)
+                                .expect("main column index out of bounds")
+                                .into(),
                             _ => panic!("expressions cannot span more than two rows"),
                         }
                     }
                     BaseEntry::Preprocessed { offset } => {
                         let prep = builder.preprocessed();
                         match offset {
-                            0 => prep.current(v.index).unwrap().into(),
-                            1 => prep.next(v.index).unwrap().into(),
+                            0 => prep
+                                .current(v.index)
+                                .expect("preprocessed column index out of bounds")
+                                .into(),
+                            1 => prep
+                                .next(v.index)
+                                .expect("preprocessed column index out of bounds")
+                                .into(),
                             _ => panic!("expressions cannot span more than two rows"),
                         }
                     }

--- a/batch-stark/benches/prove_batch.rs
+++ b/batch-stark/benches/prove_batch.rs
@@ -54,6 +54,9 @@ impl<F: Field> BaseAir<F> for FibonacciAir {
         }
         Some(m)
     }
+    fn preprocessed_width(&self) -> usize {
+        1
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/batch-stark/benches/prove_batch.rs
+++ b/batch-stark/benches/prove_batch.rs
@@ -10,7 +10,6 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeField64};
 use p3_fri::{FriParameters, TwoAdicFriPcs};
-use p3_lookup::LookupAir;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -56,8 +55,6 @@ impl<F: Field> BaseAir<F> for FibonacciAir {
         Some(m)
     }
 }
-
-impl<F: Field> LookupAir<F> for FibonacciAir {}
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -152,7 +149,6 @@ fn bench_prove_batch(c: &mut Criterion) {
                 air,
                 trace,
                 public_values: pis.clone(),
-                lookups: vec![],
             })
             .collect();
 

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -2,8 +2,7 @@ use alloc::vec::Vec;
 
 use p3_air::{Air, DebugConstraintBuilder};
 use p3_field::{ExtensionField, Field};
-use p3_lookup::AirWithLookups;
-use p3_lookup::lookup_traits::{Lookup, LookupGadget};
+use p3_lookup::{Lookup, LookupProtocol};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
@@ -50,7 +49,7 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
     F: Field,
     EF: ExtensionField<F>,
     A: for<'a> Air<DebugConstraintBuilder<'a, F, EF>>,
-    LG: LookupGadget,
+    LG: LookupProtocol,
 {
     let height = main.height();
 
@@ -112,7 +111,7 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
             &periodic_row,
         );
 
-        air.eval_with_lookups(&mut builder, lookups, lookup_gadget);
+        lookup_gadget.eval_air_and_lookups(air, &mut builder, lookups);
 
         // Stop at the first failing row and report all violations at once.
         if builder.has_failures() {

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -11,10 +11,10 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::Air;
-use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpressionExt};
+use p3_air::symbolic::SymbolicExpressionExt;
 use p3_commit::Pcs;
 use p3_field::{Algebra, BasedVectorSpace};
-use p3_lookup::Lookups;
+use p3_lookup::{InteractionSymbolicBuilder, Lookups};
 use p3_matrix::Matrix;
 use p3_uni_stark::Val;
 use p3_util::log2_strict_usize;
@@ -159,7 +159,7 @@ where
     pub fn from_instances<A>(config: &SC, instances: &[StarkInstance<'_, SC, A>]) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + Clone,
+        A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>> + Clone,
     {
         let degrees: Vec<usize> = instances.iter().map(|i| i.trace.height()).collect();
         let log_ext_degrees: Vec<usize> = degrees
@@ -187,7 +187,7 @@ where
     ) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>,
+        A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>,
     {
         assert_eq!(
             airs.len(),

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -14,8 +14,7 @@ use p3_air::Air;
 use p3_air::symbolic::{SymbolicAirBuilder, SymbolicExpressionExt};
 use p3_commit::Pcs;
 use p3_field::{Algebra, BasedVectorSpace};
-use p3_lookup::LookupAir;
-use p3_lookup::lookup_traits::Lookup;
+use p3_lookup::Lookups;
 use p3_matrix::Matrix;
 use p3_uni_stark::Val;
 use p3_util::log2_strict_usize;
@@ -70,9 +69,9 @@ pub struct CommonData<SC: SGC> {
     /// When `None`, no instance uses preprocessed columns.
     pub preprocessed: Option<GlobalPreprocessed<SC>>,
     /// The lookups used by each STARK instance.
-    /// There is one `Vec<Lookup<Val<SC>>>` per STARK instance.
+    /// There is one `Lookups<Val<SC>>` per STARK instance.
     /// They are stored in the same order as the STARK instance inputs provided to `new`.
-    pub lookups: Vec<Vec<Lookup<Val<SC>>>>,
+    pub lookups: Vec<Lookups<Val<SC>>>,
 }
 
 /// Prover-exclusive data not shared with the verifier.
@@ -101,7 +100,7 @@ pub struct ProverData<SC: SGC> {
 impl<SC: SGC> CommonData<SC> {
     pub const fn new(
         preprocessed: Option<GlobalPreprocessed<SC>>,
-        lookups: Vec<Vec<Lookup<Val<SC>>>>,
+        lookups: Vec<Lookups<Val<SC>>>,
     ) -> Self {
         Self {
             preprocessed,
@@ -113,7 +112,7 @@ impl<SC: SGC> CommonData<SC> {
     ///
     /// Use this when none of your [`Air`] implementations have preprocessed columns or lookups.
     pub fn empty(num_instances: usize) -> Self {
-        let lookups = vec![Vec::new(); num_instances];
+        let lookups = vec![Lookups::default(); num_instances];
         Self {
             preprocessed: None,
             lookups,
@@ -160,15 +159,15 @@ where
     pub fn from_instances<A>(config: &SC, instances: &[StarkInstance<'_, SC, A>]) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + LookupAir<Val<SC>> + Clone,
+        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + Clone,
     {
         let degrees: Vec<usize> = instances.iter().map(|i| i.trace.height()).collect();
         let log_ext_degrees: Vec<usize> = degrees
             .iter()
             .map(|&d| log2_strict_usize(d) + config.is_zk())
             .collect();
-        let mut airs: Vec<A> = instances.iter().map(|i| i.air.clone()).collect();
-        Self::from_airs_and_degrees(config, &mut airs, &log_ext_degrees)
+        let airs: Vec<A> = instances.iter().map(|i| i.air.clone()).collect();
+        Self::from_airs_and_degrees(config, &airs, &log_ext_degrees)
     }
 
     /// Build [`ProverData`] from [`Air`] implementations and their extended trace degree bits.
@@ -183,12 +182,12 @@ where
     /// one [`Air`] defines preprocessed columns) and the PCS prover data.
     pub fn from_airs_and_degrees<A>(
         config: &SC,
-        airs: &mut [A],
+        airs: &[A],
         trace_ext_degree_bits: &[usize],
     ) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>> + LookupAir<Val<SC>>,
+        A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>,
     {
         assert_eq!(
             airs.len(),
@@ -256,7 +255,7 @@ where
             )
         };
 
-        let lookups = airs.iter_mut().map(|air| air.get_lookups()).collect();
+        let lookups = airs.iter().map(Lookups::from_air).collect();
 
         Self {
             common: CommonData {

--- a/batch-stark/src/proof.rs
+++ b/batch-stark/src/proof.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_lookup::lookup_traits::LookupData;
+use p3_lookup::traits::LookupData;
 use p3_uni_stark::OpenedValues;
 use serde::{Deserialize, Serialize};
 

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -12,10 +12,9 @@ use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{
     Algebra, BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
 };
-use p3_lookup::AirWithLookups;
 use p3_lookup::folder::ProverConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::lookup_traits::{Kind, Lookup, LookupData, LookupGadget};
+use p3_lookup::{Kind, Lookup, LookupData, LookupProtocol};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_maybe_rayon::DisjointMutPtr;
@@ -24,7 +23,7 @@ use p3_uni_stark::{OpenedValues, PackedChallenge, PackedVal, ProverConstraintFol
 use p3_util::log2_strict_usize;
 use tracing::{debug_span, info_span, instrument};
 
-use crate::common::{CommonData, ProverData};
+use crate::common::ProverData;
 use crate::config::{Challenge, Domain, StarkGenericConfig as SGC, Val};
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof, OpenedValuesWithLookups};
 use crate::symbolic::{
@@ -44,28 +43,22 @@ pub struct StarkInstance<'a, SC: SGC, A> {
     pub trace: &'a RowMajorMatrix<Val<SC>>,
     /// Public input values exposed by this instance.
     pub public_values: Vec<Val<SC>>,
-    /// Lookup declarations (local + global) for this instance.
-    pub lookups: Vec<Lookup<Val<SC>>>,
 }
 
 impl<'a, SC: SGC, A> StarkInstance<'a, SC, A> {
-    /// Build a vector of instances from parallel slices of AIRs, traces,
-    /// public values, and the common data that stores per-instance lookups.
+    /// Build instances from parallel slices of AIRs, traces, and public values.
     pub fn new_multiple(
         airs: &'a [A],
         traces: &'a [&'a RowMajorMatrix<Val<SC>>],
         public_values: &[Vec<Val<SC>>],
-        common_data: &CommonData<SC>,
     ) -> Vec<Self> {
         airs.iter()
             .zip(traces.iter())
             .zip(public_values.iter())
-            .zip(common_data.lookups.iter())
-            .map(|(((air, trace), public_values), lookups)| Self {
+            .map(|((air, trace), public_values)| Self {
                 air,
                 trace,
                 public_values: public_values.clone(),
-                lookups: lookups.clone(),
             })
             .collect()
     }
@@ -123,11 +116,8 @@ where
     // Extended degree accounts for the ZK blinding factor (2x when ZK is enabled).
     let log_ext_degrees: Vec<usize> = log_degrees.iter().map(|&d| d + config.is_zk()).collect();
 
-    // Borrow lookups directly and build initial (zeroed) lookup data for global lookups.
-    let all_lookups: Vec<&[Lookup<Val<SC>>]> = instances
-        .iter()
-        .map(|inst| inst.lookups.as_slice())
-        .collect();
+    // Read lookups from the keygen-cached CommonData (not from instances).
+    let all_lookups: Vec<&[Lookup<Val<SC>>]> = common.lookups.iter().map(|l| &**l).collect();
     let mut lookup_data: Vec<Vec<_>> = all_lookups
         .iter()
         .map(|lookups| {
@@ -137,8 +127,8 @@ where
                 .filter_map(|lookup| match &lookup.kind {
                     Kind::Global(name) => Some(LookupData {
                         name: name.clone(),
-                        aux_idx: lookup.columns[0],
-                        expected_cumulated: SC::Challenge::ZERO,
+                        aux_column: lookup.column,
+                        cumulative_sum: SC::Challenge::ZERO,
                     }),
                     _ => None,
                 })
@@ -260,10 +250,8 @@ where
 
                     let preprocessed_trace = inst.air.preprocessed_trace();
 
-                    let perm_vals: Vec<SC::Challenge> = lookup_data[i]
-                        .iter()
-                        .map(|ld| ld.expected_cumulated)
-                        .collect();
+                    let perm_vals: Vec<SC::Challenge> =
+                        lookup_data[i].iter().map(|ld| ld.cumulative_sum).collect();
                     let lookup_constraints_inputs = (all_lookups[i], &lookup_gadget);
                     check_constraints(
                         inst.air,
@@ -294,11 +282,12 @@ where
         let debug_instances: Vec<_> = instances
             .iter()
             .zip(preprocessed_traces.iter())
-            .map(|(inst, prep)| LookupDebugInstance {
+            .zip(all_lookups.iter())
+            .map(|((inst, prep), lookups)| LookupDebugInstance {
                 main_trace: inst.trace,
                 preprocessed_trace: prep,
                 public_values: &inst.public_values,
-                lookups: &inst.lookups,
+                lookups,
                 permutation_challenges: &[],
             })
             .collect();
@@ -392,10 +381,7 @@ where
             });
 
         // Compute quotient(x) = constraints(x) / Z_H(x) on the quotient domain.
-        let perm_vals: Vec<_> = lookup_data[i]
-            .iter()
-            .map(|ld| ld.expected_cumulated)
-            .collect();
+        let perm_vals: Vec<_> = lookup_data[i].iter().map(|ld| ld.cumulative_sum).collect();
         let q_values = quotient_values(
             pcs,
             airs[i],
@@ -727,7 +713,7 @@ where
     A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>
         + for<'a> Air<ProverConstraintFolderWithLookups<'a, SC>>,
     Mat: Matrix<Val<SC>> + Sync,
-    LG: LookupGadget + Sync,
+    LG: LookupProtocol + Sync,
     SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
 {
     let quotient_size = quotient_domain.size();
@@ -919,7 +905,7 @@ where
                     permutation_challenges: &packed_perm_challenges,
                     permutation_values: &permutation_vals_packed,
                 };
-                air.eval_with_lookups(&mut folder, lookups, lookup_gadget);
+                lookup_gadget.eval_air_and_lookups(air, &mut folder, lookups);
 
                 // Combine all constraints with alpha powers and divide by the vanishing polynomial.
                 let quotient = folder.inner.finalize_constraints() * inv_vanishing;

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 
 #[cfg(debug_assertions)]
 use p3_air::DebugConstraintBuilder;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpressionExt};
+use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_air::{Air, RowWindow};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{
@@ -14,7 +14,7 @@ use p3_field::{
 };
 use p3_lookup::folder::ProverConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::{Kind, Lookup, LookupData, LookupProtocol};
+use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookup, LookupData, LookupProtocol};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_maybe_rayon::DisjointMutPtr;
@@ -88,10 +88,10 @@ impl<'a, SC: SGC, A> StarkInstance<'a, SC, A> {
 pub fn prove_batch<
     SC,
     #[cfg(debug_assertions)] A: for<'a> Air<DebugConstraintBuilder<'a, Val<SC>, SC::Challenge>>
-        + Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>
+        + Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>
         + for<'a> Air<ProverConstraintFolderWithLookups<'a, SC>>
         + Clone,
-    #[cfg(not(debug_assertions))] A: for<'a> Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>
+    #[cfg(not(debug_assertions))] A: for<'a> Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>
         + for<'a> Air<ProverConstraintFolderWithLookups<'a, SC>>
         + Clone,
 >(
@@ -710,7 +710,7 @@ pub fn quotient_values<SC, A, Mat, LG>(
 ) -> Vec<SC::Challenge>
 where
     SC: SGC,
-    A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>
+    A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>
         + for<'a> Air<ProverConstraintFolderWithLookups<'a, SC>>,
     Mat: Matrix<Val<SC>> + Sync,
     LG: LookupProtocol + Sync,

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -25,14 +25,13 @@ where
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupProtocol,
 {
-    let num_aux_cols = contexts.len() * lookup_gadget.num_aux_cols();
     let num_challenges = contexts.len() * lookup_gadget.num_challenges();
     let num_permutation_values = contexts
         .iter()
         .filter(|c| matches!(&c.kind, Kind::Global(_)))
         .count();
     let layout = AirLayout {
-        permutation_width: num_aux_cols,
+        permutation_width: contexts.len(),
         num_permutation_challenges: num_challenges,
         num_permutation_values,
         ..layout
@@ -134,14 +133,13 @@ where
     LG: LookupProtocol,
 {
     let num_lookups = contexts.len();
-    let num_aux_cols = num_lookups * lookup_gadget.num_aux_cols();
     let num_challenges = num_lookups * lookup_gadget.num_challenges();
     let num_permutation_values = contexts
         .iter()
         .filter(|c| matches!(&c.kind, Kind::Global(_)))
         .count();
     let layout = AirLayout {
-        permutation_width: num_aux_cols,
+        permutation_width: num_lookups,
         num_permutation_challenges: num_challenges,
         num_permutation_values,
         ..layout

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -1,9 +1,7 @@
 use alloc::vec::Vec;
 
 use p3_air::Air;
-use p3_air::symbolic::{
-    AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt,
-};
+use p3_air::symbolic::{AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt};
 use p3_field::{Algebra, ExtensionField, Field};
 use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookup, LookupProtocol};
 use p3_util::log2_ceil_usize;

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -5,8 +5,7 @@ use p3_air::symbolic::{
     AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
 };
 use p3_field::{Algebra, ExtensionField, Field};
-use p3_lookup::AirWithLookups;
-use p3_lookup::lookup_traits::{Kind, Lookup, LookupGadget};
+use p3_lookup::{Kind, Lookup, LookupProtocol};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
@@ -26,7 +25,7 @@ where
     EF: ExtensionField<F>,
     A: Air<SymbolicAirBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
-    LG: LookupGadget,
+    LG: LookupProtocol,
 {
     let num_aux_cols = contexts.len() * lookup_gadget.num_aux_cols();
     let num_challenges = contexts.len() * lookup_gadget.num_challenges();
@@ -41,7 +40,7 @@ where
         ..layout
     };
     let mut builder = SymbolicAirBuilder::new(layout);
-    air.eval_with_lookups(&mut builder, contexts, lookup_gadget);
+    lookup_gadget.eval_air_and_lookups(air, &mut builder, contexts);
     builder.constraint_layout()
 }
 
@@ -57,7 +56,7 @@ where
     EF: ExtensionField<F>,
     A: Air<SymbolicAirBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
-    LG: LookupGadget,
+    LG: LookupProtocol,
 {
     assert!(is_zk <= 1, "is_zk must be either 0 or 1");
 
@@ -107,7 +106,7 @@ where
     EF: ExtensionField<F>,
     A: Air<SymbolicAirBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
-    LG: LookupGadget,
+    LG: LookupProtocol,
 {
     let (base, extension) = get_symbolic_constraints(air, layout, contexts, lookup_gadget);
     let base_degree = base.iter().map(|c| c.degree_multiple()).max().unwrap_or(0);
@@ -134,7 +133,7 @@ where
     EF: ExtensionField<F>,
     A: Air<SymbolicAirBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
-    LG: LookupGadget,
+    LG: LookupProtocol,
 {
     let num_lookups = contexts.len();
     let num_aux_cols = num_lookups * lookup_gadget.num_aux_cols();
@@ -152,7 +151,7 @@ where
     let mut builder = SymbolicAirBuilder::new(layout);
 
     // Evaluate AIR and lookup constraints.
-    air.eval_with_lookups(&mut builder, contexts, lookup_gadget);
+    lookup_gadget.eval_air_and_lookups(air, &mut builder, contexts);
     let base_constraints = builder.base_constraints();
     let extension_constraints = builder.extension_constraints();
     (base_constraints, extension_constraints)

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -2,10 +2,10 @@ use alloc::vec::Vec;
 
 use p3_air::Air;
 use p3_air::symbolic::{
-    AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
+    AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt,
 };
 use p3_field::{Algebra, ExtensionField, Field};
-use p3_lookup::{Kind, Lookup, LookupProtocol};
+use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookup, LookupProtocol};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
@@ -23,7 +23,7 @@ pub fn get_constraint_layout<F, EF, A, LG>(
 where
     F: Field,
     EF: ExtensionField<F>,
-    A: Air<SymbolicAirBuilder<F, EF>>,
+    A: Air<InteractionSymbolicBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupProtocol,
 {
@@ -39,7 +39,7 @@ where
         num_permutation_values,
         ..layout
     };
-    let mut builder = SymbolicAirBuilder::new(layout);
+    let mut builder = InteractionSymbolicBuilder::new(layout);
     lookup_gadget.eval_air_and_lookups(air, &mut builder, contexts);
     builder.constraint_layout()
 }
@@ -54,7 +54,7 @@ pub fn get_log_num_quotient_chunks<F, EF, A, LG>(
 where
     F: Field,
     EF: ExtensionField<F>,
-    A: Air<SymbolicAirBuilder<F, EF>>,
+    A: Air<InteractionSymbolicBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupProtocol,
 {
@@ -104,7 +104,7 @@ pub fn get_max_constraint_degree<F, EF, A, LG>(
 where
     F: Field,
     EF: ExtensionField<F>,
-    A: Air<SymbolicAirBuilder<F, EF>>,
+    A: Air<InteractionSymbolicBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupProtocol,
 {
@@ -131,7 +131,7 @@ pub fn get_symbolic_constraints<F, EF, A, LG>(
 where
     F: Field,
     EF: ExtensionField<F>,
-    A: Air<SymbolicAirBuilder<F, EF>>,
+    A: Air<InteractionSymbolicBuilder<F, EF>>,
     SymbolicExpressionExt<F, EF>: Algebra<EF>,
     LG: LookupProtocol,
 {
@@ -148,7 +148,7 @@ where
         num_permutation_values,
         ..layout
     };
-    let mut builder = SymbolicAirBuilder::new(layout);
+    let mut builder = InteractionSymbolicBuilder::new(layout);
 
     // Evaluate AIR and lookup constraints.
     lookup_gadget.eval_air_and_lookups(air, &mut builder, contexts);

--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use hashbrown::HashMap;
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_field::PrimeCharacteristicRing;
-use p3_lookup::lookup_traits::{Kind, Lookup, LookupData, LookupGadget};
+use p3_lookup::{Kind, Lookup, LookupData, LookupProtocol};
 
 use crate::common::GlobalPreprocessed;
 use crate::config::{Challenge, Commitment, StarkGenericConfig as SGC, Val};
@@ -77,7 +77,7 @@ impl<SC: SGC> BatchTranscript<SC> {
         lookup_gadget: &LG,
     ) -> Vec<Vec<SC::Challenge>>
     where
-        LG: LookupGadget,
+        LG: LookupProtocol,
         L: AsRef<[Lookup<Val<SC>>]>,
     {
         let n = lookup_gadget.num_challenges();
@@ -112,8 +112,7 @@ impl<SC: SGC> BatchTranscript<SC> {
             self.challenger.observe(commit.clone());
             // Observe cumulated lookup sums so the verifier can check them.
             for data in lookup_data.iter().flatten() {
-                self.challenger
-                    .observe_algebra_element(data.expected_cumulated);
+                self.challenger.observe_algebra_element(data.cumulative_sum);
             }
         }
         self.challenger.sample_algebra_element()

--- a/batch-stark/src/verifier/data.rs
+++ b/batch-stark/src/verifier/data.rs
@@ -4,8 +4,7 @@ use p3_air::{Air, RowWindow};
 use p3_commit::PolynomialSpace;
 use p3_field::PrimeCharacteristicRing;
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
-use p3_lookup::lookup_traits::LookupGadget;
-use p3_lookup::{AirWithLookups, Lookup};
+use p3_lookup::{Lookup, LookupProtocol};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use p3_uni_stark::{VerificationError, VerifierConstraintFolder};
@@ -51,7 +50,7 @@ impl<'a, SC: SGC> VerifierData<'a, SC> {
     ///
     /// This evaluates the AIR constraints at the out-of-domain point and checks
     /// that constraints(zeta) / Z_H(zeta) = quotient(zeta).
-    pub fn verify_constraints_with_lookups<A, LG: LookupGadget, PcsErr: Debug>(
+    pub fn verify_constraints_with_lookups<A, LG: LookupProtocol, PcsErr: Debug>(
         &self,
         air: &A,
         lookup_gadget: &LG,
@@ -95,7 +94,7 @@ impl<'a, SC: SGC> VerifierData<'a, SC> {
             permutation_values: self.permutation_values,
         };
         // Evaluate AIR and lookup constraints.
-        air.eval_with_lookups(&mut folder, self.lookups, lookup_gadget);
+        lookup_gadget.eval_air_and_lookups(air, &mut folder, self.lookups);
 
         // Check that constraints(zeta) / Z_H(zeta) = quotient(zeta)
         if folder.inner.accumulator * sels.inv_vanishing != self.quotient {

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -7,12 +7,12 @@ use alloc::{format, vec};
 pub use data::VerifierData;
 use hashbrown::HashMap;
 use p3_air::Air;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpressionExt};
+use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, PrimeCharacteristicRing};
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::{Kind, LookupProtocol};
+use p3_lookup::{InteractionSymbolicBuilder, Kind, LookupProtocol};
 use p3_uni_stark::{
     InvalidProofShapeError, VerificationError, recompose_quotient_from_chunks, validate_degree_bits,
 };
@@ -37,7 +37,7 @@ pub fn verify_batch<SC, A>(
 where
     SC: SGC,
     SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
-    A: Air<SymbolicAirBuilder<Val<SC>, SC::Challenge>>
+    A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>
         + for<'a> Air<VerifierConstraintFolderWithLookups<'a, SC>>,
     Challenge<SC>: BasedVectorSpace<Val<SC>>,
 {

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -10,10 +10,9 @@ use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpressionExt};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, PrimeCharacteristicRing};
-use p3_lookup::Lookup;
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::lookup_traits::LookupGadget;
+use p3_lookup::{Kind, LookupProtocol};
 use p3_uni_stark::{
     InvalidProofShapeError, VerificationError, recompose_quotient_from_chunks, validate_degree_bits,
 };
@@ -227,8 +226,13 @@ where
             return Err(InvalidProofShapeError::PreprocessedWidthMismatch { air: i }.into());
         }
 
-        let expected_global_lookup_entries =
-            Lookup::global_entries(&all_lookups[i]).collect::<Vec<_>>();
+        let expected_global_lookup_entries: Vec<_> = all_lookups[i]
+            .iter()
+            .filter_map(|l| match &l.kind {
+                Kind::Global(name) => Some((name, l.column)),
+                Kind::Local => None,
+            })
+            .collect();
         let expected_global_lookup_data_len = expected_global_lookup_entries.len();
         let got_global_lookup_data_len = global_lookup_data[i].len();
         if got_global_lookup_data_len != expected_global_lookup_data_len {
@@ -239,20 +243,20 @@ where
             }
             .into());
         }
-        for (lookup_idx, ((expected_name, expected_aux_idx), data)) in
+        for (lookup_idx, ((expected_name, expected_aux_column), data)) in
             expected_global_lookup_entries
                 .into_iter()
                 .zip(global_lookup_data[i].iter())
                 .enumerate()
         {
-            if data.name != *expected_name || data.aux_idx != expected_aux_idx {
+            if data.name != *expected_name || data.aux_column != expected_aux_column {
                 return Err(InvalidProofShapeError::GlobalLookupDataMetadataMismatch {
                     air: i,
                     lookup: lookup_idx,
                     expected_name: expected_name.clone(),
                     got_name: data.name.clone(),
-                    expected_aux_idx,
-                    got_aux_idx: data.aux_idx,
+                    expected_aux_column,
+                    got_aux_column: data.aux_column,
                 }
                 .into());
             }
@@ -515,7 +519,7 @@ where
         // For constraint evaluation, we need an extension field matrix with width `aux_width``.
         let aux_width = all_lookups[i]
             .iter()
-            .flat_map(|ctx| ctx.columns.iter().cloned())
+            .map(|ctx| ctx.column)
             .max()
             .map(|m| m + 1)
             .unwrap_or(0);
@@ -580,7 +584,7 @@ where
         };
         let perm_vals: Vec<SC::Challenge> = global_lookup_data[i]
             .iter()
-            .map(|ld| ld.expected_cumulated)
+            .map(|ld| ld.cumulative_sum)
             .collect();
         let periodic_values: Vec<Challenge<SC>> = air
             .periodic_columns()
@@ -621,18 +625,23 @@ where
 
     let mut global_cumulative = HashMap::<&String, Vec<_>>::new();
     for (lookups, data_for_instance) in all_lookups.iter().zip(global_lookup_data.iter()) {
-        debug_assert_eq!(Lookup::global_count(lookups), data_for_instance.len());
-        for ((name, _), data) in Lookup::global_entries(lookups).zip(data_for_instance.iter()) {
+        let global_lookups = lookups.iter().filter(|l| matches!(l.kind, Kind::Global(_)));
+        debug_assert_eq!(global_lookups.clone().count(), data_for_instance.len());
+        for (lookup, data) in global_lookups.zip(data_for_instance.iter()) {
+            let name = match &lookup.kind {
+                Kind::Global(n) => n,
+                Kind::Local => unreachable!(),
+            };
             global_cumulative
                 .entry(name)
                 .or_default()
-                .push(data.expected_cumulated);
+                .push(data.cumulative_sum);
         }
     }
 
     for (name, all_expected_cumulative) in global_cumulative {
         lookup_gadget
-            .verify_global_final_value(&all_expected_cumulative)
+            .verify_global_sum(&all_expected_cumulative)
             .map_err(|e| VerificationError::LookupError(format!("{e:?}: {name}")))?;
     }
 

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -18,6 +18,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
+use p3_lookup::InteractionBuilder;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
@@ -275,7 +276,7 @@ impl<F> BaseAir<F> for MulAirLookups {
 impl<AB> Air<AB> for MulAirLookups
 where
     AB::Var: Debug,
-    AB: AirBuilder + PermutationAirBuilder,
+    AB: AirBuilder + PermutationAirBuilder + InteractionBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         self.air.eval(builder);
@@ -391,7 +392,7 @@ impl<F: Field> BaseAir<F> for FibAirLookups {
     }
 }
 
-impl<AB: PermutationAirBuilder> Air<AB> for FibAirLookups {
+impl<AB: PermutationAirBuilder + InteractionBuilder> Air<AB> for FibAirLookups {
     fn eval(&self, builder: &mut AB) {
         self.air.eval(builder);
 
@@ -713,7 +714,7 @@ impl<F: Field> BaseAir<F> for DemoAirWithLookups {
     }
 }
 
-impl<AB: PermutationAirBuilder> Air<AB> for DemoAirWithLookups
+impl<AB: PermutationAirBuilder + InteractionBuilder> Air<AB> for DemoAirWithLookups
 where
     AB::Var: Debug,
 {
@@ -2472,7 +2473,7 @@ impl<F> BaseAir<F> for SingleTableLocalLookupAir {
 impl<AB> Air<AB> for SingleTableLocalLookupAir
 where
     AB::Var: Debug,
-    AB: AirBuilder + PermutationAirBuilder,
+    AB: AirBuilder + PermutationAirBuilder + InteractionBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -3,10 +3,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::slice::from_ref;
 
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
-use p3_air::{
-    Air, AirBuilder, BaseAir, BaseLeaf, PeriodicAirBuilder, PermutationAirBuilder, WindowAccess,
-};
+use p3_air::{Air, AirBuilder, BaseAir, PeriodicAirBuilder, PermutationAirBuilder, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
 use p3_batch_stark::{
@@ -21,8 +18,6 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
-use p3_lookup::LookupAir;
-use p3_lookup::lookup_traits::{Direction, Kind, Lookup};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
@@ -183,7 +178,6 @@ impl<AB: AirBuilder> Air<AB> for MulAir {
         }
     }
 }
-impl<F: Field> LookupAir<F> for MulAir {}
 
 #[derive(Clone)]
 struct PeriodicAir<F> {
@@ -243,8 +237,6 @@ where
     }
 }
 
-impl<F: Field> LookupAir<F> for PeriodicAir<F> {}
-
 // --- MulAirLookups structure for local and global lookups ---
 // This AIR is a `MulAir` that can register global lookups with `FibAirLookups`, as well as local lookups with a lookup column. Its inputs are the Fibonacci values.
 // - when `is_local` is true, this AIR creates local lookups between its first column and its last column.
@@ -260,23 +252,15 @@ struct MulAirLookups {
     air: MulAir,
     is_local: bool,
     is_global: bool,
-    num_lookups: usize,
     global_names: Vec<String>,
 }
 
 impl MulAirLookups {
-    const fn new(
-        air: MulAir,
-        is_local: bool,
-        is_global: bool,
-        num_lookups: usize,
-        global_names: Vec<String>,
-    ) -> Self {
+    const fn new(air: MulAir, is_local: bool, is_global: bool, global_names: Vec<String>) -> Self {
         Self {
             air,
             is_local,
             is_global,
-            num_lookups,
             global_names,
         }
     }
@@ -295,83 +279,36 @@ where
 {
     fn eval(&self, builder: &mut AB) {
         self.air.eval(builder);
-    }
-}
 
-impl<F: Field> LookupAir<F> for MulAirLookups {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        let new_idx = self.num_lookups;
-        self.num_lookups += 1;
-        vec![new_idx]
-    }
+        // Cross-AIR and intra-AIR interactions.
+        let main = builder.main();
+        let local = main.current_slice();
+        let last_idx = <Self as BaseAir<AB::F>>::width(self) - 1;
+        let lut = local[last_idx]; // Extra column: permutation of 'a'
 
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        let mut lookups = Vec::new();
-        self.num_lookups = 0;
-
-        // Create symbolic air builder to access symbolic variables
-        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<F>::width(self),
-            ..Default::default()
-        });
-        let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
-
-        let last_idx = symbolic_air_builder.main().width() - 1;
-        let lut = symbolic_main_local[last_idx]; //  Extra column that corresponds to a permutation of 'a'
-
-        if self.is_global {
-            assert!(self.global_names.len() == self.air.reps);
-        }
-        // We add lookups rep by rep, so that we have a mix of local and global lookups, rather than having all local first then all global.
         for rep in 0..self.air.reps {
-            if self.is_local {
-                let base_idx = rep * 3;
-                let a = symbolic_main_local[base_idx]; // First input
-                // Create lookup inputs for each multiplication input
-                // We'll create a local lookup table with integers 0 to height
-                let lookup_inputs = vec![
-                    // Lookup for 'a' against a permuted column.
-                    (
-                        vec![a.into()],
-                        SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
-                        Direction::Receive,
-                    ),
-                    // Provide the range values (this would be done in the trace generation)
-                    (
-                        vec![lut.into()], // This represents the range values
-                        SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
-                        Direction::Send,
-                    ),
-                ];
+            let base_idx = rep * 3;
+            let a = local[base_idx];
+            let b = local[base_idx + 1];
 
-                let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
-                lookups.push(local_lookup);
+            // Local lookup: 'a' against the permuted column.
+            if self.is_local {
+                builder.push_local_interaction(vec![
+                    (vec![a.into()], AB::Expr::ONE),    // query (receive)
+                    (vec![lut.into()], -AB::Expr::ONE), // table (send, negated)
+                ]);
             }
 
-            // Global lookups: between MulAir inputs and FibAir inputs
+            // Global lookup: send (a, b) to FibAirLookups.
             if self.is_global {
-                let base_idx = rep * 3;
-                let a = symbolic_main_local[base_idx]; // First input
-                let b = symbolic_main_local[base_idx + 1]; // Second input
-
-                // Global lookup between MulAir inputs and FibAir inputs
-                let lookup_inputs = vec![(
-                    vec![a.into(), b.into()],
-                    SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
-                    Direction::Send, // MulAir sends data to the global lookup
-                )];
-
-                let global_lookup = LookupAir::register_lookup(
-                    self,
-                    Kind::Global(self.global_names[rep].clone()),
-                    &lookup_inputs,
+                builder.push_interaction(
+                    &self.global_names[rep],
+                    [a.into(), b.into()],
+                    -AB::Expr::ONE, // Send = negative count
+                    1,
                 );
-                lookups.push(global_lookup);
             }
         }
-
-        lookups
     }
 }
 
@@ -414,7 +351,6 @@ fn mul_trace<F: Field>(rows: usize, reps: usize) -> RowMajorMatrix<F> {
 struct FibAirLookups {
     air: FibonacciAir,
     is_global: bool,
-    num_lookups: usize,
     name_and_mult: Option<(String, u64)>,
 }
 
@@ -426,23 +362,16 @@ impl Default for FibAirLookups {
                 tamper_index: None,
             },
             is_global: false,
-            num_lookups: 0,
             name_and_mult: None,
         }
     }
 }
 
 impl FibAirLookups {
-    const fn new(
-        air: FibonacciAir,
-        is_global: bool,
-        num_lookups: usize,
-        name_and_mult: Option<(String, u64)>,
-    ) -> Self {
+    const fn new(air: FibonacciAir, is_global: bool, name_and_mult: Option<(String, u64)>) -> Self {
         Self {
             air,
             is_global,
-            num_lookups,
             name_and_mult,
         }
     }
@@ -465,53 +394,26 @@ impl<F: Field> BaseAir<F> for FibAirLookups {
 impl<AB: PermutationAirBuilder> Air<AB> for FibAirLookups {
     fn eval(&self, builder: &mut AB) {
         self.air.eval(builder);
-    }
-}
 
-impl<F: Field> LookupAir<F> for FibAirLookups {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        let new_idx = self.num_lookups;
-        self.num_lookups += 1;
-        vec![new_idx]
-    }
-
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        let mut lookups = Vec::new();
-        self.num_lookups = 0;
-
+        // Global interaction — receive (left, right) from MulAirLookups.
         if self.is_global {
-            // Create symbolic air builder to access symbolic variables
-            let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-                main_width: BaseAir::<F>::width(self),
-                num_public_values: 3,
-                ..Default::default()
-            });
-            let symbolic_main = symbolic_air_builder.main();
-            let symbolic_main_local = symbolic_main.row_slice(0).unwrap();
-
-            // Global lookups: between FibAir inputs and MulAir inputs
-            // FibAir has 2 columns: left and right
-            let left = symbolic_main_local[0]; // left column
-            let right = symbolic_main_local[1]; // right column
+            let main = builder.main();
+            let left = main.current(0).unwrap();
+            let right = main.current(1).unwrap();
 
             let (name, multiplicity) = match &self.name_and_mult {
                 Some((n, m)) => (n.clone(), *m),
                 None => ("MulFib".to_string(), 2),
             };
 
-            // Global lookup between FibAir inputs and MulAir inputs
-            let lookup_inputs = vec![(
-                vec![left.into(), right.into()],
-                SymbolicExpression::Leaf(BaseLeaf::Constant(F::from_u64(multiplicity))),
-                Direction::Receive, // FibAir receives data from the global lookup
-            )];
-
-            let global_lookup =
-                LookupAir::register_lookup(self, Kind::Global(name), &lookup_inputs);
-            lookups.push(global_lookup);
+            // Receive = positive count (counterpart to MulAirLookups' negative send).
+            builder.push_interaction(
+                &name,
+                [left.into(), right.into()],
+                AB::Expr::from_u64(multiplicity),
+                1,
+            );
         }
-
-        lookups
     }
 }
 
@@ -564,7 +466,6 @@ where
         );
     }
 }
-impl<F: Field> LookupAir<F> for PreprocessedMulAir {}
 
 fn preprocessed_mul_trace<F: Field>(rows: usize, multiplier: u64) -> RowMajorMatrix<F> {
     assert!(rows.is_power_of_two());
@@ -824,22 +725,6 @@ where
     }
 }
 
-impl<F: Field> LookupAir<F> for DemoAirWithLookups {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        match self {
-            Self::FibLookups(a) => LookupAir::<F>::add_lookup_columns(a),
-            Self::MulLookups(a) => LookupAir::<F>::add_lookup_columns(a),
-        }
-    }
-
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        match self {
-            Self::FibLookups(a) => LookupAir::<F>::get_lookups(a),
-            Self::MulLookups(a) => LookupAir::<F>::get_lookups(a),
-        }
-    }
-}
-
 impl<AB: PermutationAirBuilder> Air<AB> for DemoAir
 where
     AB::Var: Debug,
@@ -853,7 +738,6 @@ where
         }
     }
 }
-impl<F: PrimeField64> LookupAir<F> for DemoAir {}
 
 /// Creates a Fibonacci instance with specified log height.
 fn create_fib_instance(log_height: usize) -> (DemoAir, RowMajorMatrix<Val>, Vec<Val>) {
@@ -904,13 +788,11 @@ fn test_two_instances() -> Result<(), impl Debug> {
             air: &air_fib,
             trace: &fib_trace,
             public_values: fib_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul,
             trace: &mul_trace,
             public_values: mul_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -932,7 +814,6 @@ fn test_periodic_air() -> Result<(), impl Debug> {
         air: &air,
         trace: &trace,
         public_values: vec![],
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -949,7 +830,6 @@ fn test_periodic_air_zk() -> Result<(), impl Debug> {
         air: &air,
         trace: &trace,
         public_values: vec![],
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -969,13 +849,11 @@ fn test_two_instances_zk() -> Result<(), impl Debug> {
             air: &air_fib,
             trace: &fib_trace,
             public_values: fib_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul,
             trace: &mul_trace,
             public_values: mul_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1000,19 +878,16 @@ fn test_three_instances_mixed_sizes() -> Result<(), impl Debug> {
             air: &air_fib16,
             trace: &fib16_trace,
             public_values: fib16_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul8,
             trace: &mul8_trace,
             public_values: mul8_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_fib8,
             trace: &fib8_trace,
             public_values: fib8_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1035,7 +910,6 @@ fn test_invalid_public_values_rejected() -> Result<(), Box<dyn std::error::Error
         air: &air_fib,
         trace: &trace,
         public_values: fib_pis,
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -1062,7 +936,6 @@ fn test_short_public_values_rejected() -> Result<(), Box<dyn std::error::Error>>
         air: &air_fib,
         trace: &trace,
         public_values: fib_pis,
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -1100,7 +973,6 @@ fn test_degree_bits_too_large_rejected() -> Result<(), Box<dyn std::error::Error
         air: &air_fib,
         trace: &trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -1154,7 +1026,6 @@ fn test_degree_bits_too_small_for_zk_rejected() -> Result<(), Box<dyn std::error
         air: &air_fib,
         trace: &trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -1206,19 +1077,16 @@ fn test_different_widths() -> Result<(), impl Debug> {
             air: &air_mul2,
             trace: &mul2_trace,
             public_values: mul2_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_fib,
             trace: &fib_trace,
             public_values: fib_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul3,
             trace: &mul3_trace,
             public_values: mul3_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1240,7 +1108,6 @@ fn test_preprocessed_tampered_fails() -> Result<(), Box<dyn std::error::Error>> 
         air: &air,
         trace: &trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
 
     let prover_data = ProverData::from_instances(&config, &instances);
@@ -1266,9 +1133,9 @@ fn test_preprocessed_tampered_fails() -> Result<(), Box<dyn std::error::Error>> 
     // Create CommonData with tampered AIR to test verification failure
     // Use the proof's degree_bits (which are log_degrees since ZK is not supported)
     let degree_bits = proof.degree_bits.clone();
-    let mut airs_tampered = vec![air_tampered];
+    let airs_tampered = vec![air_tampered];
     let prover_data_tampered =
-        ProverData::from_airs_and_degrees(&config, &mut airs_tampered, &degree_bits);
+        ProverData::from_airs_and_degrees(&config, &airs_tampered, &degree_bits);
     let common_tampered = &prover_data_tampered.common;
 
     let res = verify_batch(&config, &airs_tampered, &proof, &[fib_pis], common_tampered);
@@ -1298,7 +1165,6 @@ fn test_preprocessed_reuse_common_multi_proofs() -> Result<(), Box<dyn std::erro
         air: &air,
         trace: &trace1,
         public_values: fib_pis1.clone(),
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances1);
     let common = &prover_data.common;
@@ -1321,7 +1187,6 @@ fn test_preprocessed_reuse_common_multi_proofs() -> Result<(), Box<dyn std::erro
         air: &airs[0],
         trace: &trace2,
         public_values: fib_pis2.clone(),
-        lookups: vec![],
     }];
     let proof2 = prove_batch(&config, &instances2, &prover_data);
 
@@ -1345,7 +1210,6 @@ fn test_single_instance() -> Result<(), impl Debug> {
         air: &air_fib,
         trace: &fib_trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
 
     let prover_data = ProverData::from_instances(&config, &instances);
@@ -1366,7 +1230,6 @@ fn test_quotient_domain_size_not_multiple_of_packed_field_width() -> Result<(), 
         air: &air_fib,
         trace: &fib_trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
 
     let prover_data = ProverData::from_instances(&config, &instances);
@@ -1388,13 +1251,11 @@ fn test_mixed_preprocessed() -> Result<(), impl Debug> {
             air: &air_fib,
             trace: &fib_trace,
             public_values: fib_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul,
             trace: &mul_trace,
             public_values: mul_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1423,7 +1284,6 @@ fn test_invalid_trace_width_rejected() {
         air: &air_fib,
         trace: &fib_trace,
         public_values: fib_pis.clone(),
-        lookups: vec![],
     }];
 
     // Generate a valid proof
@@ -1517,13 +1377,11 @@ fn test_reorder_instances_rejected() {
             air: &air_a,
             trace: &tr_a,
             public_values: pv_a.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_b,
             trace: &tr_b,
             public_values: pv_b.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1535,9 +1393,9 @@ fn test_reorder_instances_rejected() {
     let proof = prove_batch(&config, &instances, &prover_data);
 
     // Swap order at verify -> should fail (create new CommonData with swapped AIRs)
-    let mut airs_swapped = vec![air_b, air_a];
+    let airs_swapped = vec![air_b, air_a];
     let prover_data_swapped =
-        ProverData::from_airs_and_degrees(&config, &mut airs_swapped, &log_degrees);
+        ProverData::from_airs_and_degrees(&config, &airs_swapped, &log_degrees);
     let common_swapped = &prover_data_swapped.common;
     let res = verify_batch(
         &config,
@@ -1561,7 +1419,6 @@ fn test_quotient_chunk_element_len_rejected() {
         air: &air,
         trace: &tr,
         public_values: pv.clone(),
-        lookups: vec![],
     }];
     let prover_data = ProverData::from_instances(&config, &instances);
     let common = &prover_data.common;
@@ -1618,13 +1475,11 @@ fn test_circle_stark_batch() -> Result<(), impl Debug> {
             air: &airs[0],
             trace: &trace1,
             public_values: fib_pis1.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &airs[1],
             trace: &trace2,
             public_values: fib_pis2.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1659,7 +1514,6 @@ fn two_adic_compat_case() -> CompatCase<MyConfig, Val> {
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     );
 
@@ -1667,7 +1521,7 @@ fn two_adic_compat_case() -> CompatCase<MyConfig, Val> {
         log_height: log_n,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None);
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None);
 
     let mul_trace = mul_trace::<Val>(n, reps);
     let fib_trace = fib_trace::<Val>(0, 1, n);
@@ -1701,7 +1555,6 @@ fn circle_compat_case() -> CompatCase<CircleConfig, CircleVal> {
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     );
 
@@ -1709,7 +1562,7 @@ fn circle_compat_case() -> CompatCase<CircleConfig, CircleVal> {
         log_height: log_n,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None);
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None);
 
     let mul_trace = mul_trace::<CircleVal>(n, reps);
     let fib_trace = fib_trace::<CircleVal>(0, 1, n);
@@ -1751,11 +1604,11 @@ fn read_fixture(path: &str) -> std::io::Result<Vec<u8>> {
 
 #[test]
 fn verify_two_adic_compat_fixture() -> Result<(), Box<dyn std::error::Error>> {
-    let (config, mut airs, _traces, pvs, _log_degrees) = two_adic_compat_case();
+    let (config, airs, _traces, pvs, _log_degrees) = two_adic_compat_case();
     let proof_bytes = read_fixture(TWO_ADIC_FIXTURE)
         .expect("Missing fixture. Run: cargo test -p p3-batch-stark --test simple -- --ignored");
     let proof: BatchProof<MyConfig> = postcard::from_bytes(&proof_bytes)?;
-    let prover_data = ProverData::from_airs_and_degrees(&config, &mut airs, &proof.degree_bits);
+    let prover_data = ProverData::from_airs_and_degrees(&config, &airs, &proof.degree_bits);
     let common = &prover_data.common;
     verify_batch(&config, &airs, &proof, &pvs, common)?;
     Ok(())
@@ -1763,11 +1616,11 @@ fn verify_two_adic_compat_fixture() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn verify_circle_compat_fixture() -> Result<(), Box<dyn std::error::Error>> {
-    let (config, mut airs, _traces, pvs, _log_degrees) = circle_compat_case();
+    let (config, airs, _traces, pvs, _log_degrees) = circle_compat_case();
     let proof_bytes = read_fixture(CIRCLE_FIXTURE)
         .expect("Missing fixture. Run: cargo test -p p3-batch-stark --test simple -- --ignored");
     let proof: BatchProof<CircleConfig> = postcard::from_bytes(&proof_bytes)?;
-    let prover_data = ProverData::from_airs_and_degrees(&config, &mut airs, &proof.degree_bits);
+    let prover_data = ProverData::from_airs_and_degrees(&config, &airs, &proof.degree_bits);
     let common = &prover_data.common;
     verify_batch(&config, &airs, &proof, &pvs, common)?;
     Ok(())
@@ -1777,11 +1630,11 @@ fn verify_circle_compat_fixture() -> Result<(), Box<dyn std::error::Error>> {
 #[ignore]
 fn generate_two_adic_fixture() -> Result<(), Box<dyn std::error::Error>> {
     // Regen: cargo test -p p3-batch-stark --test simple -- --ignored
-    let (config, mut airs, traces, pvs, log_degrees) = two_adic_compat_case();
-    let prover_data = ProverData::from_airs_and_degrees(&config, &mut airs, &log_degrees);
-    let common = &prover_data.common;
+    let (config, airs, traces, pvs, log_degrees) = two_adic_compat_case();
+    let prover_data = ProverData::from_airs_and_degrees(&config, &airs, &log_degrees);
+    let _common = &prover_data.common;
     let traces = [&traces[0], &traces[1]];
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
     let proof = prove_batch(&config, &instances, &prover_data);
     let bytes = postcard::to_allocvec(&proof)?;
     write_fixture(TWO_ADIC_FIXTURE, &bytes)?;
@@ -1792,11 +1645,11 @@ fn generate_two_adic_fixture() -> Result<(), Box<dyn std::error::Error>> {
 #[ignore]
 fn generate_circle_fixture() -> Result<(), Box<dyn std::error::Error>> {
     // Regen: cargo test -p p3-batch-stark --test simple -- --ignored
-    let (config, mut airs, traces, pvs, log_degrees) = circle_compat_case();
-    let prover_data = ProverData::from_airs_and_degrees(&config, &mut airs, &log_degrees);
-    let common = &prover_data.common;
+    let (config, airs, traces, pvs, log_degrees) = circle_compat_case();
+    let prover_data = ProverData::from_airs_and_degrees(&config, &airs, &log_degrees);
+    let _common = &prover_data.common;
     let traces = [&traces[0], &traces[1]];
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
     let proof = prove_batch(&config, &instances, &prover_data);
     let bytes = postcard::to_allocvec(&proof)?;
     write_fixture(CIRCLE_FIXTURE, &bytes)?;
@@ -1815,7 +1668,6 @@ fn test_preprocessed_constraint_positive() -> Result<(), impl Debug> {
         air: &air,
         trace: &trace,
         public_values: pis.clone(),
-        lookups: vec![],
     }];
 
     let prover_data = ProverData::from_instances(&config, &instances);
@@ -1838,7 +1690,6 @@ fn test_preprocessed_constraint_negative() -> Result<(), Box<dyn std::error::Err
         air: &air_prove,
         trace: &trace,
         public_values: pis.clone(),
-        lookups: vec![],
     }];
 
     let prover_data = ProverData::from_instances(&config, &instances);
@@ -1849,9 +1700,9 @@ fn test_preprocessed_constraint_negative() -> Result<(), Box<dyn std::error::Err
         log_height: 4,
         multiplier: 3, // Wrong multiplier!
     });
-    let mut airs = vec![air_verify];
+    let airs = vec![air_verify];
     let degree_bits = proof.degree_bits.clone();
-    let prover_data_verify = ProverData::from_airs_and_degrees(&config, &mut airs, &degree_bits);
+    let prover_data_verify = ProverData::from_airs_and_degrees(&config, &airs, &degree_bits);
     let common_verify = &prover_data_verify.common;
 
     let res = verify_batch(&config, &airs, &proof, &[pis], common_verify);
@@ -1881,19 +1732,16 @@ fn test_mixed_preprocessed_constraints() -> Result<(), impl Debug> {
             air: &air_fib,
             trace: &fib_trace,
             public_values: fib_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_mul,
             trace: &mul_trace,
             public_values: mul_pis.clone(),
-            lookups: vec![],
         },
         StarkInstance {
             air: &air_pp_mul,
             trace: &pp_mul_trace,
             public_values: pp_mul_pis.clone(),
-            lookups: vec![],
         },
     ];
 
@@ -1916,20 +1764,19 @@ fn test_batch_stark_one_instance_local_only() -> Result<(), impl Debug> {
     let reps = 1;
     // Create MulAir instance with local lookups configuration
     let mul_air = MulAir { reps };
-    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, 0, vec![]); // local only
+    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, vec![]); // local only
 
     let log_height = 3; // 8 rows
     let mul_trace = mul_trace::<Val>(1 << log_height, reps);
 
-    let mut airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
+    let airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
 
     // Get lookups from the lookup-enabled AIRs
-    let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_height]);
+    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
     let common = &prover_data.common;
     let traces = [&mul_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -1948,7 +1795,7 @@ fn test_batch_stark_one_instance_local_fails() {
     let reps = 2;
     // Create MulAir instance with local lookups configuration
     let mul_air = MulAir { reps };
-    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, 0, vec![]); // local only
+    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, vec![]); // local only
 
     let log_height = 3; // 8 rows
     let mut mul_trace = mul_trace::<Val>(1 << log_height, reps);
@@ -1956,15 +1803,14 @@ fn test_batch_stark_one_instance_local_fails() {
     // Tamper with the permutation column to cause lookup failure.
     mul_trace.values[reps * 3] = Val::from_u64(9999);
 
-    let mut airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
+    let airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
 
     // Get lookups from the lookup-enabled AIRs
-    let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_height]);
-    let common = &prover_data.common;
+    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
+    let _common = &prover_data.common;
     let traces = [&mul_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]]);
 
     prove_batch(&config, &instances, &prover_data);
 }
@@ -1981,22 +1827,21 @@ fn test_batch_stark_one_instance_local_fails() {
     let log_height = 3; // 8 rows
     // Create MulAir instance with local lookups configuration
     let mul_air = MulAir { reps };
-    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, 0, vec![]); // local only
+    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, vec![]); // local only
 
     let mut mul_trace = mul_trace::<Val>(1 << log_height, reps);
 
     // Tamper with the permutation column to cause lookup failure.
     mul_trace.values[reps * 3] = Val::from_u64(9999);
 
-    let mut airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
+    let airs = [DemoAirWithLookups::MulLookups(mul_air_lookups)];
 
     // Get lookups from the lookup-enabled AIRs
-    let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_height]);
+    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
     let common = &prover_data.common;
     let traces = [&mul_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![]]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2012,14 +1857,13 @@ fn test_batch_stark_local_lookups_only() -> Result<(), impl Debug> {
     let height = 1 << log_height;
     // Create MulAir instance with local lookups configuration
     let mul_air = MulAir { reps: 2 };
-    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, 0, vec![]); // local only
+    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, vec![]); // local only
     let fib_air_lookups = FibAirLookups::new(
         FibonacciAir {
             log_height,
             tamper_index: None,
         },
         false,
-        0,
         None,
     ); // no lookups
 
@@ -2031,18 +1875,15 @@ fn test_batch_stark_local_lookups_only() -> Result<(), impl Debug> {
     let air1 = DemoAirWithLookups::MulLookups(mul_air_lookups);
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
 
     // Get lookups from the lookup-enabled AIRs
-    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(
-        &config,
-        &mut airs,
-        &[log_height, log_height],
-    );
+    let prover_data =
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height, log_height]);
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2050,7 +1891,7 @@ fn test_batch_stark_local_lookups_only() -> Result<(), impl Debug> {
     verify_batch(&config, &airs, &proof, &pvs, common)
 }
 
-/// Test with global lookups only using MulAirLookups and FibAirLookups  
+/// Test with global lookups only using MulAirLookups and FibAirLookups
 #[test]
 fn test_batch_stark_global_lookups_only() -> Result<(), impl Debug> {
     let config = make_config(2025);
@@ -2063,7 +1904,6 @@ fn test_batch_stark_global_lookups_only() -> Result<(), impl Debug> {
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     ); // global only
 
@@ -2074,7 +1914,7 @@ fn test_batch_stark_global_lookups_only() -> Result<(), impl Debug> {
         log_height: log_n,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None); // global lookups
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None); // global lookups
 
     let mul_trace = mul_trace::<Val>(n, 2);
     let fib_trace = fib_trace::<Val>(0, 1, n);
@@ -2085,13 +1925,13 @@ fn test_batch_stark_global_lookups_only() -> Result<(), impl Debug> {
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
     // Get lookups from the lookup-enabled AIRs
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
     let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_n, log_n]);
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_n, log_n]);
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2111,7 +1951,6 @@ fn test_batch_stark_both_lookups() -> Result<(), impl Debug> {
         mul_air,
         true,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     ); // both
 
@@ -2122,7 +1961,7 @@ fn test_batch_stark_both_lookups() -> Result<(), impl Debug> {
         log_height,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None); // global lookups
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None); // global lookups
 
     let mul_trace = mul_trace::<Val>(height, 2);
     let fib_trace = fib_trace::<Val>(0, 1, height);
@@ -2132,17 +1971,14 @@ fn test_batch_stark_both_lookups() -> Result<(), impl Debug> {
     let air1 = DemoAirWithLookups::MulLookups(mul_air_lookups);
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
     // Get lookups from the lookup-enabled AIRs
-    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(
-        &config,
-        &mut airs,
-        &[log_height, log_height],
-    );
+    let prover_data =
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height, log_height]);
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2162,7 +1998,6 @@ fn test_batch_stark_both_lookups_zk() -> Result<(), impl Debug> {
         mul_air,
         true,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     ); // both
 
@@ -2173,7 +2008,7 @@ fn test_batch_stark_both_lookups_zk() -> Result<(), impl Debug> {
         log_height,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None); // global lookups
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None); // global lookups
 
     let mul_trace = mul_trace::<Val>(height, 2);
     let fib_trace = fib_trace::<Val>(0, 1, height);
@@ -2183,17 +2018,17 @@ fn test_batch_stark_both_lookups_zk() -> Result<(), impl Debug> {
     let air1 = DemoAirWithLookups::MulLookups(mul_air_lookups);
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
     // Get lookups from the lookup-enabled AIRs
     let prover_data = ProverData::<MyHidingConfig>::from_airs_and_degrees(
         &config,
-        &mut airs,
+        &airs,
         &[log_height + config.is_zk(), log_height + config.is_zk()],
     );
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()]);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2228,7 +2063,6 @@ fn test_batch_stark_failed_global_lookup_inner() {
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib1".to_string(), "MulFib2".to_string()], // Different names!
     );
     // This creates a mismatch: MulAir sends to "MulFib1" and "MulFib2"
@@ -2239,8 +2073,7 @@ fn test_batch_stark_failed_global_lookup_inner() {
         log_height: log_n,
         tamper_index: None,
     };
-    let fib_air_lookups =
-        FibAirLookups::new(fibonacci_air, true, 0, Some(("MulFib1".to_string(), 1)));
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, Some(("MulFib1".to_string(), 1)));
 
     let mul_trace = mul_trace::<Val>(n, 2);
     let fib_trace = fib_trace::<Val>(0, 1, n);
@@ -2253,12 +2086,12 @@ fn test_batch_stark_failed_global_lookup_inner() {
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
     // Get lookups from the lookup-enabled AIRs
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
     let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_n, log_n]);
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_n, log_n]);
     let common = &prover_data.common;
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2279,7 +2112,6 @@ fn test_batch_stark_rejects_truncated_global_lookup_data() {
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib".to_string(), "MulFib".to_string()],
     );
 
@@ -2289,7 +2121,7 @@ fn test_batch_stark_rejects_truncated_global_lookup_data() {
         log_height: log_n,
         tamper_index: None,
     };
-    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, 0, None);
+    let fib_air_lookups = FibAirLookups::new(fibonacci_air, true, None);
 
     let mul_trace = mul_trace::<Val>(n, 2);
     let fib_trace = fib_trace::<Val>(0, 1, n);
@@ -2298,14 +2130,14 @@ fn test_batch_stark_rejects_truncated_global_lookup_data() {
     let air1 = DemoAirWithLookups::MulLookups(mul_air_lookups);
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
 
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
     let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_n, log_n]);
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_n, log_n]);
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
     let pvs = vec![vec![], fib_pis];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
     let mut proof = prove_batch(&config, &instances, &prover_data);
 
     proof.global_lookup_data[0].pop();
@@ -2351,7 +2183,6 @@ fn make_global_lookup_proof() -> (
         mul_air,
         false,
         true,
-        0,
         vec!["MulFib1".to_string(), "MulFib2".to_string()],
     );
 
@@ -2363,9 +2194,9 @@ fn make_global_lookup_proof() -> (
         tamper_index: None,
     };
     let fib_air_lookups_1 =
-        FibAirLookups::new(fibonacci_air, true, 0, Some(("MulFib1".to_string(), 1)));
+        FibAirLookups::new(fibonacci_air, true, Some(("MulFib1".to_string(), 1)));
     let fib_air_lookups_2 =
-        FibAirLookups::new(fibonacci_air, true, 0, Some(("MulFib2".to_string(), 1)));
+        FibAirLookups::new(fibonacci_air, true, Some(("MulFib2".to_string(), 1)));
 
     let mul_trace = mul_trace::<Val>(n, 2);
     let fib_trace_1 = fib_trace::<Val>(0, 1, n);
@@ -2376,14 +2207,14 @@ fn make_global_lookup_proof() -> (
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups_1);
     let air3 = DemoAirWithLookups::FibLookups(fib_air_lookups_2);
 
-    let mut airs = [air1, air2, air3];
+    let airs = [air1, air2, air3];
     let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_n, log_n, log_n]);
-    let common = &prover_data.common;
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_n, log_n, log_n]);
+    let _common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace_1, &fib_trace_2];
     let pvs = vec![vec![], fib_pis.clone(), fib_pis];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
     let proof = prove_batch(&config, &instances, &prover_data);
     (config, airs, proof, pvs, prover_data.common)
 }
@@ -2418,8 +2249,8 @@ fn test_batch_stark_rejects_tampered_global_lookup_metadata() {
     //   - lookup: 0                 — first global lookup within that AIR
     //   - expected_name: "MulFib1"  — what the AIR declares
     //   - got_name: "tampered"      — what the proof supplied
-    //   - expected_aux_idx: 0       — column index from the AIR
-    //   - got_aux_idx: 0            — unchanged, only name was tampered
+    //   - expected_aux_column: 0       — column index from the AIR
+    //   - got_aux_column: 0            — unchanged, only name was tampered
     match err {
         VerificationError::InvalidProofShape(
             InvalidProofShapeError::GlobalLookupDataMetadataMismatch {
@@ -2427,16 +2258,16 @@ fn test_batch_stark_rejects_tampered_global_lookup_metadata() {
                 lookup,
                 expected_name,
                 got_name,
-                expected_aux_idx,
-                got_aux_idx,
+                expected_aux_column,
+                got_aux_column,
             },
         ) => {
             assert_eq!(air, 0);
             assert_eq!(lookup, 0);
             assert_eq!(expected_name, "MulFib1");
             assert_eq!(got_name, "tampered");
-            assert_eq!(expected_aux_idx, 0);
-            assert_eq!(got_aux_idx, 0);
+            assert_eq!(expected_aux_column, 0);
+            assert_eq!(got_aux_column, 0);
         }
         _ => panic!("unexpected error: {err:?}"),
     }
@@ -2460,7 +2291,7 @@ fn test_batch_stark_rejects_tampered_global_lookup_aux_idx() {
     //     proof says:   aux_idx = 42
     //     AIR declares: aux_idx = 0
     //     → mismatch → error on AIR 0, lookup 0
-    proof.global_lookup_data[0][0].aux_idx = 42;
+    proof.global_lookup_data[0][0].aux_column = 42;
 
     let err = verify_batch(&config, &airs, &proof, &pvs, &common)
         .expect_err("Verifier should reject tampered global lookup aux index");
@@ -2470,8 +2301,8 @@ fn test_batch_stark_rejects_tampered_global_lookup_aux_idx() {
     //   - lookup: 0                 — first global lookup within that AIR
     //   - expected_name: "MulFib1"  — unchanged, only aux_idx was tampered
     //   - got_name: "MulFib1"       — matches (name is correct)
-    //   - expected_aux_idx: 0       — what the AIR declares
-    //   - got_aux_idx: 42           — the tampered value
+    //   - expected_aux_column: 0       — what the AIR declares
+    //   - got_aux_column: 42           — the tampered value
     match err {
         VerificationError::InvalidProofShape(
             InvalidProofShapeError::GlobalLookupDataMetadataMismatch {
@@ -2479,16 +2310,16 @@ fn test_batch_stark_rejects_tampered_global_lookup_aux_idx() {
                 lookup,
                 expected_name,
                 got_name,
-                expected_aux_idx,
-                got_aux_idx,
+                expected_aux_column,
+                got_aux_column,
             },
         ) => {
             assert_eq!(air, 0);
             assert_eq!(lookup, 0);
             assert_eq!(expected_name, "MulFib1");
             assert_eq!(got_name, "MulFib1");
-            assert_eq!(expected_aux_idx, 0);
-            assert_eq!(got_aux_idx, 42);
+            assert_eq!(expected_aux_column, 0);
+            assert_eq!(got_aux_column, 42);
         }
         _ => panic!("unexpected error: {err:?}"),
     }
@@ -2516,15 +2347,14 @@ macro_rules! run_batch_stark_mixed_lookups {
             mul_air_with_lookups,
             true,
             true,
-            0,
             vec!["MulFib1".to_string(), "MulFib2".to_string()],
         );
         // This AIR has no lookups.
         let mul_air_no_lookups =
-            MulAirLookups::new(mul_air_with_lookups, false, false, 0, vec![]);
+            MulAirLookups::new(mul_air_with_lookups, false, false, vec![]);
         // This AIR only has local lookups.
         let mul_air_local_lookups =
-            MulAirLookups::new(mul_air_with_lookups, true, false, 0, vec![]); // local lookups only
+            MulAirLookups::new(mul_air_with_lookups, true, false, vec![]); // local lookups only
 
         let log_n1 = 4; // 16 rows
         let log_n2 = 3; // 8 rows
@@ -2546,17 +2376,15 @@ macro_rules! run_batch_stark_mixed_lookups {
         let fib_air_with_lookups1 = FibAirLookups::new(
             fib_air_lookups,
             true,
-            0,
             Some(("MulFib1".to_string(), 1)),
         ); // global lookups
         let fib_air_with_lookups2 = FibAirLookups::new(
             fib_air_lookups,
             true,
-            0,
             Some(("MulFib2".to_string(), 1)),
         ); // global lookups
         let fib_air_no_lookups =
-            FibAirLookups::new(fib_air_no_lookups, false, 0, None); // global lookups
+            FibAirLookups::new(fib_air_no_lookups, false, None); // global lookups
 
         // Generate traces. The airs with and without lookups have different heights.
         let mul_with_lookups_trace = mul_trace::<Val>(n1, reps);
@@ -2611,7 +2439,7 @@ macro_rules! run_batch_stark_mixed_lookups {
         ];
 
         // Create instances - mixing lookup and non-lookup instances
-        let instances = StarkInstance::new_multiple(&all_airs, &traces, &all_pvs, common);
+        let instances = StarkInstance::new_multiple(&all_airs, &traces, &all_pvs);
 
         let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2633,19 +2461,11 @@ fn test_batch_stark_mixed_lookups_wide() -> Result<(), impl Debug> {
 // Single table with local lookup involving the Lagrange selectors. Since the selectors are not normalized,
 // we need to add multiplicity columns and multiply them by the selectors.
 #[derive(Debug, Clone, Copy)]
-struct SingleTableLocalLookupAir {
-    num_lookups: usize,
-}
-
-impl SingleTableLocalLookupAir {
-    const fn new() -> Self {
-        Self { num_lookups: 0 }
-    }
-}
+struct SingleTableLocalLookupAir;
 
 impl<F> BaseAir<F> for SingleTableLocalLookupAir {
     fn width(&self) -> usize {
-        7 // 7 columns: 3 sender columns (1 for each selector type), lookup table, 3 multiplicity columns (1 for each selector type)
+        7
     }
 }
 
@@ -2654,95 +2474,38 @@ where
     AB::Var: Debug,
     AB: AirBuilder + PermutationAirBuilder,
 {
-    fn eval(&self, _builder: &mut AB) {
-        // No additional constraints needed for this simple table
-    }
-}
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
 
-impl<F: Field> LookupAir<F> for SingleTableLocalLookupAir {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        let new_idx = self.num_lookups;
-        self.num_lookups += 1;
-        vec![new_idx]
-    }
+        let sender1 = local[0];
+        let sender2 = local[1];
+        let sender3 = local[2];
+        let table = local[3];
+        let mul1 = local[4];
+        let mul2 = local[5];
+        let mul3 = local[6];
 
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        let mut lookups = Vec::new();
-        self.num_lookups = 0;
+        let is_first = builder.is_first_row();
+        let is_trans = builder.is_transition();
+        let is_last = builder.is_last_row();
 
-        // Create symbolic air builder to access symbolic variables
-        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<F>::width(self),
-            ..Default::default()
-        });
-        let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
+        // Three independent local lookups, each with a different selector.
+        // Lagrange selectors are not normalized, so we multiply on both sides.
+        builder.push_local_interaction(vec![
+            (vec![sender1.into()], is_first.clone()),
+            (vec![table.into()], -(is_first * mul1.into())),
+        ]);
 
-        let sender_col1 = symbolic_main_local[0]; // Column that sends values
-        let sender_col2 = symbolic_main_local[1]; // Column that sends values
-        let sender_col3 = symbolic_main_local[2]; // Column that sends values
-        let lookup_table_col = symbolic_main_local[3]; // Column that receives lookups
-        let mul1 = symbolic_main_local[4]; // Multiplicity column for first selector
-        let mul2 = symbolic_main_local[5]; // Multiplicity column for second selector
-        let mul3 = symbolic_main_local[6]; // Multiplicity column for third selector
+        builder.push_local_interaction(vec![
+            (vec![sender2.into()], is_trans.clone()),
+            (vec![table.into()], -(is_trans * mul2.into())),
+        ]);
 
-        // Local lookup: sender column looks up into lookup table column.
-        let lookup_inputs1 = vec![
-            // Read values from the sender column with `is_first_row` multiplicity.
-            (
-                vec![sender_col1.into()],
-                symbolic_air_builder.is_first_row(),
-                Direction::Receive,
-            ),
-            // Provide values from the lookup table with `is_first_row * mul1` multiplicity.
-            // Note that we need to multiply by `is_first_row` here because the Lagrange selectors are not normalized.
-            (
-                vec![lookup_table_col.into()],
-                symbolic_air_builder.is_first_row() * mul1,
-                Direction::Send,
-            ),
-        ];
-
-        let lookup_inputs2 = vec![
-            // Read values from the sender column with `is_transition` multiplicity.
-            (
-                vec![sender_col2.into()],
-                symbolic_air_builder.is_transition(),
-                Direction::Receive,
-            ),
-            // Provide values from the lookup table with `is_transition * mul2` multiplicity.
-            // Note that we need to multiply by `is_transition` here because the Lagrange selectors are not normalized.
-            (
-                vec![lookup_table_col.into()],
-                symbolic_air_builder.is_transition() * mul2,
-                Direction::Send,
-            ),
-        ];
-
-        let lookup_inputs3 = vec![
-            // Read values from the sender column with `is_last_row` multiplicity.
-            (
-                vec![sender_col3.into()],
-                symbolic_air_builder.is_last_row(),
-                Direction::Receive,
-            ),
-            // Provide values from the lookup table with `is_last_row * mul3` multiplicity.
-            // Note that we need to multiply by `is_last_row` here because the Lagrange selectors are not normalized.
-            (
-                vec![lookup_table_col.into()],
-                symbolic_air_builder.is_last_row() * mul3,
-                Direction::Send,
-            ),
-        ];
-
-        let all_lookup_inputs = vec![lookup_inputs1, lookup_inputs2, lookup_inputs3];
-
-        for lookup_inputs in all_lookup_inputs {
-            let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
-            lookups.push(local_lookup);
-        }
-
-        lookups
+        builder.push_local_interaction(vec![
+            (vec![sender3.into()], is_last.clone()),
+            (vec![table.into()], -(is_last * mul3.into())),
+        ]);
     }
 }
 
@@ -2794,14 +2557,11 @@ fn test_single_table_local_lookup() -> Result<(), impl Debug> {
     let log_height = 3;
     let height = 1 << log_height; // Single table with 8 rows
 
-    // Create instance
-    let air = SingleTableLocalLookupAir::new();
-
-    let mut airs = [air];
+    let air = SingleTableLocalLookupAir;
+    let airs = [air];
 
     // Get lookups from the lookup-enabled AIR
-    let prover_data =
-        ProverData::<MyConfig>::from_airs_and_degrees(&config, &mut airs, &[log_height]);
+    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
     let common = &prover_data.common;
 
     // Generate trace
@@ -2810,7 +2570,7 @@ fn test_single_table_local_lookup() -> Result<(), impl Debug> {
     let traces = [&trace];
     let pvs = vec![vec![]]; // No public values
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs, common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &pvs);
 
     let proof = prove_batch(&config, &instances, &prover_data);
 
@@ -2825,14 +2585,13 @@ fn test_invalid_permutation_opening_len_rejected() {
     let log_height = 4;
     let height = 1 << log_height;
     let mul_air = MulAir { reps: 2 };
-    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, 0, vec![]);
+    let mul_air_lookups = MulAirLookups::new(mul_air, true, false, vec![]);
     let fib_air_lookups = FibAirLookups::new(
         FibonacciAir {
             log_height,
             tamper_index: None,
         },
         false,
-        0,
         None,
     );
 
@@ -2842,17 +2601,14 @@ fn test_invalid_permutation_opening_len_rejected() {
 
     let air1 = DemoAirWithLookups::MulLookups(mul_air_lookups);
     let air2 = DemoAirWithLookups::FibLookups(fib_air_lookups);
-    let mut airs = [air1, air2];
+    let airs = [air1, air2];
 
-    let prover_data = ProverData::<MyConfig>::from_airs_and_degrees(
-        &config,
-        &mut airs,
-        &[log_height, log_height],
-    );
+    let prover_data =
+        ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height, log_height]);
     let common = &prover_data.common;
     let traces = [&mul_trace, &fib_trace];
 
-    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()], common);
+    let instances = StarkInstance::new_multiple(&airs, &traces, &[vec![], fib_pis.clone()]);
     let mut proof = prove_batch(&config, &instances, &prover_data);
 
     // Find the instance with non-empty permutation openings and truncate it.

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -66,6 +66,10 @@ impl<F: Field> BaseAir<F> for FibonacciAir {
         }
         Some(m)
     }
+
+    fn preprocessed_width(&self) -> usize {
+        1
+    }
 }
 
 impl<AB: AirBuilder> Air<AB> for FibonacciAir
@@ -390,6 +394,10 @@ impl<F: Field> BaseAir<F> for FibAirLookups {
     fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
         self.air.preprocessed_trace()
     }
+
+    fn preprocessed_width(&self) -> usize {
+        <FibonacciAir as BaseAir<F>>::preprocessed_width(&self.air)
+    }
 }
 
 impl<AB: PermutationAirBuilder + InteractionBuilder> Air<AB> for FibAirLookups {
@@ -440,6 +448,10 @@ impl<F: Field> BaseAir<F> for PreprocessedMulAir {
             *v = F::from_u64(i as u64);
         }
         Some(m)
+    }
+
+    fn preprocessed_width(&self) -> usize {
+        1
     }
 
     fn preprocessed_next_row_columns(&self) -> Vec<usize> {
@@ -671,6 +683,14 @@ impl<F: PrimeField64> BaseAir<F> for DemoAir {
         }
     }
 
+    fn preprocessed_width(&self) -> usize {
+        match self {
+            Self::Fib(a) => <FibonacciAir as BaseAir<F>>::preprocessed_width(a),
+            Self::Mul(a) => <MulAir as BaseAir<F>>::preprocessed_width(a),
+            Self::PreprocessedMul(a) => <PreprocessedMulAir as BaseAir<F>>::preprocessed_width(a),
+        }
+    }
+
     fn preprocessed_next_row_columns(&self) -> Vec<usize> {
         match self {
             Self::Fib(a) => <FibonacciAir as BaseAir<F>>::preprocessed_next_row_columns(a),
@@ -710,6 +730,13 @@ impl<F: Field> BaseAir<F> for DemoAirWithLookups {
         match self {
             Self::FibLookups(a) => <FibAirLookups as BaseAir<F>>::preprocessed_trace(a),
             Self::MulLookups(a) => <MulAirLookups as BaseAir<F>>::preprocessed_trace(a),
+        }
+    }
+
+    fn preprocessed_width(&self) -> usize {
+        match self {
+            Self::FibLookups(a) => <FibAirLookups as BaseAir<F>>::preprocessed_width(a),
+            Self::MulLookups(a) => <MulAirLookups as BaseAir<F>>::preprocessed_width(a),
         }
     }
 }

--- a/lookup/benches/logup.rs
+++ b/lookup/benches/logup.rs
@@ -10,8 +10,9 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::TwoAdicFriPcs;
+use p3_lookup::LookupProtocol;
 use p3_lookup::logup::LogUpGadget;
-use p3_lookup::lookup_traits::{Direction, Kind, Lookup, LookupData, LookupGadget};
+use p3_lookup::traits::{Kind, Lookup, LookupData};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -66,34 +67,20 @@ fn build_lookups(num_lookups: usize, tuple_size: usize, trace_width: usize) -> V
             let provide_mult: SymbolicExpression<F> =
                 symbolic_main_local[base_col + 2 * tuple_size].into();
 
-            let lookup_inputs = [
-                (read_elements, read_mult, Direction::Receive),
-                (provide_elements, provide_mult, Direction::Send),
+            let elements = vec![read_elements, provide_elements];
+            let multiplicities = vec![
+                read_mult,
+                SymbolicExpression::Neg {
+                    x: Arc::new(provide_mult),
+                    degree_multiple: 1,
+                },
             ];
-
-            let element_exprs: Vec<Vec<SymbolicExpression<F>>> = lookup_inputs
-                .iter()
-                .map(|(elts, _, _): &(Vec<_>, _, _)| elts.clone())
-                .collect();
-            let multiplicities_exprs: Vec<SymbolicExpression<F>> = lookup_inputs
-                .iter()
-                .map(|(_, mult, dir): &(_, SymbolicExpression<F>, Direction)| {
-                    let m = mult.clone();
-                    match dir {
-                        Direction::Send => SymbolicExpression::Neg {
-                            x: Arc::new(m),
-                            degree_multiple: 1,
-                        },
-                        Direction::Receive => m,
-                    }
-                })
-                .collect();
 
             Lookup {
                 kind: Kind::Local,
-                element_exprs,
-                multiplicities_exprs,
-                columns: vec![lookup_idx],
+                elements,
+                multiplicities,
+                column: lookup_idx,
             }
         })
         .collect()

--- a/lookup/src/builder.rs
+++ b/lookup/src/builder.rs
@@ -1,0 +1,119 @@
+//! Trait for builders that record bus interactions.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use p3_air::{AirBuilder, DebugConstraintBuilder, SymbolicExpression};
+use p3_field::{ExtensionField, Field};
+
+/// One message sent on a named bus during symbolic evaluation.
+///
+/// Rendered per trace row as a tuple of field expressions plus a signed
+/// multiplicity telling how many times the message is emitted.
+///
+/// ```text
+///     bus_name = "memory"
+///     fields   = [addr, value]
+///     count    = is_active        (evaluates to 0 or 1 per row)
+///     weight   = 1
+/// ```
+#[derive(Clone, Debug)]
+pub struct SymbolicInteraction<F> {
+    /// Name of the bus this message belongs to.
+    ///
+    /// All AIRs sharing this string form one logical channel.
+    pub bus_name: String,
+
+    /// Message payload as symbolic expressions over the trace.
+    pub fields: Vec<SymbolicExpression<F>>,
+
+    /// Signed multiplicity: positive for a send, negative for a receive.
+    pub count: SymbolicExpression<F>,
+
+    /// Weight used in the height-bound soundness constraint
+    /// `sum_i weight_i * height_i < p`.
+    ///
+    /// - `1` for queries that must hit a real entry.
+    /// - `0` for table entries being provided.
+    pub count_weight: u32,
+}
+
+/// One intra-AIR lookup recorded during symbolic evaluation.
+///
+/// Several `(fields, count)` pairs are bundled into a single running sum
+/// that must return to zero over the trace. No cross-AIR communication.
+///
+/// ```text
+///     tuples = [(query_fields, +1), (table_fields, -mult)]
+/// ```
+#[derive(Clone, Debug)]
+pub struct SymbolicLocalInteraction<F> {
+    /// Pairs of message expressions and their signed multiplicities.
+    pub tuples: Vec<(Vec<SymbolicExpression<F>>, SymbolicExpression<F>)>,
+}
+
+/// Opt-in extension to the AIR builder for AIRs that speak on buses.
+///
+/// - AIRs that emit messages bound their builder on this trait.
+/// - Builders that do not care about interactions never implement it.
+pub trait InteractionBuilder: AirBuilder {
+    /// Record one global (cross-AIR) message on a named bus.
+    ///
+    /// # Arguments
+    ///
+    /// - `bus_name` — shared identifier linking all AIRs on the same bus.
+    /// - `fields` — message payload.
+    /// - `count` — signed multiplicity. Positive is a send, negative a receive.
+    /// - `count_weight` — soundness weight. Use `1` for queries, `0` for table entries.
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        count: impl Into<Self::Expr>,
+        count_weight: u32,
+    );
+
+    /// Record one intra-AIR lookup, both sides in one call.
+    ///
+    /// Each tuple is `(message_fields, signed_count)`. All tuples collapse
+    /// into a single running sum that must return to zero over the trace.
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    );
+
+    /// Global interactions pushed so far.
+    fn num_global_interactions(&self) -> usize {
+        0
+    }
+
+    /// Local interactions pushed so far.
+    fn num_local_interactions(&self) -> usize {
+        0
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> InteractionBuilder for DebugConstraintBuilder<'_, F, EF> {
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        _bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        _count: impl Into<Self::Expr>,
+        _count_weight: u32,
+    ) {
+        // Drain the iterator so any side effects inside a wrapping adapter still fire.
+        //
+        // Matching the semantics a recording builder would give.
+        fields.into_iter().for_each(drop);
+    }
+
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        // Same rationale as the global path:
+        //
+        // Swallow the iterator to keep caller-observable behavior consistent across builder implementations.
+        tuples.into_iter().for_each(drop);
+    }
+}

--- a/lookup/src/bus.rs
+++ b/lookup/src/bus.rs
@@ -6,7 +6,7 @@
 //!
 //! The proving system guarantees that all messages on a bus balance globally.
 
-use p3_air::AirBuilder;
+use crate::builder::InteractionBuilder;
 
 /// Subset (table-lookup) bus.
 ///
@@ -49,7 +49,7 @@ impl<'a> LookupBus<'a> {
         key: impl IntoIterator<Item = E>,
         multiplicity: impl Into<AB::Expr>,
     ) where
-        AB: AirBuilder,
+        AB: InteractionBuilder,
         E: Into<AB::Expr>,
     {
         builder.push_interaction(self.name, key, multiplicity, 1);
@@ -69,7 +69,7 @@ impl<'a> LookupBus<'a> {
         key: impl IntoIterator<Item = E>,
         num_lookups: impl Into<AB::Expr>,
     ) where
-        AB: AirBuilder,
+        AB: InteractionBuilder,
         E: Into<AB::Expr>,
     {
         builder.push_interaction(self.name, key, -num_lookups.into(), 0);
@@ -115,7 +115,7 @@ impl<'a> PermutationCheckBus<'a> {
         fields: impl IntoIterator<Item = E>,
         multiplicity: impl Into<AB::Expr>,
     ) where
-        AB: AirBuilder,
+        AB: InteractionBuilder,
         E: Into<AB::Expr>,
     {
         builder.push_interaction(self.name, fields, multiplicity, 1);
@@ -133,7 +133,7 @@ impl<'a> PermutationCheckBus<'a> {
         fields: impl IntoIterator<Item = E>,
         multiplicity: impl Into<AB::Expr>,
     ) where
-        AB: AirBuilder,
+        AB: InteractionBuilder,
         E: Into<AB::Expr>,
     {
         builder.push_interaction(self.name, fields, -multiplicity.into(), 1);
@@ -196,7 +196,9 @@ mod tests {
             unimplemented!()
         }
         fn assert_zero<I: Into<Self::Expr>>(&mut self, _: I) {}
+    }
 
+    impl InteractionBuilder for MockBuilder {
         fn push_interaction<E: Into<Self::Expr>>(
             &mut self,
             bus_name: &str,
@@ -210,6 +212,13 @@ mod tests {
                 num_fields,
                 count_weight,
             });
+        }
+
+        fn push_local_interaction(
+            &mut self,
+            tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+        ) {
+            tuples.into_iter().for_each(drop);
         }
 
         fn num_global_interactions(&self) -> usize {

--- a/lookup/src/bus.rs
+++ b/lookup/src/bus.rs
@@ -1,0 +1,267 @@
+//! Typed bus abstractions for cross-AIR communication.
+//!
+//! # Overview
+//!
+//! A bus is a named channel shared between multiple AIRs.
+//!
+//! The proving system guarantees that all messages on a bus balance globally.
+
+use p3_air::AirBuilder;
+
+/// Subset (table-lookup) bus.
+///
+/// One AIR holds a table. Other AIRs query it.
+///
+/// The proof guarantees every query hits a real entry.
+///
+/// ```text
+///                         ┌───────────┐
+/// CPU AIR ──lookup_key──▶ │ MEMORY bus│ ◀──table_entry── Memory AIR
+///                         └───────────┘
+/// ```
+#[derive(Clone, Debug)]
+pub struct LookupBus<'a> {
+    name: &'a str,
+}
+
+impl<'a> LookupBus<'a> {
+    /// Create a bus with the given name.
+    pub const fn new(name: &'a str) -> Self {
+        Self { name }
+    }
+
+    /// Bus name.
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    /// Query the table.
+    ///
+    /// Asserts that `key` exists in the table on each active row.
+    ///
+    /// # Arguments
+    ///
+    /// - `key` — elements identifying the entry.
+    /// - `multiplicity` — number of lookups this row performs.
+    pub fn lookup_key<AB, E>(
+        &self,
+        builder: &mut AB,
+        key: impl IntoIterator<Item = E>,
+        multiplicity: impl Into<AB::Expr>,
+    ) where
+        AB: AirBuilder,
+        E: Into<AB::Expr>,
+    {
+        builder.push_interaction(self.name, key, multiplicity, 1);
+    }
+
+    /// Provide a table entry.
+    ///
+    /// Contributes `key` to the table on each active row.
+    ///
+    /// # Arguments
+    ///
+    /// - `key` — elements defining the entry.
+    /// - `num_lookups` — times this entry is consumed.
+    pub fn table_entry<AB, E>(
+        &self,
+        builder: &mut AB,
+        key: impl IntoIterator<Item = E>,
+        num_lookups: impl Into<AB::Expr>,
+    ) where
+        AB: AirBuilder,
+        E: Into<AB::Expr>,
+    {
+        builder.push_interaction(self.name, key, -num_lookups.into(), 0);
+    }
+}
+
+/// Multiset equality (permutation check) bus.
+///
+/// AIRs send and receive messages.
+///
+/// The proof guarantees sends exactly equal receives.
+///
+/// ```text
+///                       ┌──────────────┐
+/// Decoder AIR ──send──▶ │ DISPATCH bus │ ◀──receive── Executor AIR
+///                       └──────────────┘
+/// ```
+#[derive(Clone, Debug)]
+pub struct PermutationCheckBus<'a> {
+    name: &'a str,
+}
+
+impl<'a> PermutationCheckBus<'a> {
+    /// Create a bus with the given name.
+    pub const fn new(name: &'a str) -> Self {
+        Self { name }
+    }
+
+    /// Bus name.
+    pub const fn name(&self) -> &str {
+        self.name
+    }
+
+    /// Send a message.
+    ///
+    /// # Arguments
+    ///
+    /// - `fields` — the message elements.
+    /// - `multiplicity` — number of sends this row performs.
+    pub fn send<AB, E>(
+        &self,
+        builder: &mut AB,
+        fields: impl IntoIterator<Item = E>,
+        multiplicity: impl Into<AB::Expr>,
+    ) where
+        AB: AirBuilder,
+        E: Into<AB::Expr>,
+    {
+        builder.push_interaction(self.name, fields, multiplicity, 1);
+    }
+
+    /// Receive a message.
+    ///
+    /// # Arguments
+    ///
+    /// - `fields` — the message elements.
+    /// - `multiplicity` — number of receives this row performs.
+    pub fn receive<AB, E>(
+        &self,
+        builder: &mut AB,
+        fields: impl IntoIterator<Item = E>,
+        multiplicity: impl Into<AB::Expr>,
+    ) where
+        AB: AirBuilder,
+        E: Into<AB::Expr>,
+    {
+        builder.push_interaction(self.name, fields, -multiplicity.into(), 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use p3_air::{AirBuilder, RowWindow};
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+
+    use super::*;
+
+    type F = BabyBear;
+
+    struct MockInteraction {
+        bus_name: String,
+        num_fields: usize,
+        count_weight: u32,
+    }
+
+    /// Records interactions without evaluating constraints.
+    struct MockBuilder {
+        interactions: Vec<MockInteraction>,
+    }
+
+    impl MockBuilder {
+        fn new() -> Self {
+            Self {
+                interactions: Vec::new(),
+            }
+        }
+    }
+
+    impl AirBuilder for MockBuilder {
+        type F = F;
+        type Expr = F;
+        type Var = F;
+        type PreprocessedWindow = RowWindow<'static, F>;
+        type MainWindow = RowWindow<'static, F>;
+        type PublicVar = F;
+
+        fn main(&self) -> Self::MainWindow {
+            unimplemented!()
+        }
+        fn preprocessed(&self) -> &Self::PreprocessedWindow {
+            unimplemented!()
+        }
+        fn is_first_row(&self) -> Self::Expr {
+            unimplemented!()
+        }
+        fn is_last_row(&self) -> Self::Expr {
+            unimplemented!()
+        }
+        fn is_transition_window(&self, _: usize) -> Self::Expr {
+            unimplemented!()
+        }
+        fn assert_zero<I: Into<Self::Expr>>(&mut self, _: I) {}
+
+        fn push_interaction<E: Into<Self::Expr>>(
+            &mut self,
+            bus_name: &str,
+            fields: impl IntoIterator<Item = E>,
+            _count: impl Into<Self::Expr>,
+            count_weight: u32,
+        ) {
+            let num_fields = fields.into_iter().count();
+            self.interactions.push(MockInteraction {
+                bus_name: String::from(bus_name),
+                num_fields,
+                count_weight,
+            });
+        }
+
+        fn num_global_interactions(&self) -> usize {
+            self.interactions.len()
+        }
+    }
+
+    #[test]
+    fn lookup_key_uses_weight_1() {
+        let bus = LookupBus::new("mem");
+        let mut b = MockBuilder::new();
+        bus.lookup_key(&mut b, [F::ONE, F::TWO], F::ONE);
+
+        assert_eq!(b.interactions.len(), 1);
+        assert_eq!(b.interactions[0].bus_name, "mem");
+        assert_eq!(b.interactions[0].num_fields, 2);
+        assert_eq!(b.interactions[0].count_weight, 1);
+    }
+
+    #[test]
+    fn table_entry_uses_weight_0() {
+        let bus = LookupBus::new("mem");
+        let mut b = MockBuilder::new();
+        bus.table_entry(&mut b, [F::ONE], F::ONE);
+
+        assert_eq!(b.interactions[0].count_weight, 0);
+    }
+
+    #[test]
+    fn permutation_check_send_receive() {
+        let bus = PermutationCheckBus::new("dispatch");
+        let mut b = MockBuilder::new();
+
+        bus.send(&mut b, [F::ONE], F::ONE);
+        bus.receive(&mut b, [F::TWO], F::ONE);
+
+        assert_eq!(b.interactions.len(), 2);
+        assert_eq!(b.interactions[0].count_weight, 1);
+        assert_eq!(b.interactions[1].count_weight, 1);
+    }
+
+    #[test]
+    fn multiple_buses_independent() {
+        let mem = LookupBus::new("memory");
+        let rc = LookupBus::new("range_check");
+        let mut b = MockBuilder::new();
+
+        mem.lookup_key(&mut b, [F::ONE], F::ONE);
+        rc.lookup_key(&mut b, [F::TWO], F::ONE);
+
+        assert_eq!(b.num_global_interactions(), 2);
+        assert_eq!(b.interactions[0].bus_name, "memory");
+        assert_eq!(b.interactions[1].bus_name, "range_check");
+    }
+}

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -15,7 +15,7 @@ use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
 
-use crate::lookup_traits::{Kind, Lookup, symbolic_to_expr};
+use crate::traits::{Kind, Lookup};
 
 /// All inputs required to replay lookup evaluations for one AIR instance.
 pub struct LookupDebugInstance<'a, F: Field> {
@@ -184,13 +184,13 @@ fn accumulate_lookup<F: Field>(
             height,
         };
 
-        for (tuple_idx, elements) in lookup.element_exprs.iter().enumerate() {
+        for (tuple_idx, elements) in lookup.elements.iter().enumerate() {
             let key = elements
                 .iter()
-                .map(|expr| symbolic_to_expr(&builder, expr))
+                .map(|expr| expr.resolve(&builder))
                 .collect::<Vec<_>>();
 
-            let multiplicity = symbolic_to_expr(&builder, &lookup.multiplicities_exprs[tuple_idx]);
+            let multiplicity = lookup.multiplicities[tuple_idx].resolve(&builder);
 
             multiset.add(
                 key,

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder, RowWindow};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
@@ -5,6 +7,8 @@ use p3_uni_stark::{
     PackedChallenge, PackedVal, ProverConstraintFolder, StarkGenericConfig, Val,
     VerifierConstraintFolder,
 };
+
+use crate::builder::InteractionBuilder;
 
 pub struct ProverConstraintFolderWithLookups<'a, SC: StarkGenericConfig> {
     pub inner: ProverConstraintFolder<'a, SC>,
@@ -200,5 +204,48 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder
 
     fn permutation_values(&self) -> &[SC::Challenge] {
         self.permutation_values
+    }
+}
+
+impl<SC: StarkGenericConfig> InteractionBuilder for ProverConstraintFolderWithLookups<'_, SC> {
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        _bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        _count: impl Into<Self::Expr>,
+        _count_weight: u32,
+    ) {
+        // Drain the iterator so side effects in a wrapping adapter still fire,
+        // preserving the semantics of a real recording builder.
+        fields.into_iter().for_each(drop);
+    }
+
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        // Same rationale as the global path: keep iterator consumption observable.
+        tuples.into_iter().for_each(drop);
+    }
+}
+
+impl<SC: StarkGenericConfig> InteractionBuilder for VerifierConstraintFolderWithLookups<'_, SC> {
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        _bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        _count: impl Into<Self::Expr>,
+        _count_weight: u32,
+    ) {
+        // Drain the iterator so side effects in a wrapping adapter still fire.
+        fields.into_iter().for_each(drop);
+    }
+
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        // Same rationale as the global path.
+        tuples.into_iter().for_each(drop);
     }
 }

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -1,15 +1,24 @@
-//! Lookup Arguments for STARKs
+//! Lookup arguments for STARKs.
+//!
+//! Implements the [LogUp] protocol for intra-AIR (local) and cross-AIR
+//! (global) lookup arguments.
+//!
+//! [LogUp]: logup::LogUpGadget
 
 #![no_std]
 
 extern crate alloc;
 
+pub mod bus;
 pub mod debug_util;
 pub mod folder;
 pub mod logup;
-pub mod lookup_traits;
+pub mod protocol;
 #[cfg(test)]
 mod tests;
+pub mod traits;
 mod types;
 
+pub use logup::LogUpGadget;
+pub use protocol::LookupProtocol;
 pub use types::*;

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -9,16 +9,20 @@
 
 extern crate alloc;
 
+pub mod builder;
 pub mod bus;
 pub mod debug_util;
 pub mod folder;
 pub mod logup;
 pub mod protocol;
+pub mod symbolic;
 #[cfg(test)]
 mod tests;
 pub mod traits;
 mod types;
 
+pub use builder::{InteractionBuilder, SymbolicInteraction, SymbolicLocalInteraction};
 pub use logup::LogUpGadget;
 pub use protocol::LookupProtocol;
+pub use symbolic::InteractionSymbolicBuilder;
 pub use types::*;

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -29,10 +29,12 @@ use p3_maybe_rayon::prelude::*;
 use p3_uni_stark::{StarkGenericConfig, Val};
 use tracing::instrument;
 
-use crate::lookup_traits::{
-    Kind, Lookup, LookupData, LookupGadget, LookupTraceBuilder, symbolic_to_expr,
-};
-use crate::types::{LookupError, LookupEvaluator};
+use crate::protocol::LookupProtocol;
+use crate::traits::LookupTraceBuilder;
+use crate::types::{Kind, Lookup, LookupData, LookupError};
+
+/// Type alias for the row evaluation context used during permutation trace generation.
+pub type RowEvalContext<'a, SC> = LookupTraceBuilder<'a, SC>;
 
 /// Core LogUp gadget implementing lookup arguments via logarithmic derivatives.
 ///
@@ -147,52 +149,48 @@ impl LogUpGadget {
     ///
     /// # Arguments:
     /// * builder - The AIR builder to construct expressions.
-    /// * context - The lookup context containing:
+    /// * lookup - The lookup context containing:
     ///     * the kind of lookup (local or global),
     ///     * elements,
     ///     * multiplicities,
-    ///     * and auxiliary column indices.
-    /// * opt_expected_cumulated - Optional expected cumulative value for global lookups. For local lookups, this should be `None`.
+    ///     * and auxiliary column index.
+    /// * opt_cumulative_sum - Optional expected cumulative value for global lookups. For local lookups, this should be `None`.
     fn eval_update<AB>(
         &self,
         builder: &mut AB,
-        context: &Lookup<AB::F>,
-        opt_expected_cumulated: Option<AB::ExprEF>,
+        lookup: &Lookup<AB::F>,
+        opt_cumulative_sum: Option<AB::ExprEF>,
     ) where
         AB: PermutationAirBuilder,
     {
         let Lookup {
             kind,
-            element_exprs,
-            multiplicities_exprs,
-            columns,
-        } = context;
+            elements,
+            multiplicities,
+            column,
+        } = lookup;
 
         assert!(
-            element_exprs.len() == multiplicities_exprs.len(),
+            elements.len() == multiplicities.len(),
             "Mismatched lengths: elements and multiplicities must have same length"
         );
-        assert_eq!(
-            columns.len(),
-            self.num_aux_cols(),
-            "There is exactly one auxiliary column for LogUp"
-        );
-        let column = columns[0];
+
+        let column = *column;
 
         // First, turn the symbolic expressions into builder expressions, for elements and multiplicities.
-        let elements = element_exprs
+        let elements = elements
             .iter()
             .map(|exprs| {
                 exprs
                     .iter()
-                    .map(|expr| symbolic_to_expr(builder, expr).into())
+                    .map(|expr| expr.resolve(builder).into())
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
 
-        let multiplicities = multiplicities_exprs
+        let multiplicities = multiplicities
             .iter()
-            .map(|expr| symbolic_to_expr(builder, expr).into())
+            .map(|expr| expr.resolve(builder).into())
             .collect::<Vec<_>>();
 
         // Access the permutation (aux) table. It carries the running sum column `s`.
@@ -236,8 +234,8 @@ impl LogUpGadget {
                 &beta.into(),
             );
 
-        if let Some(expected_cumulated) = opt_expected_cumulated {
-            // If there is an `expected_cumulated`, we are in a global lookup update.
+        if let Some(cumulative_sum) = opt_cumulative_sum {
+            // If there is a `cumulative_sum`, we are in a global lookup update.
             assert!(
                 matches!(kind, Kind::Global(_)),
                 "Expected cumulated value provided for a non-global lookup"
@@ -249,10 +247,10 @@ impl LogUpGadget {
             );
 
             // Final constraint:
-            let final_val = (expected_cumulated - s_local) * common_denominator - numerator;
+            let final_val = (cumulative_sum - s_local) * common_denominator - numerator;
             builder.when_last_row().assert_zero_ext(final_val);
         } else {
-            // If we don't have an `expected_cumulated`, we are in a local lookup update.
+            // If we don't have a `cumulative_sum`, we are in a local lookup update.
             assert!(
                 matches!(kind, Kind::Local),
                 "No expected cumulated value provided for a global lookup"
@@ -267,7 +265,7 @@ impl LogUpGadget {
     }
 }
 
-impl LookupEvaluator for LogUpGadget {
+impl LookupProtocol for LogUpGadget {
     fn num_aux_cols(&self) -> usize {
         1
     }
@@ -286,48 +284,39 @@ impl LookupEvaluator for LogUpGadget {
     /// `combined_elements[i] = ∑elements[i][n-j] * β^j`.
     ///
     /// This is implemented using a running sum column that should sum to zero.
-    fn eval_local_lookup<AB>(&self, builder: &mut AB, context: &Lookup<AB::F>)
+    fn eval_local<AB>(&self, builder: &mut AB, lookup: &Lookup<AB::F>)
     where
         AB: PermutationAirBuilder,
     {
-        if let Kind::Global(_) = context.kind {
+        if let Kind::Global(_) = lookup.kind {
             panic!("Global lookups are not supported in local evaluation")
         }
 
-        self.eval_update(builder, context, None);
+        self.eval_update(builder, lookup, None);
     }
 
     /// # Mathematical Details
     /// The constraint enforces:
     /// ```text
-    /// ∑_i(multiplicities[i] / (α - combined_elements[i])) = `expected_cumulated`
+    /// ∑_i(multiplicities[i] / (α - combined_elements[i])) = `cumulative_sum`
     /// ```
     ///
     /// where `multiplicities` can be negative, and
     /// `combined_elements[i] = ∑elements[i][n-j] * β^j`.
     ///
-    /// `expected_cumulated` is provided by the prover, and the sum of all `expected_cumulated` for this global interaction
+    /// `cumulative_sum` is provided by the prover, and the sum of all `cumulative_sum` for this global interaction
     /// should be 0. The latter is checked as the final step, after all AIRS have been verified.
     ///
-    /// This is implemented using a running sum column that should sum to `expected_cumulated`.
-    fn eval_global_update<AB>(
-        &self,
-        builder: &mut AB,
-        context: &Lookup<AB::F>,
-        expected_cumulated: AB::ExprEF,
-    ) where
+    /// This is implemented using a running sum column that should sum to `cumulative_sum`.
+    fn eval_global<AB>(&self, builder: &mut AB, lookup: &Lookup<AB::F>, cumulative_sum: AB::ExprEF)
+    where
         AB: PermutationAirBuilder,
     {
-        self.eval_update(builder, context, Some(expected_cumulated));
+        self.eval_update(builder, lookup, Some(cumulative_sum));
     }
-}
 
-impl LookupGadget for LogUpGadget {
-    fn verify_global_final_value<EF: Field>(
-        &self,
-        all_expected_cumulative: &[EF],
-    ) -> Result<(), LookupError> {
-        let total = all_expected_cumulative.iter().copied().sum::<EF>();
+    fn verify_global_sum<EF: Field>(&self, cumulative_sums: &[EF]) -> Result<(), LookupError> {
+        let total = cumulative_sums.iter().copied().sum::<EF>();
 
         if !total.is_zero() {
             // We set the name associated to the lookup to None because we don't have access to the actual name here.
@@ -351,15 +340,15 @@ impl LookupGadget for LogUpGadget {
     ///
     /// The constraint degree is then:
     /// `1 + max(deg(numerator), deg(common_denominator))`
-    fn constraint_degree<F: Field>(&self, context: &Lookup<F>) -> usize {
-        assert!(context.multiplicities_exprs.len() == context.element_exprs.len());
+    fn constraint_degree<F: Field>(&self, lookup: &Lookup<F>) -> usize {
+        assert!(lookup.multiplicities.len() == lookup.elements.len());
 
-        let n = context.multiplicities_exprs.len();
+        let n = lookup.multiplicities.len();
 
         // Compute degrees in a single pass.
         let mut degs = Vec::with_capacity(n);
         let mut deg_sum = 0;
-        for elems in &context.element_exprs {
+        for elems in &lookup.elements {
             let deg = elems
                 .iter()
                 .map(|elt| elt.degree_multiple())
@@ -373,9 +362,8 @@ impl LookupGadget for LogUpGadget {
         let deg_denom_constr = 1 + deg_sum;
 
         // Compute degree(numerator).
-        let multiplicities = &context.multiplicities_exprs;
         let deg_num = (0..n)
-            .map(|i| multiplicities[i].degree_multiple() + deg_sum - degs[i])
+            .map(|i| lookup.multiplicities[i].degree_multiple() + deg_sum - degs[i])
             .max()
             .unwrap_or(0);
 
@@ -390,14 +378,14 @@ impl LookupGadget for LogUpGadget {
         public_values: &[Val<SC>],
         lookups: &[Lookup<Val<SC>>],
         lookup_data: &mut [LookupData<SC::Challenge>],
-        permutation_challenges: &[SC::Challenge],
+        challenges: &[SC::Challenge],
     ) -> RowMajorMatrix<SC::Challenge> {
         let height = main.height();
         let width = self.num_aux_cols() * lookups.len();
 
         // Validate challenge count matches number of lookups.
         debug_assert_eq!(
-            permutation_challenges.len(),
+            challenges.len(),
             lookups.len() * self.num_challenges(),
             "perm challenge count must be per-lookup"
         );
@@ -409,7 +397,7 @@ impl LookupGadget for LogUpGadget {
 
             let mut seen = BTreeSet::new();
             for ctx in lookups {
-                let a = ctx.columns[0];
+                let a = ctx.column;
                 if !seen.insert(a) {
                     panic!("duplicate aux column index {a} across lookups");
                 }
@@ -419,12 +407,12 @@ impl LookupGadget for LogUpGadget {
         // 1. PRE-COMPUTE DENOMINATORS
         // We flatten all denominators from all rows/lookups into one giant vector.
         // Order: Row -> Lookup -> Element Tuple
-        let denoms_per_row: usize = lookups.iter().map(|l| l.element_exprs.len()).sum();
+        let denoms_per_row: usize = lookups.iter().map(|l| l.elements.len()).sum();
         let mut lookup_denom_offsets = Vec::with_capacity(lookups.len() + 1);
         lookup_denom_offsets.push(0);
         for l in lookups.iter() {
             lookup_denom_offsets
-                .push(lookup_denom_offsets.last().copied().unwrap() + l.element_exprs.len());
+                .push(lookup_denom_offsets.last().copied().unwrap() + l.elements.len());
         }
         let num_lookups = lookups.len();
 
@@ -433,13 +421,10 @@ impl LookupGadget for LogUpGadget {
         // alpha is the running-sum challenge, beta combines tuple elements.
         let lookup_challenges: Vec<(SC::Challenge, SC::Challenge)> = lookups
             .iter()
-            .map(|context| {
+            .map(|lookup| {
                 // Index into the flat challenge array by the lookup's auxiliary column index.
-                let base = self.num_challenges() * context.columns[0];
-                (
-                    permutation_challenges[base],
-                    permutation_challenges[base + 1],
-                )
+                let base = self.num_challenges() * lookup.column;
+                (challenges[base], challenges[base + 1])
             })
             .collect();
 
@@ -517,37 +502,34 @@ impl LookupGadget for LogUpGadget {
 
                     // Concrete evaluator: resolves symbolic expressions to field values
                     // using the current row's data.
-                    let row_builder: LookupTraceBuilder<'_, SC> = LookupTraceBuilder::new(
+                    let row_ctx: RowEvalContext<'_, SC> = RowEvalContext::new(
                         main_rows,
                         preprocessed_rows,
                         public_values,
-                        permutation_challenges,
+                        challenges,
                         height,
                         i,
                     );
 
                     // Walk through each lookup's element tuples and fill the flat buffers.
                     let mut offset = local_i * denoms_per_row;
-                    for (context, &(alpha, beta)) in lookups.iter().zip(lookup_challenges.iter()) {
-                        for (j, elts) in context.element_exprs.iter().enumerate() {
+                    for (lookup, &(alpha, beta)) in lookups.iter().zip(lookup_challenges.iter()) {
+                        for (j, elts) in lookup.elements.iter().enumerate() {
                             // Combine tuple elements via Horner's method:
                             //   combined = e_0 * beta^{k-1} + e_1 * beta^{k-2} + ... + e_{k-1}
                             // Then store (alpha - combined) as the denominator.
                             let mut iter = elts.iter();
                             let combined_elt = iter.next().map_or(SC::Challenge::ZERO, |first| {
                                 iter.fold(
-                                    symbolic_to_expr(&row_builder, first).into(),
-                                    |acc: SC::Challenge, e| {
-                                        acc * beta + symbolic_to_expr(&row_builder, e)
-                                    },
+                                    first.resolve(&row_ctx).into(),
+                                    |acc: SC::Challenge, e| acc * beta + e.resolve(&row_ctx),
                                 )
                             });
                             local_denoms[offset] = alpha - combined_elt;
 
                             // Store the multiplicity as a base-field element (4 bytes vs 16 for
                             // extension) to keep the buffer small and the later dot product cheap.
-                            local_mults[offset] =
-                                symbolic_to_expr(&row_builder, &context.multiplicities_exprs[j]);
+                            local_mults[offset] = lookup.multiplicities[j].resolve(&row_ctx);
                             offset += 1;
                         }
                     }
@@ -566,7 +548,7 @@ impl LookupGadget for LogUpGadget {
                 // TODO: investigate fusing batch inversion with multiplicity multiplication.
                 for local_i in 0..num_rows {
                     let inv_base = local_i * denoms_per_row;
-                    for (lookup_idx, _context) in lookups.iter().enumerate() {
+                    for (lookup_idx, _lookup) in lookups.iter().enumerate() {
                         // Slice out the range of denominators belonging to this lookup.
                         let start = lookup_denom_offsets[lookup_idx];
                         let end = lookup_denom_offsets[lookup_idx + 1];
@@ -606,8 +588,8 @@ impl LookupGadget for LogUpGadget {
         // Reuse a single buffer across all lookup columns to avoid re-allocating on every iteration.
         let mut prefix = SC::Challenge::zero_vec(height);
 
-        for (lookup_idx, context) in lookups.iter().enumerate() {
-            let aux_idx = context.columns[0];
+        for (lookup_idx, lookup) in lookups.iter().enumerate() {
+            let aux_column = lookup.column;
 
             // Fill the buffer with this column's per-row contributions.
             for (i, val) in prefix.iter_mut().enumerate() {
@@ -652,12 +634,12 @@ impl LookupGadget for LogUpGadget {
                 .skip(1)
                 .enumerate()
                 .for_each(|(i, row)| {
-                    row[aux_idx] = prefix[i];
+                    row[aux_column] = prefix[i];
                 });
 
             // For global lookups, record the total sum across all rows.
-            if matches!(context.kind, Kind::Global(_)) {
-                lookup_data[permutation_counter].expected_cumulated = prefix[height - 1];
+            if matches!(lookup.kind, Kind::Global(_)) {
+                lookup_data[permutation_counter].cumulative_sum = prefix[height - 1];
                 permutation_counter += 1;
             }
         }

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -266,10 +266,6 @@ impl LogUpGadget {
 }
 
 impl LookupProtocol for LogUpGadget {
-    fn num_aux_cols(&self) -> usize {
-        1
-    }
-
     fn num_challenges(&self) -> usize {
         2
     }
@@ -381,7 +377,7 @@ impl LookupProtocol for LogUpGadget {
         challenges: &[SC::Challenge],
     ) -> RowMajorMatrix<SC::Challenge> {
         let height = main.height();
-        let width = self.num_aux_cols() * lookups.len();
+        let width = lookups.len();
 
         // Validate challenge count matches number of lookups.
         debug_assert_eq!(

--- a/lookup/src/protocol.rs
+++ b/lookup/src/protocol.rs
@@ -9,10 +9,10 @@ use crate::types::{Kind, Lookup, LookupData, LookupError};
 
 /// A lookup protocol that can evaluate constraints, generate permutation
 /// traces, and verify global sums.
+///
+/// Each lookup uses exactly one auxiliary column in the permutation trace,
+/// matching the single [`Lookup::column`] field.
 pub trait LookupProtocol {
-    /// Auxiliary columns per lookup (1 for LogUp).
-    fn num_aux_cols(&self) -> usize;
-
     /// Random challenges per lookup (2 for LogUp: `α`, `β`).
     fn num_challenges(&self) -> usize;
 
@@ -69,6 +69,14 @@ pub trait LookupProtocol {
         air.eval(builder);
         if !lookups.is_empty() {
             self.eval_all(builder, lookups);
+        } else {
+            // No lookups declared: catch the inconsistent case where the builder
+            // was nonetheless given permutation values to consume.
+            assert_eq!(
+                0,
+                builder.permutation_values().len(),
+                "permutation values count mismatch"
+            );
         }
     }
 }

--- a/lookup/src/protocol.rs
+++ b/lookup/src/protocol.rs
@@ -1,0 +1,74 @@
+//! The lookup protocol trait.
+
+use p3_air::{Air, PermutationAirBuilder};
+use p3_field::Field;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_uni_stark::{StarkGenericConfig, Val};
+
+use crate::types::{Kind, Lookup, LookupData, LookupError};
+
+/// A lookup protocol that can evaluate constraints, generate permutation
+/// traces, and verify global sums.
+pub trait LookupProtocol {
+    /// Auxiliary columns per lookup (1 for LogUp).
+    fn num_aux_cols(&self) -> usize;
+
+    /// Random challenges per lookup (2 for LogUp: `α`, `β`).
+    fn num_challenges(&self) -> usize;
+
+    /// Evaluate a local (intra-AIR) lookup constraint.
+    fn eval_local<AB: PermutationAirBuilder>(&self, builder: &mut AB, lookup: &Lookup<AB::F>);
+
+    /// Evaluate a global (cross-AIR) lookup constraint.
+    fn eval_global<AB: PermutationAirBuilder>(
+        &self,
+        builder: &mut AB,
+        lookup: &Lookup<AB::F>,
+        cumulative_sum: AB::ExprEF,
+    );
+
+    /// Evaluate all lookups, dispatching by [`Kind`].
+    fn eval_all<AB: PermutationAirBuilder>(&self, builder: &mut AB, lookups: &[Lookup<AB::F>]) {
+        let mut pv_idx = 0;
+        for lookup in lookups {
+            match &lookup.kind {
+                Kind::Local => self.eval_local(builder, lookup),
+                Kind::Global(_) => {
+                    let expected = builder.permutation_values()[pv_idx].clone();
+                    pv_idx += 1;
+                    self.eval_global(builder, lookup, expected.into());
+                }
+            }
+        }
+        assert_eq!(pv_idx, builder.permutation_values().len());
+    }
+
+    /// Generate the permutation trace matrix.
+    fn generate_permutation<SC: StarkGenericConfig>(
+        &self,
+        main: &RowMajorMatrix<Val<SC>>,
+        preprocessed: &Option<RowMajorMatrix<Val<SC>>>,
+        public_values: &[Val<SC>],
+        lookups: &[Lookup<Val<SC>>],
+        lookup_data: &mut [LookupData<SC::Challenge>],
+        challenges: &[SC::Challenge],
+    ) -> RowMajorMatrix<SC::Challenge>;
+
+    /// Verify global cumulative sums balance to zero.
+    fn verify_global_sum<EF: Field>(&self, cumulative_sums: &[EF]) -> Result<(), LookupError>;
+
+    /// Polynomial degree of the transition constraint for a given lookup.
+    fn constraint_degree<F: Field>(&self, lookup: &Lookup<F>) -> usize;
+
+    /// Evaluate AIR constraints followed by lookup constraints.
+    fn eval_air_and_lookups<AB, A>(&self, air: &A, builder: &mut AB, lookups: &[Lookup<AB::F>])
+    where
+        AB: PermutationAirBuilder,
+        A: Air<AB>,
+    {
+        air.eval(builder);
+        if !lookups.is_empty() {
+            self.eval_all(builder, lookups);
+        }
+    }
+}

--- a/lookup/src/symbolic.rs
+++ b/lookup/src/symbolic.rs
@@ -1,0 +1,188 @@
+//! Symbolic builder that records constraints plus bus interactions.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use p3_air::symbolic::{
+    AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
+    SymbolicVariable, SymbolicVariableExt,
+};
+use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder};
+use p3_field::{Algebra, ExtensionField, Field};
+use p3_matrix::dense::RowMajorMatrix;
+
+use crate::builder::{InteractionBuilder, SymbolicInteraction, SymbolicLocalInteraction};
+
+/// Symbolic builder that captures constraints and bus interactions side by side.
+#[derive(Debug)]
+pub struct InteractionSymbolicBuilder<F: Field, EF: ExtensionField<F> = F> {
+    /// Wrapped constraint-only builder. All non-interaction methods forward here.
+    inner: SymbolicAirBuilder<F, EF>,
+    /// Cross-AIR messages pushed so far, in emission order.
+    global_interactions: Vec<SymbolicInteraction<F>>,
+    /// Intra-AIR lookups pushed so far, in emission order.
+    local_interactions: Vec<SymbolicLocalInteraction<F>>,
+}
+
+impl<F: Field, EF: ExtensionField<F>> InteractionSymbolicBuilder<F, EF> {
+    /// Create an empty builder from a column / challenge layout.
+    pub fn new(layout: AirLayout) -> Self {
+        Self {
+            inner: SymbolicAirBuilder::new(layout),
+            global_interactions: Vec::new(),
+            local_interactions: Vec::new(),
+        }
+    }
+
+    /// Cross-AIR interactions recorded so far, in the order they were pushed.
+    pub fn global_interactions(&self) -> &[SymbolicInteraction<F>] {
+        &self.global_interactions
+    }
+
+    /// Intra-AIR interactions recorded so far, in the order they were pushed.
+    pub fn local_interactions(&self) -> &[SymbolicLocalInteraction<F>] {
+        &self.local_interactions
+    }
+
+    /// Symbolic base-field constraints captured by the inner builder.
+    pub fn base_constraints(&self) -> Vec<SymbolicExpression<F>> {
+        self.inner.base_constraints()
+    }
+
+    /// Symbolic extension-field constraints captured by the inner builder.
+    pub fn extension_constraints(&self) -> Vec<SymbolicExpressionExt<F, EF>>
+    where
+        SymbolicExpressionExt<F, EF>: Algebra<EF>,
+    {
+        self.inner.extension_constraints()
+    }
+
+    /// Mapping from global constraint indices into separated base / extension streams.
+    pub fn constraint_layout(&self) -> ConstraintLayout {
+        self.inner.constraint_layout()
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> AirBuilder for InteractionSymbolicBuilder<F, EF> {
+    type F = F;
+    type Expr = SymbolicExpression<F>;
+    type Var = SymbolicVariable<F>;
+    type PreprocessedWindow = RowMajorMatrix<Self::Var>;
+    type MainWindow = RowMajorMatrix<Self::Var>;
+    type PublicVar = SymbolicVariable<F>;
+
+    fn main(&self) -> Self::MainWindow {
+        self.inner.main()
+    }
+
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
+        self.inner.preprocessed()
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        self.inner.is_first_row()
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        self.inner.is_last_row()
+    }
+
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        self.inner.is_transition_window(size)
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        self.inner.assert_zero(x);
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.inner.public_values()
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for InteractionSymbolicBuilder<F, EF>
+where
+    SymbolicExpressionExt<F, EF>: Algebra<EF>,
+{
+    type EF = EF;
+    type ExprEF = SymbolicExpressionExt<F, EF>;
+    type VarEF = SymbolicVariableExt<F, EF>;
+
+    fn assert_zero_ext<I>(&mut self, x: I)
+    where
+        I: Into<Self::ExprEF>,
+    {
+        self.inner.assert_zero_ext(x);
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> PermutationAirBuilder for InteractionSymbolicBuilder<F, EF>
+where
+    SymbolicExpressionExt<F, EF>: Algebra<EF>,
+{
+    type MP = RowMajorMatrix<Self::VarEF>;
+    type RandomVar = SymbolicVariableExt<F, EF>;
+    type PermutationVar = SymbolicVariableExt<F, EF>;
+
+    fn permutation(&self) -> Self::MP {
+        self.inner.permutation()
+    }
+
+    fn permutation_randomness(&self) -> &[Self::RandomVar] {
+        self.inner.permutation_randomness()
+    }
+
+    fn permutation_values(&self) -> &[Self::PermutationVar] {
+        self.inner.permutation_values()
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for InteractionSymbolicBuilder<F, EF> {
+    type PeriodicVar = SymbolicVariable<F>;
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.inner.periodic_values()
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> InteractionBuilder for InteractionSymbolicBuilder<F, EF> {
+    fn push_interaction<E: Into<Self::Expr>>(
+        &mut self,
+        bus_name: &str,
+        fields: impl IntoIterator<Item = E>,
+        count: impl Into<Self::Expr>,
+        count_weight: u32,
+    ) {
+        // Materialize lazy inputs into owned expressions and append one record.
+        //
+        // - Collected eagerly so the record outlives the caller's iterator.
+        // - Push order is preserved: it drives auxiliary-column assignment.
+        self.global_interactions.push(SymbolicInteraction {
+            bus_name: String::from(bus_name),
+            fields: fields.into_iter().map(Into::into).collect(),
+            count: count.into(),
+            count_weight,
+        });
+    }
+
+    fn push_local_interaction(
+        &mut self,
+        tuples: impl IntoIterator<Item = (Vec<Self::Expr>, Self::Expr)>,
+    ) {
+        // One call → one grouped record, not N separate ones.
+        //
+        // - A local lookup folds into a single running sum.
+        // - All `(fields, count)` pairs must stay paired for the folder.
+        self.local_interactions.push(SymbolicLocalInteraction {
+            tuples: tuples.into_iter().collect(),
+        });
+    }
+
+    fn num_global_interactions(&self) -> usize {
+        self.global_interactions.len()
+    }
+
+    fn num_local_interactions(&self) -> usize {
+        self.local_interactions.len()
+    }
+}

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -15,9 +15,10 @@ use p3_matrix::dense::RowMajorMatrix;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
+use crate::Lookups;
 use crate::logup::LogUpGadget;
-use crate::lookup_traits::{Direction, Kind, Lookup, LookupGadget, symbolic_to_expr};
-use crate::types::{LookupAir, LookupEvaluator};
+use crate::protocol::LookupProtocol;
+use crate::traits::{Kind, Lookup};
 
 /// Base field type for the test
 type F = BabyBear;
@@ -42,27 +43,27 @@ fn create_dummy_lookup(
     assert!(num_elements_per_tuple.len() == degree_per_element.len());
     assert!(num_elements_per_tuple.len() == degree_multiplicities.len());
 
-    let element_exprs = num_elements_per_tuple
+    let elements = num_elements_per_tuple
         .iter()
         .enumerate()
         .map(|(i, &n)| {
             assert_eq!(num_elements_per_tuple[i], degree_per_element[i].len());
             (0..n)
                 .map(|j| create_symbolic_with_degree(degree_per_element[i][j]))
-                .collect::<Vec<_>>()
+                .collect()
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    let multiplicities_exprs = degree_multiplicities
+    let multiplicities = degree_multiplicities
         .iter()
         .map(|&deg| create_symbolic_with_degree(deg))
-        .collect::<Vec<_>>();
+        .collect();
 
     Lookup {
         kind: Kind::Local,
-        element_exprs,
-        multiplicities_exprs,
-        columns: vec![0],
+        elements,
+        multiplicities,
+        column: 0,
     }
 }
 
@@ -254,81 +255,37 @@ impl PermutationAirBuilder for MockAirBuilder {
 struct RangeCheckAir {
     /// Number of independent lookups (default: 1)
     num_lookups: usize,
-    /// Number of registered lookups (for AirLookupHandler)
-    cur_num_lookups: usize,
 }
 
 impl RangeCheckAir {
     fn new() -> Self {
-        Self {
-            num_lookups: 1,
-            cur_num_lookups: 0,
-        }
+        Self { num_lookups: 1 }
     }
 
     fn with_multiple_lookups(num_lookups: usize) -> Self {
-        Self {
-            num_lookups,
-            cur_num_lookups: 0,
-        }
+        Self { num_lookups }
     }
 }
 
 impl<AB> Air<AB> for RangeCheckAir
 where
-    AB: PermutationAirBuilder<F = F, EF = EF, RandomVar = EF>,
-    AB::Var: Copy + Into<AB::ExprEF>,
-    AB::ExprEF: From<AB::Var> + From<F>,
-    F: Copy + Into<AB::ExprEF>,
+    AB: AirBuilder<F: Field>,
 {
-    fn eval(&self, _builder: &mut AB) {
-        // There are no constraints, only lookups for the range checks.
-    }
-}
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
 
-impl LookupAir<F> for RangeCheckAir {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        let new_idx = self.cur_num_lookups;
-        self.cur_num_lookups += 1;
+        for i in 0..self.num_lookups {
+            let offset = i * 3;
+            let val = local[offset]; // query value
+            let table_val = local[offset + 1]; // table value
+            let mult = local[offset + 2]; // multiplicity
 
-        vec![new_idx]
-    }
-
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<F>::width(self),
-            ..Default::default()
-        });
-
-        let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
-
-        // Perform each lookup independently using LookupContext
-        (0..self.num_lookups)
-            .map(|lookup_idx| {
-                let offset = lookup_idx * 3;
-
-                // Extract columns for this lookup: [read, provide, mult]
-                let val = symbolic_main_local[offset];
-                let table_val = symbolic_main_local[offset + 1];
-                let mult = symbolic_main_local[offset + 2];
-
-                // Create arrays with longer lifetime for the context
-                let a_elements = vec![val.into()];
-                let a_multiplicities = SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE));
-
-                let b_elements = vec![table_val.into()];
-                let b_multiplicities = mult.into();
-
-                let lookup_inputs = vec![
-                    (a_elements, a_multiplicities, Direction::Receive),
-                    (b_elements, b_multiplicities, Direction::Send),
-                ];
-
-                // Register the local lookup.
-                LookupAir::register_lookup(self, Kind::Local, &lookup_inputs)
-            })
-            .collect::<Vec<_>>()
+            builder.push_local_interaction(vec![
+                (vec![val.into()], AB::Expr::ONE),        // query side
+                (vec![table_val.into()], -(mult.into())), // table side (negated)
+            ]);
+        }
     }
 }
 
@@ -484,7 +441,7 @@ impl LookupTraceBuilder {
     /// - `challenges`: the challenges used
     fn build_with_global(
         self,
-        direction: Direction,
+        is_send: bool,
     ) -> (RowMajorMatrix<F>, RowMajorMatrix<EF>, LogUpChallenges) {
         assert!(!self.rows.is_empty(), "Must have at least one row");
 
@@ -505,7 +462,7 @@ impl LookupTraceBuilder {
             .chain(self.rows.iter().flat_map(|(read, provide, mult)| {
                 running_sum +=
                     compute_logup_contribution(self.local_challenges, read, provide, *mult);
-                let global_mult = direction.multiplicity(F::ONE);
+                let global_mult = if is_send { -F::ONE } else { F::ONE };
 
                 global_running_sum += compute_logup_contribution(
                     self.global_challenges.unwrap(),
@@ -524,9 +481,9 @@ impl LookupTraceBuilder {
 }
 
 #[test]
-fn test_symbolic_to_expr() {
+fn test_resolve() {
     use p3_air::AirBuilder;
-    use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
+    use p3_air::symbolic::SymbolicAirBuilder;
     use p3_field::PrimeCharacteristicRing;
 
     let mut builder = SymbolicAirBuilder::<F>::new(AirLayout {
@@ -590,9 +547,9 @@ fn test_symbolic_to_expr() {
         let last_expected_val = is_last_row * (mul - EF::from(local[0]));
 
         // Evaluate the constraints at row `i`.
-        let first_eval = symbolic_to_expr(&builder, &constraints[0]);
-        let transition_eval = symbolic_to_expr(&builder, &constraints[1]);
-        let last_eval = symbolic_to_expr(&builder, &constraints[2]);
+        let first_eval = constraints[0].resolve(&builder);
+        let transition_eval = constraints[1].resolve(&builder);
+        let last_eval = constraints[2].resolve(&builder);
 
         // Assert that the evaluated constraints are correct.
         assert_eq!(first_expected_val, first_eval.into());
@@ -642,32 +599,30 @@ fn test_range_check_end_to_end_valid() {
     );
 
     // Setup the AIR and builder.
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, challenges.to_vec());
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Check that the lookup was created correctly.
     assert_eq!(lookups.len(), 1, "Should have one lookup defined");
     assert_eq!(
-        lookups[0].columns,
-        vec![0],
+        lookups[0].column, 0,
         "Lookup should use the first auxiliary column"
     );
     assert_eq!(
-        lookups[0].element_exprs.len(),
+        lookups[0].elements.len(),
         2,
         "Lookup should have two element tuples (read and provide)"
     );
     assert_eq!(lookups[0].kind, Kind::Local, "Lookup should be local");
-    assert_eq!(air.cur_num_lookups, 1, "Should have one lookup registered");
 
     // Evaluate constraints for every row.
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -692,9 +647,9 @@ fn test_debug_util_detects_malformed_lookup() {
     // so the total multiset count is non-zero.
     let lookup = Lookup {
         kind: Kind::Local,
-        element_exprs: vec![vec![SymbolicExpression::Leaf(BaseLeaf::Variable(expr))]],
-        multiplicities_exprs: vec![SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE))],
-        columns: vec![0],
+        elements: vec![vec![SymbolicExpression::Leaf(BaseLeaf::Variable(expr))]],
+        multiplicities: vec![SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE))],
+        column: 0,
     };
 
     let instance: LookupDebugInstance<'_, F> = LookupDebugInstance {
@@ -758,11 +713,11 @@ fn test_range_check_end_to_end_invalid() {
     assert_ne!(final_s, EF::ZERO);
 
     // Setup the AIR and builder
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, vec![alpha, beta]);
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Evaluate constraints.
     //
@@ -770,7 +725,7 @@ fn test_range_check_end_to_end_invalid() {
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -824,18 +779,18 @@ fn test_inconsistent_witness_fails_transition() {
     // Evaluate constraints.
     //
     // This should now fail at row 1 when checking the transition to row 2.
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, challenges.to_vec());
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Evaluate the constraints.
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -880,12 +835,12 @@ fn test_zero_multiplicity_is_not_counted() {
     assert_ne!(final_s, EF::ZERO);
 
     // Evaluate constraints
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, challenges.to_vec());
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // The initial boundary constraint will fail on row 0 since s[0] is incorrect.
     //
@@ -893,7 +848,7 @@ fn test_zero_multiplicity_is_not_counted() {
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -905,17 +860,17 @@ fn test_empty_lookup_is_valid() {
     let aux_trace = RowMajorMatrix::new(vec![], 1);
     let alpha = EF::from_u8(123);
 
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, vec![alpha]);
 
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // This should not panic, as there are no rows to evaluate.
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 
@@ -993,18 +948,18 @@ fn test_nontrivial_permutation() {
     );
 
     // Setup AIR and verify all constraints
-    let mut air = RangeCheckAir::new();
+    let air = RangeCheckAir::new();
     let mut builder = MockAirBuilder::new(main_trace, aux_trace, challenges.to_vec());
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Evaluate constraints for every row
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -1104,7 +1059,7 @@ fn test_multiple_lookups_different_columns() {
     );
 
     // Setup AIR with 2 lookups and verify all constraints
-    let mut air = RangeCheckAir::with_multiple_lookups(2);
+    let air = RangeCheckAir::with_multiple_lookups(2);
     let mut builder = MockAirBuilder::new(
         main_trace,
         aux_trace,
@@ -1113,54 +1068,53 @@ fn test_multiple_lookups_different_columns() {
 
     // Register lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Check that the lookup was created correctly.
     assert_eq!(lookups.len(), 2, "Should have two lookups defined");
     assert_eq!(
-        (lookups[0].columns.clone(), lookups[1].columns.clone()),
-        (vec![0], vec![1]),
+        (lookups[0].column, lookups[1].column),
+        (0, 1),
         "Lookup should use the first two auxiliary column"
     );
     assert_eq!(
-        lookups[0].element_exprs.len(),
+        lookups[0].elements.len(),
         2,
         "Lookup should have two element tuples (read and provide)"
     );
     assert_eq!(lookups[0].kind, Kind::Local, "Lookup should be local");
-    assert_eq!(air.cur_num_lookups, 2, "Should have two lookups registered");
 
     // Evaluate constraints for every row - both lookups should pass
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
 
-// An AIR with 6 columns as follows:
-// - 3 columns the input add operation: (inp1, inp2, sum)
-// - 3 columns for the lookup table: (table_inp1, table_inp2, table_sum)
-// - 1 column for the multiplicity
+/// AIR with 7 columns: (inp1, inp2, sum, table_inp1, table_inp2, table_sum, mult).
+/// Local lookup checks (inp1,inp2,sum) ⊆ (table_inp1,table_inp2,table_sum).
+/// Optional global interaction on bus "LUT".
 struct AddAir {
-    // To keep track of registered lookups
-    num_lookups: usize,
-    with_global: (bool, Direction),
+    /// If Some(true), sends on bus "LUT". If Some(false), receives.
+    global_send: Option<bool>,
 }
 
 impl AddAir {
     fn new() -> Self {
+        Self { global_send: None }
+    }
+
+    fn new_sender() -> Self {
         Self {
-            num_lookups: 0,
-            with_global: (false, Direction::Send),
+            global_send: Some(true),
         }
     }
 
-    fn new_with_global(direction: Direction) -> Self {
+    fn new_receiver() -> Self {
         Self {
-            num_lookups: 0,
-            with_global: (true, direction),
+            global_send: Some(false),
         }
     }
 }
@@ -1173,72 +1127,43 @@ impl<F: Field> BaseAir<F> for AddAir {
 
 impl<AB> Air<AB> for AddAir
 where
-    AB: PermutationAirBuilder<F = F, EF = EF, RandomVar = EF>,
-    AB::Var: Copy + Into<AB::ExprEF>,
-    AB::ExprEF: From<AB::Var> + From<F>,
-    F: Copy + Into<AB::ExprEF>,
+    AB: AirBuilder<F: Field>,
 {
-    fn eval(&self, _builder: &mut AB) {
-        // No constraints, only lookups
-    }
-}
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
 
-impl LookupAir<F> for AddAir {
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        let new_idx = self.num_lookups;
-        self.num_lookups += 1;
+        let inp1 = local[0];
+        let inp2 = local[1];
+        let sum = local[2];
+        let table_inp1 = local[3];
+        let table_inp2 = local[4];
+        let table_sum = local[5];
+        let mult = local[6];
 
-        vec![new_idx]
-    }
+        // Local lookup: (inp1,inp2,sum) must appear in (table_inp1,table_inp2,table_sum).
+        builder.push_local_interaction(vec![
+            (vec![inp1.into(), inp2.into(), sum.into()], AB::Expr::ONE),
+            (
+                vec![table_inp1.into(), table_inp2.into(), table_sum.into()],
+                -(mult.into()),
+            ),
+        ]);
 
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        let symbolic_air_builder = SymbolicAirBuilder::<F>::new(AirLayout {
-            main_width: BaseAir::<F>::width(self),
-            ..Default::default()
-        });
-
-        let symbolic_main = symbolic_air_builder.main();
-        let symbolic_main_local = symbolic_main.current_slice();
-
-        // Extract columns for the lookup entries: [inp1, inp2, sum]
-        let inp1 = symbolic_main_local[0];
-        let inp2 = symbolic_main_local[1];
-        let sum = symbolic_main_local[2];
-
-        // Form the lookup inputs.
-        let a_elements = vec![inp1.into(), inp2.into(), sum.into()];
-        let a_multiplicities = SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE));
-
-        // Extract columns for the LUT entries: [table_inp1, table_inp2, table_sum]
-        let table_inp1 = symbolic_main_local[3];
-        let table_inp2 = symbolic_main_local[4];
-        let table_sum = symbolic_main_local[5];
-        // Form the LUT entries.
-        let b_elements = vec![table_inp1.into(), table_inp2.into(), table_sum.into()];
-        let b_multiplicities = symbolic_main_local[6].into();
-
-        let lookup_inputs = vec![
-            (a_elements, a_multiplicities, Direction::Receive),
-            (b_elements.clone(), b_multiplicities, Direction::Send),
-        ];
-
-        let local_lookup = LookupAir::register_lookup(self, Kind::Local, &lookup_inputs);
-
-        // also need is_send
-        let (is_global, direction) = self.with_global;
-        if is_global {
-            let lookup_inputs = vec![(
-                b_elements,
-                SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)),
-                direction,
-            )];
-            let global_lookup =
-                LookupAir::register_lookup(self, Kind::Global("LUT".to_string()), &lookup_inputs);
-            // Return the local and global lookups.
-            return vec![local_lookup, global_lookup];
+        // Optional global interaction on bus "LUT".
+        if let Some(is_send) = self.global_send {
+            let count = if is_send {
+                -AB::Expr::ONE // send = negative
+            } else {
+                AB::Expr::ONE // receive = positive
+            };
+            builder.push_interaction(
+                "LUT",
+                [table_inp1.into(), table_inp2.into(), table_sum.into()],
+                count,
+                1,
+            );
         }
-        // Return the local lookup.
-        vec![local_lookup]
     }
 }
 
@@ -1249,7 +1174,7 @@ fn test_tuple_lookup() {
     // Values to check: [(0, 1, 1), (0, 1, 1), (1, 1, 2), (0, 0, 0)]
     // Lookup table: [(0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 2)]
     let mut rng = SmallRng::seed_from_u64(1);
-    let mut air = AddAir::new();
+    let air = AddAir::new();
     let width = <AddAir as BaseAir<F>>::width(&air);
     let (main_trace, aux_trace, challenges) = LookupTraceBuilder::new_with_width(width, &mut rng)
         .row(&[0, 1, 1], &[0, 1, 1], 2)
@@ -1288,13 +1213,13 @@ fn test_tuple_lookup() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups = LookupAir::get_lookups(&mut air);
+    let lookups = Lookups::from_air::<EF, _>(&air);
 
     // Evaluate the constraints for every row.
     for i in 0..builder.height {
         builder.for_row(i);
         lookups.iter().for_each(|lookup| {
-            lookup_gadget.eval_local_lookup(&mut builder, lookup);
+            lookup_gadget.eval_local(&mut builder, lookup);
         });
     }
 }
@@ -1320,7 +1245,7 @@ fn test_global_lookup() {
     };
 
     // The first AIR receives LUT values from the second air.
-    let mut air1 = AddAir::new_with_global(Direction::Receive);
+    let air1 = AddAir::new_receiver();
     let width = <AddAir as BaseAir<F>>::width(&air1);
     let (main_trace1, aux_trace1, challenges1) = {
         let mut trace_builder = LookupTraceBuilder::new_with_width(width, &mut rng);
@@ -1330,11 +1255,11 @@ fn test_global_lookup() {
             .row(&[0, 1, 1], &[0, 1, 1], 2)
             .row(&[1, 1, 2], &[1, 1, 2], 1)
             .row(&[0, 0, 0], &[1, 0, 1], 0)
-            .build_with_global(Direction::Receive)
+            .build_with_global(false)
     };
 
     // The second AIR sends LUT values to the first air.
-    let mut air2 = AddAir::new_with_global(Direction::Send);
+    let air2 = AddAir::new_sender();
     let width = <AddAir as BaseAir<F>>::width(&air2);
     let (main_trace2, aux_trace2, challenges2) = {
         let mut trace_builder = LookupTraceBuilder::new_with_width(width, &mut rng);
@@ -1344,7 +1269,7 @@ fn test_global_lookup() {
             .row(&[0, 1, 1], &[0, 0, 0], 1)
             .row(&[1, 1, 2], &[1, 0, 1], 0)
             .row(&[0, 0, 0], &[1, 1, 2], 1)
-            .build_with_global(Direction::Send)
+            .build_with_global(true)
     };
 
     // The test must check the FINAL constraint: s[n-1] + c[n-1] = 0
@@ -1425,8 +1350,8 @@ fn test_global_lookup() {
 
     // Register the lookups.
     let lookup_gadget = LogUpGadget::new();
-    let lookups1 = LookupAir::get_lookups(&mut air1);
-    let lookups2 = LookupAir::get_lookups(&mut air2);
+    let lookups1 = Lookups::from_air::<EF, _>(&air1);
+    let lookups2 = Lookups::from_air::<EF, _>(&air2);
 
     assert_eq!(
         builder1.height, builder2.height,
@@ -1438,10 +1363,10 @@ fn test_global_lookup() {
         builder1.for_row(i);
         lookups1.iter().for_each(|lookup| {
             match &lookup.kind {
-                Kind::Local => lookup_gadget.eval_local_lookup(&mut builder1, lookup),
+                Kind::Local => lookup_gadget.eval_local(&mut builder1, lookup),
                 Kind::Global(name) => {
                     assert_eq!(*name, "LUT".to_string(), "Global lookup name should match");
-                    lookup_gadget.eval_global_update(&mut builder1, lookup, s_global_final1);
+                    lookup_gadget.eval_global(&mut builder1, lookup, s_global_final1);
                 }
             };
         });
@@ -1449,10 +1374,10 @@ fn test_global_lookup() {
         builder2.for_row(i);
         lookups2.iter().for_each(|lookup| {
             match &lookup.kind {
-                Kind::Local => lookup_gadget.eval_local_lookup(&mut builder2, lookup),
+                Kind::Local => lookup_gadget.eval_local(&mut builder2, lookup),
                 Kind::Global(name) => {
                     assert_eq!(*name, "LUT".to_string(), "Global lookup name should match");
-                    lookup_gadget.eval_global_update(&mut builder2, lookup, s_global_final2);
+                    lookup_gadget.eval_global(&mut builder2, lookup, s_global_final2);
                 }
             };
         });
@@ -1460,6 +1385,6 @@ fn test_global_lookup() {
 
     // Evaluate the global lookup between the two AIRs.
     lookup_gadget
-        .verify_global_final_value(&[s_global_final1, s_global_final2])
+        .verify_global_sum(&[s_global_final1, s_global_final2])
         .expect("Global lookups final values should sum to 0.");
 }

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -7,7 +7,6 @@ use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{
     Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, WindowAccess,
 };
-use crate::builder::InteractionBuilder;
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -17,6 +16,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use crate::Lookups;
+use crate::builder::InteractionBuilder;
 use crate::logup::LogUpGadget;
 use crate::protocol::LookupProtocol;
 use crate::traits::{Kind, Lookup};

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -7,6 +7,7 @@ use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{
     Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, WindowAccess,
 };
+use crate::builder::InteractionBuilder;
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -269,7 +270,7 @@ impl RangeCheckAir {
 
 impl<AB> Air<AB> for RangeCheckAir
 where
-    AB: AirBuilder<F: Field>,
+    AB: AirBuilder<F: Field> + InteractionBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
@@ -1127,7 +1128,7 @@ impl<F: Field> BaseAir<F> for AddAir {
 
 impl<AB> Air<AB> for AddAir
 where
-    AB: AirBuilder<F: Field>,
+    AB: AirBuilder<F: Field> + InteractionBuilder,
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();

--- a/lookup/src/traits.rs
+++ b/lookup/src/traits.rs
@@ -1,19 +1,13 @@
-use p3_air::{
-    AirBuilder, BaseEntry, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, RowWindow,
-    SymbolicExpression, WindowAccess,
-};
+use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, RowWindow};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{StarkGenericConfig, Val};
-use tracing::warn;
 
-pub use crate::types::{
-    Direction, Kind, Lookup, LookupData, LookupError, LookupEvaluator, LookupInput,
-};
+pub use crate::types::{Kind, Lookup, LookupData, LookupError};
 
 /// A trait for lookup argument.
-pub trait LookupGadget: LookupEvaluator {
+pub trait LookupGadget {
     /// Generates the permutation matrix for the lookup argument.
     fn generate_permutation<SC: StarkGenericConfig>(
         &self,
@@ -150,63 +144,5 @@ impl<'a, SC: StarkGenericConfig> PermutationAirBuilder for LookupTraceBuilder<'a
 
     fn permutation_values(&self) -> &[SC::Challenge] {
         &[]
-    }
-}
-
-/// Evaluates a symbolic expression in the context of an AIR builder.
-///
-/// Converts `SymbolicExpression<F>` to the builder's expression type `AB::Expr`.
-pub fn symbolic_to_expr<AB>(builder: &AB, expr: &SymbolicExpression<AB::F>) -> AB::Expr
-where
-    AB: AirBuilder + PermutationAirBuilder,
-{
-    match expr {
-        SymbolicExpression::Leaf(leaf) => match leaf {
-            BaseLeaf::Variable(v) => match v.entry {
-                BaseEntry::Main { offset } => {
-                    let main = builder.main();
-                    match offset {
-                        0 => main.current(v.index).unwrap().into(),
-                        1 => main.next(v.index).unwrap().into(),
-                        _ => panic!("Cannot have expressions involving more than two rows."),
-                    }
-                }
-                BaseEntry::Periodic => {
-                    panic!("Periodic columns are not supported in lookup resolution")
-                }
-                BaseEntry::Public => builder.public_values()[v.index].into(),
-                BaseEntry::Preprocessed { offset } => {
-                    let prep = builder.preprocessed();
-                    match offset {
-                        0 => prep.current(v.index).unwrap().into(),
-                        1 => prep.next(v.index).unwrap().into(),
-                        _ => panic!("Cannot have expressions involving more than two rows."),
-                    }
-                }
-            },
-            BaseLeaf::IsFirstRow => {
-                warn!("IsFirstRow is not normalized");
-                builder.is_first_row()
-            }
-            BaseLeaf::IsLastRow => {
-                warn!("IsLastRow is not normalized");
-                builder.is_last_row()
-            }
-            BaseLeaf::IsTransition => {
-                warn!("IsTransition is not normalized");
-                builder.is_transition_window(2)
-            }
-            BaseLeaf::Constant(c) => AB::Expr::from(*c),
-        },
-        SymbolicExpression::Add { x, y, .. } => {
-            symbolic_to_expr(builder, x) + symbolic_to_expr(builder, y)
-        }
-        SymbolicExpression::Sub { x, y, .. } => {
-            symbolic_to_expr(builder, x) - symbolic_to_expr(builder, y)
-        }
-        SymbolicExpression::Neg { x, .. } => -symbolic_to_expr(builder, x),
-        SymbolicExpression::Mul { x, y, .. } => {
-            symbolic_to_expr(builder, x) * symbolic_to_expr(builder, y)
-        }
     }
 }

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -1,275 +1,119 @@
-//! Core lookup types and traits.
-//!
-//! These types define the data structures for lookup arguments in STARKs.
-//! They were previously in `p3-air` but live here to keep the `Air` trait
-//! free of lookup concerns.
+//! Core data types for lookup arguments.
 
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Neg;
+use core::ops::Deref;
 
-use p3_air::{Air, PermutationAirBuilder, SymbolicExpression};
-use p3_field::Field;
+use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
+use p3_air::{Air, SymbolicExpression, SymbolicInteraction, SymbolicLocalInteraction};
+use p3_field::{ExtensionField, Field};
 use serde::{Deserialize, Serialize};
 
-/// Defines errors that can occur during lookup verification.
-#[derive(Debug)]
-pub enum LookupError {
-    /// Error indicating that the global cumulative sum is incorrect.
-    GlobalCumulativeMismatch(Option<String>),
-}
-
-/// Specifies whether a lookup is local to an AIR or part of a global interaction.
+/// Whether a lookup is local to one AIR or shared across AIRs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Kind {
-    /// A lookup where all entries are contained within a single AIR.
+    /// Intra-AIR lookup. Running sum must return to zero.
     Local,
-    /// A lookup that spans multiple AIRs, identified by a unique interaction name.
-    ///
-    /// The interaction name is used to identify all elements that are part of the same interaction.
+    /// Cross-AIR lookup on a named bus. Running sums are verified globally.
     Global(String),
 }
 
-/// Indicates the direction of data flow in a lookup interaction.
-#[derive(Clone, Copy)]
-pub enum Direction {
-    /// Indicates that elements are being sent (contributed) to the lookup.
-    Send,
-    /// Indicates that elements are being received (removed) from the lookup.
-    Receive,
-}
-
-impl Direction {
-    /// Helper method to compute the signed multiplicity based on the direction.
-    pub fn multiplicity<T: Neg<Output = T>>(&self, mult: T) -> T {
-        match self {
-            Self::Send => -mult,
-            Self::Receive => mult,
-        }
-    }
-}
-
-/// Data required for global lookup arguments in a multi-STARK proof.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct LookupData<F> {
-    /// Name of the global lookup interaction.
-    pub name: String,
-    /// Index of the auxiliary column (if there are multiple auxiliary columns, this is the first one)
-    pub aux_idx: usize,
-    /// Expected cumulated value for a global lookup argument.
-    pub expected_cumulated: F,
-}
-
-/// A type alias for a lookup input tuple.
-///
-/// The tuple contains:
-/// - a vector of symbolic expressions representing the elements involved in the lookup,
-/// - a symbolic expression representing the multiplicity of the lookup,
-/// - a direction indicating whether the elements are being sent or received.
-///
-/// # Example
-/// ```ignored
-/// use p3_lookup::{LookupInput, Direction};
-/// use p3_air::SymbolicExpression;
-///
-/// let lookup_input: LookupInput<F> = (
-///     vec![SymbolicExpression::Constant(F::ONE)],
-///     SymbolicExpression::Constant(F::ONE),
-///     Direction::Send
-/// );
-/// ```
-pub type LookupInput<F> = (Vec<SymbolicExpression<F>>, SymbolicExpression<F>, Direction);
-
-/// A structure that holds the lookup data necessary to generate lookup contexts.
-/// It is shared between the prover and the verifier.
+/// A single lookup argument: element tuples, multiplicities, and one
+/// auxiliary column in the permutation trace.
 #[derive(Clone, Debug)]
 pub struct Lookup<F: Field> {
-    /// Type of lookup: local or global
+    /// Local or global (with bus name).
     pub kind: Kind,
-    /// Elements being read (consumed from the table). Each `Vec<SymbolicExpression<F>>`
-    /// actually represents a tuple of elements that are bundled together to make one lookup.
-    pub element_exprs: Vec<Vec<SymbolicExpression<F>>>,
-    /// Multiplicities for the elements.
-    /// Note that Lagrange selectors may not be normalized, so they cannot be used as proper
-    /// boolean filters in the multiplicities.
-    pub multiplicities_exprs: Vec<SymbolicExpression<F>>,
-    /// The column index in the permutation trace for this lookup's running sum
-    pub columns: Vec<usize>,
+    /// Element tuples. Each inner `Vec` is one `(key0, key1, ...)` tuple.
+    pub elements: Vec<Vec<SymbolicExpression<F>>>,
+    /// Signed multiplicity per element tuple. Same length as `elements`.
+    pub multiplicities: Vec<SymbolicExpression<F>>,
+    /// Auxiliary column index in the permutation trace.
+    pub column: usize,
 }
 
-impl<F: Field> Lookup<F> {
-    /// Creates a new lookup with the specified column.
-    ///
-    /// # Arguments
-    /// * `elements` - Elements from either the main execution trace or a lookup table.
-    /// * `multiplicities` - How many times each `element` should appear
-    /// * `column` - The column index in the permutation trace for this lookup
-    pub const fn new(
-        kind: Kind,
-        element_exprs: Vec<Vec<SymbolicExpression<F>>>,
-        multiplicities_exprs: Vec<SymbolicExpression<F>>,
-        columns: Vec<usize>,
-    ) -> Self {
-        Self {
-            kind,
-            element_exprs,
-            multiplicities_exprs,
-            columns,
-        }
-    }
+/// All lookups for one AIR, with column indices assigned.
+#[derive(Clone, Debug, Default)]
+pub struct Lookups<F: Field>(Vec<Lookup<F>>);
 
-    /// Iterates over the global lookup interactions in declaration order.
-    /// Panics if any global lookup has an empty columns vec.
-    pub fn global_entries(lookups: &[Self]) -> impl Iterator<Item = (&String, usize)> + '_ {
-        lookups.iter().filter_map(|lookup| match &lookup.kind {
-            Kind::Global(name) => Some((name, lookup.columns[0])),
-            Kind::Local => None,
-        })
-    }
-
-    /// Counts how many global lookup interactions are present in `lookups`.
-    pub fn global_count(lookups: &[Self]) -> usize {
-        Self::global_entries(lookups).count()
-    }
-}
-
-/// Trait for evaluating lookup constraints.
-pub trait LookupEvaluator {
-    /// Returns the number of auxiliary columns needed by this lookup protocol.
-    ///
-    /// For example:
-    /// - LogUp needs 1 column (running sum)
-    fn num_aux_cols(&self) -> usize;
-
-    /// Returns the number of challenges for each lookup argument.
-    ///
-    /// For example, for LogUp, this is 2:
-    /// - one challenge for combining the lookup tuples,
-    /// - one challenge for the running sum.
-    fn num_challenges(&self) -> usize;
-
-    /// Evaluates a local lookup argument based on the provided context.
-    ///
-    /// For example, in LogUp:
-    /// - this checks that the running sum is updated correctly.
-    /// - it checks that the final value of the running sum is 0.
-    fn eval_local_lookup<AB>(&self, builder: &mut AB, context: &Lookup<AB::F>)
+impl<F: Field> Lookups<F> {
+    /// Extract lookups from an AIR by running symbolic evaluation.
+    pub fn from_air<EF, A>(air: &A) -> Self
     where
-        AB: PermutationAirBuilder;
-
-    /// Evaluates a global lookup update based on the provided context, and the expected cumulated value.
-    /// This evaluation is carried out at the AIR level. We still need to check that the permutation argument holds
-    /// over all AIRs involved in the interaction.
-    ///
-    /// For example, in LogUp:
-    /// - this checks that the running sum is updated correctly.
-    /// - it checks that the local final value of the running sum is equal to the value provided by the prover.
-    fn eval_global_update<AB>(
-        &self,
-        builder: &mut AB,
-        context: &Lookup<AB::F>,
-        expected_cumulated: AB::ExprEF,
-    ) where
-        AB: PermutationAirBuilder;
-
-    /// Evaluates the lookup constraints for all provided contexts.
-    ///
-    /// For each context:
-    /// - if it is a local lookup, evaluates it with `eval_local_lookup`.
-    /// - if it is a global lookup, evaluates it with `eval_global_update`, reading the expected
-    ///   cumulated value from the builder's `permutation_values()`.
-    fn eval_lookups<AB>(&self, builder: &mut AB, contexts: &[Lookup<AB::F>])
-    where
-        AB: PermutationAirBuilder,
+        EF: ExtensionField<F>,
+        A: Air<SymbolicAirBuilder<F, EF>>,
+        F: Clone + Send + Sync,
     {
-        let mut pv_idx = 0;
-        for context in contexts.iter() {
-            match &context.kind {
-                Kind::Local => {
-                    self.eval_local_lookup(builder, context);
-                }
-                Kind::Global(_) => {
-                    let expected = builder.permutation_values()[pv_idx].clone();
-                    pv_idx += 1;
-                    self.eval_global_update(builder, context, expected.into());
-                }
-            }
+        let mut builder = SymbolicAirBuilder::<F, EF>::new(AirLayout::from_air(air));
+        air.eval(&mut builder);
+        Self::from_interactions(builder.global_interactions(), builder.local_interactions())
+    }
+
+    /// Build from raw symbolic interactions.
+    ///
+    /// Local interactions first, then global — matching the LogUp column order.
+    fn from_interactions(
+        global: &[SymbolicInteraction<F>],
+        local: &[SymbolicLocalInteraction<F>],
+    ) -> Self {
+        let mut lookups = Vec::with_capacity(local.len() + global.len());
+        let mut col = 0;
+
+        for i in local {
+            let (elements, multiplicities) =
+                i.tuples.iter().map(|(f, c)| (f.clone(), c.clone())).unzip();
+            lookups.push(Lookup {
+                kind: Kind::Local,
+                elements,
+                multiplicities,
+                column: col,
+            });
+            col += 1;
         }
-        assert_eq!(
-            pv_idx,
-            builder.permutation_values().len(),
-            "permutation values count mismatch"
-        );
+
+        for i in global {
+            lookups.push(Lookup {
+                kind: Kind::Global(i.bus_name.clone()),
+                elements: vec![i.fields.clone()],
+                multiplicities: vec![i.count.clone()],
+                column: col,
+            });
+            col += 1;
+        }
+
+        Self(lookups)
     }
 }
 
-/// Extension trait for AIRs that use lookups.
-///
-/// This decouples lookup definition from the core [`Air`] trait, so AIRs
-/// that don't use lookups don't need to know about lookup types at all.
-pub trait LookupAir<F: Field> {
-    /// Allocate auxiliary columns for a new lookup and return their indices.
-    ///
-    /// Default implementation returns an empty vector, indicating no lookup columns.
-    fn add_lookup_columns(&mut self) -> Vec<usize> {
-        Vec::new()
-    }
+impl<F: Field> Deref for Lookups<F> {
+    type Target = [Lookup<F>];
 
-    /// Return all lookups registered by this AIR.
-    ///
-    /// Default implementation returns an empty vector, indicating no lookups.
-    fn get_lookups(&mut self) -> Vec<Lookup<F>> {
-        Vec::new()
-    }
-
-    /// Register a lookup to be used in this AIR.
-    ///
-    /// This is a convenience method that constructs a [`Lookup`] from inputs
-    /// and allocates auxiliary columns via [`add_lookup_columns`](Self::add_lookup_columns).
-    fn register_lookup(&mut self, kind: Kind, lookup_inputs: &[LookupInput<F>]) -> Lookup<F> {
-        let (element_exprs, multiplicities_exprs) = lookup_inputs
-            .iter()
-            .map(|(elems, mult, dir)| {
-                let multiplicity = dir.multiplicity(mult.clone());
-                (elems.clone(), multiplicity)
-            })
-            .unzip();
-
-        Lookup {
-            kind,
-            element_exprs,
-            multiplicities_exprs,
-            columns: self.add_lookup_columns(),
-        }
+    fn deref(&self) -> &[Lookup<F>] {
+        &self.0
     }
 }
 
-/// Extension of [`Air`] that adds lookup constraint evaluation.
-///
-/// This trait is blanket-implemented for every type that implements [`Air`],
-/// so any AIR automatically supports `eval_with_lookups`. It lives in
-/// `p3-lookup` (rather than `p3-air`) to keep the core `Air` trait free of
-/// lookup concerns.
-pub trait AirWithLookups<AB: PermutationAirBuilder>: Air<AB> {
-    /// Evaluate both AIR constraints and lookup constraints.
-    ///
-    /// First evaluates the core AIR constraints via [`Air::eval`], then
-    /// evaluates any lookup constraints via the provided [`LookupEvaluator`].
-    ///
-    /// For AIRs without lookups, pass an empty `lookups` slice and the
-    /// evaluator will be skipped entirely.
-    fn eval_with_lookups(
-        &self,
-        builder: &mut AB,
-        lookups: &[Lookup<AB::F>],
-        lookup_evaluator: &impl LookupEvaluator,
-    ) {
-        self.eval(builder);
-
-        if !lookups.is_empty() {
-            lookup_evaluator.eval_lookups(builder, lookups);
-        }
+impl<F: Field> AsRef<[Lookup<F>]> for Lookups<F> {
+    fn as_ref(&self) -> &[Lookup<F>] {
+        &self.0
     }
 }
 
-impl<AB: PermutationAirBuilder, A: Air<AB>> AirWithLookups<AB> for A {}
+/// Prover-provided data for one global lookup interaction.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct LookupData<F> {
+    /// Bus name.
+    pub name: String,
+    /// Auxiliary column index.
+    pub aux_column: usize,
+    /// Cumulative sum computed by the prover.
+    pub cumulative_sum: F,
+}
+
+/// Lookup verification error.
+#[derive(Debug)]
+pub enum LookupError {
+    /// Global cumulative sums do not balance to zero.
+    GlobalCumulativeMismatch(Option<String>),
+}

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -5,10 +5,13 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::ops::Deref;
 
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
-use p3_air::{Air, SymbolicExpression, SymbolicInteraction, SymbolicLocalInteraction};
+use p3_air::symbolic::AirLayout;
+use p3_air::{Air, SymbolicExpression};
 use p3_field::{ExtensionField, Field};
 use serde::{Deserialize, Serialize};
+
+use crate::builder::{SymbolicInteraction, SymbolicLocalInteraction};
+use crate::symbolic::InteractionSymbolicBuilder;
 
 /// Whether a lookup is local to one AIR or shared across AIRs.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,10 +45,10 @@ impl<F: Field> Lookups<F> {
     pub fn from_air<EF, A>(air: &A) -> Self
     where
         EF: ExtensionField<F>,
-        A: Air<SymbolicAirBuilder<F, EF>>,
+        A: Air<InteractionSymbolicBuilder<F, EF>>,
         F: Clone + Send + Sync,
     {
-        let mut builder = SymbolicAirBuilder::<F, EF>::new(AirLayout::from_air(air));
+        let mut builder = InteractionSymbolicBuilder::<F, EF>::new(AirLayout::from_air(air));
         air.eval(&mut builder);
         Self::from_interactions(builder.global_interactions(), builder.local_interactions())
     }

--- a/uni-stark/src/error.rs
+++ b/uni-stark/src/error.rs
@@ -115,15 +115,15 @@ pub enum InvalidProofShapeError {
     },
     /// Global lookup proof metadata doesn't match the AIR's declared interactions.
     #[error(
-        "air {air}: global lookup data metadata mismatch at index {lookup}: expected name={expected_name}, aux_idx={expected_aux_idx}; got name={got_name}, aux_idx={got_aux_idx}"
+        "air {air}: global lookup data metadata mismatch at index {lookup}: expected name={expected_name}, aux_column={expected_aux_column}; got name={got_name}, aux_column={got_aux_column}"
     )]
     GlobalLookupDataMetadataMismatch {
         air: usize,
         lookup: usize,
         expected_name: String,
         got_name: String,
-        expected_aux_idx: usize,
-        got_aux_idx: usize,
+        expected_aux_column: usize,
+        got_aux_column: usize,
     },
     /// Permutation local and next have different lengths.
     #[error("air {air}: permutation local/next length mismatch")]

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -52,16 +52,13 @@ where
     //   callers must use `setup_preprocessed` and pass the resulting data in.
     let preprocessed_width = preprocessed.map_or_else(
         || {
-            if let Some(preprocessed_trace) = air.preprocessed_trace() {
-                let width = preprocessed_trace.width();
-                if width > 0 {
-                    panic!(
-                        "AIR defines preprocessed columns (width = {}), \
-                         but no PreprocessedProverData was provided. \
-                         Call `setup_preprocessed` and pass it to `prove_with_preprocessed`.",
-                        width
-                    );
-                }
+            let width = air.preprocessed_width();
+            if width > 0 {
+                panic!(
+                    "AIR defines preprocessed columns (width = {width}), \
+                     but no PreprocessedProverData was provided. \
+                     Call `setup_preprocessed` and pass it to `prove_with_preprocessed`."
+                );
             }
             0
         },

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -178,8 +178,7 @@ where
     // - Otherwise, derive width from the AIR's preprocessed trace (if any).
     let preprocessed_width = preprocessed_vk
         .map(|vk| vk.width)
-        .or_else(|| air.preprocessed_trace().as_ref().map(|m| m.width))
-        .unwrap_or(0);
+        .unwrap_or_else(|| air.preprocessed_width());
 
     // Check that the proof's opened preprocessed values match the expected width.
     let preprocessed_local_len = opened_values

--- a/uni-stark/tests/mul_fib_pair.rs
+++ b/uni-stark/tests/mul_fib_pair.rs
@@ -49,6 +49,9 @@ impl<F: PrimeField64> BaseAir<F> for MulFibPAir {
             self.tamper_index,
         ))
     }
+    fn preprocessed_width(&self) -> usize {
+        NUM_PREPROCESSED_COLS
+    }
 }
 
 impl<AB: AirBuilder> Air<AB> for MulFibPAir


### PR DESCRIPTION
@Nashtare @SyxtonPrime @adr1anh I had the impression that our lookup abstractions were a bit strange with a lot of free functions (which is often the sign of a design that is not perfect) and we didn't have a system of bus that most zkvms use to balance constraints via send/receive process.

So I propose this other design. Obviously in Plonky3 directly we don't have that much of direct benefits since lookups are designed to be consumed as backend by downstream users but I think that a good overview can be seen in the batch stark tests to see the new way of defining the interactions directly inside the eval of the trace. OpenVM for example has a similar design I think.

Let me know what you think and feel free to propose something else in the PR, force push on top or open a new one if you feel we could have something better.

## Summary

- Introduces a typed bus system (`LookupBus`, `PermutationCheckBus`) for declaring cross-AIR interactions inline inside `Air::eval()`.
- Redesigns `p3-lookup` with cleaner types, a unified `LookupProtocol` trait, and proper module structure.
- Removes the old `LookupAir::get_lookups()` pattern entirely.

## Changes

### `p3-air`
- `AirBuilder` gains `push_interaction()` and `push_local_interaction()` with default no-ops.
- `SymbolicExpression::resolve()` evaluates symbolic expressions against a concrete builder.
- `AirLayout::from_air()` constructor.
- `SymbolicInteraction` and `SymbolicLocalInteraction` types.

### `p3-lookup`
- **New**: `bus` module with `LookupBus` and `PermutationCheckBus`.
- **New**: `Lookups` newtype with `Lookups::from_air()`.
- **New**: `LookupProtocol` trait (merges `LookupEvaluator` + `LookupGadget`).
- **Renamed**: `columns: Vec<usize>` → `column: usize`, `element_exprs` → `elements`, `multiplicities_exprs` → `multiplicities`, `expected_cumulated` → `cumulative_sum`.
- **Renamed**: `lookup_traits.rs` → `traits.rs`.
- **Removed**: `LookupAir`, `Direction`, `LookupInput`, `AirWithLookups`.

### `p3-batch-stark`
- `StarkInstance` no longer carries `lookups` (now in `CommonData`).
- All test AIRs migrated to `push_interaction`/`push_local_interaction` inside `eval()`.

## Test plan

- [x] `cargo test -p p3-air` — 154 passed
- [x] `cargo test -p p3-lookup` — 17 passed
- [x] `cargo test -p p3-batch-stark` — 38 passed, 2 ignored (serialized fixtures)
- [x] `cargo check --workspace` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)