### PR TITLE
perf(matrix): specialize dense vertical packing

### DIFF
--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -42,5 +42,10 @@ name = "interpolation"
 path = "benches/interpolation.rs"
 harness = false
 
+[[bench]]
+name = "vertical_packing"
+path = "benches/vertical_packing.rs"
+harness = false
+
 [lints]
 workspace = true

--- a/matrix/benches/vertical_packing.rs
+++ b/matrix/benches/vertical_packing.rs
@@ -2,14 +2,14 @@ use core::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
-use p3_field::FieldArray;
+use p3_field::Field;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
 type F = BabyBear;
-type Packed = FieldArray<F, 8>;
+type Packed = <F as Field>::Packing;
 
 const CONFIGS: &[(usize, usize)] = &[(10, 32), (14, 32), (18, 32), (14, 256)];
 
@@ -55,7 +55,7 @@ fn vertically_packed_row_pair_scalar(c: &mut Criterion) {
 }
 
 fn vertically_packed_row_packed(c: &mut Criterion) {
-    let mut group = c.benchmark_group("vertically_packed_row_packed8");
+    let mut group = c.benchmark_group("vertically_packed_row_packed");
     group.sample_size(20);
 
     for &(log_rows, width) in CONFIGS {
@@ -78,7 +78,7 @@ fn vertically_packed_row_packed(c: &mut Criterion) {
 }
 
 fn vertically_packed_row_pair_packed(c: &mut Criterion) {
-    let mut group = c.benchmark_group("vertically_packed_row_pair_packed8");
+    let mut group = c.benchmark_group("vertically_packed_row_pair_packed");
     group.sample_size(20);
 
     for &(log_rows, width) in CONFIGS {

--- a/matrix/benches/vertical_packing.rs
+++ b/matrix/benches/vertical_packing.rs
@@ -1,0 +1,105 @@
+use core::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::FieldArray;
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type Packed = FieldArray<F, 8>;
+
+const CONFIGS: &[(usize, usize)] = &[(10, 32), (14, 32), (18, 32), (14, 256)];
+
+fn vertically_packed_row_scalar(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vertically_packed_row_scalar");
+    group.sample_size(20);
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let matrix = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let start_row = rows / 2;
+        let param = format!("2^{log_rows}x{width}");
+
+        group.bench_with_input(BenchmarkId::new("row", &param), &(), |b, _| {
+            b.iter(|| {
+                black_box(
+                    matrix
+                        .vertically_packed_row::<F>(start_row)
+                        .collect::<Vec<_>>(),
+                )
+            });
+        });
+    }
+}
+
+fn vertically_packed_row_pair_scalar(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vertically_packed_row_pair_scalar");
+    group.sample_size(20);
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(1);
+        let matrix = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let start_row = rows / 2;
+        let step = 8;
+        let param = format!("2^{log_rows}x{width}");
+
+        group.bench_with_input(BenchmarkId::new("row_pair", &param), &(), |b, _| {
+            b.iter(|| black_box(matrix.vertically_packed_row_pair::<F>(start_row, step)));
+        });
+    }
+}
+
+fn vertically_packed_row_packed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vertically_packed_row_packed8");
+    group.sample_size(20);
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(2);
+        let matrix = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let start_row = rows / 2;
+        let param = format!("2^{log_rows}x{width}");
+
+        group.bench_with_input(BenchmarkId::new("row", &param), &(), |b, _| {
+            b.iter(|| {
+                black_box(
+                    matrix
+                        .vertically_packed_row::<Packed>(start_row)
+                        .collect::<Vec<_>>(),
+                )
+            });
+        });
+    }
+}
+
+fn vertically_packed_row_pair_packed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vertically_packed_row_pair_packed8");
+    group.sample_size(20);
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(3);
+        let matrix = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width);
+        let start_row = rows / 2;
+        let step = 8;
+        let param = format!("2^{log_rows}x{width}");
+
+        group.bench_with_input(BenchmarkId::new("row_pair", &param), &(), |b, _| {
+            b.iter(|| black_box(matrix.vertically_packed_row_pair::<Packed>(start_row, step)));
+        });
+    }
+}
+
+criterion_group!(
+    benches,
+    vertically_packed_row_scalar,
+    vertically_packed_row_pair_scalar,
+    vertically_packed_row_packed,
+    vertically_packed_row_pair_packed,
+);
+criterion_main!(benches);

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -530,12 +530,14 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
         let width = self.width;
         let height = self.height();
         let row = r % height;
+        let rows = (P::WIDTH != 1).then(|| self.wrapping_row_slices(r, P::WIDTH));
 
         (0..width).map(move |c| {
             if P::WIDTH == 1 {
                 unsafe { P::broadcast(*values.get_unchecked(row * width + c)) }
             } else {
-                P::from_fn(|i| unsafe { *values.get_unchecked(((row + i) % height) * width + c) })
+                let rows = rows.as_ref().unwrap();
+                P::from_fn(|i| rows[i][c])
             }
         })
     }
