### PR TITLE
perf(field): preserve packed ILP in batch_multiplicative_inverse for non-WIDTH-aligned inputs

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -21,7 +21,7 @@ use num_bigint::BigUint;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
     ExtensionField, Field, PackedValue, PrimeCharacteristicRing, PrimeField32, PrimeField64,
-    TwoAdicField,
+    TwoAdicField, batch_multiplicative_inverse,
 };
 use p3_util::iter_array_chunks_padded;
 pub use packedfield_testing::*;
@@ -343,6 +343,51 @@ where
             let z = x.inverse();
             assert_ne!(x, z);
             assert_eq!(x * z, F::ONE);
+        }
+    }
+}
+
+/// Verify [`batch_multiplicative_inverse`] against the naive per-element inverse
+/// across a range of input lengths.
+///
+/// Sizes are chosen to exercise:
+/// - the empty input,
+/// - lengths below the packing width (tail-only path),
+/// - lengths whose remainder mod the packing width is 1, 2, or 3
+///   (mixed prefix-packed + tail-serial path),
+/// - lengths that straddle the internal `par_chunks` boundary (1024)
+///   so the trailing chunk receives a non-aligned tail.
+pub fn test_batch_multiplicative_inverse<F: Field>()
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(0xBA7C);
+
+    let lengths = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 16, 17, 63, 64, 65, 1023, 1024, 1025, 1027, 2049, 4099,
+    ];
+
+    for &n in &lengths {
+        let xs: Vec<F> = (0..n)
+            .map(|_| {
+                // Reject zero so every input is invertible.
+                let mut x = rng.random::<F>();
+                while x.is_zero() {
+                    x = rng.random::<F>();
+                }
+                x
+            })
+            .collect();
+
+        let got = batch_multiplicative_inverse(&xs);
+        assert_eq!(got.len(), n, "result length mismatch for n = {n}");
+
+        for (i, (x, inv)) in xs.iter().zip(&got).enumerate() {
+            assert_eq!(
+                *x * *inv,
+                F::ONE,
+                "x[{i}] * inv[{i}] != 1 for input length {n}"
+            );
         }
     }
 }
