### PR TITLE
ci: improve CI time

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -1,0 +1,50 @@
+name: CI (heavy)
+
+# Heavy / exhaustive tests that are too slow for per-PR CI.
+# Triggered nightly and on demand.
+#
+# Currently this runs the `#[ignore]`d exhaustive WHIR sweep (and any future
+# `#[ignore]`d exhaustive tests).
+on:
+  schedule:
+    # Every day at 03:17 UTC. Off-peak to avoid colliding with PR runs.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  ignored_tests:
+    name: Run ignored / exhaustive tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-latest
+            features: "+avx2"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rs-stable
+
+      - name: Set flags
+        if: ${{ matrix.features }}
+        run: |
+          echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=${{ matrix.features }}" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `--ignored` runs only the heavy tests
+      - name: Test (ignored) with parallel
+        run: cargo test --features parallel -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "*" ]
 
+# Stop early upon follow-up pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -31,15 +36,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rs-stable
 
-      # Smarter cache for Rust builds; avoids overfilling the runner disk.
-      - uses: Swatinem/rust-cache@v2
-
       - name: Set flags
         if: ${{ matrix.features }}
         run: |
           # Append AVX2 to existing flags so we keep -C debuginfo=0.
           echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=${{ matrix.features }}" >> "$GITHUB_ENV"
 
+      # Smarter cache for Rust builds; avoids overfilling the runner disk.
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         run: cargo test

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -137,8 +137,93 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
     }
 }
 
+// See `test_whir_end_to_end_exhaustive` for more exhaustive coverage.
 #[test]
 fn test_whir_end_to_end() {
+    // (folding_factor, soundness_type, pow_bits, rs_domain_initial_reduction_factor)
+    let configs: &[(FoldingFactor, SecurityAssumption, usize, usize)] = &[
+        (
+            FoldingFactor::Constant(1),
+            SecurityAssumption::JohnsonBound,
+            0,
+            1,
+        ),
+        (
+            FoldingFactor::Constant(2),
+            SecurityAssumption::CapacityBound,
+            5,
+            1,
+        ),
+        (
+            FoldingFactor::Constant(3),
+            SecurityAssumption::UniqueDecoding,
+            0,
+            2,
+        ),
+        (
+            FoldingFactor::Constant(4),
+            SecurityAssumption::JohnsonBound,
+            10,
+            3,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(2, 1),
+            SecurityAssumption::CapacityBound,
+            5,
+            1,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(3, 1),
+            SecurityAssumption::UniqueDecoding,
+            0,
+            1,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(3, 2),
+            SecurityAssumption::JohnsonBound,
+            5,
+            2,
+        ),
+        (
+            FoldingFactor::ConstantFromSecondRound(5, 2),
+            SecurityAssumption::CapacityBound,
+            10,
+            2,
+        ),
+    ];
+
+    let mut rng = SmallRng::seed_from_u64(7);
+    for &(folding_factor, soundness_type, pow_bits, rs_domain_initial_reduction_factor) in configs {
+        // Same well-formedness invariant the exhaustive sweep enforces by skipping.
+        assert!(
+            folding_factor.at_round(0) >= rs_domain_initial_reduction_factor,
+            "smoke config must satisfy first-round folding >= RS-domain reduction",
+        );
+        let specs = random_table_specs(&mut rng, folding_factor.at_round(0));
+        run_whir_pcs::<PrefixProver<F, EF>>(
+            &specs,
+            folding_factor,
+            soundness_type,
+            pow_bits,
+            rs_domain_initial_reduction_factor,
+        );
+        run_whir_pcs::<SuffixProver<F, EF>>(
+            &specs,
+            folding_factor,
+            soundness_type,
+            pow_bits,
+            rs_domain_initial_reduction_factor,
+        );
+    }
+}
+
+/// Exhaustive WHIR sweep over the full parameter cross-product.
+///
+/// Too slow for per-PR CI (~1,800 commit/open/verify lifecycles); run via the
+/// scheduled `heavy` workflow or locally with `cargo test -- --ignored`.
+#[test]
+#[ignore = "exhaustive WHIR sweep — run via scheduled CI or `cargo test -- --ignored`"]
+fn test_whir_end_to_end_exhaustive() {
     const N: usize = 5;
 
     let folding_factors = [


### PR DESCRIPTION
## Summary

Split the heavy WHIR test causing the massive CI regression into a smaller and the (already exhausting) exhaustive one.
The former is ran as part of the default test suite, the latter is flagged `#[ignored]` and run `nightly` + `on-demand` for work on WHIR that may require some additional scrutiny from CI.

Also added suggestion from #1634 to stop early existing runs on follow-up pushes.

closes #1634 

