### PR TITLE
fix(merkle-tree): enforce opened row widths in batch verification

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -450,8 +450,14 @@ where
                         .collect_vec();
                     let batch_dims: Vec<Dimensions> = batch_heights
                         .iter()
-                        // todo: mmcs doesn't really need width
-                        .map(|&height| Dimensions { width: 0, height })
+                        .zip(mats)
+                        .map(|(&height, (_, points_and_values))| Dimensions {
+                            // Each matrix width is known from its claimed evaluations.
+                            width: points_and_values
+                                .first()
+                                .map_or(0, |(_, values)| values.len()),
+                            height,
+                        })
                         .collect_vec();
 
                     let (dims, idx) = batch_heights
@@ -546,7 +552,8 @@ where
                     );
 
                     let fl_dims = Dimensions {
-                        width: 0,
+                        // First-layer leaves hold the queried value and its sibling.
+                        width: 2,
                         height: 1 << (log_height - 1),
                     };
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -448,17 +448,25 @@ where
                         .iter()
                         .map(|(domain, _)| domain.size() << self.fri_params.log_blowup)
                         .collect_vec();
-                    let batch_dims: Vec<Dimensions> = batch_heights
-                        .iter()
-                        .zip(mats)
-                        .map(|(&height, (_, points_and_values))| Dimensions {
-                            // Each matrix width is known from its claimed evaluations.
+                    // The opened rows must pair one-to-one with the committed matrices.
+                    let batch_dims: Vec<Dimensions> = zip_eq(
+                        batch_heights.iter().zip(mats),
+                        &batch_opening.opened_values,
+                        InputError::InputShapeError,
+                    )?
+                    .map(
+                        |((&height, (_, points_and_values)), opened_row)| Dimensions {
+                            // Invariant: the commitment layer rejects opened rows that differ from this width.
+                            //
+                            //     some points → width = claimed evaluation count
+                            //     no points   → width = opened row length (no claim to enforce)
                             width: points_and_values
                                 .first()
-                                .map_or(0, |(_, values)| values.len()),
+                                .map_or(opened_row.len(), |(_, values)| values.len()),
                             height,
-                        })
-                        .collect_vec();
+                        },
+                    )
+                    .collect_vec();
 
                     let (dims, idx) = batch_heights
                         .iter()

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -134,6 +134,12 @@ pub trait Mmcs<T: Send + Sync + Clone>: Clone {
     /// - The global index used for opening (interpreted as in [`Self::open_batch`]).
     /// - A [`BatchOpeningRef`] containing the claimed opened values and the proof.
     ///
+    /// # Width enforcement
+    /// - Leaf hashing may flatten all rows opened at one height into a single element stream.
+    /// - A digest match alone then does not pin where one row ends and the next begins.
+    /// - Implementations must reject any opened row whose length differs from its claimed width.
+    /// - Callers must derive each width from verifier-known data, never from the proof itself.
+    ///
     /// # Parameters
     /// - `commit`: The original commitment.
     /// - `dimensions`: Dimensions of the committed matrices, in order.

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -86,7 +86,8 @@ pub type CommitmentWithOpeningPoints<Challenge, Commitment, Domain> = (
     Vec<(
         // The domain of the matrix
         Domain,
-        // A vector of (point, claimed_evaluation) pairs
+        // A vector of (point, claimed_evaluation) pairs.
+        // The claimed evaluation count per point is also the matrix width used by verification.
         Vec<(Challenge, Vec<Challenge>)>,
     )>,
 );

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -638,8 +638,14 @@ where
             .collect_vec();
         let batch_dims = batch_heights
             .iter()
-            // TODO: MMCS doesn't really need width; we put 0 for now.
-            .map(|&height| Dimensions { width: 0, height })
+            .zip(mats)
+            .map(|(&height, (_, points_and_values))| Dimensions {
+                // Each matrix width is known from its claimed evaluations.
+                width: points_and_values
+                    .first()
+                    .map_or(0, |(_, values)| values.len()),
+                height,
+            })
             .collect_vec();
 
         // If the maximum height of the batch is smaller than the global max height,
@@ -743,7 +749,7 @@ mod tests {
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{Field, HornerIter, PrimeCharacteristicRing, TwoAdicField};
     use p3_matrix::dense::RowMajorMatrix;
-    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_merkle_tree::{MerkleTreeError, MerkleTreeMmcs};
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
@@ -1530,16 +1536,20 @@ mod tests {
         // evaluations f_i(z) to form (f_i(z) - f_i(x)) / (z - x).
         // These two vectors must have the same length.
         //
-        // Fixture state: 2 trace columns → 2 opened values, 2 claims.
+        // Fixture state: 2 trace columns → 2 opened values, 2 claims at point 0.
         //
-        // Mutation: push an extra claim. Only touches verifier-side data,
-        // not the proof, so Merkle verification still passes. Claims are
+        // Mutation: add a second opening point with one claim too many.
+        // Point 0 still matches the matrix width, so the Merkle shape
+        // checks pass and the pairing check fires at point 1. Claims are
         // not in the transcript, so the original challenger is reused.
         //
-        //     opened values:  [f_0(x), f_1(x)]             (length 2)
-        //     claims:         [f_0(z), f_1(z), EXTRA]      (length 3)
-        //     → 2 != 3 → error
-        cwop[0].1[0].1[0].1.push(Challenge::ZERO);
+        //     opened values:   [f_0(x), f_1(x)]            (length 2)
+        //     point 0 claims:  [f_0(z), f_1(z)]            (length 2)
+        //     point 1 claims:  [0, 0, 0]                   (length 3)
+        //     → 2 != 3 → error at point 1
+        cwop[0].1[0]
+            .1
+            .push((Challenge::ZERO, vec![Challenge::ZERO; 3]));
 
         let mut challenger = f.challenger.clone();
         let err = run_verify_fri(
@@ -1561,13 +1571,46 @@ mod tests {
             } => {
                 assert_eq!(batch, 0);
                 assert_eq!(matrix, 0);
-                assert_eq!(point, 0);
+                assert_eq!(point, 1);
                 // 2 trace columns opened, but 3 claimed evaluations.
                 assert_eq!(expected, 2);
                 assert_eq!(got, 3);
             }
             other => panic!("wrong error variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn claimed_width_mismatch_rejected_by_input_mmcs() {
+        let f = make_test_fixture();
+        let mut cwop = f.commitments_with_opening_points.clone();
+
+        // The matrix width the verifier passes to the input commitment
+        // scheme comes from the first point's claimed evaluations.
+        //
+        //     opened values:  [f_0(x), f_1(x)]             (length 2)
+        //     claims:         [f_0(z), f_1(z), EXTRA]      (length 3)
+        //     → expected width 3, opened row has 2 → error
+        cwop[0].1[0].1[0].1.push(Challenge::ZERO);
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &f.proof,
+            &mut challenger,
+            &cwop,
+            &f.input_mmcs,
+        )
+        .expect_err("should reject opened rows narrower than the claimed width");
+
+        assert!(matches!(
+            err,
+            FriError::InputError(MerkleTreeError::WrongWidth {
+                matrix: 0,
+                expected: 3,
+                got: 2,
+            })
+        ));
     }
 
     #[test]

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -629,6 +629,16 @@ where
         .zip(commitments_with_opening_points.iter())
         .enumerate()
     {
+        // The opened rows must pair one-to-one with the committed matrices.
+        // Why: the width derivation below zips rows with matrix metadata.
+        if batch_opening.opened_values.len() != mats.len() {
+            return Err(FriError::BatchOpenedValuesCountMismatch {
+                batch,
+                expected: mats.len(),
+                got: batch_opening.opened_values.len(),
+            });
+        }
+
         // Find the height of each matrix in the batch.
         // Currently we only check domain.size() as the shift is
         // assumed to always be Val::GENERATOR.
@@ -639,13 +649,19 @@ where
         let batch_dims = batch_heights
             .iter()
             .zip(mats)
-            .map(|(&height, (_, points_and_values))| Dimensions {
-                // Each matrix width is known from its claimed evaluations.
-                width: points_and_values
-                    .first()
-                    .map_or(0, |(_, values)| values.len()),
-                height,
-            })
+            .zip(&batch_opening.opened_values)
+            .map(
+                |((&height, (_, points_and_values)), opened_row)| Dimensions {
+                    // Invariant: the commitment layer rejects opened rows that differ from this width.
+                    //
+                    //     some points → width = claimed evaluation count
+                    //     no points   → width = opened row length (no claim to enforce)
+                    width: points_and_values
+                        .first()
+                        .map_or(opened_row.len(), |(_, values)| values.len()),
+                    height,
+                },
+            )
             .collect_vec();
 
         // If the maximum height of the batch is smaller than the global max height,
@@ -656,14 +672,6 @@ where
             .max()
             .map(|&h| index >> (log_global_max_height - log2_strict_usize(h)))
             .unwrap_or(0);
-
-        if batch_opening.opened_values.len() != mats.len() {
-            return Err(FriError::BatchOpenedValuesCountMismatch {
-                batch,
-                expected: mats.len(),
-                got: batch_opening.opened_values.len(),
-            });
-        }
 
         input_mmcs
             .verify_batch(

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -258,6 +258,43 @@ mod tests {
     }
 
     #[test]
+    fn verify_rejects_wrong_row_width() {
+        let mut rng = SmallRng::seed_from_u64(2);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        // Commit to one matrix of width 4 through the hiding wrapper.
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 8, 4);
+        let dims = vec![mat.dimensions()];
+        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        // Mutation: append one extra element to the opened row.
+        //
+        //     opened row:  [a, b, c, d, EXTRA]   (5 values, width is 4)
+        let mut opening = mmcs.open_batch(3, &prover_data);
+        opening.opened_values[0].push(F::ONE);
+
+        // The inner tree commits to rows widened by the salt columns.
+        // The reported widths are therefore salted as well.
+        //
+        //     expected: 4 + 4 salts = 8
+        //     got:      5 + 4 salts = 9
+        let err = mmcs
+            .verify_batch(&commit, &dims, 3, (&opening).into())
+            .expect_err("row longer than the matrix width must be rejected");
+        assert!(matches!(
+            err,
+            MerkleTreeError::WrongWidth {
+                matrix: 0,
+                expected: 8,
+                got: 9,
+            }
+        ));
+    }
+
+    #[test]
     fn hiding_mmcs_is_sync() {
         assert_sync::<MyMmcs>();
     }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -14,6 +14,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use spin::Mutex;
 
+use crate::mmcs::check_widths;
 use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 
 /// A vector commitment scheme backed by a `MerkleTree`.
@@ -165,6 +166,11 @@ where
     ) -> Result<(), Self::Error> {
         let (opened_values, (salts, siblings)) = batch_opening.unpack();
 
+        // Pin each opened row to its matrix width before salting.
+        // The inner tree only sees salted widths.
+        // Without this, an over-long row could be masked by an under-long salt.
+        check_widths(dimensions, opened_values)?;
+
         let opened_salted_values = zip_eq(opened_values, salts, MerkleTreeError::WrongBatchSize)?
             .map(|(opened, salt)| opened.iter().chain(salt.iter()).copied().collect_vec())
             .collect_vec();
@@ -276,11 +282,10 @@ mod tests {
         let mut opening = mmcs.open_batch(3, &prover_data);
         opening.opened_values[0].push(F::ONE);
 
-        // The inner tree commits to rows widened by the salt columns.
-        // The reported widths are therefore salted as well.
+        // The width is checked on the unsalted row, before salt columns are appended.
         //
-        //     expected: 4 + 4 salts = 8
-        //     got:      5 + 4 salts = 9
+        //     expected: 4 (matrix width)
+        //     got:      5 (opened row length)
         let err = mmcs
             .verify_batch(&commit, &dims, 3, (&opening).into())
             .expect_err("row longer than the matrix width must be rejected");
@@ -288,8 +293,8 @@ mod tests {
             err,
             MerkleTreeError::WrongWidth {
                 matrix: 0,
-                expected: 8,
-                got: 9,
+                expected: 4,
+                got: 5,
             }
         ));
     }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -169,9 +169,19 @@ where
             .map(|(opened, salt)| opened.iter().chain(salt.iter()).copied().collect_vec())
             .collect_vec();
 
+        // The inner tree commits to rows widened by the salt columns,
+        // so the widths must be widened the same way.
+        let salted_dimensions = dimensions
+            .iter()
+            .map(|dims| Dimensions {
+                width: dims.width + SALT_ELEMS,
+                height: dims.height,
+            })
+            .collect_vec();
+
         self.inner.verify_batch(
             commit,
-            dimensions,
+            &salted_dimensions,
             index,
             BatchOpeningRef::new(&opened_salted_values, siblings),
         )

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -35,7 +35,7 @@ use thiserror::Error;
 
 use crate::MerkleTreeError::{
     CapMismatch, EmptyBatch, IncompatibleHeights, IndexOutOfBounds, MalformedPrunedProof,
-    WrongBatchSize, WrongHeight,
+    WrongBatchSize, WrongHeight, WrongWidth,
 };
 use crate::merkle_tree::{padded_len, select_arity_step};
 use crate::pruning::{MerkleAuthPath, prune_paths, restore_paths};
@@ -81,6 +81,17 @@ pub enum MerkleTreeError {
     #[error("wrong batch size: number of openings does not match expected")]
     WrongBatchSize,
 
+    /// An opened row's length does not match the width of its matrix.
+    #[error("wrong width: matrix {matrix} expected {expected} values, got {got}")]
+    WrongWidth {
+        /// Index of the offending matrix in the batch.
+        matrix: usize,
+        /// Width of the matrix according to the caller-supplied dimensions.
+        expected: usize,
+        /// Length of the opened row provided in the proof.
+        got: usize,
+    },
+
     /// The number of proof nodes does not match the expected tree height.
     #[error("wrong height: expected {expected_proof_len} siblings, got {num_siblings}")]
     WrongHeight {
@@ -115,6 +126,26 @@ pub enum MerkleTreeError {
     /// A pruned batch opening could not be restored (malformed proof).
     #[error("malformed pruned proof: cannot restore full authentication paths")]
     MalformedPrunedProof,
+}
+
+/// Check that each opened row has exactly the width of its matrix.
+///
+/// The leaf hash flattens all rows at one height into a single element stream,
+/// so a digest match alone does not pin where one row ends and the next begins.
+fn check_widths<T>(
+    dimensions: &[Dimensions],
+    opened_values: &[Vec<T>],
+) -> Result<(), MerkleTreeError> {
+    for (matrix, (dims, row)) in dimensions.iter().zip(opened_values).enumerate() {
+        if row.len() != dims.width {
+            return Err(WrongWidth {
+                matrix,
+                expected: dims.width,
+                got: row.len(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// The arity schedule and query positions for a given Merkle path.
@@ -665,6 +696,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
             if pruned_opening.opened_values[rep].len() != dimensions.len() {
                 return Err(WrongBatchSize);
             }
+            // Row boundaries within a flattened leaf hash are only pinned by the widths.
+            check_widths(dimensions, &pruned_opening.opened_values[rep])?;
         }
         for window in sorted_paths.windows(2) {
             if window[0].leaf_index >= window[1].leaf_index {
@@ -1048,6 +1081,10 @@ where
         if dimensions.len() != opened_values.len() {
             return Err(WrongBatchSize);
         }
+
+        // The leaf hash flattens all rows at one height into a single stream,
+        // so row boundaries are only authenticated by checking each row width.
+        check_widths(dimensions, opened_values)?;
 
         let mut heights_tallest_first = dimensions
             .iter()
@@ -1584,6 +1621,75 @@ mod tests {
         let batch_opening = mmcs.open_batch(17, &prover_data);
         mmcs.verify_batch(&commit, &dims, 17, (&batch_opening).into())
             .expect("expected verification to succeed");
+    }
+
+    #[test]
+    fn verify_rejects_wrong_row_width() {
+        let mut rng = SmallRng::seed_from_u64(3);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0);
+
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 8, 4);
+        let dims = vec![mat.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        // Append one extra element to the opened row: 4 values become 5.
+        let mut opening = mmcs.open_batch(3, &prover_data);
+        opening.opened_values[0].push(F::ONE);
+
+        let err = mmcs
+            .verify_batch(&commit, &dims, 3, (&opening).into())
+            .expect_err("row longer than the matrix width must be rejected");
+        assert!(matches!(
+            err,
+            MerkleTreeError::WrongWidth {
+                matrix: 0,
+                expected: 4,
+                got: 5,
+            }
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_shifted_row_boundary() {
+        let mut rng = SmallRng::seed_from_u64(4);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0);
+
+        // Two matrices of equal height hash into one flattened leaf stream:
+        //
+        //     leaf digest = hash(row_0[0..3] || row_1[0..5])
+        //
+        // Moving an element across the row boundary keeps the stream — and
+        // hence the digest — identical, so only the width check can catch it.
+        let mat_a = RowMajorMatrix::<F>::rand(&mut rng, 8, 3);
+        let mat_b = RowMajorMatrix::<F>::rand(&mut rng, 8, 5);
+        let dims = vec![mat_a.dimensions(), mat_b.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat_a, mat_b]);
+
+        // Mutation: last element of row 0 becomes the first element of row 1.
+        //
+        //     row 0: [a, b, c]    → [a, b]
+        //     row 1: [d, e, f, g, h] → [c, d, e, f, g, h]
+        let mut opening = mmcs.open_batch(5, &prover_data);
+        let moved = opening.opened_values[0].pop().unwrap();
+        opening.opened_values[1].insert(0, moved);
+
+        let err = mmcs
+            .verify_batch(&commit, &dims, 5, (&opening).into())
+            .expect_err("shifted row boundary must be rejected");
+        assert!(matches!(
+            err,
+            MerkleTreeError::WrongWidth {
+                matrix: 0,
+                expected: 3,
+                got: 2,
+            }
+        ));
     }
 
     #[test]

--- a/merkle-tree/src/mmcs.rs
+++ b/merkle-tree/src/mmcs.rs
@@ -132,7 +132,7 @@ pub enum MerkleTreeError {
 ///
 /// The leaf hash flattens all rows at one height into a single element stream,
 /// so a digest match alone does not pin where one row ends and the next begins.
-fn check_widths<T>(
+pub(crate) fn check_widths<T>(
     dimensions: &[Dimensions],
     opened_values: &[Vec<T>],
 ) -> Result<(), MerkleTreeError> {


### PR DESCRIPTION
## Summary

`MerkleTreeMmcs::verify_batch` checked `dimensions.len() == opened_values.len()` but never `opened_values[i].len() == dimensions[i].width` — `Dimensions::width` was entirely unused on the verify path.

This is more than an unenforced shape contract. The leaf hash (`hash_iter_slices`) **flattens all rows at one height into a single element stream** before hashing, so a digest match does not pin where one row ends and the next begins. When two or more same-height matrices are committed together, a prover can move elements across the row boundary without changing the leaf digest, and the tampered opening **verifies**:

```text
committed:  row_0 = [a, b, c]      row_1 = [d, e, f, g, h]
tampered:   row_0 = [a, b]         row_1 = [c, d, e, f, g, h]

leaf digest = hash(a, b, c, d, e, f, g, h)   — identical in both cases
```

Verified empirically: with the width check disabled, the boundary-shift opening passes verification against a real commitment. Downstream consumers (e.g. FRI's alpha-reduction, which zips opened rows with claimed evaluations) would silently process misaligned rows. For a *single* matrix per height a wrong-length row does change the absorbed stream and fails the cap check, which is why this went unnoticed.

## Fix

- **`merkle-tree/src/mmcs.rs`** — new `WrongWidth { matrix, expected, got }` error; every opened row's length is checked against its matrix width in both `verify_batch` and the amortized `verify_batch_pruned` (same flattened hashing, same gap).
- **`merkle-tree/src/hiding_mmcs.rs`** — the hiding wrapper now passes salt-widened dimensions (`width + SALT_ELEMS`) to the inner tree, matching what the inner tree actually commits.
- **`fri/src/verifier.rs`** — replaces the `width: 0` placeholder (old `TODO: MMCS doesn't really need width`) with the true width derived from the claimed evaluations.
- **`circle/src/pcs.rs`** — same for input batches; the first-layer dimensions use width 2 (queried value + sibling).

## Tests

- `verify_rejects_wrong_row_width` — an over-long opened row is rejected with the precise error.
- `verify_rejects_shifted_row_boundary` — the digest-preserving boundary shift between two same-height matrices is rejected (confirmed to verify as `Ok` before this fix).
- `claimed_width_mismatch_rejected_by_input_mmcs` (fri) — a claims/opening width disagreement now surfaces at the commitment layer.
- `point_evaluation_count_mismatch` (fri) — retargeted to a second opening point so the pairing check retains independent coverage.

Full workspace test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)