### PR TITLE
perf(multilinear-util): field-aware MLE recursion threshold

### DIFF
--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -17,8 +17,24 @@ use crate::split_eq::SplitEq;
 
 pub(crate) const PARALLEL_THRESHOLD: usize = 4096;
 
-/// Number of variables at which we switch from recursive to chunk-based MLE evaluation.
-const MLE_RECURSION_THRESHOLD: usize = 10;
+/// Number of variables at which we switch from recursive scalar evaluation to the
+/// SIMD-packed `SplitEq` path.
+///
+/// Crossover depends on the base-field byte width (smaller base ⇒ wider packing
+/// ⇒ `SplitEq` wins earlier), measured on aarch64 (NEON) and x86-64 (AVX2):
+///
+/// - 4-byte bases (BabyBear, KoalaBear, Mersenne31): `SplitEq` wins from n=9.
+/// - 8-byte bases (Goldilocks): recursive still wins at n=9, crosses at n=10.
+///
+/// Wider bases (e.g. BN254) keep the default 10.
+#[inline]
+const fn mle_recursion_threshold<B>() -> usize {
+    if core::mem::size_of::<B>() <= 4 {
+        9
+    } else {
+        10
+    }
+}
 
 /// Returns a vector of uninitialized elements of type `A` with the specified length.
 ///
@@ -315,7 +331,7 @@ impl<F: Field> Poly<F> {
     #[must_use]
     #[inline]
     pub fn eval_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
-        if point.num_variables() < MLE_RECURSION_THRESHOLD {
+        if point.num_variables() < mle_recursion_threshold::<F>() {
             eval_multilinear_recursive(&self.0, point.as_slice())
         } else {
             SplitEq::new_packed(point, EF::ONE).eval_base(self)
@@ -338,7 +354,7 @@ impl<F: Field> Poly<F> {
     where
         F: ExtensionField<BaseField>,
     {
-        if point.num_variables() < MLE_RECURSION_THRESHOLD {
+        if point.num_variables() < mle_recursion_threshold::<BaseField>() {
             eval_multilinear_recursive(&self.0, point.as_slice())
         } else {
             SplitEq::new_packed(point, F::ONE).eval_ext(self)
@@ -703,24 +719,12 @@ where
             // Split the evaluations into two halves, corresponding to the first variable being 0 or 1.
             let (f0, f1) = evals.split_at(evals.len() / 2);
 
-            // Recursively evaluate on the two smaller hypercubes.
-            let (f0_eval, f1_eval) = {
-                // Only spawn parallel tasks if the subproblem is large enough to overcome
-                // the overhead of threading.
-                let work_size: usize = (1 << 15) / core::mem::size_of::<F>();
-                if evals.len() > work_size {
-                    join(
-                        || eval_multilinear_recursive(f0, sub_point),
-                        || eval_multilinear_recursive(f1, sub_point),
-                    )
-                } else {
-                    // For smaller subproblems, execute sequentially.
-                    (
-                        eval_multilinear_recursive(f0, sub_point),
-                        eval_multilinear_recursive(f1, sub_point),
-                    )
-                }
-            };
+            // Sequential recurse: callers gate this function with `num_variables <
+            // mle_recursion_threshold`, so `evals.len()` is always small enough that
+            // Rayon `join` overhead would dominate.
+            let f0_eval = eval_multilinear_recursive(f0, sub_point);
+            let f1_eval = eval_multilinear_recursive(f1, sub_point);
+
             // Perform the final linear interpolation for the first variable `x`.
             f0_eval + (f1_eval - f0_eval) * *x
         }


### PR DESCRIPTION
## Summary

`Poly::eval_base` and `Poly::eval_ext` dispatch between a scalar recursive evaluator (small `n`) and the SIMD-packed `SplitEq` path (larger `n`) using a fixed `MLE_RECURSION_THRESHOLD = 10`. A new `eval_threshold` bench shows the crossover is base-field-size-dependent — 4-byte bases (BabyBear, KoalaBear, Mersenne31) cross at `n = 9`, while 8-byte bases (Goldilocks) cross at `n = 10`. Replacing the constant with a `const fn` keyed on `core::mem::size_of::<BaseField>()` gives a clean win on small-base fields with no regression elsewhere.

I also drop the unreachable `join` branch inside `eval_multilinear_recursive`. Callers gate that function with `num_variables < threshold`, so `evals.len() <= 512` (`< 2^9`), while the gate that selected `join` requires `evals.len() > work_size = (1 << 15) / size_of::<F>() >= 1024` (even BN254's 32-byte field gives 1024). Removing it leaves a comment explaining why the recurse is sequential.

The mathematical contract is unchanged: both implementations compute `f(point) = Σ_x eq(x, point) · f(x)`, and the existing `test_eval_base_field` / `test_eval_ext_field` checks `eval_reference` agreement for `k = 1..=20`, straddling the threshold.

## Bench

`cargo bench -p p3-multilinear-util --bench eval_threshold`, M1, BabyBear + `BinomialExtensionField<BabyBear, 4>` and Goldilocks + `BinomialExtensionField<Goldilocks, 2>`, criterion 60 samples, median (low-high in brackets).

| n  | BabyBear before (poly_eval_ext) | BabyBear after  | Δ      | Goldilocks before | Goldilocks after | Δ |
|----|--------------------------------:|----------------:|-------:|------------------:|-----------------:|--:|
| 6  | 346 ns                          | 342 ns          | -1%    | 230 ns            | 217 ns           | -6% |
| 7  | 714 ns                          | 711 ns          | tied   | 460 ns            | 460 ns           | tied |
| 8  | 1.45 µs                         | 1.44 µs         | tied   | 911 ns            | 911 ns           | tied |
| 9  | 2.91 µs                         | **2.47 µs**     | **-15.1%** | 1.85 µs       | 1.80 µs          | -3% |
| 10 | 4.63 µs                         | 4.68 µs         | tied   | 4.83 µs           | 4.55 µs          | tied |
| 11 | 8.12 µs                         | 8.10 µs         | tied   | 8.49 µs           | 8.48 µs          | tied |
| 12-14 | ...                          | ...             | tied   | ...               | ...              | tied |

Only the BabyBear `n = 9` cell moves materially: that's the case where the constant threshold forced `recursive` even though `SplitEq` is already faster. KoalaBear and Mersenne31 are 4-byte bases too, so they pick up the same threshold = 9 path.

The small low-`n` improvements on both fields come from removing the `join` branch's setup work at every recursion frame.

## Test plan

- [x] `cargo test -p p3-multilinear-util --lib` — 131 passed.
- [x] `cargo test -p p3-whir --lib` — 201 passed, including `test_whir_end_to_end`.
- [x] `cargo test --workspace --lib` — all green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo build --target thumbv7em-none-eabi -p p3-multilinear-util` — clean.