### PR TITLE
perf(circle): batch and parallelize the PCS open phase

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -115,19 +115,29 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
     }
 
     pub fn evaluate_at_point<EF: ExtensionField<F>>(&self, point: Point<EF>) -> Vec<EF> {
-        // Compute z_H
-        let lagrange_num = self.domain.vanishing_poly(point);
-
         // Permute the domain to get it into the right format.
         let permuted_points = cfft_permute_slice(&self.domain.points().collect_vec());
 
         // Compute the lagrange denominators. This is batched as it lets us make use of batched_multiplicative_inverse.
         let lagrange_den = compute_lagrange_den_batched(&permuted_points, point, self.domain.log_n);
 
+        self.evaluate_at_point_with_den(point, &lagrange_den)
+    }
+
+    /// Evaluate at `point` given precomputed Lagrange denominators for `(self.domain, point)`,
+    /// as produced by [`compute_lagrange_den_batched`] on the CFFT-ordered domain points.
+    pub(crate) fn evaluate_at_point_with_den<EF: ExtensionField<F>>(
+        &self,
+        point: Point<EF>,
+        lagrange_den: &[EF],
+    ) -> Vec<EF> {
+        // Compute z_H
+        let lagrange_num = self.domain.vanishing_poly(point);
+
         // The columnwise_dot_product here consumes about 5% of the runtime for example prove_poseidon2_m31_keccak.
         // Definitely something worth optimising further.
         self.values
-            .columnwise_dot_product(&lagrange_den)
+            .columnwise_dot_product(lagrange_den)
             .into_iter()
             .map(|x| x * lagrange_num)
             .collect_vec()

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -2,11 +2,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-use itertools::{Itertools, iterate};
+use itertools::{Itertools, iterate, izip};
 use p3_commit::PolynomialSpace;
 use p3_dft::{Butterfly, DifButterfly, DitButterfly, divide_by_height};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field, batch_multiplicative_inverse};
+use p3_field::{ExtensionField, Field, FieldArray, batch_multiplicative_inverse};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -141,6 +141,31 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             .into_iter()
             .map(|x| x * lagrange_num)
             .collect_vec()
+    }
+
+    /// Evaluate at two points in a single pass over the matrix, given precomputed Lagrange
+    /// denominators for each point.
+    ///
+    /// Equivalent to two [`Self::evaluate_at_point_with_den`] calls, but each matrix row is
+    /// only loaded once.
+    pub(crate) fn evaluate_at_two_points_with_dens<EF: ExtensionField<F>>(
+        &self,
+        points: [Point<EF>; 2],
+        dens: [&[EF]; 2],
+    ) -> [Vec<EF>; 2] {
+        let lagrange_nums = points.map(|point| self.domain.vanishing_poly(point));
+
+        let interleaved_dens = izip!(dens[0], dens[1])
+            .map(|(&den_0, &den_1)| FieldArray([den_0, den_1]))
+            .collect_vec();
+
+        let (ps_at_point_0, ps_at_point_1) = self
+            .values
+            .columnwise_dot_product_batched::<EF, 2>(&interleaved_dens)
+            .into_iter()
+            .map(|FieldArray([dot_0, dot_1])| (dot_0 * lagrange_nums[0], dot_1 * lagrange_nums[1]))
+            .unzip();
+        [ps_at_point_0, ps_at_point_1]
     }
 
     #[cfg(test)]

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -173,52 +173,6 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             .rowwise_packed_dot_product::<EF>(&packed_alpha_powers)
             .collect()
     }
