### PR TITLE
sumcheck: type zk handoff and residual claim producer

### DIFF
--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -387,6 +387,46 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         r
     }
 
+    /// Computes the plain quadratic coefficients for the current round without
+    /// touching the transcript or folding the polynomial.
+    pub(crate) fn round_coefficients(&self) -> (EF, EF) {
+        let order = self.order;
+        match &self.inner {
+            MaybePacked::Packed { evals, weights } => {
+                let (c0, c_inf) = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                (
+                    EF::ExtensionPacking::to_ext_iter([c0]).sum(),
+                    EF::ExtensionPacking::to_ext_iter([c_inf]).sum(),
+                )
+            }
+            MaybePacked::Unpacked { evals, weights } => {
+                order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
+            }
+        }
+    }
+
+    /// Folds both product-polynomial sides by one verifier challenge.
+    pub(crate) fn fold_round(&mut self, r: EF) {
+        self.compress(r);
+        self.transition();
+    }
+
+    /// Scales the evaluation side of the product polynomial.
+    pub(crate) fn scale_evals(&mut self, scale: EF) {
+        match &mut self.inner {
+            MaybePacked::Packed { evals, .. } => {
+                for value in evals.as_mut_slice() {
+                    *value *= scale;
+                }
+            }
+            MaybePacked::Unpacked { evals, .. } => {
+                for value in evals.as_mut_slice() {
+                    *value *= scale;
+                }
+            }
+        }
+    }
+
     /// Extracts the evaluation polynomial as a scalar [`Poly`].
     ///
     /// This unpacks the evaluations if in packed mode.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -12,9 +12,9 @@ use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 
-use crate::SumcheckData;
 use crate::constraints::Constraint;
 use crate::product_polynomial::ProductPolynomial;
+use crate::{SumcheckData, extrapolate_01inf};
 
 /// Input size at which the round-coefficient routines switch from serial to parallel execution.
 ///
@@ -370,6 +370,11 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
         Self { poly, sum }
     }
 
