### PR TITLE
chore: update CHANGELOGs

### DIFF
--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Air: document virtual pair column composition patterns (#1419)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf(monty-31/neon): specialized exp_4 skipping intermediate reduction (#1558)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Fix(batch-stark): correct misleading degree_bits documentation (#1437)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf(batch-stark): avoid cloning generated_perm (#1473)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf(circle): drop vp_denoms after batch inversion (#1502)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf(dft): butterfly micro-optimizations for Radix2DitParallel (~3% on coset_lde_batch) (#1492)
+- Fix(dft): merge twiddle and inv_twiddle locks in Radix2DFTSmallBatch (#1534)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf: faster `GoldilocksPackedNeon` field operations (#1515)
+- Perf: halve goldilocks optimizations (#1606)
+- Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Field: reinforcement of tests with edge cases and proptests (#1435)
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix overflow dot_product_5 neon (#1429)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Field: add missing extension degree for `packed_mod_add` and `packed_mod_sub` (#1421)
+- Core: couple more compile time assertions (#1525)
+- Field: specialize packed mixed_dot_product by chunk strategy (#1573)
+- Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf: faster `GoldilocksPackedNeon` field operations (#1515)
+- Field: specialize packed mixed_dot_product by chunk strategy (#1573)
+- Fix: proper reduction in goldilocks NEON add computation (#1580)
+- Fix(goldilocks): canonicalize sub_asm and harden NEON ASM tests (#1591)
+- Perf: halve goldilocks optimizations (#1606)
+- Perf: use Neon Goldilocks only for hash operations (#1517)
+- Perf(goldilocks): scalar add/sub for PackedGoldilocksNeon (#1619)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix div2_asm goldilocks neon (#1430)

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -18,10 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2025-12-12
 ### Merged PRs
+- Field.rs: `Powers::packed_collect_n` (#888) (Adrian Hamelink)
 - Chore: add descriptions to all sub-crate manifests (#906) (Himess)
+- Chore: use `collect_n` with powers when possible (#963) (Thomas Coratger)
+- Refactor: remove redundant clones in crypto modules (#1086) (Skylar Ray)
 - Clippy: small step (#1102) (Thomas Coratger)
 
 ### Authors
+- Adrian Hamelink
 - Himess
+- Skylar Ray
 - Thomas Coratger
 

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Perf: use Neon Goldilocks only for hash operations (#1517)
+- Perf(goldilocks): scalar add/sub for PackedGoldilocksNeon (#1619)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+- Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Fix overflow dot_product_5 neon (#1429)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Logup: better memory allocation (#1455)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Mds: small improvements and more testing (#1459)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Field: specialize packed mixed_dot_product by chunk strategy (#1573)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Mds: small improvements and more testing (#1459)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ## [0.4.2] - 2026-01-05

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Monty-31: improve `monty_reduce_u128` speed (#1483)
+- Fix compilation on aarch64 without neon (RUSTFLAGS="-C target-feature=-neon" cargo check) (#1514)
+- Core: couple more compile time assertions (#1525)
+- Perf(monty-31/neon): specialized exp_4 skipping intermediate reduction (#1558)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Poseidon1: speedup monty-31 packed version on avx (#1420)
+- Monty31: use transmute in poseidon1 packing (#1446)
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Monty31: faster aarch64 neon `quintic_mul_packed` (#1422)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Perf: abstract away Copy vs Clone (#1463)
+
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+### Merged PRs
+- Core: couple more compile time assertions (#1525)
+- Add carry-critical NEON dot product regression tests (#1600)
+
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
+### Merged PRs
+- Make batched_linear_combination chunk size per-impl tunable (#1451)
+- Uni stark: rm useless `check_constraints.rs` file (#1471)
+
 ## [0.5.1] - 2026-03-16
 ### Merged PRs
 - Clarify selector semantics (#1412)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.3] - 2026-05-15
+## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16
 ## [0.5.0] - 2026-03-10
 ### Merged PRs


### PR DESCRIPTION
Just fetch updated CHANGELOG files from the v0.5.3 release into `main`.