### PR TITLE
refactor: reorganize WHIR structure

### DIFF
--- a/whir/src/pcs/zk/base_case/config.rs
+++ b/whir/src/pcs/zk/base_case/config.rs
@@ -7,7 +7,7 @@ use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::pcs::zk::committer::FoldedRsCode;
-use crate::pcs::zk::config::MaskGroupShape;
+use crate::pcs::zk::mask::MaskGroupShape;
 
 /// Shared base-case protocol shape.
 #[derive(Debug, Clone)]

--- a/whir/src/pcs/zk/base_case/tests.rs
+++ b/whir/src/pcs/zk/base_case/tests.rs
@@ -24,7 +24,7 @@ use rand::{RngExt, SeedableRng};
 use super::*;
 use crate::pcs::proof::QueryOpening;
 use crate::pcs::zk::committer::FoldedRsCode;
-use crate::pcs::zk::config::{MaskCodeShape, MaskGroupShape};
+use crate::pcs::zk::mask::{MaskCodeShape, MaskGroupShape};
 use crate::pcs::zk::proof::BaseCaseZkProof;
 
 type F = BabyBear;

--- a/whir/src/pcs/zk/config.rs
+++ b/whir/src/pcs/zk/config.rs
@@ -5,13 +5,11 @@ use core::iter::once;
 use core::ops::Deref;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_dft::Radix2Dit;
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_util::log2_ceil_usize;
-use p3_zk_codes::ReedSolomonZkEncoding;
-use rand::distr::{Distribution, StandardUniform};
 use thiserror::Error;
 
+use super::mask::{MaskCodeShape, MaskGroupShape};
 use crate::parameters::{ProtocolParameters, WhirConfig, WhirConfigError};
 
 /// Reasons ZK parameters cannot extend a WHIR configuration.
@@ -63,61 +61,6 @@ pub struct ZkParameters {
     pub ell_zk: usize,
     /// Log inverse rate of the mask codewords; sets the mask code distance.
     pub mask_log_inv_rate: usize,
-}
-
-/// Shape of one small mask code: a Reed-Solomon ZK encoding over `EF`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MaskCodeShape {
-    /// Message length.
-    pub message_len: usize,
-    /// ZK randomness coefficients.
-    pub randomness_len: usize,
-    /// Codeword length (power of two).
-    pub domain_size: usize,
-}
-
-impl MaskCodeShape {
-    /// Derives the smallest power-of-two domain for the requested rate.
-    #[must_use]
-    pub const fn new(message_len: usize, randomness_len: usize, log_inv_rate: usize) -> Self {
-        let domain_size = ((message_len + randomness_len).next_power_of_two()) << log_inv_rate;
-        Self {
-            message_len,
-            randomness_len,
-            domain_size,
-        }
-    }
-
-    /// Instantiates the encoding over the extension field.
-    ///
-    /// Mask codewords are tiny, so a fresh radix-2 DIT per call is free.
-    #[must_use]
-    pub fn encoding<EF>(&self) -> ReedSolomonZkEncoding<EF, Radix2Dit<EF>>
-    where
-        EF: TwoAdicField,
-        StandardUniform: Distribution<EF>,
-    {
-        ReedSolomonZkEncoding::new(
-            self.randomness_len,
-            self.message_len,
-            self.domain_size,
-            Radix2Dit::default(),
-        )
-    }
-}
-
-/// One committed batch of same-code mask oracles.
-///
-/// - Masks committed together share an evaluation domain.
-/// - They stack into one matrix.
-/// - A single commitment and one Merkle path per opened position cover the
-///   whole group.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MaskGroupShape {
-    /// Code shared by every mask in the group.
-    pub shape: MaskCodeShape,
-    /// Number of stacked masks.
-    pub width: usize,
 }
 
 /// Fully derived HVZK-WHIR configuration.

