### PR TITLE
feat(sumcheck): add next-row (shift) statements for AIR over WHIR

### DIFF
--- a/multilinear-util/src/point.rs
+++ b/multilinear-util/src/point.rs
@@ -135,6 +135,80 @@ where
         Self::eval_eq(self.as_slice(), point.as_slice())
     }
 
+    /// Evaluates the successor polynomial `next(p, q)` for slices.
+    ///
+    /// `next` is the multilinear extension of the row-successor indicator.
+    /// Rows are indexed big-endian: coordinate `0` is the most significant bit.
+    ///
+    /// ```text
+    /// next(x, y) = 1   if y = x + 1, or x = y = (1, ..., 1)
+    /// next(x, y) = 0   otherwise                  (x, y in {0,1}^n)
+    /// ```
+    ///
+    /// - The last row maps to itself instead of wrapping to row `0`.
+    /// - AIR transition constraints must therefore mask the last row with a selector.
+    ///
+    /// # Closed form
+    ///
+    /// Sum over the pivot `j`, the lowest zero bit of `x` where the carry stops:
+    ///
+    /// ```text
+    /// next(x, y) = sum_j [prod_{k<j} eq(x_k, y_k)] * (1 - x_j) * y_j * [prod_{k>j} x_k * (1 - y_k)]
+    ///            + prod_k x_k * y_k
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// - `O(n)` field operations.
+    /// - One `n`-element allocation for the suffix products.
+    ///
+    /// # Panics
+    /// Panics if `p` and `q` have different lengths.
+    #[must_use]
+    pub fn eval_next<EF: ExtensionField<F>>(p: &[F], q: &[EF]) -> EF {
+        assert_eq!(
+            p.len(),
+            q.len(),
+            "Points must have the same number of variables"
+        );
+        let n = p.len();
+        // Zero variables: a single row whose successor is itself.
+        if n == 0 {
+            return EF::ONE;
+        }
+
+        // Suffix products: suf[j] = prod_{k > j} x_k * (1 - y_k), with suf[n - 1] = 1.
+        let mut suf = Vec::with_capacity(n);
+        suf.push(EF::ONE);
+        for k in (1..n).rev() {
+            let last = *suf.last().unwrap();
+            suf.push(last * (EF::ONE - q[k]) * p[k]);
+        }
+
+        // Forward sweep: accumulate pivot terms against a running eq prefix,
+        // and the all-ones self-loop product alongside.
+        let mut acc = EF::ZERO;
+        let mut prefix_eq = EF::ONE;
+        let mut self_loop = EF::ONE;
+        for (j, (&x, &y)) in p.iter().zip(q).enumerate() {
+            acc += prefix_eq * y * (F::ONE - x) * suf[n - 1 - j];
+            // eq(x, y) = 1 + 2xy - x - y (same identity as `eval_eq`).
+            prefix_eq *= y.double() * x - x - y + F::ONE;
+            self_loop *= y * x;
+        }
+        acc + self_loop
+    }
+
+    /// Computes `next(c, p)`, where `p` is another `Point`.
+    ///
+    /// `next` is the multilinear extension of the row-successor indicator,
+    /// with a self-loop on the all-ones row.
+    #[must_use]
+    #[inline]
+    pub fn next_poly(&self, point: &Self) -> F {
+        Self::eval_next(self.as_slice(), point.as_slice())
+    }
+
     /// Computes `select(c, pow(var))`,.
     ///
     /// The **selection polynomial** for two vectors is:
@@ -652,6 +726,69 @@ mod tests {
                 let expected = if bit == 1 { F::ONE } else { F::ZERO };
                 prop_assert_eq!(coord, expected);
             }
