### PR TITLE
whir: remove dead public items

### DIFF
--- a/whir/src/pcs/committer/mod.rs
+++ b/whir/src/pcs/committer/mod.rs
@@ -1,12 +1,8 @@
 use p3_matrix::dense::DenseMatrix;
-use p3_matrix::extension::FlatMatrixView;
 use p3_merkle_tree::MerkleTree;
 
 pub mod reader;
 pub mod writer;
-
-pub type ProverDataExt<F, EF, const N: usize, const DIGEST_ELEMS: usize> =
-    MerkleTree<F, F, FlatMatrixView<F, EF, DenseMatrix<EF>>, N, DIGEST_ELEMS>;
 
 pub type ProverData<F, const N: usize, const DIGEST_ELEMS: usize> =
     MerkleTree<F, F, DenseMatrix<F>, N, DIGEST_ELEMS>;

--- a/whir/src/pcs/committer/reader.rs
+++ b/whir/src/pcs/committer/reader.rs
@@ -1,5 +1,4 @@
 use core::fmt::Debug;
-use core::ops::Deref;
 
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
@@ -7,7 +6,6 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_multilinear_util::point::Point;
 
 use crate::constraints::statement::EqStatement;
-use crate::parameters::WhirConfig;
 use crate::pcs::proof::WhirProof;
 use crate::pcs::verifier::errors::VerifierError;
 
@@ -80,35 +78,5 @@ where
             root,
             ood_statement,
         })
-    }
-}
-
-/// Lightweight wrapper for parsing commitment data during verification.
-#[derive(Debug)]
-pub struct CommitmentReader<'a, EF, F, Challenger>(&'a WhirConfig<EF, F, Challenger>)
-where
-    F: Field,
-    EF: ExtensionField<F>;
-
-impl<'a, EF, F, Challenger> CommitmentReader<'a, EF, F, Challenger>
-where
-    F: TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
-{
-    pub const fn new(params: &'a WhirConfig<EF, F, Challenger>) -> Self {
-        Self(params)
-    }
-}
-
-impl<EF, F, Challenger> Deref for CommitmentReader<'_, EF, F, Challenger>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-{
-    type Target = WhirConfig<EF, F, Challenger>;
-
-    fn deref(&self) -> &Self::Target {
-        self.0
     }
 }

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -23,7 +23,6 @@ use crate::sumcheck::layout::Layout;
 use crate::sumcheck::strategy::{SumcheckProver, VariableOrder};
 
 pub type Proof<W, const DIGEST_ELEMS: usize> = Vec<Vec<[W; DIGEST_ELEMS]>>;
-pub type Leafs<F> = Vec<Vec<F>>;
 
 /// Per-round prover state with the Merkle authentication shapes
 /// baked in for the WHIR commitment scheme.


### PR DESCRIPTION
## What

Removes three public items in the WHIR PCS that are never constructed or referenced anywhere in the crate — including its tests, benches, and the `whir` example:

- **`CommitmentReader`** struct, its `new()` constructor, and its `Deref` impl (`pcs/committer/reader.rs`) — never instantiated.
- **`type Leafs`** (`pcs/prover/mod.rs`) — never referenced.
- **`type ProverDataExt`** (`pcs/committer/mod.rs`) — never referenced.

Also drops the imports orphaned by the removals (`Deref`, `WhirConfig`, `FlatMatrixView`). The live siblings `ProverData` and `Proof` are untouched.

## Why the compiler didn't catch these

`p3-whir` is a leaf crate with no in-workspace dependents, so every `pub` item reachable from the crate root counts as "used API" and the `dead_code` lint cannot flag it. These were found by reachability analysis across `src` + benches + example, then verified by hand (e.g. `#[from]` enum variants constructed implicitly via `?` were ruled out as false positives).

## Verification

`cargo check -p p3-whir --all-features --tests --benches` passes. Pure deletion — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)