### PR TITLE
refactor(field): unify extension-field logic under common abstraction

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -15,7 +15,9 @@ use rand::prelude::Distribution;
 use serde::{Deserialize, Serialize};
 
 use super::{HasFrobenius, HasTwoAdicBinomialExtension, PackedBinomialExtensionField};
-use crate::extension::{BinomiallyExtendable, BinomiallyExtendableAlgebra};
+use crate::extension::{
+    Binomial, BinomiallyExtendable, ExtensionAlgebra,
+};
 use crate::field::Field;
 use crate::{
     Algebra, BasedVectorSpace, Dup, ExtensionField, Packable, PrimeCharacteristicRing,
@@ -233,7 +235,7 @@ impl<F: BinomiallyExtendable<D>, const D: usize> HasFrobenius<F> for BinomialExt
 impl<F, A, const D: usize> PrimeCharacteristicRing for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D> + Copy,
+    A: ExtensionAlgebra<F, D, Binomial<F>> + Copy,
 {
     type PrimeSubfield = <A as PrimeCharacteristicRing>::PrimeSubfield;
 
@@ -430,13 +432,13 @@ where
 impl<F, A, const D: usize> Add for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     type Output = Self;
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        let value = A::binomial_add(&self.value, &rhs.value);
+        let value = <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_add(&self.value, &rhs.value);
         Self::new(value)
     }
 }
@@ -458,11 +460,11 @@ where
 impl<F, A, const D: usize> AddAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        self.value = A::binomial_add(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_add(&self.value, &rhs.value);
     }
 }
 
@@ -480,7 +482,7 @@ where
 impl<F, A, const D: usize> Sum for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D> + Copy,
+    A: ExtensionAlgebra<F, D, Binomial<F>> + Copy,
 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -491,13 +493,13 @@ where
 impl<F, A, const D: usize> Sub for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     type Output = Self;
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        let value = A::binomial_sub(&self.value, &rhs.value);
+        let value = <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_sub(&self.value, &rhs.value);
         Self::new(value)
     }
 }
@@ -520,11 +522,11 @@ where
 impl<F, A, const D: usize> SubAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        self.value = A::binomial_sub(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_sub(&self.value, &rhs.value);
     }
 }
 
@@ -542,7 +544,7 @@ where
 impl<F, A, const D: usize> Mul for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     type Output = Self;
 
@@ -551,9 +553,11 @@ where
         let a = self.value;
         let b = rhs.value;
         let mut res = Self::default();
-        let w = F::W;
 
-        A::binomial_mul(&a, &b, &mut res.value, w);
+        // Migrated to the unified shape-parameterized `ExtensionAlgebra` trait.
+        // `W` is now reached through the bridge impl (which projects `F::W`),
+        // so callers no longer pass it explicitly.
+        <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_mul(&a, &b, &mut res.value);
 
         res
     }
@@ -562,20 +566,20 @@ where
 impl<F, A, const D: usize> Mul<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(A::binomial_base_mul(self.value, rhs))
+        Self::new(<A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_base_mul(self.value, rhs))
     }
 }
 
 impl<F, A, const D: usize> MulAssign for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
@@ -586,7 +590,7 @@ where
 impl<F, A, const D: usize> MulAssign<A> for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D>,
+    A: ExtensionAlgebra<F, D, Binomial<F>>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: A) {
@@ -597,7 +601,7 @@ where
 impl<F, A, const D: usize> Product for BinomialExtensionField<F, D, A>
 where
     F: BinomiallyExtendable<D>,
-    A: BinomiallyExtendableAlgebra<F, D> + Copy,
+    A: ExtensionAlgebra<F, D, Binomial<F>> + Copy,
 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -661,7 +665,7 @@ pub fn vector_add<R: PrimeCharacteristicRing + Add<R2, Output = R>, R2: Dup, con
 
 /// Subtract two vectors element wise.
 #[inline]
-pub(crate) fn vector_sub<
+pub fn vector_sub<
     R: PrimeCharacteristicRing + Sub<R2, Output = R>,
     R2: Dup,
     const D: usize,
@@ -674,7 +678,7 @@ pub(crate) fn vector_sub<
 
 /// Multiply two vectors representing elements in a binomial extension.
 #[inline]
-pub(super) fn binomial_mul<
+pub fn binomial_mul<
     F: Field,
     R: Algebra<F> + Algebra<R2>,
     R2: Algebra<F>,
@@ -709,7 +713,7 @@ pub(super) fn binomial_mul<
 ///
 /// This is optimized for the case that R is a prime field or its packing.
 #[inline]
-pub(super) fn binomial_square<F: Field, R: Algebra<F>, const D: usize>(
+pub fn binomial_square<F: Field, R: Algebra<F>, const D: usize>(
     a: &[R; D],
     res: &mut [R; D],
     w: F,

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -2,9 +2,8 @@ use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::array;
-use core::fmt::{self, Debug, Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 use core::iter::{Product, Sum};
-use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
@@ -12,44 +11,19 @@ use num_bigint::BigUint;
 use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
-use serde::{Deserialize, Serialize};
 
-use super::{HasFrobenius, HasTwoAdicBinomialExtension, PackedBinomialExtensionField};
-use crate::extension::{
-    Binomial, BinomiallyExtendable, ExtensionAlgebra,
-};
+use super::{ExtField, HasFrobenius, HasTwoAdicBinomialExtension, PackedBinomialExtensionField};
+use crate::extension::{Binomial, BinomiallyExtendable, ExtensionAlgebra};
 use crate::field::Field;
 use crate::{
     Algebra, BasedVectorSpace, Dup, ExtensionField, Packable, PrimeCharacteristicRing,
     RawDataSerializable, TwoAdicField, field_to_array,
 };
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)] // Needed to make various casts safe.
-#[must_use]
-pub struct BinomialExtensionField<F, const D: usize, A = F> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "A: Serialize", deserialize = "A: Deserialize<'de>")
-    )]
-    pub(crate) value: [A; D],
-    _phantom: PhantomData<F>,
-}
-
-impl<F, A, const D: usize> BinomialExtensionField<F, D, A> {
-    /// Create an extension field element from an array of base elements.
-    ///
-    /// Any array is accepted. No reduction is required since
-    /// base elements are already valid field elements.
-    #[inline]
-    pub const fn new(value: [A; D]) -> Self {
-        const { assert!(D > 1) }
-        Self {
-            value,
-            _phantom: PhantomData,
-        }
-    }
-}
+/// Binomial extension field `F[X] / (X^D - W)`.
+///
+/// Type alias for the unified [`ExtField`] with `Shape = Binomial<F>`.
+pub type BinomialExtensionField<F, const D: usize, A = F> = ExtField<F, D, Binomial<F>, A>;
 
 impl<F: Copy, const D: usize> BinomialExtensionField<F, D, F> {
     /// Convert a `[[F; D]; N]` array to an array of extension field elements.
@@ -86,10 +60,7 @@ impl<F: Field, A: Algebra<F>, const D: usize> From<A> for BinomialExtensionField
 impl<F, A, const D: usize> From<[A; D]> for BinomialExtensionField<F, D, A> {
     #[inline]
     fn from(x: [A; D]) -> Self {
-        Self {
-            value: x,
-            _phantom: PhantomData,
-        }
+        Self::new(x)
     }
 }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -8,16 +8,14 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use itertools::Itertools;
 use num_bigint::BigUint;
-use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
-use rand::distr::StandardUniform;
-use rand::prelude::Distribution;
+use p3_util::{as_base_slice, as_base_slice_mut, reconstitute_from_base};
 
 use super::{ExtField, HasFrobenius, HasTwoAdicBinomialExtension, PackedBinomialExtensionField};
 use crate::extension::{Binomial, BinomiallyExtendable, ExtensionAlgebra};
 use crate::field::Field;
 use crate::{
-    Algebra, BasedVectorSpace, Dup, ExtensionField, Packable, PrimeCharacteristicRing,
-    RawDataSerializable, TwoAdicField, field_to_array,
+    Algebra, Dup, ExtensionField, PrimeCharacteristicRing, RawDataSerializable, TwoAdicField,
+    field_to_array,
 };
 
 /// Binomial extension field `F[X] / (X^D - W)`.
@@ -42,66 +40,6 @@ impl<F: Copy, const D: usize> BinomialExtensionField<F, D, F> {
             i += 1;
         }
         output
-    }
-}
-
-impl<F: Field, A: Algebra<F>, const D: usize> Default for BinomialExtensionField<F, D, A> {
-    fn default() -> Self {
-        Self::new(array::from_fn(|_| A::ZERO))
-    }
-}
-
-impl<F: Field, A: Algebra<F>, const D: usize> From<A> for BinomialExtensionField<F, D, A> {
-    fn from(x: A) -> Self {
-        Self::new(field_to_array(x))
-    }
-}
-
-impl<F, A, const D: usize> From<[A; D]> for BinomialExtensionField<F, D, A> {
-    #[inline]
-    fn from(x: [A; D]) -> Self {
-        Self::new(x)
-    }
-}
-
-impl<F: BinomiallyExtendable<D>, const D: usize> Packable for BinomialExtensionField<F, D> {}
-
-impl<F: BinomiallyExtendable<D>, A: Algebra<F>, const D: usize> BasedVectorSpace<A>
-    for BinomialExtensionField<F, D, A>
-{
-    const DIMENSION: usize = D;
-
-    #[inline]
-    fn as_basis_coefficients_slice(&self) -> &[A] {
-        &self.value
-    }
-
-    #[inline]
-    fn from_basis_coefficients_fn<Fn: FnMut(usize) -> A>(f: Fn) -> Self {
-        Self::new(array::from_fn(f))
-    }
-
-    #[inline]
-    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
-        (iter.len() == D).then(|| Self::new(array::from_fn(|_| iter.next().unwrap()))) // The unwrap is safe as we just checked the length of iter.
-    }
-
-    #[inline]
-    fn flatten_to_base(vec: Vec<Self>) -> Vec<A> {
-        unsafe {
-            // Safety:
-            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
-            flatten_to_base::<A, Self>(vec)
-        }
-    }
-
-    #[inline]
-    fn reconstitute_from_base(vec: Vec<A>) -> Vec<Self> {
-        unsafe {
-            // Safety:
-            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
-            reconstitute_from_base::<A, Self>(vec)
-        }
     }
 }
 
@@ -543,7 +481,9 @@ where
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_base_mul(self.value, rhs))
+        Self::new(<A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_base_mul(
+            self.value, rhs,
+        ))
     }
 }
 
