### PR TITLE
Add carry-critical NEON dot product regression tests

### DIFF
--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -71,9 +71,8 @@ mod tests {
             "dot_product_5 carry-critical case should overflow c_lo"
         );
         assert_eq!(
-            c_hi_prime,
-            prime - 1,
-            "dot_product_5 carry-critical case should hit c_hi_prime = P-1",
+            c_hi_prime, prime,
+            "dot_product_5 carry-critical case should hit c_hi_prime = P before final reduction",
         );
         assert!(
             c_lo < c_lo_a,

--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -20,7 +20,10 @@ pub type PackedBabyBearNeon = PackedMontyField31Neon<BabyBearParameters>;
 #[cfg(test)]
 mod tests {
     use p3_field::PrimeField32;
-    use p3_field_testing::{assert_broadcast_dot_product_matches_scalar, test_packed_field};
+    use p3_field_testing::{
+        assert_packed_broadcast_dot_product_matches_scalar, test_packed_field,
+        test_packed_field_dot_product_boundary,
+    };
 
     use super::WIDTH;
     use crate::BabyBear;
@@ -35,111 +38,34 @@ mod tests {
         p3_monty_31::PackedMontyField31Neon::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
 
-    fn to_monty(value: u32, prime: u32) -> u32 {
-        (((value as u64) << 32) % (prime as u64)) as u32
-    }
+    test_packed_field_dot_product_boundary!(crate::PackedBabyBearNeon);
 
-    fn reduce_once(value: u32, prime: u32) -> u32 {
-        let sub = value.wrapping_sub(prime);
-        value.min(sub)
-    }
+    #[test]
+    fn dot_product_5_carry_cascade_regression() {
+        const P: u32 = BabyBear::ORDER_U32;
+        // `HALF = P / 2`; `P` is odd so `2 * HALF == P - 1`.
+        const HALF: u32 = P / 2;
 
-    fn assert_dot_product_5_carry_critical(lhs: [u32; 5], rhs: [u32; 5], prime: u32) {
-        let mut products = [0_u64; 5];
-        for i in 0..5 {
-            let lhs_monty = to_monty(lhs[i], prime);
-            let rhs_monty = to_monty(rhs[i], prime);
-            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
-        }
+        // Tuned to land `c_lo == 0`, `c_hi_red == P - 1`, low-half carry = 1.
+        let lhs = [3, P - 5, P - 2, P - 1, P - 3];
+        let rhs = [HALF, 0, HALF - 1, 6, HALF - 1];
 
-        let sum_a = products[0] + products[1] + products[2];
-        let sum_b = products[3] + products[4];
-
-        let c_lo_a = sum_a as u32;
-        let c_hi_a = (sum_a >> 32) as u32;
-        let c_lo_b = sum_b as u32;
-        let c_hi_b = (sum_b >> 32) as u32;
-
-        let c_hi_a_red = reduce_once(c_hi_a, prime);
-        let (c_lo, carry) = c_lo_a.overflowing_add(c_lo_b);
-        let c_hi_sum = c_hi_a_red + c_hi_b;
-        let c_hi_red = reduce_once(c_hi_sum, prime);
-        let c_hi_prime = c_hi_red + u32::from(carry);
-
-        assert!(
-            carry,
-            "dot_product_5 carry-critical case should overflow c_lo"
-        );
-        assert_eq!(
-            c_hi_prime, prime,
-            "dot_product_5 carry-critical case should hit c_hi_prime = P before final reduction",
-        );
-        assert!(
-            c_lo < c_lo_a,
-            "carry flag and c_lo relationship should match"
-        );
-    }
-
-    fn assert_dot_product_8_carry_critical(lhs: [u32; 8], rhs: [u32; 8], prime: u32) {
-        let mut products = [0_u64; 8];
-        for i in 0..8 {
-            let lhs_monty = to_monty(lhs[i], prime);
-            let rhs_monty = to_monty(rhs[i], prime);
-            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
-        }
-
-        let sum_a = products[0] + products[1] + products[2] + products[3];
-        let sum_b = products[4] + products[5] + products[6] + products[7];
-
-        let c_lo_a = sum_a as u32;
-        let c_hi_a = (sum_a >> 32) as u32;
-        let c_lo_b = sum_b as u32;
-        let c_hi_b = (sum_b >> 32) as u32;
-
-        let c_hi_a_red = reduce_once(c_hi_a, prime);
-        let c_hi_b_red = reduce_once(c_hi_b, prime);
-        let (_, carry) = c_lo_a.overflowing_add(c_lo_b);
-        let c_hi = c_hi_a_red + c_hi_b_red + u32::from(carry);
-        let c_hi_prime = reduce_once(c_hi, prime);
-
-        assert!(
-            carry,
-            "dot_product_8 carry-critical case should overflow c_lo"
-        );
-        assert_eq!(
-            c_hi_prime,
-            prime - 1,
-            "dot_product_8 carry-critical case should hit c_hi_prime = P-1",
+        assert_packed_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 5>(
+            lhs, rhs,
         );
     }
 
     #[test]
-    fn test_dot_product_5_carry_boundary_case() {
+    fn dot_product_8_carry_cascade_regression() {
         const P: u32 = BabyBear::ORDER_U32;
         const HALF: u32 = P / 2;
-        let lhs_raw = [3, P - 5, P - 2, P - 1, P - 3];
-        let rhs_raw = [HALF, 0, HALF - 1, 6, HALF - 1];
-        assert_dot_product_5_carry_critical(lhs_raw, rhs_raw, P);
 
-        assert_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 5>(
-            BabyBear::new_array(lhs_raw),
-            BabyBear::new_array(rhs_raw),
-            "BabyBear NEON dot_product_5 carry-critical",
-        );
-    }
+        // Stresses the 4+4 split: low halves sum past `2^32`, highs stay in band.
+        let lhs = [HALF, 9, P - 3, 9, HALF, 1, 2, 2];
+        let rhs = [P - 3, 9, P - 2, 2, P - 3, 4, P - 3, 7];
 
-    #[test]
-    fn test_dot_product_8_carry_boundary_case() {
-        const P: u32 = BabyBear::ORDER_U32;
-        const HALF: u32 = P / 2;
-        let lhs_raw = [HALF, 9, P - 3, 9, HALF, 1, 2, 2];
-        let rhs_raw = [P - 3, 9, P - 2, 2, P - 3, 4, P - 3, 7];
-        assert_dot_product_8_carry_critical(lhs_raw, rhs_raw, P);
-
-        assert_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 8>(
-            BabyBear::new_array(lhs_raw),
-            BabyBear::new_array(rhs_raw),
-            "BabyBear NEON dot_product_8 carry-critical",
+        assert_packed_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 8>(
+            lhs, rhs,
         );
     }
 }

--- a/baby-bear/src/aarch64_neon/packing.rs
+++ b/baby-bear/src/aarch64_neon/packing.rs
@@ -19,7 +19,8 @@ pub type PackedBabyBearNeon = PackedMontyField31Neon<BabyBearParameters>;
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field::PrimeField32;
+    use p3_field_testing::{assert_broadcast_dot_product_matches_scalar, test_packed_field};
 
     use super::WIDTH;
     use crate::BabyBear;
@@ -33,4 +34,113 @@ mod tests {
         &[crate::PackedBabyBearNeon::ONE],
         p3_monty_31::PackedMontyField31Neon::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
+
+    fn to_monty(value: u32, prime: u32) -> u32 {
+        (((value as u64) << 32) % (prime as u64)) as u32
+    }
+
+    fn reduce_once(value: u32, prime: u32) -> u32 {
+        let sub = value.wrapping_sub(prime);
+        value.min(sub)
+    }
+
+    fn assert_dot_product_5_carry_critical(lhs: [u32; 5], rhs: [u32; 5], prime: u32) {
+        let mut products = [0_u64; 5];
+        for i in 0..5 {
+            let lhs_monty = to_monty(lhs[i], prime);
+            let rhs_monty = to_monty(rhs[i], prime);
+            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
+        }
+
+        let sum_a = products[0] + products[1] + products[2];
+        let sum_b = products[3] + products[4];
+
+        let c_lo_a = sum_a as u32;
+        let c_hi_a = (sum_a >> 32) as u32;
+        let c_lo_b = sum_b as u32;
+        let c_hi_b = (sum_b >> 32) as u32;
+
+        let c_hi_a_red = reduce_once(c_hi_a, prime);
+        let (c_lo, carry) = c_lo_a.overflowing_add(c_lo_b);
+        let c_hi_sum = c_hi_a_red + c_hi_b;
+        let c_hi_red = reduce_once(c_hi_sum, prime);
+        let c_hi_prime = c_hi_red + u32::from(carry);
+
+        assert!(
+            carry,
+            "dot_product_5 carry-critical case should overflow c_lo"
+        );
+        assert_eq!(
+            c_hi_prime,
+            prime - 1,
+            "dot_product_5 carry-critical case should hit c_hi_prime = P-1",
+        );
+        assert!(
+            c_lo < c_lo_a,
+            "carry flag and c_lo relationship should match"
+        );
+    }
+
+    fn assert_dot_product_8_carry_critical(lhs: [u32; 8], rhs: [u32; 8], prime: u32) {
+        let mut products = [0_u64; 8];
+        for i in 0..8 {
+            let lhs_monty = to_monty(lhs[i], prime);
+            let rhs_monty = to_monty(rhs[i], prime);
+            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
+        }
+
+        let sum_a = products[0] + products[1] + products[2] + products[3];
+        let sum_b = products[4] + products[5] + products[6] + products[7];
+
+        let c_lo_a = sum_a as u32;
+        let c_hi_a = (sum_a >> 32) as u32;
+        let c_lo_b = sum_b as u32;
+        let c_hi_b = (sum_b >> 32) as u32;
+
+        let c_hi_a_red = reduce_once(c_hi_a, prime);
+        let c_hi_b_red = reduce_once(c_hi_b, prime);
+        let (_, carry) = c_lo_a.overflowing_add(c_lo_b);
+        let c_hi = c_hi_a_red + c_hi_b_red + u32::from(carry);
+        let c_hi_prime = reduce_once(c_hi, prime);
+
+        assert!(
+            carry,
+            "dot_product_8 carry-critical case should overflow c_lo"
+        );
+        assert_eq!(
+            c_hi_prime,
+            prime - 1,
+            "dot_product_8 carry-critical case should hit c_hi_prime = P-1",
+        );
+    }
+
+    #[test]
+    fn test_dot_product_5_carry_boundary_case() {
+        const P: u32 = BabyBear::ORDER_U32;
+        const HALF: u32 = P / 2;
+        let lhs_raw = [3, P - 5, P - 2, P - 1, P - 3];
+        let rhs_raw = [HALF, 0, HALF - 1, 6, HALF - 1];
+        assert_dot_product_5_carry_critical(lhs_raw, rhs_raw, P);
+
+        assert_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 5>(
+            BabyBear::new_array(lhs_raw),
+            BabyBear::new_array(rhs_raw),
+            "BabyBear NEON dot_product_5 carry-critical",
+        );
+    }
+
+    #[test]
+    fn test_dot_product_8_carry_boundary_case() {
+        const P: u32 = BabyBear::ORDER_U32;
+        const HALF: u32 = P / 2;
+        let lhs_raw = [HALF, 9, P - 3, 9, HALF, 1, 2, 2];
+        let rhs_raw = [P - 3, 9, P - 2, 2, P - 3, 4, P - 3, 7];
+        assert_dot_product_8_carry_critical(lhs_raw, rhs_raw, P);
+
+        assert_broadcast_dot_product_matches_scalar::<crate::PackedBabyBearNeon, 8>(
+            BabyBear::new_array(lhs_raw),
+            BabyBear::new_array(rhs_raw),
+            "BabyBear NEON dot_product_8 carry-critical",
+        );
+    }
 }

--- a/baby-bear/src/x86_64_avx2/packing.rs
+++ b/baby-bear/src/x86_64_avx2/packing.rs
@@ -16,7 +16,7 @@ impl MontyParametersAVX2 for BabyBearParameters {
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::WIDTH;
     use crate::BabyBear;
@@ -32,4 +32,6 @@ mod tests {
         &[crate::PackedBabyBearAVX2::ONE],
         p3_monty_31::PackedMontyField31AVX2::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedBabyBearAVX2);
 }

--- a/baby-bear/src/x86_64_avx512/packing.rs
+++ b/baby-bear/src/x86_64_avx512/packing.rs
@@ -16,7 +16,7 @@ impl MontyParametersAVX512 for BabyBearParameters {
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::WIDTH;
     use crate::BabyBear;
@@ -33,4 +33,6 @@ mod tests {
         &[crate::PackedBabyBearAVX512::ONE],
         p3_monty_31::PackedMontyField31AVX512::<crate::BabyBearParameters>(super::SPECIAL_VALS)
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedBabyBearAVX512);
 }

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -645,6 +645,31 @@ where
     test_dot_n!(16);
 }
 
+/// Assert that a packed-field dot product matches scalar dot product for a broadcasted test vector.
+///
+/// This is useful for backend-specific regression tests that want deterministic scalar inputs while
+/// still checking lane-wise packed behavior.
+pub fn assert_broadcast_dot_product_matches_scalar<PF, const N: usize>(
+    lhs: [PF::Scalar; N],
+    rhs: [PF::Scalar; N],
+    case_name: &str,
+) where
+    PF: PackedField + Eq,
+{
+    let scalar_result = PF::Scalar::dot_product::<N>(&lhs, &rhs);
+    let packed_lhs = lhs.map(PF::broadcast);
+    let packed_rhs = rhs.map(PF::broadcast);
+    let packed_result = PF::dot_product::<N>(&packed_lhs, &packed_rhs);
+
+    for lane in 0..PF::WIDTH {
+        assert_eq!(
+            packed_result.as_slice()[lane],
+            scalar_result,
+            "{case_name}: dot_product::<{N}> mismatch at lane {lane}",
+        );
+    }
+}
+
 /// Test packed field operations vs scalar with 256 random packed vectors via proptest.
 ///
 /// Verifies add, sub, mul, neg match lane-by-lane scalar results.

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -4,9 +4,10 @@ use alloc::vec::Vec;
 use p3_field::extension::{
     BinomialExtensionField, BinomiallyExtendable, PackedBinomialExtensionField,
 };
+use p3_field::integers::QuotientMap;
 use p3_field::{
     Algebra, BasedVectorSpace, ExtensionField, Field, PackedField, PackedFieldExtension,
-    PackedFieldPow2, PackedValue, PrimeCharacteristicRing,
+    PackedFieldPow2, PackedValue, PrimeCharacteristicRing, PrimeField32,
 };
 use proptest::prelude::*;
 use rand::distr::{Distribution, StandardUniform};
@@ -645,28 +646,139 @@ where
     test_dot_n!(16);
 }
 
-/// Assert that a packed-field dot product matches scalar dot product for a broadcasted test vector.
+/// Eight canonical edge values that probe carry propagation in dot products.
 ///
-/// This is useful for backend-specific regression tests that want deterministic scalar inputs while
-/// still checking lane-wise packed behavior.
-pub fn assert_broadcast_dot_product_matches_scalar<PF, const N: usize>(
-    lhs: [PF::Scalar; N],
-    rhs: [PF::Scalar; N],
-    case_name: &str,
+/// - `0`: additive identity.
+/// - `1`, `2`: small coefficients.
+/// - `p / 4`, `p / 2`, `p / 2 + 1`: mid-range, straddle `2^32` after squaring.
+/// - `p - 2`, `p - 1`: maximum canonical band, products near `(p - 1)^2`.
+const fn boundary_u32_values<F: PrimeField32>() -> [u32; 8] {
+    // `ORDER_U32 > 4`, so every entry is canonical.
+    let p = F::ORDER_U32;
+    [0, 1, 2, p / 4, p / 2, p / 2 + 1, p - 2, p - 1]
+}
+
+/// Map a length-`N` array of canonical `u32`s through the field's quotient map.
+fn u32_array_to_field<F, const N: usize>(values: [u32; N]) -> [F; N]
+where
+    F: PrimeField32 + QuotientMap<u32>,
+{
+    values.map(F::from_int)
+}
+
+/// Compare a broadcast packed dot product against the scalar reference.
+///
+/// Each input is replicated across every SIMD lane, so all lanes must agree
+/// with the scalar result.
+///
+/// # Panics
+///
+/// On lane mismatch. The message echoes the raw inputs for replay.
+pub fn assert_packed_broadcast_dot_product_matches_scalar<PF, const N: usize>(
+    lhs_raw: [u32; N],
+    rhs_raw: [u32; N],
 ) where
     PF: PackedField + Eq,
+    PF::Scalar: PrimeField32 + QuotientMap<u32>,
 {
-    let scalar_result = PF::Scalar::dot_product::<N>(&lhs, &rhs);
-    let packed_lhs = lhs.map(PF::broadcast);
-    let packed_rhs = rhs.map(PF::broadcast);
-    let packed_result = PF::dot_product::<N>(&packed_lhs, &packed_rhs);
+    // Lift raw u32 inputs into the field.
+    let lhs = u32_array_to_field::<PF::Scalar, N>(lhs_raw);
+    let rhs = u32_array_to_field::<PF::Scalar, N>(rhs_raw);
 
-    for lane in 0..PF::WIDTH {
+    // Scalar reference.
+    let scalar_ref = PF::Scalar::dot_product::<N>(&lhs, &rhs);
+
+    // Packed path with each scalar broadcast over all lanes.
+    let packed_lhs: [PF; N] = lhs.map(PF::broadcast);
+    let packed_rhs: [PF; N] = rhs.map(PF::broadcast);
+    let packed = PF::dot_product::<N>(&packed_lhs, &packed_rhs);
+
+    // Every lane must equal the scalar reference.
+    for (lane, got) in packed.as_slice().iter().enumerate() {
         assert_eq!(
-            packed_result.as_slice()[lane],
-            scalar_result,
-            "{case_name}: dot_product::<{N}> mismatch at lane {lane}",
+            *got, scalar_ref,
+            "lane {lane}: packed dot_product::<{N}> mismatch — lhs={lhs_raw:?} rhs={rhs_raw:?}",
         );
+    }
+}
+
+/// Run `dot_product::<N>` against every (left, right) pair from the edge table.
+///
+/// Eight edges → 64 invocations per `N`. Deterministic.
+pub fn test_packed_dot_product_broadcast_boundary_sweep<PF, const N: usize>()
+where
+    PF: PackedField + Eq,
+    PF::Scalar: PrimeField32 + QuotientMap<u32>,
+{
+    let edges = boundary_u32_values::<PF::Scalar>();
+
+    for &v in &edges {
+        for &w in &edges {
+            // Broadcast (v, w) into both length-N input arrays.
+            assert_packed_broadcast_dot_product_matches_scalar::<PF, N>([v; N], [w; N]);
+        }
+    }
+}
+
+/// Per-lane edge-biased random stress for `dot_product::<N>`.
+///
+/// Each SIMD lane gets independently sampled inputs to expose lane-cross bugs
+/// that broadcast tests miss.
+pub fn test_packed_dot_product_lanes_random<PF, const N: usize>()
+where
+    PF: PackedField + Eq,
+    PF::Scalar: PrimeField32 + QuotientMap<u32>,
+{
+    // 1024 iterations × WIDTH lanes × N elements stays under a second per N.
+    const ITERS: usize = 1024;
+
+    let p = PF::Scalar::ORDER_U32;
+    let edges = boundary_u32_values::<PF::Scalar>();
+
+    // Fixed seed so failures replay verbatim.
+    let mut rng = SmallRng::seed_from_u64(0xD07B_0571_0DDE_DEAD);
+
+    for _ in 0..ITERS {
+        // One length-N array per lane, sampled independently per side.
+        let lhs_per_lane: Vec<[PF::Scalar; N]> = (0..PF::WIDTH)
+            .map(|_| {
+                u32_array_to_field::<PF::Scalar, N>(core::array::from_fn(|_| {
+                    sample_edge_or_uniform(&mut rng, &edges, p)
+                }))
+            })
+            .collect();
+        let rhs_per_lane: Vec<[PF::Scalar; N]> = (0..PF::WIDTH)
+            .map(|_| {
+                u32_array_to_field::<PF::Scalar, N>(core::array::from_fn(|_| {
+                    sample_edge_or_uniform(&mut rng, &edges, p)
+                }))
+            })
+            .collect();
+
+        // Transpose lane-major rows to N packed columns.
+        let packed_lhs = PF::pack_columns_fn::<N>(|lane| lhs_per_lane[lane]);
+        let packed_rhs = PF::pack_columns_fn::<N>(|lane| rhs_per_lane[lane]);
+
+        let result = PF::dot_product::<N>(&packed_lhs, &packed_rhs);
+
+        // Per-lane scalar reference.
+        for lane in 0..PF::WIDTH {
+            let expected = PF::Scalar::dot_product::<N>(&lhs_per_lane[lane], &rhs_per_lane[lane]);
+            assert_eq!(
+                result.as_slice()[lane],
+                expected,
+                "lane {lane}: packed dot_product::<{N}> mismatch (random seed)",
+            );
+        }
+    }
+}
+
+/// 50/50 draw between the eight-element edge table and uniform `[0, p)`.
+fn sample_edge_or_uniform(rng: &mut SmallRng, edges: &[u32; 8], prime: u32) -> u32 {
+    if rng.random::<bool>() {
+        edges[(rng.random::<u32>() as usize) % edges.len()]
+    } else {
+        rng.random::<u32>() % prime
     }
 }
 
@@ -765,6 +877,106 @@ macro_rules! test_packed_field {
             #[test]
             fn test_packed_vs_scalar_proptest() {
                 $crate::test_packed_vs_scalar_proptest::<$packedfield>();
+            }
+        }
+    };
+}
+
+/// Run the dot-product carry / boundary stress suite on a packed `PrimeField32`.
+///
+/// Two test functions per `N`:
+/// - boundary-pair sweep over an 8-value edge table,
+/// - per-lane edge-biased random.
+///
+/// `N` covers every SIMD dispatch arm:
+/// - tiny (`1`),
+/// - specialized (`2`, `4`, `5`, `8`),
+/// - chunk-of-4 fallbacks (`3`, `6`, `7`),
+/// - longer loops (`9`, `16`).
+#[macro_export]
+macro_rules! test_packed_field_dot_product_boundary {
+    ($packedfield:ty) => {
+        mod packed_dot_product_boundary_tests {
+            // Exhaustive sweep of (v, w) edge pairs.
+
+            #[test]
+            fn boundary_sweep_n1() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 1>();
+            }
+            #[test]
+            fn boundary_sweep_n2() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 2>();
+            }
+            #[test]
+            fn boundary_sweep_n3() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 3>();
+            }
+            #[test]
+            fn boundary_sweep_n4() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 4>();
+            }
+            #[test]
+            fn boundary_sweep_n5() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 5>();
+            }
+            #[test]
+            fn boundary_sweep_n6() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 6>();
+            }
+            #[test]
+            fn boundary_sweep_n7() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 7>();
+            }
+            #[test]
+            fn boundary_sweep_n8() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 8>();
+            }
+            #[test]
+            fn boundary_sweep_n9() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 9>();
+            }
+            #[test]
+            fn boundary_sweep_n16() {
+                $crate::test_packed_dot_product_broadcast_boundary_sweep::<$packedfield, 16>();
+            }
+
+            // Independent per-lane inputs catch shuffle / lane-cross bugs.
+
+            #[test]
+            fn lanes_random_n2() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 2>();
+            }
+            #[test]
+            fn lanes_random_n3() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 3>();
+            }
+            #[test]
+            fn lanes_random_n4() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 4>();
+            }
+            #[test]
+            fn lanes_random_n5() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 5>();
+            }
+            #[test]
+            fn lanes_random_n6() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 6>();
+            }
+            #[test]
+            fn lanes_random_n7() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 7>();
+            }
+            #[test]
+            fn lanes_random_n8() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 8>();
+            }
+            #[test]
+            fn lanes_random_n9() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 9>();
+            }
+            #[test]
+            fn lanes_random_n16() {
+                $crate::test_packed_dot_product_lanes_random::<$packedfield, 16>();
             }
         }
     };

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -355,8 +355,15 @@ macro_rules! impl_packed_value {
     };
 }
 
