### PR TITLE
feat: add WASM32 SIMD128 support for Goldilocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,21 +104,36 @@ jobs:
           cargo build --verbose --target ${{ env.target }} -p p3-util
 
   check_wasm32_simd128:
-    name: Build wasm32 simd128
+    name: Test wasm32 simd128
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     env:
-      target: wasm32-unknown-unknown
+      # Compile-coverage target for browser-style consumers.
+      build_target: wasm32-unknown-unknown
+      # Runtime target — wasi exposes the syscalls (clock, write) wasmtime needs
+      # to actually execute the SIMD tests and the smoke/bench binaries.
+      run_target: wasm32-wasip1
+      RUSTFLAGS: -C debuginfo=0 -C target-feature=+simd128
+      # Tell cargo to invoke the built `.wasm` via wasmtime.
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ env.target }}
+          targets: ${{ env.build_target }}, ${{ env.run_target }}
       - uses: Swatinem/rust-cache@v2
-      - name: Build p3-goldilocks with +simd128
-        run: cargo build --verbose --target ${{ env.target }} -p p3-goldilocks
-        env:
-          RUSTFLAGS: -C debuginfo=0 -C target-feature=+simd128
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+      - name: Build p3-goldilocks for wasm32-unknown-unknown
+        run: cargo build --verbose --target ${{ env.build_target }} -p p3-goldilocks
+      - name: Run wasm32+simd128 SIMD tests under wasmtime
+        run: cargo test --release --target ${{ env.run_target }} -p p3-goldilocks --lib wasm32_simd128
+      - name: Run wasm_smoke under wasmtime
+        run: cargo run --release --target ${{ env.run_target }} --bin wasm_smoke -p p3-goldilocks
+      - name: Run wasm_bench under wasmtime
+        run: cargo run --release --target ${{ env.run_target }} --bin wasm_bench -p p3-goldilocks
 
   lint:
     name: Formatting and Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
           cargo build --verbose --target ${{ env.target }} -p p3-dft
           cargo build --verbose --target ${{ env.target }} -p p3-field
           cargo build --verbose --target ${{ env.target }} -p p3-fri
-          cargo build --verbose --target ${{ env.target }} -p p3-goldilocks
+          # `--lib` here because p3-goldilocks has host-only bins that require std and would otherwise fail
+          cargo build --verbose --target ${{ env.target }} -p p3-goldilocks --lib
           cargo build --verbose --target ${{ env.target }} -p p3-keccak
           cargo build --verbose --target ${{ env.target }} -p p3-keccak-air
           cargo build --verbose --target ${{ env.target }} -p p3-koala-bear

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,23 @@ jobs:
           cargo build --verbose --target ${{ env.target }} -p p3-uni-stark
           cargo build --verbose --target ${{ env.target }} -p p3-util
 
+  check_wasm32_simd128:
+    name: Build wasm32 simd128
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    env:
+      target: wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build p3-goldilocks with +simd128
+        run: cargo build --verbose --target ${{ env.target }} -p p3-goldilocks
+        env:
+          RUSTFLAGS: -C debuginfo=0 -C target-feature=+simd128
+
   lint:
     name: Formatting and Clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ libm = "0.2"
 num-bigint = { version = "0.4.6", default-features = false }
 paste = "1.0.15"
 postcard = { version = "1.1.3", default-features = false }
-proptest = "1.10"
+proptest = { version = "1.10", default-features = false, features = ["std"] }
 rand = { version = "0.10.0", default-features = false }
 rand_xoshiro = "0.8.0"
 rayon = "1.11.0"

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -9,13 +9,16 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+# criterion pulls rayon transitively and rayon does not build on wasi.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+criterion.workspace = true
+
 [dependencies]
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 p3-util.workspace = true
 
-criterion.workspace = true
 num-bigint.workspace = true
 proptest.workspace = true
 rand.workspace = true

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod bench_func;
 pub mod dft_testing;
 pub mod extension_testing;
@@ -14,6 +15,7 @@ use alloc::vec::Vec;
 use core::array;
 use core::iter::successors;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use bench_func::*;
 pub use dft_testing::*;
 pub use extension_testing::*;

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -9,6 +9,10 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+# criterion pulls rayon transitively and rayon does not build on wasi.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion.workspace = true
+
 [dependencies]
 p3-challenger.workspace = true
 p3-dft.workspace = true
@@ -27,7 +31,6 @@ serde = { workspace = true, features = ["derive"] }
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }
 
-criterion.workspace = true
 proptest.workspace = true
 rand.workspace = true
 

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -1,0 +1,136 @@
+//! Coarse-grained micro-benchmark for the `wasm32+simd128`
+//! `PackedGoldilocksWasmSimd128` backend.
+//!
+//! Criterion does not build on wasm targets (its `rayon` dep won't compile on
+//! wasi, and its harness assumes a host process model). This binary stands in
+//! as a small, hand-rolled timer: each op is exercised in a tight dependent
+//! chain so the optimizer cannot fold or vectorize the loop away, and we print
+//! `Instant::now()` deltas as ns/op.
+//!
+//! Numbers under `wasmtime` are not representative of production wasm runtimes
+//! (V8 / SpiderMonkey), do not treat them as absolute performance.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="-C target-feature=+simd128" \
+//!   cargo run --release --target wasm32-wasip1 \
+//!     --bin wasm_bench -p p3-goldilocks
+//! ```
+
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+fn main() {
+    eprintln!(
+        "wasm_bench is a no-op on this target. Re-run with \
+         `cargo run --release --target wasm32-wasip1 --bin wasm_bench -p p3-goldilocks` \
+         and RUSTFLAGS=\"-C target-feature=+simd128\"."
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn main() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_field::PrimeCharacteristicRing;
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    // Number of dependent ops per timed run. Tuned so a single run takes ~ms
+    // under wasmtime — large enough to drown out Instant resolution noise,
+    // small enough that CI doesn't spend minutes here.
+    const N: u64 = 1_000_000;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>14}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    let a = PackedGoldilocksWasmSimd128([
+        Goldilocks::new(0x1234_5678_9abc_def0),
+        Goldilocks::new(0xfedc_ba98_7654_3210),
+    ]);
+    let b = PackedGoldilocksWasmSimd128([
+        Goldilocks::new(0x0fed_cba9_8765_4321),
+        Goldilocks::new(0xabcd_ef01_2345_6789),
+    ]);
+
+    // Each loop chains the result back into the input so the optimizer cannot
+    // hoist the op outside the loop. `black_box` further suppresses constant
+    // folding across the iteration boundary.
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc) + black_box(b);
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("add", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc) - black_box(b);
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("sub", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = -black_box(acc);
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("neg", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc) * black_box(b);
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("mul", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc).double();
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("double", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc).square();
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("square", N, dt);
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            acc = black_box(acc).halve();
+        }
+        let dt = t0.elapsed().as_nanos();
+        let _ = black_box(acc);
+        report("halve", N, dt);
+    }
+}