+    /// Returns the current claimed sum over the remaining unbound variables.
+    pub const fn claimed_sum(&self) -> EF {
+        self.sum
+    }
+
     /// Returns the number of remaining (unbound) variables.
     pub fn num_variables(&self) -> usize {
         self.poly.num_variables()
@@ -384,6 +389,26 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     /// Evaluates `f` at a given multilinear point via interpolation.
     pub fn eval(&self, point: &Point<EF>) -> EF {
         self.poly.eval(point)
+    }
+
+    /// Computes the current round's plain quadratic coefficients without
+    /// touching the transcript or folding the polynomial.
+    pub(crate) fn round_coefficients(&self) -> (EF, EF) {
+        self.poly.round_coefficients()
+    }
+
+    /// Folds the residual product polynomial by one challenge and updates the
+    /// claimed sum with the same quadratic extrapolation as the plain path.
+    pub(crate) fn fold_round_with_coefficients(&mut self, c0: EF, c_inf: EF, gamma: EF) {
+        self.sum = extrapolate_01inf(c0, self.sum - c0, c_inf, gamma);
+        self.poly.fold_round(gamma);
+        debug_assert_eq!(self.sum, self.poly.dot_product());
+    }
+
+    /// Applies a scalar to the evaluation side and the matching residual claim.
+    pub(crate) fn scale_evals_and_claim(&mut self, scale: EF) {
+        self.poly.scale_evals(scale);
+        self.sum *= scale;
     }
 
     /// Runs additional sumcheck rounds, optionally incorporating a new constraint.

--- a/sumcheck/src/zk/data.rs
+++ b/sumcheck/src/zk/data.rs
@@ -3,8 +3,12 @@
 use alloc::vec::Vec;
 
 use p3_commit::Mmcs;
-use p3_field::Field;
+use p3_field::{ExtensionField, Field, HornerIter};
+use p3_multilinear_util::point::Point;
 use p3_zk_codes::ZkEncoding;
+use serde::{Deserialize, Serialize};
+
+use crate::strategy::SumcheckProver;
 
 /// Per-round prover output of the HVZK sumcheck protocol.
 ///
@@ -35,7 +39,7 @@ use p3_zk_codes::ZkEncoding;
 ///
 /// Valid transcripts form an affine subspace of dimension `1 + k * (ell_zk - 1)`.
 /// The `k` dropped linear coefficients are exactly the redundant degrees of freedom of the rank-nullity argument.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZkSumcheckData<F, EF> {
     /// Sum of all mask polynomial evaluations across the boolean hypercube `{0,1}^k`.
     ///
@@ -85,3 +89,206 @@ pub type MaskOracle<EF, Enc, M> = (
     <M as Mmcs<EF>>::Commitment,
     <M as Mmcs<EF>>::ProverData<<Enc as ZkEncoding<EF>>::Codeword>,
 );
+
+/// Typed prover handoff produced by the HVZK sumcheck.
+///
+/// Downstream code-switching needs both the residual prover and the sampled
+/// `eps` scale. Carrying them in a named type makes the Construction 6.3 to
+/// Construction 9.7 boundary explicit.
+pub struct ZkSumcheckHandoff<F, EF, Enc, M>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Enc: ZkEncoding<EF>,
+    M: Mmcs<EF>,
+{
+    /// Residual sumcheck prover whose claim is scaled by `eps`.
+    pub residual_prover: SumcheckProver<F, EF>,
+    /// Per-round sumcheck challenges.
+    pub randomness: Point<EF>,
+    /// Construction 6.3 combining challenge.
+    pub eps: EF,
+    /// Plain mask messages sampled by the prover, in round order.
+    ///
+    /// These are prover-only witnesses. Code-switch composition uses them to
+    /// carry the verifier-visible masked residual as auxiliary linear claims.
+    pub mask_messages: Vec<Vec<EF>>,
+    /// Encoded mask oracles, in round order.
+    pub mask_oracles: Vec<MaskOracle<EF, Enc, M>>,
+}
+
+/// Typed verifier handoff produced by replaying an HVZK sumcheck transcript.
+///
+/// This mirrors [`ZkSumcheckHandoff`] without prover-only mask data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZkVerifierHandoff<EF> {
+    /// Per-round sumcheck challenges.
+    pub randomness: Point<EF>,
+    /// Residual claim after replay.
+    pub claimed_residual: EF,
+    /// Construction 6.3 combining challenge.
+    pub eps: EF,
+}
+
+/// Evaluates the final verifier-visible mask residual after all HVZK sumcheck rounds.
+///
+/// For masks `s_j(X)` and verifier challenges `gamma_j`, the mask part of the
+/// final Construction 6.3 target is:
+///
+/// ```text
+///     sum_j s_j(gamma_j)
+/// ```
+///
+/// This is the closed form of the live/past/future mask recurrence used while
+/// assembling the round polynomials.
+#[must_use]
+pub fn mask_residual<EF>(masks: &[Vec<EF>], gammas: &[EF]) -> EF
+where
+    EF: Field,
+{
+    assert_eq!(masks.len(), gammas.len());
+    masks
+        .iter()
+        .zip(gammas)
+        .map(|(mask, &gamma)| mask.iter().copied().horner(gamma))
+        .sum()
+}
+
+/// Linear covectors whose dot products with the masks equal [`mask_residual`].
+///
+/// TODO(#1587): plug this into the code-switching round when the residual mask
+/// claims are carried into Construction 9.7.
+#[must_use]
+pub fn mask_residual_covectors<EF>(masks: &[Vec<EF>], gammas: &[EF]) -> Vec<Vec<EF>>
+where
+    EF: Field,
+{
+    assert!(
+        masks
+            .iter()
+            .all(|mask| mask.len() == masks.first().map_or(0, Vec::len))
+    );
+    mask_residual_covectors_from_shape(masks.len(), masks.first().map_or(0, Vec::len), gammas)
+}
+
+/// Linear covectors for masks with a known rectangular shape.
+///
+/// The covector for mask `s_j` is `[1, gamma_j, gamma_j^2, ...]`.
+///
+/// TODO(#1587): use this shape-only variant when deriving verifier-side mask
+/// covectors from the ZK sumcheck handoff.
+#[must_use]
+pub fn mask_residual_covectors_from_shape<EF: Field>(
+    mask_count: usize,
+    mask_len: usize,
+    gammas: &[EF],
+) -> Vec<Vec<EF>> {
+    assert_eq!(mask_count, gammas.len());
+    gammas
+        .iter()
+        .map(|gamma| gamma.powers().collect_n(mask_len))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{Field, PrimeCharacteristicRing, dot_product};
+
+    use super::{mask_residual, mask_residual_covectors};
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+
+    fn ef(x: u64) -> EF {
+        EF::from_u64(x)
+    }
+
+    fn reference_mask_recurrence<EF>(masks: &[Vec<EF>], gammas: &[EF]) -> EF
+    where
+        EF: Field,
+    {
+        assert_eq!(masks.len(), gammas.len());
+        let k = masks.len();
+        if k == 0 {
+            return EF::ZERO;
+        }
+
+        let pow2: Vec<EF> = EF::TWO.powers().collect_n(k + 1);
+        let mut mask_evals_at_gamma = Vec::with_capacity(k);
+        let mut sum_future_endpoints: EF = masks
+            .iter()
+            .map(|mask| mask[0].double() + mask[1..].iter().copied().sum::<EF>())
+            .sum();
+        let mut target = EF::ZERO;
+
+        for (round_idx, (s_j, &gamma_j)) in masks.iter().zip(gammas).enumerate() {
+            let j = round_idx + 1;
+            let s_j_endpoints = s_j[0].double() + s_j[1..].iter().copied().sum::<EF>();
+            sum_future_endpoints -= s_j_endpoints;
+
+            let h_size = s_j.len().max(3);
+            let mut h = EF::zero_vec(h_size);
+            let mult_live = pow2[k - j];
+            for (i, &c) in s_j.iter().enumerate() {
+                h[i] += mult_live * c;
+            }
+
+            let past_mask_sum: EF = mask_evals_at_gamma.iter().copied().sum();
+            h[0] += past_mask_sum * mult_live;
+            if j < k {
+                h[0] += pow2[k - j - 1] * sum_future_endpoints;
+            }
+
+            target = h
+                .iter()
+                .rev()
+                .copied()
+                .fold(EF::ZERO, |acc, coeff| acc * gamma_j + coeff);
+
+            let s_j_at_gamma = s_j
+                .iter()
+                .rev()
+                .copied()
+                .fold(EF::ZERO, |acc, coeff| acc * gamma_j + coeff);
+            mask_evals_at_gamma.push(s_j_at_gamma);
+        }
+
+        target
+    }
+
+    #[test]
+    fn mask_residual_closed_form_matches_round_recurrence() {
+        let masks = vec![
+            vec![ef(3), ef(5), ef(7), ef(11)],
+            vec![ef(13), ef(17), ef(19), ef(23)],
+            vec![ef(29), ef(31), ef(37), ef(41)],
+        ];
+        let gammas = vec![ef(43), ef(47), ef(53)];
+
+        assert_eq!(
+            mask_residual::<EF>(&masks, &gammas),
+            reference_mask_recurrence::<EF>(&masks, &gammas),
+        );
+    }
+
+    #[test]
+    fn mask_residual_covectors_evaluate_closed_form() {
+        let masks = vec![vec![ef(2), ef(3), ef(5)], vec![ef(7), ef(11), ef(13)]];
+        let gammas = vec![ef(17), ef(19)];
+        let covectors = mask_residual_covectors::<EF>(&masks, &gammas);
+        let by_covectors = masks
+            .iter()
+            .zip(&covectors)
+            .map(|(mask, covector)| {
+                dot_product::<EF, _, _>(mask.iter().copied(), covector.iter().copied())
+            })
+            .sum::<EF>();
+
+        assert_eq!(by_covectors, mask_residual::<EF>(&masks, &gammas));
+    }
+}

