### PR TITLE
perf(circle): parallelize selectors_on_coset via fused passes

### DIFF
--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -7,6 +7,7 @@ use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, batch_multiplicative_inverse};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 use tracing::instrument;
 
@@ -215,38 +216,56 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
     #[instrument(skip_all, fields(log_n = %coset.log_n))]
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>> {
         let pts = coset.points().collect_vec();
+        let n = pts.len();
 
-        // Precompute constants and per-point numerators/denominators
         let neg_shift = -self.shift;
         let k = neg_shift.s_p_at_p(self.log_n);
 
-        let z_vals: Vec<Self::Val> = pts.iter().map(|&at| self.vanishing_poly(at)).collect();
-        let den_shift: Vec<Self::Val> = pts.iter().map(|&at| self.shift.v_tilde_p(at)).collect();
-        let den_negshift_k: Vec<Self::Val> =
-            pts.iter().map(|&at| neg_shift.v_tilde_p(at) * k).collect();
+        // Fused parallel pass over the coset points: `vanishing_poly`,
+        // `shift.v_tilde_p` and `(-shift).v_tilde_p * k` are independent per
+        // point. Computing them side-by-side reads `pts` once and writes the
+        // three outputs in parallel.
+        let mut z_vals = Self::Val::zero_vec(n);
+        let mut den_shift = Self::Val::zero_vec(n);
+        let mut den_negshift_k = Self::Val::zero_vec(n);
+        z_vals
+            .par_iter_mut()
+            .zip(den_shift.par_iter_mut())
+            .zip(den_negshift_k.par_iter_mut())
+            .zip(pts.par_iter())
+            .for_each(|(((z, ds), dnk), &at)| {
+                *z = self.vanishing_poly(at);
+                *ds = self.shift.v_tilde_p(at);
+                *dnk = neg_shift.v_tilde_p(at) * k;
+            });
 
-        // Batch inverses
+        // Batch inverses (already internally parallel).
         let inv_vanishing = batch_multiplicative_inverse(&z_vals);
         let inv_den_shift = batch_multiplicative_inverse(&den_shift);
         let inv_den_negshift_k = batch_multiplicative_inverse(&den_negshift_k);
 
-        // Build selectors
-        // TODO: If we need to make this faster we could look into using packed fields.
-        let is_first_row = z_vals
-            .iter()
-            .zip(inv_den_shift.iter())
-            .map(|(&z, &inv_d)| z * inv_d)
-            .collect();
-        let is_last_row = z_vals
-            .iter()
-            .zip(inv_den_negshift_k.iter())
-            .map(|(&z, &inv_dk)| z * inv_dk * k)
-            .collect();
-        let is_transition = z_vals
-            .iter()
-            .zip(inv_den_negshift_k.iter())
-            .map(|(&z, &inv_dk)| Self::Val::ONE - z * inv_dk)
-            .collect();
+        // Fused parallel selector build:
+        //   is_first_row[i]  = z[i] * inv_den_shift[i]
+        //   is_last_row[i]   = z[i] * inv_den_negshift_k[i] * k
+        //   is_transition[i] = 1 - z[i] * inv_den_negshift_k[i]
+        // `z * inv_den_negshift_k` is shared between the last two selectors
+        // and each input is loaded once per iteration instead of three times.
+        let mut is_first_row = Self::Val::zero_vec(n);
+        let mut is_last_row = Self::Val::zero_vec(n);
+        let mut is_transition = Self::Val::zero_vec(n);
+        is_first_row
+            .par_iter_mut()
+            .zip(is_last_row.par_iter_mut())
+            .zip(is_transition.par_iter_mut())
+            .zip(z_vals.par_iter())
+            .zip(inv_den_shift.par_iter())
+            .zip(inv_den_negshift_k.par_iter())
+            .for_each(|(((((ifr, ilr), itr), &z), &inv_d), &inv_dk)| {
+                let z_inv_dk = z * inv_dk;
+                *ifr = z * inv_d;
+                *ilr = z_inv_dk * k;
+                *itr = Self::Val::ONE - z_inv_dk;
+            });
 
         LagrangeSelectors {
             is_first_row,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -245,11 +245,6 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
         let inv_den_negshift_k = batch_multiplicative_inverse(&den_negshift_k);
 
         // Fused parallel selector build:
-        //   is_first_row[i]  = z[i] * inv_den_shift[i]
-        //   is_last_row[i]   = z[i] * inv_den_negshift_k[i] * k
-        //   is_transition[i] = 1 - z[i] * inv_den_negshift_k[i]
-        // `z * inv_den_negshift_k` is shared between the last two selectors
-        // and each input is loaded once per iteration instead of three times.
         let mut is_first_row = Self::Val::zero_vec(n);
         let mut is_last_row = Self::Val::zero_vec(n);
         let mut is_transition = Self::Val::zero_vec(n);


### PR DESCRIPTION
## Why

`CircleDomain::selectors_on_coset` was sequential end-to-end. It built three numerator/denominator vectors with three back-to-back `.iter().map().collect()` passes, ran three batched inversions, and then built three selector vectors with three more sequential passes, redundantly computing `z * inv_den_negshift_k` twice. The inline TODO at the bottom of that block explicitly flagged it for a packed/parallel rewrite.

`selectors_on_coset` is on the hot path of every Circle STARK prove (called once per AIR from `uni_stark::quotient_values` / `batch_stark` quotient compute). On the example `prove_prime_field_31 -f mersenne-31 -o poseidon-2-permutations -l 17 -m keccak-f` it was ~4.8% of total prove time on its own.

## What

Two structural changes inside the same function, no signature change, no new bounds:

- **One fused pass over the coset points** filling `z_vals`, `den_shift` and `den_negshift_k` side-by-side from a single shared traversal of `pts`. The three per-point evaluations (`vanishing_poly`, `shift.v_tilde_p`, `(-shift).v_tilde_p * k`) are independent so they parallelise cleanly with a `par_iter_mut` chain.
- **One fused pass over the inverted denominators** filling `is_first_row`, `is_last_row` and `is_transition` side-by-side, factoring out `z * inv_den_negshift_k` once across the latter two and reading each input only once per iteration.

The arithmetic and the order of writes (each output `[i]` is a pure function of `pts[i]`) are unchanged, so proofs stay byte-identical to before — the existing Circle PCS / uni-stark / batch-stark test suites all keep passing without modification.

## Benchmarks

M3 Pro, `--features parallel`, `-Ctarget-cpu=native`, 3× medians, example `prove_prime_field_31 -f mersenne-31 -o poseidon-2-permutations -m keccak-f`:

| log_trace | before sel.  | after sel.   | phase   | prove saved |
|-----------|--------------|--------------|---------|-------------|
| 12        |  3.0 ms 2.3% |  0.7 ms 0.5% |  4.3×   |  ~1.7%      |
| 14        | 11.2 ms 4.1% |  1.6 ms 0.6% |  7.0×   |  ~3.5%      |
| 16        | 46.8 ms 4.7% |  5.3 ms 0.6% |  8.8×   |  ~4.2%      |
| 18        |  193 ms 4.7% | 21.5 ms 0.6% |  9.0×   |  ~4.7%      |

The same shape holds for the keccak and blake3 example AIRs at l=17: selectors drop from ~94 ms to ~11 ms in both, saving ~4% of total prove on keccak and ~1.2% on the longer blake3 prove.

Without `--features parallel`, the fused single-pass shape alone is still ~10% faster than the original three separate passes (46.7 ms → 42.3 ms at l=16) thanks to better cache locality and the shared `z * inv_den_negshift_k`, so the change does **not** regress the sequential fallback.

## Why this approach instead of `PackedField`

The TODO suggested packed fields. Two reasons I went with parallel + fusion first:

- It is a smaller, lower-risk change — no new traits, no extension/packing plumbing, idiomatic `par_iter_mut` shape already used widely in the workspace (e.g. `batch_stark::prover`, FRI fold). The diff stays in one function.
- It already delivers the bulk of the win on every workload I measured (up to 9× on the phase, scaling with N), without touching the per-point evaluation kernels.

A follow-up that packs the per-point `vanishing_poly` / `v_tilde_p` kernels for Mersenne31 would compose cleanly on top of this shape, but it would be a separate, more invasive PR.

## Validation

| Check                                                                 | Result    |
|-----------------------------------------------------------------------|-----------|
| `cargo test -p p3-circle` (default)                                   | 24 passed |
| `cargo test -p p3-uni-stark` and `--features parallel`                | all passed|
| `cargo test -p p3-batch-stark` and `--features parallel`              | all passed|
| `cargo clippy -p p3-circle --all-targets -- -D warnings`              | clean     |
| `cargo clippy -p p3-uni-stark --all-targets --features parallel -D warnings`   | clean     |
| `cargo clippy -p p3-batch-stark --all-targets --features parallel -D warnings` | clean     |
| `cargo fmt -p p3-circle --check`                                      | clean     |
| `no_std` build                                                        | clean     |
| Byte-identical Fiat-Shamir output                                     | confirmed |