### PR TITLE
perf: fast paths for mul_2exp_u64(0) and mul_2exp_u64(1)

### DIFF
--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -246,12 +246,18 @@ impl PrimeCharacteristicRing for Goldilocks {
     #[inline]
     fn mul_2exp_u64(&self, exp: u64) -> Self {
         // In the Goldilocks field, 2^96 = -1 mod P and 2^192 = 1 mod P.
-        if exp < 96 {
-            *self * Self::POWERS_OF_TWO[exp as usize]
-        } else if exp < 192 {
-            -*self * Self::POWERS_OF_TWO[(exp - 96) as usize]
-        } else {
-            self.mul_2exp_u64(exp % 192)
+        match exp {
+            0 => *self,
+            1 => *self + *self,
+            _ => {
+                if exp < 96 {
+                    *self * Self::POWERS_OF_TWO[exp as usize]
+                } else if exp < 192 {
+                    -*self * Self::POWERS_OF_TWO[(exp - 96) as usize]
+                } else {
+                    self.mul_2exp_u64(exp % 192)
+                }
+            }
         }
     }
 

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -208,11 +208,17 @@ impl<FP: FieldParameters> PrimeCharacteristicRing for MontyField31<FP> {
         // The array FP::MONTY_POWERS_OF_TWO contains the powers of 2
         // from 2^0 to 2^63 in monty form. We can use this to quickly
         // compute 2^exp.
-        if exp < 64 {
-            *self * Self::MONTY_POWERS_OF_TWO[exp as usize]
-        } else {
-            // For larger values we use the default method.
-            *self * Self::TWO.exp_u64(exp)
+        match exp {
+            0 => *self,
+            1 => *self + *self,
+            _ => {
+                if exp < 64 {
+                    *self * Self::MONTY_POWERS_OF_TWO[exp as usize]
+                } else {
+                    // For larger values we use the default method.
+                    *self * Self::TWO.exp_u64(exp)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Symmetric counterpart to the existing `div_2exp_u64` fast paths. Avoids a full field multiplication via the `POWERS_OF_TWO` / `MONTY_POWERS_OF_TWO` table for the two trivial cases:

- `mul_2exp_u64(0)` returns `*self`
- `mul_2exp_u64(1)` returns `*self + *self`

Applied to:
- `Goldilocks` — `goldilocks/src/goldilocks.rs`
- `MontyField31` — `monty-31/src/monty_31.rs` (benefits BabyBear and KoalaBear)

Extension fields (binomial, cubic, quintic, packed variants) delegate per-coordinate to the base field's `mul_2exp_u64`, so the optimization propagates automatically. `Mersenne31` already uses bit rotation for this op and does not need a fast path.

Ported from [leanEthereum/leanMultisig@dcef38d](https://github.com/leanEthereum/leanMultisig/commit/dcef38d13f21445dfae709de612d473667b498ff). The upstream microbench reports ~0.55 ns/op → ~0.43 ns/op (~25% faster) for Goldilocks.

## Test plan

- [x] `cargo test -p p3-goldilocks test_mul_2exp_u64` — 8/8 pass (scalar, NEON-packed, quadratic/cubic-trinomial/quintic extensions)
- [x] `cargo test -p p3-baby-bear test_mul_2exp_u64` — 8/8 pass
- [x] `cargo test -p p3-koala-bear test_mul_2exp_u64` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)