### PR TITLE
refactor: remove duplication around AirBuilder `_named` methods

### DIFF
--- a/air/src/builder.rs
+++ b/air/src/builder.rs
@@ -53,6 +53,11 @@ pub trait AirBuilder: Sized {
     ///   the trait can be implemented uniformly.
     type PeriodicVar: Into<Self::Expr> + Copy;
 
+    /// Number of consecutive trace rows a constraint may reference (the window arity).
+    ///
+    /// Only two-row windows (current + next) are currently supported.
+    const WINDOW: usize = 2;
+
     /// Return the current and next row slices of the main (primary) trace.
     fn main(&self) -> Self::MainWindow;
 
@@ -68,17 +73,22 @@ pub trait AirBuilder: Sized {
     fn is_last_row(&self) -> Self::Expr;
 
     /// Expression evaluating to zero only on the last row.
-    fn is_transition(&self) -> Self::Expr {
-        self.is_transition_window(2)
-    }
+    fn is_transition(&self) -> Self::Expr;
 
     /// Expression evaluating to zero only on the last `size - 1` rows.
     ///
     /// # Panics
     ///
-    /// Implementations should panic if `size > 2`, since only two-row
-    /// windows are currently supported.
-    fn is_transition_window(&self, size: usize) -> Self::Expr;
+    /// Panics if `size > Self::WINDOW`, since only two-row windows are
+    /// currently supported.
+    fn is_transition_window(&self, size: usize) -> Self::Expr {
+        assert!(
+            size <= Self::WINDOW,
+            "window size {size} exceeds supported arity {}",
+            Self::WINDOW
+        );
+        self.is_transition()
+    }
 
     /// Returns a sub-builder whose constraints are enforced only when `condition` is nonzero.
     fn when<I: Into<Self::Expr>>(&mut self, condition: I) -> FilteredAirBuilder<'_, Self> {

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -10,7 +10,7 @@ use p3_matrix::stack::ViewPair;
 
 use crate::{
     Air, AirBuilder, AirBuilderWithContext, ExtensionBuilder, Name, NamedAirBuilder,
-    NamedExtensionBuilder, NamespaceExt, PermutationAirBuilder, RowWindow,
+    NamedExtensionBuilder, PermutationAirBuilder, RowWindow,
 };
 
 /// A single constraint violation captured during debug evaluation.
@@ -387,50 +387,6 @@ impl<F: Field, EF: ExtensionField<F>> NamedAirBuilder for DebugConstraintBuilder
         }
         self.constraint_index += 1;
     }
-
-    fn assert_zeros_named<const M: usize, I, Ns>(&mut self, array: [I; M], name: Ns)
-    where
-        I: Into<Self::Expr>,
-        Ns: crate::Namespace,
-    {
-        for (i, elem) in array.into_iter().enumerate() {
-            self.assert_zero_named(elem, name.name(|| format!("[{i}]")));
-        }
-    }
-
-    fn assert_one_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_zero_named(x.into() - Self::Expr::ONE, name);
-    }
-
-    fn assert_eq_named<I1, I2, N>(&mut self, x: I1, y: I2, name: N)
-    where
-        I1: Into<Self::Expr>,
-        I2: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_zero_named(x.into() - y.into(), name);
-    }
-
-    fn assert_bool_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_zero_named(x.into().bool_check(), name);
-    }
-
-    fn assert_bools_named<const M: usize, I, Ns>(&mut self, array: [I; M], name: Ns)
-    where
-        I: Into<Self::Expr>,
-        Ns: crate::Namespace,
-    {
-        let zero_array = array.map(|x| x.into().bool_check());
-        self.assert_zeros_named(zero_array, name);
-    }
 }
 
 impl<F: Field, EF: ExtensionField<F>> NamedExtensionBuilder for DebugConstraintBuilder<'_, F, EF> {
@@ -452,23 +408,6 @@ impl<F: Field, EF: ExtensionField<F>> NamedExtensionBuilder for DebugConstraintB
             });
         }
         self.constraint_index += 1;