+        }
+    }
+
+    /// Reference successor indicator on hypercube indices: `b = a + 1`,
+    /// with the last row mapping to itself.
+    fn next_indicator(a: usize, b: usize, num_variables: usize) -> bool {
+        let last = (1 << num_variables) - 1;
+        if a == last { b == last } else { b == a + 1 }
+    }
+
+    #[test]
+    fn test_eval_next_boolean_truth_table() {
+        // Exhaustive truth table on up to 4 variables.
+        for num_variables in 1..=4 {
+            for a in 0..1usize << num_variables {
+                for b in 0..1usize << num_variables {
+                    let x = Point::<F>::hypercube(a, num_variables);
+                    let y = Point::<F>::hypercube(b, num_variables);
+                    let expected = if next_indicator(a, b, num_variables) {
+                        F::ONE
+                    } else {
+                        F::ZERO
+                    };
+                    assert_eq!(
+                        x.next_poly(&y),
+                        expected,
+                        "next({a}, {b}) over {num_variables} variables"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_eval_next_zero_variables() {
+        // A single row: its successor is itself.
+        assert_eq!(Point::<F>::eval_next(&[], &[] as &[F]), F::ONE);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_eval_next_matches_interpolation(
+            num_variables in 1usize..=8,
+            seed in any::<u64>(),
+        ) {
+            // Invariant: next(x, y) is multilinear in both arguments, so it must
+            // equal its interpolation from the boolean truth table:
+            //     next(x, y) = sum_{a,b} next(a, b) * eq(a, x) * eq(b, y).
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let x = Point::<F>::rand(&mut rng, num_variables);
+            let y = Point::<F>::rand(&mut rng, num_variables);
+
+            let mut expected = F::ZERO;
+            for a in 0..1usize << num_variables {
+                for b in 0..1usize << num_variables {
+                    if next_indicator(a, b, num_variables) {
+                        let pa = Point::<F>::hypercube(a, num_variables);
+                        let pb = Point::<F>::hypercube(b, num_variables);
+                        expected += pa.eq_poly(&x) * pb.eq_poly(&y);
+                    }
+                }
+            }
+            prop_assert_eq!(x.next_poly(&y), expected);
         }
     }
 }

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -325,6 +325,71 @@ impl<F: Field> Poly<F> {
         Self(evals)
     }
 
+    /// Given a point `P` (as a slice), compute the evaluation vector of the successor
+    /// function `next(P, X)` for all points `X` in the boolean hypercube, scaled by a value.
+    ///
+    /// `next` is the multilinear extension of the row-successor indicator.
+    /// Rows are indexed big-endian and the last row maps to itself.
+    ///
+    /// # Algorithm
+    ///
+    /// Block-doubling butterfly over the coordinates, last to first.
+    /// `N_j` is the carry-chain table over the suffix `P[j..]`.
+    /// `L_j = scale * prod_{k >= j} P_k` is the running self-loop product.
+    ///
+    /// ```text
+    /// N_{j-1}[0||y]  = (1 - P_{j-1}) * N_j[y]
+    /// N_{j-1}[1||y]  =      P_{j-1}  * N_j[y]
+    /// N_{j-1}[1||0] += (1 - P_{j-1}) * L_j      (carry crosses coordinate j-1)
+    /// ```
+    ///
+    /// The self-loop term `L_0` lands on the all-ones row at the end.
+    ///
+    /// # Performance
+    ///
+    /// `O(2^n)` field operations, the same as the eq butterfly.
+    ///
+    /// ## Arguments
+    /// * `point`: A multilinear point.
+    /// * `scale`: A scalar value to multiply all evaluations by.
+    ///
+    /// ## Returns
+    /// A polynomial containing `scale * next(point, X)` for all `X` in `{0,1}^n`.
+    pub fn new_next_from_point(point: &[F], scale: F) -> Self {
+        let n = point.len();
+        // Zero variables: a single row whose successor is itself.
+        if n == 0 {
+            return Self(vec![scale]);
+        }
+        let len: usize = 1_usize
+            .checked_shl(n as u32)
+            .expect("Point length too large: 2^n overflows usize.");
+
+        let mut evals = F::zero_vec(len);
+        // Running self-loop product over the processed suffix of `point`.
+        let mut lambda = scale;
+        let mut filled = 1;
+        for &z in point.iter().rev() {
+            let (lo, hi) = evals.split_at_mut(filled);
+            // Tensor the new coordinate onto the carry-chain table:
+            // hi = z * N (new bit = 1), lo = (1 - z) * N (new bit = 0).
+            lo.iter_mut()
+                .zip(hi[..filled].iter_mut())
+                .for_each(|(l, h)| {
+                    *h = *l * z;
+                    *l -= *h;
+                });
+            // New pivot: the carry chain crosses this coordinate, landing on
+            // the row (1, 0, ..., 0) of the extended table.
+            hi[0] += lambda - lambda * z;
+            lambda *= z;
+            filled *= 2;
+        }
+        // Self-loop: the all-ones row maps to itself.
+        evals[len - 1] += lambda;
+        Self(evals)
+    }
+
     /// Evaluates the multilinear polynomial at `point ∈ F^n`.
     ///
     /// Computes
@@ -1972,5 +2037,103 @@ pub(crate) mod test {
         //     3-variable polynomial; ask to pad to arity 2 → must panic.
         let mut poly = Poly::<F>::zero(3);
         poly.pad_zeros(2);
+    }
+
+    #[test]
+    fn test_new_next_from_point_boolean_points() {
+        // At a boolean point z, the next table is the indicator of the
+        // successor row (self-loop on the last row).
+        for num_variables in 1..=4usize {
+            let len = 1 << num_variables;
+            for a in 0..len {
+                let z = Point::<F>::hypercube(a, num_variables);
+                let table = Poly::new_next_from_point(z.as_slice(), F::ONE);
+                let successor = if a == len - 1 { len - 1 } else { a + 1 };
+                for b in 0..len {
+                    let expected = if b == successor { F::ONE } else { F::ZERO };
+                    assert_eq!(
+                        table.as_slice()[b],
+                        expected,
+                        "next table at z = {a}, row {b}, {num_variables} variables"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_next_from_point_zero_variables() {
+        // A single row: its successor is itself, so the table is [scale].
+        let scale = F::from_u64(7);
+        let table = Poly::new_next_from_point(&[] as &[F], scale);
+        assert_eq!(table.as_slice(), &[scale]);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_next_table_matches_eval_next(
+            num_variables in 1usize..=8,
+            seed in any::<u64>(),
+        ) {
+            // Invariant: the table built by the butterfly must agree with the
+            // O(n) closed form at every hypercube row, including the scale.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let z = Point::<F>::rand(&mut rng, num_variables);
+            let scale: F = rng.random();
+
+            let table = Poly::new_next_from_point(z.as_slice(), scale);
+            for b in 0..1usize << num_variables {
+                let y = Point::<F>::hypercube(b, num_variables);
+                prop_assert_eq!(
+                    table.as_slice()[b],
+                    z.next_poly(&y) * scale,
+                    "row {}", b
+                );
+            }
+        }
+
+        #[test]
+        fn proptest_next_table_is_mle_of_next(
+            num_variables in 1usize..=8,
+            seed in any::<u64>(),
+        ) {
+            // Invariant: next(z, .) is multilinear, so interpolating its table
+            // at a random point y must reproduce the closed form next(z, y).
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let z = Point::<F>::rand(&mut rng, num_variables);
+            let y = Point::<F>::rand(&mut rng, num_variables);
+
+            let table = Poly::new_next_from_point(z.as_slice(), F::ONE);
+            prop_assert_eq!(table.eval_base(&y), z.next_poly(&y));
+        }
+
+        #[test]
+        fn proptest_next_claim_equals_shifted_column(
+            num_variables in 1usize..=8,
+            seed in any::<u64>(),
+        ) {
+            // AIR semantics: with rows indexed big-endian and g the
+            // row-shifted column (g[i] = f[i+1], g[last] = f[last]),
+            //
+            //     sum_b next(z, b) * f(b)  ==  g_hat(z)
+            //
+            // i.e. a next claim on f opens the multilinear extension of the
+            // shifted column.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let len = 1usize << num_variables;
+            let f: Vec<F> = (0..len).map(|_| rng.random()).collect();
+            let z = Point::<F>::rand(&mut rng, num_variables);
+
+            let mut shifted = f.clone();
+            shifted.rotate_left(1);
+            *shifted.last_mut().unwrap() = f[len - 1];
+
+            let table = Poly::new_next_from_point(z.as_slice(), F::ONE);
+            let claim = dot_product::<F, _, _>(
+                table.as_slice().iter().copied(),
+                f.iter().copied(),
+            );
+            prop_assert_eq!(claim, Poly::new(shifted).eval_base(&z));
+        }
     }
 }

--- a/sumcheck/src/constraints/mod.rs
+++ b/sumcheck/src/constraints/mod.rs
@@ -3,32 +3,37 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_util::log2_strict_usize;
 
-use crate::constraints::statement::{EqStatement, SelectStatement};
+use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
 
 /// Statement types for polynomial evaluation constraints.
 pub mod statement;
 
-/// A combined constraint system with equality and selection statements.
+/// A combined constraint system with equality, selection, and next statements.
 ///
 /// This struct represents a unified constraint system that combines:
 /// - **Equality constraints**: Polynomial evaluations at specific points
 /// - **Select constraints**: Selection-based polynomial evaluations
+/// - **Next constraints**: Shifted-evaluation (row-successor) claims
 ///
-/// Both constraint types are batched using powers of a random challenge `γ`.
+/// All constraint types are batched using powers of a random challenge `γ`.
 ///
 /// # Mathematical Structure
 ///
-/// Given `n_eq` equality constraints and `n_sel` select constraints, the combined
-/// constraint polynomial is:
+/// Given `n_eq` equality, `n_sel` select, and `n_next` next constraints, the
+/// combined constraint polynomial is:
 ///
 /// ```text
-/// W(X) = Σ_{i=0}^{n_eq-1} γ^i · eq(X, z_eq_i) + Σ_{j=0}^{n_sel-1} γ^{n_eq+j} · select(pow(z_sel_j), X)
+/// W(X) = Σ_{i=0}^{n_eq-1} γ^i · eq(X, z_eq_i)
+///      + Σ_{j=0}^{n_sel-1} γ^{n_eq+j} · select(pow(z_sel_j), X)
+///      + Σ_{l=0}^{n_next-1} γ^{n_eq+n_sel+l} · next(z_next_l, X)
 /// ```
 ///
 /// The combined expected evaluation is:
 ///
 /// ```text
-/// S = Σ_{i=0}^{n_eq-1} γ^i · s_eq_i + Σ_{j=0}^{n_sel-1} γ^{n_eq+j} · s_sel_j
+/// S = Σ_{i=0}^{n_eq-1} γ^i · s_eq_i
+///   + Σ_{j=0}^{n_sel-1} γ^{n_eq+j} · s_sel_j
+///   + Σ_{l=0}^{n_next-1} γ^{n_eq+n_sel+l} · s_next_l
 /// ```
 #[derive(Clone, Debug)]
 pub struct Constraint<F: Field, EF: ExtensionField<F>> {
@@ -43,11 +48,18 @@ pub struct Constraint<F: Field, EF: ExtensionField<F>> {
     /// via the power map to create a multilinear evaluation point.
     pub sel_statement: SelectStatement<F, EF>,
 
+    /// Shifted-evaluation constraints of the form `Σ_b next(z_l, b) · p(b) = s_l`.
+    ///
+    /// Each constraint opens the multilinear extension of the row-shifted
+    /// column at `z_l`, as required by AIR transition constraints.
+    pub next_statement: NextStatement<EF>,
+
     /// Random challenge `γ` used for batching constraints.
     ///
     /// Powers of this challenge weight different constraints:
     /// - Equality constraints use `γ^0, γ^1, ..., γ^{n_eq-1}`
     /// - Select constraints use `γ^{n_eq}, γ^{n_eq+1}, ..., γ^{n_eq+n_sel-1}`
+    /// - Next constraints use `γ^{n_eq+n_sel}, ..., γ^{n_eq+n_sel+n_next-1}`
     pub challenge: EF,
 }
 
@@ -82,11 +94,40 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
         //
         // This ensures the combined polynomial has a consistent domain.
         assert!(eq_statement.num_variables() == sel_statement.num_variables());
+        let num_variables = eq_statement.num_variables();
 
-        // Construct the combined constraint with both statement types.
+        // Construct the combined constraint with an empty next statement.
         Self {
             eq_statement,
             sel_statement,
+            next_statement: NextStatement::initialize(num_variables),
+            challenge,
+        }
+    }
+
+    /// Creates a new constraint combining equality, select, and next statements.
+    ///
+    /// Next constraints consume the challenge powers after the equality and
+    /// select constraints.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of variables differs between statements.
+    #[must_use]
+    pub const fn new_with_next(
+        challenge: EF,
+        eq_statement: EqStatement<EF>,
+        sel_statement: SelectStatement<F, EF>,
+        next_statement: NextStatement<EF>,
+    ) -> Self {
+        // Verify that all statements share the same number of variables.
+        assert!(eq_statement.num_variables() == sel_statement.num_variables());
+        assert!(eq_statement.num_variables() == next_statement.num_variables());
+
+        Self {
+            eq_statement,
+            sel_statement,
+            next_statement,
             challenge,
         }
     }
@@ -163,6 +204,15 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
         // This adds: Σ_{j=0}^{n_sel-1} γ^{n_eq+j} · s_sel_j
         self.sel_statement
             .combine_evals(eval, self.challenge, self.eq_statement.len());
+
+        // Accumulate next constraint evaluations weighted by γ^{n_eq+n_sel+l}.
+        //
+        // This adds: Σ_{l=0}^{n_next-1} γ^{n_eq+n_sel+l} · s_next_l
+        self.next_statement.combine_evals(
+            eval,
+            self.challenge,
+            self.eq_statement.len() + self.sel_statement.len(),
+        );
     }
 
     /// Combines constraint polynomials into weight polynomial and expected evaluation.
@@ -200,6 +250,14 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
         // The shift parameter ensures select constraints use distinct challenge powers.
         self.sel_statement
             .combine(combined, eval, self.challenge, self.eq_statement.len());
+
+        // Combine next constraints, continuing from where select left off.
+        self.next_statement.combine(
+            combined,
+            eval,
+            self.challenge,
+            self.eq_statement.len() + self.sel_statement.len(),
+        );
     }
 
     /// Combines constraint polynomials into weight polynomial and expected evaluation.
@@ -237,6 +295,14 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
         // The shift parameter ensures select constraints use distinct challenge powers.
         self.sel_statement
             .combine_packed(combined, eval, self.challenge, self.eq_statement.len());
+
+        // Combine next constraints, continuing from where select left off.
+        self.next_statement.combine_packed::<F>(
+            combined,
+            eval,
+            self.challenge,
+            self.eq_statement.len() + self.sel_statement.len(),
+        );
     }
 
     /// Creates a new combined weight polynomial and expected evaluation.
@@ -272,6 +338,14 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
             &mut eval,
             self.challenge,
             self.eq_statement.len(),
+        );
+
+        // Add next constraints, continuing the challenge powers after select.
+        self.next_statement.combine(
+            &mut combined,
+            &mut eval,
+            self.challenge,
+            self.eq_statement.len() + self.sel_statement.len(),
         );
 
         // Return the completed weight polynomial and expected evaluation.
@@ -319,6 +393,14 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
             self.eq_statement.len(),
         );
 
+        // Add next constraints, continuing the challenge powers after select.
+        self.next_statement.combine_packed::<F>(
+            &mut combined,
+            &mut eval,
+            self.challenge,
+            self.eq_statement.len() + self.sel_statement.len(),
+        );
+
         // Return the completed weight polynomial and expected evaluation.
         (combined, eval)
     }
@@ -358,6 +440,30 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
         self.sel_statement.vars.iter().zip(
             self.challenge
                 .shifted_powers(self.challenge.exp_u64(self.eq_statement.len() as u64)),
+        )
+    }
+
+    /// Iterates over next constraints with their challenge weights.
+    ///
+    /// This produces pairs `(z_l, γ^{n_eq+n_sel+l})` for each next constraint where:
+    /// - `z_l` is the shifted-evaluation point
+    /// - `γ^{n_eq+n_sel+l}` is the challenge power for this constraint
+    ///
+    /// # Returns
+    ///
+    /// An iterator over `(&Point<EF>, EF)` pairs.
+    ///
+    /// # Implementation Notes
+    ///
+    /// Challenge powers are skipped by `n_eq + n_sel` to ensure next constraints
+    /// use distinct powers from the equality and select constraints.
+    pub fn iter_nexts(&self) -> impl Iterator<Item = (&Point<EF>, EF)> {
+        // Powers start at γ^{n_eq + n_sel} to avoid overlap with the other
+        // constraint types.
+        let offset = (self.eq_statement.len() + self.sel_statement.len()) as u64;
+        self.next_statement.points.iter().zip(
+            self.challenge
+                .shifted_powers(self.challenge.exp_u64(offset)),
         )
     }
 }
