### PR TITLE
fix(uni-stark): tighten periodic quotient inference

### DIFF
--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -40,8 +40,13 @@ p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-symmetric = { path = "../symmetric" }
 
+criterion.workspace = true
 postcard = { workspace = true, features = ["alloc"] }
 rand.workspace = true
+
+[[bench]]
+name = "periodic_degree"
+harness = false
 
 [lints]
 workspace = true

--- a/uni-stark/benches/periodic_degree.rs
+++ b/uni-stark/benches/periodic_degree.rs
@@ -1,0 +1,176 @@
+use core::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_air::WindowAccess;
+use p3_air::symbolic::AirLayout;
+use p3_air::{Air, AirBuilder, BaseAir};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing};
+use p3_fri::{FriParameters, TwoAdicFriPcs};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_uni_stark::{StarkConfig, get_log_num_quotient_chunks, prove};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type Val = BabyBear;
+type Challenge = BinomialExtensionField<Val, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type ValMmcs =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+type Dft = Radix2DitParallel<Val>;
+type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+type MyConfig = StarkConfig<MyPcs, Challenge, Challenger>;
+
+const TRACE_LOG_DEGREES: [usize; 2] = [14, 16];
+const PERIODIC_CASES: [(&str, &[usize]); 3] = [
+    ("period2_x5", &[2, 2, 2, 2, 2]),
+    ("period4_x6", &[4, 4, 4, 4, 4, 4]),
+    ("period8_x9", &[8, 8, 8, 8, 8, 8, 8, 8, 8]),
+];
+
+#[derive(Clone, Debug)]
+struct PeriodicProductAir {
+    periods: Vec<usize>,
+}
+
+impl<F> BaseAir<F> for PeriodicProductAir
+where
+    F: PrimeCharacteristicRing,
+{
+    fn width(&self) -> usize {
+        1
+    }
+
+    fn num_periodic_columns(&self) -> usize {
+        self.periods.len()
+    }
+
+    fn periodic_columns(&self) -> Vec<Vec<F>> {
+        self.periods
+            .iter()
+            .enumerate()
+            .map(|(column_index, period)| {
+                (0..*period)
+                    .map(|row| F::from_usize(column_index + row + 1))
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for PeriodicProductAir
+where
+    AB::F: Field,
+{
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice()[0];
+        let product = builder
+            .periodic_values()
+            .iter()
+            .copied()
+            .map(Into::<AB::Expr>::into)
+            .reduce(|acc, value| acc * value)
+            .expect("benchmark AIR must define at least one periodic column");
+
+        builder.assert_zero(local - product);
+    }
+}
+
+fn air_layout(air: &PeriodicProductAir) -> AirLayout {
+    AirLayout {
+        main_width: 1,
+        num_periodic_columns: air.periods.len(),
+        ..Default::default()
+    }
+}
+
+fn make_trace(log_degree: usize) -> RowMajorMatrix<Val> {
+    let degree = 1 << log_degree;
+    RowMajorMatrix::new(
+        (0..degree)
+            .map(|i| Val::from_u64((i & 0xff) as u64))
+            .collect(),
+        1,
+    )
+}
+
+fn make_config() -> MyConfig {
+    let mut rng = SmallRng::seed_from_u64(1337);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
+    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+fn bench_infer_chunks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("periodic_degree_infer_chunks");
+
+    for log_degree in TRACE_LOG_DEGREES {
+        let trace_degree = 1 << log_degree;
+        for (label, periods) in PERIODIC_CASES {
+            let air = PeriodicProductAir {
+                periods: periods.to_vec(),
+            };
+            let layout = air_layout(&air);
+            group.bench_function(BenchmarkId::new(label, format!("2^{log_degree}")), |b| {
+                b.iter(|| {
+                    black_box(get_log_num_quotient_chunks::<Val, _>(
+                        black_box(&air),
+                        black_box(layout),
+                        black_box(trace_degree),
+                        black_box(0),
+                    ))
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_prove_periodic(c: &mut Criterion) {
+    let config = make_config();
+    let mut group = c.benchmark_group("periodic_degree_prove");
+    group.sample_size(10);
+
+    for log_degree in TRACE_LOG_DEGREES {
+        let trace = make_trace(log_degree);
+        for (label, periods) in PERIODIC_CASES {
+            let air = PeriodicProductAir {
+                periods: periods.to_vec(),
+            };
+            group.bench_function(BenchmarkId::new(label, format!("2^{log_degree}")), |b| {
+                b.iter(|| {
+                    black_box(prove(
+                        black_box(&config),
+                        black_box(&air),
+                        black_box(trace.clone()),
+                        black_box(&[]),
+                    ))
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_infer_chunks, bench_prove_periodic);
+criterion_main!(benches);

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -122,7 +122,7 @@ where
     // of quotient polynomials we will split Q(x) into. This is chosen to
     // always be a power of 2.
     let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, degree, config.is_zk());
 
     let num_quotient_chunks = 1 << (log_num_quotient_chunks + config.is_zk());
 

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -1,13 +1,24 @@
 //! STARK-specific quotient polynomial degree calculations.
 
+use alloc::vec::Vec;
+
 use p3_air::Air;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_max_constraint_degree_extension};
+use p3_air::symbolic::{
+    AirLayout, BaseEntry, BaseLeaf, ExtEntry, ExtLeaf, SymbolicAirBuilder, SymbolicExpr,
+    SymbolicExpression, SymbolicExpressionExt, get_all_symbolic_constraints,
+    get_max_constraint_degree_extension,
+};
 use p3_field::{ExtensionField, Field};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
 #[instrument(skip_all, level = "debug")]
-pub fn get_log_num_quotient_chunks<F, A>(air: &A, layout: AirLayout, is_zk: usize) -> usize
+pub fn get_log_num_quotient_chunks<F, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
@@ -18,22 +29,18 @@ where
         let constraint_degree = (degree_hint + is_zk).max(2);
         let result = log2_ceil_usize(constraint_degree - 1);
 
-        // This check remains at the `debug` level, as the AIR is known by both
-        // prover and verifier, i.e. a malicious prover cannot feed the verifier
-        // a different hint than the verifier computes for itself.
+        // Keep the hint-path assertion cheap: the trace-aware quotient inference
+        // below is only needed on the no-hint path.
         debug_assert!(
-            {
-                let symbolic = get_log_quotient_degree_extension::<F, F, A>(air, layout, is_zk);
-                result >= symbolic
-            },
-            "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
+            degree_hint >= get_max_constraint_degree_extension::<F, F, A>(air, layout),
+            "max_constraint_degree() hint {} is too small",
             degree_hint
         );
 
         return result;
     }
 
-    get_log_quotient_degree_extension(air, layout, is_zk)
+    get_log_quotient_degree_extension(air, layout, trace_degree, is_zk)
 }
 
 #[instrument(
@@ -44,6 +51,7 @@ where
 pub fn get_log_quotient_degree_extension<F, EF, A>(
     air: &A,
     layout: AirLayout,
+    trace_degree: usize,
     is_zk: usize,
 ) -> usize
 where
@@ -58,25 +66,164 @@ where
         let result = log2_ceil_usize(constraint_degree - 1);
 
         debug_assert!(
-            {
-                let actual = get_max_constraint_degree_extension::<F, EF, A>(air, layout);
-                degree_hint >= actual
-            },
-            "max_constraint_degree() hint {} is too small; symbolic evaluation found a larger degree",
+            degree_hint >= get_max_constraint_degree_extension::<F, EF, A>(air, layout),
+            "max_constraint_degree() hint {} is too small",
             degree_hint
         );
 
         return result;
     }
 
-    // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
-    let constraint_degree =
-        (get_max_constraint_degree_extension::<F, EF, A>(air, layout) + is_zk).max(2);
+    get_log_quotient_degree_extension_symbolic(air, layout, trace_degree, is_zk)
+}
 
-    // We bound the degree of the quotient polynomial by constraint_degree - 1,
-    // then choose the number of quotient chunks as the smallest power of two
-    // >= (constraint_degree - 1). This function returns log2(#chunks).
-    log2_ceil_usize(constraint_degree - 1)
+fn get_log_quotient_degree_extension_symbolic<F, EF, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
+{
+    let periodic_column_degrees = air
+        .periodic_columns()
+        .into_iter()
+        .map(|column| {
+            debug_assert!(
+                trace_degree.is_multiple_of(column.len()),
+                "periodic column period must divide the trace degree"
+            );
+            trace_degree - trace_degree / column.len()
+        })
+        .collect::<Vec<_>>();
+
+    let (base_constraints, extension_constraints) =
+        get_all_symbolic_constraints::<F, EF, _>(air, layout);
+
+    let base_degree = base_constraints
+        .iter()
+        .map(|constraint| {
+            symbolic_expression_degree(
+                constraint,
+                trace_degree,
+                is_zk,
+                periodic_column_degrees.as_slice(),
+            )
+        })
+        .max()
+        .unwrap_or(0);
+
+    let extension_degree = extension_constraints
+        .iter()
+        .map(|constraint| {
+            symbolic_expression_ext_degree(
+                constraint,
+                trace_degree,
+                is_zk,
+                periodic_column_degrees.as_slice(),
+            )
+        })
+        .max()
+        .unwrap_or(0);
+
+    let constraint_degree = base_degree.max(extension_degree);
+    log_chunks_from_constraint_degree(constraint_degree, trace_degree, is_zk)
+}
+
+fn symbolic_expression_degree<F: Field>(
+    expr: &SymbolicExpression<F>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    match expr {
+        SymbolicExpr::Leaf(leaf) => {
+            base_leaf_degree(leaf, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Add { x, y, .. } | SymbolicExpr::Sub { x, y, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees).max(
+                symbolic_expression_degree(y, trace_degree, is_zk, periodic_column_degrees),
+            )
+        }
+        SymbolicExpr::Neg { x, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Mul { x, y, .. } => {
+            symbolic_expression_degree(x, trace_degree, is_zk, periodic_column_degrees)
+                + symbolic_expression_degree(y, trace_degree, is_zk, periodic_column_degrees)
+        }
+    }
+}
+
+fn symbolic_expression_ext_degree<F: Field, EF: ExtensionField<F>>(
+    expr: &SymbolicExpressionExt<F, EF>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    match expr {
+        SymbolicExpr::Leaf(leaf) => match leaf {
+            ExtLeaf::Base(base_expr) => {
+                symbolic_expression_degree(base_expr, trace_degree, is_zk, periodic_column_degrees)
+            }
+            ExtLeaf::ExtVariable(variable) => match variable.entry {
+                ExtEntry::Permutation { .. } => (trace_degree << is_zk) - 1,
+                ExtEntry::Challenge | ExtEntry::PermutationValue => 0,
+            },
+            ExtLeaf::ExtConstant(_) => 0,
+        },
+        SymbolicExpr::Add { x, y, .. } | SymbolicExpr::Sub { x, y, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees).max(
+                symbolic_expression_ext_degree(y, trace_degree, is_zk, periodic_column_degrees),
+            )
+        }
+        SymbolicExpr::Neg { x, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees)
+        }
+        SymbolicExpr::Mul { x, y, .. } => {
+            symbolic_expression_ext_degree(x, trace_degree, is_zk, periodic_column_degrees)
+                + symbolic_expression_ext_degree(y, trace_degree, is_zk, periodic_column_degrees)
+        }
+    }
+}
+
+fn base_leaf_degree<F: Field>(
+    leaf: &BaseLeaf<F>,
+    trace_degree: usize,
+    is_zk: usize,
+    periodic_column_degrees: &[usize],
+) -> usize {
+    match leaf {
+        BaseLeaf::Variable(variable) => match variable.entry {
+            BaseEntry::Preprocessed { .. } | BaseEntry::Main { .. } => (trace_degree << is_zk) - 1,
+            BaseEntry::Periodic => periodic_column_degrees[variable.index],
+            BaseEntry::Public => 0,
+        },
+        BaseLeaf::IsFirstRow | BaseLeaf::IsLastRow => trace_degree - 1,
+        BaseLeaf::IsTransition | BaseLeaf::Constant(_) => 0,
+    }
+}
+
+fn log_chunks_from_constraint_degree(
+    constraint_degree: usize,
+    trace_degree: usize,
+    is_zk: usize,
+) -> usize {
+    if constraint_degree == 0 {
+        return 0;
+    }
+
+    let quotient_chunk_degree = trace_degree << is_zk;
+    let chunk_count = constraint_degree
+        .saturating_sub(trace_degree)
+        .saturating_add(1)
+        .div_ceil(quotient_chunk_degree)
+        .max(1);
+
+    log2_ceil_usize(chunk_count)
 }
 
 #[cfg(test)]
@@ -84,11 +231,14 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
-    use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicVariable};
+    use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression, SymbolicVariable};
     use p3_air::{AirBuilder, BaseAir, BaseEntry};
     use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
 
     use super::*;
+
+    const TRACE_DEGREE: usize = 1 << 6;
 
     #[derive(Debug)]
     struct MockAir {
@@ -115,6 +265,7 @@ mod tests {
             preprocessed_width,
             main_width: air.width(),
             num_public_values: air.num_public_values(),
+            num_periodic_columns: air.num_periodic_columns(),
             ..Default::default()
         }
     }
@@ -125,7 +276,7 @@ mod tests {
             constraints: vec![],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, 0);
     }
 
@@ -135,7 +286,7 @@ mod tests {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -149,7 +300,7 @@ mod tests {
             ],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), TRACE_DEGREE, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -188,7 +339,7 @@ mod tests {
             width: 4,
             degree_hint: Some(3),
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
         assert_eq!(log_chunks, log2_ceil_usize(2));
     }
 
@@ -201,7 +352,7 @@ mod tests {
             width: 4,
             degree_hint: None,
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
         assert_eq!(log_chunks, 0);
     }
 
@@ -213,7 +364,7 @@ mod tests {
             width: 4,
             degree_hint: Some(1),
         };
-        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
 
         let air_no_hint = HintedMockAir {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
@@ -221,7 +372,7 @@ mod tests {
             degree_hint: None,
         };
         let without_hint =
-            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), 0);
+            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), TRACE_DEGREE, 0);
 
         assert_eq!(with_hint, without_hint);
     }
@@ -236,6 +387,68 @@ mod tests {
             width: 4,
             degree_hint: Some(0),
         };
-        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+    }
+
+    #[derive(Clone, Debug)]
+    struct PeriodicProductAir {
+        periods: Vec<usize>,
+    }
+
+    impl BaseAir<BabyBear> for PeriodicProductAir {
+        fn width(&self) -> usize {
+            0
+        }
+
+        fn num_periodic_columns(&self) -> usize {
+            self.periods.len()
+        }
+
+        fn periodic_columns(&self) -> Vec<Vec<BabyBear>> {
+            self.periods
+                .iter()
+                .enumerate()
+                .map(|(column_index, period)| {
+                    (0..*period)
+                        .map(|row| BabyBear::from_usize(column_index + row + 1))
+                        .collect()
+                })
+                .collect()
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<BabyBear>> for PeriodicProductAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<BabyBear>) {
+            let product = builder
+                .periodic_values()
+                .iter()
+                .copied()
+                .map(SymbolicExpression::from)
+                .reduce(|acc, value| acc * value)
+                .expect("test AIR must define at least one periodic column");
+            builder.assert_zero(product);
+        }
+    }
+
+    #[test]
+    fn test_period_2_columns_reduce_inferred_chunk_count() {
+        let air = PeriodicProductAir {
+            periods: vec![2, 2, 2, 2, 2],
+        };
+
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+
+        assert_eq!(log_chunks, 1);
+    }
+
+    #[test]
+    fn test_period_4_columns_reduce_inferred_chunk_count() {
+        let air = PeriodicProductAir {
+            periods: vec![4, 4, 4, 4, 4, 4],
+        };
+
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+
+        assert_eq!(log_chunks, 2);
     }
 }

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -451,4 +451,15 @@ mod tests {
 
         assert_eq!(log_chunks, 2);
     }
+
+    #[test]
+    fn test_period_8_columns_stay_in_same_chunk_bucket() {
+        let air = PeriodicProductAir {
+            periods: vec![8, 8, 8, 8, 8, 8, 8, 8, 8],
+        };
+
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), TRACE_DEGREE, 0);
+
+        assert_eq!(log_chunks, 3);
+    }
 }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -291,8 +291,12 @@ where
         num_periodic_columns: air.num_periodic_columns(),
         ..Default::default()
     };