--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -75,7 +75,10 @@ pub mod verifier;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
-pub use data::{MaskOracle, ZkSumcheckData};
+pub use data::{
+    MaskOracle, ZkSumcheckData, ZkSumcheckHandoff, ZkVerifierHandoff, mask_residual,
+    mask_residual_covectors, mask_residual_covectors_from_shape,
+};
 pub use prover::{ZkLayout, ZkPrefixProver, ZkProver, ZkSuffixProver};
 pub use simulator::simulate_classic_unpacked;
 pub use verifier::ZkVerifier;

--- a/sumcheck/src/zk/prover/mod.rs
+++ b/sumcheck/src/zk/prover/mod.rs
@@ -23,6 +23,7 @@
 
 mod common;
 mod layout;
+mod residual;
 mod round;
 mod zk_prover;
 

--- a/sumcheck/src/zk/prover/residual.rs
+++ b/sumcheck/src/zk/prover/residual.rs
@@ -1,0 +1,287 @@
+//! HVZK overlay for an already-derived residual sumcheck claim.
+
+use alloc::vec::Vec;
+
+use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+use p3_commit::Mmcs;
+use p3_field::{ExtensionField, Field, HornerIter};
+use p3_matrix::Matrix;
+use p3_multilinear_util::point::Point;
+use p3_zk_codes::ZkEncoding;
+use rand::Rng;
+
+use super::common::{observe_masks_and_mu_tilde, sample_masks};
+use super::round::{PlainPiece, RoundContext, RoundState, round_poly_to_wire};
+use crate::strategy::SumcheckProver;
+use crate::zk::{ZkSumcheckData, ZkSumcheckHandoff};
+
+impl<F, EF> SumcheckProver<F, EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    /// Runs the HVZK sumcheck overlay on an already-derived residual product
+    /// polynomial.
+    ///
+    /// This is the post-code-switch analogue of `ZkPrefixProver::into_sumcheck`:
+    /// the caller has already reduced the layout-specific opening relation to a
+    /// product polynomial, and this method applies Construction 6.3's mask
+    /// transcript to the next batch of sumcheck rounds.
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    #[tracing::instrument(skip_all)]
+    pub fn into_zk_sumcheck<Enc, M, R, Ch>(
+        mut self,
+        zk_data: &mut ZkSumcheckData<F, EF>,
+        encoding: &Enc,
+        mmcs: &M,
+        folding_factor: usize,
+        pow_bits: usize,
+        challenger: &mut Ch,
+        rng: &mut R,
+    ) -> ZkSumcheckHandoff<F, EF, Enc, M>
+    where
+        Enc: ZkEncoding<EF>,
+        Enc::Codeword: Matrix<EF>,
+        M: Mmcs<EF>,
+        R: Rng,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
+        assert!(folding_factor >= 1, "sumcheck requires at least one round");
+        assert!(
+            folding_factor <= self.num_variables(),
+            "folding_factor must be <= residual prover arity",
+        );
+
+        let ell_zk = encoding.message_len();
+        assert!(
+            ell_zk >= 3,
+            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
+        );
+
+        // Unlike the layout-driven path, this entry receives a scalar claim
+        // directly, so bind it before the masking prelude samples `eps`.
+        challenger.observe_algebra_element(self.claimed_sum());
+
+        let (masks, mask_oracles) =
+            sample_masks::<EF, _, _, _, _>(folding_factor, encoding, mmcs, challenger, rng);
+        let mut sum_future_endpoints = observe_masks_and_mu_tilde::<F, EF, _>(
+            &masks,
+            folding_factor,
+            ell_zk,
+            challenger,
+            zk_data,
+        );
+
+        let eps: EF = challenger.sample_algebra_element();
+        let mut rs = Vec::with_capacity(folding_factor);
+        let mut mask_evals_at_gamma = Vec::with_capacity(folding_factor);
+        let pow2: Vec<EF> = EF::TWO.powers().collect_n(folding_factor + 1);
+        let round_ctx = RoundContext {
+            k: folding_factor,
+            ell_zk,
+            pow2: &pow2,
+            eps,
+        };
+
+        for (round_idx, mask) in masks.iter().enumerate() {
+            let j = round_idx + 1;
+            let mask_endpoints = mask[0].double() + mask[1..].iter().copied().sum::<EF>();
+            sum_future_endpoints -= mask_endpoints;
+
+            let (plain_c0, plain_c_inf) = self.round_coefficients();
+            let h = round_ctx.assemble(
+                RoundState {
+                    j,
+                    mask,
+                    past_mask_evals: &mask_evals_at_gamma,
+                    future_endpoints: sum_future_endpoints,
+                },
+                PlainPiece {
+                    c0: plain_c0,
+                    c_inf: plain_c_inf,
+                },
+            );
+            let wire = round_poly_to_wire(&h);
+            challenger.observe_algebra_slice(&wire);
+            zk_data.round_coefficients.push(wire);
+
+            if pow_bits > 0 {
+                zk_data.pow_witnesses.push(challenger.grind(pow_bits));
+            }
+
+            let gamma: EF = challenger.sample_algebra_element();
+            let mask_at_gamma = mask.iter().copied().horner(gamma);
+            mask_evals_at_gamma.push(mask_at_gamma);
+
+            self.fold_round_with_coefficients(plain_c0, plain_c_inf, gamma);
+            rs.push(gamma);
+        }
+
+        self.scale_evals_and_claim(eps);
+
+        ZkSumcheckHandoff {
+            residual_prover: self,
+            randomness: Point::new(rs),
+            eps,
+            mask_messages: masks,
+            mask_oracles,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{PrimeCharacteristicRing, dot_product};
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_multilinear_util::poly::Poly;
+    use p3_zk_codes::ZkEncoding;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use super::*;
+    use crate::product_polynomial::ProductPolynomial;
+    use crate::strategy::VariableOrder;
+    use crate::zk::test_helpers::{MyChallenger, MyMmcs, make_setup};
+    use crate::zk::{ZkVerifier, mask_residual};
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<BabyBear, 4>;
+
+    #[derive(Clone)]
+    struct SentinelEncoding {
+        ell_zk: usize,
+    }
+
+    impl ZkEncoding<EF> for SentinelEncoding {
+        type Codeword = RowMajorMatrix<EF>;
+
+        fn message_len(&self) -> usize {
+            self.ell_zk
+        }
+
+        fn randomness_len(&self) -> usize {
+            0
+        }
+
+        fn error(&self) -> f64 {
+            0.0
+        }
+
+        fn sample_message<R: Rng>(&self, _rng: &mut R) -> Vec<EF> {
+            (0..self.ell_zk)
+                .map(|idx| EF::from_u64(100 + idx as u64))
+                .collect()
+        }
+
+        fn query_bound(&self) -> usize {
+            0
+        }
+
+        fn encode<R: Rng>(&self, msg: &[EF], _rng: &mut R) -> Self::Codeword {
+            RowMajorMatrix::new_col(msg.to_vec())
+        }
+
+        fn simulate<R: Rng>(&self, query_set: &[usize], _rng: &mut R) -> Vec<EF> {
+            EF::zero_vec(query_set.len())
+        }
+    }
+
+    #[test]
+    fn residual_prover_zk_handoff_replays_from_claim() {
+        let evals = Poly::new((1..=8).map(EF::from_u64).collect::<Vec<_>>());
+        let weights = Poly::new((11..=18).map(EF::from_u64).collect::<Vec<_>>());
+        let claimed_sum = dot_product::<EF, _, _>(
+            evals.as_slice().iter().copied(),
+            weights.as_slice().iter().copied(),
+        );
+        let poly = ProductPolynomial::<F, EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
+        let prover = SumcheckProver::new(poly, claimed_sum);
+
+        let ell_zk = 4;
+        let folding_factor = 2;
+        let (perm, mmcs, encoding) = make_setup(17, ell_zk);
+        let mut prover_challenger = MyChallenger::new(perm.clone());
+        let mut verifier_challenger = MyChallenger::new(perm);
+        let mut rng = SmallRng::seed_from_u64(19);
+        let mut zk_data = ZkSumcheckData::<F, EF>::default();
+
+        let prover_handoff = prover.into_zk_sumcheck(
+            &mut zk_data,
+            &encoding,
+            &mmcs,
+            folding_factor,
+            0,
+            &mut prover_challenger,
+            &mut rng,
+        );
+        let mask_commits = prover_handoff
+            .mask_oracles
+            .iter()
+            .map(|(commit, _)| commit.clone())
+            .collect::<Vec<_>>();
+
+        let verifier_handoff = ZkVerifier::<F, EF>::verify_claim::<MyMmcs, _>(
+            &zk_data,
+            &mask_commits,
+            ell_zk,
+            folding_factor,
+            0,
+            claimed_sum,
+            &mut verifier_challenger,
+        )
+        .expect("honest residual ZK handoff should verify");
+
+        assert_eq!(verifier_handoff.randomness, prover_handoff.randomness);
+        assert_eq!(verifier_handoff.eps, prover_handoff.eps);
+
+        let gammas = prover_handoff
+            .randomness
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        let final_mask_residual = mask_residual::<EF>(&prover_handoff.mask_messages, &gammas);
+        assert_eq!(
+            verifier_handoff.claimed_residual,
+            prover_handoff.residual_prover.claimed_sum() + final_mask_residual,
+        );
+    }
+
+    #[test]
+    fn residual_zk_handoff_samples_masks_through_encoding() {
+        let evals = Poly::new((1..=8).map(EF::from_u64).collect::<Vec<_>>());
+        let weights = Poly::new((11..=18).map(EF::from_u64).collect::<Vec<_>>());
+        let claimed_sum = dot_product::<EF, _, _>(
+            evals.as_slice().iter().copied(),
+            weights.as_slice().iter().copied(),
+        );
+        let poly = ProductPolynomial::<F, EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
+        let prover = SumcheckProver::new(poly, claimed_sum);
+
+        let ell_zk = 4;
+        let folding_factor = 2;
+        let (perm, mmcs, _) = make_setup(23, ell_zk);
+        let encoding = SentinelEncoding { ell_zk };
+        let mut challenger = MyChallenger::new(perm);
+        let mut rng = SmallRng::seed_from_u64(29);
+        let mut zk_data = ZkSumcheckData::<F, EF>::default();
+
+        let handoff = prover.into_zk_sumcheck(
+            &mut zk_data,
+            &encoding,
+            &mmcs,
+            folding_factor,
+            0,
+            &mut challenger,
+            &mut rng,
+        );
+
+        let sentinel = encoding.sample_message(&mut rng);
+        assert_eq!(handoff.mask_messages, vec![sentinel; folding_factor]);
+    }
+}