@@ -603,17 +543,6 @@ where
     }
 }
 
-impl<F: BinomiallyExtendable<D>, const D: usize> Distribution<BinomialExtensionField<F, D>>
-    for StandardUniform
-where
-    Self: Distribution<F>,
-{
-    #[inline]
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BinomialExtensionField<F, D> {
-        BinomialExtensionField::new(array::from_fn(|_| self.sample(rng)))
-    }
-}
-
 impl<F: Field + HasTwoAdicBinomialExtension<D>, const D: usize> TwoAdicField
     for BinomialExtensionField<F, D>
 {
@@ -636,11 +565,7 @@ pub fn vector_add<R: PrimeCharacteristicRing + Add<R2, Output = R>, R2: Dup, con
 
 /// Subtract two vectors element wise.
 #[inline]
-pub fn vector_sub<
-    R: PrimeCharacteristicRing + Sub<R2, Output = R>,
-    R2: Dup,
-    const D: usize,
->(
+pub fn vector_sub<R: PrimeCharacteristicRing + Sub<R2, Output = R>, R2: Dup, const D: usize>(
     a: &[R; D],
     b: &[R2; D],
 ) -> [R; D] {
@@ -649,12 +574,7 @@ pub fn vector_sub<
 
 /// Multiply two vectors representing elements in a binomial extension.
 #[inline]
-pub fn binomial_mul<
-    F: Field,
-    R: Algebra<F> + Algebra<R2>,
-    R2: Algebra<F>,
-    const D: usize,
->(
+pub fn binomial_mul<F: Field, R: Algebra<F> + Algebra<R2>, R2: Algebra<F>, const D: usize>(
     a: &[R; D],
     b: &[R2; D],
     res: &mut [R; D],

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,5 +1,7 @@
-use super::{BinomialExtensionField, BinomiallyExtendable, HasTwoAdicBinomialExtension};
-use crate::extension::BinomiallyExtendableAlgebra;
+use super::{
+    Binomial, BinomialExtensionField, BinomiallyExtendable, ExtensionAlgebra,
+    HasTwoAdicBinomialExtension, binomial_mul, binomial_square,
+};
 use crate::{Algebra, Field, PrimeCharacteristicRing};
 
 pub type Complex<F> = BinomialExtensionField<F, 2>;
@@ -15,7 +17,17 @@ pub trait ComplexExtendable: Field {
     fn circle_two_adic_generator(bits: usize) -> Complex<Self>;
 }
 
-impl<F: ComplexExtendable> BinomiallyExtendableAlgebra<F, 2> for F {}
+impl<F: ComplexExtendable> ExtensionAlgebra<F, 2, Binomial<F>> for F {
+    #[inline]
+    fn ext_mul(a: &[Self; 2], b: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_mul::<F, Self, Self, 2>(a, b, res, <F as BinomiallyExtendable<2>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_square::<F, Self, 2>(a, res, <F as BinomiallyExtendable<2>>::W);
+    }
+}
 
 impl<F: ComplexExtendable> BinomiallyExtendable<2> for F {
     const W: Self = F::NEG_ONE;
@@ -99,9 +111,19 @@ pub trait HasComplexBinomialExtension<const D: usize>: ComplexExtendable {
     const EXT_GENERATOR: [Complex<Self>; D];
 }
 
-impl<F, const D: usize> BinomiallyExtendableAlgebra<Self, D> for Complex<F> where
-    F: HasComplexBinomialExtension<D>
+impl<F, const D: usize> ExtensionAlgebra<Self, D, Binomial<Self>> for Complex<F>
+where
+    F: HasComplexBinomialExtension<D>,
 {
+    #[inline]
+    fn ext_mul(a: &[Self; D], b: &[Self; D], res: &mut [Self; D]) {
+        binomial_mul::<Self, Self, Self, D>(a, b, res, <Self as BinomiallyExtendable<D>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; D], res: &mut [Self; D]) {
+        binomial_square::<Self, Self, D>(a, res, <Self as BinomiallyExtendable<D>>::W);
+    }
 }
 
 impl<F, const D: usize> BinomiallyExtendable<D> for Complex<F>

--- a/field/src/extension/cubic_extension.rs
+++ b/field/src/extension/cubic_extension.rs
@@ -8,7 +8,6 @@ use alloc::vec::Vec;
 use core::array;
 use core::fmt::{self, Display, Formatter};
 use core::iter::{Product, Sum};
-use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
@@ -16,13 +15,10 @@ use num_bigint::BigUint;
 use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
-use serde::{Deserialize, Serialize};
 
 use super::packed_cubic_extension::PackedCubicTrinomialExtensionField;
-use super::{HasFrobenius, HasTwoAdicCubicExtension};
-use crate::extension::{
-    CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra,
-};
+use super::{ExtField, HasFrobenius, HasTwoAdicCubicExtension};
+use crate::extension::{CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra};
 use crate::field::Field;
 use crate::{
     Algebra, BasedVectorSpace, ExtensionField, Packable, PackedFieldExtension,
@@ -32,31 +28,9 @@ use crate::{
 /// A degree-3 extension field using `X^3 - X - 1`.
 ///
 /// Elements are `a_0 + a_1 X + a_2 X^2` with coefficients in the base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)] // Needed to make various casts safe.
-#[must_use]
-pub struct CubicTrinomialExtensionField<F, A = F> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "A: Serialize", deserialize = "A: Deserialize<'de>")
-    )]
-    pub(crate) value: [A; 3],
-    _phantom: PhantomData<F>,
-}
-
-impl<F, A> CubicTrinomialExtensionField<F, A> {
-    /// Create an extension field element from an array of base elements.
-    ///
-    /// Any array is accepted. No reduction is required since
-    /// base elements are already valid field elements.
-    #[inline]
-    pub const fn new(value: [A; 3]) -> Self {
-        Self {
-            value,
-            _phantom: PhantomData,
-        }
-    }
-}
+///
+/// Type alias for the unified [`ExtField`] with `Shape = CubicTrinomial`.
+pub type CubicTrinomialExtensionField<F, A = F> = ExtField<F, 3, CubicTrinomial, A>;
 
 impl<F: Copy> CubicTrinomialExtensionField<F, F> {
     /// Convert a `[[F; D]; N]` array to an array of extension field elements.

--- a/field/src/extension/cubic_extension.rs
+++ b/field/src/extension/cubic_extension.rs
@@ -12,17 +12,15 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 
 use itertools::Itertools;
 use num_bigint::BigUint;
-use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
-use rand::distr::StandardUniform;
-use rand::prelude::Distribution;
+use p3_util::{as_base_slice, as_base_slice_mut, reconstitute_from_base};
 
 use super::packed_cubic_extension::PackedCubicTrinomialExtensionField;
 use super::{ExtField, HasFrobenius, HasTwoAdicCubicExtension};
 use crate::extension::{CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra};
 use crate::field::Field;
 use crate::{
-    Algebra, BasedVectorSpace, ExtensionField, Packable, PackedFieldExtension,
-    PrimeCharacteristicRing, RawDataSerializable, TwoAdicField, field_to_array,
+    Algebra, ExtensionField, PackedFieldExtension, PrimeCharacteristicRing, RawDataSerializable,
+    TwoAdicField, field_to_array,
 };
 
 /// A degree-3 extension field using `X^3 - X - 1`.
@@ -49,64 +47,6 @@ impl<F: Copy> CubicTrinomialExtensionField<F, F> {
             i += 1;
         }
         output
-    }
-}
-
-impl<F: Field, A: Algebra<F>> Default for CubicTrinomialExtensionField<F, A> {
-    fn default() -> Self {
-        Self::new([A::ZERO, A::ZERO, A::ZERO])
-    }
-}
-
-impl<F: Field, A: Algebra<F>> From<A> for CubicTrinomialExtensionField<F, A> {
-    fn from(x: A) -> Self {
-        Self::new([x, A::ZERO, A::ZERO])
-    }
-}
-
-impl<F, A> From<[A; 3]> for CubicTrinomialExtensionField<F, A> {
-    #[inline]
-    fn from(x: [A; 3]) -> Self {
-        Self::new(x)
-    }
-}
-
-impl<F: CubicTrinomialExtendable> Packable for CubicTrinomialExtensionField<F> {}
-
-impl<F: CubicTrinomialExtendable, A: Algebra<F>> BasedVectorSpace<A>
-    for CubicTrinomialExtensionField<F, A>
-{
-    const DIMENSION: usize = 3;
-
-    #[inline]
-    fn as_basis_coefficients_slice(&self) -> &[A] {
-        &self.value
-    }
-
-    #[inline]
-    fn from_basis_coefficients_fn<Fn: FnMut(usize) -> A>(f: Fn) -> Self {
-        Self::new(array::from_fn(f))
-    }
-
-    #[inline]
-    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
-        (iter.len() == 3).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
-    }
-
-    #[inline]
-    fn flatten_to_base(vec: Vec<Self>) -> Vec<A> {
-        // Safety:
-        // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
-        unsafe { flatten_to_base::<A, Self>(vec) }
-    }
-
-    #[inline]
-    fn reconstitute_from_base(vec: Vec<A>) -> Vec<Self> {
-        unsafe {
-            // Safety:
-            // As `Self` is a `repr(transparent)`, it is stored identically in memory to `[A; D]`
-            reconstitute_from_base::<A, Self>(vec)
-        }
     }
 }
 
@@ -368,7 +308,10 @@ where
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(
+            &self.value,
+            &rhs.value,
+        ))
     }
 }
 
@@ -393,7 +336,8 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        self.value = <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(&self.value, &rhs.value);
+        self.value =
+            <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(&self.value, &rhs.value);
     }
 }
 
@@ -428,7 +372,10 @@ where
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(
+            &self.value,
+            &rhs.value,
+        ))
     }
 }
 
@@ -454,7 +401,8 @@ where
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        self.value = <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(&self.value, &rhs.value);
+        self.value =
+            <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(&self.value, &rhs.value);
     }
 }
 
@@ -479,7 +427,11 @@ where
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         let mut res = Self::default();
-        <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_mul(&self.value, &rhs.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_mul(
+            &self.value,
+            &rhs.value,
+            &mut res.value,
+        );
         res
     }
 }
@@ -493,7 +445,9 @@ where
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_base_mul(self.value, rhs))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_base_mul(
+            self.value, rhs,
+        ))
     }
 }
 
