### PR TITLE
perf(lookup): flag-zero skip for sparse rows + dot_product tuple combine

### DIFF
--- a/lookup/benches/logup.rs
+++ b/lookup/benches/logup.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
-use p3_air::{AirBuilder, BaseLeaf, WindowAccess};
+use p3_air::{AirBuilder, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
 use p3_commit::ExtensionMmcs;
@@ -33,15 +33,43 @@ type Dft = Radix2DitParallel<F>;
 type MyPcs = TwoAdicFriPcs<F, Dft, ValMmcs, ChallengeMmcs>;
 type SC = StarkConfig<MyPcs, EF, Challenger>;
 
-/// Build a random main trace of given height and width.
-fn random_main_trace(height: usize, width: usize, rng: &mut SmallRng) -> RowMajorMatrix<F> {
-    let values: Vec<F> = (0..height * width)
-        .map(|_| F::from_u32(rng.random::<u32>() % (1 << 27)))
-        .collect();
+/// Per-lookup column stride: `tuple_size` read keys, `tuple_size` provide keys, one selector.
+const fn cols_per_lookup(tuple_size: usize) -> usize {
+    2 * tuple_size + 1
+}
+
+/// Build a main trace with random keys and a sparsity-controlled selector per lookup.
+///
+/// - Every column is random by default.
+/// - Each lookup's selector column is `1` once every `active_period` rows, else `0`.
+/// - `active_period == 1` makes every row active (a dense workload).
+fn build_trace(config: &BenchConfig, rng: &mut SmallRng) -> RowMajorMatrix<F> {
+    let height = 1 << config.log_height;
+    let width = config.trace_width;
+    let stride = cols_per_lookup(config.tuple_size);
+
+    let mut values = F::zero_vec(height * width);
+    for row in 0..height {
+        let base = row * width;
+        // Random keys fill the whole row first.
+        for v in &mut values[base..base + width] {
+            *v = F::from_u32(rng.random::<u32>() % (1 << 27));
+        }
+        // A row is active once every `active_period` rows.
+        let active = row % config.active_period == 0;
+        // Overwrite each lookup's selector column with the sparse flag.
+        for lookup_idx in 0..config.num_lookups {
+            let selector_col = lookup_idx * stride + 2 * config.tuple_size;
+            values[base + selector_col] = if active { F::ONE } else { F::ZERO };
+        }
+    }
     RowMajorMatrix::new(values, width)
 }
 
-/// Build symbolic lookup contexts similar to RangeCheckAir pattern.
+/// Build symbolic lookup contexts, both sides gated by one shared selector column.
+///
+/// A zero selector zeroes both multiplicities, so the row contributes nothing.
+/// This mirrors a selector-gated lookup (active only on some rows).
 fn build_lookups(num_lookups: usize, tuple_size: usize, trace_width: usize) -> Vec<Lookup<F>> {
     let symbolic_builder = SymbolicAirBuilder::<F>::new(AirLayout {
         main_width: trace_width,
@@ -50,28 +78,29 @@ fn build_lookups(num_lookups: usize, tuple_size: usize, trace_width: usize) -> V
     let symbolic_main = symbolic_builder.main();
     let symbolic_main_local = symbolic_main.current_slice();
 
-    let cols_per_lookup = 2 * tuple_size + 1;
+    let stride = cols_per_lookup(tuple_size);
 
     (0..num_lookups)
         .map(|lookup_idx| {
-            let base_col = lookup_idx * cols_per_lookup;
+            let base_col = lookup_idx * stride;
 
             let read_elements: Vec<SymbolicExpression<F>> = (0..tuple_size)
                 .map(|j| symbolic_main_local[base_col + j].into())
                 .collect();
-            let read_mult = SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE));
 
             let provide_elements: Vec<SymbolicExpression<F>> = (0..tuple_size)
                 .map(|j| symbolic_main_local[base_col + tuple_size + j].into())
                 .collect();
-            let provide_mult: SymbolicExpression<F> =
+
+            // One selector column gates both sides: read sends `+sel`, provide sends `-sel`.
+            let selector: SymbolicExpression<F> =
                 symbolic_main_local[base_col + 2 * tuple_size].into();
 
             let elements = vec![read_elements, provide_elements];
             let multiplicities = vec![
-                read_mult,
+                selector.clone(),
                 SymbolicExpression::Neg {
-                    x: Arc::new(provide_mult),
+                    x: Arc::new(selector),
                     degree_multiple: 1,
                 },
             ];
@@ -107,30 +136,38 @@ struct BenchConfig {
     num_lookups: usize,
     tuple_size: usize,
     trace_width: usize,
+    /// One active row every `active_period` rows; `1` is fully dense.
+    active_period: usize,
+}
+
+/// Terse constructor; `trace_width` must equal `num_lookups * cols_per_lookup(tuple_size)`.
+const fn cfg(
+    name: &'static str,
+    log_height: usize,
+    num_lookups: usize,
+    tuple_size: usize,
+    active_period: usize,
+) -> BenchConfig {
+    BenchConfig {
+        name,
+        log_height,
+        num_lookups,
+        tuple_size,
+        trace_width: num_lookups * cols_per_lookup(tuple_size),
+        active_period,
+    }
 }
 
 const CONFIGS: &[BenchConfig] = &[
-    BenchConfig {
-        name: "small",
-        log_height: 10,
-        num_lookups: 1,
-        tuple_size: 1,
-        trace_width: 3,
-    },
-    BenchConfig {
-        name: "medium",
-        log_height: 16,
-        num_lookups: 2,
-        tuple_size: 2,
-        trace_width: 10,
-    },
-    BenchConfig {
-        name: "large",
-        log_height: 20,
-        num_lookups: 4,
-        tuple_size: 1,
-        trace_width: 12,
-    },
+    // Dense baselines: every row active, so flag-zero skip never fires.
+    cfg("dense_small", 10, 1, 1, 1),
+    cfg("dense_medium", 16, 2, 2, 1),
+    cfg("dense_large", 20, 4, 1, 1),
+    // Wide selector-gated payload, swept from dense to very sparse.
+    // The flag-zero skip should make the sparse rows cheaper.
+    cfg("gated_tw4_p1", 18, 2, 4, 1),
+    cfg("gated_tw4_p8", 18, 2, 4, 8),
+    cfg("gated_tw4_p64", 18, 2, 4, 64),
 ];
 
 fn bench_generate_permutation(c: &mut Criterion) {
@@ -141,9 +178,8 @@ fn bench_generate_permutation(c: &mut Criterion) {
 
     for config in CONFIGS {
         let mut rng = SmallRng::seed_from_u64(42);
-        let height = 1 << config.log_height;
 
-        let main_trace = random_main_trace(height, config.trace_width, &mut rng);
+        let main_trace = build_trace(config, &mut rng);
         let lookups = build_lookups(config.num_lookups, config.tuple_size, config.trace_width);
         let challenges = random_challenges(config.num_lookups, &mut rng);
 
@@ -151,8 +187,8 @@ fn bench_generate_permutation(c: &mut Criterion) {
             BenchmarkId::new(
                 config.name,
                 format!(
-                    "h=2^{}_lookups={}_tuple={}",
-                    config.log_height, config.num_lookups, config.tuple_size
+                    "h=2^{}_lookups={}_tuple={}_period={}",
+                    config.log_height, config.num_lookups, config.tuple_size, config.active_period
                 ),
             ),
             |b| {

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -430,6 +430,25 @@ impl LookupProtocol for LogUpGadget {
             })
             .collect();
 
+        // Hoist the beta powers per lookup out of the hot per-row loop.
+        //
+        // The tuple combine reads them directly:
+        //
+        //     combined = sum_i e_i * beta^{k-1-i}
+        //
+        // Each step is then an extension * base product (`beta^p * e_i`).
+        // Horner instead multiplies extension * extension (`acc * beta`).
+        let max_tuple_width = lookups
+            .iter()
+            .flat_map(|lookup| lookup.elements.iter())
+            .map(Vec::len)
+            .max()
+            .unwrap_or(0);
+        let beta_powers: Vec<Vec<SC::Challenge>> = lookup_challenges
+            .iter()
+            .map(|&(_, beta)| beta.powers().collect_n(max_tuple_width))
+            .collect();
+
         // Fused chunk-local batch inversion.
         //
         // Instead of three global passes (fill denoms -> batch invert -> build row sums)
@@ -526,23 +545,53 @@ impl LookupProtocol for LogUpGadget {
 
                     // Walk through each lookup's element tuples and fill the flat buffers.
                     let mut offset = local_i * denoms_per_row;
-                    for (lookup, &(alpha, beta)) in lookups.iter().zip(lookup_challenges.iter()) {
+                    for ((lookup, &(alpha, _)), powers) in lookups
+                        .iter()
+                        .zip(lookup_challenges.iter())
+                        .zip(beta_powers.iter())
+                    {
                         for (j, elts) in lookup.elements.iter().enumerate() {
-                            // Combine tuple elements via Horner's method:
-                            //   combined = e_0 * beta^{k-1} + e_1 * beta^{k-2} + ... + e_{k-1}
-                            // Then store (alpha - combined) as the denominator.
-                            let mut iter = elts.iter();
-                            let combined_elt = iter.next().map_or(SC::Challenge::ZERO, |first| {
-                                iter.fold(
-                                    first.resolve(&row_ctx).into(),
-                                    |acc: SC::Challenge, e| acc * beta + e.resolve(&row_ctx),
-                                )
-                            });
-                            local_denoms[offset] = alpha - combined_elt;
+                            // Resolve the multiplicity first.
+                            let mult = lookup.multiplicities[j].resolve(&row_ctx);
+                            local_mults[offset] = mult;
 
-                            // Store the multiplicity as a base-field element (4 bytes vs 16 for
-                            // extension) to keep the buffer small and the later dot product cheap.
-                            local_mults[offset] = lookup.multiplicities[j].resolve(&row_ctx);
+                            // Flag-zero skip:
+                            // A zero multiplicity makes `m_j / d_j` vanish, whatever the denominator is.
+                            // So skip the element combine and pin a unit placeholder.
+                            //
+                            //   - The unit keeps batch inversion well-defined (1 inverts to 1).
+                            //   - The fraction term stays exact at `0 * 1 = 0`.
+                            //   - The verifier reads the real denominator from the trace, and
+                            //     the zero-weight term drops from both sides of `U * f = V`.
+                            local_denoms[offset] = if mult.is_zero() {
+                                SC::Challenge::ONE
+                            } else {
+                                // Combine the tuple as `sum_i e_i * beta^{k-1-i}`.
+                                //
+                                //   - The last element carries `beta^0`, so it is lifted with no multiply.
+                                //   - Each leading element pairs with a hoisted power `beta^p * e_i`,
+                                //     an extension * base product rather than extension * extension.
+                                let combined_elt = match elts.split_last() {
+                                    None => SC::Challenge::ZERO,
+                                    // Width-1 tuple: the single element carries beta^0, so lift it directly.
+                                    Some((last, [])) => last.resolve(&row_ctx).into(),
+                                    Some((last, leading)) => {
+                                        // Powers beta^{k-1} down to beta^1, aligned with e_0 .. e_{k-2}.
+                                        let high_powers =
+                                            powers[1..elts.len()].iter().rev().copied();
+                                        let leading_resolved =
+                                            leading.iter().map(|e| e.resolve(&row_ctx));
+                                        let lifted_last: SC::Challenge =
+                                            last.resolve(&row_ctx).into();
+                                        lifted_last
+                                            + dot_product::<SC::Challenge, _, _>(
+                                                high_powers,
+                                                leading_resolved,
+                                            )
+                                    }
+                                };
+                                alpha - combined_elt
+                            };
                             offset += 1;
                         }
                     }

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -417,6 +417,129 @@ fn generate_permutation_balances_to_zero_terminal() {
 }
 
 #[test]
+fn generate_permutation_flag_zero_skip_matches_real_denominators() {
+    // Invariant: a zero multiplicity must yield the same aux trace as the real
+    //            denominator would, since `0 / d = 0` for every nonzero `d`.
+    //
+    // Fixture: a range check whose table-side multiplicity is zero on even rows.
+    //   - Even rows: table tuple has m = 0 → the flag-zero skip path (unit placeholder).
+    //   - Odd rows:  table tuple has m != 0 → the full denominator path.
+    //   - The query tuple always has m = 1, so even rows still carry a nonzero fraction.
+    let height = 8;
+    let mut rng = SmallRng::seed_from_u64(0x5A17);
+
+    // Columns per row: [query value, table value, table multiplicity].
+    let mut flat = Vec::with_capacity(height * 3);
+    for r in 0..height {
+        flat.push(F::from_u32(rng.random::<u32>() % (1 << 27)));
+        flat.push(F::from_u32(rng.random::<u32>() % (1 << 27)));
+        // Zero multiplicity on even rows exercises the skip; odd rows stay nonzero.
+        let mult = if r % 2 == 0 {
+            F::ZERO
+        } else {
+            F::from_u32(1 + rng.random::<u32>() % 7)
+        };
+        flat.push(mult);
+    }
+    let main = RowMajorMatrix::new(flat, 3);
+
+    let air = RangeCheckAir::new();
+    let lookups: Lookups<F> = Lookups::from_air::<EF, _>(&air);
+    let gadget = LogUpGadget::new();
+
+    // alpha carries a nonzero extension coefficient: `alpha - base` is never zero.
+    let alpha = EF::new([F::from_u32(7), F::ONE, F::ZERO, F::ZERO]);
+    let beta = EF::from_u32(11);
+    let challenges = vec![alpha, beta];
+
+    let (aux, terminal) =
+        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+
+    // Reference fraction per row, built from the real denominators:
+    //   f[r] = 1 / (alpha - query[r])  +  (-mult[r]) / (alpha - table[r])
+    let expected_frac: Vec<EF> = (0..height)
+        .map(|r| {
+            let row = main.row_slice(r).unwrap();
+            let query_term = (alpha - row[0]).inverse();
+            let table_term = (alpha - row[1]).inverse() * (-row[2]);
+            query_term + table_term
+        })
+        .collect();
+
+    // The fraction column matches on every row, including the skipped even rows.
+    for (r, &expected) in expected_frac.iter().enumerate() {
+        assert_eq!(aux.row_slice(r).unwrap()[1], expected, "fraction row {r}");
+    }
+
+    // The accumulator column is the exclusive prefix sum of the fractions.
+    let mut acc = EF::ZERO;
+    for (r, &expected) in expected_frac.iter().enumerate() {
+        assert_eq!(aux.row_slice(r).unwrap()[0], acc, "accumulator row {r}");
+        acc += expected;
+    }
+
+    // The committed terminal is the full sum across the trace.
+    assert_eq!(terminal.unwrap().0, acc);
+}
+
+#[test]
+fn generate_permutation_multi_element_combine_matches_reference() {
+    // Invariant: a width-2 tuple's denominator is `alpha - (e_0 * beta + e_1)`.
+    //            The hoisted-power combine must reproduce that value exactly.
+    //
+    // Fixture: one lookup, one width-2 tuple `(col0, col1)` with column multiplicity col2.
+    let height = 8;
+    let mut rng = SmallRng::seed_from_u64(0xC0DE);
+
+    // Symbolic handles for the three main columns.
+    let sb = SymbolicAirBuilder::<F>::new(AirLayout {
+        main_width: 3,
+        ..Default::default()
+    });
+    let cols = sb.main();
+    let cols = cols.current_slice();
+    let lookup = Lookup {
+        kind: Kind::Local,
+        elements: vec![vec![cols[0].into(), cols[1].into()]],
+        multiplicities: vec![cols[2].into()],
+        count_weight: 0,
+        column: 0,
+    };
+    let lookups = vec![lookup];
+
+    // Columns per row: [e_0, e_1, multiplicity], multiplicity kept nonzero.
+    let mut flat = Vec::with_capacity(height * 3);
+    for _ in 0..height {
+        flat.push(F::from_u32(rng.random::<u32>() % (1 << 27)));
+        flat.push(F::from_u32(rng.random::<u32>() % (1 << 27)));
+        flat.push(F::from_u32(1 + rng.random::<u32>() % 7));
+    }
+    let main = RowMajorMatrix::new(flat, 3);
+
+    let gadget = LogUpGadget::new();
+    // Why the denominator is never zero:
+    //
+    //     alpha     = nonzero extension coefficient
+    //     beta      = base-valued
+    //     combined  = beta * e_0 + e_1         (base-valued)
+    //     alpha - combined                     (keeps alpha's extension part)
+    let alpha = EF::new([F::from_u32(7), F::ONE, F::ZERO, F::ZERO]);
+    let beta = EF::from_u32(11);
+    let challenges = vec![alpha, beta];
+
+    let (aux, _) =
+        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+
+    // Reference: f[r] = mult[r] / (alpha - (e_0[r] * beta + e_1[r])).
+    for r in 0..height {
+        let row = main.row_slice(r).unwrap();
+        let combined = beta * row[0] + row[1];
+        let expected = (alpha - combined).inverse() * row[2];
+        assert_eq!(aux.row_slice(r).unwrap()[1], expected, "fraction row {r}");
+    }
+}
+
+#[test]
 fn eval_all_passes_on_balanced_trace() {
     let mut rng = SmallRng::seed_from_u64(0xc0ffee);
     let main = balanced_range_check_main(16, &mut rng);


### PR DESCRIPTION
## What

Two complementary, independently-sound speedups to `LogUpGadget::generate_permutation` — the per-AIR auxiliary-trace builder in `lookup/src/logup.rs`.

**1. Flag-zero skip for sparse rows.** When a tuple's multiplicity resolves to `0`, the fraction term `m_j / d_j` is `0` for any nonzero denominator. So we resolve the multiplicity first and, when it is zero, skip the element combine entirely and store a unit placeholder denominator. Sparse, selector-gated lookups (memory, opcode-gated, range-gated, …) stop paying for their inactive rows.

**2. `dot_product` tuple combine.** The per-row tuple combine `Σ_i e_i · β^{k-1-i}` used Horner (`acc * β`), where `acc` is an extension element and `β` is the extension challenge — an **extension × extension** product (~16 base muls/step for a quartic). The tuple elements `e_i` are *base* field, so by hoisting the `β` powers out of the row loop the combine becomes a `dot_product` of extension powers with base elements — an **extension × base** product (~4 base muls/step). A width-1 fast path keeps single-element tuples (range checks) free of any extra multiply.

## Why each is sound

**Flag-zero skip.** A zero weight zeroes the fraction term regardless of the denominator, so the placeholder cannot change any committed value:
- The unit placeholder keeps batch inversion well-defined (`1` inverts to `1`); the term is exactly `0 · 1 = 0`.
- The verifier reads the *real* denominator from the trace. For a multi-tuple lookup, `f = Σ_{k: m_k≠0} m_k/d_k(real) = V/U`, since the zero-weight tuples drop from both sides of the fraction-pin constraint `U·f = V`.

**Combine.** Field addition is commutative, so reordering the summation makes the `dot_product` result bit-identical to Horner. Both paths are pinned to an independent reference in the tests below.

## Benchmarks

`cargo bench -p p3-lookup --bench logup` — the `generate_permutation` microbench, which this PR makes sparsity-aware (an `active_period` knob gating both multiplicities by a selector column, so the flag-zero skip is exercised). Numbers are a single back-to-back criterion run (`--save-baseline` then `--baseline`); every change has `p < 0.05`.

| config | workload | before | after | speedup |
|---|---|---|---|---|
| `dense_small`  | h=2^10, tuple width 1, dense       | 69.3 µs  | 64.1 µs  | **−7.4 %** |
| `dense_medium` | h=2^16, tuple width 2, dense       | 10.39 ms | 9.64 ms  | **−7.2 %** |
| `dense_large`  | h=2^20, tuple width 1, dense       | 273.0 ms | 257.7 ms | **−5.6 %** |
| `gated_tw4_p1`  | h=2^18, tuple width 4, dense (1/1 active)  | 67.3 ms | 47.7 ms | **−29.1 %** |
| `gated_tw4_p8`  | h=2^18, tuple width 4, 1/8 active  | 67.7 ms | 30.8 ms | **−54.5 %** |
| `gated_tw4_p64` | h=2^18, tuple width 4, 1/64 active | 67.5 ms | 28.4 ms | **−58.0 %** |

Reading the table:
- The three **dense** rows isolate the combine win — the flag-zero skip never fires when every row is active. Width-1 (`dense_small`/`dense_large`) sees ~−7 %; width-2/4 (`dense_medium`/`gated_tw4_p1`) more, as the extension×base saving scales with tuple width.
- The **gated** rows show the two optimizations stacking: the combine speeds up the active rows, the flag-zero skip drops the inactive ones — roughly halving cost at 1/8 active and better beyond.
- Before this PR the prover did the same work regardless of sparsity (`gated_tw4_p1/p8/p64` all ~67 ms); after, cost tracks the active-row fraction.

## Tests

- `generate_permutation_flag_zero_skip_matches_real_denominators` — a mixed row (one tuple with `m = 0` taking the skip, one with `m ≠ 0` taking the full path) checked against the real-denominator reference, including the accumulator and terminal.
- `generate_permutation_multi_element_combine_matches_reference` — a width-2 tuple checked against the `α − (e₀·β + e₁)` reference, pinning the `dot_product` combine.
- The existing lookup unit tests and the `p3-batch-stark` `simple` integration suite pass unchanged.

## Scope

Only `lookup/` (`logup.rs`, `tests.rs`, `benches/logup.rs`). No public API change, no proof-format change; soundness is untouched (the prover and verifier both recompute the same per-bus rational sum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