-
-    /// Compute DEEP quotients for all rows in the matrix efficiently using batch operations.
-    ///
-    /// This is an optimized version of `deep_quotient_reduce_row` that processes the entire
-    /// matrix at once.
-    ///
-    /// # Mathematical Background
-    ///
-    /// For each row `i` in the matrix, this computes:
-    /// `DEEP_quotient[i] = (f(x[i]) - f(zeta)) / (x[i] - zeta)`
-    ///
-    /// # Parameters
-    ///
-    /// - `alpha`: The random challenge scalar
-    /// - `zeta`: The random challenge point (outside the original domain)
-    /// - `ps_at_zeta`: Polynomial evaluations at challenge point `zeta`
-    ///
-    /// # Returns
-    ///
-    /// A vector of DEEP quotient values, one for each row in the matrix.
-    #[cfg(test)]
-    pub(crate) fn deep_quotient_reduce<EF: ExtensionField<F>>(
-        &self,
-        alpha: EF,
-        zeta: Point<EF>,
-        ps_at_zeta: &[EF],
-    ) -> Vec<EF> {
-        let points = cfft_permute_slice(&self.domain.points().collect_vec());
-        let vp = compute_vanishing_parts(&points, zeta);
-        let reduced_rows = self.rowwise_alpha_reduce(alpha);
-
-        let alpha_pow_width = alpha.exp_u64(self.values.width() as u64);
-        // sum_j(alpha^j * p_j[zeta]), the same for all rows.
-        let reduced_ps_at_zeta: EF = dot_product(alpha.powers(), ps_at_zeta.iter().copied());
-
-        let mut ro = EF::zero_vec(reduced_rows.len());
-        accumulate_deep_quotient(
-            &mut ro,
-            EF::ONE,
-            alpha_pow_width,
-            &reduced_rows,
-            &vp,
-            reduced_ps_at_zeta,
-        );
-        ro
-    }
 }
 
 /// Extract and remove the vanishing polynomial component from LDE evaluations.
@@ -293,6 +247,53 @@ mod tests {
 
     type F = Mersenne31;
     type EF = BinomialExtensionField<F, 3>;
+
+    impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
+        /// Compute DEEP quotients for all rows in the matrix efficiently using batch operations.
+        ///
+        /// This is an optimized version of `deep_quotient_reduce_row` that processes the entire
+        /// matrix at once.
+        ///
+        /// # Mathematical Background
+        ///
+        /// For each row `i` in the matrix, this computes:
+        /// `DEEP_quotient[i] = (f(x[i]) - f(zeta)) / (x[i] - zeta)`
+        ///
+        /// # Parameters
+        ///
+        /// - `alpha`: The random challenge scalar
+        /// - `zeta`: The random challenge point (outside the original domain)
+        /// - `ps_at_zeta`: Polynomial evaluations at challenge point `zeta`
+        ///
+        /// # Returns
+        ///
+        /// A vector of DEEP quotient values, one for each row in the matrix.
+        pub(crate) fn deep_quotient_reduce<EF: ExtensionField<F>>(
+            &self,
+            alpha: EF,
+            zeta: Point<EF>,
+            ps_at_zeta: &[EF],
+        ) -> Vec<EF> {
+            let points = cfft_permute_slice(&self.domain.points().collect_vec());
+            let vp = compute_vanishing_parts(&points, zeta);
+            let reduced_rows = self.rowwise_alpha_reduce(alpha);
+
+            let alpha_pow_width = alpha.exp_u64(self.values.width() as u64);
+            // sum_j(alpha^j * p_j[zeta]), the same for all rows.
+            let reduced_ps_at_zeta: EF = dot_product(alpha.powers(), ps_at_zeta.iter().copied());
+
+            let mut ro = EF::zero_vec(reduced_rows.len());
+            accumulate_deep_quotient(
+                &mut ro,
+                EF::ONE,
+                alpha_pow_width,
+                &reduced_rows,
+                &vp,
+                reduced_ps_at_zeta,
+            );
+            ro
+        }
+    }
 
     #[test]
     fn reduce_row_same_as_reduce_matrix() {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -7,7 +7,9 @@ use alloc::vec::Vec;
 
 use itertools::{Itertools, izip};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, PackedFieldExtension, batch_multiplicative_inverse, dot_product};
+use p3_field::{
+    ExtensionField, Field, PackedFieldExtension, batch_multiplicative_inverse, dot_product,
+};
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
@@ -100,7 +102,78 @@ pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<
     (vp_num / vp_denom) * constraint_part
 }
 
