### PR TITLE
refactor(air): merge PeriodicAirBuilder into AirBuilder

### DIFF
--- a/air/src/builder.rs
+++ b/air/src/builder.rs
@@ -45,6 +45,14 @@ pub trait AirBuilder: Sized {
     /// Variable type for public values.
     type PublicVar: Into<Self::Expr> + Copy;
 
+    /// Variable type for periodic column values at the current row.
+    ///
+    /// - Periodic columns are commitment-free witness data.
+    /// - Their values repeat with a fixed period.
+    /// - Builders without periodic data still pick a concrete type, so
+    ///   the trait can be implemented uniformly.
+    type PeriodicVar: Into<Self::Expr> + Copy;
+
     /// Return the current and next row slices of the main (primary) trace.
     fn main(&self) -> Self::MainWindow;
 
@@ -167,6 +175,15 @@ pub trait AirBuilder: Sized {
         &[]
     }
 
+    /// Values of every periodic column at the current row.
+    ///
+    /// - One entry per periodic column declared by the AIR.
+    /// - Ordering matches the AIR's declared column order.
+    /// - Default is empty for builders without periodic data.
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        &[]
+    }
+
     /// Assert that `x` is a boolean, i.e. either `0` or `1`.
     ///
     /// Where possible, batching multiple assert_bool calls
@@ -174,15 +191,6 @@ pub trait AirBuilder: Sized {
     fn assert_bool<I: Into<Self::Expr>>(&mut self, x: I) {
         self.assert_zero(x.into().bool_check());
     }
-}
-
-/// Extension of [`AirBuilder`] for builders that supply periodic column values.
-pub trait PeriodicAirBuilder: AirBuilder {
-    /// Variable type for periodic column values.
-    type PeriodicVar: Into<Self::Expr> + Copy;
-
-    /// Periodic column values at the current row.
-    fn periodic_values(&self) -> &[Self::PeriodicVar];
 }
 
 /// Extension trait for builders that carry additional runtime context.

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -10,7 +10,7 @@ use p3_matrix::stack::ViewPair;
 
 use crate::{
     Air, AirBuilder, AirBuilderWithContext, ExtensionBuilder, Name, NamedAirBuilder,
-    NamedExtensionBuilder, NamespaceExt, PeriodicAirBuilder, PermutationAirBuilder, RowWindow,
+    NamedExtensionBuilder, NamespaceExt, PermutationAirBuilder, RowWindow,
 };
 
 /// A single constraint violation captured during debug evaluation.
@@ -282,6 +282,7 @@ where
     type PreprocessedWindow = RowWindow<'a, F>;
     type MainWindow = RowWindow<'a, F>;
     type PublicVar = F;
+    type PeriodicVar = F;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
@@ -312,6 +313,10 @@ where
     fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values
     }
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_row
+    }
 }
 
 impl<F: Field, EF: ExtensionField<F>> AirBuilderWithContext for DebugConstraintBuilder<'_, F, EF> {
@@ -334,14 +339,6 @@ impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for DebugConstraintBuilde
         I: Into<Self::ExprEF>,
     {
         self.assert_zero_ext_named(x, "");
-    }
-}
-
-impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for DebugConstraintBuilder<'_, F, EF> {
-    type PeriodicVar = F;
-
-    fn periodic_values(&self) -> &[Self::PeriodicVar] {
-        self.periodic_row
     }
 }
 

--- a/air/src/filtered.rs
+++ b/air/src/filtered.rs
@@ -1,8 +1,6 @@
 use p3_field::Dup;
 
-use crate::builder::{
-    AirBuilder, AirBuilderWithContext, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
-};
+use crate::builder::{AirBuilder, AirBuilderWithContext, ExtensionBuilder, PermutationAirBuilder};
 
 /// A wrapper around an [`AirBuilder`] that enforces constraints only when a specified condition is met.
 ///
@@ -33,6 +31,7 @@ impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
     type PreprocessedWindow = AB::PreprocessedWindow;
     type MainWindow = AB::MainWindow;
     type PublicVar = AB::PublicVar;
