### PR TITLE
fix: sample HZVK masks from EF

### DIFF
--- a/sumcheck/src/zk/data.rs
+++ b/sumcheck/src/zk/data.rs
@@ -40,8 +40,8 @@ pub struct ZkSumcheckData<F, EF> {
     /// Sum of all mask polynomial evaluations across the boolean hypercube `{0,1}^k`.
     ///
     /// Observed on the transcript before the verifier samples the combining challenge.
-    /// Lives in the base field because the mask coefficients do.
-    pub mu_tilde: F,
+    /// Lives in the extension field because the mask coefficients do.
+    pub mu_tilde: EF,
 
     /// Message length of the zero-knowledge mask code.
     ///
@@ -62,11 +62,11 @@ pub struct ZkSumcheckData<F, EF> {
     pub pow_witnesses: Vec<F>,
 }
 
-impl<F: Field, EF> Default for ZkSumcheckData<F, EF> {
+impl<F, EF: Field> Default for ZkSumcheckData<F, EF> {
     fn default() -> Self {
         Self {
             // Real runs overwrite this in step 2 once the prover has summed the masks.
-            mu_tilde: F::ZERO,
+            mu_tilde: EF::ZERO,
             // Sentinel: honest runs set this to the encoding's message length; the verifier rejects 0.
             ell_zk: 0,
             // Filled with one wire entry per sumcheck round.
@@ -81,7 +81,7 @@ impl<F: Field, EF> Default for ZkSumcheckData<F, EF> {
 ///
 /// Pairs the public Merkle root with the prover-side data needed to open the codeword at requested positions.
 /// Downstream consumers use this during the codeswitch step to produce opening proofs against the mask oracles.
-pub type MaskOracle<F, Enc, M> = (
-    <M as Mmcs<F>>::Commitment,
-    <M as Mmcs<F>>::ProverData<<Enc as ZkEncoding<F>>::Codeword>,
+pub type MaskOracle<EF, Enc, M> = (
+    <M as Mmcs<EF>>::Commitment,
+    <M as Mmcs<EF>>::ProverData<<Enc as ZkEncoding<EF>>::Codeword>,
 );

--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! Let `k` be the folding factor and `ell_zk` the mask code message length.
 //!
-//! 1. Prover samples `k` univariate masks of degree `ell_zk - 1` over the base field.
+//! 1. Prover samples `k` univariate masks of degree `ell_zk - 1` over the extension field.
 //! 2. Each mask is encoded under a zero-knowledge code, MMCS-committed, and absorbed into the Fiat-Shamir transcript.
 //! 3. Prover sends `mu_tilde`, the sum of all mask evaluations over `{0,1}^k`.
 //! 4. Verifier samples a combining challenge `eps` in the extension field.

--- a/sumcheck/src/zk/prover.rs
+++ b/sumcheck/src/zk/prover.rs
@@ -64,8 +64,8 @@ pub struct ZkPrefixProver<F, EF, Enc, M>
 where
     F: Field,
     EF: ExtensionField<F>,
-    Enc: ZkEncoding<F>,
-    M: Mmcs<F>,
+    Enc: ZkEncoding<EF>,
+    M: Mmcs<EF>,
 {
     /// Plain prefix-binding prover that supplies the unmasked per-round
     /// arithmetic and the residual product polynomial.
@@ -82,8 +82,8 @@ impl<F, EF, Enc, M> ZkPrefixProver<F, EF, Enc, M>
 where
     F: Field,
     EF: ExtensionField<F>,
-    Enc: ZkEncoding<F>,
-    M: Mmcs<F>,
+    Enc: ZkEncoding<EF>,
+    M: Mmcs<EF>,
 {
     /// Wraps a plain prefix-binding prover with the HVZK ingredients.
     pub const fn new(inner: PrefixProver<F, EF>, encoding: Enc, mmcs: M) -> Self {
@@ -154,13 +154,17 @@ where
         pow_bits: usize,
         challenger: &mut Ch,
         rng: &mut R,
-    ) -> (SumcheckProver<F, EF>, Point<EF>, Vec<MaskOracle<F, Enc, M>>)
+    ) -> (
+        SumcheckProver<F, EF>,
+        Point<EF>,
+        Vec<MaskOracle<EF, Enc, M>>,
+    )
     where
         F: TwoAdicField,
         EF: ExtensionField<F> + TwoAdicField,
-        Enc::Codeword: Matrix<F>,
+        Enc::Codeword: Matrix<EF>,
         R: Rng,
-        StandardUniform: Distribution<F>,
+        StandardUniform: Distribution<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
         // Protocol shape resolved from the inner prover + mask encoding.
@@ -221,10 +225,10 @@ where
         //     s_j(X) = c_0 + c_1 X + ... + c_{ell_zk - 1} X^{ell_zk - 1}
         //
         // The encoder draws zero-knowledge padding randomness, so it needs the mutable rng.
-        let masks: Vec<Vec<F>> = (0..k)
+        let masks: Vec<Vec<EF>> = (0..k)
             .map(|_| (0..ell_zk).map(|_| rng.random()).collect())
             .collect();
-        let mask_oracles: Vec<MaskOracle<F, Enc, M>> = masks
+        let mask_oracles: Vec<MaskOracle<EF, Enc, M>> = masks
             .iter()
             .map(|mask| {
                 let codeword = self.encoding.encode(mask, rng);
@@ -240,17 +244,17 @@ where
         //                 = mask[0].double() + sum(mask[1..])
         //
         //     mu_tilde    = 2^{k - 1} * sum_l ( s_l(0) + s_l(1) )
-        let sum_endpoints_init: F = masks
+        let sum_endpoints_init: EF = masks
             .iter()
-            .map(|mask| mask[0].double() + mask[1..].iter().copied().sum::<F>())
+            .map(|mask| mask[0].double() + mask[1..].iter().copied().sum::<EF>())
             .sum();
-        let two_to_k_minus_1 = F::TWO.exp_u64((k - 1) as u64);
-        let mu_tilde: F = two_to_k_minus_1 * sum_endpoints_init;
+        let two_to_k_minus_1 = EF::TWO.exp_u64((k - 1) as u64);
+        let mu_tilde: EF = two_to_k_minus_1 * sum_endpoints_init;
 
         // Cross-check the closed form against the naive 2^k-term sum.
         #[cfg(debug_assertions)]
         {
-            let mut naive = F::ZERO;
+            let mut naive = EF::ZERO;
             for bits in 0..(1u64 << k) {
                 for (l, mask) in masks.iter().enumerate() {
                     let b_l = (bits >> l) & 1;
@@ -260,7 +264,7 @@ where
                     let s_l_eval = if b_l == 0 {
                         mask[0]
                     } else {
-                        mask.iter().copied().sum::<F>()
+                        mask.iter().copied().sum::<EF>()
                     };
                     naive += s_l_eval;
                 }
@@ -271,16 +275,16 @@ where
             );
         }
 
-        // Observe mu_tilde (lifted to EF) and stash on the transcript record.
-        challenger.observe_algebra_element(EF::from(mu_tilde));
+        // Observe mu_tilde and stash on the transcript record.
+        challenger.observe_algebra_element(mu_tilde);
         zk_data.mu_tilde = mu_tilde;
         zk_data.ell_zk = ell_zk;
 
         // Phase 4: combining challenge `eps` (Construction 6.3 step 3).
         //
-        // `eps` lives in EF; the paper samples in F.
-        // Masks stay in F to preserve sublinear proof size.
-        // The resulting hybrid F/EF `h_j` is handled by the simulator's F-subspace stratification.
+        // The construction is instantiated over `EF`: the masks, `eps`, and the
+        // round polynomials all live in `EF`, so Lemma 6.4 applies with `F := EF`
+        // and the per-round polynomial is uniform over the full extension field.
         let eps: EF = challenger.sample_algebra_element();
 
         // Phase 5: per-round sumcheck (Construction 6.3 step 4).
@@ -300,7 +304,7 @@ where
         //     mult_live   = pow2[k - j]
         //     mult_past   = pow2[k - j + 1]
         //     mult_future = pow2[k - j - 1]
-        let pow2: Vec<F> = F::TWO.powers().collect_n(k + 1);
+        let pow2: Vec<EF> = EF::TWO.powers().collect_n(k + 1);
 
         for round_idx in 0..k {
             // 1-indexed round used by the formulas.
@@ -308,7 +312,7 @@ where
             let s_j = &masks[round_idx];
 
             // Update the running future-endpoint sum: drop s_j's contribution so the round-j formula reads only sum_{l > j}.
-            let s_j_endpoints = s_j[0].double() + s_j[1..].iter().copied().sum::<F>();
+            let s_j_endpoints = s_j[0].double() + s_j[1..].iter().copied().sum::<EF>();
             sum_future_endpoints -= s_j_endpoints;
 
             // Lagrange weights at `(gamma_1, ..., gamma_{j-1})`, used by every accumulator dot product below.

--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -22,26 +22,16 @@ use super::verifier::ZkVerifier;
 ///
 /// - Sample alpha and derive `mu` from the verifier's claim batching.
 /// - Sample and commit fresh masks just like the prover.
-/// - Sample each wire coordinate at the tier matching the honest joint distribution.
+/// - Sample each wire coordinate uniformly over `EF` (the honest joint distribution).
 /// - Reconstruct the dropped `c_1` from the affine identity, so every simulated wire verifies by construction.
 ///
-/// # Wire stratification
+/// # Wire distribution
 ///
-/// Honest layout per round (`d = max(ell_zk - 1, 2)`):
-///
-/// ```text
-///     wire[0] = c_0       in EF             (eps-scaled plain)
-///     wire[1] = c_2       in EF             (eps-scaled plain)
-///     wire[i] = c_{i+1}   in F-subspace     for i >= 2 (mask-only)
-/// ```
-///
-/// Sampling tiers:
-///
-/// - `wire[0..2]`: uniform in EF.
-/// - `wire[2..]`: uniform in F, lifted into EF.
-///
-/// Without the split, a distinguisher could check whether `c_3, c_4, ...`
-/// fall in the base-field subspace and separate the views (paper §6.1).
+/// The construction is instantiated over `EF`, so every wire coordinate is
+/// uniform over the full extension field (Lemma 6.4 with `F := EF`). Each sent
+/// wire `[c_0, c_2, c_3, ..., c_d]` (`d = max(ell_zk - 1, 2)`) is drawn
+/// uniformly from `EF`; the dropped linear coefficient `c_1` is recovered from
+/// the affine identity.
 ///
 /// # Returns
 ///
@@ -65,12 +55,12 @@ pub fn simulate_classic_unpacked<F, EF, Enc, M, Challenger, R>(
 where
     F: Field,
     EF: ExtensionField<F>,
-    Enc: ZkEncoding<F>,
-    Enc::Codeword: Matrix<F>,
-    M: Mmcs<F>,
+    Enc: ZkEncoding<EF>,
+    Enc::Codeword: Matrix<EF>,
+    M: Mmcs<EF>,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     R: Rng,
-    StandardUniform: Distribution<F> + Distribution<EF>,
+    StandardUniform: Distribution<EF>,
 {
     // Protocol shape.
     let k = folding_factor;
@@ -96,7 +86,7 @@ where
     // Uniform messages produce uniform Reed-Solomon codewords.
     // Their Merkle commits are indistinguishable from the honest prover's (zero simulator error for RS).
 
-    let masks: Vec<Vec<F>> = (0..k)
+    let masks: Vec<Vec<EF>> = (0..k)
         .map(|_| (0..ell_zk).map(|_| rng.random()).collect())
         .collect();
 
@@ -114,18 +104,18 @@ where
     //              = 2^{k-1} * sum_l ( mask[0].double() + sum(mask[1..]) )
     //
     // Byte-equivalent to the honest prover under matched RNG seeds.
-    let two_to_k_minus_1 = F::TWO.exp_u64((k - 1) as u64);
-    let mu_tilde: F = two_to_k_minus_1
+    let two_to_k_minus_1 = EF::TWO.exp_u64((k - 1) as u64);
+    let mu_tilde: EF = two_to_k_minus_1
         * masks
             .iter()
-            .map(|m| m[0].double() + m[1..].iter().copied().sum::<F>())
-            .sum::<F>();
+            .map(|m| m[0].double() + m[1..].iter().copied().sum::<EF>())
+            .sum::<EF>();
 
-    // Observe mu_tilde (lifted to EF) and sample the combining challenge.
-    challenger.observe_algebra_element(EF::from(mu_tilde));
+    // Observe mu_tilde and sample the combining challenge.
+    challenger.observe_algebra_element(mu_tilde);
     let eps: EF = challenger.sample_algebra_element();
 
-    // Phase 4: per-round wire sampling (Construction 6.3 step 4 simulated; Lemma 6.4 stratification below).
+    // Phase 4: per-round wire sampling (Construction 6.3 step 4 simulated; every coordinate uniform over EF).
     //
     // Wire shape (linear coefficient c_1 dropped):
     //
@@ -149,19 +139,9 @@ where
     let mut target: EF = eps * mu + mu_tilde;
 
     for _ in 0..k {
-        // Stratified wire sample:
-        //
-        //     wire[0..2] in EF             (eps-scaled plain in honest)
-        //     wire[2..]  in F-subspace     (mask-only in honest)
-        let wire: Vec<EF> = (0..wire_size)
-            .map(|i| {
-                if i < 2 {
-                    rng.random::<EF>()
-                } else {
-                    EF::from(rng.random::<F>())
-                }
-            })
-            .collect();
+        // Every wire coordinate is uniform over the full extension field
+        // (Lemma 6.4 with `F := EF`).
+        let wire: Vec<EF> = (0..wire_size).map(|_| rng.random::<EF>()).collect();
 
         // Absorb the wire on the transcript.
         challenger.observe_algebra_slice(&wire);
@@ -203,17 +183,25 @@ where
 mod tests {
     use alloc::vec::Vec;
 
-    use p3_field::{Field, PackedValue};
+    use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing};
     use proptest::prelude::*;
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
     use super::*;
     use crate::layout::TableShape;
-    use crate::zk::test_helpers::{
-        EF, F, MyChallenger, MyMmcs, build_prover_verifier, ef_in_f_subspace, make_setup,
-    };
+    use crate::zk::test_helpers::{EF, F, MyChallenger, MyMmcs, build_prover_verifier, make_setup};
     use crate::zk::{ZkSumcheckData, ZkVerifier};
+
+    /// True when an extension element has a non-zero coordinate above the base slot.
+    ///
+    /// Every honest and simulated wire coordinate is uniform over `EF` (the
+    /// construction is instantiated over `EF`), so each coordinate escapes the
+    /// base-field subspace except with probability `|F|^{-(D-1)}`.
+    fn escapes_f_subspace(x: EF) -> bool {
+        let coeffs: &[F] = EF::as_basis_coefficients_slice(&x);
+        coeffs[1..].iter().any(|c| *c != F::ZERO)
+    }
 
     /// Lemma 6.4 view-match driver for Reed-Solomon mask encoding.
     ///
@@ -221,7 +209,7 @@ mod tests {
     ///
     /// 1. Verifier accepts both transcripts (soundness floor).
     /// 2. `mu_tilde` and mask commits match bit-for-bit under matched seeds (deterministic equality, not a distributional test).
-    /// 3. Wire coordinates with index `>= 2` lie in the base-field subspace on both sides (closes paper §6.1's distinguisher).
+    /// 3. Wire coordinates with index `>= 2` escape the base-field subspace on both sides (the masks are extension-valued, so the witness leak of an `F`-valued mask is absent).
     /// 4. The mask encoding's own simulator returns the correct shape (RS simulator error = 0).
     fn run_view_match_rs(
         n_vars: usize,
@@ -317,19 +305,24 @@ mod tests {
             return Err("matched-RNG coupling: mask commits differ");
         }
 
-        // === F-subspace stratification on both sides ===
-
+        // === Extension-valued wires on both sides ===
+        //
+        // The masks are extension-valued, so every wire coordinate is uniform
+        // over EF. We check the index-`>= 2` coordinates (mask-only, no plain
+        // piece) escape the base-field subspace on both the real and simulated
+        // sides; an `F`-valued mask would pin them to the base field and
+        // reintroduce the witness leak.
         for wire in &zk_data_real.round_coefficients {
             for &c in wire.iter().skip(2) {
-                if !ef_in_f_subspace(c) {
-                    return Err("real-prover wire[i >= 2] escapes the F-subspace");
+                if !escapes_f_subspace(c) {
+                    return Err("real-prover wire[i >= 2] collapsed into the F-subspace");
                 }
             }
         }
         for wire in &zk_data_sim.round_coefficients {
             for &c in wire.iter().skip(2) {
-                if !ef_in_f_subspace(c) {
-                    return Err("simulator wire[i >= 2] escapes the F-subspace");
+                if !escapes_f_subspace(c) {
+                    return Err("simulator wire[i >= 2] collapsed into the F-subspace");
                 }
             }
         }
@@ -350,7 +343,7 @@ mod tests {
                     positions.push(p);
                 }
             }
-            let sim_answers: Vec<F> = encoding.simulate(&positions, &mut sim_ans_rng);
+            let sim_answers: Vec<EF> = encoding.simulate(&positions, &mut sim_ans_rng);
             if sim_answers.len() != positions.len() {
                 return Err("ZkEncoding::simulate returned wrong number of answers");
             }
@@ -397,24 +390,21 @@ mod tests {
         ) {
             // Invariants asserted on every (n_vars, folding, ell_zk, num_eqs) draw:
             //
-            //   1. Shape   - output sizes match `folding_factor`, `ell_zk`, and `pow_bits = 0`.
-            //   2. Stratification (+) - every wire coordinate with index >= 2 lies in the F-subspace.
-            //   3. Stratification (-) - at least one wire[0..2] coordinate escapes the F-subspace.
-            //   4. Acceptance  - a fresh verifier replay accepts the simulated transcript (Lemma 6.4).
+            //   1. Shape      - output sizes match `folding_factor`, `ell_zk`, and `pow_bits = 0`.
+            //   2. EF wires   - every wire coordinate with index >= 2 escapes the base-field subspace.
+            //   3. Acceptance - a fresh verifier replay accepts the simulated transcript (Lemma 6.4).
             //
-            // Wire layout (linear coefficient c_1 dropped):
+            // The construction is instantiated over EF, so the wire (linear
+            // coefficient c_1 dropped) has all coordinates uniform over EF:
             //
-            //     wire[0] = c_0    in EF (eps-scaled plain piece)
-            //     wire[1] = c_2    in EF (eps-scaled plain piece)
-            //     wire[2] = c_3    in F-subspace (mask-only)
-            //     wire[3] = c_4    in F-subspace (mask-only)
-            //     ...
+            //     wire[0] = c_0, wire[1] = c_2, wire[2] = c_3, ...
             //
             // Why ell_zk >= 4: lengths 2 and 3 produce a 2-coordinate wire and wire[2..] is empty, so check 2 has no work to do.
             //
-            // Without check 2 a distinguisher trivially separates real from simulated views (paper §6.1).
-            // Without check 3 a regression that collapses both tiers to F would still pass check 2.
-            // Without check 4 a shape-correct but verifier-rejected transcript would slip through.
+            // Check 2 is the regression guard for the witness leak: an F-valued
+            // mask would pin the mask-only coordinates (index >= 2) to the base
+            // field, and the plain-bearing coordinates wire[0], wire[1] to a
+            // base-field coset, which a distinguisher separates (paper §6.1).
             let folding_factor = 1 + (seed as usize % n_vars);
 
             let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
@@ -480,40 +470,22 @@ mod tests {
                 "one challenge per round",
             );
 
-            // Check 2: positive stratification.
+            // Check 2: extension-valued wires (witness-leak regression guard).
             //
-            // wire[i] for i >= 2 must lie in the F-subspace.
+            // Each mask-only coordinate (index >= 2) is uniform over EF, so it
+            // escapes the base-field subspace except with probability
+            // `|F|^{-(D-1)}`. An F-valued mask would pin these to the base
+            // field and leak the witness; this check rejects that regression.
             for (round_idx, wire) in sim_zk_data.round_coefficients.iter().enumerate() {
                 for (pos, &coeff) in wire.iter().enumerate().skip(2) {
                     prop_assert!(
-                        ef_in_f_subspace(coeff),
-                        "simulator wire[{pos}] in round {round_idx} must live in F-subspace",
+                        escapes_f_subspace(coeff),
+                        "simulator wire[{pos}] in round {round_idx} collapsed into the F-subspace",
                     );
                 }
             }
 
-            // Check 3: negative stratification.
-            //
-            // Per coord, expected escape probability:
-            //
-            //     P[wire[0..2] not in F] = 1 - |F|^{-3}
-            //
-            // Aggregated false-negative bound:
-            //
-            //     <= 2^{-32 * folding_factor}
-            //
-            // Catches a regression that collapses both tiers to F.
-            let any_ef_coord_escapes = sim_zk_data
-                .round_coefficients
-                .iter()
-                .flat_map(|wire| wire.iter().take(2))
-                .any(|&c| !ef_in_f_subspace(c));
-            prop_assert!(
-                any_ef_coord_escapes,
-                "EF-tier samples collapsed into F-subspace across all rounds",
-            );
-
-            // Check 4: verifier accepts the simulated transcript.
+            // Check 3: verifier accepts the simulated transcript.
             //
             // Test form of Lemma 6.4:
             //

--- a/sumcheck/src/zk/test_helpers.rs
+++ b/sumcheck/src/zk/test_helpers.rs
@@ -5,9 +5,10 @@ use alloc::vec::Vec;
 
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DFTSmallBatch;
+use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::poly::Poly;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -32,12 +33,14 @@ pub type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 pub type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 /// Packed flavour of the base field, used for SIMD Merkle leaves.
 pub type PackedF = <F as Field>::Packing;
-/// Merkle commitment scheme used for the mask oracles.
-pub type MyMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
+/// Base-field Merkle commitment scheme backing the mask oracles.
+pub type BaseMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
+/// Extension-field Merkle commitment scheme used for the mask oracles.
+pub type MyMmcs = ExtensionMmcs<F, EF, BaseMmcs>;
 /// Two-adic DFT backing the Reed-Solomon encoding.
-pub type MyDft = Radix2DFTSmallBatch<F>;
+pub type MyDft = Radix2DFTSmallBatch<EF>;
 /// Reed-Solomon zero-knowledge encoding driving the mask code.
-pub type MyEnc = ReedSolomonZkEncoding<F, MyDft>;
+pub type MyEnc = ReedSolomonZkEncoding<EF, MyDft>;
 
 /// Randomness symbols appended to each mask before encoding.
 ///
@@ -71,7 +74,9 @@ pub fn make_setup(seed: u64, ell_zk: usize) -> (Perm, MyMmcs, MyEnc) {
     let merkle_hash = MyHash::new(perm.clone());
     let merkle_compress = MyCompress::new(perm.clone());
     // Zero salt: deterministic commitments for reproducibility.
-    let mmcs: MyMmcs = MyMmcs::new(merkle_hash, merkle_compress, 0);
+    let base_mmcs = BaseMmcs::new(merkle_hash, merkle_compress, 0);
+    // Lift the base-field MMCS to commit extension-field mask codewords.
+    let mmcs: MyMmcs = ExtensionMmcs::new(base_mmcs);
 
     // Codeword length, rounded up to a power of two for the butterfly schedule:
     //
@@ -224,30 +229,4 @@ pub fn run_roundtrip(
         return Err("prover/verifier disagreed on sumcheck randomness");
     }
     Ok(())
-}
-
-/// True when an extension-field element lifts a single base-field element.
-///
-/// # Why this check exists
-///
-/// Honest and simulated wire coordinates with index `>= 2` are produced as
-///
-/// ```text
-///     2^{k - j} * mask_coeff
-/// ```
-///
-/// lifted from F into EF, so both views land in the F-subspace.
-///
-/// Without enforcing this on the simulator, a distinguisher could read off the basis decomposition and separate the two views.
-///
-/// # Encoding
-///
-/// ```text
-///     x in F  <=>  basis_coeffs(x) = [ x_0, 0, 0, ..., 0 ]
-/// ```
-pub fn ef_in_f_subspace(x: EF) -> bool {
-    // Decompose into the EF basis.
-    let coeffs: &[F] = EF::as_basis_coefficients_slice(&x);
-    // First slot carries the lifted base value; all higher slots must be zero.
-    coeffs[1..].iter().all(|c| *c == F::ZERO)
 }

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -115,7 +115,7 @@ where
         challenger: &mut Ch,
     ) -> Result<(Point<EF>, EF), SumcheckError>
     where
-        M: Mmcs<F>,
+        M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
         // Lemma 6.4 hypotheses on the verifier-side parameters.
@@ -181,7 +181,7 @@ where
         for commit in mask_commits {
             challenger.observe(commit.clone());
         }
-        challenger.observe_algebra_element(EF::from(zk_data.mu_tilde));
+        challenger.observe_algebra_element(zk_data.mu_tilde);
         let eps: EF = challenger.sample_algebra_element();
 
         // Phase 4: walk the round chain (Construction 6.3 step 4 verifier replay).

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -3,6 +3,7 @@ use std::hint::black_box;
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
+use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
@@ -26,7 +27,7 @@ type EFPacked = <EF as ExtensionField<F>>::ExtensionPacking;
 
 // Mask commitment MMCS and mask encoding consumed by the HVZK arm
 // (Construction 6.3, eprint 2026/391).
-type MaskMmcs = MerkleTreeMmcs<
+type BaseMaskMmcs = MerkleTreeMmcs<
     FP,
     FP,
     PaddingFreeSponge<Perm, 16, 8, 8>,
@@ -34,7 +35,8 @@ type MaskMmcs = MerkleTreeMmcs<
     2,
     8,
 >;
-type MaskEnc = ReedSolomonZkEncoding<F, Radix2DFTSmallBatch<F>>;
+type MaskMmcs = ExtensionMmcs<F, EF, BaseMaskMmcs>;
+type MaskEnc = ReedSolomonZkEncoding<EF, Radix2DFTSmallBatch<EF>>;
 
 /// ZK code message length. Bound by Lemma 6.4 (`ℓ_zk ≥ 2`).
 ///
@@ -114,7 +116,8 @@ fn make_zk_setup() -> (MaskMmcs, MaskEnc) {
     let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(0xfeed));
     let merkle_hash = PaddingFreeSponge::new(perm.clone());
     let merkle_compress = TruncatedPermutation::new(perm);
-    let mmcs = MaskMmcs::new(merkle_hash, merkle_compress, 0);
+    let base_mmcs = BaseMaskMmcs::new(merkle_hash, merkle_compress, 0);
+    let mmcs = MaskMmcs::new(base_mmcs);
     let m = (ELL_ZK + T_RAND).next_power_of_two();
     let encoding = MaskEnc::new(T_RAND, ELL_ZK, m, Radix2DFTSmallBatch::default());
     (mmcs, encoding)


### PR DESCRIPTION
This came up during my review of #1635, but drawing masks in `F` instead of `EF` fundamentally breaks ZK. The claim inline in the code that this is done to keep the proof size sublinear makes little sense as in practice this change has no impact on proof size.