### PR TITLE
perf(challenger): precompute the grind state for MultiField32Challenger

### DIFF
--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -24,6 +24,7 @@ p3-bn254 = { path = "../bn254" }
 p3-goldilocks = { path = "../goldilocks" }
 
 num-bigint.workspace = true
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -1,10 +1,13 @@
-use p3_field::{Field, PackedValue, PrimeCharacteristicRing, PrimeField64};
+use p3_field::{
+    Field, PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32, PrimeField64,
+};
 use p3_maybe_rayon::prelude::*;
 use p3_symmetric::CryptographicPermutation;
 use tracing::instrument;
 
 use crate::{
-    CanObserve, CanSampleBits, CanSampleUniformBits, DuplexChallenger, UniformSamplingField,
+    CanObserve, CanSampleBits, CanSampleUniformBits, DuplexChallenger, MultiField32Challenger,
+    UniformSamplingField,
 };
 
 /// Trait for challengers that support proof-of-work (PoW) grinding.
@@ -280,6 +283,49 @@ where
         // Run the check one last time on the *original* challenger to update its state
         // and confirm the witness is valid.
         assert!(check_fn(self, witness));
+        witness
+    }
+}
+
+impl<F, PF, P, const WIDTH: usize, const RATE: usize> GrindingChallenger
+    for MultiField32Challenger<F, PF, P, WIDTH, RATE>
+where
+    F: PrimeField32,
+    PF: PrimeField,
+    P: CryptographicPermutation<[PF; WIDTH]>,
+{
+    type Witness = F;
+
+    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize), "bit count must be valid");
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
+
+        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
+        if bits == 0 {
+            return F::ZERO;
+        }
+
+        // The candidate-independent transcript work happens once inside `pow_check_fn`.
+        // The parallel search then runs one stack-state permutation per candidate.
+        let witness = {
+            let accepts = self.pow_check_fn(bits);
+            (0..F::ORDER_U32)
+                .into_par_iter()
+                .find_any(|&candidate| accepts(candidate))
+                .expect("failed to find proof-of-work witness")
+        };
+        // candidate < F::ORDER_U32 by construction so this is safe.
+        let witness = unsafe { F::from_canonical_unchecked(witness) };
+
+        // Re-run the standard verifier logic to validate the witness and
+        // advance the real transcript state.
+        assert!(self.check_witness(bits, witness));
         witness
     }
 }

--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -1,13 +1,10 @@
-use p3_field::{
-    Field, PackedValue, PrimeCharacteristicRing, PrimeField, PrimeField32, PrimeField64,
-};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing, PrimeField64};
 use p3_maybe_rayon::prelude::*;
 use p3_symmetric::CryptographicPermutation;
 use tracing::instrument;
 
 use crate::{
-    CanObserve, CanSampleBits, CanSampleUniformBits, DuplexChallenger, MultiField32Challenger,
-    UniformSamplingField,
+    CanObserve, CanSampleBits, CanSampleUniformBits, DuplexChallenger, UniformSamplingField,
 };
 
 /// Trait for challengers that support proof-of-work (PoW) grinding.
@@ -283,43 +280,6 @@ where
         // Run the check one last time on the *original* challenger to update its state
         // and confirm the witness is valid.
         assert!(check_fn(self, witness));
-        witness
-    }
-}
-
-impl<F, PF, P, const WIDTH: usize, const RATE: usize> GrindingChallenger
-    for MultiField32Challenger<F, PF, P, WIDTH, RATE>
-where
-    F: PrimeField32,
-    PF: PrimeField,
-    P: CryptographicPermutation<[PF; WIDTH]>,
-{
-    type Witness = F;
-
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
-    fn grind(&mut self, bits: usize) -> Self::Witness {
-        assert!(bits < (usize::BITS as usize), "bit count must be valid");
-        // Evaluate the bound in `u64` to keep the shift within its type width.
-        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
-        assert!(
-            (1u64 << bits) < F::ORDER_U64,
-            "requested bit count must fit within the field order"
-        );
-
-        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
-        if bits == 0 {
-            return F::ZERO;
-        }
-
-        let witness = (0..F::ORDER_U32)
-            .into_par_iter()
-            .map(|i| unsafe {
-                // i < F::ORDER_U32 by construction so this is safe.
-                F::from_canonical_unchecked(i)
-            })
-            .find_any(|witness| self.clone().check_witness(bits, *witness))
-            .expect("failed to find witness");
-        assert!(self.check_witness(bits, witness));
         witness
     }
 }

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -7,13 +7,10 @@ use p3_field::{
     BasedVectorSpace, PrimeField, PrimeField32, absorb_radix_bits, max_absorb_injective_limbs,
     reduce_packed, split_pf_to_field_order_limbs, squeeze_field_order_num_limbs,
 };
