### PR TITLE
perf(goldilocks): scalar add/sub for PackedGoldilocksNeon

### DIFF
--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::arch::aarch64::{
-    uint64x2_t, vaddq_u64, vandq_u64, vbicq_u64, vcgtq_s64, vdupq_n_u64, veorq_u64, vgetq_lane_u64,
-    vreinterpretq_s64_u64, vsetq_lane_u64, vshrq_n_u64, vsubq_u64,
+    uint64x2_t, vaddq_u64, vandq_u64, vdupq_n_u64, vgetq_lane_u64, vsetq_lane_u64, vshrq_n_u64,
+    vsubq_u64,
 };
 use core::fmt::Debug;
 use core::iter::{Product, Sum};
@@ -59,11 +59,17 @@ impl From<Goldilocks> for PackedGoldilocksNeon {
     }
 }
 
+// Add/Sub/Neg are emulated as two independent scalar Goldilocks operations.
+// On Apple Silicon's wide scalar pipeline, two pipelined scalar adds beat the
+// NEON modular-reduction sequence (XOR-shift + signed compare + conditional
+// add) per element. Storage stays as `[Goldilocks; 2]` (16 bytes) so the
+// compiler can keep elements in either GPRs or NEON regs as needed; only
+// `mul`/`square`/`cubic_*` use the dual-lane interleaved ASM.
 impl Add for PackedGoldilocksNeon {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::from_vector(add(self.to_vector(), rhs.to_vector()))
+        Self([self.0[0] + rhs.0[0], self.0[1] + rhs.0[1]])
     }
 }
 
@@ -71,7 +77,7 @@ impl Sub for PackedGoldilocksNeon {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::from_vector(sub(self.to_vector(), rhs.to_vector()))
+        Self([self.0[0] - rhs.0[0], self.0[1] - rhs.0[1]])
     }
 }
 
@@ -79,7 +85,7 @@ impl Neg for PackedGoldilocksNeon {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self::from_vector(neg(self.to_vector()))
+        Self([-self.0[0], -self.0[1]])
     }
 }
 
@@ -196,80 +202,6 @@ unsafe impl PackedFieldPow2 for PackedGoldilocksNeon {
             _ => panic!("unsupported block length"),
         };
         (Self::from_vector(res0), Self::from_vector(res1))
-    }
-}
-
-// NEON arithmetic uses shifted representation (XOR with 2^63) for unsigned comparison.
-
-const SIGN_BIT: uint64x2_t = unsafe { transmute([i64::MIN as u64; WIDTH]) };
-const SHIFTED_FIELD_ORDER: uint64x2_t =
-    unsafe { transmute([Goldilocks::ORDER_U64 ^ (i64::MIN as u64); WIDTH]) };
-const EPSILON_VEC: uint64x2_t = unsafe { transmute([EPSILON; WIDTH]) };
-
-#[inline(always)]
-fn shift(x: uint64x2_t) -> uint64x2_t {
-    unsafe { veorq_u64(x, SIGN_BIT) }
-}
-
-#[inline(always)]
-unsafe fn canonicalize_s(x_s: uint64x2_t) -> uint64x2_t {
-    unsafe {
-        let x_s_signed = vreinterpretq_s64_u64(x_s);
-        let order_s_signed = vreinterpretq_s64_u64(SHIFTED_FIELD_ORDER);
-        let mask = vcgtq_s64(order_s_signed, x_s_signed);
-        let wrapback_amt = vbicq_u64(EPSILON_VEC, mask);
-        vaddq_u64(x_s, wrapback_amt)
-    }
-}
-
-#[inline(always)]
-unsafe fn add_no_double_overflow_64_64s_s(x: uint64x2_t, y_s: uint64x2_t) -> uint64x2_t {
-    unsafe {
-        let res_wrapped_s = vaddq_u64(x, y_s);
-        // After XOR shift, signed comparison correctly detects overflow.
-        // Overflow occurred iff y_s > res_wrapped_s (as signed, due to shift semantics)
-        let y_s_signed = vreinterpretq_s64_u64(y_s);
-        let res_s_signed = vreinterpretq_s64_u64(res_wrapped_s);
-        let mask = vcgtq_s64(y_s_signed, res_s_signed);
-        // wrapback_amt is EPSILON on overflow
-        let wrapback_amt = vshrq_n_u64::<32>(mask);
-        vaddq_u64(res_wrapped_s, wrapback_amt)
-    }
-}
-
-/// Goldilocks modular addition.
-#[inline]
-fn add(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
-    unsafe {
-        let y_s = shift(y);
-        let res_s = add_no_double_overflow_64_64s_s(x, canonicalize_s(y_s));
-        shift(res_s)
-    }
-}
-
-/// Goldilocks modular subtraction.
-#[inline]
-fn sub(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
-    unsafe {
-        let mut y_s = shift(y);
-        y_s = canonicalize_s(y_s);
-        let x_s = shift(x);
-        let y_s_signed = vreinterpretq_s64_u64(y_s);
-        let x_s_signed = vreinterpretq_s64_u64(x_s);
-        // -1 if underflow (y > x)
-        let mask = vcgtq_s64(y_s_signed, x_s_signed);
-        let wrapback_amt = vshrq_n_u64::<32>(mask);
-        let res_wrapped = vsubq_u64(x_s, y_s);
-        vsubq_u64(res_wrapped, wrapback_amt)
-    }
-}
-
-/// Goldilocks modular negation.
-#[inline]
-fn neg(y: uint64x2_t) -> uint64x2_t {
-    unsafe {
-        let y_s = shift(y);
-        vsubq_u64(SHIFTED_FIELD_ORDER, canonicalize_s(y_s))
     }
 }
 

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -29,7 +29,11 @@ const WIDTH: usize = 2;
 /// Equal to `2^32 - 1 = 2^64 mod P`.
 const EPSILON: u64 = Goldilocks::ORDER_U64.wrapping_neg();
 
