### PR TITLE
fix(fri): enforce num_chunks > 1 in HidingFriPcs::get_quotient_ldes

### DIFF
--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -166,6 +166,10 @@ where
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
         num_chunks: usize,
     ) -> Vec<RowMajorMatrix<Val>> {
+        assert!(
+            num_chunks > 1,
+            "num_chunks must be > 1 to preserve hiding (got {num_chunks})"
+        );
         let (domains, evaluations): (Vec<_>, Vec<_>) = evaluations.into_iter().unzip();
         let cis = get_zp_cis(&domains);
         let last_chunk = num_chunks - 1;


### PR DESCRIPTION
`HidingFriPcs::get_quotient_ldes` documents that `num_chunks ∈ {0, 1}` should panic — the `num_chunks = 1` case is explicitly called out as one that "would not be hiding". In practice the implementation only relied on `num_chunks - 1` to fail indirectly:                                                       
   
  - `num_chunks = 0` panics by integer underflow (debug) or out-of-bounds index on `cis[usize::MAX]` (release) — a panic, but not an explicit one.                                                                                                                                                                     
  - `num_chunks = 1` does **not** panic. `last_chunk = 0` makes the `mul_coeffs` loop empty and `all_random_values` becomes all-zero (`(len - 1) * h * w = 0`, padded by `repeat_n(Val::ZERO, h * w)`). The function silently produces a non-hiding commitment, contradicting the doc and the security-sensitive intent
   of `HidingFriPcs`.                                                                                                                                                                                                                                                                                                  
   
This adds an explicit `assert!(num_chunks > 1, ...)` at the top of the function so both invalid inputs are rejected uniformly with a clear message, matching the documented contract.                                                                                                                                
   
The only in-tree caller (`batch-stark/src/prover.rs`) computes `n_chunks = 1 << (lq_chunks + is_zk())`, which is `≥ 2` whenever the hiding PCS is used, so no behavior change for existing callers — this only hardens the public trait method against external misuse. 