+/// The point-dependent part of the DEEP quotient on a fixed domain.
+///
+/// Holds `v_p(zeta) = re + im * i` for every domain point, along with the inverse of the
+/// squared magnitude `|v_p(zeta)|^2`. These depend only on `(domain, zeta)`, so they are
+/// shared by every matrix opened at `zeta` on that domain.
+pub(crate) struct VanishingParts<EF> {
+    re: Vec<EF>,
+    im: Vec<EF>,
+    denom_inv: Vec<EF>,
+}
+
+/// Compute the [`VanishingParts`] of the DEEP quotient at `zeta` for the given domain points.
+///
+/// `points` must be the domain points in CFFT order.
+#[instrument(skip_all, fields(n = points.len()))]
+pub(crate) fn compute_vanishing_parts<F: ComplexExtendable, EF: ExtensionField<F>>(
+    points: &[Point<F>],
+    zeta: Point<EF>,
+) -> VanishingParts<EF> {
+    let (re, im): (Vec<_>, Vec<_>) = points.par_iter().map(|&x| x.v_p(zeta)).unzip();
+    let denoms = re
+        .par_iter()
+        .zip(&im)
+        .map(|(&re, &im)| re.square() + im.square())
+        .collect::<Vec<_>>();
+    let denom_inv = batch_multiplicative_inverse(&denoms);
+    VanishingParts { re, im, denom_inv }
+}
+
+/// Accumulate one matrix/point DEEP quotient into a running reduced opening:
+///
+/// `ro[i] += alpha_offset * (re[i] - alpha^W * im[i]) / |v_p(zeta)|^2[i] * (r[i] - c)`
+///
+/// where `r[i] = sum_j(alpha^j * p_j[x_i])` are the alpha-reduced rows of the matrix,
+/// `c = sum_j(alpha^j * p_j[zeta])` is `reduced_ps_at_zeta` and `W` is the matrix width.
+#[instrument(skip_all, fields(n = ro.len()))]
+pub(crate) fn accumulate_deep_quotient<EF: Field>(
+    ro: &mut [EF],
+    alpha_offset: EF,
+    alpha_pow_width: EF,
+    reduced_rows: &[EF],
+    vp: &VanishingParts<EF>,
+    reduced_ps_at_zeta: EF,
+) {
+    ro.par_iter_mut()
+        .zip(reduced_rows)
+        .zip(&vp.re)
+        .zip(&vp.im)
+        .zip(&vp.denom_inv)
+        .for_each(|((((ro, &reduced_ps_at_x), &re), &im), &denom_inv)| {
+            *ro += alpha_offset
+                * (re - alpha_pow_width * im)
+                * denom_inv
+                * (reduced_ps_at_x - reduced_ps_at_zeta);
+        });
+}
+
 impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
+    /// Reduce each row to a single value with powers of `alpha`: `r[i] = sum_j(alpha^j * m[i][j])`.
+    ///
+    /// This is the only part of the DEEP quotient that traverses the matrix, and it does not
+    /// depend on the opening point, so it is computed once per matrix and shared by all points.
+    #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
+    pub(crate) fn rowwise_alpha_reduce<EF: ExtensionField<F>>(&self, alpha: EF) -> Vec<EF> {
+        let packed_alpha_powers =
+            EF::ExtensionPacking::packed_ext_powers_capped(alpha, self.values.width())
+                .collect_vec();
+        self.values
+            .rowwise_packed_dot_product::<EF>(&packed_alpha_powers)
+            .collect()
+    }
+
     /// Compute DEEP quotients for all rows in the matrix efficiently using batch operations.
     ///
     /// This is an optimized version of `deep_quotient_reduce_row` that processes the entire
@@ -120,55 +193,31 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
     /// # Returns
     ///
     /// A vector of DEEP quotient values, one for each row in the matrix.
