### PR TITLE
fix(whir): enforce two missing verifier length checks

### DIFF
--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -128,6 +128,16 @@ where
         challenger.observe(commitment.clone());
 
         let mut layout_verifier = Verifier::<F, EF>::new(&protocol.table_shapes(), L::strategy());
+
+        // The commitment fixes how many initial OOD answers exist.
+        // Each one drives a transcript draw, so a wrong count desyncs Fiat-Shamir.
+        // Reject it up front, matching the per-round OOD guard.
+        if proof.whir.initial_ood_answers.len() != self.commitment_ood_samples {
+            return Err(VerifierError::InitialOodAnswerCountMismatch {
+                expected: self.commitment_ood_samples,
+                actual: proof.whir.initial_ood_answers.len(),
+            });
+        }
         for &eval in &proof.whir.initial_ood_answers {
             layout_verifier.add_virtual_eval(eval, challenger);
         }

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -294,7 +294,7 @@ mod error_variant_tests {
     use crate::pcs::proof::PcsProof;
     use crate::pcs::verifier::errors::VerifierError;
     use crate::sumcheck::layout::{Layout, SuffixProver, Table};
-    use crate::sumcheck::{OpeningProtocol, TableShape, TableSpec};
+    use crate::sumcheck::{OpeningProtocol, SumcheckError, TableShape, TableSpec};
 
     /// Suffix-mode prover used for every shape-mismatch scenario.
     type L = SuffixProver<F, EF>;
@@ -657,6 +657,73 @@ mod error_variant_tests {
                 assert_eq!(a, expected - 1);
             }
             other => panic!("expected StirQueryCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_with_initial_ood_answer_count_mismatch_when_answer_is_dropped() {
+        // Invariant: the proof must carry exactly the committed number of initial OOD answers.
+        // Each answer drives a transcript draw, so a wrong count desyncs Fiat-Shamir.
+        //
+        // Fixture state: N initial OOD answers.
+        //
+        // Mutation: drop one answer.
+        //
+        //     proof.whir.initial_ood_answers:  N  ->  N - 1
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        let expected = proof.whir.initial_ood_answers.len();
+        assert!(
+            expected > 0,
+            "fixture should produce at least one initial OOD answer"
+        );
+        proof.whir.initial_ood_answers.pop();
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::InitialOodAnswerCountMismatch {
+                expected: e,
+                actual: a,
+            } => {
+                assert_eq!(e, expected);
+                assert_eq!(a, expected - 1);
+            }
+            other => panic!("expected InitialOodAnswerCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_with_round_count_mismatch_when_intermediate_sumcheck_is_short() {
+        // Invariant: an intermediate round's sumcheck sends one polynomial per folded variable.
+        // That count is the next round's folding factor.
+        // A wrong count desyncs Fiat-Shamir.
+        //
+        // Fixture state: round 0 sumcheck has FOLDING = 4 polynomial evaluations.
+        //
+        // Mutation: drop the trailing evaluation.
+        //
+        //     proof.whir.rounds[0].sumcheck.polynomial_evaluations:  4  ->  3
+        let (pcs, commitment, mut proof, protocol) = commit_and_open();
+        assert!(
+            !proof.whir.rounds.is_empty(),
+            "fixture should produce at least one WHIR round"
+        );
+        let expected = proof.whir.rounds[0].sumcheck.polynomial_evaluations().len();
+        assert!(
+            expected > 0,
+            "fixture round-0 sumcheck should send at least one polynomial"
+        );
+        proof.whir.rounds[0].sumcheck.polynomial_evaluations.pop();
+
+        let err = verify(&pcs, &commitment, &proof, protocol).unwrap_err();
+        match err {
+            VerifierError::Sumcheck(SumcheckError::RoundCountMismatch {
+                expected: e,
+                actual: a,
+            }) => {
+                assert_eq!(e, expected);
+                assert_eq!(a, expected - 1);
+            }
+            other => panic!("expected Sumcheck(RoundCountMismatch), got {other:?}"),
         }
     }
 }

--- a/whir/src/pcs/verifier/errors.rs
+++ b/whir/src/pcs/verifier/errors.rs
@@ -76,6 +76,13 @@ pub enum VerifierError {
         actual: usize,
     },
 
+    /// Initial OOD answers do not match the verifier's expected count.
+    ///
+    /// - The commitment fixes how many out-of-domain answers must be absorbed.
+    /// - A wrong count would desync the transcript instead of failing cleanly.
+    #[error("Initial OOD answer count mismatch: expected {expected}, got {actual}")]
+    InitialOodAnswerCountMismatch { expected: usize, actual: usize },
+
     /// Folding randomness is unexpectedly absent before a STIR check.
     #[error("Missing folding randomness before STIR verification at round {round}")]
     MissingFoldingRandomness { round: usize },

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -168,6 +168,20 @@ where
             constraint.combine_evals(&mut claimed_eval);
             constraints.push(constraint);
 
+            // Intermediate-round sumcheck rounds == next-round folding factor.
+            // Mirrors the initial and final sumcheck guards;
+            // Without it a wrong count desyncs Fiat-Shamir instead of rejecting cleanly.
+            let expected_round_rounds = self.folding_factor(round_index + 1);
+            let actual_round_rounds = proof.rounds[round_index]
+                .sumcheck
+                .polynomial_evaluations()
+                .len();
+            if actual_round_rounds != expected_round_rounds {
+                return Err(VerifierError::Sumcheck(SumcheckError::RoundCountMismatch {
+                    expected: expected_round_rounds,
+                    actual: actual_round_rounds,
+                }));
+            }
             let folding_randomness = proof.rounds[round_index].sumcheck.verify_rounds(
                 challenger,
                 &mut claimed_eval,


### PR DESCRIPTION
## Summary

The WHIR verifier guards every proof-shape axis — round count, initial/final sumcheck length, OOD count, query count, final-poly length — except two. On those two, a malformed count desyncs Fiat-Shamir into a panic or a probabilistic failure rather than a clean rejection. This PR closes both gaps so they reject up front with a dedicated error, matching the pattern already used everywhere else.

### 1. Intermediate-round sumcheck length (`pcs/verifier/mod.rs`)
Before `verify_rounds` runs for an intermediate round, check that the round's sumcheck carries exactly `folding_factor(round_index + 1)` polynomial evaluations (the count the prover generates). Previously unchecked, unlike the initial and final sumchecks. Returns `SumcheckError::RoundCountMismatch`.

### 2. Initial OOD answer count (`pcs/adapter.rs`)
Before absorbing `initial_ood_answers` (each drives a transcript draw), check the count against `commitment_ood_samples`. The per-round OOD path already enforces this (`RoundOodAnswerCountMismatch`); the initial path was the only one missing it. New variant `VerifierError::InitialOodAnswerCountMismatch`.

## Tests
Two negative tests on the existing `commit_and_open` / `verify` harness:
- `rejects_with_initial_ood_answer_count_mismatch_when_answer_is_dropped`
- `rejects_with_round_count_mismatch_when_intermediate_sumcheck_is_short`

Both pass; all pre-existing WHIR tests (end-to-end Poseidon2 + Keccak, and the other shape-mismatch tests) still pass; clippy is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)