### PR TITLE
perf(circle): fuse two-point openings and parallelize Lagrange denominators

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -2,11 +2,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-use itertools::{Itertools, iterate};
+use itertools::{Itertools, iterate, izip};
 use p3_commit::PolynomialSpace;
 use p3_dft::{Butterfly, DifButterfly, DitButterfly, divide_by_height};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field, batch_multiplicative_inverse};
+use p3_field::{ExtensionField, Field, FieldArray, batch_multiplicative_inverse};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -141,6 +141,31 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             .into_iter()
             .map(|x| x * lagrange_num)
             .collect_vec()
+    }
+
+    /// Evaluate at two points in a single pass over the matrix, given precomputed Lagrange
+    /// denominators for each point.
+    ///
+    /// Equivalent to two [`Self::evaluate_at_point_with_den`] calls, but each matrix row is
+    /// only loaded once.
+    pub(crate) fn evaluate_at_two_points_with_dens<EF: ExtensionField<F>>(
+        &self,
+        points: [Point<EF>; 2],
+        dens: [&[EF]; 2],
+    ) -> [Vec<EF>; 2] {
+        let lagrange_nums = points.map(|point| self.domain.vanishing_poly(point));
+
+        let interleaved_dens = izip!(dens[0], dens[1])
+            .map(|(&den_0, &den_1)| FieldArray([den_0, den_1]))
+            .collect_vec();
+
+        let (ps_at_point_0, ps_at_point_1) = self
+            .values
+            .columnwise_dot_product_batched::<EF, 2>(&interleaved_dens)
+            .into_iter()
+            .map(|FieldArray([dot_0, dot_1])| (dot_0 * lagrange_nums[0], dot_1 * lagrange_nums[1]))
+            .unzip();
+        [ps_at_point_0, ps_at_point_1]
     }
 
     #[cfg(test)]

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -246,12 +246,13 @@ where
                             CircleDomain::standard(log_height),
                             mat.as_view(),
                         );
-                        points_for_mat
+
+                        // Resolve the Lagrange denominators for every point up front.
+                        let den_idxs = points_for_mat
                             .iter()
                             .map(|&zeta_uni| {
-                                let zeta = Point::from_projective_line(zeta_uni);
                                 let key = (log_height, zeta_uni);
-                                let den_idx = lagrange_dens
+                                lagrange_dens
                                     .iter()
                                     .position(|(k, _)| *k == key)
                                     .unwrap_or_else(|| {
@@ -259,25 +260,44 @@ where
                                             .in_scope(|| {
                                                 compute_lagrange_den_batched(
                                                     &permuted_points[&log_height],
-                                                    zeta,
+                                                    Point::from_projective_line(zeta_uni),
                                                     log_height,
                                                 )
                                             });
                                         lagrange_dens.push((key, den));
                                         lagrange_dens.len() - 1
-                                    });
-                                let ps_at_zeta =
-                                    info_span!("compute opened values with Lagrange interpolation")
-                                        .in_scope(|| {
+                                    })
+                            })
+                            .collect_vec();
+
+                        let ps_for_points: Vec<Vec<Challenge>> =
+                            info_span!("compute opened values with Lagrange interpolation")
+                                .in_scope(|| match (&points_for_mat[..], &den_idxs[..]) {
+                                    // A matrix opened at two points (e.g. zeta and zeta_next)
+                                    // is traversed once for both.
+                                    (&[zeta_0, zeta_1], &[idx_0, idx_1]) => evals
+                                        .evaluate_at_two_points_with_dens(
+                                            [
+                                                Point::from_projective_line(zeta_0),
+                                                Point::from_projective_line(zeta_1),
+                                            ],
+                                            [&lagrange_dens[idx_0].1, &lagrange_dens[idx_1].1],
+                                        )
+                                        .into(),
+                                    _ => izip!(points_for_mat, &den_idxs)
+                                        .map(|(&zeta_uni, &den_idx)| {
                                             evals.evaluate_at_point_with_den(
-                                                zeta,
+                                                Point::from_projective_line(zeta_uni),
                                                 &lagrange_dens[den_idx].1,
                                             )
-                                        });
-                                challenger.observe_algebra_slice(&ps_at_zeta);
-                                ps_at_zeta
-                            })
-                            .collect()
+                                        })
+                                        .collect(),
+                                });
+
+                        for ps_at_zeta in &ps_for_points {
+                            challenger.observe_algebra_slice(ps_at_zeta);
+                        }
+                        ps_for_points
                     })
                     .collect()
             })

