### PR TITLE
perf(circle): pack the v_n_prod chain in compute_lagrange_den_batched

### DIFF
--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -33,6 +33,7 @@ p3-symmetric = { path = "../symmetric" }
 
 criterion.workspace = true
 hashbrown.workspace = true
+proptest.workspace = true
 rand.workspace = true
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -2,7 +2,9 @@ use alloc::vec::Vec;
 use core::ops::{Add, AddAssign, Mul, Neg, Sub};
 
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field, batch_multiplicative_inverse};
+use p3_field::{
+    ExtensionField, Field, PackedValue, PrimeCharacteristicRing, batch_multiplicative_inverse,
+};
 
 /// Affine representation of a point on the circle.
 /// x^2 + y^2 == 1
@@ -119,6 +121,56 @@ impl<F: Field> Point<F> {
     }
 }
 
+/// Batched [`Point::s_p_at_p`] over base-field points.
+///
+/// Equivalent to `points.iter().map(|p| p.s_p_at_p(log_n))`, but shares the
+/// `v_n_prod` iterated-squaring chain across SIMD lanes. That chain is pure
+/// base-field work and dominates the per-point cost, so packing it is the bulk
+/// of the speedup in [`compute_lagrange_den_batched`].
+fn s_p_at_p_batched<F: Field>(points: &[Point<F>], log_n: usize) -> Vec<F> {
+    // The packed chain assumes the `v_n_prod` product loop runs (`log_n >= 2`);
+    // smaller domains are rare and cheap, so defer them to the scalar path.
+    if log_n < 2 {
+        return points.iter().map(|p| p.s_p_at_p(log_n)).collect();
+    }
+
+    let exp = (2 * log_n - 1) as u64;
+    let iters = log_n - 2;
+    let width = <F::Packing as PackedValue>::WIDTH;
+
+    let mut result = F::zero_vec(points.len());
+
+    let mut chunks = points.chunks_exact(width);
+    let mut offset = 0;
+    for chunk in &mut chunks {
+        // `v_n_prod` starts its product at `x`, then folds in each step of the
+        // squaring chain `x -> 2x² - 1`.
+        let mut cur = F::Packing::from_fn(|l| chunk[l].x);
+
+        let mut output = cur;
+
+        for _ in 0..iters {
+            cur = cur.square().double() - F::Packing::ONE;
+
+            output *= cur;
+        }
+
+        let ys = F::Packing::from_fn(|l| chunk[l].y);
+
+        let s_p = -(output.mul_2exp_u64(exp) * ys);
+
+        result[offset..offset + width].copy_from_slice(s_p.as_slice());
+
+        offset += width;
+    }
+
+    for (slot, &pt) in result[offset..].iter_mut().zip(chunks.remainder()) {
+        *slot = pt.s_p_at_p(log_n);
+    }
+
+    result
+}
+
 /// Compute (ṽ_P(x,y) * s_p)^{-1} for each element in the list.
 /// This takes advantage of batched inversion.
 pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