-    #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
+    #[cfg(test)]
     pub(crate) fn deep_quotient_reduce<EF: ExtensionField<F>>(
         &self,
         alpha: EF,
         zeta: Point<EF>,
         ps_at_zeta: &[EF],
     ) -> Vec<EF> {
-        // Precompute alpha^width for the vanishing part computation
-        let alpha_pow_width = alpha.exp_u64(self.values.width() as u64);
-
-        // Get all domain points in CFFT order for efficient processing
         let points = cfft_permute_slice(&self.domain.points().collect_vec());
+        let vp = compute_vanishing_parts(&points, zeta);
+        let reduced_rows = self.rowwise_alpha_reduce(alpha);
 
-        // Compute `(x - zeta)` for all our `x` values.
-        let (vp_nums, vp_denoms): (Vec<_>, Vec<_>) = points
-            .into_iter()
-            .map(|x| deep_quotient_vanishing_part(x, zeta, alpha_pow_width))
-            .unzip();
+        let alpha_pow_width = alpha.exp_u64(self.values.width() as u64);
+        // sum_j(alpha^j * p_j[zeta]), the same for all rows.
+        let reduced_ps_at_zeta: EF = dot_product(alpha.powers(), ps_at_zeta.iter().copied());
 
-        // Invert the denominators.
-        let vp_denom_invs = batch_multiplicative_inverse(&vp_denoms);
-        // Free the denominator buffer immediately to reduce peak memory.
-        drop(vp_denoms);
-
-        // Precompute powers of alpha for constraint part computation
-        // TODO: These should be passed in as parameters to avoid recomputation
-        let packed_alpha_powers =
-            EF::ExtensionPacking::packed_ext_powers_capped(alpha, self.values.width())
-                .collect_vec();
-        let alpha_powers =
-            EF::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied()).collect_vec();
-
-        // Precompute the constraint part for the challenge point
-        // This is sum_j(alpha^j * p_j[zeta]) and is the same for all rows
-        let alpha_reduced_ps_at_zeta: EF =
-            dot_product(alpha_powers.iter().copied(), ps_at_zeta.iter().copied());
-
-        // Compute DEEP quotients for all rows in parallel
-        // For each row i: vanishing_part[i] * (constraint_part[i] - alpha_reduced_ps_at_zeta)
-        self.values
-            .rowwise_packed_dot_product::<EF>(&packed_alpha_powers)
-            .zip(vp_nums.into_par_iter())
-            .zip(vp_denom_invs.into_par_iter())
-            .map(|((reduced_ps_at_x, vp_num), vp_denom_inv)| {
-                // reduced_ps_at_x = sum_j(alpha^j * p_j[x_i])
-                // So (reduced_ps_at_x - alpha_reduced_ps_at_zeta) = sum_j(alpha^j * (p_j[x_i] - p_j[zeta]))
-                vp_num * vp_denom_inv * (reduced_ps_at_x - alpha_reduced_ps_at_zeta)
-            })
-            .collect()
+        let mut ro = EF::zero_vec(reduced_rows.len());
+        accumulate_deep_quotient(
+            &mut ro,
+            EF::ONE,
+            alpha_pow_width,
+            &reduced_rows,
+            &vp,
+            reduced_ps_at_zeta,
+        );
+        ro
     }
 }
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -16,7 +16,6 @@ use p3_fri::verifier::FriError;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixCow};
 use p3_matrix::row_index_mapped::RowIndexMappedView;
 use p3_matrix::{Dimensions, Matrix};
-use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use p3_util::zip_eq::zip_eq;
 use serde::{Deserialize, Serialize};

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -10,7 +10,7 @@ use p3_commit::{
     PeriodicLdeTable, PolynomialSpace,
 };
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field};
+use p3_field::{ExtensionField, Field, dot_product};
 use p3_fri::FriParameters;
 use p3_fri::verifier::FriError;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixCow};
@@ -23,15 +23,18 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::info_span;
 
-use crate::deep_quotient::{deep_quotient_reduce_row, extract_lambda};
+use crate::deep_quotient::{
+    VanishingParts, accumulate_deep_quotient, compute_vanishing_parts, deep_quotient_reduce_row,
+    extract_lambda,
+};
 use crate::domain::CircleDomain;
 use crate::folding::{CircleFriFolding, CircleFriFoldingForMmcs, fold_y, fold_y_row};