-use p3_maybe_rayon::prelude::*;
 use p3_symmetric::{CryptographicPermutation, Hash, MerkleCap};
-use tracing::instrument;
 
 use crate::{
     CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, DuplexChallenger, FieldChallenger,
-    GrindingChallenger,
 };
 
 /// A challenger that samples in `F: PrimeField32` while the transcript sponge lives in `PF`.
@@ -308,7 +305,8 @@ where
     PF: PrimeField,
     P: CryptographicPermutation<[PF; WIDTH]>,
 {
-    /// Build the proof-of-work acceptance predicate used by [`GrindingChallenger::grind`].
+    /// Build the proof-of-work acceptance predicate used by
+    /// [`GrindingChallenger::grind`](crate::GrindingChallenger::grind).
     ///
     /// The predicate replays `check_witness` = `observe(witness)` + `sample_bits(bits)`
     /// on a stack copy of the sponge state:
@@ -323,7 +321,7 @@ where
     /// Everything except the witness digit is candidate-independent and computed once.
     /// Each call then costs one state copy, one digit write, one permutation,
     /// and one limb split — no clone, no heap allocation.
-    fn pow_check_fn(&self, bits: usize) -> impl Fn(u32) -> bool + Sync + '_ {
+    pub(crate) fn pow_check_fn(&self, bits: usize) -> impl Fn(u32) -> bool + Sync + '_ {
         let rb = self.absorb_radix_bits();
         let absorb_n = self.absorb_num_f_elms();
         let squeeze_n = self.squeeze_num_f_elms();
@@ -374,49 +372,6 @@ where
             let limbs = split_pf_to_field_order_limbs::<PF, F>(state[RATE - 1], squeeze_n);
             (u64::from(limbs[squeeze_n - 1].as_canonical_u32()) & mask) == 0
         }
-    }
-}
-
-impl<F, PF, P, const WIDTH: usize, const RATE: usize> GrindingChallenger
-    for MultiField32Challenger<F, PF, P, WIDTH, RATE>
-where
-    F: PrimeField32,
-    PF: PrimeField,
-    P: CryptographicPermutation<[PF; WIDTH]>,
-{
-    type Witness = F;
-
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
-    fn grind(&mut self, bits: usize) -> Self::Witness {
-        assert!(bits < (usize::BITS as usize), "bit count must be valid");
-        // Evaluate the bound in `u64` to keep the shift within its type width.
-        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
-        assert!(
-            (1u64 << bits) < F::ORDER_U64,
-            "requested bit count must fit within the field order"
-        );
-
-        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
-        if bits == 0 {
-            return F::ZERO;
-        }
-
-        // The candidate-independent transcript work happens once inside `pow_check_fn`.
-        // The parallel search then runs one stack-state permutation per candidate.
-        let witness = {
-            let accepts = self.pow_check_fn(bits);
-            (0..F::ORDER_U32)
-                .into_par_iter()
-                .find_any(|&candidate| accepts(candidate))
-                .expect("failed to find proof-of-work witness")
-        };
-        // candidate < F::ORDER_U32 by construction so this is safe.
-        let witness = unsafe { F::from_canonical_unchecked(witness) };
-
-        // Re-run the standard verifier logic to validate the witness and
-        // advance the real transcript state.
-        assert!(self.check_witness(bits, witness));
-        witness
     }
 }
 

--- a/challenger/src/multi_field_challenger.rs
+++ b/challenger/src/multi_field_challenger.rs
@@ -1,15 +1,19 @@
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::array;
 
 use p3_field::{
     BasedVectorSpace, PrimeField, PrimeField32, absorb_radix_bits, max_absorb_injective_limbs,
     reduce_packed, split_pf_to_field_order_limbs, squeeze_field_order_num_limbs,
 };
+use p3_maybe_rayon::prelude::*;
 use p3_symmetric::{CryptographicPermutation, Hash, MerkleCap};
