### PR TITLE
chore: HornerIter follow-ups from #1692 review

### DIFF
--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -154,9 +154,10 @@ mod helpers {
         // via the original reduce_32 (which uses base 2^32) only when values are small.
         // Instead, manually reconstruct with the matching radix.
         let base = Goldilocks::from_u64(1u64 << pb);
-        let recomposed: Goldilocks = limbs.iter().rev().fold(Goldilocks::ZERO, |acc, &limb| {
-            acc * base + Goldilocks::from_u64(limb.as_canonical_u32() as u64)
-        });
+        let recomposed: Goldilocks = limbs
+            .iter()
+            .map(|limb| Goldilocks::from_u64(limb.as_canonical_u32() as u64))
+            .horner(base);
         assert_eq!(recomposed, g);
     }
 
@@ -228,9 +229,10 @@ mod helpers {
         }
         // Recompose in base p_F and verify.
         let p = BigUint::from(BabyBear::ORDER_U32);
-        let recomposed: BigUint = limbs.iter().rev().fold(BigUint::from(0u32), |acc, limb| {
-            acc * &p + BigUint::from(limb.as_canonical_u32())
-        });
+        let recomposed: BigUint = limbs
+            .iter()
+            .map(|limb| BigUint::from(limb.as_canonical_u32()))
+            .horner(&p);
         assert_eq!(
             recomposed,
             g.as_canonical_biguint() % p.pow(num_limbs as u32)
@@ -590,5 +592,39 @@ mod helpers {
         let high_eval: BabyBear = high.iter().copied().horner(x);
         let combined: BabyBear = low.iter().copied().horner_acc(high_eval, x);
         assert_eq!(combined, one_shot);
+    }
+
+    #[test]
+    fn horner_with_extension_accumulator_over_base_coefficients() {
+        // Production call sites have Acc = EF (extension) and Item = F (base);
+        // the bound `Acc: Add<Self::Item, Output = Acc>` is satisfied via the
+        // `Algebra<F>` supertrait of `ExtensionField`. Pin that contract here
+        // with an `x` that exercises all extension coordinates (not just the
+        // base embedding).
+        use p3_field::BasedVectorSpace;
+        type EF = p3_field::extension::BinomialExtensionField<BabyBear, 4>;
+        let coeffs: [BabyBear; 4] = [
+            BabyBear::from_u32(1),
+            BabyBear::from_u32(2),
+            BabyBear::from_u32(3),
+            BabyBear::from_u32(4),
+        ];
+        let x = EF::from_basis_coefficients_slice(&[
+            BabyBear::from_u32(5),
+            BabyBear::from_u32(6),
+            BabyBear::from_u32(7),
+            BabyBear::from_u32(8),
+        ])
+        .unwrap();
+
+        let horner: EF = coeffs.iter().copied().horner(x);
+
+        let mut expected = EF::ZERO;
+        let mut power = EF::ONE;
+        for &c in &coeffs {
+            expected += power * c;
+            power *= x;
+        }
+        assert_eq!(horner, expected);
     }
 }

