### PR TITLE
chore(multilinear-util): remove dead compress_suffix_into wrapper

### DIFF
--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -413,14 +413,6 @@ impl<F: Field> Poly<F> {
     {
         SplitEq::<F, EF>::new_packed(point, scale).compress_suffix(self)
     }
-
-    /// Like [`compress_suffix`](Self::compress_suffix), but writes into a pre-allocated buffer.
-    pub fn compress_suffix_into<EF>(&self, out: &mut [EF], point: &Point<EF>, scale: EF)
-    where
-        EF: ExtensionField<F>,
-    {
-        SplitEq::<F, EF>::new_packed(point, scale).compress_suffix_into(out, self);
-    }
 }
 
 impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {


### PR DESCRIPTION
## Summary

`Poly::compress_suffix_into` was added in #1554 (whir stacked sumcheck) but never wired up:

- The stacked sumcheck prover (`sumcheck/src/layout/prover/suffix.rs`) calls `SplitEq::compress_suffix_into` directly, since it needs the **unpacked** eq tables while the `Poly` wrapper hardcoded `new_packed`.
- The compress-kernel benches also target the `SplitEq` method.
- No caller, test, or bench references the `Poly` wrapper anywhere in the workspace — untested public surface.

## Change

Drop the wrapper (8 lines). No functionality is lost:

- `SplitEq::compress_suffix_into` (the actual kernel) remains public, used, and covered by the `compress_suffix_dot` proptests.
- The allocating sibling `Poly::compress_suffix` remains used (svo, sumcheck) and tested.

## Verification

- `cargo build --workspace --all-targets` — clean, confirming nothing referenced the removed method
- `cargo test -p p3-multilinear-util` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)