-use crate::point::Point;
+use crate::point::{Point, compute_lagrange_den_batched};
 use crate::prover::prove;
 use crate::verifier::verify;
 use crate::{
     CfftPerm, CfftPermutable, CircleEvaluations, CircleFriProof, build_periodic_lde_table_circle,
-    cfft_permute_index,
+    cfft_permute_index, cfft_permute_slice,
 };
 
 #[derive(Clone, Debug)]
@@ -206,6 +209,26 @@ where
         )>,
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
+        // Materialize the CFFT-ordered domain points once per committed height. They are shared
+        // by the Lagrange denominators and the DEEP-quotient vanishing parts below, which are in
+        // turn shared by every matrix opened at the same point on the same domain.
+        let mut permuted_points: BTreeMap<usize, Vec<Point<Val>>> = BTreeMap::new();
+        info_span!("materialize domain points").in_scope(|| {
+            for (data, _) in &rounds {
+                for mat in self.mmcs.get_matrices(data) {
+                    let log_height = log2_strict_usize(mat.height());
+                    permuted_points.entry(log_height).or_insert_with(|| {
+                        cfft_permute_slice(
+                            &CircleDomain::standard(log_height).points().collect_vec(),
+                        )
+                    });
+                }
+            }
+        });
+
+        // (log_height, point) -> Lagrange denominators.
+        let mut lagrange_dens: Vec<((usize, Challenge), Vec<Challenge>)> = vec![];
+
         // Open matrices at points
         let values: OpenedValues<Challenge> = rounds
             .iter()
@@ -226,11 +249,32 @@ where
                         );
                         points_for_mat
                             .iter()
-                            .map(|&zeta| {
-                                let zeta = Point::from_projective_line(zeta);
+                            .map(|&zeta_uni| {
+                                let zeta = Point::from_projective_line(zeta_uni);
+                                let key = (log_height, zeta_uni);
+                                let den_idx = lagrange_dens
+                                    .iter()
+                                    .position(|(k, _)| *k == key)
+                                    .unwrap_or_else(|| {
+                                        let den = info_span!("compute Lagrange denominators")
+                                            .in_scope(|| {
+                                                compute_lagrange_den_batched(
+                                                    &permuted_points[&log_height],
+                                                    zeta,
+                                                    log_height,
+                                                )
+                                            });
+                                        lagrange_dens.push((key, den));
+                                        lagrange_dens.len() - 1
+                                    });
                                 let ps_at_zeta =
                                     info_span!("compute opened values with Lagrange interpolation")
-                                        .in_scope(|| evals.evaluate_at_point(zeta));
+                                        .in_scope(|| {
+                                            evals.evaluate_at_point_with_den(
+                                                zeta,
+                                                &lagrange_dens[den_idx].1,
+                                            )
+                                        });
                                 challenger.observe_algebra_slice(&ps_at_zeta);
                                 ps_at_zeta
                             })
@@ -239,6 +283,7 @@ where
                     .collect()
             })
             .collect();
+        drop(lagrange_dens);
 
         // Batch combination challenge
         let alpha: Challenge = challenger.sample_algebra_element();
@@ -255,6 +300,9 @@ where
 
         // log_height -> (alpha offset, reduced openings column)
         let mut reduced_openings: BTreeMap<usize, (Challenge, Vec<Challenge>)> = BTreeMap::new();
+
+        // (log_height, point) -> DEEP-quotient vanishing parts.
+        let mut vanishing_parts: Vec<((usize, Challenge), VanishingParts<Challenge>)> = vec![];
 
         rounds
             .iter()
@@ -273,28 +321,49 @@ where
                         .entry(log_height)
                         .or_insert_with(|| (Challenge::ONE, Challenge::zero_vec(1 << log_height)));
 
+                    // The only pass over the matrix; it does not depend on the opening points.
+                    let reduced_rows = evals.rowwise_alpha_reduce(alpha);
+                    let alpha_pow_width = alpha.exp_u64(evals.values.width() as u64);
+
                     points_for_mat
                         .iter()
                         .zip(values.iter())
