### PR TITLE
perf(circle): evaluate out-of-domain openings on a trace-size subdomain

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -551,4 +551,35 @@ mod tests {
             );
         }
     }
+
+    /// The first `2^(log_n - b)` rows of a CFFT-ordered matrix over a domain `D` are the
+    /// CFFT-ordered matrix over the twin-coset `CircleDomain::new(log_n - b, D.shift)`, and a
+    /// polynomial of degree below that size is determined by its values there. Out-of-domain
+    /// evaluation can therefore work on the prefix alone.
+    #[test]
+    fn eval_at_point_on_subdomain_prefix_matches_full() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        for (log_n, width, log_blowup) in iproduct!(2..8, [1, 4, 11], [1, 2]) {
+            let lde_domain = CircleDomain::standard(log_n + log_blowup);
+            let lde = CircleEvaluations::<F>::from_natural_order(
+                CircleDomain::standard(log_n),
+                RowMajorMatrix::rand(&mut rng, 1 << log_n, width),
+            )
+            .extrapolate(lde_domain);
+
+            let sub_domain = CircleDomain::new(log_n, lde_domain.shift);
+            // The prefix rows are the subdomain's CFFT order: the same selection applies to
+            // the domain points.
+            assert_eq!(
+                cfft_permute_slice(&sub_domain.points().collect_vec()),
+                cfft_permute_slice(&lde_domain.points().collect_vec())[..1 << log_n],
+            );
+
+            let zeta = Point::<EF>::from_projective_line(rng.random());
+            let full = lde.evaluate_at_point(zeta);
+            let prefix = lde.values.split_rows(1 << log_n).0;
+            let sub_evals = CircleEvaluations::from_cfft_order(sub_domain, prefix);
+            assert_eq!(sub_evals.evaluate_at_point(zeta), full);
+        }
+    }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -241,10 +241,22 @@ where
                 izip!(mats, points_for_mats)
                     .map(|(mat, points_for_mat)| {
                         let log_height = log2_strict_usize(mat.height());
+                        // The committed polynomial has degree below the pre-blow-up domain
+                        // size, so its values on a sub-twin-coset of that size determine it.
+                        // The first `2^log_sub` rows of the CFFT-ordered LDE are exactly the
+                        // CFFT-ordered evaluations over `CircleDomain::new(log_sub, shift)`
+                        // (see `eval_at_point_on_subdomain_prefix_matches_full`), so the
+                        // out-of-domain evaluation only traverses `1 / blowup` of the matrix.
+                        let log_sub = log_height - self.fri_params.log_blowup;
+                        let sub_height = 1 << log_sub;
+                        let sub_domain = CircleDomain::new(
+                            log_sub,
+                            CircleDomain::<Val>::standard(log_height).shift,
+                        );
                         // It was committed in cfft order.
                         let evals = CircleEvaluations::from_cfft_order(
-                            CircleDomain::standard(log_height),
-                            mat.as_view(),
+                            sub_domain,
+                            mat.split_rows(sub_height).0,
                         );
 
                         // Resolve the Lagrange denominators for every point up front.
@@ -259,9 +271,9 @@ where
                                         let den = info_span!("compute Lagrange denominators")
                                             .in_scope(|| {
                                                 compute_lagrange_den_batched(
-                                                    &permuted_points[&log_height],
+                                                    &permuted_points[&log_height][..sub_height],
                                                     Point::from_projective_line(zeta_uni),
-                                                    log_height,
+                                                    log_sub,
                                                 )
                                             });
                                         lagrange_dens.push((key, den));


### PR DESCRIPTION
## Summary

The committed polynomial has degree below the pre-blow-up domain size, so its values on any sub-twin-coset of that size determine it. The first 2^(log_height - log_blowup) rows of a CFFT-ordered LDE are exactly the CFFT-ordered evaluations over CircleDomain::new(log_sub, shift) - the prefix property tested by eval_at_point_on_subdomain_prefix_matches_full.

Lagrange-interpolate the opened values from that prefix instead of the full LDE: the dot product and the denominator batch both shrink by the blowup factor.

Getting 116ms -> 92ms for the `open` phase on my machine