### PR TITLE
feat(sumcheck): add HVZK suffix layout overlay

### DIFF
--- a/multilinear-util/src/split_eq/mod.rs
+++ b/multilinear-util/src/split_eq/mod.rs
@@ -53,16 +53,37 @@ pub struct SplitEq<F: Field, EF: ExtensionField<F>> {
 }
 
 impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
+    /// Creates a factored eq table with a scalar (unpacked) suffix-half using an explicit split.
+    ///
+    /// The point is split as `(point[..split], point[split..])`.
+    /// The scale factor is absorbed into the prefix-half table.
+    pub fn new_unpacked_at(point: &Point<EF>, split: usize, scale: EF) -> Self {
+        assert!(split <= point.num_variables());
+        let (z0, z1) = point.split_at(split);
+        let eq0 = Poly::new_from_point(z0.as_slice(), scale);
+        let eq1 = EqMaybePacked::new_unpacked(&z1);
+        Self { eq0, eq1 }
+    }
+
     /// Creates a factored eq table with a scalar (unpacked) suffix-half.
     ///
     /// The evaluation point is split at the midpoint.
     /// The scale factor is absorbed into the prefix-half table.
     pub fn new_unpacked(point: &Point<EF>, scale: EF) -> Self {
-        // Split z into (z_prefix, z_suffix) at the midpoint.
-        let (z0, z1) = point.split_at(point.num_variables() / 2);
-        // Build eq0 = scale * eq(z_prefix, .) and eq1 = eq(z_suffix, .).
+        Self::new_unpacked_at(point, point.num_variables() / 2, scale)
+    }
+
+    /// Creates a factored eq table, using SIMD packing for the suffix-half when possible,
+    /// with an explicit split.
+    ///
+    /// Falls back to scalar if the suffix-half has fewer variables than log_2(W).
+    /// The point is split as `(point[..split], point[split..])`.
+    /// The scale factor is absorbed into the prefix-half table.
+    pub fn new_packed_at(point: &Point<EF>, split: usize, scale: EF) -> Self {
+        assert!(split <= point.num_variables());
+        let (z0, z1) = point.split_at(split);
         let eq0 = Poly::new_from_point(z0.as_slice(), scale);
-        let eq1 = EqMaybePacked::new_unpacked(&z1);
+        let eq1 = EqMaybePacked::new_packed(&z1);
         Self { eq0, eq1 }
     }
 
@@ -71,12 +92,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// Falls back to scalar if the suffix-half has fewer variables than log_2(W).
     /// The scale factor is absorbed into the prefix-half table.
     pub fn new_packed(point: &Point<EF>, scale: EF) -> Self {
-        // Split z into (z_prefix, z_suffix) at the midpoint.
-        let (z0, z1) = point.split_at(point.num_variables() / 2);
-        // Build eq0 with scale, and attempt SIMD packing for eq1.
-        let eq0 = Poly::new_from_point(z0.as_slice(), scale);
-        let eq1 = EqMaybePacked::new_packed(&z1);
-        Self { eq0, eq1 }
+        Self::new_packed_at(point, point.num_variables() / 2, scale)
     }
 
     /// Total number of variables: k = k_prefix + k_suffix.