@@ -1008,6 +1053,10 @@ macro_rules! test_field {
             #[test]
             fn test_inverse() {
                 $crate::test_inverse::<$field>();
+            }
+            #[test]
+            fn test_batch_multiplicative_inverse() {
+                $crate::test_batch_multiplicative_inverse::<$field>();
             }
             #[test]
             fn test_generator() {

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -21,9 +21,15 @@ serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
 proptest.workspace = true
+
+[[bench]]
+name = "batch_inverse"
+path = "benches/batch_inverse.rs"
+harness = false
 
 [lints]
 workspace = true

--- a/field/benches/batch_inverse.rs
+++ b/field/benches/batch_inverse.rs
@@ -22,6 +22,7 @@ use rand::{RngExt, SeedableRng};
 
 type F = BabyBear;
 type EF4 = BinomialExtensionField<F, 4>;
+type EF5 = BinomialExtensionField<F, 5>;
 
 const SIZES: &[usize] = &[
     63, 64, 65, 255, 256, 257, 511, 512, 513, 1023, 1024, 1025, 1027, 4095, 4096, 4099, 16383,
@@ -67,5 +68,14 @@ fn bench_baby_bear_ext4(c: &mut Criterion) {
     bench_field::<EF4>(c, "batch_multiplicative_inverse/BabyBear-EF4", 0xB4);
 }
 
-criterion_group!(benches, bench_baby_bear, bench_baby_bear_ext4);
+fn bench_baby_bear_ext5(c: &mut Criterion) {
+    bench_field::<EF5>(c, "batch_multiplicative_inverse/BabyBear-EF5", 0xB5);
+}
+
+criterion_group!(
+    benches,
+    bench_baby_bear,
+    bench_baby_bear_ext4,
+    bench_baby_bear_ext5
+);
 criterion_main!(benches);

--- a/field/benches/batch_inverse.rs
+++ b/field/benches/batch_inverse.rs
@@ -1,0 +1,71 @@
+//! Benchmarks for [`batch_multiplicative_inverse`].
+//!
+//! Sizes are picked to expose the four interesting regimes:
+//!
+//! - **Aligned, single chunk** (e.g. 1024): every element goes through the
+//!   packed (4-lane ILP) Montgomery path; baseline against which the fix
+//!   must not regress.
+//! - **Misaligned, single chunk** (e.g. 1023, 511): the trailing chunk has
+//!   `len % 4 != 0`. Before the fix this fell entirely to the serial path;
+//!   after the fix only the 1–3 leftover elements run serially.
+//! - **Aligned, multi-chunk** (e.g. 1024 * k): par_chunks dispatches each
+//!   chunk to packed; should show clean Rayon scaling.
+//! - **Misaligned, multi-chunk** (e.g. 4099): the last chunk gets
+//!   prefix-packed + tail-serial.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, batch_multiplicative_inverse};
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+type F = BabyBear;
+type EF4 = BinomialExtensionField<F, 4>;
+
+const SIZES: &[usize] = &[
+    63, 64, 65, 255, 256, 257, 511, 512, 513, 1023, 1024, 1025, 1027, 4095, 4096, 4099, 16383,
+    16384, 16385,
+];
+
+fn random_nonzero<G: Field>(seed: u64, n: usize) -> Vec<G>
+where
+    rand::distr::StandardUniform: rand::distr::Distribution<G>,
+{
+    let mut rng = SmallRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let mut x: G = rng.random();
+            while x.is_zero() {
+                x = rng.random();
+            }
+            x
+        })
+        .collect()
+}
+
+fn bench_field<G: Field>(c: &mut Criterion, group_name: &str, seed: u64)
+where
+    rand::distr::StandardUniform: rand::distr::Distribution<G>,
+{
+    let mut group = c.benchmark_group(group_name);
+    for &n in SIZES {
+        let xs: Vec<G> = random_nonzero(seed, n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &xs, |b, xs| {
+            b.iter(|| batch_multiplicative_inverse::<G>(std::hint::black_box(xs)));
+        });
+    }
+    group.finish();
+}
+
+fn bench_baby_bear(c: &mut Criterion) {
+    bench_field::<F>(c, "batch_multiplicative_inverse/BabyBear", 0xB1);
+}
+
+fn bench_baby_bear_ext4(c: &mut Criterion) {
+    bench_field::<EF4>(c, "batch_multiplicative_inverse/BabyBear-EF4", 0xB4);
+}
+
+criterion_group!(benches, bench_baby_bear, bench_baby_bear_ext4);
+criterion_main!(benches);

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -42,17 +42,40 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
 
     let n = x.len();
     assert_eq!(result.len(), n);
-    if !n.is_multiple_of(WIDTH) {
-        // There isn't a very clean way to do this with FieldArray; for now just do it in serial.
-        // Another simple (though suboptimal) workaround would be to make two separate calls, one
-        // for the packed part and one for the remainder.
-        return batch_multiplicative_inverse_general(x, result, |x| x.inverse());
+
+    let tail_len = n % WIDTH;
+
+    // Fast path: input is WIDTH-aligned. Single packed Montgomery pass, identical
+    // shape to the previous implementation for this case.
+    if tail_len == 0 {
+        if n == 0 {
+            return;
+        }
+        let x_packed = FieldArray::<F, WIDTH>::pack_slice(x);
+        let result_packed = FieldArray::<F, WIDTH>::pack_slice_mut(result);
+        batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
+            x_packed.inverse()
+        });
+        return;
     }
 
-    let x_packed = FieldArray::<F, 4>::pack_slice(x);
-    let result_packed = FieldArray::<F, 4>::pack_slice_mut(result);
+    // Mixed path: process the largest WIDTH-aligned prefix with packed Montgomery
+    // (4-lane ILP), then handle the 1..WIDTH-element tail with a scalar Montgomery
+    // pass. Montgomery's trick is self-contained per chunk, so independent
+    // prefix/tail passes produce the same inverses as a single contiguous pass.
+    let main_len = n - tail_len;
+    let (x_main, x_tail) = x.split_at(main_len);
+    let (result_main, result_tail) = result.split_at_mut(main_len);
 
-    batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| x_packed.inverse());
+    if !x_main.is_empty() {
+        let x_packed = FieldArray::<F, WIDTH>::pack_slice(x_main);
+        let result_packed = FieldArray::<F, WIDTH>::pack_slice_mut(result_main);
+        batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
+            x_packed.inverse()
+        });
+    }
+
+    batch_multiplicative_inverse_general(x_tail, result_tail, |x| x.inverse());
 }
 
 /// A simple single-threaded implementation of Montgomery's trick. Since not all `PrimeCharacteristicRing`s

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -6,76 +6,67 @@ use tracing::instrument;
 use crate::field::Field;
 use crate::{FieldArray, PackedValue, PrimeCharacteristicRing};
 
-/// Batch multiplicative inverses with Montgomery's trick
-/// This is Montgomery's trick. At a high level, we invert the product of the given field
-/// elements, then derive the individual inverses from that via multiplication.
+/// Compute the multiplicative inverse of every element in a slice via Montgomery's trick.
 ///
