### PR TITLE
chore: add p3-sumcheck to release-plz flow

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -129,6 +129,10 @@ name = "p3-sha256"
 version_group = "plonky3"
 
 [[package]]
+name = "p3-sumcheck"
+version_group = "plonky3"
+
+[[package]]
 name = "p3-symmetric"
 version_group = "plonky3"
 


### PR DESCRIPTION
Forgot to include it as part of the release-plz.toml flow, follow-up of #1672 