### PR TITLE
field: specialize packed mixed_dot_product by chunk strategy

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -696,6 +696,68 @@ pub trait Algebra<F>:
     }
 }
 
+/// Dot product over fixed-size arrays, processed in chunks of `CHUNK`.
+///
+/// This variant is intended for hot paths where the length is known at compile time
+/// (e.g. Poseidon matrix multiplies) and allows packed-field implementations to
+/// select a chunking strategy without changing call sites.
+#[must_use]
+#[inline]
+pub fn chunked_mixed_dot_product<
+    const CHUNK: usize,
+    A: Algebra<F> + Dup,
+    F: Dup,
+    const N: usize,
+>(
+    values: &[A; N],
+    coeffs: &[F; N],
+) -> A {
+    const { assert!(CHUNK != 0, "chunked_mixed_dot_product requires CHUNK > 0") }
+
+    // Fast path: for short vectors avoid chunk-loop overhead and preserve
+    // `sum_array`'s balanced reduction tree.
+    if N <= CHUNK {
+        let products: [A; N] = core::array::from_fn(|i| values[i].dup() * coeffs[i].dup());
+        return A::sum_array::<N>(&products);
+    }
+
+    let (val_chunks, val_rem) = values.as_slice().as_chunks::<CHUNK>();
+    let (coeff_chunks, coeff_rem) = coeffs.as_slice().as_chunks::<CHUNK>();
+
+    debug_assert_eq!(val_chunks.len(), coeff_chunks.len());
+    let mut acc = A::ZERO;
+    for (vc, cc) in zip(val_chunks, coeff_chunks) {
+        let products: [A; CHUNK] = core::array::from_fn(|i| vc[i].dup() * cc[i].dup());
+        acc += A::sum_array::<CHUNK>(&products);
+    }
+
+    debug_assert_eq!(val_rem.len(), coeff_rem.len());
+    for (v, c) in zip(val_rem, coeff_rem) {
+        acc += v.dup() * c.dup();
+    }
+    acc
+}
+
+/// Dispatch [`chunked_mixed_dot_product`] over supported chunk sizes.
+#[must_use]
+#[inline]
+pub fn dispatch_chunked_mixed_dot_product<A: Algebra<F> + Dup, F: Dup, const N: usize>(
+    values: &[A; N],
+    coeffs: &[F; N],
+    chunk: usize,
+) -> A {
+    match chunk {
+        1 => chunked_mixed_dot_product::<1, A, F, N>(values, coeffs),
+        2 => chunked_mixed_dot_product::<2, A, F, N>(values, coeffs),
+        4 => chunked_mixed_dot_product::<4, A, F, N>(values, coeffs),
+        8 => chunked_mixed_dot_product::<8, A, F, N>(values, coeffs),
+        16 => chunked_mixed_dot_product::<16, A, F, N>(values, coeffs),
+        32 => chunked_mixed_dot_product::<32, A, F, N>(values, coeffs),
+        64 => chunked_mixed_dot_product::<64, A, F, N>(values, coeffs),
+        _ => panic!("mixed_dot_product chunk must be one of 1, 2, 4, 8, 16, 32, or 64"),
+    }
+}
+
 /// Linear combination over runtime-length slices, processing in chunks of `CHUNK`.
 ///
 /// Computes `Σ values[i] * coeffs[i]` by batching into fixed-size chunks and

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -696,11 +696,31 @@ pub trait Algebra<F>:
     }
 }
 
-/// Dot product over fixed-size arrays, processed in chunks of `CHUNK`.
+/// Compute `Σ values[i] * coeffs[i]` over `N` pairs.
 ///
-/// This variant is intended for hot paths where the length is known at compile time
-/// (e.g. Poseidon matrix multiplies) and allows packed-field implementations to
-/// select a chunking strategy without changing call sites.
+/// A single long sum forces every add to wait for the previous one. Instead,
+/// we split the pairs into groups of `CHUNK`, sum each group on its own, and
+/// add up the group totals. Several partial sums run in parallel on the CPU,
+/// so the total latency is shorter than one straight chain.
+///
+/// The result is the same for every valid `CHUNK` — only the speed changes.
+///
+/// # Layout
+///
+/// For `N = q * CHUNK + r` with `0 <= r < CHUNK`:
+///
+/// ```text
+///     ┌── group 0 ──┬── group 1 ──┬─ ... ─┬── tail (r) ──┐
+///     │   CHUNK     │   CHUNK     │       │   r pairs    │
+///     └──────┬──────┴──────┬──────┴───────┴──────┬───────┘
+///            ▼             ▼                     ▼
+///       tree-sum      tree-sum             scalar adds
+///            └──► acc ◄────┴──────► acc ◄────────┘
+/// ```
+///
+/// # Panics
+///
+/// Compile-time panic if `CHUNK` is zero.
 #[must_use]
 #[inline]
 pub fn chunked_mixed_dot_product<
