### PR TITLE
perf(goldilocks): cross-permute batched Poseidon2 for widths 8 and 12

### DIFF
--- a/goldilocks/examples/poseidon2_batched_perf.rs
+++ b/goldilocks/examples/poseidon2_batched_perf.rs
@@ -1,0 +1,366 @@
+//! Perf comparison: single `Poseidon2::permute_mut` vs the cross-permute
+//! batched `permute_batch_b2_p2_w{8,12}` on the same packed type.
+//!
+//! On aarch64 the production `Poseidon2Goldilocks<8>` resolves to the
+//! fused NEON kernel; an extra fused-baseline row is printed for context.
+//!
+//! Build (AVX-2):
+//!   RUSTFLAGS="-C target-feature=+avx2" cargo build --release \
+//!     --example poseidon2_batched_perf -p p3-goldilocks
+//! Build (NEON):
+//!   cargo build --release --example poseidon2_batched_perf -p p3-goldilocks
+//!
+//! Run:
+//!   target/release/examples/poseidon2_batched_perf [N] [--seed K]
+//! Defaults: N=1_000_000, seed=1.
+
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_feature = "avx2"),
+    target_arch = "aarch64",
+)))]
+fn main() {
+    eprintln!("poseidon2_batched_perf: requires x86_64+avx2 or aarch64.");
+    std::process::exit(1);
+}
+
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "avx2"),
+    target_arch = "aarch64",
+))]
+fn main() {
+    harness::run();
+}
+
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "avx2"),
+    target_arch = "aarch64",
+))]
+mod harness {
+    use std::env;
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    use p3_goldilocks::poseidon2_batched::{
+        default_goldilocks_poseidon2_batched_8, default_goldilocks_poseidon2_batched_12,
+        permute_batch_b2_p2_w8, permute_batch_b2_p2_w12,
+    };
+    use p3_goldilocks::{
+        GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_FINAL, GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_INITIAL,
+        GOLDILOCKS_POSEIDON2_RC_8_INTERNAL, GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_FINAL,
+        GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_INITIAL, GOLDILOCKS_POSEIDON2_RC_12_INTERNAL,
+        Goldilocks, Poseidon2ExternalLayerGoldilocks, Poseidon2InternalLayerGoldilocks,
+    };
+    use p3_poseidon2::{ExternalLayerConstants, Poseidon2};
+    use p3_symmetric::Permutation;
+    use rand::SeedableRng;
+    use rand::distr::{Distribution, StandardUniform};
+    use rand::rngs::SmallRng;
+
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    type Packed = p3_goldilocks::PackedGoldilocksAVX512;
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    const PACKED_LABEL: &str = "avx512 (8L)";
+
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        not(target_feature = "avx512f")
+    ))]
+    type Packed = p3_goldilocks::PackedGoldilocksAVX2;
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        not(target_feature = "avx512f")
+    ))]
+    const PACKED_LABEL: &str = "avx2 (4L)";
+
+    #[cfg(target_arch = "aarch64")]
+    type Packed = p3_goldilocks::PackedGoldilocksNeon;
+    #[cfg(target_arch = "aarch64")]
+    const PACKED_LABEL: &str = "neon (2L)";
+
+    type GenericP2W8 = Poseidon2<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks<8>,
+        Poseidon2InternalLayerGoldilocks,
+        8,
+        7,
+    >;
+
+    fn build_generic() -> GenericP2W8 {
+        Poseidon2::new(
+            ExternalLayerConstants::new(
+                GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_INITIAL.to_vec(),
+                GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_FINAL.to_vec(),
+            ),
+            GOLDILOCKS_POSEIDON2_RC_8_INTERNAL.to_vec(),
+        )
+    }
+
+    type GenericP2W12 = Poseidon2<
+        Goldilocks,
+        Poseidon2ExternalLayerGoldilocks<12>,
+        Poseidon2InternalLayerGoldilocks,
+        12,
+        7,
+    >;
+
+    fn build_generic_w12() -> GenericP2W12 {
+        Poseidon2::new(
+            ExternalLayerConstants::new(
+                GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_INITIAL.to_vec(),
+                GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_FINAL.to_vec(),
+            ),
+            GOLDILOCKS_POSEIDON2_RC_12_INTERNAL.to_vec(),
+        )
+    }
+
+    pub fn run() {
+        let mut args: Vec<String> = env::args().skip(1).collect();
+        let mut seed: u64 = 1;
+        if let Some(idx) = args.iter().position(|a| a == "--seed") {
+            seed = args.get(idx + 1).unwrap().parse().unwrap();
+            args.drain(idx..=idx + 1);
+        }
+        let n: usize = args
+            .first()
+            .map(|s| s.parse().unwrap())
+            .unwrap_or(1_000_000);
+
+        println!("packed path:    {}", PACKED_LABEL);
+        println!("iters per run:  {}", n);
+        println!("seed:           {}", seed);
+        println!();
+
+        // Build perms.
+        let generic = build_generic();
+        let constants = default_goldilocks_poseidon2_batched_8();
+        #[cfg(target_arch = "aarch64")]
+        let fused = p3_goldilocks::default_goldilocks_poseidon2_8();
+
+        // Seed two random states (broadcast to packed lanes).
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let scalars_a: [Goldilocks; 8] = std::array::from_fn(|_| {
+            <StandardUniform as Distribution<Goldilocks>>::sample(&StandardUniform, &mut rng)
+        });
+        let scalars_b: [Goldilocks; 8] = std::array::from_fn(|_| {
+            <StandardUniform as Distribution<Goldilocks>>::sample(&StandardUniform, &mut rng)
+        });
+
+        // Bitwise gate: batched-generic == single-generic for both states.
+        {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let mut s_b: [Packed; 8] = scalars_b.map(Into::into);
+            generic.permute_mut(&mut s_a);
+            generic.permute_mut(&mut s_b);
+
+            let mut b_a: [Packed; 8] = scalars_a.map(Into::into);
+            let mut b_b: [Packed; 8] = scalars_b.map(Into::into);
+            permute_batch_b2_p2_w8(&mut b_a, &mut b_b, &constants);
+            assert_eq!(b_a, s_a, "batched-generic state_a mismatch");
+            assert_eq!(b_b, s_b, "batched-generic state_b mismatch");
+        }
+        println!("bitwise gate:   batched-generic == single-generic   OK\n");
+
+        // single-generic: time N permute_mut calls (alternating states).
+        let single_generic_ns = {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let mut s_b: [Packed; 8] = scalars_b.map(Into::into);
+            let t0 = Instant::now();
+            for i in 0..n {
+                if i & 1 == 0 {
+                    generic.permute_mut(black_box(&mut s_a));
+                } else {
+                    generic.permute_mut(black_box(&mut s_b));
+                }
+            }
+            let _ = black_box(s_a);
+            let _ = black_box(s_b);
+            t0.elapsed().as_secs_f64() * 1e9 / n as f64
+        };
+
+        // batched-generic: time N/2 permute_batch_b2 calls (each = 2 permutes).
+        let batched_generic_ns = {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let mut s_b: [Packed; 8] = scalars_b.map(Into::into);
+            let n_batches = n / 2;
+            let t0 = Instant::now();
+            for _ in 0..n_batches {
+                permute_batch_b2_p2_w8(black_box(&mut s_a), black_box(&mut s_b), &constants);
+            }
+            let _ = black_box(s_a);
+            let _ = black_box(s_b);
+            t0.elapsed().as_secs_f64() * 1e9 / (n_batches * 2) as f64
+        };
+
+        // single-fused (NEON only).
+        #[cfg(target_arch = "aarch64")]
+        let single_fused_ns = {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let mut s_b: [Packed; 8] = scalars_b.map(Into::into);
+            let t0 = Instant::now();
+            for i in 0..n {
+                if i & 1 == 0 {
+                    fused.permute_mut(black_box(&mut s_a));
+                } else {
+                    fused.permute_mut(black_box(&mut s_b));
+                }
+            }
+            let _ = black_box(s_a);
+            let _ = black_box(s_b);
+            t0.elapsed().as_secs_f64() * 1e9 / n as f64
+        };
+
+        // Serial (non-alternating) variants: hash-chain workload, period-1
+        // dependency per call. Tests whether the alternating A/B loop above
+        // is unfair to the fused path (which already extracts cross-lane
+        // ILP within a single packed state via *_dual_w8 asm and may have
+        // less marginal benefit from cross-packed-state OoO than generic).
+        let single_generic_serial_ns = {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let t0 = Instant::now();
+            for _ in 0..n {
+                generic.permute_mut(black_box(&mut s_a));
+            }
+            let _ = black_box(s_a);
+            t0.elapsed().as_secs_f64() * 1e9 / n as f64
+        };
+
+        #[cfg(target_arch = "aarch64")]
+        let single_fused_serial_ns = {
+            let mut s_a: [Packed; 8] = scalars_a.map(Into::into);
+            let t0 = Instant::now();
+            for _ in 0..n {
+                fused.permute_mut(black_box(&mut s_a));
+            }
+            let _ = black_box(s_a);
+            t0.elapsed().as_secs_f64() * 1e9 / n as f64
+        };
+
+        println!("| path                      | ns/permute |  vs single-generic |");
+        println!("|---------------------------|-----------:|-------------------:|");
+        println!(
+            "| single-generic (alt)      | {:>9.2}  |             1.000x |",
+            single_generic_ns
+        );
+        println!(
+            "| batched-generic (alt)     | {:>9.2}  |             {:>5.3}x |",
+            batched_generic_ns,
+            batched_generic_ns / single_generic_ns
+        );
+        #[cfg(target_arch = "aarch64")]
+        println!(
+            "| single-fused (alt)        | {:>9.2}  |             {:>5.3}x |",
+            single_fused_ns,
+            single_fused_ns / single_generic_ns
+        );
+        println!(
+            "| single-generic (serial)   | {:>9.2}  |             {:>5.3}x |",
+            single_generic_serial_ns,
+            single_generic_serial_ns / single_generic_ns
+        );
+        #[cfg(target_arch = "aarch64")]
+        println!(
+            "| single-fused (serial)     | {:>9.2}  |             {:>5.3}x |",
+            single_fused_serial_ns,
+            single_fused_serial_ns / single_generic_ns
+        );
+
+        println!();
+        println!(
+            "mechanism check (batched-generic vs single-generic):    {:>5.2}% reduction",
+            (1.0 - batched_generic_ns / single_generic_ns) * 100.0
+        );
+        #[cfg(target_arch = "aarch64")]
+        {
+            println!(
+                "ship-relevance (batched-generic vs single-fused):       {:>5.2}% reduction",
+                (1.0 - batched_generic_ns / single_fused_ns) * 100.0
+            );
+            println!();
+            println!("H2 test (serial / hash-chain workload):");
+            println!(
+                "  single-fused-serial vs single-generic-serial:        {:>+6.2}% (negative = fused faster)",
+                (single_fused_serial_ns / single_generic_serial_ns - 1.0) * 100.0
+            );
+            println!(
+                "  single-fused-alt    vs single-generic-alt:           {:>+6.2}% (alternating loop, for comparison)",
+                (single_fused_ns / single_generic_ns - 1.0) * 100.0
+            );
+        }
+
+        // --- width 12 ---
+        println!();
+        println!("=== width 12 ===");
+
+        let generic_w12 = build_generic_w12();
+        let constants_w12 = default_goldilocks_poseidon2_batched_12();
+
+        let scalars_a_w12: [Goldilocks; 12] = std::array::from_fn(|_| {
+            <StandardUniform as Distribution<Goldilocks>>::sample(&StandardUniform, &mut rng)
+        });
+        let scalars_b_w12: [Goldilocks; 12] = std::array::from_fn(|_| {
+            <StandardUniform as Distribution<Goldilocks>>::sample(&StandardUniform, &mut rng)
+        });
+
+        {
+            let mut s_a: [Packed; 12] = scalars_a_w12.map(Into::into);
+            let mut s_b: [Packed; 12] = scalars_b_w12.map(Into::into);
+            generic_w12.permute_mut(&mut s_a);
+            generic_w12.permute_mut(&mut s_b);
+
+            let mut b_a: [Packed; 12] = scalars_a_w12.map(Into::into);
+            let mut b_b: [Packed; 12] = scalars_b_w12.map(Into::into);
+            permute_batch_b2_p2_w12(&mut b_a, &mut b_b, &constants_w12);
+            assert_eq!(b_a, s_a, "w12 batched-generic state_a mismatch");
+            assert_eq!(b_b, s_b, "w12 batched-generic state_b mismatch");
+        }
+        println!("bitwise gate:   batched-generic == single-generic   OK\n");
+
+        let single_generic_ns_w12 = {
+            let mut s_a: [Packed; 12] = scalars_a_w12.map(Into::into);
+            let mut s_b: [Packed; 12] = scalars_b_w12.map(Into::into);
+            let t0 = Instant::now();
+            for i in 0..n {
+                if i & 1 == 0 {
+                    generic_w12.permute_mut(black_box(&mut s_a));
+                } else {
+                    generic_w12.permute_mut(black_box(&mut s_b));
+                }
+            }
+            let _ = black_box(s_a);
+            let _ = black_box(s_b);
+            t0.elapsed().as_secs_f64() * 1e9 / n as f64
+        };
+
+        let batched_generic_ns_w12 = {
+            let mut s_a: [Packed; 12] = scalars_a_w12.map(Into::into);
+            let mut s_b: [Packed; 12] = scalars_b_w12.map(Into::into);
+            let n_batches = n / 2;
+            let t0 = Instant::now();
+            for _ in 0..n_batches {
+                permute_batch_b2_p2_w12(black_box(&mut s_a), black_box(&mut s_b), &constants_w12);
+            }
+            let _ = black_box(s_a);
+            let _ = black_box(s_b);
+            t0.elapsed().as_secs_f64() * 1e9 / (n_batches * 2) as f64
+        };
+
+        println!("| path                      | ns/permute |  vs single-generic |");
+        println!("|---------------------------|-----------:|-------------------:|");
+        println!(
+            "| single-generic (alt)      | {:>9.2}  |             1.000x |",
+            single_generic_ns_w12
+        );
+        println!(
+            "| batched-generic (alt)     | {:>9.2}  |             {:>5.3}x |",
+            batched_generic_ns_w12,
+            batched_generic_ns_w12 / single_generic_ns_w12
+        );
+        println!();
+        println!(
+            "mechanism check (batched-generic vs single-generic):    {:>5.2}% reduction",
+            (1.0 - batched_generic_ns_w12 / single_generic_ns_w12) * 100.0
+        );
+    }
+}

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -14,6 +14,7 @@ pub use mds::*;
 pub use poseidon2::*;
 
 pub mod poseidon1;
