### PR TITLE
docs(uni-stark): clarify selector degree semantics

### DIFF
--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -115,9 +115,9 @@ where
     //          C(x) = C(T_1(x), ..., T_w(x), T_1(hx), ... T_w(hx), S_1(x), S_2(x), S_3(x))
     // We get the constraint bound:
     //          deg(C(x)) <= deg(C) * (N - 1) + 1
-    // The `+1` is due to the `is_transition` selector which is not accounted for in `deg(C)`. Note
-    // that these selectors are not normalized in general, so `S_i^2` is not usually equal to
-    // `S_i`; repeated selector factors still contribute to the constraint degree.
+    // The `+1` is due to the `is_transition` selector which is not accounted for in `deg(C)`.
+    // Although these selectors are not normalized in general, `S_i^2` vanishes on the same rows
+    // as `S_i`, so a constraint using `S_i^2` can always be rewritten with a single `S_i` factor.
     //
     // For now in comments we assume that `deg(C) = 3` meaning `deg(C(x)) <= 3N - 2`
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -2,21 +2,20 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
+use p3_air::symbolic::{get_symbolic_constraints, AirLayout, SymbolicAirBuilder};
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
-use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
+use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use tracing::{debug_span, info_span, instrument};
 
 use crate::{
-    Commitments, Domain, OpenedValues, PackedVal, PreprocessedProverData, Proof,
-    ProverConstraintFolder, StarkGenericConfig, Val, get_constraint_layout,
-    get_log_num_quotient_chunks,
+    get_constraint_layout, get_log_num_quotient_chunks, Commitments, Domain, OpenedValues,
+    PackedVal, PreprocessedProverData, Proof, ProverConstraintFolder, StarkGenericConfig, Val,
 };
 
 #[instrument(skip_all)]
@@ -117,7 +116,8 @@ where
     // We get the constraint bound:
     //          deg(C(x)) <= deg(C) * (N - 1) + 1
     // The `+1` is due to the `is_transition` selector which is not accounted for in `deg(C)`. Note
-    // that S_i^2 should never appear in a constraint as it should just be replaced by `S_i`.
+    // that these selectors are not normalized in general, so `S_i^2` is not usually equal to
+    // `S_i`; repeated selector factors still contribute to the constraint degree.
     //
     // For now in comments we assume that `deg(C) = 3` meaning `deg(C(x)) <= 3N - 2`
 


### PR DESCRIPTION
The current comment says `S_i^2` can be replaced by `S_i`, but the selector definitions used here are not normalized. This updates the comment to match the semantics already documented in `p3-commit` and `p3-lookup`, and keeps the degree discussion consistent with the symbolic degree model.