### PR TITLE
fix(uni-stark): reject out-of-domain point inside the trace domain

### DIFF
--- a/uni-stark/src/error.rs
+++ b/uni-stark/src/error.rs
@@ -132,4 +132,9 @@ where
         "next point unavailable: domain does not support computing the next point algebraically"
     )]
     NextPointUnavailable,
+    /// The out-of-domain point coincides with a trace-domain point.
+    ///
+    /// Selector inversion is undefined there.
+    #[error("out-of-domain point lies inside the trace domain")]
+    OodPointInDomain,
 }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -388,7 +388,15 @@ where
     // Get an out-of-domain point to open our values at.
     //
     // Soundness Error: dN/|EF| where `N` is the trace length and our constraint polynomial has degree `d`.
-    let zeta = challenger.sample_algebra_element();
+    let zeta: SC::Challenge = challenger.sample_algebra_element();
+
+    // The opening at zeta divides by the vanishing polynomial of the trace domain.
+    // Reject any zeta on the domain, where that polynomial is zero and the inverse panics.
+    // Honest Fiat-Shamir sampling reaches this only with probability |H| / |EF|.
+    if init_trace_domain.vanishing_poly_at_point(zeta).is_zero() {
+        return Err(VerificationError::OodPointInDomain);
+    }
+
     let periodic_values: Vec<SC::Challenge> = air
         .periodic_columns()
         .iter()


### PR DESCRIPTION
## Problem

The uni-STARK verifier samples an out-of-domain point `zeta` via Fiat–Shamir, then evaluates the Lagrange selectors through `selectors_at_point`, which inverts the vanishing polynomial of the trace domain.

If `zeta` lands inside the trace domain, that polynomial is zero and the inversion hits `Field::inverse()`'s `expect("Tried to invert zero")` — the non-interactive verifier **panics** instead of returning an error.

This is not a soundness break: `zeta` is drawn from the extension field, so an honest transcript reaches this case only with probability `|H| / |EF|` (and a prover cannot feasibly grind toward it). But a verifier should never panic on a malformed instance, so we guard it explicitly.

## Fix

After sampling `zeta`, reject it with a typed `VerificationError::OodPointInDomain` when it lies on the trace domain (i.e. the vanishing polynomial evaluates to zero there), before any selector inversion runs.

```rust
let zeta: SC::Challenge = challenger.sample_algebra_element();

if init_trace_domain.vanishing_poly_at_point(zeta).is_zero() {
    return Err(VerificationError::OodPointInDomain);
}
```

## Notes

- No dedicated regression test: the guard only triggers when the FS-sampled `zeta` lands in the domain (probability `~2^-120`), which cannot be produced deterministically. The only way to reach it through `verify` is a rigged challenger that hard-codes the internal sampling order — more fragile than the one-line check it would protect, so it was deliberately left out.
- `zeta` now needs an explicit type annotation since it is used before the later inference site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)