@@ -749,5 +855,121 @@ mod tests {
 
         // Verify that the iterator is empty
         assert_eq!(constraint.iter_sels().count(), 0);
+    }
+
+    #[test]
+    fn test_constraint_new_initializes_empty_next() {
+        // `new` must produce an empty next statement with matching arity.
+        let num_variables = 3;
+        let challenge = EF::from_u64(42);
+        let eq_statement = EqStatement::initialize(num_variables);
+        let sel_statement = SelectStatement::initialize(num_variables);
+
+        let constraint: Constraint<F, EF> = Constraint::new(challenge, eq_statement, sel_statement);
+
+        assert!(constraint.next_statement.is_empty());
+        assert_eq!(constraint.next_statement.num_variables(), num_variables);
+        assert_eq!(constraint.iter_nexts().count(), 0);
+    }
+
+    #[test]
+    fn test_constraint_combine_evals_with_next() {
+        // γ = 2; one eq (γ^0), one sel (γ^1), two next (γ^2, γ^3).
+        let num_variables = 2;
+        let gamma = EF::from_u64(2);
+
+        let eq_point = Point::new(vec![EF::from_u64(1), EF::from_u64(1)]);
+        let eq_statement = EqStatement::new_hypercube(vec![eq_point], vec![EF::from_u64(5)]);
+
+        let sel_statement =
+            SelectStatement::new(num_variables, vec![F::from_u64(3)], vec![EF::from_u64(7)]);
+
+        let mut next_statement = NextStatement::initialize(num_variables);
+        next_statement.add_evaluated_constraint(
+            Point::new(vec![EF::from_u64(4), EF::from_u64(6)]),
+            EF::from_u64(11),
+        );
+        next_statement.add_evaluated_constraint(
+            Point::new(vec![EF::from_u64(8), EF::from_u64(9)]),
+            EF::from_u64(13),
+        );
+
+        let constraint: Constraint<F, EF> =
+            Constraint::new_with_next(gamma, eq_statement, sel_statement, next_statement);
+
+        let mut eval = EF::ZERO;
+        constraint.combine_evals(&mut eval);
+
+        // Expected: 1*5 + 2*7 + 4*11 + 8*13 = 5 + 14 + 44 + 104 = 167
+        assert_eq!(eval, EF::from_u64(167));
+    }
+
+    #[test]
+    fn test_constraint_iter_nexts_powers() {
+        // Next constraints must consume challenge powers after eq and sel.
+        let num_variables = 2;
+        let gamma = EF::from_u64(3);
+
+        let eq_point = Point::new(vec![EF::from_u64(1), EF::from_u64(2)]);
+        let eq_statement = EqStatement::new_hypercube(vec![eq_point], vec![EF::from_u64(10)]);
+
+        let sel_statement =
+            SelectStatement::new(num_variables, vec![F::from_u64(5)], vec![EF::from_u64(30)]);
+
+        let mut next_statement = NextStatement::initialize(num_variables);
+        let next_point_0 = Point::new(vec![EF::from_u64(4), EF::from_u64(6)]);
+        let next_point_1 = Point::new(vec![EF::from_u64(7), EF::from_u64(8)]);
+        next_statement.add_evaluated_constraint(next_point_0.clone(), EF::from_u64(40));
+        next_statement.add_evaluated_constraint(next_point_1.clone(), EF::from_u64(50));
+
+        let constraint: Constraint<F, EF> =
+            Constraint::new_with_next(gamma, eq_statement, sel_statement, next_statement);
+
+        // One eq and one sel constraint precede the next constraints,
+        // so the next powers are γ^2 = 9 and γ^3 = 27.
+        let results: Vec<_> = constraint.iter_nexts().collect();
+        assert_eq!(results.len(), 2);
+        assert_eq!(*results[0].0, next_point_0);
+        assert_eq!(results[0].1, EF::from_u64(9));
+        assert_eq!(*results[1].0, next_point_1);
+        assert_eq!(results[1].1, EF::from_u64(27));
+    }
+
+    #[test]
+    fn test_constraint_combine_with_next_matches_manual() {
+        // `combine` with all three statement types must equal the manual
+        // per-statement accumulation with matching power offsets.
+        let num_variables = 3;
+        let gamma = EF::from_u64(7);
+
+        let eq_point = Point::new(vec![EF::from_u64(1), EF::from_u64(2), EF::from_u64(3)]);
+        let eq_statement = EqStatement::new_hypercube(vec![eq_point], vec![EF::from_u64(10)]);
+
+        let sel_statement =
+            SelectStatement::new(num_variables, vec![F::from_u64(5)], vec![EF::from_u64(30)]);
+
+        let mut next_statement = NextStatement::initialize(num_variables);
+        next_statement.add_evaluated_constraint(
+            Point::new(vec![EF::from_u64(4), EF::from_u64(6), EF::from_u64(9)]),
+            EF::from_u64(40),
+        );
+
+        let constraint: Constraint<F, EF> = Constraint::new_with_next(
+            gamma,
+            eq_statement.clone(),
+            sel_statement.clone(),
+            next_statement.clone(),
+        );
+
+        let (combined, eval) = constraint.combine_new();
+
+        let mut expected = Poly::zero(num_variables);
+        let mut expected_eval = EF::ZERO;
+        eq_statement.combine_hypercube::<F, true>(&mut expected, &mut expected_eval, gamma);
+        sel_statement.combine(&mut expected, &mut expected_eval, gamma, 1);
+        next_statement.combine(&mut expected, &mut expected_eval, gamma, 2);
+
+        assert_eq!(combined, expected);
+        assert_eq!(eval, expected_eval);
     }
 }

