### PR TITLE
Add fail-fast checks to periodic LDE builders

### DIFF
--- a/circle/src/periodic.rs
+++ b/circle/src/periodic.rs
@@ -28,6 +28,7 @@
 //! same period.
 
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use p3_commit::{PeriodicEvaluator, PeriodicLdeTable, PolynomialSpace};
 use p3_field::ExtensionField;
@@ -72,17 +73,32 @@ impl<F: ComplexExtendable> PeriodicEvaluator<F, CircleDomain<F>> for CirclePerio
         }
 
         let trace_len = trace_domain.size();
-        let log_blowup = lde_domain.log_n - trace_domain.log_n;
-        let blowup = 1 << log_blowup;
+        let log_blowup = lde_domain
+            .log_n
+            .checked_sub(trace_domain.log_n)
+            .expect("LDE domain log_n must be >= trace domain log_n");
+        let log_blowup_u32 = u32::try_from(log_blowup).expect("log_blowup does not fit into u32");
+        let blowup = 1usize
+            .checked_shl(log_blowup_u32)
+            .expect("blowup overflow when computing 1 << log_blowup");
 
         // Find the maximum period and validate all columns
         let max_period = periodic_table
             .iter()
             .map(|col| {
                 let period = col.len();
-                debug_assert!(
+                assert!(
+                    period > 0,
+                    "periodic column length must be > 0, got {period}",
+                );
+                assert!(
                     period.is_power_of_two(),
                     "periodic column length must be a power of 2"
+                );
+                assert_eq!(
+                    trace_len % period,
+                    0,
+                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
                 );
                 period
             })
@@ -91,14 +107,21 @@ impl<F: ComplexExtendable> PeriodicEvaluator<F, CircleDomain<F>> for CirclePerio
 
         let log_max_period = log2_strict_usize(max_period);
         let log_repetitions = log2_strict_usize(trace_len / max_period);
-        let extended_height = max_period * blowup;
+        let extended_height = max_period
+            .checked_mul(blowup)
+            .expect("extended height overflow when computing max_period * blowup");
         let num_cols = periodic_table.len();
+        let row_major_capacity = extended_height
+            .checked_mul(num_cols)
+            .expect("row-major periodic table capacity overflow");
 
         // Compute the shift for the periodic subdomain at max_period.
         // This aligns the periodic domain with the LDE domain so modular indexing works.
         let extended_shift = lde_domain.shift.repeated_double(log_repetitions);
-        let extended_periodic_domain =
-            CircleDomain::new(log_max_period + log_blowup, extended_shift);
+        let extended_log_n = log_max_period
+            .checked_add(log_blowup)
+            .expect("extended periodic domain log size overflow");
+        let extended_periodic_domain = CircleDomain::new(extended_log_n, extended_shift);
 
         // Process each column: pad to max_period, then extrapolate
         // Build the result in column-major order first, then transpose to row-major
@@ -128,7 +151,7 @@ impl<F: ComplexExtendable> PeriodicEvaluator<F, CircleDomain<F>> for CirclePerio
         }
 
         // Convert from column-major to row-major storage
