### PR TITLE
chore: use T::zero_vec(n) instead of vec![T::ZERO; n]

### DIFF
--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn test_check_all_constraints_no_failures() {
         let air = AllZeroAir::<2>;
-        let values = vec![BabyBear::ZERO; 4]; // 2 rows × 2 cols, all zero
+        let values = BabyBear::zero_vec(4); // 2 rows × 2 cols, all zero
         let main = RowMajorMatrix::new(values, 2);
         let report = check_all_constraints(&air, &main, &[], None);
         assert!(report.is_ok());
@@ -1072,7 +1072,7 @@ mod tests {
 
     impl<F: Field> BaseAir<F> for ShapeProbeAir {
         fn width(&self) -> usize {
-            // Single column; every fixture is `vec![F::ZERO; height]`.
+            // Single column; every fixture is `F::zero_vec(height)`.
             1
         }
 
@@ -1089,7 +1089,7 @@ mod tests {
             //       row 1: [ 0, 0, 0 ]
             //       flat : [ 0, 0, 0, 0, 0, 0 ]
             let total = self.prep_height * self.prep_width;
-            Some(RowMajorMatrix::new(vec![F::ZERO; total], self.prep_width))
+            Some(RowMajorMatrix::new(F::zero_vec(total), self.prep_width))
         }
     }
 
@@ -1116,7 +1116,7 @@ mod tests {
         };
 
         // Zero-valued rows; content is irrelevant because no constraint reads it.
-        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
 
         // Must return cleanly. A panic here would mean the guard rejected a well-shaped input.
         check_constraints(&air, &main, &[]);
@@ -1141,7 +1141,7 @@ mod tests {
         };
 
         // Main deliberately shorter than the advertised preprocessed trace.
-        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
 
         // Expected: panic before row 0 is ever dereferenced.
         check_constraints(&air, &main, &[]);
@@ -1158,7 +1158,7 @@ mod tests {
             prep_height: 4,
             prep_width: 1,
         };
-        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
 
         // No failure cap; we expect no failures anyway.
         let report = check_all_constraints(&air, &main, &[], None);
@@ -1182,7 +1182,7 @@ mod tests {
             prep_height: 8,
             prep_width: 1,
         };
-        let main = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
 
         // Expected: panic on entry. The would-be report is unreachable → bound to `_`.
         let _ = check_all_constraints(&air, &main, &[], None);

--- a/batch-stark/src/check_constraints.rs
+++ b/batch-stark/src/check_constraints.rs
@@ -140,8 +140,6 @@ pub(crate) fn check_constraints<'b, F, EF, A, LG>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-
     use p3_air::{Air, BaseAir, DebugConstraintBuilder};
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
@@ -166,7 +164,7 @@ mod tests {
 
     impl<F: Field> BaseAir<F> for ShapeProbeAir {
         fn width(&self) -> usize {
-            // Single column; every fixture is `vec![F::ZERO; height]`.
+            // Single column; every fixture is `F::zero_vec(height)`.
             1
         }
 
@@ -183,7 +181,7 @@ mod tests {
             //       row 1: [ 0, 0, 0 ]
             //       flat : [ 0, 0, 0, 0, 0, 0 ]
             let total = self.prep_height * self.prep_width;
-            Some(RowMajorMatrix::new(vec![F::ZERO; total], self.prep_width))
+            Some(RowMajorMatrix::new(F::zero_vec(total), self.prep_width))
         }
     }
 
@@ -217,9 +215,9 @@ mod tests {
         };
 
         // Zero-valued traces; content is irrelevant because eval reads nothing.
-        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
         let preprocessed = <ShapeProbeAir as BaseAir<BabyBear>>::preprocessed_trace(&air);
-        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 4], 1);
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(EF::zero_vec(4), 1);
 
         // Must return cleanly. A panic here would mean a guard rejected a well-shaped input.
         check_constraints::<BabyBear, EF, _, LogUpGadget>(
@@ -254,9 +252,9 @@ mod tests {
             prep_height: 8,
             prep_width: 1,
         };
-        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
         let preprocessed = <ShapeProbeAir as BaseAir<BabyBear>>::preprocessed_trace(&air);
-        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 4], 1);
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(EF::zero_vec(4), 1);
 
         // Expected: panic on entry, before any row is dereferenced.
         check_constraints::<BabyBear, EF, _, LogUpGadget>(
@@ -290,9 +288,9 @@ mod tests {
             prep_height: 0,
             prep_width: 0,
         };
-        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(vec![BabyBear::ZERO; 4], 1);
+        let main: RowMajorMatrix<BabyBear> = RowMajorMatrix::new(BabyBear::zero_vec(4), 1);
         let preprocessed: Option<RowMajorMatrix<BabyBear>> = None;
-        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(vec![EF::ZERO; 8], 1);
+        let permutation: RowMajorMatrix<EF> = RowMajorMatrix::new(EF::zero_vec(8), 1);
 
         // Expected: panic on entry, before any row is dereferenced.
         check_constraints::<BabyBear, EF, _, LogUpGadget>(

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -560,7 +560,7 @@ where
         let trace_next_ref = match &opened_values.instances[i].base_opened_values.trace_next {
             Some(v) => v.as_slice(),
             None => {
-                trace_next_zeros = vec![SC::Challenge::ZERO; A::width(air)];
+                trace_next_zeros = SC::Challenge::zero_vec(A::width(air));
                 &trace_next_zeros
             }
         };
@@ -571,7 +571,7 @@ where
         {
             Some(v) => v.as_slice(),
             None => {
-                pre_next_zeros = vec![SC::Challenge::ZERO; preprocessed_widths[i]];
+                pre_next_zeros = SC::Challenge::zero_vec(preprocessed_widths[i]);
                 &pre_next_zeros
             }
         };

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -233,8 +233,6 @@ pub fn extract_lambda<F: ComplexExtendable, EF: ExtensionField<F>>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
@@ -316,7 +314,7 @@ mod tests {
         let zeta: Point<EF> = Point::from_projective_line(rng.random());
 
         let mut alpha_offset = EF::ONE;
-        let mut ros = vec![EF::ZERO; 1 << lde_domain.log_n];
+        let mut ros = EF::zero_vec(1 << lde_domain.log_n);
 
         for _ in 0..4 {
             let evals = CircleEvaluations::from_cfft_order(

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -436,7 +436,7 @@ mod tests {
             );
             let coeffs = evals.interpolate().to_row_major_matrix();
             let (lo, hi) = coeffs.split_rows(n);
-            assert_eq!(hi.values, vec![F::ZERO; n]);
+            assert_eq!(hi.values, F::zero_vec(n));
             CircleEvaluations::evaluate(d, lo.to_row_major_matrix())
                 .to_natural_order()
                 .to_row_major_matrix()
@@ -446,16 +446,16 @@ mod tests {
         // Nonzero at first point, zero everywhere else on domain
         let is_first_row = coset_to_d(&sels.is_first_row);
         assert_ne!(is_first_row[0], F::ZERO);
-        assert_eq!(&is_first_row[1..], &vec![F::ZERO; n - 1]);
+        assert_eq!(&is_first_row[1..], &F::zero_vec(n - 1));
 
         // Nonzero at last point, zero everywhere else on domain
         let is_last_row = coset_to_d(&sels.is_last_row);
-        assert_eq!(&is_last_row[..n - 1], &vec![F::ZERO; n - 1]);
+        assert_eq!(&is_last_row[..n - 1], &F::zero_vec(n - 1));
         assert_ne!(is_last_row[n - 1], F::ZERO);
 
         // Nonzero everywhere on domain but last point
         let is_transition = coset_to_d(&sels.is_transition);
-        assert_ne!(&is_transition[..n - 1], &vec![F::ZERO; n - 1]);
+        assert_ne!(&is_transition[..n - 1], &F::zero_vec(n - 1));
         assert_eq!(is_transition[n - 1], F::ZERO);
 
         // Vanishing polynomial coefficients look like [0.. (n times), 1, 0.. (n-1 times)]

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -265,10 +265,9 @@ where
                         mat.as_view(),
                     );
 
-                    let (alpha_offset, reduced_opening_for_log_height) =
-                        reduced_openings.entry(log_height).or_insert_with(|| {
-                            (Challenge::ONE, vec![Challenge::ZERO; 1 << log_height])
-                        });
+                    let (alpha_offset, reduced_opening_for_log_height) = reduced_openings
+                        .entry(log_height)
+                        .or_insert_with(|| (Challenge::ONE, Challenge::zero_vec(1 << log_height)));
 
                     points_for_mat
                         .iter()

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
@@ -273,7 +272,7 @@ where
         //     arity = 4, index_in_group = 1:
         //     evals = [sibling_0, folded_eval, sibling_1, sibling_2]
         let index_in_group = index % arity;
-        let mut evals = vec![EF::ZERO; arity];
+        let mut evals = EF::zero_vec(arity);
         evals[index_in_group] = folded_eval;
 
         // Fill in siblings at every position except the queried one.

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
@@ -27,7 +26,7 @@ pub fn eval_coeffs_at_pt<F: Field, EF: ExtensionField<F>>(
     coeffs: &RowMajorMatrix<F>,
     x: EF,
 ) -> Vec<EF> {
-    let mut acc = vec![EF::ZERO; coeffs.width()];
+    let mut acc = EF::zero_vec(coeffs.width());
     for r in (0..coeffs.height()).rev() {
         let row = coeffs.row_slice(r).unwrap();
         for (acc_c, row_c) in acc.iter_mut().zip(row.iter()) {

--- a/dft/src/naive.rs
+++ b/dft/src/naive.rs
@@ -1,5 +1,3 @@
-use alloc::vec;
-
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
@@ -18,7 +16,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for NaiveDft {
         let log_h = log2_strict_usize(h);
         let g = F::two_adic_generator(log_h);
 
-        let mut res = RowMajorMatrix::new(vec![F::ZERO; w * h], w);
+        let mut res = RowMajorMatrix::new(F::zero_vec(w * h), w);
         for (res_r, point) in g.powers().take(h).enumerate() {
             for (src_r, point_power) in point.powers().take(h).enumerate() {
                 for c in 0..w {

--- a/dft/tests/testing.rs
+++ b/dft/tests/testing.rs
@@ -208,7 +208,7 @@ proptest! {
         let mut rng = SmallRng::seed_from_u64(seed);
         let mut row1: Vec<F> = (0..w).map(|_| rng.random()).collect();
         // Second row is all zeros, matching the zero-padded precondition.
-        let mut row2: Vec<F> = vec![F::ZERO; w];
+        let mut row2: Vec<F> = F::zero_vec(w);
         let orig1 = row1.clone();
 
         DifButterflyZeros(twiddle).apply_to_rows(&mut row1, &mut row2);
@@ -514,7 +514,7 @@ fn dft_all_zeros() {
     for log_h in 0..=6 {
         let h = 1 << log_h;
         // Build a zero matrix with 3 columns.
-        let mat = RowMajorMatrix::new(vec![F::ZERO; h * 3], 3);
+        let mat = RowMajorMatrix::new(F::zero_vec(h * 3), 3);
 
         // Check two backends as representative (the cross-impl tests
         // cover all five with randomized inputs).
@@ -532,7 +532,7 @@ fn idft_all_zeros() {
     // coefficient vector.
     for log_h in 0..=6 {
         let h = 1 << log_h;
-        let mat = RowMajorMatrix::new(vec![F::ZERO; h * 3], 3);
+        let mat = RowMajorMatrix::new(F::zero_vec(h * 3), 3);
 
         let dit = Radix2Dit::default().idft_batch(mat.clone());
         assert!(dit.values.iter().all(|x| x.is_zero()), "log_h={log_h}");
@@ -552,7 +552,7 @@ fn dft_constant_polynomial() {
         let h = 1 << log_h;
 
         // Coefficient vector: c followed by zeros.
-        let mut vals = vec![F::ZERO; h];
+        let mut vals = F::zero_vec(h);
         vals[0] = c;
         let mat = RowMajorMatrix::new(vals, 1);
 

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -134,7 +134,7 @@ mod helpers {
         let val = BabyBear::ZERO;
         let parts = split_32::<BabyBear, BabyBear>(val, 3);
 
-        assert_eq!(parts, vec![BabyBear::ZERO; 3]);
+        assert_eq!(parts, BabyBear::zero_vec(3));
     }
 
     #[test]

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -14,7 +14,6 @@
 //! If we changed our domain construction (e.g., using multiple cosets), we would need to carefully reconsider these assumptions.
 
 use alloc::borrow::Cow;
-use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use core::marker::PhantomData;
@@ -606,7 +605,7 @@ where
                 // If this is our first matrix at this height, initialise reduced_openings to zero.
                 // Otherwise, get a mutable reference to it.
                 let reduced_opening_for_log_height = reduced_openings[log_height]
-                    .get_or_insert_with(|| vec![Challenge::ZERO; mat.height()]);
+                    .get_or_insert_with(|| Challenge::zero_vec(mat.height()));
                 debug_assert_eq!(reduced_opening_for_log_height.len(), mat.height());
 
                 // Treating our matrix M as the evaluations of functions f_0, f_1, ...

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1,5 +1,4 @@
 use alloc::collections::btree_map::BTreeMap;
-use alloc::vec;
 use alloc::vec::Vec;
 
 use itertools::Itertools;
@@ -393,7 +392,7 @@ where
 
         // Reconstruct the full evaluation row from self + siblings
         let index_in_group = *start_index % arity;
-        let mut evals = vec![EF::ZERO; arity];
+        let mut evals = EF::zero_vec(arity);
         evals[index_in_group] = folded_eval;
 
         let mut sibling_idx = 0;
@@ -634,6 +633,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use core::marker::PhantomData;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -162,7 +162,7 @@ impl MockAirBuilder {
             view.extend_from_slice(&next_row);
         } else {
             // pad with zeros if we are on the last row
-            view.extend(vec![T::ZERO; trace.width()]);
+            view.extend(T::zero_vec(trace.width()));
         }
         RowMajorMatrix::new(view, trace.width())
     }
@@ -534,10 +534,9 @@ fn test_resolve() {
         // Get the local and next values for row `i`.
         let cloned_trace = main_trace.clone();
         let local = cloned_trace.row(i).unwrap().into_iter().collect::<Vec<F>>();
-        let next = cloned_trace.row(i + 1).map_or_else(
-            || vec![F::ZERO; 2],
-            |row| row.into_iter().collect::<Vec<F>>(),
-        );
+        let next = cloned_trace
+            .row(i + 1)
+            .map_or_else(|| F::zero_vec(2), |row| row.into_iter().collect::<Vec<F>>());
 
         // Compute the expected constraint values at row `i`.
         let mul = EF::from(local[0]) * EF::from(next[1]);

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -575,7 +575,7 @@ mod tests {
         let m = RowMajorMatrix::<F>::rand(&mut rng, 1 << 8, 1 << 4);
         let v = RowMajorMatrix::<EF>::rand(&mut rng, 1 << 8, 1).values;
 
-        let mut expected = vec![EF::ZERO; m.width()];
+        let mut expected = EF::zero_vec(m.width());
         for (row, &scale) in izip!(m.rows(), &v) {
             for (l, r) in izip!(&mut expected, row) {
                 *l += scale * r;
@@ -836,7 +836,7 @@ mod tests {
             let packed_v: Vec<EFPacked> = v
                 .chunks(<PF as PackedValue>::WIDTH)
                 .map(|chunk| {
-                    let mut padded = vec![EF::ZERO; <PF as PackedValue>::WIDTH];
+                    let mut padded = EF::zero_vec(<PF as PackedValue>::WIDTH);
                     padded[..chunk.len()].copy_from_slice(chunk);
                     EFPacked::from_ext_slice(&padded)
                 })

--- a/multilinear-util/benches/compress_kernels.rs
+++ b/multilinear-util/benches/compress_kernels.rs
@@ -52,13 +52,13 @@ fn bench_compress_suffix_dot(c: &mut Criterion) {
 
         // Packed-eq path: hits the SIMD kernel from PR #1574.
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
-            let mut out = vec![EF::ZERO; 1 << (k_total - split_packed.num_variables())];
+            let mut out = EF::zero_vec(1 << (k_total - split_packed.num_variables()));
             b.iter(|| split_packed.compress_suffix_into(&mut out, &poly));
         });
 
         // Unpacked-eq path: scalar reference for the same operation.
         group.bench_with_input(BenchmarkId::new("unpacked", label), &label, |b, _| {
-            let mut out = vec![EF::ZERO; 1 << (k_total - split_unpacked.num_variables())];
+            let mut out = EF::zero_vec(1 << (k_total - split_unpacked.num_variables()));
             b.iter(|| split_unpacked.compress_suffix_into(&mut out, &poly));
         });
     }

--- a/multilinear-util/benches/evaleq_batched.rs
+++ b/multilinear-util/benches/evaleq_batched.rs
@@ -74,7 +74,7 @@ fn bench_eval_eq_batch(c: &mut Criterion) {
     for &(num_vars, batch_size) in &test_cases {
         let (eval_points_data, scalars) = generate_batch_input(num_vars, batch_size);
         let eval_points = RowMajorMatrixView::new(&eval_points_data, batch_size);
-        let out = vec![EF4::ZERO; 1 << num_vars];
+        let out = EF4::zero_vec(1 << num_vars);
 
         let bench_name = format!("n{}_b{}", num_vars, batch_size);
 
@@ -123,7 +123,7 @@ fn bench_eval_eq_base_batch(c: &mut Criterion) {
     for &(num_vars, batch_size) in &test_cases {
         let (eval_points_data, scalars) = generate_base_batch_input(num_vars, batch_size);
         let eval_points = RowMajorMatrixView::new(&eval_points_data, batch_size);
-        let out = vec![EF4::ZERO; 1 << num_vars];
+        let out = EF4::zero_vec(1 << num_vars);
 
         let bench_name = format!("n{}_b{}", num_vars, batch_size);
 

--- a/multilinear-util/src/point.rs
+++ b/multilinear-util/src/point.rs
@@ -308,7 +308,7 @@ mod tests {
         let expanded = Point::expand_from_univariate(point, 4);
 
         // Since 0^k = 0 for all k, the result should be [0, 0, 0, 0]
-        let expected = vec![F::ZERO; 4];
+        let expected = F::zero_vec(4);
         assert_eq!(expanded.0, expected);
     }
 
@@ -340,8 +340,8 @@ mod tests {
 
     #[test]
     fn test_eq_poly_outside_all_zeros() {
-        let ml_point1 = Point(vec![F::ZERO; 4]);
-        let ml_point2 = Point(vec![F::ZERO; 4]);
+        let ml_point1 = Point(F::zero_vec(4));
+        let ml_point2 = Point(F::zero_vec(4));
 
         assert_eq!(ml_point1.eq_poly(&ml_point2), F::ONE);
     }

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -1219,13 +1219,13 @@ pub(crate) mod test {
             evals_raw in prop::collection::vec(0u64..F::ORDER_U64, 5),
         ) {
             let evals: Vec<F> = evals_raw[..n].iter().map(|&x| F::from_u64(x)).collect();
-            let mut out = vec![F::ZERO; 1 << n];
+            let mut out = F::zero_vec(1 << n);
             eval_eq_batch::<F, F, false>(
                 RowMajorMatrixView::new_col(&evals),
                 &mut out,
                 &[F::ONE],
             );
-            let mut expected = vec![F::ZERO; 1 << n];
+            let mut expected = F::zero_vec(1 << n);
             for (i, e) in expected.iter_mut().enumerate().take(1 << n) {
                 let mut weight = F::ONE;
                 for (j, &val) in evals.iter().enumerate() {

--- a/multilinear-util/src/split_eq/eq.rs
+++ b/multilinear-util/src/split_eq/eq.rs
@@ -522,8 +522,8 @@ mod tests {
             let packed = EqMaybePacked::<F, EF>::new_packed(&point);
 
             // Both variants must produce identical output buffers.
-            let mut out_unpacked = vec![EF::ZERO; 1 << k];
-            let mut out_packed = vec![EF::ZERO; 1 << k];
+            let mut out_unpacked = EF::zero_vec(1 << k);
+            let mut out_packed = EF::zero_vec(1 << k);
 
             unpacked.accumulate_scalar_into(&mut out_unpacked, weight);
             packed.accumulate_scalar_into(&mut out_packed, weight);
@@ -543,7 +543,7 @@ mod tests {
 
             // Accumulation into a zero buffer should match.
             let unpacked = EqMaybePacked::<F, EF>::new_unpacked(&point);
-            let mut out = vec![EF::ZERO; 1 << k];
+            let mut out = EF::zero_vec(1 << k);
             unpacked.accumulate_scalar_into(&mut out, weight);
 
             prop_assert_eq!(expected, out);
@@ -562,11 +562,11 @@ mod tests {
             let packed = EqMaybePacked::<F, EF>::new_packed(&point);
 
             // Scalar reference accumulation.
-            let mut out_scalar = vec![EF::ZERO; 1 << k];
+            let mut out_scalar = EF::zero_vec(1 << k);
             packed.accumulate_scalar_into(&mut out_scalar, weight);
 
             // Packed accumulation, then unpack for comparison.
-            let mut out_packed = vec![EP::ZERO; (1 << k) / PackedF::WIDTH];
+            let mut out_packed = EP::zero_vec((1 << k) / PackedF::WIDTH);
             packed.accumulate_packed_into(&mut out_packed, weight);
             let out_unpacked: Vec<EF> =
                 <EP as PackedFieldExtension<F, EF>>::to_ext_iter(out_packed.iter().copied())
@@ -596,8 +596,8 @@ mod tests {
             let packed = EqMaybePacked::<F, EF>::new_packed(&point);
 
             // Accumulate into separate buffers; both must match.
-            let mut out_u = vec![EF::ZERO; 1 << inner_k];
-            let mut out_p = vec![EF::ZERO; 1 << inner_k];
+            let mut out_u = EF::zero_vec(1 << inner_k);
+            let mut out_p = EF::zero_vec(1 << inner_k);
 
             unpacked.compress_prefix_into(&mut out_u, &chunk, w0);
             packed.compress_prefix_into(&mut out_p, &chunk, w0);
@@ -624,12 +624,12 @@ mod tests {
             let eq = EqMaybePacked::<F, EF>::new_packed(&point);
 
             // Scalar reference compression.
-            let mut out_scalar = vec![EF::ZERO; 1 << inner_k];
+            let mut out_scalar = EF::zero_vec(1 << inner_k);
             eq.compress_prefix_into(&mut out_scalar, &chunk, w0);
 
             // Packed compression, then unpack for comparison.
             let packed_inner = (1 << inner_k) / PackedF::WIDTH;
-            let mut out_packed = vec![EP::ZERO; packed_inner];
+            let mut out_packed = EP::zero_vec(packed_inner);
             eq.compress_prefix_to_packed_into(&mut out_packed, &chunk, w0);
             let out_unpacked: Vec<EF> =
                 <EP as PackedFieldExtension<F, EF>>::to_ext_iter(out_packed.iter().copied())

--- a/multilinear-util/src/split_eq/packed_kernel.rs
+++ b/multilinear-util/src/split_eq/packed_kernel.rs
@@ -627,7 +627,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
     use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
@@ -808,8 +807,8 @@ mod tests {
             let packed_inner = 1usize << inner_k;
             let (eq1, chunk, w0) = random_prefix_inputs(n_packed, packed_inner, seed);
 
-            let mut out_kernel = vec![PackedEF::ZERO; packed_inner];
-            let mut out_eager = vec![PackedEF::ZERO; packed_inner];
+            let mut out_kernel = PackedEF::zero_vec(packed_inner);
+            let mut out_eager = PackedEF::zero_vec(packed_inner);
 
             compress_prefix_to_packed_packed::<F, EF>(&mut out_kernel, &eq1, &chunk, w0);
             compress_prefix_to_packed_packed_kernel_eager::<F, EF>(
@@ -899,8 +898,8 @@ mod tests {
         //     packed_inner = 5         - one tile of length 5 (< TILE = 8).
         let (eq1, chunk, w0) = random_prefix_inputs(3, 5, 0xC0DE);
 
-        let mut out_kernel = vec![PackedEF::ZERO; 5];
-        let mut out_eager = vec![PackedEF::ZERO; 5];
+        let mut out_kernel = PackedEF::zero_vec(5);
+        let mut out_eager = PackedEF::zero_vec(5);
 
         compress_prefix_to_packed_packed::<F, EF>(&mut out_kernel, &eq1, &chunk, w0);
         compress_prefix_to_packed_packed_kernel_eager::<F, EF>(&mut out_eager, &eq1, &chunk, w0);
@@ -918,8 +917,8 @@ mod tests {
         //     packed_inner = 17        - two full tiles + one short tail.
         let (eq1, chunk, w0) = random_prefix_inputs(4, 17, 0xC0FFEE);
 
-        let mut out_kernel = vec![PackedEF::ZERO; 17];
-        let mut out_eager = vec![PackedEF::ZERO; 17];
+        let mut out_kernel = PackedEF::zero_vec(17);
+        let mut out_eager = PackedEF::zero_vec(17);
 
         compress_prefix_to_packed_packed::<F, EF>(&mut out_kernel, &eq1, &chunk, w0);
         compress_prefix_to_packed_packed_kernel_eager::<F, EF>(&mut out_eager, &eq1, &chunk, w0);

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -460,7 +460,7 @@ where
     let trace_next_slice = match &opened_values.trace_next {
         Some(v) => v.as_slice(),
         None => {
-            zeros = vec![SC::Challenge::ZERO; air_width];
+            zeros = SC::Challenge::zero_vec(air_width);
             &zeros
         }
     };
@@ -468,7 +468,7 @@ where
     let preprocessed_next_for_verify = match &opened_values.preprocessed_next {
         Some(v) => Some(v.as_slice()),
         None if preprocessed_width > 0 => {
-            pre_next_zeros = vec![SC::Challenge::ZERO; preprocessed_width];
+            pre_next_zeros = SC::Challenge::zero_vec(preprocessed_width);
             Some(pre_next_zeros.as_slice())
         }
         None => None,

--- a/uni-stark/tests/no_next_row.rs
+++ b/uni-stark/tests/no_next_row.rs
@@ -105,7 +105,7 @@ fn test_no_next_row_rejects_present_trace_next() {
     // Tamper: set trace_next to Some(zeros) — verifier should reject
     let mut tampered = proof;
     let air_width = <SquareAir as BaseAir<Val>>::width(&SquareAir);
-    tampered.opened_values.trace_next = Some(vec![Challenge::ZERO; air_width]);
+    tampered.opened_values.trace_next = Some(Challenge::zero_vec(air_width));
 
     let result = verify(&config, &SquareAir, &tampered, &[]);
     assert!(

--- a/util/benches/transpose.rs
+++ b/util/benches/transpose.rs
@@ -21,8 +21,8 @@ fn bench_transpose_babybear(c: &mut Criterion) {
         let size = width * height;
 
         let input: Vec<_> = (0..size as u64).map(BabyBear::from_u64).collect();
-        let mut output_neon = vec![BabyBear::ZERO; size];
-        let mut output_crate = vec![BabyBear::ZERO; size];
+        let mut output_neon = BabyBear::zero_vec(size);
+        let mut output_crate = BabyBear::zero_vec(size);
 
         group.bench_with_input(BenchmarkId::new("transpose_util", name), &size, |b, _| {
             b.iter(|| {
@@ -49,8 +49,8 @@ fn bench_transpose_goldilocks(c: &mut Criterion) {
         let size = width * height;
 
         let input: Vec<_> = (0..size as u64).map(Goldilocks::from_u64).collect();
-        let mut output_neon = vec![Goldilocks::ZERO; size];
-        let mut output_crate = vec![Goldilocks::ZERO; size];
+        let mut output_neon = Goldilocks::zero_vec(size);
+        let mut output_crate = Goldilocks::zero_vec(size);
 
         group.bench_with_input(BenchmarkId::new("transpose_util", name), &size, |b, _| {
             b.iter(|| {

--- a/util/src/transpose/rectangular.rs
+++ b/util/src/transpose/rectangular.rs
@@ -1891,7 +1891,7 @@ mod tests {
                 .collect();
 
             // Allocate output buffer.
-            let mut output = vec![BabyBear::ZERO; width * height];
+            let mut output = BabyBear::zero_vec(width * height);
 
             // Run optimized transpose.
             transpose(&input, &mut output, width, height);
@@ -1967,7 +1967,7 @@ mod tests {
                 .collect();
 
             // Allocate output buffer.
-            let mut output = vec![Goldilocks::ZERO; width * height];
+            let mut output = Goldilocks::zero_vec(width * height);
 
             // Run optimized transpose.
             transpose(&input, &mut output, width, height);

--- a/whir/src/sumcheck/svo.rs
+++ b/whir/src/sumcheck/svo.rs
@@ -709,8 +709,8 @@ mod test {
     fn evals_01inf_grid(boolean_evals: &[EF]) -> Vec<EF> {
         let num_variables = log2_strict_usize(boolean_evals.len());
         let output_len = 3usize.pow(num_variables as u32);
-        let mut output = vec![EF::ZERO; output_len];
-        let mut scratch = vec![EF::ZERO; output_len];
+        let mut output = EF::zero_vec(output_len);
+        let mut scratch = EF::zero_vec(output_len);
         evals_01inf_grid_into(boolean_evals, &mut output, &mut scratch);
         output
     }
@@ -824,9 +824,9 @@ mod test {
             let output_len = 3usize.pow(num_variables as u32);
 
             // Use all-zero input; we only care about sizes here.
-            let input = vec![EF::ZERO; input_len];
-            let mut output = vec![EF::ZERO; output_len];
-            let mut scratch = vec![EF::ZERO; output_len];
+            let input = EF::zero_vec(input_len);
+            let mut output = EF::zero_vec(output_len);
+            let mut scratch = EF::zero_vec(output_len);
 
             // Should not panic.
             evals_01inf_grid_into(&input, &mut output, &mut scratch);
@@ -843,8 +843,8 @@ mod test {
         for num_variables in 1..=4 {
             let input: Vec<EF> = (0..1 << num_variables).map(|_| rng.random()).collect();
             let output_len = 3usize.pow(num_variables as u32);
-            let mut output = vec![EF::ZERO; output_len];
-            let mut scratch = vec![EF::ZERO; output_len];
+            let mut output = EF::zero_vec(output_len);
+            let mut scratch = EF::zero_vec(output_len);
 
             evals_01inf_grid_into(&input, &mut output, &mut scratch);
 
@@ -909,8 +909,8 @@ mod test {
         for num_variables in 0..=4 {
             let input = vec![c; 1 << num_variables];
             let output_len = 3usize.pow(num_variables as u32);
-            let mut output = vec![EF::ZERO; output_len];
-            let mut scratch = vec![EF::ZERO; output_len];
+            let mut output = EF::zero_vec(output_len);
+            let mut scratch = EF::zero_vec(output_len);
 
             evals_01inf_grid_into(&input, &mut output, &mut scratch);
 

--- a/zk-codes/src/reed_solomon.rs
+++ b/zk-codes/src/reed_solomon.rs
@@ -244,7 +244,7 @@ mod tests {
         let msg = vec![F::new(1), F::new(2), F::new(3), F::new(4)];
 
         // Eval with zero randomness.
-        let encoded = encoding.encode_with_randomness(&msg, &vec![F::ZERO; t]);
+        let encoded = encoding.encode_with_randomness(&msg, &F::zero_vec(t));
 
         // Plain RS encodes by padding the message with zeros.
         let mut plain_coeffs = msg;


### PR DESCRIPTION
## Summary

Replace every `vec![T::ZERO; n]` call site with `T::zero_vec(n)`.

`PrimeCharacteristicRing::zero_vec` exists precisely so that specialized impls (e.g. `MontyField31`, `Goldilocks`) can transmute `vec![0u32; n]` / `vec![0u64; n]` and **skip the redundant userspace zeroing** that `vec![Self::ZERO; n]` causes on freshly mapped pages. Quoting the trait docstring (`field/src/field.rs:377-388`):

> Many operating systems zero pages before assigning them to a userspace process. In that case, our process should not need to write zeros, which would be redundant. However, the compiler may not always recognize this. In particular, `vec![Self::ZERO; len]` appears to result in redundant userspace zeroing.

## Scope

- **80 sites converted** across 27 files (production verifiers, prover hot paths, DFT, transpose, multilinear utils, WHIR sumcheck, tests, and benches).
- The trait's **default impl** in `field/src/field.rs:387` is intentionally kept as `vec![Self::ZERO; len]` — that's the fallback that specialization overrides.
- Two doc-comments in `air/src/check_constraints.rs` and `batch-stark/src/check_constraints.rs` updated to reference the new pattern.
- 8 now-unused `use alloc::vec;` imports dropped; one moved into `fri/src/verifier.rs`'s test module (whose tests still use the `vec!` macro).

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo fmt --all` applied
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] No remaining `vec![*::ZERO; ...]` outside the trait default impl

Generated with [Claude Code](https://claude.com/claude-code)