### PR TITLE
fix(whir): mark UniqueDecoding log_eta as undefined

### DIFF
--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -54,12 +54,16 @@ impl SecurityAssumption {
     /// E.g. in JB proximity gaps holds for every delta in (0, 1 - sqrt(rho)).
     /// eta is the distance between the chosen proximity parameter and the bound.
     /// I.e. in JB delta = 1 - sqrt(rho) - eta and in CB delta = 1 - rho - eta.
-    // TODO: Maybe it makes more sense to be multiplicative. I think this can be set in a better way.
     #[must_use]
     pub const fn log_eta(&self, log_inv_rate: usize) -> f64 {
         match self {
-            // We don't use eta in UD
-            Self::UniqueDecoding => 0., // TODO: Maybe just panic and avoid calling it in UD?
+            // eta is undefined in UD: delta is (1 - rho) / 2, with no eta term.
+            // Return INFINITY so any accidental future caller that reads this in
+            // the UD branch fails visibly (NaN / overflow propagation) instead
+            // of silently treating eta as 2^0 = 1, which is "impossibly large"
+            // and would produce a wrong delta. All current callers special-case
+            // UD before reaching the eta-dependent arithmetic.
+            Self::UniqueDecoding => f64::INFINITY,
             // Set as sqrt(rho)/20
             Self::JohnsonBound => -(0.5 * log_inv_rate as f64 + LOG2_10 + 1.),
             // Set as rho/20
@@ -558,5 +562,20 @@ mod tests {
 
         // PoW bits should never be negative
         assert!(pow_bits >= 0.);
+    }
+
+    #[test]
+    fn log_eta_undefined_in_unique_decoding() {
+        // eta does not appear in the UD distance formula `delta = (1 - rho) / 2`.
+        // Returning INFINITY locks down the invariant: if a future refactor
+        // accidentally reads this value in the UD branch, downstream arithmetic
+        // turns into NaN / overflow rather than silently treating eta as
+        // 2^0 = 1 and producing a wrong delta.
+        for log_inv_rate in [1, 2, 5, 10, 20] {
+            assert_eq!(
+                SecurityAssumption::UniqueDecoding.log_eta(log_inv_rate),
+                f64::INFINITY,
+            );
+        }
     }
 }

--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -54,16 +54,17 @@ impl SecurityAssumption {
     /// E.g. in JB proximity gaps holds for every delta in (0, 1 - sqrt(rho)).
     /// eta is the distance between the chosen proximity parameter and the bound.
     /// I.e. in JB delta = 1 - sqrt(rho) - eta and in CB delta = 1 - rho - eta.
+    /// # Panics
+    ///
+    /// Panics when called with [`SecurityAssumption::UniqueDecoding`]: eta is
+    /// undefined in UD (`delta = (1 - rho) / 2`, with no eta term). All
+    /// current callers special-case the UD branch before reaching the
+    /// eta-dependent arithmetic; the panic locks down that invariant so a
+    /// future refactor that strays into the eta path under UD fails loudly.
     #[must_use]
     pub const fn log_eta(&self, log_inv_rate: usize) -> f64 {
         match self {
-            // eta is undefined in UD: delta is (1 - rho) / 2, with no eta term.
-            // Return INFINITY so any accidental future caller that reads this in
-            // the UD branch fails visibly (NaN / overflow propagation) instead
-            // of silently treating eta as 2^0 = 1, which is "impossibly large"
-            // and would produce a wrong delta. All current callers special-case
-            // UD before reaching the eta-dependent arithmetic.
-            Self::UniqueDecoding => f64::INFINITY,
+            Self::UniqueDecoding => panic!("log_eta is undefined for UniqueDecoding"),
             // Set as sqrt(rho)/20
             Self::JohnsonBound => -(0.5 * log_inv_rate as f64 + LOG2_10 + 1.),
             // Set as rho/20
@@ -565,17 +566,12 @@ mod tests {
     }
 
     #[test]
-    fn log_eta_undefined_in_unique_decoding() {
+    #[should_panic(expected = "log_eta is undefined for UniqueDecoding")]
+    fn log_eta_panics_for_unique_decoding() {
         // eta does not appear in the UD distance formula `delta = (1 - rho) / 2`.
-        // Returning INFINITY locks down the invariant: if a future refactor
-        // accidentally reads this value in the UD branch, downstream arithmetic
-        // turns into NaN / overflow rather than silently treating eta as
-        // 2^0 = 1 and producing a wrong delta.
-        for log_inv_rate in [1, 2, 5, 10, 20] {
-            assert_eq!(
-                SecurityAssumption::UniqueDecoding.log_eta(log_inv_rate),
-                f64::INFINITY,
-            );
-        }
+        // Reading log_eta in the UD branch is a programmer error; the panic
+        // locks that down so a future refactor that strays into the eta path
+        // under UD fails loudly instead of silently propagating a bogus value.
+        let _ = SecurityAssumption::UniqueDecoding.log_eta(5);
     }
 }

--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -75,19 +75,19 @@ impl SecurityAssumption {
     /// Given a RS code (specified by the log of the degree and log inv of the rate), compute the list size at the specified distance delta.
     #[must_use]
     pub const fn list_size_bits(&self, log_degree: usize, log_inv_rate: usize) -> f64 {
-        let log_eta = self.log_eta(log_inv_rate);
         match self {
             // In UD the list size is 1
             Self::UniqueDecoding => 0.,
 
             // By the JB, RS codes are (1 - sqrt(rho) - eta, (2*eta*sqrt(rho))^-1)-list decodable.
             Self::JohnsonBound => {
+                let log_eta = self.log_eta(log_inv_rate);
                 let log_inv_sqrt_rate: f64 = log_inv_rate as f64 / 2.;
                 log_inv_sqrt_rate - (1. + log_eta)
             }
 
             // In CB we assume that RS codes are (1 - rho - eta, d/rho*eta)-list decodable (see Conjecture 5.6 in STIR).
-            Self::CapacityBound => (log_degree + log_inv_rate) as f64 - log_eta,
+            Self::CapacityBound => (log_degree + log_inv_rate) as f64 - self.log_eta(log_inv_rate),
         }
     }
 
@@ -132,8 +132,6 @@ impl SecurityAssumption {
             "num_functions must be >= 2 to compute proximity gaps error",
         );
 
-        let log_eta = self.log_eta(log_inv_rate);
-
         // Note that this does not include the field_size
         let error = match self {
             // In UD the error is |L|/|F| = d/(rho*|F|)
@@ -176,7 +174,9 @@ impl SecurityAssumption {
             }
 
             // In CB we assume the error is degree/(eta*rho^2)
-            Self::CapacityBound => (log_degree + 2 * log_inv_rate) as f64 - log_eta,
+            Self::CapacityBound => {
+                (log_degree + 2 * log_inv_rate) as f64 - self.log_eta(log_inv_rate)
+            }
         };
 
         // Error is (num_functions - 1) * error/|F|;
@@ -191,14 +191,12 @@ impl SecurityAssumption {
     /// - In CB, delta is (1 - rho - eta)
     #[must_use]
     pub fn log_1_delta(&self, log_inv_rate: usize) -> f64 {
-        let log_eta = self.log_eta(log_inv_rate);
-        let eta = libm::pow(2., log_eta);
         let rate = 1. / f64::from(1 << log_inv_rate);
 
         let delta = match self {
             Self::UniqueDecoding => 0.5 * (1. - rate),
-            Self::JohnsonBound => 1. - libm::sqrt(rate) - eta,
-            Self::CapacityBound => 1. - rate - eta,
+            Self::JohnsonBound => 1. - libm::sqrt(rate) - libm::pow(2., self.log_eta(log_inv_rate)),
+            Self::CapacityBound => 1. - rate - libm::pow(2., self.log_eta(log_inv_rate)),
         };
 
         libm::log2(1. - delta)


### PR DESCRIPTION
## Summary

`SecurityAssumption::log_eta(UniqueDecoding)` returns `0.0`, i.e. `eta = 2^0 = 1`. That value is meaningless for UD — the UD proximity distance is `(1 - rho) / 2`, with no eta term at all — and was flagged with two `TODO`s in the source. All current callers special-case the UD branch before reaching any eta-dependent arithmetic, so the wrong value is dead today. But a future refactor reading the eta path in the UD branch would silently produce a wrong delta instead of failing visibly.

This PR returns `f64::INFINITY` for the UD case, so any accidental future read propagates as NaN / overflow rather than as a plausible-looking number, and drops the two stale `TODO`s.

This follow-up was described in the body of #1626:

> "log_eta returned 0.0 for UniqueDecoding, implying eta = 1 (impossibly large). Changed to `f64::INFINITY` since eta is undefined in UD."

but did not actually land in that commit (the PR shipped only the SumcheckError tests and the `FiatShamirError` removal).

## Diff

```rust
// whir/src/parameters/soundness.rs
- // TODO: Maybe it makes more sense to be multiplicative. I think this can be set in a better way.
  pub const fn log_eta(&self, log_inv_rate: usize) -> f64 {
      match self {
-         // We don't use eta in UD
-         Self::UniqueDecoding => 0., // TODO: Maybe just panic and avoid calling it in UD?
+         // eta is undefined in UD: delta is (1 - rho) / 2, with no eta term.
+         // Return INFINITY so any accidental future caller that reads this in
+         // the UD branch fails visibly (NaN / overflow propagation) instead
+         // of silently treating eta as 2^0 = 1, which is "impossibly large"
+         // and would produce a wrong delta. All current callers special-case
+         // UD before reaching the eta-dependent arithmetic.
+         Self::UniqueDecoding => f64::INFINITY,
          ...
      }
  }
```

Plus one unit test (`log_eta_undefined_in_unique_decoding`) that pins the new contract across `log_inv_rate ∈ {1, 2, 5, 10, 20}`.

## Behaviour

No observable change for any existing caller of `log_eta`, `list_size_bits`, `prox_gaps_error`, `log_1_delta`, or downstream parameter selection — they all branch on `SecurityAssumption::UniqueDecoding` before the eta-dependent path.

## Test plan

- [x] `cargo test -p p3-whir --lib` — 201 passed (200 existing + 1 new), 0 failed.
- [x] `cargo build -p p3-whir` and `--examples` — clean.
- [x] `cargo clippy -p p3-whir --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo sort --workspace --grouped --check` — clean.
- [x] `cargo build --target thumbv7em-none-eabi -p p3-whir` (no_std) — clean.