@@ -668,6 +684,21 @@ mod tests {
             // Compress suffix variables, then evaluate in the other direction.
             let compressed = split_hi.compress_suffix(&poly);
             prop_assert_eq!(expected, split_lo.eval_ext(&compressed));
+        }
+
+        #[test]
+        fn prop_explicit_split_matches_default_suffix_compress(
+            k in 0usize..=14,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let poly = Poly::<F>::rand(&mut rng, k);
+            let point = Point::<EF>::rand(&mut rng, k);
+
+            let default = SplitEq::<F, EF>::new_packed(&point, EF::ONE).compress_suffix(&poly);
+            let all_suffix = SplitEq::<F, EF>::new_packed_at(&point, 0, EF::ONE).compress_suffix(&poly);
+
+            prop_assert_eq!(default, all_suffix);
         }
     }
 

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -260,7 +260,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
         #[cfg(debug_assertions)]
         {
             // Materialise the stacked polynomial with no challenges applied.
-            let poly = &self.compress_stacked(&Point::default());
+            let poly = &self.compress_stacked(&Point::default(), EF::ONE);
             // Check 1: weighted sum equals the direct evaluation.
             assert_eq!(eval, poly.eval_base(&point));
 
@@ -414,7 +414,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
         // Reverse the challenges before handing them to the compressors.
         let reversed = rs.reversed();
         // Factor 1 of the product: the compressed stacked poly at rs.
-        let compressed = self.compress_stacked(&reversed);
+        let compressed = self.compress_stacked(&reversed, EF::ONE);
         // Factor 2 of the product: the batched equality-weight poly.
         let weights = self.combine_eqs(&reversed, alpha);
         // Pair them; the product polynomial drives the remaining rounds.
@@ -465,7 +465,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
     ///
     /// The verifier walks its claim registry with the same three-loop order,
     /// so both sides assign the same `alpha^i` to the same claim point.
-    fn sum(&self, alpha: EF) -> EF {
+    pub(crate) fn sum(&self, alpha: EF) -> EF {
         let mut sum = EF::ZERO;
         let mut alphas = alpha.powers();
 
@@ -498,11 +498,11 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
     /// - One output slot per column; writes never overlap.
     /// - Output arity is the stacked arity minus the number of challenges.
     #[tracing::instrument(skip_all)]
-    fn compress_stacked(&self, rs: &Point<EF>) -> Poly<EF> {
+    pub(crate) fn compress_stacked(&self, rs: &Point<EF>, scale: EF) -> Poly<EF> {
         assert!(rs.num_variables() <= self.num_variables);
         // Output: residual stacked space of size 2^(num_variables - |rs|).
         let mut out = Poly::<EF>::zero(self.num_variables - rs.num_variables());
-        let rs = SplitEq::new_unpacked(rs, EF::ONE);
+        let rs = SplitEq::new_unpacked(rs, scale);
 
         for placement in &self.placements {
             for (poly_idx, selector) in placement.selectors().iter().enumerate() {
@@ -529,7 +529,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
     ///   `alpha^i * eq(svo_part, rs)`, written into the owning slot only.
     /// - Virtual claim: scaled equality table written across the full output.
     #[tracing::instrument(skip_all)]
-    fn combine_eqs(&self, rs: &Point<EF>, alpha: EF) -> Poly<EF> {
+    pub(crate) fn combine_eqs(&self, rs: &Point<EF>, alpha: EF) -> Poly<EF> {
         // Preconditions: challenge count matches the folding depth.
         assert_eq!(rs.num_variables(), self.folding);
         // Output arity: stacked arity minus the folded challenges.

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -502,7 +502,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
         assert!(rs.num_variables() <= self.num_variables);
         // Output: residual stacked space of size 2^(num_variables - |rs|).
         let mut out = Poly::<EF>::zero(self.num_variables - rs.num_variables());
-        let rs = SplitEq::new_unpacked(rs, scale);
+        // Keep all residual challenges in the suffix half so the compression kernel
+        // can use the packed suffix dot path whenever the field backend supports it.
+        let rs = SplitEq::new_packed_at(rs, 0, scale);
 
         for placement in &self.placements {
             for (poly_idx, selector) in placement.selectors().iter().enumerate() {

--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -1,6 +1,6 @@
 //! Honest-verifier zero-knowledge sumcheck for WHIR.
 //!
-//! Implements Construction 6.3 of eprint 2026/391 on top of the prefix-binding sumcheck layout.
+//! Implements Construction 6.3 of eprint 2026/391 on top of the plain sumcheck layouts.
 //!
 //! # Overview
 //!
@@ -51,9 +51,7 @@
 //!
 //! # Layout coverage
 //!
-//! Only the prefix-binding layout is supported.
-//! Routing the PCS through the suffix-binding layout produces a non-private proof.
-//! Tracked in [Plonky3#1649](https://github.com/Plonky3/Plonky3/issues/1649).
+//! Both the prefix-binding and suffix-binding layouts are supported.
 //!
 //! # Field constraints (Lemma 6.4)
 //!
@@ -75,6 +73,6 @@ pub mod verifier;
 pub(crate) mod test_helpers;
 
 pub use data::{MaskOracle, ZkSumcheckData};
-pub use prover::ZkPrefixProver;
+pub use prover::{ZkPrefixProver, ZkSuffixProver};
 pub use simulator::simulate_classic_unpacked;
 pub use verifier::ZkVerifier;

--- a/sumcheck/src/zk/prover.rs
+++ b/sumcheck/src/zk/prover.rs
@@ -1,4 +1,4 @@
-//! HVZK prover overlay on top of the prefix-binding sumcheck.
+//! HVZK prover overlays on top of the plain sumcheck layouts.
 
 use alloc::vec::Vec;
 
@@ -14,7 +14,7 @@ use rand::{Rng, RngExt};
 use super::data::{MaskOracle, ZkSumcheckData};
 use crate::extrapolate_01inf;
 use crate::lagrange::lagrange_weights_01inf_multi;
-use crate::layout::{Layout, PrefixProver};
+use crate::layout::{Layout, PrefixProver, SuffixProver};
 use crate::product_polynomial::ProductPolynomial;
 use crate::strategy::{SumcheckProver, VariableOrder};
 use crate::svo::calculate_accumulators_batch;
@@ -70,6 +70,29 @@ where
     /// Plain prefix-binding prover that supplies the unmasked per-round
     /// arithmetic and the residual product polynomial.
     inner: PrefixProver<F, EF>,
+
+    /// Zero-knowledge code used to encode the mask polynomials.
+    encoding: Enc,
+
+    /// Merkle commitment scheme used to commit each encoded mask.
+    mmcs: M,
+}
+
+/// HVZK prover for the suffix-binding sumcheck.
+///
+/// Shares the same Construction 6.3 mask flow as [`ZkPrefixProver`], but reads
+/// the plain piece from the suffix layout's accumulator structure and scales
+/// the residual polynomial through `SuffixProver::compress_stacked`.
+pub struct ZkSuffixProver<F, EF, Enc, M>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Enc: ZkEncoding<F>,
+    M: Mmcs<F>,
+{
+    /// Plain suffix-binding prover that supplies the unmasked per-round
+    /// arithmetic and the residual product polynomial.
+    inner: SuffixProver<F, EF>,
 
     /// Zero-knowledge code used to encode the mask polynomials.
     encoding: Enc,
@@ -463,13 +486,268 @@ where
     }
 }
 
+impl<F, EF, Enc, M> ZkSuffixProver<F, EF, Enc, M>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Enc: ZkEncoding<F>,
+    M: Mmcs<F>,
+{
+    /// Wraps a plain suffix-binding prover with the HVZK ingredients.
+    pub const fn new(inner: SuffixProver<F, EF>, encoding: Enc, mmcs: M) -> Self {
+        Self {
+            inner,
+            encoding,
+            mmcs,
+        }
+    }
+
+    /// Returns the folding factor of the wrapped inner prover.
+    pub const fn folding(&self) -> usize {
+        self.inner.folding
+    }
+
+    /// Returns the variable count of the stacked polynomial.
+    pub const fn num_variables(&self) -> usize {
+        self.inner.num_variables
+    }
+
+    /// Records concrete opening claims on the inner prover.
+    pub fn eval<Ch>(&mut self, table_idx: usize, polys: &[usize], challenger: &mut Ch) -> Vec<EF>
+    where
+        F: TwoAdicField,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        self.inner.eval(table_idx, polys, challenger)
+    }
+
+    /// Records a virtual opening claim on the inner prover.
+    pub fn add_virtual_eval<Ch>(&mut self, challenger: &mut Ch) -> EF
+    where
+        F: TwoAdicField,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        self.inner.add_virtual_eval(challenger)
+    }
+
+    /// Runs the HVZK sumcheck and returns the residual claim plus the mask oracles.
+    #[allow(clippy::too_many_lines, clippy::type_complexity)]
+    #[tracing::instrument(skip_all)]
+    pub fn into_sumcheck<R, Ch>(
+        self,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+        rng: &mut R,
+    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Enc::Codeword: Matrix<F>,
+        R: Rng,
+        StandardUniform: Distribution<F>,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        let k = self.inner.folding;
+        let ell_zk = self.encoding.message_len();
+        let n_vars = self.inner.num_variables;
+
+        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
+        assert!(ell_zk >= 2, "Lemma 6.4 requires ell_zk >= 2");
+        assert!(k >= 1, "sumcheck requires at least one round");
+        assert!(
+            k <= n_vars,
+            "folding_factor must be <= poly.num_variables()",
+        );
+
+        let alpha: EF = challenger.sample_algebra_element();
+
+        let n_concrete: usize = self
+            .inner
+            .placements
+            .iter()
+            .flat_map(|placement| self.inner.claim_map[placement.idx()].iter())
+            .map(|claim| claim.len())
+            .sum();
+        let n_virtual = self.inner.virtual_claims.len();
+        let all_alphas: Vec<EF> = alpha.powers().collect_n(n_concrete + n_virtual);
+        let (concrete_alphas, virtual_alphas) = all_alphas.split_at(n_concrete);
+
+        let mut offset = 0;
+        let accumulators: Vec<_> = self
+            .inner
+            .placements
+            .iter()
+            .flat_map(|placement| self.inner.claim_map[placement.idx()].iter())
+            .map(|claim| {
+                let slice = &concrete_alphas[offset..offset + claim.len()];
+                offset += claim.len();
+                calculate_accumulators_batch(claim, slice)
+            })
+            .collect();
+
+        let mut plain_sum = self.inner.sum(alpha);
+
+        let masks: Vec<Vec<F>> = (0..k)
+            .map(|_| (0..ell_zk).map(|_| rng.random()).collect())
+            .collect();
+        let mask_oracles: Vec<MaskOracle<F, Enc, M>> = masks
+            .iter()
+            .map(|mask| {
+                let codeword = self.encoding.encode(mask, rng);
+                let (commit, prover_data) = self.mmcs.commit_matrix(codeword);
+                challenger.observe(commit.clone());
+                (commit, prover_data)
+            })
+            .collect();
+
+        let sum_endpoints_init: F = masks
+            .iter()
+            .map(|mask| mask[0].double() + mask[1..].iter().copied().sum::<F>())
+            .sum();
+        let two_to_k_minus_1 = F::TWO.exp_u64((k - 1) as u64);
+        let mu_tilde: F = two_to_k_minus_1 * sum_endpoints_init;
+
+        #[cfg(debug_assertions)]
+        {
+            let mut naive = F::ZERO;
+            for bits in 0..(1u64 << k) {
+                for (l, mask) in masks.iter().enumerate() {
+                    let b_l = (bits >> l) & 1;
+                    let s_l_eval = if b_l == 0 {
+                        mask[0]
+                    } else {
+                        mask.iter().copied().sum::<F>()
+                    };
+                    naive += s_l_eval;
+                }
+            }
+            debug_assert_eq!(
+                mu_tilde, naive,
+                "mu_tilde closed form does not match naive sum over {{0,1}}^k",
+            );
+        }
+
+        challenger.observe_algebra_element(EF::from(mu_tilde));
+        zk_data.mu_tilde = mu_tilde;
+        zk_data.ell_zk = ell_zk;
+
+        let eps: EF = challenger.sample_algebra_element();
+
+        let mut rs: Vec<EF> = Vec::with_capacity(k);
+        let mut mask_evals_at_gamma: Vec<EF> = Vec::with_capacity(k);
+        let mut sum_future_endpoints = sum_endpoints_init;
+        let pow2: Vec<F> = F::TWO.powers().collect_n(k + 1);
+
+        for round_idx in 0..k {
+            let j = round_idx + 1;
+            let s_j = &masks[round_idx];
+
+            let s_j_endpoints = s_j[0].double() + s_j[1..].iter().copied().sum::<F>();
+            sum_future_endpoints -= s_j_endpoints;
+
+            let weights_lag = lagrange_weights_01inf_multi(&rs);
+            let dot = |row: &[EF]| {
+                dot_product::<EF, _, _>(row.iter().copied(), weights_lag.iter().copied())
+            };
+
+            let mut plain_c0: EF = accumulators.iter().map(|a| dot(&a[round_idx][0])).sum();
+            let mut plain_c_inf: EF = accumulators.iter().map(|a| dot(&a[round_idx][1])).sum();
+
+            for (vc, alpha_i) in self
+                .inner
+                .virtual_claims
+                .iter()
+                .zip(virtual_alphas.iter().copied())
+            {
+                plain_c0 += alpha_i * dot(&vc.data[round_idx][0]);
+                plain_c_inf += alpha_i * dot(&vc.data[round_idx][1]);
+            }
+
+            let plain_c1 = plain_sum - plain_c0.double() - plain_c_inf;
+
+            let h_size = ell_zk.max(3);
+            let mut h: Vec<EF> = EF::zero_vec(h_size);
+
+            let mult_live = pow2[k - j];
+            for (i, &c) in s_j.iter().enumerate() {
+                h[i] += mult_live * c;
+            }
+
+            let past_mask_sum: EF = mask_evals_at_gamma.iter().copied().sum();
+            h[0] += past_mask_sum * mult_live;
+
+            if j < k {
+                let mult_future = pow2[k - j - 1];
+                h[0] += mult_future * sum_future_endpoints;
+            }
+
+            h[0] += eps * plain_c0;
+            h[1] += eps * plain_c1;
+            h[2] += eps * plain_c_inf;
+
+            #[cfg(debug_assertions)]
+            {
+                let mult_past = pow2[k - j + 1];
+                let mut expected: EF =
+                    eps * plain_sum + past_mask_sum * mult_past + mult_live * s_j_endpoints;
+                if j < k {
+                    expected += mult_live * sum_future_endpoints;
+                }
+                debug_assert_eq!(
+                    h[0].double() + h[1..].iter().copied().sum::<EF>(),
+                    expected,
+                    "h_j affine consistency check failed at round {j}",
+                );
+            }
+
+            let mut wire: Vec<EF> = Vec::with_capacity(h_size - 1);
+            wire.push(h[0]);
+            wire.extend_from_slice(&h[2..]);
+
+            challenger.observe_algebra_slice(&wire);
+            zk_data.round_coefficients.push(wire);
+
+            if pow_bits > 0 {
+                zk_data.pow_witnesses.push(challenger.grind(pow_bits));
+            }
+
+            let gamma_j: EF = challenger.sample_algebra_element();
+            let s_j_at_gamma_j: EF = s_j.iter().copied().horner(gamma_j);
+            mask_evals_at_gamma.push(s_j_at_gamma_j);
+
+            plain_sum = extrapolate_01inf(plain_c0, plain_sum - plain_c0, plain_c_inf, gamma_j);
+            rs.push(gamma_j);
+        }
+
+        let rs = Point::new(rs);
+        let reversed = rs.reversed();
+        let compressed = self.inner.compress_stacked(&reversed, eps);
+        let weights = self.inner.combine_eqs(&reversed, alpha);
+        let prod_poly = ProductPolynomial::new_unpacked(VariableOrder::Suffix, compressed, weights);
+
+        let residual_sum = eps * plain_sum;
+        debug_assert_eq!(
+            prod_poly.dot_product(),
+            residual_sum,
+            "residual product polynomial dot product must equal eps * plain_residual_sum",
+        );
+
+        (
+            SumcheckProver::new(prod_poly, residual_sum),
+            rs,
+            mask_oracles,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use p3_field::{Field, PackedValue};
     use p3_util::log2_strict_usize;
     use proptest::prelude::*;
 
-    use crate::zk::test_helpers::{F, run_roundtrip};
+    use crate::zk::test_helpers::{F, run_roundtrip, run_suffix_roundtrip};
 
     #[test]
     fn prover_verifier_roundtrip_classic_unpacked() {
@@ -501,6 +779,16 @@ mod tests {
         run_roundtrip(8, 3, 32, 1, 1, 0).expect("honest roundtrip should accept");
     }
 
+    #[test]
+    fn suffix_prover_verifier_roundtrip_classic_unpacked() {
+        run_suffix_roundtrip(8, 3, 4, 1, 1, 0).expect("honest suffix roundtrip should accept");
+    }
+
+    #[test]
+    fn suffix_long_mask_horner_path() {
+        run_suffix_roundtrip(8, 3, 32, 1, 1, 0).expect("honest suffix roundtrip should accept");
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(16))]
 
@@ -530,6 +818,38 @@ mod tests {
             prop_assert!(
                 run_roundtrip(n_vars, folding_factor, ell_zk, num_concrete, num_virtual, seed)
                     .is_ok()
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn prop_suffix_completeness_classic_unpacked(
+            n_vars in 3usize..=8,
+            ell_zk in 2usize..=5,
+            num_concrete in 0usize..=2,
+            num_virtual in 0usize..=2,
+            seed in 0u64..1024,
+        ) {
+            prop_assume!(num_concrete + num_virtual >= 1);
+
+            let k_pack = log2_strict_usize(<F as Field>::Packing::WIDTH);
+            prop_assume!(n_vars > k_pack);
+
+            let folding_factor = 1 + (seed as usize % (n_vars - k_pack));
+
+            prop_assert!(
+                run_suffix_roundtrip(
+                    n_vars,
+                    folding_factor,
+                    ell_zk,
+                    num_concrete,
+                    num_virtual,
+                    seed,
+                )
+                .is_ok()
             );
         }
     }

--- a/sumcheck/src/zk/prover.rs
+++ b/sumcheck/src/zk/prover.rs
@@ -7,6 +7,7 @@ use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, HornerIter, TwoAdicField, dot_product};
 use p3_matrix::Matrix;
 use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
 use p3_zk_codes::ZkEncoding;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
@@ -99,6 +100,42 @@ where
 
     /// Merkle commitment scheme used to commit each encoded mask.
     mmcs: M,
+}
+
+#[doc(hidden)]
+pub struct ZkSuffixBenchState<F, EF, Enc, M>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Enc: ZkEncoding<F>,
+    M: Mmcs<F>,
+{
+    inner: SuffixProver<F, EF>,
+    alpha: EF,
+    virtual_alphas: Vec<EF>,
+    accumulators: Vec<Vec<[Vec<EF>; 2]>>,
+    plain_sum: EF,
+    masks: Vec<Vec<F>>,
+    mask_oracles: Vec<MaskOracle<F, Enc, M>>,
+    mu_tilde: F,
+    ell_zk: usize,
+    eps: EF,
+}
+
+#[doc(hidden)]
+pub struct ZkSuffixAfterRoundsState<F, EF, Enc, M>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Enc: ZkEncoding<F>,
+    M: Mmcs<F>,
+{
+    inner: SuffixProver<F, EF>,
+    alpha: EF,
+    plain_sum: EF,
+    eps: EF,
+    rs: Point<EF>,
+    mask_oracles: Vec<MaskOracle<F, Enc, M>>,
 }
 
 impl<F, EF, Enc, M> ZkPrefixProver<F, EF, Enc, M>
@@ -530,16 +567,11 @@ where
         self.inner.add_virtual_eval(challenger)
     }
 
-    /// Runs the HVZK sumcheck and returns the residual claim plus the mask oracles.
-    #[allow(clippy::too_many_lines, clippy::type_complexity)]
-    #[tracing::instrument(skip_all)]
-    pub fn into_sumcheck<R, Ch>(
+    fn prepare_mask_phase<R, Ch>(
         self,
-        zk_data: &mut ZkSumcheckData<F, EF>,
-        pow_bits: usize,
         challenger: &mut Ch,
         rng: &mut R,
-    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    ) -> ZkSuffixBenchState<F, EF, Enc, M>
     where
         F: TwoAdicField,
         EF: ExtensionField<F> + TwoAdicField,
@@ -586,7 +618,7 @@ where
             })
             .collect();
 
-        let mut plain_sum = self.inner.sum(alpha);
+        let plain_sum = self.inner.sum(alpha);
 
         let masks: Vec<Vec<F>> = (0..k)
             .map(|_| (0..ell_zk).map(|_| rng.random()).collect())
@@ -629,14 +661,56 @@ where
         }
 
         challenger.observe_algebra_element(EF::from(mu_tilde));
+        let eps: EF = challenger.sample_algebra_element();
+
+        ZkSuffixBenchState {
+            inner: self.inner,
+            alpha,
+            virtual_alphas: virtual_alphas.to_vec(),
+            accumulators,
+            plain_sum,
+            masks,
+            mask_oracles,
+            mu_tilde,
+            ell_zk,
+            eps,
+        }
+    }
+
+    fn finish_from_mask_phase<Ch>(
+        state: ZkSuffixBenchState<F, EF, Enc, M>,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+    ) -> ZkSuffixAfterRoundsState<F, EF, Enc, M>
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        let ZkSuffixBenchState {
+            inner,
+            alpha,
+            virtual_alphas,
+            accumulators,
+            mut plain_sum,
+            masks,
+            mask_oracles,
+            mu_tilde,
+            ell_zk,
+            eps,
+        } = state;
+
+        let k = inner.folding;
         zk_data.mu_tilde = mu_tilde;
         zk_data.ell_zk = ell_zk;
 
-        let eps: EF = challenger.sample_algebra_element();
-
         let mut rs: Vec<EF> = Vec::with_capacity(k);
         let mut mask_evals_at_gamma: Vec<EF> = Vec::with_capacity(k);
-        let mut sum_future_endpoints = sum_endpoints_init;
+        let mut sum_future_endpoints: F = masks
+            .iter()
+            .map(|mask| mask[0].double() + mask[1..].iter().copied().sum::<F>())
+            .sum();
         let pow2: Vec<F> = F::TWO.powers().collect_n(k + 1);
 
         for round_idx in 0..k {
@@ -654,12 +728,7 @@ where
             let mut plain_c0: EF = accumulators.iter().map(|a| dot(&a[round_idx][0])).sum();
             let mut plain_c_inf: EF = accumulators.iter().map(|a| dot(&a[round_idx][1])).sum();
 
-            for (vc, alpha_i) in self
-                .inner
-                .virtual_claims
-                .iter()
-                .zip(virtual_alphas.iter().copied())
-            {
+            for (vc, alpha_i) in inner.virtual_claims.iter().zip(virtual_alphas.iter().copied()) {
                 plain_c0 += alpha_i * dot(&vc.data[round_idx][0]);
                 plain_c_inf += alpha_i * dot(&vc.data[round_idx][1]);
             }
@@ -720,10 +789,35 @@ where
             rs.push(gamma_j);
         }
 
-        let rs = Point::new(rs);
+        ZkSuffixAfterRoundsState {
+            inner,
+            alpha,
+            plain_sum,
+            eps,
+            rs: Point::new(rs),
+            mask_oracles,
+        }
+    }
+
+    fn finalize_residual_from_after_rounds(
+        state: ZkSuffixAfterRoundsState<F, EF, Enc, M>,
+    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+    {
+        let ZkSuffixAfterRoundsState {
+            inner,
+            alpha,
+            plain_sum,
+            eps,
+            rs,
+            mask_oracles,
+        } = state;
+
         let reversed = rs.reversed();
-        let compressed = self.inner.compress_stacked(&reversed, eps);
-        let weights = self.inner.combine_eqs(&reversed, alpha);
+        let compressed = inner.compress_stacked(&reversed, eps);
+        let weights = inner.combine_eqs(&reversed, alpha);
         let prod_poly = ProductPolynomial::new_unpacked(VariableOrder::Suffix, compressed, weights);
 
         let residual_sum = eps * plain_sum;
@@ -733,11 +827,109 @@ where
             "residual product polynomial dot product must equal eps * plain_residual_sum",
         );
 
-        (
-            SumcheckProver::new(prod_poly, residual_sum),
-            rs,
-            mask_oracles,
-        )
+        (SumcheckProver::new(prod_poly, residual_sum), rs, mask_oracles)
+    }
+
+    #[doc(hidden)]
+    pub fn bench_prepare_mask_phase<R, Ch>(
+        self,
+        challenger: &mut Ch,
+        rng: &mut R,
+    ) -> ZkSuffixBenchState<F, EF, Enc, M>
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Enc::Codeword: Matrix<F>,
+        R: Rng,
+        StandardUniform: Distribution<F>,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        self.prepare_mask_phase(challenger, rng)
+    }
+
+    #[doc(hidden)]
+    pub fn bench_finish_rounds_and_residual<Ch>(
+        state: ZkSuffixBenchState<F, EF, Enc, M>,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        let after_rounds = Self::finish_from_mask_phase(state, zk_data, pow_bits, challenger);
+        Self::finalize_residual_from_after_rounds(after_rounds)
+    }
+
+    #[doc(hidden)]
+    pub fn bench_finish_rounds_only<Ch>(
+        state: ZkSuffixBenchState<F, EF, Enc, M>,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+    ) -> ZkSuffixAfterRoundsState<F, EF, Enc, M>
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        Self::finish_from_mask_phase(state, zk_data, pow_bits, challenger)
+    }
+
+    #[doc(hidden)]
+    pub fn bench_finalize_residual_only(
+        state: ZkSuffixAfterRoundsState<F, EF, Enc, M>,
+    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+    {
+        Self::finalize_residual_from_after_rounds(state)
+    }
+
+    /// Runs the HVZK sumcheck and returns the residual claim plus the mask oracles.
+    #[allow(clippy::too_many_lines, clippy::type_complexity)]
+    #[tracing::instrument(skip_all)]
+    pub fn into_sumcheck<R, Ch>(
+        self,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+        rng: &mut R,
+    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    where
+        F: TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
+        Enc::Codeword: Matrix<F>,
+        R: Rng,
+        StandardUniform: Distribution<F>,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        let state = self.prepare_mask_phase(challenger, rng);
+        let after_rounds = Self::finish_from_mask_phase(state, zk_data, pow_bits, challenger);
+        Self::finalize_residual_from_after_rounds(after_rounds)
+    }
+}
+
+impl<F, EF, Enc, M> ZkSuffixAfterRoundsState<F, EF, Enc, M>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    Enc: ZkEncoding<F>,
+    M: Mmcs<F>,
+{
+    #[doc(hidden)]
+    pub fn bench_compress_stacked_only(&self) -> Poly<EF> {
+        let reversed = self.rs.reversed();
+        self.inner.compress_stacked(&reversed, self.eps)
+    }
+
+    #[doc(hidden)]
+    pub fn bench_combine_eqs_only(&self) -> Poly<EF> {
+        let reversed = self.rs.reversed();
+        self.inner.combine_eqs(&reversed, self.alpha)
     }
 }
 

--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -213,6 +213,9 @@ mod tests {
     use crate::zk::test_helpers::{
         EF, F, MyChallenger, MyMmcs, build_prover_verifier, ef_in_f_subspace, make_setup,
     };
+    use crate::zk::test_helpers::{
+        SUFFIX_ZK_STRATEGY, build_suffix_prover_verifier, build_verifier_for_single_column,
+    };
     use crate::zk::{ZkSumcheckData, ZkVerifier};
 
     /// Lemma 6.4 view-match driver for Reed-Solomon mask encoding.
@@ -381,6 +384,142 @@ mod tests {
 
             prop_assert!(
                 run_view_match_rs(n_vars, folding_factor, ell_zk, num_eqs, seed).is_ok()
+            );
+        }
+    }
+
+    fn run_suffix_view_match_rs(
+        n_vars: usize,
+        folding_factor: usize,
+        ell_zk: usize,
+        num_eqs: usize,
+        seed: u64,
+    ) -> Result<(), &'static str> {
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+        let mut data_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+        let evals: Vec<F> = (0..(1usize << n_vars)).map(|_| data_rng.random()).collect();
+
+        let (mut prover, mut verifier_real, _) =
+            build_suffix_prover_verifier(evals, folding_factor, encoding.clone(), mmcs.clone());
+
+        let mut prover_ch = MyChallenger::new(perm.clone());
+        let mut verifier_real_ch = MyChallenger::new(perm.clone());
+
+        let mut virtual_evals: Vec<EF> = Vec::with_capacity(num_eqs);
+        for _ in 0..num_eqs {
+            let eval = prover.add_virtual_eval(&mut prover_ch);
+            verifier_real.add_virtual_eval(eval, &mut verifier_real_ch);
+            virtual_evals.push(eval);
+        }
+
+        let pow_bits = 0;
+        let mut zk_data_real = ZkSumcheckData::<F, EF>::default();
+        let mut real_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (_residual_real, _gammas_real, mask_oracles_real) =
+            prover.into_sumcheck(&mut zk_data_real, pow_bits, &mut prover_ch, &mut real_rng);
+        let mask_commits_real: Vec<_> = mask_oracles_real.iter().map(|(c, _)| c.clone()).collect();
+
+        let _ = verifier_real
+            .into_sumcheck::<MyMmcs, _>(
+                &zk_data_real,
+                &mask_commits_real,
+                ell_zk,
+                folding_factor,
+                pow_bits,
+                &mut verifier_real_ch,
+            )
+            .map_err(|_| "real suffix prover transcript rejected by verifier")?;
+
+        let mut verifier_sim = build_verifier_for_single_column(n_vars, SUFFIX_ZK_STRATEGY);
+        let mut sim_ch = MyChallenger::new(perm);
+        for &eval in &virtual_evals {
+            verifier_sim.add_virtual_eval(eval, &mut sim_ch);
+        }
+        let mut verifier_sim_ch = sim_ch.clone();
+
+        let mut sim_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (zk_data_sim, mask_commits_sim, _gammas_sim) =
+            simulate_classic_unpacked::<F, EF, _, _, _, _>(
+                &mut sim_ch,
+                &verifier_sim,
+                folding_factor,
+                pow_bits,
+                &encoding,
+                &mmcs,
+                &mut sim_rng,
+            );
+
+        let _ = verifier_sim
+            .into_sumcheck::<MyMmcs, _>(
+                &zk_data_sim,
+                &mask_commits_sim,
+                ell_zk,
+                folding_factor,
+                pow_bits,
+                &mut verifier_sim_ch,
+            )
+            .map_err(|_| "simulator suffix transcript rejected by verifier")?;
+
+        if zk_data_real.mu_tilde != zk_data_sim.mu_tilde {
+            return Err("matched-RNG coupling: mu_tilde differs");
+        }
+        if mask_commits_real != mask_commits_sim {
+            return Err("matched-RNG coupling: mask commits differ");
+        }
+
+        for wire in &zk_data_real.round_coefficients {
+            for &c in wire.iter().skip(2) {
+                if !ef_in_f_subspace(c) {
+                    return Err("real-prover suffix wire[i >= 2] escapes the F-subspace");
+                }
+            }
+        }
+        for wire in &zk_data_sim.round_coefficients {
+            for &c in wire.iter().skip(2) {
+                if !ef_in_f_subspace(c) {
+                    return Err("simulator suffix wire[i >= 2] escapes the F-subspace");
+                }
+            }
+        }
+
+        let t_zk = encoding.randomness_len();
+        let m = encoding.m;
+        let mut query_rng = SmallRng::seed_from_u64(seed.wrapping_add(5));
+        let mut sim_ans_rng = SmallRng::seed_from_u64(seed.wrapping_add(6));
+        for _ in 0..folding_factor {
+            let q_size = query_rng.random_range(1..=t_zk);
+            let mut positions: Vec<usize> = Vec::with_capacity(q_size);
+            while positions.len() < q_size {
+                let p = query_rng.random_range(0..m);
+                if !positions.contains(&p) {
+                    positions.push(p);
+                }
+            }
+            let sim_answers: Vec<F> = encoding.simulate(&positions, &mut sim_ans_rng);
+            if sim_answers.len() != positions.len() {
+                return Err("ZkEncoding::simulate returned wrong number of answers");
+            }
+        }
+
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn prop_suffix_simulator_view_matches_real_rs(
+            n_vars in 3usize..=8,
+            ell_zk in 2usize..=5,
+            num_eqs in 1usize..=3,
+            seed in 0u64..1024,
+        ) {
+            let k_pack = p3_util::log2_strict_usize(<F as Field>::Packing::WIDTH);
+            prop_assume!(n_vars > k_pack);
+            let folding_factor = 1 + (seed as usize % (n_vars - k_pack));
+
+            prop_assert!(
+                run_suffix_view_match_rs(n_vars, folding_factor, ell_zk, num_eqs, seed).is_ok()
             );
         }
     }

--- a/sumcheck/src/zk/test_helpers.rs
+++ b/sumcheck/src/zk/test_helpers.rs
@@ -15,8 +15,11 @@ use p3_zk_codes::reed_solomon::ReedSolomonZkEncoding;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
-use crate::layout::{Layout, PrefixProver, Table, TableShape, Witness};
-use crate::zk::{ZkPrefixProver, ZkSumcheckData, ZkVerifier};
+use crate::layout::{
+    Layout, LayoutStrategy, PrefixProver, SuffixProver, Table, TableShape, Witness,
+};
+use crate::strategy::VariableOrder;
+use crate::zk::{ZkPrefixProver, ZkSuffixProver, ZkSumcheckData, ZkVerifier};
 
 /// Base field used across the test suite.
 pub type F = BabyBear;
@@ -47,6 +50,11 @@ pub type MyEnc = ReedSolomonZkEncoding<F, MyDft>;
 /// - Sumcheck itself opens zero positions, so any `t >= 0` is sound.
 /// - `t = 2` keeps the codeword small (cheap setup) and still covers one even + one odd slot for downstream composition tests.
 pub const T: usize = 2;
+
+/// Strategy used by the current HVZK tests: selector reversal paired with prefix binding.
+pub const PREFIX_ZK_STRATEGY: LayoutStrategy = LayoutStrategy::new(true, VariableOrder::Prefix);
+/// Strategy used by the suffix HVZK tests: selector reversal paired with suffix binding.
+pub const SUFFIX_ZK_STRATEGY: LayoutStrategy = LayoutStrategy::new(true, VariableOrder::Suffix);
 
 /// Builds the per-test setup triple from a single seed.
 ///
@@ -83,14 +91,22 @@ pub fn make_setup(seed: u64, ell_zk: usize) -> (Perm, MyMmcs, MyEnc) {
     (perm, mmcs, encoding)
 }
 
-/// Builds a prover and matching verifier on the same witness.
+/// Builds a verifier registered for a single-column table under the given layout strategy.
+pub fn build_verifier_for_single_column(
+    n_vars: usize,
+    strategy: LayoutStrategy,
+) -> ZkVerifier<F, EF> {
+    ZkVerifier::<F, EF>::with_strategy(&[TableShape::new(n_vars, 1)], strategy)
+}
+
+/// Builds a prefix prover and matching verifier on the same witness.
 ///
 /// # Returns
 ///
 /// - HVZK prover wrapping a freshly built prefix-binding inner prover.
 /// - Verifier registered with the matching table shape.
 /// - The polynomial's variable count, useful for downstream shape checks.
-pub fn build_prover_verifier(
+pub fn build_prefix_prover_verifier(
     evals: Vec<F>,
     folding_factor: usize,
     encoding: MyEnc,
@@ -117,8 +133,107 @@ pub fn build_prover_verifier(
     let prover = ZkPrefixProver::new(inner, encoding, mmcs);
 
     // Verifier registered with the matching table shape (keeps claim recording in sync).
-    let verifier = ZkVerifier::<F, EF>::new(&[TableShape::new(n_vars, 1)]);
+    let verifier = build_verifier_for_single_column(n_vars, PREFIX_ZK_STRATEGY);
     (prover, verifier, n_vars)
+}
+
+/// Builds a suffix prover and matching verifier on the same witness.
+pub fn build_suffix_prover_verifier(
+    evals: Vec<F>,
+    folding_factor: usize,
+    encoding: MyEnc,
+    mmcs: MyMmcs,
+) -> (
+    ZkSuffixProver<F, EF, MyEnc, MyMmcs>,
+    ZkVerifier<F, EF>,
+    usize,
+) {
+    let n_vars = p3_util::log2_strict_usize(evals.len());
+
+    let poly = Poly::new(evals);
+    let table = Table::new(vec![poly]);
+
+    let witness: Witness<F> = SuffixProver::<F, EF>::new_witness(vec![table], folding_factor);
+
+    let inner = SuffixProver::<F, EF>::from_witness(witness);
+    let prover = ZkSuffixProver::new(inner, encoding, mmcs);
+
+    let verifier = build_verifier_for_single_column(n_vars, SUFFIX_ZK_STRATEGY);
+    (prover, verifier, n_vars)
+}
+
+/// Backward-compatible alias for the current prefix-only helper.
+pub fn build_prover_verifier(
+    evals: Vec<F>,
+    folding_factor: usize,
+    encoding: MyEnc,
+    mmcs: MyMmcs,
+) -> (
+    ZkPrefixProver<F, EF, MyEnc, MyMmcs>,
+    ZkVerifier<F, EF>,
+    usize,
+) {
+    build_prefix_prover_verifier(evals, folding_factor, encoding, mmcs)
+}
+
+/// End-to-end honest suffix prover -- verifier driver.
+pub fn run_suffix_roundtrip(
+    n_vars: usize,
+    folding_factor: usize,
+    ell_zk: usize,
+    num_concrete: usize,
+    num_virtual: usize,
+    seed: u64,
+) -> Result<(), &'static str> {
+    let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+
+    let mut data_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+    let evals: Vec<F> = (0..(1usize << n_vars)).map(|_| data_rng.random()).collect();
+
+    let (mut prover, mut verifier, _n_vars) =
+        build_suffix_prover_verifier(evals, folding_factor, encoding, mmcs);
+
+    let mut prover_challenger = MyChallenger::new(perm.clone());
+    let mut verifier_challenger = MyChallenger::new(perm);
+
+    for _ in 0..num_concrete {
+        let openings = prover.eval(0, &[0], &mut prover_challenger);
+        verifier.add_claim(0, &[0], &openings, &mut verifier_challenger);
+    }
+
+    for _ in 0..num_virtual {
+        let eval = prover.add_virtual_eval(&mut prover_challenger);
+        verifier.add_virtual_eval(eval, &mut verifier_challenger);
+    }
+
+    let pow_bits = 4;
+    let mut zk_data = ZkSumcheckData::<F, EF>::default();
+    let mut prover_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+    let (_residual_prover, prover_randomness, mask_oracles) = prover.into_sumcheck(
+        &mut zk_data,
+        pow_bits,
+        &mut prover_challenger,
+        &mut prover_rng,
+    );
+
+    let mask_commits: Vec<_> = mask_oracles.iter().map(|(c, _)| c.clone()).collect();
+
+    let (verifier_point, _final_target) = verifier
+        .into_sumcheck::<MyMmcs, _>(
+            &zk_data,
+            &mask_commits,
+            ell_zk,
+            folding_factor,
+            pow_bits,
+            &mut verifier_challenger,
+        )
+        .map_err(|_| "verifier rejected honest prover output")?;
+
+    if prover_randomness != verifier_point {
+        return Err("prover/verifier randomness mismatch");
+    }
+
+    Ok(())
 }
 
 /// End-to-end honest prover -- verifier driver.

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -1,4 +1,4 @@
-//! HVZK verifier with affine-chain replay over the prefix-binding layout.
+//! HVZK verifier with affine-chain replay over a layout-matched plain verifier.
 
 use alloc::vec::Vec;
 
@@ -13,7 +13,7 @@ use crate::layout::{LayoutStrategy, Verifier};
 use crate::strategy::VariableOrder;
 use crate::table::TableShape;
 
-/// HVZK verifier for the prefix-binding sumcheck.
+/// HVZK verifier for a layout-matched sumcheck.
 ///
 /// Per round, the verifier:
 ///
@@ -26,7 +26,7 @@ where
     F: Field,
     EF: ExtensionField<F>,
 {
-    /// Plain prefix-binding verifier holding the claims that fix `mu`.
+    /// Plain verifier holding the claims that fix `mu`.
     inner: Verifier<F, EF>,
 }
 
@@ -35,15 +35,20 @@ where
     F: Field,
     EF: ExtensionField<F>,
 {
-    /// Builds the verifier registry.
+    /// Builds the prefix-layout verifier registry.
     pub fn new(table_shapes: &[TableShape]) -> Self {
+        Self::with_strategy(
+            table_shapes,
+            LayoutStrategy::new(true, VariableOrder::Prefix),
+        )
+    }
+
+    /// Builds the verifier registry for the given plain-layout strategy.
+    pub fn with_strategy(table_shapes: &[TableShape], strategy: LayoutStrategy) -> Self {
         // Layout must match the prover's, otherwise claim points are lifted under the wrong selector.
         // Pinned by the drift-guard test in this module.
         Self {
-            inner: Verifier::new(
-                table_shapes,
-                LayoutStrategy::new(true, VariableOrder::Prefix),
-            ),
+            inner: Verifier::new(table_shapes, strategy),
         }
     }
 
@@ -242,7 +247,10 @@ mod tests {
 
     use super::*;
     use crate::layout::TableShape;
-    use crate::zk::test_helpers::{EF, F, MyChallenger, MyMmcs, build_prover_verifier, make_setup};
+    use crate::zk::test_helpers::{
+        EF, F, MyChallenger, MyMmcs, build_prover_verifier, build_suffix_prover_verifier,
+        build_verifier_for_single_column, make_setup,
+    };
     use crate::zk::{ZkSumcheckData, ZkVerifier};
 
     #[test]
@@ -527,6 +535,107 @@ mod tests {
                 "tampering with wire coordinate ({}, {}) must change target",
                 tamper_round, tamper_pos,
             );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(8))]
+
+        #[test]
+        fn prop_suffix_rbr_tampering_changes_verifier_output(
+            n_vars in 3usize..=6,
+            ell_zk in 2usize..=4,
+            num_eqs in 1usize..=2,
+            seed in 0u64..512,
+            tamper_round_seed in 0usize..16,
+            tamper_pos_seed in 0usize..8,
+        ) {
+            let k_pack = p3_util::log2_strict_usize(<F as Field>::Packing::WIDTH);
+            prop_assume!(n_vars > k_pack);
+            let folding_factor = 1 + (seed as usize % (n_vars - k_pack));
+
+            let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+
+            let mut data_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+            let evals: Vec<F> = (0..(1usize << n_vars)).map(|_| data_rng.random()).collect();
+
+            let (mut prover, mut verifier, _n_vars) =
+                build_suffix_prover_verifier(evals, folding_factor, encoding, mmcs);
+
+            let mut prover_challenger = MyChallenger::new(perm.clone());
+            let mut verifier_challenger = MyChallenger::new(perm.clone());
+            for _ in 0..num_eqs {
+                let eval = prover.add_virtual_eval(&mut prover_challenger);
+                verifier.add_virtual_eval(eval, &mut verifier_challenger);
+            }
+
+            let pow_bits = 0;
+            let mut zk_data = ZkSumcheckData::<F, EF>::default();
+            let mut prover_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+            let (_residual_prover, _gammas, mask_oracles) = prover.into_sumcheck(
+                &mut zk_data,
+                pow_bits,
+                &mut prover_challenger,
+                &mut prover_rng,
+            );
+            let mask_commits: Vec<_> = mask_oracles.iter().map(|(c, _)| c.clone()).collect();
+
+            let tamper_round = tamper_round_seed % zk_data.round_coefficients.len();
+            let wire_len = zk_data.round_coefficients[tamper_round].len();
+            let tamper_pos = tamper_pos_seed % wire_len;
+            let mut tampered_zk_data = zk_data.clone();
+            tampered_zk_data.round_coefficients[tamper_round][tamper_pos] += F::ONE;
+
+            let mut honest_v_challenger = MyChallenger::new(perm.clone());
+            let mut honest_verifier =
+                build_verifier_for_single_column(n_vars, LayoutStrategy::new(true, VariableOrder::Suffix));
+
+            let mut prover_replay = MyChallenger::new(perm.clone());
+            let mut replay_evals = Vec::with_capacity(num_eqs);
+            let (mut replay_prover, _, _) = {
+                let mut replay_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+                let evals: Vec<F> =
+                    (0..(1usize << n_vars)).map(|_| replay_rng.random()).collect();
+                let (perm2, mmcs2, encoding2) = make_setup(seed, ell_zk);
+                let _ = perm2;
+                build_suffix_prover_verifier(evals, folding_factor, encoding2, mmcs2)
+            };
+            for _ in 0..num_eqs {
+                let e = replay_prover.add_virtual_eval(&mut prover_replay);
+                honest_verifier.add_virtual_eval(e, &mut honest_v_challenger);
+                replay_evals.push(e);
+            }
+
+            let honest = verifier.into_sumcheck::<MyMmcs, _>(
+                &zk_data,
+                &mask_commits,
+                ell_zk,
+                folding_factor,
+                pow_bits,
+                &mut verifier_challenger,
+            );
+
+            let mut tampered_v_challenger = MyChallenger::new(perm);
+            let mut tampered_verifier =
+                build_verifier_for_single_column(n_vars, LayoutStrategy::new(true, VariableOrder::Suffix));
+            for &e in &replay_evals {
+                tampered_verifier.add_virtual_eval(e, &mut tampered_v_challenger);
+            }
+
+            let tampered = tampered_verifier.into_sumcheck::<MyMmcs, _>(
+                &tampered_zk_data,
+                &mask_commits,
+                ell_zk,
+                folding_factor,
+                pow_bits,
+                &mut tampered_v_challenger,
+            );
+
+            prop_assert!(honest.is_ok());
+            prop_assert!(tampered.is_ok());
+            let (_, honest_target) = honest.unwrap();
+            let (_, tampered_target) = tampered.unwrap();
+            prop_assert_ne!(honest_target, tampered_target);
         }
     }
 }

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -13,6 +13,7 @@ use p3_whir::sumcheck::SumcheckData;
 use p3_whir::sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_whir::sumcheck::strategy::sumcheck_coefficients_prefix;
 use p3_whir::sumcheck::zk::{ZkPrefixProver, ZkSuffixProver, ZkSumcheckData};
+use p3_whir::sumcheck::zk::prover::{ZkSuffixAfterRoundsState, ZkSuffixBenchState};
 use p3_zk_codes::reed_solomon::ReedSolomonZkEncoding;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -197,6 +198,267 @@ fn run_zk_suffix_sumcheck(
     black_box((data, residual, randomness, mask_oracles));
 }
 
+fn run_zk_suffix_mask_phase(
+    prover: ZkSuffixProver<F, EF, MaskEnc, MaskMmcs>,
+    challenger: &mut Challenger,
+    rng: &mut SmallRng,
+) {
+    let state = prover.bench_prepare_mask_phase(challenger, rng);
+    black_box(state);
+}
+
+fn run_zk_suffix_rounds_and_residual_only(
+    prover: ZkSuffixProver<F, EF, MaskEnc, MaskMmcs>,
+    challenger: &mut Challenger,
+    rng: &mut SmallRng,
+    folding: usize,
+) {
+    let state = prover.bench_prepare_mask_phase(challenger, rng);
+    let mut data = ZkSumcheckData::<F, EF>::default();
+    let (residual, randomness, mask_oracles) =
+        ZkSuffixProver::bench_finish_rounds_and_residual(state, &mut data, 0, challenger);
+    assert_eq!(data.round_coefficients.len(), folding);
+    assert_eq!(randomness.num_variables(), folding);
+    assert!(residual.num_variables() > 0);
+    black_box((data, residual, randomness, mask_oracles));
+}
+
+fn run_zk_suffix_rounds_only(
+    state: ZkSuffixBenchState<F, EF, MaskEnc, MaskMmcs>,
+    challenger: &mut Challenger,
+    folding: usize,
+) {
+    let mut data = ZkSumcheckData::<F, EF>::default();
+    let after_rounds = ZkSuffixProver::bench_finish_rounds_only(state, &mut data, 0, challenger);
+    assert_eq!(data.round_coefficients.len(), folding);
+    black_box((data, after_rounds));
+}
+
+fn run_zk_suffix_residual_only(
+    state: ZkSuffixAfterRoundsState<F, EF, MaskEnc, MaskMmcs>,
+    folding: usize,
+) {
+    let (residual, randomness, mask_oracles) =
+        ZkSuffixProver::bench_finalize_residual_only(state);
+    assert_eq!(randomness.num_variables(), folding);
+    assert!(residual.num_variables() > 0);
+    black_box((residual, randomness, mask_oracles));
+}
+
+fn run_zk_suffix_compress_stacked_only(
+    state: ZkSuffixAfterRoundsState<F, EF, MaskEnc, MaskMmcs>,
+) {
+    let compressed = state.bench_compress_stacked_only();
+    let _ = black_box(compressed);
+}
+
+fn run_zk_suffix_combine_eqs_only(
+    state: ZkSuffixAfterRoundsState<F, EF, MaskEnc, MaskMmcs>,
+) {
+    let weights = state.bench_combine_eqs_only();
+    let _ = black_box(weights);
+}
+
+fn bench_sumcheck_phases(c: &mut Criterion) {
+    let mut group = c.benchmark_group("whir/layout_sumcheck_phases");
+
+    let cases = [
+        (14, 4, "log14"),
+        (18, 4, "log18"),
+        (20, 4, "log20"),
+        (22, 4, "log22"),
+    ];
+
+    let (zk_mmcs, zk_encoding) = make_zk_setup();
+
+    for &(num_variables, folding, label) in &cases {
+        let table = make_table(num_variables);
+
+        group.bench_with_input(
+            BenchmarkId::new("suffix_setup_only", label),
+            &table,
+            |b, table| {
+                b.iter(|| {
+                    let setup = setup_suffix(black_box(table), black_box(folding));
+                    black_box(setup);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_setup_only", label),
+            &table,
+            |b, table| {
+                b.iter(|| {
+                    let setup = setup_zk_suffix(
+                        black_box(table),
+                        black_box(folding),
+                        black_box(&zk_encoding),
+                        black_box(&zk_mmcs),
+                    );
+                    black_box(setup);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("suffix_prove_only", label),
+            &table,
+            |b, table| {
+                let setup = setup_suffix(table, folding);
+                b.iter_batched(
+                    || setup.clone(),
+                    |(prover, mut challenger)| run_sumcheck(prover, &mut challenger, folding),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_prove_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs),
+                    |(prover, mut challenger, mut rng)| {
+                        run_zk_suffix_sumcheck(prover, &mut challenger, &mut rng, folding);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_mask_phase_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs),
+                    |(prover, mut challenger, mut rng)| {
+                        run_zk_suffix_mask_phase(prover, &mut challenger, &mut rng);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_rounds_residual_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs),
+                    |(prover, mut challenger, mut rng)| {
+                        run_zk_suffix_rounds_and_residual_only(
+                            prover,
+                            &mut challenger,
+                            &mut rng,
+                            folding,
+                        );
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_rounds_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || {
+                        let (prover, mut challenger, mut rng) =
+                            setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs);
+                        prover.bench_prepare_mask_phase(&mut challenger, &mut rng)
+                    },
+                    |state| {
+                        let mut challenger = make_challenger();
+                        run_zk_suffix_rounds_only(state, &mut challenger, folding);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_residual_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || {
+                        let (prover, mut challenger, mut rng) =
+                            setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs);
+                        let state = prover.bench_prepare_mask_phase(&mut challenger, &mut rng);
+                        let mut data = ZkSumcheckData::<F, EF>::default();
+                        ZkSuffixProver::bench_finish_rounds_only(
+                            state,
+                            &mut data,
+                            0,
+                            &mut challenger,
+                        )
+                    },
+                    |state| {
+                        run_zk_suffix_residual_only(state, folding);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_compress_stacked_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || {
+                        let (prover, mut challenger, mut rng) =
+                            setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs);
+                        let state = prover.bench_prepare_mask_phase(&mut challenger, &mut rng);
+                        let mut data = ZkSumcheckData::<F, EF>::default();
+                        ZkSuffixProver::bench_finish_rounds_only(
+                            state,
+                            &mut data,
+                            0,
+                            &mut challenger,
+                        )
+                    },
+                    |state| {
+                        run_zk_suffix_compress_stacked_only(state);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zk_suffix_combine_eqs_only", label),
+            &table,
+            |b, table| {
+                b.iter_batched(
+                    || {
+                        let (prover, mut challenger, mut rng) =
+                            setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs);
+                        let state = prover.bench_prepare_mask_phase(&mut challenger, &mut rng);
+                        let mut data = ZkSumcheckData::<F, EF>::default();
+                        ZkSuffixProver::bench_finish_rounds_only(
+                            state,
+                            &mut data,
+                            0,
+                            &mut challenger,
+                        )
+                    },
+                    |state| {
+                        run_zk_suffix_combine_eqs_only(state);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn bench_sumcheck_prover(c: &mut Criterion) {
     let mut group = c.benchmark_group("whir/layout_sumcheck");
 
@@ -329,6 +591,7 @@ fn bench_fix_prefix_var_mut(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_sumcheck_prover,
+    bench_sumcheck_phases,
     bench_round_coefficients,
     bench_fix_prefix_var_mut,
 );

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -12,7 +12,7 @@ use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::sumcheck::SumcheckData;
 use p3_whir::sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_whir::sumcheck::strategy::sumcheck_coefficients_prefix;
-use p3_whir::sumcheck::zk::{ZkPrefixProver, ZkSumcheckData};
+use p3_whir::sumcheck::zk::{ZkPrefixProver, ZkSuffixProver, ZkSumcheckData};
 use p3_zk_codes::reed_solomon::ReedSolomonZkEncoding;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -140,6 +140,26 @@ fn setup_zk(
     (prover, challenger, rng)
 }
 
+fn setup_zk_suffix(
+    table: &Table<F>,
+    folding: usize,
+    encoding: &MaskEnc,
+    mmcs: &MaskMmcs,
+) -> (
+    ZkSuffixProver<F, EF, MaskEnc, MaskMmcs>,
+    Challenger,
+    SmallRng,
+) {
+    let witness = SuffixProver::<F, EF>::new_witness(vec![table.clone()], folding);
+    let inner = SuffixProver::<F, EF>::from_witness(witness);
+    let mut prover = ZkSuffixProver::new(inner, encoding.clone(), mmcs.clone());
+    let mut challenger = make_challenger();
+    let evals = prover.eval(0, &[0], &mut challenger);
+    assert_eq!(evals.len(), 1);
+    let rng = SmallRng::seed_from_u64(0xbeef);
+    (prover, challenger, rng)
+}
+
 fn run_sumcheck<L: Layout<F, EF>>(prover: L, challenger: &mut Challenger, folding: usize) {
     let mut data = SumcheckData::default();
     let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger);
@@ -151,6 +171,20 @@ fn run_sumcheck<L: Layout<F, EF>>(prover: L, challenger: &mut Challenger, foldin
 
 fn run_zk_sumcheck(
     prover: ZkPrefixProver<F, EF, MaskEnc, MaskMmcs>,
+    challenger: &mut Challenger,
+    rng: &mut SmallRng,
+    folding: usize,
+) {
+    let mut data = ZkSumcheckData::<F, EF>::default();
+    let (residual, randomness, mask_oracles) = prover.into_sumcheck(&mut data, 0, challenger, rng);
+    assert_eq!(data.round_coefficients.len(), folding);
+    assert_eq!(randomness.num_variables(), folding);
+    assert!(residual.num_variables() > 0);
+    black_box((data, residual, randomness, mask_oracles));
+}
+
+fn run_zk_suffix_sumcheck(
+    prover: ZkSuffixProver<F, EF, MaskEnc, MaskMmcs>,
     challenger: &mut Challenger,
     rng: &mut SmallRng,
     folding: usize,
@@ -203,6 +237,16 @@ fn bench_sumcheck_prover(c: &mut Criterion) {
                 || setup_zk(table, folding, &zk_encoding, &zk_mmcs),
                 |(prover, mut challenger, mut rng)| {
                     run_zk_sumcheck(prover, &mut challenger, &mut rng, folding);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("zk_suffix", label), &table, |b, table| {
+            b.iter_batched(
+                || setup_zk_suffix(table, folding, &zk_encoding, &zk_mmcs),
+                |(prover, mut challenger, mut rng)| {
+                    run_zk_suffix_sumcheck(prover, &mut challenger, &mut rng, folding);
                 },
                 BatchSize::SmallInput,
             );


### PR DESCRIPTION
Issue: https://github.com/Plonky3/Plonky3/issues/1649

This adds the Construction 6.3 HVZK overlay for the suffix-binding sumcheck layout, then follows up by packing the suffix residual compression path that became the dominant local hotspot.

Failure mechanism
Before this change, sumcheck::zk only supported the prefix-binding layout. Routing WHIR PCS through the suffix layout therefore missed the HVZK overlay and could produce a non-private proof.

Semantic change
Add ZkSuffixProver on top of SuffixProver.
Make the shared ZkVerifier layout-aware so suffix replay uses the suffix plain strategy.
Expose the suffix plain-layout helpers needed by the overlay: sum, compress_stacked, combine_eqs.
Add zk_suffix to whir/benches/sumcheck.rs.
Add SplitEq::new_unpacked_at and SplitEq::new_packed_at, then switch SuffixProver::compress_stacked to SplitEq::new_packed_at(rs, 0, scale) so the residual suffix compression keeps the full challenge point in the packed suffix half.

Why the follow-up compression change helps
The old residual path built SplitEq from the 4-variable suffix challenge point with the default midpoint split. That turned the point into a 2 + 2 split, which left too few suffix variables to reach the packed suffix-dot kernel. The new explicit split keeps the point as 0 + 4, so compress_stacked can use the packed kernel on the hot residual path.

Preserved invariants
Existing prefix HVZK behavior is unchanged.
Verifier replay still reconstructs the dropped c_1 from the same affine identity.
Simulator coupling still matches mu_tilde, mask commits, and the base-field stratification of wire coordinates with index >= 2.
The explicit SplitEq split does not change suffix-compression semantics; the new split_eq regression test checks that explicit and midpoint splits produce the same compressed polynomial.

Clean benchmark
Before commit: d87b91d3
After commit: f9329519

Command:
cargo bench -p p3-whir --bench sumcheck -- --noplot --sample-size 20 --warm-up-time 1 --measurement-time 3 "layout_sumcheck/(prefix|suffix|zk|zk_suffix)/log20|layout_sumcheck_phases/zk_suffix_(prove_only|residual_only|compress_stacked_only|combine_eqs_only)/log20"

Environment note:
I ran the before and after measurements in separate worktrees with separate CARGO_TARGET_DIR values and the same benchmark command on both sides.

End-to-end log20 medians:
prefix: 6.5519 ms -> 5.7528 ms (-12.2%)
suffix: 9.2118 ms -> 4.5525 ms (-50.6%)
zk: 6.4967 ms -> 6.3611 ms (-2.1%)
zk_suffix: 9.8896 ms -> 5.3652 ms (-45.7%)

Hotspot-focused log20 medians:
zk_suffix_prove_only: 9.9190 ms -> 5.9595 ms (-39.9%)
zk_suffix_residual_only: 7.2063 ms -> 4.7307 ms (-34.4%)
zk_suffix_compress_stacked_only: 8.3242 ms -> 3.9564 ms (-52.5%)
zk_suffix_combine_eqs_only: 871.29 us -> 865.19 us (effectively flat)

Interpretation:
The packed residual-compression follow-up clearly pays off on both the suffix plain path and the new suffix-ZK path.
The largest direct win is on compress_stacked, which matches the phase-split diagnosis.
combine_eqs is not the real bottleneck.
The old zk path remains effectively unchanged, which matches the fact that it does not use the suffix residual path.

Testing
cargo test -p p3-sumcheck zk:: -- --nocapture
Passed: 13 passed, 0 failed.

cargo test -p p3-multilinear-util split_eq -- --nocapture
Passed: 41 passed, 0 failed.

cargo bench -p p3-whir --bench sumcheck --no-run
Passed.

git diff --check
Passed.