### PR TITLE
Isolate bit_reverse benchmark from clone overhead

### DIFF
--- a/util/benches/bit_reverse.rs
+++ b/util/benches/bit_reverse.rs
@@ -11,11 +11,9 @@ fn bench_reverse_slice_index_bits(c: &mut Criterion) {
     for log_size in [1, 3, 5, 8, 16, 24, 26] {
         let size = 1 << log_size;
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            let data: Vec<u64> = (0..size).map(|_| rng.random()).collect();
+            let mut data: Vec<u64> = (0..size).map(|_| rng.random()).collect();
             b.iter(|| {
-                let mut test_data = data.clone();
-                reverse_slice_index_bits(black_box(&mut test_data));
-                black_box(test_data)
+                reverse_slice_index_bits(black_box(&mut data));
             });
         });
     }


### PR DESCRIPTION
 Move input cloning out of the timed bit_reverse loop, so the benchmark measures reverse_slice_index_bits kernel cost instead of copy overhead.