### PR TITLE
perf: vectorize packed field

### DIFF
--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -8,7 +8,9 @@ use p3_keccak_air::KeccakAir;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use p3_poseidon2_air::{Poseidon2Air, VectorizedPoseidon2Air};
-use p3_uni_stark::{ProverConstraintFolder, StarkGenericConfig, VerifierConstraintFolder};
+use p3_uni_stark::{
+    QUOTIENT_ILP, StarkGenericConfig, VectorizedConstraintFolder, VerifierConstraintFolder,
+};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 
@@ -49,7 +51,7 @@ pub trait ExampleHashAir<F: Field, SC: StarkGenericConfig>:
     BaseAir<F>
     + for<'a> Air<DebugConstraintBuilder<'a, F>>
     + Air<SymbolicAirBuilder<F>>
-    + for<'a> Air<ProverConstraintFolder<'a, SC>>
+    + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>
     + for<'a> Air<VerifierConstraintFolder<'a, SC>>
 {
     fn generate_trace_rows(

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -14,6 +14,7 @@ mod helpers;
 pub mod integers;
 pub mod op_assign_macros;
 mod packed;
+mod vectorized;
 
 pub use array::*;
 pub use batch_inverse::*;
@@ -21,3 +22,4 @@ pub use dup::Dup;
 pub use field::*;
 pub use helpers::*;
 pub use packed::*;
+pub use vectorized::*;

--- a/field/src/vectorized.rs
+++ b/field/src/vectorized.rs
@@ -1,0 +1,484 @@
+use core::array;
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::{
+    Algebra, BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PackedValue,
+    PrimeCharacteristicRing,
+};
+
+/// `N` packed base-field vectors operated on in lockstep.
+///
+/// A single packed vector often cannot saturate the CPU's multiplier pipes: a
+/// dependency chain of packed multiplications leaves most issue slots idle
+/// (e.g. NEON's modular multiply has ~10 cycles of latency at ~1.25 cycles of
+/// throughput per vector). Widening the *data type* rather than the loop turns
+/// every ring operation into `N` independent instructions back to back, giving
+/// the out-of-order core `N` interleaved dependency chains without changing the
+/// shape of the expression being evaluated.
+///
+/// Lane `i` of the logical vector lives in `self.0[i / W].as_slice()[i % W]`
+/// where `W = F::Packing::WIDTH`, i.e. components hold consecutive blocks of
+/// lanes.
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+#[must_use]
+pub struct Vectorized<F: Field, const N: usize>(pub [F::Packing; N]);
+
+/// `N` packed extension-field vectors operated on in lockstep.
+///
+/// The extension-field counterpart of [`Vectorized`]: lane `i` corresponds to
+/// lane `i` of a `Vectorized<F, N>` operand, so the two types can be mixed in
+/// the same expression (`VectorizedExt * Vectorized`, etc.).
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+#[must_use]
+pub struct VectorizedExt<F: Field, EF: ExtensionField<F>, const N: usize>(
+    pub [EF::ExtensionPacking; N],
+);
+
+impl<F: Field, const N: usize> Vectorized<F, N> {
+    /// Map a function over the `N` packed components.
+    #[inline]
+    fn map(self, f: impl FnMut(F::Packing) -> F::Packing) -> Self {
+        Self(self.0.map(f))
+    }
+
+    /// Combine two values component-wise.
+    #[inline]
+    fn zip_with<T: Copy>(
+        self,
+        rhs: &[T; N],
+        mut f: impl FnMut(F::Packing, T) -> F::Packing,
+    ) -> Self {
+        Self(array::from_fn(|i| f(self.0[i], rhs[i])))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> VectorizedExt<F, EF, N> {
+    /// Map a function over the `N` packed components.
+    #[inline]
+    fn map(self, f: impl FnMut(EF::ExtensionPacking) -> EF::ExtensionPacking) -> Self {
+        Self(self.0.map(f))
+    }
+
+    /// Combine two values component-wise.
+    #[inline]
+    fn zip_with<T: Copy>(
+        self,
+        rhs: &[T; N],
+        mut f: impl FnMut(EF::ExtensionPacking, T) -> EF::ExtensionPacking,
+    ) -> Self {
+        Self(array::from_fn(|i| f(self.0[i], rhs[i])))
+    }
+
+    /// Build from basis coefficients, where coefficient `d` is the vectorized
+    /// base-field value `coefficients[d]`.
+    ///
+    /// This is the vectorized analogue of
+    /// [`BasedVectorSpace::from_basis_coefficients_fn`]; it takes a slice
+    /// rather than a closure so each coefficient is computed once and shared
+    /// by all `N` components.
+    #[inline]
+    pub fn from_vectorized_basis_coefficients(coefficients: &[Vectorized<F, N>]) -> Self {
+        debug_assert_eq!(coefficients.len(), EF::DIMENSION);
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::from_basis_coefficients_fn(|d| coefficients[d].0[i])
+        }))
+    }
+
+    /// Extract the extension-field element at logical lane `i`.
+    ///
+    /// Lanes `0..F::Packing::WIDTH` come from component `0`, the next
+    /// `F::Packing::WIDTH` from component `1`, and so on.
+    #[inline]
+    pub fn extract(&self, i: usize) -> EF {
+        let width = F::Packing::WIDTH;
+        self.0[i / width].extract(i % width)
+    }
+}
+
+impl<F: Field, const N: usize> Default for Vectorized<F, N> {
+    #[inline]
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Default for VectorizedExt<F, EF, N> {
+    #[inline]
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: Field, const N: usize> From<F> for Vectorized<F, N> {
+    #[inline]
+    fn from(value: F) -> Self {
+        Self([F::Packing::from(value); N])
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> From<EF> for VectorizedExt<F, EF, N> {
+    #[inline]
+    fn from(value: EF) -> Self {
+        Self([EF::ExtensionPacking::from(value); N])
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> From<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn from(value: Vectorized<F, N>) -> Self {
+        Self(value.0.map(EF::ExtensionPacking::from))
+    }
+}
+
+macro_rules! impl_binary_ops {
+    ($ty:ty, $($bound:tt)*) => {
+        impl<$($bound)*> Add for $ty {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x + y)
+            }
+        }
+
+        impl<$($bound)*> Sub for $ty {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x - y)
+            }
+        }
+
+        impl<$($bound)*> Mul for $ty {
+            type Output = Self;
+            #[inline]
+            fn mul(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x * y)
+            }
+        }
+
+        impl<$($bound)*> Neg for $ty {
+            type Output = Self;
+            #[inline]
+            fn neg(self) -> Self {
+                self.map(|x| -x)
+            }
+        }
+
+        impl<$($bound)*> AddAssign for $ty {
+            #[inline]
+            fn add_assign(&mut self, rhs: Self) {
+                *self = *self + rhs;
+            }
+        }
+
+        impl<$($bound)*> SubAssign for $ty {
+            #[inline]
+            fn sub_assign(&mut self, rhs: Self) {
+                *self = *self - rhs;
+            }
+        }
+
+        impl<$($bound)*> MulAssign for $ty {
+            #[inline]
+            fn mul_assign(&mut self, rhs: Self) {
+                *self = *self * rhs;
+            }
+        }
+
+        impl<$($bound)*> Sum for $ty {
+            #[inline]
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::ZERO, |acc, x| acc + x)
+            }
+        }
+
+        impl<$($bound)*> Product for $ty {
+            #[inline]
+            fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::ONE, |acc, x| acc * x)
+            }
+        }
+    };
+}
+
+macro_rules! impl_scalar_ops {
+    ($ty:ty, $scalar:ty, $($bound:tt)*) => {
+        impl<$($bound)*> Add<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: $scalar) -> Self {
+                self.map(|x| x + rhs)
+            }
+        }
+
+        impl<$($bound)*> Sub<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: $scalar) -> Self {
+                self.map(|x| x - rhs)
+            }
+        }
+
+        impl<$($bound)*> Mul<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn mul(self, rhs: $scalar) -> Self {
+                self.map(|x| x * rhs)
+            }
+        }
+
+        impl<$($bound)*> AddAssign<$scalar> for $ty {
+            #[inline]
+            fn add_assign(&mut self, rhs: $scalar) {
+                *self = *self + rhs;
+            }
+        }
+
+        impl<$($bound)*> SubAssign<$scalar> for $ty {
+            #[inline]
+            fn sub_assign(&mut self, rhs: $scalar) {
+                *self = *self - rhs;
+            }
+        }
+
+        impl<$($bound)*> MulAssign<$scalar> for $ty {
+            #[inline]
+            fn mul_assign(&mut self, rhs: $scalar) {
+                *self = *self * rhs;
+            }
+        }
+    };
+}
+
+impl_binary_ops!(Vectorized<F, N>, F: Field, const N: usize);
+impl_scalar_ops!(Vectorized<F, N>, F, F: Field, const N: usize);
+impl_binary_ops!(VectorizedExt<F, EF, N>, F: Field, EF: ExtensionField<F>, const N: usize);
+impl_scalar_ops!(VectorizedExt<F, EF, N>, EF, F: Field, EF: ExtensionField<F>, const N: usize);
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Add<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x + y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Sub<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x - y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Mul<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x * y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> AddAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> SubAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> MulAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn mul_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: Field, const N: usize> PrimeCharacteristicRing for Vectorized<F, N> {
+    type PrimeSubfield = F::PrimeSubfield;
+
+    const ZERO: Self = Self([F::Packing::ZERO; N]);
+    const ONE: Self = Self([F::Packing::ONE; N]);
+    const TWO: Self = Self([F::Packing::TWO; N]);
+    const NEG_ONE: Self = Self([F::Packing::NEG_ONE; N]);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        F::from_prime_subfield(f).into()
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        self.map(|x| x.double())
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        self.map(|x| x.halve())
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        self.map(|x| x.square())
+    }
+
+    #[inline]
+    fn cube(&self) -> Self {
+        self.map(|x| x.cube())
+    }
+
+    #[inline]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        self.map(|x| x.exp_const_u64::<POWER>())
+    }
+
+    #[inline]
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        self.map(|x| x.mul_2exp_u64(exp))
+    }
+
+    #[inline]
+    fn dot_product<const M: usize>(u: &[Self; M], v: &[Self; M]) -> Self {
+        Self(array::from_fn(|i| {
+            F::Packing::dot_product::<M>(
+                &array::from_fn::<_, M, _>(|j| u[j].0[i]),
+                &array::from_fn::<_, M, _>(|j| v[j].0[i]),
+            )
+        }))
+    }
+
+    #[inline]
+    fn sum_array<const M: usize>(input: &[Self]) -> Self {
+        assert_eq!(input.len(), M);
+        Self(array::from_fn(|i| {
+            F::Packing::sum_array::<M>(&array::from_fn::<_, M, _>(|j| input[j].0[i]))
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> PrimeCharacteristicRing
+    for VectorizedExt<F, EF, N>
+{
+    type PrimeSubfield = <EF::ExtensionPacking as PrimeCharacteristicRing>::PrimeSubfield;
+
+    const ZERO: Self = Self([EF::ExtensionPacking::ZERO; N]);
+    const ONE: Self = Self([EF::ExtensionPacking::ONE; N]);
+    const TWO: Self = Self([EF::ExtensionPacking::TWO; N]);
+    const NEG_ONE: Self = Self([EF::ExtensionPacking::NEG_ONE; N]);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        Self([EF::ExtensionPacking::from_prime_subfield(f); N])
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        self.map(|x| x.double())
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        self.map(|x| x.halve())
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        self.map(|x| x.square())
+    }
+}
+
+impl<F: Field, const N: usize> Algebra<F> for Vectorized<F, N> {
+    const BATCHED_LC_CHUNK: usize = <F::Packing as Algebra<F>>::BATCHED_LC_CHUNK;
+
+    #[inline]
+    fn mixed_dot_product<const M: usize>(a: &[Self; M], f: &[F; M]) -> Self {
+        Self(array::from_fn(|i| {
+            F::Packing::mixed_dot_product(&array::from_fn(|j| a[j].0[i]), f)
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Algebra<EF> for VectorizedExt<F, EF, N> {
+    const BATCHED_LC_CHUNK: usize = <EF::ExtensionPacking as Algebra<EF>>::BATCHED_LC_CHUNK;
+
+    #[inline]
+    fn mixed_dot_product<const M: usize>(a: &[Self; M], f: &[EF; M]) -> Self {
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::mixed_dot_product(&array::from_fn(|j| a[j].0[i]), f)
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Algebra<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+}
+
+// SAFETY: `Vectorized<F, N>` is `repr(transparent)` over `[F::Packing; N]` and
+// `F::Packing: PackedField` guarantees that `F::Packing` can be cast to/from
+// `[F; F::Packing::WIDTH]` without UB. Hence `Vectorized<F, N>` can be cast
+// to/from `[F; F::Packing::WIDTH * N]`.
+unsafe impl<F: Field, const N: usize> PackedValue for Vectorized<F, N> {
+    type Value = F;
+
+    const WIDTH: usize = F::Packing::WIDTH * N;
+
+    #[inline]
+    fn from_fn<Fn>(mut f: Fn) -> Self
+    where
+        Fn: FnMut(usize) -> Self::Value,
+    {
+        Self(array::from_fn(|i| {
+            F::Packing::from_fn(|j| f(i * F::Packing::WIDTH + j))
+        }))
+    }
+
+    #[inline]
+    fn from_slice(slice: &[Self::Value]) -> &Self {
+        assert_eq!(slice.len(), Self::WIDTH);
+        let (_, values, _) = unsafe { slice.align_to::<Self>() };
+        assert_eq!(values.len(), 1, "slice is not aligned to Self");
+        &values[0]
+    }
+
+    #[inline]
+    fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
+        assert_eq!(slice.len(), Self::WIDTH);
+        let (_, values, _) = unsafe { slice.align_to_mut::<Self>() };
+        assert_eq!(values.len(), 1, "slice is not aligned to Self");
+        &mut values[0]
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[Self::Value] {
+        unsafe { core::slice::from_raw_parts(core::ptr::from_ref(self).cast(), Self::WIDTH) }
+    }
+
+    #[inline]
+    fn as_slice_mut(&mut self) -> &mut [Self::Value] {
+        unsafe { core::slice::from_raw_parts_mut(core::ptr::from_mut(self).cast(), Self::WIDTH) }
+    }
+}

--- a/field/src/vectorized.rs
+++ b/field/src/vectorized.rs
@@ -1,3 +1,9 @@
+//! Lockstep evaluation over multiple packed vectors, trading register pressure
+//! for instruction-level parallelism in latency-bound field arithmetic.
+//!
+//! Inspired by stwo's `Vectorized` type:
+//! <https://github.com/starkware-libs/stwo/blob/cca98119f/crates/stwo/src/prover/backend/simd/very_packed_m31.rs>
+
 use core::array;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,11 +1,19 @@
 use alloc::vec::Vec;
 
 use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
-use p3_field::{Algebra, BasedVectorSpace};
+use p3_field::{Algebra, BasedVectorSpace, Vectorized, VectorizedExt};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
 
 use crate::{PackedChallenge, PackedVal, StarkGenericConfig, Val};
+
+/// Vectorized base-field expression type used by [`VectorizedConstraintFolder`]:
+/// `N` packed vectors evaluated in lockstep.
+pub type VectorizedVal<SC, const N: usize> = Vectorized<Val<SC>, N>;
+
+/// Vectorized extension-field expression type used by [`VectorizedConstraintFolder`].
+pub type VectorizedChallenge<SC, const N: usize> =
+    VectorizedExt<Val<SC>, <SC as StarkGenericConfig>::Challenge, N>;
 
 /// Packed constraint folder for SIMD-optimized prover evaluation.
 ///
@@ -49,6 +57,151 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub constraint_index: usize,
     /// Total number of constraints in the AIR (debug-only bookkeeping)
     pub constraint_count: usize,
+}
+
+/// Packed constraint folder evaluating `N` packed vectors per constraint in lockstep.
+///
+/// Identical in role to [`ProverConstraintFolder`], but its expression types are
+/// [`Vectorized`]/[`VectorizedExt`] over `N` packed vectors instead of a single one.
+/// One packed vector of constraint evaluations forms a single dependency chain per
+/// expression; `N` lockstep chains let the CPU overlap the long-latency modular
+/// multiplies of independent rows, which a single chain cannot saturate.
+#[derive(Debug)]
+pub struct VectorizedConstraintFolder<'a, SC: StarkGenericConfig, const N: usize> {
+    /// The [`RowMajorMatrixView`] containing rows on which the constraint polynomial is evaluated.
+    pub main: RowMajorMatrixView<'a, VectorizedVal<SC, N>>,
+    /// The preprocessed columns as a [`RowMajorMatrixView`].
+    /// Zero-width when the AIR has no preprocessed trace.
+    pub preprocessed: RowMajorMatrixView<'a, VectorizedVal<SC, N>>,
+    /// Pre-built window over the preprocessed columns.
+    pub preprocessed_window: RowWindow<'a, VectorizedVal<SC, N>>,
+    /// Periodic column values at the current row(s), one vectorized value per column.
+    pub periodic_values: &'a [VectorizedVal<SC, N>],
+    /// Public inputs to the [AIR](`p3_air::Air`) implementation.
+    pub public_values: &'a [Val<SC>],
+    /// Evaluations of the first-row selector polynomial.
+    /// Non-zero only on the first trace row.
+    pub is_first_row: VectorizedVal<SC, N>,
+    /// Evaluations of the last-row selector polynomial.
+    /// Non-zero only on the last trace row.
+    pub is_last_row: VectorizedVal<SC, N>,
+    /// Evaluations of the transition selector polynomial.
+    /// Zero only on the last trace row.
+    pub is_transition: VectorizedVal<SC, N>,
+    /// Base-field alpha powers, reordered to match base constraint emission order.
+    /// `base_alpha_powers[d][j]` = d-th basis coefficient of alpha power for j-th base constraint.
+    pub base_alpha_powers: &'a [Vec<Val<SC>>],
+    /// Extension-field alpha powers, reordered to match ext constraint emission order.
+    pub ext_alpha_powers: &'a [SC::Challenge],
+    /// Collected base-field constraints for this row group
+    pub base_constraints: Vec<VectorizedVal<SC, N>>,
+    /// Collected extension-field constraints for this row group
+    pub ext_constraints: Vec<VectorizedChallenge<SC, N>>,
+    /// Current constraint index being processed (debug-only bookkeeping)
+    pub constraint_index: usize,
+    /// Total number of constraints in the AIR (debug-only bookkeeping)
+    pub constraint_count: usize,
+}
+
+impl<SC: StarkGenericConfig, const N: usize> VectorizedConstraintFolder<'_, SC, N> {
+    /// Combine all collected constraints with their pre-computed alpha powers.
+    ///
+    /// The same scheme as [`ProverConstraintFolder::finalize_constraints`], applied
+    /// per vectorized component: the [`Algebra::mixed_dot_product`] overrides on
+    /// [`Vectorized`]/[`VectorizedExt`] delegate each component to the underlying
+    /// packed type, so the specialized SIMD dot products are still used.
+    #[inline]
+    pub fn finalize_constraints(&self) -> VectorizedChallenge<SC, N> {
+        debug_assert_eq!(self.constraint_index, self.constraint_count);
+
+        let base = &self.base_constraints;
+        let base_coefficients: Vec<VectorizedVal<SC, N>> = self
+            .base_alpha_powers
+            .iter()
+            .map(|powers| VectorizedVal::<SC, N>::batched_linear_combination(base, powers))
+            .collect();
+        let acc =
+            VectorizedChallenge::<SC, N>::from_vectorized_basis_coefficients(&base_coefficients);
+        acc + VectorizedChallenge::<SC, N>::batched_linear_combination(
+            &self.ext_constraints,
+            self.ext_alpha_powers,
+        )
+    }
+}
+
+impl<'a, SC: StarkGenericConfig, const N: usize> AirBuilder
+    for VectorizedConstraintFolder<'a, SC, N>
+{
+    type F = Val<SC>;
+    type Expr = VectorizedVal<SC, N>;
+    type Var = VectorizedVal<SC, N>;
+    type PreprocessedWindow = RowWindow<'a, VectorizedVal<SC, N>>;
+    type MainWindow = RowWindow<'a, VectorizedVal<SC, N>>;
+    type PublicVar = Val<SC>;
+    type PeriodicVar = VectorizedVal<SC, N>;
+
+    #[inline]
+    fn main(&self) -> Self::MainWindow {
+        RowWindow::from_view(&self.main)
+    }
+
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
+        &self.preprocessed_window
+    }
+
+    #[inline]
+    fn is_first_row(&self) -> Self::Expr {
+        self.is_first_row
+    }
+
+    #[inline]
+    fn is_last_row(&self) -> Self::Expr {
+        self.is_last_row
+    }
+
+    #[inline]
+    fn is_transition(&self) -> Self::Expr {
+        self.is_transition
+    }
+
+    #[inline]
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        self.base_constraints.push(x.into());
+        self.constraint_index += 1;
+    }
+
+    #[inline]
+    fn assert_zeros<const M: usize, I: Into<Self::Expr>>(&mut self, array: [I; M]) {
+        let expr_array = array.map(Into::into);
+        self.base_constraints.extend(expr_array);
+        self.constraint_index += M;
+    }
+
+    #[inline]
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
+    }
+
+    #[inline]
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_values
+    }
+}
+
+impl<SC: StarkGenericConfig, const N: usize> ExtensionBuilder
+    for VectorizedConstraintFolder<'_, SC, N>
+{
+    type EF = SC::Challenge;
+    type ExprEF = VectorizedChallenge<SC, N>;
+    type VarEF = VectorizedChallenge<SC, N>;
+
+    fn assert_zero_ext<I>(&mut self, x: I)
+    where
+        I: Into<Self::ExprEF>,
+    {
+        self.ext_constraints.push(x.into());
+        self.constraint_index += 1;
+    }
 }
 
 /// Handles constraint verification for the verifier in a STARK system.

--- a/uni-stark/src/preprocessed.rs
+++ b/uni-stark/src/preprocessed.rs
@@ -4,7 +4,7 @@ use p3_commit::Pcs;
 use p3_matrix::Matrix;
 use tracing::debug_span;
 
-use crate::{ProverConstraintFolder, StarkGenericConfig, Val};
+use crate::{QUOTIENT_ILP, StarkGenericConfig, Val, VectorizedConstraintFolder};
 
 /// Prover-side reusable data for preprocessed columns.
 ///
@@ -52,7 +52,8 @@ pub fn setup_preprocessed<SC, A>(
 ) -> Option<(PreprocessedProverData<SC>, PreprocessedVerifierKey<SC>)>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
 {
     let pcs = config.pcs();
     let is_zk = config.is_zk();

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -6,7 +6,7 @@ use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
-use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
+use p3_field::{PackedValue, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_maybe_rayon::prelude::*;
@@ -14,10 +14,19 @@ use p3_util::log2_strict_usize;
 use tracing::{debug_span, info_span, instrument};
 
 use crate::{
-    Commitments, Domain, OpenedValues, PackedVal, PreprocessedProverData, Proof,
-    ProverConstraintFolder, StarkGenericConfig, Val, get_constraint_layout,
-    get_log_num_quotient_chunks,
+    Commitments, Domain, OpenedValues, PreprocessedProverData, Proof, StarkGenericConfig, Val,
+    VectorizedConstraintFolder, VectorizedVal, get_constraint_layout, get_log_num_quotient_chunks,
 };
+
+/// Number of packed vectors evaluated in lockstep per constraint expression during
+/// quotient evaluation.
+///
+/// A single packed vector forms one dependency chain per constraint expression, which
+/// cannot hide the latency of modular multiplication (e.g. ~10 cycles at ~1.25
+/// cycles/vector throughput on NEON). Two lockstep chains let the out-of-order core
+/// overlap independent rows. Values above 2 increase register pressure with
+/// diminishing returns.
+pub const QUOTIENT_ILP: usize = 2;
 
 #[instrument(skip_all)]
 #[allow(clippy::multiple_bound_locations, clippy::type_repetition_in_bounds)] // cfg not supported in where clauses?
@@ -34,7 +43,8 @@ pub fn prove_with_preprocessed<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
 {
     #[cfg(debug_assertions)]
     p3_air::check_constraints(air, &trace, public_values);
@@ -388,7 +398,8 @@ pub fn prove<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
 {
     prove_with_preprocessed::<SC, A>(config, air, trace, public_values, None)
 }
@@ -409,7 +420,8 @@ pub fn quotient_values<SC, A, Mat>(
 ) -> Vec<SC::Challenge>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
     Mat: Matrix<Val<SC>> + Sync,
 {
     let quotient_size = quotient_domain.size();
@@ -420,9 +432,10 @@ where
     let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
     let next_step = 1 << qdb;
 
-    // We take PackedVal::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
-    // pad with default values in the case where quotient_size is smaller than PackedVal::<SC>::WIDTH.
-    for _ in quotient_size..PackedVal::<SC>::WIDTH {
+    // We take VectorizedVal::<SC, QUOTIENT_ILP>::WIDTH worth of values at a time from a
+    // quotient_size slice, so we need to pad with default values in the case where
+    // quotient_size is smaller than VectorizedVal::<SC, QUOTIENT_ILP>::WIDTH.
+    for _ in quotient_size..VectorizedVal::<SC, QUOTIENT_ILP>::WIDTH {
         sels.is_first_row.push(Val::<SC>::default());
         sels.is_last_row.push(Val::<SC>::default());
         sels.is_transition.push(Val::<SC>::default());
@@ -435,8 +448,8 @@ where
     let periodic_table =
         pcs.build_periodic_lde_table(&periodic_cols, trace_domain, quotient_domain);
 
-    let pack_width = PackedVal::<SC>::WIDTH;
-    let periodic_packed: Vec<Vec<PackedVal<SC>>> = if periodic_table.is_empty() {
+    let pack_width = VectorizedVal::<SC, QUOTIENT_ILP>::WIDTH;
+    let periodic_packed: Vec<Vec<VectorizedVal<SC, QUOTIENT_ILP>>> = if periodic_table.is_empty() {
         Vec::new()
     } else {
         let ncols = periodic_table.width();
@@ -445,7 +458,7 @@ where
             .map(|i_start| {
                 (0..ncols)
                     .map(|col_idx| {
-                        PackedVal::<SC>::from_fn(|offset| {
+                        VectorizedVal::<SC, QUOTIENT_ILP>::from_fn(|offset| {
                             *periodic_table.get(i_start + offset, col_idx)
                         })
                     })
@@ -456,14 +469,15 @@ where
 
     (0..quotient_size)
         .into_par_iter()
-        .step_by(PackedVal::<SC>::WIDTH)
+        .step_by(pack_width)
         .flat_map_iter(|i_start| {
-            let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
+            type V<SC> = VectorizedVal<SC, QUOTIENT_ILP>;
+            let i_range = i_start..i_start + pack_width;
 
-            let is_first_row = *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
-            let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
-            let is_transition = *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
-            let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
+            let is_first_row = *V::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+            let is_last_row = *V::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+            let is_transition = *V::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+            let inv_vanishing = *V::<SC>::from_slice(&sels.inv_vanishing[i_range]);
 
             let main = RowMajorMatrix::new(
                 trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
@@ -481,12 +495,13 @@ where
             let preprocessed_view = preprocessed
                 .as_ref()
                 .map_or_else(|| RowMajorMatrixView::new(&[], 0), |m| m.as_view());
-            let periodic_values: &[PackedVal<SC>] = if periodic_packed.is_empty() {
+            let periodic_values: &[VectorizedVal<SC, QUOTIENT_ILP>] = if periodic_packed.is_empty()
+            {
                 &[]
             } else {
                 &periodic_packed[i_start / pack_width]
             };
-            let mut folder = ProverConstraintFolder {
+            let mut folder = VectorizedConstraintFolder {
                 main: main.as_view(),
                 preprocessed: preprocessed_view,
                 preprocessed_window: RowWindow::from_view(&preprocessed_view),
@@ -508,7 +523,7 @@ where
             let quotient = folder.finalize_constraints() * inv_vanishing;
 
             // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
-            (0..core::cmp::min(quotient_size, PackedVal::<SC>::WIDTH))
+            (0..core::cmp::min(quotient_size, pack_width))
                 .map(move |idx_in_packing| quotient.extract(idx_in_packing))
         })
         .collect()

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -26,7 +26,10 @@ use crate::{
 /// cycles/vector throughput on NEON). Two lockstep chains let the out-of-order core
 /// overlap independent rows. Values above 2 increase register pressure with
 /// diminishing returns.
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub const QUOTIENT_ILP: usize = 2;
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+pub const QUOTIENT_ILP: usize = 1;
 
 #[instrument(skip_all)]
 #[allow(clippy::multiple_bound_locations, clippy::type_repetition_in_bounds)] // cfg not supported in where clauses?


### PR DESCRIPTION
## Motivation

  During quotient evaluation, the constraint folder evaluates the AIR expression DAG over a single packed vector per row group.
  Each expression forms one dependency chain, which cannot hide the latency of packed modular
  multiplication (for instance NEON M31 mul:
  ~10 cycles latency at 1.25 cycles/vector throughput → ~8 independent chains needed to saturate the pipes).
  
  Inspired from Stwo's `Vectorized<PackedM31, 2>`.
  
  ## Changes
  
 - `p3-field`: adds a pair of wrapper types that bundle several packed vectors (base-field and extension-field) into a single value whose arithmetic is applied to all of them in lockstep. They expose the same ring and packing
  interfaces as ordinary packed values, so existing machinery — loading trace rows, slicing selectors, and the specialized SIMD dot products used when folding constraints with alpha powers — keeps working unchanged on the
  wider type.
  
 - `p3-uni-stark`: adds a constraint folder built on these wrapper types, and switches quotient evaluation to it, so each iteration now evaluates the constraint polynomial over two packed vectors at once. The prover's trait
  bounds are updated to match; AIRs written generically over the builder (the usual pattern) compile without modification.

## Benchmarks

Running 
```bash
  cargo build --release --example prove_prime_field_31 --features parallel
  cargo build --release --example prove_goldilocks_keccak --features parallel -p p3-keccak-air
  ```
  
 - NEON, M4 Pro:
  
```bash
  ┌──────────────────────┬──────────────────────┬────────────┬───────────────────┬─────────┐
  │        Field         │ quotient main → vect │ Δ quotient │ prove main → vect │ Δ prove │
  ├──────────────────────┼──────────────────────┼────────────┼───────────────────┼─────────┤
  │ Mersenne-31 (circle) │ 390 → 335 ms         │ −14.1%     │ 1.68 → 1.67 s     │ −0.6%   │
  ├──────────────────────┼──────────────────────┼────────────┼───────────────────┼─────────┤
  │ BabyBear             │ 412 → 380 ms         │ −7.8%      │ 1.80 → 1.79 s     │ −0.6%   │
  ├──────────────────────┼──────────────────────┼────────────┼───────────────────┼─────────┤
  │ KoalaBear            │ 412 → 378 ms         │ −8.3%      │ 1.81 → 1.79 s     │ −1.1%   │
  ├──────────────────────┼──────────────────────┼────────────┼───────────────────┼─────────┤
  │ Goldilocks           │ 172 → 159 ms         │ −7.6%      │ 562 → 558 ms      │ −0.7%   │
  └──────────────────────┴──────────────────────┴────────────┴───────────────────┴─────────┘

```

It does not seem to benefit AVX2 / AVX512 so this is gated for `aarch64` targets only for now.
