### PR TITLE
fix(util): guard reverse_bits_len against oversized bit_len

### DIFF
--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -194,7 +194,7 @@ pub const fn assert_sync<T: Sync>() {}
 
 #[inline]
 pub const fn reverse_bits(x: usize, n: usize) -> usize {
-    // `n` is a domain size: its bit length is `log2(n)`, integral only for a power of two.
+    // Assert that n is a power of 2
     debug_assert!(n.is_power_of_two());
     reverse_bits_len(x, n.trailing_zeros() as usize)
 }

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -194,13 +194,16 @@ pub const fn assert_sync<T: Sync>() {}
 
 #[inline]
 pub const fn reverse_bits(x: usize, n: usize) -> usize {
-    // Assert that n is a power of 2
+    // `n` is a domain size: its bit length is `log2(n)`, integral only for a power of two.
     debug_assert!(n.is_power_of_two());
     reverse_bits_len(x, n.trailing_zeros() as usize)
 }
 
 #[inline]
 pub const fn reverse_bits_len(x: usize, bit_len: usize) -> usize {
+    // A `bit_len` wider than the word would underflow the shift below.
+    // That yields a wrong, non-panicking permutation in release, so reject it up front.
+    debug_assert!(bit_len <= usize::BITS as usize);
     // NB: The only reason we need overflowing_shr() here as opposed
     // to plain '>>' is to accommodate the case n == num_bits == 0,
     // which would become `0 >> 64`. Rust thinks that any shift of 64
@@ -928,6 +931,23 @@ mod tests {
         assert_eq!(reverse_bits_len(0b1000000000, 10), 0b0000000001);
         assert_eq!(reverse_bits_len(0b00000, 5), 0b00000);
         assert_eq!(reverse_bits_len(0b01011, 5), 0b11010);
+    }
+
+    #[test]
+    fn test_reverse_bits_len_full_width() {
+        // A full-width reversal is the largest valid bit length and must reverse every bit.
+        let bits = usize::BITS as usize;
+        assert_eq!(reverse_bits_len(1, bits), 1 << (bits - 1));
+        assert_eq!(reverse_bits_len(1 << (bits - 1), bits), 1);
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "bit_len <= usize::BITS")]
+    fn test_reverse_bits_len_rejects_oversized_bit_len() {
+        // One bit past the word width: the shift would underflow into a wrong permutation.
+        // The expected message pins the guard, not the incidental subtraction-overflow panic.
+        let _ = reverse_bits_len(0, usize::BITS as usize + 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`reverse_bits_len(x, bit_len)` computes the shift amount as `usize::BITS - bit_len as u32`. For `bit_len > usize::BITS` that `u32` subtraction underflows; in **release** builds (overflow-checks off) `overflowing_shr` then masks the shift to `bit_len & 63`, so the function **silently returns a wrong bit-reversal permutation** — the "silently corrupts a proof" class of bug.

All current callers pass `bit_len <= 64`, so this is not exploitable today; it's defensive hardening of a load-bearing primitive.

## Fix

- Add `debug_assert!(bit_len <= usize::BITS as usize)` to document and enforce the precondition. In debug the underflow already panics (with a cryptic `"attempt to subtract with overflow"`); this surfaces misuse with a clear, named precondition and is caught in CI (tests run in debug). Release behaviour is unchanged and continues to rely on the all-callers-≤64 invariant — so this is a developer aid, not a release-time guarantee. (Happy to switch to a real `assert!` if release-time protection is wanted, at the cost of a branch in a hot path.)
- Fix the misleading comment on `reverse_bits`: the power-of-two check is a `debug_assert`, not an unconditional assert. Replaced `// Assert that n is a power of 2` with an explanation of *why* `n` must be a power of two (it's a domain size whose bit length is `log2(n)`).

## Tests

- `test_reverse_bits_len_full_width` — the boundary the guard allows (`bit_len == usize::BITS`) still produces a correct full-width reversal.
- `test_reverse_bits_len_rejects_oversized_bit_len` — `#[cfg(debug_assertions)]` + `#[should_panic(expected = "bit_len <= usize::BITS")]`. The pinned message matters: I verified that without the guard the panic is `"attempt to subtract with overflow"` and the test **fails**, so it specifically confirms the new guard fires first.

`cargo test -p p3-util` passes; `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)