--- a/goldilocks/src/bin/wasm_smoke.rs
+++ b/goldilocks/src/bin/wasm_smoke.rs
@@ -1,0 +1,201 @@
+//! Smoke test for the `wasm32+simd128` `PackedGoldilocksWasmSimd128` backend.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="-C target-feature=+simd128" \
+//!   cargo run --release --target wasm32-wasip1 \
+//!     --bin wasm_smoke -p p3-goldilocks
+//! ```
+//! (requires the `wasm32-wasip1` toolchain target and a `wasmtime` runner —
+//! either via `CARGO_TARGET_WASM32_WASIP1_RUNNER=wasmtime` env var or a
+//! `[target.wasm32-wasip1] runner = "wasmtime"` entry in `.cargo/config.toml`).
+//!
+//! On non-wasm32 targets this binary is a no-op.
+
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+fn main() {
+    eprintln!(
+        "wasm_smoke is a no-op on this target. Re-run with \
+         `cargo run --target wasm32-wasip1 --bin wasm_smoke -p p3-goldilocks` \
+         and RUSTFLAGS=\"-C target-feature=+simd128\"."
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn main() {
+    use p3_field::{Field, PackedFieldPow2, PackedValue, PrimeCharacteristicRing, PrimeField64};
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    const P: u64 = Goldilocks::ORDER_U64;
+
+    // Distinct lane values catch lane-swap bugs.
+    let pack =
+        |a: u64, b: u64| PackedGoldilocksWasmSimd128([Goldilocks::new(a), Goldilocks::new(b)]);
+
+    // ---- add ---------------------------------------------------------------
+    let cases: &[(u64, u64, u64, u64)] = &[
+        (0, 0, 0, 0),
+        (1, 2, 3, 4),
+        (P - 1, 1, 1, P - 1), // both lanes wrap differently
+        (P - 1, P - 1, P - 1, P - 1),
+        (0xffff_ffff, 0xffff_ffff_ffff_ffff, 1, 1),
+    ];
+    for &(a0, a1, b0, b1) in cases {
+        let got = pack(a0, a1) + pack(b0, b1);
+        let want = [
+            Goldilocks::new(a0) + Goldilocks::new(b0),
+            Goldilocks::new(a1) + Goldilocks::new(b1),
+        ];
+        assert_eq!(
+            got.0, want,
+            "add mismatch: ({a0:#x},{a1:#x}) + ({b0:#x},{b1:#x})"
+        );
+    }
+    println!("add: OK");
+
+    // ---- sub ---------------------------------------------------------------
+    for &(a0, a1, b0, b1) in cases {
+        let got = pack(a0, a1) - pack(b0, b1);
+        let want = [
+            Goldilocks::new(a0) - Goldilocks::new(b0),
+            Goldilocks::new(a1) - Goldilocks::new(b1),
+        ];
+        assert_eq!(
+            got.0, want,
+            "sub mismatch: ({a0:#x},{a1:#x}) - ({b0:#x},{b1:#x})"
+        );
+    }
+    println!("sub: OK");
+
+    // ---- neg ---------------------------------------------------------------
+    for &a in &[0u64, 1, 2, P - 1, P - 2, 0xffff_ffff, 0xffff_ffff_ffff_ffff] {
+        let got = -PackedGoldilocksWasmSimd128([Goldilocks::new(a), Goldilocks::new(a)]);
+        let want = -Goldilocks::new(a);
+        assert_eq!(got.0, [want, want], "neg mismatch: {a:#x}");
+    }
+    println!("neg: OK");
+
+    // ---- mul ---------------------------------------------------------------
+    // Includes the `(P-1)^2` boundary, which is the worst case for `reduce128`.
+    let mul_cases: &[(u64, u64)] = &[
+        (0, 0),
+        (1, 1),
+        (2, 3),
+        (P - 1, 2),
+        (P - 1, P - 1),
+        (0xffff_ffff, 0xffff_ffff),
+        (0x1234_5678_9abc_def0, 0xfedc_ba98_7654_3210),
+    ];
+    for &(a, b) in mul_cases {
+        let got = PackedGoldilocksWasmSimd128([Goldilocks::new(a), Goldilocks::new(a)])
+            * PackedGoldilocksWasmSimd128([Goldilocks::new(b), Goldilocks::new(b)]);
+        let want = Goldilocks::new(a) * Goldilocks::new(b);
+        assert_eq!(got.0, [want, want], "mul mismatch: {a:#x} * {b:#x}");
+    }
+    println!("mul: OK");
+
+    // ---- halve -------------------------------------------------------------
+    // Mixed-parity lanes exercise both branches of `halve`.
+    for &(a, b) in &[
+        (0u64, 0u64),
+        (2, 4),
+        (1, 3),
+        (0xffff_fffe, 0xffff_ffff),
+        (P - 2, P - 1),
+    ] {
+        let got = pack(a, b).halve();
+        let want = [Goldilocks::new(a).halve(), Goldilocks::new(b).halve()];
+        assert_eq!(got.0, want, "halve mismatch: ({a:#x},{b:#x})");
+    }
+    println!("halve: OK");
+
+    // ---- double ------------------------------------------------------------
+    // Hits both halves of the canonicalize-then-add path used by `double`.
+    for &(a, b) in &[
+        (0u64, 0u64),
+        (1, P - 1),
+        (P - 1, P - 1),
+        (P - 2, 2),
+        (0xffff_ffff, 0xffff_ffff_ffff_ffff),
+    ] {
+        let got = pack(a, b).double();
+        let want = [Goldilocks::new(a).double(), Goldilocks::new(b).double()];
+        assert_eq!(got.0, want, "double mismatch: ({a:#x},{b:#x})");
+    }
+    println!("double: OK");
+
+    // ---- square ------------------------------------------------------------
+    for &a in &[0u64, 1, 2, P - 1, 0xdead_beef_cafe_babe] {
+        let p = PackedGoldilocksWasmSimd128([Goldilocks::new(a), Goldilocks::new(a)]);
+        let got = p.square();
+        let want = Goldilocks::new(a).square();
+        assert_eq!(got.0, [want, want], "square mismatch: {a:#x}");
+    }
+    println!("square: OK");
+
+    // ---- interleave --------------------------------------------------------
+    let v0 = pack(1, 2);
+    let v1 = pack(3, 4);
+    let (r0, r1) = v0.interleave(v1, 1);
+    assert_eq!(
+        r0.0,
+        [Goldilocks::new(1), Goldilocks::new(3)],
+        "interleave block_len=1 lane 0"
+    );
+    assert_eq!(
+        r1.0,
+        [Goldilocks::new(2), Goldilocks::new(4)],
+        "interleave block_len=1 lane 1"
+    );
+    let (r0, r1) = v0.interleave(v1, 2);
+    assert_eq!(r0.0, v0.0, "interleave block_len=2 lane 0");
+    assert_eq!(r1.0, v1.0, "interleave block_len=2 lane 1");
+    println!("interleave: OK");
+
+    // ---- inverse -----------------------------------------------------------
+    // Round-trip via the scalar inverse to validate that mul+reduce composes
+    // cleanly with the inverse algorithm — catches reduction errors that pure
+    // `a * b` tests don't surface because they only exercise one direction.
+    for &(a, b) in &[(1u64, 2u64), (3, 7), (P - 1, 2), (0xffff_ffff, 0xdead_beef)] {
+        let av = Goldilocks::new(a);
+        let bv = Goldilocks::new(b);
+        let packed = pack(a, b)
+            * pack(
+                av.inverse().as_canonical_u64(),
+                bv.inverse().as_canonical_u64(),
+            );
+        assert_eq!(
+            packed.0,
+            [Goldilocks::ONE, Goldilocks::ONE],
+            "a * a^-1 != 1 for ({a:#x},{b:#x})"
+        );
+    }
+    println!("inverse: OK");
+
+    // ---- mixed scalar op ---------------------------------------------------
+    // Exercises the `Algebra<Goldilocks>` / `impl_*_base_field!` wiring: a
+    // packed + scalar add must match a per-lane add against `broadcast(s)`.
+    for &(a, b, s) in &[
+        (0u64, 0u64, 0u64),
+        (1, P - 1, 5),
+        (P - 1, P - 2, P - 1),
+        (0xffff_ffff_ffff_ffff, 1, 0xdead_beef),
+    ] {
+        let sv = Goldilocks::new(s);
+        let got = pack(a, b) + sv;
+        let want = [Goldilocks::new(a) + sv, Goldilocks::new(b) + sv];
+        assert_eq!(
+            got.0, want,
+            "packed + scalar mismatch: ({a:#x},{b:#x}) + {s:#x}"
+        );
+    }
+    println!("mixed scalar add: OK");
+
+    // ---- PackedValue from_fn round-trip ------------------------------------
+    let lanes = [Goldilocks::new(0x42), Goldilocks::new(0xdead_beef)];
+    let packed = PackedGoldilocksWasmSimd128::from_fn(|i| lanes[i]);
+    assert_eq!(packed.0, lanes, "from_fn round-trip mismatch");
+    println!("from_fn: OK");
+
+    println!("all packed wasm32+simd128 ops match scalar Goldilocks");
+}

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -376,7 +376,7 @@ impl Field for Goldilocks {
     type Packing = crate::PackedGoldilocksNeon;
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    type Packing = crate::PackedGoldilocksWasm;
+    type Packing = crate::PackedGoldilocksWasmSimd128;
 
     #[cfg(not(any(
         all(

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -375,6 +375,9 @@ impl Field for Goldilocks {
     #[cfg(target_arch = "aarch64")]
     type Packing = crate::PackedGoldilocksNeon;
 
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    type Packing = crate::PackedGoldilocksWasm;
+
     #[cfg(not(any(
         all(
             target_arch = "x86_64",
@@ -383,6 +386,7 @@ impl Field for Goldilocks {
         ),
         all(target_arch = "x86_64", target_feature = "avx512f"),
         target_arch = "aarch64",
+        all(target_arch = "wasm32", target_feature = "simd128"),
     )))]
     type Packing = Self;
 

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -40,3 +40,9 @@ mod x86_64_avx512;
 
 #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub use x86_64_avx512::*;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+mod wasm32_simd128;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub use wasm32_simd128::*;

--- a/goldilocks/src/wasm32_simd128/mod.rs
+++ b/goldilocks/src/wasm32_simd128/mod.rs
@@ -1,0 +1,2 @@
+mod packing;
+pub use packing::*;

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -1,0 +1,444 @@
+use alloc::vec::Vec;
+use core::arch::wasm32::{
+    i32x4_shuffle, i64x2_add, i64x2_extmul_low_u32x4, i64x2_gt, i64x2_shl, i64x2_shuffle,
+    i64x2_sub, u64x2_shr, u64x2_splat, v128, v128_and, v128_andnot, v128_or, v128_xor,
+};
+use core::fmt::Debug;
+use core::iter::{Product, Sum};
+use core::mem::transmute;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use p3_field::exponentiation::exp_10540996611094048183;
+use p3_field::op_assign_macros::{
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
+    impl_sum_prod_base_field, ring_sum,
+};
+use p3_field::{
+    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
+};
+use p3_util::reconstitute_from_base;
+use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
+
+use crate::{Goldilocks, P};
+
+const WIDTH: usize = 2;
+
+/// Equal to `2^32 - 1 = 2^64 mod P`.
+const EPSILON: u64 = Goldilocks::ORDER_U64.wrapping_neg();
+
+// Compile-time guard: `PackedGoldilocksWasm` is only sound to transmute to/from `v128` if
+// its byte layout matches. `[Goldilocks; 2]` === `[u64; 2]` === `v128` (16 bytes total).
+const _LAYOUT_INVARIANTS: () = {
+    assert!(size_of::<[Goldilocks; WIDTH]>() == size_of::<v128>());
+    assert!(size_of::<Goldilocks>() == size_of::<u64>());
+};
+
+/// Vectorized wasm32-simd128 implementation of `Goldilocks` arithmetic.
+///
+/// `repr(transparent)` over `[Goldilocks; WIDTH]` so we can `transmute` freely
+/// between `[Goldilocks; 2]`, `[u64; 2]`, and `v128`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
+#[must_use]
+pub struct PackedGoldilocksWasm(pub [Goldilocks; WIDTH]);
+
+impl PackedGoldilocksWasm {
+    #[inline]
+    #[must_use]
+    pub(crate) fn to_vector(self) -> v128 {
+        // SAFETY: see `_LAYOUT_INVARIANTS` — byte layout matches.
+        unsafe { transmute(self) }
+    }
+
+    /// Make a packed field vector from an arch-specific vector.
+    ///
+    /// Elements of `Goldilocks` are allowed to be arbitrary `u64`s so this function
+    /// is safe unlike the `Mersenne31/MontyField31` variants.
+    #[inline]
+    pub(crate) fn from_vector(vector: v128) -> Self {
+        // SAFETY: see `_LAYOUT_INVARIANTS` — byte layout matches.
+        unsafe { transmute(vector) }
+    }
+
+    /// Copy `value` to all positions in a packed vector. This is the same as
+    /// `From<Goldilocks>::from`, but `const`.
+    #[inline]
+    const fn broadcast(value: Goldilocks) -> Self {
+        Self([value; WIDTH])
+    }
+}
+
+impl From<Goldilocks> for PackedGoldilocksWasm {
+    fn from(x: Goldilocks) -> Self {
+        Self::broadcast(x)
+    }
+}
+
+impl Add for PackedGoldilocksWasm {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self::from_vector(add(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl Sub for PackedGoldilocksWasm {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self::from_vector(sub(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl Neg for PackedGoldilocksWasm {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self::from_vector(neg(self.to_vector()))
+    }
+}
+
+impl Mul for PackedGoldilocksWasm {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self::from_vector(mul(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl_add_assign!(PackedGoldilocksWasm);
+impl_sub_assign!(PackedGoldilocksWasm);
+impl_mul_methods!(PackedGoldilocksWasm);
+ring_sum!(PackedGoldilocksWasm);
+impl_rng!(PackedGoldilocksWasm);
+
+impl PrimeCharacteristicRing for PackedGoldilocksWasm {
+    type PrimeSubfield = Goldilocks;
+
+    const ZERO: Self = Self::broadcast(Goldilocks::ZERO);
+    const ONE: Self = Self::broadcast(Goldilocks::ONE);
+    const TWO: Self = Self::broadcast(Goldilocks::TWO);
+    const NEG_ONE: Self = Self::broadcast(Goldilocks::NEG_ONE);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        f.into()
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        Self::from_vector(halve(self.to_vector()))
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        Self::from_vector(square(self.to_vector()))
+    }
+
+    #[inline]
+    fn zero_vec(len: usize) -> Vec<Self> {
+        // SAFETY: this is a repr(transparent) wrapper around an array.
+        unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
+    }
+}
+
+impl InjectiveMonomial<7> for PackedGoldilocksWasm {}
+
+impl PermutationMonomial<7> for PackedGoldilocksWasm {
+    /// In the field `Goldilocks`, `a^{1/7}` is equal to a^{10540996611094048183}.
+    ///
+    /// This follows from the calculation `7*10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1)`.
+    fn injective_exp_root_n(&self) -> Self {
+        exp_10540996611094048183(*self)
+    }
+}
+
+impl_add_base_field!(PackedGoldilocksWasm, Goldilocks);
+impl_sub_base_field!(PackedGoldilocksWasm, Goldilocks);
+impl_mul_base_field!(PackedGoldilocksWasm, Goldilocks);
+impl_div_methods!(PackedGoldilocksWasm, Goldilocks);
+impl_packed_field_div!(PackedGoldilocksWasm);
+impl_sum_prod_base_field!(PackedGoldilocksWasm, Goldilocks);
+
+impl Algebra<Goldilocks> for PackedGoldilocksWasm {
+    // Matches the aarch64 NEON chunk for the same WIDTH=2 lane layout.
+    const BATCHED_LC_CHUNK: usize = 2;
+}
+
+impl_packed_value!(PackedGoldilocksWasm, Goldilocks, WIDTH);
+
+unsafe impl PackedField for PackedGoldilocksWasm {
+    type Scalar = Goldilocks;
+}
+
+/// Interleave two `u64x2` vectors at the element level.
+/// For `block_len = 1`: `[a0, a1] x [b0, b1] -> ([a0, b0], [a1, b1])`.
+#[inline]
+pub fn interleave_u64(v0: v128, v1: v128) -> (v128, v128) {
+    // `i64x2_shuffle::<I0, I1>(a, b)` selects lanes from `concat(a; b)`, where 0,1 are
+    // lanes of `a` and 2,3 are lanes of `b`.
+    let r0 = i64x2_shuffle::<0, 2>(v0, v1);
+    let r1 = i64x2_shuffle::<1, 3>(v0, v1);
+    (r0, r1)
+}
+
+unsafe impl PackedFieldPow2 for PackedGoldilocksWasm {
+    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
+        let (v0, v1) = (self.to_vector(), other.to_vector());
+        let (res0, res1) = match block_len {
+            1 => interleave_u64(v0, v1),
+            2 => (v0, v1),
+            _ => panic!("unsupported block length"),
+        };
+        (Self::from_vector(res0), Self::from_vector(res1))
+    }
+}
+
+// Resources:
+// 1. WebAssembly SIMD proposal: https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md
+// 2. The arithmetic recipes are the standard Goldilocks SIMD recipes, modeled on Plonky3's existing
+//    `aarch64_neon` and `x86_64_avx2` backends with the following intrinsic correspondence:
+//
+//      uint64x2_t                 → v128
+//      veorq_u64(a, b)            → v128_xor(a, b)
+//      vaddq_u64(a, b)            → i64x2_add(a, b)
+//      vsubq_u64(a, b)            → i64x2_sub(a, b)
+//      vcgtq_s64(a, b)            → i64x2_gt(a, b)
+//      vbicq_u64(a, b)            → v128_andnot(a, b)  (= a & !b)
+//      vshrq_n_u64::<32>(a)       → u64x2_shr(a, 32)
+//      vdupq_n_u64(x)             → u64x2_splat(x)
+//      vreinterpretq_s64_u64(x)   → identity (v128 is type-erased)
+
+const SIGN_BIT: v128 =
+    unsafe { transmute::<[u64; WIDTH], v128>([0x8000_0000_0000_0000u64; WIDTH]) };
+const SHIFTED_FIELD_ORDER: v128 = unsafe {
+    transmute::<[u64; WIDTH], v128>([Goldilocks::ORDER_U64 ^ 0x8000_0000_0000_0000u64; WIDTH])
+};
+const EPSILON_VEC: v128 = unsafe { transmute::<[u64; WIDTH], v128>([EPSILON; WIDTH]) };
+
+/// Add `2^63` with overflow. Needed to emulate unsigned comparisons.
+#[inline(always)]
+fn shift(x: v128) -> v128 {
+    v128_xor(x, SIGN_BIT)
+}
+
+/// If `x_s < SHIFTED_FIELD_ORDER` (signed comparison), add `EPSILON` to canonicalize.
+/// The neon impl uses `vbicq_u64(EPSILON_VEC, mask) = EPSILON_VEC & !mask`. wasm32's
+/// `v128_andnot(a, b) = a & !b` matches.
+#[inline(always)]
+fn canonicalize_s(x_s: v128) -> v128 {
+    let mask = i64x2_gt(SHIFTED_FIELD_ORDER, x_s);
+    let wrapback_amt = v128_andnot(EPSILON_VEC, mask);
+    i64x2_add(x_s, wrapback_amt)
+}
+
+/// Addition `u64 + u64 -> u64`. Assumes that `x + y < 2^64 + FIELD_ORDER`. The second
+/// argument is pre-shifted by `1 << 63`. The result is similarly shifted.
+#[inline(always)]
+fn add_no_double_overflow_64_64s_s(x: v128, y_s: v128) -> v128 {
+    let res_wrapped_s = i64x2_add(x, y_s);
+    // Overflow detected: `y_s > res_wrapped_s` (signed). On overflow, add `EPSILON`.
+    let mask = i64x2_gt(y_s, res_wrapped_s);
+    let wrapback_amt = u64x2_shr(mask, 32);
+    i64x2_add(res_wrapped_s, wrapback_amt)
+}
+
+/// Goldilocks modular addition. Computes `x + y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
+#[inline]
+fn add(x: v128, y: v128) -> v128 {
+    let y_s = shift(y);
+    let res_s = add_no_double_overflow_64_64s_s(x, canonicalize_s(y_s));
+    shift(res_s)
+}
+
+/// Goldilocks modular subtraction. Computes `x - y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
+#[inline]
+fn sub(x: v128, y: v128) -> v128 {
+    let y_s = canonicalize_s(shift(y));
+    let x_s = shift(x);
+    let mask = i64x2_gt(y_s, x_s);
+    let wrapback_amt = u64x2_shr(mask, 32);
+    let res_wrapped = i64x2_sub(x_s, y_s);
+    i64x2_sub(res_wrapped, wrapback_amt)
+}
+
+/// Goldilocks modular negation. Computes `-x mod FIELD_ORDER`.
+///
+/// Input can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
+#[inline]
+fn neg(y: v128) -> v128 {
+    let y_s = shift(y);
+    i64x2_sub(SHIFTED_FIELD_ORDER, canonicalize_s(y_s))
+}
+
+/// Halve a vector of Goldilocks field elements.
+#[inline(always)]
+pub(crate) fn halve(input: v128) -> v128 {
+    let one = u64x2_splat(1);
+    let zero = u64x2_splat(0);
+    let half_v = u64x2_splat(P.div_ceil(2));
+    let least_bit = v128_and(input, one);
+    let t = u64x2_shr(input, 1);
+    // `neg_least_bit` is 0 or -1 (all bits set within each lane).
+    let neg_least_bit = i64x2_sub(zero, least_bit);
+    let maybe_half = v128_and(half_v, neg_least_bit);
+    i64x2_add(t, maybe_half)
+}
+
+// ============================================================================
+// Multiplication: schoolbook 64×64 → 128 + Goldilocks reduction.
+// ============================================================================
+
+/// Pack the low 32 bits of each `u64` lane into `u32` lanes 0 and 1.
+/// Input  `u32x4` view: `[a0_lo, a0_hi, a1_lo, a1_hi]`.
+/// Output `u32x4` view: `[a0_lo, a1_lo,    *,     *]`.
+#[inline(always)]
+fn lo32(a: v128) -> v128 {
+    i32x4_shuffle::<0, 2, 0, 0>(a, a)
+}
+
+/// Pack the high 32 bits of each `u64` lane into `u32` lanes 0 and 1.
+/// Input  `u32x4` view: `[a0_lo, a0_hi, a1_lo, a1_hi]`.
+/// Output `u32x4` view: `[a0_hi, a1_hi,    *,     *]`.
+#[inline(always)]
+fn hi32(a: v128) -> v128 {
+    i32x4_shuffle::<1, 3, 0, 0>(a, a)
+}
+
+/// 32×32 → 64-bit unsigned multiply, lane-aligned.
+#[inline(always)]
+fn mul_u32_lanes(a_packed: v128, b_packed: v128) -> v128 {
+    i64x2_extmul_low_u32x4(a_packed, b_packed)
+}
+
+/// Full 64×64 → 128 multiply per lane. Returns `(hi, lo)` where the 128-bit product
+/// per lane equals `lo + hi * 2^64`. Translation of the AVX2 `mul64_64`.
+#[inline]
+fn mul64_64(x: v128, y: v128) -> (v128, v128) {
+    let x_lo = lo32(x);
+    let x_hi = hi32(x);
+    let y_lo = lo32(y);
+    let y_hi = hi32(y);
+
+    // Four pairwise 32×32 → 64 products.
+    let ll = mul_u32_lanes(x_lo, y_lo); // x_lo * y_lo
+    let lh = mul_u32_lanes(x_lo, y_hi); // x_lo * y_hi
+    let hl = mul_u32_lanes(x_hi, y_lo);
+    let hh = mul_u32_lanes(x_hi, y_hi);
+
+    // Bignum addition (AVX2 algorithm verbatim):
+    //   t0 = hl + (ll >> 32)              (no overflow: ≤ (2^32-1)^2 + (2^32-1) < 2^64)
+    //   t1 = lh + (t0 & 0xFFFFFFFF)       (no overflow)
+    //   t2 = hh + (t0 >> 32)              (no overflow)
+    //   res_hi = t2 + (t1 >> 32)          (no overflow)
+    //   res_lo = (ll & 0xFFFFFFFF) | ((t1 & 0xFFFFFFFF) << 32)
+    let ll_hi = u64x2_shr(ll, 32);
+    let t0 = i64x2_add(hl, ll_hi);
+    let t0_lo = v128_and(t0, EPSILON_VEC);
+    let t0_hi = u64x2_shr(t0, 32);
+    let t1 = i64x2_add(lh, t0_lo);
+    let t2 = i64x2_add(hh, t0_hi);
+    let t1_hi = u64x2_shr(t1, 32);
+    let res_hi = i64x2_add(t2, t1_hi);
+
+    let ll_lo32 = v128_and(ll, EPSILON_VEC);
+    let t1_lo32 = v128_and(t1, EPSILON_VEC);
+    let t1_shifted = i64x2_shl(t1_lo32, 32);
+    let res_lo = v128_or(ll_lo32, t1_shifted);
+
+    (res_hi, res_lo)
+}
+
+/// Goldilocks addition of a "small" number. `x_s` is pre-shifted by `2^63`. `y` is
+/// assumed to be `<= 2^64 - 2^32 = 0xffffffff00000000`. The result is shifted by `2^63`.
+#[inline(always)]
+fn add_small_64s_64_s(x_s: v128, y: v128) -> v128 {
+    let res_wrapped_s = i64x2_add(x_s, y);
+    let mask = i64x2_gt(x_s, res_wrapped_s); // -1 if overflow
+    let wrapback_amt = u64x2_shr(mask, 32); // 0xFFFFFFFF if overflow else 0
+    i64x2_add(res_wrapped_s, wrapback_amt)
+}
+
+/// Goldilocks subtraction of a "small" number. `x_s` is pre-shifted by `2^63`. `y` is
+/// assumed to be `<= 0xffffffff00000000`. The result is shifted by `2^63`.
+#[inline(always)]
+fn sub_small_64s_64_s(x_s: v128, y: v128) -> v128 {
+    let res_wrapped_s = i64x2_sub(x_s, y);
+    let mask = i64x2_gt(res_wrapped_s, x_s); // -1 if underflow
+    let wrapback_amt = u64x2_shr(mask, 32);
+    i64x2_sub(res_wrapped_s, wrapback_amt)
+}
+
+/// Given a 128-bit value `(hi, lo)`, reduce it modulo the Goldilocks field order.
+///
+/// The result will be a 64-bit value but may be larger than `FIELD_ORDER`. Uses
+/// `2^64 ≡ 2^32 - 1 (mod p)` and `2^96 ≡ -1 (mod p)`.
+#[inline]
+fn reduce128(hi: v128, lo: v128) -> v128 {
+    let lo_s = shift(lo);
+    // `2^96 ≡ -1`, so the contribution of `hi_hi * 2^96` is `-hi_hi`.
+    let hi_hi = u64x2_shr(hi, 32);
+    let lo1_s = sub_small_64s_64_s(lo_s, hi_hi);
+
+    // `hi_lo32 * EPSILON` where `EPSILON = 2^32 - 1`.
+    // Computed as `(hi_lo32 << 32) - hi_lo32`, avoiding a full multiply.
+    // `hi_lo32 <= 2^32 - 1`, so `(hi_lo32 << 32) <= 2^64 - 2^32`, no overflow.
+    let hi_lo32 = v128_and(hi, EPSILON_VEC);
+    let hi_lo32_shifted = i64x2_shl(hi_lo32, 32);
+    let t1 = i64x2_sub(hi_lo32_shifted, hi_lo32);
+
+    // Result is at most `(2^32 - 1)^2 < 2^64`, so `add_small_64s_64_s` applies.
+    let lo2_s = add_small_64s_64_s(lo1_s, t1);
+    shift(lo2_s)
+}
+
+/// Goldilocks modular multiplication. Computes `x * y mod FIELD_ORDER`.
+///
+/// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
+#[inline]
+fn mul(x: v128, y: v128) -> v128 {
+    let (hi, lo) = mul64_64(x, y);
+    reduce128(hi, lo)
+}
+
+/// Goldilocks modular square. Computes `x^2 mod FIELD_ORDER`.
+///
+/// No specialized squaring path on simd128 — falls through to `mul`.
+#[inline(always)]
+fn square(x: v128) -> v128 {
+    mul(x, x)
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field_testing::test_packed_field;
+
+    use super::{Goldilocks, PackedGoldilocksWasm, WIDTH};
+
+    const SPECIAL_VALS: [Goldilocks; WIDTH] =
+        Goldilocks::new_array([0xFFFF_FFFF_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]);
+
+    const ZEROS: PackedGoldilocksWasm = PackedGoldilocksWasm(Goldilocks::new_array([
+        0x0000_0000_0000_0000,
+        0xFFFF_FFFF_0000_0001, // = P, canonicalizes to 0
+    ]));
+
+    const ONES: PackedGoldilocksWasm = PackedGoldilocksWasm(Goldilocks::new_array([
+        0x0000_0000_0000_0001,
+        0xFFFF_FFFF_0000_0002, // = P + 1, canonicalizes to 1
+    ]));
+
+    test_packed_field!(
+        crate::PackedGoldilocksWasm,
+        &[super::ZEROS],
+        &[super::ONES],
+        crate::PackedGoldilocksWasm(super::SPECIAL_VALS)
+    );
+}

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -43,7 +43,7 @@ const WIDTH: usize = 2;
 /// Equal to `2^32 - 1 = 2^64 mod P`.
 const EPSILON: u64 = Goldilocks::ORDER_U64.wrapping_neg();
 
-// Compile-time guard: `PackedGoldilocksWasm` is only sound to transmute to/from `v128` if
+// Compile-time guard: `PackedGoldilocksWasmSimd128` is only sound to transmute to/from `v128` if
 // its byte layout matches. `[Goldilocks; 2]` === `[u64; 2]` === `v128` (16 bytes total).
 const _LAYOUT_INVARIANTS: () = {
     assert!(size_of::<[Goldilocks; WIDTH]>() == size_of::<v128>());
@@ -57,9 +57,9 @@ const _LAYOUT_INVARIANTS: () = {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
 #[must_use]
-pub struct PackedGoldilocksWasm(pub [Goldilocks; WIDTH]);
+pub struct PackedGoldilocksWasmSimd128(pub [Goldilocks; WIDTH]);
 
-impl PackedGoldilocksWasm {
+impl PackedGoldilocksWasmSimd128 {
     #[inline]
     #[must_use]
     pub(crate) fn to_vector(self) -> v128 {
@@ -85,13 +85,13 @@ impl PackedGoldilocksWasm {
     }
 }
 
-impl From<Goldilocks> for PackedGoldilocksWasm {
+impl From<Goldilocks> for PackedGoldilocksWasmSimd128 {
     fn from(x: Goldilocks) -> Self {
         Self::broadcast(x)
     }
 }
 
-impl Add for PackedGoldilocksWasm {
+impl Add for PackedGoldilocksWasmSimd128 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
@@ -99,7 +99,7 @@ impl Add for PackedGoldilocksWasm {
     }
 }
 
-impl Sub for PackedGoldilocksWasm {
+impl Sub for PackedGoldilocksWasmSimd128 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
@@ -107,7 +107,7 @@ impl Sub for PackedGoldilocksWasm {
     }
 }
 
-impl Neg for PackedGoldilocksWasm {
+impl Neg for PackedGoldilocksWasmSimd128 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
@@ -115,7 +115,7 @@ impl Neg for PackedGoldilocksWasm {
     }
 }
 
-impl Mul for PackedGoldilocksWasm {
+impl Mul for PackedGoldilocksWasmSimd128 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
@@ -123,13 +123,13 @@ impl Mul for PackedGoldilocksWasm {
     }
 }
 
-impl_add_assign!(PackedGoldilocksWasm);
-impl_sub_assign!(PackedGoldilocksWasm);
-impl_mul_methods!(PackedGoldilocksWasm);
-ring_sum!(PackedGoldilocksWasm);
-impl_rng!(PackedGoldilocksWasm);
+impl_add_assign!(PackedGoldilocksWasmSimd128);
+impl_sub_assign!(PackedGoldilocksWasmSimd128);
+impl_mul_methods!(PackedGoldilocksWasmSimd128);
+ring_sum!(PackedGoldilocksWasmSimd128);
+impl_rng!(PackedGoldilocksWasmSimd128);
 
-impl PrimeCharacteristicRing for PackedGoldilocksWasm {
+impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
     type PrimeSubfield = Goldilocks;
 
     const ZERO: Self = Self::broadcast(Goldilocks::ZERO);
@@ -164,9 +164,9 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasm {
     }
 }
 
-impl InjectiveMonomial<7> for PackedGoldilocksWasm {}
+impl InjectiveMonomial<7> for PackedGoldilocksWasmSimd128 {}
 
-impl PermutationMonomial<7> for PackedGoldilocksWasm {
+impl PermutationMonomial<7> for PackedGoldilocksWasmSimd128 {
     /// In the field `Goldilocks`, `a^{1/7}` is equal to a^{10540996611094048183}.
     ///
     /// This follows from the calculation `7*10540996611094048183 = 4*(2^64 - 2**32) + 1 = 1 mod (p - 1)`.
@@ -175,21 +175,21 @@ impl PermutationMonomial<7> for PackedGoldilocksWasm {
     }
 }
 
-impl_add_base_field!(PackedGoldilocksWasm, Goldilocks);
-impl_sub_base_field!(PackedGoldilocksWasm, Goldilocks);
-impl_mul_base_field!(PackedGoldilocksWasm, Goldilocks);
-impl_div_methods!(PackedGoldilocksWasm, Goldilocks);
-impl_packed_field_div!(PackedGoldilocksWasm);
-impl_sum_prod_base_field!(PackedGoldilocksWasm, Goldilocks);
+impl_add_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
+impl_sub_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
+impl_mul_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
+impl_div_methods!(PackedGoldilocksWasmSimd128, Goldilocks);
+impl_packed_field_div!(PackedGoldilocksWasmSimd128);
+impl_sum_prod_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
 
-impl Algebra<Goldilocks> for PackedGoldilocksWasm {
+impl Algebra<Goldilocks> for PackedGoldilocksWasmSimd128 {
     // Matches the aarch64 NEON chunk for the same WIDTH=2 lane layout.
     const BATCHED_LC_CHUNK: usize = 2;
 }
 
-impl_packed_value!(PackedGoldilocksWasm, Goldilocks, WIDTH);
+impl_packed_value!(PackedGoldilocksWasmSimd128, Goldilocks, WIDTH);
 
-unsafe impl PackedField for PackedGoldilocksWasm {
+unsafe impl PackedField for PackedGoldilocksWasmSimd128 {
     type Scalar = Goldilocks;
 }
 
@@ -204,7 +204,7 @@ pub fn interleave_u64(v0: v128, v1: v128) -> (v128, v128) {
     (r0, r1)
 }
 
-unsafe impl PackedFieldPow2 for PackedGoldilocksWasm {
+unsafe impl PackedFieldPow2 for PackedGoldilocksWasmSimd128 {
     fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
         let (v0, v1) = (self.to_vector(), other.to_vector());
         let (res0, res1) = match block_len {
@@ -430,25 +430,26 @@ fn double(x: v128) -> v128 {
 mod tests {
     use p3_field_testing::test_packed_field;
 
-    use super::{Goldilocks, PackedGoldilocksWasm, WIDTH};
+    use super::{Goldilocks, PackedGoldilocksWasmSimd128, WIDTH};
 
     const SPECIAL_VALS: [Goldilocks; WIDTH] =
         Goldilocks::new_array([0xFFFF_FFFF_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]);
 
-    const ZEROS: PackedGoldilocksWasm = PackedGoldilocksWasm(Goldilocks::new_array([
-        0x0000_0000_0000_0000,
-        0xFFFF_FFFF_0000_0001, // = P, canonicalizes to 0
-    ]));
+    const ZEROS: PackedGoldilocksWasmSimd128 =
+        PackedGoldilocksWasmSimd128(Goldilocks::new_array([
+            0x0000_0000_0000_0000,
+            0xFFFF_FFFF_0000_0001, // = P, canonicalizes to 0
+        ]));
 
-    const ONES: PackedGoldilocksWasm = PackedGoldilocksWasm(Goldilocks::new_array([
+    const ONES: PackedGoldilocksWasmSimd128 = PackedGoldilocksWasmSimd128(Goldilocks::new_array([
         0x0000_0000_0000_0001,
         0xFFFF_FFFF_0000_0002, // = P + 1, canonicalizes to 1
     ]));
 
     test_packed_field!(
-        crate::PackedGoldilocksWasm,
+        crate::PackedGoldilocksWasmSimd128,
         &[super::ZEROS],
         &[super::ONES],
-        crate::PackedGoldilocksWasm(super::SPECIAL_VALS)
+        crate::PackedGoldilocksWasmSimd128(super::SPECIAL_VALS)
     );
 }

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -1,17 +1,18 @@
-/// Resources:
-/// 1. WebAssembly SIMD proposal: https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md
-/// 2. The arithmetic recipes are the standard Goldilocks SIMD recipes, mimicking the existing
-///    `aarch64_neon` and `x86_64_avx2` backends with the following intrinsic correspondence:
-///
-///      uint64x2_t                 → v128
-///      veorq_u64(a, b)            → v128_xor(a, b)
-///      vaddq_u64(a, b)            → i64x2_add(a, b)
-///      vsubq_u64(a, b)            → i64x2_sub(a, b)
-///      vcgtq_s64(a, b)            → i64x2_gt(a, b)
-///      vbicq_u64(a, b)            → v128_andnot(a, b)  (= a & !b)
-///      vshrq_n_u64::<32>(a)       → u64x2_shr(a, 32)
-///      vdupq_n_u64(x)             → u64x2_splat(x)
-///      vreinterpretq_s64_u64(x)   → identity (v128 is type-erased)
+//! Resources:
+//! 1. WebAssembly SIMD proposal: https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md
+//! 2. The arithmetic recipes are the standard Goldilocks SIMD recipes, mimicking the existing
+//!    `aarch64_neon` and `x86_64_avx2` backends with the following intrinsic correspondence:
+//!
+//!      uint64x2_t                 → v128
+//!      veorq_u64(a, b)            → v128_xor(a, b)
+//!      vaddq_u64(a, b)            → i64x2_add(a, b)
+//!      vsubq_u64(a, b)            → i64x2_sub(a, b)
+//!      vcgtq_s64(a, b)            → i64x2_gt(a, b)
+//!      vbicq_u64(a, b)            → v128_andnot(a, b)  (= a & !b)
+//!      vshrq_n_u64::<32>(a)       → u64x2_shr(a, 32)
+//!      vdupq_n_u64(x)             → u64x2_splat(x)
+//!      vreinterpretq_s64_u64(x)   → identity (v128 is type-erased)
+
 use alloc::vec::Vec;
 use core::arch::wasm32::{
     i32x4_shuffle, i64x2_add, i64x2_extmul_low_u32x4, i64x2_gt, i64x2_shl, i64x2_shuffle,

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -1,3 +1,17 @@
+/// Resources:
+/// 1. WebAssembly SIMD proposal: https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md
+/// 2. The arithmetic recipes are the standard Goldilocks SIMD recipes, mimicking the existing
+///    `aarch64_neon` and `x86_64_avx2` backends with the following intrinsic correspondence:
+///
+///      uint64x2_t                 → v128
+///      veorq_u64(a, b)            → v128_xor(a, b)
+///      vaddq_u64(a, b)            → i64x2_add(a, b)
+///      vsubq_u64(a, b)            → i64x2_sub(a, b)
+///      vcgtq_s64(a, b)            → i64x2_gt(a, b)
+///      vbicq_u64(a, b)            → v128_andnot(a, b)  (= a & !b)
+///      vshrq_n_u64::<32>(a)       → u64x2_shr(a, 32)
+///      vdupq_n_u64(x)             → u64x2_splat(x)
+///      vreinterpretq_s64_u64(x)   → identity (v128 is type-erased)
 use alloc::vec::Vec;
 use core::arch::wasm32::{
     i32x4_shuffle, i64x2_add, i64x2_extmul_low_u32x4, i64x2_gt, i64x2_shl, i64x2_shuffle,
@@ -134,6 +148,11 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasm {
     }
 
     #[inline]
+    fn double(&self) -> Self {
+        Self::from_vector(double(self.to_vector()))
+    }
+
+    #[inline]
     fn square(&self) -> Self {
         Self::from_vector(square(self.to_vector()))
     }
@@ -197,21 +216,6 @@ unsafe impl PackedFieldPow2 for PackedGoldilocksWasm {
     }
 }
 
-// Resources:
-// 1. WebAssembly SIMD proposal: https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md
-// 2. The arithmetic recipes are the standard Goldilocks SIMD recipes, modeled on Plonky3's existing
-//    `aarch64_neon` and `x86_64_avx2` backends with the following intrinsic correspondence:
-//
-//      uint64x2_t                 → v128
-//      veorq_u64(a, b)            → v128_xor(a, b)
-//      vaddq_u64(a, b)            → i64x2_add(a, b)
-//      vsubq_u64(a, b)            → i64x2_sub(a, b)
-//      vcgtq_s64(a, b)            → i64x2_gt(a, b)
-//      vbicq_u64(a, b)            → v128_andnot(a, b)  (= a & !b)
-//      vshrq_n_u64::<32>(a)       → u64x2_shr(a, 32)
-//      vdupq_n_u64(x)             → u64x2_splat(x)
-//      vreinterpretq_s64_u64(x)   → identity (v128 is type-erased)
-
 const SIGN_BIT: v128 =
     unsafe { transmute::<[u64; WIDTH], v128>([0x8000_0000_0000_0000u64; WIDTH]) };
 const SHIFTED_FIELD_ORDER: v128 = unsafe {
@@ -225,9 +229,9 @@ fn shift(x: v128) -> v128 {
     v128_xor(x, SIGN_BIT)
 }
 
-/// If `x_s < SHIFTED_FIELD_ORDER` (signed comparison), add `EPSILON` to canonicalize.
-/// The neon impl uses `vbicq_u64(EPSILON_VEC, mask) = EPSILON_VEC & !mask`. wasm32's
-/// `v128_andnot(a, b) = a & !b` matches.
+// If `x_s < SHIFTED_FIELD_ORDER` (signed comparison), add `EPSILON` to canonicalize.
+// The neon impl uses `vbicq_u64(EPSILON_VEC, mask) = EPSILON_VEC & !mask`. wasm32's
+// `v128_andnot(a, b) = a & !b` matches.
 #[inline(always)]
 fn canonicalize_s(x_s: v128) -> v128 {
     let mask = i64x2_gt(SHIFTED_FIELD_ORDER, x_s);
@@ -414,6 +418,12 @@ fn mul(x: v128, y: v128) -> v128 {
 #[inline(always)]
 fn square(x: v128) -> v128 {
     mul(x, x)
+}
+
+/// Goldilocks modular doubling, falls back to `add`.
+#[inline(always)]
+fn double(x: v128) -> v128 {
+    add(x, x)
 }
 
 #[cfg(test)]

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -162,6 +162,15 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
     }
+
+    #[inline]
+    fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        Self::from_fn(|lane| {
+            let lhs_lane: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].as_slice()[lane]);
+            let rhs_lane: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].as_slice()[lane]);
+            Goldilocks::dot_product(&lhs_lane, &rhs_lane)
+        })
+    }
 }
 
 impl InjectiveMonomial<7> for PackedGoldilocksWasmSimd128 {}
@@ -185,6 +194,14 @@ impl_sum_prod_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
 impl Algebra<Goldilocks> for PackedGoldilocksWasmSimd128 {
     // Matches the aarch64 NEON chunk for the same WIDTH=2 lane layout.
     const BATCHED_LC_CHUNK: usize = 2;
+
+    #[inline]
+    fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
+        Self::from_fn(|lane| {
+            let a_lane: [Goldilocks; N] = core::array::from_fn(|i| a[i].as_slice()[lane]);
+            Goldilocks::dot_product(&a_lane, f)
+        })
+    }
 }
 
 impl_packed_value!(PackedGoldilocksWasmSimd128, Goldilocks, WIDTH);
@@ -412,12 +429,29 @@ fn mul(x: v128, y: v128) -> v128 {
     reduce128(hi, lo)
 }
 
-/// Goldilocks modular square. Computes `x^2 mod FIELD_ORDER`.
-///
-/// No specialized squaring path on simd128 — falls through to `mul`.
-#[inline(always)]
+/// Full 64×64 → 128 squaring.
+/// Exploits `lh = hl` so only three 32×32 products are needed instead of four.
+#[inline]
+fn square64(x: v128) -> (v128, v128) {
+    let x_lo = lo32(x);
+    let x_hi = hi32(x);
+    let ll = mul_u32_lanes(x_lo, x_lo);
+    let lh = mul_u32_lanes(x_lo, x_hi);
+    let hh = mul_u32_lanes(x_hi, x_hi);
+    // 128-bit product = ll + lh·2^33 + hh·2^64.
+    let ll_hi = u64x2_shr(ll, 33);
+    let t0 = i64x2_add(lh, ll_hi);
+    let t0_hi = u64x2_shr(t0, 31);
+    let res_hi = i64x2_add(hh, t0_hi);
+    let lh_shifted = i64x2_shl(lh, 33);
+    let res_lo = i64x2_add(ll, lh_shifted);
+    (res_hi, res_lo)
+}
+
+#[inline]
 fn square(x: v128) -> v128 {
-    mul(x, x)
+    let (hi, lo) = square64(x);
+    reduce128(hi, lo)
 }
 
 /// Goldilocks modular doubling, falls back to `add`.


### PR DESCRIPTION
Add wasm32 SIMD backend to p3-goldilocks.

Work from @WiktorStarczewski at Miden, ported to Plonky3 for general use. May inspire similar work for 31-bit fields too.