@@ -550,16 +504,6 @@ where
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
-    }
-}
-
-impl<F: CubicTrinomialExtendable> Distribution<CubicTrinomialExtensionField<F>> for StandardUniform
-where
-    Self: Distribution<F>,
-{
-    #[inline]
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CubicTrinomialExtensionField<F> {
-        CubicTrinomialExtensionField::new(array::from_fn(|_| self.sample(rng)))
     }
 }
 

--- a/field/src/extension/cubic_extension.rs
+++ b/field/src/extension/cubic_extension.rs
@@ -20,7 +20,9 @@ use serde::{Deserialize, Serialize};
 
 use super::packed_cubic_extension::PackedCubicTrinomialExtensionField;
 use super::{HasFrobenius, HasTwoAdicCubicExtension};
-use crate::extension::{CubicExtendableAlgebra, CubicTrinomialExtendable};
+use crate::extension::{
+    CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra,
+};
 use crate::field::Field;
 use crate::{
     Algebra, BasedVectorSpace, ExtensionField, Packable, PackedFieldExtension,
@@ -219,7 +221,7 @@ impl<F: CubicTrinomialExtendable> CubicTrinomialExtensionField<F> {
 impl<F, A> PrimeCharacteristicRing for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial> + Copy,
 {
     type PrimeSubfield = <A as PrimeCharacteristicRing>::PrimeSubfield;
 
@@ -241,7 +243,7 @@ where
     #[inline(always)]
     fn square(&self) -> Self {
         let mut res = Self::default();
-        A::cubic_square(&self.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_square(&self.value, &mut res.value);
         res
     }
 
@@ -386,13 +388,13 @@ where
 impl<F, A> Add for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::new(A::cubic_add(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(&self.value, &rhs.value))
     }
 }
 
@@ -413,11 +415,11 @@ where
 impl<F, A> AddAssign for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        self.value = A::cubic_add(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_add(&self.value, &rhs.value);
     }
 }
 
@@ -435,7 +437,7 @@ where
 impl<F, A> Sum for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial> + Copy,
 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -446,13 +448,13 @@ where
 impl<F, A> Sub for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::new(A::cubic_sub(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(&self.value, &rhs.value))
     }
 }
 
@@ -474,11 +476,11 @@ where
 impl<F, A> SubAssign for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        self.value = A::cubic_sub(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_sub(&self.value, &rhs.value);
     }
 }
 
@@ -496,14 +498,14 @@ where
 impl<F, A> Mul for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         let mut res = Self::default();
-        A::cubic_mul(&self.value, &rhs.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_mul(&self.value, &rhs.value, &mut res.value);
         res
     }
 }
@@ -511,20 +513,20 @@ where
 impl<F, A> Mul<A> for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(A::cubic_base_mul(self.value, rhs))
+        Self::new(<A as ExtensionAlgebra<F, 3, CubicTrinomial>>::ext_base_mul(self.value, rhs))
     }
 }
 
 impl<F, A> MulAssign for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
