### PR TITLE
fix(circle): reject oversized query-index widths

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -947,4 +947,54 @@ mod tests {
         assert_eq!(log_arity, 0);
         assert_eq!(max, pcs.fri_params.max_log_arity);
     }
+
+    #[test]
+    fn reject_global_max_height_too_large() {
+        // Invariant: the query-index width fits the circle group of order 2^CIRCLE_TWO_ADICITY.
+        //
+        //     field order = 2^CIRCLE_TWO_ADICITY - 1   (one short of the group order)
+        //     => width of CIRCLE_TWO_ADICITY bits is unsampleable => verifier must reject
+        let (mut pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        // Zero both proof-of-work targets.
+        // Otherwise grinding rejects the cloned witnesses before the width check runs.
+        pcs.fri_params.commit_proof_of_work_bits = 0;
+        pcs.fri_params.query_proof_of_work_bits = 0;
+
+        // Mutation: clone commit-phase rounds until the width reaches the bound.
+        //
+        //     num_index_bits = rounds + log_blowup + extra_query_index_bits (= 1 for circle)
+        //     stop once num_index_bits >= CIRCLE_TWO_ADICITY
+        let extra_query_index_bits = 1;
+        let commit = proof.fri_proof.commit_phase_commits[0].clone();
+        let witness = proof.fri_proof.commit_pow_witnesses[0];
+        while proof.fri_proof.commit_phase_commits.len()
+            + pcs.fri_params.log_blowup
+            + extra_query_index_bits
+            < Val::CIRCLE_TWO_ADICITY
+        {
+            proof.fri_proof.commit_phase_commits.push(commit.clone());
+            proof.fri_proof.commit_pow_witnesses.push(witness);
+            // Each query proof needs one opening per round.
+            for qp in &mut proof.fri_proof.query_proofs {
+                let opening = qp.commit_phase_openings[0].clone();
+                qp.commit_phase_openings.push(opening);
+            }
+        }
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected GlobalMaxHeightTooLarge");
+
+        let FriError::GlobalMaxHeightTooLarge {
+            log_global_max_height,
+            two_adicity,
+        } = err
+        else {
+            panic!("expected GlobalMaxHeightTooLarge, got {err:?}");
+        };
+        // The reported bound is the circle group two-adicity.
+        assert_eq!(two_adicity, Val::CIRCLE_TWO_ADICITY);
+        // The rejecting width is at least that bound.
+        assert!(log_global_max_height >= two_adicity);
+    }
 }

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, Mmcs};
+use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriFoldingStrategy, FriParameters};
@@ -21,7 +22,7 @@ pub fn verify<Folding, Val, Challenge, M, Challenger>(
     ) -> Result<Vec<(usize, Challenge)>, Folding::InputError>,
 ) -> Result<(), FriError<M::Error, Folding::InputError>>
 where
-    Val: Field,
+    Val: ComplexExtendable,
     Challenge: ExtensionField<Val>,
     M: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
@@ -158,9 +159,25 @@ where
     let total_log_reduction: usize = log_arities.iter().sum();
     let log_max_height = total_log_reduction + params.log_blowup;
 
+    // Invariant: the query-index width fits the circle group of order 2^CIRCLE_TWO_ADICITY.
+    //
+    //     num_index_bits = sum(log_arities) + log_blowup + extra_query_index_bits
+    //     field order    = 2^CIRCLE_TWO_ADICITY - 1   (one short of the group order)
+    //     => a width of CIRCLE_TWO_ADICITY bits is unsampleable
+    //
+    // A malformed arity schedule inflates the round count, hence the width.
+    // A typed error keeps the challenger's bound assertion from aborting the verifier.
+    let num_index_bits = log_max_height + folding.extra_query_index_bits();
+    if num_index_bits >= Val::CIRCLE_TWO_ADICITY {
+        return Err(FriError::GlobalMaxHeightTooLarge {
+            log_global_max_height: num_index_bits,
+            two_adicity: Val::CIRCLE_TWO_ADICITY,
+        });
+    }
+
     for qp in &proof.query_proofs {
         // Sample a random query index uniformly from the initial domain.
-        let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
+        let index = challenger.sample_bits(num_index_bits);
 
         // Open the input polynomials at this query index.
         // Returns (log_height, evaluation) pairs sorted by height descending.

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -166,7 +166,6 @@ where
     //     => a width of CIRCLE_TWO_ADICITY bits is unsampleable
     //
     // A malformed arity schedule inflates the round count, hence the width.
-    // A typed error keeps the challenger's bound assertion from aborting the verifier.
     let num_index_bits = log_max_height + folding.extra_query_index_bits();
     if num_index_bits >= Val::CIRCLE_TWO_ADICITY {
         return Err(FriError::GlobalMaxHeightTooLarge {


### PR DESCRIPTION
## Summary

The Circle verifier derives the query-index width from prover-supplied folding-schedule data and feeds it straight into the challenger:

```rust
let log_max_height = total_log_reduction + params.log_blowup;
let index = challenger.sample_bits(log_max_height + folding.extra_query_index_bits());
```

The round count equals `commit_phase_commits.len()`, which is attacker-controlled, so a malformed proof can drive the width past the challenger's internal bound. `sample_bits` then hits an `assert!` (`(1 << bits) < F::ORDER_U64`) and **panics** instead of returning a structured error — an in-process DoS for anyone verifying untrusted proofs. Generic FRI already guards the analogous case via `FriError::GlobalMaxHeightTooLarge`; Circle did not.

## Fix

Bound the width before sampling and return the existing typed error:

```rust
let num_index_bits = log_max_height + folding.extra_query_index_bits();
if num_index_bits >= Val::CIRCLE_TWO_ADICITY {
    return Err(FriError::GlobalMaxHeightTooLarge {
        log_global_max_height: num_index_bits,
        two_adicity: Val::CIRCLE_TWO_ADICITY,
    });
}
```

- The verifier bound is tightened from `Val: Field` to `Val: ComplexExtendable` to reach `CIRCLE_TWO_ADICITY`; the only caller (the PCS layer) already satisfies this.

## Why `>=`, not the two-adic `>`

This is the load-bearing subtlety, and it differs from generic FRI on purpose:

- Generic FRI checks `log_global_max_height > Val::TWO_ADICITY`. For a two-adic field, `p > 2^TWO_ADICITY`, so a width of exactly `TWO_ADICITY` bits *is* sampleable — strict `>` is right.
- For Circle/M31, `CIRCLE_TWO_ADICITY = 31` is the two-adicity of the **circle group order** `p + 1 = 2^31`, while the field order is `p = 2^31 − 1` — one *short* of the group. A width of exactly 31 bits is therefore **unsampleable** (`1 << 31 > p`), so the guard must reject `>=` to close a one-bit panic window.

This generalizes: for any `ComplexExtendable` field (`p ≡ −1 mod 2^v`), widths up to `v − 1` are always sampleable and `>= v` rejects exactly the unsampleable ones, never an honest proof (honest M31 proofs cap at width 30).

## Testing

- New `reject_global_max_height_too_large`: inflates the round count until the width reaches the bound and asserts the typed error rather than a panic.
- `cargo test -p p3-circle --lib` → 28 passed (1 new).
- `cargo fmt -p p3-circle --check` and `cargo clippy -p p3-circle --all-targets` → clean.

Sibling of #1772 (zero-query guard); both bring Circle's malformed-proof handling in line with generic FRI. Independent changes, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
