### PR TITLE
fix: leverage packing for `Powers`

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1205,11 +1205,18 @@ impl<R: PrimeCharacteristicRing> Powers<R> {
             .zip(self)
             .for_each(|(out, next)| *out = next);
     }
+}
 
+impl<F: Field> Powers<F> {
     /// Wrapper for `self.take(n).collect()`.
+    ///
+    /// Bounded to `F: Field` on purpose: the body resolves `.collect()` to the inherent
+    /// [`BoundedPowers::collect`] SIMD fast path, which only exists under `F: Field`.
+    /// Defining this method under a wider bound (e.g. `PrimeCharacteristicRing`) would
+    /// silently fall back to `Iterator::collect` and bypass packed-field acceleration.
     #[inline]
     #[must_use]
-    pub fn collect_n(self, n: usize) -> Vec<R> {
+    pub fn collect_n(self, n: usize) -> Vec<F> {
         self.take(n).collect()
     }
 }


### PR DESCRIPTION
@adr1anh noticed that `Powers::collect_n` was defined under `R: PrimeCharacteristicRing`, but the SIMD fast path lives on `BoundedPowers` under the tighter `F: Field` bound.
Inside `collect_n`'s body, the compiler can't see the `Field`-bounded inherent method, so s`elf.take(n).collect()` silently resolves to Iterator::collect — serial scalar. Every `.collect_n(n)` call site in the workspace was getting the slow path, even for fields with `F::Packing` SIMD available.

This fixes it by moving the implementation of `collect_n` to `Powers<F: Field>` instead of `Powers<R: PrimeCharacteristicRing>`.

Note that this is not a performance critical component, but it seems worth fixing for the next minor release of Plonky3, out of consistency (benchmarks below for M4 pro, didn't feel like including the benchmarking file would be useful but I can bring it back).

```
  ┌───────────┬───────────────────────┬───────────────────────┬─────────────────────┐
  │     n     │ collect_n (post-fix)  │ iter_collect          │       speedup       │
  ├───────────┼───────────────────────┼───────────────────────┼─────────────────────┤
  │ 8         │ 52 ns                 │ 51 ns                 │ 1×                  │
  ├───────────┼───────────────────────┼───────────────────────┼─────────────────────┤
  │ 16        │ 31 ns                 │ 84 ns                 │ 2.7×                │
  ├───────────┼───────────────────────┼───────────────────────┼─────────────────────┤
  │ 1 024     │ 710 ns (1.44 Gelem/s) │ 3.07 µs (332 Melem/s) │ 4.3×                │
  ├───────────┼───────────────────────┼───────────────────────┼─────────────────────┤
  │ 65 536    │ 47 µs (1.39 Gelem/s)  │ 192 µs (340 Melem/s)  │ 4.1×                │
  ├───────────┼───────────────────────┼───────────────────────┼─────────────────────┤
  │ 1 048 576 │ 686 µs (1.53 Gelem/s) │ 3.05 ms (344 Melem/s) │ 4.4×                │
  └───────────┴───────────────────────┴───────────────────────┴─────────────────────┘ 
  ```