### PR TITLE
fix(matrix): correct strided view height for offset >= stride

### DIFF
--- a/matrix/src/strided.rs
+++ b/matrix/src/strided.rs
@@ -22,21 +22,24 @@ impl VerticallyStridedRowIndexMap {
     /// Create a new vertically strided view over a matrix.
     ///
     /// This selects rows in the inner matrix starting from `offset`, and then every `stride` rows after.
+    /// Any choice of `offset` is valid.
+    /// An `offset` at or past the inner height yields an empty view.
     ///
     /// # Arguments
     /// - `inner`: The inner matrix to view.
     /// - `stride`: The number of rows between each selected row.
-    /// - `offset`: The initial row to start from.
+    /// - `offset`: The inner row index of the first selected row.
+    ///
+    /// # Panics
+    /// Panics if `stride` is zero.
     pub fn new_view<T: Send + Sync + Clone, Inner: Matrix<T>>(
         inner: Inner,
         stride: usize,
         offset: usize,
     ) -> VerticallyStridedMatrixView<Inner> {
-        let h = inner.height();
-        let full_strides = h / stride;
-        let remainder = h % stride;
-        let final_stride = offset < remainder;
-        let height = full_strides + final_stride as usize;
+        // View row i maps to inner row offset + i * stride, valid while < h.
+        // Count of valid rows: ceil((h - offset) / stride), saturating to 0 when offset >= h.
+        let height = inner.height().saturating_sub(offset).div_ceil(stride);
         RowIndexMappedView {
             index_map: Self {
                 height,
@@ -179,5 +182,69 @@ mod tests {
         // offset == 6 > height == 5 → no valid row
         assert_eq!(view.height(), 0);
         assert_eq!(view.get(0, 0), None); // out of bounds
+    }
+
+    #[test]
+    fn test_vertically_strided_view_offset_greater_than_stride() {
+        // Regression: with offset >= stride the old height formula over-reported,
+        // letting view rows map past the inner height.
+        //
+        //     h = 5, stride = 2, offset = 3 → inner rows 3, 5, 7, ... → only row 3 in bounds
+        let matrix = sample_matrix();
+        let view = VerticallyStridedRowIndexMap::new_view(matrix, 2, 3);
+
+        assert_eq!(view.height(), 1);
+        // The single view row is inner row 3.
+        assert_eq!(view.get(0, 0), Some(40));
+        // View row 1 would be inner row 5, past the inner height → rejected.
+        assert_eq!(view.get(1, 0), None);
+    }
+
+    #[test]
+    fn test_vertically_strided_view_offset_equal_to_stride() {
+        // h = 6, stride = 2, offset = 2 → inner rows 2, 4, 6, ... → rows 2 and 4 in bounds.
+        let matrix = RowMajorMatrix::new(vec![10, 20, 30, 40, 50, 60], 1);
+        let view = VerticallyStridedRowIndexMap::new_view(matrix, 2, 2);
+
+        assert_eq!(view.height(), 2);
+        assert_eq!(view.get(0, 0), Some(30)); // inner row 2
+        assert_eq!(view.get(1, 0), Some(50)); // inner row 4
+        // View row 2 would be inner row 6, past the inner height → rejected.
+        assert_eq!(view.get(2, 0), None);
+    }
+
+    #[test]
+    fn test_vertically_strided_view_exhaustive_height_and_bounds() {
+        // Invariant: for any (stride, offset), the view height matches a brute-force count
+        // and every view row reads the expected inner row.
+        for stride in 1..=7usize {
+            // Sweep offsets covering offset < stride, stride <= offset < h, and offset >= h.
+            for offset in 0..=12usize {
+                let matrix = sample_matrix();
+                let h = matrix.height();
+                let view = VerticallyStridedRowIndexMap::new_view(matrix, stride, offset);
+
+                // Brute-force reference: count inner rows offset + i * stride < h.
+                let expected_height = (offset..h).step_by(stride).count();
+                assert_eq!(
+                    view.height(),
+                    expected_height,
+                    "height mismatch for stride={stride}, offset={offset}"
+                );
+
+                // Every view row must read back the matching inner row,
+                // proving the mapped index stays in bounds.
+                for (i, inner_row) in (offset..h).step_by(stride).enumerate() {
+                    assert_eq!(
+                        view.get(i, 0),
+                        Some(10 * (inner_row as i32 + 1)),
+                        "wrong row for stride={stride}, offset={offset}, view row {i}"
+                    );
+                }
+
+                // The first row past the reported height must be rejected.
+                assert_eq!(view.get(expected_height, 0), None);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

`VerticallyStridedRowIndexMap::new_view` computed the view height as `h / stride + (offset < h % stride)`, which is only correct when `offset < stride`. For larger offsets it over-reports the height, so view rows can map to out-of-bounds inner rows — UB through the unchecked accessor paths.

Example: `h = 5, stride = 2, offset = 3` reported height 2, mapping view row 1 to inner row 5.

## Fix

Replace the formula with the exact count of valid rows `offset + i * stride < h`:

```rust
let height = inner.height().saturating_sub(offset).div_ceil(stride);
```

- Correct for all offsets, including `offset >= stride` and `offset >= h` (empty view), at the same cost.
- Reduces to the old formula when `offset < stride`, so existing behavior is unchanged.
- Documents the `stride == 0` panic.

## Tests

- Regression test for `offset > stride` (the OOB case above).
- Regression test for `offset == stride` where the old formula also over-reported.
- Exhaustive sweep of `stride ∈ 1..=7`, `offset ∈ 0..=12` against a brute-force `(offset..h).step_by(stride)` reference, checking height, every row value, and rejection past the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)