### PR TITLE
fix(challenger): reject absorb length tags that overflow u8

### DIFF
--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -110,6 +110,11 @@ where
     /// Clears `input_buffer` and `output_buffer` before absorbing. Used by
     /// [`MultiField32Challenger`](crate::MultiField32Challenger) so packed scalar and native-digest
     /// absorbs share this [`DuplexChallenger`]'s sponge state without queuing through `observe`.
+    ///
+    /// # Why the tag is a byte
+    ///
+    /// - The tag distinguishes at most 256 absorb lengths.
+    /// - Callers must keep logical lengths at most 255, or lengths differing by 256 collide.
     pub fn absorb_rate_padded_with_tag(&mut self, values: &[F], length_tag: u8) {
         const {
             assert!(

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -91,6 +91,13 @@ where
         if RATE >= WIDTH {
             return Err(String::from("RATE must be less than WIDTH"));
         }
+        // A full flush stamps up to limbs-per-slot * RATE scalars into a byte-sized length tag.
+        // Past 255, lengths differing by 256 would share a tag and collide in the transcript.
+        if max_absorb_injective_limbs::<F, PF>() * RATE > u8::MAX as usize {
+            return Err(String::from(
+                "absorb length tag must fit in a u8: max_absorb_injective_limbs * RATE must be at most 255",
+            ));
+        }
 
         Ok(Self {
             inner: DuplexChallenger::new(permutation),
@@ -112,7 +119,9 @@ where
             .chunks(absorb_n)
             .map(|chunk| reduce_packed(chunk, rb))
             .collect();
-        self.inner.absorb_rate_padded_with_tag(&packed, n_in as u8);
+        // Invariant: the constructor bounds a full flush at 255 scalars, so this never truncates.
+        let tag = u8::try_from(n_in).expect("absorb length tag must fit in a u8");
+        self.inner.absorb_rate_padded_with_tag(&packed, tag);
         self.f_buffer.clear();
         self.f_squeeze_buffer.clear();
     }
@@ -186,8 +195,9 @@ where
         let words: &[PF; N] = values.as_ref();
 
         for chunk in words.chunks(RATE) {
-            self.inner
-                .absorb_rate_padded_with_tag(chunk, chunk.len() as u8);
+            // Invariant: each block holds at most RATE words, bounded at 255 by the constructor.
+            let tag = u8::try_from(chunk.len()).expect("absorb length tag must fit in a u8");
+            self.inner.absorb_rate_padded_with_tag(chunk, tag);
             self.f_squeeze_buffer.clear();
         }
     }
@@ -352,6 +362,41 @@ mod tests {
     }
 
     impl CryptographicPermutation<[PF; WIDTH]> for MixingPermutation {}
+
+    /// A no-op permutation generic over the state width.
+    /// Lets tests instantiate challengers at widths the fixed-width permutations cannot reach.
+    #[derive(Clone)]
+    struct WideIdentityPermutation;
+
+    impl<const W: usize> Permutation<[PF; W]> for WideIdentityPermutation {
+        fn permute_mut(&self, _input: &mut [PF; W]) {}
+    }
+
+    impl<const W: usize> CryptographicPermutation<[PF; W]> for WideIdentityPermutation {}
+
+    #[test]
+    fn test_new_rejects_length_tag_overflow() {
+        // The capacity length tag is a single byte stamped per padded absorb.
+        // A full flush absorbs up to limbs-per-slot * RATE scalars at once.
+        //
+        // Fixture state: BabyBear packs 2 limbs per Goldilocks rate slot.
+        assert_eq!(max_absorb_injective_limbs::<F, PF>(), 2);
+
+        // Mutation: push RATE past the byte boundary.
+        //
+        //     RATE = 128 → 2 * 128 = 256 > 255 → reject
+        //     RATE = 127 → 2 * 127 = 254 ≤ 255 → accept
+        let too_wide = MultiField32Challenger::<F, PF, _, 129, 128>::new(WideIdentityPermutation);
+        assert_eq!(
+            too_wide.err().as_deref(),
+            Some(
+                "absorb length tag must fit in a u8: max_absorb_injective_limbs * RATE must be at most 255"
+            )
+        );
+
+        let in_range = MultiField32Challenger::<F, PF, _, 128, 127>::new(WideIdentityPermutation);
+        assert!(in_range.is_ok());
+    }
 
     #[test]
     fn test_packing() {


### PR DESCRIPTION
## Problem

The capacity length tag stamped by `DuplexChallenger::absorb_rate_padded_with_tag` is a `u8`, but both call sites in `MultiField32Challenger` cast a `usize` length with `as u8`, which silently wraps:

- `flush_f_if_non_empty`: tag is `n_in <= max_absorb_injective_limbs * RATE`. With e.g. BabyBear over BN254 (`limbs = 8`) and `RATE >= 32`, the bound exceeds 255.
- `observe(Hash)`: tag is `chunk.len() <= RATE`, wrapping when `RATE >= 256`.

When the wrap is reachable, two absorbs whose lengths differ by a multiple of 256 stamp the same tag, and the padded rate rows can be identical too: absorbing `[x]` vs `[x]` followed by 256 zeros packs to the same rate row (zero chunks pack to zero, the tail is zero-padded either way) with tags `1 == 257 mod 256` — a genuine transcript collision.

No realistic configuration (`RATE <= 16`) reaches this, but nothing enforced the bound.

## Fix

- `MultiField32Challenger::new` now returns an error when `max_absorb_injective_limbs::<F, PF>() * RATE > 255` (following the error-instead-of-panic direction of #1737). Since `new` already requires `F::order() < PF::order()`, limbs-per-slot is at least 1, so this single bound also covers the digest-block path (`RATE <= 255`).
- Both `as u8` casts become checked `u8::try_from(...).expect(...)` conversions, so a future refactor that breaks the constructor invariant panics loudly instead of wrapping silently.
- The byte-sized tag domain is documented on `absorb_rate_padded_with_tag`.

## Test

`test_new_rejects_length_tag_overflow` pins the boundary with BabyBear/Goldilocks (`limbs = 2`): `RATE = 128` (2 x 128 = 256) is rejected with the exact error message, `RATE = 127` (254) is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)