-/// Vectorized NEON implementation of `Goldilocks` arithmetic.
+/// Width-2 packed `Goldilocks` for aarch64.
+///
+/// `mul`, `square`, and the cubic-extension helpers use a dual-lane interleaved
+/// scalar ASM block (`mul_reduce_dual_asm`); `add`, `sub`, and `neg` operate on
+/// the underlying `[Goldilocks; 2]` storage directly in scalar `u64` space.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
 #[must_use]

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -59,12 +59,6 @@ impl From<Goldilocks> for PackedGoldilocksNeon {
     }
 }
 
-// Add/Sub/Neg are emulated as two independent scalar Goldilocks operations.
-// On Apple Silicon's wide scalar pipeline, two pipelined scalar adds beat the
-// NEON modular-reduction sequence (XOR-shift + signed compare + conditional
-// add) per element. Storage stays as `[Goldilocks; 2]` (16 bytes) so the
-// compiler can keep elements in either GPRs or NEON regs as needed; only
-// `mul`/`square`/`cubic_*` use the dual-lane interleaved ASM.
 impl Add for PackedGoldilocksNeon {
     type Output = Self;
     #[inline]

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -372,6 +372,9 @@ impl Field for Goldilocks {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedGoldilocksAVX512;
 
+    #[cfg(target_arch = "aarch64")]
+    type Packing = crate::PackedGoldilocksNeon;
+
     #[cfg(not(any(
         all(
             target_arch = "x86_64",
@@ -379,6 +382,7 @@ impl Field for Goldilocks {
             not(target_feature = "avx512f")
         ),
         all(target_arch = "x86_64", target_feature = "avx512f"),
+        target_arch = "aarch64",
     )))]
     type Packing = Self;
 

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -40,4 +40,3 @@ mod x86_64_avx512;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;
-

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -41,14 +41,3 @@ mod x86_64_avx512;
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;
 
-/// Packed scalar type intended for Merkle trees and sponge hashes (e.g. Poseidon2 leaf batching).
-///
-/// On **aarch64** this is always [`PackedGoldilocksNeon`], even if [`Goldilocks::Packing`] is
-/// set to [`Goldilocks`] for arithmetic.
-///
-/// On **other targets** this is [`Goldilocks::Packing`] (AVX2, AVX-512, or scalar).
-#[cfg(target_arch = "aarch64")]
-pub type HashPackedGoldilocks = PackedGoldilocksNeon;
-
-#[cfg(not(target_arch = "aarch64"))]
-pub type HashPackedGoldilocks = <Goldilocks as p3_field::Field>::Packing;

