### PR TITLE
fix(poseidon1-air): add missing (11, 1) S-box constraint degree

### DIFF
--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -189,6 +189,8 @@ pub(crate) const fn sbox_constraint_degree(degree: u64, registers: usize) -> usi
         (5, 0) => 5,
         (7, 0) => 7,
         (5, 1) | (7, 1) | (11, 2) => 3,
+        // One register for x^11: the output (x^3)^3 * x^2 reaches degree 5.
+        (11, 1) => 5,
         _ => panic!("Unexpected (DEGREE, REGISTERS)"),
     }
 }
@@ -414,6 +416,8 @@ fn eval_sparse_partial_round<
 /// |        |           | output `x^3 * x^2` (constraint degree 3).         |
 /// | 7      | 1         | Commit `x^3`, constrain `x^3 = x * x * x`,        |
 /// |        |           | output `(x^3)^2 * x` (constraint degree 3).       |
+/// | 11     | 1         | Commit `x^3`, constrain `x^3 = x * x * x`,        |
+/// |        |           | output `(x^3)^3 * x^2` (constraint degree 5).     |
 /// | 11     | 2         | Commit `x^3` and `x^9`,                           |
 /// |        |           | constrain `x^3 = x^2 * x` and `x^9 = (x^3)^3`,    |
 /// |        |           | output `x^9 * x^2` (constraint degree 3).         |

--- a/poseidon1-air/src/lib.rs
+++ b/poseidon1-air/src/lib.rs
@@ -77,6 +77,8 @@ mod tests {
     use core::borrow::Borrow;
     use core::mem::size_of;
 
+    use p3_air::BaseAir;
+    use p3_air::symbolic::{AirLayout, get_max_constraint_degree};
     use p3_baby_bear::{
         BABYBEAR_POSEIDON1_HALF_FULL_ROUNDS, BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_16,
         BABYBEAR_POSEIDON1_RC_16, BABYBEAR_S_BOX_DEGREE, BabyBear, MDSBabyBearData,
@@ -134,9 +136,6 @@ mod tests {
 
     #[test]
     fn test_poseidon1_air_degree_babybear() {
-        use p3_air::BaseAir;
-        use p3_air::symbolic::{AirLayout, get_max_constraint_degree};
-
         let raw = babybear_poseidon1_constants_16();
         let (full, partial) = raw.to_optimized();
         let air: Poseidon1Air<
@@ -157,6 +156,42 @@ mod tests {
             degree, 3,
             "Expected constraint degree 3 for BabyBear (7, 1)"
         );
+    }
+
+    #[test]
+    fn test_poseidon1_air_degree_sbox_11_1() {
+        // The x^11 one-register S-box must report a degree bound.
+        let raw = babybear_poseidon1_constants_16();
+        let (full, partial) = raw.to_optimized();
+        let air: Poseidon1Air<F, WIDTH, 11, 1, HALF_FULL_ROUNDS, PARTIAL_ROUNDS> =
+            Poseidon1Air::new(full, partial);
+
+        // The reported bound is what the prover queries before evaluation.
+        assert_eq!(air.max_constraint_degree(), Some(5));
+
+        // The symbolic walk over the actual constraints must agree with the bound:
+        //     commit x^3, constrain x^3 = x * x * x         → degree 3
+        //     output (x^3)^3 * x^2, asserted against post   → degree 5
+        let layout = AirLayout {
+            main_width: air.width(),
+            ..Default::default()
+        };
+        let degree = get_max_constraint_degree::<F, _>(&air, layout);
+        assert_eq!(degree, 5, "Expected constraint degree 5 for (11, 1)");
+    }
+
+    #[test]
+    fn test_constraint_satisfaction_sbox_11_1() {
+        // Trace generation and constraint evaluation implement the (11, 1) S-box independently;
+        // Check the two agree on real traces.
+        let raw = babybear_poseidon1_constants_16();
+        let (full, partial) = raw.to_optimized();
+        let air: Poseidon1Air<F, WIDTH, 11, 1, HALF_FULL_ROUNDS, PARTIAL_ROUNDS> =
+            Poseidon1Air::new(full, partial);
+
+        // Generate 16 permutations and check every constraint row-by-row.
+        let trace = air.generate_trace_rows(16, 0);
+        p3_air::check_constraints(&air, &trace, &[]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `(SBOX_DEGREE, SBOX_REGISTERS) = (11, 1)` configuration is implemented on both sides of the AIR:

- `generate_sbox` writes the committed `x^3` and outputs `(x^3)^3 * x^2` (documented in its strategy table)
- `eval_sbox` constrains `committed_x3 = x^3` and produces the same degree-5 output expression

but `sbox_constraint_degree` had no arm for it and `panic!`ed. Since `BaseAir::max_constraint_degree` (both the scalar and vectorized AIRs) calls this lookup, instantiating `(11, 1)` panicked at proving time despite being a fully supported configuration.

For comparison, `poseidon2-air`'s supported sets are consistent — it implements no `(11, 1)` anywhere.

## Fix

- Add the `(11, 1) => 5` arm. Degree 5 is exact: the committed-cube constraint `x^3 = x · x · x` has degree 3, and the output `(x^3)^3 · x^2` (degree 5) is asserted against the committed post-state after the linear MDS layer.
- Add the missing `(11, 1)` row to the `eval_sbox` supported-configurations doc table (it documented `(11, 2)` but not `(11, 1)`).

## Tests

- `test_poseidon1_air_degree_sbox_11_1` — instantiates the `(11, 1)` AIR, asserts `max_constraint_degree() == Some(5)` (the exact call that panicked), and cross-checks with `get_max_constraint_degree` that the actual symbolic constraint degree is also 5.
- `test_constraint_satisfaction_sbox_11_1` — generates 16 permutation traces with the `(11, 1)` config and checks every constraint row-by-row, pinning that trace generation and constraint evaluation agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)