### PR TITLE
perf(sumcheck): fuse round-0 residual weights into the packed buffer

### DIFF
--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -235,6 +235,46 @@ where
     }
 }
 
+/// Pin the fast `add_assign_lane` override against its default.
+///
+/// - The default rebuilds a full packed element and adds it.
+/// - The override touches only the `D` base lanes at the target lane.
+/// - Both must agree on every lane.
+/// - Only the target lane may change.
+pub fn test_add_assign_lane_ext<BF, EF, PE>()
+where
+    BF: Field,
+    EF: ExtensionField<BF, ExtensionPacking = PE>,
+    PE: PackedFieldExtension<BF, EF> + Copy + Eq,
+    StandardUniform: Distribution<PE> + Distribution<EF>,
+{
+    let mut rng = SmallRng::seed_from_u64(0xa55e_3b1c);
+    let width = BF::Packing::WIDTH;
+
+    // Random starting register and the scalar to inject, over several trials.
+    for _ in 0..32 {
+        let start: PE = rng.random();
+        let value: EF = rng.random();
+        // Inject into each lane in turn.
+        for lane in 0..width {
+            // Fast path: the per-type override.
+            let mut fast = start;
+            fast.add_assign_lane(lane, value);
+
+            // Reference: add `value` only to the target lane via the public constructor.
+            let reference = start + PE::from_ext_fn(|l| if l == lane { value } else { EF::ZERO });
+            assert_eq!(fast, reference, "lane {lane} mismatch");
+
+            // The target lane gains exactly `value`.
+            // Every other lane is untouched.
+            for other in 0..width {
+                let expected = start.extract(other) + if other == lane { value } else { EF::ZERO };
+                assert_eq!(fast.extract(other), expected, "leaked into lane {other}");
+            }
+        }
+    }
+}
+
 /// Verify packed binomial extension division against scalar reference results.
 ///
 /// Tests four operations:
@@ -1089,6 +1129,10 @@ macro_rules! test_packed_extension_field {
                     $extfield,
                     $packedextfield,
                 >();
+            }
+            #[test]
+            fn test_add_assign_lane_ext() {
+                $crate::test_add_assign_lane_ext::<$basefield, $extfield, $packedextfield>();
             }
         }
     };

--- a/field/src/extension/packed_binomial_extension.rs
+++ b/field/src/extension/packed_binomial_extension.rs
@@ -198,6 +198,14 @@ where
     }
 
     #[inline]
+    fn add_assign_lane(&mut self, lane: usize, value: BinomialExtensionField<F, D>) {
+        // Add each coefficient into its own base packing at the shared lane.
+        for (coeff, v) in self.value.iter_mut().zip(value.value) {
+            coeff.as_slice_mut()[lane] += v;
+        }
+    }
+
+    #[inline]
     fn packed_ext_powers(base: BinomialExtensionField<F, D>) -> crate::Powers<Self> {
         let width = F::Packing::WIDTH;
         let powers = base.powers().collect_n(width + 1);

--- a/field/src/extension/packed_cubic_extension.rs
+++ b/field/src/extension/packed_cubic_extension.rs
@@ -168,6 +168,14 @@ impl<F: CubicTrinomialExtendable> PackedFieldExtension<F, CubicTrinomialExtensio
     }
 
     #[inline]
+    fn add_assign_lane(&mut self, lane: usize, value: CubicTrinomialExtensionField<F>) {
+        // Add each coefficient into its own base packing at the shared lane.
+        for (coeff, v) in self.value.iter_mut().zip(value.value) {
+            coeff.as_slice_mut()[lane] += v;
+        }
+    }
+
+    #[inline]
     fn packed_ext_powers(base: CubicTrinomialExtensionField<F>) -> Powers<Self> {
         let width = F::Packing::WIDTH;
         let powers = base.powers().collect_n(width + 1);

--- a/field/src/extension/packed_quintic_extension.rs
+++ b/field/src/extension/packed_quintic_extension.rs
@@ -172,6 +172,14 @@ impl<F: QuinticTrinomialExtendable> PackedFieldExtension<F, QuinticTrinomialExte
     }
 
     #[inline]