+    type PeriodicVar = AB::PeriodicVar;
 
     fn main(&self) -> Self::MainWindow {
         self.inner.main()
@@ -65,10 +64,6 @@ impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
     fn public_values(&self) -> &[Self::PublicVar] {
         self.inner.public_values()
     }
-}
-
-impl<AB: PeriodicAirBuilder> PeriodicAirBuilder for FilteredAirBuilder<'_, AB> {
-    type PeriodicVar = AB::PeriodicVar;
 
     fn periodic_values(&self) -> &[Self::PeriodicVar] {
         self.inner.periodic_values()

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -12,8 +12,8 @@ use crate::symbolic::expression::BaseLeaf;
 use crate::symbolic::expression_ext::SymbolicExpressionExt;
 use crate::symbolic::variable::{BaseEntry, ExtEntry, SymbolicVariableExt};
 use crate::{
-    Air, AirBuilder, BaseAir, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder,
-    SymbolicExpression, SymbolicVariable, WindowAccess,
+    Air, AirBuilder, BaseAir, ExtensionBuilder, PermutationAirBuilder, SymbolicExpression,
+    SymbolicVariable, WindowAccess,
 };
 
 /// Describes the shape of an AIR for symbolic constraint evaluation.
@@ -34,7 +34,7 @@ pub struct AirLayout {
     pub num_permutation_challenges: usize,
     /// Length of [`PermutationAirBuilder::permutation_values`].
     pub num_permutation_values: usize,
-    /// Length of [`PeriodicAirBuilder::periodic_values`].
+    /// Length of [`AirBuilder::periodic_values`].
     pub num_periodic_columns: usize,
 }
 
@@ -281,6 +281,7 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
     type PreprocessedWindow = RowMajorMatrix<Self::Var>;
     type MainWindow = RowMajorMatrix<Self::Var>;
     type PublicVar = SymbolicVariable<F>;
+    type PeriodicVar = SymbolicVariable<F>;
 
     fn main(&self) -> Self::MainWindow {
         self.main.clone()
@@ -315,6 +316,10 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
 
     fn public_values(&self) -> &[Self::PublicVar] {
         &self.public_values
+    }
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        &self.periodic
     }
 }
 