@@ -535,7 +537,7 @@ where
 impl<F, A> MulAssign<A> for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: A) {
@@ -546,7 +548,7 @@ where
 impl<F, A> Product for CubicTrinomialExtensionField<F, A>
 where
     F: CubicTrinomialExtendable,
-    A: CubicExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 3, CubicTrinomial> + Copy,
 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -610,7 +612,7 @@ pub fn trinomial_cubic_mul<R: PrimeCharacteristicRing>(a: &[R; 3], b: &[R; 3], r
 }
 
 #[inline]
-pub(super) fn cubic_square<R: PrimeCharacteristicRing>(a: &[R; 3], res: &mut [R; 3]) {
+pub fn cubic_square<R: PrimeCharacteristicRing>(a: &[R; 3], res: &mut [R; 3]) {
     let a0_plus_a2 = a[0].dup() + a[2].dup();
     let a1_plus_a2 = a[1].dup() + a[2].dup();
 

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -52,15 +52,15 @@ mod sealed {
 }
 
 /// Marker for the binomial reducer `X^D - W` (degree-generic).
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub struct Binomial<F>(PhantomData<F>);
 
 /// Marker for the trinomial reducer `X^3 - X - 1`.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub struct CubicTrinomial;
 
 /// Marker for the trinomial reducer `X^5 + X^2 - 1`.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 pub struct QuinticTrinomial;
 
 impl<F: Field> sealed::Sealed for Binomial<F> {}
@@ -70,6 +70,48 @@ impl sealed::Sealed for QuinticTrinomial {}
 impl<F: Field> ExtensionShape for Binomial<F> {}
 impl ExtensionShape for CubicTrinomial {}
 impl ExtensionShape for QuinticTrinomial {}
+
+/// Unified extension-field representation.
+///
+/// An `ExtField<F, D, Shape, A>` represents an element of a degree-`D` extension
+/// of the base field `F`, with the reducing polynomial determined by `Shape`.
+/// The `A` parameter is the algebra over `F` storing each coefficient — usually
+/// `F` itself for scalar elements, or `F::Packing` for SIMD-packed elements.
+///
+/// The three public-facing extension types — [`BinomialExtensionField`],
+/// [`CubicTrinomialExtensionField`], [`QuinticTrinomialExtensionField`] — are
+/// type aliases over this struct with their respective `Shape`s.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize, PartialOrd, Ord)]
+#[repr(transparent)] // Needed to make various casts safe.
+#[must_use]
+pub struct ExtField<F, const D: usize, Shape, A = F> {
+    #[serde(
+        with = "p3_util::array_serialization",
+        bound(serialize = "A: serde::Serialize", deserialize = "A: serde::Deserialize<'de>")
+    )]
+    pub(crate) value: [A; D],
+
+    _phantom: PhantomData<(F, Shape)>,
+}
+
+impl<F, const D: usize, Shape, A> ExtField<F, D, Shape, A> {
+    /// Create an extension field element from an array of base/algebra elements.
+    ///
+    /// Any array is accepted. No reduction is required since each entry is
+    /// already a valid element of the algebra over `F`.
+    ///
+    /// # Panics
+    /// Panics (at compile time) if `D <= 1`. A degree-0 or degree-1 "extension"
+    /// is degenerate — use `F` directly instead.
+    #[inline]
+    pub const fn new(value: [A; D]) -> Self {
+        const { assert!(D > 1) }
+        Self {
+            value,
+            _phantom: PhantomData,
+        }
+    }
+}
 
 /// Algebra over `F` that supports degree-`D` extension arithmetic with a given reducer `Shape`.
 ///

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -1,4 +1,5 @@
 use core::iter;
+use core::marker::PhantomData;
 
 use crate::field::Field;
 use crate::{Algebra, ExtensionField};
@@ -15,11 +16,97 @@ use alloc::vec::Vec;
 
 pub use binomial_extension::*;
 pub use complex::*;
-pub use cubic_extension::{CubicTrinomialExtensionField, trinomial_cubic_mul};
+pub use cubic_extension::{CubicTrinomialExtensionField, cubic_square, trinomial_cubic_mul};
 pub use packed_binomial_extension::*;
 pub use packed_cubic_extension::PackedCubicTrinomialExtensionField;
 pub use packed_quintic_extension::PackedQuinticTrinomialExtensionField;
-pub use quintic_extension::{QuinticTrinomialExtensionField, trinomial_quintic_mul};
+pub use quintic_extension::{QuinticTrinomialExtensionField, quintic_square, trinomial_quintic_mul};
+
+// ---------------------------------------------------------------------------
+// Shape-parameterized algebra for extension fields
+// ---------------------------------------------------------------------------
+//
+// Extension-ring arithmetic (mul / square / add / sub / base_mul) is exposed
+// via a single trait `ExtensionAlgebra<F, D, Shape>`, parameterized by:
+//   - the base field `F`,
+//   - the extension degree `D`,
+//   - a marker `Shape: ExtensionShape` selecting the reducing polynomial.
+//
+// The three supported shapes are:
+//   - `Binomial<F>`     — `F[X] / (X^D - W)`, degree-generic, `W = F::W`.
+//   - `CubicTrinomial`  — `F[X] / (X^3 - X - 1)`.
+//   - `QuinticTrinomial`— `F[X] / (X^5 + X^2 - 1)`.
+//
+// SIMD-packed types override `ext_mul` / `ext_square` with optimized kernels;
+// the other three methods have sensible coefficient-wise defaults.
+
+/// Sealed marker for the reducing polynomial shape of an extension field.
+///
+/// The three concrete shapes — [`Binomial`], [`CubicTrinomial`], and
+/// [`QuinticTrinomial`] — correspond to the reducers
+/// `X^D - W`, `X^3 - X - 1`, and `X^5 + X^2 - 1` respectively.
+pub trait ExtensionShape: 'static + sealed::Sealed {}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker for the binomial reducer `X^D - W` (degree-generic).
+#[derive(Debug)]
+pub struct Binomial<F>(PhantomData<F>);
+
+/// Marker for the trinomial reducer `X^3 - X - 1`.
+#[derive(Debug)]
+pub struct CubicTrinomial;
+
+/// Marker for the trinomial reducer `X^5 + X^2 - 1`.
+#[derive(Debug)]
+pub struct QuinticTrinomial;
+
+impl<F: Field> sealed::Sealed for Binomial<F> {}
+impl sealed::Sealed for CubicTrinomial {}
+impl sealed::Sealed for QuinticTrinomial {}
+
+impl<F: Field> ExtensionShape for Binomial<F> {}
+impl ExtensionShape for CubicTrinomial {}
+impl ExtensionShape for QuinticTrinomial {}
+
+/// Algebra over `F` that supports degree-`D` extension arithmetic with a given reducer `Shape`.
+///
+/// Of the five methods, `ext_add`/`ext_sub`/`ext_base_mul` are shape-agnostic and
+/// come with sensible default impls. `ext_mul`/`ext_square` are shape-dependent
+/// and must be supplied by each impl (typically a one-line delegation to the
+/// shape's free helper: `binomial_mul`/`binomial_square` for `Binomial<F>`,
+/// `trinomial_cubic_mul`/`cubic_square` for `CubicTrinomial`, and
+/// `trinomial_quintic_mul`/`quintic_square` for `QuinticTrinomial`).
+pub trait ExtensionAlgebra<F: Field, const D: usize, Shape: ExtensionShape>: Algebra<F> {
+    /// Multiplication in the algebra extension ring.
+    fn ext_mul(a: &[Self; D], b: &[Self; D], res: &mut [Self; D]);
+
+    /// Squaring in the algebra extension ring.
+    fn ext_square(a: &[Self; D], res: &mut [Self; D]);
+
+    /// Coefficient-wise addition.
+    #[inline]
+    #[must_use]
+    fn ext_add(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
+        vector_add(a, b)
+    }
+
+    /// Coefficient-wise subtraction.
+    #[inline]
+    #[must_use]
+    fn ext_sub(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
+        vector_sub(a, b)
+    }
+
+    /// Multiply an extension element by a base-field scalar.
+    #[inline]
+    #[must_use]
+    fn ext_base_mul(lhs: [Self; D], rhs: Self) -> [Self; D] {
+        lhs.map(|x| x * rhs.dup())
+    }
+}
 
 /// Trait for fields that support binomial extension of the form `F[X]/(X^D - W)`.
 ///
@@ -28,7 +115,7 @@ pub use quintic_extension::{QuinticTrinomialExtensionField, trinomial_quintic_mu
 ///
 /// This is used to construct extension fields with efficient arithmetic.
 pub trait BinomiallyExtendable<const D: usize>:
-    Field + BinomiallyExtendableAlgebra<Self, D>
+    Field + ExtensionAlgebra<Self, D, Binomial<Self>>
 {
     /// The constant coefficient `W` in the binomial `X^D - W`.
     const W: Self;
@@ -43,47 +130,6 @@ pub trait BinomiallyExtendable<const D: usize>:
     ///
     /// This is an array of size `D`, where each entry is a base field element.
     const EXT_GENERATOR: [Self; D];
-}
-
-/// Trait for algebras which support binomial extensions of the form `A[X]/(X^D - W)`
-/// with `W` in the base field `F`.
-pub trait BinomiallyExtendableAlgebra<F: Field, const D: usize>: Algebra<F> {
-    /// Multiplication in the algebra extension ring `A<X> / (X^D - W)`.
-    ///
-    /// Some algebras may want to reimplement this with faster methods.
-    #[inline]
-    fn binomial_mul(a: &[Self; D], b: &[Self; D], res: &mut [Self; D], w: F) {
-        binomial_mul::<F, Self, Self, D>(a, b, res, w);
-    }
-
-    /// Addition of elements in the algebra extension ring `A<X> / (X^D - W)`.
-    ///
-    /// As addition has no dependence on `W` so this is equivalent
-    /// to an algorithm for adding arrays of elements of `A`.
-    ///
-    /// Some algebras may want to reimplement this with faster methods.
-    #[inline]
-    #[must_use]
-    fn binomial_add(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
-        vector_add(a, b)
-    }
-
-    /// Subtraction of elements in the algebra extension ring `A<X> / (X^D - W)`.
-    ///
-    /// As subtraction has no dependence on `W` so this is equivalent
-    /// to an algorithm for subtracting arrays of elements of `A`.
-    ///
-    /// Some algebras may want to reimplement this with faster methods.
-    #[inline]
-    #[must_use]
-    fn binomial_sub(a: &[Self; D], b: &[Self; D]) -> [Self; D] {
-        vector_sub(a, b)
-    }
-
-    #[inline]
-    fn binomial_base_mul(lhs: [Self; D], rhs: Self) -> [Self; D] {
-        lhs.map(|x| x * rhs.dup())
-    }
 }
 
 /// Trait for extension fields that support Frobenius automorphisms.
@@ -144,7 +190,7 @@ pub trait HasTwoAdicBinomialExtension<const D: usize>: BinomiallyExtendable<D> {
 /// Trait for fields that support a degree-3 extension using the trinomial `X^3 - X - 1`.
 ///
 /// Implement only when `X^3 - X - 1` is irreducible over the base field.
-pub trait CubicTrinomialExtendable: Field + CubicExtendableAlgebra<Self> {
+pub trait CubicTrinomialExtendable: Field + ExtensionAlgebra<Self, 3, CubicTrinomial> {
     /// Linear map for the Frobenius automorphism on `Σ a_i X^i` in the power basis `(1, X, X^2)`.
     ///
     /// Row `i` contains the coefficients of the image of `X^i` under Frobenius (the first row
@@ -153,50 +199,6 @@ pub trait CubicTrinomialExtendable: Field + CubicExtendableAlgebra<Self> {
 
     /// A generator of the multiplicative group of `F_{p^3}^*`, as polynomial coefficients.
     const EXT_GENERATOR: [Self; 3];
-}
-
-/// Trait for algebras supporting cubic extension arithmetic over `A[X]/(X^3 - X - 1)`.
-pub trait CubicExtendableAlgebra<F: Field>: Algebra<F> {
-    /// Multiply two elements in the cubic extension ring.
-    ///
-    /// Computes `a * b mod (X^3 - X - 1)` and stores the result in `res`.
-    #[inline]
-    fn cubic_mul(a: &[Self; 3], b: &[Self; 3], res: &mut [Self; 3]) {
-        cubic_extension::trinomial_cubic_mul(a, b, res);
-    }
-
-    /// Square an element in the cubic extension ring.
-    ///
-    /// Computes `a^2 mod (X^3 - X - 1)` and stores the result in `res`.
-    /// Uses optimized formulas exploiting the symmetry `a_i * a_j = a_j * a_i`.
-    #[inline]
-    fn cubic_square(a: &[Self; 3], res: &mut [Self; 3]) {
-        cubic_extension::cubic_square(a, res);
-    }
-
-    /// Add two elements in the cubic extension ring.
-    ///
-    /// Addition is coefficient-wise and independent of the modulus polynomial.
-    #[inline]
-    #[must_use]
-    fn cubic_add(a: &[Self; 3], b: &[Self; 3]) -> [Self; 3] {
-        vector_add(a, b)
-    }
-
-    /// Subtract two elements in the cubic extension ring.
-    ///
-    /// Subtraction is coefficient-wise and independent of the modulus polynomial.
-    #[inline]
-    #[must_use]
-    fn cubic_sub(a: &[Self; 3], b: &[Self; 3]) -> [Self; 3] {
-        vector_sub(a, b)
-    }
-
-    /// Multiply a cubic extension element by a base field scalar.
-    #[inline]
-    fn cubic_base_mul(lhs: [Self; 3], rhs: Self) -> [Self; 3] {
-        lhs.map(|x| x * rhs.dup())
-    }
 }
 
 /// Trait for cubic trinomial extensions that expose two-adic subgroup generators.
@@ -213,7 +215,7 @@ pub trait HasTwoAdicCubicExtension: CubicTrinomialExtendable {
 ///
 /// This trait should only be implemented for fields where `X^5 + X^2 - 1` is irreducible.
 /// The implementor must verify irreducibility for their specific field.
-pub trait QuinticTrinomialExtendable: Field + QuinticExtendableAlgebra<Self> {
+pub trait QuinticTrinomialExtendable: Field + ExtensionAlgebra<Self, 5, QuinticTrinomial> {
     /// Frobenius coefficients for the quintic extension.
     ///
     /// `FROBENIUS_COEFFS[k]` represents `X^{(k+1)*p} mod (X^5 + X^2 - 1)` as a polynomial
@@ -226,53 +228,6 @@ pub trait QuinticTrinomialExtendable: Field + QuinticExtendableAlgebra<Self> {
     ///
     /// Represented as polynomial coefficients `[g_0, g_1, g_2, g_3, g_4]`.
     const EXT_GENERATOR: [Self; 5];
-}
-
-/// Trait for algebras supporting quintic extension arithmetic over `A[X]/(X^5 + X^2 - 1)`.
-///
-/// Implementors may override the default methods with optimized versions
-/// (e.g., SIMD implementations for packed fields).
-pub trait QuinticExtendableAlgebra<F: Field>: Algebra<F> {
-    /// Multiply two elements in the quintic extension ring.
-    ///
-    /// Computes `a * b mod (X^5 + X^2 - 1)` and stores the result in `res`.
-    #[inline]
-    fn quintic_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
-        quintic_extension::trinomial_quintic_mul(a, b, res);
-    }
-
-    /// Square an element in the quintic extension ring.
-    ///
-    /// Computes `a^2 mod (X^5 + X^2 - 1)` and stores the result in `res`.
-    /// Uses optimized formulas exploiting the symmetry `a_i * a_j = a_j * a_i`.
-    #[inline]
-    fn quintic_square(a: &[Self; 5], res: &mut [Self; 5]) {
-        quintic_extension::quintic_square(a, res);
-    }
-
-    /// Add two elements in the quintic extension ring.
-    ///
-    /// Addition is coefficient-wise and independent of the modulus polynomial.
-    #[inline]
-    #[must_use]
-    fn quintic_add(a: &[Self; 5], b: &[Self; 5]) -> [Self; 5] {
-        vector_add(a, b)
-    }
-
-    /// Subtract two elements in the quintic extension ring.
-    ///
-    /// Subtraction is coefficient-wise and independent of the modulus polynomial.
-    #[inline]
-    #[must_use]
-    fn quintic_sub(a: &[Self; 5], b: &[Self; 5]) -> [Self; 5] {
-        vector_sub(a, b)
-    }
-
-    /// Multiply a quintic extension element by a base field scalar.
-    #[inline]
-    fn quintic_base_mul(lhs: [Self; 5], rhs: Self) -> [Self; 5] {
-        lhs.map(|x| x * rhs.dup())
-    }
 }
 
 /// Trait for quintic extensions that support two-adic subgroup generators.

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -2,7 +2,7 @@ use core::iter;
 use core::marker::PhantomData;
 
 use crate::field::Field;
-use crate::{Algebra, ExtensionField};
+use crate::{Algebra, ExtensionField, PackedField};
 
 mod binomial_extension;
 mod complex;
@@ -20,7 +20,9 @@ pub use cubic_extension::{CubicTrinomialExtensionField, cubic_square, trinomial_
 pub use packed_binomial_extension::*;
 pub use packed_cubic_extension::PackedCubicTrinomialExtensionField;
 pub use packed_quintic_extension::PackedQuinticTrinomialExtensionField;
-pub use quintic_extension::{QuinticTrinomialExtensionField, quintic_square, trinomial_quintic_mul};
+pub use quintic_extension::{
+    QuinticTrinomialExtensionField, quintic_square, trinomial_quintic_mul,
+};
 
 // ---------------------------------------------------------------------------
 // Shape-parameterized algebra for extension fields
@@ -81,13 +83,18 @@ impl ExtensionShape for QuinticTrinomial {}
 /// The three public-facing extension types — [`BinomialExtensionField`],
 /// [`CubicTrinomialExtensionField`], [`QuinticTrinomialExtensionField`] — are
 /// type aliases over this struct with their respective `Shape`s.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize, PartialOrd, Ord)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize, PartialOrd, Ord,
+)]
 #[repr(transparent)] // Needed to make various casts safe.
 #[must_use]
 pub struct ExtField<F, const D: usize, Shape, A = F> {
     #[serde(
         with = "p3_util::array_serialization",
-        bound(serialize = "A: serde::Serialize", deserialize = "A: serde::Deserialize<'de>")
+        bound(
+            serialize = "A: serde::Serialize",
+            deserialize = "A: serde::Deserialize<'de>"
+        )
     )]
     pub(crate) value: [A; D],
 
@@ -110,6 +117,131 @@ impl<F, const D: usize, Shape, A> ExtField<F, D, Shape, A> {
             value,
             _phantom: PhantomData,
         }
+    }
+}
+
+/// Unified packed extension-field representation (SIMD-lane parallel).
+///
+/// `PackedExtField<F, PF, D, Shape>` stores `D` packed coefficients (one per
+/// SIMD lane), representing the `WIDTH` extension-field elements that fit in
+/// one SIMD register simultaneously.
+///
+/// The three public-facing packed types — [`PackedBinomialExtensionField`],
+/// [`PackedCubicTrinomialExtensionField`], [`PackedQuinticTrinomialExtensionField`]
+/// — are type aliases over this struct with their respective `Shape`s.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Hash, Debug, serde::Serialize, serde::Deserialize, PartialOrd, Ord,
+)]
+#[repr(transparent)]
+#[must_use]
+pub struct PackedExtField<F: Field, PF: PackedField<Scalar = F>, const D: usize, Shape> {
+    #[serde(
+        with = "p3_util::array_serialization",
+        bound(
+            serialize = "PF: serde::Serialize",
+            deserialize = "PF: serde::Deserialize<'de>"
+        )
+    )]
+    pub(crate) value: [PF; D],
+    _phantom: PhantomData<Shape>,
+}
+
+impl<F: Field, PF: PackedField<Scalar = F>, const D: usize, Shape> PackedExtField<F, PF, D, Shape> {
+    /// Create a packed extension-field element from an array of packed coefficients.
+    #[inline]
+    pub const fn new(value: [PF; D]) -> Self {
+        Self {
+            value,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape-agnostic impls on the unified struct
+// ---------------------------------------------------------------------------
+//
+// These three traits — `Default`, `From<A>`, `From<[A; D]>` — have the same
+// implementation across every shape. They live here on the unified struct
+// rather than being triplicated across the per-shape files.
+
+impl<F: Field, A: Algebra<F>, const D: usize, Shape: ExtensionShape> Default
+    for ExtField<F, D, Shape, A>
+{
+    #[inline]
+    fn default() -> Self {
+        Self::new(core::array::from_fn(|_| A::ZERO))
+    }
+}
+
+impl<F: Field, A: Algebra<F>, const D: usize, Shape: ExtensionShape> From<A>
+    for ExtField<F, D, Shape, A>
+{
+    #[inline]
+    fn from(x: A) -> Self {
+        Self::new(crate::field_to_array(x))
+    }
+}
+
+impl<F, A, const D: usize, Shape: ExtensionShape> From<[A; D]> for ExtField<F, D, Shape, A> {
+    #[inline]
+    fn from(x: [A; D]) -> Self {
+        Self::new(x)
+    }
+}
+
+impl<F, const D: usize, Shape> crate::Packable for ExtField<F, D, Shape>
+where
+    F: Field + ExtensionAlgebra<F, D, Shape>,
+    Shape: ExtensionShape + Copy + Eq + core::hash::Hash + Send + Sync,
+{
+}
+
+impl<F, A: Algebra<F>, const D: usize, Shape: ExtensionShape + Clone> crate::BasedVectorSpace<A>
+    for ExtField<F, D, Shape, A>
+where
+    F: Field + ExtensionAlgebra<F, D, Shape>,
+{
+    const DIMENSION: usize = D;
+
+    #[inline]
+    fn as_basis_coefficients_slice(&self) -> &[A] {
+        &self.value
+    }
+
+    #[inline]
+    fn from_basis_coefficients_fn<Fn: FnMut(usize) -> A>(f: Fn) -> Self {
+        Self::new(core::array::from_fn(f))
+    }
+
+    #[inline]
+    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
+        // The unwrap is safe as we just checked the length of iter.
+        (iter.len() == D).then(|| Self::new(core::array::from_fn(|_| iter.next().unwrap())))
+    }
+
+    #[inline]
+    fn flatten_to_base(vec: Vec<Self>) -> Vec<A> {
+        // Safety: `Self` is `#[repr(transparent)]` over `[A; D]`.
+        unsafe { p3_util::flatten_to_base::<A, Self>(vec) }
+    }
+
+    #[inline]
+    fn reconstitute_from_base(vec: Vec<A>) -> Vec<Self> {
+        // Safety: `Self` is `#[repr(transparent)]` over `[A; D]`.
+        unsafe { p3_util::reconstitute_from_base::<A, Self>(vec) }
+    }
+}
+
+impl<F, const D: usize, Shape: ExtensionShape> rand::distr::Distribution<ExtField<F, D, Shape>>
+    for rand::distr::StandardUniform
+where
+    F: Field + ExtensionAlgebra<F, D, Shape>,
+    Self: rand::distr::Distribution<F>,
+{
+    #[inline]
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> ExtField<F, D, Shape> {
+        ExtField::new(core::array::from_fn(|_| self.sample(rng)))
     }
 }
 

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -1,45 +1,30 @@
 use alloc::vec::Vec;
 use core::array;
-use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_util::{flatten_to_base, reconstitute_from_base};
 use rand::distr::{Distribution, StandardUniform};
-use serde::{Deserialize, Serialize};
 
-use super::{BinomialExtensionField, binomial_mul, vector_add, vector_sub};
-use crate::extension::{BinomiallyExtendable, binomial_square};
+use super::{BinomialExtensionField, PackedExtField, binomial_mul, vector_add, vector_sub};
+use crate::extension::{Binomial, BinomiallyExtendable, binomial_square};
 use crate::{
     Algebra, BasedVectorSpace, Dup, Field, PackedField, PackedFieldExtension, PackedValue, Powers,
     PrimeCharacteristicRing, field_to_array,
 };
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)] // Needed to make various casts safe.
-#[must_use]
-pub struct PackedBinomialExtensionField<F: Field, PF: PackedField<Scalar = F>, const D: usize> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "PF: Serialize", deserialize = "PF: Deserialize<'de>")
-    )]
-    pub(crate) value: [PF; D],
-}
-
-impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> PackedBinomialExtensionField<F, PF, D> {
-    const fn new(value: [PF; D]) -> Self {
-        Self { value }
-    }
-}
+/// Packed binomial extension field `F[X] / (X^D - W)`, one element per SIMD lane.
+///
+/// Type alias for the unified [`PackedExtField`] with `Shape = Binomial<F>`.
+pub type PackedBinomialExtensionField<F, PF, const D: usize> =
+    PackedExtField<F, PF, D, Binomial<F>>;
 
 impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> Default
     for PackedBinomialExtensionField<F, PF, D>
 {
     #[inline]
     fn default() -> Self {
-        Self {
-            value: array::from_fn(|_| PF::ZERO),
-        }
+        Self::new(array::from_fn(|_| PF::ZERO))
     }
 }
 
