### PR TITLE
perf: extend collect_n and shifted_powers to remaining call sites

### DIFF
--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -284,8 +284,7 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
         // evals of Z_H(X) = X^n - 1
         let evals = Val::two_adic_generator(rate_bits)
             .powers()
-            .collect_n(1 << rate_bits)
-            .into_iter()
+            .take(1 << rate_bits)
             .map(|x| s_pow_n * x - Val::ONE)
             .collect_vec();
 

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -284,7 +284,8 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
         // evals of Z_H(X) = X^n - 1
         let evals = Val::two_adic_generator(rate_bits)
             .powers()
-            .take(1 << rate_bits)
+            .collect_n(1 << rate_bits)
+            .into_iter()
             .map(|x| s_pow_n * x - Val::ONE)
             .collect_vec();
 

--- a/dft/src/radix_2_dit.rs
+++ b/dft/src/radix_2_dit.rs
@@ -52,7 +52,7 @@ impl<F: TwoAdicField> Radix2Dit<F> {
             .or_insert_with(|| {
                 let n = 1 << log_h;
                 let root = F::two_adic_generator(log_h);
-                Arc::from(root.powers().take(n / 2).collect())
+                Arc::from(root.powers().collect_n(n / 2))
             })
             .clone()
     }

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -4,7 +4,6 @@ use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use itertools::Itertools;
 use p3_util::{flatten_to_base, reconstitute_from_base};
 use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