--- a/keccak-air/examples/prove_goldilocks_poseidon2.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon2.rs
@@ -3,9 +3,10 @@ use core::fmt::Debug;
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
+use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriParameters, TwoAdicFriPcs};
-use p3_goldilocks::{Goldilocks, HashPackedGoldilocks, Poseidon2Goldilocks};
+use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_keccak_air::{KeccakAir, generate_trace_rows};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -43,8 +44,8 @@ fn main() -> Result<(), impl Debug> {
     type MyCompress = TruncatedPermutation<Perm, 2, 4, 8>;
     let compress = MyCompress::new(perm.clone());
 
-    type ValMmcs =
-        MerkleTreeMmcs<HashPackedGoldilocks, HashPackedGoldilocks, MyHash, MyCompress, 2, 4>;
+    type ValPacking = <Val as Field>::Packing;
+    type ValMmcs = MerkleTreeMmcs<ValPacking, ValPacking, MyHash, MyCompress, 2, 4>;
     let val_mmcs = ValMmcs::new(hash, compress, 0);
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;

--- a/poseidon1/benches/poseidon1.rs
+++ b/poseidon1/benches/poseidon1.rs
@@ -4,8 +4,8 @@ use p3_baby_bear::{
     BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_24, BabyBear, MdsMatrixBabyBear, Poseidon1BabyBear,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_goldilocks::poseidon1::{default_goldilocks_poseidon1_8, default_goldilocks_poseidon1_12};
 use p3_goldilocks::Goldilocks;
+use p3_goldilocks::poseidon1::{default_goldilocks_poseidon1_8, default_goldilocks_poseidon1_12};
 use p3_koala_bear::{
     KOALABEAR_POSEIDON_HALF_FULL_ROUNDS, KOALABEAR_POSEIDON_PARTIAL_ROUNDS_16,
     KOALABEAR_POSEIDON_PARTIAL_ROUNDS_24, KoalaBear, MdsMatrixKoalaBear, Poseidon1KoalaBear,

--- a/poseidon1/benches/poseidon1.rs
+++ b/poseidon1/benches/poseidon1.rs
@@ -5,7 +5,7 @@ use p3_baby_bear::{
 };
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_goldilocks::poseidon1::{default_goldilocks_poseidon1_8, default_goldilocks_poseidon1_12};
-use p3_goldilocks::{Goldilocks, HashPackedGoldilocks};
+use p3_goldilocks::Goldilocks;
 use p3_koala_bear::{
     KOALABEAR_POSEIDON_HALF_FULL_ROUNDS, KOALABEAR_POSEIDON_PARTIAL_ROUNDS_16,
     KOALABEAR_POSEIDON_PARTIAL_ROUNDS_24, KoalaBear, MdsMatrixKoalaBear, Poseidon1KoalaBear,
@@ -68,12 +68,12 @@ fn bench_poseidon1(c: &mut Criterion) {
     // Goldilocks width 8.
     let gl_8 = default_goldilocks_poseidon1_8();
     poseidon1_scalar::<Goldilocks, _, 8>(c, &gl_8);
-    poseidon1_goldilocks_packed::<_, 8>(c, &gl_8);
+    poseidon1_packed::<Goldilocks, _, 8>(c, &gl_8);
 
     // Goldilocks width 12.
     let gl_12 = default_goldilocks_poseidon1_12();
     poseidon1_scalar::<Goldilocks, _, 12>(c, &gl_12);
-    poseidon1_goldilocks_packed::<_, 12>(c, &gl_12);
+    poseidon1_packed::<Goldilocks, _, 12>(c, &gl_12);
 
     // Mersenne31 width 16.
     let m31_16 = default_mersenne31_poseidon1_16();
@@ -108,24 +108,6 @@ where
     let name = format!(
         "poseidon-packed::<{}, {}>",
         pretty_name::<F::Packing>(),
-        WIDTH
-    );
-    let id = BenchmarkId::new(name, WIDTH);
-    c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon.permute(input)));
-}
-
-/// Goldilocks packed benchmark target.
-///
-/// On aarch64 this is [`PackedGoldilocksNeon`] via [`HashPackedGoldilocks`],
-/// while on other targets it resolves to `<Goldilocks as Field>::Packing`.
-fn poseidon1_goldilocks_packed<Perm, const WIDTH: usize>(c: &mut Criterion, poseidon: &Perm)
-where
-    Perm: Permutation<[HashPackedGoldilocks; WIDTH]>,
-{
-    let input = [HashPackedGoldilocks::ZERO; WIDTH];
-    let name = format!(
-        "poseidon-packed::<{}, {}>",
-        pretty_name::<HashPackedGoldilocks>(),
         WIDTH
     );
     let id = BenchmarkId::new(name, WIDTH);

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -4,7 +4,7 @@ use p3_bn254::{
     BN254_POSEIDON2_HALF_FULL_ROUNDS, BN254_POSEIDON2_PARTIAL_ROUNDS_3, Bn254, Poseidon2Bn254,
 };
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_goldilocks::{HashPackedGoldilocks, Poseidon2Goldilocks};
+use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};
 use p3_symmetric::Permutation;
@@ -31,11 +31,11 @@ fn bench_poseidon12(c: &mut Criterion) {
     poseidon2::<Mersenne31, Poseidon2Mersenne31<24>, 24>(c, &poseidon2_m31_24);
 
     let poseidon2_gold_8 = Poseidon2Goldilocks::<8>::new_from_rng_128(&mut rng);
-    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<8>, 8>(c, &poseidon2_gold_8);
+    poseidon2::<Goldilocks, Poseidon2Goldilocks<8>, 8>(c, &poseidon2_gold_8);
     let poseidon2_gold_12 = Poseidon2Goldilocks::<12>::new_from_rng_128(&mut rng);
-    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<12>, 12>(c, &poseidon2_gold_12);
+    poseidon2::<Goldilocks, Poseidon2Goldilocks<12>, 12>(c, &poseidon2_gold_12);
     let poseidon2_gold_16 = Poseidon2Goldilocks::<16>::new_from_rng_128(&mut rng);
-    poseidon2_goldilocks_packed::<Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
+    poseidon2::<Goldilocks, Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
 
     let poseidon2_bn254 = Poseidon2Bn254::<3>::new_from_rng(
         2 * BN254_POSEIDON2_HALF_FULL_ROUNDS,
@@ -52,24 +52,6 @@ where
 {
     let input = [F::Packing::ZERO; WIDTH];
     let name = format!("poseidon2::<{}, {}>", pretty_name::<F::Packing>(), WIDTH);
-    let id = BenchmarkId::new(name, WIDTH);
-    c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon2.permute(input)));
-}
-
-/// Goldilocks packed benchmark target.
-///
-/// On aarch64 this is [`PackedGoldilocksNeon`] via [`HashPackedGoldilocks`],
-/// while on other targets it resolves to `<Goldilocks as Field>::Packing`.
-fn poseidon2_goldilocks_packed<Perm, const WIDTH: usize>(c: &mut Criterion, poseidon2: &Perm)
-where
-    Perm: Permutation<[HashPackedGoldilocks; WIDTH]>,
-{
-    let input = [HashPackedGoldilocks::ZERO; WIDTH];
-    let name = format!(
-        "poseidon2::<{}, {}>",
-        pretty_name::<HashPackedGoldilocks>(),
-        WIDTH
-    );
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon2.permute(input)));
 }