+use tracing::instrument;
 
 use crate::{
     CanFinalizeDigest, CanObserve, CanSample, CanSampleBits, DuplexChallenger, FieldChallenger,
+    GrindingChallenger,
 };
 
 /// A challenger that samples in `F: PrimeField32` while the transcript sponge lives in `PF`.
@@ -298,6 +302,124 @@ where
     }
 }
 
+impl<F, PF, P, const WIDTH: usize, const RATE: usize> MultiField32Challenger<F, PF, P, WIDTH, RATE>
+where
+    F: PrimeField32,
+    PF: PrimeField,
+    P: CryptographicPermutation<[PF; WIDTH]>,
+{
+    /// Build the proof-of-work acceptance predicate used by [`GrindingChallenger::grind`].
+    ///
+    /// The predicate replays `check_witness` = `observe(witness)` + `sample_bits(bits)`
+    /// on a stack copy of the sponge state:
+    ///
+    /// ```text
+    ///     pending scalars | witness  ->  packed rate slots, zero tail, length tag
+    ///                                ->  permute
+    ///                                ->  last limb of last rate cell
+    ///                                ->  accept iff low `bits` are zero
+    /// ```
+    ///
+    /// Everything except the witness digit is candidate-independent and computed once.
+    /// Each call then costs one state copy, one digit write, one permutation,
+    /// and one limb split — no clone, no heap allocation.
+    fn pow_check_fn(&self, bits: usize) -> impl Fn(u32) -> bool + Sync + '_ {
+        let rb = self.absorb_radix_bits();
+        let absorb_n = self.absorb_num_f_elms();
+        let squeeze_n = self.squeeze_num_f_elms();
+
+        // The witness joins the pending scalars at the next free position.
+        let n_pending = self.f_buffer.len();
+        // Invariant: the constructor bounds a full flush at 255 scalars, so this never truncates.
+        let tag = u8::try_from(n_pending + 1).expect("absorb length tag must fit in a u8");
+
+        // Packed-slot coordinates of the witness digit.
+        let chunk_idx = n_pending / absorb_n;
+        let pos_in_chunk = n_pending % absorb_n;
+
+        // The packing is little-endian Horner: digit `j` of a chunk weighs `2^(rb * j)`.
+        let shift = PF::from_u64(1u64 << rb).exp_u64(pos_in_chunk as u64);
+
+        // Digits below the witness in its own chunk.
+        let const_tail: PF = reduce_packed(&self.f_buffer[chunk_idx * absorb_n..], rb);
+
+        // Candidate-independent pre-permutation state.
+        // Mirrors `absorb_rate_padded_with_tag(packed_chunks, tag)` on the inner sponge.
+        let base_state: [PF; WIDTH] = array::from_fn(|i| {
+            if i < chunk_idx {
+                // Full constant chunks fill the leading rate slots.
+                reduce_packed(&self.f_buffer[i * absorb_n..(i + 1) * absorb_n], rb)
+            } else if i < RATE {
+                // The witness chunk (rebuilt per candidate) and the unused rate slots are zeroed.
+                PF::ZERO
+            } else if i == RATE {
+                // The first capacity element carries the length tag.
+                self.inner.sponge_state[RATE] + PF::from_u8(tag)
+            } else {
+                // The rest of the capacity carries forward unchanged.
+                self.inner.sponge_state[i]
+            }
+        });
+
+        // Accept when the low `bits` of the checked challenge are zero.
+        let mask = (1u64 << bits) - 1;
+
+        move |candidate| {
+            // One stack copy, one digit write, one permutation per candidate.
+            let mut state = base_state;
+            state[chunk_idx] = const_tail + shift * PF::from_u32(candidate);
+            self.inner.permutation.permute_mut(&mut state);
+
+            // `sample_bits` pops the last limb split from the last rate cell.
+            let limbs = split_pf_to_field_order_limbs::<PF, F>(state[RATE - 1], squeeze_n);
+            (u64::from(limbs[squeeze_n - 1].as_canonical_u32()) & mask) == 0
+        }
+    }
+}
+
+impl<F, PF, P, const WIDTH: usize, const RATE: usize> GrindingChallenger
+    for MultiField32Challenger<F, PF, P, WIDTH, RATE>
+where
+    F: PrimeField32,
+    PF: PrimeField,
+    P: CryptographicPermutation<[PF; WIDTH]>,
+{
+    type Witness = F;
+
+    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    fn grind(&mut self, bits: usize) -> Self::Witness {
+        assert!(bits < (usize::BITS as usize), "bit count must be valid");
+        // Evaluate the bound in `u64` to keep the shift within its type width.
+        // A `u32` shift by `bits >= 32` would wrap and accept a trivial proof-of-work.
+        assert!(
+            (1u64 << bits) < F::ORDER_U64,
+            "requested bit count must fit within the field order"
+        );
+
+        // Trivial case: 0 bits mean no PoW is required and any witness is valid.
+        if bits == 0 {
+            return F::ZERO;
+        }
+
+        // The candidate-independent transcript work happens once inside `pow_check_fn`.
+        // The parallel search then runs one stack-state permutation per candidate.
+        let witness = {
+            let accepts = self.pow_check_fn(bits);
+            (0..F::ORDER_U32)
+                .into_par_iter()
+                .find_any(|&candidate| accepts(candidate))
+                .expect("failed to find proof-of-work witness")
+        };
+        // candidate < F::ORDER_U32 by construction so this is safe.
+        let witness = unsafe { F::from_canonical_unchecked(witness) };
+
+        // Re-run the standard verifier logic to validate the witness and
+        // advance the real transcript state.
+        assert!(self.check_witness(bits, witness));
+        witness
+    }
+}
+
 impl<F, PF, P, const WIDTH: usize, const RATE: usize> CanFinalizeDigest
     for MultiField32Challenger<F, PF, P, WIDTH, RATE>
 where