--- a/sumcheck/src/zk/prover/zk_prover.rs
+++ b/sumcheck/src/zk/prover/zk_prover.rs
@@ -19,7 +19,7 @@ use crate::lagrange::lagrange_weights_01inf_multi;
 use crate::layout::{PrefixProver, SuffixProver};
 use crate::strategy::SumcheckProver;
 use crate::svo::calculate_accumulators_batch;
-use crate::zk::data::{MaskOracle, ZkSumcheckData};
+use crate::zk::data::{ZkSumcheckData, ZkSumcheckHandoff};
 
 /// Honest-verifier zero-knowledge sumcheck prover.
 ///
@@ -143,14 +143,15 @@ where
     ///
     /// - Residual sumcheck prover over the mode-specific product polynomial, scaled by `eps`.
     /// - Vector of per-round challenges `gamma_1, ..., gamma_k`.
-    /// - One mask oracle per round, in round order.
+    /// - Combining challenge `eps`, made explicit for code-switch composition.
+    /// - Plain mask messages and one mask oracle per round, in round order.
     ///
     /// # Panics
     ///
     /// - Base field characteristic is `2` (violates Lemma 6.4).
     /// - Mask code message length is below `3` (mask must cover the degree-2 plain piece).
     /// - Folding factor is `0` or exceeds the polynomial's arity.
