### PR TITLE
fix(fri): reject zero-query instances on both sides

### DIFF
--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -63,6 +63,10 @@ where
 {
     assert!(!inputs.is_empty());
     assert!(
+        params.num_queries > 0,
+        "num_queries must be at least 1 for FRI soundness"
+    );
+    assert!(
         params.max_log_arity > 0,
         "max_log_arity must be at least 1 to guarantee folding progress"
     );

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -41,6 +41,12 @@ where
     FinalPolyLengthMismatch { expected: usize, got: usize },
     #[error("query proof count mismatch: expected {expected}, got {got}")]
     QueryProofCountMismatch { expected: usize, got: usize },
+    /// The instance is configured with zero queries.
+    ///
+    /// - The query loop never runs, so any final polynomial would be accepted.
+    /// - At least one query is required for the protocol to prove anything.
+    #[error("FRI instance has zero queries; at least one is required for soundness")]
+    ZeroQueries,
     #[error("missing initial reduced opening at log height {expected}")]
     MissingInitialReducedOpening { expected: usize },
     #[error("initial reduced opening height mismatch: expected {expected}, got {got}")]
@@ -154,6 +160,13 @@ where
             InputProof = Vec<BatchOpening<Val, InputMmcs>>,
         >,
 {
+    // Reject a vacuous instance before any transcript work.
+    // With zero queries the per-query loop never runs.
+    // Any final polynomial would then pass.
+    if params.num_queries == 0 {
+        return Err(FriError::ZeroQueries);
+    }
+
     // Generate the Batch combination challenge
     // Soundness Error: `|f|/|EF|` where `|f|` is the number of different functions of the form
     // `(f(zeta) - fi(x))/(zeta - x)` which need to be checked.
@@ -1750,5 +1763,77 @@ mod tests {
 
         // The two must differ — this is what the verifier would catch.
         assert_ne!(honest_eval, corrupted_eval);
+    }
+
+    #[test]
+    fn rejects_with_zero_queries() {
+        // Invariant: a zero-query FRI instance proves nothing.
+        // The per-query loop never runs.
+        // Without the guard the verifier returns Ok for any final polynomial.
+        //
+        // Fixture state: an honest proof built with 2 queries.
+        //
+        // Mutation: verify it under params with num_queries = 0.
+        let f = make_test_fixture();
+        let mut params = f.fri_params.clone();
+        params.num_queries = 0;
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &params,
+            &f.proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("zero-query instance must be rejected");
+
+        assert!(
+            matches!(err, FriError::ZeroQueries),
+            "expected ZeroQueries, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "num_queries must be at least 1")]
+    fn prover_rejects_zero_queries() {
+        // The prover must refuse to build a vacuous proof.
+        // The verifier guards the same config, so the failure is symmetric.
+        let mut rng = SmallRng::seed_from_u64(42);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+        let input_mmcs = ValMmcs::new(hash.clone(), compress.clone(), 0);
+        let challenge_mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress, 0));
+
+        // Zero queries; every other parameter is otherwise valid.
+        let fri_params = FriParameters {
+            log_blowup: 1,
+            log_final_poly_len: 0,
+            max_log_arity: 1,
+            num_queries: 0,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+            mmcs: challenge_mmcs,
+        };
+        let pcs = TwoAdicFriPcs::new(Radix2Dit::default(), input_mmcs, fri_params);
+
+        // Commit succeeds; the assert fires inside the opening (FRI prover).
+        let log_degree = 3;
+        let domain = <TwoAdicFriPcs<Val, Radix2Dit<Val>, ValMmcs, ChallengeMmcs> as Pcs<
+            Challenge,
+            Challenger,
+        >>::natural_domain_for_degree(&pcs, 1 << log_degree);
+        let trace = RowMajorMatrix::<Val>::rand_nonzero(&mut rng, 1 << log_degree, 2);
+        let (commitment, prover_data) =
+            <TwoAdicFriPcs<Val, Radix2Dit<Val>, ValMmcs, ChallengeMmcs> as Pcs<
+                Challenge,
+                Challenger,
+            >>::commit(&pcs, [(domain, trace)]);
+
+        let mut challenger = Challenger::new(perm);
+        challenger.observe(&commitment);
+        let zeta: Challenge = challenger.sample_algebra_element();
+        let _ = pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut challenger);
     }
 }


### PR DESCRIPTION
@Nashtare I don't think that this really happen in reality but worth checking probably.

## Summary

With `num_queries == 0`, FRI verification is vacuous: the per-query loop in `verify_fri` never runs, so it returns `Ok(())` for **any** final polynomial. `conjectured_soundness_bits()` reports only the PoW bits with no indication the instance is unsound. The prover only guarded `max_log_arity` and a non-empty input set — never the query count.

This rejects the zero-query case on both sides, the fix the audit calls for.

### Prover (`prove_fri`)
`assert!(num_queries > 0, ...)` alongside the existing guards, so an unsound config fails fast at proving time rather than producing a proof the verifier must reject.

### Verifier (`verify_fri`)
Return the new `FriError::ZeroQueries` before any transcript work, so the instance is rejected up front instead of vacuously accepted.

## Tests
- `rejects_with_zero_queries` — replays an honest 2-query proof under `num_queries = 0` and asserts `FriError::ZeroQueries`.
- `prover_rejects_zero_queries` — `#[should_panic]` on a commit+open with `num_queries = 0`.

All FRI tests pass; clippy is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)