-    }
-
-    fn assert_eq_ext_named<I1, I2, N>(&mut self, x: I1, y: I2, name: N)
-    where
-        I1: Into<Self::ExprEF>,
-        I2: Into<Self::ExprEF>,
-        N: Name,
-    {
-        self.assert_zero_ext_named(x.into() - y.into(), name);
-    }
-
-    fn assert_one_ext_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::ExprEF>,
-        N: Name,
-    {
-        self.assert_zero_ext_named(x.into() - Self::ExprEF::ONE, name);
     }
 }
 

--- a/air/src/check_constraints.rs
+++ b/air/src/check_constraints.rs
@@ -300,8 +300,7 @@ where
         self.is_last_row
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.is_transition
     }
 

--- a/air/src/filtered.rs
+++ b/air/src/filtered.rs
@@ -53,10 +53,6 @@ impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
         self.inner.is_transition()
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        self.inner.is_transition_window(size)
-    }
-
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
         self.inner.assert_zero(self.condition() * x.into());
     }

--- a/air/src/named.rs
+++ b/air/src/named.rs
@@ -1,5 +1,6 @@
 //! Labeled constraint infrastructure.
 
+use alloc::format;
 use core::fmt;
 use core::fmt::Display;
 
@@ -130,36 +131,56 @@ pub trait NamedAirBuilder: AirBuilder {
         I: Into<Self::Expr>,
         N: Name;
 
-    /// Assert all elements are zero, with a label.
+    /// Assert all elements are zero, labeling element `i` with `name[i]`.
+    ///
+    /// Builders that can batch unlabeled assertions should override this to do so.
     fn assert_zeros_named<const M: usize, I, Ns>(&mut self, array: [I; M], name: Ns)
     where
         I: Into<Self::Expr>,
-        Ns: Namespace;
+        Ns: Namespace,
+    {
+        for (i, elem) in array.into_iter().enumerate() {
+            self.assert_zero_named(elem, name.name(|| format!("[{i}]")));
+        }
+    }
 
     /// Assert one with a label.
     fn assert_one_named<I, N>(&mut self, x: I, name: N)
     where
         I: Into<Self::Expr>,
-        N: Name;
+        N: Name,
+    {
+        self.assert_zero_named(x.into() - Self::Expr::ONE, name);
+    }
 
     /// Assert equality with a label.
     fn assert_eq_named<I1, I2, N>(&mut self, x: I1, y: I2, name: N)
     where
         I1: Into<Self::Expr>,
         I2: Into<Self::Expr>,
-        N: Name;
+        N: Name,
+    {
+        self.assert_zero_named(x.into() - y.into(), name);
+    }
 
     /// Assert boolean with a label.
     fn assert_bool_named<I, N>(&mut self, x: I, name: N)
     where
         I: Into<Self::Expr>,
-        N: Name;
+        N: Name,
+    {
+        self.assert_zero_named(x.into().bool_check(), name);
+    }
 
     /// Assert all elements are boolean, with a label.
     fn assert_bools_named<const M: usize, I, Ns>(&mut self, array: [I; M], name: Ns)
     where
         I: Into<Self::Expr>,
-        Ns: Namespace;
+        Ns: Namespace,
+    {
+        let zero_array = array.map(|x| x.into().bool_check());
+        self.assert_zeros_named(zero_array, name);
+    }
 }
 
 /// Marker for builders that discard constraint labels.
@@ -187,39 +208,6 @@ impl<T: PassthroughNamedAirBuilder> NamedAirBuilder for T {
     {
         self.assert_zeros(array);
     }
-
-    fn assert_one_named<I, N>(&mut self, x: I, _name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_one(x);
-    }
-
-    fn assert_eq_named<I1, I2, N>(&mut self, x: I1, y: I2, _name: N)
-    where
-        I1: Into<Self::Expr>,
-        I2: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_eq(x, y);
-    }
-
-    fn assert_bool_named<I, N>(&mut self, x: I, _name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.assert_bool(x);
-    }
-
-    fn assert_bools_named<const M: usize, I, Ns>(&mut self, array: [I; M], _name: Ns)
-    where
-        I: Into<Self::Expr>,
-        Ns: Namespace,
-    {
-        self.assert_bools(array);
-    }
 }
 
 impl<AB: NamedAirBuilder> NamedAirBuilder for FilteredAirBuilder<'_, AB> {