--- a/sumcheck/src/constraints/statement/mod.rs
+++ b/sumcheck/src/constraints/statement/mod.rs
@@ -4,13 +4,17 @@
 //!
 //! - **Equality**: explicit multilinear points `p(z_i) = s_i`, batched via eq polynomials.
 //! - **Select**: univariate evaluation claims, batched via the power-map select function.
-//! - **Initial**: mutable builder that accumulates constraints during commitment.
+//! - **Next**: shifted-evaluation (row-successor) claims, batched via the next polynomial.
 
 /// Equality-based evaluation constraints with batched eq-polynomial combination.
 pub mod eq;
+
+/// Shifted-evaluation constraints using the row-successor polynomial.
+pub mod next;
 
 /// Selection-based evaluation constraints using the power-map expansion.
 pub mod select;
 
 pub use eq::EqStatement;
+pub use next::NextStatement;
 pub use select::SelectStatement;

--- a/sumcheck/src/constraints/statement/next.rs
+++ b/sumcheck/src/constraints/statement/next.rs
@@ -1,0 +1,503 @@
+use alloc::vec::Vec;
+
+use itertools::Itertools;
+use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, dot_product};
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
+use p3_util::log2_strict_usize;
+use tracing::instrument;
+
+/// A batched system of shifted-evaluation constraints on `{0,1}^m`.
+///
+/// Each entry ties a point `z_i` to a claimed weighted sum over the hypercube:
+///
+/// ```text
+/// sum_{b in {0,1}^m} next(z_i, b) * P(b) = s_i
+/// ```
+///
+/// `next` is the multilinear extension of the row-successor indicator:
+/// rows are indexed big-endian and the last row maps to itself.
+///
+/// # Overview
+///
+/// - Let `g` be the row-shifted column: `g[r] = P[r + 1]`, `g[last] = P[last]`.
+/// - Each constraint asserts that the multilinear extension of `g` evaluates to `s_i` at `z_i`.
+/// - This is the "next row" opening required by AIR transition constraints
+///   over a multilinear commitment.
+///
+/// # Soundness
+///
+/// - The weight is linear in the committed value and multilinear in the point.
+/// - It therefore fits the constrained Reed-Solomon framework
+///   (WHIR, ePrint 2024/1586) with the same analysis as an equality weight.
+/// - The verifier evaluates the weight at the folding point in `O(m)` operations.
+///
+/// # Scope
+///
+/// - The kernel spans the statement's full variable space: one committed column.
+/// - Stacked layouts need the factored form `eq(selector, .) (x) next(z, .)`.
+/// - The SVO fast path needs the kernel split into `l_0 + 2` eq-shaped groups.
+/// - Both belong to the layout layer and are out of scope here.
+///
+/// # Invariants
+///
+/// - `points.len() == evaluations.len()`.
+/// - Every `Point` in `points` has exactly `num_variables` coordinates.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NextStatement<F> {
+    /// Number of variables in the multilinear polynomial space.
+    num_variables: usize,
+    /// List of shifted-evaluation points.
+    pub points: Vec<Point<F>>,
+    /// List of target evaluations.
+    pub evaluations: Vec<F>,
+}
+
+impl<F: Field> NextStatement<F> {
+    /// Creates an empty `NextStatement<F>` for polynomials with `num_variables` variables.
+    #[must_use]
+    pub const fn initialize(num_variables: usize) -> Self {
+        Self {
+            num_variables,
+            points: Vec::new(),
+            evaluations: Vec::new(),
+        }
+    }
+
+    /// Creates a filled `NextStatement<F>` from aligned points and evaluations.
+    ///
+    /// # Panics
+    /// Panics if the lists have different lengths or inconsistent arities.
+    #[must_use]
+    pub fn new(points: Vec<Point<F>>, evaluations: Vec<F>) -> Self {
+        assert_eq!(
+            points.len(),
+            evaluations.len(),
+            "Number of points ({}) must match number of evaluations ({})",
+            points.len(),
+            evaluations.len()
+        );
+        let num_variables = points
+            .iter()
+            .map(Point::num_variables)
+            .all_equal_value()
+            .unwrap();
+        Self {
+            num_variables,
+            points,
+            evaluations,
+        }
+    }
+
+    /// Returns the number of variables defining the polynomial space.
+    #[must_use]
+    pub const fn num_variables(&self) -> usize {
+        self.num_variables
+    }
+
+    /// Returns true if the statement contains no constraints.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        debug_assert!(self.points.is_empty() == self.evaluations.is_empty());
+        self.points.is_empty()
+    }
+
+    /// Returns the number of constraints in the statement.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        debug_assert!(self.points.len() == self.evaluations.len());
+        self.points.len()
+    }
+
+    /// Returns an iterator over the shifted-evaluation constraints in the statement.
+    pub fn iter(&self) -> impl Iterator<Item = (&Point<F>, &F)> {
+        self.points.iter().zip(self.evaluations.iter())
+    }
+
+    /// Concatenates another statement's constraints into this one.
+    pub fn concatenate(&mut self, other: &Self) {
+        assert_eq!(self.num_variables, other.num_variables);
+        self.points.extend_from_slice(&other.points);
+        self.evaluations.extend_from_slice(&other.evaluations);
+    }
+
+    /// Adds a shifted-evaluation constraint `sum_b next(z, b) * P(b) = s` to the system.
+    ///
+    /// Assumes the evaluation `s` is already known.
+    ///
+    /// # Panics
+    /// Panics if the number of variables in the `point` does not match the statement.
+    pub fn add_evaluated_constraint(&mut self, point: Point<F>, eval: F) {
+        assert_eq!(point.num_variables(), self.num_variables());
+        self.points.push(point);
+        self.evaluations.push(eval);
+    }
+
+    /// Verifies that a given polynomial satisfies all constraints in the statement.
+    #[must_use]
+    pub fn verify(&self, poly: &Poly<F>) -> bool {
+        self.iter().all(|(point, &expected_eval)| {
+            let weights = Poly::new_next_from_point(point.as_slice(), F::ONE);
+            dot_product::<F, _, _>(weights.iter().copied(), poly.iter().copied()) == expected_eval
+        })
+    }
+
+    /// Combine all constraints into a single batched weight polynomial and expected sum.
+    ///
+    /// Adds, for all `b in {0,1}^k`:
+    ///
+    /// ```text
+    /// W(b) += sum_i gamma^{i+shift} * next(z_i, b)
+    /// S    += sum_i gamma^{i+shift} * s_i
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `acc_weights`: weight accumulator with `2^k` entries; always added to.
+    /// - `acc_sum`: target-sum accumulator; always added to.
+    /// - `challenge`: random batching challenge `gamma`.
+    /// - `shift`: power offset so statement types share one challenge
+    ///   with non-overlapping powers.
+    ///
+    /// # Performance
+    ///
+    /// One `O(2^k)` butterfly per constraint, matching an equality statement
+    /// of the same size.
+    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    pub fn combine(&self, acc_weights: &mut Poly<F>, acc_sum: &mut F, challenge: F, shift: usize) {
+        if self.points.is_empty() {
+            return;
+        }
+
+        // W(b) += sum_i gamma^{i+shift} * next(z_i, b)
+        self.points
+            .iter()
+            .zip(challenge.shifted_powers(challenge.exp_u64(shift as u64)))
+            .for_each(|(point, gamma_i)| {
+                let table = Poly::new_next_from_point(point.as_slice(), gamma_i);
+                acc_weights
+                    .as_mut_slice()
+                    .iter_mut()
+                    .zip_eq(table.iter())
+                    .for_each(|(out, &w)| *out += w);
+            });
+
+        // S += sum_i gamma^{i+shift} * s_i
+        self.combine_evals(acc_sum, challenge, shift);
+    }
+
+    /// SIMD-packed variant of constraint batching.
+    ///
+    /// Produces the same result as the scalar version.
+    /// Accumulates into a packed weight polynomial, one element per
+    /// `Packing::WIDTH` consecutive hypercube entries.
+    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    pub fn combine_packed<Base>(
+        &self,
+        weights: &mut Poly<F::ExtensionPacking>,
+        sum: &mut F,
+        challenge: F,
+        shift: usize,
+    ) where
+        Base: Field,
+        F: ExtensionField<Base>,
+    {
+        if self.points.is_empty() {
+            return;
+        }
+
+        let k = self.num_variables();
+        let k_pack = log2_strict_usize(Base::Packing::WIDTH);
+        assert!(k >= k_pack);
+        assert_eq!(weights.num_variables() + k_pack, k);
+
+        // S += sum_i gamma^{i+shift} * s_i
+        self.combine_evals(sum, challenge, shift);
+
+        // W(b) += sum_i gamma^{i+shift} * next(z_i, b), packed chunk by chunk.
+        self.points
+            .iter()
+            .zip(challenge.shifted_powers(challenge.exp_u64(shift as u64)))
+            .for_each(|(point, gamma_i)| {
+                let table = Poly::new_next_from_point(point.as_slice(), gamma_i);
+                weights
+                    .as_mut_slice()
+                    .iter_mut()
+                    .zip_eq(table.as_slice().chunks(Base::Packing::WIDTH))
+                    .for_each(|(out, chunk)| {
+                        *out += F::ExtensionPacking::from_ext_slice(chunk);
+                    });
+            });
+    }
+
+    /// Batches expected evaluation values into a single target sum using challenge powers.
+    ///
+    /// Adds `S = sum_i gamma^{i+shift} * s_i` to the accumulator.
+    pub fn combine_evals(&self, claimed_eval: &mut F, gamma: F, shift: usize) {
+        *claimed_eval += dot_product(
+            self.evaluations.iter().copied(),
+            gamma.shifted_powers(gamma.exp_u64(shift as u64)),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+
+    /// Reference shifted column: g[r] = f[r + 1], with a self-loop on the last row.
+    fn shifted_column<T: Copy>(f: &[T]) -> Vec<T> {
+        let mut g = f.to_vec();
+        g.rotate_left(1);
+        *g.last_mut().unwrap() = f[f.len() - 1];
+        g
+    }
+
+    #[test]
+    fn test_constructors_and_basic_properties() {
+        let point = Point::new(vec![F::ONE]);
+        let eval = F::from_u64(42);
+        let statement = NextStatement::new(vec![point], vec![eval]);
+
+        assert_eq!(statement.num_variables(), 1);
+        assert_eq!(statement.len(), 1);
+        assert!(!statement.is_empty());
+
+        let empty_statement = NextStatement::<F>::initialize(2);
+        assert_eq!(empty_statement.num_variables(), 2);
+        assert_eq!(empty_statement.len(), 0);
+        assert!(empty_statement.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "Number of points (2) must match number of evaluations (1)")]
+    fn test_new_mismatched_lengths() {
+        let points = vec![Point::new(vec![F::ONE]), Point::new(vec![F::ZERO])];
+        let evaluations = vec![F::from_u64(100)];
+        let _ = NextStatement::new(points, evaluations);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn test_wrong_variable_count() {
+        let mut statement = NextStatement::<F>::initialize(1);
+        let wrong_point = Point::new(vec![F::ONE, F::ZERO]);
+        statement.add_evaluated_constraint(wrong_point, F::from_u64(5));
+    }
+
+    #[test]
+    fn test_concatenate() {
+        let mut statement1 = NextStatement::<F>::initialize(1);
+        let mut statement2 = NextStatement::<F>::initialize(1);
+        statement1.add_evaluated_constraint(Point::new(vec![F::ZERO]), F::from_u64(10));
+        statement2.add_evaluated_constraint(Point::new(vec![F::ONE]), F::from_u64(20));
+
+        statement1.concatenate(&statement2);
+        assert_eq!(statement1.len(), 2);
+    }
+
+    #[test]
+    fn test_verify_against_shifted_column() {
+        // A next constraint on f is an evaluation constraint on the
+        // shifted column g.
+        let mut rng = SmallRng::seed_from_u64(0);
+        let num_variables = 4;
+        let f: Vec<F> = (0..1 << num_variables).map(|_| rng.random()).collect();
+        let g = Poly::new(shifted_column(&f));
+        let poly = Poly::new(f);
+
+        let point = Point::rand(&mut rng, num_variables);
+        let eval = g.eval_ext::<F>(&point);
+
+        let mut statement = NextStatement::<F>::initialize(num_variables);
+        statement.add_evaluated_constraint(point, eval);
+        assert!(statement.verify(&poly));
+
+        // A mismatched evaluation must fail.
+        let mut bad = NextStatement::<F>::initialize(num_variables);
+        bad.add_evaluated_constraint(Point::rand(&mut rng, num_variables), F::from_u64(999));
+        assert!(!bad.verify(&poly));
+    }
+
+    #[test]
+    fn test_combine_single_constraint() {
+        let mut statement = NextStatement::<F>::initialize(2);
+        let point = Point::new(vec![F::from_u64(3), F::from_u64(5)]);
+        let expected_eval = F::from_u64(7);
+        statement.add_evaluated_constraint(point.clone(), expected_eval);
+
+        let challenge = F::from_u64(2);
+        let mut combined_weights = Poly::zero(statement.num_variables());
+        let mut combined_sum = F::ZERO;
+        statement.combine(&mut combined_weights, &mut combined_sum, challenge, 0);
+
+        // With one constraint and shift 0 the weight is gamma^0 = 1.
+        let expected_weights = Poly::new_next_from_point(point.as_slice(), F::ONE);
+        assert_eq!(combined_weights, expected_weights);
+        assert_eq!(combined_sum, expected_eval);
+    }
+
+    #[test]
+    fn test_combine_respects_shift() {
+        let mut statement = NextStatement::<F>::initialize(2);
+        let point = Point::new(vec![F::from_u64(3), F::from_u64(5)]);
+        let eval = F::from_u64(7);
+        statement.add_evaluated_constraint(point.clone(), eval);
+
+        let challenge = F::from_u64(2);
+        let shift = 3;
+        let mut weights = Poly::zero(statement.num_variables());
+        let mut sum = F::ZERO;
+        statement.combine(&mut weights, &mut sum, challenge, shift);
+
+        // With shift 3 the single constraint is weighted by gamma^3 = 8.
+        let gamma_shift = challenge.exp_u64(shift as u64);
+        let expected_weights = Poly::new_next_from_point(point.as_slice(), gamma_shift);
+        assert_eq!(weights, expected_weights);
+        assert_eq!(sum, gamma_shift * eval);
+    }
+
+    #[test]
+    fn test_combine_accumulates() {
+        // `combine` must add on top of existing accumulator contents.
+        let mut statement = NextStatement::<F>::initialize(1);
+        statement.add_evaluated_constraint(Point::new(vec![F::from_u64(4)]), F::from_u64(6));
+
+        let mut weights = Poly::new(vec![F::from_u64(100), F::from_u64(200)]);
+        let baseline = weights.clone();
+        let mut sum = F::from_u64(50);
+        statement.combine(&mut weights, &mut sum, F::from_u64(3), 0);
+
+        let table = Poly::new_next_from_point(&[F::from_u64(4)], F::ONE);
+        for ((&got, &base), &w) in weights.iter().zip(baseline.iter()).zip(table.iter()) {
+            assert_eq!(got, base + w);
+        }
+        assert_eq!(sum, F::from_u64(56));
+    }
+
+    proptest! {
+        #[test]
+        fn prop_combine_matches_naive(
+            num_variables in 1usize..=8,
+            num_constraints in 1usize..=5,
+            shift in 0usize..=4,
+            seed in any::<u64>(),
+        ) {
+            // Invariant: the batched combine must equal the naive per-constraint
+            // sum  W(b) = sum_i gamma^{i+shift} * next(z_i, b)  on every row.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let challenge: EF = rng.random();
+
+            let points = (0..num_constraints)
+                .map(|_| Point::rand(&mut rng, num_variables))
+                .collect::<Vec<_>>();
+            let evals = (0..num_constraints).map(|_| rng.random()).collect::<Vec<EF>>();
+            let statement = NextStatement::new(points.clone(), evals.clone());
+
+            let mut weights = Poly::<EF>::zero(num_variables);
+            let mut sum = EF::ZERO;
+            statement.combine(&mut weights, &mut sum, challenge, shift);
+
+            let mut expected_weights = Poly::<EF>::zero(num_variables);
+            let mut expected_sum = EF::ZERO;
+            let mut gamma_i = challenge.exp_u64(shift as u64);
+            for (point, eval) in points.iter().zip(&evals) {
+                let table = Poly::new_next_from_point(point.as_slice(), gamma_i);
+                for (out, &w) in expected_weights.as_mut_slice().iter_mut().zip(table.iter()) {
+                    *out += w;
+                }
+                expected_sum += gamma_i * *eval;
+                gamma_i *= challenge;
+            }
+
+            prop_assert_eq!(weights, expected_weights);
+            prop_assert_eq!(sum, expected_sum);
+        }
+
+        #[test]
+        fn prop_packed_combine_roundtrip(
+            k in 4usize..=10,
+            n in 1usize..=8,
+            shift in 0usize..=4,
+            seed in 0u64..100,
+        ) {
+            use p3_field::{Field, PackedFieldExtension};
+
+            let k_pack = log2_strict_usize(<F as Field>::Packing::WIDTH);
+            if k < k_pack {
+                return Ok(());
+            }
+
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let challenge: EF = rng.random();
+
+            let points = (0..n)
+                .map(|_| Point::rand(&mut rng, k))
+                .collect::<Vec<_>>();
+            let evals = (0..n).map(|_| rng.random()).collect::<Vec<EF>>();
+            let statement = NextStatement::new(points, evals);
+
+            // Scalar path.
+            let mut scalar_weights = Poly::<EF>::zero(k);
+            let mut scalar_sum = EF::ZERO;
+            statement.combine(&mut scalar_weights, &mut scalar_sum, challenge, shift);
+
+            // Packed path.
+            let mut packed_weights =
+                Poly::<<EF as ExtensionField<F>>::ExtensionPacking>::zero(k - k_pack);
+            let mut packed_sum = EF::ZERO;
+            statement.combine_packed::<F>(&mut packed_weights, &mut packed_sum, challenge, shift);
+
+            let unpacked =
+                <<EF as ExtensionField<F>>::ExtensionPacking as PackedFieldExtension<F, EF>>::to_ext_iter(
+                    packed_weights.as_slice().iter().copied(),
+                )
+                .collect::<Vec<_>>();
+            prop_assert_eq!(scalar_weights.as_slice(), &unpacked[..]);
+            prop_assert_eq!(scalar_sum, packed_sum);
+        }
+
+        #[test]
+        fn prop_next_claim_workflow(
+            num_variables in 1usize..=8,
+            seed in any::<u64>(),
+        ) {
+            // End-to-end semantics: build a next claim from the shifted column,
+            // verify it, and check the batched sumcheck identity
+            //     sum_b W(b) * f(b) == S.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let f: Vec<F> = (0..1usize << num_variables).map(|_| rng.random()).collect();
+            let g = Poly::new(shifted_column(&f));
+            let poly = Poly::new(f);
+
+            let mut statement = NextStatement::<F>::initialize(num_variables);
+            for _ in 0..3 {
+                let point = Point::rand(&mut rng, num_variables);
+                let eval = g.eval_ext::<F>(&point);
+                statement.add_evaluated_constraint(point, eval);
+            }
+            prop_assert!(statement.verify(&poly));
+
+            let challenge: F = rng.random();
+            let mut weights = Poly::<F>::zero(num_variables);
+            let mut sum = F::ZERO;
+            statement.combine(&mut weights, &mut sum, challenge, 0);
+
+            let lhs = dot_product::<F, _, _>(weights.iter().copied(), poly.iter().copied());
+            prop_assert_eq!(lhs, sum);
+        }
+    }
+}

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -132,6 +132,8 @@ pub(super) mod test_utils {
     pub(crate) const ROUND_EQ_POINTS: usize = 10;
     /// STIR-style selector points sampled for the intermediate round.
     pub(crate) const ROUND_SEL_POINTS: usize = 100;
+    /// Shifted-evaluation (next) points sampled for the intermediate round.
+    pub(crate) const ROUND_NEXT_POINTS: usize = 3;
 
     /// Opening schedule with columns in ascending order inside each claim.
     pub(crate) const ASCENDING_POLYS: &[(usize, &[usize])] =
@@ -247,6 +249,7 @@ pub(super) mod test_utils {
             stacked_num_variables - FOLDING,
             ROUND_EQ_POINTS,
             ROUND_SEL_POINTS,
+            ROUND_NEXT_POINTS,
         );
         intermediate_constraint.combine_evals(&mut sum);
         constraints.push(intermediate_constraint);
@@ -290,6 +293,7 @@ pub(super) mod test_utils {
             prover.num_variables(),
             ROUND_EQ_POINTS,
             ROUND_SEL_POINTS,
+            ROUND_NEXT_POINTS,
             &prover.evals(),
         );
 

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -336,7 +336,12 @@ impl VariableOrder {
                     .iter_sels()
                     .map(|(&var, coeff)| coeff * local_challenge.select_poly(var))
                     .sum::<EF>();
-                eq_contrib + sel_contrib
+                // Successor term: sum_{(z, c)} c * next(z, local_challenge).
+                let next_contrib = constraint
+                    .iter_nexts()
+                    .map(|(point, coeff)| coeff * point.next_poly(&local_challenge))
+                    .sum::<EF>();
+                eq_contrib + sel_contrib + next_contrib
             })
             .sum()
     }
@@ -471,7 +476,7 @@ mod tests {
 
     use super::VariableOrder;
     use crate::constraints::Constraint;
-    use crate::constraints::statement::{EqStatement, SelectStatement};
+    use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
 
     type F = BabyBear;
     type EF = BinomialExtensionField<BabyBear, 4>;
@@ -530,7 +535,14 @@ mod tests {
                 (0..rng.random_range(0..=3))
                     .for_each(|_| sel_statement.add_constraint(rng.random(), rng.random()));
 
-                Constraint::new(gamma, eq_statement, sel_statement)
+                // Up to 3 next constraints at random points.
+                let mut next_statement = NextStatement::initialize(num_variables);
+                (0..rng.random_range(0..=3)).for_each(|_| {
+                    next_statement
+                        .add_evaluated_constraint(Point::rand(rng, num_variables), rng.random());
+                });
+
+                Constraint::new_with_next(gamma, eq_statement, sel_statement, next_statement)
             })
             .collect()
     }

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -13,7 +13,7 @@ use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
 use crate::constraints::Constraint;