### PR DESCRIPTION
Closes #1581.
  
### Summary

`PackedGoldilocksNeon` was reverted to `Goldilocks` for `<Goldilocks as Field>::Packing` in #1517, which fixed an addition slowdown but reintroduced the packed-mul gap that #1581 reports on Apple Silicon. This PR re-enables the NEON packing for arithmetic, but switches `Add`/`Sub`/`Neg` to operate on the underlying `[Goldilocks; 2]` storage in scalar `u64` space. Multiplication and squaring remain on the existing dual-lane interleaved ASM (`mul_reduce_dual_asm`), so the packed-mul win is preserved.

The asymmetric routing is not arbitrary: NEON modular reduction for add/sub costs ~11 instructions per element (XOR-shift + signed compare + conditional add) and forces `umov`/`ins` traffic between NEON and GPR register files; two
pipelined scalar Goldilocks adds cost ~3 instructions each and stay in GPRs. For mul, the cost is dominated by the multiplier units, and packing two lanes through the dual-lane ASM is a net win.

### Changes

- `goldilocks/src/aarch64_neon/packing.rs`
- `Add`/`Sub`/`Neg` impls now do `Self([self.0[0] OP rhs.0[0], self.0[1] OP rhs.0[1]])`.
- Removed unused NEON helpers: `add`, `sub`, `neg`, `canonicalize_s`, `shift`, `add_no_double_overflow_64_64s_s`, and the constants `SIGN_BIT`/`SHIFTED_FIELD_ORDER`/`EPSILON_VEC`.
- Removed the corresponding NEON intrinsics from `core::arch::aarch64` import (`vandq_u64`, `vbicq_u64`, `vcgtq_s64`, `veorq_u64`, `vreinterpretq_s64_u64`).
- `goldilocks/src/goldilocks.rs`
- Restored `#[cfg(target_arch = "aarch64")] type Packing = crate::PackedGoldilocksNeon;`
- Re-added `target_arch = "aarch64"` to the exclusion list on the scalar `Packing = Self` fallback.

### Benchmarks

Same `bench_goldilocks_2` as the issue: `BinomialExtensionField<Goldilocks, 2>`, `n = 10^9`, `target-cpu=native`.

**Raspberry Pi 5 — Cortex-A76 (governor=performance, taskset -c 3):**

| | width | muls/sec | adds/sec |
|---|---|---|---|
| Before 3e4da72a    | 2 | 72 M | 267 M |
| `main`             | 1 | 67 M | 747 M |
| This PR            | 2 | **72 M** | **959 M** |

Strict improvement vs `main`: +7% mul, +28% add. And vs the pre-regression state: same mul, ~3.6× adds.

**Apple M4 (numbers from #1581 by @TomWambsgans, for reference):**

| | width | muls/sec | adds/sec |
|---|---|---|---|
| Before 3e4da72a    | 2 | 317 M |  491 M |
| `main`             | 1 | 214 M | 2167 M |

(No M4 to test on, the Pi 5 numbers above are clean. M4 verification welcome before merge.)

### Credit

Approach mirrors the change in @TomWambsgans's `goldilocks_3` branch (commit `f4c63f2d`), reduced to the minimal subset that addresses #1581.

Co-authored-by: Tom Wambsgans <TomWambsgans@users.noreply.github.com>
