### PR TITLE
perf(matrix): specialize base-field interpolate_coset

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -23,7 +23,7 @@ use num_bigint::BigUint;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
     ExtensionField, Field, PackedValue, PrimeCharacteristicRing, PrimeField32, PrimeField64,
-    TwoAdicField, batch_multiplicative_inverse,
+    TwoAdicField, batch_multiplicative_inverse, batch_multiplicative_inverse_scaled,
 };
 use p3_util::iter_array_chunks_padded;
 pub use packedfield_testing::*;
@@ -391,6 +391,64 @@ where
                 "x[{i}] * inv[{i}] != 1 for input length {n}"
             );
         }
+    }
+}
+
+/// Verify [`batch_multiplicative_inverse_scaled`] against the naive `scale / x_i`,
+/// and confirm that `scale = 1` reproduces the plain batch inverse.
+///
+/// Sizes mirror the unscaled test: empty, sub-packing-width, every remainder mod the
+/// packing width, and lengths straddling the internal `par_chunks` boundary (1024).
+pub fn test_batch_multiplicative_inverse_scaled<F: Field>()
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(0x5CA1);
+
+    let lengths = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 16, 17, 63, 64, 65, 1023, 1024, 1025, 1027, 2049, 4099,
+    ];
+
+    for &n in &lengths {
+        // Reject zero so every input is invertible.
+        let xs: Vec<F> = (0..n)
+            .map(|_| {
+                let mut x = rng.random::<F>();
+                while x.is_zero() {
+                    x = rng.random::<F>();
+                }
+                x
+            })
+            .collect();
+
+        // A nonzero scale exercises the fold; zero would collapse every output.
+        let scale = {
+            let mut s = rng.random::<F>();
+            while s.is_zero() {
+                s = rng.random::<F>();
+            }
+            s
+        };
+
+        let got = batch_multiplicative_inverse_scaled(&xs, scale);
+        assert_eq!(got.len(), n, "result length mismatch for n = {n}");
+
+        // Each output must equal scale times the true inverse of the input.
+        for (i, (x, out)) in xs.iter().zip(&got).enumerate() {
+            assert_eq!(
+                *x * *out,
+                scale,
+                "x[{i}] * out[{i}] != scale for input length {n}"
+            );
+        }
+
+        // scale = 1 must match the plain batch inverse element for element.
+        let unscaled = batch_multiplicative_inverse_scaled(&xs, F::ONE);
+        assert_eq!(
+            unscaled,
+            batch_multiplicative_inverse(&xs),
+            "scale = 1 diverged from the plain batch inverse for n = {n}"
+        );
     }
 }
 