-use crate::constraints::statement::{EqStatement, SelectStatement};
+use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
 use crate::layout::{Layout, PrefixProver, SuffixProver, TableShape, Verifier};
 use crate::strategy::VariableOrder;
 use crate::test_util::{stacked_num_variables, table_point_schedule, table_specs_to_tables};
@@ -52,7 +52,9 @@ pub(crate) fn challenger() -> MyChallenger {
 //      them as "equality" constraints (poly(point) == eval).
 //   2. Samples `num_sels` random indices in the multiplicative subgroup, evaluates the
 //      polynomial as a univariate (Horner's method), and records them as "select" constraints.
-//   3. Draws a random combining coefficient alpha and bundles everything into a Constraint.
+//   3. Samples `num_nexts` random multilinear points, computes the shifted evaluation
+//      against the next weight table, and records them as "next" constraints.
+//   4. Draws a random combining coefficient alpha and bundles everything into a Constraint.
 //
 // The evaluations are pushed into `constraint_evals` so the verifier can read them later
 // (simulating what would normally be transmitted in the proof).
@@ -62,6 +64,7 @@ pub(crate) fn make_constraint_ext<Challenger>(
     num_variables: usize,
     num_eqs: usize,
     num_sels: usize,
+    num_nexts: usize,
     poly: &Poly<EF>,
 ) -> Constraint<F, EF>
 where
@@ -70,9 +73,10 @@ where
     // omega is the 2^num_variables-th root of unity; powers of omega form the evaluation domain.
     let omega = F::two_adic_generator(num_variables);
 
-    // Initialize empty eq and select statements for this round's variable count.
+    // Initialize empty eq, select, and next statements for this round's variable count.
     let mut eq_statement = EqStatement::initialize(num_variables);
     let mut sel_statement = SelectStatement::initialize(num_variables);
+    let mut next_statement = NextStatement::initialize(num_variables);
 
     // - Sample `num_eqs` univariate challenge points.
     // - Evaluate the sumcheck polynomial on them.
@@ -122,12 +126,33 @@ where
         sel_statement.add_constraint(var, eval);
     });
 