-    #[allow(clippy::too_many_lines, clippy::type_complexity)]
+    #[allow(clippy::too_many_lines)]
     #[tracing::instrument(skip_all)]
     pub fn into_sumcheck<R, Ch>(
         self,
@@ -158,11 +159,7 @@ where
         pow_bits: usize,
         challenger: &mut Ch,
         rng: &mut R,
-    ) -> (
-        SumcheckProver<F, EF>,
-        Point<EF>,
-        Vec<MaskOracle<EF, Enc, M>>,
-    )
+    ) -> ZkSumcheckHandoff<F, EF, Enc, M>
     where
         EF: TwoAdicField,
         Enc::Codeword: Matrix<EF>,
@@ -353,11 +350,13 @@ where
             "residual product polynomial dot product must equal eps * plain_residual_sum",
         );
 
-        (
-            SumcheckProver::new(prod_poly, residual_sum),
-            rs,
+        ZkSumcheckHandoff {
+            residual_prover: SumcheckProver::new(prod_poly, residual_sum),
+            randomness: rs,
+            eps,
+            mask_messages: masks,
             mask_oracles,
-        )
+        }
     }
 }
 

--- a/sumcheck/src/zk/test_helpers.rs
+++ b/sumcheck/src/zk/test_helpers.rs
@@ -264,20 +264,24 @@ where
     }
 
     // Prover-side sumcheck; consumes `prover`.
