### PR TITLE
test(fri): clarify valid Pcs::commit call styles

### DIFF
--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -83,6 +83,10 @@ where
     /// the polynomials defined by those evaluations. If `zk` is enabled, the evaluations are
     /// first randomized as explained in Section 3 of <https://eprint.iacr.org/2024/1037.pdf>.
     ///
+    /// Method-call syntax like `pcs.commit(...)` works when Rust can infer the
+    /// `Pcs<Challenge, Challenger>` parameters. Otherwise use explicit UFCS, e.g.
+    /// `<MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, ...)`.
+    ///
     /// Returns both the commitment which should be sent to the verifier
     /// and the prover data which can be used to produce opening proofs.
     #[allow(clippy::type_complexity)]

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -256,6 +256,70 @@ mod babybear_fri_pcs {
 
         assert_eq!(evals, expected);
     }
+
+    #[test]
+    fn commit_call_styles_match() {
+        use p3_matrix::Matrix;
+
+        fn commit_with_method_syntax<P>(
+            pcs: &P,
+            domain: <MyPcs as Pcs<Challenge, Challenger>>::Domain,
+            trace: RowMajorMatrix<Val>,
+        ) -> (
+            <MyPcs as Pcs<Challenge, Challenger>>::Commitment,
+            <MyPcs as Pcs<Challenge, Challenger>>::ProverData,
+        )
+        where
+            P: Pcs<
+                Challenge,
+                Challenger,
+                Domain = <MyPcs as Pcs<Challenge, Challenger>>::Domain,
+                Commitment = <MyPcs as Pcs<Challenge, Challenger>>::Commitment,
+                ProverData = <MyPcs as Pcs<Challenge, Challenger>>::ProverData,
+            >,
+        {
+            pcs.commit([(domain, trace)])
+        }
+
+        let (pcs, _) = get_pcs(1);
+        let mut rng = seeded_rng();
+
+        let degree = 1 << 4;
+        let width = 3;
+        let trace = RowMajorMatrix::<Val>::rand(&mut rng, degree, width);
+
+        let method_domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, degree);
+        let (method_commitment, method_data) =
+            commit_with_method_syntax(&pcs, method_domain, trace.clone());
+
+        let ufcs_domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, degree);
+        let (ufcs_commitment, ufcs_data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(ufcs_domain, trace.clone())]);
+
+        assert_eq!(method_commitment, ufcs_commitment);
+
+        let disjoint_domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, degree)
+                .create_disjoint_domain(degree);
+        let method_evals = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+            &pcs,
+            &method_data,
+            0,
+            disjoint_domain,
+        )
+        .to_row_major_matrix();
+        let ufcs_evals = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+            &pcs,
+            &ufcs_data,
+            0,
+            disjoint_domain,
+        )
+        .to_row_major_matrix();
+
+        assert_eq!(method_evals, ufcs_evals);
+    }
 }
 
 mod m31_fri_pcs {

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -271,12 +271,12 @@ mod babybear_fri_pcs {
         )
         where
             P: Pcs<
-                Challenge,
-                Challenger,
-                Domain = <MyPcs as Pcs<Challenge, Challenger>>::Domain,
-                Commitment = <MyPcs as Pcs<Challenge, Challenger>>::Commitment,
-                ProverData = <MyPcs as Pcs<Challenge, Challenger>>::ProverData,
-            >,
+                    Challenge,
+                    Challenger,
+                    Domain = <MyPcs as Pcs<Challenge, Challenger>>::Domain,
+                    Commitment = <MyPcs as Pcs<Challenge, Challenger>>::Commitment,
+                    ProverData = <MyPcs as Pcs<Challenge, Challenger>>::ProverData,
+                >,
         {
             pcs.commit([(domain, trace)])
         }


### PR DESCRIPTION
This addresses #1279.

The issue is not an implementation bug in `TwoAdicFriPcs`, but a user-facing confusion around where Rust can infer the `Pcs<Challenge, Challenger>` trait parameters for `commit`.

This PR keeps the API unchanged and instead adds executable clarification.

It adds a focused test showing the two valid call styles on the same PCS instance:
- `pcs.commit(...)` when the trait parameters are inferable
- `<MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, ...)` when explicit UFCS is needed

It also adds a short note on `Pcs::commit` documenting that distinction.

Why this shape:
- `Pcs::commit` is defined on the trait, not on `TwoAdicFriPcs` itself
- the repository already uses both styles today in `fri/tests/pcs.rs`
- https://github.com/Plonky3/Plonky3/issues/1279#issuecomment-3831899479 already points to explicit UFCS as the expected fallback

Why the test uses a helper for the method-call case:
- raw `pcs.commit(...)` in arbitrary test scope can hit the same ambiguity as the original issue
- the helper establishes a context where the relevant `Pcs<Challenge, Challenger>` implementation is already fixed
- that lets the test demonstrate the intended method-call form without changing API shape

Non-goals:
- no API change to `TwoAdicFriPcs`
- no extra generic parameters added to the struct
- no wrapper convenience method

Testing:
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p p3-fri --test pcs`