--- a/field/tests/helpers_test.rs
+++ b/field/tests/helpers_test.rs
@@ -1,10 +1,10 @@
 mod helpers {
     use p3_baby_bear::BabyBear;
     use p3_field::{
-        Field, HornerIter, PrimeCharacteristicRing, PrimeField, PrimeField32, absorb_radix_bits,
-        add_scaled_slice_in_place, chunked_mixed_dot_product, dispatch_chunked_mixed_dot_product,
-        dot_product, field_to_array, injective_pack_bits, max_absorb_injective_limbs,
-        max_packed_injective_limbs, max_shifted_absorb_injective_limbs,
+        BasedVectorSpace, Field, HornerIter, PrimeCharacteristicRing, PrimeField, PrimeField32,
+        absorb_radix_bits, add_scaled_slice_in_place, chunked_mixed_dot_product,
+        dispatch_chunked_mixed_dot_product, dot_product, field_to_array, injective_pack_bits,
+        max_absorb_injective_limbs, max_packed_injective_limbs, max_shifted_absorb_injective_limbs,
         max_shifted_packed_injective_limbs, par_add_scaled_slice_in_place,
         pf_packed_limbs_cover_order, reduce_32, reduce_packed, reduce_packed_shifted, split_32,
         split_pf_to_field_order_limbs, split_pf_to_packed_limbs, squeeze_field_order_num_limbs,
@@ -596,19 +596,19 @@ mod helpers {
 
     #[test]
     fn horner_with_extension_accumulator_over_base_coefficients() {
-        // Production call sites have Acc = EF (extension) and Item = F (base);
-        // the bound `Acc: Add<Self::Item, Output = Acc>` is satisfied via the
-        // `Algebra<F>` supertrait of `ExtensionField`. Pin that contract here
-        // with an `x` that exercises all extension coordinates (not just the
-        // base embedding).
-        use p3_field::BasedVectorSpace;
+        // Cross-type Horner: base-field coefficients, extension-field point.
+        // The other Horner tests in this file use the same field on both sides.
         type EF = p3_field::extension::BinomialExtensionField<BabyBear, 4>;
+
         let coeffs: [BabyBear; 4] = [
             BabyBear::from_u32(1),
             BabyBear::from_u32(2),
             BabyBear::from_u32(3),
             BabyBear::from_u32(4),
         ];
+
+        // All coordinates non-zero so the evaluation exercises every extension
+        // component, not just the base-field embedding.
         let x = EF::from_basis_coefficients_slice(&[
             BabyBear::from_u32(5),
             BabyBear::from_u32(6),
@@ -619,6 +619,7 @@ mod helpers {
 
         let horner: EF = coeffs.iter().copied().horner(x);
 
+        // Reference: explicit sum_{i} c_i * x^i.
         let mut expected = EF::ZERO;
         let mut power = EF::ONE;
         for &c in &coeffs {

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -1588,11 +1588,7 @@ mod tests {
         proof.final_poly[0] += Challenge::ONE;
 
         // Evaluate the corrupted polynomial at the same point.
-        let corrupted_eval = proof
-            .final_poly
-            .iter()
-            .rev()
-            .fold(Challenge::ZERO, |acc, &c| acc * x + c);
+        let corrupted_eval: Challenge = proof.final_poly.iter().copied().horner(x);
 
         // The two must differ — this is what the verifier would catch.
         assert_ne!(honest_eval, corrupted_eval);

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -310,20 +310,13 @@ fn compute_logup_contribution(
     let beta = challenges.beta;
     let vals_read_len = vals_read.len();
     let val_read: EF = vals_read.iter().rev().copied().horner(beta);
-
-    let val_provided: EF = vals_provided
-        .iter()
-        .rev()
-        .copied()
-        .map(EF::from)
-        .horner(beta);
+    let val_provided: EF = vals_provided.iter().rev().copied().horner(beta);
 
     if vals_read_len == 0 {
         // Then we're only computing the contribution for the provided value.
-        (alpha - EF::from(val_provided)).inverse() * EF::from(mult)
+        (alpha - val_provided).inverse() * EF::from(mult)
     } else {
-        (alpha - EF::from(val_read)).inverse()
-            - (alpha - EF::from(val_provided)).inverse() * EF::from(mult)
+        (alpha - val_read).inverse() - (alpha - val_provided).inverse() * EF::from(mult)
     }
 }
 


### PR DESCRIPTION
Follow-ups to #1692 caught in post-merge review. All changes are test-only or test-side cleanup; no prover/verifier semantics change.

## Summary
- **fri**: migrate the remaining `iter().rev().fold(...)` Horner evaluation in `final_poly_mismatch` so both the honest and corrupted evaluations use the new `horner` API (the PR migrated one of the two but left the other).
- **lookup**: drop the asymmetric `.map(EF::from)` on `val_provided` (the symmetric fix to commit `0056d9a`'s removal on `val_read`) and remove the now-redundant `EF::from(val_*)` identity conversions on the `alpha - …` operands.
- **field**: migrate the two remaining `iter().rev().fold(...)` recompositions in `helpers_test` — the Goldilocks limb roundtrip and the BigUint base-`p` roundtrip — to `.horner(...)`.
- **field**: add `horner_with_extension_accumulator_over_base_coefficients` pinning the `Acc = EF`, `Item = F` cross-type contract that every production call site of `HornerIter` relies on. The previous tests only exercised `Acc = Item = BabyBear`, leaving the `Algebra<F>`-mediated `Add<Self::Item>` bound untested. The new test uses an `x` with non-zero coordinates in every extension component so the embedding case is not the only one covered.

## Test plan
- [x] `cargo test -p p3-field --test helpers_test` — 38 tests pass, including the 5 Horner tests.
- [x] `cargo test -p p3-fri --lib final_poly_mismatch` — passes.
- [x] `cargo test -p p3-lookup --tests` — 17 tests pass.
- [x] `cargo clippy -p p3-field -p p3-fri -p p3-lookup --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.