### PR TITLE
whir: add HVZK sumcheck domain separator shape

### DIFF
--- a/whir/src/fiat_shamir/domain_separator.rs
+++ b/whir/src/fiat_shamir/domain_separator.rs
@@ -24,6 +24,19 @@ pub(crate) struct SumcheckParams {
     pub pow_bits: usize,
 }
 
+/// Configuration for an HVZK sumcheck phase in the protocol.
+#[derive(Debug)]
+pub struct ZkSumcheckParams {
+    /// Number of sumcheck rounds.
+    pub rounds: usize,
+
+    /// Proof-of-work difficulty in bits.
+    pub pow_bits: usize,
+
+    /// Mask-code message length `ell_zk`.
+    pub ell_zk: usize,
+}
+
 /// Encodes the structure of an interactive protocol as a sequence of field elements.
 ///
 /// # Overview
@@ -326,6 +339,36 @@ where
         }
     }
 
+    /// Append a Construction 6.3 HVZK sumcheck sub-protocol.
+    ///
+    /// # Transcript shape
+    ///
+    /// 1. Observe one mask commitment per sumcheck round.
+    /// 2. Observe `mu_tilde`.
+    /// 3. Sample the combining challenge `eps`.
+    /// 4. For each round, observe the wire polynomial coefficients, optionally
+    ///    grind, then sample the folding challenge.
+    pub fn add_zk_sumcheck<const DIGEST_ELEMS: usize>(&mut self, params: &ZkSumcheckParams) {
+        let ZkSumcheckParams {
+            rounds,
+            pow_bits,
+            ell_zk,
+        } = *params;
+
+        for _ in 0..rounds {
+            self.observe(DIGEST_ELEMS, Observe::MerkleDigest);
+        }
+        self.observe(1, Observe::ZkSumcheckMuTilde);
+        self.sample(1, Sample::ZkSumcheckCombinationRandomness);
+
+        let wire_coefficients = ell_zk.max(3) - 1;
+        for _ in 0..rounds {
+            self.observe(wire_coefficients, Observe::ZkSumcheckPoly);
+            self.pow(pow_bits);
+            self.sample(1, Sample::FoldingRandomness);
+        }
+    }
+
     /// Optionally append a proof-of-work challenge.
     ///
     /// When `bits` is positive, encodes:
@@ -340,5 +383,74 @@ where
             // Observe the nonce that solves the challenge.
             self.observe(8, Observe::PowNonce);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+
+    fn observe_entry(count: usize, observe: Observe) -> F {
+        observe.as_field_element::<F>()
+            + F::from_usize(count)
+            + Pattern::Observe.as_field_element::<F>()
+    }
+
+    fn sample_entry(count: usize, sample: Sample) -> F {
+        sample.as_field_element::<F>()
+            + F::from_usize(count)
+            + Pattern::Sample.as_field_element::<F>()
+    }
+
+    #[test]
+    fn zk_sumcheck_domain_separator_shape_matches_transcript() {
+        let mut separator = DomainSeparator::<EF, F>::new(Vec::new());
+
+        separator.add_zk_sumcheck::<8>(&ZkSumcheckParams {
+            rounds: 2,
+            pow_bits: 0,
+            ell_zk: 4,
+        });
+
+        assert_eq!(
+            separator.pattern,
+            vec![
+                observe_entry(8, Observe::MerkleDigest),
+                observe_entry(8, Observe::MerkleDigest),
+                observe_entry(1, Observe::ZkSumcheckMuTilde),
+                sample_entry(1, Sample::ZkSumcheckCombinationRandomness),
+                observe_entry(3, Observe::ZkSumcheckPoly),
+                sample_entry(1, Sample::FoldingRandomness),
+                observe_entry(3, Observe::ZkSumcheckPoly),
+                sample_entry(1, Sample::FoldingRandomness),
+            ],
+        );
+    }
+
+    #[test]
+    fn zk_sumcheck_domain_separator_uses_minimum_wire_width() {
+        let mut separator = DomainSeparator::<EF, F>::new(Vec::new());
+
+        separator.add_zk_sumcheck::<8>(&ZkSumcheckParams {
+            rounds: 1,
+            pow_bits: 0,
+            ell_zk: 2,
+        });
+
+        assert!(
+            separator
+                .pattern
+                .contains(&observe_entry(2, Observe::ZkSumcheckPoly)),
+            "ell_zk < 3 still sends max(ell_zk, 3) - 1 wire coefficients",
+        );
     }
 }

--- a/whir/src/fiat_shamir/pattern.rs
+++ b/whir/src/fiat_shamir/pattern.rs
@@ -55,6 +55,8 @@ pub enum Sample {
     /// to keep the domain separator synchronized with the actual prover/verifier
     /// transcript.
     TranscriptCheckpoint,
+    /// Combining challenge `eps` in the HVZK sumcheck overlay.
+    ZkSumcheckCombinationRandomness,
 }
 
 impl Sample {
@@ -92,6 +94,13 @@ pub enum Observe {
     /// to the specific protocol configuration. Each parameter is
     /// encoded as a (marker, value) pair.
     ProtocolParam,
+    /// Sum of all mask evaluations in the HVZK sumcheck overlay.
+    ZkSumcheckMuTilde,
+    /// Coefficients sent by one HVZK sumcheck round.
+    ///
+    /// The wire skips the linear coefficient and has
+    /// `max(ell_zk, 3) - 1` extension-field elements.
+    ZkSumcheckPoly,
 }
 
 impl Observe {


### PR DESCRIPTION
## Summary

Extracted from #1657 as the first small PR in the HVZK code-switching stack.

This adds only the Fiat-Shamir domain-separator shape needed for the HVZK sumcheck transcript:

- `ZkSumcheckParams`
- `DomainSeparator::add_zk_sumcheck`
- transcript labels for `mu_tilde`, `eps`, and widened ZK sumcheck round wires
- focused domain-separator tests, kept at the bottom of the file

No WHIR round/prover/verifier wiring is included here. Later stacked PRs will use this helper from the ZK sumcheck handoff and Construction 9.7 code-switching changes.

## Verification

```text
cargo test -p p3-whir fiat_shamir::domain_separator::tests
cargo +nightly fmt --check
cargo +stable clippy -p p3-whir --all-targets -- -D warnings
```
