### PR TITLE
refactor(challenger): align bits==0 short-circuit across grind impls

### DIFF
--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -294,6 +294,12 @@ where
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize), "bit count must be valid");
         assert!((1 << bits) < F::ORDER_U32);
+
+        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
+        if bits == 0 {
+            return F::ZERO;
+        }
+
         let witness = (0..F::ORDER_U32)
             .into_par_iter()
             .map(|i| unsafe {

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -255,6 +255,7 @@ mod tests {
     use p3_symmetric::Permutation;
 
     use super::*;
+    use crate::grinding_challenger::GrindingChallenger;
 
     const WIDTH: usize = 8;
     const RATE: usize = 4;
@@ -404,5 +405,22 @@ mod tests {
             RATE * num_f_elms,
             "After duplexing, output buffer should contain RATE * num_f_elms elements"
         );
+    }
+
+    #[test]
+    fn test_grind_zero_bits_returns_zero() {
+        // bits == 0: must short-circuit to ZERO without touching state.
+        let mut challenger =
+            MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+
+        // Snapshot to detect any transcript mutation.
+        let before = challenger.clone();
+
+        let witness = challenger.grind(0);
+
+        assert_eq!(witness, F::ZERO);
+        assert_eq!(challenger.input_buffer, before.input_buffer);
+        assert_eq!(challenger.output_buffer, before.output_buffer);
+        assert_eq!(challenger.sponge_state, before.sponge_state);
     }
 }

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -443,3 +443,78 @@ where
         self.inner.finalize()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_goldilocks::Goldilocks;
+    use p3_symmetric::CryptographicHasher;
+
+    use super::*;
+    use crate::HashChallenger;
+
+    /// Toy byte hasher: deterministic length-only fingerprint.
+    ///
+    /// Enough to drive the challenger plumbing without pulling in a real hash crate.
+    #[derive(Clone)]
+    struct ByteCountHasher;
+
+    impl CryptographicHasher<u8, [u8; 32]> for ByteCountHasher {
+        fn hash_iter<I>(&self, input: I) -> [u8; 32]
+        where
+            I: IntoIterator<Item = u8>,
+        {
+            let len = input.into_iter().count() as u8;
+            core::array::from_fn(|i| len.wrapping_add(i as u8))
+        }
+
+        fn hash_iter_slices<'a, I>(&self, input: I) -> [u8; 32]
+        where
+            I: IntoIterator<Item = &'a [u8]>,
+        {
+            let len = input.into_iter().map(<[u8]>::len).sum::<usize>() as u8;
+            core::array::from_fn(|i| len.wrapping_add(i as u8))
+        }
+    }
+
+    type Inner = HashChallenger<u8, ByteCountHasher, 32>;
+
+    #[test]
+    fn test_serializing_challenger32_grind_zero_bits_returns_zero() {
+        // bits == 0: must short-circuit to ZERO without consuming bytes.
+        type F = BabyBear;
+        let inner = Inner::new(vec![0, 1, 2, 3], ByteCountHasher);
+        let mut challenger = SerializingChallenger32::<F, Inner>::new(inner);
+
+        // Pristine shadow: equal next-byte proves no inner mutation.
+        let mut shadow = challenger.clone();
+
+        let witness = challenger.grind(0);
+
+        assert_eq!(witness, F::ZERO);
+        let after_grind: u8 = challenger.inner.sample();
+        let no_grind: u8 = shadow.inner.sample();
+        assert_eq!(after_grind, no_grind);
+    }
+
+    #[test]
+    fn test_serializing_challenger64_grind_zero_bits_returns_zero() {
+        // bits == 0: must short-circuit to ZERO without consuming bytes.
+        type F = Goldilocks;
+        let inner = Inner::new(vec![0, 1, 2, 3], ByteCountHasher);
+        let mut challenger = SerializingChallenger64::<F, Inner>::new(inner);
+
+        // Pristine shadow: equal next-byte proves no inner mutation.
+        let mut shadow = challenger.clone();
+
+        let witness = challenger.grind(0);
+
+        assert_eq!(witness, F::ZERO);
+        let after_grind: u8 = challenger.inner.sample();
+        let no_grind: u8 = shadow.inner.sample();
+        assert_eq!(after_grind, no_grind);
+    }
+}

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -206,6 +206,12 @@ where
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
         assert!((1 << bits) < F::ORDER_U32);
+
+        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
+        if bits == 0 {
+            return F::ZERO;
+        }
+
         let witness = (0..F::ORDER_U32)
             .into_par_iter()
             .map(|i| unsafe {
@@ -390,6 +396,12 @@ where
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < 64);
         assert!((1u64 << bits) < F::ORDER_U64);
+
+        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
+        if bits == 0 {
+            return F::ZERO;
+        }
+
         let witness = (0..F::ORDER_U64)
             .into_par_iter()
             .map(|i| unsafe {


### PR DESCRIPTION
Mirror `DuplexChallenger::grind`'s `if bits == 0 { return F::ZERO; }` early-return into the other three `GrindingChallenger` implementations (`SerializingChallenger32`, `SerializingChallenger64`, `MultiField32Challenger`) for trait-implementation consistency; behavior is unchanged since `check_witness`
  already short-circuits on `bits == 0`.