--- a/whir/src/pcs/zk/mask.rs
+++ b/whir/src/pcs/zk/mask.rs
@@ -1,0 +1,64 @@
+//! Mask-code geometry for the HVZK-WHIR pipeline.
+//!
+//! Code shapes and committed mask groups, shared by the configuration, the
+//! verifier replay, and the base case.
+
+use p3_dft::Radix2Dit;
+use p3_field::TwoAdicField;
+use p3_zk_codes::ReedSolomonZkEncoding;
+use rand::distr::{Distribution, StandardUniform};
+
+/// Shape of one small mask code: a Reed-Solomon ZK encoding over `EF`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaskCodeShape {
+    /// Message length.
+    pub message_len: usize,
+    /// ZK randomness coefficients.
+    pub randomness_len: usize,
+    /// Codeword length (power of two).
+    pub domain_size: usize,
+}
+
+impl MaskCodeShape {
+    /// Derives the smallest power-of-two domain for the requested rate.
+    #[must_use]
+    pub const fn new(message_len: usize, randomness_len: usize, log_inv_rate: usize) -> Self {
+        let domain_size = ((message_len + randomness_len).next_power_of_two()) << log_inv_rate;
+        Self {
+            message_len,
+            randomness_len,
+            domain_size,
+        }
+    }
+
+    /// Instantiates the encoding over the extension field.
+    ///
+    /// Mask codewords are tiny, so a fresh radix-2 DIT per call is free.
+    #[must_use]
+    pub fn encoding<EF>(&self) -> ReedSolomonZkEncoding<EF, Radix2Dit<EF>>
+    where
+        EF: TwoAdicField,
+        StandardUniform: Distribution<EF>,
+    {
+        ReedSolomonZkEncoding::new(
+            self.randomness_len,
+            self.message_len,
+            self.domain_size,
+            Radix2Dit::default(),
+        )
+    }
+}
+
+/// One committed batch of same-code mask oracles.
+///
+/// - Masks committed together share an evaluation domain.
+/// - They stack into one matrix.
+/// - A single commitment and one Merkle path per opened position cover the
+///   whole group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaskGroupShape {
+    /// Code shared by every mask in the group.
+    pub shape: MaskCodeShape,
+    /// Number of stacked masks.
+    pub width: usize,
+}

--- a/whir/src/pcs/zk/mod.rs
+++ b/whir/src/pcs/zk/mod.rs
@@ -55,25 +55,30 @@
 //! - <https://eprint.iacr.org/2026/391> (HVZK-WHIR),
 //! - <https://eprint.iacr.org/2024/1586> (base WHIR).
 
-pub mod code_switch;
-
 mod adapter;
 mod base_case;
+mod code_switch;
 mod committer;
 mod config;
 mod constraint;
+mod mask;
 mod proof;
 mod prover;
 mod verifier;
 
-pub use adapter::*;
-pub use base_case::*;
+pub use adapter::HidingWhirPcs;
+pub use base_case::{
+    BaseCaseZkConfig, BaseCaseZkError, BaseCaseZkProver, BaseCaseZkVerifier, MaskGroupWitness,
+    MaskProverData,
+};
+pub use code_switch::CodeSwitchError;
 pub use committer::FoldedRsCode;
-pub use config::*;
-pub use constraint::*;
-pub use proof::*;
-pub use prover::*;
-pub use verifier::*;
+pub use config::{ZkConfigError, ZkParameters, ZkWhirConfig};
+pub use constraint::{MaskClaims, SourceClaim, SourceConstraint, SourceTerm};
+pub use mask::{MaskCodeShape, MaskGroupShape};
+pub use proof::{BaseCaseZkProof, BlindedMask, MaskOpeningPair, ZkRoundProof, ZkWhirProof};
+pub use prover::{HidingWhirProver, HidingWhirProverData};
+pub use verifier::{HidingWhirVerifier, ZkVerifierError};
 
 #[cfg(test)]
 mod tests;