+pub mod poseidon2_batched;
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64_neon;

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -705,7 +705,7 @@ pub const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] = Goldilocks::new_array([
     0x0b3694a940bd2394,
 ]);
 
-fn internal_layer_mat_mul_goldilocks_8<A: Algebra<Goldilocks>>(state: &mut [A; 8]) {
+pub(crate) fn internal_layer_mat_mul_goldilocks_8<A: Algebra<Goldilocks>>(state: &mut [A; 8]) {
     let sum: A = state.iter().map(|r| r.dup()).sum();
 
     let s0 = state[0].dup();
@@ -750,7 +750,7 @@ fn internal_layer_mat_mul_goldilocks_8<A: Algebra<Goldilocks>>(state: &mut [A; 8
     state[7] = sum - four_s7;
 }
 
-fn internal_layer_mat_mul_goldilocks_12<A: Algebra<Goldilocks>>(state: &mut [A; 12]) {
+pub(crate) fn internal_layer_mat_mul_goldilocks_12<A: Algebra<Goldilocks>>(state: &mut [A; 12]) {
     let sum: A = state.iter().map(|r| r.dup()).sum();
 
     let s0 = state[0].dup();

--- a/goldilocks/src/poseidon2_batched.rs
+++ b/goldilocks/src/poseidon2_batched.rs
@@ -1,0 +1,369 @@
+//! Cross-permute batched Poseidon2 for Goldilocks.
+//!
+//! Inlines the full round structure across two states inside one function
+//! scope, exposing cross-permute ILP that the single-permute trait method
+//! hides behind a function-call boundary. Widths 8 and 12.
+
+use alloc::vec::Vec;
+
+use p3_field::{Algebra, InjectiveMonomial};
+use p3_poseidon2::{ExternalLayerConstants, MDSMat4, mds_light_permutation};
+
+use crate::Goldilocks;
+use crate::poseidon1::GOLDILOCKS_S_BOX_DEGREE;
+use crate::poseidon2::{
+    GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_FINAL, GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_INITIAL,
+    GOLDILOCKS_POSEIDON2_RC_8_INTERNAL, GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_FINAL,
+    GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_INITIAL, GOLDILOCKS_POSEIDON2_RC_12_INTERNAL,
+    internal_layer_mat_mul_goldilocks_8, internal_layer_mat_mul_goldilocks_12,
+};
+
+/// Pre-computed Poseidon2 constants for the batched paths.
+#[derive(Clone, Debug)]
+pub struct Poseidon2BatchedConstants<const W: usize> {
+    pub external: ExternalLayerConstants<Goldilocks, W>,
+    pub internal: Vec<Goldilocks>,
+}
+
+pub fn default_goldilocks_poseidon2_batched_8() -> Poseidon2BatchedConstants<8> {
+    Poseidon2BatchedConstants {
+        external: ExternalLayerConstants::new(
+            GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_INITIAL.to_vec(),
+            GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_FINAL.to_vec(),
+        ),
+        internal: GOLDILOCKS_POSEIDON2_RC_8_INTERNAL.to_vec(),
+    }
+}
+
+pub fn default_goldilocks_poseidon2_batched_12() -> Poseidon2BatchedConstants<12> {
+    Poseidon2BatchedConstants {
+        external: ExternalLayerConstants::new(
+            GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_INITIAL.to_vec(),
+            GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_FINAL.to_vec(),
+        ),
+        internal: GOLDILOCKS_POSEIDON2_RC_12_INTERNAL.to_vec(),
+    }
+}
+
+#[inline(always)]
+fn external_round_b2<A, const W: usize>(
+    state_a: &mut [A; W],
+    state_b: &mut [A; W],
+    rc: &[Goldilocks; W],
+) where
+    A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+{
+    for (s, &c) in state_a.iter_mut().zip(rc.iter()) {
+        *s += c;
+    }
+    for (s, &c) in state_b.iter_mut().zip(rc.iter()) {
+        *s += c;
+    }
+    for s in state_a.iter_mut() {
+        *s = s.injective_exp_n();
+    }
+    for s in state_b.iter_mut() {
+        *s = s.injective_exp_n();
+    }
+    mds_light_permutation(state_a, &MDSMat4);
+    mds_light_permutation(state_b, &MDSMat4);
+}
+
+/// Apply two Poseidon2 (width 8) permutations in lock-step.
+///
+/// Bitwise-equivalent to two calls of `Poseidon2Goldilocks<8>::permute_mut`
+/// on the platform-generic path.
+pub fn permute_batch_b2_p2_w8<A>(
+    state_a: &mut [A; 8],
+    state_b: &mut [A; 8],
+    constants: &Poseidon2BatchedConstants<8>,
+) where
+    A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+{
+    mds_light_permutation(state_a, &MDSMat4);
+    mds_light_permutation(state_b, &MDSMat4);
+    for rc in constants.external.get_initial_constants() {
+        external_round_b2(state_a, state_b, rc);
+    }
+
+    for &rc in constants.internal.iter() {
+        state_a[0] += rc;
+        state_b[0] += rc;
+        state_a[0] = state_a[0].injective_exp_n();
+        state_b[0] = state_b[0].injective_exp_n();
+        internal_layer_mat_mul_goldilocks_8(state_a);
+        internal_layer_mat_mul_goldilocks_8(state_b);
+    }
+
+    for rc in constants.external.get_terminal_constants() {
+        external_round_b2(state_a, state_b, rc);
+    }
+}
+
+/// Apply two Poseidon2 (width 12) permutations in lock-step.
+pub fn permute_batch_b2_p2_w12<A>(
+    state_a: &mut [A; 12],
+    state_b: &mut [A; 12],
+    constants: &Poseidon2BatchedConstants<12>,
+) where
+    A: Algebra<Goldilocks> + InjectiveMonomial<GOLDILOCKS_S_BOX_DEGREE>,
+{
+    mds_light_permutation(state_a, &MDSMat4);
+    mds_light_permutation(state_b, &MDSMat4);
+    for rc in constants.external.get_initial_constants() {
+        external_round_b2(state_a, state_b, rc);
+    }
+
+    for &rc in constants.internal.iter() {
+        state_a[0] += rc;
+        state_b[0] += rc;
+        state_a[0] = state_a[0].injective_exp_n();
+        state_b[0] = state_b[0].injective_exp_n();
+        internal_layer_mat_mul_goldilocks_12(state_a);
+        internal_layer_mat_mul_goldilocks_12(state_b);
+    }
+
+    for rc in constants.external.get_terminal_constants() {
+        external_round_b2(state_a, state_b, rc);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_poseidon2::Poseidon2;
+    use p3_symmetric::Permutation;
+
+    use super::*;
+    use crate::poseidon2::{Poseidon2ExternalLayerGoldilocks, Poseidon2InternalLayerGoldilocks};
+
+    type F = Goldilocks;
+    type Poseidon2GoldilocksGeneric8 = Poseidon2<
+        F,
+        Poseidon2ExternalLayerGoldilocks<8>,
+        Poseidon2InternalLayerGoldilocks,
+        8,
+        GOLDILOCKS_S_BOX_DEGREE,
+    >;
+
+    fn build_generic_p2_w8() -> Poseidon2GoldilocksGeneric8 {
+        Poseidon2::new(
+            ExternalLayerConstants::new(
+                GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_INITIAL.to_vec(),
+                GOLDILOCKS_POSEIDON2_RC_8_EXTERNAL_FINAL.to_vec(),
+            ),
+            GOLDILOCKS_POSEIDON2_RC_8_INTERNAL.to_vec(),
+        )
+    }
+
+    type Poseidon2GoldilocksGeneric12 = Poseidon2<
+        F,
+        Poseidon2ExternalLayerGoldilocks<12>,
+        Poseidon2InternalLayerGoldilocks,
+        12,
+        GOLDILOCKS_S_BOX_DEGREE,
+    >;
+
+    fn build_generic_p2_w12() -> Poseidon2GoldilocksGeneric12 {
+        Poseidon2::new(
+            ExternalLayerConstants::new(
+                GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_INITIAL.to_vec(),
+                GOLDILOCKS_POSEIDON2_RC_12_EXTERNAL_FINAL.to_vec(),
+            ),
+            GOLDILOCKS_POSEIDON2_RC_12_INTERNAL.to_vec(),
+        )
+    }
+
+    #[test]
+    fn batched_b2_matches_single_w8_scalar() {
+        let perm = build_generic_p2_w8();
+        let constants = default_goldilocks_poseidon2_batched_8();
+
+        let in_a: [F; 8] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7]);
+        let in_b: [F; 8] = F::new_array([100, 101, 102, 103, 104, 105, 106, 107]);
+
+        let mut exp_a = in_a;
+        let mut exp_b = in_b;
+        perm.permute_mut(&mut exp_a);
+        perm.permute_mut(&mut exp_b);
+
+        let mut got_a = in_a;
+        let mut got_b = in_b;
+        permute_batch_b2_p2_w8(&mut got_a, &mut got_b, &constants);
+
+        assert_eq!(got_a, exp_a, "p2 w8 scalar a mismatch");
+        assert_eq!(got_b, exp_b, "p2 w8 scalar b mismatch");
+    }
+
+    #[test]
+    fn batched_b2_matches_single_w12_scalar() {
+        let perm = build_generic_p2_w12();
+        let constants = default_goldilocks_poseidon2_batched_12();
+
+        let in_a: [F; 12] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        let in_b: [F; 12] =
+            F::new_array([100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]);
+
+        let mut exp_a = in_a;
+        let mut exp_b = in_b;
+        perm.permute_mut(&mut exp_a);
+        perm.permute_mut(&mut exp_b);
+
+        let mut got_a = in_a;
+        let mut got_b = in_b;
+        permute_batch_b2_p2_w12(&mut got_a, &mut got_b, &constants);
+
+        assert_eq!(got_a, exp_a, "p2 w12 scalar a mismatch");
+        assert_eq!(got_b, exp_b, "p2 w12 scalar b mismatch");
+    }
+
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    mod avx512 {
+        use super::*;
+        use crate::PackedGoldilocksAVX512;
+
+        #[test]
+        fn batched_b2_matches_single_w8_avx512() {
+            let perm = build_generic_p2_w8();
+            let constants = default_goldilocks_poseidon2_batched_8();
+
+            let in_a: [F; 8] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7]);
+            let in_b: [F; 8] = F::new_array([100, 101, 102, 103, 104, 105, 106, 107]);
+
+            let mut exp_a: [PackedGoldilocksAVX512; 8] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksAVX512; 8] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksAVX512; 8] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksAVX512; 8] = in_b.map(Into::into);
+            permute_batch_b2_p2_w8(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w8 avx512 a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w8 avx512 b mismatch");
+        }
+
+        #[test]
+        fn batched_b2_matches_single_w12_avx512() {
+            let perm = build_generic_p2_w12();
+            let constants = default_goldilocks_poseidon2_batched_12();
+
+            let in_a: [F; 12] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+            let in_b: [F; 12] =
+                F::new_array([100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]);
+
+            let mut exp_a: [PackedGoldilocksAVX512; 12] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksAVX512; 12] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksAVX512; 12] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksAVX512; 12] = in_b.map(Into::into);
+            permute_batch_b2_p2_w12(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w12 avx512 a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w12 avx512 b mismatch");
+        }
+    }
+
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        not(target_feature = "avx512f")
+    ))]
+    mod avx2 {
+        use super::*;
+        use crate::PackedGoldilocksAVX2;
+
+        #[test]
+        fn batched_b2_matches_single_w8_avx2() {
+            let perm = build_generic_p2_w8();
+            let constants = default_goldilocks_poseidon2_batched_8();
+
+            let in_a: [F; 8] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7]);
+            let in_b: [F; 8] = F::new_array([100, 101, 102, 103, 104, 105, 106, 107]);
+
+            let mut exp_a: [PackedGoldilocksAVX2; 8] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksAVX2; 8] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksAVX2; 8] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksAVX2; 8] = in_b.map(Into::into);
+            permute_batch_b2_p2_w8(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w8 avx2 a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w8 avx2 b mismatch");
+        }
+
+        #[test]
+        fn batched_b2_matches_single_w12_avx2() {
+            let perm = build_generic_p2_w12();
+            let constants = default_goldilocks_poseidon2_batched_12();
+
+            let in_a: [F; 12] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+            let in_b: [F; 12] =
+                F::new_array([100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]);
+
+            let mut exp_a: [PackedGoldilocksAVX2; 12] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksAVX2; 12] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksAVX2; 12] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksAVX2; 12] = in_b.map(Into::into);
+            permute_batch_b2_p2_w12(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w12 avx2 a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w12 avx2 b mismatch");
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    mod neon {
+        use super::*;
+        use crate::PackedGoldilocksNeon;
+
+        #[test]
+        fn batched_b2_matches_single_w8_neon() {
+            let perm = build_generic_p2_w8();
+            let constants = default_goldilocks_poseidon2_batched_8();
+
+            let in_a: [F; 8] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7]);
+            let in_b: [F; 8] = F::new_array([100, 101, 102, 103, 104, 105, 106, 107]);
+
+            let mut exp_a: [PackedGoldilocksNeon; 8] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksNeon; 8] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksNeon; 8] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksNeon; 8] = in_b.map(Into::into);
+            permute_batch_b2_p2_w8(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w8 neon a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w8 neon b mismatch");
+        }
+
+        #[test]
+        fn batched_b2_matches_single_w12_neon() {
+            let perm = build_generic_p2_w12();
+            let constants = default_goldilocks_poseidon2_batched_12();
+
+            let in_a: [F; 12] = F::new_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+            let in_b: [F; 12] =
+                F::new_array([100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111]);
+
+            let mut exp_a: [PackedGoldilocksNeon; 12] = in_a.map(Into::into);
+            let mut exp_b: [PackedGoldilocksNeon; 12] = in_b.map(Into::into);
+            perm.permute_mut(&mut exp_a);
+            perm.permute_mut(&mut exp_b);
+
+            let mut got_a: [PackedGoldilocksNeon; 12] = in_a.map(Into::into);
+            let mut got_b: [PackedGoldilocksNeon; 12] = in_b.map(Into::into);
+            permute_batch_b2_p2_w12(&mut got_a, &mut got_b, &constants);
+
+            assert_eq!(got_a, exp_a, "p2 w12 neon a mismatch");
+            assert_eq!(got_b, exp_b, "p2 w12 neon b mismatch");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a hand-rolled cross-permute batched Poseidon2 permute for Goldilocks widths 8 and 12 (`permute_batch_b2_p2_w{8,12}`) that processes two independent states with their rounds interleaved in a single function scope. This exposes cross-permute ILP that the single-permute `Permutation::permute_mut` API hides behind the trait-method call boundary.

Per-permute wall-time reduction across measured configs (post-#1645, 5-seed N=1M):

|              | Zen 5 AVX-2 (4L) | Zen 5 AVX-512 (8L) | Pi 5 NEON (2L) |
|--------------|-----------------:|-------------------:|---------------:|
| **Width 8**  | ~27.2% ± 0.7     | ~31.5% ± 0.9       | ~10.82% ± 0.08 |
| **Width 12** | ~18.6% ± 0.2     | ~26.6% ± 0.3       | ~2.65% ± 0.04  |

5 of 6 measured configs reduce >10% per permute. Pi 5 NEON width 12 is the floor at 2.65% (small but stable).

## Mechanism

Within one `permute_mut` call, the function-call boundary of the layer trait methods hides the partial-round dependency chain (round N's S-box on `state[0]` depends on round N-1's MDS output) from LLVM and the OoO engine. Calling `permute_mut(a); permute_mut(b)` back-to-back gives **0%** improvement on Zen 5 (verified by trivial-batched H1 test) because LLVM cannot see across the boundary to interleave the two states.

Hand-rolling the round structure across two states inside one function scope makes both states' operations visible to the compiler. LLVM emits an interleaved instruction stream; the OoO engine schedules state-A and state-B ops to fill issue slots that sequential single-permute leaves unused.

Microarchitectural sanity-check on the sibling Poseidon1 port (same mechanism, separate investigation): IPC 2.484 → 2.954 (+18.9%) with unchanged instruction count per permute, ~2.7× instruction scaling matching 2-states × full-vs-partial round structure, *lower* register spill rate in batched (4.5%) vs single (7.2%). Poseidon2 wall-time wins above are consistent with the same OoO-slack story.

## Where this applies

**Useful**: any caller that invokes `Permutation::permute_mut` on independent states in a loop. Primary candidate is Merkle tree layer compression at `merkle-tree/src/merkle_tree.rs:488-504`, where sibling compressions within a layer are independent and the loop is parallel-chunkable. FRI commit-phase tree builds are a secondary target.

**Doesn't apply to sequential paths**: sponge-absorb hash chains (`symmetric/src/sponge.rs:189,196`) have a per-call data dependency (each output feeds into the next), so cross-permute interleaving has no slack to capture. These callers continue using the unchanged `permute_mut` path with no behavior change.

This PR exposes the primitive only. Production call-site wiring (`TruncatedPermutation::compress_batch_b2` or similar) is intentionally left as a follow-up so the API-shape conversation can happen in review.

## Why NEON width 12 is small

The mechanism requires spare execution-port issue width and OoO reorder budget. Cortex-A76 has 2 NEON pipes vs Zen 5's 4 vector pipes, plus a smaller OoO window. Width 12's internal-round path (`internal_layer_mat_mul_goldilocks_12`) does more ops per round than `_8`, bringing single-permute closer to pipe saturation on NEON. Less slack to harvest.

Pipe-limit confirmed with a B=4 probe at width 8 on NEON: 4 × 8 = 32 hot state regs fits NEON's 32 v-registers, but **B=4 slightly loses to B=2** (mean 10.55% vs 11.16% across 5 seeds). Adding states past B=2 has no extra pipe capacity. On x86 both AVX-2 and AVX-512 win MORE at B=4 (+2-4pp), consistent with more issue width available.

## Numbers (single seed reference, full data in commit)

Mean ns/permute, single seed (seed=1):

| Width | ISA           | Single | Batched | Reduction |
|------:|---------------|-------:|--------:|----------:|
| 8     | Zen 5 AVX-2   | 1734   | 1243    | 28.28%    |
| 8     | Zen 5 AVX-512 | 1715   | 1170    | 31.79%    |
| 8     | Pi 5 NEON     | 3891   | 3473    | 10.75%    |
| 12    | Zen 5 AVX-2   | 2260   | 1846    | 18.32%    |
| 12    | Zen 5 AVX-512 | 2284   | 1676    | 26.60%    |
| 12    | Pi 5 NEON     | 5678   | 5530    | 2.60%     |

**Hardware**:
- Zen 5: Ryzen 9 9950X3D, `taskset -c 0`, governor=performance, `target-cpu=native`.
- Pi 5: Cortex-A76, `taskset -c 3`, governor=performance, `perf_event_paranoid=1`.

Not measured on Apple M-series, AWS Graviton, or Intel x86. Happy to add numbers if a maintainer can run them. The mechanism is microarchitecture-dependent in magnitude (it exploits OoO reorder budget and execution-port issue width), so the *direction* of the speedup should hold on any superscalar OoO core, but the *magnitude* depends on the specific microarchitecture's issue width, vector-pipe count, and OoO window depth. The Pi 5 NEON width 12 floor of 2.65% reflects Cortex-A76's 2 vector pipes; wider cores (Apple M-series, Graviton 4, Intel server) likely sit closer to the Zen 5 numbers.

## API shape

This PR ships a free function `pub fn permute_batch_b2_p2_w{8,12}` in `goldilocks::poseidon2_batched`. Width-specific because the partial-round matmul (`internal_layer_mat_mul_goldilocks_{8,12}`) is width-specific.

The natural shape for upstream integration is a `BatchedPermutation<T, const B: usize>` marker trait extending `Permutation<T>`, with default-impl looping and specialised impls where the win exists. I deliberately left the trait out of this PR so the primitive can land independently of the API conversation. Happy to add the trait shape to this PR if you'd prefer that direction.

## Scope / follow-ups

- **Width 16 + 20 Goldilocks**: same mechanism applies; partial-round matmul exists for each width. Not ported here.
- **Monty31 fields (Mersenne31, KoalaBear, BabyBear)**: mechanism is field-agnostic; port is mechanical once the trait shape is settled.
- **`BatchedPermutation` marker trait + `TruncatedPermutation::compress_batch_b2`**: API design conversation, follow-up PR.
- **B > 2**: B=4 wins +2-4pp on x86 but loses 0.6pp on NEON (pipe saturation). B=2 is the cross-arch sweet spot.

## Related

- Builds on #1645 (`Poseidon2GoldilocksFused` full-round MDS fix); the baseline above is post-#1645.
- Mechanism-distinct from #1656 (currently open): #1656 routes `Poseidon2GoldilocksFused<8>` packed permute through the generic path on aarch64. The NEON numbers cited here are *batched-generic vs single-generic*, which holds independent of #1656's land status.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`: clean
- [x] `cargo +stable clippy --all-targets -- -D warnings`: clean
- [x] `cargo +stable sort --workspace --grouped --check`: clean
- [x] `cargo test -p p3-goldilocks` on Zen 5: 163 passed, 0 failed
- [x] AVX-2 + AVX-512 cfg-gated tests on Zen 5: 4/4 passed each
- [x] NEON cfg-gated tests on Raspberry Pi 5: 4/4 passed
- [ ] CI macOS aarch64 verification on PR open

cc @Nashtare . post-#1645 follow-up, would value your eye on the API-shape question in particular.