### PR TITLE
whir: fail fast on STIR query and index count mismatch

### DIFF
--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -554,6 +554,63 @@ mod error_variant_tests {
             "expected MissingFinalPoly, got {err:?}"
         );
     }
+
+    #[test]
+    fn rejects_with_stir_query_count_mismatch_when_intermediate_query_is_dropped() {
+        // Invariant: queries.len() == verifier-sampled indices for the round.
+        //
+        // Mutation: drop the trailing query from round 0.
+        //
+        //     proof.whir.rounds[0].queries:  n  ->  n - 1
+        //     -> round_index = 0, expected = n, actual = n - 1
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        let expected = proof.whir.rounds[0].queries.len();
+        assert!(expected > 0, "fixture should produce at least one STIR query");
+        proof.whir.rounds[0].queries.pop();
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::StirQueryCountMismatch {
+                round_index,
+                expected: e,
+                actual: a,
+            } => {
+                assert_eq!(round_index, 0);
+                assert_eq!(e, expected);
+                assert_eq!(a, expected - 1);
+            }
+            other => panic!("expected StirQueryCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_with_stir_query_count_mismatch_when_final_query_is_dropped() {
+        // Invariant: final_queries.len() == verifier-sampled indices for the final round.
+        //
+        // Mutation: drop the trailing query from final_queries.
+        //
+        //     proof.whir.final_queries:  n  ->  n - 1
+        //     -> round_index = n_rounds, expected = n, actual = n - 1
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        let n_rounds = pcs.n_rounds();
+        let expected = proof.whir.final_queries.len();
+        assert!(expected > 0, "fixture should produce at least one final query");
+        proof.whir.final_queries.pop();
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::StirQueryCountMismatch {
+                round_index,
+                expected: e,
+                actual: a,
+            } => {
+                assert_eq!(round_index, n_rounds);
+                assert_eq!(e, expected);
+                assert_eq!(a, expected - 1);
+            }
+            other => panic!("expected StirQueryCountMismatch, got {other:?}"),
+        }
+    }
 }
 
 mod keccak_tests {

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -565,7 +565,10 @@ mod error_variant_tests {
         //     -> round_index = 0, expected = n, actual = n - 1
         let (pcs, commitment, mut proof, protocol) = commit_and_open();
         let expected = proof.whir.rounds[0].queries.len();
-        assert!(expected > 0, "fixture should produce at least one STIR query");
+        assert!(
+            expected > 0,
+            "fixture should produce at least one STIR query"
+        );
         proof.whir.rounds[0].queries.pop();
 
         let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
@@ -594,7 +597,10 @@ mod error_variant_tests {
         let (pcs, commitment, mut proof, protocol) = commit_and_open();
         let n_rounds = pcs.n_rounds();
         let expected = proof.whir.final_queries.len();
-        assert!(expected > 0, "fixture should produce at least one final query");
+        assert!(
+            expected > 0,
+            "fixture should produce at least one final query"
+        );
         proof.whir.final_queries.pop();
 
         let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();

--- a/whir/src/pcs/verifier/errors.rs
+++ b/whir/src/pcs/verifier/errors.rs
@@ -28,6 +28,14 @@ pub enum VerifierError {
         details: String,
     },
 
+    /// STIR query count does not match the sampled challenge count.
+    #[error("STIR query count mismatch at round {round_index}: expected {expected}, got {actual}")]
+    StirQueryCountMismatch {
+        round_index: usize,
+        expected: usize,
+        actual: usize,
+    },
+
     /// The proof carries the wrong number of opening evaluation batches.
     ///
     /// Raised by the adapter before any sumcheck or Merkle work.

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -336,6 +336,14 @@ where
                 .queries
         };
 
+        if queries.len() != indices.len() {
+            return Err(VerifierError::StirQueryCountMismatch {
+                round_index,
+                expected: indices.len(),
+                actual: queries.len(),
+            });
+        }
+
         let mut results = Vec::with_capacity(indices.len());
 
         for (&index, query) in indices.iter().zip(queries.iter()) {


### PR DESCRIPTION
Add a pre-loop length check in `verify_merkle_proof`, so malformed proofs return `StirQueryCountMismatch` instead of being silently truncated.