### PR TITLE
Add debug shape checks

### DIFF
--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -1031,4 +1031,133 @@ mod tests {
         assert_eq!(failures[1].label.as_deref(), Some("range_check::limb_1"));
         assert_eq!(failures[2].label.as_deref(), Some("col_2"));
     }
+
+    /// No-constraint AIR with a configurable preprocessed trace.
+    ///
+    /// Lets a test force a preprocessed shape independent of the main trace.
+    #[derive(Debug)]
+    struct ShapeProbeAir {
+        /// Rows advertised in the preprocessed trace. `0` reports `None`.
+        prep_height: usize,
+        /// Columns of the advertised preprocessed trace. Ignored when height is `0`.
+        prep_width: usize,
+    }
+
+    impl<F: Field> BaseAir<F> for ShapeProbeAir {
+        fn width(&self) -> usize {
+            // Single column; every fixture is `vec![F::ZERO; height]`.
+            1
+        }
+
+        fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+            // Height == 0 is the sentinel for "AIR has no preprocessed trace".
+            if self.prep_height == 0 {
+                return None;
+            }
+
+            // Row-major flat buffer: height * width zero elements.
+            //
+            //     layout (prep_height = 2, prep_width = 3):
+            //       row 0: [ 0, 0, 0 ]
+            //       row 1: [ 0, 0, 0 ]
+            //       flat : [ 0, 0, 0, 0, 0, 0 ]
+            let total = self.prep_height * self.prep_width;
+            Some(RowMajorMatrix::new(vec![F::ZERO; total], self.prep_width))
+        }
+    }
+
+    impl<F: Field> Air<DebugConstraintBuilder<'_, F>> for ShapeProbeAir {
+        fn eval(&self, _builder: &mut DebugConstraintBuilder<'_, F>) {
+            // Empty: every panic must come from a pre-loop guard, not from eval.
+        }
+    }
+
+    #[test]
+    fn test_preprocessed_height_matches_main_passes() {
+        // Invariant: matching heights → guard accepts → empty eval loop runs cleanly.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : 4 rows × 1 col  (advertised by the AIR)
+        //
+        //     main rows : [0, 1, 2, 3]
+        //     prep rows : [0, 1, 2, 3]
+        //                 → 4 == 4 → guard passes
+        let air = ShapeProbeAir {
+            prep_height: 4,
+            prep_width: 1,
+        };
+
+        // Zero-valued rows; content is irrelevant because no constraint reads it.
+        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+
+        // Must return cleanly. A panic here would mean the guard rejected a well-shaped input.
+        check_constraints(&air, &main, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "preprocessed trace height")]
+    fn test_preprocessed_height_mismatch_panics_in_check_constraints() {
+        // Invariant: a taller preprocessed trace must trip the guard before
+        // any `unsafe` row-indexing on the oversized matrix runs.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : 8 rows × 1 col  (AIR advertises an oversized shape)
+        //
+        //     main rows : [0, 1, 2, 3]
+        //     prep rows : [0, 1, 2, 3, 4, 5, 6, 7]
+        //                 → 8 != 4 → guard panics on entry
+        let air = ShapeProbeAir {
+            prep_height: 8,
+            prep_width: 1,
+        };
+
+        // Main deliberately shorter than the advertised preprocessed trace.
+        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+
+        // Expected: panic before row 0 is ever dereferenced.
+        check_constraints(&air, &main, &[]);
+    }
+
+    #[test]
+    fn test_preprocessed_height_matches_main_passes_in_check_all_constraints() {
+        // Invariant: collect-all carries the same guard; matching heights also succeed.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : 4 rows × 1 col  → empty report returned
+        let air = ShapeProbeAir {
+            prep_height: 4,
+            prep_width: 1,
+        };
+        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+
+        // No failure cap; we expect no failures anyway.
+        let report = check_all_constraints(&air, &main, &[], None);
+
+        // Empty AIR → no failures recorded.
+        assert!(report.is_ok());
+
+        // Loop still walked every row.
+        assert_eq!(report.total_rows, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "preprocessed trace height")]
+    fn test_preprocessed_height_mismatch_panics_in_check_all_constraints() {
+        // Invariant: same mismatch as the single-pass case → collect-all panics the same way.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : 8 rows × 1 col  → 8 != 4 → guard panics on entry
+        let air = ShapeProbeAir {
+            prep_height: 8,
+            prep_width: 1,
+        };
+        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+
+        // Expected: panic on entry. The would-be report is unreachable → bound to `_`.
+        let _ = check_all_constraints(&air, &main, &[], None);
+    }
 }

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -477,6 +477,15 @@ where
 {
     let height = main.height();
     let preprocessed = air.preprocessed_trace();
+    if let Some(prep) = preprocessed.as_ref() {
+        assert_eq!(
+            prep.height(),
+            height,
+            "debug constraint check requires preprocessed trace height ({}) to match main trace height ({})",
+            prep.height(),
+            height
+        );
+    }
 
     for row_index in 0..height {
         let row_index_next = (row_index + 1) % height;
@@ -572,6 +581,15 @@ where
 {
     let height = main.height();
     let preprocessed = air.preprocessed_trace();
+    if let Some(prep) = preprocessed.as_ref() {
+        assert_eq!(
+            prep.height(),
+            height,
+            "debug constraint check requires preprocessed trace height ({}) to match main trace height ({})",
+            prep.height(),
+            height
+        );
+    }
 
     // Accumulate violations across all rows.
     let mut all_failures = Vec::new();

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -53,6 +53,22 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
     LG: LookupGadget,
 {
     let height = main.height();
+    if let Some(prep) = preprocessed.as_ref() {
+        assert_eq!(
+            prep.height(),
+            height,
+            "debug constraint check requires preprocessed trace height ({}) to match main trace height ({})",
+            prep.height(),
+            height
+        );
+    }
+    assert_eq!(
+        permutation.height(),
+        height,
+        "debug constraint check requires permutation trace height ({}) to match main trace height ({})",
+        permutation.height(),
+        height
+    );
 
     let (lookups, lookup_gadget) = lookup_constraints_inputs;
 

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -140,3 +140,173 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_air::{Air, BaseAir, DebugConstraintBuilder};
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_lookup::logup::LogUpGadget;
+
+    use super::*;
+
+    /// Quartic extension over the base field; matches the arity used in the rest of the test suite.
+    type EF = BinomialExtensionField<BabyBear, 4>;
+
+    /// No-constraint AIR with a configurable preprocessed trace.
+    ///
+    /// Lets a test force a preprocessed shape independent of the main trace.
+    #[derive(Debug)]
+    struct ShapeProbeAir {
+        /// Rows advertised in the preprocessed trace. `0` reports `None`.
+        prep_height: usize,
+        /// Columns of the advertised preprocessed trace. Ignored when height is `0`.
+        prep_width: usize,
+    }
+
+    impl<F: Field> BaseAir<F> for ShapeProbeAir {
+        fn width(&self) -> usize {
+            // Single column; every fixture is `vec![F::ZERO; height]`.
+            1
+        }
+
+        fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+            // Height == 0 is the sentinel for "AIR has no preprocessed trace".
+            if self.prep_height == 0 {
+                return None;
+            }
+
+            // Row-major flat buffer: height * width zero elements.
+            //
+            //     layout (prep_height = 2, prep_width = 3):
+            //       row 0: [ 0, 0, 0 ]
+            //       row 1: [ 0, 0, 0 ]
+            //       flat : [ 0, 0, 0, 0, 0, 0 ]
+            let total = self.prep_height * self.prep_width;
+            Some(RowMajorMatrix::new(vec![F::ZERO; total], self.prep_width))
+        }
+    }
+
+    impl<F, EF> Air<DebugConstraintBuilder<'_, F, EF>> for ShapeProbeAir
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+    {
+        fn eval(&self, _builder: &mut DebugConstraintBuilder<'_, F, EF>) {
+            // Empty: every panic must come from a pre-loop guard, not from eval.
+        }
+    }
+
+    #[test]
+    fn test_matching_heights_pass_through() {
+        // Invariant: all three traces share a height → both guards accept → empty loop runs.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col  (base field)
+        //   preprocessed : 4 rows × 1 col  (advertised by the AIR)
+        //   permutation  : 4 rows × 1 col  (extension field)
+        //
+        //     row index :  0   1   2   3
+        //     main      : [0] [0] [0] [0]
+        //     prep      : [0] [0] [0] [0]
+        //     perm      : [0] [0] [0] [0]
+        //                 → all heights == 4 → guards pass
+        let air = ShapeProbeAir {
+            prep_height: 4,
+            prep_width: 1,
+        };
+
+        // Zero-valued traces; content is irrelevant because eval reads nothing.
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let preprocessed = <ShapeProbeAir as BaseAir<BabyBear>>::preprocessed_trace(&air);
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 4], 1);
+
+        // Must return cleanly. A panic here would mean a guard rejected a well-shaped input.
+        check_constraints::<BabyBear, EF, _, LogUpGadget>(
+            &air,
+            &main,
+            &preprocessed,
+            &permutation,
+            &[],
+            &[],
+            &[],
+            (&[], &LogUpGadget),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "preprocessed trace height")]
+    fn test_preprocessed_height_mismatch_panics() {
+        // Invariant: a taller preprocessed trace must trip the first pre-loop guard.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : 8 rows × 1 col  (AIR advertises an oversized shape)
+        //   permutation  : 4 rows × 1 col  (matches main deliberately)
+        //
+        //     main rows : [0, 1, 2, 3]
+        //     prep rows : [0, 1, 2, 3, 4, 5, 6, 7]
+        //     perm rows : [0, 1, 2, 3]
+        //                 → prep guard trips first: 8 != 4
+        //
+        // Why permutation matches: a correct permutation isolates the preprocessed guard.
+        let air = ShapeProbeAir {
+            prep_height: 8,
+            prep_width: 1,
+        };
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let preprocessed = <ShapeProbeAir as BaseAir<BabyBear>>::preprocessed_trace(&air);
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 4], 1);
+
+        // Expected: panic on entry, before any row is dereferenced.
+        check_constraints::<BabyBear, EF, _, LogUpGadget>(
+            &air,
+            &main,
+            &preprocessed,
+            &permutation,
+            &[],
+            &[],
+            &[],
+            (&[], &LogUpGadget),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "permutation trace height")]
+    fn test_permutation_height_mismatch_panics() {
+        // Invariant: the permutation guard is unconditional → fires regardless of preprocessed.
+        //
+        // Fixture state:
+        //   main         : 4 rows × 1 col
+        //   preprocessed : absent   (None — first guard is skipped entirely)
+        //   permutation  : 8 rows × 1 col  (deliberately oversized)
+        //
+        //     main rows : [0, 1, 2, 3]
+        //     perm rows : [0, 1, 2, 3, 4, 5, 6, 7]
+        //                 → first guard skipped, second trips: 8 != 4
+        //
+        // Why preprocessed is absent: first guard skipped → panic must come from the second.
+        let air = ShapeProbeAir {
+            prep_height: 0,
+            prep_width: 0,
+        };
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let preprocessed: Option<RowMajorMatrix<BabyBear>> = None;
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 8], 1);
+
+        // Expected: panic on entry, before any row is dereferenced.
+        check_constraints::<BabyBear, EF, _, LogUpGadget>(
+            &air,
+            &main,
+            &preprocessed,
+            &permutation,
+            &[],
+            &[],
+            &[],
+            (&[], &LogUpGadget),
+        );
+    }
+}


### PR DESCRIPTION
  Debug constraint checking was using `row_slice_unchecked` on `preprocessed` and `permutation` rows without first proving they share the same height as `main`, so mismatched inputs could produce hard-to-diagnose failures in an unsafe indexing path.
                                                                                                                                                                                      
  This PR adds explicit pre-loop height assertions in `air` and `batch-stark` debug constraint entry points (`check_constraints` / `check_all_constraints`) with clear expected-vs-actual error messages. The change is minimal and behavior-preserving for valid inputs, and it is validated by `cargo check -p p3-air`, `cargo check -p p3-batch-stark`, plus targeted `p3-air` constraint-check tests.   