-/// The usual Montgomery trick involves calculating an array of cumulative products,
-/// resulting in a long dependency chain. To increase instruction-level parallelism, we
-/// compute WIDTH separate cumulative product arrays that only meet at the end.
+/// Replaces `n` field inversions with one inversion plus `~3n` multiplications:
+/// - forward pass: build prefix products of the inputs,
+/// - one inversion of the full product,
+/// - reverse pass: derive each individual inverse from the prefix products.
+///
+/// The forward pass is a long dependency chain. It is parallelised on two axes:
+/// - 4-lane packed arrays — four independent chains run side by side,
+/// - 1024-element chunks — dispatched across Rayon workers.
+///
+/// Lengths not a multiple of 4 finish with a scalar pass on the trailing 1..=3 elements.
 ///
 /// # Panics
-/// This will panic if any of the inputs is zero.
+///
+/// Panics if any input is zero.
 #[instrument(level = "debug", skip_all)]
 #[must_use]
 pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
-    // How many elements to invert in one thread.
+    // 1024-element chunks per Rayon task.
+    //
+    // Why 1024:
+    //   - amortizes the one field inversion per chunk over many multiplies,
+    //   - leaves enough chunks for work-stealing on long slices.
     const CHUNK_SIZE: usize = 1024;
 
-    let n = x.len();
-    let mut result = F::zero_vec(n);
+    // 4-lane packing.
+    //
+    // Why 4:
+    //   - smallest packed-field width on every backend,
+    //   - wider lanes risk register spills in the per-lane dependency chains.
+    const WIDTH: usize = 4;
+
+    // Pre-allocate the output: each Rayon task writes a disjoint sub-slice.
+    let mut result = F::zero_vec(x.len());
 
     x.par_chunks(CHUNK_SIZE)
         .zip(result.par_chunks_mut(CHUNK_SIZE))
-        .for_each(|(x, result)| {
-            batch_multiplicative_inverse_helper(x, result);
+        .for_each(|(x_chunk, result_chunk)| {
+            // Phase 1 — split the chunk:
+            //   - packed: 4-aligned prefix viewed as 4-lane arrays,
+            //   - tail:   0..=3 trailing scalars (m = n - n%4).
+            //
+            //     x_chunk:  [ x_0 .. x_{m-1} | x_m .. x_{n-1} ]
+            //               └──── packed ────┘└──── tail ────┘
+            let (x_packed, x_tail) = FieldArray::<F, WIDTH>::pack_slice_with_suffix(x_chunk);
+            let (result_packed, result_tail) =
+                FieldArray::<F, WIDTH>::pack_slice_with_suffix_mut(result_chunk);
+
+            // Phase 2 — packed pass: 4 independent Montgomery chains, one per lane.
+            //
+            // Final inversion lands on a 4-lane array → one scalar inversion per chunk.
+            batch_multiplicative_inverse_general(x_packed, result_packed, |y| y.inverse());
+
+            // Phase 3 — tail pass: 0..=3 leftover scalars.
+            //
+            // Empty when n % 4 == 0; this call then returns immediately.
+            batch_multiplicative_inverse_general(x_tail, result_tail, |y| y.inverse());
         });
 
     result
-}
-
-/// Like `batch_multiplicative_inverse`, but writes the result to the given output buffer.
-fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
-    // Higher WIDTH increases instruction-level parallelism, but too high a value will cause us
-    // to run out of registers.
-    const WIDTH: usize = 4;
-
-    let n = x.len();
-    assert_eq!(result.len(), n);
-
-    let tail_len = n % WIDTH;
-
-    // Fast path: input is WIDTH-aligned. Single packed Montgomery pass, identical
-    // shape to the previous implementation for this case.
-    if tail_len == 0 {
-        if n == 0 {
-            return;
-        }
-        let x_packed = FieldArray::<F, WIDTH>::pack_slice(x);
-        let result_packed = FieldArray::<F, WIDTH>::pack_slice_mut(result);
-        batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
-            x_packed.inverse()
-        });
-        return;
-    }
-
-    // Mixed path: process the largest WIDTH-aligned prefix with packed Montgomery
-    // (4-lane ILP), then handle the 1..WIDTH-element tail with a scalar Montgomery
-    // pass. Montgomery's trick is self-contained per chunk, so independent
-    // prefix/tail passes produce the same inverses as a single contiguous pass.
-    let main_len = n - tail_len;
-    let (x_main, x_tail) = x.split_at(main_len);
-    let (result_main, result_tail) = result.split_at_mut(main_len);
-
-    if !x_main.is_empty() {
-        let x_packed = FieldArray::<F, WIDTH>::pack_slice(x_main);
-        let result_packed = FieldArray::<F, WIDTH>::pack_slice_mut(result_main);
-        batch_multiplicative_inverse_general(x_packed, result_packed, |x_packed| {
-            x_packed.inverse()
-        });
-    }
-
-    batch_multiplicative_inverse_general(x_tail, result_tail, |x| x.inverse());
 }
 
 /// A simple single-threaded implementation of Montgomery's trick. Since not all `PrimeCharacteristicRing`s
