### PR TITLE
perf(matrix): avoid prefill in transpose

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -3,7 +3,10 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::mem::MaybeUninit;
 use core::ops::Deref;
+use core::slice;
 
 use p3_field::{
     ExtensionField, Field, PackedValue, par_scale_slice_in_place, scale_slice_in_place_single_core,
@@ -804,18 +807,26 @@ impl<T: Clone + Default + Send + Sync> DenseMatrix<T> {
     }
 }
 
-impl<T: Copy + Default + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
+impl<T: Copy + Send + Sync, V: DenseStorage<T>> DenseMatrix<T, V> {
     /// Return the transpose of this matrix.
     pub fn transpose(&self) -> RowMajorMatrix<T> {
         let nelts = self.height() * self.width();
-        let mut values = vec![T::default(); nelts];
-        p3_util::transpose::transpose(
-            self.values.borrow(),
-            &mut values,
-            self.width(),
-            self.height(),
-        );
-        RowMajorMatrix::new(values, self.height())
+        let mut values = Vec::<MaybeUninit<T>>::with_capacity(nelts);
+        unsafe {
+            values.set_len(nelts);
+            let output = slice::from_raw_parts_mut(values.as_mut_ptr().cast::<T>(), nelts);
+            p3_util::transpose::transpose(
+                self.values.borrow(),
+                output,
+                self.width(),
+                self.height(),
+            );
+            let mut values = ManuallyDrop::new(values);
+            RowMajorMatrix::new(
+                Vec::from_raw_parts(values.as_mut_ptr().cast::<T>(), nelts, values.capacity()),
+                self.height(),
+            )
+        }
     }
 
     /// Transpose the matrix returning the result in `other` without intermediate allocation.


### PR DESCRIPTION
This partially addresses #50.

Scope note:
- `#50` originally asked for cache-friendly transpose work as a building block for batch-FFT experimentation
- current `main` already has substantial transpose infrastructure:
  - `p3_util::transpose::transpose`
  - `RowMajorMatrix::transpose_into`
  - dedicated transpose benchmarks
- this PR therefore takes a narrow residual hot-path win in the current transpose entry point instead of redoing the broader algorithmic work

Failure mechanism:
- `DenseMatrix::transpose()` allocated its output with `vec![T::default(); nelts]`
- `p3_util::transpose::transpose(...)` then overwrote every output element immediately
- that default-fill pass was pure extra work on the allocation-heavy path that returns a fresh transposed matrix

Semantic change:
- allocate the output buffer for `DenseMatrix::transpose()` without pre-filling it
- let `p3_util::transpose::transpose(...)` fully initialize the buffer
- narrow the impl bound from `T: Copy + Default` to `T: Copy`, which matches what this method actually needs
- keep `transpose_into()` and the underlying transpose implementation unchanged

Why this shape:
- preserves the existing API and transpose semantics
- targets a real residual cost in the current hot path
- keeps reviewer scope to one file and one behavior-preserving optimization

Files changed:
- `matrix/src/dense.rs`

Tests:
- `cargo test -p p3-matrix transpose -- --nocapture`
- `cargo test -p p3-matrix -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`