### PR TITLE
perf(circle): kill data-movement passes across `extrapolate`

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -65,10 +65,12 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
             compute_twiddles(domain)
                 .into_iter()
                 .map(|ts| {
-                    batch_multiplicative_inverse(&ts)
-                        .into_iter()
-                        .map(|t| DifButterfly(t))
-                        .collect_vec()
+                    CfftLayer::Butterflies(
+                        batch_multiplicative_inverse(&ts)
+                            .into_iter()
+                            .map(|t| DifButterfly(t))
+                            .collect_vec(),
+                    )
                 })
                 .collect_vec()
         });
@@ -189,106 +191,79 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
         let log_n = log2_strict_usize(coeffs.height());
         assert!(log_n <= domain.log_n);
 
-        if log_n < domain.log_n {
-            // We could simply pad coeffs like this:
-            // coeffs.pad_to_height(target_domain.size(), F::ZERO);
-            // But the first `added_bits` layers will simply fill out the zeros
-            // with the lower order values. (In `DitButterfly`, `x_2` is 0, so
-            // both `x_1` and `x_2` are set to `x_1`).
-            // So instead we directly repeat the coeffs and skip the initial layers.
-            //
-            // After any number of doublings the buffer is the original `h` rows tiled end to end.
-            // Output row `j` is therefore a copy of original row `j mod h`.
-            //
-            //     originals : r_0 r_1 ... r_{h-1}
-            //     filled    : r_0 ... r_{h-1} | r_0 ... r_{h-1} | r_0 ... r_{h-1}
-            //                 \_h originals_/   \___ identical tiled copies ___/
-            //
-            // Reserve the full target once, then fill the new tail in parallel.
-            // Each tail row is written by exactly one task.
-            // The original rows are only read.
-            // So the concurrent writes never race.
-            debug_span!("extend coeffs").in_scope(|| {
-                let w = coeffs.width();
-                // Rows present before the blow-up.
-                let initial_h = coeffs.height();
-                // Rows required after the blow-up.
-                let target_h = domain.size();
-                let initial_len = initial_h * w;
-                let target_len = target_h * w;
+        let added_bits = domain.log_n - log_n;
+        let w = coeffs.width();
+        let target_len = domain.size() * w;
 
-                // Grow to the final size in one allocation; the tail stays uninitialised.
-                coeffs.values.reserve_exact(target_len - initial_len);
-
-                // SAFETY:
-                // - The reservation above guarantees capacity for `target_len` elements.
-                // - The read view covers `[0, initial_len)`.
-                // - The write view covers `[initial_len, target_len)`.
-                // - The two ranges are disjoint parts of one allocation.
-                // - Each tail row is handed to exactly one task, so the writes never alias.
-                // - `MaybeUninit::write` stores without reading or dropping the prior bytes.
-                // - The length is updated only after every tail element is written.
-                unsafe {
-                    // Base pointer of the reserved allocation.
-                    let ptr = coeffs.values.as_mut_ptr();
-
-                    // Read-only view of the rows already present.
-                    let initial_region: &[F] = core::slice::from_raw_parts(ptr, initial_len);
-
-                    // Write view of the uninitialised tail, just past the existing rows.
-                    let new_region: &mut [MaybeUninit<F>] = core::slice::from_raw_parts_mut(
-                        ptr.add(initial_len).cast::<MaybeUninit<F>>(),
-                        target_len - initial_len,
-                    );
-
-                    // One task per destination row.
-                    new_region
-                        .par_chunks_mut(w)
-                        .enumerate()
-                        .for_each(|(i, dst_row)| {
-                            // `i` indexes the tail, so this is global output row `initial_h + i`.
-                            // The tail starts on a multiple of `initial_h`.
-                            // So the source row reduces to `i mod initial_h`.
-                            let src_row_start = (i % initial_h) * w;
-                            let src_row = &initial_region[src_row_start..src_row_start + w];
-                            // Copy the chosen original row into this tail slot.
-                            for (dst, &src) in dst_row.iter_mut().zip(src_row) {
-                                dst.write(src);
-                            }
-                        });
-
-                    // Every tail element is initialised; publish them as live `Vec` entries.
-                    coeffs.values.set_len(target_len);
-                }
-            });
-        }
-        assert_eq!(coeffs.height(), 1 << domain.log_n);
+        // A `DitButterfly` layer acting on coefficients whose upper half is zero sets both
+        // outputs to the lower input, so the first `added_bits` layers of the transform are
+        // pure row duplications. Instead of materializing the zero-padding (or the tiled
+        // copies it collapses to) in a separate sweep, the duplications run as [`Dup`]
+        // layers inside the first fused pass, while the rows are cache-resident. Only the
+        // capacity is reserved here; the duplication layers initialise the tail.
+        coeffs
+            .values
+            .reserve_exact(target_len - coeffs.values.len());
 
         let twiddles = debug_span!("twiddles").in_scope(|| {
             compute_twiddles(domain)
                 .into_iter()
                 .map(|ts| ts.into_iter().map(|t| DitButterfly(t)).collect_vec())
                 .rev()
-                .skip(domain.log_n - log_n)
+                .skip(added_bits)
+                .map(CfftLayer::Butterflies)
                 .collect_vec()
         });