--- a/whir/src/pcs/zk/verifier/masks.rs
+++ b/whir/src/pcs/zk/verifier/masks.rs
@@ -1,0 +1,85 @@
+//! Mask-claim bookkeeping for the HVZK-WHIR verifier replay.
+//!
+//! The symbolic counterpart of the prover's `ProverMasks`: the verifier
+//! reconstructs the same mask covectors, group shapes, and commitments round
+//! by round, then hands them to the base case.
+
+use alloc::vec::Vec;
+
+use p3_commit::Mmcs;
+use p3_field::{ExtensionField, Field};
+use p3_multilinear_util::point::Point;
+use p3_sumcheck::zk::mask_residual_covectors_from_shape;
+
+use crate::pcs::zk::constraint::MaskClaims;
+use crate::pcs::zk::mask::{MaskCodeShape, MaskGroupShape};
+
+/// Verifier-side mask state carried to the base case.
+///
+/// One covector, group shape, and commitment per mask oracle, in commit order.
+pub(super) struct VerifierMasks<F, EF, MT>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    MT: Mmcs<F>,
+{
+    /// Dense covectors with their accumulated scales.
+    pub(super) claims: MaskClaims<EF>,
+    /// Group widths and codes, in commit order.
+    pub(super) groups: Vec<MaskGroupShape>,
+    /// One commitment per mask group, matching `groups`.
+    pub(super) commitments: Vec<MT::Commitment>,
+}
+
+impl<F, EF, MT> VerifierMasks<F, EF, MT>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    MT: Mmcs<F>,
+{
+    pub(super) const fn new() -> Self {
+        Self {
+            claims: MaskClaims::new(),
+            groups: Vec::new(),
+            commitments: Vec::new(),
+        }
+    }
+
+    /// Records one masked sumcheck batch.
+    ///
+    /// The carried covectors absorb `eps * 2^{-k}`; the batch's `k` fresh
+    /// sumcheck masks enter at scale one as power covectors of the round
+    /// randomness.
+    pub(super) fn record_sumcheck_batch(
+        &mut self,
+        eps: EF,
+        folding: usize,
+        ell_zk: usize,
+        randomness: &Point<EF>,
+        shape: MaskCodeShape,
+        commitment: MT::Commitment,
+    ) {
+        self.claims.absorb_sumcheck(eps, folding);
+        let gammas: Vec<EF> = randomness.iter().copied().collect();
+        for covector in mask_residual_covectors_from_shape(folding, ell_zk, &gammas) {
+            self.claims.push(covector);
+        }
+        self.groups.push(MaskGroupShape {
+            shape,
+            width: folding,
+        });
+        self.commitments.push(commitment);
+    }
+
+    /// Records one code-switch round's fresh mask as a width-one group.
+    pub(super) fn push_switch_mask(
+        &mut self,
+        covector: Vec<EF>,
+        shape: MaskCodeShape,
+        commitment: MT::Commitment,
+    ) {
+        self.claims.push(covector);
+        self.groups.push(MaskGroupShape { shape, width: 1 });
+        self.commitments.push(commitment);
+    }
+}

--- a/whir/src/pcs/zk/verifier/mod.rs
+++ b/whir/src/pcs/zk/verifier/mod.rs
@@ -6,10 +6,13 @@
 //!
 //! The carried claim is tracked symbolically throughout.
 
+mod masks;
+
 use alloc::vec;
 use alloc::vec::Vec;
 use core::slice::from_ref;
 
+use masks::VerifierMasks;
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, TwoAdicField};
@@ -17,14 +20,14 @@ use p3_matrix::Dimensions;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::SumcheckError;
-use p3_sumcheck::zk::{ZkVerifier, mask_residual_covectors_from_shape};
+use p3_sumcheck::zk::ZkVerifier;
 use thiserror::Error;
 use tracing::instrument;
 
 use super::base_case::{BaseCaseZkConfig, BaseCaseZkError, BaseCaseZkVerifier};
 use super::code_switch::{CodeSwitchError, ZkMaskClaim, switch_mask_covector};
-use super::config::{MaskGroupShape, ZkWhirConfig};
-use super::constraint::{MaskClaims, SourceClaim};
+use super::config::ZkWhirConfig;
+use super::constraint::SourceClaim;
 use super::proof::ZkWhirProof;
 use crate::pcs::proof::QueryOpening;
 use crate::pcs::utils::get_challenge_stir_queries;
@@ -191,9 +194,7 @@ where
             source.push_eq(point.clone(), coeff);
             target += coeff * *eval;
         }
-        let mut masks = MaskClaims::new();
-        let mut mask_groups: Vec<MaskGroupShape> = Vec::new();
-        let mut mask_commitments: Vec<MT::Commitment> = Vec::new();
+        let mut masks = VerifierMasks::new();
 
         // Initial masked sumcheck batch.
         let mut randomness = self.replay_sumcheck_batch(
@@ -204,8 +205,6 @@ where
             &mut target,
             &mut source,
             &mut masks,
-            &mut mask_groups,
-            &mut mask_commitments,
             challenger,
         )?;
 