@@ -329,6 +451,7 @@ mod tests {
     };
     use p3_goldilocks::Goldilocks;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
 
     use super::*;
     use crate::grinding_challenger::GrindingChallenger;
@@ -724,5 +847,106 @@ mod tests {
         let mut challenger =
             MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
         let _ = challenger.grind(32);
+    }
+
+    #[test]
+    fn test_grind_advances_state_like_direct_check() {
+        // The fast grind precomputes the pre-permutation state once per search.
+        // Its result and final transcript must match a direct `check_witness`.
+        //
+        // Pending counts cover every packing geometry (absorb_n = 2, RATE = 4):
+        //
+        //     0  ->  witness opens chunk 0          (chunk_idx 0, pos 0)
+        //     1  ->  witness completes chunk 0      (chunk_idx 0, pos 1)
+        //     4  ->  witness opens chunk 2          (chunk_idx 2, pos 0)
+        //     7  ->  witness fills the whole batch  (flush fires inside observe)
+        for pending in [0usize, 1, 4, 7] {
+            let mut challenger =
+                MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+            for i in 0..pending {
+                challenger.observe(F::from_u8(i as u8));
+            }
+
+            // Shadow challenger consumes the witness through the plain verifier path.
+            let mut direct = challenger.clone();
+
+            let bits = 2;
+            let witness = challenger.grind(bits);
+
+            // The witness validates, and both transcripts land on the same state.
+            assert!(direct.check_witness(bits, witness), "pending = {pending}");
+            assert_eq!(challenger.inner.sponge_state, direct.inner.sponge_state);
+            assert_eq!(challenger.inner.input_buffer, direct.inner.input_buffer);
+            assert_eq!(challenger.inner.output_buffer, direct.inner.output_buffer);
+            assert_eq!(challenger.f_buffer, direct.f_buffer);
+            assert_eq!(challenger.f_squeeze_buffer, direct.f_squeeze_buffer);
+        }
+    }
+
+    #[test]
+    fn test_grind_advances_state_like_direct_check_bn254() {
+        // Bn254 splits each squeezed cell into several BabyBear limbs,
+        // so this pins the limb-extraction path the Goldilocks fixture cannot reach.
+        use p3_bn254::Bn254;
+
+        type PF254 = Bn254;
+
+        #[derive(Clone)]
+        struct Bn254MixingPermutation;
+
+        impl Permutation<[PF254; WIDTH]> for Bn254MixingPermutation {
+            fn permute_mut(&self, input: &mut [PF254; WIDTH]) {
+                let sum: PF254 = input.iter().copied().sum();
+                for (i, val) in input.iter_mut().enumerate() {
+                    *val = sum + PF254::from_u8((i + 1) as u8);
+                }
+            }
+        }
+
+        impl CryptographicPermutation<[PF254; WIDTH]> for Bn254MixingPermutation {}
+
+        let mut challenger =
+            MultiField32Challenger::<F, PF254, _, WIDTH, RATE>::new(Bn254MixingPermutation)
+                .unwrap();
+        assert!(challenger.squeeze_num_f_elms() > 1);
+        for i in 0..3u8 {
+            challenger.observe(F::from_u8(i));
+        }
+
+        let mut direct = challenger.clone();
+
+        let bits = 2;
+        let witness = challenger.grind(bits);
+
+        assert!(direct.check_witness(bits, witness));
+        assert_eq!(challenger.inner.sponge_state, direct.inner.sponge_state);
+        assert_eq!(challenger.f_buffer, direct.f_buffer);
+        assert_eq!(challenger.f_squeeze_buffer, direct.f_squeeze_buffer);
+    }
+
+    proptest! {
+        #[test]
+        fn prop_pow_check_matches_check_witness(
+            pending_values in prop::collection::vec(0u32..F::ORDER_U32, 0..8),
+            candidate in 0u32..F::ORDER_U32,
+            bits in 1usize..8,
+        ) {
+            // Specialization-vs-reference pin:
+            // the precomputed-state predicate must agree with the plain
+            // `observe + sample_bits` verifier path on every candidate.
+            let mut challenger =
+                MultiField32Challenger::<F, PF, _, WIDTH, RATE>::new(MixingPermutation).unwrap();
+            for &v in &pending_values {
+                challenger.observe(F::from_u32(v));
+            }
+
+            let fast = challenger.pow_check_fn(bits)(candidate);
+
+            // Reference path on a clone; `candidate` is canonical by the range above.
+            let witness = F::from_u32(candidate);
+            let reference = challenger.clone().check_witness(bits, witness);
+
+            prop_assert_eq!(fast, reference);
+        }
     }
 }


