### PR TITLE
Couple fixes

### DIFF
--- a/challenger/src/hash_challenger.rs
+++ b/challenger/src/hash_challenger.rs
@@ -63,10 +63,6 @@ where
     H: CryptographicHasher<T, [T; OUT_LEN]>,
 {
     fn observe(&mut self, values: [T; N]) {
-        if N == 0 {
-            return;
-        }
-
         self.output_buffer.clear();
         self.input_buffer.extend(values);
     }
@@ -410,5 +406,24 @@ mod tests {
 
         // Verify that the output buffer is cleared after observing
         assert!(hash_challenger.output_buffer.is_empty());
+    }
+
+    #[test]
+    fn test_observe_empty_array_clears_output_buffer() {
+        let test_hasher = TestHasher {};
+        let initial_state = vec![F::from_u8(1), F::from_u8(2)];
+        let mut hash_challenger = HashChallenger::new(initial_state.clone(), test_hasher);
+
+        // Populate artificially the output buffer
+        hash_challenger.output_buffer.push(F::from_u8(42));
+        assert!(!hash_challenger.output_buffer.is_empty());
+
+        // Observing an empty array still invalidates the output buffer
+        let values: [F; 0] = [];
+        hash_challenger.observe(values);
+
+        assert!(hash_challenger.output_buffer.is_empty());
+        // Input buffer is unchanged because no values were appended
+        assert_eq!(hash_challenger.input_buffer, initial_state);
     }
 }

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -378,7 +378,7 @@ impl Field for Goldilocks {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     type Packing = crate::PackedGoldilocksAVX512;
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     type Packing = crate::PackedGoldilocksNeon;
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]

--- a/goldilocks/src/lib.rs
+++ b/goldilocks/src/lib.rs
@@ -15,10 +15,10 @@ pub use poseidon2::*;
 
 pub mod poseidon1;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 mod aarch64_neon;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub use aarch64_neon::*;
 
 #[cfg(all(

--- a/goldilocks/src/poseidon1.rs
+++ b/goldilocks/src/poseidon1.rs
@@ -91,7 +91,7 @@ pub type Poseidon1GoldilocksGeneric<const WIDTH: usize> = Poseidon1<
 /// Karatsuba MDS convolution.
 ///
 /// Supports both scalar and packed state representations transparently.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub type Poseidon1Goldilocks<const WIDTH: usize> = crate::Poseidon1GoldilocksDispatch<WIDTH>;
 
 /// Unified Poseidon1 permutation for Goldilocks.