+        let layers = (0..added_bits)
+            .map(|l| CfftLayer::Dup { blocks: 1 << l })
+            .chain(twiddles)
+            .collect_vec();
 
         cfft_layers(
             coeffs.values.as_mut_ptr(),
-            coeffs.height(),
-            coeffs.width,
-            &twiddles,
+            domain.size(),
+            w,
+            &layers,
             None::<&RowMajorMatrix<F>>,
             None,
         );
+
+        // SAFETY: every row with one of the top `added_bits` index bits set is written by
+        // the duplication layer of its highest such bit (later duplication layers rewrite
+        // it consistently), so all `target_len` elements behind the reservation above are
+        // initialised once `cfft_layers` returns.
+        unsafe {
+            coeffs.values.set_len(target_len);
+        }
 
         Self::from_cfft_order(domain, coeffs)
     }
 }
 
+/// One layer of a fused CFFT pass.
+enum CfftLayer<B> {
+    /// Copy the lower half of each of `blocks` row blocks onto its upper half.
+    ///
+    /// This realizes a `DitButterfly` layer acting on coefficients whose upper half is
+    /// zero (for which both outputs equal the lower input), i.e. the zero-padding part
+    /// of an LDE, without materializing the padding in a separate sweep.
+    Dup { blocks: usize },
+    /// A twiddle butterfly layer, one twiddle per block.
+    Butterflies(Vec<B>),
+}
+
+impl<B> CfftLayer<B> {
+    const fn blocks(&self) -> usize {
+        match self {
+            Self::Dup { blocks } => *blocks,
+            Self::Butterflies(ts) => ts.len(),
+        }
+    }
+}
+
 /// The bit position by which a layer's butterfly partners differ.
 ///