@@ -355,14 +360,6 @@ where
 
     fn permutation_values(&self) -> &[Self::PermutationVar] {
         &self.permutation_values
-    }
-}
-
-impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for SymbolicAirBuilder<F, EF> {
-    type PeriodicVar = SymbolicVariable<F>;
-
-    fn periodic_values(&self) -> &[Self::PeriodicVar] {
-        &self.periodic
     }
 }
 

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -75,14 +75,28 @@ impl<F: Field, EF: ExtensionField<F>> From<F> for SymbolicExpression<EF> {
 }
 
 impl<F: Field> SymbolicExpression<F> {
-    /// Evaluate this symbolic expression against a concrete [`AirBuilder`].
+    /// Evaluate this symbolic expression against a concrete builder.
     ///
-    /// Leaves resolve from the builder's trace windows, public values,
-    /// and selectors. Arithmetic nodes recurse into children.
+    /// # Overview
+    ///
+    /// - Walk the expression tree top-down.
+    /// - Replace each leaf with the builder's concrete value.
+    /// - Recurse into arithmetic nodes; combine in the builder's algebra.
+    ///
+    /// # Algorithm
+    ///
+    /// ```text
+    ///     leaf   → builder lookup (main / preprocessed / public / periodic / selector / constant)
+    ///     x + y  → resolve(x) + resolve(y)
+    ///     x - y  → resolve(x) - resolve(y)
+    ///     x * y  → resolve(x) * resolve(y)
+    ///     -x     → -resolve(x)
+    /// ```
     ///
     /// # Panics
     ///
-    /// Panics on periodic columns and row offsets beyond 1.
+    /// - Row offset other than 0 or 1.
+    /// - Column index out of bounds.
     pub fn resolve<AB>(&self, builder: &AB) -> AB::Expr
     where
         AB: AirBuilder<F = F>,
@@ -90,6 +104,8 @@ impl<F: Field> SymbolicExpression<F> {
         match self {
             Self::Leaf(leaf) => match leaf {
                 BaseLeaf::Variable(v) => match v.entry {
+                    // Main trace: offset 0 = current row, offset 1 = next row.
+                    // Symbolic builders only emit two-row windows.
                     BaseEntry::Main { offset } => {
                         let main = builder.main();
                         match offset {
@@ -104,6 +120,7 @@ impl<F: Field> SymbolicExpression<F> {
                             _ => panic!("expressions cannot span more than two rows"),
                         }
                     }
+                    // Preprocessed trace: same shape, commitment-free trace.
                     BaseEntry::Preprocessed { offset } => {
                         let prep = builder.preprocessed();
                         match offset {
@@ -118,16 +135,20 @@ impl<F: Field> SymbolicExpression<F> {
                             _ => panic!("expressions cannot span more than two rows"),
                         }
                     }
+                    // Public input: direct slice lookup.
                     BaseEntry::Public => builder.public_values()[v.index].into(),
-                    BaseEntry::Periodic => {
-                        panic!("periodic columns cannot be resolved in this context")
-                    }
+                    // Periodic column at the current row.
+                    // Empty default slice → out-of-bounds panic on stray emissions.
+                    BaseEntry::Periodic => builder.periodic_values()[v.index].into(),
                 },
+                // Boundary and transition selectors come straight from the builder.
                 BaseLeaf::IsFirstRow => builder.is_first_row(),
                 BaseLeaf::IsLastRow => builder.is_last_row(),
                 BaseLeaf::IsTransition => builder.is_transition_window(2),
+                // Lift the field constant into the builder's expression algebra.
                 BaseLeaf::Constant(c) => AB::Expr::from(*c),
             },
+            // Arithmetic: recurse on operands, combine in the builder's algebra.
             Self::Add { x, y, .. } => x.resolve(builder) + y.resolve(builder),
             Self::Sub { x, y, .. } => x.resolve(builder) - y.resolve(builder),
             Self::Neg { x, .. } => -x.resolve(builder),
@@ -791,10 +812,17 @@ mod tests {
         assert_eq!(result.degree_multiple(), 0);
     }
 
-    /// Two-row trace builder.
+    /// Minimal builder used to drive symbolic-expression resolution.
+    ///
+    /// Carries:
+    /// - a 2-row main trace,
+    /// - a public-value slice,
+    /// - precomputed selector values for the current row,
+    /// - a periodic-column row evaluated at the current step.
     struct ResolveTestBuilder {
         main: RowMajorMatrix<BabyBear>,
         public_values: Vec<BabyBear>,
+        periodic_row: Vec<BabyBear>,
         is_first: BabyBear,
         is_last: BabyBear,
         is_transition: BabyBear,
@@ -807,6 +835,7 @@ mod tests {
         type PreprocessedWindow = RowMajorMatrix<BabyBear>;
         type MainWindow = RowMajorMatrix<BabyBear>;
         type PublicVar = BabyBear;
+        type PeriodicVar = BabyBear;
 
         fn main(&self) -> Self::MainWindow {
             self.main.clone()
@@ -833,13 +862,18 @@ mod tests {
         fn public_values(&self) -> &[Self::PublicVar] {
             &self.public_values
         }
+
+        fn periodic_values(&self) -> &[Self::PeriodicVar] {
+            &self.periodic_row
+        }
     }
 
-    /// 2-row × 2-column trace:
+    /// 2-row × 2-column trace, plus a 2-cell periodic row at the current step:
     ///
     /// ```text
-    ///     row 0 (current): [10, 20]
-    ///     row 1 (next):    [30, 40]
+    ///     main row 0 (current): [10, 20]
+    ///     main row 1 (next):    [30, 40]
+    ///     periodic_row (curr):  [7, 13]
     /// ```
     fn test_builder() -> ResolveTestBuilder {
         ResolveTestBuilder {
@@ -853,6 +887,9 @@ mod tests {
                 2, // width
             ),
             public_values: vec![BabyBear::new(99)],
+            // Two periodic columns at the current row.
+            // Distinct primes so any cross-stream mix-up is visible.
+            periodic_row: vec![BabyBear::new(7), BabyBear::new(13)],
             is_first: BabyBear::ONE,
             is_last: BabyBear::ZERO,
             is_transition: BabyBear::ONE,
@@ -934,11 +971,51 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "periodic columns cannot be resolved")]
-    fn resolve_periodic_panics() {
+    fn resolve_periodic_columns() {
+        // Invariant: a periodic leaf reads from the builder's
+        // periodic-value slice, in declared column order.
+        //
+        // Fixture:
+        //
+        //     periodic row (current step) : [7, 13]
+        //     index 0 →  7
+        //     index 1 → 13
         let b = test_builder();
-        let expr =
+
+        // Column 0 → 7.
+        let p0 =
             SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 0));
-        let _ = expr.resolve(&b);
+        assert_eq!(p0.resolve(&b), BabyBear::new(7));
+
+        // Column 1 → 13.
+        let p1 =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 1));
+        assert_eq!(p1.resolve(&b), BabyBear::new(13));
+    }
+
+    #[test]
+    fn resolve_periodic_combines_with_arithmetic() {
+        // Invariant: periodic leaves compose under the same algebra
+        // as main, public, and preprocessed leaves.
+        //
+        // Fixture:
+        //
+        //     periodic row : [7, 13]
+        //     main row 0   : [10, 20]
+        //
+        //     expression   : main[0] * periodic[0] + periodic[1]
+        //                  = 10 * 7 + 13
+        //                  = 83
+        let b = test_builder();
+
+        let col0 =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0));
+        let p0 =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 0));
+        let p1 =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 1));
+
+        let expr = col0 * p0 + p1;
+        assert_eq!(expr.resolve(&b), BabyBear::new(83));
     }
 }

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -75,7 +75,7 @@ impl<F: Field, EF: ExtensionField<F>> From<F> for SymbolicExpression<EF> {
 }
 
 impl<F: Field> SymbolicExpression<F> {
-    /// Evaluate this symbolic expression against a concrete builder.
+    /// Evaluate this symbolic expression against a concrete [`AirBuilder`].
     ///
     /// # Overview
     ///

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::slice::from_ref;
 
-use p3_air::{Air, AirBuilder, BaseAir, PeriodicAirBuilder, PermutationAirBuilder, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir, PermutationAirBuilder, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
 use p3_batch_stark::{
@@ -228,7 +228,7 @@ impl<F: Field> BaseAir<F> for PeriodicAir<F> {
     }
 }
 
-impl<AB: AirBuilder + PeriodicAirBuilder> Air<AB> for PeriodicAir<AB::F>
+impl<AB: AirBuilder> Air<AB> for PeriodicAir<AB::F>
 where
     AB::F: Field,
 {

--- a/lookup/src/bus.rs
+++ b/lookup/src/bus.rs
@@ -179,6 +179,7 @@ mod tests {
         type PreprocessedWindow = RowWindow<'static, F>;
         type MainWindow = RowWindow<'static, F>;
         type PublicVar = F;
+        type PeriodicVar = F;
 
         fn main(&self) -> Self::MainWindow {
             unimplemented!()

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -221,6 +221,7 @@ impl<'a, F: Field> AirBuilder for MiniLookupBuilder<'a, F> {
     type PreprocessedWindow = RowWindow<'a, F>;
     type MainWindow = RowWindow<'a, F>;
     type PublicVar = F;
+    type PeriodicVar = F;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder, RowWindow};
+use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, RowWindow};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{
@@ -24,6 +24,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
     type MainWindow = RowWindow<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
+    type PeriodicVar = PackedVal<SC>;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_view(&self.inner.main)
@@ -63,10 +64,6 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     fn public_values(&self) -> &[Self::PublicVar] {
         self.inner.public_values
     }
-}
-
-impl<SC: StarkGenericConfig> PeriodicAirBuilder for ProverConstraintFolderWithLookups<'_, SC> {
-    type PeriodicVar = PackedVal<SC>;
 
     #[inline]
     fn periodic_values(&self) -> &[Self::PeriodicVar] {
@@ -122,6 +119,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLook
     type PublicVar = Val<SC>;
     type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
     type MainWindow = RowWindow<'a, SC::Challenge>;
+    type PeriodicVar = SC::Challenge;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.inner.main.top.values, self.inner.main.bottom.values)
@@ -161,10 +159,6 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLook
     fn assert_zeros<const N: usize, I: Into<Self::Expr>>(&mut self, array: [I; N]) {
         self.inner.assert_zeros(array);
     }
-}
-
-impl<SC: StarkGenericConfig> PeriodicAirBuilder for VerifierConstraintFolderWithLookups<'_, SC> {
-    type PeriodicVar = SC::Challenge;
 
     #[inline]
     fn periodic_values(&self) -> &[Self::PeriodicVar] {

--- a/lookup/src/symbolic.rs
+++ b/lookup/src/symbolic.rs
@@ -7,7 +7,7 @@ use p3_air::symbolic::{
     AirLayout, ConstraintLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicExpressionExt,
     SymbolicVariable, SymbolicVariableExt,
 };
-use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, PermutationAirBuilder};
+use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder};
 use p3_field::{Algebra, ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 
@@ -70,6 +70,7 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for InteractionSymbolicBuilder<
     type PreprocessedWindow = RowMajorMatrix<Self::Var>;
     type MainWindow = RowMajorMatrix<Self::Var>;
     type PublicVar = SymbolicVariable<F>;
+    type PeriodicVar = SymbolicVariable<F>;
 
     fn main(&self) -> Self::MainWindow {
         self.inner.main()
@@ -97,6 +98,10 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for InteractionSymbolicBuilder<
 
     fn public_values(&self) -> &[Self::PublicVar] {
         self.inner.public_values()
+    }
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.inner.periodic_values()
     }
 }
 
@@ -134,14 +139,6 @@ where
 
     fn permutation_values(&self) -> &[Self::PermutationVar] {
         self.inner.permutation_values()
-    }
-}
-
-impl<F: Field, EF: ExtensionField<F>> PeriodicAirBuilder for InteractionSymbolicBuilder<F, EF> {
-    type PeriodicVar = SymbolicVariable<F>;
-
-    fn periodic_values(&self) -> &[Self::PeriodicVar] {
-        self.inner.periodic_values()
     }
 }
 

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -175,6 +175,7 @@ impl AirBuilder for MockAirBuilder {
     type PreprocessedWindow = RowMajorMatrix<F>;
     type MainWindow = RowMajorMatrix<F>;
     type PublicVar = F;
+    type PeriodicVar = F;
 
     fn main(&self) -> Self::MainWindow {
         self.window(&self.main)

--- a/lookup/src/traits.rs
+++ b/lookup/src/traits.rs
@@ -74,6 +74,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
     type PreprocessedWindow = RowWindow<'a, Val<SC>>;
     type MainWindow = RowWindow<'a, Val<SC>>;
     type PublicVar = Val<SC>;
+    type PeriodicVar = Val<SC>;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use p3_air::{AirBuilder, ExtensionBuilder, PeriodicAirBuilder, RowWindow};
+use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
 use p3_field::{Algebra, BasedVectorSpace};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
@@ -117,6 +117,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     type PreprocessedWindow = RowWindow<'a, PackedVal<SC>>;
     type MainWindow = RowWindow<'a, PackedVal<SC>>;
     type PublicVar = Val<SC>;
+    type PeriodicVar = PackedVal<SC>;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
@@ -160,6 +161,11 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values
     }
+
+    #[inline]
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_values
+    }
 }
 
 impl<SC: StarkGenericConfig> ExtensionBuilder for ProverConstraintFolder<'_, SC> {
