### PR TITLE
Guard Rescue num_rounds against invalid capacity

### DIFF
--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -40,7 +40,9 @@ where
     /// Rescue Prime paper in Section 2.5 and following. See the paper
     /// for justifications.
     pub fn num_rounds(capacity: usize, sec_level: usize) -> usize {
-        let rate = (WIDTH - capacity) as u64;
+        let rate = WIDTH
+            .checked_sub(capacity)
+            .expect("Rescue::num_rounds requires capacity <= WIDTH") as u64;
         // This iterator produces pairs (dcon, v) increasing by a fixed
         // amount (determined by the formula in the paper) each iteration,
         // together with the value log2(binomial(v + dcon, v)). These values
@@ -241,5 +243,11 @@ mod tests {
 
         let actual = rescue_sponge.hash_iter(input);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity <= WIDTH")]
+    fn test_num_rounds_panics_when_capacity_exceeds_width() {
+        let _ = RescuePrimeM31Default::num_rounds(WIDTH + 1, 128);
     }
 }


### PR DESCRIPTION
Add an explicit capacity bound check in Rescue::num_rounds, and add a regression test to prevent invalid input from skewing round calculations.