### PR TITLE
docs: clarify zero-knowledge guarantees

### DIFF
--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -60,6 +60,8 @@ where
     type Error: Debug;
 
     /// Set to true to activate randomization and achieve zero-knowledge.
+    ///
+    /// The exact zero-knowledge guarantees depend on the PCS implementation.
     const ZK: bool;
 
     /// Index of the trace commitment in the computed opened values.

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -90,6 +90,9 @@ where
     );
     type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
 
+    /// Provides statistical zero-knowledge via randomization polynomials.
+    ///
+    /// The current construction does not provide perfect zero-knowledge.
     const ZK: bool = true;
 
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {


### PR DESCRIPTION
Clarify the documentation of Pcs::ZK and HidingPcs

The current codebase already contains comments describing the masking construction used by HidingPcs. This PR adds matching rustdoc comments so that the public API documentation better reflects the implementation.