### PR TITLE
Harden log_arity validation in FRI and Circle

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -841,7 +841,10 @@ mod tests {
         // Invariant: all query proofs must use the same per-round folding
         // arity schedule. The verifier takes the first query proof's
         // schedule as a reference and rejects any that differ.
-        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+        let (mut pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+        // Allow arity 2 so this mutation remains a schedule mismatch rather
+        // than being rejected as an out-of-range arity.
+        pcs.fri_params.max_log_arity = 2;
 
         // This check compares query 1 against query 0, so we need at least
         // two query proofs. With testing parameters this is always true, but
@@ -886,5 +889,29 @@ mod tests {
         assert_eq!(expected, reference_arities);
         // The got schedule is query 1's corrupted version.
         assert_eq!(got, corrupted_arities);
+    }
+
+    #[test]
+    fn reject_invalid_log_arity() {
+        // Invariant: each log_arity must be in 1..=max_log_arity.
+        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        // Mutation: force an invalid zero arity in query 0, round 0.
+        proof.fri_proof.query_proofs[0].commit_phase_openings[0].log_arity = 0;
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected InvalidLogArity");
+
+        let FriError::InvalidLogArity {
+            round,
+            log_arity,
+            max,
+        } = err
+        else {
+            panic!("expected InvalidLogArity, got {err:?}");
+        };
+        assert_eq!(round, 0);
+        assert_eq!(log_arity, 0);
+        assert_eq!(max, pcs.fri_params.max_log_arity);
     }
 }

--- a/circle/src/proof.rs
+++ b/circle/src/proof.rs
@@ -41,3 +41,16 @@ pub struct CircleCommitPhaseProofStep<F: Field, M: Mmcs<F>> {
 
     pub opening_proof: M::Proof,
 }
+
+impl<F: Field, M: Mmcs<F>> CircleCommitPhaseProofStep<F, M> {
+    /// Convert `log_arity` to `usize` and enforce the protocol bounds.
+    ///
+    /// Returns `None` when `log_arity` is zero or exceeds `max_log_arity`.
+    #[inline]
+    pub(crate) fn checked_log_arity(&self, max_log_arity: usize) -> Option<usize> {
+        let log_arity = self.log_arity as usize;
+        (1..=max_log_arity)
+            .contains(&log_arity)
+            .then_some(log_arity)
+    }
+}

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -93,24 +93,40 @@ where
     // different queries would fold through incompatible domain decompositions.
     //
     // We take the first query proof's schedule as the reference:
-    let log_arities: Vec<usize> = proof
-        .query_proofs
-        .first()
-        .map(|qp| {
-            qp.commit_phase_openings
-                .iter()
-                .map(|o| o.log_arity as usize)
-                .collect()
-        })
-        .unwrap_or_default();
+    let log_arities: Vec<usize> = if let Some(qp) = proof.query_proofs.first() {
+        qp.commit_phase_openings
+            .iter()
+            .enumerate()
+            .map(|(round, opening)| {
+                opening
+                    .checked_log_arity(params.max_log_arity)
+                    .ok_or(FriError::InvalidLogArity {
+                        round,
+                        log_arity: opening.log_arity as usize,
+                        max: params.max_log_arity,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        Vec::new()
+    };
 
     // Compare every subsequent query proof against the reference schedule.
     for (query, qp) in proof.query_proofs.iter().enumerate().skip(1) {
         let got_log_arities: Vec<usize> = qp
             .commit_phase_openings
             .iter()
-            .map(|o| o.log_arity as usize)
-            .collect();
+            .enumerate()
+            .map(|(round, opening)| {
+                opening
+                    .checked_log_arity(params.max_log_arity)
+                    .ok_or(FriError::InvalidLogArity {
+                        round,
+                        log_arity: opening.log_arity as usize,
+                        max: params.max_log_arity,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         if got_log_arities != log_arities {
             return Err(FriError::QueryLogAritiesMismatch {
                 query,
@@ -240,7 +256,14 @@ where
 
     for (round, ((&beta, comm), opening)) in steps.enumerate() {
         // This round folds 2^{log_arity} siblings into one parent.
-        let log_arity = opening.log_arity as usize;
+        let max_log_arity = core::cmp::min(params.max_log_arity, log_current_height);
+        let Some(log_arity) = opening.checked_log_arity(max_log_arity) else {
+            return Err(FriError::InvalidLogArity {
+                round,
+                log_arity: opening.log_arity as usize,
+                max: max_log_arity,
+            });
+        };
         let arity = 1 << log_arity;
 
         // Shape check: the prover must supply exactly (arity - 1) siblings.

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -40,3 +40,16 @@ pub struct CommitPhaseProofStep<F: Field, M: Mmcs<F>> {
 
     pub opening_proof: M::Proof,
 }
+
+impl<F: Field, M: Mmcs<F>> CommitPhaseProofStep<F, M> {
+    /// Convert `log_arity` to `usize` and enforce the protocol bounds.
+    ///
+    /// Returns `None` when `log_arity` is zero or exceeds `max_log_arity`.
+    #[inline]
+    pub(crate) fn checked_log_arity(&self, max_log_arity: usize) -> Option<usize> {
+        let log_arity = self.log_arity as usize;
+        (1..=max_log_arity)
+            .contains(&log_arity)
+            .then_some(log_arity)
+    }
+}

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -156,39 +156,44 @@ where
     }
 
     // Extract the per-round folding arities from the proof and ensure they are consistent.
-    let log_arities: Vec<usize> = proof
-        .query_proofs
-        .first()
-        .map(|qp| {
-            qp.commit_phase_openings
-                .iter()
-                .map(|o| o.log_arity as usize)
-                .collect()
-        })
-        .unwrap_or_default();
+    let log_arities: Vec<usize> = if let Some(qp) = proof.query_proofs.first() {
+        qp.commit_phase_openings
+            .iter()
+            .enumerate()
+            .map(|(round, opening)| {
+                opening
+                    .checked_log_arity(params.max_log_arity)
+                    .ok_or(FriError::InvalidLogArity {
+                        round,
+                        log_arity: opening.log_arity as usize,
+                        max: params.max_log_arity,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        Vec::new()
+    };
 
     for (query, qp) in proof.query_proofs.iter().enumerate().skip(1) {
         let got_log_arities = qp
             .commit_phase_openings
             .iter()
-            .map(|o| o.log_arity as usize)
-            .collect::<Vec<_>>();
+            .enumerate()
+            .map(|(round, opening)| {
+                opening
+                    .checked_log_arity(params.max_log_arity)
+                    .ok_or(FriError::InvalidLogArity {
+                        round,
+                        log_arity: opening.log_arity as usize,
+                        max: params.max_log_arity,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         if got_log_arities != log_arities {
             return Err(FriError::QueryLogAritiesMismatch {
                 query,
                 expected: log_arities,
                 got: got_log_arities,
-            });
-        }
-    }
-
-    // Bound the prover-supplied folding arities.
-    for (round, &log_arity) in log_arities.iter().enumerate() {
-        if log_arity == 0 || log_arity > params.max_log_arity {
-            return Err(FriError::InvalidLogArity {
-                round,
-                log_arity,
-                max: params.max_log_arity,
             });
         }
     }
@@ -395,7 +400,14 @@ where
     // We start with evaluations over a domain of size (1 << log_global_max_height). We fold
     // using FRI until the domain size reaches (1 << log_final_height).
     for (round, ((&beta, comm), opening)) in fold_data_iter.enumerate() {
-        let log_arity = opening.log_arity as usize;
+        let max_log_arity = core::cmp::min(params.max_log_arity, log_current_height);
+        let Some(log_arity) = opening.checked_log_arity(max_log_arity) else {
+            return Err(FriError::InvalidLogArity {
+                round,
+                log_arity: opening.log_arity as usize,
+                max: max_log_arity,
+            });
+        };
         let arity = 1 << log_arity;
 
         // Validate that sibling_values has the expected length (arity - 1)
@@ -913,6 +925,10 @@ mod tests {
     fn query_log_arities_mismatch() {
         let f = make_test_fixture();
         let mut proof = f.proof.clone();
+        let mut params = f.fri_params.clone();
+        // Allow arity 2 so this mutation remains "shape mismatch" instead of
+        // being rejected as an out-of-range arity.
+        params.max_log_arity = 2;
 
         // The folding schedule is the sequence of log-arities that
         // controls how much the domain shrinks each round. In this fixture,
@@ -945,7 +961,7 @@ mod tests {
 
         let mut challenger = f.challenger.clone();
         let err = run_verify_fri(
-            &f.fri_params,
+            &params,
             &proof,
             &mut challenger,
             &f.commitments_with_opening_points,
@@ -1148,6 +1164,38 @@ mod tests {
                 assert_eq!(round, 0);
                 assert_eq!(expected, 1);
                 assert_eq!(got, 2);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_log_arity_rejected() {
+        let f = make_test_fixture();
+        let mut proof = f.proof.clone();
+
+        // Mutation: set the first round arity to zero (invalid).
+        proof.query_proofs[0].commit_phase_openings[0].log_arity = 0;
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("should reject invalid log_arity");
+
+        match err {
+            FriError::InvalidLogArity {
+                round,
+                log_arity,
+                max,
+            } => {
+                assert_eq!(round, 0);
+                assert_eq!(log_arity, 0);
+                assert_eq!(max, f.fri_params.max_log_arity);
             }
             other => panic!("wrong error variant: {other:?}"),
         }


### PR DESCRIPTION
This change centralizes and enforces `log_arity` bounds in FRI and Circle verifier paths, preventing malformed proofs from reaching shift and height arithmetic with unchecked values.