### PR TITLE
fix(monty-31): merge twiddle cache locks

### DIFF
--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -40,24 +40,33 @@ fn coset_shift_and_scale_rows<F: Field>(
         });
 }
 
+/// Paired twiddle and inverse-twiddle tables, always updated atomically.
+#[derive(Clone, Debug)]
+struct TwiddlePair<F> {
+    twiddles: Arc<[Vec<F>]>,
+    inv_twiddles: Arc<[Vec<F>]>,
+}
+
+impl<F> Default for TwiddlePair<F> {
+    fn default() -> Self {
+        Self {
+            twiddles: Arc::from(Vec::new()),
+            inv_twiddles: Arc::from(Vec::new()),
+        }
+    }
+}
+
 /// Recursive DFT, decimation-in-frequency in the forward direction,
 /// decimation-in-time in the backward (inverse) direction.
 #[derive(Clone, Debug, Default)]
 pub struct RecursiveDft<F> {
-    /// Forward twiddle tables
-    #[allow(clippy::type_complexity)]
-    twiddles: Arc<RwLock<Arc<[Vec<F>]>>>,
-    /// Inverse twiddle tables
-    #[allow(clippy::type_complexity)]
-    inv_twiddles: Arc<RwLock<Arc<[Vec<F>]>>>,
+    /// Forward and inverse twiddle tables stored under one lock.
+    cache: Arc<RwLock<TwiddlePair<F>>>,
 }
 
 impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
     pub fn new(n: usize) -> Self {
-        let res = Self {
-            twiddles: Arc::default(),
-            inv_twiddles: Arc::default(),
-        };
+        let res = Self::default();
         res.update_twiddles(n);
         res
     }
@@ -98,10 +107,8 @@ impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
         // As we don't save the twiddles for the final layer where
         // the only twiddle is 1, roots_of_unity_table(fft_len)
         // returns a vector of twiddles of length log_2(fft_len) - 1.
-        // let curr_max_fft_len = 2 << self.twiddles.read().len();
         let need = log2_strict_usize(fft_len);
-        let snapshot = self.twiddles.read().clone();
-        let have = snapshot.len() + 1;
+        let have = self.cache.read().twiddles.len() + 1;
         if have >= need {
             return;
         }
@@ -121,31 +128,31 @@ impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
                     .collect()
             })
             .collect::<Vec<_>>();
-        // Helper closure to extend a table under its lock.
         let have_minus_one = have - 1;
-        let extend_table = |lock: &RwLock<Arc<[Vec<_>]>>, missing: &[Vec<_>]| {
-            let mut w = lock.write();
-            let current_len = w.len();
-            // Double-check if an update is still needed after acquiring the write lock.
-            if (current_len + 1) < need {
-                let mut v = w.to_vec();
-                // Append only the portion needed in case another thread did a partial update.
-                let extend_from = current_len.saturating_sub(have_minus_one);
-                v.extend_from_slice(&missing[extend_from..]);
-                *w = v.into();
-            }
-        };
-        // Atomically update each table. This two-step process is the source of the race condition.
-        extend_table(&self.twiddles, &missing_twiddles);
-        extend_table(&self.inv_twiddles, &missing_inv_twiddles);
+        let mut cache = self.cache.write();
+        let current_len = cache.twiddles.len();
+        // Double-check if an update is still needed after acquiring the write lock.
+        if (current_len + 1) < need {
+            // Append only the portion needed in case another thread extended the cache.
+            let extend_from = current_len.saturating_sub(have_minus_one);
+
+            let mut twiddles = cache.twiddles.to_vec();
+            twiddles.extend_from_slice(&missing_twiddles[extend_from..]);
+
+            let mut inv_twiddles = cache.inv_twiddles.to_vec();
+            inv_twiddles.extend_from_slice(&missing_inv_twiddles[extend_from..]);
+
+            cache.twiddles = twiddles.into();
+            cache.inv_twiddles = inv_twiddles.into();
+        }
     }
 
     fn get_twiddles(&self) -> Arc<[Vec<MontyField31<MP>>]> {
-        self.twiddles.read().clone()
+        self.cache.read().twiddles.clone()
     }
 
     fn get_inv_twiddles(&self) -> Arc<[Vec<MontyField31<MP>>]> {
-        self.inv_twiddles.read().clone()
+        self.cache.read().inv_twiddles.clone()
     }
 }
 


### PR DESCRIPTION
Before: `RecursiveDft::update_twiddles` stored `twiddles` and `inv_twiddles` behind separate `RwLock`s. A thread could observe the forward table after an extension and skip the update while `inv_twiddles` was still stale, which could panic or compute with the wrong inverse table.

After: both tables live in a single `TwiddlePair<F>` behind one `RwLock`. Cache growth appends both missing slices while holding the same write lock, so readers only see matching forward and inverse tables.