@@ -1059,6 +1117,10 @@ macro_rules! test_field {
             #[test]
             fn test_batch_multiplicative_inverse() {
                 $crate::test_batch_multiplicative_inverse::<$field>();
+            }
+            #[test]
+            fn test_batch_multiplicative_inverse_scaled() {
+                $crate::test_batch_multiplicative_inverse_scaled::<$field>();
             }
             #[test]
             fn test_generator() {

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -47,6 +47,70 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
     x.par_chunks(CHUNK_SIZE)
         .zip(result.par_chunks_mut(CHUNK_SIZE))
         .for_each(|(x_chunk, result_chunk)| {
+            // Phase 1 — split the chunk into a 4-aligned packed prefix and a 0..=3 scalar tail.
+            //
+            //     x_chunk:  [ x_0 .. x_{m-1} | x_m .. x_{n-1} ]
+            //               └──── packed ────┘└──── tail ────┘
+            let (x_packed, x_tail) = FieldArray::<F, WIDTH>::pack_slice_with_suffix(x_chunk);
+            let (result_packed, result_tail) =
+                FieldArray::<F, WIDTH>::pack_slice_with_suffix_mut(result_chunk);
+
+            // Phase 2 — packed pass: 4 independent Montgomery chains, one per lane.
+            batch_multiplicative_inverse_general(x_packed, result_packed, |y| y.inverse());
+
+            // Phase 3 — tail pass: 0..=3 leftover scalars (empty when n % 4 == 0).
+            batch_multiplicative_inverse_general(x_tail, result_tail, |y| y.inverse());
+        });
+
+    result
+}
+
+/// Compute `scale / x_i` for every element of a slice via Montgomery's trick.
+///
+/// # Overview
+///
+/// The post-scaling is folded into the one inversion of the full product.
+/// This removes the separate `O(n)` pass that would otherwise scale each inverse.
+/// With `scale = 1` the result is a plain batch inverse.
+///
+/// # Algorithm
+///
+/// - Forward pass: build the prefix products of the inputs.
+/// - Invert the full product once, then pre-multiply that inverse by `scale`.
+/// - Reverse pass: peel `scale / x_i` off the prefix products, one element at a time.
+///
+/// The forward pass is a long dependency chain, parallelised on two axes:
+/// - 4-lane packed arrays run four independent chains side by side,
+/// - 1024-element chunks are dispatched across Rayon workers.
+///
+/// Lengths not a multiple of 4 finish with a scalar pass on the trailing `1..=3` elements.
+///
+/// # Panics
+///
+/// Panics if any input is zero.
+#[instrument(level = "debug", skip_all)]
+#[must_use]
+pub fn batch_multiplicative_inverse_scaled<F: Field>(x: &[F], scale: F) -> Vec<F> {
+    // 1024-element chunks per Rayon task.
+    //
+    // Why 1024:
+    //   - amortizes the one field inversion per chunk over many multiplies,
+    //   - leaves enough chunks for work-stealing on long slices.
+    const CHUNK_SIZE: usize = 1024;
+
+    // 4-lane packing.
+    //
+    // Why 4:
+    //   - smallest packed-field width on every backend,
+    //   - wider lanes risk register spills in the per-lane dependency chains.
+    const WIDTH: usize = 4;
+
+    // Pre-allocate the output: each Rayon task writes a disjoint sub-slice.
+    let mut result = F::zero_vec(x.len());
+
+    x.par_chunks(CHUNK_SIZE)
+        .zip(result.par_chunks_mut(CHUNK_SIZE))
+        .for_each(|(x_chunk, result_chunk)| {
             // Phase 1 — split the chunk:
             //   - packed: 4-aligned prefix viewed as 4-lane arrays,
             //   - tail:   0..=3 trailing scalars (m = n - n%4).
@@ -60,46 +124,17 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
             // Phase 2 — packed pass: 4 independent Montgomery chains, one per lane.
             //
             // Final inversion lands on a 4-lane array → one scalar inversion per chunk.
-            batch_multiplicative_inverse_general(x_packed, result_packed, |y| y.inverse());
-
-            // Phase 3 — tail pass: 0..=3 leftover scalars.
-            //
-            // Empty when n % 4 == 0; this call then returns immediately.
-            batch_multiplicative_inverse_general(x_tail, result_tail, |y| y.inverse());
-        });
-
-    result
-}
-
-/// Compute `scale / x_i` for every element of a slice via Montgomery's trick.
-///
-/// This folds one uniform post-scaling into the single inversion of the full product,
-/// avoiding a separate pass of per-element multiplications after batch inversion.
-///
-/// # Panics
-///
-/// Panics if any input is zero.
-#[instrument(level = "debug", skip_all)]
-#[must_use]
-pub fn batch_multiplicative_inverse_scaled<F: Field>(x: &[F], scale: F) -> Vec<F> {
-    const CHUNK_SIZE: usize = 1024;
-    const WIDTH: usize = 4;
-
-    let mut result = F::zero_vec(x.len());
-
-    x.par_chunks(CHUNK_SIZE)
-        .zip(result.par_chunks_mut(CHUNK_SIZE))
-        .for_each(|(x_chunk, result_chunk)| {
-            let (x_packed, x_tail) = FieldArray::<F, WIDTH>::pack_slice_with_suffix(x_chunk);
-            let (result_packed, result_tail) =
-                FieldArray::<F, WIDTH>::pack_slice_with_suffix_mut(result_chunk);
-
+            // `scale` broadcasts across all lanes via `FieldArray: From<F>` (`[scale; 4]`).
             batch_multiplicative_inverse_general_scaled(
                 x_packed,
                 result_packed,
                 scale.into(),
                 |y| y.inverse(),
             );
+
+            // Phase 3 — tail pass: 0..=3 leftover scalars.
+            //
+            // Empty when n % 4 == 0, in which case this call returns immediately.
             batch_multiplicative_inverse_general_scaled(x_tail, result_tail, scale, |y| {
                 y.inverse()
             });
@@ -141,6 +176,10 @@ where
 }
 
 /// Allocation-free Montgomery inversion that writes `scale / x_i` into `result`.
+///
+/// Single-threaded, writing into a caller-provided buffer.
+/// Suited to small fixed-size inputs such as packed-field lanes.
+/// The unscaled variant is the `scale = 1` case.
 #[inline]
 pub fn batch_multiplicative_inverse_general_scaled<F, Inv>(
     x: &[F],
@@ -163,6 +202,8 @@ pub fn batch_multiplicative_inverse_general_scaled<F, Inv>(
     }
 
     let product = result[n - 1] * x[n - 1];
+    // Fold the global scaling into this one inversion.
+    // Every value peeled off below is then `scale / x_i`, not `1 / x_i`.
     let mut inv = scale * inv(product);
 
     for i in (0..n).rev() {

--- a/field/src/batch_inverse.rs
+++ b/field/src/batch_inverse.rs
@@ -71,6 +71,43 @@ pub fn batch_multiplicative_inverse<F: Field>(x: &[F]) -> Vec<F> {
     result
 }
 
+/// Compute `scale / x_i` for every element of a slice via Montgomery's trick.
+///
+/// This folds one uniform post-scaling into the single inversion of the full product,
+/// avoiding a separate pass of per-element multiplications after batch inversion.
+///
+/// # Panics
+///
+/// Panics if any input is zero.
+#[instrument(level = "debug", skip_all)]
+#[must_use]
+pub fn batch_multiplicative_inverse_scaled<F: Field>(x: &[F], scale: F) -> Vec<F> {
+    const CHUNK_SIZE: usize = 1024;
+    const WIDTH: usize = 4;
+
+    let mut result = F::zero_vec(x.len());
+
+    x.par_chunks(CHUNK_SIZE)
+        .zip(result.par_chunks_mut(CHUNK_SIZE))
+        .for_each(|(x_chunk, result_chunk)| {
+            let (x_packed, x_tail) = FieldArray::<F, WIDTH>::pack_slice_with_suffix(x_chunk);
+            let (result_packed, result_tail) =
+                FieldArray::<F, WIDTH>::pack_slice_with_suffix_mut(result_chunk);
+
+            batch_multiplicative_inverse_general_scaled(
+                x_packed,
+                result_packed,
+                scale.into(),
+                |y| y.inverse(),
+            );
+            batch_multiplicative_inverse_general_scaled(x_tail, result_tail, scale, |y| {
+                y.inverse()
+            });
+        });
+
+    result
+}
+
 /// A simple single-threaded implementation of Montgomery's trick. Since not all `PrimeCharacteristicRing`s
 /// support inversion, this takes a custom inversion function.
 ///
@@ -96,6 +133,37 @@ where
 
     let product = result[n - 1] * x[n - 1];
     let mut inv = inv(product);
+
+    for i in (0..n).rev() {
+        result[i] *= inv;
+        inv *= x[i];
+    }
+}
+
+/// Allocation-free Montgomery inversion that writes `scale / x_i` into `result`.
+#[inline]
+pub fn batch_multiplicative_inverse_general_scaled<F, Inv>(
+    x: &[F],
+    result: &mut [F],
+    scale: F,
+    inv: Inv,
+) where
+    F: PrimeCharacteristicRing + Copy,
+    Inv: Fn(F) -> F,
+{
+    let n = x.len();
+    assert_eq!(result.len(), n);
+    if n == 0 {
+        return;
+    }
+
+    result[0] = F::ONE;
+    for i in 1..n {
+        result[i] = result[i - 1] * x[i - 1];
+    }
+
+    let product = result[n - 1] * x[n - 1];
+    let mut inv = scale * inv(product);
 
     for i in (0..n).rev() {
         result[i] *= inv;

--- a/matrix/benches/interpolation.rs
+++ b/matrix/benches/interpolation.rs
@@ -3,7 +3,9 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse};
+use p3_field::{
+    BasedVectorSpace, Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse,
+};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::interpolation::{Interpolate, compute_adjusted_weights};
 use rand::SeedableRng;
@@ -36,15 +38,29 @@ fn interpolate_coset(c: &mut Criterion) {
 
     let shift = F::GENERATOR;
 
+    // Two opening-point regimes drive two different code paths:
+    //   - a base-field point        → specialized base-only branch,
+    //   - a genuine extension point → generic extension branch.
+    // Bench both so neither path regresses unobserved.
+
+    // A scalar lifted into the extension stays in the base field.
+    let base_point = EF::from_u32(123456789);
+    // A nonzero degree-1 coordinate forces a genuine extension point.
+    let ext_point =
+        EF::from_basis_coefficients_slice(&[F::from_u32(123456789), F::ONE, F::ZERO, F::ZERO])
+            .unwrap();
+
     for &(log_rows, width) in CONFIGS {
         let rows = 1usize << log_rows;
         let mut rng = SmallRng::seed_from_u64(0);
         let m = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
-        let point = EF::from_u32(123456789);
 
         let param = format!("2^{log_rows}x{width}");
-        group.bench_with_input(BenchmarkId::new("full", &param), &(), |b, _| {
-            b.iter(|| m.interpolate_coset(shift, point));
+        group.bench_with_input(BenchmarkId::new("full_base", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset(shift, base_point));
+        });
+        group.bench_with_input(BenchmarkId::new("full_ext", &param), &(), |b, _| {
+            b.iter(|| m.interpolate_coset(shift, ext_point));
         });
     }
 

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -122,6 +122,28 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
             .iter()
             .collect();
 
+        if let Some(point_base) = <EF as ExtensionField<F>>::as_base(&point) {
+            // Base-field points can stay on the cheaper F-weight path all the way
+            // through the SIMD dot product, then lift the final column results back into EF.
+            let diffs: Vec<F> = coset.par_iter().map(|&g| point_base - g).collect();
+
+            if let Some(i) = diffs.iter().position(|d| d.is_zero()) {
+                return self.row(i).unwrap().into_iter().map(EF::from).collect();
+            }
+
+            let scaling_factor = interpolation_scaling_factor(shift, point_base, log_height);
+            let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
+            let scaled_point_inv = scaling_factor * point_base.inverse();
+            let scaled_adjusted =
+                compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
+
+            return self
+                .columnwise_dot_product(&scaled_adjusted)
+                .into_iter()
+                .map(EF::from)
+                .collect();
+        }
+
         // Compute z - x_i in parallel, then batch-invert in one shot
         // (Montgomery's trick: single field inversion + O(N) multiplications).
         let diffs: Vec<EF> = coset.par_iter().map(|&g| point - g).collect();
@@ -576,6 +598,28 @@ mod tests {
         // The precomputation variant must produce the same result.
         let result = evals_mat.interpolate_coset_with_precomputation(shift, point, &adjusted);
         assert_eq!(result, vec![F::from_u16(10203)]);
+    }
+
+    #[test]
+    fn test_interpolate_coset_genuine_extension_point() {
+        let shift = F::GENERATOR;
+        let coeffs = [F::from_u32(3), F::from_u32(2), F::from_u32(1)];
+        let evals: Vec<F> = eval_poly_on_coset(&coeffs, shift, 3);
+        let evals_mat = RowMajorMatrix::new(evals, 1);
+        let point =
+            EF4::from_basis_coefficients_slice(&[F::from_u32(100), F::ONE, F::ZERO, F::ZERO])
+                .unwrap();
+
+        let result = evals_mat.interpolate_coset(shift, point);
+        let expected = eval_poly(&coeffs, point);
+        assert_eq!(result, vec![expected]);
+
+        let coset = F::two_adic_generator(3).shifted_powers(shift).collect_n(8);
+        let diffs: Vec<EF4> = coset.iter().map(|&x| point - x).collect();
+        let diff_invs = batch_multiplicative_inverse(&diffs);
+        let adjusted = compute_adjusted_weights(point, &diff_invs);
+        let precomputed = evals_mat.interpolate_coset_with_precomputation(shift, point, &adjusted);
+        assert_eq!(result, precomputed);
     }
 
     #[test]

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -86,6 +86,28 @@ fn interpolation_scaling_factor<F: TwoAdicField, EF: ExtensionField<F>>(
     point * (z_pow_n - g_pow_n) * denom_inv
 }
 
+fn interpolate_coset_base_point<F: TwoAdicField, M: Matrix<F> + ?Sized>(
+    matrix: &M,
+    shift: F,
+    point: F,
+    log_height: usize,
+    coset: &[F],
+) -> Vec<F> {
+    let diffs: Vec<F> = coset.par_iter().map(|&g| point - g).collect();
+
+    if let Some(i) = diffs.iter().position(|d| d.is_zero()) {
+        return matrix.row(i).unwrap().into_iter().collect();
+    }
+
+    let scaling_factor = interpolation_scaling_factor(shift, point, log_height);
+    let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
+    let scaled_point_inv = scaling_factor * point.inverse();
+    let scaled_adjusted =
+        compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
+
+    matrix.columnwise_dot_product(&scaled_adjusted)
+}
+
 /// Barycentric Lagrange interpolation over two-adic cosets.
 ///
 /// Blanket-implemented for every matrix over a two-adic field.
@@ -123,22 +145,7 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
             .collect();
 
         if let Some(point_base) = <EF as ExtensionField<F>>::as_base(&point) {
-            // Base-field points can stay on the cheaper F-weight path all the way
-            // through the SIMD dot product, then lift the final column results back into EF.
-            let diffs: Vec<F> = coset.par_iter().map(|&g| point_base - g).collect();
-
-            if let Some(i) = diffs.iter().position(|d| d.is_zero()) {
-                return self.row(i).unwrap().into_iter().map(EF::from).collect();
-            }
-
-            let scaling_factor = interpolation_scaling_factor(shift, point_base, log_height);
-            let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
-            let scaled_point_inv = scaling_factor * point_base.inverse();
-            let scaled_adjusted =
-                compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
-
-            return self
-                .columnwise_dot_product(&scaled_adjusted)
+            return interpolate_coset_base_point(self, shift, point_base, log_height, &coset)
                 .into_iter()
                 .map(EF::from)
                 .collect();

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -43,7 +43,7 @@ use alloc::vec::Vec;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
     ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse,
-    scale_slice_in_place_single_core,
+    batch_multiplicative_inverse_scaled, scale_slice_in_place_single_core,
 };
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -69,6 +69,21 @@ pub fn compute_adjusted_weights<EF: Field>(point: EF, diff_invs: &[EF]) -> Vec<E
     let point_inv = point.inverse();
     // Subtract z^{-1} from each 1/(z - x_i) in parallel.
     diff_invs.par_iter().map(|&d| d - point_inv).collect()
+}
+
+fn compute_adjusted_weights_with_point_inv<EF: Field>(point_inv: EF, diff_invs: &[EF]) -> Vec<EF> {
+    diff_invs.par_iter().map(|&d| d - point_inv).collect()
+}
+
+fn interpolation_scaling_factor<F: TwoAdicField, EF: ExtensionField<F>>(
+    shift: F,
+    point: EF,
+    log_height: usize,
+) -> EF {
+    let z_pow_n = point.exp_power_of_2(log_height);
+    let g_pow_n = shift.exp_power_of_2(log_height);
+    let denom_inv = g_pow_n.mul_2exp_u64(log_height as u64).inverse();
+    point * (z_pow_n - g_pow_n) * denom_inv
 }
 
 /// Barycentric Lagrange interpolation over two-adic cosets.
@@ -117,11 +132,15 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
             return self.row(i).unwrap().into_iter().map(EF::from).collect();
         }
 
-        let diff_invs = batch_multiplicative_inverse(&diffs);
+        let scaling_factor = interpolation_scaling_factor(shift, point, log_height);
+        let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
+        let scaled_point_inv = scaling_factor * point.inverse();
 
-        // Convert to adjusted weights and delegate to the zero-allocation hot path.
-        let adjusted = compute_adjusted_weights(point, &diff_invs);
-        self.interpolate_coset_with_precomputation(shift, point, &adjusted)
+        // Fold the global post-scaling into the batch inversion, so the hot path
+        // only needs the SIMD dot product over pre-scaled adjusted weights.
+        let scaled_adjusted =
+            compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
+        self.columnwise_dot_product(&scaled_adjusted)
     }
 
     /// Fastest interpolation path — zero allocation beyond the result vector.
@@ -177,13 +196,7 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
         //   s = z * (z^N - g^N) / (N * g^N)
         //
         // z^N via extension-field repeated squaring (expensive).
-        let z_pow_n = point.exp_power_of_2(log_height);
-        // g^N via base-field repeated squaring (cheap — single-word ops).
-        let g_pow_n = shift.exp_power_of_2(log_height);
-        // Combine denominator N * g^N and invert once (only base-field inversion).
-        let denom_inv = g_pow_n.mul_2exp_u64(log_height as u64).inverse();
-        // Assemble: z * (z^N - g^N) * 1/(N * g^N).
-        let scaling_factor = point * (z_pow_n - g_pow_n) * denom_inv;
+        let scaling_factor = interpolation_scaling_factor(shift, point, log_height);
 
         // Phase 2: Weighted column sums via the SIMD-optimized dot product.
         //

--- a/matrix/src/interpolation.rs
+++ b/matrix/src/interpolation.rs
@@ -71,10 +71,6 @@ pub fn compute_adjusted_weights<EF: Field>(point: EF, diff_invs: &[EF]) -> Vec<E
     diff_invs.par_iter().map(|&d| d - point_inv).collect()
 }
 
-fn compute_adjusted_weights_with_point_inv<EF: Field>(point_inv: EF, diff_invs: &[EF]) -> Vec<EF> {
-    diff_invs.par_iter().map(|&d| d - point_inv).collect()
-}
-
 fn interpolation_scaling_factor<F: TwoAdicField, EF: ExtensionField<F>>(
     shift: F,
     point: EF,
@@ -101,9 +97,13 @@ fn interpolate_coset_base_point<F: TwoAdicField, M: Matrix<F> + ?Sized>(
 
     let scaling_factor = interpolation_scaling_factor(shift, point, log_height);
     let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
+    // Pre-scaled z^{-1}: the global factor s rides along for free in the subtraction.
     let scaled_point_inv = scaling_factor * point.inverse();
-    let scaled_adjusted =
-        compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
+    // Adjusted weights s * (1/(z - x_i) - 1/z), still entirely in the base field.
+    let scaled_adjusted: Vec<F> = scaled_diff_invs
+        .par_iter()
+        .map(|&d| d - scaled_point_inv)
+        .collect();
 
     matrix.columnwise_dot_product(&scaled_adjusted)
 }
@@ -163,12 +163,15 @@ pub trait Interpolate<F: TwoAdicField>: Matrix<F> {
 
         let scaling_factor = interpolation_scaling_factor(shift, point, log_height);
         let scaled_diff_invs = batch_multiplicative_inverse_scaled(&diffs, scaling_factor);
+        // Pre-scaled z^{-1}: the global factor s rides along for free in the subtraction.
         let scaled_point_inv = scaling_factor * point.inverse();
 
         // Fold the global post-scaling into the batch inversion, so the hot path
         // only needs the SIMD dot product over pre-scaled adjusted weights.
-        let scaled_adjusted =
-            compute_adjusted_weights_with_point_inv(scaled_point_inv, &scaled_diff_invs);
+        let scaled_adjusted: Vec<EF> = scaled_diff_invs
+            .par_iter()
+            .map(|&d| d - scaled_point_inv)
+            .collect();
         self.columnwise_dot_product(&scaled_adjusted)
     }
 
@@ -850,6 +853,111 @@ mod tests {
             let result = evals_mat.interpolate_coset(shift, point);
             let expected = eval_poly(&coeffs, point);
             prop_assert_eq!(result[0], expected);
+        }
+
+        // Invariant: interpolating f at a genuine (non-base) point recovers f(point).
+        //
+        // Coverage gap this closes:
+        //   - the base-field branch diverts every base point away from the generic path,
+        //   - so the other proptests never exercise the generic extension branch,
+        //   - a nonzero degree-1 coordinate keeps this point off the base field.
+        //
+        // It also checks the generic path agrees with the precomputation entry point.
+        #[test]
+        fn prop_roundtrip_coset_extension_point(
+            log_n in 1usize..=4,
+            width in 1usize..=4,
+            coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=64),
+            c0 in 0u32..2013265921u32,
+            c1 in 1u32..2013265921u32,
+            c2 in 0u32..2013265921u32,
+            c3 in 0u32..2013265921u32,
+        ) {
+            // N = 2^log_n coset points; shift moves the subgroup off the origin.
+            let n = 1usize << log_n;
+            let shift = F::GENERATOR;
+
+            // Degree-1 coordinate `c1 >= 1` guarantees the point is not in the base field.
+            let point = EF4::from_basis_coefficients_slice(&[
+                F::from_u32(c0), F::from_u32(c1), F::from_u32(c2), F::from_u32(c3),
+            ]).unwrap();
+            // Guard the precondition: a base point here would silently test the wrong branch.
+            prop_assert!(<EF4 as ExtensionField<F>>::as_base(&point).is_none());
+
+            // One polynomial per column, each of degree < n.
+            // Column c reads a rotated window of the shared coefficient pool.
+            let polys: Vec<Vec<F>> = (0..width)
+                .map(|c| (0..n).map(|i| F::from_u32(coeffs_raw[(c + i) % coeffs_raw.len()])).collect())
+                .collect();
+
+            // Lay out evaluations row-major.
+            //   row i = [f_0(coset_i), ..., f_{width-1}(coset_i)]
+            let subgroup_gen = F::two_adic_generator(log_n);
+            let coset: Vec<F> = subgroup_gen.shifted_powers(shift).collect_n(n);
+            let mut evals = Vec::with_capacity(n * width);
+            for &x in &coset {
+                for poly in &polys {
+                    evals.push(eval_poly(poly, x));
+                }
+            }
+            let evals_mat = RowMajorMatrix::new(evals, width);
+
+            // Interpolated column c must equal direct Horner evaluation of f_c.
+            let result = evals_mat.interpolate_coset(shift, point);
+            for (c, poly) in polys.iter().enumerate() {
+                prop_assert_eq!(result[c], eval_poly(poly, point));
+            }
+
+            // Re-derive the adjusted weights by hand and feed the precomputation path.
+            // Both paths must agree bit-for-bit.
+            let diffs: Vec<EF4> = coset.iter().map(|&x| point - x).collect();
+            let diff_invs = batch_multiplicative_inverse(&diffs);
+            let adjusted = compute_adjusted_weights(point, &diff_invs);
+            let precomputed = evals_mat.interpolate_coset_with_precomputation(shift, point, &adjusted);
+            prop_assert_eq!(result, precomputed);
+        }
+
+        // Invariant: the base-field branch recovers f(point) for every column.
+        //
+        // Why width > 1: it drives the packed column dot product this branch optimizes.
+        // The single-column proptests never exercise that packed path.
+        #[test]
+        fn prop_roundtrip_coset_base_point_multicol(
+            log_n in 1usize..=4,
+            width in 2usize..=5,
+            coeffs_raw in prop::collection::vec(0u32..2013265921, 1..=64),
+            point_raw in 1u32..2013265921u32,
+        ) {
+            // N = 2^log_n coset points; shift moves the subgroup off the origin.
+            let n = 1usize << log_n;
+            let shift = F::GENERATOR;
+
+            // A scalar lifted into the extension stays in the base field.
+            let point = EF4::from_u32(point_raw);
+            // Guard the precondition: this must reach the base-field specialization.
+            prop_assert!(<EF4 as ExtensionField<F>>::as_base(&point).is_some());
+
+            // One polynomial per column, each of degree < n (rotated coefficient window).
+            let polys: Vec<Vec<F>> = (0..width)
+                .map(|c| (0..n).map(|i| F::from_u32(coeffs_raw[(c + i) % coeffs_raw.len()])).collect())
+                .collect();
+
+            // Row-major evaluations: row i = [f_0(coset_i), ..., f_{width-1}(coset_i)].
+            let subgroup_gen = F::two_adic_generator(log_n);
+            let coset: Vec<F> = subgroup_gen.shifted_powers(shift).collect_n(n);
+            let mut evals = Vec::with_capacity(n * width);
+            for &x in &coset {
+                for poly in &polys {
+                    evals.push(eval_poly(poly, x));
+                }
+            }
+            let evals_mat = RowMajorMatrix::new(evals, width);
+
+            // Interpolated column c must equal direct Horner evaluation of f_c.
+            let result = evals_mat.interpolate_coset(shift, point);
+            for (c, poly) in polys.iter().enumerate() {
+                prop_assert_eq!(result[c], eval_poly(poly, point));
+            }
         }
 
         // Path equivalence: standard vs precomputation


### PR DESCRIPTION
This addresses #529.

Failure mechanism:
- `matrix::Interpolate::interpolate_coset` was still routing base-field opening points through the generic extension-field weight path
- that path builds `Vec<EF>` denominator inverses and feeds `columnwise_dot_product` with extension weights, so the hot loop pays `EF::ExtensionPacking` multiply costs even when the point and all adjusted weights are actually in the base field

Semantic change:
- keep `batch_multiplicative_inverse_scaled` as the shared fused scaling primitive in `p3-field`
- specialize `matrix::Interpolate::interpolate_coset` for the `point.as_base().is_some()` case
- in that branch, compute diffs, scaled inverses, adjusted weights, and the columnwise dot product entirely in `F`, then lift the final column results back into `EF`
- keep the generic extension-point path unchanged
- keep `interpolate_coset_with_precomputation` semantics unchanged for existing callers

Preserved invariants:
- on-domain points still short-circuit to the matching row in both the base-point and generic extension-point paths
- genuine extension points still use the original `EF` path
- the precomputation API still expects the same adjusted-weight semantics as before

Bench

`RUSTFLAGS=-Ctarget-cpu=native cargo bench -p p3-matrix --bench interpolation interpolate_coset --features p3-maybe-rayon/parallel,p3-util/parallel`, Windows 11 Pro for Workstations, Intel Core Ultra 7 270K Plus, criterion 20 samples, mean point estimate.

| shape | before | after | Δ |
| --- | ---: | ---: | ---: |
| `2^10 x 1` | 176.69 us | 111.22 us | -37.0% |
| `2^10 x 128` | 186.18 us | 113.32 us | -39.1% |
| `2^14 x 16` | 341.17 us | 195.18 us | -42.8% |
| `2^18 x 1` | 3.76 ms | 1.94 ms | -48.3% |
| `2^18 x 128` | 5.17 ms | 3.24 ms | -37.4% |

This benchmark uses the existing `matrix/benches/interpolation.rs` `interpolate_coset/full/*` workload, which opens at `EF::from_u32(123456789)`. That point lies in the base field, so these numbers measure the exact regime this specialization targets.

Tests:
- `cargo test -p p3-matrix interpolation -- --nocapture`
- `cargo test -p p3-fri -- --nocapture`
- `cargo fmt --all`
- `RUSTFLAGS=-Ctarget-cpu=native cargo bench -p p3-matrix --bench interpolation --no-run --features p3-maybe-rayon/parallel,p3-util/parallel`
