### PR TITLE
perf(whir): use collect_n for select challenge powers

### DIFF
--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -432,7 +432,9 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
         // ---------------------------------------------------------------
 
         // Precompute [gamma^shift, gamma^{shift+1}, ..., gamma^{shift+n-1}].
-        let challenges = challenge.powers().skip(shift).take(n).collect::<Vec<_>>();
+        let challenges = challenge
+            .shifted_powers(challenge.exp_u64(shift as u64))
+            .collect_n(n);
 
         // W(b) += sum_i gamma^{i+shift} * z_i^b
         acc.par_chunks(n)


### PR DESCRIPTION
## Summary

- Route WHIR select-statement challenge-power precomputation through `Powers::collect_n`.
- Start the sequence with `shifted_powers(gamma^shift)` so it still produces `gamma^shift, gamma^(shift + 1), ...`.
- Reuse the packed powers collection path enabled by #1639 without changing the batched constraint semantics.