### PR TITLE
ci: reduce WHIR test cost

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -1,0 +1,46 @@
+name: Heavy CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  whir_exhaustive:
+    name: WHIR exhaustive tests
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-latest
+            features: "+avx2"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rs-stable
+
+      - name: Set flags
+        if: ${{ matrix.features }}
+        run: |
+          # Append AVX2 to existing flags so we keep -C debuginfo=0.
+          echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=${{ matrix.features }}" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test WHIR exhaustive sweep
+        run: cargo test -p p3-whir pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact
+
+      - name: Test WHIR exhaustive sweep with parallel
+        run: cargo test -p p3-whir --features parallel pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact

--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"
+  pull_request:
+    branches: [ "*" ]
+    paths:
+      - "whir/src/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "*" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -31,15 +35,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rs-stable
 
-      # Smarter cache for Rust builds; avoids overfilling the runner disk.
-      - uses: Swatinem/rust-cache@v2
-
       - name: Set flags
         if: ${{ matrix.features }}
         run: |
           # Append AVX2 to existing flags so we keep -C debuginfo=0.
           echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=${{ matrix.features }}" >> "$GITHUB_ENV"
 
+      # Smarter cache for Rust builds; avoids overfilling the runner disk.
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         run: cargo test

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -18,7 +18,7 @@ use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, W
 use crate::pcs::prover::WhirProver;
 use crate::sumcheck::layout::{Layout, PrefixProver, SuffixProver, Witness};
 use crate::sumcheck::tests::{random_table_specs, table_specs_to_tables};
-use crate::sumcheck::{OpeningProtocol, TableSpec};
+use crate::sumcheck::{OpeningProtocol, TableShape, TableSpec};
 
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
@@ -137,8 +137,113 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
     }
 }
 
+/// Smoke matrix covering each WHIR parameter axis at least once.
+///
+/// The full randomized sweep lives in [`test_whir_end_to_end_exhaustive`] and
+/// runs from the Heavy CI workflow.
 #[test]
 fn test_whir_end_to_end() {
+    let table_spec_sets = [
+        vec![
+            TableSpec::new(
+                TableShape::new(12, 3),
+                vec![vec![0, 1, 2], vec![0, 2], vec![1]],
+            ),
+            TableSpec::new(TableShape::new(10, 2), vec![vec![0, 1], vec![1]]),
+        ],
+        vec![TableSpec::new(
+            TableShape::new(14, 4),
+            vec![vec![0, 1, 2, 3], vec![0, 3]],
+        )],
+    ];
+
+    let smoke_cases = [
+        (
+            FoldingFactor::Constant(1),
+            SecurityAssumption::JohnsonBound,
+            0,
+            1,
+        ),
+        (
+            FoldingFactor::Constant(2),
+            SecurityAssumption::CapacityBound,
+            5,
+            2,
+        ),
+        (
+            FoldingFactor::Constant(3),
+            SecurityAssumption::UniqueDecoding,
+            10,
+            3,
+        ),
+        (
+            FoldingFactor::Constant(4),
+            SecurityAssumption::JohnsonBound,
+            5,
+            3,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(2, 1),
+            SecurityAssumption::CapacityBound,
+            10,
+            2,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(3, 1),
+            SecurityAssumption::UniqueDecoding,
+            0,
+            3,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(3, 2),
+            SecurityAssumption::JohnsonBound,
+            10,
+            3,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(5, 2),
+            SecurityAssumption::CapacityBound,
+            5,
+            3,
+        ),
+        (
+            FoldingFactor::Constant(2),
+            SecurityAssumption::UniqueDecoding,
+            0,
+            1,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(5, 2),
+            SecurityAssumption::JohnsonBound,
+            10,
+            1,
+        ),
+    ];
+
+    for (i, (folding_factor, soundness_type, pow_bits, rs_domain_initial_reduction_factor)) in
+        smoke_cases.into_iter().enumerate()
+    {
+        let specs = &table_spec_sets[i % table_spec_sets.len()];
+        run_whir_pcs::<PrefixProver<F, EF>>(
+            specs,
+            folding_factor,
+            soundness_type,
+            pow_bits,
+            rs_domain_initial_reduction_factor,
+        );
+        run_whir_pcs::<SuffixProver<F, EF>>(
+            specs,
+            folding_factor,
+            soundness_type,
+            pow_bits,
+            rs_domain_initial_reduction_factor,
+        );
+    }
+}
+
+#[test]
+#[ignore = "exhaustive WHIR configuration sweep; run from heavy CI"]
+fn test_whir_end_to_end_exhaustive() {
     const N: usize = 5;
 
     let folding_factors = [


### PR DESCRIPTION
Closes #1634.

## Why

`whir::pcs::tests::test_whir_end_to_end` currently runs 1,800 WHIR commit/open/verify lifecycles in normal PR CI:

- 20 valid `(folding_factor, rs_domain_initial_reduction_factor)` pairs
- 3 soundness modes
- 3 PoW settings
- `N = 5` random table specs
- 2 layouts (`PrefixProver` and `SuffixProver`)

That cost is then multiplied across the CI matrix by both `cargo test` and `cargo test --features parallel` on Linux, Linux AVX2, macOS, and Windows.

## What

This PR keeps WHIR coverage but moves the exhaustive parameter sweep out of per-push CI:

1. Replaces the normal `test_whir_end_to_end` with a deterministic 10-case smoke matrix, still run across both layouts, for 20 total lifecycles instead of 1,800.
2. Preserves the old randomized exhaustive sweep as `test_whir_end_to_end_exhaustive`, marked `#[ignore]`.
3. Adds a new `Heavy CI` workflow with `workflow_dispatch` and a nightly cron to run the exhaustive sweep on Ubuntu and Ubuntu AVX2, both with and without `--features parallel`.
4. Adds CI concurrency cancellation so rapid pushes do not queue multiple full matrices.
5. Moves the AVX2 `RUSTFLAGS` setup before `Swatinem/rust-cache@v2`, so the AVX2 cache key reflects the actual compilation environment.

## Smoke coverage

The new smoke matrix covers each main WHIR parameter axis at least once:

| Axis | Smoke coverage |
|---|---|
| `FoldingFactor` | all 8 values from the old sweep |
| Soundness mode | `JohnsonBound`, `CapacityBound`, `UniqueDecoding` |
| `pow_bits` | `0`, `5`, `10` |
| `rs_domain_initial_reduction_factor` | `1`, `2`, `3` |
| Layout | `PrefixProver`, `SuffixProver` |
| Opening shape | fixed one-table and two-table multi-point layouts |

The randomized shape coverage from the old test is preserved by the ignored exhaustive sweep and the new Heavy CI workflow.

## Validation

Ran locally:

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo +stable sort --workspace --grouped --check`
- `actionlint .github/workflows/ci.yml .github/workflows/ci-heavy.yml`
- `cargo test -p p3-whir pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact --list`
- `cargo test -p p3-whir --features parallel pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact --list`
- `cargo test -p p3-whir`
- `cargo test -p p3-whir --features parallel`
- `cargo test`
- `cargo test --features parallel`
- `cargo +stable clippy --all-targets -- -D warnings`