-    let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+    let log_num_quotient_chunks = get_log_num_quotient_chunks::<Val<SC>, A>(
+        air,
+        layout,
+        degree >> config.is_zk(),
+        config.is_zk(),
+    );
     let (_, num_quotient_chunks) = checked_log_size_sum(log_num_quotient_chunks, config.is_zk())
         .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
             air: None,


### PR DESCRIPTION
## Summary

This addresses the periodic-column half of #1382.

The old no-hint path in `uni-stark` treated every periodic column like a generic degree-1 symbolic leaf. That is intentionally only an approximation. For periodic-heavy AIRs, it can keep quotient-degree inference in a more conservative quotient-chunk bucket than necessary.

This PR threads the original trace degree into no-hint quotient inference and uses the trace-aware periodic-column degree `n - n/p` instead.

## Scope

- keep the existing symbolic-expression API unchanged
- keep the current `max_constraint_degree()` hint contract unchanged
- tighten only the inferred no-hint quotient-degree / quotient-chunk path in `uni-stark`

## Failure mechanism

- `air/src/symbolic/variable.rs` still gives `BaseEntry::Periodic` a fixed symbolic degree multiple of `1`
- `uni-stark` was previously using that approximation directly on the no-hint path
- for periodic-heavy AIRs, that can keep the prover/verifier on a larger quotient-chunk bucket than needed