### PR DESCRIPTION
## What

Ports the `DuplexChallenger` packed-grind strategy to `MultiField32Challenger::grind`.

The old implementation brute-forced PoW candidates with `self.clone().check_witness(...)` per candidate, paying for each one:

- a full challenger clone (two `Vec` allocations),
- a re-pack of all pending scalars (including the candidate-independent chunks),
- the permutation,
- `RATE` BigUint cell splits in the squeeze refill — of which only one limb of one cell is actually checked.

The new implementation builds the candidate-independent pre-permutation sponge state **once** (constant packed chunks, zero tail, length tag, carried capacity). Each candidate then costs one stack copy, one packed-digit write, one permutation, and a single-cell limb split — no clone, no heap allocation.

The identity preserved is exactly `check_witness = observe(w); sample_bits(bits)`: the witness digit lands at weight `2^(rb·pos)` in packed slot `chunk_idx` (little-endian Horner packing), and the checked challenge is the last limb split from the last rate cell. `grind` still finishes with `assert!(self.check_witness(bits, witness))`, so the real transcript advances through the unmodified verifier path.

The trait impl moves from `grinding_challenger.rs` into `multi_field_challenger.rs` so the sponge fields stay private (same precedent as `DuplexChallenger`, whose grind lives next to its `pub` fields). Public API, bounds, and transcript behavior are unchanged.

## Benchmarks

Release mode, serial search (no rayon), same transcript prefix per round. Both paths found **identical witnesses**, which doubles as an end-to-end functional check on real permutations.

`MultiField32Challenger<BabyBear, Bn254, Poseidon2Bn254<3>, 3, 2>` (recursion config, permutation-dominated), `bits = 10`:

| round | old (clone + full check) | new (precomputed state) | speedup |
|---|---|---|---|
| 0 | 63.27 ms | 48.86 ms | 1.29x |
| 1 | 11.94 ms | 9.26 ms | 1.29x |
| 2 | 10.83 ms | 8.35 ms | 1.30x |

`MultiField32Challenger<BabyBear, Goldilocks, Poseidon2Goldilocks<8>, 8, 4>` (cheap permutation, overhead-dominated), `bits = 14`:

| round | old | new | speedup |
|---|---|---|---|
| 0 | 17.81 ms | 8.04 ms | 2.22x |
| 1 | 5.52 ms | 2.49 ms | 2.22x |
| 2 | 83.38 ms | 38.06 ms | 2.19x |

<details>
<summary>Benchmark harness used (temporary integration test, not committed)</summary>

