### PR TITLE
fix(batch-stark): reject out-of-domain point inside the trace domain

### DIFF
--- a/batch-stark/src/verifier/data.rs
+++ b/batch-stark/src/verifier/data.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use p3_air::{Air, RowWindow};
 use p3_commit::PolynomialSpace;
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::{Lookup, LookupProtocol};
 use p3_matrix::dense::RowMajorMatrixView;
@@ -58,6 +58,17 @@ impl<'a, SC: SGC> VerifierData<'a, SC> {
     where
         A: for<'b> Air<VerifierConstraintFolderWithLookups<'b, SC>>,
     {
+        // The constraint check below divides by the vanishing polynomial of this trace domain.
+        // Reject any zeta on the domain, where that polynomial is zero and `inv_vanishing` panics.
+        // Honest Fiat-Shamir sampling reaches this only with probability |H| / |EF|.
+        if self
+            .trace_domain
+            .vanishing_poly_at_point(self.zeta)
+            .is_zero()
+        {
+            return Err(VerificationError::OodPointInDomain);
+        }
+
         let sels = self.trace_domain.selectors_at_point(self.zeta);
 
         let main = VerticalPair::new(
@@ -102,5 +113,118 @@ impl<'a, SC: SGC> VerifierData<'a, SC> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_air::{Air, AirBuilder, BaseAir};
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
+    use p3_commit::{ExtensionMmcs, Pcs};
+    use p3_dft::Radix2DitParallel;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_fri::{FriParameters, TwoAdicFriPcs};
+    use p3_lookup::logup::LogUpGadget;
+    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use p3_uni_stark::StarkConfig;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::*;
+
+    // Standard two-adic test stack: BabyBear + Poseidon2 + FRI.
+    type TestVal = BabyBear;
+    type TestChallenge = BinomialExtensionField<TestVal, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type ValMmcs = MerkleTreeMmcs<
+        <TestVal as Field>::Packing,
+        <TestVal as Field>::Packing,
+        MyHash,
+        MyCompress,
+        2,
+        8,
+    >;
+    type ChallengeMmcs = ExtensionMmcs<TestVal, TestChallenge, ValMmcs>;
+    type Challenger = DuplexChallenger<TestVal, Perm, 16, 8>;
+    type Dft = Radix2DitParallel<TestVal>;
+    type MyPcs = TwoAdicFriPcs<TestVal, Dft, ValMmcs, ChallengeMmcs>;
+    type MyConfig = StarkConfig<MyPcs, TestChallenge, Challenger>;
+
+    fn make_config() -> MyConfig {
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+        let val_mmcs = ValMmcs::new(hash, compress, 0);
+        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+        let dft = Dft::default();
+        let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
+        let pcs = MyPcs::new(dft, val_mmcs, fri_params);
+        let challenger = Challenger::new(perm);
+        StarkConfig::new(pcs, challenger)
+    }
+
+    // No columns, no constraints.
+    // Only present to satisfy the generic bound; the guard returns before it is evaluated.
+    struct EmptyAir;
+
+    impl<F> BaseAir<F> for EmptyAir {
+        fn width(&self) -> usize {
+            0
+        }
+    }
+
+    impl<AB: AirBuilder> Air<AB> for EmptyAir {
+        fn eval(&self, _builder: &mut AB) {}
+    }
+
+    #[test]
+    fn ood_point_inside_trace_domain_is_rejected_not_panicked() {
+        let config = make_config();
+
+        // A size-8 trace domain `gH`.
+        let domain =
+            <MyPcs as Pcs<TestChallenge, Challenger>>::natural_domain_for_degree(config.pcs(), 8);
+
+        // `first_point()` is the coset shift `g`, which lies in `gH`.
+        //
+        //     Z_H(g) = (g^{-1} g)^|H| - 1 = 1 - 1 = 0
+        //
+        // so the selector inverse `1/Z_H` would panic.
+        let zeta = TestChallenge::from(domain.first_point());
+
+        // Every trace slice is empty; the guard fires before any of them is read.
+        let verifier_data = VerifierData::<MyConfig> {
+            zeta,
+            alpha: TestChallenge::ZERO,
+            trace_local: &[],
+            trace_next: &[],
+            preprocessed_local: &[],
+            preprocessed_next: &[],
+            permutation_local: &[],
+            permutation_next: &[],
+            permutation_challenges: &[],
+            permutation_values: &[],
+            periodic_values: &[],
+            lookups: &[],
+            public_values: &[],
+            trace_domain: domain,
+            quotient: TestChallenge::ZERO,
+        };
+
+        let result = verifier_data.verify_constraints_with_lookups::<EmptyAir, LogUpGadget, ()>(
+            &EmptyAir,
+            &LogUpGadget::new(),
+        );
+
+        // The domain-coincident point is rejected with a clean error, not a panic.
+        assert!(
+            matches!(result, Err(VerificationError::OodPointInDomain)),
+            "expected OodPointInDomain, got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The batch-STARK verifier evaluates Lagrange selectors at the Fiat–Shamir point `zeta` via `Domain::selectors_at_point`, which computes `1 / Z_H(zeta)`. When `zeta` lands **inside** the trace domain, `Z_H(zeta) = 0` and the field inverse panics (`"Tried to invert zero"`), aborting the verifier rather than returning a clean error.

The uni-STARK verifier already guards this (`uni-stark/src/verifier.rs`, returning `VerificationError::OodPointInDomain`); the batch verifier did not — a parity gap.

## Fix

Add the guard at the start of `VerifierData::verify_constraints_with_lookups`, before any selector inversion, so **every** instance is protected at the exact site that divides by `Z_H(zeta)`:

```rust
if self.trace_domain.vanishing_poly_at_point(self.zeta).is_zero() {
    return Err(VerificationError::OodPointInDomain);
}
```

- No new error variant: `OodPointInDomain` already exists on the shared `p3_uni_stark::VerificationError` (auto-converted via `BatchVerificationError`'s `#[from]`).
- No visibility changes: `VerifierData`'s fields stay `pub(crate)`.

## Severity

Honest Fiat–Shamir sampling reaches this only with probability `|H| / |EF|`, and the failure mode is a panic (the verifier *rejects*, never accepts a bad proof). So this is a **verifier-robustness fix** (DoS-by-panic on a malformed/adversarial proof) that brings batch-STARK to parity with uni-STARK — not a soundness change.

## Test

`zeta` is Fiat–Shamir-derived and cannot be steered into the trace domain through the public `verify_batch` API, so the test lives in-crate next to the guard (where `VerifierData`'s `pub(crate)` fields are accessible). It builds a `VerifierData` with `zeta = domain.first_point()` (a domain point, so `Z_H(zeta) = 0`) and asserts a clean `OodPointInDomain` instead of the previous panic.

- `cargo test -p p3-batch-stark` — green
- `cargo clippy -p p3-batch-stark --all-targets` — clean
- `cargo fmt -p p3-batch-stark --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