-        let mut row_major_values = Vec::with_capacity(extended_height * num_cols);
+        let mut row_major_values = Vec::with_capacity(row_major_capacity);
         for row_idx in 0..extended_height {
             for col in &columns {
                 row_major_values.push(col[row_idx]);

--- a/circle/src/periodic.rs
+++ b/circle/src/periodic.rs
@@ -28,7 +28,6 @@
 //! same period.
 
 use alloc::vec::Vec;
-use core::convert::TryFrom;
 
 use p3_commit::{PeriodicEvaluator, PeriodicLdeTable, PolynomialSpace};
 use p3_field::ExtensionField;
@@ -77,33 +76,22 @@ impl<F: ComplexExtendable> PeriodicEvaluator<F, CircleDomain<F>> for CirclePerio
             .log_n
             .checked_sub(trace_domain.log_n)
             .expect("LDE domain log_n must be >= trace domain log_n");
-        let log_blowup_u32 = u32::try_from(log_blowup).expect("log_blowup does not fit into u32");
         let blowup = 1usize
-            .checked_shl(log_blowup_u32)
+            .checked_shl(log_blowup as u32)
             .expect("blowup overflow when computing 1 << log_blowup");
 
-        // Find the maximum period and validate all columns
-        let max_period = periodic_table
-            .iter()
-            .map(|col| {
-                let period = col.len();
-                assert!(
-                    period > 0,
-                    "periodic column length must be > 0, got {period}",
-                );
-                assert!(
-                    period.is_power_of_two(),
-                    "periodic column length must be a power of 2"
-                );
-                assert_eq!(
-                    trace_len % period,
-                    0,
-                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
-                );
-                period
-            })
-            .max()
-            .unwrap();
+        for col in periodic_table {
+            let period = col.len();
+            assert!(
+                period > 0 && period.is_power_of_two(),
+                "periodic column length must be a non-zero power of 2, got {period}",
+            );
+            assert!(
+                trace_len.is_multiple_of(period),
+                "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
+            );
+        }
+        let max_period = periodic_table.iter().map(|c| c.len()).max().unwrap();
 
         let log_max_period = log2_strict_usize(max_period);
         let log_repetitions = log2_strict_usize(trace_len / max_period);
@@ -166,9 +154,21 @@ impl<F: ComplexExtendable> PeriodicEvaluator<F, CircleDomain<F>> for CirclePerio
         trace_domain: &CircleDomain<F>,
         point: EF,
     ) -> Vec<EF> {
+        let trace_len = trace_domain.size();
         periodic_table
             .iter()
-            .map(|col| PolynomialSpace::evaluate_periodic_column_at(trace_domain, col, point))
+            .map(|col| {
+                let period = col.len();
+                assert!(
+                    period > 0 && period.is_power_of_two(),
+                    "periodic column length must be a non-zero power of 2, got {period}",
+                );
+                assert!(
+                    trace_len.is_multiple_of(period),
+                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
+                );
+                PolynomialSpace::evaluate_periodic_column_at(trace_domain, col, point)
+            })
             .collect()
     }
 }

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -312,10 +312,52 @@ where
         }
         let trace_size = trace_domain.size();
         let quotient_size = quotient_domain.size();
+        assert!(
+            quotient_size >= trace_size,
+            "quotient domain size ({quotient_size}) must be >= trace domain size ({trace_size})",
+        );
+        assert_eq!(
+            quotient_size % trace_size,
+            0,
+            "quotient domain size ({quotient_size}) must be divisible by trace domain size ({trace_size})",
+        );
         let blowup = quotient_size / trace_size;
-        let max_period = periodic_cols.iter().map(|c| c.len()).max().unwrap();
-        let extended_height = max_period * blowup;
+        assert!(
+            blowup.is_power_of_two(),
+            "blowup factor ({blowup}) must be a power of two",
+        );
+        let max_period = periodic_cols
+            .iter()
+            .map(|col| {
+                let period = col.len();
+                assert!(
+                    period > 0,
+                    "periodic column length must be > 0, got {period}",
+                );
+                assert!(
+                    period.is_power_of_two(),
+                    "periodic column length must be a power of 2"
+                );
+                assert_eq!(
+                    trace_size % period,
+                    0,
+                    "trace domain size ({trace_size}) must be divisible by periodic column length ({period})",
+                );
+                period
+            })
+            .max()
+            .unwrap();
+        let extended_height = max_period
+            .checked_mul(blowup)
+            .expect("extended height overflow when computing max_period * blowup");
+        assert!(
+            extended_height <= quotient_size,
+            "extended periodic height ({extended_height}) must be <= quotient domain size ({quotient_size})",
+        );
         let num_cols = periodic_cols.len();
+        let row_major_capacity = extended_height
+            .checked_mul(num_cols)
+            .expect("row-major periodic table capacity overflow");
 
         let mut quotient_pts = Vec::with_capacity(extended_height);
         let mut pt = quotient_domain.first_point();
@@ -331,7 +373,7 @@ where
             .map(|col| (0..max_period).map(|i| col[i % col.len()]).collect())
             .collect();
 
