### PR TITLE
perf(dft): skip trivial coset scaling in RecursiveDft

### DIFF
--- a/dft/tests/testing.rs
+++ b/dft/tests/testing.rs
@@ -12,6 +12,7 @@ use p3_dft::{
 use p3_field::{Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use p3_monty_31::dft::RecursiveDft;
 use proptest::prelude::*;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -616,6 +617,20 @@ fn coset_lde_with_shift_one_equals_lde() {
         let lde = dft.lde_batch(mat.clone(), 2);
         // Coset LDE with trivial shift.
         let coset_lde = dft.coset_lde_batch(mat, 2, F::ONE);
+
+        assert_eq!(lde, coset_lde, "log_h={log_h}");
+    }
+}
+
+#[test]
+fn recursive_coset_lde_with_shift_one_equals_lde() {
+    let dft = RecursiveDft::<F>::default();
+    for log_h in 1..=6 {
+        let h = 1 << log_h;
+        let mat = rand_matrix(456, h, 4);
+
+        let lde = dft.lde_batch(mat.clone(), 2).to_row_major_matrix();
+        let coset_lde = dft.coset_lde_batch(mat, 2, F::ONE).to_row_major_matrix();
 
         assert_eq!(lde, coset_lde, "log_h={log_h}");
     }

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -40,6 +40,18 @@ fn coset_shift_and_scale_rows<F: Field>(
         });
 }
 
+/// Scale each row of `mat` by `scale`, leaving the zero-padded tail untouched.
+#[instrument(level = "debug", skip_all)]
+fn scale_rows<F: Field>(out: &mut [F], out_ncols: usize, mat: &[F], ncols: usize, scale: F) {
+    out.par_chunks_exact_mut(out_ncols)
+        .zip(mat.par_chunks_exact(ncols))
+        .for_each(|(out_row, in_row)| {
+            izip!(out_row.iter_mut(), in_row).for_each(|(out, &coeff)| {
+                *out = coeff * scale;
+            });
+        });
+}
+
 /// Paired twiddle and inverse-twiddle tables, always updated atomically
 /// under a single lock to prevent concurrent observers from seeing a
 /// half-updated state.
@@ -318,7 +330,11 @@ impl<MP: MontyParameters + FieldParameters + TwoAdicData> TwoAdicSubgroupDft<Mon
         // Normalise inverse DFT and coset shift in one go.
         let log_rows = log2_ceil_usize(nrows);
         let inv_len = MontyField31::ONE.div_2exp_u64(log_rows as u64);
-        coset_shift_and_scale_rows(&mut padded, result_nrows, coeffs, nrows, shift, inv_len);
+        if shift == MontyField31::ONE {
+            scale_rows(&mut padded, result_nrows, coeffs, nrows, inv_len);
+        } else {
+            coset_shift_and_scale_rows(&mut padded, result_nrows, coeffs, nrows, shift, inv_len);
+        }
 
         // `padded` is implicitly zero padded since it was initialised
         // to zeros when declared above.


### PR DESCRIPTION
This partially addresses #445.

Scope note:
- the original issue listed three possible improvements around `RecursiveDft` coset LDEs
- current `main` already covers two of them in substance:
  - `MontyField31::div_2exp_u64` already special-cases the Monty `2^{-n}` path
  - `RecursiveDft::coset_lde_batch` already fuses inverse-DFT scaling with the nontrivial coset shift
- this PR targets the remaining low-risk residual win on today's code: the trivial-shift path

Failure mechanism:
- `dft::TwoAdicSubgroupDft::lde_batch()` defaults to `coset_lde_batch(..., F::ONE)`
- `RecursiveDft::coset_lde_batch` still built `shifted_powers` and multiplied every coefficient by a trivial `1^i` weight on that path
- for plain LDEs this adds avoidable work in the hot row-scaling loop

Semantic change:
- add a scale-only helper for the zero-padded coefficient buffer
- in `RecursiveDft::coset_lde_batch`, use that helper when `shift == ONE`
- keep the existing fused shift-and-scale path unchanged for nontrivial shifts
- add a dedicated regression test showing `RecursiveDft::coset_lde_batch(..., ONE)` still matches `lde_batch(...)`

Why this shape:
- preserves the existing API and nontrivial-shift behavior
- targets the exact plain-LDE path exercised by the default trait implementation
- keeps the change local to `RecursiveDft` instead of broadening it into a generic DFT refactor

Files changed:
- `monty-31/src/dft/mod.rs`
- `dft/tests/testing.rs`

Tests:
- `cargo test -p p3-dft recursive_coset_lde_with_shift_one_equals_lde -- --nocapture`
- `cargo test -p p3-dft coset_lde_with_shift_one_equals_lde -- --nocapture`
- `cargo test -p p3-monty-31 -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`