@@ -84,6 +75,7 @@ fn batch_multiplicative_inverse_helper<F: Field>(x: &[F], result: &mut [F]) {
 /// Unlike [`batch_multiplicative_inverse`], this writes into a caller-provided buffer,
 /// avoiding heap allocation. This makes it suitable for small, fixed-size inputs
 /// such as packed field lanes.
+#[inline]
 pub fn batch_multiplicative_inverse_general<F, Inv>(x: &[F], result: &mut [F], inv: Inv)
 where
     F: PrimeCharacteristicRing + Copy,


### PR DESCRIPTION
## Summary

`batch_multiplicative_inverse_helper` currently falls back to a fully-scalar Montgomery's trick whenever the input length is not a multiple of `WIDTH = 4`, discarding the 4-lane packed ILP. The existing comment flagged this as a *"suboptimal workaround"*.

This PR processes the WIDTH-aligned prefix with packed Montgomery (4-lane ILP) and handles the 1..WIDTH-element tail with a scalar pass. Montgomery's trick is self-contained per chunk, so independent prefix and tail passes produce the same inverses as one contiguous pass.

## Changes

- `field/src/batch_inverse.rs` — split into fast-path (WIDTH-aligned, identical shape to previous code) and mixed-path (prefix-packed + tail-serial).
- `field-testing/src/lib.rs` — add generic `test_batch_multiplicative_inverse<F>` and wire it into the `test_field!` macro. Covers empty, sub-WIDTH, mixed prefix+tail, and cross-chunk-boundary lengths. Every concrete field that uses the macro now exercises this path automatically.
- `field/benches/batch_inverse.rs` — new benchmark with 19 sizes (aligned/misaligned × single-chunk/multi-chunk) for BabyBear and its degree-4 extension.
- `field/Cargo.toml` — `criterion` dev-dep + `[[bench]]` entry.

## Benchmark — Apple M1, aarch64-NEON, BabyBear (degree-4 extension)

| n     | aligned | before     | after      | change   |
|-------|---------|------------|------------|----------|
| 63    | no      | 1.79 µs    | 1.04 µs    | **−42.1%** |
| 255   | no      | 6.96 µs    | 3.23 µs    | **−53.6%** |
| 511   | no      | 13.69 µs   | 6.25 µs    | **−54.4%** |
| 1023  | no      | 27.25 µs   | 12.20 µs   | **−55.2%** |
| 4095  | no      | 66.90 µs   | 51.05 µs   | **−23.7%** |
| 16383 | no      | 232.15 µs  | 196.09 µs  | **−15.5%** |
| 64    | yes     | 0.93 µs    | 0.93 µs    | +0.3%    |
| 256   | yes     | 3.22 µs    | 3.17 µs    | −1.7%    |
| 1024  | yes     | 12.18 µs   | 11.99 µs   | −1.5%    |
| 4096  | yes     | 49.79 µs   | 49.74 µs   | −0.1%    |
| 16384 | yes     | 199.68 µs  | 194.12 µs  | −2.8%    |

Misaligned single-chunk: ~2× speedup. Misaligned multi-chunk: 15–25% improvement. WIDTH-aligned: within measurement noise.

## Correctness

Existing downstream tests cover `batch_multiplicative_inverse` indirectly through interpolation, FRI, and lookup tests; all pass unchanged. The new generic test in `p3-field-testing` exercises the function directly across BabyBear, KoalaBear, Goldilocks, Mersenne31, BN254 and their extensions, with explicit length coverage:

- `n = 0` (empty input)
- `n ∈ {1, 2, 3}` (sub-WIDTH, tail-only)
- `n ∈ {5, 6, 7, ..., 17}` (small mixed prefix + tail)
- `n ∈ {1023, 1025, 1027, 2049, 4099}` (single-chunk and multi-chunk crossings)

Each output is checked against `x[i] * inv[i] == 1` per element.

## Test plan

- [x] `cargo test -p p3-field` — passes
- [x] `cargo test -p p3-field-testing` — passes
- [x] `cargo test -p p3-baby-bear -p p3-goldilocks -p p3-koala-bear -p p3-mersenne-31 -p p3-bn254` — passes (13 fields × the new test)
- [x] `cargo test -p p3-matrix -p p3-fri -p p3-circle -p p3-commit -p p3-lookup -p p3-uni-stark` — no regression
- [x] `cargo clippy -p p3-field -p p3-field-testing` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo bench -p p3-field --bench batch_inverse` — numbers above