@@ -241,42 +229,6 @@ impl<AB: NamedAirBuilder> NamedAirBuilder for FilteredAirBuilder<'_, AB> {
         self.inner
             .assert_zeros_named(array.map(|elem| condition.dup() * elem.into()), name);
     }
-
-    fn assert_one_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.inner
-            .assert_zero_named(self.condition() * (x.into() - Self::Expr::ONE), name);
-    }
-
-    fn assert_eq_named<I1, I2, N>(&mut self, x: I1, y: I2, name: N)
-    where
-        I1: Into<Self::Expr>,
-        I2: Into<Self::Expr>,
-        N: Name,
-    {
-        self.inner
-            .assert_zero_named(self.condition() * (x.into() - y.into()), name);
-    }
-
-    fn assert_bool_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::Expr>,
-        N: Name,
-    {
-        self.inner
-            .assert_zero_named(self.condition() * x.into().bool_check(), name);
-    }
-
-    fn assert_bools_named<const M: usize, I, Ns>(&mut self, array: [I; M], name: Ns)
-    where
-        I: Into<Self::Expr>,
-        Ns: Namespace,
-    {
-        self.assert_zeros_named(array.map(|elem| elem.into().bool_check()), name);
-    }
 }
 
 /// Labeled variants of extension-field assertions.
@@ -297,13 +249,19 @@ pub trait NamedExtensionBuilder: ExtensionBuilder + NamedAirBuilder {
     where
         I1: Into<Self::ExprEF>,
         I2: Into<Self::ExprEF>,
-        N: Name;
+        N: Name,
+    {
+        self.assert_zero_ext_named(x.into() - y.into(), name);
+    }
 
     /// Assert one over the extension field, with a label.
     fn assert_one_ext_named<I, N>(&mut self, x: I, name: N)
     where
         I: Into<Self::ExprEF>,
-        N: Name;
+        N: Name,
+    {
+        self.assert_zero_ext_named(x.into() - Self::ExprEF::ONE, name);
+    }
 }
 
 impl<T: PassthroughNamedAirBuilder + ExtensionBuilder> NamedExtensionBuilder for T {
@@ -313,23 +271,6 @@ impl<T: PassthroughNamedAirBuilder + ExtensionBuilder> NamedExtensionBuilder for
         N: Name,
     {
         self.assert_zero_ext(x);
-    }
-
-    fn assert_eq_ext_named<I1, I2, N>(&mut self, x: I1, y: I2, _name: N)
-    where
-        I1: Into<Self::ExprEF>,
-        I2: Into<Self::ExprEF>,
-        N: Name,
-    {
-        self.assert_eq_ext(x, y);
-    }
-
-    fn assert_one_ext_named<I, N>(&mut self, x: I, _name: N)
-    where
-        I: Into<Self::ExprEF>,
-        N: Name,
-    {
-        self.assert_one_ext(x);
     }
 }
 
@@ -342,26 +283,5 @@ impl<AB: NamedExtensionBuilder> NamedExtensionBuilder for FilteredAirBuilder<'_,
         let ext_x: Self::ExprEF = x.into();
         let condition: AB::Expr = self.condition();
         self.inner.assert_zero_ext_named(ext_x * condition, name);
-    }
-
-    fn assert_eq_ext_named<I1, I2, N>(&mut self, x: I1, y: I2, name: N)
-    where
-        I1: Into<Self::ExprEF>,
-        I2: Into<Self::ExprEF>,
-        N: Name,
-    {
-        let diff: Self::ExprEF = x.into() - y.into();
-        let condition: AB::Expr = self.condition();
-        self.inner.assert_zero_ext_named(diff * condition, name);
-    }
-
-    fn assert_one_ext_named<I, N>(&mut self, x: I, name: N)
-    where
-        I: Into<Self::ExprEF>,
-        N: Name,
-    {
-        let diff: Self::ExprEF = x.into() - Self::ExprEF::ONE;
-        let condition: AB::Expr = self.condition();
-        self.inner.assert_zero_ext_named(diff * condition, name);
     }
 }

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -299,14 +299,8 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for SymbolicAirBuilder<F, EF> {
         SymbolicExpr::Leaf(BaseLeaf::IsLastRow)
     }
 
