### PR TITLE
perf(field): make halving helpers branchless

### DIFF
--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -109,7 +109,8 @@ pub const fn field_to_array<R: PrimeCharacteristicRing, const D: usize>(x: R) ->
 pub const fn halve_u32<const P: u32>(x: u32) -> u32 {
     let shift = (P + 1) >> 1;
     let half = x >> 1;
-    if x & 1 == 0 { half } else { half + shift }
+    let mask = 0u32.wrapping_sub(x & 1);
+    half.wrapping_add(mask & shift)
 }
 
 /// Given an element x from a 64 bit field F_P compute x/2.
@@ -118,7 +119,8 @@ pub const fn halve_u32<const P: u32>(x: u32) -> u32 {
 pub const fn halve_u64<const P: u64>(x: u64) -> u64 {
     let shift = (P + 1) >> 1;
     let half = x >> 1;
-    if x & 1 == 0 { half } else { half + shift }
+    let mask = 0u64.wrapping_sub(x & 1);
+    half.wrapping_add(mask & shift)
 }
 
 /// Reduce a slice of 32-bit field elements into a single element of a larger field.


### PR DESCRIPTION
## Summary

Use mask arithmetic in the generic scalar halving helpers. This removes the parity branch while preserving the same field element result for both 32-bit and 64-bit prime-field helpers.

## Changes

- Make `halve_u32` and `halve_u64` compute the odd-element correction with a mask.
- Keep the existing `const fn` API and arithmetic formula unchanged.

## Test plan

- [x] `rustfmt +nightly --edition 2024 --check field/src/helpers.rs`
- [x] `cargo +stable test -p p3-field`
- [x] `cargo +stable test -p p3-mersenne-31`