-                        .for_each(|(&zeta, ps_at_zeta)| {
-                            let zeta = Point::from_projective_line(zeta);
-
-                            // Reduce this matrix, as a deep quotient, into one column with powers of α.
-                            let mat_ros = evals.deep_quotient_reduce(alpha, zeta, ps_at_zeta);
-
-                            // Fold it into our running reduction, offset by alpha_offset.
-                            reduced_opening_for_log_height
-                                .par_iter_mut()
-                                .zip(mat_ros)
-                                .for_each(|(ro, mat_ro)| {
-                                    *ro += *alpha_offset * mat_ro;
+                        .for_each(|(&zeta_uni, ps_at_zeta)| {
+                            let zeta = Point::from_projective_line(zeta_uni);
+                            let key = (log_height, zeta_uni);
+                            let vp_idx = vanishing_parts
+                                .iter()
+                                .position(|(k, _)| *k == key)
+                                .unwrap_or_else(|| {
+                                    let vp = compute_vanishing_parts(
+                                        &permuted_points[&log_height],
+                                        zeta,
+                                    );
+                                    vanishing_parts.push((key, vp));
+                                    vanishing_parts.len() - 1
                                 });
 
+                            // sum_j(alpha^j * p_j[zeta]), the same for all rows.
+                            let reduced_ps_at_zeta: Challenge =
+                                dot_product(alpha.powers(), ps_at_zeta.iter().copied());
+
+                            // Reduce this matrix, as a deep quotient, into the running
+                            // reduction, offset by alpha_offset.
+                            accumulate_deep_quotient(
+                                reduced_opening_for_log_height,
+                                *alpha_offset,
+                                alpha_pow_width,
+                                &reduced_rows,
+                                &vanishing_parts[vp_idx].1,
+                                reduced_ps_at_zeta,
+                            );
+
                             // Update alpha_offset from α^i -> α^(i + 2 * width)
-                            *alpha_offset *= alpha.exp_u64(2 * evals.values.width() as u64);
+                            *alpha_offset *= alpha_pow_width.square();
                         });
                 });
             });
+        drop(vanishing_parts);
 
         // Iterate over our reduced columns and extract lambda - the multiple of the vanishing polynomial
         // which may appear in the reduced quotient due to CFFT dimension gap.

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -246,12 +246,13 @@ where
                             CircleDomain::standard(log_height),
                             mat.as_view(),
                         );
-                        points_for_mat
+
+                        // Resolve the Lagrange denominators for every point up front.
+                        let den_idxs = points_for_mat
                             .iter()
                             .map(|&zeta_uni| {
-                                let zeta = Point::from_projective_line(zeta_uni);
                                 let key = (log_height, zeta_uni);
-                                let den_idx = lagrange_dens
+                                lagrange_dens
                                     .iter()
                                     .position(|(k, _)| *k == key)
                                     .unwrap_or_else(|| {
@@ -259,25 +260,44 @@ where
                                             .in_scope(|| {
                                                 compute_lagrange_den_batched(
                                                     &permuted_points[&log_height],
-                                                    zeta,
+                                                    Point::from_projective_line(zeta_uni),
                                                     log_height,
                                                 )
                                             });
                                         lagrange_dens.push((key, den));
                                         lagrange_dens.len() - 1
-                                    });
-                                let ps_at_zeta =
-                                    info_span!("compute opened values with Lagrange interpolation")
-                                        .in_scope(|| {
+                                    })
+                            })
+                            .collect_vec();
+
+                        let ps_for_points: Vec<Vec<Challenge>> =
+                            info_span!("compute opened values with Lagrange interpolation")
+                                .in_scope(|| match (&points_for_mat[..], &den_idxs[..]) {
+                                    // A matrix opened at two points (e.g. zeta and zeta_next)
+                                    // is traversed once for both.
+                                    (&[zeta_0, zeta_1], &[idx_0, idx_1]) => evals
+                                        .evaluate_at_two_points_with_dens(
+                                            [
+                                                Point::from_projective_line(zeta_0),
+                                                Point::from_projective_line(zeta_1),
+                                            ],
+                                            [&lagrange_dens[idx_0].1, &lagrange_dens[idx_1].1],
+                                        )
+                                        .into(),
+                                    _ => izip!(points_for_mat, &den_idxs)
+                                        .map(|(&zeta_uni, &den_idx)| {
                                             evals.evaluate_at_point_with_den(
-                                                zeta,
+                                                Point::from_projective_line(zeta_uni),
                                                 &lagrange_dens[den_idx].1,
                                             )
-                                        });
-                                challenger.observe_algebra_slice(&ps_at_zeta);
-                                ps_at_zeta
-                            })
-                            .collect()
+                                        })
+                                        .collect(),
+                                });
+
+                        for ps_at_zeta in &ps_for_points {
+                            challenger.observe_algebra_slice(ps_at_zeta);
+                        }
+                        ps_for_points
                     })
                     .collect()
             })

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -5,6 +5,7 @@ use p3_field::extension::ComplexExtendable;
 use p3_field::{
     ExtensionField, Field, PackedValue, PrimeCharacteristicRing, batch_multiplicative_inverse,
 };
