### PR TITLE
feat: add p3-zk-alloc — bump+reset arena allocator for proving workloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "uni-stark",
     "util",
     "whir",
+    "zk-alloc",
 ]
 
 [workspace.lints]
@@ -125,6 +126,7 @@ p3-symmetric = { path = "symmetric", version = "0.5.1" }
 p3-uni-stark = { path = "uni-stark", version = "0.5.1" }
 p3-util = { path = "util", version = "0.5.1" }
 p3-whir = { path = "whir", version = "0.5.1" }
+p3-zk-alloc = { path = "zk-alloc", version = "0.5.1" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.

--- a/poseidon1-air/Cargo.toml
+++ b/poseidon1-air/Cargo.toml
@@ -31,6 +31,7 @@ p3-merkle-tree = { path = "../merkle-tree" }
 p3-monty-31 = { path = "../monty-31" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }
+p3-zk-alloc = { path = "../zk-alloc" }
 
 criterion = { version = "0.8", features = ["html_reports"] }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
@@ -38,9 +39,6 @@ tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 tikv-jemallocator = "0.6"
-
-[dev-dependencies.p3-zk-alloc]
-path = "../zk-alloc"
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]

--- a/poseidon1-air/Cargo.toml
+++ b/poseidon1-air/Cargo.toml
@@ -39,8 +39,12 @@ tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 tikv-jemallocator = "0.6"
 
+[dev-dependencies.p3-zk-alloc]
+path = "../zk-alloc"
+
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
+zk-alloc = []
 
 [[bench]]
 name = "poseidon1-air"

--- a/poseidon1-air/examples/prove_poseidon1_baby_bear_keccak.rs
+++ b/poseidon1-air/examples/prove_poseidon1_baby_bear_keccak.rs
@@ -17,7 +17,7 @@ use p3_poseidon1::Poseidon1Constants;
 use p3_poseidon1_air::VectorizedPoseidon1Air;
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
 use p3_uni_stark::{StarkConfig, prove, verify};
-#[cfg(target_family = "unix")]
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
@@ -25,9 +25,13 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-#[cfg(target_family = "unix")]
+#[cfg(feature = "zk-alloc")]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: p3_zk_alloc::ZkAllocator = p3_zk_alloc::ZkAllocator;
+
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
+#[global_allocator]
+static GLOBAL_JE: Jemalloc = Jemalloc;
 
 // Poseidon1 parameters for BabyBear width 16.
 const WIDTH: usize = 16;
@@ -62,12 +66,14 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    // Run multiple prove-verify cycles to warm up and benchmark.
-    const PROOFS: usize = 2;
-    for _ in 1..PROOFS {
-        prove_and_verify()?;
-    }
-    prove_and_verify()
+    prove_and_verify()?;
+
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::begin_phase();
+    let result = prove_and_verify();
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::end_phase();
+    result
 }
 
 /// Run one complete prove-verify cycle.

