### PR TITLE
test(field): cover packed-extension Div with per-lane consistency check

### DIFF
--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -1,5 +1,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
+use core::ops::Div;
 
 use p3_field::extension::{
     BinomialExtensionField, BinomiallyExtendable, PackedBinomialExtensionField,
@@ -325,6 +326,75 @@ where
             extract_lane(&quot_scalar_assign, lane),
             extract_lane(&quot_scalar, lane),
             "packed/scalar div_assign mismatch at lane {lane}"
+        );
+    }
+}
+
+/// Verify that packed divide agrees with scalar divide on every SIMD lane.
+///
+/// # Invariant
+///
+/// For every lane `i`:
+///
+/// ```text
+/// (a / b).lane(i) == a.lane(i) / b.lane(i)
+/// ```
+pub fn test_packed_extension_div_consistency<F, EF, PEF>()
+where
+    F: Field,
+    EF: ExtensionField<F, ExtensionPacking = PEF>,
+    PEF: PackedFieldExtension<F, EF> + Div<Output = PEF> + Copy,
+    StandardUniform: Distribution<EF>,
+{
+    // SIMD lane count.
+    // - Goldilocks NEON → 2.
+    // - KoalaBear NEON → 4.
+    // - Scalar → 1.
+    let width = F::Packing::WIDTH;
+
+    // Fixed seed → reproducible bytes on any failure.
+    let mut rng = SmallRng::seed_from_u64(0x_d1ef_d1ef_d1ef_d1ef);
+
+    // Numerator lane fixture: any value, zeros are fine.
+    //
+    //     lane:   0    1    …    W-1
+    //     nums:  [n0,  n1,  …,   n_{W-1}]
+    let nums: Vec<EF> = (0..width).map(|_| rng.random()).collect();
+
+    // Denominator lane fixture: reject-sample so every lane is invertible.
+    //
+    //     lane:   0       1       …    W-1
+    //     dens:  [d0 ≠ 0, d1 ≠ 0, …,   d_{W-1} ≠ 0]
+    let dens: Vec<EF> = (0..width)
+        .map(|_| {
+            loop {
+                let x: EF = rng.random();
+                if !x.is_zero() {
+                    break x;
+                }
+            }
+        })
+        .collect();
+
+    // Pack the per-lane scalars into one SIMD value each.
+    //
+    //     lanes [n0, n1, …, n_{W-1}]  →  one packed extension value
+    //     lanes [d0, d1, …, d_{W-1}]  →  one packed extension value
+    let pef_n: PEF = PEF::from_ext_slice(&nums);
+    let pef_d: PEF = PEF::from_ext_slice(&dens);
+
+    // Run the packed divide. Each lane must independently compute n_i / d_i.
+    let pef_q = pef_n / pef_d;
+
+    // Per-lane invariant:
+    //
+    //     packed quotient at lane i  ==  nums[i] / dens[i]
+    for lane in 0..width {
+        let expected = nums[lane] / dens[lane];
+        let got = pef_q.extract(lane);
+        assert_eq!(
+            got, expected,
+            "lane {lane}: packed Div disagrees with scalar Div (W = {width})"
         );
     }
 }
@@ -1007,6 +1077,14 @@ macro_rules! test_packed_extension_field {
             #[test]
             fn test_batched_linear_combination_ext() {
                 $crate::test_batched_linear_combination_ext::<
+                    $basefield,
+                    $extfield,
+                    $packedextfield,
+                >();
+            }
+            #[test]
+            fn test_packed_extension_div_consistency() {
+                $crate::test_packed_extension_div_consistency::<
                     $basefield,
                     $extfield,
                     $packedextfield,


### PR DESCRIPTION
## Summary

@adr1anh Follow-up to #1620.

That PR removed an unsound `PackedValue`/`PackedField` impl on the cubic and quintic packed-extension types and consolidated their `Div` through a shared lane-by-lane wrapper. The bug was latent (no in-tree caller exercised it), but the broken per-lane divide *was* publicly reachable — it just had no regression coverage to catch it.

This PR adds the missing coverage:

- New generic helper `test_packed_extension_div_consistency<F, EF, PEF>` in `field-testing`.
- Wired into `test_packed_extension_field!`, so every existing packed-extension test site (binomial 2/4/5/8, cubic trinomial, quintic trinomial, Mersenne31 complex) now checks it automatically.

The invariant it enforces:

```text
(a / b).lane(i) == a.lane(i) / b.lane(i)   for every lane i
```

The check uses only the public `PackedFieldExtension` surface (`from_ext_slice`, `extract`) plus the `Div` operator, so it is layout-agnostic and survives any future refactor of the per-lane inverse path.

Manually verified by reverting #1620 locally: this test fails at cubic (Goldilocks, W=2) and quintic (KoalaBear, W=4); it passes for every binomial site in both branches.

## Test plan

- [ ] `cargo test -p p3-field-testing`
- [ ] `cargo test -p p3-goldilocks` (covers binomial 2, cubic trinomial, binomial 5)
- [ ] `cargo test -p p3-koala-bear` (covers binomial 4, binomial 8, quintic trinomial)
- [ ] `cargo test -p p3-baby-bear` (covers binomial extensions)
- [ ] `cargo test -p p3-mersenne-31` (covers complex extension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)