### PR TITLE
feat(lookup): degree-budget-aware same-bus column packing

### DIFF
--- a/batch-stark/benches/lookup.rs
+++ b/batch-stark/benches/lookup.rs
@@ -10,24 +10,29 @@
 //!     proof size       serialized bytes
 //!     peak heap        high-water bytes during one prove
 //!
-//! The workload is a balanced range-check AIR with four knobs:
+//! The workload is one balanced lookup AIR with these knobs:
 //!
-//!     n_interactions   how many lookups the AIR declares
+//!     n_interactions   query/provide pairs, all on one shared bus
 //!     tuple_width      field elements per message
-//!     fold             lookups merged into one committed column
+//!     base_degree      degree of an optional base constraint, or 0 for none
 //!     active_period    one active row every `active_period` rows (row-sparsity)
+//!     n_airs           identical instances proven in one batch
 //!
-//! The `fold` knob stands in for grouping:
+//! Every case is measured twice, with same-bus packing on and off:
 //!
-//!     merge lookups  → one multi-tuple local interaction
-//!     same aux-trace shape as a same-bus grouping
-//!     so grouped-vs-ungrouped reads off the `fold` sweep
+//!     base_degree 0  → no spare budget → packing folds nothing → both rows match
+//!     base_degree d  → spare budget    → packing folds → fewer columns, less cost
+//!
+//! So the table proves the two claims side by side:
+//!
+//!     no-budget rows identical  → packing never regresses
+//!     budget rows packed lower  → packing is a strict win
 //!
 //! Running it:
 //!
 //!     cargo bench -p p3-batch-stark --bench lookup
 //!
-//! and optionally with `--features parallel` argument.
+//! and optionally with `--features parallel`.
 //!
 //! The metrics table prints first, then the criterion timings.
 //! Comment out entries in `CASES` to shorten a local run.
@@ -46,7 +51,7 @@ use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_fri::{FriParameters, TwoAdicFriPcs};
-use p3_lookup::InteractionBuilder;
+use p3_lookup::{Count, InteractionBuilder, LookupBus, Lookups};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -123,22 +128,28 @@ fn disarm_heap() -> usize {
 }
 
 // ---------------------------------------------------------------------------
-// Workload: a balanced range-check AIR
+// Workload: a balanced same-bus lookup AIR
 // ---------------------------------------------------------------------------
 
-/// A lookup-only AIR with no base constraints.
+/// The single bus every interaction speaks on.
 ///
