### PR TITLE
test(whir): BCSS25 proximity gap validation + UniqueDecoding log_eta fix

### DIFF
--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -573,131 +573,322 @@ mod tests {
         let _ = SecurityAssumption::UniqueDecoding.log_eta(5);
     }
 
-    // -------------------------------------------------------------------
-    // BCSS25 proximity gap improvement over BCI+20
+    // BCSS25 vs BCI+20: Johnson-bound proximity gap improvement.
     //
-    // [BCI+20] "Proximity Gaps for Reed-Solomon Codes" (FOCS 2020, eprint 2020/654)
-    //   Theorem 1.2: Johnson bound error ε_J = (k+1)² / (2·min(η,√ρ/(2δ)))⁷ · q
-    //   Soundness error a/q with a = O(n²/η⁷) for the Guruswami-Sudan regime.
+    // Bounds on the size of the exceptional set |S|:
     //
-    // [BCSS25] "On Proximity Gaps for Reed-Solomon Codes" (eprint 2025/2055)
-    //   Theorem 1.5: improves to a = O(n/η⁵), saving a factor of n.
+    //     [BCI+20] Thm 5.1 :  |S| > (m + 1/2)^7 / 3      * n^2 / rho^{3/2}
+    //     [BCSS25] Thm 1.5 :  |S| > 2 * (m + 1/2)^5 / 3  * n   / rho^{3/2}
     //
-    // The tests below verify the improvement holds across all relevant
-    // parameters and that 128-bit security is achievable with degree-5
-    // KoalaBear extensions.
-    // -------------------------------------------------------------------
+    // Safety choice eta = sqrt(rho) / 20  =>  multiplicity m = 10.
+    //
+    // Gain in log form:
+    //
+    //     gain = log_2((m + 1/2)^2 / 2) + log_2(n)
+    //          = log_2(55.125)          + log_2(n)
+    //         ~= log_2(n) + 5.78  bits.
+    //
+    // Tests in this section:
+    // - strict improvement, with the exact analytical gap pinned;
+    // - new bound clears `security_level - MAX_POW_BITS` over a 155-bit field;
+    // - full WHIR security budget hits 128 bits at a reference config;
+    // - curve folding costs log_2(M) bits per [BCSS25] Thm 4.2.
 
-    /// Compute the JohnsonBound proximity gaps error using the *old* BCI+20
-    /// bound (Theorem 1.2, equation 1.2) for comparison against BCSS25.
+    /// Field size in bits used by every test in this section.
     ///
-    /// With η = √ρ/20 (same safe gap as the implementation), m = 10:
-    ///   a ~ 2·(m+½)⁷ / (3·ρ^{7/2}) · n²
+    /// Equals `5 * ceil(log_2(p_KoalaBear))` with `p_KoalaBear = 2^31 - 2^24 + 1`,
+    /// i.e. a degree-5 extension of the KoalaBear prime field.
     ///