@@ -48,9 +33,7 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<BinomialExtensi
 {
     #[inline]
     fn from(x: BinomialExtensionField<F, D>) -> Self {
-        Self {
-            value: x.value.map(Into::into),
-        }
+        Self::new(x.value.map(Into::into))
     }
 }
 
@@ -59,9 +42,7 @@ impl<F: Field, PF: PackedField<Scalar = F>, const D: usize> From<PF>
 {
     #[inline]
     fn from(x: PF) -> Self {
-        Self {
-            value: field_to_array(x),
-        }
+        Self::new(field_to_array(x))
     }
 }
 
@@ -117,21 +98,13 @@ where
 {
     type PrimeSubfield = PF::PrimeSubfield;
 
-    const ZERO: Self = Self {
-        value: [PF::ZERO; D],
-    };
+    const ZERO: Self = Self::new([PF::ZERO; D]);
 
-    const ONE: Self = Self {
-        value: field_to_array(PF::ONE),
-    };
+    const ONE: Self = Self::new(field_to_array(PF::ONE));
 
-    const TWO: Self = Self {
-        value: field_to_array(PF::TWO),
-    };
+    const TWO: Self = Self::new(field_to_array(PF::TWO));
 
-    const NEG_ONE: Self = Self {
-        value: field_to_array(PF::NEG_ONE),
-    };
+    const NEG_ONE: Self = Self::new(field_to_array(PF::NEG_ONE));
 
     #[inline]
     fn from_prime_subfield(val: Self::PrimeSubfield) -> Self {
@@ -187,9 +160,7 @@ where
 
     #[inline]
     fn from_basis_coefficients_fn<Fn: FnMut(usize) -> PF>(f: Fn) -> Self {
-        Self {
-            value: array::from_fn(f),
-        }
+        Self::new(array::from_fn(f))
     }
 
     #[inline]
@@ -252,9 +223,7 @@ where
 
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            value: self.value.map(PF::neg),
-        }
+        Self::new(self.value.map(PF::neg))
     }
 }
 
