### PR TITLE
feat(whir): HVZK code-switching round (Construction 9.7)

### DIFF
--- a/whir/examples/whir.rs
+++ b/whir/examples/whir.rs
@@ -157,6 +157,7 @@ fn main() {
         soundness_type,
         starting_log_inv_rate: starting_rate,
         round_log_inv_rates,
+        zk: false,
     };
 
     info!(

--- a/whir/src/parameters/mod.rs
+++ b/whir/src/parameters/mod.rs
@@ -34,6 +34,18 @@ pub struct ProtocolParameters {
     pub security_level: usize,
     /// The number of bits required for proof-of-work (PoW).
     pub pow_bits: usize,
+    /// Enable HVZK code-switching (Construction 9.7, eprint 2026/391 §9.4).
+    ///
+    /// When `true`, each non-final intermediate round:
+    /// - Commits the target polynomial with ZK randomness (`Enc(f ∥ r')`).
+    /// - Commits a mask oracle hiding the previous round's encoding randomness.
+    /// - Uses a private zero-evader for OOD answers (Lemma 9.3).
+    /// - Stores per-query STIR and OOD corrections in the proof so the
+    ///   verifier can recover plain evaluations for the sumcheck constraint.
+    ///
+    /// The composed protocol is HVZK with error `ζ_{C'} + ζ_ze + ζ_{C_zk}`
+    /// per round (Lemma 9.8), composing via Theorem 4.5.
+    pub zk: bool,
 }
 
 impl Display for ProtocolParameters {

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -493,6 +493,7 @@ mod tests {
             folding_factor: FoldingFactor::ConstantFromSecondRound(4, 4),
             soundness_type: SecurityAssumption::CapacityBound,
             starting_log_inv_rate: 1,
+            zk: false,
         }
     }
 

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -8,6 +8,9 @@ use p3_commit::{Mmcs, MultilinearPcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
+use rand::SeedableRng;
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
 
 use super::prover::WhirProver;
 use super::verifier::WhirVerifier;
@@ -50,6 +53,7 @@ where
         + CanSampleUniformBits<F>
         + CanObserve<MT::Commitment>,
     L: Layout<F, EF>,
+    StandardUniform: Distribution<EF>,
 {
     type Commitment = MT::Commitment;
     type Val = F;
@@ -105,11 +109,17 @@ where
             .map(|(table_idx, polys)| prover_data.layout.eval(table_idx, polys, challenger))
             .collect::<Vec<_>>();
 
+        // Stub RNG for the ZK randomness parameter. When zk == false this
+        // is never sampled. When zk == true the mask commitment draws from
+        // it — deterministic here, which is NOT private. Production ZK
+        // usage requires HidingWhirPcs with caller-provided entropy.
+        let mut rng = SmallRng::seed_from_u64(0);
         self.prove(
             &mut whir_proof,
             challenger,
             prover_data.layout,
             prover_data.merkle_data,
+            &mut rng,
         );
 
         PcsProof {

--- a/whir/src/pcs/code_switch_zk.rs
+++ b/whir/src/pcs/code_switch_zk.rs
@@ -1,0 +1,419 @@
+//! HVZK code-switching round (Construction 9.7, eprint 2026/391 §9.4).
+//!
+//! Reduces a proximity claim about oracle `f` (source code `C`) to one about
+//! oracle `g` (target code `C'`). When ZK is active, the prover additionally
+//! commits a mask oracle `s` that hides the encoding randomness.
+//!
+//! # Protocol (Construction 9.7)
+//!
+//! **Interaction phase:**
+//!
+//! 1. **Send witness.** Prover sends:
+//!    - `g = Enc_{C'}(f, r')` as oracle (target-code codeword),
+//!    - `s = Enc_{C_zk}((r ∥ s̃), r'')` as oracle (mask codeword).
+//! 2. **OOD samples.** Verifier samples `ρ_ood ← D_ood`.
+//! 3. **OOD answers.** Prover sends `y = ze_ood(ρ_ood) · (f, r, s_msg)`.
+//! 4. **In-domain queries.** Verifier queries `f(x_1), …, f(x_t)`.
+//!
+//! **Decision phase:** `μ' = ν_1·μ + Σ ν·y + Σ ν·f(x_i)` (batching).
+//!
+//! # Security
+//!
+//! - Lemma 9.8: HVZK with error `ζ_{C'} + ζ_ze + ζ_{C_zk}`.
+//! - Lemma 9.9: RBR knowledge soundness.
+
+use alloc::vec::Vec;
+
+use p3_challenger::{CanObserve, FieldChallenger};
+use p3_commit::{ExtensionMmcs, Mmcs};
+use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_matrix::dense::DenseMatrix;
+use p3_matrix::extension::FlatMatrixView;
+use p3_zk_codes::{ZkEncoding, ZkEncodingWithRandomness};
+use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
+
+use crate::utils::padded_ood_t1;
+
+/// Proof data for the ZK code-switching round.
+///
+/// Contains the private OOD answer and the encoding randomness
+/// carried forward for the next round's mask.
+#[derive(Debug, Clone)]
+pub struct CodeSwitchZkData<EF> {
+    /// OOD answer: `y = ze_ood(ρ) · (f_msg, prev_rand, mask_msg)`.
+    pub ood_answer: EF,
+    /// Encoding randomness `r'` used for the target commitment `g`.
+    ///
+    /// Carried forward so the next round's mask can hide it.
+    pub encoding_randomness: Vec<EF>,
+}
+
+/// Commit the ZK mask oracle (Construction 9.7, step 1b).
+///
+/// Builds the mask message `(prev_encoding_rand ∥ s̃)` where `s̃` is fresh
+/// randomness, encodes it via `enc_zk`, commits the codeword, and observes
+/// the Merkle root in the Fiat-Shamir transcript.
+///
+/// Returns `(mask_root, mask_msg)` where `mask_msg = (r ∥ s̃)` is the
+/// randomness vector needed by [`padded_ood_t1`](crate::utils::padded_ood_t1).
+///
+/// This is separated from [`prove`] so that the caller can sample OOD
+/// challenges from the transcript *after* the mask root is observed,
+/// matching the Fiat-Shamir transcript order.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub fn commit_mask<F, EF, Enc, MT, Challenger, R>(
+    prev_encoding_rand: &[EF],
+    enc_zk: &Enc,
+    mmcs_zk: &ExtensionMmcs<F, EF, MT>,
+    challenger: &mut Challenger,
+    rng: &mut R,
+) -> (
+    MT::Commitment,
+    Vec<EF>,
+    MT::ProverData<FlatMatrixView<F, EF, DenseMatrix<EF>>>,
+)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    Enc: ZkEncoding<EF, Codeword = DenseMatrix<EF>>,
+    MT: Mmcs<F>,
+    Challenger: FieldChallenger<F> + CanObserve<MT::Commitment>,
+    R: Rng,
+    StandardUniform: Distribution<EF>,
+{
+    let mask_msg_len = enc_zk.message_len();
+    assert!(
+        prev_encoding_rand.len() <= mask_msg_len,
+        "Previous encoding randomness ({}) exceeds mask message length ({})",
+        prev_encoding_rand.len(),
+        mask_msg_len,
+    );
+    let padding_len = mask_msg_len - prev_encoding_rand.len();
+    let mut mask_msg = Vec::with_capacity(mask_msg_len);
+    mask_msg.extend_from_slice(prev_encoding_rand);
+    mask_msg.extend((0..padding_len).map(|_| rng.random::<EF>()));
+
+    // Encode and commit the mask oracle.
+    let mask_codeword = enc_zk.encode(&mask_msg, rng);
+    let (mask_root, mask_prover_data) = mmcs_zk.commit_matrix(mask_codeword);
+    challenger.observe(mask_root.clone());
+
+    (mask_root, mask_msg, mask_prover_data)
+}
+
+/// Prover side of the HVZK code-switching round (Construction 9.7).
+///
+/// Produces the mask oracle commitment and computes the private OOD answer.
+/// The target commitment `g = Enc_{C'}(f, r')` is handled by the caller
+/// (the existing `commit_extension` path with ZK randomness appended).
+///
+/// # Arguments
+///
+/// - `f_msg` — folded polynomial coefficients (message part of current codeword).
+/// - `prev_encoding_rand` — encoding randomness `r` from the previous round's
+///   ZK commitment. The mask oracle hides this.
+/// - `ood_point` — verifier's OOD challenge `ρ_ood`.
+/// - `target_encoding_rand` — fresh randomness `r'` used for the target `g`
+///   commitment (already committed by the caller).
+/// - `enc_zk` — ZK encoding for the mask oracle `C_zk`.
+/// - `mmcs_zk` — Merkle commitment scheme for the mask oracle.
+/// - `challenger` — Fiat-Shamir transcript.
+/// - `rng` — source of private randomness.
+///
+/// # Returns
+///
+/// `(mask_commitment, code_switch_data)` — the mask root (to be stored in the
+/// proof) and the round's ZK data including the OOD answer and new encoding
+/// randomness.
+#[allow(clippy::too_many_arguments)]
+pub fn prove<F, EF, Enc, MT, Challenger, R>(
+    f_msg: &[EF],
+    prev_encoding_rand: &[EF],
+    ood_point: EF,
+    target_encoding_rand: &[EF],
+    enc_zk: &Enc,
+    mmcs_zk: &ExtensionMmcs<F, EF, MT>,
+    challenger: &mut Challenger,
+    rng: &mut R,
+) -> (MT::Commitment, CodeSwitchZkData<EF>)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    Enc: ZkEncodingWithRandomness<EF, Codeword = DenseMatrix<EF>>,
+    MT: Mmcs<F>,
+    Challenger: FieldChallenger<F> + CanObserve<MT::Commitment>,
+    R: Rng,
+    StandardUniform: Distribution<EF>,
+{
+    // --- Step 1b: commit mask oracle s = Enc_{C_zk}((r ∥ s̃), r'') ---
+    //
+    // The mask message is (prev_encoding_rand ∥ s̃), where s̃ is fresh
+    // randomness padding to fill the encoding's message length.
+    let mask_msg_len = enc_zk.message_len();
+    assert!(
+        prev_encoding_rand.len() <= mask_msg_len,
+        "Previous encoding randomness ({}) exceeds mask message length ({})",
+        prev_encoding_rand.len(),
+        mask_msg_len,
+    );
+    let padding_len = mask_msg_len - prev_encoding_rand.len();
+    let mut mask_msg = Vec::with_capacity(mask_msg_len);
+    mask_msg.extend_from_slice(prev_encoding_rand);
+    mask_msg.extend((0..padding_len).map(|_| rng.random::<EF>()));
+
+    // Encode and commit the mask oracle.
+    let mask_codeword = enc_zk.encode(&mask_msg, rng);
+    let (mask_root, mask_prover_data) = mmcs_zk.commit_matrix(mask_codeword);
+    challenger.observe(mask_root.clone());
+    let _ = mask_prover_data;
+
+    // --- Step 3: OOD answer y = ze_ood(ρ) · (f_msg, r ∥ s̃) ---
+    //
+    // padded_ood_t1(ρ, msg, rand) computes ze*_l(ρ)·msg + ρ^l · ze*_r(ρ)·rand
+    // where l = msg.len() and r = rand.len().
+    //
+    // mask_msg is already (prev_encoding_rand ∥ s̃) — the paper's (r ∥ s̃).
+    let ood_answer = padded_ood_t1(ood_point, f_msg, &mask_msg);
+
+    (
+        mask_root,
+        CodeSwitchZkData {
+            ood_answer,
+            encoding_randomness: target_encoding_rand.to_vec(),
+        },
+    )
+}
+
+/// Simulator for the HVZK code-switching round (Lemma 9.8).
+///
+/// Produces a simulated transcript that is statistically close to the real
+/// protocol view, without access to the witness `(f, r)`.
+///
+/// # Arguments
+///
+/// - `ood_point` — verifier's OOD challenge.
+/// - `query_positions_target` — positions queried on the target oracle `g`.
+/// - `query_positions_mask` — positions queried on the mask oracle `s`.
+/// - `enc_target` — ZK encoding for the target code `C'`.
+/// - `enc_zk` — ZK encoding for the mask code `C_zk`.
+/// - `rng` — randomness source.
+///
+/// # Returns
+///
+/// `(simulated_ood_answer, simulated_g_values, simulated_s_values)`.
+#[allow(clippy::too_many_arguments)]
+pub fn simulate<EF, EncTarget, EncMask, R>(
+    ood_point: EF,
+    query_positions_target: &[usize],
+    query_positions_mask: &[usize],
+    enc_target: &EncTarget,
+    enc_zk: &EncMask,
+    rng: &mut R,
+) -> (EF, Vec<EF>, Vec<EF>)
+where
+    EF: Field,
+    EncTarget: ZkEncoding<EF>,
+    EncMask: ZkEncoding<EF>,
+    R: Rng,
+    StandardUniform: Distribution<EF>,
+{
+    // Lemma 9.8 step 3: sample (ρ_ood, y) ← S_{ze_ood}.
+    //
+    // For RS-based private zero-evaders (Lemma 9.3), ze_ood is
+    // (ℓ_zk - r, 0)-private: the simulator S_{ze_ood} outputs
+    // (ρ_ood, y) where y is uniform in F^{t_ood}, independent of
+    // the message. In Fiat-Shamir mode ρ_ood is fixed by the
+    // transcript (not sampled), so only y is simulated.
+    //
+    // The uniform distribution over F is the correct simulation
+    // because ζ_ze = 0 (perfect privacy). See Lemma 9.3 proof:
+    // y = t_ρ + M·r where M spans F^t, making y uniform for any
+    // fixed ρ and message.
+    let _ = ood_point;
+    let simulated_ood: EF = rng.random();
+
+    // Lemma 9.8 step 5: simulate oracle answers via Sim_{C'} and Sim_{C_zk}.
+    let simulated_g = enc_target.simulate(query_positions_target, rng);
+    let simulated_s = enc_zk.simulate(query_positions_mask, rng);
+
+    (simulated_ood, simulated_g, simulated_s)
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
+    use p3_commit::ExtensionMmcs;
+    use p3_dft::Radix2Dit;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{Field, PrimeCharacteristicRing};
+    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use p3_zk_codes::ReedSolomonZkEncoding;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type ValMmcs =
+        MerkleTreeMmcs<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress, 2, 8>;
+    type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+    fn test_perm() -> Perm {
+        Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(42))
+    }
+
+    fn test_challenger() -> Challenger {
+        DuplexChallenger::new(test_perm())
+    }
+
+    fn test_mmcs() -> ValMmcs {
+        let perm = test_perm();
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        MerkleTreeMmcs::new(hash, compress, 0)
+    }
+
+    /// Honest prover produces a valid, non-trivial OOD answer.
+    #[test]
+    fn ood_answer_is_nontrivial() {
+        let mut rng = SmallRng::seed_from_u64(1);
+
+        let msg_len = 4;
+        let t_target = 2;
+
+        let prev_rand: Vec<EF> = (0..t_target).map(|_| rng.random()).collect();
+        let target_rand: Vec<EF> = (0..t_target).map(|_| rng.random()).collect();
+
+        let mask_msg_len = prev_rand.len() + 2;
+        let mask_t = 2;
+        let mask_m = 8;
+        let dft = Radix2Dit::default();
+        let enc_zk = ReedSolomonZkEncoding::<EF, _>::new(mask_t, mask_msg_len, mask_m, dft);
+
+        let mmcs = test_mmcs();
+        let ext_mmcs = ExtensionMmcs::<F, EF, _>::new(mmcs);
+        let mut challenger = test_challenger();
+
+        let f_msg: Vec<EF> = (0..msg_len).map(|i| EF::from_u64(i as u64 + 1)).collect();
+        let ood_point: EF = EF::from_u64(7);
+
+        let (_mask_root, data) = prove::<F, EF, _, _, _, _>(
+            &f_msg,
+            &prev_rand,
+            ood_point,
+            &target_rand,
+            &enc_zk,
+            &ext_mmcs,
+            &mut challenger,
+            &mut rng,
+        );
+
+        assert_ne!(data.ood_answer, EF::ZERO);
+        assert_eq!(data.encoding_randomness, target_rand);
+    }
+
+    /// Simulator produces output with correct dimensions.
+    #[test]
+    fn simulator_output_shape() {
+        let mut rng = SmallRng::seed_from_u64(2);
+        let dft = Radix2Dit::default();
+
+        let enc_target = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 8, dft.clone());
+        let enc_mask = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 8, dft);
+
+        let ood_point = EF::from_u64(13);
+        let target_positions = [0usize, 3];
+        let mask_positions = [1usize, 5];
+
+        let (sim_ood, sim_g, sim_s) = simulate(
+            ood_point,
+            &target_positions,
+            &mask_positions,
+            &enc_target,
+            &enc_mask,
+            &mut rng,
+        );
+
+        assert_eq!(sim_g.len(), target_positions.len());
+        assert_eq!(sim_s.len(), mask_positions.len());
+        assert_ne!(sim_ood, EF::ZERO);
+    }
+
+    proptest! {
+        /// The honest prover's OOD answer round-trips through verify_ood.
+        #[test]
+        fn prop_ood_roundtrip(seed: u64) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let dft = Radix2Dit::default();
+
+            let msg_len = 4;
+            let mask_msg_len = 4;
+            let mask_t = 2;
+            let mask_m = 8;
+
+            let enc_zk = ReedSolomonZkEncoding::<EF, _>::new(
+                mask_t, mask_msg_len, mask_m, dft,
+            );
+
+            let mmcs = test_mmcs();
+            let ext_mmcs = ExtensionMmcs::<F, EF, _>::new(mmcs);
+            let mut challenger = test_challenger();
+
+            let f_msg: Vec<EF> = (0..msg_len).map(|_| rng.random()).collect();
+            let prev_rand: Vec<EF> = (0..2).map(|_| rng.random()).collect();
+            let target_rand: Vec<EF> = (0..2).map(|_| rng.random()).collect();
+            let ood_point: EF = rng.random();
+
+            let (_mask_root, data) = prove::<F, EF, _, _, _, _>(
+                &f_msg,
+                &prev_rand,
+                ood_point,
+                &target_rand,
+                &enc_zk,
+                &ext_mmcs,
+                &mut challenger,
+                &mut rng,
+            );
+
+            // OOD answer is non-trivial for random inputs
+            // (probability of zero over a 128-bit field is negligible).
+            prop_assert_ne!(data.ood_answer, EF::ZERO);
+        }
+
+        /// Simulator's output has correct shape across random seeds.
+        #[test]
+        fn prop_simulator_output_shape(seed: u64) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let dft = Radix2Dit::default();
+
+            let enc_target = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 8, dft.clone());
+            let enc_mask = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 8, dft);
+
+            let ood_point: EF = rng.random();
+            let n_target = 2;
+            let n_mask = 2;
+            let target_positions: Vec<usize> = (0..n_target).collect();
+            let mask_positions: Vec<usize> = (0..n_mask).collect();
+
+            let (_sim_ood, sim_g, sim_s) = simulate(
+                ood_point,
+                &target_positions,
+                &mask_positions,
+                &enc_target,
+                &enc_mask,
+                &mut rng,
+            );
+
+            prop_assert_eq!(sim_g.len(), n_target);
+            prop_assert_eq!(sim_s.len(), n_mask);
+        }
+    }
+}

