### PR TITLE
fix: faster packed than scalar Goldilocks MDS layer for poseidon1

### DIFF
--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -16,7 +16,7 @@ use crate::{
 /// to feed the Karatsuba helpers.
 const fn sml_row_to_goldilocks_col<const N: usize>(row: &[i64; N]) -> [Goldilocks; N] {
     let col_i64 = first_row_to_first_col(row);
-    let mut col = [Goldilocks::new(0); N];
+    let mut col = [Goldilocks::ZERO; N];
     let mut i = 0;
     while i < N {
         col[i] = Goldilocks::new(col_i64[i] as u64);

--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -1,26 +1,36 @@
 use p3_mds::MdsPermutation;
-use p3_mds::util::apply_circulant;
+use p3_mds::karatsuba_convolution::{
+    mds_circulant_karatsuba_8, mds_circulant_karatsuba_12, mds_circulant_karatsuba_16,
+};
+use p3_mds::util::{apply_circulant, first_row_to_first_col};
 use p3_symmetric::Permutation;
 
 use crate::x86_64_avx2::packing::PackedGoldilocksAVX2;
 use crate::{
-    MATRIX_CIRC_MDS_8_SML_ROW, MATRIX_CIRC_MDS_12_SML_ROW, MATRIX_CIRC_MDS_16_SML_ROW,
+    Goldilocks, MATRIX_CIRC_MDS_8_SML_ROW, MATRIX_CIRC_MDS_12_SML_ROW, MATRIX_CIRC_MDS_16_SML_ROW,
     MATRIX_CIRC_MDS_24_GOLDILOCKS, MdsMatrixGoldilocks,
 };
-const fn convert_array<const N: usize>(arr: [i64; N]) -> [u64; N] {
-    let mut result: [u64; N] = [0; N];
+
+/// Convert a `[i64; N]` row of small non-negative MDS coefficients into the
+/// matching circulant first column as `[Goldilocks; N]`. Used at compile time
+/// to feed the Karatsuba helpers.
+const fn sml_row_to_goldilocks_col<const N: usize>(row: &[i64; N]) -> [Goldilocks; N] {
+    let col_i64 = first_row_to_first_col(row);
+    let mut col = [Goldilocks::new(0); N];
     let mut i = 0;
     while i < N {
-        result[i] = arr[i] as u64;
+        col[i] = Goldilocks::new(col_i64[i] as u64);
         i += 1;
     }
-    result
+    col
 }
 
 impl Permutation<[PackedGoldilocksAVX2; 8]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX2; 8]) -> [PackedGoldilocksAVX2; 8] {
-        const MATRIX_CIRC_MDS_8_SML_ROW_U64: [u64; 8] = convert_array(MATRIX_CIRC_MDS_8_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_8_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 8] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_8_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_8(&mut state, &COL);
+        state
     }
 }
 
@@ -28,8 +38,10 @@ impl MdsPermutation<PackedGoldilocksAVX2, 8> for MdsMatrixGoldilocks {}
 
 impl Permutation<[PackedGoldilocksAVX2; 12]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX2; 12]) -> [PackedGoldilocksAVX2; 12] {
-        const MATRIX_CIRC_MDS_12_SML_ROW_U64: [u64; 12] = convert_array(MATRIX_CIRC_MDS_12_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_12_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 12] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_12_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_12(&mut state, &COL);
+        state
     }
 }
 
@@ -37,8 +49,10 @@ impl MdsPermutation<PackedGoldilocksAVX2, 12> for MdsMatrixGoldilocks {}
 
 impl Permutation<[PackedGoldilocksAVX2; 16]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX2; 16]) -> [PackedGoldilocksAVX2; 16] {
-        const MATRIX_CIRC_MDS_16_SML_ROW_U64: [u64; 16] = convert_array(MATRIX_CIRC_MDS_16_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_16_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 16] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_16_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_16(&mut state, &COL);
+        state
     }
 }
 