-    /// In log form:
-    ///   log₂(a) = 2·log₂(n) + log₂(2·10.5⁷/3) + 3.5·log_inv_rate
+    /// Chosen because it is the smallest extension that gives the [BCSS25]
+    /// bound enough headroom for 128-bit WHIR soundness in the regimes tested.
+    const KOALABEAR_QUINTIC_BITS: usize = 155;
+
+    /// Conventional ceiling for Fiat-Shamir grinding, in bits.
+    ///
+    /// Above roughly 30 bits, grinding becomes impractical for honest provers.
+    ///
+    /// Every algebraic bound contributing to the folding error must clear
+    /// `security_level - MAX_POW_BITS` on its own.
+    const MAX_POW_BITS: f64 = 30.0;
+
+    /// Old prox-gap baseline used by the improvement test.
+    ///
+    /// # Overview
+    ///
+    /// [BCI+20] Theorem 5.1 at the safety choice `eta = sqrt(rho) / 20`
+    /// (so `m = 10`):
+    ///
+    /// ```text
+    ///     |S| > (m + 1/2)^7 / 3 * n^2 / rho^{3/2}.
+    /// ```
+    ///
+    /// No leading factor of `2`: that factor belongs to the [BCSS25]
+    /// statement only and would inflate this baseline.
+    ///
+    /// # Equivalence with [BCI+20] Theorem 1.2
+    ///
+    /// Substituting `n = (k + 1) / rho` rewrites the bound as
+    /// `(k + 1)^2 * 10^7 / rho^{7/2}` — the [BCI+20] Theorem 1.2 form,
+    /// up to a small leading constant.
+    ///
+    /// # Returns
+    ///
+    /// Field-size bits minus `log_2` of the lower bound on `|S|`.
     fn bci20_jb_prox_gaps_error(
         log_degree: usize,
         log_inv_rate: usize,
         field_size_bits: usize,
     ) -> f64 {
-        let log_n_sq = ((log_degree + log_inv_rate) * 2) as f64;
-        let constant = libm::log2(2. * libm::pow(10.5, 7.) / 3.);
-        let log_rho_neg = 3.5 * log_inv_rate as f64;
-        let error_bits = log_n_sq + constant + log_rho_neg;
+        // Multiplicity at the safety choice eta = sqrt(rho) / 20.
+        const M_PLUS_HALF: f64 = 10.5;
 
+        // n = 2^(log_degree + log_inv_rate), so log_2(n^2) collects
+        // 2 * log_degree + 2 * log_inv_rate.
+        let log_n_squared = 2.0 * (log_degree + log_inv_rate) as f64;
+
+        // Leading constant of the bound; no extra factor of 2 here.
+        let log_leading_constant = libm::log2(libm::pow(M_PLUS_HALF, 7.0) / 3.0);
+
+        // The rho^{-3/2} term: log_2(rho^{-3/2}) = 3/2 * log_inv_rate.
+        let log_rho_pow_neg_three_halves = 1.5 * log_inv_rate as f64;
+
+        // Log_2 of the lower bound on |S|.
+        let error_bits = log_n_squared + log_leading_constant + log_rho_pow_neg_three_halves;
+
+        // Provable security in bits.
         field_size_bits as f64 - error_bits
     }
 
-    /// BCSS25 Theorem 1.5 strictly improves over BCI+20 Theorem 1.2
-    /// for JohnsonBound across all relevant parameter ranges.
     #[test]
