### PR TITLE
whir: allow partial final constant fold

### DIFF
--- a/whir/src/fiat_shamir/domain_separator.rs
+++ b/whir/src/fiat_shamir/domain_separator.rs
@@ -282,14 +282,14 @@ where
         // Initial combination randomness and first sumcheck phase.
         self.sample(1, Sample::InitialCombinationRandomness);
         self.add_sumcheck(&SumcheckParams {
-            rounds: config.folding_factor.at_round(0),
+            rounds: config.round_folding_factor(0),
             pow_bits: config.starting_folding_pow_bits,
         });
 
         // Intermediate rounds: commitment → OOD → PoW → checkpoint → queries → sumcheck.
         let mut domain_size = config.starting_domain_size();
         for (round, r) in config.round_parameters.iter().enumerate() {
-            let folded_domain_size = domain_size >> config.folding_factor.at_round(round);
+            let folded_domain_size = domain_size >> config.round_folding_factor(round);
             // Byte length needed to encode a position in the folded domain.
             let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
 
@@ -314,17 +314,15 @@ where
             self.sample(1, Sample::CombinationRandomness);
 
             self.add_sumcheck(&SumcheckParams {
-                rounds: config.folding_factor.at_round(round + 1),
+                rounds: config.round_folding_factor(round + 1),
                 pow_bits: r.folding_pow_bits,
             });
             domain_size >>= config.rs_reduction_factor(round);
         }
 
         // Final round: coefficients → PoW → queries → sumcheck → deferred hints.
-        let folded_domain_size = domain_size
-            >> config
-                .folding_factor
-                .at_round(config.round_parameters.len());
+        let folded_domain_size =
+            domain_size >> config.round_folding_factor(config.round_parameters.len());
         let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
 
         // Observe all coefficients of the final folded polynomial.
@@ -438,7 +436,7 @@ where
         // Claim batching challenge and the initial masked sumcheck batch.
         self.sample(1, Sample::InitialCombinationRandomness);
         self.add_zk_residual_sumcheck::<DIGEST_ELEMS>(&ZkSumcheckParams {
-            rounds: config.folding_factor(0),
+            rounds: config.round_folding_factor(0),
             pow_bits: config.starting_folding_pow_bits,
             ell_zk: config.zk.ell_zk,
         });
@@ -446,7 +444,7 @@ where
         // Code-switching rounds.
         let mut domain_size = config.starting_domain_size();
         for (round, r) in config.round_parameters.iter().enumerate() {
-            let folded_domain_size = domain_size >> config.folding_factor(round);
+            let folded_domain_size = domain_size >> config.round_folding_factor(round);
             let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
 
             // New oracle and fresh code-switch mask.
@@ -465,7 +463,7 @@ where
             // Batching challenge, then the next masked sumcheck batch.
             self.sample(1, Sample::CombinationRandomness);
             self.add_zk_residual_sumcheck::<DIGEST_ELEMS>(&ZkSumcheckParams {
-                rounds: config.folding_factor(round + 1),
+                rounds: config.round_folding_factor(round + 1),
                 pow_bits: r.folding_pow_bits,
                 ell_zk: config.zk.ell_zk,
             });

--- a/whir/src/parameters/folding.rs
+++ b/whir/src/parameters/folding.rs
@@ -31,6 +31,10 @@ pub enum FoldingFactorError {
         remaining: usize,
         threshold: usize,
     },
+
+    /// The explicit per-round schedule contains no folding factors.
+    #[error("per-round folding schedule is empty; WHIR requires at least one fold")]
+    EmptySchedule,
 }
 
 /// Defines the folding factor for polynomial commitments.