--- a/circle/src/point.rs
+++ b/circle/src/point.rs
@@ -5,6 +5,7 @@ use p3_field::extension::ComplexExtendable;
 use p3_field::{
     ExtensionField, Field, PackedValue, PrimeCharacteristicRing, batch_multiplicative_inverse,
 };
+use p3_maybe_rayon::prelude::*;
 
 /// Affine representation of a point on the circle.
 /// x^2 + y^2 == 1
@@ -143,30 +144,31 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
             let exp = (2 * log_n - 1) as u64;
             let iters = log_n - 2;
             let width = F::Packing::WIDTH;
+            let packed_len = (points.len() / width) * width;
 
-            let mut chunks = points.chunks_exact(width);
-            let mut offset = 0;
-            for chunk in &mut chunks {
-                // Seed the running product with the x-coordinates of the lane.
-                let mut cur = F::Packing::from_fn(|l| chunk[l].x);
-                let mut output = cur;
+            s_p[..packed_len]
+                .par_chunks_exact_mut(width)
+                .zip(points.par_chunks_exact(width))
+                .for_each(|(slots, chunk)| {
+                    // Seed the running product with the x-coordinates of the lane.
+                    let mut cur = F::Packing::from_fn(|l| chunk[l].x);
+                    let mut output = cur;
 
-                // Fold in each squaring-chain step `x -> 2 x^2 - 1`.
-                for _ in 0..iters {
-                    cur = cur.square().double() - F::Packing::ONE;
-                    output *= cur;
-                }
+                    // Fold in each squaring-chain step `x -> 2 x^2 - 1`.
+                    for _ in 0..iters {
+                        cur = cur.square().double() - F::Packing::ONE;
+                        output *= cur;
+                    }
 
-                // Close the formula: scale by the power of two and the y-coordinate.
-                let ys = F::Packing::from_fn(|l| chunk[l].y);
-                let packed_s_p = -(output.mul_2exp_u64(exp) * ys);
+                    // Close the formula: scale by the power of two and the y-coordinate.
+                    let ys = F::Packing::from_fn(|l| chunk[l].y);
+                    let packed_s_p = -(output.mul_2exp_u64(exp) * ys);
 
-                s_p[offset..offset + width].copy_from_slice(packed_s_p.as_slice());
-                offset += width;
-            }
+                    slots.copy_from_slice(packed_s_p.as_slice());
+                });
 
             // Trailing points below one full lane fall back to the scalar formula.
-            for (slot, &pt) in s_p[offset..].iter_mut().zip(chunks.remainder()) {
+            for (slot, &pt) in s_p[packed_len..].iter_mut().zip(&points[packed_len..]) {
                 *slot = pt.s_p_at_p(log_n);
             }
         }
@@ -175,7 +177,7 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
 
     // Pair each numerator with its denominator before inverting.
     let (numer, denom): (Vec<_>, Vec<_>) = points
-        .iter()
+        .par_iter()
         .zip(&s_p)
         .map(|(&pt, &s_p)| {
             let diff = at - pt;
@@ -190,8 +192,8 @@ pub fn compute_lagrange_den_batched<F: Field, EF: ExtensionField<F>>(
 
     // Recombine each numerator with its inverted denominator.
     numer
-        .iter()
-        .zip(inv_d.iter())
+        .par_iter()
+        .zip(inv_d.par_iter())
         .map(|(&num, &inv_d)| num * inv_d)
         .collect()
 }


### PR DESCRIPTION
Yields another ~15% savings on the `open` phase