@@ -859,7 +859,7 @@ pub const GOLDILOCKS_POSEIDON1_RC_12: [[Goldilocks; 12]; 30] = Goldilocks::new_2
 /// Returns the platform-optimal implementation: dual-dispatch on aarch64
 /// (generic for scalar, fused ASM for packed), generic Karatsuba on all
 /// other platforms.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub fn default_goldilocks_poseidon1_8() -> Poseidon1Goldilocks<8> {
     let constants = Poseidon1Constants {
         rounds_f: 2 * GOLDILOCKS_POSEIDON_HALF_FULL_ROUNDS,
@@ -891,7 +891,7 @@ pub fn default_goldilocks_poseidon1_8() -> Poseidon1Goldilocks<8> {
 /// Returns the platform-optimal implementation: dual-dispatch on aarch64
 /// (generic for scalar, fused ASM for packed), generic Karatsuba on all
 /// other platforms.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub fn default_goldilocks_poseidon1_12() -> Poseidon1Goldilocks<12> {
     let constants = Poseidon1Constants {
         rounds_f: 2 * GOLDILOCKS_POSEIDON_HALF_FULL_ROUNDS,
@@ -1160,7 +1160,7 @@ mod tests {
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     mod neon {
         use super::*;
         use crate::PackedGoldilocksNeon;

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -49,7 +49,7 @@ pub const GOLDILOCKS_POSEIDON2_PARTIAL_ROUNDS_16: usize = 22;
 /// An implementation of the Poseidon2 hash function for the Goldilocks field.
 ///
 /// It acts on arrays of the form `[Goldilocks; WIDTH]`.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub type Poseidon2Goldilocks<const WIDTH: usize> = crate::Poseidon2GoldilocksFused<WIDTH>;
 
 /// An implementation of the Poseidon2 hash function for the Goldilocks field.
@@ -578,7 +578,7 @@ pub fn default_goldilocks_poseidon2_8() -> Poseidon2Goldilocks<8> {
 }
 
 /// Create a default width-8 Poseidon2 permutation for Goldilocks.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub fn default_goldilocks_poseidon2_8() -> Poseidon2Goldilocks<8> {
     crate::Poseidon2GoldilocksFused::new(
         &ExternalLayerConstants::new(
@@ -602,7 +602,7 @@ pub fn default_goldilocks_poseidon2_12() -> Poseidon2Goldilocks<12> {
 }
 
 /// Create a default width-12 Poseidon2 permutation for Goldilocks.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub fn default_goldilocks_poseidon2_12() -> Poseidon2Goldilocks<12> {
     crate::Poseidon2GoldilocksFused::new(
         &ExternalLayerConstants::new(
@@ -626,7 +626,7 @@ pub fn default_goldilocks_poseidon2_16() -> Poseidon2Goldilocks<16> {
 }
 
 /// Create a default width-16 Poseidon2 permutation for Goldilocks.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub fn default_goldilocks_poseidon2_16() -> Poseidon2Goldilocks<16> {
     crate::Poseidon2GoldilocksFused::new(
         &ExternalLayerConstants::new(

--- a/symmetric/src/hash.rs
+++ b/symmetric/src/hash.rs
@@ -29,15 +29,6 @@ pub struct MerkleCap<F, Digest> {
     _marker: PhantomData<F>,
 }
 
-impl<F, Digest: Default> Default for MerkleCap<F, Digest> {
-    fn default() -> Self {
-        Self {
-            cap: vec![Digest::default()],
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<F, Digest> MerkleCap<F, Digest> {
     /// Create a new `MerkleCap` from a vector of digests.
     pub fn new(cap: Vec<Digest>) -> Self {

--- a/symmetric/src/hash.rs
+++ b/symmetric/src/hash.rs
@@ -41,7 +41,7 @@ impl<F, Digest: Default> Default for MerkleCap<F, Digest> {
 impl<F, Digest> MerkleCap<F, Digest> {
     /// Create a new `MerkleCap` from a vector of digests.
     pub fn new(cap: Vec<Digest>) -> Self {
-        assert!(cap.len().is_power_of_two() || cap.is_empty());
+        assert!(cap.len().is_power_of_two());
         Self {
             cap,
             _marker: PhantomData,
@@ -155,5 +155,58 @@ impl<F, W, const DIGEST_ELEMS: usize> Borrow<[W; DIGEST_ELEMS]> for Hash<F, W, D
 impl<F, W, const DIGEST_ELEMS: usize> AsRef<[W; DIGEST_ELEMS]> for Hash<F, W, DIGEST_ELEMS> {
     fn as_ref(&self) -> &[W; DIGEST_ELEMS] {
         &self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_goldilocks::Goldilocks;
+
+    use super::*;
+
+    type F = Goldilocks;
+    type Digest = [u8; 4];
+
+    #[test]
+    fn test_merkle_cap_new_with_power_of_two_sizes() {
+        let cap = MerkleCap::<F, Digest>::new(vec![[7u8; 4]]);
+        assert_eq!(cap.num_roots(), 1);
+        assert_eq!(cap.height(), 0);
+
+        let cap = MerkleCap::<F, Digest>::new(vec![[0u8; 4]; 2]);
+        assert_eq!(cap.num_roots(), 2);
+        assert_eq!(cap.height(), 1);
+
+        let cap = MerkleCap::<F, Digest>::new(vec![[0u8; 4]; 8]);
+        assert_eq!(cap.num_roots(), 8);
+        assert_eq!(cap.height(), 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_merkle_cap_new_panics_on_empty() {
+        let _ = MerkleCap::<F, Digest>::new(vec![]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_merkle_cap_new_panics_on_three() {
+        let _ = MerkleCap::<F, Digest>::new(vec![[0u8; 4]; 3]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_merkle_cap_from_vec_panics_on_empty() {
+        let _: MerkleCap<F, Digest> = vec![].into();
+    }
+
+    #[test]
+    fn test_merkle_cap_from_hash() {
+        let hash = Hash::<F, u8, 4>::from([1u8, 2, 3, 4]);
+        let cap: MerkleCap<F, [u8; 4]> = hash.into();
+        assert_eq!(cap.num_roots(), 1);
+        assert_eq!(cap.height(), 0);
     }
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -330,7 +330,7 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 const fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     // Aarch64 can reverse bits in one instruction, so the trivial version works best.
     // use manual `while` loop to enable `const`

--- a/util/src/transpose/rectangular.rs
+++ b/util/src/transpose/rectangular.rs
@@ -67,9 +67,9 @@
 //! - **Medium (<`MEDIUM_LEN` elements)**: `TILE_SIZE`×`TILE_SIZE` Tiled - L2-friendly tiles
 //! - **Large (≥`MEDIUM_LEN` elements)**: Recursive + Tiled - Cache-oblivious
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use core::arch::aarch64::*;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use core::mem::MaybeUninit;
 #[cfg(all(target_arch = "aarch64", feature = "parallel"))]
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -79,7 +79,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 /// Brings the cache line containing `ptr` into the L1 data cache in exclusive
 /// state, preparing for a subsequent store. This avoids Read-For-Ownership
 /// (RFO) stalls when writing to memory not already in L1.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline(always)]
 unsafe fn prefetch_write(ptr: *const u8) {
     // PRFM PSTL1KEEP: Prefetch for Store, L1 cache, temporal (keep in cache).
@@ -132,7 +132,7 @@ const TILE_SIZE: usize = 16;
 ///
 /// At this point, the sub-matrix (up to `RECURSIVE_LIMIT`×`RECURSIVE_LIMIT` elements)
 /// fits in L2 cache, so we switch to tiled transpose.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 const RECURSIVE_LIMIT: usize = 128;
 
 /// Minimum number of elements before enabling parallel processing.
@@ -212,7 +212,7 @@ pub fn transpose<T: Copy + Send + Sync>(
     }
 
     // Architecture dispatch
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
         // Use NEON-optimized path for 4-byte elements.
         //
@@ -287,7 +287,7 @@ pub fn transpose<T: Copy + Send + Sync>(
 ///
 /// Caller must ensure `input` and `output` point to valid memory regions
 /// of at least `width * height` elements each.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_neon_4b(input: *const u32, output: *mut u32, width: usize, height: usize) {
     // Total number of elements in the matrix.
@@ -435,7 +435,7 @@ unsafe fn transpose_neon_4b_parallel(
 /// # Safety
 ///
 /// Caller must ensure valid pointers for `width * height` elements.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_small_4b(input: *const u32, output: *mut u32, width: usize, height: usize) {
     // Outer loop over columns (output rows).
@@ -485,7 +485,7 @@ unsafe fn transpose_small_4b(input: *const u32, output: *mut u32, width: usize, 
 /// # Safety
 ///
 /// Caller must ensure valid pointers for `width * height` elements.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tiled_4b(input: *const u32, output: *mut u32, width: usize, height: usize) {
     // Compute tile counts and remainders
@@ -626,7 +626,7 @@ unsafe fn transpose_tiled_4b(input: *const u32, output: *mut u32, width: usize, 
 /// # Safety
 ///
 /// Caller must ensure valid pointers and that coordinate ranges are within bounds.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_recursive_4b(
     input: *const u32,
@@ -736,7 +736,7 @@ unsafe fn transpose_recursive_4b(
 /// - Valid pointers for `total_cols * total_rows` elements
 /// - `row_start < row_end <= total_rows`
 /// - `col_start < col_end <= total_cols`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_region_tiled_4b(
@@ -846,9 +846,9 @@ unsafe fn transpose_region_tiled_4b(
 ///
 /// Caller must ensure:
 /// - Valid pointers for the full matrix
-/// - `x_start + 16 <= width`
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 /// - `y_start + 16 <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tile_16x16_neon(
     input: *const u32,
@@ -908,7 +908,7 @@ unsafe fn transpose_tile_16x16_neon(
 /// - Valid pointers for the full matrix
 /// - `x_start + 16 <= width`
 /// - `y_start + 16 <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tile_16x16_neon_buffered(
     input: *const u32,
@@ -988,11 +988,11 @@ unsafe fn transpose_tile_16x16_neon_buffered(
 ///
 /// # Safety
 ///
-/// Caller must ensure:
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 /// - Valid pointers for the full matrix
 /// - `x_start + block_width <= width`
 /// - `y_start + block_height <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_block_scalar(
@@ -1095,12 +1095,12 @@ unsafe fn transpose_block_scalar(
 /// - **Total**: ~16 cycles for 16 elements = **1 cycle/element**
 ///
 /// # Safety
-///
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 /// Caller must ensure:
 /// - `src` is valid for reading 4 rows of `src_stride` elements each
 /// - `dst` is valid for writing 4 rows of `dst_stride` elements each
 /// - The first 4 elements of each row are accessible
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline(always)]
 unsafe fn transpose_4x4_neon(src: *const u32, dst: *mut u32, src_stride: usize, dst_stride: usize) {
     unsafe {
@@ -1195,7 +1195,7 @@ unsafe fn transpose_4x4_neon(src: *const u32, dst: *mut u32, src_stride: usize, 
 ///
 /// Caller must ensure `input` and `output` point to valid memory regions
 /// of at least `width * height` elements each.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_neon_8b(input: *const u64, output: *mut u64, width: usize, height: usize) {
     let len = width * height;
@@ -1270,7 +1270,7 @@ unsafe fn transpose_neon_8b_parallel(
 /// # Safety
 ///
 /// Caller must ensure valid pointers for `width * height` elements.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_small_8b(input: *const u64, output: *mut u64, width: usize, height: usize) {
     for x in 0..width {
@@ -1290,7 +1290,7 @@ unsafe fn transpose_small_8b(input: *const u64, output: *mut u64, width: usize, 
 /// # Safety
 ///
 /// Caller must ensure valid pointers for `width * height` elements.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tiled_8b(input: *const u64, output: *mut u64, width: usize, height: usize) {
     let x_tile_count = width / TILE_SIZE;
@@ -1367,7 +1367,7 @@ unsafe fn transpose_tiled_8b(input: *const u64, output: *mut u64, width: usize, 
 /// # Safety
 ///
 /// Caller must ensure valid pointers and that coordinate ranges are within bounds.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_recursive_8b(
     input: *const u64,
@@ -1435,7 +1435,7 @@ unsafe fn transpose_recursive_8b(
 /// - Valid pointers for `total_cols * total_rows` elements
 /// - `row_start < row_end <= total_rows`
 /// - `col_start < col_end <= total_cols`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_region_tiled_8b(
@@ -1535,7 +1535,7 @@ unsafe fn transpose_region_tiled_8b(
 /// - Valid pointers for the full matrix
 /// - `x_start + 16 <= width`
 /// - `y_start + 16 <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tile_16x16_neon_8b(
     input: *const u64,
@@ -1591,7 +1591,7 @@ unsafe fn transpose_tile_16x16_neon_8b(
 /// - Valid pointers for the full matrix
 /// - `x_start + 16 <= width`
 /// - `y_start + 16 <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 unsafe fn transpose_tile_16x16_neon_8b_buffered(
     input: *const u64,
@@ -1661,7 +1661,7 @@ unsafe fn transpose_tile_16x16_neon_8b_buffered(
 /// - Valid pointers for the full matrix
 /// - `x_start + block_width <= width`
 /// - `y_start + block_height <= height`
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline]
 #[allow(clippy::too_many_arguments)]
 unsafe fn transpose_block_scalar_8b(
@@ -1724,7 +1724,7 @@ unsafe fn transpose_block_scalar_8b(
 /// - `src` is valid for reading 4 rows of `src_stride` elements each
 /// - `dst` is valid for writing 4 rows of `dst_stride` elements each
 /// - The first 4 elements of each row are accessible
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 #[inline(always)]
 unsafe fn transpose_4x4_neon_8b(
     src: *const u64,


### PR DESCRIPTION
Namely:

- remove `Default` from `MerkleCap` as we can't initialize it with the proper nb of digests (we were defaulting to 1 which does not make much sense)
- forbid empty caps (no usecases, and removes a footgun)
- ensure we flush the output buffer when calling `HashChallenger::observe()` for dummy case of `N = 0` (no practical issue, just out of consistency with other instantiations)
- Make sure `neon` code is not activated on non-neon aarch targets (similarly to how it was already done in any crate but `goldilocks` / `util`