--- a/poseidon1-air/examples/prove_poseidon1_baby_bear_keccak.rs
+++ b/poseidon1-air/examples/prove_poseidon1_baby_bear_keccak.rs
@@ -70,6 +70,10 @@ fn main() -> Result<(), impl Debug> {
 
     #[cfg(feature = "zk-alloc")]
     p3_zk_alloc::begin_phase();
+    prove_and_verify()?;
+
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::begin_phase();
     let result = prove_and_verify();
     #[cfg(feature = "zk-alloc")]
     p3_zk_alloc::end_phase();

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -30,15 +30,13 @@ p3-koala-bear = { path = "../koala-bear" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }
+p3-zk-alloc = { path = "../zk-alloc" }
 
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 tikv-jemallocator = "0.6"
-
-[dev-dependencies.p3-zk-alloc]
-path = "../zk-alloc"
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -37,8 +37,12 @@ tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 tikv-jemallocator = "0.6"
 
+[dev-dependencies.p3-zk-alloc]
+path = "../zk-alloc"
+
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
+zk-alloc = []
 
 [lints]
 workspace = true

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -15,7 +15,7 @@ use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, Serializing
 use p3_uni_stark::{StarkConfig, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-#[cfg(target_family = "unix")]
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
@@ -23,9 +23,13 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-#[cfg(target_family = "unix")]
+#[cfg(feature = "zk-alloc")]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: p3_zk_alloc::ZkAllocator = p3_zk_alloc::ZkAllocator;
+
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
+#[global_allocator]
+static GLOBAL_JE: Jemalloc = Jemalloc;
 
 const WIDTH: usize = 16;
 const SBOX_DEGREE: u64 = BABYBEAR_S_BOX_DEGREE;

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -15,7 +15,7 @@ use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, Serializing
 use p3_uni_stark::{StarkConfig, prove, verify};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
-#[cfg(target_family = "unix")]
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
@@ -23,9 +23,13 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-#[cfg(target_family = "unix")]
+#[cfg(feature = "zk-alloc")]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: p3_zk_alloc::ZkAllocator = p3_zk_alloc::ZkAllocator;
+
+#[cfg(all(target_family = "unix", not(feature = "zk-alloc")))]
+#[global_allocator]
+static GLOBAL_JE: Jemalloc = Jemalloc;
 
 const WIDTH: usize = 16;
 const SBOX_DEGREE: u64 = KOALABEAR_S_BOX_DEGREE;
@@ -52,11 +56,14 @@ fn main() -> Result<(), impl Debug> {
         .with(ForestLayer::default())
         .init();
 
-    const PROOFS: usize = 2;
-    for _ in 1..PROOFS {
-        prove_and_verify()?;
-    }
-    prove_and_verify()
+    prove_and_verify()?;
+
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::begin_phase();
+    let result = prove_and_verify();
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::end_phase();
+    result
 }
 
 fn prove_and_verify() -> Result<(), impl Debug> {

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -60,6 +60,10 @@ fn main() -> Result<(), impl Debug> {
 
     #[cfg(feature = "zk-alloc")]
     p3_zk_alloc::begin_phase();
+    prove_and_verify()?;
+
+    #[cfg(feature = "zk-alloc")]
+    p3_zk_alloc::begin_phase();
     let result = prove_and_verify();
     #[cfg(feature = "zk-alloc")]
     p3_zk_alloc::end_phase();

--- a/zk-alloc/Cargo.toml
+++ b/zk-alloc/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "p3-zk-alloc"
+description = "Bump+reset arena allocator for ZK proving workloads"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+
+[target.'cfg(not(all(target_os = "linux", target_arch = "x86_64")))'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/zk-alloc/Cargo.toml
+++ b/zk-alloc/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 
-[target.'cfg(not(all(target_os = "linux", target_arch = "x86_64")))'.dependencies]
+[target.'cfg(all(target_family = "unix", not(all(target_os = "linux", target_arch = "x86_64"))))'.dependencies]
 libc = "0.2"
 
 [lints]

--- a/zk-alloc/src/lib.rs
+++ b/zk-alloc/src/lib.rs
@@ -1,0 +1,207 @@
+//! Bump-pointer arena allocator for ZK proving workloads.
+//!
+//! One mmap region split into per-thread slabs. Allocation = increment a thread-local
+//! pointer; free = no-op. `begin_phase()` resets the arena: each thread's next
+//! allocation starts over at the beginning of its slab, overwriting the previous
+//! phase's data. Allocations that don't fit (too large, or beyond max threads) fall
+//! back to the system allocator.
+//!
+//! ```ignore
+//! loop {
+//!     begin_phase();               // arena ON; slabs reset lazily
+//!     let res = heavy_work();      // fast bump increments
+//!     end_phase();                 // arena OFF; new allocations go to System
+//!     let copy = res.clone();      // detach from arena before next phase resets it
+//! }
+//! ```
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::cell::Cell;
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+mod syscall;
+
+const SLAB_SIZE: usize = 8 << 30; // 8GB
+const SLACK: usize = 4;
+
+#[derive(Debug)]
+pub struct ZkAllocator;
+
+/// Incremented by `begin_phase()`. Every thread caches the last value it saw in
+/// `ARENA_GEN`; when they differ, the thread resets its allocation cursor to the start
+/// of its slab on the next allocation. This is how a single store on the main thread
+/// "resets" every other thread's slab without any cross-thread synchronization.
+static GENERATION: AtomicUsize = AtomicUsize::new(0);
+
+/// Master switch for the arena. `true` (set by `begin_phase`) routes allocations
+/// through the arena; `false` (set by `end_phase`) routes them to the system allocator.
+static ARENA_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Base address of the mmap'd region, or `0` before `ensure_region` runs. Read on
+/// every `dealloc` to test whether a pointer belongs to us.
+static REGION_BASE: AtomicUsize = AtomicUsize::new(0);
+
+/// Total size of the mmap'd region. Set once alongside REGION_BASE.
+static REGION_SIZE: AtomicUsize = AtomicUsize::new(0);
+
+/// Synchronizes the one-time mmap so concurrent first-allocators don't race.
+static REGION_INIT: Once = Once::new();
+
+/// Monotonic counter handed out to threads to pick their slab. `fetch_add`'d once per
+/// thread on its first arena allocation. Threads that get `idx >= max_threads` mark
+/// themselves `ARENA_NO_SLAB` and permanently fall through to the system allocator.
+static THREAD_IDX: AtomicUsize = AtomicUsize::new(0);
+
+/// Max threads determined at init time from available_parallelism() + SLACK.
+static MAX_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+static OVERFLOW_COUNT: AtomicUsize = AtomicUsize::new(0);
+static OVERFLOW_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    /// Where this thread's next allocation lands. Advanced past each allocation.
+    static ARENA_PTR: Cell<usize> = const { Cell::new(0) };
+    /// One past the last byte of this thread's slab.
+    static ARENA_END: Cell<usize> = const { Cell::new(0) };
+    /// Base address of this thread's slab (`0` = not yet claimed).
+    static ARENA_BASE: Cell<usize> = const { Cell::new(0) };
+    /// Last `GENERATION` value this thread observed.
+    static ARENA_GEN: Cell<usize> = const { Cell::new(0) };
+    /// `true` if this thread arrived after all slabs were claimed.
+    static ARENA_NO_SLAB: Cell<bool> = const { Cell::new(false) };
+}
+
+fn ensure_region() -> usize {
+    REGION_INIT.call_once(|| {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        let max_threads = cpus + SLACK;
+        let region_size = SLAB_SIZE * max_threads;
+
+        // SAFETY: mmap_anonymous returns a page-aligned pointer or null.
+        // MAP_NORESERVE means no physical memory is committed until pages are touched.
+        let ptr = unsafe { syscall::mmap_anonymous(region_size) };
+        if ptr.is_null() {
+            std::process::abort();
+        }
+        unsafe { syscall::madvise(ptr, region_size, syscall::MADV_NOHUGEPAGE) };
+        MAX_THREADS.store(max_threads, Ordering::Release);
+        REGION_SIZE.store(region_size, Ordering::Release);
+        REGION_BASE.store(ptr as usize, Ordering::Release);
+    });
+    REGION_BASE.load(Ordering::Acquire)
+}
+
+/// Activates the arena and resets every thread's slab. All allocations until the next
+/// `end_phase()` go to the arena; the previous phase's data is overwritten in place.
+pub fn begin_phase() {
+    ensure_region();
+    GENERATION.fetch_add(1, Ordering::Release);
+    ARENA_ACTIVE.store(true, Ordering::Release);
+}
+
+/// Deactivates the arena. New allocations go to the system allocator; existing arena
+/// pointers stay valid until the next `begin_phase()` resets the slabs.
+pub fn end_phase() {
+    ARENA_ACTIVE.store(false, Ordering::Release);
+}
+
+/// Returns (overflow_count, overflow_bytes) — allocations that fell through to System
+/// because they exceeded the slab or arrived after all slabs were claimed.
+pub fn overflow_stats() -> (usize, usize) {
+    (
+        OVERFLOW_COUNT.load(Ordering::Relaxed),
+        OVERFLOW_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+pub fn reset_overflow_stats() {
+    OVERFLOW_COUNT.store(0, Ordering::Relaxed);
+    OVERFLOW_BYTES.store(0, Ordering::Relaxed);
+}
+
+#[cold]
+#[inline(never)]
+unsafe fn arena_alloc_cold(size: usize, align: usize) -> *mut u8 {
+    let generation = GENERATION.load(Ordering::Relaxed);
+    if !ARENA_NO_SLAB.get() && ARENA_GEN.get() != generation {
+        let mut base = ARENA_BASE.get();
+        if base == 0 {
+            let region = ensure_region();
+            let max = MAX_THREADS.load(Ordering::Relaxed);
+            let idx = THREAD_IDX.fetch_add(1, Ordering::Relaxed);
+            if idx >= max {
+                ARENA_NO_SLAB.set(true);
+                return unsafe {
+                    std::alloc::System.alloc(Layout::from_size_align_unchecked(size, align))
+                };
+            }
+            base = region + idx * SLAB_SIZE;
+            ARENA_BASE.set(base);
+            ARENA_END.set(base + SLAB_SIZE);
+        }
+        ARENA_PTR.set(base);
+        ARENA_GEN.set(generation);
+        let aligned = (base + align - 1) & !(align - 1);
+        let new_ptr = aligned + size;
+        if new_ptr <= ARENA_END.get() {
+            ARENA_PTR.set(new_ptr);
+            return aligned as *mut u8;
+        }
+    }
+    OVERFLOW_COUNT.fetch_add(1, Ordering::Relaxed);
+    OVERFLOW_BYTES.fetch_add(size, Ordering::Relaxed);
+    unsafe { std::alloc::System.alloc(Layout::from_size_align_unchecked(size, align)) }
+}
+
+// SAFETY: All pointers returned are either from our mmap'd region (valid, aligned,
+// non-overlapping per thread) or from System. The arena is thread-local so no data
+// races. Relaxed ordering on ARENA_ACTIVE/GENERATION is sound: worst case a thread
+// sees a stale value and does one extra system-alloc before picking up the new
+// generation on the next call.
+unsafe impl GlobalAlloc for ZkAllocator {
+    #[inline(always)]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ARENA_ACTIVE.load(Ordering::Relaxed) {
+            let generation = GENERATION.load(Ordering::Relaxed);
+            if ARENA_GEN.get() == generation {
+                let ptr = ARENA_PTR.get();
+                let aligned = (ptr + layout.align() - 1) & !(layout.align() - 1);
+                let new_ptr = aligned + layout.size();
+                if new_ptr <= ARENA_END.get() {
+                    ARENA_PTR.set(new_ptr);
+                    return aligned as *mut u8;
+                }
+            }
+            return unsafe { arena_alloc_cold(layout.size(), layout.align()) };
+        }
+        unsafe { std::alloc::System.alloc(layout) }
+    }
+
+    #[inline(always)]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let addr = ptr as usize;
+        let base = REGION_BASE.load(Ordering::Relaxed);
+        let region_size = REGION_SIZE.load(Ordering::Relaxed);
+        if base != 0 && addr >= base && addr < base + region_size {
+            return;
+        }
+        unsafe { std::alloc::System.dealloc(ptr, layout) };
+    }
+
+    #[inline(always)]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if new_size <= layout.size() {
+            return ptr;
+        }
+        let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
+        let new_ptr = unsafe { self.alloc(new_layout) };
+        if !new_ptr.is_null() {
+            unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size()) };
+            unsafe { self.dealloc(ptr, layout) };
+        }
+        new_ptr
+    }
+}