-pub use {
-    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
-    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
-    impl_sum_prod_base_field, ring_sum,
-};
+pub use impl_add_assign;
+pub use impl_add_base_field;
+pub use impl_div_methods;
+pub use impl_mul_base_field;
+pub use impl_mul_methods;
+pub use impl_packed_field_div;
+pub use impl_packed_value;
+pub use impl_rng;
+pub use impl_sub_assign;
+pub use impl_sub_base_field;
+pub use impl_sum_prod_base_field;
+pub use ring_sum;

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -355,15 +355,8 @@ macro_rules! impl_packed_value {
     };
 }
 
-pub use impl_add_assign;
-pub use impl_add_base_field;
-pub use impl_div_methods;
-pub use impl_mul_base_field;
-pub use impl_mul_methods;
-pub use impl_packed_field_div;
-pub use impl_packed_value;
-pub use impl_rng;
-pub use impl_sub_assign;
-pub use impl_sub_base_field;
-pub use impl_sum_prod_base_field;
-pub use ring_sum;
+pub use {
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
+    impl_sum_prod_base_field, ring_sum,
+};

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -18,7 +18,10 @@ pub type PackedKoalaBearNeon = PackedMontyField31Neon<KoalaBearParameters>;
 #[cfg(test)]
 mod tests {
     use p3_field::PrimeField32;
-    use p3_field_testing::{assert_broadcast_dot_product_matches_scalar, test_packed_field};
+    use p3_field_testing::{
+        assert_packed_broadcast_dot_product_matches_scalar, test_packed_field,
+        test_packed_field_dot_product_boundary,
+    };
 
     use super::WIDTH;
     use crate::KoalaBear;
@@ -33,110 +36,34 @@ mod tests {
         p3_monty_31::PackedMontyField31Neon::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
 
-    fn to_monty(value: u32, prime: u32) -> u32 {
-        (((value as u64) << 32) % (prime as u64)) as u32
-    }
+    test_packed_field_dot_product_boundary!(crate::PackedKoalaBearNeon);
 
-    fn reduce_once(value: u32, prime: u32) -> u32 {
-        let sub = value.wrapping_sub(prime);
-        value.min(sub)
-    }
+    #[test]
+    fn dot_product_5_carry_cascade_regression() {
+        const P: u32 = KoalaBear::ORDER_U32;
 
-    fn assert_dot_product_5_carry_critical(lhs: [u32; 5], rhs: [u32; 5], prime: u32) {
-        let mut products = [0_u64; 5];
-        for i in 0..5 {
-            let lhs_monty = to_monty(lhs[i], prime);
-            let rhs_monty = to_monty(rhs[i], prime);
-            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
-        }
+        // 5-tuple tuned for KoalaBear's prime; pushes the merge into the
+        // reduce-after-carry boundary.
+        let lhs = [P - 1, 1, 8, P - 3, P - 2];
+        let rhs = [P - 4, 9, P - 2, P - 5, 6];
 
-        let sum_a = products[0] + products[1] + products[2];
-        let sum_b = products[3] + products[4];
-
-        let c_lo_a = sum_a as u32;
-        let c_hi_a = (sum_a >> 32) as u32;
-        let c_lo_b = sum_b as u32;
-        let c_hi_b = (sum_b >> 32) as u32;
-
-        let c_hi_a_red = reduce_once(c_hi_a, prime);
-        let (c_lo, carry) = c_lo_a.overflowing_add(c_lo_b);
-        let c_hi_sum = c_hi_a_red + c_hi_b;
-        let c_hi_red = reduce_once(c_hi_sum, prime);
-        let c_hi_prime = c_hi_red + u32::from(carry);
-
-        assert!(
-            carry,
-            "dot_product_5 carry-critical case should overflow c_lo"
-        );
-        assert_eq!(
-            c_hi_prime, prime,
-            "dot_product_5 carry-critical case should hit c_hi_prime = P before final reduction",
-        );
-        assert!(
-            c_lo < c_lo_a,
-            "carry flag and c_lo relationship should match"
-        );
-    }
-
-    fn assert_dot_product_8_carry_critical(lhs: [u32; 8], rhs: [u32; 8], prime: u32) {
-        let mut products = [0_u64; 8];
-        for i in 0..8 {
-            let lhs_monty = to_monty(lhs[i], prime);
-            let rhs_monty = to_monty(rhs[i], prime);
-            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
-        }
-
-        let sum_a = products[0] + products[1] + products[2] + products[3];
-        let sum_b = products[4] + products[5] + products[6] + products[7];
-
-        let c_lo_a = sum_a as u32;
-        let c_hi_a = (sum_a >> 32) as u32;
-        let c_lo_b = sum_b as u32;
-        let c_hi_b = (sum_b >> 32) as u32;
-
-        let c_hi_a_red = reduce_once(c_hi_a, prime);
-        let c_hi_b_red = reduce_once(c_hi_b, prime);
-        let (_, carry) = c_lo_a.overflowing_add(c_lo_b);
-        let c_hi = c_hi_a_red + c_hi_b_red + u32::from(carry);
-        let c_hi_prime = reduce_once(c_hi, prime);
-
-        assert!(
-            carry,
-            "dot_product_8 carry-critical case should overflow c_lo"
-        );
-        assert_eq!(
-            c_hi_prime,
-            prime - 1,
-            "dot_product_8 carry-critical case should hit c_hi_prime = P-1",
+        assert_packed_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 5>(
+            lhs, rhs,
         );
     }
 
     #[test]
-    fn test_dot_product_5_carry_boundary_case() {
+    fn dot_product_8_carry_cascade_regression() {
         const P: u32 = KoalaBear::ORDER_U32;
-        let lhs_raw = [P - 1, 1, 8, P - 3, P - 2];
-        let rhs_raw = [P - 4, 9, P - 2, P - 5, 6];
-        assert_dot_product_5_carry_critical(lhs_raw, rhs_raw, P);
-
-        assert_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 5>(
-            KoalaBear::new_array(lhs_raw),
-            KoalaBear::new_array(rhs_raw),
-            "KoalaBear NEON dot_product_5 carry-critical",
-        );
-    }
-
-    #[test]
-    fn test_dot_product_8_carry_boundary_case() {
-        const P: u32 = KoalaBear::ORDER_U32;
+        // First lane sits just above the midpoint to shift where the low-half
+        // overflow happens.
         const HALF_PLUS_ONE: u32 = (P / 2) + 1;
-        let lhs_raw = [HALF_PLUS_ONE, P - 2, 6, 0, P - 1, 5, 6, P - 1];
-        let rhs_raw = [9, 5, 2, 7, P - 3, P - 1, 9, P - 5];
-        assert_dot_product_8_carry_critical(lhs_raw, rhs_raw, P);
 
-        assert_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 8>(
-            KoalaBear::new_array(lhs_raw),
-            KoalaBear::new_array(rhs_raw),
-            "KoalaBear NEON dot_product_8 carry-critical",
+        let lhs = [HALF_PLUS_ONE, P - 2, 6, 0, P - 1, 5, 6, P - 1];
+        let rhs = [9, 5, 2, 7, P - 3, P - 1, 9, P - 5];
+
+        assert_packed_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 8>(
+            lhs, rhs,
         );
     }
 }

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -69,9 +69,8 @@ mod tests {
             "dot_product_5 carry-critical case should overflow c_lo"
         );
         assert_eq!(
-            c_hi_prime,
-            prime - 1,
-            "dot_product_5 carry-critical case should hit c_hi_prime = P-1",
+            c_hi_prime, prime,
+            "dot_product_5 carry-critical case should hit c_hi_prime = P before final reduction",
         );
         assert!(
             c_lo < c_lo_a,

--- a/koala-bear/src/aarch64_neon/packing.rs
+++ b/koala-bear/src/aarch64_neon/packing.rs
@@ -17,7 +17,8 @@ pub type PackedKoalaBearNeon = PackedMontyField31Neon<KoalaBearParameters>;
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field::PrimeField32;
+    use p3_field_testing::{assert_broadcast_dot_product_matches_scalar, test_packed_field};
 
     use super::WIDTH;
     use crate::KoalaBear;
@@ -31,4 +32,112 @@ mod tests {
         &[crate::PackedKoalaBearNeon::ONE],
         p3_monty_31::PackedMontyField31Neon::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
+
+    fn to_monty(value: u32, prime: u32) -> u32 {
+        (((value as u64) << 32) % (prime as u64)) as u32
+    }
+
+    fn reduce_once(value: u32, prime: u32) -> u32 {
+        let sub = value.wrapping_sub(prime);
+        value.min(sub)
+    }
+
+    fn assert_dot_product_5_carry_critical(lhs: [u32; 5], rhs: [u32; 5], prime: u32) {
+        let mut products = [0_u64; 5];
+        for i in 0..5 {
+            let lhs_monty = to_monty(lhs[i], prime);
+            let rhs_monty = to_monty(rhs[i], prime);
+            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
+        }
+
+        let sum_a = products[0] + products[1] + products[2];
+        let sum_b = products[3] + products[4];
+
+        let c_lo_a = sum_a as u32;
+        let c_hi_a = (sum_a >> 32) as u32;
+        let c_lo_b = sum_b as u32;
+        let c_hi_b = (sum_b >> 32) as u32;
+
+        let c_hi_a_red = reduce_once(c_hi_a, prime);
+        let (c_lo, carry) = c_lo_a.overflowing_add(c_lo_b);
+        let c_hi_sum = c_hi_a_red + c_hi_b;
+        let c_hi_red = reduce_once(c_hi_sum, prime);
+        let c_hi_prime = c_hi_red + u32::from(carry);
+
+        assert!(
+            carry,
+            "dot_product_5 carry-critical case should overflow c_lo"
+        );
+        assert_eq!(
+            c_hi_prime,
+            prime - 1,
+            "dot_product_5 carry-critical case should hit c_hi_prime = P-1",
+        );
+        assert!(
+            c_lo < c_lo_a,
+            "carry flag and c_lo relationship should match"
+        );
+    }
+
+    fn assert_dot_product_8_carry_critical(lhs: [u32; 8], rhs: [u32; 8], prime: u32) {
+        let mut products = [0_u64; 8];
+        for i in 0..8 {
+            let lhs_monty = to_monty(lhs[i], prime);
+            let rhs_monty = to_monty(rhs[i], prime);
+            products[i] = (lhs_monty as u64) * (rhs_monty as u64);
+        }
+
+        let sum_a = products[0] + products[1] + products[2] + products[3];
+        let sum_b = products[4] + products[5] + products[6] + products[7];
+
+        let c_lo_a = sum_a as u32;
+        let c_hi_a = (sum_a >> 32) as u32;
+        let c_lo_b = sum_b as u32;
+        let c_hi_b = (sum_b >> 32) as u32;
+
+        let c_hi_a_red = reduce_once(c_hi_a, prime);
+        let c_hi_b_red = reduce_once(c_hi_b, prime);
+        let (_, carry) = c_lo_a.overflowing_add(c_lo_b);
+        let c_hi = c_hi_a_red + c_hi_b_red + u32::from(carry);
+        let c_hi_prime = reduce_once(c_hi, prime);
+
+        assert!(
+            carry,
+            "dot_product_8 carry-critical case should overflow c_lo"
+        );
+        assert_eq!(
+            c_hi_prime,
+            prime - 1,
+            "dot_product_8 carry-critical case should hit c_hi_prime = P-1",
+        );
+    }
+
+    #[test]
+    fn test_dot_product_5_carry_boundary_case() {
+        const P: u32 = KoalaBear::ORDER_U32;
+        let lhs_raw = [P - 1, 1, 8, P - 3, P - 2];
+        let rhs_raw = [P - 4, 9, P - 2, P - 5, 6];
+        assert_dot_product_5_carry_critical(lhs_raw, rhs_raw, P);
+
+        assert_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 5>(
+            KoalaBear::new_array(lhs_raw),
+            KoalaBear::new_array(rhs_raw),
+            "KoalaBear NEON dot_product_5 carry-critical",
+        );
+    }
+
+    #[test]
+    fn test_dot_product_8_carry_boundary_case() {
+        const P: u32 = KoalaBear::ORDER_U32;
+        const HALF_PLUS_ONE: u32 = (P / 2) + 1;
+        let lhs_raw = [HALF_PLUS_ONE, P - 2, 6, 0, P - 1, 5, 6, P - 1];
+        let rhs_raw = [9, 5, 2, 7, P - 3, P - 1, 9, P - 5];
+        assert_dot_product_8_carry_critical(lhs_raw, rhs_raw, P);
+
+        assert_broadcast_dot_product_matches_scalar::<crate::PackedKoalaBearNeon, 8>(
+            KoalaBear::new_array(lhs_raw),
+            KoalaBear::new_array(rhs_raw),
+            "KoalaBear NEON dot_product_8 carry-critical",
+        );
+    }
 }

--- a/koala-bear/src/x86_64_avx2/packing.rs
+++ b/koala-bear/src/x86_64_avx2/packing.rs
@@ -16,7 +16,7 @@ impl MontyParametersAVX2 for KoalaBearParameters {
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::WIDTH;
     use crate::KoalaBear;
@@ -32,4 +32,6 @@ mod tests {
         &[crate::PackedKoalaBearAVX2::ONE],
         p3_monty_31::PackedMontyField31AVX2::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedKoalaBearAVX2);
 }

--- a/koala-bear/src/x86_64_avx512/packing.rs
+++ b/koala-bear/src/x86_64_avx512/packing.rs
@@ -16,7 +16,7 @@ impl MontyParametersAVX512 for KoalaBearParameters {
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::WIDTH;
     use crate::KoalaBear;
@@ -33,4 +33,6 @@ mod tests {
         &[crate::PackedKoalaBearAVX512::ONE],
         p3_monty_31::PackedMontyField31AVX512::<crate::KoalaBearParameters>(super::SPECIAL_VALS)
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedKoalaBearAVX512);
 }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -368,7 +368,7 @@ impl_packed_field_pow_2!(
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::{Mersenne31, PackedMersenne31Neon};
 
@@ -387,4 +387,6 @@ mod tests {
         &[crate::PackedMersenne31Neon::ONE],
         super::SPECIAL_VALS
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedMersenne31Neon);
 }

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -415,7 +415,7 @@ impl_packed_field_pow_2!(
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::{Mersenne31, PackedMersenne31AVX2};
 
@@ -436,4 +436,6 @@ mod tests {
         &[crate::PackedMersenne31AVX2::ONE],
         super::SPECIAL_VALS
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedMersenne31AVX2);
 }

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -435,7 +435,7 @@ impl_packed_field_pow_2!(
 
 #[cfg(test)]
 mod tests {
-    use p3_field_testing::test_packed_field;
+    use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::{Mersenne31, PackedMersenne31AVX512};
 
@@ -458,4 +458,6 @@ mod tests {
         &[crate::PackedMersenne31AVX512::ONE],
         super::SPECIAL_VALS
     );
+
+    test_packed_field_dot_product_boundary!(crate::PackedMersenne31AVX512);
 }

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -13,9 +13,8 @@ use p3_field::op_assign_macros::{
     impl_sum_prod_base_field, ring_sum,
 };
 use p3_field::{
-    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, uint32x4_mod_add,
-    uint32x4_mod_sub,
+    impl_packed_field_pow_2, uint32x4_mod_add, uint32x4_mod_sub, Algebra, Field, InjectiveMonomial,
+    PackedField, PackedFieldPow2, PackedValue, PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -1083,9 +1082,11 @@ where
         let c_hi_red = aarch64::vminq_u32(c_hi_sum, c_hi_sub);
 
         // Now incorporate carry: c_hi_red ∈ [0, P-2] (max is 2P-2 reduced to P-2).
-        // Adding carry (0 or 1) gives at most P-1, so no further reduction needed.
+        // Adding carry (0 or 1) can produce P in boundary cases, so reduce once more.
         // Subtracting -1 adds 1; subtracting 0 is a no-op.
-        let c_hi_prime = aarch64::vsubq_u32(c_hi_red, carry);
+        let c_hi_with_carry = aarch64::vsubq_u32(c_hi_red, carry);
+        let c_hi_prime_sub = aarch64::vsubq_u32(c_hi_with_carry, P::PACKED_P);
+        let c_hi_prime = aarch64::vminq_u32(c_hi_with_carry, c_hi_prime_sub);
 
         // Montgomery reduction (identical to dot_product_4).
         //

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -13,8 +13,9 @@ use p3_field::op_assign_macros::{
     impl_sum_prod_base_field, ring_sum,
 };
 use p3_field::{
-    impl_packed_field_pow_2, uint32x4_mod_add, uint32x4_mod_sub, Algebra, Field, InjectiveMonomial,
-    PackedField, PackedFieldPow2, PackedValue, PermutationMonomial, PrimeCharacteristicRing,
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, uint32x4_mod_add,
+    uint32x4_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -1076,18 +1076,13 @@ where
         // carry = -1 (all 1s) if c_lo wrapped, 0 otherwise.
         let carry = aarch64::vcltq_u32(c_lo, c_lo_a);
 
-        // Reduce c_hi_sum BEFORE incorporating carry for better ILP.
-        // c_hi_sum = c_hi_a' + c_hi_b ∈ [0, 2P-2] (both < P).
+        // c_hi_sum ∈ [0, 2P-2].
         let c_hi_sum = aarch64::vaddq_u32(c_hi_a_red, c_hi_b);
-        let c_hi_sub = aarch64::vsubq_u32(c_hi_sum, P::PACKED_P);
-        let c_hi_red = aarch64::vminq_u32(c_hi_sum, c_hi_sub);
-
-        // Now incorporate carry: c_hi_red ∈ [0, P-2] (max is 2P-2 reduced to P-2).
-        // Adding carry (0 or 1) can produce P in boundary cases, so reduce once more.
-        // Subtracting -1 adds 1; subtracting 0 is a no-op.
-        let c_hi_with_carry = aarch64::vsubq_u32(c_hi_red, carry);
-        let c_hi_prime_sub = aarch64::vsubq_u32(c_hi_with_carry, P::PACKED_P);
-        let c_hi_prime = aarch64::vminq_u32(c_hi_with_carry, c_hi_prime_sub);
+        // Subtracting -1 adds 1; subtracting 0 is a no-op. c_hi ∈ [0, 2P-1].
+        let c_hi = aarch64::vsubq_u32(c_hi_sum, carry);
+        // Conditional subtract by P → c_hi_prime ∈ [0, P-1].
+        let c_hi_sub = aarch64::vsubq_u32(c_hi, P::PACKED_P);
+        let c_hi_prime = aarch64::vminq_u32(c_hi, c_hi_sub);
 
         // Montgomery reduction (identical to dot_product_4).
         //


### PR DESCRIPTION
Add carry-critical regression tests for NEON dot_product_5 and dot_product_8, ensuring packed outputs match scalar references at overflow boundaries.