-    fn test_bcss25_improves_over_bci20() {
+    fn jb_prox_gap_strictly_improves_over_old_bound() {
+        // Invariant: the new bound exceeds the old one by exactly
+        //
+        //     gap = log_2((m + 1/2)^2 / 2) + log_2(n).
+        //
+        // At m = 10 (safety choice eta = sqrt(rho) / 20), the additive
+        // constant is log_2(55.125) ~= 5.78.
+        //
+        // Fixture state:
+        //
+        //     log_degree   : 10 ..= 25   (polynomial degree 2^10 .. 2^25)
+        //     log_inv_rate :  1 ..=  4   (rho = 1/2 .. 1/16)
+        //     field        : 155-bit     (degree-5 KoalaBear extension)
         let jb = SecurityAssumption::JohnsonBound;
+
+        // Ratio of leading constants between old and new bounds:
+        //
+        //     old   : (m + 1/2)^7 / 3
+        //     new   : 2 * (m + 1/2)^5 / 3
+        //     ratio = (m + 1/2)^2 / 2  =  55.125  at  m = 10.
+        let leading_ratio_log = libm::log2(10.5_f64.powi(2) / 2.0);
 
         for log_degree in 10..=25 {
             for log_inv_rate in 1..=4 {
-                let field_size_bits = 155; // degree-5 KoalaBear extension
+                // Provable security under the new bound.
+                let new_bits =
+                    jb.prox_gaps_error(log_degree, log_inv_rate, KOALABEAR_QUINTIC_BITS, 2);
 
-                let bcss25_bits = jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
-                let bci20_bits =
-                    bci20_jb_prox_gaps_error(log_degree, log_inv_rate, field_size_bits);
+                // Provable security under the old bound (local reference).
+                let old_bits =
+                    bci20_jb_prox_gaps_error(log_degree, log_inv_rate, KOALABEAR_QUINTIC_BITS);
 
+                // Strict improvement: more provable security bits.
                 assert!(
-                    bcss25_bits > bci20_bits,
-                    "BCSS25 must improve over BCI+20: \
-                     log_degree={log_degree}, log_inv_rate={log_inv_rate}, \
-                     BCSS25={bcss25_bits:.2} bits, BCI+20={bci20_bits:.2} bits"
+                    new_bits > old_bits,
+                    "no improvement at log_degree={log_degree}, \
+                     log_inv_rate={log_inv_rate}: new={new_bits:.4}, old={old_bits:.4}"
                 );
 
-                // Improvement should be approximately log₂(n) = log_degree + log_inv_rate
-                // (BCSS25 eliminates one factor of n from the exceptional-z count).
-                let improvement = bcss25_bits - bci20_bits;
-                let expected_improvement = (log_degree + log_inv_rate) as f64;
+                // Headline claim: gap = log_2(n) + log_2((m+1/2)^2 / 2).
+                //
+                // Both terms are exact under the implementation's choice of multiplicity.
+                // The 1e-9 tolerance only absorbs floating-point rounding in pow / log2.
+                let log_n = (log_degree + log_inv_rate) as f64;
+                let observed = new_bits - old_bits;
+                let expected = log_n + leading_ratio_log;
+
                 assert!(
-                    improvement > expected_improvement * 0.5,
-                    "improvement {improvement:.2} should be at least half of \
-                     log₂(n)={expected_improvement:.1}: \
-                     log_degree={log_degree}, log_inv_rate={log_inv_rate}"
+                    (observed - expected).abs() < 1e-9,
+                    "gap mismatch at log_degree={log_degree}, \
+                     log_inv_rate={log_inv_rate}: expected={expected:.6}, \
+                     got={observed:.6}"
                 );
             }
         }
     }
 
-    /// 128-bit security is achievable with degree-5 KoalaBear extension
-    /// (field_size_bits = 155) under JohnsonBound using BCSS25.
     #[test]
-    fn test_128bit_security_with_koalabear_quintic() {
+    fn jb_prox_gap_covers_security_level_minus_pow_over_koalabear_quintic() {
+        // Invariant: the prox-gap bound alone clears
+        // `security_level - MAX_POW_BITS`, so a feasible PoW budget
+        // bridges the rest to the target security level.
+        //
+        // Fixture state:
+        //
+        //     security_level    = 128
+        //     MAX_POW_BITS      =  30
+        //     min_required_bits = 128 - 30 = 98
+        //     field_size_bits   = 155
+        //     log_inv_rate      : 1 ..= 2   (rho in {1/2, 1/4})
+        //     log_degree        : 10 ..= 22
         let jb = SecurityAssumption::JohnsonBound;
-        let field_size_bits = 155;
+
+        // f64 because every use site compares against a float bound.
+        let security_level: f64 = 128.0;
+        let min_required_bits = security_level - MAX_POW_BITS;
 
         for log_inv_rate in 1..=2 {
             for log_degree in 10..=22 {
+                // 2-fold combination (line case, num_functions = 2).
                 let prox_gap_bits =
-                    jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
+                    jb.prox_gaps_error(log_degree, log_inv_rate, KOALABEAR_QUINTIC_BITS, 2);
 
+                // Must clear 98 bits, leaving at most 30 bits for PoW.
                 assert!(
-                    prox_gap_bits > 100.0,
-                    "proximity gap security too low for 128-bit target: \
-                     log_degree={log_degree}, log_inv_rate={log_inv_rate}, \
-                     got {prox_gap_bits:.2} bits"
+                    prox_gap_bits > min_required_bits,
+                    "prox-gap below {min_required_bits:.0} bits at \
+                     log_degree={log_degree}, log_inv_rate={log_inv_rate}: \
+                     got {prox_gap_bits:.2}"
                 );
             }
         }
     }
 
-    /// Full security budget achieves 128 bits for representative WHIR config.
     #[test]
-    fn test_full_security_budget_jb() {
+    fn jb_full_security_budget_reaches_128_bits() {
+        // Invariant: the full WHIR soundness budget reaches
+        // `security_level` bits at a representative configuration.
+        //
+        // Components that may lean on PoW (>= security_level - MAX_POW_BITS):
+        // - prox-gap
+        // - sumcheck
+        // - query-linear-combination
+        //
+        // Components that must self-sustain (>= security_level):
+        // - out-of-domain sample
+        // - FRI query phase
+        //
+        // PoW grinding must not exceed MAX_POW_BITS in total.
+        //
+        // Fixture state:
+        //
+        //     log_degree      = 20   (2^20 evaluation domain elements)
+        //     log_inv_rate    =  2   (rho = 1/4)
+        //     field_size_bits = 155  (degree-5 KoalaBear extension)
+        //     security_level  = 128
         let jb = SecurityAssumption::JohnsonBound;
-        let field_size_bits = 155;
-        let security_level = 128;
 
+        // Passed as usize to sizing helpers; cast to f64 in asserts.
+        let security_level: usize = 128;
+        let min_with_pow = security_level as f64 - MAX_POW_BITS;
         let log_degree = 20;
         let log_inv_rate = 2;
-        let num_queries = jb.queries(security_level, log_inv_rate);
-        let ood_samples =
-            jb.determine_ood_samples(security_level, log_degree, log_inv_rate, field_size_bits);
 
-        let prox_gap = jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
-        let sumcheck = jb.fold_sumcheck_error(field_size_bits, log_degree, log_inv_rate);
-        let ood = jb.ood_error(log_degree, log_inv_rate, field_size_bits, ood_samples);
+        // FRI query count for the query phase to reach security_level alone.
+        let num_queries = jb.queries(security_level, log_inv_rate);
+
+        // OOD sample count for the OOD term to reach security_level alone.
+        let ood_samples = jb.determine_ood_samples(
+            security_level,
+            log_degree,
+            log_inv_rate,
+            KOALABEAR_QUINTIC_BITS,
+        );
+
+        // Five algebraic error bounds at the chosen configuration.
+        let prox_gap = jb.prox_gaps_error(log_degree, log_inv_rate, KOALABEAR_QUINTIC_BITS, 2);
+        let sumcheck = jb.fold_sumcheck_error(KOALABEAR_QUINTIC_BITS, log_degree, log_inv_rate);
+        let ood = jb.ood_error(
+            log_degree,
+            log_inv_rate,
+            KOALABEAR_QUINTIC_BITS,
+            ood_samples,
+        );
         let query = jb.queries_error(log_inv_rate, num_queries);
         let combination = jb.queries_combination_error(
-            field_size_bits,
+            KOALABEAR_QUINTIC_BITS,
             log_degree,
             log_inv_rate,
             ood_samples,
             num_queries,
         );
 
-        assert!(prox_gap > 50.0, "proximity gap: {prox_gap:.2} bits");
-        assert!(sumcheck > 100.0, "sumcheck: {sumcheck:.2} bits");
-        assert!(ood >= security_level as f64, "OOD: {ood:.2} bits");
-        assert!(query >= security_level as f64, "query: {query:.2} bits");
-        assert!(combination > 100.0, "combination: {combination:.2} bits");
+        // Three components that may lean on PoW.
+        assert!(
+            prox_gap >= min_with_pow,
+            "prox-gap {prox_gap:.2} bits < {min_with_pow:.0}"
+        );
+        assert!(
+            sumcheck >= min_with_pow,
+            "sumcheck {sumcheck:.2} bits < {min_with_pow:.0}"
+        );
+        assert!(
+            combination >= min_with_pow,
+            "combination {combination:.2} bits < {min_with_pow:.0}"
+        );
 
-        let pow = jb.folding_pow_bits(security_level, field_size_bits, log_degree, log_inv_rate);
-        assert!(pow < 30.0, "PoW grinding {pow:.2} bits is too high");
+        // Two components that must reach the full target alone.
+        assert!(
+            ood >= security_level as f64,
+            "OOD {ood:.2} bits < {security_level}"
+        );
+        assert!(
+            query >= security_level as f64,
+            "query {query:.2} bits < {security_level}"
+        );
+
+        // PoW closes the residual gap without exceeding the ceiling.
+        let pow = jb.folding_pow_bits(
+            security_level,
+            KOALABEAR_QUINTIC_BITS,
+            log_degree,
+            log_inv_rate,
+        );
+        assert!(
+            pow <= MAX_POW_BITS,
+            "PoW grinding {pow:.2} bits > {MAX_POW_BITS:.0} cap"
+        );
+    }
+
+    #[test]
+    fn jb_prox_gap_scales_by_log_curve_degree() {
+        // Invariant: combining `M + 1` functions costs exactly `log_2(M)`
+        // bits of prox-gap vs. the line case (M = 1), per [BCSS25] Thm 4.2.
+        //
+        // Fixture state:  log_degree=20, log_inv_rate=2, field=155.
+        //
+        //     num_functions  |  M  |  expected loss
+        //     ---------------+-----+----------------
+        //          2         |  1  |  baseline
+        //          3         |  2  |    1.0 bit
+        //          5         |  4  |    2.0 bits
+        //          9         |  8  |    3.0 bits
+        let jb = SecurityAssumption::JohnsonBound;
+        let log_degree = 20;
+        let log_inv_rate = 2;
+
+        // Baseline: 2-function combination (line, M = 1).
+        let line_bits = jb.prox_gaps_error(log_degree, log_inv_rate, KOALABEAR_QUINTIC_BITS, 2);
+
+        for (num_functions, expected_loss) in [(3_usize, 1.0_f64), (5, 2.0), (9, 3.0)] {
+            // Prox-gap bits over a degree-M curve (M = num_functions - 1).
+            let curve_bits = jb.prox_gaps_error(
+                log_degree,
+                log_inv_rate,
+                KOALABEAR_QUINTIC_BITS,
+                num_functions,
+            );
+
+            // Observed loss relative to the line case.
+            let loss = line_bits - curve_bits;
+
+            // Expected loss = log_2(M) = log_2(num_functions - 1).
+            assert!(
+                (loss - expected_loss).abs() < 1e-9,
+                "curve scaling off at num_functions={num_functions}: \
+                 expected log_2({}) = {expected_loss:.1} bits, got {loss:.6}",
+                num_functions - 1
+            );
+        }
     }
 }

--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -572,4 +572,132 @@ mod tests {
         // under UD fails loudly instead of silently propagating a bogus value.
         let _ = SecurityAssumption::UniqueDecoding.log_eta(5);
     }
+
+    // -------------------------------------------------------------------
+    // BCSS25 proximity gap improvement over BCI+20
+    //
+    // [BCI+20] "Proximity Gaps for Reed-Solomon Codes" (FOCS 2020, eprint 2020/654)
+    //   Theorem 1.2: Johnson bound error ε_J = (k+1)² / (2·min(η,√ρ/(2δ)))⁷ · q
+    //   Soundness error a/q with a = O(n²/η⁷) for the Guruswami-Sudan regime.
+    //
+    // [BCSS25] "On Proximity Gaps for Reed-Solomon Codes" (eprint 2025/2055)
+    //   Theorem 1.5: improves to a = O(n/η⁵), saving a factor of n.
+    //
+    // The tests below verify the improvement holds across all relevant
+    // parameters and that 128-bit security is achievable with degree-5
+    // KoalaBear extensions.
+    // -------------------------------------------------------------------
+
+    /// Compute the JohnsonBound proximity gaps error using the *old* BCI+20
+    /// bound (Theorem 1.2, equation 1.2) for comparison against BCSS25.
+    ///
+    /// With η = √ρ/20 (same safe gap as the implementation), m = 10:
+    ///   a ~ 2·(m+½)⁷ / (3·ρ^{7/2}) · n²
+    ///
+    /// In log form:
+    ///   log₂(a) = 2·log₂(n) + log₂(2·10.5⁷/3) + 3.5·log_inv_rate
+    fn bci20_jb_prox_gaps_error(
+        log_degree: usize,
+        log_inv_rate: usize,
+        field_size_bits: usize,
+    ) -> f64 {
+        let log_n_sq = ((log_degree + log_inv_rate) * 2) as f64;
+        let constant = libm::log2(2. * libm::pow(10.5, 7.) / 3.);
+        let log_rho_neg = 3.5 * log_inv_rate as f64;
+        let error_bits = log_n_sq + constant + log_rho_neg;
+
+        field_size_bits as f64 - error_bits
+    }
+
+    /// BCSS25 Theorem 1.5 strictly improves over BCI+20 Theorem 1.2
+    /// for JohnsonBound across all relevant parameter ranges.
+    #[test]
+    fn test_bcss25_improves_over_bci20() {
+        let jb = SecurityAssumption::JohnsonBound;
+
+        for log_degree in 10..=25 {
+            for log_inv_rate in 1..=4 {
+                let field_size_bits = 155; // degree-5 KoalaBear extension
+
+                let bcss25_bits = jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
+                let bci20_bits =
+                    bci20_jb_prox_gaps_error(log_degree, log_inv_rate, field_size_bits);
+
+                assert!(
+                    bcss25_bits > bci20_bits,
+                    "BCSS25 must improve over BCI+20: \
+                     log_degree={log_degree}, log_inv_rate={log_inv_rate}, \
+                     BCSS25={bcss25_bits:.2} bits, BCI+20={bci20_bits:.2} bits"
+                );
+
+                // Improvement should be approximately log₂(n) = log_degree + log_inv_rate
+                // (BCSS25 eliminates one factor of n from the exceptional-z count).
+                let improvement = bcss25_bits - bci20_bits;
+                let expected_improvement = (log_degree + log_inv_rate) as f64;
+                assert!(
+                    improvement > expected_improvement * 0.5,
+                    "improvement {improvement:.2} should be at least half of \
+                     log₂(n)={expected_improvement:.1}: \
+                     log_degree={log_degree}, log_inv_rate={log_inv_rate}"
+                );
+            }
+        }
+    }
+
+    /// 128-bit security is achievable with degree-5 KoalaBear extension
+    /// (field_size_bits = 155) under JohnsonBound using BCSS25.
+    #[test]
+    fn test_128bit_security_with_koalabear_quintic() {
+        let jb = SecurityAssumption::JohnsonBound;
+        let field_size_bits = 155;
+
+        for log_inv_rate in 1..=2 {
+            for log_degree in 10..=22 {
+                let prox_gap_bits =
+                    jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
+
+                assert!(
+                    prox_gap_bits > 100.0,
+                    "proximity gap security too low for 128-bit target: \
+                     log_degree={log_degree}, log_inv_rate={log_inv_rate}, \
+                     got {prox_gap_bits:.2} bits"
+                );
+            }
+        }
+    }
+
+    /// Full security budget achieves 128 bits for representative WHIR config.
+    #[test]
+    fn test_full_security_budget_jb() {
+        let jb = SecurityAssumption::JohnsonBound;
+        let field_size_bits = 155;
+        let security_level = 128;
+
+        let log_degree = 20;
+        let log_inv_rate = 2;
+        let num_queries = jb.queries(security_level, log_inv_rate);
+        let ood_samples =
+            jb.determine_ood_samples(security_level, log_degree, log_inv_rate, field_size_bits);
+
+        let prox_gap = jb.prox_gaps_error(log_degree, log_inv_rate, field_size_bits, 2);
+        let sumcheck = jb.fold_sumcheck_error(field_size_bits, log_degree, log_inv_rate);
+        let ood = jb.ood_error(log_degree, log_inv_rate, field_size_bits, ood_samples);
+        let query = jb.queries_error(log_inv_rate, num_queries);
+        let combination = jb.queries_combination_error(
+            field_size_bits,
+            log_degree,
+            log_inv_rate,
+            ood_samples,
+            num_queries,
+        );
+
+        assert!(prox_gap > 50.0, "proximity gap: {prox_gap:.2} bits");
+        assert!(sumcheck > 100.0, "sumcheck: {sumcheck:.2} bits");
+        assert!(ood >= security_level as f64, "OOD: {ood:.2} bits");
+        assert!(query >= security_level as f64, "query: {query:.2} bits");
+        assert!(combination > 100.0, "combination: {combination:.2} bits");
+
+        let pow = jb.folding_pow_bits(security_level, field_size_bits, log_degree, log_inv_rate);
+        assert!(pow < 30.0, "PoW grinding {pow:.2} bits is too high");
+    }
 }


### PR DESCRIPTION
Split from #1626 per reviewer request; soundness tests kept separate from verifier error coverage.

## BCSS25 vs BCI+20 proximity gap comparison

4 tests validating the BCSS25 (eprint 2025/2055, Theorem 1.5) improvement over BCI+20 (eprint 2020/654, Theorem 1.2):

- **BCSS25 strictly improves over BCI+20** across `log_degree ∈ {10..25}`, `log_inv_rate ∈ {1..4}`. Improvement is approximately `log₂(n)` bits — one factor of `n` eliminated from the exceptional-z count.
- **128-bit security with degree-5 KoalaBear** (155-bit field) confirmed under JohnsonBound across realistic WHIR parameter ranges.
- **Full error budget**: proximity gaps + sumcheck + OOD + query + combination all contribute adequate security; PoW grinding stays under 30 bits.

## UniqueDecoding `log_eta` fix

`log_eta` for `UniqueDecoding` returned `0.0`, which would give `2^0 = 1` (incorrect eta = 1) if ever used in arithmetic. Changed to `f64::INFINITY` — eta is undefined in UD, and infinity correctly produces zero error contribution in any formula involving `1/eta`. All UD callers (`list_size_bits`, `prox_gaps_error`, `log_1_delta`) short-circuit before using the value, so the change is safe.