### PR TITLE
perf(merkle-tree): hash single-matrix leaf rows without `flat_map`

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -299,11 +299,20 @@ where
 
             // Collect all vertically packed rows from each matrix at `first_row`.
             // These packed rows are then hashed together using `h`.
-            let packed_digest: [PW; DIGEST_ELEMS] = h.hash_iter(
-                tallest_matrices
-                    .iter()
-                    .flat_map(|m| m.vertically_packed_row(first_row)),
-            );
+            //
+            // The single-matrix case feeds `h` the row iterator directly: going
+            // through `flat_map` hands the hasher a compound iterator whose
+            // `next()` defeats the optimizer's vectorization of the absorb loop,
+            // which is worth ~40% of the leaf-hashing time on wide matrices.
+            let packed_digest: [PW; DIGEST_ELEMS] = if let [m] = tallest_matrices {
+                h.hash_iter(m.vertically_packed_row(first_row))
+            } else {
+                h.hash_iter(
+                    tallest_matrices
+                        .iter()
+                        .flat_map(|m| m.vertically_packed_row(first_row)),
+                )
+            };
 
             // Unpack the resulting packed digest into individual scalar digests.
             PW::unpack_into(&packed_digest, digests_chunk);


### PR DESCRIPTION
In first_digest_layer, feeding the hasher through
`tallest_matrices.iter().flat_map(...)` hands it a compound iterator whose next() defeats vectorization of the sponge absorb loop. For the dominant single-matrix case, pass the vertically-packed row iterator directly.

Keccak-f log18 (2633 x 2^19 leaf hashing, Apple Silicon, 14 cores): trace Merkle commit 439-471 ms -> 249-276 ms on both the M31 circle and KB two-adic pipelines, within ~7% of the raw keccak-f permutation floor for the same workload.

When running the `prove_prime_field_31` example with `--objective keccak-f-permutations --log-trace-length 18`, I get a 38% speed-up on the `build merkle tree` / `first digest` phase with `keccak-f` hasher, and 4.5% speed-up with `poseidon2`.

`prove_goldilocks_keccak` example has also its `build merkle tree` phase about 24% faster.