### PR TITLE
fix(field): make from_int total for iN::MIN

### DIFF
--- a/field-testing/src/from_integer_tests.rs
+++ b/field-testing/src/from_integer_tests.rs
@@ -107,6 +107,14 @@ macro_rules! generate_from_large_i_int_tests {
         assert_eq!(<$field>::from_canonical_checked(-half), None);
         assert_eq!(<$field>::from_canonical_checked(<$int_type>::MAX), None);
         assert_eq!(<$field>::from_canonical_checked(<$int_type>::MIN), None);
+
+        // `from_int` is total, so the minimum value must not overflow the internal negation.
+        // Check it via the ring-homomorphism identity `from_int(MIN) == from_int(MIN + 1) - 1`.
+        let min = <$int_type>::MIN;
+        assert_eq!(
+            <$field>::from_int(min),
+            <$field>::from_int(min + 1) - <$field>::ONE
+        );
         )*
     };
 }

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -378,7 +378,8 @@ macro_rules! quotient_map_large_iint {
                 if int >= 0 {
                     Self::from_int(int as $large_int)
                 } else {
-                    -Self::from_int(-int as $large_int)
+                    // `unsigned_abs` gives the magnitude without overflowing on the minimum value.
+                    -Self::from_int(int.unsigned_abs())
                 }
             }
 


### PR DESCRIPTION
## Summary

`quotient_map_large_iint!`'s `from_int` converts negative inputs via:

```rust
-Self::from_int(-int as $large_int)
```

For `int == iN::MIN`, `-int` overflows (`-i64::MIN` / `-i128::MIN` are not representable):
- **debug builds**: panics with `attempt to negate with overflow`, violating the documented *total* contract of `from_int` ("Convert a given integer into a field element");
- **release builds**: relies on two's-complement wraparound — it happens to land on the correct value, but it's fragile and undocumented.

## Fix

Use `int.unsigned_abs()`, which returns the correct magnitude for the minimum value with no overflow. The macro pairs each signed type with its same-width unsigned counterpart (Goldilocks `i128`, Mersenne31 `i64`/`i128`), so `unsigned_abs()` returns exactly the `$large_int` type that `from_int` expects. `from_int` is now genuinely total in all build profiles.

## Test

The shared `generate_from_large_i_int_tests` macro only checked `MIN` through `from_canonical_checked` (which returns `None` and never reaches the negation), so the buggy path was untested. Added a `from_int(MIN)` check via the ring-homomorphism identity `from_int(MIN) == from_int(MIN + 1) - 1` — field-order agnostic, and exercised by every field using the harness.

Verified it **fails** (`attempt to negate with overflow`) against the pre-fix code and passes after. `cargo test -p p3-goldilocks -p p3-mersenne-31` passes (331 + 188); `cargo fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)