@@ -230,7 +229,7 @@ where
     #[inline]
     fn packed_ext_powers(base: BinomialExtensionField<F, D>) -> crate::Powers<Self> {
         let width = F::Packing::WIDTH;
-        let powers = base.powers().take(width + 1).collect_vec();
+        let powers = base.powers().collect_n(width + 1);
         // Transpose first WIDTH powers
         let current = Self::from_ext_slice(&powers[..width]);
 

--- a/field/src/extension/packed_cubic_extension.rs
+++ b/field/src/extension/packed_cubic_extension.rs
@@ -201,9 +201,8 @@ impl<F: CubicTrinomialExtendable> PackedFieldExtension<F, CubicTrinomialExtensio
 
     #[inline]
     fn packed_ext_powers(base: CubicTrinomialExtensionField<F>) -> Powers<Self> {
-        use itertools::Itertools;
         let width = F::Packing::WIDTH;
-        let powers = base.powers().take(width + 1).collect_vec();
+        let powers = base.powers().collect_n(width + 1);
         // Transpose first WIDTH powers
         let current = Self::from_ext_slice(&powers[..width]);
 

--- a/field/src/extension/packed_quintic_extension.rs
+++ b/field/src/extension/packed_quintic_extension.rs
@@ -205,9 +205,8 @@ impl<F: QuinticTrinomialExtendable> PackedFieldExtension<F, QuinticTrinomialExte
 
     #[inline]
     fn packed_ext_powers(base: QuinticTrinomialExtensionField<F>) -> Powers<Self> {
-        use itertools::Itertools;
         let width = F::Packing::WIDTH;
-        let powers = base.powers().take(width + 1).collect_vec();
+        let powers = base.powers().collect_n(width + 1);
         // Transpose first WIDTH powers
         let current = Self::from_ext_slice(&powers[..width]);
 

--- a/sumcheck/src/constraints/mod.rs
+++ b/sumcheck/src/constraints/mod.rs
@@ -355,10 +355,10 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
     pub fn iter_sels(&self) -> impl Iterator<Item = (&F, EF)> {
         // Pair each select variable with its corresponding challenge power.
         // Powers start at γ^{n_eq} to avoid overlap with equality constraints.
-        self.sel_statement
-            .vars
-            .iter()
-            .zip(self.challenge.powers().skip(self.eq_statement.len()))
+        self.sel_statement.vars.iter().zip(
+            self.challenge
+                .shifted_powers(self.challenge.exp_u64(self.eq_statement.len() as u64)),
+        )
     }
 }
 

--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -496,7 +496,7 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
         if k_pack * 2 > k {
             self.vars
                 .iter()
-                .zip(challenge.powers().skip(shift))
+                .zip(challenge.shifted_powers(challenge.exp_u64(shift as u64)))
                 .for_each(|(&var, challenge)| {
                     // gamma^{shift+i} * [1, z, z^2, ..., z^{2^k - 1}]
                     let pow = EF::from(var).shifted_powers(challenge).collect_n(1 << k);
@@ -575,7 +575,9 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
         // This is equivalent to dot_product(evaluations, [γ^shift, γ^{shift+1}, ...])
         *claimed_eval += dot_product::<EF, _, _>(
             self.evaluations.iter().copied(),
-            challenge.powers().skip(shift).take(self.len()),
+            challenge
+                .shifted_powers(challenge.exp_u64(shift as u64))
+                .take(self.len()),
         );
     }
 }

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -309,7 +309,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
             for (vc, alpha_i) in self
                 .virtual_claims
                 .iter()
-                .zip(alpha.powers().skip(n_claims))
+                .zip(alpha.shifted_powers(alpha.exp_u64(n_claims as u64)))
             {
                 let vc_accs = &vc.data;
                 c0 += alpha_i
@@ -396,7 +396,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
         // Virtual claims continue the alpha sequence right after the concrete ones.
         sum += dot_product::<EF, _, _>(
             self.virtual_claims.iter().map(Claim::eval),
-            alpha.powers().skip(self.num_claims()),
+            alpha.shifted_powers(alpha.exp_u64(self.num_claims() as u64)),
         );
 
         sum

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -385,7 +385,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
             for (vc, alpha_i) in self
                 .virtual_claims
                 .iter()
-                .zip(alpha.powers().skip(n_claims))
+                .zip(alpha.shifted_powers(alpha.exp_u64(n_claims as u64)))
             {
                 let vc_accs = &vc.data;
                 c0 += alpha_i
@@ -481,7 +481,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
         // Virtual claims continue the alpha sequence right after the concrete ones.
         sum += dot_product::<EF, _, _>(
             self.virtual_claims.iter().map(Claim::eval),
-            alpha.powers().skip(self.num_claims()),
+            alpha.shifted_powers(alpha.exp_u64(self.num_claims() as u64)),
         );
 
         sum

--- a/sumcheck/src/layout/verifier.rs
+++ b/sumcheck/src/layout/verifier.rs
@@ -201,7 +201,7 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
         // Virtual claims: continue the alpha sequence right after the concrete ones.
         sum += dot_product::<EF, _, _>(
             self.virtual_claims.iter().map(VerifierVirtualClaim::eval),
-            alpha.powers().skip(self.num_claims()),
+            alpha.shifted_powers(alpha.exp_u64(self.num_claims() as u64)),
         );
 
         sum


### PR DESCRIPTION
## Summary

Follow-up to #1681 and #1682. Sweeps the rest of the codebase for the same patterns:

- `.powers().take(n).collect()` → `.powers().collect_n(n)` — uses the SIMD parallel collect path (when `n >= 16`; falls back to plain `take().collect()` below that, so a strict swap is neutral-or-better).
- `.powers().skip(s)` → `.shifted_powers(base.exp_u64(s as u64))` — `skip` walks `s` powers via `next()` (one multiplication each); `exp_u64` is `O(log s)` upfront.

### Sites

- **dft**: `radix_2_dit` twiddle precompute (`n/2` is the FFT half-size — large).
- **field**: `packed_ext_powers` in packed binomial / cubic / quintic extensions (also drops a stale `use itertools::Itertools`). `width + 1` triggers the SIMD path at AVX-512 width=16; serial fallback for narrower packings is neutral.
- **sumcheck**:
  - `Constraints::iter_sels`
  - `SelectStatement` naive fallback + `combine_evals`
  - `PrefixProver` / `SuffixProver` virtual-claim weight + sum
  - `Verifier::sum`

### Sites considered but skipped

- `commit/src/domain.rs` `selectors_on_coset` — initially included a `.take(n).map().collect()` → `.collect_n(n).into_iter().map().collect()` rewrite (the #1682 shape). Reverted after a second look: `1 << rate_bits` here is the LDE blowup (typically 2–8), below `collect_n`'s SIMD threshold of 16. In that fallback regime, adding `.into_iter()` materializes an extra `Vec` for no benefit.
- `fri/src/hiding_pcs.rs:233` — currently a streaming `for_each`; switching to `collect_n` would add a fresh `h`-sized `Vec` allocation. Trade-off less obvious than in the #1682 case (which already collected to a Vec).
- `dft/src/naive.rs`, `zk-codes/src/reed_solomon.rs`, `field/src/helpers.rs` — intentionally allocation-free / reference implementations.
- Small fixed-`D` loops in `binomial_extension.rs` (`D` ≤ 5) where the parallel path's threshold of 16 wouldn't kick in.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test --release -p p3-dft -p p3-field -p p3-commit -p p3-sumcheck`
