### PR TITLE
fix: do not reduce Mersenne::ZEROS[1]

### DIFF
--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -671,7 +671,10 @@ mod tests {
     }
 
     // Mersenne31 has a redundant representation of Zero but no redundant representation of One.
-    const ZEROS: [Mersenne31; 2] = [Mersenne31::ZERO, Mersenne31::new((1_u32 << 31) - 1)];
+    // The second entry deliberately uses `new_reduced` to *preserve* the `value == P` encoding:
+    // the public `new` constructor reduces modulo P and would silently collapse it to 0,
+    // making the redundant-representation tests no-ops (cf. #1684).
+    const ZEROS: [Mersenne31; 2] = [Mersenne31::ZERO, Mersenne31::new_reduced((1_u32 << 31) - 1)];
     const ONES: [Mersenne31; 1] = [Mersenne31::ONE];
 
     // Get the prime factorization of the order of the multiplicative group.


### PR DESCRIPTION
## Summary

Ensure that `Mersenne31::ZEROS[1]` actually contains the redundant zero `P` without reduction.

## Motivation

Somewhat related to #1684 (cc @tcoratger).
The original intent for ZEROS[1] was to hold the redundant zero representation in the field (i.e. exactly `P`) so that `test_field!` / `test_prime_field_32!` / `test_prime_field_64!` could all check the effect on both encodings, but we were silently reducing it to 0 upon constructing it. This is why it never got detected until the MDS partial-reduction bug I believe.