### PR TITLE
fix(challenger): evaluate PoW bit-bound in u64 to close release-mode bypass

### DIFF
--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -293,7 +293,12 @@ where
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize), "bit count must be valid");
-        assert!((1 << bits) < F::ORDER_U32);
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
 
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -286,7 +286,12 @@ where
     /// We have 1/2^b - 1/p ≤ P1, P2 ≤ 1/2^b + 1/p
     fn sample_bits(&mut self, bits: usize) -> usize {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U32);
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `u32` shift by `bits >= 32` would wrap and zero the mask, accepting any witness.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
         let rand_f: F = self.sample();
         let rand_usize = rand_f.as_canonical_u32() as usize;
         rand_usize & ((1 << bits) - 1)
@@ -700,5 +705,24 @@ mod tests {
         assert_eq!(challenger.inner.input_buffer, before.inner.input_buffer);
         assert_eq!(challenger.inner.output_buffer, before.inner.output_buffer);
         assert_eq!(challenger.inner.sponge_state, before.inner.sponge_state);
+    }
+
+    #[test]
+    #[should_panic = "requested bit count must fit within the field order"]
+    fn test_sample_bits_rejects_oversized_request() {
+        // Sampled field is BabyBear, order ~2^30.9, so a 32-bit request must be rejected.
+        // The bound is evaluated in u64, so the guard fires in every build profile.
+        let mut challenger =
+            MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+        let _ = challenger.sample_bits(32);
+    }
+
+    #[test]
+    #[should_panic = "requested bit count must fit within the field order"]
+    fn test_grind_rejects_oversized_request() {
+        // Same guard, reached through the proof-of-work entry point.
+        let mut challenger =
+            MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+        let _ = challenger.grind(32);
     }
 }

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -161,8 +161,12 @@ where
 {
     fn sample_bits(&mut self, bits: usize) -> usize {
         assert!(bits < (usize::BITS as usize));
-        // Limiting the number of bits to the field size
-        assert!((1 << bits) <= F::ORDER_U64 as usize);
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `usize` shift by `bits >= 32` overflows on 32-bit targets and would zero the mask.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
         let rand_usize = u32::from_le_bytes(self.inner.sample_array()) as usize;
         rand_usize & ((1 << bits) - 1)
     }
@@ -205,7 +209,12 @@ where
     #[instrument(name = "grind for proof-of-work witness", skip_all)]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
-        assert!((1 << bits) < F::ORDER_U32);
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
 
         // Trivial case: 0 bits mean no PoW is required and any witness is valid.
         if bits == 0 {
@@ -516,5 +525,26 @@ mod tests {
         let after_grind: u8 = challenger.inner.sample();
         let no_grind: u8 = shadow.inner.sample();
         assert_eq!(after_grind, no_grind);
+    }
+
+    #[test]
+    #[should_panic = "requested bit count must fit within the field order"]
+    fn test_serializing_challenger32_sample_bits_rejects_oversized_request() {
+        // BabyBear order is ~2^30.9, so a 32-bit request must be rejected.
+        // The bound is evaluated in u64, so the guard fires in every build profile.
+        type F = BabyBear;
+        let inner = Inner::new(vec![0, 1, 2, 3], ByteCountHasher);
+        let mut challenger = SerializingChallenger32::<F, Inner>::new(inner);
+        let _ = challenger.sample_bits(32);
+    }
+
+    #[test]
+    #[should_panic = "requested bit count must fit within the field order"]
+    fn test_serializing_challenger32_grind_rejects_oversized_request() {
+        // Same guard, reached through the proof-of-work entry point.
+        type F = BabyBear;
+        let inner = Inner::new(vec![0, 1, 2, 3], ByteCountHasher);
+        let mut challenger = SerializingChallenger32::<F, Inner>::new(inner);
+        let _ = challenger.grind(32);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a release-mode soundness bug in the proof-of-work / bit-sampling guard of the 32-bit challengers.

The width guard used `assert!((1 << bits) < F::ORDER_U32)`, where the literal `1` infers to `u32` (the comparison's RHS type). For `bits >= 32` the shift `1u32 << bits` is **over-width**: with `overflow-checks` off (the default release profile — the workspace `Cargo.toml` does not enable them), the shift amount is hardware-masked, so `1u32 << 32 == 1`. The guard `1 < ORDER` then passes, and `sample_bits` computes `rand & ((1u32 << bits) - 1) == rand & 0 == 0` — **every PoW witness passes**, collapsing proof-of-work security to ~1 bit.

`DuplexChallenger` was never affected (it uses `1u64` + `bits < 64` and has a dedicated security test). This brings the 32-bit and serializing-32 challengers in line.

## Fix

Evaluate the bound in `u64`, mirroring `DuplexChallenger`. The preceding `assert!(bits < 64)` guarantees `1u64 << bits` never overflows, and the `u64` comparison correctly rejects oversized requests in **every** build profile:

- `MultiField32Challenger::sample_bits` / `grind`
- `SerializingChallenger32::sample_bits` / `grind` (the `sample_bits` site also switched `<=` → `<` for convention consistency)

Verification routes through `sample_bits` via `check_witness`, so both the prove and verify paths are covered.

## Tests

Each guard now carries a descriptive panic message, and four release-safe `#[should_panic = "requested bit count must fit within the field order"]` tests request 32 bits over the ~2^30.9 BabyBear field. They fire via the explicit `assert!`, so they catch the regression regardless of build profile — unlike pre-existing tests that only panicked in debug via overflow checks. The message match ensures the panic is the field-order guard and not an unrelated failure.

All 55 challenger tests pass under `cargo test --release -p p3-challenger`; `cargo fmt --check` and `cargo clippy --release --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)