### PR TITLE
fix: tweak config parameters to support 128 bit security target

### DIFF
--- a/whir/benches/whir_pcs.rs
+++ b/whir/benches/whir_pcs.rs
@@ -10,7 +10,7 @@ use p3_challenger::DuplexChallenger;
 use p3_commit::MultilinearPcs;
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
-use p3_field::extension::BinomialExtensionField;
+use p3_field::extension::QuinticTrinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::poly::Poly;
@@ -26,7 +26,7 @@ use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
 type F = KoalaBear;
-type EF = BinomialExtensionField<F, 4>;
+type EF = QuinticTrinomialExtensionField<F>;
 
 type Poseidon16 = Poseidon2KoalaBear<16>;
 type Poseidon24 = Poseidon2KoalaBear<24>;


### PR DESCRIPTION
`whir_pcs` bench was targeting 128 bits of security with a quartic extension of KB, which caused the PoW to blowup and crash on the proving phase because going over the field order.

This fixes it by keeping the 128 bit security target but leveraging the Quintic extension of KB instead.