### PR TITLE
perf(goldilocks): fix Poseidon2GoldilocksFused<8> packed permute regression on aarch64 NEON

### DIFF
--- a/goldilocks/src/aarch64_neon/poseidon2.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 
 use p3_poseidon2::{
     ExternalLayer, ExternalLayerConstants, ExternalLayerConstructor, InternalLayer,
-    InternalLayerConstructor, poseidon2_round_numbers_128,
+    InternalLayerConstructor, Poseidon2, poseidon2_round_numbers_128,
 };
 use p3_symmetric::{CryptographicPermutation, Permutation};
 use rand::distr::{Distribution, StandardUniform};
@@ -21,7 +21,10 @@ use rand::{Rng, RngExt};
 use super::packing::PackedGoldilocksNeon;
 use super::poseidon2_asm::*;
 use super::utils::{pack_lanes, unpack_lanes};
-use crate::{Goldilocks, MATRIX_DIAG_20_GOLDILOCKS, P};
+use crate::{
+    Goldilocks, MATRIX_DIAG_20_GOLDILOCKS, P, Poseidon2ExternalLayerGoldilocks,
+    Poseidon2InternalLayerGoldilocks,
+};
 
 /// Degree of the chosen permutation polynomial for Goldilocks.
 const GOLDILOCKS_S_BOX_DEGREE: u64 = 7;
@@ -302,6 +305,13 @@ pub struct Poseidon2GoldilocksFused<const WIDTH: usize> {
     internal_constants_raw: Vec<u64>,
     initial_constants_raw: Vec<[u64; WIDTH]>,
     terminal_constants_raw: Vec<[u64; WIDTH]>,
+    generic: Poseidon2<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks<WIDTH>,
+        Poseidon2InternalLayerGoldilocks,
+        WIDTH,
+        GOLDILOCKS_S_BOX_DEGREE,
+    >,
 }
 
 /// Reduce a `Goldilocks::value` to canonical form. One subtraction suffices because
@@ -330,10 +340,12 @@ impl<const WIDTH: usize> Poseidon2GoldilocksFused<WIDTH> {
             .iter()
             .map(|rc| core::array::from_fn(|i| to_canonical_u64(rc[i].value)))
             .collect();
+        let generic = Poseidon2::new(external_constants.clone(), internal_constants.to_vec());
         Self {
             internal_constants_raw,
             initial_constants_raw,
             terminal_constants_raw,
+            generic,
         }
     }
 
@@ -409,12 +421,9 @@ impl Permutation<[Goldilocks; 20]> for Poseidon2GoldilocksFused<20> {
 impl CryptographicPermutation<[Goldilocks; 20]> for Poseidon2GoldilocksFused<20> {}
 
 impl Permutation<[PackedGoldilocksNeon; 8]> for Poseidon2GoldilocksFused<8> {
+    #[inline]
     fn permute_mut(&self, state: &mut [PackedGoldilocksNeon; 8]) {
-        let (mut lane0, mut lane1) = unpack_lanes(state);
-        external_initial_permute_dual_w8(&mut lane0, &mut lane1, &self.initial_constants_raw);
-        internal_permute_split_dual_w8(&mut lane0, &mut lane1, &self.internal_constants_raw);
-        external_terminal_permute_dual_w8(&mut lane0, &mut lane1, &self.terminal_constants_raw);
-        pack_lanes(state, &lane0, &lane1);
+        self.generic.permute_mut(state);
     }
 }
 

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -959,7 +959,7 @@ impl<A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>>
 }
 
 /// The external layers of the Poseidon2 permutation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Poseidon2ExternalLayerGoldilocks<const WIDTH: usize> {
     pub(crate) external_constants: ExternalLayerConstants<Goldilocks, WIDTH>,
 }


### PR DESCRIPTION
## Summary

On Pi 5 Cortex-A76, `Poseidon2GoldilocksFused<8>`'s packed-type `Permutation` impl is ~16% slower than the platform-generic Poseidon2 SIMD path on a Merkle workload. The fused `_dual_w8` pipeline loses on every per-phase comparison and adds unpack/pack overhead per permute. A naive whole-permute microbenchmark hides this gap (fused wins per-permute by 3.5% via out-of-order overlap across phases), but the Merkle layer chain's data-dependency serialises permutes and the structural gap dominates.

This routes `Permutation<[PackedGoldilocksNeon; 8]>` through a generic `Poseidon2` stored on the fused struct. The scalar `[Goldilocks; 8]` verifier path keeps the fused `_w8` asm and is unchanged.

## Scope of measurement

All numbers below are Pi 5 Cortex-A76 (r4p1, cargo 1.95.0). The aarch64 NEON code path is shared with Apple Silicon M-series, but I have no M-series hardware to benchmark on, CI's `macos-latest` covers correctness via test runs, but the perf delta on M-series is not measured here. Cortex-A76 and M-series differ in issue width and OoO window depth, so the magnitude of the win may differ; the structural per-phase gap _should_ still apply directionally.