@@ -268,7 +237,7 @@ where
     #[inline]
     fn add(self, rhs: Self) -> Self {
         let value = vector_add(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -283,7 +252,7 @@ where
     #[inline]
     fn add(self, rhs: BinomialExtensionField<F, D>) -> Self {
         let value = vector_add(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -360,7 +329,7 @@ where
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         let value = vector_sub(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -375,7 +344,7 @@ where
     #[inline]
     fn sub(self, rhs: BinomialExtensionField<F, D>) -> Self {
         let value = vector_sub(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -390,7 +359,7 @@ where
     fn sub(self, rhs: PF) -> Self {
         let mut res = self.value;
         res[0] -= rhs;
-        Self { value: res }
+        Self::new(res)
     }
 }
 
@@ -478,9 +447,7 @@ where
 
     #[inline]
     fn mul(self, rhs: PF) -> Self {
-        Self {
-            value: self.value.map(|x| x * rhs),
-        }
+        Self::new(self.value.map(|x| x * rhs))
     }
 }
 

--- a/field/src/extension/packed_cubic_extension.rs
+++ b/field/src/extension/packed_cubic_extension.rs
@@ -4,49 +4,29 @@
 
 use alloc::vec::Vec;
 use core::array;
-use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_util::{flatten_to_base, reconstitute_from_base};
 use rand::distr::{Distribution, StandardUniform};
-use serde::{Deserialize, Serialize};
 
 use super::cubic_extension::{cubic_square, trinomial_cubic_mul};
-use super::{CubicTrinomialExtensionField, vector_add, vector_sub};
-use crate::extension::CubicTrinomialExtendable;
+use super::{CubicTrinomialExtensionField, PackedExtField, vector_add, vector_sub};
+use crate::extension::{CubicTrinomial, CubicTrinomialExtendable};
 use crate::{
     Algebra, BasedVectorSpace, Field, PackedField, PackedFieldExtension, PackedValue, Powers,
     PrimeCharacteristicRing, field_to_array,
 };
 
-/// Packed cubic extension field.
+/// Packed cubic extension field, one element per SIMD lane.
 ///
-/// This is a wrapper around `[PF; 3]` where `PF` is a packed field type.
-/// It enables SIMD-style operations on multiple cubic extension field elements.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)]
-#[must_use]
-pub struct PackedCubicTrinomialExtensionField<F: Field, PF: PackedField<Scalar = F>> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "PF: Serialize", deserialize = "PF: Deserialize<'de>")
-    )]
-    pub(crate) value: [PF; 3],
-}
-
-impl<F: Field, PF: PackedField<Scalar = F>> PackedCubicTrinomialExtensionField<F, PF> {
-    const fn new(value: [PF; 3]) -> Self {
-        Self { value }
-    }
-}
+/// Type alias for the unified [`PackedExtField`] with `Shape = CubicTrinomial`.
+pub type PackedCubicTrinomialExtensionField<F, PF> = PackedExtField<F, PF, 3, CubicTrinomial>;
 
 impl<F: Field, PF: PackedField<Scalar = F>> Default for PackedCubicTrinomialExtensionField<F, PF> {
     #[inline]
     fn default() -> Self {
-        Self {
-            value: [PF::ZERO, PF::ZERO, PF::ZERO],
-        }
+        Self::new([PF::ZERO, PF::ZERO, PF::ZERO])
     }
 }
 
@@ -55,18 +35,14 @@ impl<F: Field, PF: PackedField<Scalar = F>> From<CubicTrinomialExtensionField<F>
 {
     #[inline]
     fn from(x: CubicTrinomialExtensionField<F>) -> Self {
-        Self {
-            value: x.value.map(Into::into),
-        }
+        Self::new(x.value.map(Into::into))
     }
 }
 
 impl<F: Field, PF: PackedField<Scalar = F>> From<PF> for PackedCubicTrinomialExtensionField<F, PF> {
     #[inline]
     fn from(x: PF) -> Self {
-        Self {
-            value: [x, PF::ZERO, PF::ZERO],
-        }
+        Self::new([x, PF::ZERO, PF::ZERO])
     }
 }
 
@@ -101,21 +77,13 @@ where
 {
     type PrimeSubfield = PF::PrimeSubfield;
 
-    const ZERO: Self = Self {
-        value: [PF::ZERO; 3],
-    };
+    const ZERO: Self = Self::new([PF::ZERO; 3]);
 
-    const ONE: Self = Self {
-        value: field_to_array(PF::ONE),
-    };
+    const ONE: Self = Self::new(field_to_array(PF::ONE));
 
-    const TWO: Self = Self {
-        value: field_to_array(PF::TWO),
-    };
+    const TWO: Self = Self::new(field_to_array(PF::TWO));
 
-    const NEG_ONE: Self = Self {
-        value: field_to_array(PF::NEG_ONE),
-    };
+    const NEG_ONE: Self = Self::new(field_to_array(PF::NEG_ONE));
 
     #[inline]
     fn from_prime_subfield(val: Self::PrimeSubfield) -> Self {
@@ -252,7 +220,7 @@ where
     #[inline]
     fn add(self, rhs: CubicTrinomialExtensionField<F>) -> Self {
         let value = vector_add(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -341,7 +309,7 @@ where
     #[inline]
     fn sub(self, rhs: CubicTrinomialExtensionField<F>) -> Self {
         let value = vector_sub(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -356,7 +324,7 @@ where
     fn sub(self, rhs: PF) -> Self {
         let mut res = self.value;
         res[0] -= rhs;
-        Self { value: res }
+        Self::new(res)
     }
 }
 
@@ -430,9 +398,7 @@ where
 
     #[inline]
     fn mul(self, rhs: PF) -> Self {
-        Self {
-            value: self.value.map(|x| x * rhs),
-        }
+        Self::new(self.value.map(|x| x * rhs))
     }
 }
 

--- a/field/src/extension/packed_quintic_extension.rs
+++ b/field/src/extension/packed_quintic_extension.rs
@@ -4,51 +4,31 @@
 
 use alloc::vec::Vec;
 use core::array;
-use core::fmt::Debug;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use p3_util::{flatten_to_base, reconstitute_from_base};
 use rand::distr::{Distribution, StandardUniform};
-use serde::{Deserialize, Serialize};
 
 use super::quintic_extension::{quintic_square, trinomial_quintic_mul};
-use super::{QuinticTrinomialExtensionField, vector_add, vector_sub};
-use crate::extension::QuinticTrinomialExtendable;
+use super::{PackedExtField, QuinticTrinomialExtensionField, vector_add, vector_sub};
+use crate::extension::{QuinticTrinomial, QuinticTrinomialExtendable};
 use crate::{
     Algebra, BasedVectorSpace, Field, PackedField, PackedFieldExtension, PackedValue, Powers,
     PrimeCharacteristicRing, field_to_array,
 };
 
-/// Packed quintic extension field.
+/// Packed quintic extension field, one element per SIMD lane.
 ///
-/// This is a wrapper around `[PF; 5]` where `PF` is a packed field type.
-/// It enables SIMD-style operations on multiple quintic extension field elements.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)]
-#[must_use]
-pub struct PackedQuinticTrinomialExtensionField<F: Field, PF: PackedField<Scalar = F>> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "PF: Serialize", deserialize = "PF: Deserialize<'de>")
-    )]
-    pub(crate) value: [PF; 5],
-}
-
-impl<F: Field, PF: PackedField<Scalar = F>> PackedQuinticTrinomialExtensionField<F, PF> {
-    const fn new(value: [PF; 5]) -> Self {
-        Self { value }
-    }
-}
+/// Type alias for the unified [`PackedExtField`] with `Shape = QuinticTrinomial`.
+pub type PackedQuinticTrinomialExtensionField<F, PF> = PackedExtField<F, PF, 5, QuinticTrinomial>;
 
 impl<F: Field, PF: PackedField<Scalar = F>> Default
     for PackedQuinticTrinomialExtensionField<F, PF>
 {
     #[inline]
     fn default() -> Self {
-        Self {
-            value: array::from_fn(|_| PF::ZERO),
-        }
+        Self::new(array::from_fn(|_| PF::ZERO))
     }
 }
 
@@ -57,9 +37,7 @@ impl<F: Field, PF: PackedField<Scalar = F>> From<QuinticTrinomialExtensionField<
 {
     #[inline]
     fn from(x: QuinticTrinomialExtensionField<F>) -> Self {
-        Self {
-            value: x.value.map(Into::into),
-        }
+        Self::new(x.value.map(Into::into))
     }
 }
 
@@ -68,9 +46,7 @@ impl<F: Field, PF: PackedField<Scalar = F>> From<PF>
 {
     #[inline]
     fn from(x: PF) -> Self {
-        Self {
-            value: field_to_array(x),
-        }
+        Self::new(field_to_array(x))
     }
 }
 
@@ -105,21 +81,13 @@ where
 {
     type PrimeSubfield = PF::PrimeSubfield;
 
-    const ZERO: Self = Self {
-        value: [PF::ZERO; 5],
-    };
+    const ZERO: Self = Self::new([PF::ZERO; 5]);
 
-    const ONE: Self = Self {
-        value: field_to_array(PF::ONE),
-    };
+    const ONE: Self = Self::new(field_to_array(PF::ONE));
 
-    const TWO: Self = Self {
-        value: field_to_array(PF::TWO),
-    };
+    const TWO: Self = Self::new(field_to_array(PF::TWO));
 
-    const NEG_ONE: Self = Self {
-        value: field_to_array(PF::NEG_ONE),
-    };
+    const NEG_ONE: Self = Self::new(field_to_array(PF::NEG_ONE));
 
     #[inline]
     fn from_prime_subfield(val: Self::PrimeSubfield) -> Self {
@@ -256,7 +224,7 @@ where
     #[inline]
     fn add(self, rhs: QuinticTrinomialExtensionField<F>) -> Self {
         let value = vector_add(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -346,7 +314,7 @@ where
     #[inline]
     fn sub(self, rhs: QuinticTrinomialExtensionField<F>) -> Self {
         let value = vector_sub(&self.value, &rhs.value);
-        Self { value }
+        Self::new(value)
     }
 }
 
@@ -361,7 +329,7 @@ where
     fn sub(self, rhs: PF) -> Self {
         let mut res = self.value;
         res[0] -= rhs;
-        Self { value: res }
+        Self::new(res)
     }
 }
 
@@ -436,9 +404,7 @@ where
 
     #[inline]
     fn mul(self, rhs: PF) -> Self {
-        Self {
-            value: self.value.map(|x| x * rhs),
-        }
+        Self::new(self.value.map(|x| x * rhs))
     }
 }
 

--- a/field/src/extension/quintic_extension.rs
+++ b/field/src/extension/quintic_extension.rs
@@ -9,7 +9,7 @@ use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::array;
-use core::fmt::{self, Debug, Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -19,10 +19,9 @@ use num_bigint::BigUint;
 use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
-use serde::{Deserialize, Serialize};
 
 use super::packed_quintic_extension::PackedQuinticTrinomialExtensionField;
-use super::{HasFrobenius, HasTwoAdicQuinticExtension};
+use super::{ExtField, HasFrobenius, HasTwoAdicQuinticExtension};
 use crate::extension::{
     ExtensionAlgebra, QuinticTrinomial, QuinticTrinomialExtendable,
 };
@@ -35,30 +34,9 @@ use crate::{
 /// A degree-5 extension field using the trinomial `X^5 + X^2 - 1`.
 ///
 /// Elements are represented as `a_0 + a_1*X + a_2*X^2 + a_3*X^3 + a_4*X^4`.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, PartialOrd, Ord)]
-#[repr(transparent)] // Required for safe memory layout casts.
-#[must_use]
-pub struct QuinticTrinomialExtensionField<F, A = F> {
-    #[serde(
-        with = "p3_util::array_serialization",
-        bound(serialize = "A: Serialize", deserialize = "A: Deserialize<'de>")
-    )]
-    pub(crate) value: [A; 5],
-    _phantom: PhantomData<F>,
-}
-
-impl<F, A> QuinticTrinomialExtensionField<F, A> {
-    /// Create an extension field element from coefficient array.
-    ///
-    /// The coefficients represent the polynomial `value[0] + value[1]*X + ... + value[4]*X^4`.
-    #[inline]
-    pub const fn new(value: [A; 5]) -> Self {
-        Self {
-            value,
-            _phantom: PhantomData,
-        }
-    }
-}
+///
+/// Type alias for the unified [`ExtField`] with `Shape = QuinticTrinomial`.
+pub type QuinticTrinomialExtensionField<F, A = F> = ExtField<F, 5, QuinticTrinomial, A>;
 
 impl<F: Copy> QuinticTrinomialExtensionField<F, F> {
     /// Convert a `[[F; 5]; N]` array to an array of extension field elements.

--- a/field/src/extension/quintic_extension.rs
+++ b/field/src/extension/quintic_extension.rs
@@ -23,7 +23,9 @@ use serde::{Deserialize, Serialize};
 
 use super::packed_quintic_extension::PackedQuinticTrinomialExtensionField;
 use super::{HasFrobenius, HasTwoAdicQuinticExtension};
-use crate::extension::{QuinticExtendableAlgebra, QuinticTrinomialExtendable};
+use crate::extension::{
+    ExtensionAlgebra, QuinticTrinomial, QuinticTrinomialExtendable,
+};
 use crate::field::Field;
 use crate::{
     Algebra, BasedVectorSpace, ExtensionField, Packable, PackedFieldExtension,
@@ -233,7 +235,7 @@ impl<F: QuinticTrinomialExtendable> QuinticTrinomialExtensionField<F> {
 impl<F, A> PrimeCharacteristicRing for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial> + Copy,
 {
     type PrimeSubfield = <A as PrimeCharacteristicRing>::PrimeSubfield;
 
@@ -255,7 +257,7 @@ where
     #[inline(always)]
     fn square(&self) -> Self {
         let mut res = Self::default();
-        A::quintic_square(&self.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_square(&self.value, &mut res.value);
         res
     }
 
@@ -403,13 +405,13 @@ where
 impl<F, A> Add for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::new(A::quintic_add(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(&self.value, &rhs.value))
     }
 }
 
@@ -430,11 +432,11 @@ where
 impl<F, A> AddAssign for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        self.value = A::quintic_add(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(&self.value, &rhs.value);
     }
 }
 
@@ -452,7 +454,7 @@ where
 impl<F, A> Sum for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial> + Copy,
 {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -463,13 +465,13 @@ where
 impl<F, A> Sub for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::new(A::quintic_sub(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(&self.value, &rhs.value))
     }
 }
 
@@ -491,11 +493,11 @@ where
 impl<F, A> SubAssign for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        self.value = A::quintic_sub(&self.value, &rhs.value);
+        self.value = <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(&self.value, &rhs.value);
     }
 }
 
@@ -513,14 +515,14 @@ where
 impl<F, A> Mul for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         let mut res = Self::default();
-        A::quintic_mul(&self.value, &rhs.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_mul(&self.value, &rhs.value, &mut res.value);
         res
     }
 }
@@ -528,20 +530,20 @@ where
 impl<F, A> Mul<A> for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: A) -> Self {
-        Self::new(A::quintic_base_mul(self.value, rhs))
+        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_base_mul(self.value, rhs))
     }
 }
 
 impl<F, A> MulAssign for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: Self) {
@@ -552,7 +554,7 @@ where
 impl<F, A> MulAssign<A> for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F>,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial>,
 {
     #[inline]
     fn mul_assign(&mut self, rhs: A) {
@@ -563,7 +565,7 @@ where
 impl<F, A> Product for QuinticTrinomialExtensionField<F, A>
 where
     F: QuinticTrinomialExtendable,
-    A: QuinticExtendableAlgebra<F> + Copy,
+    A: ExtensionAlgebra<F, 5, QuinticTrinomial> + Copy,
 {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -660,7 +662,7 @@ pub fn trinomial_quintic_mul<R: PrimeCharacteristicRing>(a: &[R; 5], b: &[R; 5],
 
 /// Square an element in the quintic extension field.
 #[inline]
-pub(super) fn quintic_square<R: PrimeCharacteristicRing>(a: &[R; 5], res: &mut [R; 5]) {
+pub fn quintic_square<R: PrimeCharacteristicRing>(a: &[R; 5], res: &mut [R; 5]) {
     // Precompute doubled coefficients for cross terms
     let a0_2 = a[0].double();
     let a1_2 = a[1].double();

--- a/field/src/extension/quintic_extension.rs
+++ b/field/src/extension/quintic_extension.rs
@@ -11,24 +11,19 @@ use alloc::vec::Vec;
 use core::array;
 use core::fmt::{self, Display, Formatter};
 use core::iter::{Product, Sum};
-use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use itertools::Itertools;
 use num_bigint::BigUint;
-use p3_util::{as_base_slice, as_base_slice_mut, flatten_to_base, reconstitute_from_base};
-use rand::distr::StandardUniform;
-use rand::prelude::Distribution;
+use p3_util::{as_base_slice, as_base_slice_mut, reconstitute_from_base};
 
 use super::packed_quintic_extension::PackedQuinticTrinomialExtensionField;
 use super::{ExtField, HasFrobenius, HasTwoAdicQuinticExtension};
-use crate::extension::{
-    ExtensionAlgebra, QuinticTrinomial, QuinticTrinomialExtendable,
-};
+use crate::extension::{ExtensionAlgebra, QuinticTrinomial, QuinticTrinomialExtendable};
 use crate::field::Field;
 use crate::{
-    Algebra, BasedVectorSpace, ExtensionField, Packable, PackedFieldExtension,
-    PrimeCharacteristicRing, RawDataSerializable, TwoAdicField, field_to_array,
+    Algebra, ExtensionField, PackedFieldExtension, PrimeCharacteristicRing, RawDataSerializable,
+    TwoAdicField, field_to_array,
 };
 
 /// A degree-5 extension field using the trinomial `X^5 + X^2 - 1`.
@@ -53,63 +48,6 @@ impl<F: Copy> QuinticTrinomialExtensionField<F, F> {
             i += 1;
         }
         output
-    }
-}
-
-impl<F: Field, A: Algebra<F>> Default for QuinticTrinomialExtensionField<F, A> {
-    fn default() -> Self {
-        Self::new(array::from_fn(|_| A::ZERO))
-    }
-}
-
-impl<F: Field, A: Algebra<F>> From<A> for QuinticTrinomialExtensionField<F, A> {
-    fn from(x: A) -> Self {
-        Self::new(field_to_array(x))
-    }
-}
-
-impl<F, A> From<[A; 5]> for QuinticTrinomialExtensionField<F, A> {
-    #[inline]
-    fn from(x: [A; 5]) -> Self {
-        Self {
-            value: x,
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<F: QuinticTrinomialExtendable> Packable for QuinticTrinomialExtensionField<F> {}
-
-impl<F: QuinticTrinomialExtendable, A: Algebra<F>> BasedVectorSpace<A>
-    for QuinticTrinomialExtensionField<F, A>
-{
-    const DIMENSION: usize = 5;
-
-    #[inline]
-    fn as_basis_coefficients_slice(&self) -> &[A] {
-        &self.value
-    }
-
-    #[inline]
-    fn from_basis_coefficients_fn<Fn: FnMut(usize) -> A>(f: Fn) -> Self {
-        Self::new(array::from_fn(f))
-    }
-
-    #[inline]
-    fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = A>>(mut iter: I) -> Option<Self> {
-        (iter.len() == 5).then(|| Self::new(array::from_fn(|_| iter.next().unwrap())))
-    }
-
-    #[inline]
-    fn flatten_to_base(vec: Vec<Self>) -> Vec<A> {
-        // SAFETY: `Self` is `repr(transparent)` over `[A; 5]`.
-        unsafe { flatten_to_base::<A, Self>(vec) }
-    }
-
-    #[inline]
-    fn reconstitute_from_base(vec: Vec<A>) -> Vec<Self> {
-        // SAFETY: `Self` is `repr(transparent)` over `[A; 5]`.
-        unsafe { reconstitute_from_base::<A, Self>(vec) }
     }
 }
 
@@ -389,7 +327,10 @@ where
 
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(
+            &self.value,
+            &rhs.value,
+        ))
     }
 }
 
@@ -414,7 +355,8 @@ where
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        self.value = <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(&self.value, &rhs.value);
+        self.value =
+            <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_add(&self.value, &rhs.value);
     }
 }
 
@@ -449,7 +391,10 @@ where
 
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(&self.value, &rhs.value))
+        Self::new(<A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(
+            &self.value,
+            &rhs.value,
+        ))
     }
 }
 