-/// A layer whose twiddle array has `blocks` entries acts on `blocks` equal blocks of rows,
+/// A layer with `blocks` blocks acts on `blocks` equal blocks of rows,
 /// pairing the two halves of each block: rows `j` and `j ^ (h / (2 * blocks))`.
 const fn flipped_bit(log_h: usize, blocks: usize) -> usize {
     log_h - log2_strict_usize(blocks) - 1
@@ -324,16 +299,23 @@ fn log_group_rows<F>(log_h: usize, width: usize) -> usize {
 /// When `scale` is set, every element is additionally multiplied by it during the final pass,
 /// while its group is still cache-resident.
 ///
+/// [`CfftLayer::Dup`] layers may act on uninitialised rows: a duplication layer writes every
+/// row with its flipped bit set, so once all duplication layers have run, every row beyond the
+/// original (lowest-index) block is initialised. Since duplications are copies rather than
+/// arithmetic, each one widens the window budget of its run by one bit instead of consuming it,
+/// keeping the number of passes unchanged.
+///
 /// # Safety-relevant contract (not `unsafe fn` to keep call sites readable)
 ///
-/// `base` must be valid for reads and writes of `h * width` elements. Without `ingest`, those
-/// elements must already be initialised. `layers` must not be empty if `ingest` or `scale` is
-/// set (otherwise no pass would perform the copy or the scaling).
+/// `base` must be valid for reads and writes of `h * width` elements. Elements must be
+/// initialised, except (without `ingest`) rows whose index has a [`CfftLayer::Dup`] flipped
+/// bit set, and (with `ingest`) the whole buffer. `layers` must not be empty if `ingest` or
+/// `scale` is set (otherwise no pass would perform the copy or the scaling).
 fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
     base: *mut F,
     h: usize,
     width: usize,
-    layers: &[Vec<B>],
+    layers: &[CfftLayer<B>],
     ingest: Option<&M>,
     scale: Option<F>,
 ) {
@@ -345,29 +327,45 @@ fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
         "ingest and scale require at least one layer pass"
     );
 
+    // Duplication layers may widen a window beyond `log_group` (see above), but never so far
+    // that the larger groups leave the thread pool idle.
+    let budget_cap =
+        log_group.max(log_h.saturating_sub(log2_ceil_usize(4 * current_num_threads())));
+
     let mut start = 0;
     while start < layers.len() {
-        let first_bit = flipped_bit(log_h, layers[start].len());
+        let is_dup = |l: &CfftLayer<B>| matches!(l, CfftLayer::Dup { .. });
+        let first_bit = flipped_bit(log_h, layers[start].blocks());
         let (mut lo_bit, mut hi_bit) = (first_bit, first_bit);
+        let mut budget = (log_group + usize::from(is_dup(&layers[start]))).min(budget_cap);
         let mut end = start + 1;
-        while let Some(ts) = layers.get(end) {
-            let bit = flipped_bit(log_h, ts.len());
-            if bit.max(hi_bit) - bit.min(lo_bit) >= log_group {
+        while let Some(layer) = layers.get(end) {
+            let bit = flipped_bit(log_h, layer.blocks());
+            let new_budget = (budget + usize::from(is_dup(layer))).min(budget_cap);
+            if bit.max(hi_bit) - bit.min(lo_bit) >= new_budget {
                 break;
             }
+            budget = new_budget;
             (lo_bit, hi_bit) = (bit.min(lo_bit), bit.max(hi_bit));
             end += 1;
         }
-        let log_stride = lo_bit.min(log_h - log_group);
+        let log_group_run = log_group.max(hi_bit - lo_bit + 1).min(log_h);
+        let log_stride = lo_bit.min(log_h - log_group_run);
         let pass_ingest = if start == 0 { ingest } else { None };
         let pass_scale = scale.filter(|_| end == layers.len());
-        debug_span!("fused_layers", layers = end - start, log_group, log_stride).in_scope(|| {
+        debug_span!(
+            "fused_layers",
+            layers = end - start,
+            log_group_run,
+            log_stride
+        )
+        .in_scope(|| {
             par_group_pass(
                 base,
                 h,
                 width,
                 &layers[start..end],
-                log_group,
+                log_group_run,
                 log_stride,
                 pass_ingest,
                 pass_scale,
@@ -391,7 +389,7 @@ fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
     base: *mut F,
     h: usize,
     width: usize,
-    layers: &[Vec<B>],
+    layers: &[CfftLayer<B>],
     log_group: usize,
     log_stride: usize,
     ingest: Option<&M>,
@@ -418,26 +416,57 @@ fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
                 }
             }
         }
-        for ts in layers {
-            let e = flipped_bit(log_h, ts.len()) - log_stride;
-            let slice_len = 1 << (log_group - e - 1);
-            let slice = &ts[hi * slice_len..][..slice_len];
-            for (s, &t) in slice.iter().enumerate() {
-                for u in 0..1usize << e {
-                    let row_lo = first_row + (((s << (e + 1)) | u) << log_stride);
-                    let row_hi = row_lo + (1 << (e + log_stride));
-                    // SAFETY: every row index decomposes uniquely as
-                    // `hi << (log_group + log_stride) | t << log_stride | lo`, so the task for
-                    // group `g = (hi, lo)` is the only one touching its rows, and within a layer
-                    // each row appears in exactly one butterfly, so `row_lo` and `row_hi` never
-                    // alias. All indices stay below `h` since `t < 2^log_group`.
-                    let (row_lo, row_hi) = unsafe {
-                        (
-                            core::slice::from_raw_parts_mut(base.add(row_lo * width), width),
-                            core::slice::from_raw_parts_mut(base.add(row_hi * width), width),
-                        )
-                    };
-                    t.apply_to_rows(row_lo, row_hi);
+        for layer in layers {
+            let e = flipped_bit(log_h, layer.blocks()) - log_stride;
+            match layer {
+                CfftLayer::Dup { .. } => {
+                    for s in 0..1usize << (log_group - e - 1) {
+                        for u in 0..1usize << e {
+                            let row_lo = first_row + (((s << (e + 1)) | u) << log_stride);
+                            let row_hi = row_lo + (1 << (e + log_stride));
+                            // SAFETY: row ownership and non-aliasing as for the butterfly
+                            // case below. The copy goes through `MaybeUninit`, so it is
+                            // sound even while either row is still uninitialised (a
+                            // garbage copy is later overwritten by the duplication layer
+                            // of the destination row's highest flipped bit).
+                            unsafe {
+                                core::ptr::copy_nonoverlapping(
+                                    base.add(row_lo * width).cast::<MaybeUninit<F>>(),
+                                    base.add(row_hi * width).cast::<MaybeUninit<F>>(),
+                                    width,
+                                );
+                            }
+                        }
+                    }
+                }
+                CfftLayer::Butterflies(ts) => {
+                    let slice_len = 1 << (log_group - e - 1);
+                    let slice = &ts[hi * slice_len..][..slice_len];
+                    for (s, &t) in slice.iter().enumerate() {
+                        for u in 0..1usize << e {
+                            let row_lo = first_row + (((s << (e + 1)) | u) << log_stride);
+                            let row_hi = row_lo + (1 << (e + log_stride));
+                            // SAFETY: every row index decomposes uniquely as
+                            // `hi << (log_group + log_stride) | t << log_stride | lo`, so the task
+                            // for group `g = (hi, lo)` is the only one touching its rows, and
+                            // within a layer each row appears in exactly one butterfly, so
+                            // `row_lo` and `row_hi` never alias. All indices stay below `h` since
+                            // `t < 2^log_group`.
+                            let (row_lo, row_hi) = unsafe {
+                                (
+                                    core::slice::from_raw_parts_mut(
+                                        base.add(row_lo * width),
+                                        width,
+                                    ),
+                                    core::slice::from_raw_parts_mut(
+                                        base.add(row_hi * width),
+                                        width,
+                                    ),
+                                )
+                            };
+                            t.apply_to_rows(row_lo, row_hi);
+                        }
+                    }
                 }
             }
         }

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -6,9 +6,7 @@ use itertools::{Itertools, iterate, izip};
 use p3_commit::PolynomialSpace;
 use p3_dft::{Butterfly, DifButterfly, DitButterfly};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{
-    ExtensionField, Field, FieldArray, PackedValue, batch_multiplicative_inverse,
-};
+use p3_field::{ExtensionField, Field, FieldArray, PackedValue, batch_multiplicative_inverse};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -47,8 +45,21 @@ impl<F: Copy + Send + Sync, M: Matrix<F>> CircleEvaluations<F, M> {
 impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
     #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
     pub fn interpolate(self) -> RowMajorMatrix<F> {
+        let len = self.domain.size() * self.values.width();
+        self.interpolate_with_capacity(len)
+    }
+
+    /// Interpolate into a freshly allocated buffer with at least `capacity` elements
+    /// reserved, so a caller can extend the result in place without reallocating.
+    ///
+    /// The source matrix is read directly by the first butterfly pass: each parallel
+    /// task copies its own rows into the output buffer and immediately applies every
+    /// layer of the pass while they are cache-resident, so the input is never
+    /// materialized separately.
+    fn interpolate_with_capacity(self, capacity: usize) -> RowMajorMatrix<F> {
         let Self { domain, values } = self;
-        let mut values = debug_span!("to_rmm").in_scope(|| values.to_row_major_matrix());
+        let w = values.width();
+        let len = domain.size() * w;
 
         let twiddles = debug_span!("twiddles").in_scope(|| {
             compute_twiddles(domain)
@@ -68,9 +79,23 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
         // scaling into the last butterfly pass touches the data while it is cache-resident,
         // instead of paying a separate full sweep over the matrix.
         let h_inv = F::ONE.div_2exp_u64(domain.log_n as u64);
-        cfft_layers(&mut values.values, values.width, &twiddles, Some(h_inv));
 
-        values
+        let mut buf: Vec<F> = Vec::with_capacity(capacity.max(len));
+        cfft_layers(
+            buf.as_mut_ptr(),
+            domain.size(),
+            w,
+            &twiddles,
+            Some(&values),
+            Some(h_inv),
+        );
+        // SAFETY: the first pass of `cfft_layers` copied every row of `values` into
+        // `buf` before transforming it, so all `len` elements are initialised, and the
+        // reservation above covers them.
+        unsafe {
+            buf.set_len(len);
+        }
+        RowMajorMatrix::new(buf, w)
     }
 
     #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
@@ -79,42 +104,13 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
         target_domain: CircleDomain<F>,
     ) -> CircleEvaluations<F, RowMajorMatrix<F>> {
         assert!(target_domain.log_n >= self.domain.log_n);
-        let Self { domain, values } = self;
 
-        // Materialize the evaluations into a buffer sized for the full LDE up front.
-        // `interpolate` keeps the buffer (and its spare capacity) through
-        // `to_row_major_matrix`, so the blow-up in `evaluate` fills the spare
-        // capacity instead of reallocating: the whole extrapolation performs a
-        // single allocation, and every page is first touched by a parallel write.
-        let w = values.width();
-        let initial_len = values.height() * w;
-        let target_len = target_domain.size() * w;
-        let values = debug_span!("to_rmm").in_scope(|| {
-            let mut buf = Vec::with_capacity(target_len);
-            // Each source row is copied into its slot by exactly one task,
-            // covering `[0, initial_len)` of the spare capacity.
-            buf.spare_capacity_mut()[..initial_len]
-                .par_chunks_mut(w)
-                .enumerate()
-                .for_each(|(r, dst_row)| {
-                    // SAFETY: `r < values.height()`, since the chunks cover
-                    // exactly `values.height()` rows.
-                    let src_row = unsafe { values.row_slice_unchecked(r) };
-                    // `MaybeUninit::write` stores without reading or dropping
-                    // the uninitialised bytes.
-                    for (dst, &src) in dst_row.iter_mut().zip(src_row.iter()) {
-                        dst.write(src);
-                    }
-                });
-            // SAFETY: the loop above initialised the first `initial_len`
-            // elements, and the capacity reserved covers them.
-            unsafe {
-                buf.set_len(initial_len);
-            }
-            RowMajorMatrix::new(buf, w)
-        });
-
-        let coeffs = CircleEvaluations::from_cfft_order(domain, values).interpolate();
+        // Reserve the buffer for the full LDE up front: the blow-up in `evaluate` then
+        // fills the spare capacity instead of reallocating, so the whole extrapolation
+        // performs a single allocation, and every page is first touched by a parallel
+        // write inside the first interpolation pass.
+        let target_len = target_domain.size() * self.values.width();
+        let coeffs = self.interpolate_with_capacity(target_len);
         CircleEvaluations::evaluate(target_domain, coeffs)
     }
 
@@ -277,7 +273,14 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
                 .collect_vec()
         });
 
-        cfft_layers(&mut coeffs.values, coeffs.width, &twiddles, None);
+        cfft_layers(
+            coeffs.values.as_mut_ptr(),
+            coeffs.height(),
+            coeffs.width,
+            &twiddles,
+            None::<&RowMajorMatrix<F>>,
+            None,
+        );
 
         Self::from_cfft_order(domain, coeffs)
     }
@@ -313,17 +316,34 @@ fn log_group_rows<F>(log_h: usize, width: usize) -> usize {
 /// applies every layer of the run to one cache-resident group, costing one pass over memory per
 /// run instead of one per layer.
 ///
+/// When `ingest` is set, the buffer behind `base` may be entirely uninitialised: each task of
+/// the first pass copies its own rows from the source matrix before transforming them, so the
+/// input is pulled in during the first pass instead of a separate materialization sweep. After
+/// the call, all `h * width` elements behind `base` are initialised.
+///
 /// When `scale` is set, every element is additionally multiplied by it during the final pass,
 /// while its group is still cache-resident.
-fn cfft_layers<F: Field, B: Butterfly<F>>(
-    values: &mut [F],
+///
+/// # Safety-relevant contract (not `unsafe fn` to keep call sites readable)
+///
+/// `base` must be valid for reads and writes of `h * width` elements. Without `ingest`, those
+/// elements must already be initialised. `layers` must not be empty if `ingest` or `scale` is
+/// set (otherwise no pass would perform the copy or the scaling).
+fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
+    base: *mut F,
+    h: usize,
     width: usize,
     layers: &[Vec<B>],
+    ingest: Option<&M>,
     scale: Option<F>,
 ) {
-    let h = values.len() / width;
     let log_h = log2_strict_usize(h);
     let log_group = log_group_rows::<F>(log_h, width);
+    debug_assert!(ingest.is_none_or(|m| m.height() == h && m.width() == width));
+    assert!(
+        !layers.is_empty() || (ingest.is_none() && scale.is_none()),
+        "ingest and scale require at least one layer pass"
+    );
 
     let mut start = 0;
     while start < layers.len() {
@@ -339,14 +359,17 @@ fn cfft_layers<F: Field, B: Butterfly<F>>(
             end += 1;
         }
         let log_stride = lo_bit.min(log_h - log_group);
+        let pass_ingest = if start == 0 { ingest } else { None };
         let pass_scale = scale.filter(|_| end == layers.len());
         debug_span!("fused_layers", layers = end - start, log_group, log_stride).in_scope(|| {
             par_group_pass(
-                values,
+                base,
+                h,
                 width,
                 &layers[start..end],
                 log_group,
                 log_stride,
+                pass_ingest,
                 pass_scale,
             );
         });
@@ -361,24 +384,40 @@ fn cfft_layers<F: Field, B: Butterfly<F>>(
 /// | lo` for `t` in `[0, 2^log_group)`. A layer with `b` blocks pairs rows differing in bit
 /// `e = flipped_bit - log_stride` of `t` and applies the twiddle `b * j / h`, which reduces to
 /// index `t >> (e + 1)` into the contiguous twiddle slice for `hi`.
-fn par_group_pass<F: Field, B: Butterfly<F>>(
-    values: &mut [F],
+///
+/// See [`cfft_layers`] for the `ingest` and `scale` semantics and the safety contract.
+#[allow(clippy::too_many_arguments)]
+fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
+    base: *mut F,
+    h: usize,
     width: usize,
     layers: &[Vec<B>],
     log_group: usize,
     log_stride: usize,
+    ingest: Option<&M>,
     scale: Option<F>,
 ) {
-    let h = values.len() / width;
     let log_h = log2_strict_usize(h);
     let num_groups = h >> log_group;
-    let base_addr = values.as_mut_ptr() as usize;
+    let base_addr = base as usize;
     let packed_scale = scale.map(F::Packing::from);
     (0..num_groups).into_par_iter().for_each(|g| {
         let base = base_addr as *mut F;
         let hi = g >> log_stride;
         let lo = g & ((1 << log_stride) - 1);
         let first_row = (hi << (log_group + log_stride)) | lo;
+        if let Some(src) = ingest {
+            for t in 0..1usize << log_group {
+                let row = first_row + (t << log_stride);
+                // SAFETY: `row < h` since `t < 2^log_group`, and this task owns the
+                // destination row (the groups partition the rows), so the raw copy
+                // neither races nor reads uninitialised destination memory.
+                unsafe {
+                    let src_row = src.row_slice_unchecked(row);
+                    core::ptr::copy_nonoverlapping(src_row.as_ptr(), base.add(row * width), width);
+                }
+            }
+        }
         for ts in layers {
             let e = flipped_bit(log_h, ts.len()) - log_stride;
             let slice_len = 1 << (log_group - e - 1);

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -4,9 +4,11 @@ use core::mem::MaybeUninit;
 
 use itertools::{Itertools, iterate, izip};
 use p3_commit::PolynomialSpace;
-use p3_dft::{Butterfly, DifButterfly, DitButterfly, divide_by_height};
+use p3_dft::{Butterfly, DifButterfly, DitButterfly};
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field, FieldArray, batch_multiplicative_inverse};
+use p3_field::{
+    ExtensionField, Field, FieldArray, PackedValue, batch_multiplicative_inverse,
+};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -62,10 +64,12 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
 
         assert_eq!(twiddles.len(), domain.log_n);
 
-        cfft_layers(&mut values.values, values.width, &twiddles);
+        // The interpolation must divide every element by the domain size. Folding the
+        // scaling into the last butterfly pass touches the data while it is cache-resident,
+        // instead of paying a separate full sweep over the matrix.
+        let h_inv = F::ONE.div_2exp_u64(domain.log_n as u64);
+        cfft_layers(&mut values.values, values.width, &twiddles, Some(h_inv));
 
-        // TODO: omit this?
-        divide_by_height(&mut values);
         values
     }
 
@@ -273,7 +277,7 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
                 .collect_vec()
         });
 
-        cfft_layers(&mut coeffs.values, coeffs.width, &twiddles);
+        cfft_layers(&mut coeffs.values, coeffs.width, &twiddles, None);
 
         Self::from_cfft_order(domain, coeffs)
     }
@@ -308,7 +312,15 @@ fn log_group_rows<F>(log_h: usize, width: usize) -> usize {
 /// independent groups of `2^log_group` rows sitting `2^log_stride` rows apart. Each parallel task
 /// applies every layer of the run to one cache-resident group, costing one pass over memory per
 /// run instead of one per layer.
-fn cfft_layers<F: Field, B: Butterfly<F>>(values: &mut [F], width: usize, layers: &[Vec<B>]) {
+///
+/// When `scale` is set, every element is additionally multiplied by it during the final pass,
+/// while its group is still cache-resident.
+fn cfft_layers<F: Field, B: Butterfly<F>>(
+    values: &mut [F],
+    width: usize,
+    layers: &[Vec<B>],
+    scale: Option<F>,
+) {
     let h = values.len() / width;
     let log_h = log2_strict_usize(h);
     let log_group = log_group_rows::<F>(log_h, width);
@@ -327,8 +339,17 @@ fn cfft_layers<F: Field, B: Butterfly<F>>(values: &mut [F], width: usize, layers
             end += 1;
         }
         let log_stride = lo_bit.min(log_h - log_group);
-        debug_span!("fused_layers", layers = end - start, log_group, log_stride)
-            .in_scope(|| par_group_pass(values, width, &layers[start..end], log_group, log_stride));
+        let pass_scale = scale.filter(|_| end == layers.len());
+        debug_span!("fused_layers", layers = end - start, log_group, log_stride).in_scope(|| {
+            par_group_pass(
+                values,
+                width,
+                &layers[start..end],
+                log_group,
+                log_stride,
+                pass_scale,
+            );
+        });
         start = end;
     }
 }
@@ -346,11 +367,13 @@ fn par_group_pass<F: Field, B: Butterfly<F>>(
     layers: &[Vec<B>],
     log_group: usize,
     log_stride: usize,
+    scale: Option<F>,
 ) {
     let h = values.len() / width;
     let log_h = log2_strict_usize(h);
     let num_groups = h >> log_group;
     let base_addr = values.as_mut_ptr() as usize;
+    let packed_scale = scale.map(F::Packing::from);
     (0..num_groups).into_par_iter().for_each(|g| {
         let base = base_addr as *mut F;
         let hi = g >> log_stride;
@@ -376,6 +399,21 @@ fn par_group_pass<F: Field, B: Butterfly<F>>(
                         )
                     };
                     t.apply_to_rows(row_lo, row_hi);
+                }
+            }
+        }
+        if let (Some(scale), Some(packed_scale)) = (scale, packed_scale) {
+            for t in 0..1usize << log_group {
+                let row = first_row + (t << log_stride);
+                // SAFETY: the group decomposition above guarantees this task is the only
+                // one touching its rows, and `row < h` since `t < 2^log_group`.
+                let row = unsafe { core::slice::from_raw_parts_mut(base.add(row * width), width) };
+                let (packed, suffix) = F::Packing::pack_slice_with_suffix_mut(row);
+                for x in packed {
+                    *x *= packed_scale;
+                }
+                for x in suffix {
+                    *x *= scale;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **fold the height division into the final CFFT pass**
interpolate ended with divide_by_height, a separate full sweep multiplying every element by 1/N (~25 ms). cfft_layers/par_group_pass now take an optional scale: Option<F>; during the last fused pass, each task scales its
  own row group (packed multiply) right after applying its butterfly layers, while the group is still in cache. The standalone sweep is gone.

- **ingest the input matrix inside the first interpolation pass**
  interpolate started with to_row_major_matrix(), which for the CfftView used by extrapolate is a full permuted-gather sweep (~79 ms) whose output the first butterfly pass immediately re-reads. The pass machinery now works
  from a raw base pointer over a fresh (uninitialized) buffer with an optional ingest: Option<&M> source: each task of the first pass copies its own rows from the source matrix (raw ptr::copy, before any slices are formed)
  and then runs the pass's layers on them in cache. The input is read exactly once. A new interpolate_with_capacity preserves the single-allocation property from #1795: extrapolate reserves the full LDE size up front so the
  blow-up in evaluate fills spare capacity instead of reallocating.

- **run the LDE blow-up inside the first evaluate pass**
  evaluate materialized the zero-padding blow-up by tiling the coefficient rows across the full LDE buffer in a separate parallel sweep (~85–96 ms). That tiling is exactly what the skipped initial DitButterfly layers do to
  zero-padded coefficients (both outputs equal the lower input), so the layer list now represents them as explicit Dup variants of a new CfftLayer enum, executed inside the first fused pass via MaybeUninit raw copies (sound
  even while the tail is uninitialized; each tail row is finalized by the dup layer of its highest set bit). Two scheduling details matter:
  - A Dup is a copy, not arithmetic, so it widens its pass's window budget by one bit instead of consuming it — otherwise the 19-layer sequence would have needed a 4th pass and given back most of the win.
  - That widening is capped by the parallelism budget (found during benchmarking): without the cap, narrow quotient-chunk matrices grew groups to 2^14 rows, leaving 32 tasks for 14 cores and doubling their extrapolate cost
  (~10 → ~20 ms). With the cap they're back to ~9–12 ms.



Brings `extrapolate` step on my machine from 310ms to 265ms on average when running the `prove_prime_field_31` example.