### PR TITLE
whir: reject final polynomial length mismatch

### DIFF
--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -7,12 +7,12 @@ use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::MultilinearPcs;
 use p3_dft::Radix2DFTSmallBatch;
-use p3_field::extension::BinomialExtensionField;
 use p3_field::Field;
+use p3_field::extension::BinomialExtensionField;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use rand::rngs::SmallRng;
 use rand::SeedableRng;
+use rand::rngs::SmallRng;
 
 use crate::fiat_shamir::domain_separator::DomainSeparator;
 use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
@@ -283,11 +283,11 @@ mod error_variant_tests {
 
     use p3_commit::MultilinearPcs;
     use p3_multilinear_util::poly::Poly;
-    use rand::rngs::SmallRng;
     use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use super::{
-        challenger, MyChallenger, MyCompress, MyDft, MyHash, MyMmcs, Perm, TestWhirPcs, EF, F,
+        EF, F, MyChallenger, MyCompress, MyDft, MyHash, MyMmcs, Perm, TestWhirPcs, challenger,
     };
     use crate::fiat_shamir::domain_separator::DomainSeparator;
     use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
@@ -675,8 +675,8 @@ mod keccak_tests {
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_multilinear_util::poly::Poly;
     use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
-    use rand::rngs::SmallRng;
     use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     use crate::fiat_shamir::domain_separator::DomainSeparator;
     use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -7,12 +7,12 @@ use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::MultilinearPcs;
 use p3_dft::Radix2DFTSmallBatch;
-use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
+use p3_field::Field;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::SeedableRng;
 
 use crate::fiat_shamir::domain_separator::DomainSeparator;
 use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
@@ -283,11 +283,11 @@ mod error_variant_tests {
 
     use p3_commit::MultilinearPcs;
     use p3_multilinear_util::poly::Poly;
-    use rand::SeedableRng;
     use rand::rngs::SmallRng;
+    use rand::SeedableRng;
 
     use super::{
-        EF, F, MyChallenger, MyCompress, MyDft, MyHash, MyMmcs, Perm, TestWhirPcs, challenger,
+        challenger, MyChallenger, MyCompress, MyDft, MyHash, MyMmcs, Perm, TestWhirPcs, EF, F,
     };
     use crate::fiat_shamir::domain_separator::DomainSeparator;
     use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
@@ -534,6 +534,38 @@ mod error_variant_tests {
     }
 
     #[test]
+    fn rejects_with_final_poly_length_mismatch_when_tail_has_extra_evals() {
+        // Invariant: the final polynomial must have exactly the verifier-expected
+        // number of evaluations before it is absorbed into the transcript.
+        //
+        // Mutation: duplicate the honest tail, preserving Poly's power-of-two
+        // shape but changing the WHIR-level final length.
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        let final_poly = proof
+            .whir
+            .final_poly
+            .as_ref()
+            .expect("honest fixture should contain final_poly");
+        let expected = final_poly.num_evals();
+        let mut evals = final_poly.as_slice().to_vec();
+        let duplicate = evals.clone();
+        evals.extend_from_slice(&duplicate);
+        proof.whir.final_poly = Some(Poly::new(evals));
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::FinalPolyLengthMismatch {
+                expected: e,
+                actual,
+            } => {
+                assert_eq!(e, expected);
+                assert_eq!(actual, expected * 2);
+            }
+            other => panic!("expected FinalPolyLengthMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn rejects_with_round_ood_answer_count_mismatch_when_answer_is_dropped() {
         // Invariant: each round carries exactly the verifier-expected OOD answers.
         //
@@ -643,8 +675,8 @@ mod keccak_tests {
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_multilinear_util::poly::Poly;
     use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
-    use rand::SeedableRng;
     use rand::rngs::SmallRng;
+    use rand::SeedableRng;
 
     use crate::fiat_shamir::domain_separator::DomainSeparator;
     use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};

--- a/whir/src/pcs/verifier/errors.rs
+++ b/whir/src/pcs/verifier/errors.rs
@@ -87,4 +87,8 @@ pub enum VerifierError {
     /// Proof is missing the final polynomial evaluations.
     #[error("Proof is missing the final polynomial evaluations")]
     MissingFinalPoly,
+
+    /// Final polynomial has the wrong number of evaluations.
+    #[error("Final polynomial length mismatch: expected {expected}, got {actual}")]
+    FinalPolyLengthMismatch { expected: usize, actual: usize },
 }

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -16,12 +16,12 @@ use tracing::instrument;
 use super::committer::reader::ParsedCommitment;
 use super::utils::get_challenge_stir_queries;
 use crate::alloc::string::ToString;
-use crate::constraints::Constraint;
 use crate::constraints::statement::SelectStatement;
+use crate::constraints::Constraint;
 use crate::parameters::{RoundConfig, WhirConfig};
 use crate::pcs::proof::{QueryOpening, WhirProof};
 use crate::sumcheck::strategy::VariableOrder;
-use crate::sumcheck::{SumcheckError, verify_final_sumcheck_rounds};
+use crate::sumcheck::{verify_final_sumcheck_rounds, SumcheckError};
 
 pub mod errors;
 
@@ -183,6 +183,15 @@ where
             .final_poly
             .clone()
             .ok_or(VerifierError::MissingFinalPoly)?;
+        let final_round_config = self.final_round_config();
+        let expected_final_poly_len = 1usize << final_round_config.num_variables;
+        let actual_final_poly_len = final_evaluations.num_evals();
+        if actual_final_poly_len != expected_final_poly_len {
+            return Err(VerifierError::FinalPolyLengthMismatch {
+                expected: expected_final_poly_len,
+                actual: actual_final_poly_len,
+            });
+        }
         challenger.observe_algebra_slice(final_evaluations.as_slice());
 
         // Verify final STIR challenges.
@@ -194,7 +203,7 @@ where
         let stir_statement = self.verify_stir_challenges(
             proof,
             challenger,
-            &self.final_round_config(),
+            &final_round_config,
             &prev_commitment,
             final_round_folding_randomness,
             self.n_rounds(),

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -16,12 +16,12 @@ use tracing::instrument;
 use super::committer::reader::ParsedCommitment;
 use super::utils::get_challenge_stir_queries;
 use crate::alloc::string::ToString;
-use crate::constraints::statement::SelectStatement;
 use crate::constraints::Constraint;
+use crate::constraints::statement::SelectStatement;
 use crate::parameters::{RoundConfig, WhirConfig};
 use crate::pcs::proof::{QueryOpening, WhirProof};
 use crate::sumcheck::strategy::VariableOrder;
-use crate::sumcheck::{verify_final_sumcheck_rounds, SumcheckError};
+use crate::sumcheck::{SumcheckError, verify_final_sumcheck_rounds};
 
 pub mod errors;
 


### PR DESCRIPTION
## Summary

Reject WHIR proofs whose final polynomial length does not match the verifier's final round shape before observing it in the transcript.

This follows the existing malformed-proof hardening in the WHIR verifier by returning a typed `FinalPolyLengthMismatch` error instead of letting an invalid tail polynomial flow into final STIR and sumcheck checks.