### PR TITLE
fix: correct `max_constraint_degree` for `p3-poseidon2-air`

### DIFF
--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -175,6 +175,22 @@ impl<
     fn main_next_row_columns(&self) -> Vec<usize> {
         vec![]
     }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        Some(sbox_constraint_degree(SBOX_DEGREE, SBOX_REGISTERS))
+    }
+}
+
+/// The maximum degree among the constraints emitted by [`eval_sbox`] for a given
+/// `(DEGREE, REGISTERS)` configuration.
+pub(crate) const fn sbox_constraint_degree(degree: u64, registers: usize) -> usize {
+    match (degree, registers) {
+        (3, 0) => 3,
+        (5, 0) => 5,
+        (7, 0) => 7,
+        (5, 1) | (7, 1) | (11, 2) => 3,
+        _ => panic!("Unexpected (DEGREE, REGISTERS)"),
+    }
 }
 
 /// Evaluate all Poseidon1 constraints for one trace row.

--- a/poseidon1-air/src/vectorized.rs
+++ b/poseidon1-air/src/vectorized.rs
@@ -41,7 +41,7 @@ use rand::{RngExt, SeedableRng};
 use crate::air::eval;
 use crate::{
     FullRoundConstants, PartialRoundConstants, Poseidon1Air, Poseidon1Cols,
-    generate_vectorized_trace_rows,
+    generate_vectorized_trace_rows, sbox_constraint_degree,
 };
 
 /// Column layout for a vectorized Poseidon1 row.
@@ -272,6 +272,10 @@ impl<
     /// No next-row columns. All permutations are fully constrained within one row.
     fn main_next_row_columns(&self) -> Vec<usize> {
         vec![]
+    }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        Some(sbox_constraint_degree(SBOX_DEGREE, SBOX_REGISTERS))
     }
 }
 

--- a/poseidon2-air/src/air.rs
+++ b/poseidon2-air/src/air.rs
@@ -137,7 +137,19 @@ impl<
     }
 
     fn max_constraint_degree(&self) -> Option<usize> {
-        Some(SBOX_DEGREE as usize)
+        Some(sbox_constraint_degree(SBOX_DEGREE, SBOX_REGISTERS))
+    }
+}
+
+/// The maximum degree among the constraints emitted by [`eval_sbox`] for a given
+/// `(DEGREE, REGISTERS)` configuration.
+pub(crate) const fn sbox_constraint_degree(degree: u64, registers: usize) -> usize {
+    match (degree, registers) {
+        (3, 0) => 3,
+        (5, 0) => 5,
+        (7, 0) => 7,
+        (5, 1) | (7, 1) | (11, 2) => 3,
+        _ => panic!("Unexpected (DEGREE, REGISTERS)"),
     }
 }
 

--- a/poseidon2-air/src/vectorized.rs
+++ b/poseidon2-air/src/vectorized.rs
@@ -13,7 +13,7 @@ use rand::{RngExt, SeedableRng};
 
 use crate::air::eval;
 use crate::constants::RoundConstants;
-use crate::{Poseidon2Air, Poseidon2Cols, generate_vectorized_trace_rows};
+use crate::{Poseidon2Air, Poseidon2Cols, generate_vectorized_trace_rows, sbox_constraint_degree};
 
 /// A "vectorized" version of Poseidon2Cols, for computing multiple Poseidon2 permutations per row.
 #[repr(C)]
@@ -236,6 +236,10 @@ impl<
 
     fn main_next_row_columns(&self) -> Vec<usize> {
         vec![]
+    }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        Some(sbox_constraint_degree(SBOX_DEGREE, SBOX_REGISTERS))
     }
 }
 


### PR DESCRIPTION
PR #1331 added an override of max_constraint_degree() for poseidon2 AIR implementation, but ignored SBOX_REGISTERS associated constant which bumped max degree to 5 & 7 for other fields than KB regardless of intermediary registers.

This fixes it and adds the same logic for poseidon1 AIR to not rely on symbolic evaluation.