```rust
use std::time::Instant;

use p3_baby_bear::BabyBear;
use p3_bn254::{
    BN254_POSEIDON2_HALF_FULL_ROUNDS, BN254_POSEIDON2_PARTIAL_ROUNDS_3, Bn254, Poseidon2Bn254,
};
use p3_challenger::{CanObserve, GrindingChallenger, MultiField32Challenger};
use p3_field::PrimeCharacteristicRing;
use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
use rand::SeedableRng;
use rand::rngs::SmallRng;

type F = BabyBear;

#[test]
fn grind_timing() {
    let mut rng = SmallRng::seed_from_u64(1);
    let perm = Poseidon2Bn254::<3>::new_from_rng(
        2 * BN254_POSEIDON2_HALF_FULL_ROUNDS,
        BN254_POSEIDON2_PARTIAL_ROUNDS_3,
        &mut rng,
    );
    let base = MultiField32Challenger::<F, Bn254, _, 3, 2>::new(perm).unwrap();
    let bits = 10;

    for round in 0u32..3 {
        let mut c1 = base.clone();
        c1.observe(F::from_u32(round));
        let t = Instant::now();
        let w_new = c1.grind(bits);
        let new_t = t.elapsed();

        let mut c2 = base.clone();
        c2.observe(F::from_u32(round));
        let t = Instant::now();
        // Old implementation shape: serial scan, full challenger clone + check per candidate.
        let w_old = (0u32..)
            .map(F::from_u32)
            .find(|w| c2.clone().check_witness(bits, *w))
            .unwrap();
        assert!(c2.check_witness(bits, w_old));
        let old_t = t.elapsed();

        println!("round {round}: new = {new_t:?} (w = {w_new:?}), old = {old_t:?} (w = {w_old:?})");
    }
}

#[test]
fn grind_timing_goldilocks() {
    let mut rng = SmallRng::seed_from_u64(1);
    let perm = Poseidon2Goldilocks::<8>::new_from_rng_128(&mut rng);
    let base = MultiField32Challenger::<F, Goldilocks, _, 8, 4>::new(perm).unwrap();
    let bits = 14;

    for round in 0u32..3 {
        let mut c1 = base.clone();
        c1.observe(F::from_u32(round));
        let t = Instant::now();
        let w_new = c1.grind(bits);
        let new_t = t.elapsed();

        let mut c2 = base.clone();
        c2.observe(F::from_u32(round));
        let t = Instant::now();
        let w_old = (0u32..)
            .map(F::from_u32)
            .find(|w| c2.clone().check_witness(bits, *w))
            .unwrap();
        assert!(c2.check_witness(bits, w_old));
        let old_t = t.elapsed();

        println!("round {round}: new = {new_t:?} (w = {w_new:?}), old = {old_t:?} (w = {w_old:?})");
    }
}
```

Run with:

```
cargo test -p p3-challenger --release --test grind_timing_tmp -- --nocapture
```

</details>

## Tests

- `prop_pow_check_matches_check_witness` — proptest pinning the precomputed-state predicate to the `clone().check_witness` reference over random pending transcripts, candidates, and bit counts.
- `test_grind_advances_state_like_direct_check` — pending counts `{0, 1, 4, 7}` cover every packing geometry: witness opening a chunk, completing a chunk, opening a later chunk, and filling the whole batch (flush fires inside `observe`). Asserts full state equality (sponge state, both inner buffers, `f_buffer`, squeeze queue) against a direct `check_witness`.
- `test_grind_advances_state_like_direct_check_bn254` — pins the multi-limb squeeze extraction path (`squeeze_n > 1`) that the Goldilocks fixture cannot reach.
- Existing `grind(0)` no-op and oversized-`bits` panic tests unchanged and passing.

`cargo test -p p3-challenger` (59 passed), `cargo clippy -p p3-challenger --all-targets` (clean), `cargo fmt --check` (clean); `p3-fri`, `p3-uni-stark`, `p3-batch-stark`, `p3-whir` compile.

## Not done (deliberately)

- **Serializing challengers**: their grind is hash-bound — `CryptographicHasher` exposes no incremental API, so each candidate needs one full Keccak/Blake3 over the buffered transcript regardless; the clone is noise next to the hash. The real fix is an incremental-hash API, a separate design change.
- **Packed-lane search over `PF::Packing`**: would require adding `CryptographicPermutation<[PF::Packing; WIDTH]>` to the impl bounds — a breaking API change, and a no-op for the dominant Bn254 use case (unit packing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)