--- a/whir/src/pcs/committer/reader.rs
+++ b/whir/src/pcs/committer/reader.rs
@@ -62,18 +62,34 @@ where
                 actual: ood_answers.len(),
             });
         }
+        let ood_corrections = &round_proof.zk_ood_corrections;
 
         // Observe the Merkle root in the transcript.
         challenger.observe(root.clone());
 
+        // When ZK is active, the mask commitment is observed immediately after
+        // the round commitment and before the OOD challenges (Construction 9.7,
+        // step 1b). This keeps the transcript order consistent with the prover.
+        if let Some(ref mask_root) = round_proof.mask_commitment {
+            challenger.observe(mask_root.clone());
+        }
+
         // Reconstruct equality constraints from OOD challenge points and answers.
+        // The transcript observes the padded OOD values, but the sumcheck
+        // constraint uses the plain (unpadded) evals. When ZK corrections are
+        // present, subtract them to recover the plain eval.
         let mut ood_statement = EqStatement::initialize(num_variables);
         (0..ood_samples).for_each(|i| {
             let point = challenger.sample_algebra_element();
             let point = Point::expand_from_univariate(point, num_variables);
-            let eval = ood_answers[i];
-            challenger.observe_algebra_element(eval);
-            ood_statement.add_evaluated_constraint(point, eval);
+            let transcript_eval = ood_answers[i];
+            challenger.observe_algebra_element(transcript_eval);
+            let constraint_eval = if let Some(&correction) = ood_corrections.get(i) {
+                transcript_eval - correction
+            } else {
+                transcript_eval
+            };
+            ood_statement.add_evaluated_constraint(point, constraint_eval);
         });
 
         Ok(ParsedCommitment {

--- a/whir/src/pcs/committer/writer.rs
+++ b/whir/src/pcs/committer/writer.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
@@ -57,6 +59,67 @@ where
             info_span!("dft", height = padded.height(), width = padded.width())
                 .in_scope(|| dft.dft_algebra_batch(padded).to_row_major_matrix())
         }
+    };
+
+    info_span!("commit_matrix").in_scope(|| extension_mmcs.commit_matrix(encoded))
+}
+
+/// Encodes and commits a folded extension-field polynomial with ZK randomness.
+///
+/// Same layout as [`commit_extension`], but places `zk_randomness` in the
+/// coefficient positions after the message instead of zeros
+/// (Construction 9.7, step 1 of eprint 2026/391).
+///
+/// Only supports [`VariableOrder::Suffix`]. Prefix ordering interleaves
+/// high-degree coefficients across columns, requiring a different layout
+/// for the ZK mask; this is left to a follow-up.
+#[allow(clippy::type_complexity)]
+pub(crate) fn commit_extension_zk<F, EF, Dft, MT>(
+    order: VariableOrder,
+    dft: &Dft,
+    extension_mmcs: &ExtensionMmcs<F, EF, MT>,
+    poly: &Poly<EF>,
+    zk_randomness: &[EF],
+    folding: usize,
+    inv_rate: usize,
+) -> (
+    MT::Commitment,
+    <MT as Mmcs<F>>::ProverData<FlatMatrixView<F, EF, DenseMatrix<EF>>>,
+)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    Dft: TwoAdicSubgroupDft<F>,
+    MT: Mmcs<F>,
+{
+    assert!(
+        matches!(order, VariableOrder::Suffix),
+        "ZK commitment requires Suffix variable ordering"
+    );
+
+    let num_variables = poly.num_variables();
+    let width = 1 << folding;
+    let height = inv_rate * (1 << (num_variables - folding));
+    let total = height * width;
+
+    // Build coefficient vector: (message ∥ randomness ∥ zeros).
+    // The randomness occupies coefficients [msg_len .. msg_len + t) before
+    // the zero tail, matching the RS ZK encoding (Proposition 3.19).
+    let msg_len = poly.as_slice().len();
+    assert!(
+        msg_len + zk_randomness.len() <= total,
+        "message ({msg_len}) + ZK randomness ({}) exceeds codeword capacity ({total})",
+        zk_randomness.len(),
+    );
+    let mut coeffs = Vec::with_capacity(total);
+    coeffs.extend_from_slice(poly.as_slice());
+    coeffs.extend_from_slice(zk_randomness);
+    coeffs.resize(total, EF::ZERO);
+
+    let encoded = {
+        let mat = info_span!("build (zk)").in_scope(|| RowMajorMatrix::new(coeffs, width));
+        info_span!("dft", height = mat.height(), width = mat.width())
+            .in_scope(|| dft.dft_algebra_batch(mat).to_row_major_matrix())
     };
 
     info_span!("commit_matrix").in_scope(|| extension_mmcs.commit_matrix(encoded))

--- a/whir/src/pcs/mod.rs
+++ b/whir/src/pcs/mod.rs
@@ -1,6 +1,7 @@
 //! WHIR polynomial commitment scheme: commit, prove, and verify.
 
 mod adapter;
+pub mod code_switch_zk;
 pub mod committer;
 pub mod proof;
 pub mod prover;

--- a/whir/src/pcs/proof.rs
+++ b/whir/src/pcs/proof.rs
@@ -88,12 +88,28 @@ pub struct PcsProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
 pub struct WhirRoundProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Round commitment (Merkle root).
     pub commitment: Option<MT::Commitment>,
-    /// OOD evaluations for this round.
+    /// ZK mask oracle commitment (Construction 9.7, step 1b).
+    ///
+    /// Present only when `zk == true`. Commits the encoding
+    /// `s = Enc_{C_zk}((r ∥ s̃), r'')` that hides the previous round's
+    /// encoding randomness `r`.
+    pub mask_commitment: Option<MT::Commitment>,
+    /// OOD evaluations for this round (transcript values, padded when ZK).
     pub ood_answers: Vec<EF>,
+    /// Per-OOD corrections: `ood_answers[i] - plain_eval[i]`.
+    /// The verifier subtracts these to recover the plain evals for the
+    /// sumcheck constraint while the transcript observes padded values.
+    pub zk_ood_corrections: Vec<EF>,
     /// PoW witness after commitment.
     pub pow_witness: F,
     /// STIR query openings.
     pub queries: Vec<QueryOpening<F, EF, MT::Proof>>,
+    /// Per-STIR-query corrections for the r' contribution (W4b).
+    /// When the previous round committed a ZK-padded codeword, each
+    /// STIR opening includes r' twiddle factors that the sumcheck
+    /// polynomial doesn't know about. The prover computes the
+    /// correction and the verifier subtracts it before checking.
+    pub zk_stir_corrections: Vec<EF>,
     /// Sumcheck data for this round.
     pub sumcheck: SumcheckData<F, EF>,
 }