+    fn add_assign_lane(&mut self, lane: usize, value: QuinticTrinomialExtensionField<F>) {
+        // Add each coefficient into its own base packing at the shared lane.
+        for (coeff, v) in self.value.iter_mut().zip(value.value) {
+            coeff.as_slice_mut()[lane] += v;
+        }
+    }
+
+    #[inline]
     fn packed_ext_powers(base: QuinticTrinomialExtensionField<F>) -> Powers<Self> {
         let width = F::Packing::WIDTH;
         let powers = base.powers().collect_n(width + 1);

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -429,6 +429,18 @@ pub trait PackedFieldExtension<
         })
     }
 
+    /// Accumulate `value` into a single SIMD lane, leaving the other `W - 1` lanes unchanged.
+    ///
+    /// This is the accumulating dual of the per-lane read [`PackedFieldExtension::extract`].
+    /// It scatters one scalar extension element into a packed buffer, one lane at a time.
+    ///
+    /// The default rebuilds a full packed element and adds it.
+    /// Concrete types override it to touch only the `D` base lanes at the target lane.
+    #[inline]
+    fn add_assign_lane(&mut self, lane: usize, value: ExtField) {
+        *self += Self::from_ext_fn(|l| if l == lane { value } else { ExtField::ZERO });
+    }
+
     /// Write all `W` lanes into the given slice.
     ///
     /// This is the extension-field analog of [`PackedValue::as_slice`], but the lanes of
@@ -569,6 +581,12 @@ impl<F: Field> PackedFieldExtension<F, F> for F::Packing {
     #[inline]
     fn packed_ext_powers(base: F) -> Powers<Self> {
         F::Packing::packed_powers(base)
+    }
+
+    #[inline]
+    fn add_assign_lane(&mut self, lane: usize, value: F) {
+        // Degree-1 case: the lane is a single base element.
+        self.as_slice_mut()[lane] += value;
     }
 }
 

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -5,11 +5,14 @@ use alloc::vec::Vec;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{ExtensionField, Field, TwoAdicField, dot_product};
+use p3_field::{
+    ExtensionField, Field, PackedFieldExtension, PackedValue, TwoAdicField, dot_product,
+};
 use p3_matrix::dense::DenseMatrix;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_multilinear_util::split_eq::SplitEq;
+use p3_util::log2_strict_usize;
 
 use crate::commit::commit_base;
 use crate::lagrange::lagrange_weights_01inf_multi;
@@ -333,7 +336,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         let compressed = tracing::info_span!("compress_prefix_to_packed")
             .in_scope(|| self.poly.compress_prefix_to_packed(&rs, EF::ONE));
 
-        let weights = self.combine_eqs(&rs, alpha).pack::<F, EF>();
+        let weights = self.residual_weights_packed(&rs, alpha);
         let prod_poly =
             ProductPolynomial::<F, EF>::new_packed(VariableOrder::Prefix, compressed, weights);
         debug_assert_eq!(prod_poly.dot_product(), sum);
@@ -402,8 +405,69 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
         sum
     }
 