+    // Build "next" constraints: sample multilinear points, compute the
+    // shifted-evaluation Σ_b next(point, b) · poly(b), and record the pairs.
+    (0..num_nexts).for_each(|_| {
+        // Sample a univariate challenge and expand to a multilinear point.
+        let point =
+            Point::expand_from_univariate(challenger.sample_algebra_element(), num_variables);
+
+        // Honest shifted evaluation: dot the next weight table against the polynomial.
+        let weights = Poly::new_next_from_point(point.as_slice(), EF::ONE);
+        let eval = p3_field::dot_product::<EF, _, _>(weights.iter().copied(), poly.iter().copied());
+
+        // Store evaluation for verifier to read later.
+        constraint_evals.push(eval);
+
+        // Add the evaluation result to the transcript for Fiat-Shamir soundness.
+        challenger.observe_algebra_element(eval);
+
+        // Add the shifted-evaluation constraint.
+        next_statement.add_evaluated_constraint(point, eval);
+    });
+
     // Sample a random combining coefficient alpha from the Fiat-Shamir transcript.
-    // This alpha is used to take a random linear combination of all eq and sel constraints
-    // into a single aggregated constraint for the next sumcheck round.
+    // This alpha is used to take a random linear combination of all eq, sel, and next
+    // constraints into a single aggregated constraint for the next sumcheck round.
     let alpha: EF = challenger.sample_algebra_element();
 
