### PR TITLE
perf(monty-31): skip trivial coset shift in RecursiveDft

### DIFF
--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -30,6 +30,10 @@ fn coset_shift_and_scale_rows<F: Field>(
     shift: F,
     scale: F,
 ) {
+    debug_assert!(out.len().is_multiple_of(out_ncols));
+    debug_assert!(mat.len().is_multiple_of(ncols));
+    debug_assert!(out_ncols >= ncols);
+    debug_assert_eq!(out.len() / out_ncols, mat.len() / ncols);
     let powers = shift.shifted_powers(scale).collect_n(ncols);
     out.par_chunks_exact_mut(out_ncols)
         .zip(mat.par_chunks_exact(ncols))


### PR DESCRIPTION
Partially addresses #445

Follow-up to #1713

When shift==ONE, coset_lde_batch was computing shift^i=1 for every coefficient needlessly. Add a scale_rows helper that skips the power computation for the trivial-shift path, and harden both helpers with debug_assert invariants covering length divisibility, out_ncols>=ncols, and matching row counts, without these guards, par_chunks_exact and izip silently truncate on invariant violations which is unacceptable in ZK infrastructure