@@ -124,6 +128,11 @@ impl FoldingFactor {
                 Ok(schedule)
             }
             Self::PerRound(factors) => {
+                // WHIR always performs at least one fold before direct send,
+                // so an empty explicit schedule can never run.
+                if factors.is_empty() {
+                    return Err(FoldingFactorError::EmptySchedule);
+                }
                 for &factor in factors {
                     if factor == 0 {
                         return Err(FoldingFactorError::ZeroFactor);
@@ -158,8 +167,13 @@ impl FoldingFactor {
     ///
     /// # Errors
     ///
-    /// An explicit per-round schedule errors if a round folds more variables than remain.
-    /// It also errors if the factors together fail to reach the direct-send threshold.
+    /// Propagates every error of [`Self::compute_folding_schedule`]:
+    ///
+    /// - a zero folding factor,
+    /// - a first fold larger than the variable count,
+    /// - an empty explicit schedule,
+    /// - an explicit round folding more variables than remain,
+    /// - an explicit schedule stopping above the direct-send threshold.
     pub fn compute_number_of_rounds(
         &self,
         num_variables: usize,
@@ -350,6 +364,16 @@ mod tests {
         assert_eq!(
             FoldingFactor::PerRound(vec![2, 0]).compute_number_of_rounds(15),
             Err(FoldingFactorError::ZeroFactor)
+        );
+        // An empty explicit schedule is rejected.
+        // The guard fires even below the direct-send threshold.
+        assert_eq!(
+            FoldingFactor::PerRound(vec![]).compute_number_of_rounds(4),
+            Err(FoldingFactorError::EmptySchedule)
+        );
+        assert_eq!(
+            FoldingFactor::PerRound(vec![]).check_validity(15),
+            Err(FoldingFactorError::EmptySchedule)
         );
     }
 

--- a/whir/src/parameters/folding.rs
+++ b/whir/src/parameters/folding.rs
@@ -40,13 +40,17 @@ pub enum FoldingFactor {
     Constant(usize),
     /// Uses a different folding factor for the first round and a fixed one for the rest.
     ConstantFromSecondRound(usize, usize),
-    /// Explicit folding factors for each folding phase, including the initial
-    /// fold and the final sumcheck fold.
+    /// Explicit folding factors for each pre-direct-send folding phase,
+    /// including the initial fold.
     PerRound(Vec<usize>),
 }
 
 impl FoldingFactor {
-    /// Retrieves the folding factor for a given round.
+    /// Retrieves the nominal configured folding factor for a given round.
+    ///
+    /// This does not apply the partial-final-fold clamp used by constant
+    /// schedules. Use [`Self::compute_folding_schedule`] when the concrete
+    /// derived factors matter.
     #[must_use]
     pub fn at_round(&self, round: usize) -> usize {
         match self {
@@ -64,46 +68,88 @@ impl FoldingFactor {
 
     /// Checks the validity of the folding factor against the number of variables.
     pub fn check_validity(&self, num_variables: usize) -> Result<(), FoldingFactorError> {
+        self.compute_folding_schedule(num_variables).map(|_| ())
+    }
+
+    /// Derive the concrete folding factors used before the final direct-send phase.
+    ///
+    /// Constant schedules may use a smaller final fold when fewer than `factor`
+    /// variables remain. Explicit per-round schedules stay exact and therefore
+    /// still reject any factor larger than the current remainder.
+    pub fn compute_folding_schedule(
+        &self,
+        num_variables: usize,
+    ) -> Result<Vec<usize>, FoldingFactorError> {
         match self {
             Self::Constant(factor) => {
+                if *factor == 0 {
+                    return Err(FoldingFactorError::ZeroFactor);
+                }
                 if *factor > num_variables {
-                    // A folding factor cannot be greater than the number of available variables.
-                    Err(FoldingFactorError::TooLarge(*factor, num_variables))
-                } else if *factor == 0 {
-                    // A folding factor of zero is invalid since folding must reduce variables.
-                    Err(FoldingFactorError::ZeroFactor)
-                } else {
-                    Ok(())
+                    return Err(FoldingFactorError::TooLarge(*factor, num_variables));
+                }
+                let mut remaining = num_variables;
+                let mut schedule = Vec::new();
+                loop {
+                    let round_factor = (*factor).min(remaining);
+                    schedule.push(round_factor);
+                    remaining -= round_factor;
+                    if remaining <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                        return Ok(schedule);
+                    }
                 }
             }
             Self::ConstantFromSecondRound(first_round_factor, factor) => {
+                if *first_round_factor == 0 || *factor == 0 {
+                    return Err(FoldingFactorError::ZeroFactor);
+                }
                 if *first_round_factor > num_variables {
-                    // The first round folding factor must not exceed the available variables.
-                    Err(FoldingFactorError::TooLarge(
+                    return Err(FoldingFactorError::TooLarge(
                         *first_round_factor,
                         num_variables,
-                    ))
-                } else if *factor > num_variables {
-                    // Subsequent round folding factors must also not exceed the available
-                    // variables.
-                    Err(FoldingFactorError::TooLarge(*factor, num_variables))
-                } else if *factor == 0 || *first_round_factor == 0 {
-                    // Folding should occur at least once; zero is not valid.
-                    Err(FoldingFactorError::ZeroFactor)
-                } else {
-                    Ok(())
+                    ));
                 }
+
+                let mut remaining = num_variables;
+                let mut schedule = Vec::new();
+
+                schedule.push(*first_round_factor);
+                remaining -= *first_round_factor;
+                while remaining > MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                    let round_factor = (*factor).min(remaining);
+                    schedule.push(round_factor);
+                    remaining -= round_factor;
+                }
+
+                Ok(schedule)
             }
             Self::PerRound(factors) => {
                 for &factor in factors {
-                    if factor > num_variables {
-                        return Err(FoldingFactorError::TooLarge(factor, num_variables));
-                    }
                     if factor == 0 {
                         return Err(FoldingFactorError::ZeroFactor);
                     }
+                    if factor > num_variables {
+                        return Err(FoldingFactorError::TooLarge(factor, num_variables));
+                    }
                 }
-                Ok(())
+
+                let mut remaining = num_variables;
+                let mut schedule = Vec::new();
+                for &factor in factors {
+                    if factor > remaining {
+                        return Err(FoldingFactorError::TooLarge(factor, remaining));
+                    }
+                    schedule.push(factor);
+                    remaining -= factor;
+                    if remaining <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                        return Ok(schedule);
+                    }
+                }
+                Err(FoldingFactorError::InsufficientFolding {
+                    num_variables,
+                    remaining,
+                    threshold: MAX_NUM_VARIABLES_TO_SEND_COEFFS,
+                })
             }
         }
     }
@@ -118,82 +164,9 @@ impl FoldingFactor {
         &self,
         num_variables: usize,
     ) -> Result<(usize, usize), FoldingFactorError> {
-        match self {
-            Self::Constant(factor) => {
-                if num_variables <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
-                    // the first folding is mandatory in the current implem (TODO don't fold, send directly the polynomial)
-                    return Ok((0, num_variables - factor));
-                }
-                // Starting from `num_variables`, each round reduces the number of variables by `factor`. As soon as the
-                // number of variables is less of equal than `MAX_NUM_VARIABLES_TO_SEND_COEFFS`, we stop folding and the
-                // prover sends directly the coefficients of the polynomial.
-                let num_rounds =
-                    (num_variables - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(*factor);
-                let final_sumcheck_rounds = num_variables - num_rounds * factor;
-                // The -1 accounts for the fact that the last round does not require another folding.
-                Ok((num_rounds - 1, final_sumcheck_rounds))
-            }
-            Self::ConstantFromSecondRound(first_round_factor, factor) => {
-                // Compute the number of variables remaining after the first round.
-                let nv_except_first_round = num_variables - *first_round_factor;
-                if nv_except_first_round < MAX_NUM_VARIABLES_TO_SEND_COEFFS {
-                    // This case is equivalent to Constant(first_round_factor)
-                    // the first folding is mandatory in the current implem (TODO don't fold, send directly the polynomial)
-                    return Ok((0, nv_except_first_round));
-                }
-                // Starting from `num_variables`, the first round reduces the number of variables by `first_round_factor`,
-                // and the next ones by `factor`. As soon as the number of variables is less of equal than
-                // `MAX_NUM_VARIABLES_TO_SEND_COEFFS`, we stop folding and the prover sends directly the coefficients of the polynomial.
-                let num_rounds =
-                    (nv_except_first_round - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(*factor);
-                let final_sumcheck_rounds = nv_except_first_round - num_rounds * factor;
-                // No need to minus 1 because the initial round is already excepted out
-                Ok((num_rounds, final_sumcheck_rounds))
-            }
-            Self::PerRound(factors) => {
-                // Fold one explicit factor per round until the remainder reaches the threshold.
-                let mut remaining = num_variables;
-                for (i, &factor) in factors.iter().enumerate() {
-                    // A round cannot fold more variables than remain.
-                    //
-                    //     remaining = 7, factor = 9  ->  over-folds
-                    if factor > remaining {
-                        return Err(FoldingFactorError::TooLarge(factor, remaining));
-                    }
-                    remaining -= factor;
-                    // Threshold reached: `i` full rounds, `remaining` sent direct.
-                    if remaining <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
-                        return Ok((i, remaining));
-                    }
-                }
-                // Factors exhausted but the polynomial is still above the threshold.
-                //
-                //     num_variables = 20, sum(factors) = 5  ->  remaining 15 > 6
-                Err(FoldingFactorError::InsufficientFolding {
-                    num_variables,
-                    remaining,
-                    threshold: MAX_NUM_VARIABLES_TO_SEND_COEFFS,
-                })
-            }
-        }
-    }
-
-    /// Computes the total number of folding rounds over `n_rounds` iterations.
-    #[must_use]
-    pub fn total_number(&self, n_rounds: usize) -> usize {
-        match self {
-            Self::Constant(factor) => {
-                // - Each round folds `factor` variables,
-                // - There are `n_rounds + 1` iterations (including the original input size).
-                *factor * (n_rounds + 1)
-            }
-            Self::ConstantFromSecondRound(first_round_factor, factor) => {
-                // - The first round folds `first_round_factor` variables,
-                // - Subsequent rounds fold `factor` variables each.
-                *first_round_factor + *factor * n_rounds
-            }
-            Self::PerRound(factors) => factors.iter().take(n_rounds + 1).sum(),
-        }
+        let schedule = self.compute_folding_schedule(num_variables)?;
+        let folded: usize = schedule.iter().sum();
+        Ok((schedule.len() - 1, num_variables - folded))
     }
 }
 
@@ -246,10 +219,11 @@ mod tests {
             FoldingFactor::ConstantFromSecondRound(4, 2).check_validity(3),
             Err(FoldingFactorError::TooLarge(4, 3))
         );
-        // Second round factor too large
+        // A later constant factor may be larger than the later remainder; the
+        // derived schedule clamps only that final fold.
         assert_eq!(
-            FoldingFactor::ConstantFromSecondRound(2, 5).check_validity(4),
-            Err(FoldingFactorError::TooLarge(5, 4))
+            FoldingFactor::ConstantFromSecondRound(2, 5).compute_folding_schedule(4),
+            Ok(vec![2])
         );
         // First round zero
         assert_eq!(
@@ -334,6 +308,121 @@ mod tests {
     }
 
     #[test]
+    fn constant_schedule_allows_partial_final_fold() {
+        let schedule = FoldingFactor::Constant(8);
+
+        assert_eq!(schedule.compute_folding_schedule(15), Ok(vec![8, 7]));
+        assert_eq!(schedule.compute_number_of_rounds(15), Ok((1, 0)));
+        assert_eq!(schedule.check_validity(15), Ok(()));
+    }
+
+    #[test]
+    fn constant_from_second_round_allows_partial_final_fold() {
+        let schedule = FoldingFactor::ConstantFromSecondRound(8, 8);
+
+        assert_eq!(schedule.compute_folding_schedule(15), Ok(vec![8, 7]));
+        assert_eq!(schedule.compute_number_of_rounds(15), Ok((1, 0)));
+        assert_eq!(schedule.check_validity(15), Ok(()));
+    }
+
+    #[test]
+    fn compute_number_of_rounds_keeps_degenerate_guards() {
+        assert_eq!(
+            FoldingFactor::Constant(0).compute_number_of_rounds(15),
+            Err(FoldingFactorError::ZeroFactor)
+        );
+        assert_eq!(
+            FoldingFactor::Constant(16).compute_number_of_rounds(15),
+            Err(FoldingFactorError::TooLarge(16, 15))
+        );
+        assert_eq!(
+            FoldingFactor::ConstantFromSecondRound(0, 8).compute_number_of_rounds(15),
+            Err(FoldingFactorError::ZeroFactor)
+        );
+        assert_eq!(
+            FoldingFactor::ConstantFromSecondRound(8, 0).compute_number_of_rounds(15),
+            Err(FoldingFactorError::ZeroFactor)
+        );
+        assert_eq!(
+            FoldingFactor::ConstantFromSecondRound(16, 8).compute_number_of_rounds(15),
+            Err(FoldingFactorError::TooLarge(16, 15))
+        );
+        assert_eq!(
+            FoldingFactor::PerRound(vec![2, 0]).compute_number_of_rounds(15),
+            Err(FoldingFactorError::ZeroFactor)
+        );
+    }
+
+    #[test]
+    fn computed_rounds_match_old_formula_when_old_formula_did_not_overfold() {
+        fn old_constant(num_variables: usize, factor: usize) -> Option<(usize, usize)> {
+            if factor == 0 || factor > num_variables {
+                return None;
+            }
+            if num_variables <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                return Some((0, num_variables - factor));
+            }
+            let num_rounds = (num_variables - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(factor);
+            let folded = num_rounds.checked_mul(factor)?;
+            if folded <= num_variables {
+                Some((num_rounds - 1, num_variables - folded))
+            } else {
+                None
+            }
+        }
+
+        fn old_constant_from_second_round(
+            num_variables: usize,
+            first_round_factor: usize,
+            factor: usize,
+        ) -> Option<(usize, usize)> {
+            if first_round_factor == 0
+                || factor == 0
+                || first_round_factor > num_variables
+                || factor > num_variables
+            {
+                return None;
+            }
+            let remaining = num_variables - first_round_factor;
+            if remaining < MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                return Some((0, remaining));
+            }
+            let num_rounds = (remaining - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(factor);
+            let folded = num_rounds.checked_mul(factor)?;
+            if folded <= remaining {
+                Some((num_rounds, remaining - folded))
+            } else {
+                None
+            }
+        }
+
+        for num_variables in 1..40 {
+            for factor in 1..12 {
+                if let Some(expected) = old_constant(num_variables, factor) {
+                    assert_eq!(
+                        FoldingFactor::Constant(factor).compute_number_of_rounds(num_variables),
+                        Ok(expected),
+                        "Constant({factor}) @ {num_variables}"
+                    );
+                }
+
+                for first_round_factor in 1..12 {
+                    if let Some(expected) =
+                        old_constant_from_second_round(num_variables, first_round_factor, factor)
+                    {
+                        assert_eq!(
+                            FoldingFactor::ConstantFromSecondRound(first_round_factor, factor)
+                                .compute_number_of_rounds(num_variables),
+                            Ok(expected),
+                            "ConstantFromSecondRound({first_round_factor}, {factor}) @ {num_variables}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn per_round_factors_that_under_fold_error() {
         // Invariant: a per-round schedule that under-folds is rejected with an error, not a panic.
         //
@@ -373,17 +462,5 @@ mod tests {
             schedule.compute_number_of_rounds(10),
             Err(FoldingFactorError::TooLarge(9, 7))
         );
-    }
-
-    #[test]
-    fn test_total_number() {
-        let factor = FoldingFactor::Constant(2);
-        assert_eq!(factor.total_number(3), 8); // 2 * (3 + 1)
-
-        let variable_factor = FoldingFactor::ConstantFromSecondRound(3, 2);
-        assert_eq!(variable_factor.total_number(3), 9); // 3 + 2 * 3
-
-        let per_round = FoldingFactor::PerRound(vec![3, 2, 1]);
-        assert_eq!(per_round.total_number(1), 5);
     }
 }

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -114,6 +114,11 @@ where
     pub params: ProtocolParameters,
     /// Per-round derived configuration for each intermediate STIR round.
     pub round_parameters: Vec<RoundConfig<F>>,
+    /// Concrete folding factors used before the final direct-send phase.
+    ///
+    /// For constant schedules the last entry may be smaller than the nominal
+    /// configured factor, e.g. `Constant(8)` on 15 variables derives `[8, 7]`.
+    pub folding_schedule: Vec<usize>,
     /// Number of out-of-domain samples during the commitment phase.
     pub commitment_ood_samples: usize,
     /// PoW bits for the initial folding sumcheck (before any STIR rounds).
@@ -177,10 +182,11 @@ where
         // tracks the remaining variables as we consume them round by round.
         let initial_num_variables = num_variables;
 
-        // Reject folding factors that are incompatible with the polynomial size.
-        whir_parameters
+        // Derive the concrete folding schedule once. Validation is a property
+        // of this derivation, so all later code uses the same source of truth.
+        let folding_schedule = whir_parameters
             .folding_factor
-            .check_validity(num_variables)?;
+            .compute_folding_schedule(num_variables)?;
 
         // PoW contributes an independent additive term to security,
         // so the algebraic protocol only needs to cover the remainder.
@@ -217,7 +223,7 @@ where
         //
         // A larger folding_factor_0 pushes the folded domain below the limit.
         // This does NOT restrict how much data can be committed.
-        let log_folded_domain_size = log_domain_size - whir_parameters.folding_factor.at_round(0);
+        let log_folded_domain_size = log_domain_size - folding_schedule[0];
         if log_folded_domain_size > F::TWO_ADICITY {
             return Err(WhirConfigError::FoldedDomainExceedsTwoAdicity {
                 log_folded_domain_size,
@@ -232,15 +238,15 @@ where
         // How many intermediate STIR rounds, and how many variables remain
         // for the final direct-send sumcheck.
         // An invalid per-round schedule surfaces as a folding-factor config error.
-        let (num_rounds, final_sumcheck_rounds) = whir_parameters
-            .folding_factor
-            .compute_number_of_rounds(num_variables)?;
+        let folded_variables: usize = folding_schedule.iter().sum();
+        let num_rounds = folding_schedule.len() - 1;
+        let final_sumcheck_rounds = num_variables - folded_variables;
 
         let round_log_inv_rates = if whir_parameters.round_log_inv_rates.is_empty() {
             let mut rates = Vec::with_capacity(num_rounds);
             let mut rate = whir_parameters.starting_log_inv_rate;
-            for round in 0..num_rounds {
-                rate += whir_parameters.folding_factor.at_round(round) - 1;
+            for &folding_factor in folding_schedule.iter().take(num_rounds) {
+                rate += folding_factor - 1;
                 rates.push(rate);
             }
             rates
@@ -300,10 +306,10 @@ where
 
         // Subtract the first-round folding factor; the loop below
         // handles subsequent rounds.
-        num_variables -= whir_parameters.folding_factor.at_round(0);
+        num_variables -= folding_schedule[0];
 
         for (round, &next_rate) in round_log_inv_rates.iter().enumerate() {
-            let folding_factor = whir_parameters.folding_factor.at_round(round);
+            let folding_factor = folding_schedule[round];
             if next_rate > log_inv_rate + folding_factor {
                 return Err(WhirConfigError::RateGrowsDomain { round });
             }
@@ -356,7 +362,7 @@ where
                 next_rate,
             );
 
-            let next_folding_factor = whir_parameters.folding_factor.at_round(round + 1);
+            let next_folding_factor = folding_schedule[round + 1];
 
             // Generator of the two-adic subgroup for the folded domain.
             let folded_domain_gen =
@@ -406,10 +412,7 @@ where
         // Validate construction
         assert_eq!(
             initial_num_variables,
-            whir_parameters
-                .folding_factor
-                .total_number(round_parameters.len())
-                + final_sumcheck_rounds
+            folding_schedule.iter().sum::<usize>() + final_sumcheck_rounds
         );
 
         let config = Self {
@@ -418,6 +421,7 @@ where
             num_variables: initial_num_variables,
             starting_folding_pow_bits: starting_folding_pow_bits as usize,
             round_parameters,
+            folding_schedule,
             final_queries,
             final_pow_bits: final_pow_bits as usize,
             final_sumcheck_rounds,
@@ -472,14 +476,14 @@ where
         } else {
             self.round_parameters[round - 1].log_inv_rate
         };
-        previous_log_inv_rate + self.folding_factor(round)
+        previous_log_inv_rate + self.round_folding_factor(round)
             - self.round_parameters[round].log_inv_rate
     }
 
     /// Returns the log2 size of the largest FFT
     /// (At commitment we perform 2^folding_factor FFT of size 2^max_fft_size)
     pub fn max_fft_size(&self) -> usize {
-        self.num_variables + self.params.starting_log_inv_rate - self.folding_factor(0)
+        self.num_variables + self.params.starting_log_inv_rate - self.round_folding_factor(0)
     }
 
     /// Returns whether all PoW difficulties are within the configured maximum.
@@ -503,9 +507,14 @@ where
             .all(|r| r.pow_bits <= max_bits && r.folding_pow_bits <= max_bits)
     }
 
-    /// Retrieves the folding factor for a given round.
-    pub fn folding_factor(&self, round: usize) -> usize {
-        self.params.folding_factor.at_round(round)
+    /// Retrieves the concrete derived folding factor for a given round.
+    pub fn round_folding_factor(&self, round: usize) -> usize {
+        self.folding_schedule[round]
+    }
+
+    /// Total variables folded through the given round index, inclusive.
+    pub fn total_folded_through(&self, round: usize) -> usize {
+        self.folding_schedule.iter().take(round + 1).sum()
     }
 
     /// Compute the synthetic or derived `RoundConfig` for the final phase.
@@ -523,14 +532,14 @@ where
             // the initial fold leads directly to the final phase.
             // Use the starting domain and initial folding factor.
             RoundConfig {
-                num_variables: self.num_variables - self.folding_factor(0),
-                folding_factor: self.folding_factor(self.n_rounds()),
+                num_variables: self.num_variables - self.round_folding_factor(0),
+                folding_factor: self.round_folding_factor(self.n_rounds()),
                 num_queries: self.final_queries,
                 pow_bits: self.final_pow_bits,
                 log_inv_rate: self.params.starting_log_inv_rate,
                 domain_size: self.starting_domain_size(),
                 folded_domain_gen: F::two_adic_generator(
-                    self.starting_domain_size().ilog2() as usize - self.folding_factor(0),
+                    self.starting_domain_size().ilog2() as usize - self.round_folding_factor(0),
                 ),
                 ood_samples: 0,
                 folding_pow_bits: self.final_folding_pow_bits,
@@ -539,7 +548,7 @@ where
             // Apply the last round's domain reduction to get the domain
             // size entering the final phase.
             let rs_reduction_factor = self.rs_reduction_factor(self.n_rounds() - 1);
-            let folding_factor = self.folding_factor(self.n_rounds());
+            let folding_factor = self.round_folding_factor(self.n_rounds());
 
             let last = self.round_parameters.last().unwrap();
 
@@ -548,7 +557,7 @@ where
 
             // Generator for the final folded domain.
             let folded_domain_gen = F::two_adic_generator(
-                domain_size.ilog2() as usize - self.folding_factor(self.n_rounds()),
+                domain_size.ilog2() as usize - self.round_folding_factor(self.n_rounds()),
             );
 
             RoundConfig {
@@ -782,6 +791,37 @@ mod tests {
         //     [4, 3, 2] @ 14  ->  2 intermediate rounds
         check(10, FoldingFactor::PerRound(vec![3, 2]));
         check(14, FoldingFactor::PerRound(vec![4, 3, 2]));
+    }
+
+    #[test]
+    fn constant_schedule_uses_smaller_final_pre_direct_fold() {
+        // Thomas's motivating case:
+        //
+        //     m = 15, Constant(8)  ->  concrete schedule [8, 7]
+        //
+        // Rejecting this would forbid a valid WHIR instance. The derived
+        // schedule must be used everywhere downstream, not only in validation.
+        let params = ProtocolParameters {
+            security_level: 100,
+            pow_bits: 20,
+            round_log_inv_rates: vec![],
+            folding_factor: FoldingFactor::Constant(8),
+            soundness_type: SecurityAssumption::UniqueDecoding,
+            starting_log_inv_rate: 1,
+        };
+
+        let config = WhirConfig::<F, F, MyChallenger>::new(15, params).unwrap();
+
+        assert_eq!(config.folding_schedule, vec![8, 7]);
+        assert_eq!(config.n_rounds(), 1);
+        assert_eq!(config.round_folding_factor(0), 8);
+        assert_eq!(config.round_folding_factor(1), 7);
+        assert_eq!(config.total_folded_through(0), 8);
+        assert_eq!(config.total_folded_through(1), 15);
+        assert_eq!(config.round_parameters[0].folding_factor, 8);
+        assert_eq!(config.final_sumcheck_rounds, 0);
+        assert_eq!(config.final_round_config().folding_factor, 7);
+        assert_eq!(config.final_round_config().num_variables, 0);
     }
 
     #[test]

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -508,11 +508,18 @@ where
     }
 
     /// Retrieves the concrete derived folding factor for a given round.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `round > self.n_rounds()`.
+    /// The schedule has one entry per fold, including the final pre-direct-send fold.
     pub fn round_folding_factor(&self, round: usize) -> usize {
         self.folding_schedule[round]
     }
 
     /// Total variables folded through the given round index, inclusive.
+    ///
+    /// Indices past the last fold saturate to the full folded variable count.
     pub fn total_folded_through(&self, round: usize) -> usize {
         self.folding_schedule.iter().take(round + 1).sum()
     }

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -74,7 +74,7 @@ where
             &self.mmcs,
             challenger,
             witness,
-            self.config.folding_factor.at_round(0),
+            self.config.round_folding_factor(0),
             self.config.starting_log_inv_rate,
         );
         (

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -149,7 +149,7 @@ where
         Dft: TwoAdicSubgroupDft<F>,
         Challenger: CanObserve<MT::Commitment>,
     {
-        assert_eq!(self.folding_factor.at_round(0), layout.folding());
+        assert_eq!(self.round_folding_factor(0), layout.folding());
         let variable_order = L::variable_order();
 
         let (sumcheck_prover, folding_randomness) = layout.into_sumcheck(
@@ -170,7 +170,7 @@ where
         }
     }
 
-    #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.params.folding_factor.total_number(round_index)))]
+    #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.total_folded_through(round_index)))]
     #[allow(clippy::too_many_lines)]
     fn round(
         &self,
@@ -183,8 +183,7 @@ where
         Challenger: CanObserve<MT::Commitment>,
     {
         let folded_evaluations = &round_state.sumcheck_prover.evals();
-        let num_variables =
-            self.num_variables - self.params.folding_factor.total_number(round_index);
+        let num_variables = self.num_variables - self.total_folded_through(round_index);
         assert_eq!(num_variables, folded_evaluations.num_variables());
 
         // Final round: send polynomial in the clear.
@@ -193,7 +192,7 @@ where
         }
 
         let round_params = &self.round_parameters[round_index];
-        let folding_factor_next = self.params.folding_factor.at_round(round_index + 1);
+        let folding_factor_next = self.round_folding_factor(round_index + 1);
         let inv_rate = self.inv_rate(round_index);
 
         let (root, prover_data) = commit_extension(
@@ -233,7 +232,7 @@ where
         // STIR query sampling.
         let stir_challenges_indexes = get_challenge_stir_queries::<Challenger, F>(
             round_params.domain_size,
-            self.params.folding_factor.at_round(round_index),
+            self.round_folding_factor(round_index),
             round_params.num_queries,
             challenger,
         );
@@ -339,7 +338,7 @@ where
         // Final STIR queries.
         let final_challenge_indexes = get_challenge_stir_queries::<Challenger, F>(
             self.final_round_config().domain_size,
-            self.params.folding_factor.at_round(round_index),
+            self.round_folding_factor(round_index),
             self.final_queries,
             challenger,
         );

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -42,13 +42,14 @@ pub(crate) fn challenger() -> MyChallenger {
 }
 
 fn default_round_log_inv_rates(num_variables: usize, folding_factor: &FoldingFactor) -> Vec<usize> {
-    let (num_rounds, _) = folding_factor
-        .compute_number_of_rounds(num_variables)
+    let folding_schedule = folding_factor
+        .compute_folding_schedule(num_variables)
         .expect("valid folding schedule");
+    let num_rounds = folding_schedule.len() - 1;
     let mut rates = Vec::with_capacity(num_rounds);
     let mut rate = 1;
-    for round in 0..num_rounds {
-        rate += folding_factor.at_round(round) - 1;
+    for &folding in folding_schedule.iter().take(num_rounds) {
+        rate += folding - 1;
         rates.push(rate);
     }
     rates
@@ -231,6 +232,30 @@ fn test_whir_end_to_end() {
         );
         run_whir_pcs::<SuffixProver<F, EF>>(specs, folding_factor, soundness_type, pow_bits);
     }
+}
+
+#[test]
+fn test_whir_end_to_end_partial_final_fold() {
+    // Regression for Constant(8) on 15 variables:
+    // the concrete folding schedule is [8, 7], so prover, verifier, and
+    // transcript shape must all use the smaller final pre-direct fold.
+    let specs = vec![TableSpec::new(
+        TableShape::new(15, 2),
+        vec![vec![0], vec![1]],
+    )];
+
+    run_whir_pcs::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(8),
+        SecurityAssumption::UniqueDecoding,
+        0,
+    );
+    run_whir_pcs::<SuffixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(8),
+        SecurityAssumption::UniqueDecoding,
+        0,
+    );
 }
 
 #[test]

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -118,7 +118,7 @@ where
         constraints.push(initial_constraint);
 
         // Initial sumcheck rounds == first-round folding factor.
-        let expected_initial_rounds = self.folding_factor(0);
+        let expected_initial_rounds = self.round_folding_factor(0);
         let actual_initial_rounds = proof.initial_sumcheck.polynomial_evaluations().len();
         if actual_initial_rounds != expected_initial_rounds {
             return Err(VerifierError::Sumcheck(SumcheckError::RoundCountMismatch {
@@ -171,7 +171,7 @@ where
             // Intermediate-round sumcheck rounds == next-round folding factor.
             // Mirrors the initial and final sumcheck guards;
             // Without it a wrong count desyncs Fiat-Shamir instead of rejecting cleanly.
-            let expected_round_rounds = self.folding_factor(round_index + 1);
+            let expected_round_rounds = self.round_folding_factor(round_index + 1);
             let actual_round_rounds = proof.rounds[round_index]
                 .sumcheck
                 .polynomial_evaluations()

--- a/whir/src/pcs/zk/config.rs
+++ b/whir/src/pcs/zk/config.rs
@@ -173,11 +173,11 @@ where
         // saturates the domain, which would reveal a limb polynomial outright.
         for (round, &randomness) in oracle_randomness.iter().enumerate() {
             let (message_rows, height) = if round == 0 {
-                let rows = 1 << (num_variables - inner.folding_factor(0));
+                let rows = 1 << (num_variables - inner.round_folding_factor(0));
                 (rows, rows << inner.starting_log_inv_rate)
             } else {
                 let prev = &inner.round_parameters[round - 1];
-                let rows = 1 << (prev.num_variables - inner.folding_factor(round));
+                let rows = 1 << (prev.num_variables - inner.round_folding_factor(round));
                 (rows, rows * inner.inv_rate(round - 1))
             };
             let slack = height - message_rows;
@@ -245,7 +245,7 @@ where
         let mut groups = Vec::with_capacity(2 * self.n_rounds() + 1);
         groups.push(MaskGroupShape {
             shape: self.sumcheck_mask,
-            width: self.folding_factor(0),
+            width: self.round_folding_factor(0),
         });
         for round in 0..self.n_rounds() {
             groups.push(MaskGroupShape {
@@ -254,7 +254,7 @@ where
             });
             groups.push(MaskGroupShape {
                 shape: self.sumcheck_mask,
-                width: self.folding_factor(round + 1),
+                width: self.round_folding_factor(round + 1),
             });
         }
         groups
@@ -319,7 +319,7 @@ mod tests {
         // Expected flat mask count: one per sumcheck round, one per
         // code-switching round.
         let expected_sumcheck_masks: usize = (0..=config.n_rounds())
-            .map(|i| config.folding_factor(i))
+            .map(|i| config.round_folding_factor(i))
             .sum();
         // Groups tile the flat mask list exactly.
         let group_total: usize = config.mask_groups().iter().map(|g| g.width).sum();

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -90,7 +90,7 @@ where
         rng: &mut R,
     ) -> (MT::Commitment, HidingWhirProverData<F, EF, MT>) {
         assert_eq!(message.num_variables(), self.config.num_variables);
-        let folding = self.config.folding_factor(0);
+        let folding = self.config.round_folding_factor(0);
         let randomness: Vec<F> = (0..(self.config.oracle_randomness[0] << folding))
             .map(|_| rng.random())
             .collect();
@@ -179,7 +179,7 @@ where
             &mut zk_data,
             &sumcheck_mask_encoding,
             &self.extension_mmcs,
-            config.folding_factor(0),
+            config.round_folding_factor(0),
             config.starting_folding_pow_bits,
             EF::ZERO,
             challenger,
@@ -211,8 +211,8 @@ where
         // Code-switching rounds.
         for round in 0..config.n_rounds() {
             let round_params = &config.round_parameters[round];
-            let folding = config.folding_factor(round);
-            let folding_next = config.folding_factor(round + 1);
+            let folding = config.round_folding_factor(round);
+            let folding_next = config.round_folding_factor(round + 1);
             let next_randomness_len = config.oracle_randomness[round + 1];
 
             let message = batch.residual_prover.evals();

--- a/whir/src/pcs/zk/tests.rs
+++ b/whir/src/pcs/zk/tests.rs
@@ -246,6 +246,22 @@ fn zk_whir_end_to_end_multi_round() {
 }
 
 #[test]
+fn zk_whir_end_to_end_partial_final_fold() {
+    // Clamped schedule: Constant(8) on 15 variables derives [8, 7].
+    // The final-round zk oracle then carries a single message row,
+    // which is the tightest point of the config's rate-slack bound.
+    let setup = Setup::new(4)
+        .num_variables(15)
+        .folding_factor(FoldingFactor::Constant(8));
+    assert_eq!(
+        setup.pcs().config.folding_schedule,
+        vec![8, 7],
+        "fixture must derive a clamped final fold",
+    );
+    setup.assert_round_trip();
+}
+
+#[test]
 fn zk_whir_code_switch_overhead_accounting() {
     // Construction 9.7 per-round overhead (eprint 2026/391, #1587):
     //

--- a/whir/src/pcs/zk/verifier/mod.rs
+++ b/whir/src/pcs/zk/verifier/mod.rs
@@ -200,7 +200,7 @@ where
         let mut randomness = self.replay_sumcheck_batch(
             proof,
             0,
-            config.folding_factor(0),
+            config.round_folding_factor(0),
             config.starting_folding_pow_bits,
             &mut target,
             &mut source,
@@ -209,14 +209,14 @@ where
         )?;
 
         let mut active = ActiveOracle::Base(commitment);
-        let mut num_variables = config.num_variables - config.folding_factor(0);
+        let mut num_variables = config.num_variables - config.round_folding_factor(0);
 
         // Code-switching rounds.
         for round in 0..n_rounds {
             let round_params = &config.round_parameters[round];
             let round_proof = &proof.rounds[round];
-            let folding = config.folding_factor(round);
-            let folding_next = config.folding_factor(round + 1);
+            let folding = config.round_folding_factor(round);
+            let folding_next = config.round_folding_factor(round + 1);
 
             // New oracle and code-switch mask commitments.
             let new_commitment = &round_proof.commitment;


### PR DESCRIPTION
# Summary

Fixes WHIR folding schedule derivation so validation and round-count derivation accept exactly the same parameter set.

The motivating case is `FoldingFactor::Constant(8)` with `num_variables = 15`: validation accepted it, but `compute_number_of_rounds(15)` tried to schedule two full folds of 8 and underflowed. WHIR supports per-round folding factors with the constraint that the folded variables do not exceed the arity, so the correct concrete schedule is `[8, 7]`, leaving `final_sumcheck_rounds = 0`.

# Changes

- Add `FoldingFactor::compute_folding_schedule(...)` as the single source of truth for validation and round-count derivation.
- Allow constant schedules to use a smaller final pre-direct-send fold via `min(k, remaining)`.
- Apply the same fix to `ConstantFromSecondRound`.
- Keep degenerate guards in schedule derivation: zero factors, oversized first fold, over-folding explicit `PerRound`, and insufficient explicit `PerRound` schedules.
- Store the concrete `folding_schedule` in `WhirConfig`, and route prover, verifier, ZK config, and Fiat-Shamir proof-shape code through `round_folding_factor(...)`.
- Remove the stale nominal `total_number(...)` helper, which cannot represent partial final folds.
- Document `FoldingFactor::at_round(...)` as nominal/pre-clamp to avoid confusing it with the derived schedule.

# Tests

- `Constant(8) @ 15` derives `[8, 7]` and `(n_rounds = 1, final_sumcheck_rounds = 0)`.
- `ConstantFromSecondRound(8, 8) @ 15` gets the same partial final fold behavior.
- Sweep test proves currently non-overfolding `Constant` and `ConstantFromSecondRound` configs keep their old `(n_rounds, final_sumcheck_rounds)` outputs.
- End-to-end PCS regression proves `Constant(8) @ 15` verifies in both prefix and suffix layouts.

# Notes

This makes the `final_sumcheck_rounds == 0` path more common, but that path was already reachable before this change, for example with `Constant(6)` on 6 variables. This PR only fixes schedule derivation and keeps the zero-final-round proof canonicality question separate.

# Verification

```text
cargo test -p p3-whir
cargo +stable clippy -p p3-whir --all-targets -- -D warnings
cargo +nightly fmt --check
git diff --check
```
