### PR TITLE
feat(field): add Field::mul_slices for elementwise slice multiplication

### DIFF
--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -198,6 +198,26 @@ where
     });
 }
 
+/// Benchmark the time taken to multiply two slices together elementwise.
+pub fn benchmark_mul_slices<F: Field, const LENGTH: usize>(c: &mut Criterion, name: &str)
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    let mut slice_1 = Vec::new();
+    let mut slice_2 = Vec::new();
+    for _ in 0..LENGTH {
+        slice_1.push(rng.random());
+        slice_2.push(rng.random());
+    }
+    c.bench_function(&format!("{name} mul slices/{LENGTH}"), |b| {
+        let mut in_slice = slice_1.clone();
+        b.iter(|| {
+            F::mul_slices(&mut in_slice, &slice_2);
+        });
+    });
+}
+
 pub fn benchmark_add_latency<R: PrimeCharacteristicRing + Copy, const N: usize>(
     c: &mut Criterion,
     name: &str,

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -325,6 +325,28 @@ where
     }
 }
 
+pub fn test_mul_slice<F: Field>()
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    let lengths = [
+        F::Packing::WIDTH - 1,
+        F::Packing::WIDTH,
+        (F::Packing::WIDTH - 1) + (F::Packing::WIDTH << 10),
+    ];
+    for len in lengths {
+        let mut slice_1: Vec<_> = (&mut rng).sample_iter(StandardUniform).take(len).collect();
+        let slice_1_copy = slice_1.clone();
+        let slice_2: Vec<_> = (&mut rng).sample_iter(StandardUniform).take(len).collect();
+
+        F::mul_slices(&mut slice_1, &slice_2);
+        for i in 0..len {
+            assert_eq!(slice_1[i], slice_1_copy[i] * slice_2[i]);
+        }
+    }
+}
+
 pub fn test_inverse<F: Field>()
 where
     StandardUniform: Distribution<F>,
@@ -1028,6 +1050,14 @@ macro_rules! test_field {
             #[test]
             fn test_field_axioms_proptest() {
                 $crate::test_field_axioms_proptest::<$field>();
+            }
+            #[test]
+            fn test_add_slice() {
+                $crate::test_add_slice::<$field>();
+            }
+            #[test]
+            fn test_mul_slice() {
+                $crate::test_mul_slice::<$field>();
             }
         }
 

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -916,6 +916,33 @@ pub trait Field:
         }
     }
 
+    /// Multiply two slices of field elements together elementwise, returning the result in the first slice.
+    ///
+    /// Makes use of packing to speed up the multiplication.
+    ///
+    /// This is optimal for cases where the two slices are small to medium length. E.g. between
+    /// `F::Packing::WIDTH` and roughly however many elements fit in a cache line.
+    ///
+    /// For larger slices, it's likely worthwhile to use parallelization before calling this.
+    /// Similarly if you need to multiply a large number of slices together, it's best to
+    /// break them into small chunks and call this on the smaller chunks.
+    ///
+    /// # Panics
+    /// The function will panic if the lengths of the two slices are not equal.
+    #[inline]
+    fn mul_slices(slice_1: &mut [Self], slice_2: &[Self]) {
+        let (shorts_1, suffix_1) = Self::Packing::pack_slice_with_suffix_mut(slice_1);
+        let (shorts_2, suffix_2) = Self::Packing::pack_slice_with_suffix(slice_2);
+        debug_assert_eq!(shorts_1.len(), shorts_2.len());
+        debug_assert_eq!(suffix_1.len(), suffix_2.len());
+        for (x_1, &x_2) in shorts_1.iter_mut().zip(shorts_2) {
+            *x_1 *= x_2;
+        }
+        for (x_1, &x_2) in suffix_1.iter_mut().zip(suffix_2) {
+            *x_1 *= x_2;
+        }
+    }
+
     /// The number of elements in the field.
     ///
     /// This will either be prime if the field is a PrimeField or a power of a

--- a/koala-bear/benches/extension.rs
+++ b/koala-bear/benches/extension.rs
@@ -2,7 +2,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use p3_field::extension::{BinomialExtensionField, QuinticTrinomialExtensionField};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_slices, benchmark_add_throughput, benchmark_inv,
-    benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
+    benchmark_mul_latency, benchmark_mul_slices, benchmark_mul_throughput, benchmark_square,
 };
 use p3_koala_bear::KoalaBear;
 
@@ -21,6 +21,8 @@ fn bench_quartic_extension(c: &mut Criterion) {
     benchmark_add_latency::<EF4, L_REPS>(c, name);
     benchmark_add_slices::<EF4, 8>(c, name);
     benchmark_add_slices::<EF4, 1000>(c, name);
+    benchmark_mul_slices::<EF4, 8>(c, name);
+    benchmark_mul_slices::<EF4, 1000>(c, name);
     benchmark_square::<EF4>(c, name);
     benchmark_inv::<EF4>(c, name);
     benchmark_mul_throughput::<EF4, REPS>(c, name);
@@ -40,6 +42,8 @@ fn bench_octic_extension(c: &mut Criterion) {
     benchmark_add_latency::<EF8, L_REPS>(c, name);
     benchmark_add_slices::<EF8, 8>(c, name);
     benchmark_add_slices::<EF8, 1000>(c, name);
+    benchmark_mul_slices::<EF8, 8>(c, name);
+    benchmark_mul_slices::<EF8, 1000>(c, name);
     benchmark_square::<EF8>(c, name);
     benchmark_inv::<EF8>(c, name);
     benchmark_mul_throughput::<EF8, REPS>(c, name);


### PR DESCRIPTION
We had the addition version of it but were missing the multiplication version.

## Summary

- Adds `Field::mul_slices` as a multiplicative sibling to the existing `Field::add_slices`. Same SIMD-friendly split-prefix + scalar-tail pattern via `<Self::Packing as PackedValue>::pack_slice_with_suffix{_mut}`. Default impl, no extension overrides (multiplication is not F-linear, so the `repr(transparent)` cast trick used by `add_slices` overrides on `BinomialExtensionField` / `QuinticTrinomialExtensionField` does not apply).
- Wires `test_add_slice` and `test_mul_slice` into the `test_field!` macro so every existing call site gets coverage for free: KoalaBear, BabyBear, Mersenne31, Mersenne31Complex, Goldilocks, BN254, plus all binomial / quintic / octic / complex extensions (34 new tests across 5 field crates).
- Adds `benchmark_mul_slices` to `field-testing/src/bench_func.rs` and registers it next to the existing `benchmark_add_slices` in `koala-bear/benches/extension.rs` for `EF4` and `EF8` at lengths 8 and 1000.

Mirrors the design of plonky2's `field/src/batch_util::batch_multiply_inplace`. Plonky2's `batch_add_inplace` is already covered by the existing `Field::add_slices`, so this PR only adds the missing multiplicative half.

## Test plan

- [x] `cargo build -p p3-field --no-default-features` (no_std clean)
- [x] `cargo test -p p3-koala-bear -p p3-baby-bear -p p3-mersenne-31 -p p3-goldilocks -p p3-bn254 --lib` — 861 pass (was 827 before, +34 new tests)
- [x] `cargo clippy -p p3-field -p p3-field-testing -p p3-koala-bear -p p3-baby-bear -p p3-mersenne-31 -p p3-goldilocks -p p3-bn254 --no-deps -- -D warnings`
- [x] `cargo build -p p3-koala-bear --bench extension`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p p3-field --no-deps`
- [x] `cargo fmt --check -p p3-field -p p3-field-testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)