### PR TITLE
test(whir): pin final-round variable accounting invariant

### DIFF
--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -389,7 +389,7 @@ where
                 + final_sumcheck_rounds
         );
 
-        Ok(Self {
+        let config = Self {
             params: whir_parameters,
             commitment_ood_samples,
             num_variables: initial_num_variables,
@@ -401,7 +401,19 @@ where
             final_folding_pow_bits: final_folding_pow_bits as usize,
             _extension_field: PhantomData,
             _challenger: PhantomData,
-        })
+        };
+
+        // The final-round config must expose exactly the direct-send variable count.
+        //
+        //     prover     : sends 2^count final evaluations in the clear
+        //     verifier   : length-checks the final polynomial against 2^count
+        //     transcript : absorbs 2^count final coefficients
+        assert_eq!(
+            config.final_round_config().num_variables,
+            config.final_sumcheck_rounds
+        );
+
+        Ok(config)
     }
 
     /// Returns the size of the initial evaluation domain.
@@ -610,6 +622,58 @@ mod tests {
         let config = WhirConfig::<F, F, MyChallenger>::new(10, params).unwrap();
 
         assert_eq!(config.n_rounds(), config.round_parameters.len());
+    }
+
+    #[test]
+    fn final_round_config_num_variables_equals_final_sumcheck_rounds() {
+        // Invariant: the final-round config exposes exactly `final_sumcheck_rounds` variables.
+        //
+        // Three places key off this single count and must agree:
+        //
+        //     prover     : sends 2^count final evaluations in the clear
+        //     verifier   : length-checks the final polynomial against 2^count
+        //     transcript : absorbs 2^count final coefficients
+        //
+        // Sweep every folding strategy across the direct-send threshold so both branches are hit.
+        fn check(num_variables: usize, folding_factor: FoldingFactor) {
+            // UniqueDecoding needs no out-of-domain samples, so construction always succeeds here.
+            let params = ProtocolParameters {
+                security_level: 100,
+                pow_bits: 20,
+                round_log_inv_rates: vec![],
+                folding_factor,
+                soundness_type: SecurityAssumption::UniqueDecoding,
+                starting_log_inv_rate: 1,
+            };
+            // Construction runs the same assertion internally.
+            // This explicit check documents and pins the invariant.
+            let config = WhirConfig::<F, F, MyChallenger>::new(num_variables, params).unwrap();
+            assert_eq!(
+                config.final_round_config().num_variables,
+                config.final_sumcheck_rounds,
+                "num_variables = {num_variables}"
+            );
+        }
+
+        // Constant: small sizes stay in the empty branch, larger ones reach the non-empty branch.
+        for nv in 4..=24 {
+            check(nv, FoldingFactor::Constant(4));
+        }
+        for nv in 2..=24 {
+            check(nv, FoldingFactor::Constant(2));
+        }
+
+        // ConstantFromSecondRound: a larger first fold, then smaller folds.
+        for nv in 5..=24 {
+            check(nv, FoldingFactor::ConstantFromSecondRound(3, 2));
+        }
+
+        // PerRound: explicit schedules whose length is num_rounds + 1.
+        //
+        //     [3, 2]    @ 10  ->  1 intermediate round
+        //     [4, 3, 2] @ 14  ->  2 intermediate rounds
+        check(10, FoldingFactor::PerRound(vec![3, 2]));
+        check(14, FoldingFactor::PerRound(vec![4, 3, 2]));
     }
 
     #[test]


### PR DESCRIPTION
## What

The final-phase variable count is relied on in three places that must agree:

- the prover sends `2^count` final evaluations in the clear (`prover/mod.rs` final round, `sumcheck_prover.evals()`),
- the verifier length-checks the final polynomial against `2^count` (`verifier/mod.rs`, `expected_final_poly_len`),
- the domain separator absorbs `2^count` final coefficients (`domain_separator.rs`, `FinalCoeffs`).

Concretely those are the prover's folded `evals()` length, `final_round_config().num_variables`, and `final_sumcheck_rounds`. They are provably equal in every configuration:

- non-empty branch: `last.num_variables − ff(n_rounds)` = `initial − total_number(n_rounds)`;
- empty branch: `initial − ff(0)` = `initial − total_number(0)`;
- the existing assert in `new` gives `final_sumcheck_rounds = initial − total_number(n_rounds)`.

There was no bug, but nothing guarded that `final_round_config` keeps producing this count if either of its branches is refactored.

## Changes

- Construction-time assertion in `WhirConfig::new`: `final_round_config().num_variables == final_sumcheck_rounds`. It is placed after the config is built so it exercises the real `final_round_config` code path (catching a regression in either branch), and runs once per construction.
- New sweep test `final_round_config_num_variables_equals_final_sumcheck_rounds` covering `Constant`, `ConstantFromSecondRound`, and `PerRound`, sized to hit both the empty and non-empty round-parameter branches. It uses `UniqueDecoding` so construction always succeeds over the 31-bit base field.

No behavior change: the assertion holds for every valid configuration (it also runs inside every other config test).

`cargo fmt` and `cargo clippy --all-targets` are clean; the parameter test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)