+use p3_maybe_rayon::prelude::*;
 
 /// Affine representation of a point on the circle.
 /// x^2 + y^2 == 1
@@ -143,30 +144,31 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
             let exp = (2 * log_n - 1) as u64;
             let iters = log_n - 2;
             let width = F::Packing::WIDTH;
+            let packed_len = (points.len() / width) * width;
 
-            let mut chunks = points.chunks_exact(width);
-            let mut offset = 0;
-            for chunk in &mut chunks {
-                // Seed the running product with the x-coordinates of the lane.
-                let mut cur = F::Packing::from_fn(|l| chunk[l].x);
-                let mut output = cur;
+            s_p[..packed_len]
+                .par_chunks_exact_mut(width)
+                .zip(points.par_chunks_exact(width))
+                .for_each(|(slots, chunk)| {
+                    // Seed the running product with the x-coordinates of the lane.
+                    let mut cur = F::Packing::from_fn(|l| chunk[l].x);
+                    let mut output = cur;
 
-                // Fold in each squaring-chain step `x -> 2 x^2 - 1`.
-                for _ in 0..iters {
-                    cur = cur.square().double() - F::Packing::ONE;
-                    output *= cur;
-                }
+                    // Fold in each squaring-chain step `x -> 2 x^2 - 1`.
+                    for _ in 0..iters {
+                        cur = cur.square().double() - F::Packing::ONE;
+                        output *= cur;
+                    }
 
-                // Close the formula: scale by the power of two and the y-coordinate.
-                let ys = F::Packing::from_fn(|l| chunk[l].y);
-                let packed_s_p = -(output.mul_2exp_u64(exp) * ys);
+                    // Close the formula: scale by the power of two and the y-coordinate.
+                    let ys = F::Packing::from_fn(|l| chunk[l].y);
+                    let packed_s_p = -(output.mul_2exp_u64(exp) * ys);
 
-                s_p[offset..offset + width].copy_from_slice(packed_s_p.as_slice());
-                offset += width;
-            }
+                    slots.copy_from_slice(packed_s_p.as_slice());
+                });
 
             // Trailing points below one full lane fall back to the scalar formula.
-            for (slot, &pt) in s_p[offset..].iter_mut().zip(chunks.remainder()) {
+            for (slot, &pt) in s_p[packed_len..].iter_mut().zip(&points[packed_len..]) {
                 *slot = pt.s_p_at_p(log_n);
             }
         }
@@ -175,7 +177,7 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
 
     // Pair each numerator with its denominator before inverting.
     let (numer, denom): (Vec<_>, Vec<_>) = points
-        .iter()
+        .par_iter()
         .zip(&s_p)
         .map(|(&pt, &s_p)| {
             let diff = at - pt;
@@ -190,8 +192,8 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
 
     // Recombine each numerator with its inverted denominator.
     numer
-        .iter()
-        .zip(inv_d.iter())
+        .par_iter()
+        .zip(inv_d.par_iter())
         .map(|(&num, &inv_d)| num * inv_d)
         .collect()
 }


### PR DESCRIPTION
Make the `open` span for circle STARK around −36% faster