### PR TITLE
fix(matrix): handle on-domain point in interpolate_coset

### DIFF
--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -107,17 +107,16 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
             .iter()
             .collect();
 
-        // If point lies on the coset, return that row directly.
-        // Mirrors the arbitrary-domain shortcut and avoids 0.inverse().
-        for (i, &x) in coset.iter().enumerate() {
-            if point == EF::from(x) {
-                return self.row(i).unwrap().into_iter().map(EF::from).collect();
-            }
-        }
-
         // Compute z - x_i in parallel, then batch-invert in one shot
         // (Montgomery's trick: single field inversion + O(N) multiplications).
         let diffs: Vec<EF> = coset.par_iter().map(|&g| point - g).collect();
+
+        // If point lies on the coset, return that row directly.
+        // Detected by scanning the already-computed diffs to keep the off-domain path parallel.
+        if let Some(i) = diffs.iter().position(|d| d.is_zero()) {
+            return self.row(i).unwrap().into_iter().map(EF::from).collect();
+        }
+
         let diff_invs = batch_multiplicative_inverse(&diffs);
 
         // Convert to adjusted weights and delegate to the zero-allocation hot path.
@@ -309,6 +308,12 @@ pub trait InterpolateArbitrary<F: Field>: Matrix<F> {
         debug_assert_eq!(weights.len(), self.height());
         debug_assert_eq!(diff_invs.len(), self.height());
 
+        // Empty domain -> undetermined polynomial. Return zero per column.
+        // Handling this explicitly keeps the loud panic on the standard path for caller-side contract violations.
+        if self.height() == 0 {
+            return EF::zero_vec(self.width());
+        }
+
         // Barycentric second form:
         //
         //     s_i    = w_i / (z - x_i)
@@ -326,9 +331,7 @@ pub trait InterpolateArbitrary<F: Field>: Matrix<F> {
 
         // Denominator: sum of all scale factors.
         let denominator = col_scale.iter().copied().fold(EF::ZERO, |a, b| a + b);
-        let Some(denom_inv) = denominator.try_inverse() else {
-            return alloc::vec![EF::ZERO; self.width()];
-        };
+        let denom_inv = denominator.inverse();
 
         // Numerator per column via SIMD-packed M^T * col_scale.
         let mut evals = self.columnwise_dot_product(&col_scale);
@@ -577,6 +580,70 @@ mod tests {
 
         let result = evals_mat.interpolate_coset(shift, point);
         assert_eq!(result, vec![c]);
+    }
+
+    #[test]
+    fn test_interpolate_coset_point_on_coset() {
+        // On-domain target must return the matching row, never panic on 0.inverse().
+        let log_n = 3;
+        let n = 1usize << log_n;
+        let shift = F::GENERATOR;
+        let h = F::two_adic_generator(log_n);
+
+        let coset: Vec<F> = (0..n).map(|i| shift * h.exp_u64(i as u64)).collect();
+        let evals: Vec<F> = (0..n as u32).map(|i| F::from_u32(100 + i)).collect();
+        let m = RowMajorMatrix::new(evals.clone(), 1);
+
+        // Sweep every coset element so off-by-one in the index would surface.
+        for (i, &x) in coset.iter().enumerate() {
+            let result = m.interpolate_coset(shift, x);
+            assert_eq!(result, vec![evals[i]]);
+        }
+    }
+
+    #[test]
+    fn test_interpolate_coset_point_on_coset_extension() {
+        // Same shortcut, but the target is a coset element lifted into EF4.
+        // Two columns to verify the lift covers every column entry of the row.
+        let log_n = 3;
+        let n = 1usize << log_n;
+        let shift = F::GENERATOR;
+        let h = F::two_adic_generator(log_n);
+
+        let coset: Vec<F> = (0..n).map(|i| shift * h.exp_u64(i as u64)).collect();
+
+        let mut evals: Vec<F> = Vec::with_capacity(n * 2);
+        for i in 0..n {
+            evals.push(F::from_u32(200 + i as u32));
+            evals.push(F::from_u32(300 + i as u32));
+        }
+        let m = RowMajorMatrix::new(evals, 2);
+
+        // Non-zero index avoids hitting the i=0 corner.
+        let i = 3;
+        let result = m.interpolate_coset(shift, EF4::from(coset[i]));
+        assert_eq!(
+            result,
+            vec![
+                EF4::from(F::from_u32(200 + i as u32)),
+                EF4::from(F::from_u32(300 + i as u32)),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_interpolate_subgroup_point_on_subgroup() {
+        // Subgroup wrapper is the shift=1 coset; on-subgroup target must short-circuit too.
+        let log_n = 2;
+        let n = 1usize << log_n;
+        let h = F::two_adic_generator(log_n);
+
+        let evals: Vec<F> = (0..n as u32).map(|i| F::from_u32(10 + i)).collect();
+        let m = RowMajorMatrix::new(evals.clone(), 1);
+
+        // h^2 is non-identity, so the test also exercises a non-trivial coset element.
+        let result = m.interpolate_subgroup(h.exp_u64(2));
+        assert_eq!(result, vec![evals[2]]);
     }
 
     #[test]
@@ -1068,6 +1135,16 @@ mod tests {
         let evals = RowMajorMatrix::<F>::new(vec![], 3);
         let result = evals.interpolate_arbitrary_point(&xs, F::from_u32(42));
         assert_eq!(result, Some(vec![F::ZERO, F::ZERO, F::ZERO]));
+    }
+
+    #[test]
+    fn test_interpolate_arbitrary_with_precomputation_empty_direct() {
+        // Precomputed hot path is on the public trait surface; empty domain must not panic.
+        let weights: Vec<F> = vec![];
+        let diff_invs: Vec<F> = vec![];
+        let evals = RowMajorMatrix::<F>::new(vec![], 5);
+        let result = evals.interpolate_arbitrary_with_precomputation(&weights, &diff_invs);
+        assert_eq!(result, vec![F::ZERO; 5]);
     }
 
     #[test]

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -107,6 +107,14 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
             .iter()
             .collect();
 
+        // If point lies on the coset, return that row directly.
+        // Mirrors the arbitrary-domain shortcut and avoids 0.inverse().
+        for (i, &x) in coset.iter().enumerate() {
+            if point == EF::from(x) {
+                return self.row(i).unwrap().into_iter().map(EF::from).collect();
+            }
+        }
+
         // Compute z - x_i in parallel, then batch-invert in one shot
         // (Montgomery's trick: single field inversion + O(N) multiplications).
         let diffs: Vec<EF> = coset.par_iter().map(|&g| point - g).collect();
@@ -318,7 +326,9 @@ pub trait InterpolateArbitrary<F: Field>: Matrix<F> {
 
         // Denominator: sum of all scale factors.
         let denominator = col_scale.iter().copied().fold(EF::ZERO, |a, b| a + b);
-        let denom_inv = denominator.inverse();
+        let Some(denom_inv) = denominator.try_inverse() else {
+            return alloc::vec![EF::ZERO; self.width()];
+        };
 
         // Numerator per column via SIMD-packed M^T * col_scale.
         let mut evals = self.columnwise_dot_product(&col_scale);
@@ -1048,6 +1058,17 @@ mod tests {
                 F::from_u32(4),
             ]
         );
+    }
+
+
+    #[test]
+    fn test_interpolate_arbitrary_empty_matrix() {
+        // height=0 -> col_scale is empty -> denominator folds to EF::ZERO
+        // must NOT panic, must return a zero vector of length == width
+        let xs: Vec<F> = vec![];
+        let evals = RowMajorMatrix::<F>::new(vec![], 3);
+        let result = evals.interpolate_arbitrary_point(&xs, F::from_u32(42));
+        assert_eq!(result, Some(vec![F::ZERO, F::ZERO, F::ZERO]));
     }
 
     #[test]

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -1060,7 +1060,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_interpolate_arbitrary_empty_matrix() {
         // height=0 -> col_scale is empty -> denominator folds to EF::ZERO


### PR DESCRIPTION
Fix two panic vectors in interpolatecoset and interpolatearbitrarywithprecomputation: an empty matrix caused unconditional 0.Fix two panic vectors in interpolate_coset and interpolate_arbitrary_with_precomputation: an empty matrix caused unconditional 0.inverse() via the barycentric denominator, and a coincident evaluation point in the two-adic path had no on-domain guard, unlike the arbitrary path which already handled this correctly. Both are fixed with minimal, symmetric changes.