### PR TITLE
perf(whir): drop redundant leaf clones in fold-query evaluation

### DIFF
--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -121,6 +121,13 @@ impl<F> Poly<F> {
         &mut self.0
     }
 
+    /// Consumes the polynomial and returns the owned evaluation table.
+    #[inline]
+    #[must_use]
+    pub fn into_evals(self) -> Vec<F> {
+        self.0
+    }
+
     /// Pads the evaluation vector with zeros up to `num_variables`.
     ///
     /// # Panics

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -252,31 +252,47 @@ where
         match &round_state.round_data {
             RoundData::Base(data) => {
                 for &challenge in &stir_challenges_indexes {
-                    let commitment = self.mmcs.open_batch(challenge, data);
-                    let answer = commitment.opened_values[0].clone();
+                    let opening = self.mmcs.open_batch(challenge, data);
+                    // WHIR commits a single matrix per round, so take its one opened row.
+                    let answer = opening
+                        .opened_values
+                        .into_iter()
+                        .next()
+                        .expect("a committed batch opens at least one matrix");
 
-                    let eval = Poly::new(answer.clone()).eval_base(&query_randomness);
+                    // Evaluate the fold by borrowing the row.
+                    // Then hand the same allocation to the proof, with no per-query leaf copy.
+                    let poly = Poly::new(answer);
+                    let eval = poly.eval_base(&query_randomness);
                     let var = round_params.folded_domain_gen.exp_u64(challenge as u64);
                     stir_statement.add_constraint(var, eval);
 
                     queries.push(QueryOpening::Base {
-                        values: answer,
-                        proof: commitment.opening_proof,
+                        values: poly.into_evals(),
+                        proof: opening.opening_proof,
                     });
                 }
             }
             RoundData::Ext(data) => {
                 for &challenge in &stir_challenges_indexes {
-                    let commitment = self.extension_mmcs.open_batch(challenge, data);
-                    let answer = commitment.opened_values[0].clone();
+                    let opening = self.extension_mmcs.open_batch(challenge, data);
+                    // WHIR commits a single matrix per round, so take its one opened row.
+                    let answer = opening
+                        .opened_values
+                        .into_iter()
+                        .next()
+                        .expect("a committed batch opens at least one matrix");
 
-                    let eval = Poly::new(answer.clone()).eval_ext::<F>(&query_randomness);
+                    // Evaluate the fold by borrowing the row.
+                    // Then hand the same allocation to the proof, with no per-query leaf copy.
+                    let poly = Poly::new(answer);
+                    let eval = poly.eval_ext::<F>(&query_randomness);
                     let var = round_params.folded_domain_gen.exp_u64(challenge as u64);
                     stir_statement.add_constraint(var, eval);
 
                     queries.push(QueryOpening::Extension {
-                        values: answer,
-                        proof: commitment.opening_proof,
+                        values: poly.into_evals(),
+                        proof: opening.opening_proof,
                     });
                 }
             }


### PR DESCRIPTION
## What

Each STIR query in a folding round cloned the opened Merkle leaf **twice**:

```rust
let answer = commitment.opened_values[0].clone();          // clone 1
let eval   = Poly::new(answer.clone()).eval_base(&rr);     // clone 2 (answer reused below)
queries.push(QueryOpening::Base { values: answer, ... });
```

The second clone exists only because `answer` is consumed by `Poly::new` for the evaluation yet still needed for the proof.

## Change

- Move the single opened row out of the `BatchOpening` (`opened_values.into_iter().next()`) instead of cloning it.
- Wrap it in a `Poly` (a zero-cost `const fn` newtype), evaluate the fold by borrow (`&self`), then hand the same allocation to the proof via a new `Poly::into_evals(self) -> Vec<F>`.

Net: **zero** per-query leaf copies, down from two.

`Poly::into_evals` is the owned-`Vec` counterpart of the existing `as_slice`/`as_mut_slice` accessors.

## Notes

- WHIR commits exactly one matrix per round, so the opened batch always contains exactly one row; the `expect` documents that structural invariant and replaces the previous implicit `[0]` index panic with a clearer message. It cannot be a propagated error because `MultilinearPcs::open` returns `Proof`, not `Result`.
- The verifier already moved an owned row into `Poly::new` (`answer` comes from `answers.into_iter()`), so it is unchanged.
- No behavior change; the produced proof is identical.

## Testing

`cargo fmt` and `cargo clippy --all-targets` are clean. The existing end-to-end round-trip tests exercise both fold-evaluation paths for both variable orders (`test_whir_keccak_end_to_end_prefix` / `_suffix`) and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)