### PR TITLE
fix(mersenne-31): allow value == P in MDS partial-reduction

### DIFF
--- a/mersenne-31/src/mds.rs
+++ b/mersenne-31/src/mds.rs
@@ -7,7 +7,6 @@
 //! database.
 
 use p3_field::PrimeCharacteristicRing;
-use p3_field::integers::QuotientMap;
 use p3_mds::MdsPermutation;
 use p3_mds::karatsuba_convolution::Convolve;
 use p3_mds::util::{dot_product, first_row_to_first_col};
@@ -141,18 +140,21 @@ impl Convolve<Mersenne31, i64, i64> for LargeConvolveMersenne31 {
         const MASK: i64 = (1 << 31) - 1;
         // Morally, our value is a i62 not a i64 as the top 3 bits are
         // guaranteed to be equal.
-        let low_bits = unsafe {
-            // This is safe as 0 <= z & MASK < 2^31
-            Mersenne31::from_canonical_unchecked((z & MASK) as u32)
-        };
+        //
+        // The masked value can equal 2^31 - 1 (the non-canonical representation of zero).
+        //
+        // So the constructor must accept it.
+        let low_bits = Mersenne31::new_reduced((z & MASK) as u32);
 
         let high_bits = ((z >> 31) & MASK) as i32;
         let sign_bits = (z >> 62) as i32;
 
-        let high = unsafe {
-            // This is safe as high_bits + sign_bits > 0 as by assumption b[63] = b[61].
-            Mersenne31::from_canonical_unchecked((high_bits + sign_bits) as u32)
-        };
+        // The sum lies in [0, 2^31 - 1].
+        //
+        // A negative `z` forces the upper-bit chunk to be at least 1.
+        //
+        // So the sign correction of -1 cannot drag the sum below zero.
+        let high = Mersenne31::new_reduced((high_bits + sign_bits) as u32);
         low_bits + high
     }
 }
@@ -263,9 +265,35 @@ impl MdsPermutation<Mersenne31, 64> for MdsMatrixMersenne31 {}
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
+    use p3_mds::karatsuba_convolution::Convolve;
     use p3_symmetric::Permutation;
 
-    use super::{MdsMatrixMersenne31, Mersenne31};
+    use super::{LargeConvolveMersenne31, MdsMatrixMersenne31, Mersenne31};
+
+    #[test]
+    fn large_convolve_reduce_accepts_p_representation() {
+        // Invariant: the reducer accepts inputs whose low 31 bits are all ones.
+        //
+        // Reason: 2^31 - 1 is the non-canonical representation of zero.
+
+        // Fixture state:
+        //
+        //     P     = 2^31 - 1
+        //     z_neg = -1     (bit pattern: all 64 bits set)
+        //     z_pos =  P     (bit pattern: low 31 bits set, rest zero)
+        //
+        // Masking either value by `(1 << 31) - 1` produces P, the edge case under test.
+
+        // Case 1: z = -1  →  -1 ≡ P - 1   (mod P).
+        let got = LargeConvolveMersenne31::reduce(-1);
+        let expected = Mersenne31::ZERO - Mersenne31::ONE;
+        assert_eq!(got, expected);
+
+        // Case 2: z = P   →   P ≡ 0   (mod P).
+        let got = LargeConvolveMersenne31::reduce((1i64 << 31) - 1);
+        assert_eq!(got, Mersenne31::ZERO);
+    }
 
     #[test]
     fn mersenne8() {


### PR DESCRIPTION
@Nashtare Looks like a bug highlighted by https://github.com/Plonky3/Plonky3/pull/1683 for some reason

## Summary

`LargeConvolveMersenne31::reduce` (the partial-reduction step at the tail of the large-RHS Karatsuba convolution) constructs two `Mersenne31` intermediates via `from_canonical_unchecked`. Both inputs can equal `P = 2^31 - 1` — the non-canonical representation of the field's zero element — within the bounds the surrounding proof already establishes:

- `(z & MASK) == P` whenever the low 31 bits of `z` are all ones (e.g. `z = -1`, `z = P`).
- `high_bits + sign_bits == P` is excluded by the function's own size bounds, but the constructor was still strict on it.

`from_canonical_unchecked` requires `int < ORDER_U32` strictly, enforced by a `debug_assert!`. The boundary case `int == P` is therefore a debug-only panic. Release builds compute the correct field element (`Add` normalises `P + x` correctly), so this is purely an assertion-vs-bound mismatch — the math was always right.

## Symptom

`proptest` happens to find triggering inputs over time. Most recently it surfaced on PR #1683's CI run via:

```
thread 'aarch64_neon::poseidon1::tests::poseidon1_neon_matches_scalar_width_32' panicked at
mersenne-31/src/mersenne_31.rs:433:9:
assertion failed: int < Self::ORDER_U32
```

The MDS path runs inside the Poseidon1 NEON parity test, so the panic appears far from its root cause. Once `proptest` saves the seed in `mersenne-31/proptest-regressions/aarch64_neon/poseidon1.txt`, every subsequent debug-mode run replays it.

## Fix

Switch the two `from_canonical_unchecked` calls to `Mersenne31::new_reduced`, which already accepts `[0, P]` — the exact range the bounds in this function prove. No `unsafe` needed, no behavior change in release.

## Test

Adds `large_convolve_reduce_accepts_p_representation` — a direct unit test on `LargeConvolveMersenne31::reduce` that feeds `z = -1` and `z = P` and checks the field-reduced result. Verified failing on the pre-fix code with the exact same `assertion failed: int < Self::ORDER_U32` panic, and passing on the fix.

## Test plan

- [x] `cargo test -p p3-mersenne-31 --lib` (debug, 188 pass)
- [x] Manually re-applied the buggy code and confirmed the new test reproduces the original panic