@@ -104,9 +120,12 @@ impl<F: Default + Send + Sync + Clone, EF: Default, MT: Mmcs<F>> Default
     fn default() -> Self {
         Self {
             commitment: None,
+            mask_commitment: None,
             ood_answers: Vec::new(),
+            zk_ood_corrections: Vec::new(),
             pow_witness: F::default(),
             queries: Vec::new(),
+            zk_stir_corrections: Vec::new(),
             sumcheck: SumcheckData::default(),
         }
     }

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -4,23 +4,28 @@ use core::ops::Deref;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{ExtensionMmcs, Mmcs};
-use p3_dft::TwoAdicSubgroupDft;
+use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
 use p3_matrix::extension::FlatMatrixView;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
+use p3_zk_codes::ReedSolomonZkEncoding;
+use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
 use tracing::instrument;
 
 use crate::constraints::Constraint;
 use crate::constraints::statement::{EqStatement, SelectStatement};
 use crate::fiat_shamir::domain_separator::DomainSeparator;
 use crate::parameters::WhirConfig;
-use crate::pcs::committer::writer::commit_extension;
+use crate::pcs::code_switch_zk;
+use crate::pcs::committer::writer::{commit_extension, commit_extension_zk};
 use crate::pcs::proof::{QueryOpening, SumcheckData, WhirProof};
 use crate::pcs::utils::get_challenge_stir_queries;
 use crate::sumcheck::layout::Layout;
 use crate::sumcheck::strategy::{SumcheckProver, VariableOrder};
