### PR TITLE
perf(whir): avoid extra allocation in prefix-order commit encoding

### DIFF
--- a/sumcheck/src/commit.rs
+++ b/sumcheck/src/commit.rs
@@ -5,7 +5,7 @@ use p3_commit::Mmcs;
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::TwoAdicField;
 use p3_matrix::Matrix;
-use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixView};
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_multilinear_util::poly::Poly;
 use tracing::info_span;
 
@@ -42,20 +42,36 @@ where
     let encoded = match order {
         VariableOrder::Prefix => {
             let padded = info_span!("transpose & pad").in_scope(|| {
-                let mut mat =
-                    RowMajorMatrixView::new(poly.as_slice(), 1 << (num_variables - folding))
-                        .transpose();
-                mat.pad_to_height(height, F::ZERO);
-                mat
+                let width = 1 << folding;
+
+                // Allocate the zero-padded codeword buffer once.
+                // Trailing rows stay zero and become the Reed-Solomon expansion.
+                let mut values = F::zero_vec(height * width);
+
+                // Transpose the folding blocks straight into the leading rows.
+                // This reuses the cache-blocked transpose with no extra allocation.
+                let folded =
+                    RowMajorMatrixView::new(poly.as_slice(), 1 << (num_variables - folding));
+                folded.transpose_into(&mut RowMajorMatrixViewMut::new(
+                    &mut values[..1 << num_variables],
+                    width,
+                ));
+
+                RowMajorMatrix::new(values, width)
             });
             info_span!("dft", height = padded.height(), width = padded.width())
                 .in_scope(|| dft.dft_batch(padded).to_row_major_matrix())
         }
         VariableOrder::Suffix => {
             let padded = info_span!("pad").in_scope(|| {
-                let mut mat = RowMajorMatrix::new(poly.as_slice().to_vec(), 1 << folding);
-                mat.pad_to_height(height, F::ZERO);
-                mat
+                let width = 1 << folding;
+                let src = poly.as_slice();
+
+                // Folding blocks are already contiguous, so copy them into the
+                // leading rows of one zero-padded buffer; no realloc on pad.
+                let mut values = F::zero_vec(height * width);
+                values[..src.len()].copy_from_slice(src);
+                RowMajorMatrix::new(values, width)
             });
             info_span!("dft", height = padded.height(), width = padded.width())
                 .in_scope(|| dft.dft_batch(padded).to_row_major_matrix())

--- a/whir/src/pcs/committer/writer.rs
+++ b/whir/src/pcs/committer/writer.rs
@@ -2,7 +2,7 @@ use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::Matrix;
-use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixView};
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_matrix::extension::FlatMatrixView;
 use p3_multilinear_util::poly::Poly;
 use tracing::info_span;
@@ -39,11 +39,22 @@ where
     let encoded = match order {
         VariableOrder::Prefix => {
             let padded = info_span!("transpose & pad").in_scope(|| {
-                let mut mat =
-                    RowMajorMatrixView::new(poly.as_slice(), 1 << (num_variables - folding))
-                        .transpose();
-                mat.pad_to_height(height, EF::ZERO);
-                mat
+                let width = 1 << folding;
+
+                // Allocate the zero-padded codeword buffer once.
+                // Trailing rows stay zero and become the Reed-Solomon expansion.
+                let mut values = EF::zero_vec(height * width);
+
+                // Transpose the folding blocks straight into the leading rows.
+                // This reuses the cache-blocked transpose with no extra allocation.
+                let folded =
+                    RowMajorMatrixView::new(poly.as_slice(), 1 << (num_variables - folding));
+                folded.transpose_into(&mut RowMajorMatrixViewMut::new(
+                    &mut values[..1 << num_variables],
+                    width,
+                ));
+
+                RowMajorMatrix::new(values, width)
             });
             info_span!("dft", height = padded.height(), width = padded.width())
                 .in_scope(|| dft.dft_algebra_batch(padded).to_row_major_matrix())


### PR DESCRIPTION
## What

The prefix-order commit encoding built the codeword matrix in two steps:

```rust
let mut mat = RowMajorMatrixView::new(poly.as_slice(), ...).transpose(); // alloc 2^nv
mat.pad_to_height(height, ZERO);                                         // realloc to inv_rate·2^nv
```

That is one intermediate allocation (the transpose) plus a reallocating, copying grow (`pad_to_height`) before the DFT. The suffix path already avoided this with a single zeroed buffer.

## Change

Allocate the zero-padded codeword buffer once and transpose the folding blocks directly into its leading rows with `transpose_into` (already in `p3-matrix`), which reuses the same cache-blocked transpose routine — no intermediate matrix, no pad-time reallocation. The trailing rows stay zero and serve as the Reed-Solomon coefficient padding.

The destination is a `RowMajorMatrixViewMut` over the leading `2^num_variables` elements of the padded buffer. The `transpose_into` dimension asserts hold: `self.height() == other.width()` and `other.height() == self.width()`.

Applied to:
- `sumcheck/src/commit.rs` — first-round base-field commit (the dominant encoding);
- `whir/src/pcs/committer/writer.rs` — per-round extension-field commit.

Also aligned the base-field **suffix** branch with the leaner `zero_vec` + `copy_from_slice` shape already used on the extension side (it previously did `to_vec()` + `pad_to_height`, another double-allocation).

## Notes

- The transpose itself is intrinsic to prefix folding with a column-wise FFT (the folding sub-polynomials are contiguous in memory, so they must become columns); only the surrounding allocation overhead was removable.
- No behavior change: the produced matrix is byte-identical to the previous path, padding included.

## Testing

`cargo fmt` and `cargo clippy --all-targets` are clean on both crates. The existing end-to-end round-trip tests exercise both commit paths for both variable orders (`test_whir_keccak_end_to_end_prefix` / `_suffix`); all whir (61) and sumcheck (188) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)