-    Constraint::new(alpha, eq_statement, sel_statement)
+    Constraint::new_with_next(alpha, eq_statement, sel_statement, next_statement)
 }
 
 // Verifier-side counterpart of `make_constraint_ext`. Reconstructs the same Constraint
@@ -143,6 +168,7 @@ pub(crate) fn read_constraint<Challenger>(
     num_variables: usize,
     num_eqs: usize,
     num_sels: usize,
+    num_nexts: usize,
 ) -> Constraint<F, EF>
 where
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -188,11 +214,33 @@ where
         sel_statement.add_constraint(var, eval);
     }
 
+    // Initialize an empty next statement for this round.
+    let mut next_statement = NextStatement::initialize(num_variables);
+
+    // Reconstruct each next constraint: sample the same random point as the prover,
+    // then read the shifted evaluation from the proof data.
+    for i in 0..num_nexts {
+        // Sample the same univariate challenge as the prover and expand it.
+        let point =
+            Point::expand_from_univariate(challenger.sample_algebra_element(), num_variables);
+
+        // Read the committed evaluation. Next evaluations are stored after
+        // the eq and sel evaluations.
+        let eval = constraint_evals[num_eqs + num_sels + i];
+
+        // Observe the evaluation to keep the challenger synchronized (must match prover)
+        challenger.observe_algebra_element(eval);
+
+        // Add the shifted-evaluation constraint.
+        next_statement.add_evaluated_constraint(point, eval);
+    }
+
     // Sample the same combining coefficient alpha as the prover and assemble the constraint.
