### PR TITLE
perf: add idft_batch_bit_reversed to TwoAdicSubgroupDft

### DIFF
--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -40,6 +40,11 @@ fn bench_fft(c: &mut Criterion) {
 
     ifft::<Goldilocks, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
 
+    ifft_bit_reversed::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
+    ifft_bit_reversed::<BabyBear, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
+    ifft_bit_reversed::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
+    ifft_bit_reversed::<Goldilocks, Radix2DitParallel<_>, BATCH_SIZE>(c, log_sizes);
+
     coset_lde::<BabyBear, RecursiveDft<_>, BATCH_SIZE>(c, log_sizes);
     coset_lde::<BabyBear, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
     coset_lde::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
@@ -167,6 +172,35 @@ where
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
             b.iter(|| {
                 dft.idft_batch(messages.clone());
+            });
+        });
+    }
+}
+
+fn ifft_bit_reversed<F, Dft, const BATCH_SIZE: usize>(c: &mut Criterion, log_sizes: &[usize])
+where
+    F: TwoAdicField,
+    Dft: TwoAdicSubgroupDft<F>,
+    StandardUniform: Distribution<F>,
+{
+    let mut group = c.benchmark_group(format!(
+        "ifft_bit_reversed/{}/{}/ncols={}",
+        pretty_name::<F>(),
+        pretty_name::<Dft>(),
+        BATCH_SIZE
+    ));
+    group.sample_size(10);
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    for n_log in log_sizes {
+        let n = 1 << n_log;
+
+        let messages = RowMajorMatrix::rand(&mut rng, n, BATCH_SIZE);
+
+        let dft = Dft::default();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
+            b.iter(|| {
+                dft.idft_batch_bit_reversed(messages.clone());
             });
         });
     }

--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 
 use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::Matrix;
+use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_matrix::util::reverse_matrix_index_bits;
 use p3_maybe_rayon::prelude::*;