-    let (_residual_prover, prover_randomness, mask_oracles) = prover.into_sumcheck(
+    let prover_handoff = prover.into_sumcheck(
         &mut zk_data,
         pow_bits,
         &mut prover_challenger,
         &mut prover_rng,
     );
-    let mask_commits: Vec<_> = mask_oracles.iter().map(|(c, _)| c.clone()).collect();
+    let mask_commits: Vec<_> = prover_handoff
+        .mask_oracles
+        .iter()
+        .map(|(c, _)| c.clone())
+        .collect();
 
     ProverRun {
         verifier,
         verifier_challenger,
         zk_data,
         mask_commits,
-        prover_randomness,
+        prover_randomness: prover_handoff.randomness,
         virtual_evals,
     }
 }
@@ -289,7 +293,7 @@ pub fn replay_verifier(
     folding_factor: usize,
     pow_bits: usize,
 ) -> Result<p3_multilinear_util::point::Point<EF>, &'static str> {
-    let (verifier_point, _final_target) = run
+    let verifier_handoff = run
         .verifier
         .into_sumcheck::<MyMmcs, _>(
             &run.zk_data,
@@ -300,7 +304,7 @@ pub fn replay_verifier(
             &mut run.verifier_challenger,
         )
         .map_err(|_| "verifier rejected honest prover output")?;
-    Ok(verifier_point)
+    Ok(verifier_handoff.randomness)
 }
 
 /// End-to-end honest prover/verifier driver, parameterised by binding direction.

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -7,7 +7,7 @@ use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, HornerIter};
 use p3_multilinear_util::point::Point;
 
-use super::data::ZkSumcheckData;
+use super::data::{ZkSumcheckData, ZkVerifierHandoff};
 use crate::error::SumcheckError;
 use crate::layout::{LayoutStrategy, Verifier};
 use crate::strategy::VariableOrder;
