### PR TITLE
poseidon1: verify generated constants against Rust tables

### DIFF
--- a/baby-bear/src/poseidon1.rs
+++ b/baby-bear/src/poseidon1.rs
@@ -438,51 +438,40 @@ mod tests {
 
     type F = BabyBear;
 
-    fn assert_constants_match_generator(width: usize) {
-        let script =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-        let width_arg = width.to_string();
+    /// Run `generate_constants.py --check-rust-only` for `(field, width)` and panic on mismatch.
+    ///
+    /// Tries `python3`, `python`, then `py -3` to cover Linux, macOS, and Windows.
+    fn assert_constants_match_generator(field: &str, width: usize) {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let script = manifest.join("../poseidon1/generate_constants.py");
+        let repo_root = manifest.join("..");
+        let width_str = width.to_string();
 
-        let script_arg = script.to_string_lossy().into_owned();
-        let repo_root_arg = repo_root.to_string_lossy().into_owned();
-
-        let python_launchers: [(&str, &[&str]); 3] =
-            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let launchers: &[(&str, &[&str])] = &[("python3", &[]), ("python", &[]), ("py", &["-3"])];
         let mut errors = Vec::new();
 
-        for (bin, prefix) in python_launchers {
-            let mut cmd = Command::new(bin);
-            cmd.args(prefix);
-            cmd.args([
-                script_arg.as_str(),
-                "--field",
-                "babybear",
-                "--width",
-                width_arg.as_str(),
-                "--skip-mds",
-                "--check-rust-only",
-                "--repo-root",
-                repo_root_arg.as_str(),
-            ]);
-
-            match cmd.output() {
-                Ok(output) if output.status.success() => return,
-                Ok(output) => {
-                    errors.push(format!(
-                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
-                        output.status.code(),
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr),
-                    ));
-                }
-                Err(err) => errors.push(format!("{bin}: {err}")),
+        for &(bin, prefix) in launchers {
+            let result = Command::new(bin)
+                .args(prefix)
+                .arg(&script)
+                .args(["--field", field, "--width", &width_str])
+                .args(["--skip-mds", "--check-rust-only", "--repo-root"])
+                .arg(&repo_root)
+                .output();
+            match result {
+                Ok(out) if out.status.success() => return,
+                Ok(out) => errors.push(format!(
+                    "{bin}: exit {:?}\nstdout: {}\nstderr: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr),
+                )),
+                Err(e) => errors.push(format!("{bin}: {e}")),
             }
         }
-
         panic!(
-            "Failed to verify BabyBear Poseidon1 constants for width {width}.\n{}",
-            errors.join("\n\n")
+            "Failed to verify {field} Poseidon1 width {width}:\n{}",
+            errors.join("\n")
         );
     }
 
@@ -524,11 +513,11 @@ mod tests {
 
     #[test]
     fn test_poseidon_constants_match_generator_width_16() {
-        assert_constants_match_generator(16);
+        assert_constants_match_generator("babybear", 16);
     }
 
     #[test]
     fn test_poseidon_constants_match_generator_width_24() {
-        assert_constants_match_generator(24);
+        assert_constants_match_generator("babybear", 24);
     }
 }

--- a/baby-bear/src/poseidon1.rs
+++ b/baby-bear/src/poseidon1.rs
@@ -427,8 +427,7 @@ mod tests {
     extern crate std;
 
     use alloc::format;
-    use alloc::string::String;
-    use alloc::string::ToString;
+    use alloc::string::{String, ToString};
     use alloc::vec::Vec;
     use std::path::PathBuf;
     use std::process::Command;

--- a/baby-bear/src/poseidon1.rs
+++ b/baby-bear/src/poseidon1.rs
@@ -424,11 +424,68 @@ pub fn default_babybear_poseidon1_24() -> Poseidon1BabyBear<24> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
+    use std::path::PathBuf;
+    use std::process::Command;
+
     use p3_symmetric::Permutation;
 
     use super::*;
 
     type F = BabyBear;
+
+    fn assert_constants_match_generator(width: usize) {
+        let script =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+        let width_arg = width.to_string();
+
+        let script_arg = script.to_string_lossy().into_owned();
+        let repo_root_arg = repo_root.to_string_lossy().into_owned();
+
+        let python_launchers: [(&str, &[&str]); 3] =
+            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let mut errors = Vec::new();
+
+        for (bin, prefix) in python_launchers {
+            let mut cmd = Command::new(bin);
+            cmd.args(prefix);
+            cmd.args([
+                script_arg.as_str(),
+                "--field",
+                "babybear",
+                "--width",
+                width_arg.as_str(),
+                "--skip-mds",
+                "--check-rust-only",
+                "--repo-root",
+                repo_root_arg.as_str(),
+            ]);
+
+            match cmd.output() {
+                Ok(output) if output.status.success() => return,
+                Ok(output) => {
+                    errors.push(format!(
+                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr),
+                    ));
+                }
+                Err(err) => errors.push(format!("{bin}: {err}")),
+            }
+        }
+
+        panic!(
+            "Failed to verify BabyBear Poseidon1 constants for width {width}.\n{}",
+            errors.join("\n\n")
+        );
+    }
 
     #[test]
     fn test_poseidon_width_16() {
@@ -464,5 +521,15 @@ mod tests {
 
         perm.permute_mut(&mut input);
         assert_eq!(input, expected);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_16() {
+        assert_constants_match_generator(16);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_24() {
+        assert_constants_match_generator(24);
     }
 }

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -355,8 +355,15 @@ macro_rules! impl_packed_value {
     };
 }
 
-pub use {
-    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
-    impl_sum_prod_base_field, ring_sum,
-};
+pub use impl_add_assign;
+pub use impl_add_base_field;
+pub use impl_div_methods;
+pub use impl_mul_base_field;
+pub use impl_mul_methods;
+pub use impl_packed_field_div;
+pub use impl_packed_value;
+pub use impl_rng;
+pub use impl_sub_assign;
+pub use impl_sub_base_field;
+pub use impl_sum_prod_base_field;
+pub use ring_sum;

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -355,15 +355,8 @@ macro_rules! impl_packed_value {
     };
 }
 
-pub use impl_add_assign;
-pub use impl_add_base_field;
-pub use impl_div_methods;
-pub use impl_mul_base_field;
-pub use impl_mul_methods;
-pub use impl_packed_field_div;
-pub use impl_packed_value;
-pub use impl_rng;
-pub use impl_sub_assign;
-pub use impl_sub_base_field;
-pub use impl_sum_prod_base_field;
-pub use ring_sum;
+pub use {
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
+    impl_sum_prod_base_field, ring_sum,
+};

--- a/goldilocks/src/poseidon1.rs
+++ b/goldilocks/src/poseidon1.rs
@@ -923,8 +923,7 @@ mod tests {
     extern crate std;
 
     use alloc::format;
-    use alloc::string::String;
-    use alloc::string::ToString;
+    use alloc::string::{String, ToString};
     use alloc::vec::Vec;
     use std::path::PathBuf;
     use std::process::Command;

--- a/goldilocks/src/poseidon1.rs
+++ b/goldilocks/src/poseidon1.rs
@@ -920,6 +920,15 @@ pub fn default_goldilocks_poseidon1_12() -> Poseidon1Goldilocks<12> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
+    use std::path::PathBuf;
+    use std::process::Command;
+
     use p3_symmetric::Permutation;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
@@ -927,6 +936,54 @@ mod tests {
     use super::*;
 
     type F = Goldilocks;
+
+    fn assert_constants_match_generator(width: usize) {
+        let script =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+        let width_arg = width.to_string();
+
+        let script_arg = script.to_string_lossy().into_owned();
+        let repo_root_arg = repo_root.to_string_lossy().into_owned();
+
+        let python_launchers: [(&str, &[&str]); 3] =
+            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let mut errors = Vec::new();
+
+        for (bin, prefix) in python_launchers {
+            let mut cmd = Command::new(bin);
+            cmd.args(prefix);
+            cmd.args([
+                script_arg.as_str(),
+                "--field",
+                "goldilocks",
+                "--width",
+                width_arg.as_str(),
+                "--skip-mds",
+                "--check-rust-only",
+                "--repo-root",
+                repo_root_arg.as_str(),
+            ]);
+
+            match cmd.output() {
+                Ok(output) if output.status.success() => return,
+                Ok(output) => {
+                    errors.push(format!(
+                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr),
+                    ));
+                }
+                Err(err) => errors.push(format!("{bin}: {err}")),
+            }
+        }
+
+        panic!(
+            "Failed to verify Goldilocks Poseidon1 constants for width {width}.\n{}",
+            errors.join("\n\n")
+        );
+    }
 
     /// Known-answer test for width 8 (sequential 0..7 input).
     #[test]
@@ -972,6 +1029,16 @@ mod tests {
             18181291031484020550,
         ]);
         assert_eq!(input, expected);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_8() {
+        assert_constants_match_generator(8);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_12() {
+        assert_constants_match_generator(12);
     }
 
     /// Smoke test for width 16 with random constants.

--- a/goldilocks/src/poseidon1.rs
+++ b/goldilocks/src/poseidon1.rs
@@ -936,51 +936,40 @@ mod tests {
 
     type F = Goldilocks;
 
-    fn assert_constants_match_generator(width: usize) {
-        let script =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-        let width_arg = width.to_string();
+    /// Run `generate_constants.py --check-rust-only` for `(field, width)` and panic on mismatch.
+    ///
+    /// Tries `python3`, `python`, then `py -3` to cover Linux, macOS, and Windows.
+    fn assert_constants_match_generator(field: &str, width: usize) {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let script = manifest.join("../poseidon1/generate_constants.py");
+        let repo_root = manifest.join("..");
+        let width_str = width.to_string();
 
-        let script_arg = script.to_string_lossy().into_owned();
-        let repo_root_arg = repo_root.to_string_lossy().into_owned();
-
-        let python_launchers: [(&str, &[&str]); 3] =
-            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let launchers: &[(&str, &[&str])] = &[("python3", &[]), ("python", &[]), ("py", &["-3"])];
         let mut errors = Vec::new();
 
-        for (bin, prefix) in python_launchers {
-            let mut cmd = Command::new(bin);
-            cmd.args(prefix);
-            cmd.args([
-                script_arg.as_str(),
-                "--field",
-                "goldilocks",
-                "--width",
-                width_arg.as_str(),
-                "--skip-mds",
-                "--check-rust-only",
-                "--repo-root",
-                repo_root_arg.as_str(),
-            ]);
-
-            match cmd.output() {
-                Ok(output) if output.status.success() => return,
-                Ok(output) => {
-                    errors.push(format!(
-                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
-                        output.status.code(),
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr),
-                    ));
-                }
-                Err(err) => errors.push(format!("{bin}: {err}")),
+        for &(bin, prefix) in launchers {
+            let result = Command::new(bin)
+                .args(prefix)
+                .arg(&script)
+                .args(["--field", field, "--width", &width_str])
+                .args(["--skip-mds", "--check-rust-only", "--repo-root"])
+                .arg(&repo_root)
+                .output();
+            match result {
+                Ok(out) if out.status.success() => return,
+                Ok(out) => errors.push(format!(
+                    "{bin}: exit {:?}\nstdout: {}\nstderr: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr),
+                )),
+                Err(e) => errors.push(format!("{bin}: {e}")),
             }
         }
-
         panic!(
-            "Failed to verify Goldilocks Poseidon1 constants for width {width}.\n{}",
-            errors.join("\n\n")
+            "Failed to verify {field} Poseidon1 width {width}:\n{}",
+            errors.join("\n")
         );
     }
 
@@ -1032,12 +1021,12 @@ mod tests {
 
     #[test]
     fn test_poseidon_constants_match_generator_width_8() {
-        assert_constants_match_generator(8);
+        assert_constants_match_generator("goldilocks", 8);
     }
 
     #[test]
     fn test_poseidon_constants_match_generator_width_12() {
-        assert_constants_match_generator(12);
+        assert_constants_match_generator("goldilocks", 12);
     }
 
     /// Smoke test for width 16 with random constants.

--- a/koala-bear/src/poseidon1.rs
+++ b/koala-bear/src/poseidon1.rs
@@ -484,51 +484,40 @@ mod tests {
 
     type F = KoalaBear;
 
-    fn assert_constants_match_generator(width: usize) {
-        let script =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-        let width_arg = width.to_string();
+    /// Run `generate_constants.py --check-rust-only` for `(field, width)` and panic on mismatch.
+    ///
+    /// Tries `python3`, `python`, then `py -3` to cover Linux, macOS, and Windows.
+    fn assert_constants_match_generator(field: &str, width: usize) {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let script = manifest.join("../poseidon1/generate_constants.py");
+        let repo_root = manifest.join("..");
+        let width_str = width.to_string();
 
-        let script_arg = script.to_string_lossy().into_owned();
-        let repo_root_arg = repo_root.to_string_lossy().into_owned();
-
-        let python_launchers: [(&str, &[&str]); 3] =
-            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let launchers: &[(&str, &[&str])] = &[("python3", &[]), ("python", &[]), ("py", &["-3"])];
         let mut errors = Vec::new();
 
-        for (bin, prefix) in python_launchers {
-            let mut cmd = Command::new(bin);
-            cmd.args(prefix);
-            cmd.args([
-                script_arg.as_str(),
-                "--field",
-                "koalabear",
-                "--width",
-                width_arg.as_str(),
-                "--skip-mds",
-                "--check-rust-only",
-                "--repo-root",
-                repo_root_arg.as_str(),
-            ]);
-
-            match cmd.output() {
-                Ok(output) if output.status.success() => return,
-                Ok(output) => {
-                    errors.push(format!(
-                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
-                        output.status.code(),
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr),
-                    ));
-                }
-                Err(err) => errors.push(format!("{bin}: {err}")),
+        for &(bin, prefix) in launchers {
+            let result = Command::new(bin)
+                .args(prefix)
+                .arg(&script)
+                .args(["--field", field, "--width", &width_str])
+                .args(["--skip-mds", "--check-rust-only", "--repo-root"])
+                .arg(&repo_root)
+                .output();
+            match result {
+                Ok(out) if out.status.success() => return,
+                Ok(out) => errors.push(format!(
+                    "{bin}: exit {:?}\nstdout: {}\nstderr: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr),
+                )),
+                Err(e) => errors.push(format!("{bin}: {e}")),
             }
         }
-
         panic!(
-            "Failed to verify KoalaBear Poseidon1 constants for width {width}.\n{}",
-            errors.join("\n\n")
+            "Failed to verify {field} Poseidon1 width {width}:\n{}",
+            errors.join("\n")
         );
     }
 
@@ -570,11 +559,11 @@ mod tests {
 
     #[test]
     fn test_poseidon_constants_match_generator_width_16() {
-        assert_constants_match_generator(16);
+        assert_constants_match_generator("koalabear", 16);
     }
 
     #[test]
     fn test_poseidon_constants_match_generator_width_24() {
-        assert_constants_match_generator(24);
+        assert_constants_match_generator("koalabear", 24);
     }
 }

--- a/koala-bear/src/poseidon1.rs
+++ b/koala-bear/src/poseidon1.rs
@@ -473,8 +473,7 @@ mod tests {
     extern crate std;
 
     use alloc::format;
-    use alloc::string::String;
-    use alloc::string::ToString;
+    use alloc::string::{String, ToString};
     use alloc::vec::Vec;
     use std::path::PathBuf;
     use std::process::Command;

--- a/koala-bear/src/poseidon1.rs
+++ b/koala-bear/src/poseidon1.rs
@@ -470,11 +470,68 @@ pub fn default_koalabear_poseidon1_24() -> Poseidon1KoalaBear<24> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
+    use std::path::PathBuf;
+    use std::process::Command;
+
     use p3_symmetric::Permutation;
 
     use super::*;
 
     type F = KoalaBear;
+
+    fn assert_constants_match_generator(width: usize) {
+        let script =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../poseidon1/generate_constants.py");
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+        let width_arg = width.to_string();
+
+        let script_arg = script.to_string_lossy().into_owned();
+        let repo_root_arg = repo_root.to_string_lossy().into_owned();
+
+        let python_launchers: [(&str, &[&str]); 3] =
+            [("python3", &[]), ("python", &[]), ("py", &["-3"])];
+        let mut errors = Vec::new();
+
+        for (bin, prefix) in python_launchers {
+            let mut cmd = Command::new(bin);
+            cmd.args(prefix);
+            cmd.args([
+                script_arg.as_str(),
+                "--field",
+                "koalabear",
+                "--width",
+                width_arg.as_str(),
+                "--skip-mds",
+                "--check-rust-only",
+                "--repo-root",
+                repo_root_arg.as_str(),
+            ]);
+
+            match cmd.output() {
+                Ok(output) if output.status.success() => return,
+                Ok(output) => {
+                    errors.push(format!(
+                        "{bin}: exit {:?}\nstdout:\n{}\nstderr:\n{}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr),
+                    ));
+                }
+                Err(err) => errors.push(format!("{bin}: {err}")),
+            }
+        }
+
+        panic!(
+            "Failed to verify KoalaBear Poseidon1 constants for width {width}.\n{}",
+            errors.join("\n\n")
+        );
+    }
 
     #[test]
     fn test_poseidon_width_16() {
@@ -510,5 +567,15 @@ mod tests {
 
         perm.permute_mut(&mut input);
         assert_eq!(input, expected);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_16() {
+        assert_constants_match_generator(16);
+    }
+
+    #[test]
+    fn test_poseidon_constants_match_generator_width_24() {
+        assert_constants_match_generator(24);
     }
 }

--- a/poseidon1/generate_constants.py
+++ b/poseidon1/generate_constants.py
@@ -1210,82 +1210,56 @@ def format_json_poseidon1(
 # =============================================================================
 
 
+_NUMBER_RE = re.compile(r"0x[0-9a-fA-F_]+|\d+")
+
+
+def _parse_int(token):
+    token = token.replace("_", "")
+    return int(token, 16) if token.lower().startswith("0x") else int(token)
+
+
 def _parse_rust_round_constants(rust_path, const_name, width):
     """
     Parse a Poseidon1 2D round-constant array from a Rust source file.
 
-    Returns:
-        List[List[int]] with shape [num_rounds][width].
+    Expects a declaration of the form:
+
+        pub const NAME: [[T; W]; R] = ...::new_2d_array([ <body> ]);
+
+    Returns a list of `R` rows, each a list of `W` ints.
     """
     source = rust_path.read_text(encoding="utf-8")
     pattern = re.compile(
-        rf"pub const {re.escape(const_name)}\s*:\s*\[\[[^\]]+;\s*{width}\s*\];\s*(\d+)\s*\]\s*="
-        rf"\s*[^=]+?::new_2d_array\(\[(.*?)\]\);",
+        rf"pub const {re.escape(const_name)}\s*:\s*\[\s*\[[^;]+;\s*{width}\s*\]\s*;\s*(\d+)\s*\]"
+        rf".*?new_2d_array\(\s*\[(.*?)\]\s*\)\s*;",
         re.S,
     )
     match = pattern.search(source)
     if not match:
+        raise ValueError(f"Could not find {const_name} (width {width}) in {rust_path}")
+
+    rounds = int(match.group(1))
+    # Strip `// ...` line comments before extracting numeric literals.
+    body = "\n".join(line.split("//", 1)[0] for line in match.group(2).splitlines())
+    values = [_parse_int(tok) for tok in _NUMBER_RE.findall(body)]
+
+    expected = rounds * width
+    if len(values) != expected:
         raise ValueError(
-            f"Could not find constant '{const_name}' with width {width} in {rust_path}"
+            f"{const_name}: expected {expected} values ({rounds}×{width}), found {len(values)}"
         )
-
-    declared_rounds = int(match.group(1))
-    body = match.group(2)
-
-    # Strip line comments so numeric extraction isn't polluted by doc examples.
-    body = "\n".join(line.split("//", 1)[0] for line in body.splitlines())
-
-    # Collect top-level rows from the 2D array payload.
-    rows = []
-    depth = 0
-    current = []
-    for ch in body:
-        if ch == "[":
-            depth += 1
-            if depth == 1:
-                current = []
-                continue
-        if ch == "]":
-            if depth == 1:
-                rows.append("".join(current))
-                current = []
-                depth -= 1
-                continue
-            depth -= 1
-        if depth >= 1:
-            current.append(ch)
-
-    parsed = []
-    for row in rows:
-        tokens = re.findall(r"0x[0-9a-fA-F_]+|\d+", row)
-        values = [
-            int(tok.replace("_", ""), 16) if tok.lower().startswith("0x") else int(tok)
-            for tok in tokens
-        ]
-        parsed.append(values)
-
-    if len(parsed) != declared_rounds:
-        raise ValueError(
-            f"{const_name} in {rust_path} declares {declared_rounds} rounds but parsed {len(parsed)}"
-        )
-    for idx, values in enumerate(parsed):
-        if len(values) != width:
-            raise ValueError(
-                f"{const_name} row {idx} in {rust_path} has width {len(values)}, expected {width}"
-            )
-    return parsed
+    return [values[r * width : (r + 1) * width] for r in range(rounds)]
 
 
-def verify_generated_constants_against_rust(field_name, width, generated_round_constants, repo_root=None):
+def verify_generated_constants_against_rust(field_name, width, generated, repo_root=None):
     """
-    Compare freshly generated constants with in-tree Rust constants.
+    Compare freshly generated constants against in-tree Rust constants.
 
-    Returns:
-        (ok: bool, message: str)
+    Returns (ok, message).
     """
     key = (field_name, width)
     if key not in RUST_ROUND_CONSTANTS:
-        return False, f"No in-tree mapping defined for field={field_name}, width={width}"
+        return False, f"No mapping for field={field_name}, width={width}"
 
     root = Path(repo_root) if repo_root else Path(__file__).resolve().parent.parent
     rel_path, const_name = RUST_ROUND_CONSTANTS[key]
@@ -1293,31 +1267,22 @@ def verify_generated_constants_against_rust(field_name, width, generated_round_c
     if not rust_path.exists():
         return False, f"Rust file not found: {rust_path}"
 
-    rust_constants = _parse_rust_round_constants(rust_path, const_name, width)
+    rust = _parse_rust_round_constants(rust_path, const_name, width)
+    if rust == generated:
+        return True, f"Rust constants match generated values: {const_name}"
 
-    if len(rust_constants) != len(generated_round_constants):
-        return (
-            False,
-            f"Round count mismatch for {const_name}: rust={len(rust_constants)} "
-            f"generated={len(generated_round_constants)}",
-        )
-
-    for round_idx, (rust_row, gen_row) in enumerate(zip(rust_constants, generated_round_constants)):
-        if len(rust_row) != len(gen_row):
-            return (
-                False,
-                f"Width mismatch at round {round_idx} for {const_name}: "
-                f"rust={len(rust_row)} generated={len(gen_row)}",
-            )
-        for col_idx, (rust_v, gen_v) in enumerate(zip(rust_row, gen_row)):
-            if rust_v != gen_v:
-                return (
-                    False,
-                    f"Mismatch in {const_name} at round {round_idx}, col {col_idx}: "
-                    f"rust={hex(rust_v)} generated={hex(gen_v)}",
+    # Find the first divergence to report.
+    for r, (rust_row, gen_row) in enumerate(zip(rust, generated)):
+        for c, (rv, gv) in enumerate(zip(rust_row, gen_row)):
+            if rv != gv:
+                return False, (
+                    f"{const_name}: mismatch at round {r}, col {c}: "
+                    f"rust={hex(rv)} generated={hex(gv)}"
                 )
-
-    return True, f"Rust constants match generated values: {const_name}"
+    return False, (
+        f"{const_name}: shape mismatch (rust {len(rust)} rounds, "
+        f"generated {len(generated)} rounds)"
+    )
 
 
 # =============================================================================

--- a/poseidon1/generate_constants.py
+++ b/poseidon1/generate_constants.py
@@ -32,8 +32,10 @@ Usage:
 
 import argparse
 import json
+import re
 import sys
 from math import ceil, floor, gcd, log, log2, inf
+from pathlib import Path
 
 # =============================================================================
 # Field Definitions
@@ -56,6 +58,16 @@ FIELDS = {
         "prime": (1 << 31) - 1,
         "valid_widths": [16, 32],
     },
+}
+
+# Round-constant locations for in-tree reproducibility checks.
+RUST_ROUND_CONSTANTS = {
+    ("babybear", 16): ("baby-bear/src/poseidon1.rs", "BABYBEAR_POSEIDON1_RC_16"),
+    ("babybear", 24): ("baby-bear/src/poseidon1.rs", "BABYBEAR_POSEIDON1_RC_24"),
+    ("koalabear", 16): ("koala-bear/src/poseidon1.rs", "KOALABEAR_POSEIDON1_RC_16"),
+    ("koalabear", 24): ("koala-bear/src/poseidon1.rs", "KOALABEAR_POSEIDON1_RC_24"),
+    ("goldilocks", 8): ("goldilocks/src/poseidon1.rs", "GOLDILOCKS_POSEIDON1_RC_8"),
+    ("goldilocks", 12): ("goldilocks/src/poseidon1.rs", "GOLDILOCKS_POSEIDON1_RC_12"),
 }
 
 
@@ -1194,6 +1206,121 @@ def format_json_poseidon1(
 
 
 # =============================================================================
+# Rust Constant Verification
+# =============================================================================
+
+
+def _parse_rust_round_constants(rust_path, const_name, width):
+    """
+    Parse a Poseidon1 2D round-constant array from a Rust source file.
+
+    Returns:
+        List[List[int]] with shape [num_rounds][width].
+    """
+    source = rust_path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"pub const {re.escape(const_name)}\s*:\s*\[\[[^\]]+;\s*{width}\s*\];\s*(\d+)\s*\]\s*="
+        rf"\s*[^=]+?::new_2d_array\(\[(.*?)\]\);",
+        re.S,
+    )
+    match = pattern.search(source)
+    if not match:
+        raise ValueError(
+            f"Could not find constant '{const_name}' with width {width} in {rust_path}"
+        )
+
+    declared_rounds = int(match.group(1))
+    body = match.group(2)
+
+    # Strip line comments so numeric extraction isn't polluted by doc examples.
+    body = "\n".join(line.split("//", 1)[0] for line in body.splitlines())
+
+    # Collect top-level rows from the 2D array payload.
+    rows = []
+    depth = 0
+    current = []
+    for ch in body:
+        if ch == "[":
+            depth += 1
+            if depth == 1:
+                current = []
+                continue
+        if ch == "]":
+            if depth == 1:
+                rows.append("".join(current))
+                current = []
+                depth -= 1
+                continue
+            depth -= 1
+        if depth >= 1:
+            current.append(ch)
+
+    parsed = []
+    for row in rows:
+        tokens = re.findall(r"0x[0-9a-fA-F_]+|\d+", row)
+        values = [
+            int(tok.replace("_", ""), 16) if tok.lower().startswith("0x") else int(tok)
+            for tok in tokens
+        ]
+        parsed.append(values)
+
+    if len(parsed) != declared_rounds:
+        raise ValueError(
+            f"{const_name} in {rust_path} declares {declared_rounds} rounds but parsed {len(parsed)}"
+        )
+    for idx, values in enumerate(parsed):
+        if len(values) != width:
+            raise ValueError(
+                f"{const_name} row {idx} in {rust_path} has width {len(values)}, expected {width}"
+            )
+    return parsed
+
+
+def verify_generated_constants_against_rust(field_name, width, generated_round_constants, repo_root=None):
+    """
+    Compare freshly generated constants with in-tree Rust constants.
+
+    Returns:
+        (ok: bool, message: str)
+    """
+    key = (field_name, width)
+    if key not in RUST_ROUND_CONSTANTS:
+        return False, f"No in-tree mapping defined for field={field_name}, width={width}"
+
+    root = Path(repo_root) if repo_root else Path(__file__).resolve().parent.parent
+    rel_path, const_name = RUST_ROUND_CONSTANTS[key]
+    rust_path = root / rel_path
+    if not rust_path.exists():
+        return False, f"Rust file not found: {rust_path}"
+
+    rust_constants = _parse_rust_round_constants(rust_path, const_name, width)
+
+    if len(rust_constants) != len(generated_round_constants):
+        return (
+            False,
+            f"Round count mismatch for {const_name}: rust={len(rust_constants)} "
+            f"generated={len(generated_round_constants)}",
+        )
+
+    for round_idx, (rust_row, gen_row) in enumerate(zip(rust_constants, generated_round_constants)):
+        if len(rust_row) != len(gen_row):
+            return (
+                False,
+                f"Width mismatch at round {round_idx} for {const_name}: "
+                f"rust={len(rust_row)} generated={len(gen_row)}",
+            )
+        for col_idx, (rust_v, gen_v) in enumerate(zip(rust_row, gen_row)):
+            if rust_v != gen_v:
+                return (
+                    False,
+                    f"Mismatch in {const_name} at round {round_idx}, col {col_idx}: "
+                    f"rust={hex(rust_v)} generated={hex(gen_v)}",
+                )
+
+    return True, f"Rust constants match generated values: {const_name}"
+
+
+# =============================================================================
 # CLI
 # =============================================================================
 
@@ -1237,7 +1364,21 @@ def main():
         "--test-vector", action="store_true",
         help="Compute and print a test vector using the reference permutation",
     )
+    parser.add_argument(
+        "--check-rust", action="store_true",
+        help="Verify generated round constants against in-tree Rust constants for this field/width",
+    )
+    parser.add_argument(
+        "--check-rust-only", action="store_true",
+        help="Run --check-rust and suppress formatted constant output",
+    )
+    parser.add_argument(
+        "--repo-root", default=None,
+        help="Repository root to use for --check-rust (defaults to script-relative root)",
+    )
     args = parser.parse_args()
+    if args.check_rust_only:
+        args.check_rust = True
 
     field_info = FIELDS[args.field]
     p = field_info["prime"]
@@ -1275,6 +1416,17 @@ def main():
         print("Generating round constants...", flush=True)
     round_constants = generate_round_constants_poseidon1(grain, p, n, t, R_F, R_P)
 
+    # --- Optional in-tree Rust constant verification ---
+    if args.check_rust:
+        ok, msg = verify_generated_constants_against_rust(
+            args.field, t, round_constants, repo_root=args.repo_root,
+        )
+        if not ok:
+            print(f"Rust constant verification failed: {msg}", file=sys.stderr)
+            sys.exit(1)
+        if args.verbose:
+            print(msg)
+
     # --- Generate MDS matrix ---
     if not args.skip_mds:
         if args.verbose:
@@ -1292,10 +1444,11 @@ def main():
     fmt_args = (
         args.field, t, round_constants, mds, p, n, alpha, R_F, R_P, args.skip_mds,
     )
-    if args.format == "default":
-        print(format_default_poseidon1(*fmt_args))
-    elif args.format == "json":
-        print(format_json_poseidon1(*fmt_args))
+    if not args.check_rust_only:
+        if args.format == "default":
+            print(format_default_poseidon1(*fmt_args))
+        elif args.format == "json":
+            print(format_json_poseidon1(*fmt_args))
 
     # --- Test vector ---
     if args.test_vector:


### PR DESCRIPTION
Add reproducibility checks that compare generated Poseidon1 constants with in-tree Rust tables, and enforce them via crate-level regression tests for BabyBear, KoalaBear, and Goldilocks.