### PR TITLE
Harden WHIR verifier against malformed proof panics

### DIFF
--- a/whir/src/pcs/committer/reader.rs
+++ b/whir/src/pcs/committer/reader.rs
@@ -54,7 +54,14 @@ where
             .commitment
             .clone()
             .ok_or(VerifierError::MissingRoundCommitment { round: round_index })?;
-        let ood_answers = round_proof.ood_answers.clone();
+        let ood_answers = &round_proof.ood_answers;
+        if ood_answers.len() != ood_samples {
+            return Err(VerifierError::RoundOodAnswerCountMismatch {
+                round: round_index,
+                expected: ood_samples,
+                actual: ood_answers.len(),
+            });
+        }
 
         // Observe the Merkle root in the transcript.
         challenger.observe(root.clone());

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -534,6 +534,38 @@ mod error_variant_tests {
     }
 
     #[test]
+    fn rejects_with_round_ood_answer_count_mismatch_when_answer_is_dropped() {
+        // Invariant: each round carries exactly the verifier-expected OOD answers.
+        //
+        // Fixture state: round 0 has N OOD answers.
+        //
+        // Mutation: drop one answer.
+        //
+        //     proof.whir.rounds[0].ood_answers:  N  ->  N - 1
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        let expected = proof.whir.rounds[0].ood_answers.len();
+        assert!(
+            expected > 0,
+            "fixture should produce at least one round-0 OOD answer"
+        );
+        proof.whir.rounds[0].ood_answers.pop();
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::RoundOodAnswerCountMismatch {
+                round,
+                expected: e,
+                actual: a,
+            } => {
+                assert_eq!(round, 0);
+                assert_eq!(e, expected);
+                assert_eq!(a, expected - 1);
+            }
+            other => panic!("expected RoundOodAnswerCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn rejects_with_stir_query_count_mismatch_when_intermediate_query_is_dropped() {
         // Invariant: queries.len() == verifier-sampled indices for the round.
         //

--- a/whir/src/pcs/verifier/errors.rs
+++ b/whir/src/pcs/verifier/errors.rs
@@ -68,6 +68,18 @@ pub enum VerifierError {
     #[error("Proof is missing the Merkle commitment for round {round}")]
     MissingRoundCommitment { round: usize },
 
+    /// Round OOD answers do not match the verifier's expected count.
+    #[error("Round {round} OOD answer count mismatch: expected {expected}, got {actual}")]
+    RoundOodAnswerCountMismatch {
+        round: usize,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// Folding randomness is unexpectedly absent before a STIR check.
+    #[error("Missing folding randomness before STIR verification at round {round}")]
+    MissingFoldingRandomness { round: usize },
+
     /// Proof contains an unexpected number of rounds.
     #[error("Proof has {actual} rounds, expected {expected}")]
     RoundCountMismatch { expected: usize, actual: usize },

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -148,12 +148,15 @@ where
             )?;
 
             // Verify STIR in-domain challenges against the previous commitment.
+            let current_folding_randomness = round_folding_randomness
+                .last()
+                .ok_or(VerifierError::MissingFoldingRandomness { round: round_index })?;
             let stir_statement = self.verify_stir_challenges(
                 proof,
                 challenger,
                 round_params,
                 &prev_commitment,
-                round_folding_randomness.last().unwrap(),
+                current_folding_randomness,
                 round_index,
             )?;
 
@@ -183,12 +186,17 @@ where
         challenger.observe_algebra_slice(final_evaluations.as_slice());
 
         // Verify final STIR challenges.
+        let final_round_folding_randomness = round_folding_randomness.last().ok_or_else(|| {
+            VerifierError::MissingFoldingRandomness {
+                round: self.n_rounds(),
+            }
+        })?;
         let stir_statement = self.verify_stir_challenges(
             proof,
             challenger,
             &self.final_round_config(),
             &prev_commitment,
-            round_folding_randomness.last().unwrap(),
+            final_round_folding_randomness,
             self.n_rounds(),
         )?;
 


### PR DESCRIPTION
This change converts remaining WHIR verifier panic paths for incomplete proofs into structured errors, so malformed external inputs fail safely with actionable diagnostics.