@@ -176,15 +182,6 @@ impl<SC: StarkGenericConfig> ExtensionBuilder for ProverConstraintFolder<'_, SC>
     }
 }
 
-impl<SC: StarkGenericConfig> PeriodicAirBuilder for ProverConstraintFolder<'_, SC> {
-    type PeriodicVar = PackedVal<SC>;
-
-    #[inline]
-    fn periodic_values(&self) -> &[Self::PeriodicVar] {
-        self.periodic_values
-    }
-}
-
 impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC> {
     type F = Val<SC>;
     type Expr = SC::Challenge;
@@ -192,6 +189,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     type PreprocessedWindow = RowWindow<'a, SC::Challenge>;
     type MainWindow = RowWindow<'a, SC::Challenge>;
     type PublicVar = Val<SC>;
+    type PeriodicVar = SC::Challenge;
 
     fn main(&self) -> Self::MainWindow {
         RowWindow::from_two_rows(self.main.top.values, self.main.bottom.values)
@@ -222,10 +220,6 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
     fn public_values(&self) -> &[Self::PublicVar] {
         self.public_values
     }
-}
-
-impl<SC: StarkGenericConfig> PeriodicAirBuilder for VerifierConstraintFolder<'_, SC> {
-    type PeriodicVar = SC::Challenge;
 
     #[inline]
     fn periodic_values(&self) -> &[Self::PeriodicVar] {

--- a/uni-stark/src/sub_builder.rs
+++ b/uni-stark/src/sub_builder.rs
@@ -75,6 +75,7 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
     type PreprocessedWindow = AB::PreprocessedWindow;
     type MainWindow = SubSliced<AB::MainWindow, AB::Var>;
     type PublicVar = AB::PublicVar;
+    type PeriodicVar = AB::PeriodicVar;
 
     fn main(&self) -> Self::MainWindow {
         SubSliced {
@@ -107,5 +108,9 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
 
     fn public_values(&self) -> &[Self::PublicVar] {
         self.inner.public_values()
+    }
+
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.inner.periodic_values()
     }
 }

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
-use p3_air::{Air, AirBuilder, BaseAir, PeriodicAirBuilder, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_circle::CirclePcs;
@@ -64,7 +64,7 @@ impl<F: Field> BaseAir<F> for PeriodicAir<F> {
     }
 }
 
-impl<AB: AirBuilder + PeriodicAirBuilder> Air<AB> for PeriodicAir<AB::F>
+impl<AB: AirBuilder> Air<AB> for PeriodicAir<AB::F>
 where
     AB::F: Field,
 {


### PR DESCRIPTION
cc @adr1anh

## Summary

- Folds `type PeriodicVar` and `fn periodic_values()` onto the base `AirBuilder` trait, with an empty default slice for builders that do not carry periodic data.
- Removes the standalone `PeriodicAirBuilder` extension trait across the workspace.
- `SymbolicExpression::resolve` now resolves periodic leaves through `builder.periodic_values()` instead of panicking — symbolic expressions referencing periodic columns can be evaluated against any concrete builder.

Closes #1610. Follow-up to the design discussion in #1566 ([thread](https://github.com/Plonky3/Plonky3/pull/1566#discussion_r3188238343)).

## Changes

### `p3-air`
- New `type PeriodicVar` and default `fn periodic_values()` on `AirBuilder`.
- `PeriodicAirBuilder` trait removed.
- `SymbolicExpression::resolve` handles `BaseEntry::Periodic` by indexing into the builder's periodic-value slice.
- All in-tree `AirBuilder` impls (`FilteredAirBuilder`, `DebugConstraintBuilder`, `SymbolicAirBuilder`) declare the new associated type.

### `p3-uni-stark`
- `ProverConstraintFolder` / `VerifierConstraintFolder` fold their `PeriodicAirBuilder` impls into the base `AirBuilder` impl.
- `SubAirBuilder` forwards `PeriodicVar` and `periodic_values()`.
- `tests/periodic_air.rs` drops the `PeriodicAirBuilder` bound — `Air<AB: AirBuilder>` now suffices.

### `p3-lookup`
- `ProverConstraintFolderWithLookups` / `VerifierConstraintFolderWithLookups` / `InteractionSymbolicBuilder` folded similarly.
- Test/auxiliary builders (`MockAirBuilder`, `MiniLookupBuilder`, `LookupTraceBuilder`, the bus-test `MockBuilder`) declare `type PeriodicVar`.

### `p3-batch-stark`
- `tests/simple.rs` drops the `PeriodicAirBuilder` bound from the periodic-AIR fixture.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p p3-air -p p3-uni-stark -p p3-batch-stark -p p3-lookup --all-targets -- -D warnings` — clean
- [x] `cargo test -p p3-air --lib` — 158 pass (including two new positive tests for periodic resolution)
- [x] `cargo test -p p3-lookup --lib` — 17 pass
- [x] `cargo test -p p3-uni-stark --test periodic_air` — 3 pass
- [x] `cargo test -p p3-batch-stark` — 38 pass, 2 ignored (serialized fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)