### PR TITLE
fix(goldilocks): canonicalize sub_asm and harden NEON ASM tests

### DIFF
--- a/goldilocks/src/aarch64_neon/mod.rs
+++ b/goldilocks/src/aarch64_neon/mod.rs
@@ -10,3 +10,5 @@ pub use mds::MdsNeonGoldilocks;
 pub use packing::*;
 pub use poseidon1::*;
 pub use poseidon2::*;
+#[cfg(test)]
+pub(super) use utils::tests::{EDGE_VALUES, danger_array, danger_u64};

--- a/goldilocks/src/aarch64_neon/poseidon1_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon1_asm.rs
@@ -404,14 +404,13 @@ pub unsafe fn add_scalar_s0_asm(state: &mut [u64], rc: u64) {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
-
     use p3_field::PrimeField64;
     use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
     use super::*;
+    use crate::aarch64_neon::danger_array;
     use crate::{Goldilocks, P};
 
     type F = Goldilocks;
@@ -424,50 +423,6 @@ mod tests {
     /// against field-level references.
     fn canon(x: u64) -> u64 {
         F::new(x).as_canonical_u64()
-    }
-
-    const EPSILON: u64 = P.wrapping_neg();
-
-    /// Boundary u64s probed against every scalar ASM op.
-    const EDGE_VALUES: &[u64] = &[
-        0,
-        1,
-        2,
-        EPSILON - 1,
-        EPSILON,
-        EPSILON + 1,
-        1u64 << 31,
-        (1u64 << 32) + 1,
-        1u64 << 33,
-        1u64 << 63,
-        P - 2,
-        P - 1,
-        P,
-        P + 1,
-        P + 2,
-        18_446_744_069_605_983_184,
-        18_446_744_073_709_551_599,
-        u64::MAX - 1,
-        u64::MAX,
-    ];
-
-    /// Strategy biased toward the non-canonical band.
-    fn danger_u64() -> impl Strategy<Value = u64> {
-        prop_oneof![
-            prop::sample::select(EDGE_VALUES.to_vec()),
-            P..u64::MAX,
-            P..=P.saturating_add(EPSILON - 1),
-            any::<u64>(),
-        ]
-    }
-
-    /// Length-`WIDTH` array of danger-band u64s.
-    fn danger_array<const WIDTH: usize>() -> impl Strategy<Value = [u64; WIDTH]> {
-        prop::collection::vec(danger_u64(), WIDTH).prop_map(|v: Vec<u64>| {
-            let mut a = [0u64; WIDTH];
-            a.copy_from_slice(&v);
-            a
-        })
     }
 
     proptest! {

--- a/goldilocks/src/aarch64_neon/poseidon1_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon1_asm.rs
@@ -404,13 +404,15 @@ pub unsafe fn add_scalar_s0_asm(state: &mut [u64], rc: u64) {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use p3_field::PrimeField64;
     use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
     use super::*;
-    use crate::Goldilocks;
+    use crate::{Goldilocks, P};
 
     type F = Goldilocks;
 
@@ -422,6 +424,50 @@ mod tests {
     /// against field-level references.
     fn canon(x: u64) -> u64 {
         F::new(x).as_canonical_u64()
+    }
+
+    const EPSILON: u64 = P.wrapping_neg();
+
+    /// Boundary u64s probed against every scalar ASM op.
+    const EDGE_VALUES: &[u64] = &[
+        0,
+        1,
+        2,
+        EPSILON - 1,
+        EPSILON,
+        EPSILON + 1,
+        1u64 << 31,
+        (1u64 << 32) + 1,
+        1u64 << 33,
+        1u64 << 63,
+        P - 2,
+        P - 1,
+        P,
+        P + 1,
+        P + 2,
+        18_446_744_069_605_983_184,
+        18_446_744_073_709_551_599,
+        u64::MAX - 1,
+        u64::MAX,
+    ];
+
+    /// Strategy biased toward the non-canonical band.
+    fn danger_u64() -> impl Strategy<Value = u64> {
+        prop_oneof![
+            prop::sample::select(EDGE_VALUES.to_vec()),
+            P..u64::MAX,
+            P..=P.saturating_add(EPSILON - 1),
+            any::<u64>(),
+        ]
+    }
+
+    /// Length-`WIDTH` array of danger-band u64s.
+    fn danger_array<const WIDTH: usize>() -> impl Strategy<Value = [u64; WIDTH]> {
+        prop::collection::vec(danger_u64(), WIDTH).prop_map(|v: Vec<u64>| {
+            let mut a = [0u64; WIDTH];
+            a.copy_from_slice(&v);
+            a
+        })
     }
 
     proptest! {
@@ -837,6 +883,183 @@ mod tests {
             for i in 0..12 {
                 prop_assert_eq!(canon(s0[i]), canon(ref0[i]));
                 prop_assert_eq!(canon(s1[i]), canon(ref1[i]));
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Danger-zone proptests.
+    // -------------------------------------------------------------------
+
+    proptest! {
+        #[test]
+        fn test_sbox_s0_asm_danger(vals in danger_array::<8>()) {
+            let x = F::new(vals[0]);
+            let x2 = x * x;
+            let expected = x2 * x * (x2 * x2);
+            let mut state = vals;
+            unsafe { sbox_s0_asm(&mut state); }
+            prop_assert_eq!(canon(state[0]), expected.as_canonical_u64());
+        }
+
+        #[test]
+        fn test_add_rc_w8_danger(
+            vals in danger_array::<8>(),
+            rc in danger_array::<8>(),
+        ) {
+            let expected: [u64; 8] = core::array::from_fn(|i| {
+                (F::new(vals[i]) + F::new(rc[i])).as_canonical_u64()
+            });
+            let mut state = vals;
+            unsafe { add_rc_asm(&mut state, &rc); }
+            for i in 0..8 {
+                prop_assert_eq!(canon(state[i]), expected[i]);
+            }
+        }
+
+        #[test]
+        fn test_cheap_matmul_w8_danger(
+            vals in danger_array::<8>(),
+            first_row in danger_array::<8>(),
+            v in danger_array::<8>(),
+        ) {
+            let f: [F; 8] = vals.map(F::new);
+            let fr: [F; 8] = first_row.map(F::new);
+            let fv: [F; 8] = v.map(F::new);
+            let old = f[0];
+            let new0: F = (0..8).map(|i| f[i] * fr[i]).sum();
+            let mut expected = f;
+            for i in 1..8 {
+                expected[i] = f[i] + old * fv[i - 1];
+            }
+            expected[0] = new0;
+            let mut state = vals;
+            unsafe { cheap_matmul_asm_w8(&mut state, &first_row, &v); }
+            for i in 0..8 {
+                prop_assert_eq!(canon(state[i]), expected[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_cheap_matmul_w12_danger(
+            vals in danger_array::<12>(),
+            first_row in danger_array::<12>(),
+            v in danger_array::<12>(),
+        ) {
+            let f: [F; 12] = vals.map(F::new);
+            let fr: [F; 12] = first_row.map(F::new);
+            let fv: [F; 12] = v.map(F::new);
+            let old = f[0];
+            let new0: F = (0..12).map(|i| f[i] * fr[i]).sum();
+            let mut expected = f;
+            for i in 1..12 {
+                expected[i] = f[i] + old * fv[i - 1];
+            }
+            expected[0] = new0;
+            let mut state = vals;
+            unsafe { cheap_matmul_asm_w12(&mut state, &first_row, &v); }
+            for i in 0..12 {
+                prop_assert_eq!(canon(state[i]), expected[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_dense_matmul_w8_danger(vals in danger_array::<8>()) {
+            let mut rng = SmallRng::seed_from_u64(101);
+            let m: [[u64; 8]; 8] = rand::RngExt::random(&mut rng);
+            let f: [F; 8] = vals.map(F::new);
+            let expected: [F; 8] = core::array::from_fn(|i| {
+                (0..8).map(|j| f[j] * F::new(m[i][j])).sum()
+            });
+            let mut state = vals;
+            dense_matmul_asm_w8(&mut state, &m);
+            for i in 0..8 {
+                prop_assert_eq!(canon(state[i]), expected[i].as_canonical_u64());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Adversarial-state stress tests against field-level references.
+    // -------------------------------------------------------------------
+
+    fn adversarial_states_w8() -> [[u64; 8]; 5] {
+        [
+            [P - 1; 8],
+            [u64::MAX; 8],
+            core::array::from_fn(|i| if i % 2 == 0 { P - 1 } else { u64::MAX }),
+            core::array::from_fn(|i| P + (i as u64)),
+            [0; 8],
+        ]
+    }
+
+    fn adversarial_states_w12() -> [[u64; 12]; 5] {
+        [
+            [P - 1; 12],
+            [u64::MAX; 12],
+            core::array::from_fn(|i| if i % 2 == 0 { P - 1 } else { u64::MAX }),
+            core::array::from_fn(|i| P + (i as u64)),
+            [0; 12],
+        ]
+    }
+
+    #[test]
+    fn test_cheap_matmul_w8_stress() {
+        let first_row = [P - 1; 8];
+        let v = [u64::MAX; 8];
+        for state in adversarial_states_w8() {
+            let f: [F; 8] = state.map(F::new);
+            let fr: [F; 8] = first_row.map(F::new);
+            let fv: [F; 8] = v.map(F::new);
+            let old = f[0];
+            let new0: F = (0..8).map(|i| f[i] * fr[i]).sum();
+            let mut expected = f;
+            for i in 1..8 {
+                expected[i] = f[i] + old * fv[i - 1];
+            }
+            expected[0] = new0;
+            let mut got = state;
+            unsafe { cheap_matmul_asm_w8(&mut got, &first_row, &v); }
+            for i in 0..8 {
+                assert_eq!(canon(got[i]), expected[i].as_canonical_u64(), "i={i}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_cheap_matmul_w12_stress() {
+        let first_row = [P - 1; 12];
+        let v = [u64::MAX; 12];
+        for state in adversarial_states_w12() {
+            let f: [F; 12] = state.map(F::new);
+            let fr: [F; 12] = first_row.map(F::new);
+            let fv: [F; 12] = v.map(F::new);
+            let old = f[0];
+            let new0: F = (0..12).map(|i| f[i] * fr[i]).sum();
+            let mut expected = f;
+            for i in 1..12 {
+                expected[i] = f[i] + old * fv[i - 1];
+            }
+            expected[0] = new0;
+            let mut got = state;
+            unsafe { cheap_matmul_asm_w12(&mut got, &first_row, &v); }
+            for i in 0..12 {
+                assert_eq!(canon(got[i]), expected[i].as_canonical_u64(), "i={i}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_add_rc_w8_stress() {
+        let rc = [u64::MAX; 8];
+        for state in adversarial_states_w8() {
+            let expected: [u64; 8] = core::array::from_fn(|i| {
+                (F::new(state[i]) + F::new(rc[i])).as_canonical_u64()
+            });
+            let mut got = state;
+            unsafe { add_rc_asm(&mut got, &rc); }
+            for i in 0..8 {
+                assert_eq!(canon(got[i]), expected[i], "i={i}");
             }
         }
     }

--- a/goldilocks/src/aarch64_neon/poseidon1_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon1_asm.rs
@@ -896,7 +896,9 @@ mod tests {
         fn test_sbox_s0_asm_danger(vals in danger_array::<8>()) {
             let x = F::new(vals[0]);
             let x2 = x * x;
-            let expected = x2 * x * (x2 * x2);
+            let x3 = x2 * x;
+            let x4 = x2 * x2;
+            let expected = x3 * x4;
             let mut state = vals;
             unsafe { sbox_s0_asm(&mut state); }
             prop_assert_eq!(canon(state[0]), expected.as_canonical_u64());
@@ -1019,7 +1021,9 @@ mod tests {
             }
             expected[0] = new0;
             let mut got = state;
-            unsafe { cheap_matmul_asm_w8(&mut got, &first_row, &v); }
+            unsafe {
+                cheap_matmul_asm_w8(&mut got, &first_row, &v);
+            }
             for i in 0..8 {
                 assert_eq!(canon(got[i]), expected[i].as_canonical_u64(), "i={i}");
             }
@@ -1042,7 +1046,9 @@ mod tests {
             }
             expected[0] = new0;
             let mut got = state;
-            unsafe { cheap_matmul_asm_w12(&mut got, &first_row, &v); }
+            unsafe {
+                cheap_matmul_asm_w12(&mut got, &first_row, &v);
+            }
             for i in 0..12 {
                 assert_eq!(canon(got[i]), expected[i].as_canonical_u64(), "i={i}");
             }
@@ -1053,11 +1059,12 @@ mod tests {
     fn test_add_rc_w8_stress() {
         let rc = [u64::MAX; 8];
         for state in adversarial_states_w8() {
-            let expected: [u64; 8] = core::array::from_fn(|i| {
-                (F::new(state[i]) + F::new(rc[i])).as_canonical_u64()
-            });
+            let expected: [u64; 8] =
+                core::array::from_fn(|i| (F::new(state[i]) + F::new(rc[i])).as_canonical_u64());
             let mut got = state;
-            unsafe { add_rc_asm(&mut got, &rc); }
+            unsafe {
+                add_rc_asm(&mut got, &rc);
+            }
             for i in 0..8 {
                 assert_eq!(canon(got[i]), expected[i], "i={i}");
             }

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -1708,12 +1708,7 @@ mod tests {
     #[test]
     fn test_div16_asm_edge_values() {
         for &a in EDGE_VALUES {
-            let expected = F::new(a)
-                .halve()
-                .halve()
-                .halve()
-                .halve()
-                .as_canonical_u64();
+            let expected = F::new(a).halve().halve().halve().halve().as_canonical_u64();
             let got = canon(unsafe { div16_asm(a) });
             assert_eq!(got, expected, "div16({a})");
         }
@@ -2833,7 +2828,9 @@ mod tests {
             for i in 0..8 {
                 let x = F::new(state[i]);
                 let x2 = x * x;
-                let expected = x2 * x * (x2 * x2);
+                let x3 = x2 * x;
+                let x4 = x2 * x2;
+                let expected = x3 * x4;
                 prop_assert_eq!(canon(got[i]), expected.as_canonical_u64());
             }
         }
@@ -2879,7 +2876,9 @@ mod tests {
             let mut expected: [F; 8] = core::array::from_fn(|i| F::new(state[i]) + F::new(rc[i]));
             for x in expected.iter_mut() {
                 let x2 = *x * *x;
-                *x = x2 * *x * (x2 * x2);
+                let x3 = x2 * *x;
+                let x4 = x2 * x2;
+                *x = x3 * x4;
             }
             mds_light_permutation(&mut expected, &MDSMat4);
             let mut got = state;
@@ -2910,15 +2909,13 @@ mod tests {
     // Compares the ASM permute against a field-level reference.
     // -------------------------------------------------------------------
 
-    fn field_internal_round<const WIDTH: usize>(
-        state: &mut [F; WIDTH],
-        diag: [F; WIDTH],
-        rc: u64,
-    ) {
+    fn field_internal_round<const WIDTH: usize>(state: &mut [F; WIDTH], diag: [F; WIDTH], rc: u64) {
         state[0] += F::new(rc);
         let s = state[0];
         let s2 = s * s;
-        state[0] = s2 * s * (s2 * s2);
+        let s3 = s2 * s;
+        let s4 = s2 * s2;
+        state[0] = s3 * s4;
         matmul_internal(state, diag);
     }
 
@@ -2962,14 +2959,16 @@ mod tests {
 
         let canon_consts = vec![P - 1; 22];
         let noncanon_consts = vec![u64::MAX; 22];
-        let mixed_consts: Vec<u64> = (0..22).map(|i| if i % 2 == 0 { P } else { u64::MAX - i as u64 }).collect();
+        let mixed_consts: Vec<u64> = (0..22)
+            .map(|i| if i % 2 == 0 { P } else { u64::MAX - i as u64 })
+            .collect();
 
         vec![
             (max_canonical, canon_consts.clone()),
-            (max_noncanonical, canon_consts.clone()),
+            (max_noncanonical, canon_consts),
             (max_noncanonical, noncanon_consts.clone()),
             (alternating, mixed_consts.clone()),
-            (near_p_plus, mixed_consts.clone()),
+            (near_p_plus, mixed_consts),
             (zero_state, noncanon_consts),
         ]
     }
@@ -3001,7 +3000,6 @@ mod tests {
             run_internal_stress(MATRIX_DIAG_20_GOLDILOCKS, state, &consts);
         }
     }
-
 
     #[test]
     fn test_internal_permute_specialized_w8_stress() {
@@ -3059,12 +3057,16 @@ mod tests {
             let mut expected: [F; 8] = core::array::from_fn(|i| F::new(state[i]) + F::new(rc[i]));
             for x in expected.iter_mut() {
                 let x2 = *x * *x;
-                *x = x2 * *x * (x2 * x2);
+                let x3 = x2 * *x;
+                let x4 = x2 * x2;
+                *x = x3 * x4;
             }
             mds_light_permutation(&mut expected, &MDSMat4);
 
             let mut got = state;
-            unsafe { external_round_asm(&mut got, &rc); }
+            unsafe {
+                external_round_asm(&mut got, &rc);
+            }
 
             for i in 0..8 {
                 assert_eq!(canon(got[i]), expected[i].as_canonical_u64());
@@ -3078,10 +3080,14 @@ mod tests {
             let rc = [u64::MAX; 8];
 
             let mut expected = state;
-            unsafe { external_round_asm(&mut expected, &rc); }
+            unsafe {
+                external_round_asm(&mut expected, &rc);
+            }
 
             let mut got = state;
-            unsafe { external_round_fused_w8(&mut got, &rc); }
+            unsafe {
+                external_round_fused_w8(&mut got, &rc);
+            }
 
             for i in 0..8 {
                 assert_eq!(canon(got[i]), canon(expected[i]));

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -1588,6 +1588,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
+    use crate::aarch64_neon::{EDGE_VALUES, danger_array, danger_u64};
     use crate::{
         Goldilocks, MATRIX_DIAG_8_GOLDILOCKS, MATRIX_DIAG_12_GOLDILOCKS, MATRIX_DIAG_16_GOLDILOCKS,
         MATRIX_DIAG_20_GOLDILOCKS,
@@ -1608,50 +1609,6 @@ mod tests {
     /// Extract both u64 lanes from a NEON vector.
     unsafe fn read_neon(v: uint64x2_t) -> (u64, u64) {
         unsafe { (vgetq_lane_u64::<0>(v), vgetq_lane_u64::<1>(v)) }
-    }
-
-    const EPSILON: u64 = P.wrapping_neg();
-
-    /// Boundary u64s probed against every scalar ASM op.
-    const EDGE_VALUES: &[u64] = &[
-        0,
-        1,
-        2,
-        EPSILON - 1,
-        EPSILON,
-        EPSILON + 1,
-        1u64 << 31,
-        (1u64 << 32) + 1,
-        1u64 << 33,
-        1u64 << 63,
-        P - 2,
-        P - 1,
-        P,
-        P + 1,
-        P + 2,
-        18_446_744_069_605_983_184,
-        18_446_744_073_709_551_599,
-        u64::MAX - 1,
-        u64::MAX,
-    ];
-
-    /// Strategy biased toward the non-canonical band.
-    fn danger_u64() -> impl Strategy<Value = u64> {
-        prop_oneof![
-            prop::sample::select(EDGE_VALUES.to_vec()),
-            P..u64::MAX,
-            P..=P.saturating_add(EPSILON - 1),
-            any::<u64>(),
-        ]
-    }
-
-    /// Length-`WIDTH` array of danger-band u64s.
-    fn danger_array<const WIDTH: usize>() -> impl Strategy<Value = [u64; WIDTH]> {
-        prop::collection::vec(danger_u64(), WIDTH).prop_map(|v: Vec<u64>| {
-            let mut a = [0u64; WIDTH];
-            a.copy_from_slice(&v);
-            a
-        })
     }
 
     // -------------------------------------------------------------------

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -95,20 +95,35 @@ unsafe fn div_2_32_asm(x: u64) -> u64 {
     result
 }
 
-/// Subtract two Goldilocks elements with borrow handling using inline assembly.
+/// Subtract two Goldilocks elements, accepting non-canonical inputs.
 #[inline(always)]
 unsafe fn sub_asm(a: u64, b: u64) -> u64 {
     let result: u64;
+    let _t0: u64;
+    let _t1: u64;
     let _adj: u64;
 
     unsafe {
         asm!(
-            "subs  {result}, {a}, {b}",
+            // Canonicalize one input: if b >= P, subtract P.
+            "subs  {t0}, {b}, {p}",
+            "csel  {b_canon}, {t0}, {b}, cs",
+
+            // Subtract, folding 2^64 underflow via EPSILON.
+            "subs  {result}, {a}, {b_canon}",
             "csetm {adj:w}, cc",
             "sub   {result}, {result}, {adj}",
+
+            // Final reduction: if result >= P, subtract P.
+            "subs  {t1}, {result}, {p}",
+            "csel  {result}, {t1}, {result}, cs",
             a = in(reg) a,
             b = in(reg) b,
+            b_canon = out(reg) _,
+            p = in(reg) P,
             result = out(reg) result,
+            t0 = out(reg) _t0,
+            t1 = out(reg) _t1,
             adj = out(reg) _adj,
             options(pure, nomem, nostack),
         );
@@ -1563,6 +1578,7 @@ pub fn external_terminal_neon<const WIDTH: usize>(
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use alloc::vec::Vec;
 
     use p3_field::{PrimeCharacteristicRing, PrimeField64};
@@ -1592,6 +1608,143 @@ mod tests {
     /// Extract both u64 lanes from a NEON vector.
     unsafe fn read_neon(v: uint64x2_t) -> (u64, u64) {
         unsafe { (vgetq_lane_u64::<0>(v), vgetq_lane_u64::<1>(v)) }
+    }
+
+    const EPSILON: u64 = P.wrapping_neg();
+
+    /// Boundary u64s probed against every scalar ASM op.
+    const EDGE_VALUES: &[u64] = &[
+        0,
+        1,
+        2,
+        EPSILON - 1,
+        EPSILON,
+        EPSILON + 1,
+        1u64 << 31,
+        (1u64 << 32) + 1,
+        1u64 << 33,
+        1u64 << 63,
+        P - 2,
+        P - 1,
+        P,
+        P + 1,
+        P + 2,
+        18_446_744_069_605_983_184,
+        18_446_744_073_709_551_599,
+        u64::MAX - 1,
+        u64::MAX,
+    ];
+
+    /// Strategy biased toward the non-canonical band.
+    fn danger_u64() -> impl Strategy<Value = u64> {
+        prop_oneof![
+            prop::sample::select(EDGE_VALUES.to_vec()),
+            P..u64::MAX,
+            P..=P.saturating_add(EPSILON - 1),
+            any::<u64>(),
+        ]
+    }
+
+    /// Length-`WIDTH` array of danger-band u64s.
+    fn danger_array<const WIDTH: usize>() -> impl Strategy<Value = [u64; WIDTH]> {
+        prop::collection::vec(danger_u64(), WIDTH).prop_map(|v: Vec<u64>| {
+            let mut a = [0u64; WIDTH];
+            a.copy_from_slice(&v);
+            a
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Deterministic edge-value coverage for unary / binary scalar ops.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_sub_asm_edge_pairs() {
+        for &a in EDGE_VALUES {
+            for &b in EDGE_VALUES {
+                let expected = (F::new(a) - F::new(b)).as_canonical_u64();
+                let got = canon(unsafe { sub_asm(a, b) });
+                assert_eq!(got, expected, "sub({a}, {b})");
+            }
+        }
+    }
+
+    #[test]
+    fn test_double_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = (F::new(a) + F::new(a)).as_canonical_u64();
+            let got = canon(unsafe { double_asm(a) });
+            assert_eq!(got, expected, "double({a})");
+        }
+    }
+
+    #[test]
+    fn test_div2_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = F::new(a).halve().as_canonical_u64();
+            let got = canon(unsafe { div2_asm(a) });
+            assert_eq!(got, expected, "div2({a})");
+        }
+    }
+
+    #[test]
+    fn test_div4_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = F::new(a).halve().halve().as_canonical_u64();
+            let got = canon(unsafe { div4_asm(a) });
+            assert_eq!(got, expected, "div4({a})");
+        }
+    }
+
+    #[test]
+    fn test_div8_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = F::new(a).halve().halve().halve().as_canonical_u64();
+            let got = canon(unsafe { div8_asm(a) });
+            assert_eq!(got, expected, "div8({a})");
+        }
+    }
+
+    #[test]
+    fn test_div16_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = F::new(a)
+                .halve()
+                .halve()
+                .halve()
+                .halve()
+                .as_canonical_u64();
+            let got = canon(unsafe { div16_asm(a) });
+            assert_eq!(got, expected, "div16({a})");
+        }
+    }
+
+    #[test]
+    fn test_div32_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let expected = F::new(a)
+                .halve()
+                .halve()
+                .halve()
+                .halve()
+                .halve()
+                .as_canonical_u64();
+            let got = canon(unsafe { div32_asm(a) });
+            assert_eq!(got, expected, "div32({a})");
+        }
+    }
+
+    #[test]
+    fn test_div_2_32_asm_edge_values() {
+        for &a in EDGE_VALUES {
+            let mut v = F::new(a);
+            for _ in 0..32 {
+                v = v.halve();
+            }
+            let expected = v.as_canonical_u64();
+            let got = canon(unsafe { div_2_32_asm(a) });
+            assert_eq!(got, expected, "div_2_32({a})");
+        }
     }
 
     proptest! {
@@ -2617,5 +2770,322 @@ mod tests {
     #[test]
     fn test_internal_permute_neon_generic_w20() {
         test_internal_neon_generic_matches_scalar(MATRIX_DIAG_20_GOLDILOCKS);
+    }
+
+    // -------------------------------------------------------------------
+    // Danger-zone proptests:
+    //
+    // Same shape as the uniform variants, but inputs are concentrated in the non-canonical band.
+    // -------------------------------------------------------------------
+
+    proptest! {
+        #[test]
+        fn test_sub_asm_danger(a in danger_u64(), b in danger_u64()) {
+            let expected = (F::new(a) - F::new(b)).as_canonical_u64();
+            let got = canon(unsafe { sub_asm(a, b) });
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn test_double_asm_danger(a in danger_u64()) {
+            let expected = (F::new(a) + F::new(a)).as_canonical_u64();
+            let got = canon(unsafe { double_asm(a) });
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn test_div2_asm_danger(a in danger_u64()) {
+            let expected = F::new(a).halve().as_canonical_u64();
+            let got = canon(unsafe { div2_asm(a) });
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn test_div_2_32_asm_danger(a in danger_u64()) {
+            let mut v = F::new(a);
+            for _ in 0..32 { v = v.halve(); }
+            let got = canon(unsafe { div_2_32_asm(a) });
+            prop_assert_eq!(got, v.as_canonical_u64());
+        }
+
+        #[test]
+        fn test_apply_mat4_asm_danger(state in danger_array::<4>()) {
+            let f: [F; 4] = state.map(F::new);
+            let two = F::TWO;
+            let three = two + F::ONE;
+            let expected = [
+                two * f[0] + three * f[1] + f[2] + f[3],
+                f[0] + two * f[1] + three * f[2] + f[3],
+                f[0] + f[1] + two * f[2] + three * f[3],
+                three * f[0] + f[1] + f[2] + two * f[3],
+            ];
+            let mut got = state;
+            unsafe { apply_mat4_asm(&mut got); }
+            for i in 0..4 {
+                prop_assert_eq!(canon(got[i]), expected[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_sbox_layer_asm_danger(state in danger_array::<8>()) {
+            let mut got = state;
+            unsafe { sbox_layer_asm(&mut got); }
+            for i in 0..8 {
+                let x = F::new(state[i]);
+                let x2 = x * x;
+                let expected = x2 * x * (x2 * x2);
+                prop_assert_eq!(canon(got[i]), expected.as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_mds_light_w8_danger(state in danger_array::<8>()) {
+            let mut field_state: [F; 8] = state.map(F::new);
+            mds_light_permutation(&mut field_state, &MDSMat4);
+            let mut asm_state = state;
+            unsafe { mds_light_permutation_asm(&mut asm_state); }
+            for i in 0..8 {
+                prop_assert_eq!(canon(asm_state[i]), field_state[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_mds_light_w12_danger(state in danger_array::<12>()) {
+            let mut field_state: [F; 12] = state.map(F::new);
+            mds_light_permutation(&mut field_state, &MDSMat4);
+            let mut asm_state = state;
+            unsafe { mds_light_permutation_asm(&mut asm_state); }
+            for i in 0..12 {
+                prop_assert_eq!(canon(asm_state[i]), field_state[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_mds_light_w16_danger(state in danger_array::<16>()) {
+            let mut field_state: [F; 16] = state.map(F::new);
+            mds_light_permutation(&mut field_state, &MDSMat4);
+            let mut asm_state = state;
+            unsafe { mds_light_permutation_asm(&mut asm_state); }
+            for i in 0..16 {
+                prop_assert_eq!(canon(asm_state[i]), field_state[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_external_round_w8_danger(
+            state in danger_array::<8>(),
+            rc in danger_array::<8>(),
+        ) {
+            let mut expected: [F; 8] = core::array::from_fn(|i| F::new(state[i]) + F::new(rc[i]));
+            for x in expected.iter_mut() {
+                let x2 = *x * *x;
+                *x = x2 * *x * (x2 * x2);
+            }
+            mds_light_permutation(&mut expected, &MDSMat4);
+            let mut got = state;
+            unsafe { external_round_asm(&mut got, &rc); }
+            for i in 0..8 {
+                prop_assert_eq!(canon(got[i]), expected[i].as_canonical_u64());
+            }
+        }
+
+        #[test]
+        fn test_external_round_fused_w8_danger(
+            state in danger_array::<8>(),
+            rc in danger_array::<8>(),
+        ) {
+            let mut ref_state = state;
+            let mut got = state;
+            unsafe { external_round_asm(&mut ref_state, &rc); }
+            unsafe { external_round_fused_w8(&mut got, &rc); }
+            for i in 0..8 {
+                prop_assert_eq!(canon(got[i]), canon(ref_state[i]));
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Adversarial-state stress tests for the full internal permute.
+    //
+    // Compares the ASM permute against a field-level reference.
+    // -------------------------------------------------------------------
+
+    fn field_internal_round<const WIDTH: usize>(
+        state: &mut [F; WIDTH],
+        diag: [F; WIDTH],
+        rc: u64,
+    ) {
+        state[0] += F::new(rc);
+        let s = state[0];
+        let s2 = s * s;
+        state[0] = s2 * s * (s2 * s2);
+        matmul_internal(state, diag);
+    }
+
+    fn run_internal_stress<const WIDTH: usize>(
+        diag: [F; WIDTH],
+        state_init: [u64; WIDTH],
+        constants: &[u64],
+    ) {
+        let mut state_field: [F; WIDTH] = state_init.map(F::new);
+        for &rc in constants {
+            field_internal_round(&mut state_field, diag, rc);
+        }
+
+        let mut state_asm = state_init;
+        let diag_raw: [u64; WIDTH] = core::array::from_fn(|i| diag[i].value);
+        internal_permute_state_asm(&mut state_asm, &diag_raw, constants);
+
+        for i in 0..WIDTH {
+            assert_eq!(
+                canon(state_asm[i]),
+                state_field[i].as_canonical_u64(),
+                "i={i}, init={state_init:?}, constants={constants:?}",
+            );
+        }
+    }
+
+    /// State + constants designed to hit the non-canonical band hard:
+    /// (a) all canonical max,
+    /// (b) all non-canonical max,
+    /// (c) alternating,
+    /// (d) all-zero state with non-canonical constants.
+    ///
+    /// Repeated rounds compound any latent reduction bug.
+    fn adversarial_states<const WIDTH: usize>() -> Vec<([u64; WIDTH], Vec<u64>)> {
+        let max_canonical = [P - 1; WIDTH];
+        let max_noncanonical = [u64::MAX; WIDTH];
+        let alternating: [u64; WIDTH] =
+            core::array::from_fn(|i| if i % 2 == 0 { P - 1 } else { u64::MAX });
+        let near_p_plus: [u64; WIDTH] = core::array::from_fn(|i| P + (i as u64));
+        let zero_state = [0u64; WIDTH];
+
+        let canon_consts = vec![P - 1; 22];
+        let noncanon_consts = vec![u64::MAX; 22];
+        let mixed_consts: Vec<u64> = (0..22).map(|i| if i % 2 == 0 { P } else { u64::MAX - i as u64 }).collect();
+
+        vec![
+            (max_canonical, canon_consts.clone()),
+            (max_noncanonical, canon_consts.clone()),
+            (max_noncanonical, noncanon_consts.clone()),
+            (alternating, mixed_consts.clone()),
+            (near_p_plus, mixed_consts.clone()),
+            (zero_state, noncanon_consts),
+        ]
+    }
+
+    #[test]
+    fn test_internal_permute_w8_stress() {
+        for (state, consts) in adversarial_states::<8>() {
+            run_internal_stress(MATRIX_DIAG_8_GOLDILOCKS, state, &consts);
+        }
+    }
+
+    #[test]
+    fn test_internal_permute_w12_stress() {
+        for (state, consts) in adversarial_states::<12>() {
+            run_internal_stress(MATRIX_DIAG_12_GOLDILOCKS, state, &consts);
+        }
+    }
+
+    #[test]
+    fn test_internal_permute_w16_stress() {
+        for (state, consts) in adversarial_states::<16>() {
+            run_internal_stress(MATRIX_DIAG_16_GOLDILOCKS, state, &consts);
+        }
+    }
+
+    #[test]
+    fn test_internal_permute_w20_stress() {
+        for (state, consts) in adversarial_states::<20>() {
+            run_internal_stress(MATRIX_DIAG_20_GOLDILOCKS, state, &consts);
+        }
+    }
+
+
+    #[test]
+    fn test_internal_permute_specialized_w8_stress() {
+        for (state, consts) in adversarial_states::<8>() {
+            let mut got = state;
+            internal_permute_state_asm_w8(&mut got, &consts);
+
+            let mut expected = state;
+            let diag: [u64; 8] = core::array::from_fn(|i| MATRIX_DIAG_8_GOLDILOCKS[i].value);
+            internal_permute_state_asm(&mut expected, &diag, &consts);
+
+            for i in 0..8 {
+                assert_eq!(canon(got[i]), canon(expected[i]));
+            }
+        }
+    }
+
+    #[test]
+    fn test_internal_permute_specialized_w12_stress() {
+        for (state, consts) in adversarial_states::<12>() {
+            let mut got = state;
+            internal_permute_state_asm_w12(&mut got, &consts);
+
+            let mut expected = state;
+            let diag: [u64; 12] = core::array::from_fn(|i| MATRIX_DIAG_12_GOLDILOCKS[i].value);
+            internal_permute_state_asm(&mut expected, &diag, &consts);
+
+            for i in 0..12 {
+                assert_eq!(canon(got[i]), canon(expected[i]));
+            }
+        }
+    }
+
+    #[test]
+    fn test_internal_permute_specialized_w16_stress() {
+        for (state, consts) in adversarial_states::<16>() {
+            let mut got = state;
+            internal_permute_state_asm_w16(&mut got, &consts);
+
+            let mut expected = state;
+            let diag: [u64; 16] = core::array::from_fn(|i| MATRIX_DIAG_16_GOLDILOCKS[i].value);
+            internal_permute_state_asm(&mut expected, &diag, &consts);
+
+            for i in 0..16 {
+                assert_eq!(canon(got[i]), canon(expected[i]));
+            }
+        }
+    }
+
+    #[test]
+    fn test_external_round_w8_stress() {
+        for (state, _) in adversarial_states::<8>() {
+            let rc = [P - 1; 8];
+
+            let mut expected: [F; 8] = core::array::from_fn(|i| F::new(state[i]) + F::new(rc[i]));
+            for x in expected.iter_mut() {
+                let x2 = *x * *x;
+                *x = x2 * *x * (x2 * x2);
+            }
+            mds_light_permutation(&mut expected, &MDSMat4);
+
+            let mut got = state;
+            unsafe { external_round_asm(&mut got, &rc); }
+
+            for i in 0..8 {
+                assert_eq!(canon(got[i]), expected[i].as_canonical_u64());
+            }
+        }
+    }
+
+    #[test]
+    fn test_external_round_fused_w8_stress() {
+        for (state, _) in adversarial_states::<8>() {
+            let rc = [u64::MAX; 8];
+
+            let mut expected = state;
+            unsafe { external_round_asm(&mut expected, &rc); }
+
+            let mut got = state;
+            unsafe { external_round_fused_w8(&mut got, &rc); }
+
+            for i in 0..8 {
+                assert_eq!(canon(got[i]), canon(expected[i]));
+            }
+        }
     }
 }

--- a/goldilocks/src/aarch64_neon/utils.rs
+++ b/goldilocks/src/aarch64_neon/utils.rs
@@ -213,7 +213,9 @@ pub(super) fn pack_lanes<const WIDTH: usize>(
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
+    use alloc::vec::Vec;
+
     use p3_field::{PrimeCharacteristicRing, PrimeField64};
     use proptest::prelude::*;
 
@@ -226,19 +228,8 @@ mod tests {
         F::new(x).as_canonical_u64()
     }
 
-    #[test]
-    fn test_add_asm_large_values() {
-        let a: u64 = 18_446_744_069_605_983_184; // = p + 191_398_863
-        let b: u64 = 18_446_744_073_709_551_599; // = p + 4_294_967_278
-        // (a + b) mod p == 4_486_366_141
-        let expected = 4_486_366_141u64;
-
-        let got = canon(unsafe { add_asm(a, b) });
-        assert_eq!(got, expected);
-    }
-
     /// Boundary u64s probed against every scalar ASM op.
-    const EDGE_VALUES: &[u64] = &[
+    pub const EDGE_VALUES: &[u64] = &[
         0,
         1,
         2,
@@ -261,13 +252,32 @@ mod tests {
     ];
 
     /// Strategy biased toward the non-canonical band.
-    fn danger_u64() -> impl Strategy<Value = u64> {
+    pub fn danger_u64() -> impl Strategy<Value = u64> {
         prop_oneof![
             prop::sample::select(EDGE_VALUES.to_vec()),
             P..u64::MAX,
             P..=P.saturating_add(EPSILON - 1),
             any::<u64>(),
         ]
+    }
+
+    /// Length-`WIDTH` array of danger-band u64s.
+    pub fn danger_array<const WIDTH: usize>() -> impl Strategy<Value = [u64; WIDTH]> {
+        prop::collection::vec(danger_u64(), WIDTH).prop_map(|v: Vec<u64>| {
+            v.try_into()
+                .expect("prop::collection::vec produces exactly WIDTH elements")
+        })
+    }
+
+    #[test]
+    fn test_add_asm_large_values() {
+        let a: u64 = 18_446_744_069_605_983_184; // = p + 191_398_863
+        let b: u64 = 18_446_744_073_709_551_599; // = p + 4_294_967_278
+        // (a + b) mod p == 4_486_366_141
+        let expected = 4_486_366_141u64;
+
+        let got = canon(unsafe { add_asm(a, b) });
+        assert_eq!(got, expected);
     }
 
     #[test]

--- a/goldilocks/src/aarch64_neon/utils.rs
+++ b/goldilocks/src/aarch64_neon/utils.rs
@@ -237,6 +237,88 @@ mod tests {
         assert_eq!(got, expected);
     }
 
+    /// Boundary u64s probed against every scalar ASM op.
+    const EDGE_VALUES: &[u64] = &[
+        0,
+        1,
+        2,
+        EPSILON - 1,
+        EPSILON,
+        EPSILON + 1,
+        1u64 << 31,
+        (1u64 << 32) + 1,
+        1u64 << 33,
+        1u64 << 63,
+        P - 2,
+        P - 1, // largest canonical
+        P,     // smallest non-canonical (= 0 mod P)
+        P + 1,
+        P + 2,
+        18_446_744_069_605_983_184, // PR #1580 regression input a
+        18_446_744_073_709_551_599, // PR #1580 regression input b
+        u64::MAX - 1,
+        u64::MAX, // largest non-canonical
+    ];
+
+    /// Strategy biased toward the non-canonical band.
+    fn danger_u64() -> impl Strategy<Value = u64> {
+        prop_oneof![
+            prop::sample::select(EDGE_VALUES.to_vec()),
+            P..u64::MAX,
+            P..=P.saturating_add(EPSILON - 1),
+            any::<u64>(),
+        ]
+    }
+
+    #[test]
+    fn test_add_asm_edge_pairs() {
+        for &a in EDGE_VALUES {
+            for &b in EDGE_VALUES {
+                let expected = (F::new(a) + F::new(b)).as_canonical_u64();
+                let got = canon(unsafe { add_asm(a, b) });
+                assert_eq!(got, expected, "add({a}, {b})");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mul_asm_edge_pairs() {
+        for &a in EDGE_VALUES {
+            for &b in EDGE_VALUES {
+                let expected = (F::new(a) * F::new(b)).as_canonical_u64();
+                let got = canon(unsafe { mul_asm(a, b) });
+                assert_eq!(got, expected, "mul({a}, {b})");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mul_add_asm_edge_triples() {
+        for &a in EDGE_VALUES {
+            for &b in EDGE_VALUES {
+                for &c in EDGE_VALUES {
+                    let expected = (F::new(a) * F::new(b) + F::new(c)).as_canonical_u64();
+                    let got = canon(unsafe { mul_add_asm(a, b, c) });
+                    assert_eq!(got, expected, "mul_add({a}, {b}, {c})");
+                }
+            }
+        }
+    }
+
+    /// Repeated accumulation drives intermediate values deep into the non-canonical band.
+    ///
+    /// The canonical end result must still match.
+    #[test]
+    fn test_add_asm_chained_accumulation() {
+        let mut acc_asm: u64 = P - 1;
+        let mut acc_ref = F::new(P - 1);
+        for _ in 0..1000 {
+            acc_asm = unsafe { add_asm(acc_asm, P - 1) };
+            acc_ref += F::new(P - 1);
+        }
+        assert_eq!(canon(acc_asm), acc_ref.as_canonical_u64());
+    }
+
     proptest! {
         // ----------------------------------------------------------------
         // Scalar field arithmetic
@@ -261,6 +343,32 @@ mod tests {
         /// Verify ASM fused multiply-add against field multiply-add.
         #[test]
         fn test_mul_add_asm(a: u64, b: u64, c: u64) {
+            let expected = (F::new(a) * F::new(b) + F::new(c)).as_canonical_u64();
+            let got = canon(unsafe { mul_add_asm(a, b, c) });
+            prop_assert_eq!(got, expected);
+        }
+
+        /// Same checks, biased toward the non-canonical band.
+        #[test]
+        fn test_add_asm_danger(a in danger_u64(), b in danger_u64()) {
+            let expected = (F::new(a) + F::new(b)).as_canonical_u64();
+            let got = canon(unsafe { add_asm(a, b) });
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn test_mul_asm_danger(a in danger_u64(), b in danger_u64()) {
+            let expected = (F::new(a) * F::new(b)).as_canonical_u64();
+            let got = canon(unsafe { mul_asm(a, b) });
+            prop_assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn test_mul_add_asm_danger(
+            a in danger_u64(),
+            b in danger_u64(),
+            c in danger_u64(),
+        ) {
             let expected = (F::new(a) * F::new(b) + F::new(c)).as_canonical_u64();
             let got = canon(unsafe { mul_add_asm(a, b, c) });
             prop_assert_eq!(got, expected);


### PR DESCRIPTION
@Nashtare It looks like we had the same problem for `sub_asm`.

Also to avoid potential future issues, I've added a bunch of super edge case scenarios found by Claude to prevent potential future bugs during optimizations because these edge cases are often the trickiest to detect.

## Summary

The NEON `sub_asm` had the same shape of bug as the `add_asm` issue fixed in #1580: it never canonicalized the second operand, so for non-canonical `b > P` where `a < b - P`, the result was not congruent mod P. Current Poseidon2 callers happened to dodge it because they always pass a canonical first operand (the output of an `add_asm`, which is now reduced to `[0, P)`), but a future optimization could trip it. Applied the same canonicalize-`b`-then-final-reduction pattern.

A concrete failing input on `main`:

```rust
sub_asm(0, P + 1)
// returns 2^64 - 1, which canonicalizes to EPSILON - 1 = 4_294_967_294
// expected:                         P - 1 = 18_446_744_069_414_584_320
```

The PR also broadens test coverage for the NEON ASM primitives so this class of bug cannot slip through again. Uniform `u64` sampling lands in the non-canonical band `[P, 2^64)` with probability ~`2^-32`, so the existing proptests almost never exercised that range — which is why both this and the #1580 bug went undetected.

### What's added

- Inlined boundary tables (`EDGE_VALUES`) and biased proptest strategies (`danger_u64`, `danger_array`) in each test module.
- Exhaustive edge-pair / edge-triple checks for every scalar op: `add_asm`, `sub_asm`, `mul_asm`, `mul_add_asm`, `double_asm`, `div2/4/8/16/32_asm`, `div_2_32_asm`.
- 1000-iter chained-accumulation regression for `add_asm`.
- Danger-zone proptest variants for layer-level ops: `apply_mat4_asm`, `sbox_layer_asm`, `mds_light_permutation_asm` (w8/w12/w16), `external_round_asm`, `external_round_fused_w8`.
- Adversarial-state stress tests for the full Poseidon2 internal permute at widths 8/12/16/20 (generic + specialized) and the external rounds, compared against a field-level reference.
- Stress tests for Poseidon1 `cheap_matmul_asm_w8/w12` and `add_rc_asm`.

### Bug discovery

The new `test_sub_asm_edge_pairs` and `test_sub_asm_danger` tests fail on `main` (without the `sub_asm` fix in this PR) and pass with it.

## Test plan

- [x] `cargo test -p p3-goldilocks --lib` — all 319 tests pass on aarch64 NEON.
- [x] `test_sub_asm_edge_pairs` confirmed to fail on the unfixed `sub_asm`, pass with the fix.
- [x] All adversarial-state stress tests for Poseidon2 internal/external permutes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)