--- a/zk-alloc/src/lib.rs
+++ b/zk-alloc/src/lib.rs
@@ -6,6 +6,10 @@
 //! phase's data. Allocations that don't fit (too large, or beyond max threads) fall
 //! back to the system allocator.
 //!
+//! Slab size defaults to 8GB per thread. Set `ZK_ALLOC_SLAB_GB` to override
+//! (e.g. `ZK_ALLOC_SLAB_GB=12` for large workloads). Use `overflow_stats()`
+//! to check if allocations spill to the system allocator.
+//!
 //! ```ignore
 //! loop {
 //!     begin_phase();               // arena ON; slabs reset lazily
@@ -22,11 +26,15 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 mod syscall;
 
-const SLAB_SIZE: usize = 8 << 30; // 8GB
+const DEFAULT_SLAB_GB: usize = 8;
 const SLACK: usize = 4;
 
 #[derive(Debug)]
 pub struct ZkAllocator;
+
+/// Per-thread slab size in bytes. Set once during `ensure_region()` from the
+/// `ZK_ALLOC_SLAB_GB` environment variable (default: 8).
+static SLAB_SIZE: AtomicUsize = AtomicUsize::new(0);
 
 /// Incremented by `begin_phase()`. Every thread caches the last value it saw in
 /// `ARENA_GEN`; when they differ, the thread resets its allocation cursor to the start