## Merkle wall time (Pi 5 Cortex-A76, `taskset -c 0`, 5 seeds × 5 reps = n=25 per cell)

| log2 leaves | pre (ms, mean ± SD) | post (ms, mean ± SD) | reduction |
| ---: | ---: | ---: | ---: |
| 14 |   73.964 ± 0.053 |    61.852 ± 0.255 | 16.38% |
| 16 |  296.070 ± 0.100 |   247.616 ± 0.229 | 16.37% |
| 18 | 1183.927 ± 1.184 |   990.154 ± 0.732 | 16.37% |

Post-change Merkle `fused/generic` ratio across n=25: `1.0007 ± 0.0021` (log2=14), `1.0014 ± 0.0011` (16), `1.0011 ± 0.0008` (18). Within noise of the gold path.

## Per-phase decomposition (Pi 5, `poseidon2_phase_decomp` harness, 1M iters/permute, seed 1)

| phase    | fused ns | generic ns | delta ns | delta % |
| -------- | -------: | ---------: | -------: | ------: |
| ext-init |  1406.78 |    1372.79 |   +33.99 |  +2.48% |
| internal |  1733.21 |    1524.54 |  +208.67 | +13.69% |
| ext-term |  1337.87 |    1294.73 |   +43.15 |  +3.33% |
| unpack + pack (fused only) | — | — |   +14.69 | — |
| **predicted per-permute gap** | | |     **+300.50** | |

Internal-rounds dominates (208.67 / 300.50 = 69% of the gap). The fused `_dual_w8` internal-permute runs 13.69% slower than the generic SIMD path on this shape. Note `_dual_w8` is the 2-lane interleaved variant, thus distinct from the single-lane `_w8` powering the scalar verifier `Permutation<[Goldilocks; 8]>`, which is untouched.

Harness sanity gates from the same run: per-phase sum / decomposed whole-permute = 1.000x for both fused (+0.01%) and generic (−0.03%) so instrumentation reconciles.

## Why per-permute and Merkle disagree

Two whole-permute measurement modes from the same harness run, same seed:

| variant | fused ns | generic ns | fused/generic |
| --- | ---: | ---: | ---: |
| decomp (per phase, then summed) | 4491.92 | 4193.14 | 1.071 |
| natural (single contiguous loop) | 4040.13 | 4187.71 | 0.965 |

- **Decomp variant** isolates each phase; OoO overlap between phases is suppressed. Fused is +298.78 ns slower (≈ the +300.50 predicted gap, within 2 ns).
- **Natural variant** lets the OoO engine interleave independent permutes. Fused gains 11.18% from cross-phase overlap; generic gains only 0.13%. The result inverts: fused is *faster* per-permute by 3.5%.

In Merkle aggregation, the layer-wise data-dependency chain serialises permutes and removes the OoO mask, so the structural +300 ns gap dominates → 16.4% wall-time reduction by switching to generic SIMD. **Isolated whole-permute microbenchmarks don't predict the Merkle outcome; per-phase decomposition does.**

## Implementation note

`#[inline]` on the wrapper is load-bearing. Without it, a residual 7.14–7.25% Merkle wall-time gap remains (n=25 per cell across log2={14,16,18}); with it, the gap collapses to ~0.09%. Trait-method-via-field dispatch doesn't fold across the trait boundary in release here.

| log2 | post no-inline (ms) | post +inline (ms) | reduction-if-generic without inline |
| ---: | ---: | ---: | ---: |
| 14 |   66.570 ± 0.084 |   61.852 ± 0.255 | 7.25% |
| 16 |  266.400 ± 0.269 |  247.616 ± 0.229 | 7.14% |
| 18 | 1066.481 ± 0.880 |  990.154 ± 0.732 | 7.16% |

The existing `test_fused_matches_generic_width_8` (`goldilocks/src/aarch64_neon/poseidon2.rs`) already covers the gate (scalar fused-vs-generic + per-lane packed-vs-scalar). After this change, the packed path *is* the generic path, so a packed-vs-packed test would be tautological; the existing test stays load-bearing.

The `Debug` derive on `Poseidon2ExternalLayerGoldilocks` in `goldilocks/src/poseidon2.rs` is a sibling-consistency fix and `Poseidon2InternalLayerGoldilocks` already has `Debug`, and the fused struct can no longer auto-derive it without this.

## Open question

W={12, 16, 20} packed `Permutation` impls use a different shape (`lanes_to_neon` / `neon_to_lanes` + `external_initial_neon` + `internal_permute_neon_w{12,16}`) rather than `unpack_lanes`/`pack_lanes` + `_dual_w8`. Phase-decomp data so far only covers W=8. Happy to measure those as a follow-up if you'd like, before any widening.