@@ -32,6 +33,20 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2Bowers {
         divide_by_height(&mut mat);
         reverse_matrix_index_bits(&mut mat);
         mat
+    }
+
+    /// Like `idft_batch`, but skips the final bit-reversal: the returned view
+    /// presents natural-order coefficients to a reader while the inner matrix
+    /// already holds the coefficients in bit-reversed order.
+    fn idft_batch_bit_reversed(
+        &self,
+        mut mat: RowMajorMatrix<F>,
+    ) -> BitReversedMatrixView<RowMajorMatrix<F>> {
+        // The `bowers_g_t` network outputs coefficients in bit-reversed order,
+        // so after scaling by 1/h we can wrap directly.
+        bowers_g_t(&mut mat.as_view_mut());
+        divide_by_height(&mut mat);
+        BitReversalPerm::new_view(mat)
     }
 
     fn lde_batch(&self, mut mat: RowMajorMatrix<F>, added_bits: usize) -> RowMajorMatrix<F> {

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -165,6 +165,34 @@ impl<F: TwoAdicField + Ord> TwoAdicSubgroupDft<F> for Radix2DitParallel<F> {
         mat.bit_reverse_rows()
     }
 
+    #[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions()))]
+    fn idft_batch_bit_reversed(
+        &self,
+        mut mat: RowMajorMatrix<F>,
+    ) -> BitReversedMatrixView<RowMajorMatrix<F>> {
+        let h = mat.height();
+        let log_h = log2_strict_usize(h);
+        let mid = log_h.div_ceil(2);
+
+        // Mirror of `dft_batch`: same split-butterfly structure, with inverse
+        // twiddles and the 1/h scaling folded into the second half.
+        let inverse_twiddles = self.get_or_compute_inverse_twiddles(log_h);
+
+        reverse_matrix_index_bits(&mut mat);
+        first_half(&mut mat, mid, &inverse_twiddles.twiddles);
+
+        reverse_matrix_index_bits(&mut mat);
+
+        // Fold the 1/h scaling into the first butterfly layer of the second half,
+        // matching the pattern in `coset_lde_batch`.  If `F` is an extension field,
+        // inverting in the prime subfield is much cheaper.
+        let h_inv_subfield = F::PrimeSubfield::from_int(h).try_inverse();
+        let scale = h_inv_subfield.map(F::from_prime_subfield);
+        second_half(&mut mat, mid, &inverse_twiddles.bitrev_twiddles, scale);
+
+        mat.bit_reverse_rows()
+    }
+
     #[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions(), added_bits = added_bits))]
     fn coset_lde_batch(
         &self,

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -253,6 +253,14 @@ where
         mat
     }
 
+    // `Radix2DFTSmallBatch` intentionally does not override `idft_batch_bit_reversed`.
+    // The skip-the-initial-reverse shortcut used by `Radix2Bowers` does not apply
+    // here: this backend's DIF pipeline is structured around a bit-reversed
+    // intermediate rather than a bit-reversed output, so skipping the initial
+    // reversal changes the interpretation of the input instead of saving a pass.
+    // The trait default (materialise + reverse, then wrap) is the conservative
+    // fallback and still benefits any caller that peels the view.
+
     fn coset_lde_batch(
         &self,
         mut mat: RowMajorMatrix<F>,

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -2,9 +2,9 @@ use alloc::vec::Vec;
 
 use p3_field::{BasedVectorSpace, TwoAdicField};
 use p3_matrix::Matrix;
-use p3_matrix::bitrev::BitReversibleMatrix;
+use p3_matrix::bitrev::{BitReversalPerm, BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_matrix::util::swap_rows;
+use p3_matrix::util::{reverse_matrix_index_bits, swap_rows};
 
 use crate::util::{coset_shift_cols, divide_by_height};
 
@@ -119,6 +119,34 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         }
 
         dft
+    }
+
+    /// Compute the inverse DFT of each column in `mat`, returning a view over
+    /// bit-reversed coefficients.
+    ///
+    /// Reading the returned view row-by-row yields natural-order coefficients
+    /// (identical to `idft_batch`).  Callers that want to consume the coefficients
+    /// in bit-reversed order can peel the view via `bit_reverse_rows()` and avoid
+    /// the physical reordering.  Backends whose `idft_batch` internally materialises
+    /// a bit-reversed intermediate (e.g. `Radix2Bowers`, `Radix2DitParallel`) can
+    /// override this method to skip the final reversal entirely.
+    ///
+    /// #### Mathematical Description
+    ///
+    /// Let `H` denote the unique multiplicative subgroup of order `mat.height()`.
+    /// Treating each column of `mat` as the evaluations of a polynomial on `H`,
+    /// compute the coefficients of those polynomials.
+    fn idft_batch_bit_reversed(
+        &self,
+        mat: RowMajorMatrix<F>,
+    ) -> BitReversedMatrixView<RowMajorMatrix<F>> {
+        // Default: run the standard iDFT and physically bit-reverse the result so
+        // that the wrapping view presents natural-order coefficients to a reader
+        // and the inner matrix holds bit-reversed coefficients for callers that
+        // peel the view.
+        let mut coeffs = self.idft_batch(mat);
+        reverse_matrix_index_bits(&mut coeffs);
+        BitReversalPerm::new_view(coeffs)
     }
 
     /// Compute the "coset iDFT" of `vec`. This is the inverse operation of "coset DFT".

--- a/dft/tests/testing.rs
+++ b/dft/tests/testing.rs
@@ -334,6 +334,32 @@ proptest! {
     }
 
     #[test]
+    fn all_idft_bit_reversed_agree(seed: u64, log_h in 0usize..=7, w in arb_width()) {
+        let h = 1 << log_h;
+        let mat = rand_matrix(seed, h, w);
+
+        // The returned view, materialized to row-major, must equal the natural
+        // iDFT of the same matrix for every backend.
+        let expected = NaiveDft.idft_batch(mat.clone());
+
+        let naive = NaiveDft.idft_batch_bit_reversed(mat.clone()).to_row_major_matrix();
+        let dit = Radix2Dit::default().idft_batch_bit_reversed(mat.clone()).to_row_major_matrix();
+        let bowers = Radix2Bowers.idft_batch_bit_reversed(mat.clone()).to_row_major_matrix();
+        let parallel = Radix2DitParallel::default()
+            .idft_batch_bit_reversed(mat.clone())
+            .to_row_major_matrix();
+        let small_batch = Radix2DFTSmallBatch::default()
+            .idft_batch_bit_reversed(mat)
+            .to_row_major_matrix();
+
+        prop_assert_eq!(&expected, &naive);
+        prop_assert_eq!(&expected, &dit);
+        prop_assert_eq!(&expected, &bowers);
+        prop_assert_eq!(&expected, &parallel);
+        prop_assert_eq!(&expected, &small_batch);
+    }
+
+    #[test]
     fn all_ldes_agree(
         seed: u64, log_h in 0usize..=7, w in arb_width(), added_bits in arb_added_bits()
     ) {


### PR DESCRIPTION
Closes #1364.                                                                 
                  
  ## What's added

  A new `idft_batch_bit_reversed` method on `TwoAdicSubgroupDft` returning      
  `BitReversedMatrixView<RowMajorMatrix<F>>`.  Reading the view row-by-row
  yields natural-order coefficients (identical to `idft_batch`); peeling the    
  view via `bit_reverse_rows()` hands back the inner matrix holding coefficients
   in bit-reversed order, so callers that want bit-reversed output avoid the
  physical reordering.

  ## Backend overrides

  - **`Radix2Bowers`**: `bowers_g_t` already produces bit-reversed coefficients.
    The override drops the trailing `reverse_matrix_index_bits` and wraps.
  - **`Radix2DitParallel`**: new inverse pipeline mirroring `dft_batch` via     
  `first_half` / `second_half`, with `inverse_twiddles` and the `1/h` factor    
  folded into the second-half butterfly (same pattern `coset_lde_batch` already
  uses for its iDFT portion).                                                   
  - **`Radix2Dit`**, **`Radix2DFTSmallBatch`**, **`NaiveDft`**: inherit the
  default.  `Radix2DFTSmallBatch`'s DIF pipeline is structured around a         
  bit-reversed *intermediate*, so the skip-the-initial-reversal shortcut would
  change the interpretation of the input rather than save a pass; I deliberately
   did not provide an override.  Happy to revisit if there's a cleaner path.

  ## Default behaviour

  The trait default is `reverse_matrix_index_bits(self.idft_batch(mat))` wrapped
   in a `BitReversalPerm` view, so non-overriding impls still satisfy the
  semantic contract at the cost of one extra linear pass.                       
                  
  ## Tests

  - New `all_idft_bit_reversed_agree` proptest in `dft/tests/testing.rs`: for   
  every backend, materialising the returned view must equal
  `NaiveDft.idft_batch`.  Covers log_h ∈ [0, 7] and widths ∈ [1, 17].           
                                                                           
  ## Benches                                                                    
            
  Added an `ifft_bit_reversed` function in `dft/benches/fft.rs`, wired up for   
  BabyBear and Goldilocks on `Radix2Bowers` and `Radix2DitParallel`.  Directly  
  comparable to the existing `ifft` group.                                    
                                                                                
  ## Choices worth feedback
                                                                                
  - **Method name**: `idft_batch_bit_reversed` is explicit at the call site but
  long.  I'd be happy to rename to `idft_batch_bitrev` or similar.                     
  - **Return type**: chose a concrete `BitReversedMatrixView<RowMajorMatrix<F>>`
   rather than a new associated type on the trait, to keep the diff small.      
  - **`Radix2DFTSmallBatch` override**: described above.  I'd rather ship     
  without it than ship something subtly wrong; if there's a clean path to a
  savings-generating override, I'll take a follow-up. 