### PR TITLE
fix(symbolic): count circle transition selector degree

### DIFF
--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -43,8 +43,8 @@ impl<F: Field> SymLeaf for BaseLeaf<F> {
     fn degree_multiple(&self) -> usize {
         match self {
             Self::Variable(v) => v.degree_multiple(),
-            Self::IsFirstRow | Self::IsLastRow => 1,
-            Self::IsTransition | Self::Constant(_) => 0,
+            Self::IsFirstRow | Self::IsLastRow | Self::IsTransition => 1,
+            Self::Constant(_) => 0,
         }
     }
 
@@ -234,8 +234,8 @@ mod tests {
         let is_transition = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
         assert_eq!(
             is_transition.degree_multiple(),
-            0,
-            "IsTransition should have degree 0"
+            1,
+            "IsTransition should have degree 1"
         );
 
         let add_expr = SymbolicExpr::<BaseLeaf<BabyBear>>::Add {

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -179,6 +179,28 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct TransitionSelectorAir {
+        width: usize,
+        degree_hint: Option<usize>,
+    }
+
+    impl BaseAir<BabyBear> for TransitionSelectorAir {
+        fn width(&self) -> usize {
+            self.width
+        }
+
+        fn max_constraint_degree(&self) -> Option<usize> {
+            self.degree_hint
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<BabyBear>> for TransitionSelectorAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<BabyBear>) {
+            builder.assert_zero(builder.is_transition_window(2));
+        }
+    }
+
     #[test]
     fn test_max_constraint_degree_hint_is_used() {
         // Actual degree is 1 (single variable), hint says 3.
@@ -234,6 +256,17 @@ mod tests {
         let air = HintedMockAir {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
             width: 4,
+            degree_hint: Some(0),
+        };
+        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "max_constraint_degree() hint")]
+    fn test_transition_selector_hint_too_small_panics() {
+        let air = TransitionSelectorAir {
+            width: 1,
             degree_hint: Some(0),
         };
         let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);


### PR DESCRIPTION
## Summary

This fixes a mismatch between the symbolic selector-degree model and the circle STARK quotient-degree analysis.

`BaseLeaf::IsTransition` was still assigned symbolic degree 0, while `uni-stark` already treats the transition selector as contributing a `+1` term in the quotient-degree bound. That left the symbolic model inconsistent with the prover-side degree analysis.

This PR brings the symbolic model back in line with the prover/verifier reasoning.

## Evidence

- `air/src/symbolic/expression.rs:46` now counts `IsTransition` together with `IsFirstRow` and `IsLastRow` as degree `1`.
- `air/src/symbolic/expression.rs:234-238` updates the unit-test expectation to `"IsTransition should have degree 1"`.
- `uni-stark/src/prover.rs:116` already documents the extra `+1` term coming from `is_transition` in the quotient-degree bound.
- `uni-stark/src/symbolic.rs:267` adds the matching regression guard: a selector-only AIR with a zero degree hint must panic in debug builds.

So the primary validation axis here is semantic consistency plus regression coverage, not performance.

## Semantic change

- count `IsTransition` as degree `1` in the symbolic expression model
- update the matching symbolic test expectation
- add a `uni-stark` regression test for the selector-only hint-underflow case

## Testing

- `cargo fmt --all --check`
- `cargo test -p p3-air symbolic -- --nocapture`
- `cargo test -p p3-uni-stark symbolic -- --nocapture`