### PR TITLE
fix(whir): use unbiased rejection sampling for STIR query indices

### DIFF
--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -8,8 +8,8 @@ use p3_util::log2_ceil_u64;
 use tracing::instrument;
 
 use crate::{
-    CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, FieldChallenger, GrindingChallenger,
-    HashChallenger,
+    CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, CanSampleUniformBits, FieldChallenger,
+    GrindingChallenger, HashChallenger, ResamplingError,
 };
 
 /// Given a challenger that can observe and sample bytes, produces a challenger that is able to
@@ -168,6 +168,23 @@ where
     }
 }
 
+/// The inner challenger draws uniform bytes (cryptographic hash output), so
+/// taking the low `bits` of a `u32` assembled from those bytes is exactly
+/// uniform on `[0, 2^bits)`. No field-side rejection is required and the
+/// `RESAMPLE` flag is irrelevant — sampling never errors.
+impl<F, Inner> CanSampleUniformBits<F> for SerializingChallenger32<F, Inner>
+where
+    F: PrimeField32,
+    Inner: CanSample<u8>,
+{
+    fn sample_uniform_bits<const RESAMPLE: bool>(
+        &mut self,
+        bits: usize,
+    ) -> Result<usize, ResamplingError> {
+        Ok(self.sample_bits(bits))
+    }
+}
+
 impl<F, Inner> GrindingChallenger for SerializingChallenger32<F, Inner>
 where
     F: PrimeField32,
@@ -322,6 +339,22 @@ where
         assert!((1u64 << bits) <= F::ORDER_U64);
         let rand_u64 = u64::from_le_bytes(self.inner.sample_array());
         (rand_u64 & ((1u64 << bits) - 1)) as usize
+    }
+}
+
+/// See [`CanSampleUniformBits`] for `SerializingChallenger32` — the same
+/// reasoning applies here: uniform inner bytes give uniform low bits with
+/// no field-side rejection.
+impl<F, Inner> CanSampleUniformBits<F> for SerializingChallenger64<F, Inner>
+where
+    F: PrimeField64,
+    Inner: CanSample<u8>,
+{
+    fn sample_uniform_bits<const RESAMPLE: bool>(
+        &mut self,
+        bits: usize,
+    ) -> Result<usize, ResamplingError> {
+        Ok(self.sample_bits(bits))
     }
 }
 

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -168,19 +168,29 @@ where
     }
 }
 
-/// The inner challenger draws uniform bytes (cryptographic hash output), so
-/// taking the low `bits` of a `u32` assembled from those bytes is exactly
-/// uniform on `[0, 2^bits)`. No field-side rejection is required and the
-/// `RESAMPLE` flag is irrelevant — sampling never errors.
 impl<F, Inner> CanSampleUniformBits<F> for SerializingChallenger32<F, Inner>
 where
     F: PrimeField32,
     Inner: CanSample<u8>,
 {
+    /// Sample uniform bits by masking bytes from the inner stream.
+    ///
+    /// # Overview
+    ///
+    /// The inner stream emits cryptographic-hash bytes uniform on `[0, 2^8)`.
+    ///
+    /// Reading 4 bytes as a 32-bit integer and masking the low `bits` is
+    /// exactly uniform on `[0, 2^bits)`.
+    ///
+    /// No field-element decomposition occurs, so no rejection band exists.
+    /// The const generic is therefore inert: this function never errors
+    /// and never resamples.
     fn sample_uniform_bits<const RESAMPLE: bool>(
         &mut self,
         bits: usize,
     ) -> Result<usize, ResamplingError> {
+        // Byte-sourced sampling is uniform without rejection, so the
+        // result is always valid and the error arm is unreachable.
         Ok(self.sample_bits(bits))
     }
 }
@@ -342,18 +352,29 @@ where
     }
 }
 
-/// See [`CanSampleUniformBits`] for `SerializingChallenger32` — the same
-/// reasoning applies here: uniform inner bytes give uniform low bits with
-/// no field-side rejection.
 impl<F, Inner> CanSampleUniformBits<F> for SerializingChallenger64<F, Inner>
 where
     F: PrimeField64,
     Inner: CanSample<u8>,
 {
+    /// Sample uniform bits by masking bytes from the inner stream.
+    ///
+    /// # Overview
+    ///
+    /// The inner stream emits cryptographic-hash bytes uniform on `[0, 2^8)`.
+    ///
+    /// Reading 8 bytes as a 64-bit integer and masking the low `bits` is
+    /// exactly uniform on `[0, 2^bits)`.
+    ///
+    /// No field-element decomposition occurs, so no rejection band exists.
+    /// The const generic is therefore inert: this function never errors
+    /// and never resamples.
     fn sample_uniform_bits<const RESAMPLE: bool>(
         &mut self,
         bits: usize,
     ) -> Result<usize, ResamplingError> {
+        // Byte-sourced sampling is uniform without rejection, so the
+        // result is always valid and the error arm is unreachable.
         Ok(self.sample_bits(bits))
     }
 }

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -3,7 +3,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{Mmcs, MultilinearOpenedValues, MultilinearPcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, TwoAdicField};
@@ -125,8 +125,11 @@ where
     F: TwoAdicField + Ord,
     EF: ExtensionField<F> + TwoAdicField,
     MT: Mmcs<F>,