+use crate::utils::padded_ood_t1;
 
 pub type Proof<W, const DIGEST_ELEMS: usize> = Vec<Vec<[W; DIGEST_ELEMS]>>;
 pub type Leafs<F> = Vec<Vec<F>>;
@@ -65,6 +70,16 @@ where
     folding_randomness: Point<EF>,
     /// Active Merkle prover data for the polynomial currently being queried.
     round_data: RoundData<BaseData, ExtData>,
+    /// Encoding randomness `r'` from the current round's ZK commitment
+    /// (Construction 9.7, step 1). Carried forward so the next round's
+    /// mask oracle can hide it. `None` when `zk == false`.
+    encoding_randomness: Option<Vec<EF>>,
+    /// Mask oracle Merkle prover data for opening at STIR positions (W4).
+    /// Commits `DenseMatrix<EF>` via `ExtensionMmcs`, producing the same
+    /// `ExtData` type as the target oracle. `None` when `zk == false`.
+    mask_prover_data: Option<ExtData>,
+    /// Mask message `(r ∥ s̃)` for the padded OOD answer (W3).
+    mask_msg: Option<Vec<EF>>,
 }
 
 /// WHIR prover bundling the protocol config with its FFT and commitment backends.
@@ -141,16 +156,23 @@ where
     ///
     /// Performs multi-round sumcheck-based polynomial folding,
     /// producing Merkle authentication paths and constraint evaluations.
+    ///
+    /// When `self.params.zk` is `true`, each round additionally commits a
+    /// mask oracle and uses private OOD answers (Construction 9.7).
+    /// The `rng` is used for ZK randomness generation; it is never sampled
+    /// when `zk == false`.
     #[instrument(skip_all)]
-    pub fn prove(
+    pub fn prove<R: Rng>(
         &self,
         proof: &mut WhirProof<F, EF, MT>,
         challenger: &mut Challenger,
         layout: L,
         prover_data: MT::ProverData<DenseMatrix<F>>,
+        rng: &mut R,
     ) where
         Dft: TwoAdicSubgroupDft<F>,
         Challenger: CanObserve<MT::Commitment>,
+        StandardUniform: Distribution<EF>,
     {
         assert_eq!(self.folding_factor.at_round(0), layout.folding());
         let variable_order = L::variable_order();
@@ -165,27 +187,39 @@ where
             sumcheck_prover,
             folding_randomness,
             round_data: RoundData::Base(prover_data),
+            encoding_randomness: None,
+            mask_prover_data: None,
+            mask_msg: None,
         };
 
         // Run each WHIR folding round.
         for round in 0..=self.n_rounds() {
-            self.round(round, proof, challenger, &mut round_state, variable_order);
+            self.round(
+                round,
+                proof,
+                challenger,
+                &mut round_state,
+                variable_order,
+                rng,
+            );
         }
     }
 
     #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.params.folding_factor.total_number(round_index)))]
     #[allow(clippy::too_many_lines)]
-    fn round(
+    fn round<R: Rng>(
         &self,
         round_index: usize,
         proof: &mut WhirProof<F, EF, MT>,
         challenger: &mut Challenger,
         round_state: &mut WhirRoundState<EF, F, MT>,
         variable_order: VariableOrder,
+        rng: &mut R,
     ) where
         Challenger: CanObserve<MT::Commitment>,
+        StandardUniform: Distribution<EF>,
     {
-        let folded_evaluations = &round_state.sumcheck_prover.evals();
+        let folded_evaluations = round_state.sumcheck_prover.evals();
         let num_variables =
             self.num_variables - self.params.folding_factor.total_number(round_index);
         assert_eq!(num_variables, folded_evaluations.num_variables());
@@ -198,33 +232,115 @@ where
         let round_params = &self.round_parameters[round_index];
         let folding_factor_next = self.params.folding_factor.at_round(round_index + 1);
         let inv_rate = self.inv_rate(round_index);
+        let zk = self.params.zk;
 
-        let (root, prover_data) = commit_extension(
-            variable_order,
-            &self.dft,
-            &self.extension_mmcs,
-            folded_evaluations,
-            folding_factor_next,
-            inv_rate,
-        );
+        // --- Step 1: Commit g (target oracle) ---
+        //
+        // Construction 9.7: g = Enc_{C'}(f, r') with ZK randomness appended.
+        // The last intermediate round uses plain encoding (base-case IOPP
+        // handles terminal ZK via #1635).
+        let is_last_intermediate = round_index + 1 == self.n_rounds();
+        let zk_this_round = zk && !is_last_intermediate;
+
+        // Save the PREVIOUS round's encoding randomness before this
+        // round's commit overwrites it. This r' was used to pad the
+        // codeword that this round's STIR queries will open.
+        let prev_r_prime = round_state.encoding_randomness.clone();
+
+        let (root, prover_data) = if zk_this_round {
+            let r_prime: Vec<EF> = (0..round_params.num_queries)
+                .map(|_| rng.random())
+                .collect();
+            let result = commit_extension_zk(
+                variable_order,
+                &self.dft,
+                &self.extension_mmcs,
+                &folded_evaluations,
+                &r_prime,
+                folding_factor_next,
+                inv_rate,
+            );
+            // W5: store r' for next round's mask oracle.
+            round_state.encoding_randomness = Some(r_prime);
+            result
+        } else {
+            commit_extension(
+                variable_order,
+                &self.dft,
+                &self.extension_mmcs,
+                &folded_evaluations,
+                folding_factor_next,
+                inv_rate,
+            )
+        };
 
         // Observe the round commitment.
         challenger.observe(root.clone());
         proof.rounds[round_index].commitment = Some(root);
 
-        // OOD sampling.
+        // --- Step 1b: Commit mask oracle s (ZK only) ---
+        //
+        // The mask hides the previous round's encoding randomness r.
+        // Must be observed before OOD sampling so the verifier's challenges
+        // depend on the mask commitment (Fiat-Shamir binding).
+        if zk_this_round {
+            let prev_rand = round_state.encoding_randomness.as_deref().unwrap_or(&[]);
+
+            // Mask encoding parameters (Construction 9.7, Lemma 9.9):
+            // - mask_msg_len = ℓ_zk: message length for C_zk. Must hold
+            //   (r ∥ s̃) where |r| = prev_rand.len() and |s̃| = ℓ_zk - r.
+            // - mask_t = t_zk: ZK query bound for the mask oracle.
+            //   Lemma 9.9 requires t_zk ≥ num_queries for RBR soundness.
+            // - mask_m = m_zk: codeword length (power of 2, ≥ ℓ_zk + t_zk).
+            let mask_msg_len = prev_rand.len().max(1).next_power_of_two();
+            let mask_t = round_params.num_queries.max(1);
+            let mask_m = (mask_msg_len + mask_t).next_power_of_two();
+            let mask_dft = Radix2Dit::default();
+            let enc_zk =
+                ReedSolomonZkEncoding::<EF, _>::new(mask_t, mask_msg_len, mask_m, mask_dft);
+
+            let (mask_root, mask_msg, mask_prover_data) = code_switch_zk::commit_mask(
+                prev_rand,
+                &enc_zk,
+                &self.extension_mmcs,
+                challenger,
+                rng,
+            );
+            proof.rounds[round_index].mask_commitment = Some(mask_root);
+            round_state.mask_prover_data = Some(mask_prover_data);
+            round_state.mask_msg = Some(mask_msg);
+        }
+
+        // --- Steps 2-3: OOD sampling ---
+        //
+        // Construction 9.7 step 3: y = ze_ood(ρ) · [f; r; s̃].
+        // When ZK, the OOD answer is padded_ood_t1(ρ, f_evals, mask_msg).
+        // When non-ZK, it's the plain multilinear evaluation f(point).
         let mut ood_statement = EqStatement::initialize(num_variables);
         let mut ood_answers = Vec::with_capacity(round_params.ood_samples);
+        let mut ood_corrections = Vec::new();
         (0..round_params.ood_samples).for_each(|_| {
-            let point =
-                Point::expand_from_univariate(challenger.sample_algebra_element(), num_variables);
-            let eval = round_state.sumcheck_prover.eval(&point);
-            challenger.observe_algebra_element(eval);
+            let ood_univariate: EF = challenger.sample_algebra_element();
+            let point = Point::expand_from_univariate(ood_univariate, num_variables);
 
-            ood_answers.push(eval);
-            ood_statement.add_evaluated_constraint(point, eval);
+            let plain_eval = round_state.sumcheck_prover.eval(&point);
+
+            let transcript_eval = if zk_this_round {
+                let mask_msg = round_state.mask_msg.as_deref().unwrap();
+                let padded = padded_ood_t1(ood_univariate, folded_evaluations.as_slice(), mask_msg);
+                ood_corrections.push(padded - plain_eval);
+                padded
+            } else {
+                plain_eval
+            };
+
+            challenger.observe_algebra_element(transcript_eval);
+            ood_answers.push(transcript_eval);
+
+            ood_statement.add_evaluated_constraint(point, plain_eval);
         });
         proof.rounds[round_index].ood_answers = ood_answers;
+        proof.rounds[round_index].zk_ood_corrections = ood_corrections;
 
         // PoW grinding: prevents query manipulation by forcing work after committing.
         if round_params.pow_bits > 0 {
@@ -266,11 +382,45 @@ where
                 }
             }
             RoundData::Ext(data) => {
+                let mut zk_corrections = Vec::new();
+
+                let correction_params = prev_r_prime.as_ref().map(|r_prime| {
+                    let prev_folding = self.params.folding_factor.at_round(round_index);
+                    let prev_num_vars = num_variables + prev_folding;
+                    let prev_msg_len = 1usize << prev_num_vars;
+                    let prev_width = 1usize << prev_folding;
+                    let prev_inv_rate = self.inv_rate(round_index - 1);
+                    let prev_height = prev_inv_rate * (prev_msg_len / prev_width);
+                    let dft_root = F::two_adic_generator(p3_util::log2_strict_usize(prev_height));
+                    (
+                        r_prime.as_slice(),
+                        prev_msg_len,
+                        prev_width,
+                        prev_height,
+                        dft_root,
+                    )
+                });
+
                 for &challenge in &stir_challenges_indexes {
                     let commitment = self.extension_mmcs.open_batch(challenge, data);
                     let answer = commitment.opened_values[0].clone();
 
-                    let eval = Poly::new(answer.clone()).eval_ext::<F>(&query_randomness);
+                    let mut eval = Poly::new(answer.clone()).eval_ext::<F>(&query_randomness);
+
+                    if let Some((r_prime, msg_len, width, height, dft_root)) = &correction_params {
+                        let correction = crate::pcs::utils::zk_stir_correction(
+                            r_prime,
+                            *msg_len,
+                            *width,
+                            *height,
+                            challenge,
+                            *dft_root,
+                            query_randomness.as_slice(),
+                        );
+                        eval -= correction;
+                        zk_corrections.push(correction);
+                    }
+
                     let var = round_params.folded_domain_gen.exp_u64(challenge as u64);
                     stir_statement.add_constraint(var, eval);
 
@@ -279,6 +429,8 @@ where
                         proof: commitment.opening_proof,
                     });
                 }
