### PR TITLE
fix: pass actual length to invalid_length in array deserializer

### DIFF
--- a/util/src/array_serialization.rs
+++ b/util/src/array_serialization.rs
@@ -37,7 +37,7 @@ where
         for _ in 0..N {
             match seq.next_element()? {
                 Some(val) => data.push(val),
-                None => return Err(serde::de::Error::invalid_length(N, &self)),
+                None => return Err(serde::de::Error::invalid_length(data.len(), &self)),
             }
         }
         data.try_into().map_or_else(|_| unreachable!(), Ok)
@@ -53,6 +53,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use serde::{Deserialize, Serialize};
     use serde_json;
 
@@ -97,5 +98,15 @@ mod tests {
 
         let parsed: Wrapper<0> = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, data);
+    }
+
+    #[test]
+    fn test_deserialize_wrong_length_error_message() {
+        let json = r#"{"arr":[1,2]}"#;
+        let err = serde_json::from_str::<Wrapper<3>>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid length 2"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
Fix incorrect `invalid_length` reporting in array deserialization.

Previously, deserialization errors reported the expected array length as the actual received length, producing confusing messages such as:

`invalid length 3, expected an array of length 3`

This change reports the real number of parsed elements instead and adds a regression test covering the error message.