@@ -126,15 +178,15 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
     at: Point<EF>,
     log_n: usize,
 ) -> Vec<EF> {
-    // This following line costs about 2% of the runtime for example prove_poseidon2_m31_keccak.
-    // Would be nice to find further speedups.
-    // Maybe modify to use packed fields here?
+    let s_p = s_p_at_p_batched(points, log_n);
+
     let (numer, denom): (Vec<_>, Vec<_>) = points
         .iter()
-        .map(|&pt| {
+        .zip(&s_p)
+        .map(|(&pt, &s_p)| {
             let diff = at - pt;
             let numer = diff.x + F::ONE;
-            let denom = diff.y * pt.s_p_at_p(log_n);
+            let denom = diff.y * s_p;
             (numer, denom)
         })
         .unzip();
@@ -244,5 +296,22 @@ mod tests {
     fn test_s_p_at_p_underflow_log_n_0() {
         let p = Pt::generator(3);
         let _ = p.s_p_at_p(0);
+    }
+
+    #[test]
+    fn s_p_at_p_batched_matches_scalar() {
+        // Cover the scalar fallback (log_n < 2), full packed chunks, and the
+        // sub-width remainder by sweeping a range of domain sizes.
+        for log_n in 1..9 {
+            let points: Vec<Pt> = crate::CircleDomain::standard(log_n).points().collect();
+
+            let batched = s_p_at_p_batched(&points, log_n);
+
+            assert_eq!(batched.len(), points.len());
+
+            for (p, &b) in points.iter().zip(&batched) {
+                assert_eq!(p.s_p_at_p(log_n), b);
+            }
+        }
     }
 }

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -121,65 +121,59 @@ impl<F: Field> Point<F> {
     }
 }
 
-/// Batched [`Point::s_p_at_p`] over base-field points.
-///
-/// Equivalent to `points.iter().map(|p| p.s_p_at_p(log_n))`, but shares the
-/// `v_n_prod` iterated-squaring chain across SIMD lanes. That chain is pure
-/// base-field work and dominates the per-point cost, so packing it is the bulk
-/// of the speedup in [`compute_lagrange_den_batched`].
-fn s_p_at_p_batched<F: Field>(points: &[Point<F>], log_n: usize) -> Vec<F> {
-    // The packed chain assumes the `v_n_prod` product loop runs (`log_n >= 2`);
-    // smaller domains are rare and cheap, so defer them to the scalar path.
-    if log_n < 2 {
-        return points.iter().map(|p| p.s_p_at_p(log_n)).collect();
-    }
-
-    let exp = (2 * log_n - 1) as u64;
-    let iters = log_n - 2;
-    let width = <F::Packing as PackedValue>::WIDTH;
-
-    let mut result = F::zero_vec(points.len());
-
-    let mut chunks = points.chunks_exact(width);
-    let mut offset = 0;
-    for chunk in &mut chunks {
-        // `v_n_prod` starts its product at `x`, then folds in each step of the
-        // squaring chain `x -> 2x² - 1`.
-        let mut cur = F::Packing::from_fn(|l| chunk[l].x);
-
-        let mut output = cur;
-
-        for _ in 0..iters {
-            cur = cur.square().double() - F::Packing::ONE;
-
-            output *= cur;
-        }
-
-        let ys = F::Packing::from_fn(|l| chunk[l].y);
-
-        let s_p = -(output.mul_2exp_u64(exp) * ys);
-
-        result[offset..offset + width].copy_from_slice(s_p.as_slice());
-
-        offset += width;
-    }
-
-    for (slot, &pt) in result[offset..].iter_mut().zip(chunks.remainder()) {
-        *slot = pt.s_p_at_p(log_n);
-    }
-
-    result
-}
-
 /// Compute (ṽ_P(x,y) * s_p)^{-1} for each element in the list.
-/// This takes advantage of batched inversion.
+///
+/// All denominators share a single batch inversion instead of one inversion per point.
 pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
     points: &[Point<F>],
     at: Point<EF>,
     log_n: usize,
 ) -> Vec<EF> {
-    let s_p = s_p_at_p_batched(points, log_n);
+    // Selector normalization `s_p` for every point, computed packed.
+    let s_p = {
+        let mut s_p = F::zero_vec(points.len());
 
+        if log_n < 2 {
+            // The squaring chain is empty, so the packed path buys nothing.
+            for (slot, p) in s_p.iter_mut().zip(points) {
+                *slot = p.s_p_at_p(log_n);
+            }
+        } else {
+            // Power-of-two scaling and chain length, shared by every lane.
+            let exp = (2 * log_n - 1) as u64;
+            let iters = log_n - 2;
+            let width = F::Packing::WIDTH;
+
+            let mut chunks = points.chunks_exact(width);
+            let mut offset = 0;
+            for chunk in &mut chunks {
+                // Seed the running product with the x-coordinates of the lane.
+                let mut cur = F::Packing::from_fn(|l| chunk[l].x);
+                let mut output = cur;
+
+                // Fold in each squaring-chain step `x -> 2 x^2 - 1`.
+                for _ in 0..iters {
+                    cur = cur.square().double() - F::Packing::ONE;
+                    output *= cur;
+                }
+
+                // Close the formula: scale by the power of two and the y-coordinate.
+                let ys = F::Packing::from_fn(|l| chunk[l].y);
+                let packed_s_p = -(output.mul_2exp_u64(exp) * ys);
+
+                s_p[offset..offset + width].copy_from_slice(packed_s_p.as_slice());
+                offset += width;
+            }
+
+            // Trailing points below one full lane fall back to the scalar formula.
+            for (slot, &pt) in s_p[offset..].iter_mut().zip(chunks.remainder()) {
+                *slot = pt.s_p_at_p(log_n);
+            }
+        }
+        s_p
+    };
+
+    // Pair each numerator with its denominator before inverting.
     let (numer, denom): (Vec<_>, Vec<_>) = points
         .iter()
         .zip(&s_p)
@@ -191,8 +185,10 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
         })
         .unzip();
 
+    // One inversion covers the whole batch via Montgomery's trick.
     let inv_d = batch_multiplicative_inverse(&denom);
 
+    // Recombine each numerator with its inverted denominator.
     numer
         .iter()
         .zip(inv_d.iter())