## Semantic change

- `uni-stark/src/symbolic.rs:91-99` computes per-column periodic degrees as `trace_degree - trace_degree / period`
- `uni-stark/src/symbolic.rs:202` uses those trace-aware values for `BaseEntry::Periodic`
- `uni-stark/src/prover.rs:125` and `uni-stark/src/verifier.rs:294` now pass trace degree into `get_log_num_quotient_chunks`
- explicit `max_constraint_degree()` hints stay on the old compatibility path

## Bench

Synthetic periodic-heavy AIR, Criterion `estimates.json`, same harness on base and PR worktrees:
`cargo bench -p p3-uni-stark --bench periodic_degree`

Inference itself is slower because it now computes trace-aware periodic degrees:

| case | base infer | PR infer | Δ |
|---|---:|---:|---:|
| `period2_x5, 2^14` | `521.23 ns` | `724.04 ns` | `+38.91%` |
| `period4_x6, 2^14` | `782.85 ns` | `1045.47 ns` | `+33.55%` |
| `period8_x9, 2^14` | `792.40 ns` | `1241.71 ns` | `+56.70%` |
| `period2_x5, 2^16` | `575.36 ns` | `733.96 ns` | `+27.57%` |
| `period4_x6, 2^16` | `598.94 ns` | `865.20 ns` | `+44.46%` |
| `period8_x9, 2^16` | `979.93 ns` | `1415.86 ns` | `+44.49%` |

