### PR TITLE
verifier: add a couple strengthening checks

### DIFF
--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -67,6 +67,9 @@ where
         let constraint_degree = (max_degree + is_zk).max(2);
         let result = log2_ceil_usize(constraint_degree - 1);
 
+        // This check remains at the `debug` level, as the AIR is known by both
+        // prover and verifier, i.e. a malicious prover cannot feed the verifier
+        // a different hint than the verifier computes for itself.
         debug_assert!(
             {
                 let actual = get_max_constraint_degree(air, layout, contexts, lookup_gadget);

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -94,8 +94,12 @@ where
     let mut ext_domain_sizes = Vec::with_capacity(airs.len());
 
     for (i, air) in airs.iter().enumerate() {
-        let (base_db, ext_domain_size) =
-            validate_degree_bits(Some(i), degree_bits[i], config.is_zk())?;
+        let (base_db, ext_domain_size) = validate_degree_bits(
+            Some(i),
+            degree_bits[i],
+            config.is_zk(),
+            pcs.log_max_lde_height(),
+        )?;
         base_degree_bits.push(base_db);
         ext_domain_sizes.push(ext_domain_size);
 

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -15,7 +15,7 @@ use p3_circle::CirclePcs;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_lookup::InteractionBuilder;
@@ -1027,7 +1027,7 @@ fn test_degree_bits_too_large_rejected() -> Result<(), Box<dyn std::error::Error
 
     // Verify the error carries the correct diagnostic fields:
     //   - air: Some(0)          — first (and only) AIR instance
-    //   - maximum: BITS - 1     — largest safe exponent (63 on 64-bit)
+    //   - maximum: TWO_ADICITY  — largest degree supported by the PCS
     //   - got: BITS             — the tampered value we injected (64)
     match err {
         VerificationError::InvalidProofShape(InvalidProofShapeError::DegreeBitsTooLarge {
@@ -1036,7 +1036,7 @@ fn test_degree_bits_too_large_rejected() -> Result<(), Box<dyn std::error::Error
             got,
         }) => {
             assert_eq!(air, Some(0));
-            assert_eq!(maximum, usize::BITS as usize - 1);
+            assert_eq!(maximum, Val::TWO_ADICITY);
             assert_eq!(got, usize::BITS as usize);
         }
         _ => panic!("unexpected error: {err:?}"),

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -121,6 +121,10 @@ where
         CircleDomain::standard(log2_strict_usize(degree))
     }
 
+    fn log_max_lde_height(&self) -> usize {
+        Val::CIRCLE_TWO_ADICITY
+    }
+
     fn commit(
         &self,
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -492,6 +492,11 @@ where
                         let alpha_pow_width_2 = alpha.exp_u64(ps_at_x.len() as u64).square();
 
                         for (zeta_uni, ps_at_zeta) in mat_points_and_values {
+                            // The claimed opening must have exactly as many
+                            // values as the committed row has columns.
+                            if ps_at_zeta.len() != ps_at_x.len() {
+                                return Err(InputError::InputShapeError);
+                            }
                             let zeta = Point::from_projective_line(*zeta_uni);
 
                             *ro += *alpha_offset

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -74,6 +74,11 @@ where
     /// This should return a domain such that `Domain::next_point` returns `Some`.
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain;
 
+    /// The base-2 logarithm of the largest evaluation domain this PCS can construct.
+    fn log_max_lde_height(&self) -> usize {
+        usize::BITS as usize - 1
+    }
+
     /// Given a collection of evaluation matrices, produce a binding commitment to
     /// the polynomials defined by those evaluations. If `zk` is enabled, the evaluations are
     /// first randomized as explained in Section 3 of https://eprint.iacr.org/2024/1037.pdf .

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -98,6 +98,11 @@ where
             &self.inner, degree)
     }
 
+    fn log_max_lde_height(&self) -> usize {
+        <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::log_max_lde_height(
+            &self.inner)
+    }
+
     fn commit(
         &self,
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -286,6 +286,10 @@ where
         TwoAdicMultiplicativeCoset::new(Val::ONE, log2_strict_usize(degree)).unwrap()
     }
 
+    fn log_max_lde_height(&self) -> usize {
+        Val::TWO_ADICITY
+    }
+
     /// Commit to a collection of evaluation matrices.
     ///
     /// Each element of `evaluations` contains a coset `shift * H` and a matrix `mat` with `mat.height() = |H|`.

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -53,6 +53,12 @@ where
         expected: usize,
         got: usize,
     },
+    #[error("round {round}: invalid log-arity {log_arity}: must be in 1..={max}")]
+    InvalidLogArity {
+        round: usize,
+        log_arity: usize,
+        max: usize,
+    },
     #[error("final folded height mismatch: expected {expected}, got {got}")]
     FinalFoldHeightMismatch { expected: usize, got: usize },
     #[error(
@@ -172,6 +178,17 @@ where
                 query,
                 expected: log_arities,
                 got: got_log_arities,
+            });
+        }
+    }
+
+    // Bound the prover-supplied folding arities.
+    for (round, &log_arity) in log_arities.iter().enumerate() {
+        if log_arity == 0 || log_arity > params.max_log_arity {
+            return Err(FriError::InvalidLogArity {
+                round,
+                log_arity,
+                max: params.max_log_arity,
             });
         }
     }

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -1105,25 +1105,20 @@ where
 
         let default_digest = [PW::Value::default(); DIGEST_ELEMS];
 