@@ -260,11 +256,16 @@ impl<F: Field> Mul<usize> for Point<F> {
 
 #[cfg(test)]
 mod tests {
+    use p3_field::extension::BinomialExtensionField;
     use p3_mersenne_31::Mersenne31;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
 
     type F = Mersenne31;
+    type EF = BinomialExtensionField<F, 3>;
     type Pt = Point<F>;
 
     #[test]
@@ -298,20 +299,44 @@ mod tests {
         let _ = p.s_p_at_p(0);
     }
 
-    #[test]
-    fn s_p_at_p_batched_matches_scalar() {
-        // Cover the scalar fallback (log_n < 2), full packed chunks, and the
-        // sub-width remainder by sweeping a range of domain sizes.
-        for log_n in 1..9 {
-            let points: Vec<Pt> = crate::CircleDomain::standard(log_n).points().collect();
+    /// Independent reference: the pre-batched formulation, one inversion per point.
+    fn lagrange_den_scalar(points: &[Pt], at: Point<EF>, log_n: usize) -> Vec<EF> {
+        points
+            .iter()
+            .map(|&pt| {
+                let diff = at - pt;
+                let numer = diff.x + F::ONE;
+                let denom = diff.y * pt.s_p_at_p(log_n);
+                numer * denom.inverse()
+            })
+            .collect()
+    }
 
-            let batched = s_p_at_p_batched(&points, log_n);
+    proptest! {
+        #[test]
+        fn compute_lagrange_den_batched_matches_scalar(
+            log_n in 1usize..19,
+            len in 0usize..40,
+            at_seed in any::<u64>(),
+        ) {
+            // A small prefix of real domain points keeps every `s_p` nonzero.
+            let prefix: Vec<Pt> = crate::CircleDomain::standard(log_n).points().take(40).collect();
+            let points = &prefix[..len.min(prefix.len())];
 
-            assert_eq!(batched.len(), points.len());
+            // A pseudo-random extension point stands in for the out-of-domain query.
+            let mut rng = SmallRng::seed_from_u64(at_seed);
+            let at = Point::<EF>::from_projective_line(rng.random());
 
-            for (p, &b) in points.iter().zip(&batched) {
-                assert_eq!(p.s_p_at_p(log_n), b);
-            }
+            // Discard the measure-zero draws that would invert a zero denominator.
+            let all_invertible = points
+                .iter()
+                .all(|&pt| (at - pt).y * pt.s_p_at_p(log_n) != EF::ZERO);
+            prop_assume!(all_invertible);
+
+            prop_assert_eq!(
+                compute_lagrange_den_batched(points, at, log_n),
+                lagrange_den_scalar(points, at, log_n)
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

`compute_lagrange_den_batched` computed `s_p_at_p` once per point, and the call site carried a maintainer note flagging it as ~2% of `prove_poseidon2_m31_keccak` with the hint *"Maybe modify to use packed fields here?"*. `s_p_at_p`'s cost is dominated by `v_n_prod`'s iterated-squaring chain `x -> 2x² - 1`, which is pure base-field work, identical in shape across points.

This hoists that chain into `s_p_at_p_batched`, which runs it across `F::Packing` lanes (with a scalar tail for the sub-width remainder), then folds in `y` and the `2^(2·log_n - 1)` factor. The result is bit-identical to the per-point `s_p_at_p`. `compute_lagrange_den_batched` keeps its scalar extension-field diff / batched-inverse tail unchanged, so the public behaviour and the `EF`-side arithmetic are untouched.

## Correctness

- New unit test `s_p_at_p_batched_matches_scalar` sweeps `log_n = 1..9`, covering the scalar fallback (`log_n < 2`), full packed chunks, and the sub-width remainder, asserting equality with the scalar `s_p_at_p`.
- Existing `eval_at_point_matches_cfft`, `eval_at_point_matches_lde`, and `circle_pcs` continue to validate the full `evaluate_at_point` path against independent references (the `circle_basis` dot product and LDE consistency).

## Bench

`compute_lagrange_den_batched` median, M1 (aarch64), Mersenne31 base + degree-3 extension, inputs from `CircleDomain::standard(log_n).points()`, criterion (50 samples):

| log_n | before  | after   | speedup |
|------:|--------:|--------:|--------:|
| 16    | 4.45 ms | 2.40 ms | 1.85×   |
| 18    | 19.8 ms | 10.2 ms | 1.94×   |
| 20    | 88.8 ms | 43.3 ms | 2.05×   |

The win scales with the packing width, so it tracks `F::Packing::WIDTH` on a given target; the scalar tail keeps non-multiple-of-width inputs correct.

## Test plan

- [x] `cargo test -p p3-circle --lib` — 26 passed.
- [x] `cargo test -p p3-uni-stark --test fib_air` — circle-STARK path green.
- [x] `cargo clippy -p p3-circle --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo build --target thumbv7em-none-eabi -p p3-circle` — clean (no_std).