### PR TITLE
perf(circle): fill the LDE extension in parallel

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -148,49 +148,67 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
             // both `x_1` and `x_2` are set to `x_1`).
             // So instead we directly repeat the coeffs and skip the initial layers.
             //
-            // Performing the repeated doublings via `extend_from_within(..)` is
-            // a single-threaded `memcpy`. Once the buffer is large enough
-            // (multi-GiB for production-sized traces) it becomes a bandwidth-
-            // bound bottleneck. Compose the final repetition pattern directly
-            // (`new_row[i] = orig[i % initial_h]` after any number of
-            // doublings) and fill the new region in parallel: every
-            // destination row is written exactly once and the source region is
-            // only read, so the parallel writes do not race.
+            // After any number of doublings the buffer is the original `h` rows tiled end to end.
+            // Output row `j` is therefore a copy of original row `j mod h`.
+            //
+            //     originals : r_0 r_1 ... r_{h-1}
+            //     filled    : r_0 ... r_{h-1} | r_0 ... r_{h-1} | r_0 ... r_{h-1}
+            //                 \_h originals_/   \___ identical tiled copies ___/
+            //
+            // Reserve the full target once, then fill the new tail in parallel.
+            // Each tail row is written by exactly one task.
+            // The original rows are only read.
+            // So the concurrent writes never race.
             debug_span!("extend coeffs").in_scope(|| {
                 let w = coeffs.width();
+                // Rows present before the blow-up.
                 let initial_h = coeffs.height();
+                // Rows required after the blow-up.
                 let target_h = domain.size();
                 let initial_len = initial_h * w;
                 let target_len = target_h * w;
 
+                // Grow to the final size in one allocation; the tail stays uninitialised.
                 coeffs.values.reserve_exact(target_len - initial_len);
 
-                // SAFETY: We just reserved space for `target_len - initial_len`
-                // more elements. `initial_region` and `new_region` are disjoint
-                // views into the same allocation (`new_region` starts at
-                // `initial_len`). Each row of `new_region` is written by
-                // exactly one Rayon task. `initial_region` is only read.
-                // `F: Copy + Send + Sync` so per-element writes do not drop
-                // existing values and cross-thread sharing is sound.
+                // SAFETY:
+                // - The reservation above guarantees capacity for `target_len` elements.
+                // - The read view covers `[0, initial_len)`.
+                // - The write view covers `[initial_len, target_len)`.
+                // - The two ranges are disjoint parts of one allocation.
+                // - Each tail row is handed to exactly one task, so the writes never alias.
+                // - `MaybeUninit::write` stores without reading or dropping the prior bytes.
+                // - The length is updated only after every tail element is written.
                 unsafe {
+                    // Base pointer of the reserved allocation.
                     let ptr = coeffs.values.as_mut_ptr();
+
+                    // Read-only view of the rows already present.
                     let initial_region: &[F] = core::slice::from_raw_parts(ptr, initial_len);
+
+                    // Write view of the uninitialised tail, just past the existing rows.
                     let new_region: &mut [MaybeUninit<F>] = core::slice::from_raw_parts_mut(
                         ptr.add(initial_len).cast::<MaybeUninit<F>>(),
                         target_len - initial_len,
                     );
 
+                    // One task per destination row.
                     new_region
                         .par_chunks_mut(w)
                         .enumerate()
                         .for_each(|(i, dst_row)| {
+                            // `i` indexes the tail, so this is global output row `initial_h + i`.
+                            // The tail starts on a multiple of `initial_h`.
+                            // So the source row reduces to `i mod initial_h`.
                             let src_row_start = (i % initial_h) * w;
                             let src_row = &initial_region[src_row_start..src_row_start + w];
+                            // Copy the chosen original row into this tail slot.
                             for (dst, &src) in dst_row.iter_mut().zip(src_row) {
                                 dst.write(src);
                             }
                         });
 
+                    // Every tail element is initialised; publish them as live `Vec` entries.
                     coeffs.values.set_len(target_len);
                 }
             });

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -1,5 +1,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 use itertools::{Itertools, iterate, izip};
 use p3_commit::PolynomialSpace;
@@ -146,10 +147,51 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
             // with the lower order values. (In `DitButterfly`, `x_2` is 0, so
             // both `x_1` and `x_2` are set to `x_1`).
             // So instead we directly repeat the coeffs and skip the initial layers.