@@ -546,15 +548,14 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
         T: Copy,
         P: PackedValue<Value = T>,
     {
-        let values = self.values.borrow();
-        let width = self.width;
-        let height = self.height();
-        let row = r % height;
-        let next_row = (r + step) % height;
-
-        let mut out = Vec::with_capacity(width * 2);
-
         if P::WIDTH == 1 {
+            let values = self.values.borrow();
+            let width = self.width;
+            let height = self.height();
+            let row = r % height;
+            let next_row = (r + step) % height;
+            let mut out = Vec::with_capacity(width * 2);
+
             out.extend(
                 (0..width).map(|c| unsafe { P::broadcast(*values.get_unchecked(row * width + c)) }),
             );
@@ -562,18 +563,16 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
                 (0..width)
                     .map(|c| unsafe { P::broadcast(*values.get_unchecked(next_row * width + c)) }),
             );
+            out
         } else {
-            out.extend((0..width).map(|c| {
-                P::from_fn(|i| unsafe { *values.get_unchecked(((row + i) % height) * width + c) })
-            }));
-            out.extend((0..width).map(|c| {
-                P::from_fn(|i| unsafe {
-                    *values.get_unchecked(((next_row + i) % height) * width + c)
-                })
-            }));
-        }
+            let rows = self.wrapping_row_slices(r, P::WIDTH);
+            let next_rows = self.wrapping_row_slices(r + step, P::WIDTH);
 
-        out
+            (0..self.width())
+                .map(|c| P::from_fn(|i| rows[i][c]))
+                .chain((0..self.width()).map(|c| P::from_fn(|i| next_rows[i][c])))
+                .collect::<Vec<_>>()
+        }
     }
 }
 

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -519,6 +519,62 @@ impl<T: Clone + Send + Sync, S: DenseStorage<T>> Matrix<T> for DenseMatrix<T, S>
             (!sfx.is_empty()).then(|| P::from_fn(|i| sfx.get(i).cloned().unwrap_or_default())),
         )
     }