-        let mut row_major = Vec::with_capacity(extended_height * num_cols);
+        let mut row_major = Vec::with_capacity(row_major_capacity);
         for point in quotient_pts.iter().take(extended_height) {
             for padded in &padded_cols {
                 row_major.push(trace_domain.evaluate_periodic_column_at(padded, *point));

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -316,44 +316,31 @@ where
             quotient_size >= trace_size,
             "quotient domain size ({quotient_size}) must be >= trace domain size ({trace_size})",
         );
-        assert_eq!(
-            quotient_size % trace_size,
-            0,
+        assert!(
+            quotient_size.is_multiple_of(trace_size),
             "quotient domain size ({quotient_size}) must be divisible by trace domain size ({trace_size})",
         );
         let blowup = quotient_size / trace_size;
-        assert!(
-            blowup.is_power_of_two(),
-            "blowup factor ({blowup}) must be a power of two",
-        );
-        let max_period = periodic_cols
-            .iter()
-            .map(|col| {
-                let period = col.len();
-                assert!(
-                    period > 0,
-                    "periodic column length must be > 0, got {period}",
-                );
-                assert!(
-                    period.is_power_of_two(),
-                    "periodic column length must be a power of 2"
-                );
-                assert_eq!(
-                    trace_size % period,
-                    0,
-                    "trace domain size ({trace_size}) must be divisible by periodic column length ({period})",
-                );
-                period
-            })
-            .max()
-            .unwrap();
+
+        for col in periodic_cols {
+            let period = col.len();
+            assert!(
+                period > 0 && period.is_power_of_two(),
+                "periodic column length must be a non-zero power of 2, got {period}",
+            );
+            assert!(
+                trace_size.is_multiple_of(period),
+                "trace domain size ({trace_size}) must be divisible by periodic column length ({period})",
+            );
+        }
+        let max_period = periodic_cols.iter().map(|c| c.len()).max().unwrap();
         let extended_height = max_period
             .checked_mul(blowup)
             .expect("extended height overflow when computing max_period * blowup");
-        assert!(
-            extended_height <= quotient_size,
-            "extended periodic height ({extended_height}) must be <= quotient domain size ({quotient_size})",
-        );
+        // Implied by the column checks above.
+        // Each period divides the trace size, so max_period <= trace_size.
+        // Therefore extended_height = max_period * blowup <= trace_size * blowup = quotient_size.
+        debug_assert!(extended_height <= quotient_size);
         let num_cols = periodic_cols.len();
         let row_major_capacity = extended_height
             .checked_mul(num_cols)

--- a/fri/src/periodic.rs
+++ b/fri/src/periodic.rs
@@ -28,7 +28,6 @@
 //! could be computed once per distinct period and reused across columns sharing that period.
 
 use alloc::vec::Vec;
-use core::convert::TryFrom;
 
 use p3_commit::{PeriodicEvaluator, PeriodicLdeTable};
 use p3_dft::TwoAdicSubgroupDft;
@@ -92,9 +91,8 @@ where
             lde_len >= trace_len,
             "LDE domain size ({lde_len}) must be >= trace domain size ({trace_len})",
         );
-        assert_eq!(
-            lde_len % trace_len,
-            0,
+        assert!(
+            lde_len.is_multiple_of(trace_len),
             "LDE domain size ({lde_len}) must be divisible by trace domain size ({trace_len})",
         );
         let lde_shift = lde_domain.shift();
@@ -105,28 +103,18 @@ where
         );
         let log_blowup = log2_strict_usize(blowup);
 
-        // Find the maximum period and validate all columns
-        let max_period = periodic_table
-            .iter()
-            .map(|col| {
-                let period = col.len();
-                assert!(
-                    period > 0,
-                    "periodic column length must be > 0, got {period}",
-                );
-                assert!(
-                    period.is_power_of_two(),
-                    "periodic column length must be a power of 2"
-                );
-                assert_eq!(
-                    trace_len % period,
-                    0,
-                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
-                );
-                period
-            })
-            .max()
-            .unwrap();
+        for col in periodic_table {
+            let period = col.len();
+            assert!(
+                period > 0 && period.is_power_of_two(),
+                "periodic column length must be a non-zero power of 2, got {period}",
+            );
+            assert!(
+                trace_len.is_multiple_of(period),
+                "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
+            );
+        }
+        let max_period = periodic_table.iter().map(|c| c.len()).max().unwrap();
 
         let extended_height = max_period
             .checked_mul(blowup)
@@ -138,14 +126,11 @@ where
 
         // Compute the shift for the periodic subdomain at max_period.
         // This aligns the periodic domain with the LDE domain so modular indexing works.
-        assert_eq!(
-            lde_len % extended_height,
-            0,
-            "LDE domain size ({lde_len}) must be divisible by extended periodic height ({extended_height})",
-        );
-        let shift_exp = u64::try_from(lde_len / extended_height)
-            .expect("periodic shift exponent does not fit into u64");
-        let periodic_shift = lde_shift.exp_u64(shift_exp);
+        //
+        // Divisibility holds by construction: lde_len = blowup * trace_len.
+        // extended_height = blowup * max_period, and max_period divides trace_len.
+        // So extended_height divides lde_len.
+        let periodic_shift = lde_shift.exp_u64((lde_len / extended_height) as u64);
 
         let dft = Dft::default();
 
@@ -191,24 +176,16 @@ where
             .map(|col| {
                 let period = col.len();
                 assert!(
-                    period > 0,
-                    "periodic column length must be > 0, got {period}",
+                    period > 0 && period.is_power_of_two(),
+                    "periodic column length must be a non-zero power of 2, got {period}",
                 );
                 assert!(
-                    period.is_power_of_two(),
-                    "periodic column length must be a power of 2"
-                );
-                assert_eq!(
-                    trace_len % period,
-                    0,
+                    trace_len.is_multiple_of(period),
                     "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
                 );
 
-                let exponent = u64::try_from(trace_len / period)
-                    .expect("periodic projection exponent does not fit into u64");
-
                 // Project point to periodic subdomain: ζ^(n/p)
-                let periodic_point = point.exp_u64(exponent);
+                let periodic_point = point.exp_u64((trace_len / period) as u64);
 
                 // Evaluate the periodic polynomial at the projected point
                 eval_periodic_poly(col, periodic_point)

--- a/fri/src/periodic.rs
+++ b/fri/src/periodic.rs
@@ -28,6 +28,7 @@
 //! could be computed once per distinct period and reused across columns sharing that period.
 
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use p3_commit::{PeriodicEvaluator, PeriodicLdeTable};
 use p3_dft::TwoAdicSubgroupDft;
@@ -87,8 +88,21 @@ where
 
         let trace_len = trace_domain.size();
         let lde_len = lde_domain.size();
+        assert!(
+            lde_len >= trace_len,
+            "LDE domain size ({lde_len}) must be >= trace domain size ({trace_len})",
+        );
+        assert_eq!(
+            lde_len % trace_len,
+            0,
+            "LDE domain size ({lde_len}) must be divisible by trace domain size ({trace_len})",
+        );
         let lde_shift = lde_domain.shift();
         let blowup = lde_len / trace_len;
+        assert!(
+            blowup.is_power_of_two(),
+            "blowup factor ({blowup}) must be a power of two",
+        );
         let log_blowup = log2_strict_usize(blowup);
 
         // Find the maximum period and validate all columns
@@ -96,21 +110,42 @@ where
             .iter()
             .map(|col| {
                 let period = col.len();
-                debug_assert!(
+                assert!(
+                    period > 0,
+                    "periodic column length must be > 0, got {period}",
+                );
+                assert!(
                     period.is_power_of_two(),
                     "periodic column length must be a power of 2"
+                );
+                assert_eq!(
+                    trace_len % period,
+                    0,
+                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
                 );
                 period
             })
             .max()
             .unwrap();
 
-        let extended_height = max_period * blowup;
+        let extended_height = max_period
+            .checked_mul(blowup)
+            .expect("extended height overflow when computing max_period * blowup");
         let num_cols = periodic_table.len();
+        let row_major_capacity = extended_height
+            .checked_mul(num_cols)
+            .expect("row-major periodic table capacity overflow");
 
         // Compute the shift for the periodic subdomain at max_period.
         // This aligns the periodic domain with the LDE domain so modular indexing works.
-        let periodic_shift = lde_shift.exp_u64((lde_len / extended_height) as u64);
+        assert_eq!(
+            lde_len % extended_height,
+            0,
+            "LDE domain size ({lde_len}) must be divisible by extended periodic height ({extended_height})",
+        );
+        let shift_exp = u64::try_from(lde_len / extended_height)
+            .expect("periodic shift exponent does not fit into u64");
+        let periodic_shift = lde_shift.exp_u64(shift_exp);
 
         let dft = Dft::default();
 
@@ -134,7 +169,7 @@ where
         }
 
         // Convert from column-major to row-major storage
-        let mut row_major_values = Vec::with_capacity(extended_height * num_cols);
+        let mut row_major_values = Vec::with_capacity(row_major_capacity);
         for row_idx in 0..extended_height {
             for col in &columns {
                 row_major_values.push(col[row_idx]);
@@ -155,12 +190,22 @@ where
             .iter()
             .map(|col| {
                 let period = col.len();
-                debug_assert!(
+                assert!(
+                    period > 0,
+                    "periodic column length must be > 0, got {period}",
+                );
+                assert!(
                     period.is_power_of_two(),
                     "periodic column length must be a power of 2"
                 );
+                assert_eq!(
+                    trace_len % period,
+                    0,
+                    "trace domain size ({trace_len}) must be divisible by periodic column length ({period})",
+                );
 
-                let exponent = (trace_len / period) as u64;
+                let exponent = u64::try_from(trace_len / period)
+                    .expect("periodic projection exponent does not fit into u64");
 
                 // Project point to periodic subdomain: ζ^(n/p)
                 let periodic_point = point.exp_u64(exponent);


### PR DESCRIPTION
Add release-grade validation and checked arithmetic for periodic LDE construction, preventing invalid domain and period inputs from propagating into expensive stages.