### PR TITLE
Enforce Positive max_log_arity

### DIFF
--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -28,6 +28,11 @@ where
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     Folding: FriFoldingStrategy<Val, Challenge>,
 {
+    assert!(
+        params.max_log_arity > 0,
+        "max_log_arity must be at least 1 to guarantee folding progress"
+    );
+
     // check sorted descending
     assert!(
         inputs
@@ -89,6 +94,11 @@ where
     Challenger: FieldChallenger<Val> + CanObserve<M::Commitment>,
     Folding: FriFoldingStrategy<Val, Challenge>,
 {
+    assert!(
+        params.max_log_arity > 0,
+        "max_log_arity must be at least 1 to guarantee folding progress"
+    );
+
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();
     let mut commits = vec![];

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -155,6 +155,10 @@ pub fn compute_log_arity_for_round(
     log_final_height: usize,
     max_log_arity: usize,
 ) -> usize {
+    assert!(
+        max_log_arity > 0,
+        "max_log_arity must be at least 1 to guarantee folding progress"
+    );
     debug_assert!(
         log_current_height > log_final_height,
         "should only be called when above final height"

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -63,6 +63,10 @@ where
 {
     assert!(!inputs.is_empty());
     assert!(
+        params.max_log_arity > 0,
+        "max_log_arity must be at least 1 to guarantee folding progress"
+    );
+    assert!(
         inputs
             .iter()
             .tuple_windows()
@@ -178,6 +182,11 @@ where
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     Folding: FriFoldingStrategy<Val, Challenge>,
 {
+    assert!(
+        params.max_log_arity > 0,
+        "max_log_arity must be at least 1 to guarantee folding progress"
+    );
+
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();
     let mut commits = vec![];


### PR DESCRIPTION
  `max_log_arity = 0` breaks a core FRI invariant: every folding round must reduce height. If `log_arity` becomes `0` (`arity = 1`), commit-phase loops in both `fri` and `circle` can stop making progress.                                                                                                                                                                                 
                                                                                                                                                                                                 
  This PR adds explicit `max_log_arity > 0` assertions in the shared arity computation and the affected prover paths, so invalid configs fail fast with a clear error instead of stalling deep in proving.                                                                                                                                                                                         
                                                                                                                                                                                                 
  Correctness for valid configs is unchanged, and `cargo test -p p3-fri -p p3-circle --lib` passes (44/44 tests).  