@@ -712,25 +732,29 @@ pub fn chunked_mixed_dot_product<
     values: &[A; N],
     coeffs: &[F; N],
 ) -> A {
+    // CHUNK = 0 would make the group count undefined.
     const { assert!(CHUNK != 0, "chunked_mixed_dot_product requires CHUNK > 0") }
 
-    // Fast path: for short vectors avoid chunk-loop overhead and preserve
-    // `sum_array`'s balanced reduction tree.
+    // Fast path: N fits in one group → single balanced tree, no outer loop.
     if N <= CHUNK {
         let products: [A; N] = core::array::from_fn(|i| values[i].dup() * coeffs[i].dup());
         return A::sum_array::<N>(&products);
     }
 
+    // Split off q complete groups; r leftover pairs go to the tail.
     let (val_chunks, val_rem) = values.as_slice().as_chunks::<CHUNK>();
     let (coeff_chunks, coeff_rem) = coeffs.as_slice().as_chunks::<CHUNK>();
-
     debug_assert_eq!(val_chunks.len(), coeff_chunks.len());
+
+    // One add per group; runs in parallel with the next group's multiplies.
     let mut acc = A::ZERO;
     for (vc, cc) in zip(val_chunks, coeff_chunks) {
         let products: [A; CHUNK] = core::array::from_fn(|i| vc[i].dup() * cc[i].dup());
+        // Balanced tree of depth log2(CHUNK), folded into acc.
         acc += A::sum_array::<CHUNK>(&products);
     }
 
+    // Tail: at most CHUNK - 1 pairs as a serial multiply-add chain.
     debug_assert_eq!(val_rem.len(), coeff_rem.len());
     for (v, c) in zip(val_rem, coeff_rem) {
         acc += v.dup() * c.dup();
@@ -738,7 +762,17 @@ pub fn chunked_mixed_dot_product<
     acc
 }
 
-/// Dispatch [`chunked_mixed_dot_product`] over supported chunk sizes.
+/// Lower a runtime chunk size into a const-generic call to the fixed-chunk dot product.
+///
+/// Each backend picks its preferred chunk size at runtime; the inner routine
+/// needs it as a const for unrolling. This wrapper bridges the gap.
+///
+/// Supported sizes: `1, 2, 4, 8, 16, 32, 64` — powers of two only, so the
+/// inner balanced tree stays balanced.
+///
+/// # Panics
+///
+/// Runtime panic if `chunk` is outside the supported set.
 #[must_use]
 #[inline]
 pub fn dispatch_chunked_mixed_dot_product<A: Algebra<F> + Dup, F: Dup, const N: usize>(
@@ -754,6 +788,7 @@ pub fn dispatch_chunked_mixed_dot_product<A: Algebra<F> + Dup, F: Dup, const N: 
         16 => chunked_mixed_dot_product::<16, A, F, N>(values, coeffs),
         32 => chunked_mixed_dot_product::<32, A, F, N>(values, coeffs),
         64 => chunked_mixed_dot_product::<64, A, F, N>(values, coeffs),
+        // Unsupported chunk = configuration bug in a backend.
         _ => panic!("mixed_dot_product chunk must be one of 1, 2, 4, 8, 16, 32, or 64"),
     }
 }

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -1,7 +1,8 @@
 mod helpers {
     use p3_baby_bear::BabyBear;
     use p3_field::{
-        PrimeCharacteristicRing, add_scaled_slice_in_place, dot_product, field_to_array,
+        PrimeCharacteristicRing, add_scaled_slice_in_place, chunked_mixed_dot_product,
+        dispatch_chunked_mixed_dot_product, dot_product, field_to_array,
         par_add_scaled_slice_in_place, reduce_32, split_32,
     };
 
@@ -267,5 +268,121 @@ mod helpers {
 
         // Should be all zeros: [0, 0, 0]
         assert_eq!(arr, [BabyBear::ZERO; 3]);
+    }
+
+    #[test]
+    fn test_chunked_mixed_dot_product_zero_length() {
+        // Empty inputs hit the N <= CHUNK fast path with N = 0.
+        // The fast path builds an empty product array and reduces it.
+        // Expected: empty sum yields the additive identity.
+        let a: [BabyBear; 0] = [];
+        let f: [BabyBear; 0] = [];
+
+        assert_eq!(
+            chunked_mixed_dot_product::<4, BabyBear, BabyBear, 0>(&a, &f),
+            BabyBear::ZERO,
+        );
+    }
+
+    #[test]
+    fn test_chunked_mixed_dot_product_fast_path_n_equals_chunk() {
+        // Boundary: N == CHUNK. The condition `N <= CHUNK` is still true,
+        // so this exercises the fast path on its upper edge — no outer
+        // loop, single balanced reduction over CHUNK products.
+        //
+        //     a = [2, 3, 5, 7]
+        //     f = [11, 13, 17, 19]
+        //     expected = 2*11 + 3*13 + 5*17 + 7*19
+        //              = 22  + 39  + 85  + 133  = 279
+        let a = [
+            BabyBear::TWO,
+            BabyBear::from_u8(3),
+            BabyBear::from_u8(5),
+            BabyBear::from_u8(7),
+        ];
+        let f = [
+            BabyBear::from_u8(11),
+            BabyBear::from_u8(13),
+            BabyBear::from_u8(17),
+            BabyBear::from_u8(19),
+        ];
+
+        assert_eq!(
+            chunked_mixed_dot_product::<4, BabyBear, BabyBear, 4>(&a, &f),
+            BabyBear::from_u32(279),
+        );
+    }
+
+    #[test]
+    fn test_chunked_mixed_dot_product_no_remainder() {
+        // N = 8, CHUNK = 4: exactly two complete groups, no tail.
+        // Exercises the chunked main loop only.
+        //
+        //     a = [1, 2, 3, 4, 5, 6, 7, 8]
+        //     f = [1; 8]
+        //     expected = 1+2+3+...+8 = 36
+        let a: [BabyBear; 8] = core::array::from_fn(|i| BabyBear::from_u8((i + 1) as u8));
+        let f: [BabyBear; 8] = [BabyBear::ONE; 8];
+
+        assert_eq!(
+            chunked_mixed_dot_product::<4, BabyBear, BabyBear, 8>(&a, &f),
+            BabyBear::from_u8(36),
+        );
+    }
+
+    #[test]
+    fn test_chunked_mixed_dot_product_with_remainder() {
+        // N = 10, CHUNK = 4: two complete groups plus a tail of 2.
+        // Exercises both the chunked main loop and the scalar tail.
+        //
+        //     layout:  [group_0 = pairs 0..=3][group_1 = pairs 4..=7][tail = pairs 8..=9]
+        //     a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        //     f = [1; 10]
+        //     expected = 1+2+...+10 = 55
+        let a: [BabyBear; 10] = core::array::from_fn(|i| BabyBear::from_u8((i + 1) as u8));
+        let f: [BabyBear; 10] = [BabyBear::ONE; 10];
+
+        assert_eq!(
+            chunked_mixed_dot_product::<4, BabyBear, BabyBear, 10>(&a, &f),
+            BabyBear::from_u8(55),
+        );
+    }
+
+    #[test]
+    fn test_dispatch_chunked_mixed_dot_product_invariant_over_valid_chunks() {
+        // Field addition is associative, so the chunk choice never changes
+        // the mathematical result. Run all seven supported chunk values
+        // against the same input and assert agreement.
+        //
+        // N = 20 was picked so different chunks land in different paths:
+        //
+        //     CHUNK = 1   → 20 chunked groups, no tail        (chunked path)
+        //     CHUNK = 2   → 10 chunked groups, no tail        (chunked path)
+        //     CHUNK = 4   →  5 chunked groups, no tail        (chunked path)
+        //     CHUNK = 8   →  2 chunked groups, tail of 4      (chunked + tail)
+        //     CHUNK = 16  →  1 chunked group,  tail of 4      (chunked + tail)
+        //     CHUNK = 32  → fast path                          (N <= CHUNK)
+        //     CHUNK = 64  → fast path                          (N <= CHUNK)
+        let a: [BabyBear; 20] = core::array::from_fn(|i| BabyBear::from_u32(i as u32 * 7 + 11));
+        let f: [BabyBear; 20] = core::array::from_fn(|i| BabyBear::from_u32(i as u32 * 13 + 5));
+
+        // Reference: any valid chunk yields the same value.
+        let reference = chunked_mixed_dot_product::<1, BabyBear, BabyBear, 20>(&a, &f);
+
+        // Every supported runtime chunk size must reproduce that value.
+        for chunk in [1usize, 2, 4, 8, 16, 32, 64] {
+            let r = dispatch_chunked_mixed_dot_product::<BabyBear, BabyBear, 20>(&a, &f, chunk);
+            assert_eq!(r, reference, "chunk={chunk} disagreed with reference");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "mixed_dot_product chunk must be one of 1, 2, 4, 8, 16, 32, or 64")]
+    fn test_dispatch_chunked_mixed_dot_product_panics_on_invalid_chunk() {
+        // Any chunk outside the supported power-of-two set must panic.
+        let a = [BabyBear::ONE; 4];
+        let f = [BabyBear::ONE; 4];
+
+        let _ = dispatch_chunked_mixed_dot_product::<BabyBear, BabyBear, 4>(&a, &f, 3);
     }
 }

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -14,7 +14,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, impl_packed_field_pow_2,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, dispatch_chunked_mixed_dot_product,
+    impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -166,6 +167,11 @@ impl_sum_prod_base_field!(PackedGoldilocksAVX2, Goldilocks);
 impl Algebra<Goldilocks> for PackedGoldilocksAVX2 {
     // Benchmarked on AVX2: chunk=32 ≈ 226ns, chunk=2 ≈ 228ns, chunk=16 ≈ 229ns.
     const BATCHED_LC_CHUNK: usize = 32;
+
+    #[inline(always)]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
+        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(a, f, Self::BATCHED_LC_CHUNK)
+    }
 }
 
 impl_packed_value!(PackedGoldilocksAVX2, Goldilocks, WIDTH);

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -170,7 +170,11 @@ impl Algebra<Goldilocks> for PackedGoldilocksAVX2 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(a, f, Self::BATCHED_LC_CHUNK)
+        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
+            a,
+            f,
+            <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
+        )
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -156,7 +156,11 @@ impl Algebra<Goldilocks> for PackedGoldilocksAVX512 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(a, f, Self::BATCHED_LC_CHUNK)
+        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
+            a,
+            f,
+            <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
+        )
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -14,7 +14,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, impl_packed_field_pow_2,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64, dispatch_chunked_mixed_dot_product,
+    impl_packed_field_pow_2,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -152,6 +153,11 @@ impl_sum_prod_base_field!(PackedGoldilocksAVX512, Goldilocks);
 impl Algebra<Goldilocks> for PackedGoldilocksAVX512 {
     // Benchmarked on AVX-512: chunk=4 ≈ 198ns, chunk=2 ≈ 198ns, chunk=32 ≈ 199ns.
     const BATCHED_LC_CHUNK: usize = 4;
+
+    #[inline(always)]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
+        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(a, f, Self::BATCHED_LC_CHUNK)
+    }
 }
 
 // Degree of the smallest permutation polynomial for Goldilocks.

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -229,7 +229,11 @@ impl Algebra<Mersenne31> for PackedMersenne31Neon {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
+            a,
+            f,
+            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
+        )
     }
 }
 

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -13,8 +13,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, uint32x4_mod_add,
-    uint32x4_mod_sub,
+    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
+    impl_packed_field_pow_2, uint32x4_mod_add, uint32x4_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -226,6 +226,11 @@ impl_sum_prod_base_field!(PackedMersenne31Neon, Mersenne31);
 impl Algebra<Mersenne31> for PackedMersenne31Neon {
     // Benchmarked on AArch64 NEON: chunk=16 ≈ 51ns, chunk=8 ≈ 54ns, chunk=4 ≈ 59ns.
     const BATCHED_LC_CHUNK: usize = 16;
+
+    #[inline(always)]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+    }
 }
 
 /// Given a `val` in `0, ..., 2 P`, return a `res` in `0, ..., P` such that `res = val (mod P)`

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -218,7 +218,11 @@ impl Algebra<Mersenne31> for PackedMersenne31AVX2 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
+            a,
+            f,
+            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
+        )
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -13,8 +13,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, mm256_mod_add,
-    mm256_mod_sub,
+    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
+    impl_packed_field_pow_2, mm256_mod_add, mm256_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -215,6 +215,11 @@ impl_sum_prod_base_field!(PackedMersenne31AVX2, Mersenne31);
 impl Algebra<Mersenne31> for PackedMersenne31AVX2 {
     // Benchmarked on AVX2: chunk=32 ≈ 73ns, chunk=4 ≈ 74ns, chunk=8 ≈ 74ns.
     const BATCHED_LC_CHUNK: usize = 32;
+
+    #[inline(always)]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+    }
 }
 
 #[inline]

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -13,8 +13,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, mm512_mod_add,
-    mm512_mod_sub,
+    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
+    impl_packed_field_pow_2, mm512_mod_add, mm512_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -217,6 +217,11 @@ impl_sum_prod_base_field!(PackedMersenne31AVX512, Mersenne31);
 impl Algebra<Mersenne31> for PackedMersenne31AVX512 {
     // Benchmarked on AVX-512: chunk=8 ≈ 77ns, chunk=2 ≈ 77ns, chunk=4 ≈ 78ns.
     const BATCHED_LC_CHUNK: usize = 8;
+
+    #[inline(always)]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+    }
 }
 
 #[inline]

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -220,7 +220,11 @@ impl Algebra<Mersenne31> for PackedMersenne31AVX512 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(a, f, Self::BATCHED_LC_CHUNK)
+        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
+            a,
+            f,
+            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
+        )
     }
 }
 