--- a/goldilocks/src/x86_64_avx2/mds.rs
+++ b/goldilocks/src/x86_64_avx2/mds.rs
@@ -1,3 +1,4 @@
+use p3_field::PrimeCharacteristicRing;
 use p3_mds::MdsPermutation;
 use p3_mds::karatsuba_convolution::{
     mds_circulant_karatsuba_8, mds_circulant_karatsuba_12, mds_circulant_karatsuba_16,

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -16,7 +16,7 @@ use crate::{
 /// to feed the Karatsuba helpers.
 const fn sml_row_to_goldilocks_col<const N: usize>(row: &[i64; N]) -> [Goldilocks; N] {
     let col_i64 = first_row_to_first_col(row);
-    let mut col = [Goldilocks::new(0); N];
+    let mut col = [Goldilocks::ZERO; N];
     let mut i = 0;
     while i < N {
         col[i] = Goldilocks::new(col_i64[i] as u64);

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -1,3 +1,4 @@
+use p3_field::PrimeCharacteristicRing;
 use p3_mds::MdsPermutation;
 use p3_mds::karatsuba_convolution::{
     mds_circulant_karatsuba_8, mds_circulant_karatsuba_12, mds_circulant_karatsuba_16,

--- a/goldilocks/src/x86_64_avx512/mds.rs
+++ b/goldilocks/src/x86_64_avx512/mds.rs
@@ -1,26 +1,36 @@
 use p3_mds::MdsPermutation;
-use p3_mds::util::apply_circulant;
+use p3_mds::karatsuba_convolution::{
+    mds_circulant_karatsuba_8, mds_circulant_karatsuba_12, mds_circulant_karatsuba_16,
+};
+use p3_mds::util::{apply_circulant, first_row_to_first_col};
 use p3_symmetric::Permutation;
 
 use crate::x86_64_avx512::packing::PackedGoldilocksAVX512;
 use crate::{
-    MATRIX_CIRC_MDS_8_SML_ROW, MATRIX_CIRC_MDS_12_SML_ROW, MATRIX_CIRC_MDS_16_SML_ROW,
+    Goldilocks, MATRIX_CIRC_MDS_8_SML_ROW, MATRIX_CIRC_MDS_12_SML_ROW, MATRIX_CIRC_MDS_16_SML_ROW,
     MATRIX_CIRC_MDS_24_GOLDILOCKS, MdsMatrixGoldilocks,
 };
-const fn convert_array<const N: usize>(arr: [i64; N]) -> [u64; N] {
-    let mut result: [u64; N] = [0; N];
+
+/// Convert a `[i64; N]` row of small non-negative MDS coefficients into the
+/// matching circulant first column as `[Goldilocks; N]`. Used at compile time
+/// to feed the Karatsuba helpers.
+const fn sml_row_to_goldilocks_col<const N: usize>(row: &[i64; N]) -> [Goldilocks; N] {
+    let col_i64 = first_row_to_first_col(row);
+    let mut col = [Goldilocks::new(0); N];
     let mut i = 0;
     while i < N {
-        result[i] = arr[i] as u64;
+        col[i] = Goldilocks::new(col_i64[i] as u64);
         i += 1;
     }
-    result
+    col
 }
 
 impl Permutation<[PackedGoldilocksAVX512; 8]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX512; 8]) -> [PackedGoldilocksAVX512; 8] {
-        const MATRIX_CIRC_MDS_8_SML_ROW_U64: [u64; 8] = convert_array(MATRIX_CIRC_MDS_8_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_8_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 8] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_8_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_8(&mut state, &COL);
+        state
     }
 }
 
@@ -28,8 +38,10 @@ impl MdsPermutation<PackedGoldilocksAVX512, 8> for MdsMatrixGoldilocks {}
 
 impl Permutation<[PackedGoldilocksAVX512; 12]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX512; 12]) -> [PackedGoldilocksAVX512; 12] {
-        const MATRIX_CIRC_MDS_12_SML_ROW_U64: [u64; 12] = convert_array(MATRIX_CIRC_MDS_12_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_12_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 12] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_12_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_12(&mut state, &COL);
+        state
     }
 }
 
@@ -37,8 +49,10 @@ impl MdsPermutation<PackedGoldilocksAVX512, 12> for MdsMatrixGoldilocks {}
 
 impl Permutation<[PackedGoldilocksAVX512; 16]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [PackedGoldilocksAVX512; 16]) -> [PackedGoldilocksAVX512; 16] {
-        const MATRIX_CIRC_MDS_16_SML_ROW_U64: [u64; 16] = convert_array(MATRIX_CIRC_MDS_16_SML_ROW);
-        apply_circulant(&MATRIX_CIRC_MDS_16_SML_ROW_U64, &input)
+        const COL: [Goldilocks; 16] = sml_row_to_goldilocks_col(&MATRIX_CIRC_MDS_16_SML_ROW);
+        let mut state = input;
+        mds_circulant_karatsuba_16(&mut state, &COL);
+        state
     }
 }
 

--- a/mds/src/karatsuba_convolution.rs
+++ b/mds/src/karatsuba_convolution.rs
@@ -388,6 +388,23 @@ impl<F: Field, A: Algebra<F> + Copy> Convolve<A, A, F> for FieldConvolve<F, A> {
     }
 }
 
+/// Circulant matrix-vector multiply for width 8 via Karatsuba convolution.
+#[inline]
+pub fn mds_circulant_karatsuba_8<F: Field, A: Algebra<F> + Copy>(state: &mut [A; 8], col: &[F; 8]) {
+    let input = *state;
+    FieldConvolve::<F, A>::conv8(input, *col, state.as_mut_slice());
+}
+
+/// Circulant matrix-vector multiply for width 12 via Karatsuba convolution.
+#[inline]
+pub fn mds_circulant_karatsuba_12<F: Field, A: Algebra<F> + Copy>(
+    state: &mut [A; 12],
+    col: &[F; 12],
+) {
+    let input = *state;
+    FieldConvolve::<F, A>::conv12(input, *col, state.as_mut_slice());
+}
+
 /// Circulant matrix-vector multiply for width 16 via Karatsuba convolution.
 #[inline]
 pub fn mds_circulant_karatsuba_16<F: Field, A: Algebra<F> + Copy>(


### PR DESCRIPTION
Dispatch to Karatsuba implementation instead of relying on naive O(n^2) alg for the MDS layer on AVX.

closes #1642 