-    /// Builds the residual equality-weight polynomial after the prefix SVO rounds.
-    #[tracing::instrument(skip_all)]
+    /// Builds the residual equality weights in packed form.
+    ///
+    /// Two routes produce the identical polynomial; each call takes the cheaper one:
+    ///
+    /// - Scatter: write directly into the packed buffer, visiting only claimed slots.
+    /// - Pack: build the full scalar table, then transpose-copy it into packed form.
+    ///
+    /// The scatter wins on a sparsely claimed residual.
+    /// The vectorized transpose wins when the claims fill most of the space.
+    pub(crate) fn residual_weights_packed(
+        &self,
+        rs: &Point<EF>,
+        alpha: EF,
+    ) -> Poly<EF::ExtensionPacking> {
+        if self.scatter_beats_pack(rs) {
+            self.combine_eqs_packed(rs, alpha)
+        } else {
+            self.combine_eqs(rs, alpha).pack::<F, EF>()
+        }
+    }
+
+    /// Decides whether the scatter route beats the transpose route.
+    ///
+    /// True when the concrete claims occupy at most a third of the residual space:
+    ///
+    /// ```text
+    ///     occupied = sum over openings of 2^(table_arity - folding)
+    ///     residual = 2^(num_variables - folding)
+    ///     scatter  <=>  3 * occupied <= residual
+    /// ```
+    ///
+    /// The crossover sits near half occupancy:
+    ///
+    /// - At a quarter, the scatter is clearly ahead.
+    /// - At a half, the two routes tie.
+    /// - Above a half, the transpose pulls ahead.
+    ///
+    /// The one-third cutoff keeps a margin below the crossover.
+    /// So the chosen route is never slower, across machines and SIMD widths.
+    ///
+    /// Virtual claims span the whole space and cost the same either way.
+    /// They do not enter the decision.
+    fn scatter_beats_pack(&self, rs: &Point<EF>) -> bool {
+        let residual = 1usize << (self.num_variables - rs.num_variables());
+        let occupied: usize = self
+            .placements
+            .iter()
+            .map(|placement| {
+                let local =
+                    1usize << (self.num_variables_table(placement.idx()) - rs.num_variables());
+                self.claim_map[placement.idx()]
+                    .iter()
+                    .map(|claim| claim.len() * local)
+                    .sum::<usize>()
+            })
+            .sum();
+        occupied.saturating_mul(3) <= residual
+    }
+
+    /// Builds the residual equality weights as a scalar polynomial.
+    ///
+    /// This is the dense-residual route: it materializes the full table.
+    /// The packed route shares the same accumulation but skips this buffer.
     pub(crate) fn combine_eqs(&self, rs: &Point<EF>, alpha: EF) -> Poly<EF> {
         assert_eq!(rs.num_variables(), self.folding);
         let mut out = Poly::<EF>::zero(self.num_variables - rs.num_variables());
@@ -439,5 +503,217 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
         }
 
         out