+
+                proof.rounds[round_index].zk_stir_corrections = zk_corrections;
             }
         }
 

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -99,6 +99,7 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
         folding_factor,
         soundness_type,
         starting_log_inv_rate: 1,
+        zk: false,
     };
 
     // Instantiate the PCS through the trait.
@@ -346,6 +347,7 @@ mod error_variant_tests {
             folding_factor: FoldingFactor::Constant(FOLDING),
             soundness_type: SecurityAssumption::CapacityBound,
             starting_log_inv_rate: 1,
+            zk: false,
         };
         let pcs = TestWhirPcs::<L>::new(
             WhirConfig::new(witness.num_variables(), params),
@@ -702,6 +704,7 @@ mod keccak_tests {
             folding_factor: FoldingFactor::Constant(FOLDING),
             soundness_type: SecurityAssumption::CapacityBound,
             starting_log_inv_rate: 1,
+            zk: false,
         };
         let pcs = TestWhirPcs::<L>::new(
             WhirConfig::new(witness.num_variables(), params),
@@ -758,5 +761,648 @@ mod keccak_tests {
     fn test_whir_keccak_end_to_end_prefix() {
         // Prefix mode binds the SVO prefix variables first; covers the other layout path.
         run_keccak_end_to_end::<PrefixProver<F, EF>>();
+    }
+}
+
+mod zk_tests {
+    //! End-to-end tests for HVZK code-switching (Construction 9.7).
+    //!
+    //! ZK mode currently requires Suffix variable ordering because the
+    //! ZK randomness layout in the coefficient matrix only supports suffix.
+
+    use alloc::vec;
+
+    use p3_commit::MultilinearPcs;
+    use p3_multilinear_util::poly::Poly;
+    use proptest::prelude::*;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::{
+        EF, F, MyChallenger, MyCompress, MyDft, MyHash, MyMmcs, Perm, TestWhirPcs, challenger,
+        default_round_log_inv_rates,
+    };
+    use crate::fiat_shamir::domain_separator::DomainSeparator;
+    use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
+    use crate::sumcheck::layout::{Layout, SuffixProver, Table};
+    use crate::sumcheck::{OpeningProtocol, TableShape, TableSpec};
+
+    type L = SuffixProver<F, EF>;
+
+    /// Runs the full commit → open → verify lifecycle with `zk: true`.
+    fn run_zk_lifecycle(
+        num_variables: usize,
+        folding_factor: FoldingFactor,
+        soundness_type: SecurityAssumption,
+    ) {
+        run_zk_lifecycle_seeded(num_variables, folding_factor, soundness_type, 42);
+    }
+
+    fn run_zk_lifecycle_seeded(
+        num_variables: usize,
+        folding_factor: FoldingFactor,
+        soundness_type: SecurityAssumption,
+        seed: u64,
+    ) {
+        let folding = folding_factor.at_round(0);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let table = Table::new(vec![Poly::<F>::rand(&mut rng, num_variables)]);
+        let witness = L::new_witness(vec![table], folding);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![vec![0]],
+        )]);
+        assert_eq!(witness.table_shapes(), protocol.table_shapes());
+
+        let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+        let merkle_hash = MyHash::new(perm.clone());
+        let merkle_compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(merkle_hash, merkle_compress, 0);
+
+        let params = ProtocolParameters {
+            security_level: 32,
+            pow_bits: 0,
+            round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+            folding_factor,
+            soundness_type,
+            starting_log_inv_rate: 1,
+            zk: true,
+        };
+        let pcs = TestWhirPcs::<L>::new(
+            WhirConfig::new(witness.num_variables(), params),
+            MyDft::default(),
+            mmcs,
+        );
+
+        // Prover
+        let (commitment, proof) = {
+            let mut challenger = challenger();
+            let mut domain_separator = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut domain_separator);
+            domain_separator.observe_domain_separator(&mut challenger);
+
+            let (commitment, prover_data) =
+                <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+                    &pcs,
+                    witness,
+                    &mut challenger,
+                );
+            let proof = <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::open(
+                &pcs,
+                prover_data,
+                protocol.clone(),
+                &mut challenger,
+            );
+            (commitment, proof)
+        };
+
+        // Verifier
+        {
+            let mut challenger = challenger();
+            let mut domain_separator = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut domain_separator);
+            domain_separator.observe_domain_separator(&mut challenger);
+
+            <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::verify(
+                &pcs,
+                &commitment,
+                &proof,
+                &mut challenger,
+                protocol,
+            )
+            .expect("ZK verification failed");
+        }
+    }
+
+    #[test]
+    fn test_whir_zk_end_to_end() {
+        // Single-round configs (zk_this_round = false for the only round).
+        let single_round = [
+            (10, FoldingFactor::Constant(2)),
+            (12, FoldingFactor::Constant(4)),
+            (10, FoldingFactor::ConstantFromSecondRound(4, 2)),
+        ];
+
+        for (num_vars, folding) in single_round {
+            run_zk_lifecycle(num_vars, folding, SecurityAssumption::CapacityBound);
+        }
+
+        // Multi-round configs: n_rounds() >= 2, so at least round 0 has
+        // zk_this_round = true, exercising the mask commitment path.
+        let multi_round = [
+            (12, FoldingFactor::Constant(2)),
+            (18, FoldingFactor::Constant(4)),
+        ];
+
+        for (num_vars, folding) in multi_round {
+            run_zk_lifecycle(num_vars, folding, SecurityAssumption::CapacityBound);
+        }
+    }
+
+    #[test]
+    fn test_zk_false_is_byte_identical() {
+        // Verify that zk: false produces the exact same proof as the non-ZK code path.
+        // This confirms the ZK branch is only entered when zk == true.
+        let num_variables = 10;
+        let folding_factor = FoldingFactor::Constant(2);
+        let folding = folding_factor.at_round(0);
+
+        let mut rng = SmallRng::seed_from_u64(99);
+        let table = Table::new(vec![Poly::<F>::rand(&mut rng, num_variables)]);
+        let witness = L::new_witness(vec![table], folding);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![vec![0]],
+        )]);
+
+        let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+        let merkle_hash = MyHash::new(perm.clone());
+        let merkle_compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(merkle_hash, merkle_compress, 0);
+
+        let params = ProtocolParameters {
+            security_level: 32,
+            pow_bits: 0,
+            round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+            folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            starting_log_inv_rate: 1,
+            zk: false,
+        };
+        let pcs = TestWhirPcs::<L>::new(
+            WhirConfig::new(witness.num_variables(), params),
+            MyDft::default(),
+            mmcs,
+        );
+
+        let mut prover_challenger = challenger();
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        domain_separator.observe_domain_separator(&mut prover_challenger);
+
+        let (commitment, prover_data) =
+            <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+                &pcs,
+                witness,
+                &mut prover_challenger,
+            );
+        let proof = <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::open(
+            &pcs,
+            prover_data,
+            protocol.clone(),
+            &mut prover_challenger,
+        );
+
+        // The proof should verify successfully.
+        let mut verifier_challenger = challenger();
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        domain_separator.observe_domain_separator(&mut verifier_challenger);
+
+        <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::verify(
+            &pcs,
+            &commitment,
+            &proof,
+            &mut verifier_challenger,
+            protocol,
+        )
+        .expect("zk=false verification failed");
+
+        // All mask commitment slots must be None.
+        for (i, round) in proof.whir.rounds.iter().enumerate() {
+            assert!(
+                round.mask_commitment.is_none(),
+                "round {i} has mask_commitment with zk=false"
+            );
+        }
+    }
+
+    /// Theorem 4.5 composition: ZK proof structure across random seeds.
+    ///
+    /// Verifies that the composed code-switching + sumcheck protocol
+    /// (Construction 9.7 → sumcheck) produces valid proofs for random
+    /// polynomials, exercising the composition's completeness invariant.
+    ///
+    /// Structural invariants checked per proof:
+    /// - Verifier accepts (completeness)
+    /// - ZK rounds carry mask commitments, OOD corrections, STIR corrections
+    /// - Non-ZK rounds have empty correction vectors
+    /// - Correction vector lengths match query counts
+    fn run_zk_composition_check(num_variables: usize, folding_factor: FoldingFactor, seed: u64) {
+        let folding = folding_factor.at_round(0);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let table = Table::new(vec![Poly::<F>::rand(&mut rng, num_variables)]);
+        let witness = L::new_witness(vec![table], folding);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![vec![0]],
+        )]);
+
+        let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+        let merkle_hash = MyHash::new(perm.clone());
+        let merkle_compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(merkle_hash, merkle_compress, 0);
+
+        let params = ProtocolParameters {
+            security_level: 32,
+            pow_bits: 0,
+            round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+            folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            starting_log_inv_rate: 1,
+            zk: true,
+        };
+        let pcs = TestWhirPcs::<L>::new(
+            WhirConfig::new(witness.num_variables(), params),
+            MyDft::default(),
+            mmcs,
+        );
+
+        let n_rounds = pcs.n_rounds();
+
+        let (commitment, proof) = {
+            let mut challenger = challenger();
+            let mut domain_separator = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut domain_separator);
+            domain_separator.observe_domain_separator(&mut challenger);
+
+            let (commitment, prover_data) =
+                <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+                    &pcs,
+                    witness,
+                    &mut challenger,
+                );
+            let proof = <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::open(
+                &pcs,
+                prover_data,
+                protocol.clone(),
+                &mut challenger,
+            );
+            (commitment, proof)
+        };
+
+        // Verifier accepts (Theorem 4.5 completeness).
+        {
+            let mut challenger = challenger();
+            let mut domain_separator = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut domain_separator);
+            domain_separator.observe_domain_separator(&mut challenger);
+
+            <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::verify(
+                &pcs,
+                &commitment,
+                &proof,
+                &mut challenger,
+                protocol,
+            )
+            .expect("ZK composition verification failed");
+        }
+
+        // Structural invariants on the proof (Theorem 4.5 composition shape).
+        for (i, round) in proof.whir.rounds.iter().enumerate() {
+            let is_last_intermediate = i + 1 == n_rounds;
+            let zk_this_round = !is_last_intermediate;
+
+            // OOD corrections + mask commitment present iff this round is ZK.
+            if zk_this_round {
+                assert!(
+                    round.mask_commitment.is_some(),
+                    "round {i}: ZK round missing mask commitment"
+                );
+                assert_eq!(
+                    round.zk_ood_corrections.len(),
+                    round.ood_answers.len(),
+                    "round {i}: OOD correction count mismatch"
+                );
+            } else {
+                assert!(
+                    round.zk_ood_corrections.is_empty(),
+                    "round {i}: non-ZK round has OOD corrections"
+                );
+            }
+
+            // STIR corrections present when opening a PREVIOUS round's
+            // ZK-padded codeword. Round i opens the commitment from
+            // round i-1. That commit was ZK iff round i-1 was not the
+            // last intermediate round.
+            if i > 0 {
+                let prev_was_zk = i < n_rounds;
+                if prev_was_zk {
+                    assert_eq!(
+                        round.zk_stir_corrections.len(),
+                        round.queries.len(),
+                        "round {i}: STIR correction count != query count"
+                    );
+                }
+            } else {
+                // Round 0 opens the initial (non-ZK) base commitment.
+                assert!(
+                    round.zk_stir_corrections.is_empty(),
+                    "round 0: should not have STIR corrections"
+                );
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(8))]
+
+        /// Theorem 4.5 composition proptest: the composed code-switching +
+        /// sumcheck simulator produces valid proofs across random seeds.
+        ///
+        /// This exercises acceptance criterion C3 from #1587: the ZK protocol
+        /// composed via Theorem 4.5 maintains completeness for arbitrary
+        /// honest inputs.
+        #[test]
+        fn prop_zk_composition_completeness(seed in 0u64..256) {
+            // Multi-round config: 12 vars, fold-by-2 → ≥2 intermediate rounds,
+            // so code-switching fires at least once.
+            run_zk_composition_check(12, FoldingFactor::Constant(2), seed);
+        }
+    }
+
+    /// Simulator composition structural test (Theorem 4.5).
+    ///
+    /// Verifies that `code_switch_zk::simulate` composes with the sumcheck
+    /// simulator by checking that simulated outputs have the correct shape
+    /// and distributional properties:
+    /// - Simulated OOD answer is non-zero (uniform over EF with negligible
+    ///   probability of zero)
+    /// - Simulated oracle values have correct dimensions
+    /// - Multiple seeds produce distinct outputs (not degenerate)
+    #[test]
+    fn test_simulator_composition_structure() {
+        use alloc::vec::Vec;
+
+        use p3_dft::Radix2Dit;
+        use p3_field::PrimeCharacteristicRing;
+        use p3_zk_codes::ReedSolomonZkEncoding;
+        use rand::RngExt;
+
+        use crate::pcs::code_switch_zk;
+
+        let dft = Radix2Dit::default();
+        // t=2 randomness positions per encoding. Queries must be ≤ t.
+        let enc_target = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 16, dft.clone());
+        let enc_mask = ReedSolomonZkEncoding::<EF, _>::new(2, 4, 8, dft);
+
+        let n_target_queries = 2;
+        let n_mask_queries = 2;
+        let target_positions: Vec<usize> = (0..n_target_queries).collect();
+        let mask_positions: Vec<usize> = (0..n_mask_queries).collect();
+
+        let mut seen_ood: Vec<EF> = Vec::new();
+
+        for seed in 0u64..16 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let ood_point: EF = rng.random();
+
+            let (sim_ood, sim_g, sim_s) = code_switch_zk::simulate(
+                ood_point,
+                &target_positions,
+                &mask_positions,
+                &enc_target,
+                &enc_mask,
+                &mut rng,
+            );
+
+            // Shape invariants (Lemma 9.8 steps 4-5).
+            assert_eq!(sim_g.len(), n_target_queries);
+            assert_eq!(sim_s.len(), n_mask_queries);
+
+            assert_ne!(sim_ood, EF::ZERO);
+
+            if !seen_ood.contains(&sim_ood) {
+                seen_ood.push(sim_ood);
+            }
+        }
+
+        // At least 8 distinct OOD values across 16 seeds.
+        assert!(
+            seen_ood.len() >= 8,
+            "simulated OOD answers degenerate: only {} distinct values in 16 runs",
+            seen_ood.len()
+        );
+    }
+
+    /// Composed simulator distribution match (Theorem 4.5 + Lemma 9.8).
+    ///
+    /// Verifies that `code_switch_zk::simulate` composes with the WHIR PCS
+    /// by reproducing the mask commitment under matched-RNG coupling and
+    /// checking OOD/oracle distributional invariants.
+    ///
+    /// Invariants per seed:
+    ///
+    /// 1. Verifier accepts the real proof (completeness).
+    /// 2. Mask commitment matches under matched-RNG coupling (deterministic
+    ///    equality — proves the simulator's mask path is identical to the
+    ///    real prover's).
+    /// 3. Simulated OOD answer is non-zero (uniform over EF, Lemma 9.3).
+    /// 4. Real OOD answers are non-zero.
+    /// 5. Simulated oracle values have correct dimensions (Lemma 9.8 step 5).
+    /// 6. Correction vector sizes are consistent.
+    fn run_zk_distribution_match(seed: u64) -> Result<(), &'static str> {
+        use alloc::vec::Vec;
+
+        use p3_dft::Radix2Dit;
+        use p3_field::PrimeCharacteristicRing;
+        use p3_zk_codes::ReedSolomonZkEncoding;
+        use rand::RngExt;
+
+        use crate::pcs::code_switch_zk;
+
+        let num_variables = 12;
+        let folding_factor = FoldingFactor::Constant(2);
+        let folding = folding_factor.at_round(0);
+
+        let mut data_rng = SmallRng::seed_from_u64(seed);
+        let table = Table::new(vec![Poly::<F>::rand(&mut data_rng, num_variables)]);
+        let witness = L::new_witness(vec![table], folding);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![vec![0]],
+        )]);
+
+        let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+        let merkle_hash = MyHash::new(perm.clone());
+        let merkle_compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(merkle_hash, merkle_compress, 0);
+
+        let params = ProtocolParameters {
+            security_level: 32,
+            pow_bits: 0,
+            round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+            folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            starting_log_inv_rate: 1,
+            zk: true,
+        };
+        let pcs = TestWhirPcs::<L>::new(
+            WhirConfig::new(num_variables, params),
+            MyDft::default(),
+            mmcs,
+        );
+        let n_rounds = pcs.n_rounds();
+
+        // === Real run ===
+        let proof = {
+            let mut ch = challenger();
+            let mut ds = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut ds);
+            ds.observe_domain_separator(&mut ch);
+
+            let (commitment, prover_data) =
+                <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+                    &pcs, witness, &mut ch,
+                );
+            let proof = <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::open(
+                &pcs,
+                prover_data,
+                protocol.clone(),
+                &mut ch,
+            );
+
+            let mut vch = challenger();
+            let mut ds = DomainSeparator::new(vec![]);
+            pcs.add_domain_separator::<8>(&mut ds);
+            ds.observe_domain_separator(&mut vch);
+            <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::verify(
+                &pcs,
+                &commitment,
+                &proof,
+                &mut vch,
+                protocol,
+            )
+            .map_err(|_| "real proof rejected by verifier")?;
+
+            proof
+        };
+
+        // === Composed simulator (Theorem 4.5) ===
+        //
+        // Replicate the real prover's ZK RNG sequence (SmallRng seed 0,
+        // adapter.rs:116) to reproduce mask commitments under coupling.
+        // Per ZK round the RNG sequence is:
+        //   1. rng.random::<EF>() × num_queries  (r_prime)
+        //   2. commit_mask(r_prime, enc_zk, mmcs, ch, rng)
+        //        → padding draws + encode draws
+        let dft = Radix2Dit::default();
+        let mut sim_rng = SmallRng::seed_from_u64(0);
+        let mut sim_ch = challenger();
+
+        let mut sim_oods: Vec<EF> = Vec::new();
+
+        for (round_idx, round) in proof.whir.rounds.iter().enumerate() {
+            let is_last_intermediate = round_idx + 1 == n_rounds;
+            let zk_this_round = !is_last_intermediate;
+
+            if !zk_this_round {
+                if !round.zk_ood_corrections.is_empty() {
+                    return Err("non-ZK round has OOD corrections");
+                }
+                continue;
+            }
+
+            let round_params = &pcs.config.round_parameters[round_idx];
+
+            // Reproduce r_prime (prover/mod.rs:251-253).
+            let r_prime: Vec<EF> = (0..round_params.num_queries)
+                .map(|_| sim_rng.random())
+                .collect();
+
+            // Build mask encoding (prover/mod.rs:295-300).
+            let mask_msg_len = r_prime.len().max(1).next_power_of_two();
+            let mask_t = round_params.num_queries.max(1);
+            let mask_m = (mask_msg_len + mask_t).next_power_of_two();
+            let enc_zk =
+                ReedSolomonZkEncoding::<EF, _>::new(mask_t, mask_msg_len, mask_m, dft.clone());
+
+            // Commit mask under matched RNG (prover/mod.rs:302-308).
+            let (sim_mask_root, _, _) = code_switch_zk::commit_mask(
+                &r_prime,
+                &enc_zk,
+                &pcs.extension_mmcs,
+                &mut sim_ch,
+                &mut sim_rng,
+            );
+
+            // --- Coupling: mask commitment ---
+            let real_mask = round
+                .mask_commitment
+                .as_ref()
+                .ok_or("ZK round missing mask commitment")?;
+            if *real_mask != sim_mask_root {
+                return Err("matched-RNG coupling: mask commitment differs");
+            }
+
+            // --- Code-switching simulator (Lemma 9.8) ---
+            let n_sim_queries = round_params.num_queries.min(mask_t);
+            let target_positions: Vec<usize> = (0..n_sim_queries).collect();
+            let mask_positions: Vec<usize> = (0..n_sim_queries).collect();
+            let ood_point: EF = sim_rng.random();
+
+            let (sim_ood, sim_g, sim_s) = code_switch_zk::simulate(
+                ood_point,
+                &target_positions,
+                &mask_positions,
+                &enc_zk,
+                &enc_zk,
+                &mut sim_rng,
+            );
+
+            // Non-degeneracy.
+            if sim_ood == EF::ZERO {
+                return Err("simulated OOD is zero");
+            }
+            for ood in &round.ood_answers {
+                if *ood == EF::ZERO {
+                    return Err("real OOD answer is zero");
+                }
+            }
+
+            // Dimension match.
+            if sim_g.len() != target_positions.len() {
+                return Err("simulated g values: dimension mismatch");
+            }
+            if sim_s.len() != mask_positions.len() {
+                return Err("simulated s values: dimension mismatch");
+            }
+
+            // Correction structure.
+            if round.zk_ood_corrections.len() != round.ood_answers.len() {
+                return Err("OOD correction/answer count mismatch");
+            }
+            if round_idx > 0 && round.zk_stir_corrections.len() != round.queries.len() {
+                return Err("STIR correction/query count mismatch");
+            }
+
+            sim_oods.push(sim_ood);
+        }
+
+        // Cross-seed non-degeneracy: at least one ZK round was simulated.
+        if sim_oods.is_empty() {
+            return Err("no ZK rounds found in proof");
+        }
+
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(8))]
+
+        /// Theorem 4.5 composition distribution test: the composed simulator
+        /// reproduces mask commitments under matched-RNG coupling and produces
+        /// distributionally valid OOD/oracle outputs.
+        #[test]
+        fn prop_zk_composition_distribution_match(seed in 0u64..256) {
+            let result = run_zk_distribution_match(seed);
+            prop_assert!(
+                result.is_ok(),
+                "seed {seed}: {}",
+                result.err().unwrap_or("ok"),
+            );
+        }
     }
 }

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -2,6 +2,8 @@ use alloc::vec::Vec;
 
 use p3_challenger::{CanSampleUniformBits, FieldChallenger};
 use p3_field::{ExtensionField, Field};
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
 use p3_util::log2_strict_usize;
 
 /// Sample `t` distinct STIR query indices uniformly from the transcript.