@@ -475,7 +420,8 @@ where
 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        self.value = <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(&self.value, &rhs.value);
+        self.value =
+            <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_sub(&self.value, &rhs.value);
     }
 }
 
@@ -500,7 +446,11 @@ where
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         let mut res = Self::default();
-        <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_mul(&self.value, &rhs.value, &mut res.value);
+        <A as ExtensionAlgebra<F, 5, QuinticTrinomial>>::ext_mul(
+            &self.value,
+            &rhs.value,
+            &mut res.value,
+        );
         res
     }
 }
@@ -571,17 +521,6 @@ where
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
-    }
-}
-
-impl<F: QuinticTrinomialExtendable> Distribution<QuinticTrinomialExtensionField<F>>
-    for StandardUniform
-where
-    Self: Distribution<F>,
-{
-    #[inline]
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> QuinticTrinomialExtensionField<F> {
-        QuinticTrinomialExtensionField::new(array::from_fn(|_| self.sample(rng)))
     }
 }
 

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,12 +1,23 @@
 use p3_field::extension::{
-    BinomiallyExtendable, BinomiallyExtendableAlgebra, CubicExtendableAlgebra,
-    CubicTrinomialExtendable, HasTwoAdicBinomialExtension, HasTwoAdicCubicExtension,
+    Binomial, BinomiallyExtendable, CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra,
+    HasTwoAdicBinomialExtension, HasTwoAdicCubicExtension, binomial_mul, binomial_square,
+    cubic_square, trinomial_cubic_mul,
 };
 use p3_field::{PrimeCharacteristicRing, TwoAdicField, field_to_array};
 
 use crate::Goldilocks;
 