@@ -306,20 +305,19 @@ where
 
             // Mask side: the fresh code-switch mask enters the relation as
             // its own width-one group.
-            masks.push(switch_mask_covector(
-                1 << num_variables,
-                config.oracle_randomness[round],
-                round_params.ood_samples,
-                &rho_points,
-                ood_coeffs,
-                &query_points,
-                query_coeffs,
-            ));
-            mask_groups.push(MaskGroupShape {
-                shape: config.switch_masks[round],
-                width: 1,
-            });
-            mask_commitments.push(mask_commitment.clone());
+            masks.push_switch_mask(
+                switch_mask_covector(
+                    1 << num_variables,
+                    config.oracle_randomness[round],
+                    round_params.ood_samples,
+                    &rho_points,
+                    ood_coeffs,
+                    &query_points,
+                    query_coeffs,
+                ),
+                config.switch_masks[round],
+                mask_commitment.clone(),
+            );
 
             // Next masked sumcheck batch over the new oracle.
             randomness = self.replay_sumcheck_batch(
@@ -330,8 +328,6 @@ where
                 &mut target,
                 &mut source,
                 &mut masks,
-                &mut mask_groups,
-                &mut mask_commitments,
                 challenger,
             )?;
 
@@ -348,7 +344,7 @@ where
         );
         let base_config = BaseCaseZkConfig {
             code: source_code,
-            mask_groups,
+            mask_groups: masks.groups,
             num_queries: config.final_queries,
             mask_queries: config.mask_queries,
             pow_bits: config.final_pow_bits,
@@ -366,8 +362,8 @@ where
         base_verifier.verify(
             &proof.base_case,
             source_covector.as_slice(),
-            &masks.covectors,
-            &mask_commitments,
+            &masks.claims.covectors,
+            &masks.commitments,
             target,
             |position, opening| {
                 self.verify_and_fold_leaf(&active, &dims, position, opening, n_rounds, &randomness)
@@ -391,9 +387,7 @@ where
         pow_bits: usize,
         target: &mut EF,
         source: &mut SourceClaim<EF>,
-        masks: &mut MaskClaims<EF>,
-        mask_groups: &mut Vec<MaskGroupShape>,
-        mask_commitments: &mut Vec<MT::Commitment>,
+        masks: &mut VerifierMasks<F, EF, MT>,
         challenger: &mut Challenger,
     ) -> Result<Point<EF>, ZkVerifierError> {
         let ell_zk = self.config.zk.ell_zk;
@@ -409,24 +403,20 @@ where
         )?;
 
         // Source constraints fold, then absorb the combining challenge.
-        //
-        //     source covectors        ->  scale eps
-        //     carried mask covectors  ->  scale eps * 2^{-k}
-        //     fresh sumcheck masks    ->  scale one
         source.fold(&handoff.randomness);
         for constraint in &mut source.constraints {
             constraint.coeff *= handoff.eps;
         }
-        masks.absorb_sumcheck(handoff.eps, folding);
-        let gammas: Vec<EF> = handoff.randomness.iter().copied().collect();
-        for covector in mask_residual_covectors_from_shape(folding, ell_zk, &gammas) {
-            masks.push(covector);
-        }
-        mask_groups.push(MaskGroupShape {
-            shape: self.config.sumcheck_mask,
-            width: folding,
-        });
-        mask_commitments.push(commitment.clone());
+        // Mask side: carried covectors absorb eps * 2^{-k}, the batch's fresh
+        // sumcheck masks enter at scale one.
+        masks.record_sumcheck_batch(
+            handoff.eps,
+            folding,
+            ell_zk,
+            &handoff.randomness,
+            self.config.sumcheck_mask,
+            commitment.clone(),
+        );
 
         *target = handoff.claimed_residual;
         Ok(handoff.randomness)


### PR DESCRIPTION
Light reorganization around the WHIR crate mostly out of clarity (no functional change):

- mimic prover layout for the verifier one (split into a module for clarity)
- group masking logic into a dedicated module
- reduced code_switch visibility