### PR TITLE
bench(dft): use iter_batched to exclude clone cost from measurement

### DIFF
--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_dft::{Radix2Bowers, Radix2DFTSmallBatch, Radix2Dit, Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::extension::{BinomialExtensionField, Complex};
@@ -79,9 +79,11 @@ where
 
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
-            b.iter(|| {
-                dft.dft_batch(messages.clone());
-            });
+            b.iter_batched(
+                || messages.clone(),
+                |m| dft.dft_batch(m),
+                BatchSize::LargeInput,
+            );
         });
     }
 }
@@ -110,9 +112,11 @@ where
 
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
-            b.iter(|| {
-                dft.dft_algebra_batch(messages.clone());
-            });
+            b.iter_batched(
+                || messages.clone(),
+                |m| dft.dft_algebra_batch(m),
+                BatchSize::LargeInput,
+            );
         });
     }
 }
@@ -165,9 +169,11 @@ where
 
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
-            b.iter(|| {
-                dft.idft_batch(messages.clone());
-            });
+            b.iter_batched(
+                || messages.clone(),
+                |m| dft.idft_batch(m),
+                BatchSize::LargeInput,
+            );
         });
     }
 }
@@ -194,9 +200,11 @@ where
 
         let dft = Dft::default();
         group.bench_with_input(BenchmarkId::from_parameter(n), &dft, |b, dft| {
-            b.iter(|| {
-                dft.coset_lde_batch(messages.clone(), 1, F::GENERATOR);
-            });
+            b.iter_batched(
+                || messages.clone(),
+                |m| dft.coset_lde_batch(m, 1, F::GENERATOR),
+                BatchSize::LargeInput,
+            );
         });
     }
 }


### PR DESCRIPTION
# bench(dft): use `iter_batched` to exclude clone cost from FFT measurement

## Summary

Move `messages.clone()` out of the timed region in all four DFT
benchmarks that consume their input by switching from `b.iter()` to
[`iter_batched(LargeInput)`](https://docs.rs/criterion/0.8.2/criterion/struct.Bencher.html#method.iter_batched).

One file changed, no production code touched.

```
 dft/benches/fft.rs | 34 +++++++++++++++++++++-------------
 1 file changed, 21 insertions(+), 13 deletions(-)
```

## The problem

Four benchmark functions — `fft`, `fft_algebra`, `ifft`, `coset_lde`
— pass ownership of the input matrix to the DFT routine, so each
Criterion iteration must clone it first. The clone was inside
`b.iter()`:

```rust
b.iter(|| {
    dft.coset_lde_batch(messages.clone(), 1, F::GENERATOR);
});
```

For larger sizes (2^20 × 256 BabyBear ≈ 1 GB) the clone dominates
the measurement. `perf record --call-graph dwarf` on the
`coset_lde/Radix2DitParallel/ncols=256/2^20` case showed:

| share of measured time | source |
|---|---|
| ~42% | `Vec::from_iter` (the clone) |
| ~10% | kernel page-fault handlers (`alloc_pages_mpol`, `clear_page_rep`) |
| ~4% | `dit_layer_rev` (actual FFT butterfly work) |

More than half of the reported time was allocation + OS page
zero-fill, not the DFT compute we intended to measure. This masks
real compute-side regressions and improvements alike.

## The fix

[`iter_batched`](https://docs.rs/criterion/0.8.2/criterion/struct.Bencher.html#method.iter_batched)
with [`BatchSize::LargeInput`](https://docs.rs/criterion/0.8.2/criterion/enum.BatchSize.html#variant.LargeInput)
moves the clone into Criterion's setup phase (outside the timed
region) and passes the prepared input to the routine:

```rust
b.iter_batched(
    || messages.clone(),
    |m| dft.coset_lde_batch(m, 1, F::GENERATOR),
    BatchSize::LargeInput,
);
```

`LargeInput` tells Criterion to use a batch size of 1 (one setup per
sample), appropriate for inputs that are expensive to prepare.
Measurement overhead is documented at ~750 ps per sample — negligible
against the multi-millisecond DFT runtimes.

## What changed

| function | before | after | notes |
|---|---|---|---|
| `fft` | `b.iter(\|\| dft.dft_batch(messages.clone()))` | `iter_batched` | consumes input |
| `fft_algebra` | `b.iter(\|\| dft.dft_algebra_batch(messages.clone()))` | `iter_batched` | consumes input |
| `ifft` | `b.iter(\|\| dft.idft_batch(messages.clone()))` | `iter_batched` | consumes input |
| `coset_lde` | `b.iter(\|\| dft.coset_lde_batch(messages.clone(), ...))` | `iter_batched` | consumes input |
| `m31_fft` | `b.iter(\|\| Mersenne31Dft::dft_batch::<Dft>(&messages))` | **unchanged** | borrows input, no clone |

`m31_fft` passes `&messages` (immutable borrow), so there is no
per-iteration allocation to exclude.

## Impact

On an AMD EPYC Genoa (c7a.2xlarge, Zen 4, AVX-512) with
`RUSTFLAGS="-C target-cpu=native"`, the `coset_lde` bench at 2^20
dropped from ~1170 ms to ~542 ms on identical production code — all
of that difference was clone overhead that is now excluded.

Smaller sizes (2^14–2^18) and other functions (`fft`, `ifft`) see
proportionally smaller absolute shifts since their input matrices are
smaller, but the measurement is still cleaner: the timed region now
reflects DFT compute time only.

## Test plan

- [ ] `cargo test -p p3-dft --release`
- [ ] `cargo bench -p p3-dft --bench fft` — verify benches still run
      and report sensible times
- [ ] `cargo +nightly fmt --all -- --check`
