### PR TITLE
fix: require ell_zk >= 3 in HVZK sumcheck

### DIFF
--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -58,7 +58,7 @@
 //! # Field constraints (Lemma 6.4)
 //!
 //! - Base field characteristic must not be `2`.
-//! - Mask message length `ell_zk` must be at least `2`.
+//! - Mask message length `ell_zk` must be at least `3`, so the mask (degree `ell_zk - 1`) covers the degree-2 plain round polynomial.
 //!
 //! Both are checked at constructor entry.
 //!

--- a/sumcheck/src/zk/prover.rs
+++ b/sumcheck/src/zk/prover.rs
@@ -144,7 +144,7 @@ where
     /// # Panics
     ///
     /// - Base field characteristic is `2` (violates Lemma 6.4).
-    /// - Mask code message length is below `2` (Lemma 6.4 floor).
+    /// - Mask code message length is below `3` (mask must cover the degree-2 plain piece).
     /// - Folding factor is `0` or exceeds the polynomial's arity.
     #[allow(clippy::too_many_lines, clippy::type_complexity)]
     #[tracing::instrument(skip_all)]
@@ -174,7 +174,10 @@ where
 
         // Lemma 6.4 hypotheses + sanity bounds on the folding factor.
         assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(ell_zk >= 2, "Lemma 6.4 requires ell_zk >= 2");
+        assert!(
+            ell_zk >= 3,
+            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
+        );
         assert!(k >= 1, "sumcheck requires at least one round");
         assert!(
             k <= n_vars,
@@ -511,7 +514,7 @@ mod tests {
         #[test]
         fn prop_completeness_classic_unpacked(
             n_vars in 3usize..=8,
-            ell_zk in 2usize..=5,
+            ell_zk in 3usize..=5,
             num_concrete in 0usize..=2,
             num_virtual in 0usize..=2,
             seed in 0u64..1024,

--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -68,7 +68,10 @@ where
 
     // Lemma 6.4 hypotheses.
     assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-    assert!(ell_zk >= 2, "Lemma 6.4 requires ell_zk >= 2");
+    assert!(
+        ell_zk >= 3,
+        "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
+    );
     assert!(k >= 1, "sumcheck requires at least one round");
 
     // Phase 1: sample alpha and derive mu (replays Construction 6.3 prelude).
@@ -358,7 +361,7 @@ mod tests {
         #[test]
         fn prop_simulator_view_matches_real_rs(
             n_vars in 3usize..=8,
-            ell_zk in 2usize..=5,
+            ell_zk in 3usize..=5,
             num_eqs in 1usize..=3,
             seed in 0u64..1024,
         ) {

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -102,7 +102,7 @@ where
     /// # Panics
     ///
     /// - Base field characteristic is `2`.
-    /// - Mask code message length is below `2`.
+    /// - Mask code message length is below `3`.
     /// - Folding factor is `0`.
     #[allow(clippy::too_many_arguments)]
     pub fn into_sumcheck<M, Ch>(
@@ -120,7 +120,10 @@ where
     {
         // Lemma 6.4 hypotheses on the verifier-side parameters.
         assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(ell_zk >= 2, "Lemma 6.4 requires ell_zk >= 2");
+        assert!(
+            ell_zk >= 3,
+            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
+        );
         assert!(folding_factor >= 1, "sumcheck requires at least one round");
 
         // Phase 1: shape checks (input validation before Construction 6.3 replay).
@@ -394,7 +397,7 @@ mod tests {
         #[test]
         fn prop_rbr_tampering_changes_verifier_output(
             n_vars in 3usize..=6,
-            ell_zk in 2usize..=4,
+            ell_zk in 3usize..=4,
             num_eqs in 1usize..=2,
             seed in 0u64..512,
             tamper_round_seed in 0usize..16,


### PR DESCRIPTION
## What

Tightens the HVZK sumcheck mask-length floor from `ell_zk >= 2` to `ell_zk >= 3` in the prover, verifier, and simulator, updates the floor docs, and bumps the proptest lower bounds off `ell_zk = 2`. Follow-up to #1726.

## Why

#1726 correctly moved the masks to `EF` so the plain-bearing wire coordinates are blinded over the *full* extension rather than a base-field coset. But a separate, degree-coverage problem survives that fix and bites at the boundary value `ell_zk = 2`.

In this implementation the plain (real) round polynomial is **degree 2**, because WHIR's sumcheck is over a *product* of two multilinears. The code reflects this: `h_size = ell_zk.max(3)` and the `X^2` coefficient is written explicitly:

```rust
h[0] += eps * plain_c0;
h[1] += eps * plain_c1;
h[2] += eps * plain_c_inf;   // degree-2 coefficient of the plain piece
```

The mask `s_j` has degree `ell_zk - 1` and only contributes to slots `h[0..ell_zk]`. So `h[2]` is blinded only when `ell_zk - 1 >= 2`, i.e. `ell_zk >= 3`.

At `ell_zk = 2` (mask `= [m0, m1]`, degree 1):

```
              real prover                    blinded?   on the wire?
h[0] = 2^{k-j}*m0 + ... + eps*plain_c0       yes (m0)   yes  (wire[0])
h[1] = 2^{k-j}*m1       + eps*plain_c1       yes (m1)   no   (dropped; verifier rebuilds c_1)
h[2] =                    eps*plain_c_inf    NO         yes  (wire[1])   <-- leak
```

The two random mask coefficients `m0, m1` blind `h[0]` and `h[1]`, but `h[1]` is the linear coefficient that is dropped from the wire and reconstructed by the verifier from the affine identity — so `m1`'s randomness is spent keeping that identity consistent, not hiding a sent value. The coordinate actually sent, `h[2] = eps * plain_c_inf`, has no mask term, and `plain_c_inf` is a deterministic function of the witness. The simulator draws that coordinate uniformly over `EF`, so the real and simulated views diverge ⇒ not HVZK.

For `ell_zk >= 3` the mask coefficient `m2` blinds `h[2]` (`h[2] = 2^{k-j}*m2 + eps*plain_c_inf`, uniform over `EF`) and the views match. Equivalently, sent wire coordinates `= max(ell_zk,3) - 1` and independent random mask coefficients available to blind them `= ell_zk - 1`; the inequality `ell_zk - 1 >= max(ell_zk,3) - 1` holds iff `ell_zk >= 3`.

## Why the paper says `>= 2`

Construction 6.3 in eprint 2026/391 is a pure interleaved-code folding sumcheck whose round polynomial is **degree 1** (`ĥ_j ∈ F^{<max{2, ell_zk}}`), so its floor is 2. This implementation's plain piece is one degree higher (the `.max(3)` vs the paper's `max(2, ·)`), so the floor shifts up by one. The merged assertion copied the paper's `2` without accounting for the product sumcheck's extra degree.

## Impact

No effect on real WHIR parameters — soundness forces `ell_zk` to be large (`Õ(λ)`), well above 3. The only thing that exercised the non-ZK config was the assertion permitting `ell_zk = 2` and the proptests sweeping from 2; the view-match test could not detect the leak because it only inspects `wire[i >= 2]` (empty at `ell_zk = 2`) plus acceptance.

## Tests

`cargo test -p p3-sumcheck zk::`, `cargo fmt`, and `cargo clippy -p p3-sumcheck --all-targets` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
