### PR TITLE
fix(circle): reject zero-query configurations

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -759,6 +759,64 @@ mod tests {
     }
 
     #[test]
+    fn reject_zero_queries() {
+        // Invariant: a zero-query instance performs no low-degree spot checks.
+        // The per-query loop never runs.
+        // Without the guard any final polynomial would verify.
+        //
+        // Fixture state: an honest proof built with the testing query count.
+        //
+        // Mutation: verify it under params with num_queries = 0.
+        let (mut pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
+        pcs.fri_params.num_queries = 0;
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("zero-query instance must be rejected");
+
+        assert!(
+            matches!(err, FriError::ZeroQueries),
+            "expected ZeroQueries, got {err:?}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "num_queries must be at least 1")]
+    fn prover_rejects_zero_queries() {
+        // The prover must refuse to build a vacuous proof.
+        // The verifier guards the same config, so the failure is symmetric.
+        let mut rng = SmallRng::seed_from_u64(0);
+
+        // Build the hash stack: field hasher → compression → Merkle tree.
+        let byte_hash = ByteHash {};
+        let field_hash = FieldHash::new(byte_hash);
+        let compress = MyCompress::new(byte_hash);
+        let val_mmcs = ValMmcs::new(field_hash, compress, 0);
+        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+        // Zero queries; every other parameter is otherwise valid.
+        let mut fri_params = FriParameters::new_testing(challenge_mmcs, 0);
+        fri_params.num_queries = 0;
+
+        let pcs = TestPcs {
+            mmcs: val_mmcs,
+            fri_params,
+            _phantom: PhantomData,
+        };
+
+        // Commit to a random single-column trace of 2^{10} rows.
+        let log_n = 10;
+        let d =
+            <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_n);
+        let evals = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
+        let (_comm, data) = <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals)]);
+
+        // Commit succeeds; the assert fires inside the opening (FRI prover).
+        let zeta: Challenge = rng.random();
+        let mut chal = Challenger::from_hasher(vec![], byte_hash);
+        let _ = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
+    }
+
+    #[test]
     fn reject_commit_pow_witness_count_mismatch() {
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
         let num_rounds = proof.fri_proof.commit_phase_commits.len();

--- a/circle/src/prover.rs
+++ b/circle/src/prover.rs
@@ -33,6 +33,13 @@ where
         "max_log_arity must be at least 1 to guarantee folding progress"
     );
 
+    // A zero-query instance performs no low-degree spot checks.
+    // The verifier rejects it, so refuse to emit one locally.
+    assert!(
+        params.num_queries > 0,
+        "num_queries must be at least 1 for Circle-FRI soundness"
+    );
+
     // check sorted descending
     assert!(
         inputs

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -27,6 +27,13 @@ where
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     Folding: FriFoldingStrategy<Val, Challenge>,
 {
+    // Reject a vacuous instance before any transcript work.
+    // With zero queries the per-query loop never runs.
+    // Any final polynomial would then pass.
+    if params.num_queries == 0 {
+        return Err(FriError::ZeroQueries);
+    }
+
     // There must be exactly one commit-phase proof-of-work witness per round.
     if proof.commit_pow_witnesses.len() != proof.commit_phase_commits.len() {
         return Err(FriError::CommitPowWitnessCountMismatch {


### PR DESCRIPTION
## Summary

A Circle-FRI instance configured with `num_queries == 0` performs **no low-degree spot checks**: the verifier's per-query loop never executes, so the function falls through to `Ok(())` and accepts any final polynomial. The proof collapses to transcript-shape plus final-polynomial consistency — the soundness-giving query phase is skipped entirely.

Generic FRI already guards this exact configuration (`fri/src/verifier.rs` returns `FriError::ZeroQueries`, and `fri/src/prover.rs` asserts `num_queries > 0`). Circle lacked both. This PR closes the gap symmetrically.

## Changes

- **`circle/src/verifier.rs`** — reject `num_queries == 0` with `FriError::ZeroQueries` as the first step in `verify`, before any transcript work (mirrors generic FRI). The error variant already exists in `p3-fri`, so no new type is introduced.
- **`circle/src/prover.rs`** — `assert!(params.num_queries > 0, ...)` alongside the existing `max_log_arity > 0` precondition, matching the generic FRI prover. `num_queries` is local, trusted configuration, so a panic on misconfiguration is the convention here (untrusted input is what gets a typed `Err`).
- **`circle/src/pcs.rs`** — regression tests:
  - `reject_zero_queries`: an honest proof verified under `num_queries = 0` is rejected with `FriError::ZeroQueries`.
  - `prover_rejects_zero_queries`: building a proof with `num_queries = 0` panics.

## Why the prover panics but the verifier returns `Err`

The verifier ingests untrusted proofs/params and must never crash on bad input, so it returns a recoverable `FriError`. The prover's `num_queries` is operator-chosen local config; a zero is a programming error, so failing fast with `assert!` is correct and consistent with the rest of Plonky3.

## Testing

- `cargo test -p p3-circle --lib` → 29 passed (2 new).
- `cargo fmt -p p3-circle --check` → clean.
- `cargo clippy -p p3-circle --all-targets` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
