### PR TITLE
fix(goldilocks): make serde encoding canonical

### DIFF
--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -33,6 +33,7 @@ p3-field-testing = { path = "../field-testing" }
 
 proptest.workspace = true
 rand.workspace = true
+serde_json.workspace = true
 
 [[bench]]
 name = "bench_field"

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -21,20 +21,40 @@ use p3_field::{
 use p3_util::{assume, branch_hint, flatten_to_base, gcd_inner};
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
-use serde::{Deserialize, Serialize};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// The Goldilocks prime
 pub(crate) const P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// The prime field known as Goldilocks, defined as `F_p` where `p = 2^64 - 2^32 + 1`.
 ///
-/// Note that the safety of deriving `Serialize` and `Deserialize` relies on the fact that the internal value can be any u64.
-#[derive(Copy, Clone, Default, Serialize, Deserialize)]
+/// The serde encoding is canonical: every field element has exactly one valid byte representation.
+#[derive(Copy, Clone, Default)]
 #[repr(transparent)] // Important for reasoning about memory layout
 #[must_use]
 pub struct Goldilocks {
     /// Not necessarily canonical.
     pub(crate) value: u64,
+}
+
+impl Serialize for Goldilocks {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Emit the canonical representative so every field element has one encoding.
+        serializer.serialize_u64(self.as_canonical_u64())
+    }
+}
+
+impl<'de> Deserialize<'de> for Goldilocks {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let val = u64::deserialize(d)?;
+        // Reject non-canonical encodings so a proof cannot be re-encoded without the witness.
+        if val < P {
+            Ok(Self::new(val))
+        } else {
+            Err(D::Error::custom("Goldilocks value is out of range"))
+        }
+    }
 }
 
 impl Goldilocks {
@@ -750,6 +770,36 @@ mod tests {
 
     type F = Goldilocks;
     type EF = BinomialExtensionField<F, 5>;
+
+    #[test]
+    fn deserialize_rejects_non_canonical_encodings() {
+        // p, p + i, and u64::MAX are all field-equal to canonical values.
+        // Only the canonical encoding may deserialize.
+        // This blocks re-encoding a proof as p + i without the witness.
+        for non_canonical in [P, P + 5, u64::MAX] {
+            let json = serde_json::to_string(&non_canonical).unwrap();
+            assert!(serde_json::from_str::<F>(&json).is_err());
+        }
+
+        // The largest canonical value, p - 1, still deserializes.
+        let max_canonical_json = serde_json::to_string(&(P - 1)).unwrap();
+        let max_canonical: F = serde_json::from_str(&max_canonical_json).unwrap();
+        assert_eq!(max_canonical.as_canonical_u64(), P - 1);
+    }
+
+    #[test]
+    fn serialize_is_canonical() {
+        // A non-canonical in-memory value serializes to its canonical representative.
+        //     in memory : p + 5
+        //     canonical : 5
+        let non_canonical = F::new(P + 5);
+        let json = serde_json::to_string(&non_canonical).unwrap();
+        assert_eq!(json, "5");
+
+        // The canonical encoding round-trips back to the same field element.
+        let roundtrip: F = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip, non_canonical);
+    }
 
     #[test]
     fn test_goldilocks() {


### PR DESCRIPTION
## Problem

`Goldilocks` stores an explicitly non-canonical `u64` and derived its serde impls, so the wire encoding accepted **any** `u64` with no `< P` check:

```rust
/// Note that the safety of deriving `Serialize` and `Deserialize` relies on
/// the fact that the internal value can be any u64.
#[derive(Copy, Clone, Default, Serialize, Deserialize)]
pub struct Goldilocks { pub(crate) value: u64 }
```

Meanwhile equality canonicalizes (`eq` compares `as_canonical_u64()`). So `i` and `p + i` deserialize to **field-equal** elements with **different bytes**. A proof π can be re-encoded into a distinct π′ that still verifies, without the witness — a malleability hole. (`MontyField31` already guards against this by rejecting out-of-range values on deserialize.)

## Fix

Replace the derived impls with hand-written ones, mirroring `MontyField31`:

```rust
impl Serialize for Goldilocks {
    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
        s.serialize_u64(self.as_canonical_u64()) // canonical representative
    }
}

impl<'de> Deserialize<'de> for Goldilocks {
    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
        let val = u64::deserialize(d)?;
        if val < P { Ok(Self::new(val)) } else { Err(D::Error::custom("Goldilocks value is out of range")) }
    }
}
```

Every field element now has exactly one valid encoding: serialization emits the canonical representative, and deserialization rejects anything `>= P`.

### Compatibility

- **postcard** (the proof format): a single-field struct already encodes as the bare `u64`, so canonical values produce identical bytes. Only non-canonical encodings change behavior — they are now rejected (the fix).
- **JSON**: now a bare integer (e.g. `5`) instead of `{"value":5}`, matching `MontyField31`.

## Tests

In the goldilocks crate (adds `serde_json` dev-dep, as `baby-bear` already has):
- `deserialize_rejects_non_canonical_encodings`: `p`, `p + 5`, and `u64::MAX` are rejected; `p - 1` is accepted.
- `serialize_is_canonical`: a non-canonical in-memory value (`p + 5`) serializes to its canonical form (`5`) and round-trips.

The existing `field-testing` JSON round-trip suite now also exercises the canonical serde for both the base and extension fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)