### PR DESCRIPTION
Add chunk-strategy `mixed_dot_product` overrides for Mersenne31 and Goldilocks packed SIMD types, reducing hot-path dot-product dependency depth in Poseidon1.

## What changed

- New free functions in `p3_field`:
  - `chunked_mixed_dot_product::<CHUNK, A, F, N>` — fixed-size dot product that splits `N` pairs into groups of `CHUNK`, sums each group with a balanced tree, and folds the group totals into one accumulator. Several partial sums run in parallel on the CPU instead of one straight add chain.
  - `dispatch_chunked_mixed_dot_product` — runtime → const-generic bridge over the supported chunk sizes (`1, 2, 4, 8, 16, 32, 64`).
- `Algebra::mixed_dot_product` overrides on packed SIMD types:
  - `PackedMersenne31Neon` (chunk = 16)
  - `PackedMersenne31AVX2` (chunk = 32)
  - `PackedMersenne31AVX512` (chunk = 8)
  - `PackedGoldilocksAVX2` (chunk = 32)
  - `PackedGoldilocksAVX512` (chunk = 4)
- Documentation + path-coverage tests for the new helpers in `field/tests/helpers_test.rs`.

## Benchmark — Mersenne31 packed `mixed_dot_product` on Apple Silicon (aarch64 / NEON)

Same machine, same bench code; criterion `--save-baseline pre-pr` on the PR base, then `--baseline pre-pr` at the PR HEAD.

| `N` | pre-PR     | post-PR    | change      | criterion verdict    |
|-----|------------|------------|-------------|----------------------|
| 32  | 30.84 ns   | 30.51 ns   | −0.83%      | within noise         |
| 64  | 72.37 ns   | 60.81 ns   | **−16.34%** | Performance improved |
| 128 | 147.50 ns  | 121.78 ns  | **−17.79%** | Performance improved |
| 256 | 281.04 ns  | 242.36 ns  | **−14.02%** | Performance improved |

All deltas with `p < 0.05`.

### Why the shape makes sense

- `N <= CHUNK` (chunk = 16 here): the new code takes a fast path identical to the previous default — one balanced reduction tree, no outer loop. Existing in-tree benches all run at `N = 1..6`, which is why they show no change.
- `N = 32`: exactly two chunks, one outer iteration → essentially equivalent to the old chain. Falls in noise.
- `N >= 64`: the chunked accumulator opens up multiple in-flight reductions and the dependency chain shrinks → consistent **14–18%** wins.
