### PR TITLE
refactor(fri): hoist height-1 check and unify prover max-height

### DIFF
--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -78,7 +78,12 @@ where
         "Inputs are not sorted in descending order of length."
     );
 
-    let log_max_height = log2_strict_usize(inputs[0].len());
+    // Index sampling and `open_input` must agree on the height; the caller's value is canonical.
+    debug_assert_eq!(
+        log_global_max_height,
+        log2_strict_usize(inputs[0].len()),
+        "log_global_max_height must match the largest input length"
+    );
     let log_min_height = log2_strict_usize(inputs.last().unwrap().len());
     if params.log_final_poly_len > 0 {
         // Final_poly_degree must be less than or equal to the degree of the smallest polynomial.
@@ -107,12 +112,13 @@ where
         // (Grabbed this from wikipedia page on the birthday problem)
         // N!/(N^{num_queries} * (N - num_queries)!) ~ (1 - 1/N)^{num_queries * (num_queries - 1)/2}
         //                                           ~ (1 - num_queries^2/2N)
-        // Here N = 2^log_max_height.
+        // Here N = 2^log_global_max_height.
         // With num_queries = 100, N = 2^20, this is 0.995 so there is a .5% chance of a collision.
         // Due to this, security conscious users may want to set num_queries a little higher than the
         // theoretical minimum.
         iter::repeat_with(|| {
-            let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
+            let index =
+                challenger.sample_bits(log_global_max_height + folding.extra_query_index_bits());
             // For each index, create a proof that the folding operations along the chain are correct.
             // With variable arity, the index shifts by log_arity each round.
             QueryProof {

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -712,15 +712,15 @@ where
                 }
             }
         }
+    }
 
-        // `reduced_openings` would have a log_height = log_blowup entry only if there was a
-        // trace matrix of height 1. In this case `f` is constant, so `f(zeta) - f(x))/(zeta - x)`
-        // must equal `0`.
-        if let Some((_, ro)) = reduced_openings.get(&params.log_blowup)
-            && !ro.is_zero()
-        {
-            return Err(FriError::FinalPolyMismatch);
-        }
+    // The blowup-height entry exists only for a height-1 (constant) trace matrix.
+    // Its quotient `(f(zeta) - f(x)) / (zeta - x)` must then be zero.
+    // One check after all batches suffices: the random combining challenge rules out cancellation.
+    if let Some((_, ro)) = reduced_openings.get(&params.log_blowup)
+        && !ro.is_zero()
+    {
+        return Err(FriError::FinalPolyMismatch);
     }
 
     // Return reduced openings descending by log_height.


### PR DESCRIPTION
## Summary

Two behavior-preserving cleanups in FRI (audit item L18).

### 1. Verifier — hoist the height-1 zero-check out of the per-batch loop

`open_input` accumulates reduced openings over all batches, then a `log_blowup` entry exists only for a height-1 (constant) trace matrix, whose quotient `(f(zeta) - f(x))/(zeta - x)` must be zero. That check sat **inside** the per-batch loop (running once per batch); it now runs once after the loop.

This is sound: the `log_blowup` entry is an α-weighted sum of contributions, and the random combining challenge rules out any cross-batch cancellation (Schwartz–Zippel), so checking the final value once is equivalent to checking every partial sum.

### 2. Prover — collapse two names for the same quantity

Query-index sampling used a local `log_max_height = log2(inputs[0].len())` while `open_input` used the passed-in `log_global_max_height`. They are always equal by construction (the largest input is the reduced opening at the global max height, and the verifier samples indices using `log_global_max_height` too), but the two names were a latent desync footgun.

- Use the canonical `log_global_max_height` for index sampling.
- Add `debug_assert_eq!(log_global_max_height, log2(inputs[0].len()))` to document the precondition and catch a caller that ever passes a mismatched value.
- Update the collision-probability comment accordingly.

(The unrelated `log_max_height` inside `open_input` is a genuinely different per-matrix height and is left untouched.)

No new tests — both are refactors fully exercised by the existing FRI round-trip suite. `cargo test -p p3-fri` passes; `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)