+            //
+            // Performing the repeated doublings via `extend_from_within(..)` is
+            // a single-threaded `memcpy`. Once the buffer is large enough
+            // (multi-GiB for production-sized traces) it becomes a bandwidth-
+            // bound bottleneck. Compose the final repetition pattern directly
+            // (`new_row[i] = orig[i % initial_h]` after any number of
+            // doublings) and fill the new region in parallel: every
+            // destination row is written exactly once and the source region is
+            // only read, so the parallel writes do not race.
             debug_span!("extend coeffs").in_scope(|| {
-                coeffs.values.reserve(domain.size() * coeffs.width());
-                for _ in log_n..domain.log_n {
-                    coeffs.values.extend_from_within(..);
+                let w = coeffs.width();
+                let initial_h = coeffs.height();
+                let target_h = domain.size();
+                let initial_len = initial_h * w;
+                let target_len = target_h * w;
+
+                coeffs.values.reserve_exact(target_len - initial_len);
+
+                // SAFETY: We just reserved space for `target_len - initial_len`
+                // more elements. `initial_region` and `new_region` are disjoint
+                // views into the same allocation (`new_region` starts at
+                // `initial_len`). Each row of `new_region` is written by
+                // exactly one Rayon task. `initial_region` is only read.
+                // `F: Copy + Send + Sync` so per-element writes do not drop
+                // existing values and cross-thread sharing is sound.
+                unsafe {
+                    let ptr = coeffs.values.as_mut_ptr();
+                    let initial_region: &[F] = core::slice::from_raw_parts(ptr, initial_len);
+                    let new_region: &mut [MaybeUninit<F>] = core::slice::from_raw_parts_mut(
+                        ptr.add(initial_len).cast::<MaybeUninit<F>>(),
+                        target_len - initial_len,
+                    );
+
+                    new_region
+                        .par_chunks_mut(w)
+                        .enumerate()
+                        .for_each(|(i, dst_row)| {
+                            let src_row_start = (i % initial_h) * w;
+                            let src_row = &initial_region[src_row_start..src_row_start + w];
+                            for (dst, &src) in dst_row.iter_mut().zip(src_row) {
+                                dst.write(src);
+                            }
+                        });
+
+                    coeffs.values.set_len(target_len);
                 }
             });
         }


### PR DESCRIPTION
## Why

`CircleEvaluations::evaluate` repeatedly doubled the coefficient buffer with `Vec::extend_from_within(..)` so that the subsequent CFFT layers could operate on a buffer of `domain.size()` rows. Each doubling is a single-threaded `memcpy` and for a production-sized trace the buffer is large enough (multi-GiB) that this becomes a memory-bandwidth-bound sequential phase on top of an otherwise parallel CFFT pipeline. On the example `prove_prime_field_31 -f mersenne-31 -o poseidon-2-permutations -l 17 -m keccak-f` it was **~3.7% of total prove time**.

## What

After any number of doublings the final row layout is just `row[i] = orig[i mod initial_h]`. So instead of running the loop of doublings as `extend_from_within`, pre-reserve the full target capacity and fill the new tail region directly with that pattern in parallel:

- View the existing rows as a shared `&[F]` and the uninitialised tail as `&mut [MaybeUninit<F>]`.
- `par_chunks_mut(width)` over the tail; each chunk is one destination row and is written by a single Rayon task.
- Set the `Vec` length at the end.

The parallel writes do not race because every tail row is owned by a single task and the source region is only read. The final buffer contents are bit-identical to what the old `extend_from_within` loop produced, so the downstream CFFT layers operate on identical data and proofs stay byte-identical.

The same `if log_n < domain.log_n` block, the same `debug_span!("extend coeffs")` instrumentation and the same surrounding comments are preserved — only the body of that block changes.

## Benchmarks

M3 Pro, `--features parallel`, `-Ctarget-cpu=native`, 10× medians, `prove_prime_field_31 -f mersenne-31 -o poseidon-2-permutations -m keccak-f`:

| log_trace | `extend coeffs` before | `extend coeffs` after | phase   | prove saved |
|-----------|------------------------|-----------------------|---------|-------------|
| 16        | ~38 ms (3.5%)          | 27 ms (2.4%)          | 1.4×    | ~1.0%       |
| 17        | 76.7 ms (3.8%)         | 42 ms (2.0%)          | **1.82×** | **~1.7%** |
| 18        | ~150 ms (3.7%)         | 72 ms (1.7%)          | 2.1×    | ~2.0%      |

The phase is memory-bandwidth bound, so the speedup is limited by aggregate cross-core bandwidth rather than core count — but it still consistently clears the 1% bar at every workload size I measured.

## Validation

| Check                                                                          | Result |
|--------------------------------------------------------------------------------|--------|
| `cargo test -p p3-circle` (default)                                            | 28 passed |
| `cargo test -p p3-uni-stark` and `--features parallel`                         | all passed |
| `cargo test -p p3-batch-stark` and `--features parallel`                       | all passed |
| `cargo clippy -p p3-circle --all-targets -D warnings`                          | clean  |
| `cargo clippy -p p3-uni-stark --all-targets --features parallel -D warnings`   | clean  |
| `cargo clippy -p p3-batch-stark --all-targets --features parallel -D warnings` | clean  |
| `cargo fmt -p p3-circle --check`                                               | clean  |
| `no_std` build                                                                 | clean  |

## Safety / review wildcard

The change introduces an `unsafe` block to derive a `&[F]` view of the already-initialised rows and a `&mut [MaybeUninit<F>]` view of the reserved tail from the same allocation. The two views cover disjoint byte ranges, each tail row is written by exactly one Rayon task, and the source region is only read — the SAFETY comment in the diff spells these conditions out. The shape mirrors the existing pattern in `dft/src/radix_2_dit_parallel.rs::coset_lde_batch_with_transform`, which already derives a `&mut [F]` head and a `&mut [MaybeUninit<F>]` tail of one `RowMajorMatrix` allocation in the same way.