### PR TITLE
fix(circle): reject proofs that under-report commit rounds

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -423,6 +423,34 @@ where
         let log_global_max_height =
             proof.fri_proof.commit_phase_commits.len() + self.fri_params.log_blowup + 1;
 
+        // Guard the query-phase height subtraction against an under-reported round count.
+        //
+        // Invariant: the proof's global height covers every claimed matrix.
+        //
+        //     H_proof = commit-phase round count + log_blowup + 1   (first-layer fold)
+        //     H_claim = max committed log_n + log_blowup
+        //
+        // The query phase computes `index >> (log_global_max_height - log_height)`.
+        //   - `log_height <= H_claim` holds for every matrix
+        //   - `H_proof < H_claim` makes that usize subtraction underflow and the shift wrap
+        // Over-reporting is caught downstream (two-adicity bound, Merkle openings), so the
+        // under-report is the only case to reject here.
+        let expected_log_global_max_height = rounds
+            .iter()
+            .flat_map(|(_, mats)| {
+                mats.iter()
+                    .map(|(domain, _)| domain.log_n + self.fri_params.log_blowup)
+            })
+            .max();
+        if let Some(expected) = expected_log_global_max_height
+            && log_global_max_height < expected
+        {
+            return Err(FriError::GlobalMaxHeightMismatch {
+                expected,
+                got: log_global_max_height,
+            });
+        }
+
         let folding: CircleFriFoldingForMmcs<Val, Challenge, InputMmcs, FriMmcs> =
             CircleFriFolding(PhantomData);
 
@@ -832,6 +860,43 @@ mod tests {
         };
         assert_eq!(expected, num_rounds);
         assert_eq!(got, num_rounds - 1);
+    }
+
+    #[test]
+    fn reject_under_reported_commit_rounds() {
+        // Invariant: the reported commit-round count must cover the claimed matrix height.
+        //   - log_global_max_height is derived from the proof's round count
+        //   - under-reporting drives it below a matrix's log_height
+        //   - then `index >> (log_global_max_height - log_height)` would underflow
+        // The verifier must reject before that subtraction runs.
+        let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
+
+        // On an honest proof the two height derivations coincide:
+        //
+        //     H_claim = log_n + log_blowup                            (claimed matrix)
+        //     H_proof = commit_phase_commits.len() + log_blowup + 1   (first-layer fold)
+        let log_blowup = pcs.fri_params.log_blowup;
+        let expected = d.log_n + log_blowup;
+        let original = proof.fri_proof.commit_phase_commits.len() + log_blowup + 1;
+        assert_eq!(original, expected, "fixture must start height-consistent");
+
+        // Mutation: drop one commit-phase commitment so the round count falls short.
+        //
+        //     before: commit_phase_commits = [c_0, ..., c_{n-1}]   → H_proof = expected
+        //     after:  commit_phase_commits = [c_0, ..., c_{n-2}]   → H_proof = expected - 1
+        //     → H_proof < H_claim → GlobalMaxHeightMismatch (no underflow)
+        proof.fri_proof.commit_phase_commits.pop();
+
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("expected GlobalMaxHeightMismatch");
+
+        let FriError::GlobalMaxHeightMismatch { expected: exp, got } = err else {
+            panic!("expected GlobalMaxHeightMismatch, got {err:?}");
+        };
+        // The verifier wants the height the claimed matrix demands.
+        assert_eq!(exp, expected);
+        // The proof under-reports by exactly the one round we removed.
+        assert_eq!(got, expected - 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Circle PCS verifier (`CirclePcs::verify`) derives `log_global_max_height` from **attacker-controlled** proof data:

```rust
let log_global_max_height =
    proof.fri_proof.commit_phase_commits.len() + self.fri_params.log_blowup + 1;
```

It then subtracts it from matrix log-heights taken from the *claimed* domains, at three query-phase sites (`circle/src/pcs.rs:482,497,539`):

```rust
index >> (log_global_max_height - log_batch_max_height)   // 482
let bits_reduced = log_global_max_height - log_height;     // 497, 539
```

A proof that **under-reports** its commit-round count drives `log_global_max_height` below a claimed matrix's `log_height`, so the `usize` subtraction underflows — a panic in debug builds, a wrapped (huge) shift amount in release.

## Fix

Add a single guard right after `log_global_max_height` is computed (before any query index is sampled), modeled on the sibling two-adic verifier's `GlobalMaxHeightMismatch` cross-check (`fri/src/verifier.rs`). It rejects when the reported global height fails to cover the tallest claimed matrix:

```rust
let expected_log_global_max_height = rounds
    .iter()
    .flat_map(|(_, mats)| mats.iter().map(|(domain, _)| domain.log_n + self.fri_params.log_blowup))
    .max();
if let Some(expected) = expected_log_global_max_height
    && log_global_max_height < expected
{
    return Err(FriError::GlobalMaxHeightMismatch { expected, got: log_global_max_height });
}
```

### Why `<` and not `!=`

`verify_fri` uses strict equality, but Circle already guards **over**-reporting downstream: the two-adicity bound (`GlobalMaxHeightTooLarge`) and the Merkle openings (which can't be forged) reject an inflated round count. Using `!=` here would intercept over-reporting too, making `GlobalMaxHeightTooLarge` unreachable at the PCS layer and removing the existing `reject_global_max_height_too_large` coverage. The `<` guard is surgical — it fixes the reported underflow and is purely additive; no existing behavior or test changes.

## Testing

- New `reject_under_reported_commit_rounds`: drops one commit-phase commitment and asserts `GlobalMaxHeightMismatch { expected, got: expected - 1 }` (previously a debug underflow panic).
- `cargo test -p p3-circle --lib` → 31 passed, 0 failed (existing `reject_global_max_height_too_large` still passes, confirming over-reporting still routes to its original guard).
- `cargo +nightly fmt` and `cargo clippy -p p3-circle --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)