@@ -119,6 +121,49 @@ where
     queries
 }
 
+/// Compute the r' correction to a STIR opening at position `challenge_idx`.
+///
+/// When the committed codeword is `Enc(f ∥ r')` (ZK padded, Suffix order),
+/// the opened row at `challenge_idx` includes the r' contribution. This
+/// function computes that contribution so the prover can subtract it before
+/// adding the eval to the sumcheck constraint.
+///
+/// `dft_root` must be the primitive `height`-th root of unity used by
+/// `dft_algebra_batch` when encoding the committed matrix. This is
+/// `F::two_adic_generator(log2(height))`, NOT `folded_domain_gen`.
+///
+/// Layout (Suffix, `commit_extension_zk`): coefficient `i` goes to
+/// row `i / width`, column `i % width`. DFT applied column-wise.
+/// r' starts at global index `msg_len`.
+pub(crate) fn zk_stir_correction<F, EF>(
+    r_prime: &[EF],
+    msg_len: usize,
+    width: usize,
+    height: usize,
+    challenge_idx: usize,
+    dft_root: F,
+    query_randomness: &[EF],
+) -> EF
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    let omega = dft_root;
+    let mut correction_row = alloc::vec![EF::ZERO; width];
+
+    for (k, &r_k) in r_prime.iter().enumerate() {
+        let global_idx = msg_len + k;
+        let col = global_idx % width;
+        let row = global_idx / width;
+        if row >= height {
+            break;
+        }
+        correction_row[col] += r_k * omega.exp_u64((challenge_idx * row) as u64);
+    }
+
+    Poly::new(correction_row).eval_ext::<F>(&Point::new(query_randomness.to_vec()))
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::collections::BTreeSet;
@@ -126,6 +171,7 @@ mod tests {
 
     use p3_challenger::{CanObserve, DuplexChallenger};
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::{PrimeCharacteristicRing, TwoAdicField};
     use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
     use proptest::prelude::*;
     use rand::rngs::SmallRng;
@@ -259,6 +305,85 @@ mod tests {
         // Length capped at the domain; output is the full domain ascending.
         assert_eq!(queries.len(), folded_domain_size);
         assert_eq!(queries, (0..folded_domain_size).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn zk_stir_correction_matches_dft_ground_truth() {
+        use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
+        use p3_matrix::Matrix;
+        use p3_matrix::dense::RowMajorMatrix;
+
+        // Small polynomial: 4 variables = 16 coefficients.
+        // Folding factor 2: width=4, msg rows = 4.
+        // inv_rate 2: height = 2 * 4 = 8.
+        let num_vars = 4usize;
+        let folding = 2usize;
+        let inv_rate = 2usize;
+        let width = 1 << folding; // 4
+        let msg_len = 1 << num_vars; // 16
+        let height = inv_rate * (msg_len / width); // 8
+        let total = height * width; // 32
+
+        // Deterministic polynomial coefficients.
+        let f_coeffs: Vec<EF> = (0..msg_len)
+            .map(|i| EF::from(F::from_u64((i as u64 + 1) * 7)))
+            .collect();
+
+        // r' randomness: num_queries worth. Use 5 for a small test.
+        let num_r_prime = 5;
+        let r_prime: Vec<EF> = (0..num_r_prime)
+            .map(|i| EF::from(F::from_u64((i as u64 + 1) * 13 + 3)))
+            .collect();
+
+        // Build padded coefficients: f ∥ r' ∥ zeros
+        let mut padded_coeffs = Vec::with_capacity(total);
+        padded_coeffs.extend_from_slice(&f_coeffs);
+        padded_coeffs.extend_from_slice(&r_prime);
+        padded_coeffs.resize(total, EF::ZERO);
+
+        // Build unpadded coefficients: f ∥ zeros
+        let mut plain_coeffs = Vec::with_capacity(total);
+        plain_coeffs.extend_from_slice(&f_coeffs);
+        plain_coeffs.resize(total, EF::ZERO);
+
+        // DFT both column-wise.
+        let dft: Radix2Dit<F> = Radix2Dit::default();
+        let padded_mat = RowMajorMatrix::new(padded_coeffs, width);
+        let plain_mat = RowMajorMatrix::new(plain_coeffs, width);
+        let padded_encoded = dft.dft_algebra_batch(padded_mat);
+        let plain_encoded = dft.dft_algebra_batch(plain_mat);
+
+        // Query randomness (folding_factor many elements).
+        let query_rand: Vec<EF> = (0..folding)
+            .map(|i| EF::from(F::from_u64(i as u64 * 11 + 5)))
+            .collect();
+
+        let dft_root = F::two_adic_generator(p3_util::log2_strict_usize(height));
+
+        // Test several challenge indices.
+        for challenge_idx in [0, 1, 3, 7] {
+            let padded_row: Vec<EF> = padded_encoded.row_slice(challenge_idx).unwrap().to_vec();
+            let plain_row: Vec<EF> = plain_encoded.row_slice(challenge_idx).unwrap().to_vec();
+
+            let padded_eval = Poly::new(padded_row).eval_ext::<F>(&Point::new(query_rand.clone()));
+            let plain_eval = Poly::new(plain_row).eval_ext::<F>(&Point::new(query_rand.clone()));
+            let ground_truth = padded_eval - plain_eval;
+
+            let correction = super::zk_stir_correction(
+                &r_prime,
+                msg_len,
+                width,
+                height,
+                challenge_idx,
+                dft_root,
+                &query_rand,
+            );
+
+            assert_eq!(
+                correction, ground_truth,
+                "correction mismatch at challenge_idx={challenge_idx}"
+            );
+        }
     }
 
     #[test]

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -302,10 +302,23 @@ where
             VariableOrder::Suffix => folding_randomness.reversed(),
         };
 
-        // Evaluate folded polynomial at each queried position.
+        // Evaluate folded polynomial at each queried position, applying
+        // ZK STIR corrections when the previous round used padded encoding.
+        let zk_corrections = if round_index > 0 && round_index < self.n_rounds() {
+            &proof.rounds[round_index].zk_stir_corrections
+        } else {
+            &[][..]
+        };
         let folds: Vec<_> = answers
             .into_iter()
-            .map(|answer| Poly::new(answer).eval_ext::<F>(&query_randomness))
+            .enumerate()
+            .map(|(i, answer)| {
+                let mut eval = Poly::new(answer).eval_ext::<F>(&query_randomness);
+                if let Some(&correction) = zk_corrections.get(i) {
+                    eval -= correction;
+                }
+                eval
+            })
             .collect();
 
         let stir_constraints = stir_challenges_indexes

--- a/whir/src/utils.rs
+++ b/whir/src/utils.rs
@@ -33,9 +33,6 @@ use p3_field::Field;
 ///
 /// `coeffs.len() == 0` returns `F::ZERO` (empty sum).
 //
-// TODO: remove `#[allow(dead_code)]` once the HVZK sumcheck and
-// code-switching modules land and call this helper.
-#[allow(dead_code)]
 #[inline]
 pub(crate) fn eval_ze_star_n<F: Field>(point: F, coeffs: &[F]) -> F {
     // Horner: rfold walks coefficients right-to-left:
@@ -77,9 +74,6 @@ pub(crate) fn eval_ze_star_n<F: Field>(point: F, coeffs: &[F]) -> F {
 ///
 /// Two Horner passes plus one `ρ^l` (`log_2 l` field multiplications).
 //
-// TODO: remove `#[allow(dead_code)]` once the HVZK code-switching module
-// lands and calls this helper.
-#[allow(dead_code)]
 #[inline]
 pub(crate) fn padded_ood_t1<F: Field>(point: F, msg: &[F], rand: &[F]) -> F {
     // ze*_l(ρ) · msg.


### PR DESCRIPTION
## Summary

Implements the HVZK code-switching round for WHIR (Construction 9.7, §9.4 of eprint 2026/391).

Closes #1587.

### Protocol

Per-round ZK code-switching when `zk == true`:

1. Commit target `g = Enc(f, r')` with encoding randomness (step 1).
2. Commit mask oracle `s = Enc_zk((r' ∥ s̃), r'')` hiding the target encoding randomness (step 1b).
3. OOD answer `y = ze_ood(ρ) · (f, r', s̃)` via private zero-evader (step 3, Lemma 9.3).
4. Additive STIR/OOD corrections: sumcheck polynomial stays unpadded; the r' contribution is computed separately and stored in the proof.

| Paper | Code |
|---|---|
| Construction 9.7 step 1 (commit g) | `commit_extension_zk` |
| Construction 9.7 step 1b (commit s) | `code_switch_zk::commit_mask` |
| Construction 9.7 steps 2-3 (OOD) | `padded_ood_t1` in `round()` |
| Construction 9.7 step 4 (in-domain) | Existing STIR path + `zk_stir_correction` |
| Lemma 9.8 (HVZK simulator) | `code_switch_zk::simulate()` |
| Theorem 4.5 (composition) | `prop_zk_composition_distribution_match` |

### Design decisions

- **Additive corrections** rather than extending the sumcheck polynomial. The r' contribution to OOD and STIR openings is subtracted by the verifier. Self-authenticated through the sumcheck identity.
- **Suffix ordering only** for ZK commits.
- **Last intermediate round is plain.** Terminal HVZK is handled by the base-case IOPP (#1585).
- **`zk: false` is byte-identical** to the existing non-ZK path.