### PR TITLE
refactor(batch-stark): drop redundant quotient-chunk count check

### DIFF
--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -365,9 +365,6 @@ where
         let inst_qcs = &opened_values.instances[i]
             .base_opened_values
             .quotient_chunks;
-        if inst_qcs.len() != domains.len() {
-            return Err(InvalidProofShapeError::QuotientDomainsCountMismatch { air: i }.into());
-        }
         for (d, vals) in zip_eq(
             domains.iter(),
             inst_qcs,


### PR DESCRIPTION
## Summary

In the quotient-commitment opening loop, the verifier checked the chunk count twice:

```rust
if inst_qcs.len() != domains.len() {
    return Err(InvalidProofShapeError::QuotientDomainsCountMismatch { air: i }.into());
}
for (d, vals) in zip_eq(
    domains.iter(),
    inst_qcs,
    VerificationError::from(InvalidProofShapeError::QuotientDomainsCountMismatch { air: i }),
)? { ... }
```

`zip_eq` already rejects a length mismatch with that exact error, so the explicit `if` made the `zip_eq` guard unreachable.

## Change

Remove the manual check and let `zip_eq` be the single length guard.

Behaviour is unchanged — both paths resolve to the identical error value `BatchVerificationError::Verification(VerificationError::InvalidProofShape(QuotientDomainsCountMismatch { air: i }))` (the manual `.into()` and `VerificationError::from(...)` produce the same thing). `zip_eq` is kept as the surviving guard, matching the crate's safe-zip idiom.

`cargo test -p p3-batch-stark` passes (38 tests, including the proof-shape rejection tests); `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)