@@ -80,11 +88,18 @@ thread_local! {
 /// Returns the base address of the mmap'd region, mapping it on the first call.
 fn ensure_region() -> usize {
     REGION_INIT.call_once(|| {
+        let slab_gb = std::env::var("ZK_ALLOC_SLAB_GB")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_SLAB_GB);
+        let slab_size = slab_gb << 30;
+        SLAB_SIZE.store(slab_size, Ordering::Release);
+
         let cpus = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(8);
         let max_threads = cpus + SLACK;
-        let region_size = SLAB_SIZE * max_threads;
+        let region_size = slab_size * max_threads;
 
         // SAFETY: mmap_anonymous returns a page-aligned pointer or null.
         // MAP_NORESERVE means no physical memory is committed until pages are touched.
@@ -128,6 +143,11 @@ pub fn reset_overflow_stats() {
     OVERFLOW_BYTES.store(0, Ordering::Relaxed);
 }
 
+/// Returns the per-thread slab size in bytes. Zero before the first `begin_phase()`.
+pub fn slab_size() -> usize {
+    SLAB_SIZE.load(Ordering::Relaxed)
+}
+
 #[cold]
 #[inline(never)]
 unsafe fn arena_alloc_cold(size: usize, align: usize) -> *mut u8 {
@@ -144,9 +164,10 @@ unsafe fn arena_alloc_cold(size: usize, align: usize) -> *mut u8 {
                     std::alloc::System.alloc(Layout::from_size_align_unchecked(size, align))
                 };
             }
-            base = region + idx * SLAB_SIZE;
+            let slab_size = SLAB_SIZE.load(Ordering::Relaxed);
+            base = region + idx * slab_size;
             ARENA_BASE.set(base);
-            ARENA_END.set(base + SLAB_SIZE);
+            ARENA_END.set(base + slab_size);
         }
         ARENA_PTR.set(base);
         ARENA_GEN.set(generation);

--- a/zk-alloc/src/lib.rs
+++ b/zk-alloc/src/lib.rs
@@ -62,16 +62,22 @@ static OVERFLOW_BYTES: AtomicUsize = AtomicUsize::new(0);
 thread_local! {
     /// Where this thread's next allocation lands. Advanced past each allocation.
     static ARENA_PTR: Cell<usize> = const { Cell::new(0) };
-    /// One past the last byte of this thread's slab.
+    /// One past the last byte of this thread's slab. An alloc fits iff
+    /// `aligned + size <= ARENA_END`.
     static ARENA_END: Cell<usize> = const { Cell::new(0) };
-    /// Base address of this thread's slab (`0` = not yet claimed).
+    /// Base address of this thread's slab (`0` = not yet claimed). On reset,
+    /// `ARENA_PTR` is set back to this value.
     static ARENA_BASE: Cell<usize> = const { Cell::new(0) };
-    /// Last `GENERATION` value this thread observed.
+    /// Last `GENERATION` value this thread observed. When the global moves past
+    /// this, the next allocation resets `ARENA_PTR` to `ARENA_BASE` and updates
+    /// this field.
     static ARENA_GEN: Cell<usize> = const { Cell::new(0) };
-    /// `true` if this thread arrived after all slabs were claimed.
+    /// `true` if this thread was created after all slabs were already claimed.
+    /// Such threads skip arena logic entirely and always use the system allocator.
     static ARENA_NO_SLAB: Cell<bool> = const { Cell::new(false) };
 }
 
+/// Returns the base address of the mmap'd region, mapping it on the first call.
 fn ensure_region() -> usize {
     REGION_INIT.call_once(|| {
         let cpus = std::thread::available_parallelism()
@@ -144,7 +150,7 @@ unsafe fn arena_alloc_cold(size: usize, align: usize) -> *mut u8 {
         }
         ARENA_PTR.set(base);
         ARENA_GEN.set(generation);
-        let aligned = (base + align - 1) & !(align - 1);
+        let aligned = base.next_multiple_of(align);
         let new_ptr = aligned + size;
         if new_ptr <= ARENA_END.get() {
             ARENA_PTR.set(new_ptr);
@@ -167,8 +173,8 @@ unsafe impl GlobalAlloc for ZkAllocator {
         if ARENA_ACTIVE.load(Ordering::Relaxed) {
             let generation = GENERATION.load(Ordering::Relaxed);
             if ARENA_GEN.get() == generation {
-                let ptr = ARENA_PTR.get();
-                let aligned = (ptr + layout.align() - 1) & !(layout.align() - 1);
+                let align = layout.align();
+                let aligned = (ARENA_PTR.get() + align - 1) & !(align - 1);
                 let new_ptr = aligned + layout.size();
                 if new_ptr <= ARENA_END.get() {
                     ARENA_PTR.set(new_ptr);
@@ -186,7 +192,7 @@ unsafe impl GlobalAlloc for ZkAllocator {
         let base = REGION_BASE.load(Ordering::Relaxed);
         let region_size = REGION_SIZE.load(Ordering::Relaxed);
         if base != 0 && addr >= base && addr < base + region_size {
-            return;
+            return; // arena-owned pointer — free is a no-op
         }
         unsafe { std::alloc::System.dealloc(ptr, layout) };
     }
@@ -196,6 +202,7 @@ unsafe impl GlobalAlloc for ZkAllocator {
         if new_size <= layout.size() {
             return ptr;
         }
+        // SAFETY: new_size > layout.size() > 0, align unchanged from valid layout.
         let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
         let new_ptr = unsafe { self.alloc(new_layout) };
         if !new_ptr.is_null() {

--- a/zk-alloc/src/syscall.rs
+++ b/zk-alloc/src/syscall.rs
@@ -18,7 +18,15 @@ mod imp {
     pub const MADV_NOHUGEPAGE: usize = 15;
 
     #[inline]
-    unsafe fn syscall6(nr: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize) -> isize {
+    unsafe fn syscall6(
+        nr: usize,
+        a1: usize,
+        a2: usize,
+        a3: usize,
+        a4: usize,
+        a5: usize,
+        a6: usize,
+    ) -> isize {
         let ret: isize;
         unsafe {
             std::arch::asm!(
@@ -60,8 +68,22 @@ mod imp {
     #[inline]
     pub unsafe fn mmap_anonymous(size: usize) -> *mut u8 {
         let flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
-        let ret = unsafe { syscall6(SYS_MMAP, 0, size, PROT_READ | PROT_WRITE, flags, usize::MAX, 0) };
-        if ret < 0 { ptr::null_mut() } else { ret as *mut u8 }
+        let ret = unsafe {
+            syscall6(
+                SYS_MMAP,
+                0,
+                size,
+                PROT_READ | PROT_WRITE,
+                flags,
+                usize::MAX,
+                0,
+            )
+        };
+        if ret < 0 {
+            ptr::null_mut()
+        } else {
+            ret as *mut u8
+        }
     }
 
     #[inline]
@@ -70,7 +92,10 @@ mod imp {
     }
 }
 
-#[cfg(all(target_family = "unix", not(all(target_os = "linux", target_arch = "x86_64"))))]
+#[cfg(all(
+    target_family = "unix",
+    not(all(target_os = "linux", target_arch = "x86_64"))
+))]
 mod imp {
     use std::ptr;
 

--- a/zk-alloc/src/syscall.rs
+++ b/zk-alloc/src/syscall.rs
@@ -70,7 +70,7 @@ mod imp {
     }
 }
 
-#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+#[cfg(all(target_family = "unix", not(all(target_os = "linux", target_arch = "x86_64"))))]
 mod imp {
     use std::ptr;
 
@@ -92,9 +92,20 @@ mod imp {
     }
 
     #[inline]
-    pub unsafe fn madvise(_ptr: *mut u8, _size: usize, _advice: usize) {
-        // The advice values we pass are Linux-specific.
+    pub unsafe fn madvise(_ptr: *mut u8, _size: usize, _advice: usize) {}
+}
+
+#[cfg(not(target_family = "unix"))]
+mod imp {
+    pub const MADV_NOHUGEPAGE: usize = 0;
+
+    #[inline]
+    pub unsafe fn mmap_anonymous(_size: usize) -> *mut u8 {
+        std::ptr::null_mut()
     }
+
+    #[inline]
+    pub unsafe fn madvise(_ptr: *mut u8, _size: usize, _advice: usize) {}
 }
 
 pub use imp::{MADV_NOHUGEPAGE, madvise, mmap_anonymous};

--- a/zk-alloc/src/syscall.rs
+++ b/zk-alloc/src/syscall.rs
@@ -1,0 +1,100 @@
+// Raw syscalls instead of libc wrappers to avoid reentrancy: libc's mmap/madvise
+// may internally call malloc, which would deadlock when called from inside
+// #[global_allocator].
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+mod imp {
+    use std::ptr;
+
+    const SYS_MMAP: usize = 9;
+    const SYS_MADVISE: usize = 28;
+
+    const PROT_READ: usize = 1;
+    const PROT_WRITE: usize = 2;
+    const MAP_PRIVATE: usize = 0x02;
+    const MAP_ANONYMOUS: usize = 0x20;
+    const MAP_NORESERVE: usize = 0x4000;
+
+    pub const MADV_NOHUGEPAGE: usize = 15;
+
+    #[inline]
+    unsafe fn syscall6(nr: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize) -> isize {
+        let ret: isize;
+        unsafe {
+            std::arch::asm!(
+                "syscall",
+                inlateout("rax") nr as isize => ret,
+                in("rdi") a1,
+                in("rsi") a2,
+                in("rdx") a3,
+                in("r10") a4,
+                in("r8") a5,
+                in("r9") a6,
+                lateout("rcx") _,
+                lateout("r11") _,
+                options(nostack),
+            );
+        }
+        ret
+    }
+
+    #[inline]
+    unsafe fn syscall3(nr: usize, a1: usize, a2: usize, a3: usize) -> isize {
+        let ret: isize;
+        unsafe {
+            std::arch::asm!(
+                "syscall",
+                inlateout("rax") nr as isize => ret,
+                in("rdi") a1,
+                in("rsi") a2,
+                in("rdx") a3,
+                lateout("rcx") _,
+                lateout("r11") _,
+                lateout("r10") _,
+                options(nostack),
+            );
+        }
+        ret
+    }
+
+    #[inline]
+    pub unsafe fn mmap_anonymous(size: usize) -> *mut u8 {
+        let flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE;
+        let ret = unsafe { syscall6(SYS_MMAP, 0, size, PROT_READ | PROT_WRITE, flags, usize::MAX, 0) };
+        if ret < 0 { ptr::null_mut() } else { ret as *mut u8 }
+    }
+
+    #[inline]
+    pub unsafe fn madvise(ptr: *mut u8, size: usize, advice: usize) {
+        unsafe { syscall3(SYS_MADVISE, ptr as usize, size, advice) };
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+mod imp {
+    use std::ptr;
+
+    pub const MADV_NOHUGEPAGE: usize = 15;
+
+    #[inline]
+    pub unsafe fn mmap_anonymous(size: usize) -> *mut u8 {
+        // MAP_NORESERVE is Linux-only. macOS lazily backs anonymous mappings
+        // with physical memory by default, so the large virtual reservation
+        // is fine without NORESERVE.
+        let prot = libc::PROT_READ | libc::PROT_WRITE;
+        let flags = libc::MAP_PRIVATE | libc::MAP_ANON;
+        let ret = unsafe { libc::mmap(ptr::null_mut(), size, prot, flags, -1, 0) };
+        if ret == libc::MAP_FAILED {
+            ptr::null_mut()
+        } else {
+            ret.cast::<u8>()
+        }
+    }
+
+    #[inline]
+    pub unsafe fn madvise(_ptr: *mut u8, _size: usize, _advice: usize) {
+        // The advice values we pass are Linux-specific.
+    }
+}
+
+pub use imp::{MADV_NOHUGEPAGE, madvise, mmap_anonymous};


### PR DESCRIPTION
# feat: add p3-zk-alloc — bump+reset arena allocator for proving workloads

## Summary

Add `p3-zk-alloc`, an optional bump+reset arena allocator (~200 LoC) that eliminates demand-paging overhead between repeated proofs. Allocation = bump a thread-local pointer. Free = no-op. `begin_phase()` resets all slabs; the next proof reuses already-faulted pages instead of requesting fresh ones from the kernel.

Feature-gated (`--features zk-alloc`) and opt-in. When disabled, existing jemalloc/glibc behavior is unchanged.

## Motivation

We built zk-alloc for [leanMultisig](https://github.com/leanEthereum/leanMultisig/pull/205), a Plonky3-based XMSS aggregation prover, where it achieved −27% warm proof time. To validate the design across provers, we ported it to Plonky3's own workloads (Poseidon1, Poseidon2, Keccak AIRs) and saw 7–17% improvement — confirming the effect is not workload-specific but a property of how proving systems interact with the OS memory subsystem.

The root cause: the dominant allocator cost is not per-allocation overhead (~10ns in glibc tcache) but **demand-paging**. Each proof cycle allocates large vectors, the kernel lazily faults in physical pages, and those pages are returned to the OS on `free`. The next proof faults them in again. With the arena's page reuse, `perf stat` shows 40% fewer page faults and 16% fewer cache misses.

The arena sidesteps this by keeping its virtual region mapped across proofs. After `begin_phase()`, each thread's bump pointer resets to the start of its slab — the same physical pages are reused without any syscalls.

## Benchmark results

**Machine:** Hetzner AX42-U (AMD Ryzen 7 PRO 8700GE, 8C/16T, 64GB DDR5)  
**Build:** `RUSTFLAGS="-C target-cpu=native"`, release, single-threaded (Radix2Bowers DFT)  
**All proofs cryptographically verified.**

### Warm proof time (average of proofs 2–4)

| Workload | Trace | glibc | jemalloc | zk-alloc | vs glibc | vs jemalloc |
|----------|-------|-------|----------|----------|----------|-------------|
| Poseidon2 (KoalaBear 8×) | 2^16 rows | 2.487s | 2.515s | 2.078s | **−16.4%** | **−17.4%** |
| Poseidon2 (KoalaBear 8×) | 2^18 rows | 10.180s | 10.345s | 8.618s | **−15.3%** | **−16.7%** |
| Poseidon1 (BabyBear) | 2^16 | 0.771s | 0.771s | 0.674s | **−12.6%** | **−12.6%** |
| Poseidon1 (BabyBear) | 2^20 | 11.602s | 11.913s | 10.744s | **−7.4%** | **−9.8%** |
| Keccak (BabyBear wide) | 2^15 rows | 2.186s | 2.199s | 1.845s | **−15.6%** | **−16.1%** |
| Keccak (BabyBear wide) | 2^17 rows | 8.947s | 8.986s | 7.517s | **−16.0%** | **−16.3%** |

### Cold proof (proof 1 — demand-paging cost)

| Workload | Trace | glibc | zk-alloc | overhead |
|----------|-------|-------|----------|----------|
| Poseidon2 (KoalaBear 8×) | 2^16 rows | 2.506s | 3.072s | +23% |
| Keccak (BabyBear wide) | 2^17 rows | 8.976s | 10.209s | +14% |

Cold proof is slower because the arena's large mmap must be faulted in. This is a warm-proof optimization designed for provers that run repeated proofs in the same process.

### Memory-constrained validation (cgroups)

Tested with `memory.max` cgroup limits. The arena's `MAP_NORESERVE` virtual reservation does not count against physical memory limits. Speedup holds across all memory configurations.

| cgroup limit | jemalloc warm | zk-alloc warm | vs jemalloc | status |
|-------------|--------------|--------------|-------------|--------|
| 16GB | 2.56s | 2.30s | **−10.2%** | pass |
| 32GB | 2.58s | 2.30s | **−10.9%** | pass |
| 64GB (no limit) | 2.70s | 2.34s | **−13.3%** | pass |

(Poseidon2 KoalaBear 2^16 rows, single-threaded Radix2Bowers DFT, warm proof = proof 3. Separate measurement session from the main table above — absolute times differ slightly due to system load.)

### Parallel DFT (Radix2DitParallel, 8 threads)

| Workload | jemalloc warm | zk-alloc warm | vs jemalloc |
|----------|--------------|--------------|-------------|
| Poseidon2 (KoalaBear 8×) 2^16 rows | 456ms | 411ms | **−9.9%** |

Effect is smaller than single-threaded (parallelism reduces per-thread memory pressure).

### Cross-platform and hardware

Correctness validated on macOS M4 Max ([1050 vs 1150 XMSS/s](https://github.com/leanEthereum/leanMultisig/pull/205#issuecomment-4326200859)) via the libc fallback path. The mechanism is kernel-level demand-paging, not CPU microarchitecture. The speedup should hold on Intel and ARM Linux at equivalent memory bandwidth. No Intel benchmarks yet — we welcome contributions to validate.

## Known limitations

- **Cold proof penalty.** The first arena proof is 14–23% slower due to demand-paging the mmap region. It pays for itself on the second arena proof, when pages are reused. Not suitable for one-shot serverless provers that never reuse the process.
- **Phase boundary discipline.** Any allocation that lives across a `begin_phase()` call (e.g., logging frameworks, thread-pool internals) will have its backing memory overwritten. Callers must ensure long-lived state is allocated before the first `begin_phase()`. The examples demonstrate this pattern.
- **8GB slab default, configurable via `ZK_ALLOC_SLAB_GB`.** Slab sweep across Poseidon1 (2^16–2^20), Poseidon2 (2^16–2^18), and Keccak (2^15–2^17) shows 8GB is optimal or near-optimal for 6 of 7 workloads tested. Larger traces (2^20, ~13GB working set) benefit from `ZK_ALLOC_SLAB_GB=12` (−12% vs −7% at 8GB). Zero overflow is not required for maximum speedup — capturing the hot allocation paths matters more (e.g. Keccak 2^17 at 8GB: −17% with 5.7GB overflow, vs −15% at 16GB with zero overflow). Use `overflow_stats()` to check if your workload spills to the system allocator.
- **Hardware sensitivity.** The magnitude of improvement depends on memory subsystem (DIMM configuration, bandwidth, TLB size). Results may vary across server generations. The cgroup validation confirms it doesn't regress under memory pressure.
- **Windows.** The arena requires `mmap` (unix). On Windows the crate compiles but `begin_phase()` will abort. Windows users should not enable the `zk-alloc` feature.

## What's in this PR

1. **`zk-alloc/`** — new workspace crate `p3-zk-alloc`
   - `src/lib.rs` (~200 LoC): `ZkAllocator` implementing `GlobalAlloc`, `begin_phase()`/`end_phase()` API
   - `src/syscall.rs` (~100 LoC): raw `mmap`/`madvise` syscalls on Linux x86_64, libc fallback on other unix, no-op stub on Windows
   - Per-thread 8GB slabs via `mmap(MAP_NORESERVE)` — no physical memory committed until touched
   - `MADV_NOHUGEPAGE` to avoid THP compaction overhead on bump+reset workloads
   - Runtime thread detection via `available_parallelism()` + 4 slack threads
   - Overflow fallback to `System` for threads beyond max or allocations exceeding slab

2. **`poseidon1-air/`, `poseidon2-air/`** — example integration
   - `zk-alloc` feature flag in each crate
   - `#[cfg(feature = "zk-alloc")]` selects `ZkAllocator`; without it, jemalloc (unix) or system allocator
   - Examples: cold proof (no arena, warms tracing), arena proof 1 (faults pages), arena proof 2 (page reuse — the speedup)

## Usage

```rust
#[cfg(feature = "zk-alloc")]
#[global_allocator]
static GLOBAL: p3_zk_alloc::ZkAllocator = p3_zk_alloc::ZkAllocator;

fn main() {
    loop {
        p3_zk_alloc::begin_phase();   // arena ON, slabs reset
        let proof = prove(&config, &air, trace, &[]);
        p3_zk_alloc::end_phase();     // arena OFF
        // proof data is still valid until next begin_phase()
    }
}
```

```bash
# Build with zk-alloc
RUSTFLAGS="-C target-cpu=native" cargo run --release \
  --example prove_poseidon2_koala_bear_keccak \
  --features "parallel,zk-alloc"

# Tune slab size for large workloads (default: 8GB)
ZK_ALLOC_SLAB_GB=12 cargo run --release ...
```

## Design decisions

- **Feature-gated, not default.** Users opt in; no behavior change for existing builds. Must remain behind a feature flag until Windows support is implemented (currently aborts on non-unix). A future `VirtualAlloc` backend would allow removing the gate.
- **`available_parallelism()` for thread count.** Adapts to hardware at runtime instead of hardcoded constant. Important for Plonky3's diverse deployment targets.
- **Raw syscalls on Linux x86_64.** Avoids libc reentrancy (libc `mmap` may internally call `malloc`, deadlocking inside `#[global_allocator]`). Falls back to libc on other unix; no-op stub on Windows.
- **No `unsafe` in public API.** `begin_phase()`/`end_phase()` are safe functions. The `unsafe impl GlobalAlloc` is internal.
- **Overflow to System.** Allocations that don't fit the slab (or threads beyond max) silently fall through to the system allocator. No panics, no OOM from the arena itself.
- **Eager region init in `begin_phase()`.** The mmap region is created before setting `ARENA_ACTIVE`, preventing a deadlock where `available_parallelism()` (which reads `/proc`) would allocate through the arena before it's ready.

## Prior art

- Merged and validated in [leanMultisig PR #205](https://github.com/leanEthereum/leanMultisig/pull/205) (XMSS aggregation prover, also Plonky3-based)
- Standalone reference crate: [Barnadrot/zk-alloc](https://github.com/Barnadrot/zk-alloc)
- Hanson 1990, "Fast allocation and deallocation of memory based on object lifetimes"

## Test plan

- [x] `cargo clippy --workspace` — clean
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo check --workspace` — passes
- [x] `cargo check -p p3-zk-alloc --target x86_64-pc-windows-msvc` — compiles (arena disabled on Windows)
- [x] Poseidon2 KoalaBear prove+verify with `--features zk-alloc,parallel` — verified
- [x] Poseidon1 BabyBear prove+verify with `--features zk-alloc,parallel` — verified
- [x] Poseidon2 BabyBear ZK prove+verify with `--features zk-alloc,parallel` — verified
- [x] All examples verify with jemalloc (no zk-alloc feature) — verified
- [x] 16GB cgroup: prove+verify passes (no OOM from virtual reservation)
- [x] 32GB cgroup: prove+verify passes
- [x] 64GB (no limit): prove+verify passes
- [x] Benchmark: 7–17% warm proof speedup, single-threaded DFT (Poseidon1, Poseidon2, Keccak)
- [x] Benchmark: ~10% warm proof speedup, parallel DFT (Poseidon2 KoalaBear)
