### PR TITLE
fix(fri): reject input matrices opened at zero points

### DIFF
--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -90,6 +90,10 @@ where
         got: usize,
     },
     #[error(
+        "batch {batch}, matrix {matrix}: opened at no points; its width cannot be authenticated"
+    )]
+    MatrixWithoutOpeningPoints { batch: usize, matrix: usize },
+    #[error(
         "batch {batch}, matrix {matrix}, point {point}: evaluation count mismatch: expected {expected}, got {got}"
     )]
     PointEvaluationCountMismatch {
@@ -658,20 +662,24 @@ where
         let batch_dims = batch_heights
             .iter()
             .zip(mats)
-            .zip(&batch_opening.opened_values)
-            .map(
-                |((&height, (_, points_and_values)), opened_row)| Dimensions {
-                    // Invariant: the commitment layer rejects opened rows that differ from this width.
-                    //
-                    //     some points → width = claimed evaluation count
-                    //     no points   → width = opened row length (no claim to enforce)
-                    width: points_and_values
-                        .first()
-                        .map_or(opened_row.len(), |(_, values)| values.len()),
+            .enumerate()
+            .map(|(matrix, (&height, (_, points_and_values)))| {
+                // Pin each matrix width to its claimed evaluation count, never to the proof.
+                //
+                // Why: the leaf hash flattens all same-height rows into one stream.
+                //   - `check_widths` (in the MMCS) is the only authenticator of row boundaries
+                //   - a matrix opened at no points carries no claim to pin its width
+                //   - reading the width from the proof-supplied row leaves that boundary unchecked
+                // Every input matrix is opened at >= 1 point, so reject the degenerate case.
+                let (_, values) = points_and_values
+                    .first()
+                    .ok_or(FriError::MatrixWithoutOpeningPoints { batch, matrix })?;
+                Ok(Dimensions {
+                    width: values.len(),
                     height,
-                },
-            )
-            .collect_vec();
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         // If the maximum height of the batch is smaller than the global max height,
         // we need to correct the index by right shifting it.
@@ -1020,6 +1028,41 @@ mod tests {
                 assert_eq!(query, 0);
                 assert_eq!(expected, expected_rounds);
                 assert_eq!(got, expected_rounds + 1);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matrix_without_opening_points() {
+        let f = make_test_fixture();
+
+        // A matrix's width feeds the authenticated MMCS dimensions. With opening
+        // points it is pinned to the claimed evaluation count; with none it could
+        // only be read back from the proof, so the verifier must reject instead.
+        //
+        // Mutation: strip the sole matrix's opening points, leaving it in the batch.
+        //
+        //     before: mats[0] points = [(zeta, values)]   → width pinned by claim
+        //     after:  mats[0] points = []                 → no claim → reject
+        let mut cwop = f.commitments_with_opening_points.clone();
+        cwop[0].1[0].1 = vec![];
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &f.proof,
+            &mut challenger,
+            &cwop,
+            &f.input_mmcs,
+        )
+        .expect_err("should reject a matrix opened at zero points");
+
+        match err {
+            FriError::MatrixWithoutOpeningPoints { batch, matrix } => {
+                // The lone batch holds the lone matrix.
+                assert_eq!(batch, 0);
+                assert_eq!(matrix, 0);
             }
             other => panic!("wrong error variant: {other:?}"),
         }


### PR DESCRIPTION
## Summary

In `open_input` (`fri/src/verifier.rs`), each input matrix's `width` — used in the `Dimensions` passed to the authenticated MMCS `verify_batch` — was derived as:

```rust
width: points_and_values
    .first()
    .map_or(opened_row.len(), |(_, values)| values.len()),
```

- **with opening points:** width = claimed evaluation count (trusted statement) ✅
- **with no opening points:** width = `opened_row.len()` — i.e. taken from the **proof** ❌

That width is the *only* thing `check_widths` (merkle-tree MMCS) uses to authenticate row boundaries: the leaf hash flattens all same-height rows into one stream, so `check_widths` is what separates one matrix row from the next. Taking the width from the proof makes that check vacuous (`row.len() == row.len()`), leaving the boundary of a no-points matrix unauthenticated.

This is the residual gap left by #1757 (which replaced the old `width: 0` with the claim-derived width but kept the proof fallback for the no-points case).

## Fix

Every input matrix is opened at **≥ 1 point** across all current callers — verified across `uni-stark`, `batch-stark`, `lookup`, and `circle` (no caller ever passes an empty per-matrix points list; the only "empty" case is omitting a matrix entirely). So the fallback served no real path.

Reject the degenerate case with a new `FriError::MatrixWithoutOpeningPoints { batch, matrix }`, which makes the width **always** come from the claimed evaluation count — never the proof. A no-points matrix is also dead weight (it contributes nothing to the reduced opening), so rejecting it loses nothing.

## Testing

- New `matrix_without_opening_points`: strips the fixture matrix's opening points and asserts `MatrixWithoutOpeningPoints { batch: 0, matrix: 0 }`.
- `cargo test -p p3-fri --lib` → 33 passed (incl. existing `claimed_width_mismatch_rejected_by_input_mmcs`, confirming with-points pinning is unchanged).
- `cargo test -p p3-uni-stark --lib` → 19 passed (downstream consumer of this shared code path: no regression).
- `cargo +nightly fmt` and `cargo clippy -p p3-fri --all-targets` clean.

Note: the Circle PCS has the same `map_or(opened_row.len(), …)` construct (`circle/src/pcs.rs`); this PR scopes to the reported FRI location, but the parallel fix there is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)