-impl BinomiallyExtendableAlgebra<Self, 2> for Goldilocks {}
+impl ExtensionAlgebra<Self, 2, Binomial<Self>> for Goldilocks {
+    #[inline]
+    fn ext_mul(a: &[Self; 2], b: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_mul::<Self, Self, Self, 2>(a, b, res, <Self as BinomiallyExtendable<2>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_square::<Self, Self, 2>(a, res, <Self as BinomiallyExtendable<2>>::W);
+    }
+}
 
 impl BinomiallyExtendable<2> for Goldilocks {
     // Verifiable in Sage with
@@ -36,7 +47,17 @@ impl HasTwoAdicBinomialExtension<2> for Goldilocks {
     }
 }
 
-impl CubicExtendableAlgebra<Self> for Goldilocks {}
+impl ExtensionAlgebra<Self, 3, CubicTrinomial> for Goldilocks {
+    #[inline]
+    fn ext_mul(a: &[Self; 3], b: &[Self; 3], res: &mut [Self; 3]) {
+        trinomial_cubic_mul::<Self>(a, b, res);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 3], res: &mut [Self; 3]) {
+        cubic_square::<Self>(a, res);
+    }
+}
 
 impl CubicTrinomialExtendable for Goldilocks {
     // Verifiable via:
@@ -86,7 +107,17 @@ impl HasTwoAdicCubicExtension for Goldilocks {
     }
 }
 
-impl BinomiallyExtendableAlgebra<Self, 5> for Goldilocks {}
+impl ExtensionAlgebra<Self, 5, Binomial<Self>> for Goldilocks {
+    #[inline]
+    fn ext_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
+        binomial_mul::<Self, Self, Self, 5>(a, b, res, <Self as BinomiallyExtendable<5>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 5], res: &mut [Self; 5]) {
+        binomial_square::<Self, Self, 5>(a, res, <Self as BinomiallyExtendable<5>>::W);
+    }
+}
 
 impl BinomiallyExtendable<5> for Goldilocks {
     // Verifiable via:

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,12 +1,22 @@
 use p3_field::extension::{
-    BinomiallyExtendable, BinomiallyExtendableAlgebra, Complex, HasComplexBinomialExtension,
-    HasTwoAdicComplexBinomialExtension,
+    Binomial, BinomiallyExtendable, Complex, ExtensionAlgebra, HasComplexBinomialExtension,
+    HasTwoAdicComplexBinomialExtension, binomial_mul, binomial_square,
 };
 use p3_field::{PrimeCharacteristicRing, TwoAdicField, field_to_array};
 
 use crate::Mersenne31;
 
-impl BinomiallyExtendableAlgebra<Self, 3> for Mersenne31 {}
+impl ExtensionAlgebra<Self, 3, Binomial<Self>> for Mersenne31 {
+    #[inline]
+    fn ext_mul(a: &[Self; 3], b: &[Self; 3], res: &mut [Self; 3]) {
+        binomial_mul::<Self, Self, Self, 3>(a, b, res, <Self as BinomiallyExtendable<3>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 3], res: &mut [Self; 3]) {
+        binomial_square::<Self, Self, 3>(a, res, <Self as BinomiallyExtendable<3>>::W);
+    }
+}
 
 impl BinomiallyExtendable<3> for Mersenne31 {
     // ```sage

--- a/monty-31/src/aarch64_neon/packing.rs
+++ b/monty-31/src/aarch64_neon/packing.rs
@@ -1403,7 +1403,7 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
     b: MontyField31<FP>,
     res: &mut [MontyField31<FP>; WIDTH],
 ) where
-    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+    FP: FieldParameters,
 {
     match WIDTH {
         1 => res[0] = a[0] * b,

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -1,6 +1,6 @@
 use p3_field::extension::{
-    BinomiallyExtendable, BinomiallyExtendableAlgebra, HasTwoAdicBinomialExtension,
-    HasTwoAdicQuinticExtension, QuinticExtendableAlgebra, QuinticTrinomialExtendable,
+    Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension,
+    HasTwoAdicQuinticExtension, QuinticTrinomial, QuinticTrinomialExtendable,
 };
 use p3_field::{
     PrimeCharacteristicRing, TwoAdicField, field_to_array, packed_mod_add, packed_mod_sub,
@@ -18,12 +18,12 @@ use crate::{
 // We perform no checks to make sure the data given in BinomialExtensionData<WIDTH> is valid and
 // corresponds to an actual field extension. Ensuring that is left to the implementer.
 
-impl<const WIDTH: usize, FP> BinomiallyExtendableAlgebra<Self, WIDTH> for MontyField31<FP>
+impl<const WIDTH: usize, FP> ExtensionAlgebra<Self, WIDTH, Binomial<Self>> for MontyField31<FP>
 where
     FP: BinomialExtensionData<WIDTH> + FieldParameters,
 {
     #[inline(always)]
-    fn binomial_mul(a: &[Self; WIDTH], b: &[Self; WIDTH], res: &mut [Self; WIDTH], _w: Self) {
+    fn ext_mul(a: &[Self; WIDTH], b: &[Self; WIDTH], res: &mut [Self; WIDTH]) {
         match WIDTH {
             4 => quartic_mul_packed(a, b, res),
             5 => quintic_mul_packed(a, b, res),
@@ -33,7 +33,13 @@ where
     }
 
     #[inline(always)]
-    fn binomial_add(a: &[Self; WIDTH], b: &[Self; WIDTH]) -> [Self; WIDTH] {
+    fn ext_square(a: &[Self; WIDTH], res: &mut [Self; WIDTH]) {
+        // No specialized SIMD square kernel; reuse the mul path with a=b.
+        Self::ext_mul(a, a, res);
+    }
+
+    #[inline(always)]
+    fn ext_add(a: &[Self; WIDTH], b: &[Self; WIDTH]) -> [Self; WIDTH] {
         let mut res = [Self::ZERO; WIDTH];
         unsafe {
             // Safe as Self is repr(transparent) and stores a single u32.
@@ -47,7 +53,7 @@ where
     }
 
     #[inline(always)]
-    fn binomial_sub(a: &[Self; WIDTH], b: &[Self; WIDTH]) -> [Self; WIDTH] {
+    fn ext_sub(a: &[Self; WIDTH], b: &[Self; WIDTH]) -> [Self; WIDTH] {
         let mut res = [Self::ZERO; WIDTH];
         unsafe {
             // Safe as Self is repr(transparent) and stores a single u32.
@@ -61,7 +67,7 @@ where
     }
 
     #[inline(always)]
-    fn binomial_base_mul(lhs: [Self; WIDTH], rhs: Self) -> [Self; WIDTH] {
+    fn ext_base_mul(lhs: [Self; WIDTH], rhs: Self) -> [Self; WIDTH] {
         let mut res = [Self::ZERO; WIDTH];
         base_mul_packed(lhs, rhs, &mut res);
         res
@@ -98,13 +104,50 @@ where
     }
 }
 
-impl<FP> QuinticExtendableAlgebra<Self> for MontyField31<FP>
+impl<FP> ExtensionAlgebra<Self, 5, QuinticTrinomial> for MontyField31<FP>
 where
     FP: TrinomialQuinticData + FieldParameters,
 {
     #[inline(always)]
-    fn quintic_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
+    fn ext_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
         quintic_mul_packed_trinomial(a, b, res);
+    }
+
+    #[inline(always)]
+    fn ext_square(a: &[Self; 5], res: &mut [Self; 5]) {
+        // No specialized SIMD square kernel for the trinomial reducer; reuse mul.
+        Self::ext_mul(a, a, res);
+    }
+
+    #[inline(always)]
+    fn ext_add(a: &[Self; 5], b: &[Self; 5]) -> [Self; 5] {
+        let mut res = [Self::ZERO; 5];
+        unsafe {
+            let a: &[u32; 5] = &*(a.as_ptr() as *const [u32; 5]);
+            let b: &[u32; 5] = &*(b.as_ptr() as *const [u32; 5]);
+            let res: &mut [u32; 5] = &mut *(res.as_mut_ptr() as *mut [u32; 5]);
+            packed_mod_add(a, b, res, FP::PRIME, add::<FP>);
+        }
+        res
+    }
+
+    #[inline(always)]
+    fn ext_sub(a: &[Self; 5], b: &[Self; 5]) -> [Self; 5] {
+        let mut res = [Self::ZERO; 5];
+        unsafe {
+            let a: &[u32; 5] = &*(a.as_ptr() as *const [u32; 5]);
+            let b: &[u32; 5] = &*(b.as_ptr() as *const [u32; 5]);
+            let res: &mut [u32; 5] = &mut *(res.as_mut_ptr() as *mut [u32; 5]);
+            packed_mod_sub(a, b, res, FP::PRIME, sub::<FP>);
+        }
+        res
+    }
+
+    #[inline(always)]
+    fn ext_base_mul(lhs: [Self; 5], rhs: Self) -> [Self; 5] {
+        let mut res = [Self::ZERO; 5];
+        base_mul_packed(lhs, rhs, &mut res);
+        res
     }
 }
 

--- a/monty-31/src/no_packing/mod.rs
+++ b/monty-31/src/no_packing/mod.rs
@@ -62,7 +62,7 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
     b: MontyField31<FP>,
     res: &mut [MontyField31<FP>; WIDTH],
 ) where
-    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+    FP: FieldParameters,
 {
     res.iter_mut().zip(a.iter()).for_each(|(r, a)| *r = *a * b);
 }

--- a/monty-31/src/x86_64_avx2/packing.rs
+++ b/monty-31/src/x86_64_avx2/packing.rs
@@ -1305,7 +1305,7 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
     b: MontyField31<FP>,
     res: &mut [MontyField31<FP>; WIDTH],
 ) where
-    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+    FP: FieldParameters,
 {
     match WIDTH {
         1 => res[0] = a[0] * b,

--- a/monty-31/src/x86_64_avx512/packing.rs
+++ b/monty-31/src/x86_64_avx512/packing.rs
@@ -1625,7 +1625,7 @@ pub(crate) fn base_mul_packed<FP, const WIDTH: usize>(
     b: MontyField31<FP>,
     res: &mut [MontyField31<FP>; WIDTH],
 ) where
-    FP: FieldParameters + BinomialExtensionData<WIDTH>,
+    FP: FieldParameters,
 {
     match WIDTH {
         1 => res[0] = a[0] * b,


### PR DESCRIPTION
Unifies the three parallel families of extension-field machinery (binomial / cubic / quintic) into one single abstraction parameterized by a `Shape` marker type.
  
The public API is preserved via type aliases so downstream impls don't require changes (only trait implementors).

LMK what you think!