### PR TITLE
Add prover tracing context fields

### DIFF
--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -13,7 +13,17 @@ use tracing::{info_span, instrument};
 
 use crate::{CircleCommitPhaseProofStep, CircleFriProof, CircleQueryProof};
 
-#[instrument(name = "FRI prover", skip_all)]
+#[instrument(
+    name = "FRI prover",
+    skip_all,
+    fields(
+        num_inputs = inputs.len(),
+        num_queries = params.num_queries,
+        log_blowup = params.log_blowup,
+        max_log_arity = params.max_log_arity,
+        query_pow_bits = params.query_proof_of_work_bits
+    )
+)]
 pub fn prove<Folding, Val, Challenge, M, Challenger>(
     folding: &Folding,
     params: &FriParameters<M>,
@@ -80,7 +90,15 @@ struct CommitPhaseResult<F: Field, M: Mmcs<F>> {
     final_poly: F,
 }
 
-#[instrument(name = "commit phase", skip_all)]
+#[instrument(
+    name = "commit phase",
+    skip_all,
+    fields(
+        num_inputs = inputs.len(),
+        log_blowup = params.log_blowup,
+        max_log_arity = params.max_log_arity
+    )
+)]
 fn commit_phase<Folding, Val, Challenge, M, Challenger>(
     folding: &Folding,
     params: &FriParameters<M>,

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -39,7 +39,20 @@ use crate::{
 /// - `log_global_max_height`: The log of the maximum height of the input matrices.
 /// - `prover_data_with_opening_points`: A list of pairs of a batch commitment to a collection
 ///   of matrices and a list of points to open those matrices at.
-#[instrument(name = "FRI prover", skip_all)]
+#[instrument(
+    name = "FRI prover",
+    skip_all,
+    fields(
+        num_inputs = inputs.len(),
+        num_queries = params.num_queries,
+        log_blowup = params.log_blowup,
+        log_final_poly_len = params.log_final_poly_len,
+        max_log_arity = params.max_log_arity,
+        commit_pow_bits = params.commit_proof_of_work_bits,
+        query_pow_bits = params.query_proof_of_work_bits,
+        log_global_max_height = log_global_max_height
+    )
+)]
 pub fn prove_fri<Folding, Val, Challenge, InputMmcs, FriMmcs, Challenger>(
     folding: &Folding,
     params: &FriParameters<FriMmcs>,
@@ -168,7 +181,17 @@ struct CommitPhaseResult<F: Field, M: Mmcs<F>, Witness> {
 ///   evaluation vector must be in bit reversed order. This function assumes that commitments to these vectors
 ///   have already been produced and observed by the challenger.
 /// - `challenger`: The Fiat-Shamir challenger to use for sampling challenges.
-#[instrument(name = "commit phase", skip_all)]
+#[instrument(
+    name = "commit phase",
+    skip_all,
+    fields(
+        num_inputs = inputs.len(),
+        log_blowup = params.log_blowup,
+        log_final_poly_len = params.log_final_poly_len,
+        max_log_arity = params.max_log_arity,
+        commit_pow_bits = params.commit_proof_of_work_bits
+    )
+)]
 fn commit_phase<Folding, Val, Challenge, M, Challenger>(
     folding: &Folding,
     params: &FriParameters<M>,

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -19,7 +19,16 @@ use crate::{
     get_log_num_quotient_chunks,
 };
 
-#[instrument(skip_all)]
+#[instrument(
+    skip_all,
+    fields(
+        is_zk = config.is_zk(),
+        trace_height = trace.height(),
+        trace_width = trace.width(),
+        public_values_len = public_values.len(),
+        has_preprocessed = preprocessed.is_some()
+    )
+)]
 #[allow(clippy::multiple_bound_locations, clippy::type_repetition_in_bounds)] // cfg not supported in where clauses?
 pub fn prove_with_preprocessed<
     SC,
@@ -374,7 +383,16 @@ where
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(
+    skip_all,
+    fields(
+        is_zk = config.is_zk(),
+        trace_height = trace.height(),
+        trace_width = trace.width(),
+        public_values_len = public_values.len(),
+        has_preprocessed = false
+    )
+)]
 #[allow(clippy::multiple_bound_locations, clippy::type_repetition_in_bounds)] // cfg not supported in where clauses?
 pub fn prove<
     SC,
@@ -393,7 +411,18 @@ where
     prove_with_preprocessed::<SC, A>(config, air, trace, public_values, None)
 }
 
-#[instrument(skip_all, level = "debug")]
+#[instrument(
+    skip_all,
+    level = "debug",
+    fields(
+        is_zk = SC::Pcs::ZK,
+        trace_domain_size = trace_domain.size(),
+        quotient_domain_size = quotient_domain.size(),
+        trace_width = trace_on_quotient_domain.width(),
+        has_preprocessed = preprocessed_on_quotient_domain.is_some(),
+        public_values_len = public_values.len()
+    )
+)]
 // TODO: Group some arguments to remove the `allow`?
 #[allow(clippy::too_many_arguments)]
 pub fn quotient_values<SC, A, Mat>(

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -141,7 +141,18 @@ where
     ///
     /// Performs multi-round sumcheck-based polynomial folding,
     /// producing Merkle authentication paths and constraint evaluations.
-    #[instrument(skip_all)]
+    #[instrument(
+        skip_all,
+        fields(
+            n_rounds = self.n_rounds(),
+            final_queries = self.final_queries,
+            starting_folding_pow_bits = self.starting_folding_pow_bits,
+            final_pow_bits = self.final_pow_bits,
+            final_folding_pow_bits = self.final_folding_pow_bits,
+            folding_strategy = ?self.params.folding_factor,
+            variable_order = ?L::variable_order()
+        )
+    )]
     pub fn prove(
         &self,
         proof: &mut WhirProof<F, EF, MT>,
@@ -173,7 +184,31 @@ where
         }
     }
 
-    #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.params.folding_factor.total_number(round_index)))]
+    #[instrument(
+        skip_all,
+        fields(
+            round_number = round_index,
+            is_final_round = round_index == self.n_rounds(),
+            log_size = self.num_variables - self.params.folding_factor.total_number(round_index),
+            folding_factor = self.folding_factor(round_index),
+            round_queries = if round_index < self.n_rounds() {
+                self.round_parameters[round_index].num_queries
+            } else {
+                self.final_queries
+            },
+            round_pow_bits = if round_index < self.n_rounds() {
+                self.round_parameters[round_index].pow_bits
+            } else {
+                self.final_pow_bits
+            },
+            round_folding_pow_bits = if round_index < self.n_rounds() {
+                self.round_parameters[round_index].folding_pow_bits
+            } else {
+                self.final_folding_pow_bits
+            },
+            variable_order = ?variable_order
+        )
+    )]
     #[allow(clippy::too_many_lines)]
     fn round(
         &self,
@@ -306,7 +341,16 @@ where
         round_state.round_data = RoundData::Ext(prover_data);
     }
 
-    #[instrument(skip_all)]
+    #[instrument(
+        skip_all,
+        fields(
+            round_number = round_index,
+            final_queries = self.final_queries,
+            final_pow_bits = self.final_pow_bits,
+            final_sumcheck_rounds = self.final_sumcheck_rounds,
+            folding_factor = self.params.folding_factor.at_round(round_index)
+        )
+    )]
     fn final_round(
         &self,
         round_index: usize,


### PR DESCRIPTION
This change adds key prover configuration fields to tracing spans, making production debugging and benchmark triage faster without altering protocol behavior. 