-/// Each interaction queries a key and provides the same key on every active row.
-/// Query and table cancel per row, so any trace balances to a zero terminal.
-/// Cost is set by the structure, not the values: column count, height, width.
+/// One shared bus lets the packer fold interactions into common columns.
+const SHARED_BUS: LookupBus<'static> = LookupBus::new("shared");
+
+/// A balanced lookup AIR with a tunable base-constraint degree.
+///
+/// - Every slot queries a key and provides the same key on the shared bus.
+/// - Query and provide cancel, so any trace balances to a zero terminal.
+/// - An optional degree-`base_degree` constraint sets the spare quotient budget.
+/// - That budget is exactly what the same-bus packer folds into.
 #[derive(Clone, Copy)]
 struct LookupLoadAir {
-    /// Number of independent lookups the AIR declares.
+    /// Query/provide pairs the AIR declares, all on the shared bus.
     n_interactions: usize,
     /// Field elements per message.
     tuple_width: usize,
-    /// Lookups merged into one committed column.
-    fold: usize,
+    /// Degree of the base constraint, or 0 for none.
+    base_degree: usize,
 }
 
 impl LookupLoadAir {
@@ -146,11 +157,22 @@ impl LookupLoadAir {
     const fn stride(&self) -> usize {
         self.tuple_width + 1
     }
+
+    /// Whether a base constraint, hence a witness pair, is present.
+    const fn has_base(&self) -> bool {
+        self.base_degree >= 2
+    }
+
+    /// First column of the witness pair `(w, y = w^base_degree)`.
+    const fn witness_offset(&self) -> usize {
+        self.n_interactions * self.stride()
+    }
 }
 
 impl<F: Field> BaseAir<F> for LookupLoadAir {
     fn width(&self) -> usize {
-        self.n_interactions * self.stride()
+        // Per-interaction columns, then the optional two-column witness.
+        self.n_interactions * self.stride() + if self.has_base() { 2 } else { 0 }
     }
 }
 
@@ -160,32 +182,32 @@ impl<AB: PermutationAirBuilder + InteractionBuilder> Air<AB> for LookupLoadAir {
         let local = main.current_slice();
         let stride = self.stride();
 
-        // Walk interactions in fixed-size folds.
-        // Each fold becomes one local lookup, hence one committed fraction column.
-        let mut start = 0;
-        while start < self.n_interactions {
-            let end = (start + self.fold).min(self.n_interactions);
+        // Optional base constraint `w^base_degree - y = 0`.
+        // It alone fixes the AIR's degree, hence the packer's spare budget.
+        if self.has_base() {
+            let off = self.witness_offset();
+            let w = local[off];
+            let y = local[off + 1];
 
-            let mut tuples = Vec::with_capacity(2 * (end - start));
-            for i in start..end {
-                let off = i * stride;
-
-                // Key occupies the first `tuple_width` columns of this interaction.
-                let key: Vec<AB::Expr> = (0..self.tuple_width)
-                    .map(|j| local[off + j].into())
-                    .collect();
-
-                // Selector gates both sides, so inactive rows contribute nothing.
-                let selector = local[off + self.tuple_width];
-
-                // Query side: +selector.
-                tuples.push((key.clone(), selector.into()));
-                // Table side: -selector on the same key, cancelling the query.
-                tuples.push((key, -(selector.into())));
+            // Raise w to base_degree by repeated multiplication.
+            let mut power: AB::Expr = w.into();
+            for _ in 1..self.base_degree {
+                power *= w.into();
             }
+            builder.assert_zero(power - y.into());
+        }
 
-            builder.push_local_interaction(tuples);
-            start = end;
+        // Each slot sends a query and a matching provide on the shared bus.
+        for i in 0..self.n_interactions {
+            let off = i * stride;
+            let key: Vec<AB::Expr> = (0..self.tuple_width)
+                .map(|j| local[off + j].into())
+                .collect();
+            let selector = local[off + self.tuple_width];
+
+            // Query (+selector, weight 1) cancels the provide (-selector) on the same key.
+            SHARED_BUS.lookup_key(builder, key.clone(), Count::bounded(selector.into(), 1));
+            SHARED_BUS.table_entry(builder, key, selector.into());
         }
     }
 }
@@ -201,157 +223,67 @@ struct Case {
     name: &'static str,
     /// log2 of the trace height.
     log_height: usize,
-    /// Lookups declared by the AIR.
+    /// Query/provide pairs the AIR declares.
     n_interactions: usize,
     /// Field elements per message.
     tuple_width: usize,
-    /// Lookups merged per committed column.
-    fold: usize,
+    /// Degree of the base constraint, or 0 for none.
+    base_degree: usize,
     /// One active row every `active_period` rows.
     active_period: usize,
     /// Number of identical AIR instances in the batch.
     n_airs: usize,
 }
 
-/// The default sweep.
+/// Terse case constructor so the sweep below stays readable.
+const fn case(
+    name: &'static str,
+    log_height: usize,
+    n_interactions: usize,
+    tuple_width: usize,
+    base_degree: usize,
+    active_period: usize,
+    n_airs: usize,
+) -> Case {
+    Case {
+        name,
+        log_height,
+        n_interactions,
+        tuple_width,
+        base_degree,
+        active_period,
+        n_airs,
+    }
+}
+
+/// The default sweep, grouped by the axis each block isolates.
 ///
-/// Grouped by the axis each block isolates.
+/// Columns are: name, logH, n, tuple_width, base_degree, active_period, n_airs.
 /// Comment out blocks to shorten a local run.
 const CASES: &[Case] = &[
     // Smoke point: tiny, validates the pipeline fast.
-    Case {
-        name: "smoke",
-        log_height: 8,
-        n_interactions: 1,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
+    case("smoke", 8, 1, 1, 0, 1, 1),
     // Interaction count: cost as a function of #lookups, one column each.
-    Case {
-        name: "n=1",
-        log_height: 14,
-        n_interactions: 1,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "n=4",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "n=8",
-        log_height: 14,
-        n_interactions: 8,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "n=16",
-        log_height: 14,
-        n_interactions: 16,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    // Fold: 8 lookups, more merged per column → fewer columns, higher degree.
-    // Case `fold=1` contained in case `n=8` above
-    Case {
-        name: "fold=2",
-        log_height: 14,
-        n_interactions: 8,
-        tuple_width: 1,
-        fold: 2,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "fold=4",
-        log_height: 14,
-        n_interactions: 8,
-        tuple_width: 1,
-        fold: 4,
-        active_period: 1,
-        n_airs: 1,
-    },
-    // Tuple width: wider messages raise the combine degree.
-    Case {
-        name: "tw=2",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 2,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "tw=4",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 4,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
+    case("n=1", 14, 1, 1, 0, 1, 1),
+    case("n=4", 14, 4, 1, 0, 1, 1),
+    case("n=8", 14, 8, 1, 0, 1, 1),
+    case("n=16", 14, 16, 1, 0, 1, 1),
+    // Tuple width: wider messages, same per-lookup degree.
+    case("tw=2", 14, 4, 2, 0, 1, 1),
+    case("tw=4", 14, 4, 4, 0, 1, 1),
     // Row-sparsity: fraction of active rows. Baseline cost is sparsity-blind today.
-    Case {
-        name: "period=4",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 4,
-        n_airs: 1,
-    },
-    Case {
-        name: "period=16",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 16,
-        n_airs: 1,
-    },
+    case("period=4", 14, 4, 1, 0, 4, 1),
+    case("period=16", 14, 4, 1, 0, 16, 1),
     // Batch size: several identical instances proven together.
-    Case {
-        name: "airs=4",
-        log_height: 14,
-        n_interactions: 4,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 4,
-    },
+    case("airs=4", 14, 4, 1, 0, 1, 4),
+    // Spare budget: a degree-3 base constraint lets the packer fold two per column.
+    // The benchmark FRI uses log-blowup 1, capping the quotient at degree 3.
+    // So degree 3 is the deepest packing this config can show.
+    case("deg3_n=8", 14, 8, 1, 3, 1, 1),
+    case("deg3_n=16", 14, 16, 1, 3, 1, 1),
     // Heavy points at log_height 18: comment these out for a faster bench.
-    Case {
-        name: "n=32_h18",
-        log_height: 18,
-        n_interactions: 32,
-        tuple_width: 1,
-        fold: 1,
-        active_period: 1,
-        n_airs: 1,
-    },
-    Case {
-        name: "fold=8_h18",
-        log_height: 18,
-        n_interactions: 8,
-        tuple_width: 1,
-        fold: 8,
-        active_period: 1,
-        n_airs: 1,
-    },
+    case("n=32_h18", 18, 32, 1, 0, 1, 1),
+    case("deg3_n=32_h18", 18, 32, 1, 3, 1, 1),
 ];
 
 // ---------------------------------------------------------------------------
@@ -379,25 +311,38 @@ fn build_workload(case: &Case) -> (Vec<LookupLoadAir>, Vec<RowMajorMatrix<Val>>,
     let air = LookupLoadAir {
         n_interactions: case.n_interactions,
         tuple_width: case.tuple_width,
-        fold: case.fold,
+        base_degree: case.base_degree,
     };
 
     let height = 1 << case.log_height;
-    let width = case.n_interactions * (case.tuple_width + 1);
+    let width = <LookupLoadAir as BaseAir<Val>>::width(&air);
+    let witness = air.witness_offset();
     let mut rng = SmallRng::seed_from_u64(0xD1CE_F00D);
 
-    // Fill keys with arbitrary values; the lookup balances regardless.
     let mut values = Val::zero_vec(height * width);
     for r in 0..height {
+        let base = r * width;
+        // A row is active once every `active_period` rows.
         let active = r % case.active_period == 0;
+
+        // Keys are arbitrary: query and provide cancel whatever the key holds.
         for i in 0..case.n_interactions {
-            let off = i * (case.tuple_width + 1);
+            let off = base + i * (case.tuple_width + 1);
             for j in 0..case.tuple_width {
-                values[r * width + off + j] = Val::from_u32(rng.random());
+                values[off + j] = Val::from_u32(rng.random());
             }
-            values[r * width + off + case.tuple_width] = if active { Val::ONE } else { Val::ZERO };
+            // Selector gates both sides, so inactive rows contribute nothing.
+            values[off + case.tuple_width] = if active { Val::ONE } else { Val::ZERO };
+        }
+
+        // Witness pair satisfies the base constraint: y = w^base_degree.
+        if air.has_base() {
+            let w = Val::from_u32(rng.random());
+            values[base + witness] = w;
+            values[base + witness + 1] = w.exp_u64(case.base_degree as u64);
         }
     }
+
     let trace = RowMajorMatrix::new(values, width);
 
     // Replicate the same instance to fill the batch.
@@ -437,6 +382,17 @@ fn aux_columns(prover_data: &ProverData<MyConfig>) -> usize {
         .sum()
 }
 
+/// Rebuild `prover_data` with the unpacked layout: one column per interaction.
+///
+/// The default path folds same-bus interactions; this overwrites that decision
+/// with the straight-from-the-AIR lookups, so a caller can measure both layouts.
+fn force_unpacked(prover_data: &mut ProverData<MyConfig>, airs: &[LookupLoadAir]) {
+    prover_data.common.lookups = airs
+        .iter()
+        .map(Lookups::<Val>::from_air::<Challenge, _>)
+        .collect();
+}
+
 // ---------------------------------------------------------------------------
 // Metrics report
 // ---------------------------------------------------------------------------
@@ -450,13 +406,20 @@ struct Metrics {
     verify_ms: f64,
 }
 
-/// Run one case once, checking correctness and collecting every metric.
-fn measure(config: &MyConfig, case: &Case) -> Metrics {
+/// Run one case once, packed or unpacked, checking correctness and collecting metrics.
+///
+/// - `packed = true` keeps the default folded layout.
+/// - `packed = false` rebuilds one column per interaction.
+/// - The two differ only in the aux-trace layout, isolating the packer's effect.
+fn measure(config: &MyConfig, case: &Case, packed: bool) -> Metrics {
     let (airs, traces, public_values) = build_workload(case);
     let instances = make_instances(&airs, &traces, &public_values);
-    let prover_data = ProverData::from_instances(config, &instances);
+    let mut prover_data = ProverData::from_instances(config, &instances);
+    if !packed {
+        force_unpacked(&mut prover_data, &airs);
+    }
 
-    // One-shot prove, with a wall-clock estimate.
+    // One-shot prove with a wall-clock estimate; the metrics table reads this.
     let t = Instant::now();
     let proof = prove_batch(config, &instances, &prover_data);
     let prove_ms = t.elapsed().as_secs_f64() * 1e3;
@@ -488,18 +451,22 @@ fn measure(config: &MyConfig, case: &Case) -> Metrics {
 }
 
 /// Print the full metrics table once, before criterion timing.
+///
+/// Each case prints two rows, packed and unpacked, so the no-regression and the
+/// win read straight off the pairs.
 fn print_report(config: &MyConfig) {
     eprintln!();
-    eprintln!("lookup end-to-end metrics");
+    eprintln!("lookup end-to-end metrics (each case packed and unpacked)");
     eprintln!(
-        "{:<11} {:>5} {:>5} {:>4} {:>5} {:>7} {:>5} {:>8} {:>10} {:>9} {:>9} {:>9}",
+        "{:<14} {:>5} {:>4} {:>4} {:>4} {:>7} {:>5} {:>7} {:>8} {:>10} {:>9} {:>9} {:>10}",
         "case",
         "logH",
         "n",
         "tw",
-        "fold",
+        "deg",
         "period",
         "airs",
+        "packed",
         "aux_cols",
         "proof(KB)",
         "peak(MB)",
@@ -507,22 +474,25 @@ fn print_report(config: &MyConfig) {
         "verify(ms)",
     );
     for case in CASES {
-        let m = measure(config, case);
-        eprintln!(
-            "{:<11} {:>5} {:>5} {:>4} {:>5} {:>7} {:>5} {:>8} {:>10.1} {:>9.1} {:>9.1} {:>9.2}",
-            case.name,
-            case.log_height,
-            case.n_interactions,
-            case.tuple_width,
-            case.fold,
-            case.active_period,
-            case.n_airs,
-            m.aux_columns,
-            m.proof_bytes as f64 / 1024.0,
-            m.peak_bytes as f64 / (1024.0 * 1024.0),
-            m.prove_ms,
-            m.verify_ms,
-        );
+        for packed in [false, true] {
+            let m = measure(config, case, packed);
+            eprintln!(
+                "{:<14} {:>5} {:>4} {:>4} {:>4} {:>7} {:>5} {:>7} {:>8} {:>10.1} {:>9.1} {:>9.1} {:>10.2}",
+                case.name,
+                case.log_height,
+                case.n_interactions,
+                case.tuple_width,
+                case.base_degree,
+                case.active_period,
+                case.n_airs,
+                packed,
+                m.aux_columns,
+                m.proof_bytes as f64 / 1024.0,
+                m.peak_bytes as f64 / (1024.0 * 1024.0),
+                m.prove_ms,
+                m.verify_ms,
+            );
+        }
     }
     eprintln!();
 }
@@ -534,7 +504,7 @@ fn print_report(config: &MyConfig) {
 fn bench_lookup(c: &mut Criterion) {
     let config = make_config();
 
-    // The table carries aux columns, proof size, and peak heap.
+    // The table carries aux columns, proof size, and peak heap, packed vs unpacked.
     // Criterion below carries the rigorous prove and verify timings.
     print_report(&config);
 
@@ -544,19 +514,41 @@ fn bench_lookup(c: &mut Criterion) {
     for case in CASES {
         let (airs, traces, public_values) = build_workload(case);
         let instances = make_instances(&airs, &traces, &public_values);
-        let prover_data = ProverData::from_instances(&config, &instances);
 
-        group.bench_function(BenchmarkId::new("prove", case.name), |b| {
-            b.iter(|| prove_batch(&config, &instances, &prover_data));
-        });
+        // Packing changes the layout only when the AIR has spare budget.
+        // Time both arms there; otherwise the default path alone.
+        let arms: &[bool] = if case.base_degree >= 2 {
+            &[true, false]
+        } else {
+            &[true]
+        };
 
-        // A committed proof to verify repeatedly.
-        let proof = prove_batch(&config, &instances, &prover_data);
-        group.bench_function(BenchmarkId::new("verify", case.name), |b| {
-            b.iter(|| {
-                verify_batch(&config, &airs, &proof, &public_values, &prover_data.common).unwrap();
+        for &packed in arms {
+            let mut prover_data = ProverData::from_instances(&config, &instances);
+            if !packed {
+                force_unpacked(&mut prover_data, &airs);
+            }
+
+            // The default path keeps the bare name; the unpacked arm is suffixed.
+            let id = if packed {
+                case.name.to_string()
+            } else {
+                format!("{}/unpacked", case.name)
+            };
+
+            group.bench_function(BenchmarkId::new("prove", id.clone()), |b| {
+                b.iter(|| prove_batch(&config, &instances, &prover_data));
             });
-        });
+
+            // A committed proof to verify repeatedly.
+            let proof = prove_batch(&config, &instances, &prover_data);
+            group.bench_function(BenchmarkId::new("verify", id), |b| {
+                b.iter(|| {
+                    verify_batch(&config, &airs, &proof, &public_values, &prover_data.common)
+                        .unwrap();
+                });
+            });
+        }
     }
 
     group.finish();

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -11,16 +11,17 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::Air;
-use p3_air::symbolic::SymbolicExpressionExt;
+use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_commit::Pcs;
 use p3_field::{Algebra, BasedVectorSpace};
-use p3_lookup::{InteractionSymbolicBuilder, Lookups};
+use p3_lookup::{InteractionSymbolicBuilder, LogUpGadget, Lookups};
 use p3_matrix::Matrix;
 use p3_uni_stark::Val;
 use p3_util::log2_strict_usize;
 
 use crate::config::{Challenge, Commitment, Domain, StarkGenericConfig as SGC};
 use crate::prover::StarkInstance;
+use crate::symbolic::get_log_num_quotient_chunks;
 
 /// Per-instance metadata for a preprocessed trace that lives inside a
 /// global preprocessed commitment.
@@ -255,7 +256,51 @@ where
             )
         };
 
-        let lookups = airs.iter().map(Lookups::from_air).collect();
+        // Build each AIR's lookups, then fold same-bus globals into shared columns.
+        //
+        // The budget is the largest fraction-pin degree that keeps the quotient
+        // chunk count fixed, so folding only removes columns, never adds work.
+        // An AIR with no spare degree gets a budget that folds nothing.
+        // Prover and verifier fold deterministically, so the layout needs no exchange.
+        let lookup_gadget = LogUpGadget::new();
+        let lookups: Vec<Lookups<Val<SC>>> = airs
+            .iter()
+            .map(|air| {
+                let unpacked = Lookups::<Val<SC>>::from_air::<SC::Challenge, A>(air);
+
+                // `log_chunks` fixes the quotient bucket: n_chunks = 2^log_chunks.
+                let log_chunks =
+                    get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                        air,
+                        AirLayout::from_air(air),
+                        &unpacked,
+                        is_zk,
+                        &lookup_gadget,
+                    );
+
+                // Largest fraction-pin degree still inside that bucket.
+                //
+                //     log2_ceil((d + is_zk).max(2) - 1) <= log_chunks
+                //  => d <= 2^log_chunks + 1 - is_zk
+                let budget = (1usize << log_chunks) + 1 - is_zk;
+                let packed = unpacked.pack_same_bus(&lookup_gadget, budget);
+
+                // The fold must not have moved the quotient bucket.
+                debug_assert_eq!(
+                    get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                        air,
+                        AirLayout::from_air(air),
+                        &packed,
+                        is_zk,
+                        &lookup_gadget,
+                    ),
+                    log_chunks,
+                    "same-bus packing must preserve the quotient chunk count"
+                );
+
+                packed
+            })
+            .collect();
 
         Self {
             common: CommonData {

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::builder::{SymbolicInteraction, SymbolicLocalInteraction};
+use crate::protocol::LookupProtocol;
 use crate::symbolic::InteractionSymbolicBuilder;
 
 /// Whether a lookup is confined to one AIR or shared across AIRs on a named bus.
@@ -111,6 +112,102 @@ impl<F: Field> Lookups<F> {
         }
 
         Self(lookups)
+    }
+
+    /// Fold global lookups on the same bus into shared fraction columns.
+    ///
+    /// One folded column carries several interactions as a single rational sum:
+    /// ```text
+    ///     f_col[r] = sum_j  m_j[r] / (prefix_bus - combine(payload_j[r]))
+    /// ```
+    ///
+    /// - All folded interactions sit on one bus.
+    /// - So they share one challenge pair, and the per-row sum is well defined.
+    /// - A folded column never exceeds the fraction-pin degree `max_degree`.
+    /// - Local lookups are grouped by their author already, so they pass through.
+    ///
+    /// # Soundness
+    ///
+    /// - Folding only moves a fraction from its own column into a shared one.
+    /// - The per-bus rational sum, and every committed terminal, is unchanged.
+    /// - So the cross-AIR balance and the per-bus separation still hold.
+    /// - Both sides fold in emission order, so they agree on the layout.
+    ///
+    /// # Performance
+    ///
+    /// - Folding raises only the merged column's fraction-pin degree.
+    /// - The cap holds that degree within the AIR's spare quotient budget.
+    /// - Fewer columns then cost strictly less to commit and open.
+    ///
+    /// # Arguments
+    ///
+    /// - `gadget` — reports the exact fraction-pin degree of a candidate column.
+    /// - `max_degree` — the largest degree that leaves the quotient cost unchanged.
+    #[must_use]
+    pub fn pack_same_bus<LG: LookupProtocol>(self, gadget: &LG, max_degree: usize) -> Self {
+        // Locals keep their leading columns, untouched.
+        let mut packed: Vec<Lookup<F>> = Vec::with_capacity(self.0.len());
+        // Globals bucket by bus name, in first-appearance order.
+        let mut buses: Vec<(String, Vec<Lookup<F>>)> = Vec::new();
+
+        // Sort each lookup: locals straight through, globals into their bus bucket.
+        for lookup in self.0 {
+            match &lookup.kind {
+                Kind::Local => packed.push(lookup),
+                Kind::Global(name) => match buses.iter_mut().find(|(n, _)| n == name) {
+                    // Bus already seen: append to its bucket.
+                    Some((_, members)) => members.push(lookup),
+                    None => {
+                        // First sighting of this bus: clone the name, then open a bucket.
+                        let bus = name.clone();
+                        buses.push((bus, vec![lookup]));
+                    }
+                },
+            }
+        }
+
+        // Fill columns greedily within each bus.
+        // Seal a column when the next interaction would exceed the degree budget.
+        for (_name, members) in buses {
+            let mut current: Option<Lookup<F>> = None;
+            for member in members {
+                match current.take() {
+                    // A lone interaction always fits: its degree is the unpacked degree.
+                    None => current = Some(member),
+                    Some(mut cur) => {
+                        // Trial-merge: append the candidate's tuples to the open column.
+                        let pivot = cur.elements.len();
+                        cur.elements.extend(member.elements.iter().cloned());
+                        cur.multiplicities
+                            .extend(member.multiplicities.iter().cloned());
+
+                        if gadget.constraint_degree(&cur) <= max_degree {
+                            // Within budget: keep the merge.
+                            // Each tuple holds its own per-row query bound, so the bounds add.
+                            cur.count_weight = cur.count_weight.saturating_add(member.count_weight);
+                            current = Some(cur);
+                        } else {
+                            // Over budget: undo the trial, seal the column, start a new one.
+                            cur.elements.truncate(pivot);
+                            cur.multiplicities.truncate(pivot);
+                            packed.push(cur);
+                            current = Some(member);
+                        }
+                    }
+                }
+            }
+            // Flush the last open column for this bus.
+            if let Some(cur) = current {
+                packed.push(cur);
+            }
+        }
+
+        // Slot i owns fraction column i + 1, so indices must stay contiguous.
+        for (i, lookup) in packed.iter_mut().enumerate() {
+            lookup.column = i;
+        }
+
+        Self(packed)
     }
 
     /// Sum of this AIR's lookup weights.
@@ -255,10 +352,12 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
+    use p3_air::symbolic::{BaseEntry, SymbolicVariable};
     use p3_baby_bear::BabyBear;
     use p3_field::{PrimeCharacteristicRing, PrimeField32};
 
     use super::*;
+    use crate::logup::LogUpGadget;
 
     type F = BabyBear;
 
@@ -276,6 +375,35 @@ mod tests {
             })
             .collect();
         Lookups::from_interactions(&global, &[])
+    }
+
+    /// One global interaction carrying a single degree-1 main-column payload.
+    fn global_payload(bus: &str, weight: u32) -> SymbolicInteraction<F> {
+        // A main-column payload has degree 1.
+        // So a lone tuple pins at degree 2, and a fold of g tuples pins at degree g + 1.
+        let col = SymbolicVariable::<F>::new(BaseEntry::Main { offset: 0 }, 0);
+        SymbolicInteraction {
+            bus_name: String::from(bus),
+            fields: vec![SymbolicExpression::from(col)],
+            count: SymbolicExpression::from(F::ONE),
+            count_weight: weight,
+        }
+    }
+
+    /// Unpacked lookups for several payload interactions on one bus.
+    fn same_bus(bus: &str, count: usize) -> Lookups<F> {
+        // Each interaction is identical; only their count drives the packing tests.
+        let global: Vec<SymbolicInteraction<F>> =
+            (0..count).map(|_| global_payload(bus, 1)).collect();
+        Lookups::from_interactions(&global, &[])
+    }
+
+    /// Column indices must stay `0..len` for the fraction-column mapping to hold.
+    fn assert_contiguous_columns(lookups: &Lookups<F>) {
+        // Slot at position i must own column i, with no gaps.
+        for (i, l) in lookups.iter().enumerate() {
+            assert_eq!(l.column, i, "columns must be contiguous after packing");
+        }
     }
 
     #[test]
@@ -374,5 +502,124 @@ mod tests {
         // One AIR of lookups but two heights is an orchestration bug, not bad input.
         let lookups = [global_lookups(&[1])];
         let _ = check_multiplicity_height_bound(&lookups, &[1, 2]);
+    }
+
+    #[test]
+    fn pack_merges_same_bus_within_budget() {
+        // Four width-1 interactions, budget 3.
+        // A fold of g tuples pins at degree g + 1.
+        // So g = 2 fits (degree 3) but g = 3 does not (degree 4).
+        // Greedy packs two per column: ceil(4 / 2) = 2 columns.
+        let packed = same_bus("a", 4).pack_same_bus(&LogUpGadget, 3);
+
+        assert_eq!(packed.len(), 2);
+        assert_eq!(packed[0].elements.len(), 2);
+        assert_eq!(packed[1].elements.len(), 2);
+        assert_contiguous_columns(&packed);
+    }
+
+    #[test]
+    fn pack_minimal_budget_leaves_every_interaction_alone() {
+        // Budget 2 admits only a lone tuple (degree 2).
+        // So no two interactions ever share a column.
+        let packed = same_bus("a", 4).pack_same_bus(&LogUpGadget, 2);
+
+        assert_eq!(packed.len(), 4);
+        assert!(packed.iter().all(|l| l.elements.len() == 1));
+        assert_contiguous_columns(&packed);
+    }
+
+    #[test]
+    fn pack_never_merges_across_buses() {
+        // Two buses, generous budget.
+        // A column may fold one bus, never two.
+        let global: Vec<SymbolicInteraction<F>> = vec![
+            global_payload("a", 1),
+            global_payload("b", 1),
+            global_payload("a", 1),
+            global_payload("b", 1),
+        ];
+        let packed = Lookups::from_interactions(&global, &[]).pack_same_bus(&LogUpGadget, 16);
+
+        // Each bus collapses to one column.
+        // The two buses never share a column.
+        assert_eq!(packed.len(), 2);
+        assert_eq!(packed[0].kind, Kind::Global(String::from("a")));
+        assert_eq!(packed[1].kind, Kind::Global(String::from("b")));
+        assert_eq!(packed[0].elements.len(), 2);
+        assert_eq!(packed[1].elements.len(), 2);
+    }
+
+    #[test]
+    fn pack_keeps_locals_leading_and_untouched() {
+        // One local, then three same-bus globals, budget 3.
+        // The local keeps column 0.
+        // The three globals fold into two columns: two tuples, then one.
+        let local = vec![SymbolicLocalInteraction {
+            tuples: vec![(vec![], SymbolicExpression::from(F::ONE))],
+        }];
+        let global = vec![
+            global_payload("a", 1),
+            global_payload("a", 1),
+            global_payload("a", 1),
+        ];
+        let packed = Lookups::from_interactions(&global, &local).pack_same_bus(&LogUpGadget, 3);
+
+        assert_eq!(packed.len(), 3);
+        assert_eq!(packed[0].kind, Kind::Local);
+        assert_eq!(packed[0].elements.len(), 1);
+        assert_eq!(packed[1].elements.len(), 2);
+        assert_eq!(packed[2].elements.len(), 1);
+        assert_contiguous_columns(&packed);
+    }
+
+    #[test]
+    fn pack_preserves_total_count_weight() {
+        // Folding adds the per-interaction weights.
+        // So the AIR's height-bound term stays invariant.
+        let global: Vec<SymbolicInteraction<F>> = [1, 0, 1, 1]
+            .iter()
+            .map(|&w| global_payload("a", w))
+            .collect();
+        let unpacked = Lookups::from_interactions(&global, &[]);
+        let before = unpacked.total_count_weight();
+
+        let packed = unpacked.pack_same_bus(&LogUpGadget, 5);
+        assert_eq!(packed.total_count_weight(), before);
+        assert_eq!(before, 3);
+    }
+
+    #[test]
+    fn pack_sweep_preserves_invariants() {
+        // Sweep interaction count against degree budget.
+        // A width-1 column holds at most (budget - 1) tuples.
+        // So the packed column count is exactly ceil(n / (budget - 1)).
+        for n in 1..=16usize {
+            for budget in 2..=8usize {
+                let packed = same_bus("a", n).pack_same_bus(&LogUpGadget, budget);
+
+                // Column count matches the closed form.
+                let per_column = budget - 1;
+                let expected_columns = n.div_ceil(per_column);
+                assert_eq!(
+                    packed.len(),
+                    expected_columns,
+                    "n={n} budget={budget}: column count"
+                );
+
+                // Folding moves tuples between columns but never drops one.
+                let total_tuples: usize = packed.iter().map(|l| l.elements.len()).sum();
+                assert_eq!(total_tuples, n, "n={n} budget={budget}: tuples conserved");
+
+                // No packed column exceeds the degree budget.
+                for l in packed.iter() {
+                    assert!(
+                        LogUpGadget.constraint_degree(l) <= budget,
+                        "n={n} budget={budget}: degree within budget"
+                    );
+                }
+                assert_contiguous_columns(&packed);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Fold global lookups that share a bus into shared fraction columns, **capped at the AIR's spare quotient-degree budget**. Today every global interaction gets its own committed auxiliary column; this packs several onto one column when — and only when — doing so leaves the quotient unchanged.

## Why it never regresses

The quotient chunk count is `2^ceil(log2((max_degree + is_zk).max(2) - 1))`. Folding interactions into one column only ever raises that column's fraction-pin degree. So the safe rule is:

> Fold same-bus globals into a column only while its degree stays `<= 2^B + 1 - is_zk`, where `B` is the *unpacked* AIR's `log_num_quotient_chunks`.

This keeps the quotient bucket **identical** (a debug assert enforces it), so quotient work — the expensive part — is unchanged, and only auxiliary columns drop.

- **No spare budget** (e.g. a pure range-check table, degree 2): budget folds nothing → byte-identical to before.
- **Spare budget** (any AIR with a degree-≥3 constraint, the common case): folds for free.

Both prover and verifier recompute the fold deterministically from the public AIRs, so the layout is never transmitted and soundness is untouched — folding only reorganizes the same per-bus rational sum.

## Measured (end-to-end bench, BabyBear, 100-query FRI)

Each case is measured packed and unpacked in one table.

| case | aux cols | proof (KB) | peak (MB) | prove |
|---|---|---|---|---|
| `n=16`, deg 0 (no budget) | 33 = 33 | 686.2 = 686.2 | 32.9 = 32.9 | — *(identical)* |
| `deg3_n=16` | 33 → **17** | 688.3 → **629.9** | 33.7 → **25.7** | 403 → **287 ms** *(criterion, ~29%)* |
| `deg3_n=32` (h=2^18) | 65 → **33** | 1074 → **957** | 944 → **591** | 12.5 → **8.2 s** |

Every no-budget case is byte-identical packed vs unpacked (no regression); every spare-budget case improves on all metrics.

## Changes

- **`lookup`**: `Lookups::pack_same_bus(gadget, max_degree)` — pure fold of same-bus globals into multi-tuple lookups under a degree cap; sums weights, reassigns contiguous columns, leaves local lookups untouched. Unit-tested incl. a full `n × budget` invariant sweep.
- **`batch-stark`**: apply the fold at lookup-build time with the is_zk-aware budget, guarded by a debug assert that the quotient chunk count is preserved.
- **bench**: extend the end-to-end harness with a `base_degree` knob and a packed-vs-unpacked column, so the no-regression guard and the win read off the same table.

## Scope

This is the provably-safe core (Miden #2962's column packing, restricted to same-bus folding within the spare degree budget). Follow-ups, intentionally left out: mutual-exclusivity-aware `degree = max` grouping (needs a disjoint-selector API), prover flag-zero skip, and the typed bus-id cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)