### PR TITLE
chore: release v0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,45 +94,45 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.4.2" }
-p3-baby-bear = { path = "baby-bear", version = "0.4.2" }
-p3-blake3 = { path = "blake3", version = "0.4.2" }
-p3-blake3-air = { path = "blake3-air", version = "0.4.2" }
-p3-bn254 = { path = "bn254", version = "0.4.2" }
-p3-challenger = { path = "challenger", version = "0.4.2" }
-p3-circle = { path = "circle", version = "0.4.2" }
-p3-commit = { path = "commit", version = "0.4.2" }
-p3-dft = { path = "dft", version = "0.4.2" }
+p3-air = { path = "air", version = "0.4.3" }
+p3-baby-bear = { path = "baby-bear", version = "0.4.3" }
+p3-blake3 = { path = "blake3", version = "0.4.3" }
+p3-blake3-air = { path = "blake3-air", version = "0.4.3" }
+p3-bn254 = { path = "bn254", version = "0.4.3" }
+p3-challenger = { path = "challenger", version = "0.4.3" }
+p3-circle = { path = "circle", version = "0.4.3" }
+p3-commit = { path = "commit", version = "0.4.3" }
+p3-dft = { path = "dft", version = "0.4.3" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.4.2" }
-p3-field-testing = { path = "field-testing", version = "0.4.2" }
-p3-fri = { path = "fri", version = "0.4.2" }
-p3-goldilocks = { path = "goldilocks", version = "0.4.2" }
-p3-interpolation = { path = "interpolation", version = "0.4.2" }
-p3-keccak = { path = "keccak", version = "0.4.2" }
-p3-keccak-air = { path = "keccak-air", version = "0.4.2" }
-p3-koala-bear = { path = "koala-bear", version = "0.4.2" }
-p3-lookup = { path = "lookup", version = "0.4.2" }
-p3-matrix = { path = "matrix", version = "0.4.2" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.4.2" }
-p3-mds = { path = "mds", version = "0.4.2" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.4.2" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.4.2" }
-p3-monty-31 = { path = "monty-31", version = "0.4.2" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.4.2" }
-p3-poseidon = { path = "poseidon", version = "0.4.2" }
-p3-poseidon2 = { path = "poseidon2", version = "0.4.2" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.4.2" }
-p3-rescue = { path = "rescue", version = "0.4.2" }
-p3-sha256 = { path = "sha256", version = "0.4.2" }
-p3-symmetric = { path = "symmetric", version = "0.4.2" }
-p3-uni-stark = { path = "uni-stark", version = "0.4.2" }
-p3-util = { path = "util", version = "0.4.2" }
+p3-field = { path = "field", version = "0.4.3" }
+p3-field-testing = { path = "field-testing", version = "0.4.3" }
+p3-fri = { path = "fri", version = "0.4.3" }
+p3-goldilocks = { path = "goldilocks", version = "0.4.3" }
+p3-interpolation = { path = "interpolation", version = "0.4.3" }
+p3-keccak = { path = "keccak", version = "0.4.3" }
+p3-keccak-air = { path = "keccak-air", version = "0.4.3" }
+p3-koala-bear = { path = "koala-bear", version = "0.4.3" }
+p3-lookup = { path = "lookup", version = "0.4.3" }
+p3-matrix = { path = "matrix", version = "0.4.3" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.4.3" }
+p3-mds = { path = "mds", version = "0.4.3" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.4.3" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.4.3" }
+p3-monty-31 = { path = "monty-31", version = "0.4.3" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.4.3" }
+p3-poseidon = { path = "poseidon", version = "0.4.3" }
+p3-poseidon2 = { path = "poseidon2", version = "0.4.3" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.4.3" }
+p3-rescue = { path = "rescue", version = "0.4.3" }
+p3-sha256 = { path = "sha256", version = "0.4.3" }
+p3-symmetric = { path = "symmetric", version = "0.4.3" }
+p3-uni-stark = { path = "uni-stark", version = "0.4.3" }
+p3-util = { path = "util", version = "0.4.3" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Air: document virtual pair column composition patterns (#1419)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix: add range check in MontyField31 deserialization (#1399)
+- Add KoalaBear Deserialize Boundary Tests (#1406)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Chore: minor fixes (#1246)
+- Fix: avoid unnecessary clone of quotient chunk matrices in batch-stark prover (#1341)
+- Fix: add lookup expected_cumulated value in FS transcript (#1385)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor(field): Add packed field extraction helpers and FieldArray utilities (#1211) (Adrian Hamelink)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix(bn254): use subtraction instead of multiplication for negation (#1263)
+- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Perf: optimize HashChallenger buffering (#1266)
+- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
+- Fix: restrict MultiField32Challenger output to rate portion only (#1299)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - SIMD optimization for proof-of-work grinding in DuplexChallenger (#1208) (Utsav Sharma)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
+- Perf(circle): drop vp_denoms after batch inversion (#1502)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Enable ZK for preprocessing and in batch-stark (#1178) (Linda Guiga)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Enable ZK for preprocessing and in batch-stark (#1178) (Linda Guiga)

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix(dft): reduce twiddle factor allocation in Radix2Dit (#1285)
+- Perf(dft): butterfly micro-optimizations for Radix2DitParallel (~3% on coset_lde_batch) (#1492)
+- Fix(dft): merge twiddle and inv_twiddle locks in Radix2DFTSmallBatch (#1534)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix(field): return ONE for empty Product iterator (#1272)
+- Field: implement quintic extension for KoalaBear (#1293)
+- Add KoalaBear Deserialize Boundary Tests (#1406)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Field: relax redundant bounds in From<[A; D]> for BinomialExtensionField (#1231)
+- Chore(field): Remove deprecated scale_slice_in_place wrapper (#1264)
+- Fix(field): return ONE for empty Product iterator (#1272)
+- Field: small touchup for binomial extension (#1300)
+- Field: implement quintic extension for KoalaBear (#1293)
+- Field: faster `quintic_mul` and `quintic_square` (#1301)
+- SIMD for koala-bear extension 5 (#1305)
+- Field: add missing extension degree for `packed_mod_add` and `packed_mod_sub` (#1421)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Chore(field): Make `BinomialExtensionField::new` public (#1209) (Adrian Hamelink)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Chore: minor fixes (#1246)
+- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Enable ZK for preprocessing and in batch-stark (#1178) (Linda Guiga)

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Field: implement quintic extension for KoalaBear (#1293)
+- Field: faster `quintic_mul` and `quintic_square` (#1301)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Update Cargo.toml (#1297)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Small changes for recursive lookups (#1229) (Linda Guiga)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Feat(matrix): add `columnwise_dot_product_batched` for multi-point evaluation (#1225)
+- Transpose: use p3-util rectangular transposition everywhere (#1256)
+- Perf: optimize rowwise dot-product for `Matrix` (#1284)
+- Fix(matrix): correct idx initialization in FlatMatrixView::row_subseq_unchecked (#1286)
+- Matrix: remove spurious extra element from `padded_horizontally_packed_row` (#1309)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor(field): Add packed field extraction helpers and FieldArray utilities (#1211) (Adrian Hamelink)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Refactor maybe-rayon cfg usage to remove duplicated prelude/iter modules (#1255)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - SIMD optimization for proof-of-work grinding in DuplexChallenger (#1208) (Utsav Sharma)

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Chore(mds): expand naive coverage across fields and widths (#1347)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor(field): Add packed field extraction helpers and FieldArray utilities (#1211) (Adrian Hamelink)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Perf: optimize dot product for Mersenne31 (#1280)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Feat: use compile-time asserts for const generic parameters (#1232) (Himess)

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Transpose: use p3-util rectangular transposition everywhere (#1256)
+- Field: implement quintic extension for KoalaBear (#1293)
+- SIMD for koala-bear extension 5 (#1305)
+- Fix: dead code removal and twiddle table race condition (#1318)
+- Fix: add range check in MontyField31 deserialization (#1399)
+- Monty 31: faster forward dft (#1418)
+- Fix compilation on aarch64 without neon (RUSTFLAGS="-C target-feature=-neon" cargo check) (#1514)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/poseidon/CHANGELOG.md
+++ b/poseidon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix: dead code removal and twiddle table race condition (#1318)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Small changes for recursive lookups (#1229) (Linda Guiga)

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix: dead code removal and twiddle table race condition (#1318)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Fix: reformat sha256 Cargo.toml features for cargo-sort 2.1.1 (#1408)
+- Add KoalaBear Deserialize Boundary Tests (#1406)
+
 ## [0.4.2] - 2026-01-05
 ### Authors
 

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Feat: use compile-time asserts for const generic parameters (#1232) (Himess)

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
+- Fix: dead code removal and twiddle table race condition (#1318)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor(field): Add packed field extraction helpers and FieldArray utilities (#1211) (Adrian Hamelink)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.3] - 2026-05-15
+### Merged PRs
+- Util: better rect transpose with NEON for 32 bits fields (#1192)
+- Update square.rs (#1261)
+- Fix: deduplicate key lookup logic in LinearMap (#1291)
+- Util: faster rectangular transposition 64-bit fields (#1332)
+
 ## [0.4.2] - 2026-01-05
 ### Merged PRs
 - Refactor: add public const `new` and `new_array` for all fields (#1222) (Adrian Hamelink)


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.4.2 -> 0.4.3
* `p3-util`: 0.4.2 -> 0.4.3
* `p3-field`: 0.4.2 -> 0.4.3
* `p3-matrix`: 0.4.2 -> 0.4.3
* `p3-air`: 0.4.2 -> 0.4.3
* `p3-dft`: 0.4.2 -> 0.4.3
* `p3-symmetric`: 0.4.2 -> 0.4.3
* `p3-mds`: 0.4.2 -> 0.4.3
* `p3-poseidon2`: 0.4.2 -> 0.4.3
* `p3-monty-31`: 0.4.2 -> 0.4.3
* `p3-challenger`: 0.4.2 -> 0.4.3
* `p3-baby-bear`: 0.4.2 -> 0.4.3
* `p3-goldilocks`: 0.4.2 -> 0.4.3
* `p3-koala-bear`: 0.4.2 -> 0.4.3
* `p3-bn254`: 0.4.2 -> 0.4.3
* `p3-field-testing`: 0.4.2 -> 0.4.3
* `p3-mersenne-31`: 0.4.2 -> 0.4.3
* `p3-poseidon`: 0.4.2 -> 0.4.3
* `p3-commit`: 0.4.2 -> 0.4.3
* `p3-uni-stark`: 0.4.2 -> 0.4.3
* `p3-lookup`: 0.4.2 -> 0.4.3
* `p3-batch-stark`: 0.4.2 -> 0.4.3
* `p3-interpolation`: 0.4.2 -> 0.4.3
* `p3-fri`: 0.4.2 -> 0.4.3
* `p3-circle`: 0.4.2 -> 0.4.3
* `p3-keccak`: 0.4.2 -> 0.4.3
* `p3-merkle-tree`: 0.4.2 -> 0.4.3
* `p3-blake3`: 0.4.2 -> 0.4.3
* `p3-rescue`: 0.4.2 -> 0.4.3
* `p3-blake3-air`: 0.4.2 -> 0.4.3
* `p3-sha256`: 0.4.2 -> 0.4.3
* `p3-keccak-air`: 0.4.2 -> 0.4.3
* `p3-poseidon2-air`: 0.4.2 -> 0.4.3
* `p3-monolith`: 0.4.2 -> 0.4.3
* `p3-multilinear-util`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `p3-maybe-rayon`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Refactor maybe-rayon cfg usage to remove duplicated prelude/iter modules (#1255)
</blockquote>

## `p3-util`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Util: better rect transpose with NEON for 32 bits fields (#1192)
- Update square.rs (#1261)
- Fix: deduplicate key lookup logic in LinearMap (#1291)
- Util: faster rectangular transposition 64-bit fields (#1332)
</blockquote>

## `p3-field`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Field: relax redundant bounds in From<[A; D]> for BinomialExtensionField (#1231)
- Chore(field): Remove deprecated scale_slice_in_place wrapper (#1264)
- Fix(field): return ONE for empty Product iterator (#1272)
- Field: small touchup for binomial extension (#1300)
- Field: implement quintic extension for KoalaBear (#1293)
- Field: faster `quintic_mul` and `quintic_square` (#1301)
- SIMD for koala-bear extension 5 (#1305)
- Field: add missing extension degree for `packed_mod_add` and `packed_mod_sub` (#1421)
</blockquote>

## `p3-matrix`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Feat(matrix): add `columnwise_dot_product_batched` for multi-point evaluation (#1225)
- Transpose: use p3-util rectangular transposition everywhere (#1256)
- Perf: optimize rowwise dot-product for `Matrix` (#1284)
- Fix(matrix): correct idx initialization in FlatMatrixView::row_subseq_unchecked (#1286)
- Matrix: remove spurious extra element from `padded_horizontally_packed_row` (#1309)
</blockquote>

## `p3-air`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Air: document virtual pair column composition patterns (#1419)
</blockquote>

## `p3-dft`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix(dft): reduce twiddle factor allocation in Radix2Dit (#1285)
- Perf(dft): butterfly micro-optimizations for Radix2DitParallel (~3% on coset_lde_batch) (#1492)
- Fix(dft): merge twiddle and inv_twiddle locks in Radix2DFTSmallBatch (#1534)
</blockquote>


## `p3-mds`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Chore(mds): expand naive coverage across fields and widths (#1347)
</blockquote>


## `p3-monty-31`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Transpose: use p3-util rectangular transposition everywhere (#1256)
- Field: implement quintic extension for KoalaBear (#1293)
- SIMD for koala-bear extension 5 (#1305)
- Fix: dead code removal and twiddle table race condition (#1318)
- Fix: add range check in MontyField31 deserialization (#1399)
- Monty 31: faster forward dft (#1418)
- Fix compilation on aarch64 without neon (RUSTFLAGS="-C target-feature=-neon" cargo check) (#1514)
</blockquote>

## `p3-challenger`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Perf: optimize HashChallenger buffering (#1266)
- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
- Fix: restrict MultiField32Challenger output to rate portion only (#1299)
</blockquote>

## `p3-baby-bear`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix: add range check in MontyField31 deserialization (#1399)
- Add KoalaBear Deserialize Boundary Tests (#1406)
</blockquote>


## `p3-koala-bear`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Field: implement quintic extension for KoalaBear (#1293)
- Field: faster `quintic_mul` and `quintic_square` (#1301)
</blockquote>

## `p3-bn254`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix(bn254): use subtraction instead of multiplication for negation (#1263)
- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
</blockquote>

## `p3-field-testing`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix(field): return ONE for empty Product iterator (#1272)
- Field: implement quintic extension for KoalaBear (#1293)
- Add KoalaBear Deserialize Boundary Tests (#1406)
</blockquote>

## `p3-mersenne-31`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Perf: optimize dot product for Mersenne31 (#1280)
</blockquote>


## `p3-commit`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
</blockquote>

## `p3-uni-stark`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
- Fix: dead code removal and twiddle table race condition (#1318)
</blockquote>

## `p3-lookup`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Update Cargo.toml (#1297)
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Chore: minor fixes (#1246)
- Fix: avoid unnecessary clone of quotient chunk matrices in batch-stark prover (#1341)
- Fix: add lookup expected_cumulated value in FS transcript (#1385)
</blockquote>


## `p3-fri`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Chore: minor fixes (#1246)
- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
</blockquote>

## `p3-circle`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Feat: add Clone to StarkConfig and StarkGenericConfig (#1328)
- Perf(circle): drop vp_denoms after batch inversion (#1502)
</blockquote>




## `p3-rescue`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix: dead code removal and twiddle table race condition (#1318)
</blockquote>

## `p3-blake3-air`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Refactor: minor code cleanups across blake3-air, bn254, challenger (#1287)
</blockquote>

## `p3-sha256`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix: reformat sha256 Cargo.toml features for cargo-sort 2.1.1 (#1408)
- Add KoalaBear Deserialize Boundary Tests (#1406)
</blockquote>


## `p3-poseidon2-air`

<blockquote>

## [0.4.3] - 2026-05-15

### Merged PRs
- Fix: dead code removal and twiddle table race condition (#1318)
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).