-    Challenger:
-        FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<MT::Commitment> + Clone,
+    Challenger: FieldChallenger<F>
+        + GrindingChallenger<Witness = F>
+        + CanObserve<MT::Commitment>
+        + CanSampleUniformBits<F>
+        + Clone,
     Dft: TwoAdicSubgroupDft<F>,
 {
     type Val = F;

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::ops::Deref;
 
-use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, TwoAdicField};
@@ -64,7 +64,7 @@ impl<EF, F, MT, Challenger> WhirProver<'_, EF, F, MT, Challenger>
 where
     F: TwoAdicField + Ord,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanSampleUniformBits<F>,
     MT: Mmcs<F>,
 {
     const fn validate_parameters(&self) -> bool {

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -60,6 +60,15 @@ use crate::fiat_shamir::errors::FiatShamirError;
 /// # Panics
 ///
 /// `domain_size >> folding_factor` must be a power of two.
+///
+/// # TODO (possible recursion ideas)
+///
+/// - Prefer `n` independent draws (with duplicates allowed) over
+///   `n` distinct indices for recursion-friendliness.
+/// - The WHIR paper's `(1 - delta)^t` bound is over independent
+///   draws; distinctness only lets `t` shrink slightly for the
+///   same security, with negligible practical effect.
+/// - Revisit when wiring this through a recursive verifier.
 pub fn get_challenge_stir_queries<Challenger, F, EF>(
     domain_size: usize,
     folding_factor: usize,

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -32,12 +32,17 @@ use crate::fiat_shamir::errors::FiatShamirError;
 ///   eps_shift  <=  (1 - delta)^t
 /// ```
 ///
-/// `t` must count **distinct, uniform** positions. Two leaks closed here:
+/// `t` counts independent **uniformly-sampled** positions; distinctness
+/// is not required (collisions waste opening work but do not weaken the
+/// bound). Per-draw uniformity is the only leak closed here:
 ///
 /// - **Biased draws** — bit-decomposing a uniform field element biases
-///   each draw by `~ 2^bits / |F|`, which inflates `delta`.
-/// - **Dedup shrinkage** — sample-with-replacement plus deduplication
-///   returns fewer positions than asked, which lowers `t`.
+///   each draw by `~ 2^bits / |F|`, which inflates `delta`. Routed
+///   through `sample_uniform_bits` for exact uniformity.
+///
+/// Duplicate rejection is a cleanliness choice — it pins output length
+/// at `t = min(num_queries, folded_domain_size)` and unifies the
+/// common-case and saturation-case paths below.
 ///
 /// # Saturation
 ///

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -1,85 +1,58 @@
 use alloc::vec::Vec;
 
-use p3_challenger::FieldChallenger;
+use p3_challenger::{CanSampleUniformBits, FieldChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_util::log2_strict_usize;
 
 use crate::fiat_shamir::errors::FiatShamirError;
 
-/// Upper bound on bits drawn from a single Fiat-Shamir squeeze.
+/// Sample distinct STIR query indices in `[0, domain_size >> folding_factor)`
+/// from the Fiat–Shamir transcript.
 ///
-/// # Why 20
+/// Indices are drawn uniformly **without replacement** and returned sorted.
+/// The output length is `min(num_queries, folded_domain_size)`: when the
+/// requested count exceeds the folded domain (typical of WHIR's final round),
+/// the verifier opens every position, which is the strongest possible check.
 ///
-/// Two competing constraints pin this value:
+/// # Soundness
 ///
-/// - **Must cover the folded domain.**
-///   Starting domains range from 2^18 to 2^30.
-///   Folding with k >= 4 shrinks by >= 2^4 per round.
-///   So 2^20 ~ 1M comfortably exceeds any folded domain.
+/// The WHIR shift-query bound (Arnon, Chiesa, Fenzi, Yogev 2024,
+/// Theorem 5.2) is `ε^shift ≤ (1 - δ)^t`, where `t` is the number of
+/// *distinct* query positions. A sample-with-replacement implementation
+/// followed by `dedup()` leaks soundness in two ways:
 ///
-/// - **Must keep modular bias negligible.**
-///   Drawing `b` bits and reducing mod `n` biases by `2^b / n - 1`.
+/// 1. **Modular bias.** [`p3_challenger::CanSampleBits::sample_bits`]
+///    bit-decomposes a uniformly drawn field element and is documented
+///    as "reasonably close to" — not exactly — uniform. The per-draw
+///    bias is bounded by `2^bits / |F|` but non-zero, and inflates the
+///    effective `δ` in the bound.
+/// 2. **Birthday-paradox shrinkage.** A `dedup()` pass on collisions
+///    returns fewer than `num_queries` distinct positions, weakening
+///    the effective `t`.
 ///
-/// ```text
-///   Field          b    n = 2^18    bias
-///   ─────────────  ──   ────────    ──────────
-///   KoalaBear 31   20   2^18        ~3  (capped to b = 30 by F::bits()-1)
-///   Goldilocks 64  20   2^18        ~2^{-44}  (negligible)
-/// ```
+/// This implementation closes both gaps:
 ///
-/// At runtime the effective limit is `min(F::bits() - 1, 20)`,
-/// so smaller fields automatically tighten the budget.
+/// - [`CanSampleUniformBits::sample_uniform_bits`] with `RESAMPLE = true`
+///   uses field-side rejection sampling so each draw is exactly uniform
+///   on `[0, 2^bits)`; and
+/// - duplicates are rejected so the returned vector has length exactly
+///   `min(num_queries, folded_domain_size)`, matching the soundness
+///   bound's `t` tightly.
 ///
-/// # Soundness context (WHIR paper, Theorem 5.2)
+/// # Performance
 ///
-/// These indices feed the shift-query check:
-///
-/// ```text
-///   epsilon^shift  <=  (1 - delta)^t
-/// ```
-///
-/// The proof assumes uniform sampling.
-/// Any bias inflates the effective `delta`, so keeping it small is security-critical.
-///
-/// Reference: Arnon, Chiesa, Fenzi, Yogev 2024, Section 2.1.3, Step 5.
-const MAX_SAMPLE_BITS: usize = 20;
-
-/// Sample cryptographically secure STIR query indices from the transcript.
-///
-/// - Draws `num_queries` random indices in `[0, folded_domain_size)`,
-/// - Then sorts and deduplicates them.
-///
-/// The returned vector may therefore contain **fewer** than `num_queries` entries when collisions occur.
-///
-/// # Soundness note
-///
-/// The WHIR shift-query soundness bound is `(1 - δ)^t` where `t` is the number
-/// of *distinct* query positions (Theorem 5.2, ε^shift). Duplicate queries test
-/// the same codeword position twice and contribute no additional soundness.
-/// Because `folded_domain_size` is typically ≥ 2^18 and `num_queries` = O(λ)
-/// with λ ≤ 128, the birthday-bound collision probability is negligible
-/// (~t² / 2n ≈ 2^{-4}), so dedup almost never reduces the effective count.
-///
-/// TODO: consider switching to rejection sampling (sample-without-replacement)
-/// to guarantee exactly `num_queries` distinct indices and tighten the
-/// soundness accounting. The current approach relies on the collision
-/// probability being negligible, which should be validated for small domains
-/// or high query counts.
-///
-/// # Batching strategy
-///
-/// When possible, multiple query indices are extracted from a single
-/// `challenger.sample_bits` call to reduce Fiat-Shamir overhead:
-///
-/// - If all bits fit in one call (≤ `max_bits_per_call`), a single sample
-///   suffices.
-/// - Otherwise, indices are batched into groups that fit within the per-call
-///   bit budget.
-/// - As a fallback, one transcript call is made per query.
+/// `sample_uniform_bits::<true>(bits)` is essentially free for
+/// `bits ≤ MAX_SINGLE_SAMPLE_BITS` on small fields (single field draw,
+/// resample probability `≈ 1 / |F|`). The duplicate-rejection loop runs
+/// in `O(target)` iterations in expectation when `folded_domain_size`
+/// is much larger than `target` (the typical WHIR regime), and in
+/// `O(target · log target)` in the worst case when `target` approaches
+/// `folded_domain_size` (coupon-collector behaviour).
 ///
 /// # Panics
 ///
-/// Panics if `domain_size` is not a power of two.
+/// Panics if `domain_size >> folding_factor` is not a power of two
+/// (precondition of [`log2_strict_usize`]).
 pub fn get_challenge_stir_queries<Challenger, F, EF>(
     domain_size: usize,
     folding_factor: usize,
@@ -87,64 +60,210 @@ pub fn get_challenge_stir_queries<Challenger, F, EF>(
     challenger: &mut Challenger,
 ) -> Result<Vec<usize>, FiatShamirError>
 where
-    Challenger: FieldChallenger<F>,
+    Challenger: FieldChallenger<F> + CanSampleUniformBits<F>,
     F: Field,
     EF: ExtensionField<F>,
 {
-    // Apply folding to get the reduced domain size.
     let folded_domain_size = domain_size >> folding_factor;
-    // Bits needed to index the folded domain.
     let domain_size_bits = log2_strict_usize(folded_domain_size);
 
-    // Conservative limit to avoid statistical bias.
-    let max_bits_per_call = (F::bits() - 1).min(MAX_SAMPLE_BITS);
+    // Cap requested queries at the domain size. When `num_queries` would
+    // exceed `folded_domain_size`, the only set of distinct positions of
+    // the requested size is the entire domain.
+    let target = num_queries.min(folded_domain_size);
 
-    let total_bits_needed = num_queries * domain_size_bits;
-    let mut queries = Vec::with_capacity(num_queries);
-
-    if total_bits_needed <= max_bits_per_call {
-        // All bits fit in a single transcript call.
-        let mut all_bits = challenger.sample_bits(total_bits_needed);
-        let mask = (1 << domain_size_bits) - 1;
-
-        for _ in 0..num_queries {
-            let query_bits = all_bits & mask;
-            queries.push(query_bits % folded_domain_size);
-            all_bits >>= domain_size_bits;
+    let mut queries: Vec<usize> = Vec::with_capacity(target);
+    while queries.len() < target {
+        let q = challenger
+            .sample_uniform_bits::<true>(domain_size_bits)
+            .expect("Error impossible here due to resampling strategy");
+        if !queries.contains(&q) {
+            queries.push(q);
         }
-    } else {
-        let queries_per_batch = max_bits_per_call / domain_size_bits;
+    }
+    queries.sort_unstable();
+    Ok(queries)
+}
 
-        if queries_per_batch >= 2 {
-            // Batch multiple queries per transcript call.
-            let mut remaining = num_queries;
-            let mask = (1 << domain_size_bits) - 1;
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeSet;
+    use alloc::vec::Vec;
 
-            while remaining > 0 {
-                let batch_size = remaining.min(queries_per_batch);
-                let batch_bits = batch_size * domain_size_bits;
+    use p3_challenger::{CanObserve, DuplexChallenger};
+    use p3_field::extension::BinomialExtensionField;
+    use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
-                let mut all_bits = challenger.sample_bits(batch_bits);
+    use super::*;
 
-                for _ in 0..batch_size {
-                    let query_index = (all_bits & mask) % folded_domain_size;
-                    queries.push(query_index);
-                    all_bits >>= domain_size_bits;
-                }
+    type F = KoalaBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2KoalaBear<16>;
+    type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 
-                remaining -= batch_size;
+    /// Build a `DuplexChallenger` whose Poseidon2 instance is fixed (seed 42)
+    /// and whose absorbed transcript is determined by `seed`.
+    ///
+    /// Two challengers built from the same `seed` are byte-identical and will
+    /// therefore produce identical sample sequences — that is what the
+    /// determinism property asserts.
+    fn challenger_with_seed(seed: u64) -> MyChallenger {
+        let mut perm_rng = SmallRng::seed_from_u64(42);
+        let perm = Perm::new_from_rng_128(&mut perm_rng);
+        let mut challenger = MyChallenger::new(perm);
+
+        let mut transcript_rng = SmallRng::seed_from_u64(seed);
+        let primer: Vec<F> = (0..8).map(|_| transcript_rng.random()).collect();
+        challenger.observe_slice(&primer);
+        challenger
+    }
+
+    /// Generate `(domain_size, folding_factor, num_queries)` such that
+    /// `folded = domain_size >> folding_factor` is a positive power of two
+    /// and `num_queries ∈ [1, folded]`. This keeps the strategy in the
+    /// "common case" regime where the function returns exactly `num_queries`
+    /// distinct positions; the saturation case is covered separately below.
+    fn arb_query_params() -> impl Strategy<Value = (usize, usize, usize)> {
+        (1usize..=8, 0usize..=4).prop_flat_map(|(log_folded, folding_factor)| {
+            let folded = 1usize << log_folded;
+            let domain_size = folded << folding_factor;
+            (1usize..=folded)
+                .prop_map(move |num_queries| (domain_size, folding_factor, num_queries))
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        /// Length, range, sortedness, distinctness, and determinism in a
+        /// single property so each case pays for one challenger setup.
+        #[test]
+        fn prop_get_challenge_stir_queries_invariants(
+            (domain_size, folding_factor, num_queries) in arb_query_params(),
+            seed in any::<u64>(),
+        ) {
+            let folded_domain_size = domain_size >> folding_factor;
+
+            let mut challenger_a = challenger_with_seed(seed);
+            let queries_a = get_challenge_stir_queries::<MyChallenger, F, EF>(
+                domain_size,
+                folding_factor,
+                num_queries,
+                &mut challenger_a,
+            )
+            .expect("sampling under RESAMPLE = true cannot fail");
+
+            // 1. Length: exactly num_queries when num_queries ≤ folded_domain_size.
+            prop_assert_eq!(queries_a.len(), num_queries);
+
+            // 2. Range: every q in [0, folded_domain_size).
+            for &q in &queries_a {
+                prop_assert!(
+                    q < folded_domain_size,
+                    "query {} out of range [0, {})", q, folded_domain_size
+                );
             }
-        } else {
-            // Fallback: one transcript call per query.
-            for _ in 0..num_queries {
-                let value = challenger.sample_bits(domain_size_bits);
-                queries.push(value);
-            }
+
+            // 3. Sortedness (ascending).
+            prop_assert!(
+                queries_a.windows(2).all(|w| w[0] < w[1]),
+                "queries not strictly sorted: {:?}", queries_a
+            );
+
+            // 4. Distinctness (already implied by strict sort, but assert
+            //    explicitly via a set for clarity).
+            let unique: BTreeSet<usize> = queries_a.iter().copied().collect();
+            prop_assert_eq!(unique.len(), num_queries, "duplicates in {:?}", queries_a);
+
+            // 5. Determinism: a fresh challenger from the same seed yields
+            //    a byte-identical query vector.
+            let mut challenger_b = challenger_with_seed(seed);
+            let queries_b = get_challenge_stir_queries::<MyChallenger, F, EF>(
+                domain_size,
+                folding_factor,
+                num_queries,
+                &mut challenger_b,
+            )
+            .expect("sampling under RESAMPLE = true cannot fail");
+            prop_assert_eq!(queries_a, queries_b);
         }
     }
 
-    queries.sort_unstable();
-    queries.dedup();
+    /// Saturation: when `num_queries > folded_domain_size`, return every
+    /// position. This is the WHIR final-round regime where the folded domain
+    /// is small (often 1–4) but `final_queries` can be much larger.
+    #[test]
+    fn saturates_when_num_queries_exceeds_domain() {
+        // Folded domain of size 4 (= 16 >> 2); request 75 queries.
+        let domain_size = 16usize;
+        let folding_factor = 2usize;
+        let folded_domain_size = domain_size >> folding_factor;
+        let num_queries = 75usize;
 
-    Ok(queries)
+        let mut challenger = challenger_with_seed(0xC0FFEE);
+        let queries = get_challenge_stir_queries::<MyChallenger, F, EF>(
+            domain_size,
+            folding_factor,
+            num_queries,
+            &mut challenger,
+        )
+        .expect("sampling under RESAMPLE = true cannot fail");
+
+        assert_eq!(queries.len(), folded_domain_size);
+        assert_eq!(queries, (0..folded_domain_size).collect::<Vec<_>>());
+    }
+
+    /// Empirical uniformity check for single-query draws on a small folded
+    /// domain.
+    ///
+    /// We draw one query per fresh challenger (seeded by a counter) and bin
+    /// the results into `N = 16` buckets. With `M = 4096` independent draws
+    /// and per-bucket expectation `M/N = 256`, Hoeffding on the indicator
+    /// `1[q == k]` gives, for any fixed bucket `k`,
+    ///
+    ///     Pr[ |count_k − M/N| ≥ t ] ≤ 2 · exp(−2 t² / M).
+    ///
+    /// Tolerance `t = 160` gives `32 · exp(−160² / 2048) ≈ 1.2 · 10⁻⁴` after
+    /// union-bounding both tails over 16 buckets — comfortably below CI's
+    /// flake threshold.
+    ///
+    /// This is a plain `#[test]`, not a proptest: the challenger already
+    /// supplies all the randomness needed; stacking proptest on top would
+    /// only inflate the bound.
+    #[test]
+    fn empirical_uniformity_single_query() {
+        const FOLDED_DOMAIN_SIZE: usize = 16;
+        const NUM_DRAWS: usize = 4096;
+        const TOLERANCE: usize = 160;
+
+        let domain_size: usize = 64;
+        let folding_factor: usize = 2;
+        assert_eq!(domain_size >> folding_factor, FOLDED_DOMAIN_SIZE);
+
+        let mut counts = [0usize; FOLDED_DOMAIN_SIZE];
+        for seed in 0u64..NUM_DRAWS as u64 {
+            let mut challenger = challenger_with_seed(seed);
+            let q = get_challenge_stir_queries::<MyChallenger, F, EF>(
+                domain_size,
+                folding_factor,
+                1,
+                &mut challenger,
+            )
+            .expect("sampling under RESAMPLE = true cannot fail");
+            assert_eq!(q.len(), 1);
+            counts[q[0]] += 1;
+        }
+
+        let expected = NUM_DRAWS / FOLDED_DOMAIN_SIZE;
+        for (bucket, &count) in counts.iter().enumerate() {
+            let deviation = count.abs_diff(expected);
+            assert!(
+                deviation <= TOLERANCE,
+                "bucket {bucket}: count {count} deviates from expected {expected} by {deviation} > {TOLERANCE}; full counts = {counts:?}"
+            );
+        }
+    }
 }

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -6,53 +6,55 @@ use p3_util::log2_strict_usize;
 
 use crate::fiat_shamir::errors::FiatShamirError;
 
-/// Sample distinct STIR query indices in `[0, domain_size >> folding_factor)`
-/// from the Fiat–Shamir transcript.
+/// Sample `t` distinct STIR query indices uniformly from the transcript.
 ///
-/// Indices are drawn uniformly **without replacement** and returned sorted.
-/// The output length is `min(num_queries, folded_domain_size)`: when the
-/// requested count exceeds the folded domain (typical of WHIR's final round),
-/// the verifier opens every position, which is the strongest possible check.
+/// # Pipeline
+///
+/// ```text
+///   transcript --> uniform draws --> reject collisions --> sort
+///                  [0, 2^k)          distinct              ascending
+/// ```
+///
+/// with `k = log2(folded_domain_size)` and
+/// `folded_domain_size = domain_size >> folding_factor`.
+///
+/// # Output
+///
+/// - length = `t = min(num_queries, folded_domain_size)`
+/// - range  = `[0, folded_domain_size)`
+/// - order  = strictly ascending, pairwise distinct, uniform per index
 ///
 /// # Soundness
 ///
-/// The WHIR shift-query bound (Arnon, Chiesa, Fenzi, Yogev 2024,
-/// Theorem 5.2) is `ε^shift ≤ (1 - δ)^t`, where `t` is the number of
-/// *distinct* query positions. A sample-with-replacement implementation
-/// followed by `dedup()` leaks soundness in two ways:
+/// WHIR shift-query bound (Arnon-Chiesa-Fenzi-Yogev 2024, Thm 5.2):
 ///
-/// 1. **Modular bias.** [`p3_challenger::CanSampleBits::sample_bits`]
-///    bit-decomposes a uniformly drawn field element and is documented
-///    as "reasonably close to" — not exactly — uniform. The per-draw
-///    bias is bounded by `2^bits / |F|` but non-zero, and inflates the
-///    effective `δ` in the bound.
-/// 2. **Birthday-paradox shrinkage.** A `dedup()` pass on collisions
-///    returns fewer than `num_queries` distinct positions, weakening
-///    the effective `t`.
+/// ```text
+///   eps_shift  <=  (1 - delta)^t
+/// ```
 ///
-/// This implementation closes both gaps:
+/// `t` must count **distinct, uniform** positions. Two leaks closed here:
 ///
-/// - [`CanSampleUniformBits::sample_uniform_bits`] with `RESAMPLE = true`
-///   uses field-side rejection sampling so each draw is exactly uniform
-///   on `[0, 2^bits)`; and
-/// - duplicates are rejected so the returned vector has length exactly
-///   `min(num_queries, folded_domain_size)`, matching the soundness
-///   bound's `t` tightly.
+/// - **Biased draws** — bit-decomposing a uniform field element biases
+///   each draw by `~ 2^bits / |F|`, which inflates `delta`.
+/// - **Dedup shrinkage** — sample-with-replacement plus deduplication
+///   returns fewer positions than asked, which lowers `t`.
 ///
-/// # Performance
+/// # Saturation
 ///
-/// `sample_uniform_bits::<true>(bits)` is essentially free for
-/// `bits ≤ MAX_SINGLE_SAMPLE_BITS` on small fields (single field draw,
-/// resample probability `≈ 1 / |F|`). The duplicate-rejection loop runs
-/// in `O(target)` iterations in expectation when `folded_domain_size`
-/// is much larger than `target` (the typical WHIR regime), and in
-/// `O(target · log target)` in the worst case when `target` approaches
-/// `folded_domain_size` (coupon-collector behaviour).
+/// `num_queries > folded_domain_size` returns the full domain. This is
+/// WHIR's final round: 1-4 folded positions vs. `final_queries` up to 75.
+///
+/// # Cost
+///
+/// ```text
+///   per draw         | 1-2 field samples, reject prob ~ 1 / |F|
+///   loop, common     | O(t)
+///   loop, saturated  | O(t log t)   (coupon collector)
+/// ```
 ///
 /// # Panics
 ///
-/// Panics if `domain_size >> folding_factor` is not a power of two
-/// (precondition of [`log2_strict_usize`]).
+/// `domain_size >> folding_factor` must be a power of two.
 pub fn get_challenge_stir_queries<Challenger, F, EF>(
     domain_size: usize,
     folding_factor: usize,
@@ -64,23 +66,43 @@ where
     F: Field,
     EF: ExtensionField<F>,
 {
+    // Phase 1: derive the addressable folded domain.
+    //
+    //   folded_domain_size = domain_size >> folding_factor
+    //   k                  = log2(folded_domain_size)
+    //
+    // Each index fits in `k` bits.
     let folded_domain_size = domain_size >> folding_factor;
     let domain_size_bits = log2_strict_usize(folded_domain_size);
 
-    // Cap requested queries at the domain size. When `num_queries` would
-    // exceed `folded_domain_size`, the only set of distinct positions of
-    // the requested size is the entire domain.
+    // Phase 2: cap the request at the domain size.
+    //
+    //   num_queries <= folded_domain_size  ->  target = num_queries
+    //   num_queries  > folded_domain_size  ->  target = folded_domain_size
+    //                                          (open every position)
     let target = num_queries.min(folded_domain_size);
 
+    // Phase 3: rejection-sample distinct indices.
+    //
+    //   loop:
+    //     q <- uniform on [0, 2^k)
+    //     append q if not already present
+    //   until len == target
     let mut queries: Vec<usize> = Vec::with_capacity(target);
     while queries.len() < target {
+        // RESAMPLE = true: the impl loops on field-side rejection internally.
+        //
+        // So the error arm is unreachable for every challenger in this workspace.
         let q = challenger
             .sample_uniform_bits::<true>(domain_size_bits)
-            .expect("Error impossible here due to resampling strategy");
+            .expect("RESAMPLE = true: rejection loops internally, never errors");
+
         if !queries.contains(&q) {
             queries.push(q);
         }
     }
+
+    // Phase 4: verifier and Merkle-proof code consume ascending indices.
     queries.sort_unstable();
     Ok(queries)
 }
@@ -104,28 +126,35 @@ mod tests {
     type Perm = Poseidon2KoalaBear<16>;
     type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 
-    /// Build a `DuplexChallenger` whose Poseidon2 instance is fixed (seed 42)
-    /// and whose absorbed transcript is determined by `seed`.
+    /// Build a deterministic duplex challenger from a seed.
     ///
-    /// Two challengers built from the same `seed` are byte-identical and will
-    /// therefore produce identical sample sequences — that is what the
-    /// determinism property asserts.
+    /// - Permutation: fixed across calls (seed-independent)
+    /// - Transcript prefix: derived from `seed`
+    ///
+    /// Same seed -> byte-identical sample stream.
     fn challenger_with_seed(seed: u64) -> MyChallenger {
+        // Permutation: deterministic across all test runs.
         let mut perm_rng = SmallRng::seed_from_u64(42);
         let perm = Perm::new_from_rng_128(&mut perm_rng);
         let mut challenger = MyChallenger::new(perm);
 
+        // Transcript primer: 8 field elements derived from `seed`. This is
+        // what makes two challengers with the same seed byte-identical.
         let mut transcript_rng = SmallRng::seed_from_u64(seed);
         let primer: Vec<F> = (0..8).map(|_| transcript_rng.random()).collect();
         challenger.observe_slice(&primer);
         challenger
     }
 
-    /// Generate `(domain_size, folding_factor, num_queries)` such that
-    /// `folded = domain_size >> folding_factor` is a positive power of two
-    /// and `num_queries ∈ [1, folded]`. This keeps the strategy in the
-    /// "common case" regime where the function returns exactly `num_queries`
-    /// distinct positions; the saturation case is covered separately below.
+    /// Strategy for non-saturated `(domain_size, folding_factor, num_queries)`.
+    ///
+    /// ```text
+    ///   log_folded     in [1, 8]   -> folded in [2, 256]
+    ///   folding_factor in [0, 4]
+    ///   num_queries    in [1, folded]
+    /// ```
+    ///
+    /// Saturation (`num_queries > folded`) is covered by a dedicated test.
     fn arb_query_params() -> impl Strategy<Value = (usize, usize, usize)> {
         (1usize..=8, 0usize..=4).prop_flat_map(|(log_folded, folding_factor)| {
             let folded = 1usize << log_folded;
@@ -138,15 +167,20 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(64))]
 
-        /// Length, range, sortedness, distinctness, and determinism in a
-        /// single property so each case pays for one challenger setup.
         #[test]
         fn prop_get_challenge_stir_queries_invariants(
             (domain_size, folding_factor, num_queries) in arb_query_params(),
             seed in any::<u64>(),
         ) {
+            // Five invariants, one challenger setup per case:
+            // (1) length
+            // (2) range
+            // (3) strict sort
+            // (4) distinct
+            // (5) deterministic replay
             let folded_domain_size = domain_size >> folding_factor;
 
+            // First run: seed -> queries_a.
             let mut challenger_a = challenger_with_seed(seed);
             let queries_a = get_challenge_stir_queries::<MyChallenger, F, EF>(
                 domain_size,
@@ -154,32 +188,32 @@ mod tests {
                 num_queries,
                 &mut challenger_a,
             )
-            .expect("sampling under RESAMPLE = true cannot fail");
+            .expect("RESAMPLE = true cannot fail");
 
-            // 1. Length: exactly num_queries when num_queries ≤ folded_domain_size.
+            // (1) length == request.
             prop_assert_eq!(queries_a.len(), num_queries);
 
-            // 2. Range: every q in [0, folded_domain_size).
+            // (2) every index in [0, folded_domain_size).
             for &q in &queries_a {
                 prop_assert!(
                     q < folded_domain_size,
-                    "query {} out of range [0, {})", q, folded_domain_size
+                    "out of range: {} not in [0, {})", q, folded_domain_size
                 );
             }
 
-            // 3. Sortedness (ascending).
+            // (3) strictly ascending.
             prop_assert!(
                 queries_a.windows(2).all(|w| w[0] < w[1]),
-                "queries not strictly sorted: {:?}", queries_a
+                "not sorted: {:?}", queries_a
             );
 
-            // 4. Distinctness (already implied by strict sort, but assert
-            //    explicitly via a set for clarity).
+            // (4) pairwise distinct -- redundant given (3); set check
+            //     guards against a future weakening of (3).
             let unique: BTreeSet<usize> = queries_a.iter().copied().collect();
             prop_assert_eq!(unique.len(), num_queries, "duplicates in {:?}", queries_a);
 
-            // 5. Determinism: a fresh challenger from the same seed yields
-            //    a byte-identical query vector.
+            // (5) determinism: same seed -> byte-identical output.
+            //     This is the prover/verifier Fiat-Shamir replay property.
             let mut challenger_b = challenger_with_seed(seed);
             let queries_b = get_challenge_stir_queries::<MyChallenger, F, EF>(
                 domain_size,
@@ -187,17 +221,18 @@ mod tests {
                 num_queries,
                 &mut challenger_b,
             )
-            .expect("sampling under RESAMPLE = true cannot fail");
+            .expect("RESAMPLE = true cannot fail");
             prop_assert_eq!(queries_a, queries_b);
         }
     }
 
-    /// Saturation: when `num_queries > folded_domain_size`, return every
-    /// position. This is the WHIR final-round regime where the folded domain
-    /// is small (often 1–4) but `final_queries` can be much larger.
     #[test]
     fn saturates_when_num_queries_exceeds_domain() {
-        // Folded domain of size 4 (= 16 >> 2); request 75 queries.
+        // WHIR final-round regime: ask for more queries than positions.
+        //
+        //   folded_domain_size = 16 >> 2 = 4
+        //   num_queries        = 75            (>> 4)
+        //   expected           = [0, 1, 2, 3]  (full domain, ascending)
         let domain_size = 16usize;
         let folding_factor = 2usize;
         let folded_domain_size = domain_size >> folding_factor;
@@ -210,40 +245,42 @@ mod tests {
             num_queries,
             &mut challenger,
         )
-        .expect("sampling under RESAMPLE = true cannot fail");
+        .expect("RESAMPLE = true cannot fail");
 
+        // Length capped at the domain; output is the full domain ascending.
         assert_eq!(queries.len(), folded_domain_size);
         assert_eq!(queries, (0..folded_domain_size).collect::<Vec<_>>());
     }
 
-    /// Empirical uniformity check for single-query draws on a small folded
-    /// domain.
-    ///
-    /// We draw one query per fresh challenger (seeded by a counter) and bin
-    /// the results into `N = 16` buckets. With `M = 4096` independent draws
-    /// and per-bucket expectation `M/N = 256`, Hoeffding on the indicator
-    /// `1[q == k]` gives, for any fixed bucket `k`,
-    ///
-    ///     Pr[ |count_k − M/N| ≥ t ] ≤ 2 · exp(−2 t² / M).
-    ///
-    /// Tolerance `t = 160` gives `32 · exp(−160² / 2048) ≈ 1.2 · 10⁻⁴` after
-    /// union-bounding both tails over 16 buckets — comfortably below CI's
-    /// flake threshold.
-    ///
-    /// This is a plain `#[test]`, not a proptest: the challenger already
-    /// supplies all the randomness needed; stacking proptest on top would
-    /// only inflate the bound.
     #[test]
     fn empirical_uniformity_single_query() {
+        // Histogram-based regression detector for uniform sampling.
+        //
+        //   N = 16 buckets, M = 4096 draws, expected = M/N = 256
+        //
+        // Hoeffding on the bucket indicator 1[q == k]:
+        //
+        //   Pr[ |count_k - 256| >= t ]  <=  2 * exp(-2 t^2 / M)
+        //
+        // With t = 160:
+        //
+        //   per-bucket    : 2  * exp(-12.5) ~ 7.4e-6
+        //   union 16 bins : 32 * exp(-12.5) ~ 1.2e-4
+        //
+        // Cryptographic uniformity rests on the field-side rejection
+        // primitive; this test only catches gross regressions.
         const FOLDED_DOMAIN_SIZE: usize = 16;
         const NUM_DRAWS: usize = 4096;
         const TOLERANCE: usize = 160;
 
+        // Pick parameters so the folded domain has exactly 16 positions.
         let domain_size: usize = 64;
         let folding_factor: usize = 2;
         assert_eq!(domain_size >> folding_factor, FOLDED_DOMAIN_SIZE);
 
+        // Histogram one draw per challenger seed.
         let mut counts = [0usize; FOLDED_DOMAIN_SIZE];
+        // Histogram: one draw per seed.
         for seed in 0u64..NUM_DRAWS as u64 {
             let mut challenger = challenger_with_seed(seed);
             let q = get_challenge_stir_queries::<MyChallenger, F, EF>(
@@ -252,17 +289,18 @@ mod tests {
                 1,
                 &mut challenger,
             )
-            .expect("sampling under RESAMPLE = true cannot fail");
+            .expect("RESAMPLE = true cannot fail");
             assert_eq!(q.len(), 1);
             counts[q[0]] += 1;
         }
 
+        // Each bucket within +/- TOLERANCE of expected count.
         let expected = NUM_DRAWS / FOLDED_DOMAIN_SIZE;
         for (bucket, &count) in counts.iter().enumerate() {
             let deviation = count.abs_diff(expected);
             assert!(
                 deviation <= TOLERANCE,
-                "bucket {bucket}: count {count} deviates from expected {expected} by {deviation} > {TOLERANCE}; full counts = {counts:?}"
+                "bucket {bucket}: count {count} deviates from {expected} by {deviation} > {TOLERANCE}; counts = {counts:?}"
             );
         }
     }

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 use core::slice::from_ref;
 
 use errors::VerifierError;
-use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
@@ -38,7 +38,7 @@ impl<'a, EF, F, MT, Challenger> WhirVerifier<'a, EF, F, MT, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanSampleUniformBits<F>,
     MT: Mmcs<F>,
 {
     pub const fn new(params: &'a WhirConfig<EF, F, MT, Challenger>) -> Self {


### PR DESCRIPTION
## TL;DR

WHIR's STIR query sampler was calling the slightly-biased [`CanSampleBits::sample_bits`](https://github.com/Plonky3/Plonky3/blob/main/challenger/src/lib.rs#L62-L71) primitive and then de-duplicating with `sort_unstable + dedup`. This PR swaps the call site to the unbiased [`CanSampleUniformBits::sample_uniform_bits::<true>`](https://github.com/Plonky3/Plonky3/blob/main/challenger/src/lib.rs#L78-L96) (which already exists in this repo and uses field-side rejection sampling) and replaces the post-hoc dedup with an explicit reject-and-retry loop. **`sample_bits` itself is unchanged** — it remains correct for callers like grinding/PoW where small bias is acceptable.

## The bug

Vs. the WHIR shift-query bound `ε^shift ≤ (1 − δ)^t` (Theorem 5.2 in Arnon–Chiesa–Fenzi–Yogev 2024), the bound is over `t` independent **uniformly-sampled** query positions; per-draw uniformity is what the bound requires.

`sample_bits` bit-decomposes a uniformly drawn field element. Values in `[m, p)`, where `m = ⌊p / 2^bits⌋ · 2^bits`, induce bias on the low `bits`. The trait's own docstring admits "may arise when bit-decomposing a uniformly sampled field element". Per-draw bias (TV distance from uniform) is bounded by `2^bits / |F|` — negligible on Goldilocks (~`2^{-44}` at 20 bits), and at most ~`2^{-11}` on KoalaBear at the same. The old code mitigated by capping `bits ≤ MAX_SAMPLE_BITS = 20`, but the bias was non-zero and inflated the effective `δ`.

## What changed (algorithmically)

Old hot loop in `whir/src/pcs/utils.rs` (3 batched branches around `sample_bits`, simplified):

```rust
let max_bits_per_call = (F::bits() - 1).min(MAX_SAMPLE_BITS);  // = 20
// ... pack queries into batched sample_bits calls ...
let mut all_bits = challenger.sample_bits(batch_bits);   // <-- biased
for _ in 0..batch_size {
    let q = (all_bits & mask) % folded_domain_size;
    queries.push(q);
    all_bits >>= domain_size_bits;
}
// ...
queries.sort_unstable();
queries.dedup();
```

New hot loop:

```rust
let target = num_queries.min(folded_domain_size);
let mut queries: Vec<usize> = Vec::with_capacity(target);
while queries.len() < target {
    let q = challenger
        .sample_uniform_bits::<true>(domain_size_bits)   // <-- unbiased
        .expect("Error impossible here due to resampling strategy");
    if !queries.contains(&q) {
        queries.push(q);
    }
}
queries.sort_unstable();
```

`MAX_SAMPLE_BITS` is deleted because the 20-bit cap was a mitigation for the bias that no longer exists.

## What `sample_uniform_bits::<true>` does differently

For each draw, [`DuplexChallenger`](https://github.com/Plonky3/Plonky3/blob/main/challenger/src/duplex_challenger.rs#L309-L327) rejects field elements that fall in `[m, p)` and resamples:

```rust
let mut result: F = challenger.sample();
while result.as_canonical_u64() >= m {  // <-- reject and resample
    result = challenger.sample();
}
// result is now uniform on [0, m), low `bits` are exactly uniform on [0, 2^bits)
```

Resample probability per draw is `≤ 2^bits / |F|` (and exactly `1/|F|` for KoalaBear/BabyBear/Goldilocks at typical `bits`, due to those primes' structure). The loop terminates in essentially one iteration. KoalaBear/BabyBear/Goldilocks/Mersenne31 all have `UniformSamplingField` impls, so this works out of the box.

The `.expect()` matches the existing pattern at [`grinding_challenger.rs:75-79`](https://github.com/Plonky3/Plonky3/blob/main/challenger/src/grinding_challenger.rs#L75-L79) (`check_witness_uniform`) — with `RESAMPLE = true` the underlying impl loops on rejection rather than erroring, so the `Err` arm is unreachable. Happy to switch to a `Resampling(ResamplingError)` variant on `FiatShamirError` + `?` propagation if reviewers prefer.

## Saturation: the `min(num_queries, folded_domain_size)` cap

In WHIR's final round the folded domain shrinks to ~1–4 positions while `final_queries` can be much larger (75 in `test_whir_end_to_end`). The implementation caps at `target = min(num_queries, folded_domain_size)`: when the requested count exceeds the folded domain, the verifier opens every position, which is the strongest possible verification at that round.

## Auxiliary change: `CanSampleUniformBits` for `SerializingChallenger`

The new bound on `WhirPcs`'s `MultilinearPcs` impl would have broken the WHIR keccak end-to-end test (`whir/src/pcs/tests.rs::keccak_tests::test_whir_keccak_end_to_end`), because `SerializingChallenger32` did not implement `CanSampleUniformBits<F>`. Added trivial impls for both `SerializingChallenger32` and `SerializingChallenger64`:

```rust
impl<F, Inner> CanSampleUniformBits<F> for SerializingChallenger32<F, Inner>
where
    F: PrimeField32,
    Inner: CanSample<u8>,
{
    fn sample_uniform_bits<const RESAMPLE: bool>(
        &mut self,
        bits: usize,
    ) -> Result<usize, ResamplingError> {
        Ok(self.sample_bits(bits))
    }
}
```

Justification: `SerializingChallenger32::sample_bits` is **already exactly uniform** (it draws bytes from a cryptographic-hash inner challenger and masks — no field-element decomposition, hence no `[m, p)` rejection band). The `RESAMPLE` flag is a no-op for this challenger family. The struct-level docstring already advertises "Avoids modulo bias".

Note: I did **not** add the impl for `MultiField32Challenger` (no in-tree user, so the workspace builds clean). Easy to add as a follow-up — same shape as above — if external users need it.

## Why scope it as a call-site swap rather than fix `sample_bits`?

`sample_bits` is documented as "reasonably close to uniform" and is used in places where that's fine — notably [`GrindingChallenger::check_witness`](https://github.com/Plonky3/Plonky3/blob/main/challenger/src/grinding_challenger.rs#L40-L46) for proof-of-work. Tightening `sample_bits` to mean "exactly uniform" would either silently change semantics for those callers (with perf implications: extra resampling on every PoW check) or require introducing a new method anyway. WHIR's query sampler is the wrong layer at which to make a workspace-wide trait-semantics change. Routing WHIR through the existing `sample_uniform_bits` is the surgical fix.

## Files changed

| File | Δ | Purpose |
| --- | --- | --- |
| `whir/src/pcs/utils.rs` | +258 / -96 | Function rewrite + 3-test proptest module + doc tightening. |
| `challenger/src/serializing_challenger.rs` | +56 / -2 | New `CanSampleUniformBits<F>` impls for `SerializingChallenger32/64` + doc tightening. |
| `whir/src/pcs/adapter.rs` | +6 / -3 | `+ CanSampleUniformBits<F>` on `MultilinearPcs` impl bound. |
| `whir/src/pcs/prover/mod.rs` | +2 / -2 | Same bound on `WhirProver` impl. |
| `whir/src/pcs/verifier/mod.rs` | +2 / -2 | Same bound on `WhirVerifier` impl. |

## Test plan

- [x] `cargo test -p p3-whir` — **186 tests pass**, including `pcs::tests::test_whir_end_to_end` and `pcs::tests::keccak_tests::test_whir_keccak_end_to_end` (the latter exercises the new `SerializingChallenger32` impl through the WHIR PCS).
- [x] `cargo test -p p3-challenger` — **38 tests pass**.
- [x] `cargo check --workspace --all-targets` — clean across the workspace (uni-stark, fri, circle, batch-stark, examples, …).
- [x] `cargo fmt --all` — no diff.
- [x] `cargo clippy -p p3-whir -p p3-challenger --all-targets -- -D warnings` — no warnings.
- [x] **New tests** in `whir/src/pcs/utils.rs::tests`:
  - `prop_get_challenge_stir_queries_invariants` — 64-case proptest covering length, in-range, strict sortedness, distinctness, and **determinism** (rebuild challenger with same seed → byte-identical output).
  - `saturates_when_num_queries_exceeds_domain` — explicit final-round regime: requesting 75 queries from a 4-position folded domain returns exactly `[0, 1, 2, 3]`.
  - `empirical_uniformity_single_query` — 4096 single-query draws into a 16-bucket histogram. Hoeffding tolerance `t = 160` chosen so per-run flake probability is `< 1.2 × 10⁻⁴` after union-bounding both tails over all buckets. **Regression detector**, not a uniformity certificate (the cryptographic claim rests on `sample_uniform_bits`'s contract).

## Soundness rationale (one paragraph)

WHIR's shift-query soundness (Theorem 5.2) requires `t` independent uniformly-sampled query positions. The previous sampler used `sample_bits`, whose bit-decomposition of a uniform field element introduces a per-draw bias bounded by `2^bits / |F|` — small but non-zero, which would inflate the effective `δ` in the bound. The fix is small but principled: route through the existing `sample_uniform_bits<true>` primitive (field-side rejection sampling, exactly uniform on `[0, 2^bits)`). The bias was small enough not to break security at the parameter sets shipped today, but closing the gap removes a real footnote in the soundness accounting and makes the implementation match the paper's bound at face value.

## Related

- [`leanEthereum/leanMultisig#184`](https://github.com/leanEthereum/leanMultisig/issues/184) — same biased-truncation pattern in lean's `sample_in_range`. Lean can adopt the same primitive in a follow-up PR.
- WHIR paper (Arnon, Chiesa, Fenzi, Yogev 2024), Section 2.1.3 / Theorem 5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
