### PR TITLE
fix: local refs for dev-deps

### DIFF
--- a/batch-stark/Cargo.toml
+++ b/batch-stark/Cargo.toml
@@ -25,7 +25,6 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 tracing.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit" }
@@ -36,6 +35,8 @@ p3-matrix = { path = "../matrix" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-symmetric = { path = "../symmetric" }
+
+criterion.workspace = true
 postcard = { workspace = true, features = ["alloc"] }
 rand.workspace = true
 

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -19,10 +19,11 @@ p3-util.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-num-bigint.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-bn254 = { path = "../bn254" }
 p3-goldilocks = { path = "../goldilocks" }
+
+num-bigint.workspace = true
 
 [lints]
 workspace = true

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -21,9 +21,10 @@ serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
+
+criterion.workspace = true
 proptest.workspace = true
 
 [[bench]]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -16,9 +16,10 @@ p3-util.workspace = true
 tiny-keccak = { workspace = true, features = ["keccak"] }
 
 [dev-dependencies]
-criterion.workspace = true
-p3-field.workspace = true
+p3-field = { path = "../field" }
 p3-mersenne-31 = { path = "../mersenne-31" }
+
+criterion.workspace = true
 
 [[bench]]
 name = "bench_keccak"

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -19,7 +19,6 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-challenger = { path = "../challenger" }
 p3-commit = { path = "../commit" }
@@ -28,7 +27,9 @@ p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-symmetric = { path = "../symmetric" }
-rand = { workspace = true }
+
+criterion.workspace = true
+rand.workspace = true
 
 [features]
 default = []

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -20,11 +20,11 @@ serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 
 [dev-dependencies]
-
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-mersenne-31 = { path = "../mersenne-31" }
+
+criterion.workspace = true
 proptest.workspace = true
 
 [[bench]]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -30,9 +30,9 @@ p3-blake3 = { path = "../blake3" }
 p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-rescue = { path = "../rescue" }
-proptest.workspace = true
 
 criterion.workspace = true
+proptest.workspace = true
 
 [[bench]]
 name = "merkle_tree"

--- a/multilinear-util/Cargo.toml
+++ b/multilinear-util/Cargo.toml
@@ -21,9 +21,9 @@ tracing.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 
+criterion.workspace = true
 proptest.workspace = true
 
 [features]

--- a/symmetric/Cargo.toml
+++ b/symmetric/Cargo.toml
@@ -17,8 +17,9 @@ itertools.workspace = true
 serde = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
-p3-goldilocks.workspace = true
+p3-goldilocks = { path = "../goldilocks" }
 p3-koala-bear = { path = "../koala-bear" }
+
 proptest.workspace = true
 
 [lints]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,10 +15,11 @@ serde.workspace = true
 transpose = "0.2"
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-field = { path = "../field" }
 p3-goldilocks = { path = "../goldilocks" }
+
+criterion.workspace = true
 proptest.workspace = true
 rand.workspace = true
 serde_json.workspace = true

--- a/whir/Cargo.toml
+++ b/whir/Cargo.toml
@@ -30,11 +30,12 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-clap.workspace = true
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-keccak = { path = "../keccak" }
 p3-koala-bear = { path = "../koala-bear" }
+
+clap.workspace = true
+criterion.workspace = true
 proptest.workspace = true
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }

--- a/zk-codes/Cargo.toml
+++ b/zk-codes/Cargo.toml
@@ -18,10 +18,11 @@ p3-util.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-koala-bear = { path = "../koala-bear" }
+
+criterion.workspace = true
 proptest.workspace = true
 rand_xoshiro.workspace = true
 


### PR DESCRIPTION
## Summary

- Use local paths for `p3-` dev-dependencies (known bug with release-plz publishing flow).
- Also add consistent separation between local vs non-local dev-dependencies in config files for readability. 