### PR TITLE
whir: hoist ExtensionMmcs out of per-round verify path

### DIFF
--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -54,6 +54,11 @@ where
     pub(crate) config: &'a WhirConfig<EF, F, Challenger>,
     /// Base-field Merkle commitment scheme used to authenticate STIR queries.
     pub(crate) mmcs: &'a MT,
+    /// Extension-field view over the base Merkle scheme.
+    ///
+    /// - Authenticates query openings whose values live in the extension field.
+    /// - Built once at construction, not rebuilt on each per-round opening check.
+    pub(crate) extension_mmcs: ExtensionMmcs<F, EF, &'a MT>,
     /// Binding direction used to interpret folding randomness.
     pub(crate) variable_order: VariableOrder,
 }
@@ -80,6 +85,7 @@ where
         Self {
             config,
             mmcs,
+            extension_mmcs: ExtensionMmcs::new(mmcs),
             variable_order,
         }
     }
@@ -352,8 +358,6 @@ where
         dimensions: &[Dimensions],
         round_index: usize,
     ) -> Result<Vec<Vec<EF>>, VerifierError> {
-        let extension_mmcs = ExtensionMmcs::new(self.mmcs);
-
         let queries = if round_index == self.n_rounds() {
             &proof.final_queries
         } else {
@@ -398,7 +402,7 @@ where
                     values.iter().map(|&f| f.into()).collect()
                 }
                 QueryOpening::Extension { values, proof } => {
-                    extension_mmcs
+                    self.extension_mmcs
                         .verify_batch(
                             root,
                             dimensions,


### PR DESCRIPTION
## Summary

The extension-field Merkle wrapper (`ExtensionMmcs`) was reconstructed inside every `verify_merkle_proof` call, which the WHIR verifier invokes once per round. The wrapper only holds a borrow of the base Merkle scheme (a copied reference plus zero-sized `PhantomData`), so it can be built once and reused.

This hoists the construction into the `WhirVerifier` constructor, storing it as a `pub(crate)` field. `verify_merkle_proof` now reuses `self.extension_mmcs`. No public signature changes; `new` remains `const`.

This addresses finding **C1** from a WHIR audit (Plonky3 vs. worldfnd/whir). It is a code-hygiene cleanup — since the wrapper is a zero-cost borrow, the runtime impact is negligible.

## Validation

- `cargo fmt -p p3-whir` — clean
- `cargo clippy -p p3-whir --all-targets` — clean
- `cargo test -p p3-whir` — 60 passed, 0 failed (includes end-to-end Prefix/Suffix and Keccak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)