-    Constraint::new(
+    Constraint::new_with_next(
         challenger.sample_algebra_element(),
         eq_statement,
         sel_statement,
+        next_statement,
     )
 }
 
@@ -233,6 +281,7 @@ where
     const FOLDING: usize = 4;
     const NUM_EQS: usize = 5;
     const NUM_SELS: usize = 10;
+    const NUM_NEXTS: usize = 3;
 
     // Round schedule for a constant folding factor `FOLDING`.
     const MAX_NUM_VARIABLES_TO_SEND_COEFFS: usize = 6;
@@ -278,6 +327,7 @@ where
             num_variables_inter,
             NUM_EQS,
             NUM_SELS,
+            NUM_NEXTS,
             &sumcheck.evals(),
         );
         all_constraint_evals.push(constraint_evals);
@@ -344,6 +394,7 @@ where
             num_variables_inter,
             NUM_EQS,
             NUM_SELS,
+            NUM_NEXTS,
         );
         constraint.combine_evals(&mut sum);
         constraints.push(constraint);


### PR DESCRIPTION
## Overview

AIR transition constraints relate row `i` and row `i+1`. Over a multilinear commitment a trace column is `f̂(X_1, ..., X_m)` on the hypercube, and "row + 1" is an integer increment with carries — not a point evaluation. The zerocheck sumcheck therefore ends with a claim the PCS cannot natively open: `f̂_next(z)`, the MLE of the row-shifted column.

WHIR proves *constrained* Reed–Solomon codes `Σ_b ŵ(f̂(b), b) = σ` for an arbitrary weight, so the shifted opening becomes a native statement with weight `ŵ = Z · next(z, ·)`, where `next` is the MLE of the successor indicator (last row self-loops):

```text
next(x, y) = sum_j [ prod_{k<j} eq(x_k, y_k) ] * (1 - x_j) * y_j * [ prod_{k>j} x_k (1 - y_k) ]
           + prod_k x_k * y_k
```

One term per carry pivot `j` (the lowest zero bit of `x`), plus the self-loop. The weight is linear in `Z` and multilinear in `X`, so it slots into the existing soundness analysis exactly like an eq-weight.

## What this PR adds

**Kernel (`p3-multilinear-util`)**
- `Point::eval_next` / `Point::next_poly`: closed-form evaluation in `O(m)` ops — the only cost the verifier ever pays.
- `Poly::new_next_from_point`: the full `next(z, b)` table in `O(2^m)` via a block-doubling butterfly (eq doubling + one carry-pivot injection per step), same cost as the eq butterfly.

**Statement (`p3-sumcheck`)**
- `NextStatement`, a sibling of `EqStatement` / `SelectStatement`: batched claims `Σ_b next(z_i, b) · P(b) = s_i` with scalar and SIMD-packed combination.

**Constraint batching**
- `Constraint` now carries all three weight types under one challenge, with next constraints consuming the powers after eq and select:

```text
W(X) = Σ_i γ^i eq(z_i, X) + Σ_j γ^{n_eq+j} select(z_j, X) + Σ_l γ^{n_eq+n_sel+l} next(z_l, X)
```

- `VariableOrder::eval_constraints_poly` gained the `next` term. Since `WhirVerifier::verify` consumes a `Constraint` directly, the WHIR verifier supports next claims with no further changes.

## Tests

- Exhaustive boolean truth tables and multilinearity/interpolation proptests for the kernel.
- The semantics-pinning test: with `g[r] = f[r+1]` (`g[last] = f[last]`), `Σ_b next(z, b) · f(b) == ĝ(z)` — a next claim on the committed column *is* an opening of the shifted column.
- Scalar vs packed combine roundtrips, challenge-power offsets, accumulation.
- The multi-table layout sumcheck roundtrip (full protocol skeleton, both Prefix and Suffix binding) now injects next constraints at every intermediate round and checks the final identity `sum = f(r) · W(r)`.

## Follow-up (out of scope)

The stacked-layout / SVO fast path: lifting a next claim into a stacked commitment factors as `eq(selector, ·) ⊗ next(z, ·)`, and the SVO accumulator rounds need the kernel decomposed into `l_0 + 2` eq-shaped groups (one per carry pivot inside the SVO window, plus the carry-into-prefix and self-loop boundary groups). This mirrors leanVM's `compress_next_claim` and belongs in the `layout` layer as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)