+
+    #[inline]
+    fn vertically_packed_row<P>(&self, r: usize) -> impl Iterator<Item = P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        let values = self.values.borrow();
+        let width = self.width;
+        let height = self.height();
+        let row = r % height;
+
+        (0..width).map(move |c| {
+            if P::WIDTH == 1 {
+                unsafe { P::broadcast(*values.get_unchecked(row * width + c)) }
+            } else {
+                P::from_fn(|i| unsafe { *values.get_unchecked(((row + i) % height) * width + c) })
+            }
+        })
+    }
+
+    #[inline]
+    fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        let values = self.values.borrow();
+        let width = self.width;
+        let height = self.height();
+        let row = r % height;
+        let next_row = (r + step) % height;
+
+        let mut out = Vec::with_capacity(width * 2);
+
+        if P::WIDTH == 1 {
+            out.extend(
+                (0..width).map(|c| unsafe { P::broadcast(*values.get_unchecked(row * width + c)) }),
+            );
+            out.extend(
+                (0..width)
+                    .map(|c| unsafe { P::broadcast(*values.get_unchecked(next_row * width + c)) }),
+            );
+        } else {
+            out.extend((0..width).map(|c| {
+                P::from_fn(|i| unsafe { *values.get_unchecked(((row + i) % height) * width + c) })
+            }));
+            out.extend((0..width).map(|c| {
+                P::from_fn(|i| unsafe {
+                    *values.get_unchecked(((next_row + i) % height) * width + c)
+                })
+            }));
+        }
+
+        out
+    }
 }
 
 impl<T: Clone + Default + Send + Sync> DenseMatrix<T> {
@@ -1711,6 +1767,26 @@ mod tests {
     }
 
     #[test]
+    fn test_vertically_packed_row_scalar_width_1() {
+        type Packed = BabyBear;
+
+        let matrix = RowMajorMatrix::new((1..17).map(BabyBear::new).collect::<Vec<_>>(), 4);
+        let packed = matrix
+            .vertically_packed_row::<Packed>(2)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            packed,
+            vec![
+                BabyBear::new(9),
+                BabyBear::new(10),
+                BabyBear::new(11),
+                BabyBear::new(12),
+            ]
+        );
+    }
+
+    #[test]
     fn test_vertically_packed_row_pair() {
         type Packed = FieldArray<BabyBear, 2>;
 
@@ -1740,6 +1816,28 @@ mod tests {
                 .chain(9..13)
                 .map(|i| [BabyBear::new(i), BabyBear::new(i + 4)].into())
                 .collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_vertically_packed_row_pair_scalar_width_1() {
+        type Packed = BabyBear;
+
+        let matrix = RowMajorMatrix::new((1..17).map(BabyBear::new).collect::<Vec<_>>(), 4);
+        let packed = matrix.vertically_packed_row_pair::<Packed>(1, 2);
+
+        assert_eq!(
+            packed,
+            vec![
+                BabyBear::new(5),
+                BabyBear::new(6),
+                BabyBear::new(7),
+                BabyBear::new(8),
+                BabyBear::new(13),
+                BabyBear::new(14),
+                BabyBear::new(15),
+                BabyBear::new(16),
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

This addresses #1440.

The real bottleneck here is the scalar no-packing case (`P::WIDTH == 1`).

The original generic `Matrix` path routes `vertically_packed_row` and `vertically_packed_row_pair` through `wrapping_row_slices()`. That is fine for arbitrary matrices, but for `DenseMatrix` it pays extra row-slice materialization even when the data is already contiguous and the scalar case only needs direct loads.

This PR specializes the dense implementation, but now does so more narrowly:

- keep a direct contiguous fast path only for `P::WIDTH == 1`
- keep the packed `P::WIDTH > 1` path on the old `wrapping_row_slices()` semantics

That shape matters because the first version of this PR improved the scalar path but also changed the packed path enough to cause a large regression in `vertically_packed_row_pair::<Packed>`. The final version keeps the intended scalar win while removing that packed regression risk.

The behavioral contract is unchanged:

- scalar vertical packing still returns the same values as before
- packed-width vertical packing still follows the same wraparound row semantics as before

## Benchmark

Command:

`RUSTFLAGS=-Ctarget-cpu=native cargo bench -p p3-matrix --bench vertical_packing --features p3-maybe-rayon/parallel,p3-util/parallel`

Machine:

- CPU: Intel Core Ultra 7 270K Plus
- OS: Microsoft Windows
- logical processors: 24
- Criterion sample size: 20
- numbers below are `mean.point_estimate` from `target/criterion/.../new/estimates.json`

### Scalar path (`P = F`)

| benchmark | shape | before | after | delta |
|---|---:|---:|---:|---:|
| `vertically_packed_row` | `2^10 x 32` | 66.215 ns | 36.049 ns | `-45.56%` |
| `vertically_packed_row` | `2^14 x 32` | 67.908 ns | 37.176 ns | `-45.26%` |
| `vertically_packed_row` | `2^18 x 32` | 68.096 ns | 37.132 ns | `-45.47%` |
| `vertically_packed_row` | `2^14 x 256` | 141.772 ns | 44.275 ns | `-68.77%` |
| `vertically_packed_row_pair` | `2^10 x 32` | 116.088 ns | 35.627 ns | `-69.31%` |
| `vertically_packed_row_pair` | `2^14 x 32` | 116.265 ns | 35.642 ns | `-69.34%` |
| `vertically_packed_row_pair` | `2^18 x 32` | 116.912 ns | 35.611 ns | `-69.54%` |
| `vertically_packed_row_pair` | `2^14 x 256` | 304.912 ns | 50.118 ns | `-83.56%` |

### Packed path (`P = <F as Field>::Packing`)

| benchmark | shape | before | after | delta |
|---|---:|---:|---:|---:|
| `vertically_packed_row` | `2^10 x 32` | 142.793 ns | 143.555 ns | `+0.53%` |
| `vertically_packed_row` | `2^14 x 32` | 143.355 ns | 143.137 ns | `-0.15%` |
| `vertically_packed_row` | `2^18 x 32` | 145.049 ns | 143.974 ns | `-0.74%` |
| `vertically_packed_row` | `2^14 x 256` | 608.783 ns | 615.302 ns | `+1.07%` |
| `vertically_packed_row_pair` | `2^10 x 32` | 284.795 ns | 287.877 ns | `+1.08%` |
| `vertically_packed_row_pair` | `2^14 x 32` | 286.744 ns | 287.104 ns | `+0.13%` |
| `vertically_packed_row_pair` | `2^18 x 32` | 287.523 ns | 291.381 ns | `+1.34%` |
| `vertically_packed_row_pair` | `2^14 x 256` | 1477.228 ns | 1474.436 ns | `-0.19%` |

Interpretation:

- the scalar no-packing target is a clear win across every tested shape
- the packed path is now effectively flat, which is the right outcome for this PR
- the earlier packed `row_pair` regression is gone once the specialization is narrowed back to `P::WIDTH == 1`

So the evidence supports the narrower optimization, not the broader one.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo bench -p p3-matrix --bench vertical_packing --no-run --features p3-maybe-rayon/parallel,p3-util/parallel`
- [x] `cargo test -p p3-matrix dense -- --nocapture`
- [x] `cargo test -p p3-merkle-tree -- --nocapture`
- [x] `cargo test -p p3-uni-stark -- --nocapture`
- [x] `cargo test -p p3-batch-stark -- --nocapture`
