### PR TITLE
perf(circle): parallelize FRI fold butterflies

### DIFF
--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -8,6 +8,7 @@ use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, batch_multiplicative_inverse};
 use p3_fri::FriFoldingStrategy;
 use p3_matrix::Matrix;
+use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 
 use crate::domain::CircleDomain;
@@ -55,15 +56,15 @@ fn fold<F: ComplexExtendable, EF: ExtensionField<F>>(
     twiddles: &[F],
 ) -> Vec<EF> {
     evals
-        .rows()
-        .zip(twiddles)
+        .par_rows()
+        .zip(twiddles.par_iter())
         .map(|(mut row, &t)| {
             let (lo, hi) = row.next_tuple().unwrap();
             let sum = lo + hi;
             let diff = (lo - hi) * t;
             (sum + beta * diff).halve()
         })
-        .collect_vec()
+        .collect()
 }
 
 pub(crate) fn fold_y<F: ComplexExtendable, EF: ExtensionField<F>>(


### PR DESCRIPTION
## Summary

`circle::folding::fold` runs the per-row arity-2 butterfly serially via `Matrix::rows().zip(twiddles).map(...)`. The equivalent path in standard FRI (`fri/src/two_adic_pcs.rs::fold_matrix`) already uses `par_rows()` for the same butterfly shape, so the Circle FRI prover loses parallelism on every commit-phase fold.

This PR replaces the sequential row iterator with `par_rows()` zipped against `twiddles.par_iter()`. The closure body is unchanged and side-effect free, so the rayon `IndexedParallelIterator::collect` produces a bit-identical result.

## Motivation — comparison with standard FRI

**Standard FRI** (`fri/src/two_adic_pcs.rs::fold_matrix`):

```rust
m.par_rows()
    .zip(halve_inv_powers)
    .map(|(mut row, halve_inv_power)| {
        let (lo, hi) = row.next_tuple().unwrap();
        (lo + hi).halve() + (lo - hi) * beta * halve_inv_power
    })
    .collect()
```

**Circle FRI** before this PR (`circle/src/folding.rs::fold`):

```rust
evals
    .rows()                  // sequential
    .zip(twiddles)           // sequential
    .map(|(mut row, &t)| { /* ... */ })
    .collect_vec()
```

The two functions implement the same arity-2 butterfly pattern, but the Circle variant never scales beyond a single core.

## Diff

```diff
+use p3_maybe_rayon::prelude::*;
...
-        .rows()
-        .zip(twiddles)
+        .par_rows()
+        .zip(twiddles.par_iter())
         .map(|(mut row, &t)| {
             let (lo, hi) = row.next_tuple().unwrap();
             let sum = lo + hi;
             let diff = (lo - hi) * t;
             (sum + beta * diff).halve()
         })
-        .collect_vec()
+        .collect()
```

## Correctness

- The closure is pure: it reads `lo, hi` from the row iterator, reads `t` from the twiddle slice, reads the captured `beta`, and returns one `EF` value. No mutation, no shared state.
- `IndexedParallelIterator::collect` preserves order, so the output `Vec<EF>` is bit-identical to the previous serial version.
- The existing `fold_matrix_same_as_row` proptest in `circle/src/folding.rs` directly compares `fold_y`/`fold_x` (this code path) against the row-by-row reference (`fold_y_row`/`fold_x_row`) over random inputs. It still passes.

## Expected impact

For a Circle STARK prover with trace height `2^k`, the first commit-phase fold processes `2^(k-1)` butterflies. Before this PR every butterfly ran on a single thread; after this PR they distribute across all available cores. On an 8–16 core machine this is a meaningful fraction of FRI commit time, and FRI commit is a non-trivial slice of overall prover wall-clock for Circle STARKs.

I have not added a benchmark in this PR because the existing `fold` function is `pub(crate)` and benching it from `circle/benches/` would require an API surface change. Maintainers running an end-to-end Circle STARK proving benchmark should observe the speedup directly.

## Test plan

- [x] `cargo test -p p3-circle` — 24 passed, including `fold_matrix_same_as_row` (parallel-vs-row equivalence).
- [x] `cargo test -p p3-fri` — 20 passed.
- [x] `cargo test -p p3-uni-stark` — 7 passed.
- [x] `cargo clippy -p p3-circle` — clean.
- [x] `cargo fmt -p p3-circle --check` — clean.