-    /// # Panics
-    /// This function panics if `size` is not `2`.
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        if size == 2 {
-            SymbolicExpr::Leaf(BaseLeaf::IsTransition)
-        } else {
-            panic!("uni-stark only supports a window size of 2")
-        }
+    fn is_transition(&self) -> Self::Expr {
+        SymbolicExpr::Leaf(BaseLeaf::IsTransition)
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
@@ -670,7 +664,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "uni-stark only supports a window size of 2")]
+    #[should_panic(expected = "exceeds supported arity")]
     fn test_is_transition_window_size_3_panics() {
         // Window size 3 is not supported and should panic.
         let builder = SymbolicAirBuilder::<F>::new(layout(0, 2, 0, 0));

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -853,7 +853,7 @@ mod tests {
             self.is_last
         }
 
-        fn is_transition_window(&self, _: usize) -> Self::Expr {
+        fn is_transition(&self) -> Self::Expr {
             self.is_transition
         }
 

--- a/lookup/src/bus.rs
+++ b/lookup/src/bus.rs
@@ -193,7 +193,7 @@ mod tests {
         fn is_last_row(&self) -> Self::Expr {
             unimplemented!()
         }
-        fn is_transition_window(&self, _: usize) -> Self::Expr {
+        fn is_transition(&self) -> Self::Expr {
             unimplemented!()
         }
         fn assert_zero<I: Into<Self::Expr>>(&mut self, _: I) {}

--- a/lookup/src/debug_util.rs
+++ b/lookup/src/debug_util.rs
@@ -239,8 +239,7 @@ impl<'a, F: Field> AirBuilder for MiniLookupBuilder<'a, F> {
         F::from_bool(self.row + 1 == self.height)
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         F::from_bool(self.row + 1 < self.height)
     }
 

--- a/lookup/src/folder.rs
+++ b/lookup/src/folder.rs
@@ -45,8 +45,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolderWithLookup
     }
 
     #[inline]
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.inner.is_transition
     }
 
@@ -145,8 +144,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolderWithLook
     }
 
     #[inline]
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.inner.is_transition
     }
 

--- a/lookup/src/symbolic.rs
+++ b/lookup/src/symbolic.rs
@@ -88,8 +88,8 @@ impl<F: Field, EF: ExtensionField<F>> AirBuilder for InteractionSymbolicBuilder<
         self.inner.is_last_row()
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        self.inner.is_transition_window(size)
+    fn is_transition(&self) -> Self::Expr {
+        self.inner.is_transition()
     }
 
     fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -193,8 +193,7 @@ impl AirBuilder for MockAirBuilder {
         F::from_bool(self.current_row == self.height - 1)
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         F::from_bool(self.current_row < self.height - 1)
     }
 

--- a/lookup/src/traits.rs
+++ b/lookup/src/traits.rs
@@ -96,8 +96,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
     }
 
     #[inline]
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         Self::F::from_bool(self.row + 1 < self.height)
     }
 

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -139,8 +139,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     }
 
     #[inline]
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.is_transition
     }
 
@@ -207,8 +206,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
         self.is_last_row
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.is_transition
     }
 

--- a/uni-stark/src/sub_builder.rs
+++ b/uni-stark/src/sub_builder.rs
@@ -97,8 +97,7 @@ impl<AB: AirBuilder, SubAir: BaseAir<AB::F>, F> AirBuilder for SubAirBuilder<'_,
         self.inner.is_last_row()
     }
 
-    fn is_transition_window(&self, size: usize) -> Self::Expr {
-        assert!(size <= 2, "only two-row windows are supported, got {size}");
+    fn is_transition(&self) -> Self::Expr {
         self.inner.is_transition()
     }
 


### PR DESCRIPTION
No concrete behavioral changes, just deduplication / simplification of builder trait impls:

- instead of duplicating all methods into `_named` variants, we now make those the default ones to implement and derive the "unnamed" ones
- make `is_transition` the required method and derive `is_transition_window` from it with a hardcoded `WINDOW` value check 