@@ -70,6 +70,111 @@ where
     /// Downstream consumers use it to dispatch on the binding direction.
     pub const fn strategy(&self) -> LayoutStrategy {
         self.inner.strategy()
+    }
+
+    fn validate_shape<M>(
+        zk_data: &ZkSumcheckData<F, EF>,
+        mask_commits: &[M::Commitment],
+        ell_zk: usize,
+        folding_factor: usize,
+        pow_bits: usize,
+    ) -> Result<(), SumcheckError>
+    where
+        M: Mmcs<EF>,
+    {
+        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
+        assert!(
+            ell_zk >= 3,
+            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
+        );
+        assert!(folding_factor >= 1, "sumcheck requires at least one round");
+
+        if zk_data.ell_zk != ell_zk {
+            return Err(SumcheckError::EllZkMismatch {
+                expected: ell_zk,
+                actual: zk_data.ell_zk,
+            });
+        }
+        if zk_data.round_coefficients.len() != folding_factor {
+            return Err(SumcheckError::RoundCountMismatch {
+                expected: folding_factor,
+                actual: zk_data.round_coefficients.len(),
+            });
+        }
+        if mask_commits.len() != folding_factor {
+            return Err(SumcheckError::MaskCommitmentCountMismatch {
+                expected: folding_factor,
+                actual: mask_commits.len(),
+            });
+        }
+        let expected_pow = if pow_bits > 0 { folding_factor } else { 0 };
+        if zk_data.pow_witnesses.len() != expected_pow {
+            return Err(SumcheckError::PowWitnessCountMismatch {
+                expected: expected_pow,
+                actual: zk_data.pow_witnesses.len(),
+            });
+        }
+
+        let h_size = ell_zk.max(3);
+        let wire_size = h_size - 1;
+        for (idx, wire) in zk_data.round_coefficients.iter().enumerate() {
+            if wire.len() != wire_size {
+                return Err(SumcheckError::WireSizeMismatch {
+                    round: idx + 1,
+                    expected: wire_size,
+                    actual: wire.len(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn replay_claim_unchecked<M, Ch>(
+        zk_data: &ZkSumcheckData<F, EF>,
+        mask_commits: &[M::Commitment],
+        folding_factor: usize,
+        pow_bits: usize,
+        claimed_sum: EF,
+        challenger: &mut Ch,
+    ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
+    where
+        M: Mmcs<EF>,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        for commit in mask_commits {
+            challenger.observe(commit.clone());
+        }
+        challenger.observe_algebra_element(zk_data.mu_tilde);
+        let eps: EF = challenger.sample_algebra_element();
+
+        let mut target: EF = eps * claimed_sum + zk_data.mu_tilde;
+        let mut randomness: Vec<EF> = Vec::with_capacity(folding_factor);
+
+        for (j_idx, wire) in zk_data.round_coefficients.iter().enumerate() {
+            let c0 = wire[0];
+            let high_sum: EF = wire[1..].iter().copied().sum();
+            let c1 = target - c0.double() - high_sum;
+
+            challenger.observe_algebra_slice(wire);
+
+            if pow_bits > 0 && !challenger.check_witness(pow_bits, zk_data.pow_witnesses[j_idx]) {
+                return Err(SumcheckError::InvalidPowWitness);
+            }
+
+            let gamma_j: EF = challenger.sample_algebra_element();
+            target = core::iter::once(c0)
+                .chain(core::iter::once(c1))
+                .chain(wire[1..].iter().copied())
+                .horner(gamma_j);
+            randomness.push(gamma_j);
+        }
+
+        Ok(ZkVerifierHandoff {
+            randomness: Point::new(randomness),
+            claimed_residual: target,
+            eps,
+        })
     }
 
     /// Records concrete opening claims on the inner verifier.
@@ -146,66 +251,13 @@ where
         folding_factor: usize,
         pow_bits: usize,
         challenger: &mut Ch,
-    ) -> Result<(Point<EF>, EF), SumcheckError>
+    ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
     where
         M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
-        // Lemma 6.4 hypotheses on the verifier-side parameters.
-        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(
-            ell_zk >= 3,
-            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
-        );
-        assert!(folding_factor >= 1, "sumcheck requires at least one round");
-
         // Phase 1: shape checks (input validation before Construction 6.3 replay).
-
-        // ell_zk mismatch reject.
-        // Closes the (2, 3) non-injectivity gap in the wire-shape check: lengths 2 and 3 share a wire layout.
-        if zk_data.ell_zk != ell_zk {
-            return Err(SumcheckError::EllZkMismatch {
-                expected: ell_zk,
-                actual: zk_data.ell_zk,
-            });
-        }
-        // One wire entry per round.
-        if zk_data.round_coefficients.len() != folding_factor {
-            return Err(SumcheckError::RoundCountMismatch {
-                expected: folding_factor,
-                actual: zk_data.round_coefficients.len(),
-            });
-        }
-        // One mask commitment per round.
-        if mask_commits.len() != folding_factor {
-            return Err(SumcheckError::MaskCommitmentCountMismatch {
-                expected: folding_factor,
-                actual: mask_commits.len(),
-            });
-        }
-        // PoW witnesses are required only when grinding is enabled.
-        let expected_pow = if pow_bits > 0 { folding_factor } else { 0 };
-        if zk_data.pow_witnesses.len() != expected_pow {
-            return Err(SumcheckError::PowWitnessCountMismatch {
-                expected: expected_pow,
-                actual: zk_data.pow_witnesses.len(),
-            });
-        }
-        // Each wire carries h_size - 1 coefficients (c_1 dropped):
-        //
-        //     h_size    = max(ell_zk, 3)
-        //     wire_size = h_size - 1
-        let h_size = ell_zk.max(3);
-        let wire_size = h_size - 1;
-        for (idx, wire) in zk_data.round_coefficients.iter().enumerate() {
-            if wire.len() != wire_size {
-                return Err(SumcheckError::WireSizeMismatch {
-                    round: idx + 1,
-                    expected: wire_size,
-                    actual: wire.len(),
-                });
-            }
-        }
+        Self::validate_shape::<M>(zk_data, mask_commits, ell_zk, folding_factor, pow_bits)?;
 
         // Phase 2: transcript prelude (matches the prover byte-for-byte; replays Construction 6.3 setup).
 
@@ -213,56 +265,49 @@ where
         let alpha: EF = challenger.sample_algebra_element();
         let mu = self.inner.sum(alpha);
 
-        // Phase 3: absorb mask commits and mu_tilde, sample eps (Construction 6.3 steps 1-3 replay).
-        for commit in mask_commits {
-            challenger.observe(commit.clone());
-        }
-        challenger.observe_algebra_element(zk_data.mu_tilde);
-        let eps: EF = challenger.sample_algebra_element();
+        // Phase 3: absorb mask commits and mu_tilde, sample eps, and walk the round chain.
+        Self::replay_claim_unchecked::<M, _>(
+            zk_data,
+            mask_commits,
+            folding_factor,
+            pow_bits,
+            mu,
+            challenger,
+        )
+    }
 
-        // Phase 4: walk the round chain (Construction 6.3 step 4 verifier replay).
-        //
-        // Round-1 target from the initial Construction 6.3 verifier identity:
-        //
-        //     h_1(0) + h_1(1) = eps * mu + mu_tilde
-        let mut target: EF = eps * mu + zk_data.mu_tilde;
-        let mut randomness: Vec<EF> = Vec::with_capacity(folding_factor);
-
-        for (j_idx, wire) in zk_data.round_coefficients.iter().enumerate() {
-            // Wire layout (`c_1` dropped):  [ c_0, c_2, c_3, ..., c_d ].
-            let c0 = wire[0];
-            let high_sum: EF = wire[1..].iter().copied().sum();
-
-            // Reconstruct c_1 from the Construction 6.3 verifier identity:
-            //
-            //     2 c_0 + c_1 + sum_{i>=2} c_i = target
-            //     => c_1 = target - 2 c_0 - sum_{i>=2} c_i
-            let c1 = target - c0.double() - high_sum;
-
-            // Absorb the wire on the transcript.
-            challenger.observe_algebra_slice(wire);
-
-            // Optional proof-of-work check before the per-round challenge.
-            if pow_bits > 0 && !challenger.check_witness(pow_bits, zk_data.pow_witnesses[j_idx]) {
-                return Err(SumcheckError::InvalidPowWitness);
-            }
-
-            // Sample the per-round challenge.
-            let gamma_j: EF = challenger.sample_algebra_element();
-
-            // Next target via Horner (Construction 6.3 round chaining: target_{j+1} = h_j(gamma_j)):
-            //
-            //     h_j(gamma) = c_0 + gamma * (c_1 + gamma * (c_2 + ... + gamma * c_d))
-            let h_at_gamma_j: EF = core::iter::once(c0)
-                .chain(core::iter::once(c1))
-                .chain(wire[1..].iter().copied())
-                .horner(gamma_j);
-
-            target = h_at_gamma_j;
-            randomness.push(gamma_j);
-        }
-
-        Ok((Point::new(randomness), target))
+    /// Replays an HVZK sumcheck transcript for an already-batched scalar claim.
+    ///
+    /// This is the verifier-side counterpart of
+    /// [`crate::strategy::SumcheckProver::into_zk_sumcheck`]. It skips the
+    /// claim-batching `alpha` prelude because the caller already supplies the
+    /// scalar claim that the masked sumcheck should prove. The scalar is
+    /// absorbed before the masking prelude so this standalone residual-claim
+    /// API is transcript-bound even without recorded layout claims.
+    #[allow(clippy::too_many_arguments)]
+    pub fn verify_claim<M, Ch>(
+        zk_data: &ZkSumcheckData<F, EF>,
+        mask_commits: &[M::Commitment],
+        ell_zk: usize,
+        folding_factor: usize,
+        pow_bits: usize,
+        claimed_sum: EF,
+        challenger: &mut Ch,
+    ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
+    where
+        M: Mmcs<EF>,
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    {
+        Self::validate_shape::<M>(zk_data, mask_commits, ell_zk, folding_factor, pow_bits)?;
+        challenger.observe_algebra_element(claimed_sum);
+        Self::replay_claim_unchecked::<M, _>(
+            zk_data,
+            mask_commits,
+            folding_factor,
+            pow_bits,
+            claimed_sum,
+            challenger,
+        )
     }
 }
 
@@ -580,7 +625,7 @@ mod tests {
             &mut honest_v_challenger,
         );
         prop_assert!(honest_result.is_ok());
-        let (_honest_rand, honest_target) = honest_result.unwrap();
+        let honest_target = honest_result.unwrap().claimed_residual;
 
         // Tampered verifier replay from the same starting state.
         let tampered_verifier = run.verifier.clone();
@@ -594,7 +639,7 @@ mod tests {
             &mut tampered_v_challenger,
         );
         prop_assert!(tampered_result.is_ok());
-        let (_tampered_rand, tampered_target) = tampered_result.unwrap();
+        let tampered_target = tampered_result.unwrap().claimed_residual;
 
         // The two targets must differ.
         // Accidental coincidence is bounded by Lemma 6.5's negligible soundness error.

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -160,11 +160,11 @@ fn run_zk_sumcheck<L>(
     L: ZkLayout<F, EF>,
 {
     let mut data = ZkSumcheckData::<F, EF>::default();
-    let (residual, randomness, mask_oracles) = prover.into_sumcheck(&mut data, 0, challenger, rng);
+    let handoff = prover.into_sumcheck(&mut data, 0, challenger, rng);
     assert_eq!(data.round_coefficients.len(), folding);
-    assert_eq!(randomness.num_variables(), folding);
-    assert!(residual.num_variables() > 0);
-    black_box((data, residual, randomness, mask_oracles));
+    assert_eq!(handoff.randomness.num_variables(), folding);
+    assert!(handoff.residual_prover.num_variables() > 0);
+    black_box((data, handoff));
 }
 
 fn bench_sumcheck_prover(c: &mut Criterion) {


### PR DESCRIPTION
## Summary

This PR prepares the HVZK sumcheck handoff needed by the upcoming code-switching round work.

Part of the HVZK-WHIR effort (#1590). This is a prerequisite for the #1587 code-switching round; the full `HidingWhirPcs` composition remains #1589.

It:
- replaces tuple returns with typed `ZkSumcheckHandoff` / `ZkVerifierHandoff`
- exposes the `eps` and residual claim boundary explicitly
- adds `SumcheckProver::into_zk_sumcheck` for an already-derived residual product claim
- adds `ZkVerifier::verify_claim` for replaying that already-batched claim
- adds closed-form mask residual helpers used by downstream composition

The closed-form residual is checked against the live/past/future recurrence in `mask_residual_closed_form_matches_round_recurrence`.

The residual producer reuses the existing Construction 6.3 helpers for mask sampling, `mu_tilde`, round assembly, and wire formatting, so the normal HVZK path and residual-claim path stay in sync.

One correctness detail: this also ensures residual masks are sampled through `ZkEncoding::sample_message` instead of raw RNG. The regression test `residual_zk_handoff_samples_masks_through_encoding` pins that behavior.

This is intentionally sumcheck-only. The consumer is the next code-switching round PR for #1587; no WHIR adapter/code-switch wiring is included here.

## Validation

```text
cargo test -p p3-sumcheck --lib zk
cargo test -p p3-sumcheck --lib
cargo test -p p3-whir
cargo +nightly fmt --check
cargo +stable clippy -p p3-sumcheck -p p3-whir --all-targets -- -D warnings
cargo bench -p p3-whir --bench sumcheck --no-run
git diff --check
```