That is not the point of the optimization. The actual target is the downstream prover cost after quotient-chunk inference becomes tighter:

| case | base prove | PR prove | Δ |
|---|---:|---:|---:|
| `period2_x5, 2^14` | `541.06 ms` | `436.10 ms` | `-19.40%` |
| `period4_x6, 2^14` | `731.46 ms` | `528.47 ms` | `-27.75%` |
| `period8_x9, 2^14` | `736.04 ms` | `716.28 ms` | `-2.68%` |
| `period2_x5, 2^16` | `2.1666 s` | `1.7464 s` | `-19.39%` |
| `period4_x6, 2^16` | `2.9497 s` | `2.1104 s` | `-28.45%` |
| `period8_x9, 2^16` | `2.9627 s` | `2.8823 s` | `-2.71%` |

The shape split matches the chunk-bucket analysis exactly:

- `period2_x5` and `period4_x6` cross into a smaller quotient-chunk bucket, so prove time drops materially
- `period8_x9` stays in the same bucket, so only a small residual difference remains

That bucket behavior is now locked in by tests:

- `uni-stark/src/symbolic.rs:434` -> period-2 case gives `log_chunks = 1`
- `uni-stark/src/symbolic.rs:445` -> period-4 case gives `log_chunks = 2`
- `uni-stark/src/symbolic.rs:456` -> period-8 x9 case stays at `log_chunks = 3`

## Testing

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p p3-air symbolic -- --nocapture`
- `cargo test -p p3-uni-stark symbolic -- --nocapture`
- `cargo test -p p3-uni-stark --test periodic_air -- --nocapture`
- `cargo bench -p p3-uni-stark --bench periodic_degree --no-run`