-        // Replay the arity schedule that the prover computed during tree
-        // construction. We use the remaining matrix heights to decide at
-        // each level whether this was an N-ary or a binary step.
+        // Derive the arity schedule from verifier-known dimensions and the configured cap height.
+        let arity_schedule = self.proof_arity_schedule(dimensions)?;
+        let expected_proof_len: usize = arity_schedule.iter().map(|step| step - 1).sum();
+        if opening_proof.len() != expected_proof_len {
+            return Err(WrongHeight {
+                expected_proof_len,
+                num_siblings: opening_proof.len(),
+            });
+        }
+
         let mut proof_pos: usize = 0;
 
-        while proof_pos < opening_proof.len() {
-            let step = select_arity_step::<N>(
-                curr_height_padded,
-                leaf_height_npt,
-                heights_tallest_first.clone().map(|(_, dims)| dims.height),
-            );
-
+        for &step in &arity_schedule {
             let num_siblings = step - 1;
-            if proof_pos + num_siblings > opening_proof.len() {
-                return Err(WrongHeight {
-                    expected_proof_len: proof_pos + num_siblings,
-                    num_siblings: opening_proof.len(),
-                });
-            }
             let siblings = &opening_proof[proof_pos..proof_pos + num_siblings];
             proof_pos += num_siblings;
 

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -18,6 +18,9 @@ where
         let constraint_degree = (degree_hint + is_zk).max(2);
         let result = log2_ceil_usize(constraint_degree - 1);
 
+        // This check remains at the `debug` level, as the AIR is known by both
+        // prover and verifier, i.e. a malicious prover cannot feed the verifier
+        // a different hint than the verifier computes for itself.
         debug_assert!(
             {
                 let symbolic = get_log_quotient_degree_extension::<F, F, A>(air, layout, is_zk);

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -26,11 +26,20 @@ pub fn validate_degree_bits(
     air: Option<usize>,
     degree_bits: usize,
     is_zk: usize,
+    max_log_degree: usize,
 ) -> Result<(usize, usize), InvalidProofShapeError> {
     if degree_bits < is_zk {
         return Err(InvalidProofShapeError::DegreeBitsTooSmall {
             air,
             minimum: is_zk,
+            got: degree_bits,
+        });
+    }
+
+    if degree_bits > max_log_degree {
+        return Err(InvalidProofShapeError::DegreeBitsTooLarge {
+            air,
+            maximum: max_log_degree,
             got: degree_bits,
         });
     }
@@ -256,7 +265,8 @@ where
     let degree_bits = *degree_bits;
 
     let pcs = config.pcs();
-    let (base_degree_bits, degree) = validate_degree_bits(None, degree_bits, config.is_zk())?;
+    let (base_degree_bits, degree) =
+        validate_degree_bits(None, degree_bits, config.is_zk(), pcs.log_max_lde_height())?;
     let trace_domain = pcs.natural_domain_for_degree(degree);
     // TODO: allow moving preprocessed commitment to preprocess time, if known in advance
     let (preprocessed_width, preprocessed_commit) =

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -7,7 +7,7 @@ use p3_circle::CirclePcs;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
 use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
 use p3_keccak::{Keccak256Hash, KeccakF};
 use p3_matrix::dense::RowMajorMatrix;
@@ -350,14 +350,14 @@ fn test_degree_bits_too_large_rejected() {
     // Unlike batch-stark, uni-stark has a single AIR so `air` is None.
     //
     //   - air: None              — uni-stark doesn't index by AIR
-    //   - maximum: BITS - 1      — largest safe exponent (63 on 64-bit)
+    //   - maximum: TWO_ADICITY   — largest degree supported by the PCS
     //   - got: BITS              — the tampered value we injected (64)
     match err {
         p3_uni_stark::VerificationError::InvalidProofShape(
             InvalidProofShapeError::DegreeBitsTooLarge { air, maximum, got },
         ) => {
             assert_eq!(air, None);
-            assert_eq!(maximum, usize::BITS as usize - 1);
+            assert_eq!(maximum, BabyBear::TWO_ADICITY);
             assert_eq!(got, usize::BITS as usize);
         }
         _ => panic!("unexpected error: {err:?}"),


### PR DESCRIPTION
## Summary

Add a couple checks / tweaks to strengthen the verifier flow, namely:

* reject too wide circle opening claims
* bound FRI folding log_arity
* derive verify_batch arity schedule from dimensions
* reject proof degree_bits exceeding PCS max domain size
* clarify comment around quotient-degree hint (no concrete changes, just clarifying the doc around the debug_assertion)