### PR TITLE
symmetric: assert MultiField32Pad10 const parameters

### DIFF
--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -522,6 +522,11 @@ where
     PF: Field,
 {
     pub fn new(permutation: P) -> Result<Self, String> {
+        const {
+            assert!(RATE > 0);
+            assert!(RATE < WIDTH);
+            assert!(OUT <= WIDTH);
+        }
         if F::order() >= PF::order() {
             return Err(String::from("F::order() must be less than PF::order()"));
         }


### PR DESCRIPTION
## Summary

Follow up to #1629

- Add constructor-time const assertions for `MultiField32Pad10Sponge`.
- Check the same `RATE > 0`, `RATE < WIDTH`, and `OUT <= WIDTH` bounds used by the adjacent sponge constructors.
- Keep invalid const-parameter combinations from reaching the padding and squeeze paths.