+    }
+
+    /// Builds the residual equality weights straight into the packed buffer.
+    ///
+    /// Scatters each claim's contribution into packed lanes directly.
+    /// This skips the scalar table and the transpose-copy the dense route pays.
+    ///
+    /// # Identity
+    ///
+    /// For a concrete opening on a column at point `z = (z_svo, z_rest)`:
+    ///
+    /// ```text
+    ///     out[(y << s) | v] += alpha^i * eq(z_svo, rs) * eq(z_rest, y)
+    /// ```
+    ///
+    /// - `(s, v)` is the column's selector: `s` selector bits, slot index `v`.
+    /// - `y` ranges over the local table.
+    /// - scalar index `(y << s) | v` maps to packed word `idx >> k_pack`, lane `idx & (W - 1)`.
+    ///
+    /// Virtual claims span the whole residual space.
+    /// They continue the alpha sequence after the concrete openings.
+    ///
+    /// # Panics
+    ///
+    /// - `rs` must have exactly `folding` variables.
+    /// - The residual space must hold at least one packed element.
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn combine_eqs_packed(
+        &self,
+        rs: &Point<EF>,
+        alpha: EF,
+    ) -> Poly<EF::ExtensionPacking> {
+        assert_eq!(rs.num_variables(), self.folding);
+        let k_pack = log2_strict_usize(F::Packing::WIDTH);
+        let out_variables = self.num_variables - rs.num_variables();
+        assert!(out_variables >= k_pack);
+
+        let mut out = Poly::<EF::ExtensionPacking>::zero(out_variables - k_pack);
+        let lane_mask = F::Packing::WIDTH - 1;
+
+        // Concrete claims: scatter each column's local table into its packed slot.
+        // Alpha powers run in (placement, claim, opening) order, matching the verifier.
+        let mut alphas = alpha.powers();
+        for placement in &self.placements {
+            let local_rest_variables =
+                self.num_variables_table(placement.idx()) - rs.num_variables();
+            for claim in &self.claim_map[placement.idx()] {
+                for opening in claim.openings() {
+                    let col = opening.poly_idx().unwrap();
+                    let selector = &placement.selectors()[col];
+                    // Materialize alpha^i * eq(z_svo, rs) * eq(z_rest, .) for this column.
+                    let mut local = Poly::<EF>::zero(local_rest_variables);
+                    claim
+                        .point()
+                        .accumulate_into(local.as_mut_slice(), rs, alphas.next().unwrap());
+
+                    // Scatter local[y] into out[(y << s) | v], lane by lane.
+                    let s = selector.num_variables();
+                    let v = selector.index();
+                    for (y, &value) in local.as_slice().iter().enumerate() {
+                        let idx = (y << s) | v;
+                        out.as_mut_slice()[idx >> k_pack].add_assign_lane(idx & lane_mask, value);
+                    }
+                }
+            }
+        }
+
+        // Virtual claims span the full residual space; accumulate packed.
+        let mut alpha_i = alpha.exp_u64(self.num_claims() as u64);
+        for claim in &self.virtual_claims {
+            let (svo, rest) = claim.point.split_at(rs.num_variables());
+            let scale = alpha_i * Point::eval_eq(svo.as_slice(), rs.as_slice());
+            SplitEq::new_packed(&rest, scale).accumulate_into_packed(out.as_mut_slice(), None);
+            alpha_i *= alpha;
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_field::PrimeCharacteristicRing;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::layout::prover::test_utils::{
+        FOLDING, arb_opening_schedule, arb_witness_and_schedule, build_tables, tables_from_shape,
+    };
+    use crate::tests::{EF, F, challenger};
+
+    /// Replays a schedule plus virtual claims, then pins packed against scalar.
+    fn assert_packed_matches_scalar(
+        witness: Witness<F>,
+        schedule: &[(usize, Vec<usize>)],
+        num_virtual: usize,
+    ) {
+        let mut prover = PrefixProver::<F, EF>::from_witness(witness);
+        let mut ch = challenger();
+        // Record concrete openings; `eval` samples points and absorbs evals internally.
+        for (table_idx, polys) in schedule {
+            prover.eval(*table_idx, polys, &mut ch);
+        }
+        // Record virtual claims; they continue the alpha sequence after concrete ones.
+        for _ in 0..num_virtual {
+            let _ = prover.add_virtual_eval(&mut ch);
+        }
+        // Random batching challenge and SVO folding point.
+        let alpha: EF = ch.sample_algebra_element();
+        let rs = Point::expand_from_univariate(ch.sample_algebra_element(), FOLDING);
+        // The packed path must equal the scalar reference followed by packing.
+        let scalar = prover.combine_eqs(&rs, alpha).pack::<F, EF>();
+        let packed = prover.combine_eqs_packed(&rs, alpha);
+        assert_eq!(scalar, packed);
+        // The adaptive dispatcher must return that same polynomial on either branch.
+        assert_eq!(prover.residual_weights_packed(&rs, alpha), packed);
+    }
+
+    #[test]
+    fn scatter_beats_pack_routes_on_occupancy() {
+        let mut ch = challenger();
+        let rs = Point::expand_from_univariate(ch.sample_algebra_element(), FOLDING);
+
+        // Builds a four-column table and opens the first `open` of them.
+        // Four columns tile a power-of-two space, so `open` columns is `open/4` occupancy.
+        let mut routed = |open: usize| {
+            let mut prover =
+                PrefixProver::<F, EF>::from_witness(PrefixProver::<F, EF>::new_witness(
+                    vec![Table::new((0..4).map(|_| Poly::<F>::zero(8)).collect())],
+                    FOLDING,
+                ));
+            let cols: Vec<usize> = (0..open).collect();
+            prover.eval(0, &cols, &mut ch);
+            prover.scatter_beats_pack(&rs)
+        };
+
+        // The threshold routes to the scatter only below a third occupancy.
+        assert!(routed(1), "25% occupancy must pick scatter");
+        assert!(!routed(2), "50% occupancy must fall back to pack");
+        assert!(!routed(4), "100% occupancy must fall back to pack");
+
+        // A holey layout (one of five columns) sits far below the threshold.
+        let mut sparse = PrefixProver::<F, EF>::from_witness(PrefixProver::<F, EF>::new_witness(
+            vec![Table::new((0..5).map(|_| Poly::<F>::zero(8)).collect())],
+            FOLDING,
+        ));
+        sparse.eval(0, &[2], &mut ch);
+        assert!(
+            sparse.scatter_beats_pack(&rs),
+            "holey layout must pick scatter"
+        );
+    }
+
+    #[test]
+    fn combine_eqs_packed_no_claims_is_zero() {
+        // No claims at all: the scatter is skipped and every weight is zero.
+        let witness = PrefixProver::<F, EF>::new_witness(build_tables(), FOLDING);
+        let prover = PrefixProver::<F, EF>::from_witness(witness);
+        let mut ch = challenger();
+        let alpha: EF = ch.sample_algebra_element();
+        let rs = Point::expand_from_univariate(ch.sample_algebra_element(), FOLDING);
+        let packed = prover.combine_eqs_packed(&rs, alpha);
+        assert!(
+            packed
+                .iter()
+                .all(|&w| w == <EF as ExtensionField<F>>::ExtensionPacking::ZERO)
+        );
+    }
+
+    #[test]
+    fn combine_eqs_packed_virtual_claims_only() {
+        // No concrete openings: only the virtual-claim accumulation contributes.
+        let witness = PrefixProver::<F, EF>::new_witness(build_tables(), FOLDING);
+        assert_packed_matches_scalar(witness, &[], 2);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        // Invariant: the packed scatter equals the scalar build followed by pack.
+        //
+        //     fixed two-table witness: mixed selector widths, padding holes
+        //     coverage: openings sharing a slot, plus 0..=2 virtual claims
+        #[test]
+        fn combine_eqs_packed_matches_scalar(
+            schedule in arb_opening_schedule(),
+            num_virtual in 0usize..=2,
+        ) {
+            let witness = PrefixProver::<F, EF>::new_witness(build_tables(), FOLDING);
+            assert_packed_matches_scalar(witness, &schedule, num_virtual);
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        // Invariant: packed and scalar agree on random witness shapes.
+        //
+        //     includes single-table layouts with zero selector bits
+        #[test]
+        fn combine_eqs_packed_matches_scalar_shapes(
+            (shape, schedule) in arb_witness_and_schedule(),
+            num_virtual in 0usize..=1,
+        ) {
+            let witness = PrefixProver::<F, EF>::new_witness(tables_from_shape(&shape), FOLDING);
+            // Packing needs at least one full SIMD lane in the residual space.
+            let k_pack = log2_strict_usize(<F as Field>::Packing::WIDTH);
+            prop_assume!(witness.num_variables() >= FOLDING + k_pack);
+            assert_packed_matches_scalar(witness, &schedule, num_virtual);
+        }
     }
 }

--- a/sumcheck/src/zk/prover/layout.rs
+++ b/sumcheck/src/zk/prover/layout.rs
@@ -61,10 +61,11 @@ where
     where
         EF: TwoAdicField,
     {
-        // Prefix packs the residual weights: one full SIMD lane must survive the fold.
-        // `Poly::pack` requires `num_variables - k >= k_pack`, else it panics.
-        // Suffix is unpacked and unconstrained, so this guard is prefix-only.
-        // Phrased as `k + k_pack <= num_variables` to avoid `usize` underflow.
+        // Invariant: the packed residual needs one full SIMD lane to survive the fold.
+        //
+        //     both packed routes panic unless  num_variables - folding >= k_pack
+        //     suffix mode is unpacked, so this guard is prefix-only
+        //     phrased as  k_pack <= num_variables - folding  to avoid usize underflow
         let k_pack = log2_strict_usize(<F as Field>::Packing::WIDTH);
         assert!(
             rs.num_variables() + k_pack <= self.num_variables(),
@@ -75,8 +76,8 @@ where
         // The combining challenge is baked into the compression scale.
         let compressed = tracing::info_span!("compress_prefix_to_packed")
             .in_scope(|| self.poly.compress_prefix_to_packed(rs, eps));
-        // Pack the equality weights for the SIMD-friendly residual rounds.
-        let weights = self.combine_eqs(rs, alpha).pack::<F, EF>();
+        // Build the equality weights in packed form, fused scatter or pack as cheaper.
+        let weights = self.residual_weights_packed(rs, alpha);
         ProductPolynomial::new_packed(VariableOrder::Prefix, compressed, weights)
     }
 }


### PR DESCRIPTION
## What

The prefix sumcheck prover builds the residual equality-weight polynomial at the round-0 handoff, then hands it to the packed residual rounds. Today it builds a scalar `Poly<EF>` of size `2^(n−k)` and then calls `pack()`, which **allocates and transpose-copies a second full-size buffer**.

This PR adds a fused path, `combine_eqs_packed`, that scatters each claim's contribution **straight into the packed buffer**, visiting only the slots a claim actually touches. An adaptive dispatcher (`residual_weights_packed`) picks the cheaper route per call:

- **Scatter** when the residual is sparsely claimed (the common batched/multi-column case).
- **Scalar-then-`pack`** (the existing path, unchanged) when the residual is densely claimed.

The scatter is enabled by a small new field primitive, `PackedFieldExtension::add_assign_lane` — the accumulating dual of `extract` — with a correct default impl and fast per-type overrides on the three packed extension types and the trivial `F::Packing` case.

## Why it's safe (never slower)

The dispatcher routes to the scatter **only below one-third residual occupancy**, which keeps a clear margin under the measured crossover (~half occupancy). Above that it runs the exact pre-existing `combine_eqs().pack()` code. So the chosen route is never slower than `main` on any layout.

## Numbers

All on BabyBear, degree-4 extension, `FOLDING = 4`, Criterion, Apple M-series. The combine micro-bench sweeps occupancy (fraction of the residual space the claims fill). **`dispatched` is what actually ships** — it must never be slower than `baseline`.

### Combine step — occupancy sweep

| occupancy | `baseline` (combine + pack) | `scatter` (raw) | **`dispatched` (ships)** | dispatched vs baseline |
|---|---|---|---|---|
| 25 % (open 1 of 4 cols) | 217 µs | 191 µs | **193 µs** (scatter) | **−11 %** |
| 50 % (open 2 of 4) | 380 µs | 373 µs | **380 µs** (pack) | ≈ 0 % |
| 75 % (open 3 of 4) | 546 µs | 555 µs | **544 µs** (pack) | ≈ 0 % |
| 100 % (open 4 of 4) | 710 µs | 741 µs | **709 µs** (pack) | ≈ 0 % |
| holey (open 1 of 5) | 266 µs | 198 µs | **198 µs** (scatter) | **−25 %** |

The two rows where the raw scatter is *slower* (75 %, 100 %) are exactly where the dispatcher refuses it and runs `pack` instead, so the shipped column matches `baseline` there. It wins only where it's a clear win.

### Handoff context — `into_sumcheck`

Where the combine step sits inside the full prefix→residual handoff (SVO fold + base-poly compress + weight build):

| workload | handoff total | combine share |
|---|---|---|
| dense (4 cols, all opened) | 1.60 ms | ~45 % (routes to `pack`, unchanged) |
| sparse (1 of 5 cols) | 1.99 ms | ~13 %, cut ~25 % → ~3 % faster handoff |

### End-to-end `whir_pcs` prove — branch vs `main`

Single-column PCS prove (a dense layout, so the dispatcher picks `pack`), compared with Criterion baselines:

| size | prove time | vs `main` |
|---|---|---|
| small (2¹⁴) | 17.9 ms | **No change** (p = 0.16) |
| medium (2¹⁸) | 82.1 ms | **No change** (p = 0.97) |
| large (2²⁰) | 392 ms | **No change** (p = 0.07) |

Net: a real win on sparse/batched openings, provably free everywhere else, plus one fewer full-size allocation on the fast path.

## Tests

- Proptests pin `combine_eqs_packed` **and** the dispatcher equal to `combine_eqs().pack()` over random opening schedules and random witness shapes (repeated columns, virtual claims, zero-selector single-table layouts).
- A routing test pins the dispatcher's thresholds (25 % → scatter, 50 %/100 % → pack, holey → scatter).
- `add_assign_lane` is pinned against its default impl by a generic test wired into the `test_packed_extension_field!` macro, so it runs for every packed extension type across all field crates.

## Benchmark code (intentionally not committed)

To keep the PR non-invasive, the benchmark is **not** included in the tree. To reproduce the tables above:

1. Add to `sumcheck/Cargo.toml`:
   ```toml
   [dev-dependencies]
   criterion.workspace = true

   [[bench]]
   name = "combine_eqs"
   harness = false
   ```
2. Temporarily widen visibility of `combine_eqs`, `combine_eqs_packed`, and `residual_weights_packed` from `pub(crate)` to `pub`.
3. Drop in `sumcheck/benches/combine_eqs.rs`:

<details>
<summary><code>sumcheck/benches/combine_eqs.rs</code></summary>

```rust
//! Residual equality-weight construction at the prefix→packed handoff.

use std::hint::black_box;

use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
use p3_challenger::DuplexChallenger;
use p3_field::extension::BinomialExtensionField;
use p3_multilinear_util::point::Point;
use p3_multilinear_util::poly::Poly;
use p3_sumcheck::SumcheckData;
use p3_sumcheck::layout::{Layout, PrefixProver, Table};
use rand::rngs::SmallRng;
use rand::{RngExt, SeedableRng};

type F = BabyBear;
type EF = BinomialExtensionField<F, 4>;
type Perm = Poseidon2BabyBear<16>;
type Challenger = DuplexChallenger<F, Perm, 16, 8>;

const FOLDING: usize = 4;

struct Scenario {
    name: &'static str,
    cols: usize,
    arity: usize,
    opened: &'static [usize],
}

fn challenger() -> Challenger {
    let mut rng = SmallRng::seed_from_u64(2);
    Challenger::new(Perm::new_from_rng_128(&mut rng))
}

fn build_prover(scenario: &Scenario) -> PrefixProver<F, EF> {
    let mut rng = SmallRng::seed_from_u64(1);
    let columns: Vec<Poly<F>> = (0..scenario.cols)
        .map(|_| Poly::<F>::rand(&mut rng, scenario.arity))
        .collect();
    let witness = PrefixProver::<F, EF>::new_witness(vec![Table::new(columns)], FOLDING);
    let mut prover = PrefixProver::<F, EF>::from_witness(witness);
    let mut ch = challenger();
    prover.eval(0, scenario.opened, &mut ch);
    prover
}

const COMBINE_SCENARIOS: &[Scenario] = &[
    Scenario { name: "4cols_open1_q25", cols: 4, arity: 18, opened: &[0] },
    Scenario { name: "4cols_open2_q50", cols: 4, arity: 18, opened: &[0, 1] },
    Scenario { name: "4cols_open3_q75", cols: 4, arity: 18, opened: &[0, 1, 2] },
    Scenario { name: "4cols_open4_q100", cols: 4, arity: 18, opened: &[0, 1, 2, 3] },
    Scenario { name: "5cols_open1_holey", cols: 5, arity: 18, opened: &[2] },
];

fn bench_combine(c: &mut Criterion) {
    for scenario in COMBINE_SCENARIOS {
        let prover = build_prover(scenario);
        let mut rng = SmallRng::seed_from_u64(3);
        let rs = Point::new((0..FOLDING).map(|_| rng.random()).collect());
        let alpha: EF = rng.random();

        let mut group = c.benchmark_group(format!("combine/{}", scenario.name));
        group.bench_function("baseline_combine_then_pack", |b| {
            b.iter(|| black_box(prover.combine_eqs(&rs, alpha).pack::<F, EF>()));
        });
        group.bench_function("scatter_combine_eqs_packed", |b| {
            b.iter(|| black_box(prover.combine_eqs_packed(&rs, alpha)));
        });
        group.bench_function("dispatched_residual_weights", |b| {
            b.iter(|| black_box(prover.residual_weights_packed(&rs, alpha)));
        });
        group.finish();
    }
}

fn bench_into_sumcheck(c: &mut Criterion) {
    let scenarios = [
        Scenario { name: "dense_4cols_open4", cols: 4, arity: 18, opened: &[0, 1, 2, 3] },
        Scenario { name: "sparse_5cols_open1", cols: 5, arity: 18, opened: &[2] },
    ];
    for scenario in &scenarios {
        let prover = build_prover(scenario);
        let mut group = c.benchmark_group(format!("into_sumcheck/{}", scenario.name));
        group.bench_function("handoff", |b| {
            b.iter_batched(
                || (prover.clone(), challenger(), SumcheckData::<F, EF>::default()),
                |(prover, mut ch, mut data)| black_box(prover.into_sumcheck(&mut data, 0, &mut ch)),
                BatchSize::LargeInput,
            );
        });
        group.finish();
    }
}

criterion_group!(benches, bench_combine, bench_into_sumcheck);
criterion_main!(benches);
```
</details>

Run: `cargo bench -p p3-sumcheck --bench combine_eqs`

The end-to-end no-regression table uses the existing `whir/benches/whir_pcs.rs`: `cargo bench -p p3-whir --bench whir_pcs -- scaling/prove --save-baseline main` on `main`, then `--baseline main` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
