### PR TITLE
ci: install taplo-cli with --locked to fix taplo/time E0119 build break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,11 @@ jobs:
       - name: Install cargo-sort and taplo
         run: |
           cargo install cargo-sort
-          cargo install taplo-cli
+          # `--locked` uses taplo-cli's shipped Cargo.lock, pinning its `time`
+          # dependency to a version whose impls do not collide with taplo's
+          # blanket `From` impls (an unlocked resolve picks a newer `time` that
+          # fails to compile with E0119).
+          cargo install taplo-cli --locked
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Problem

CI's `Lint` job currently fails for every PR (and `main`) at the `Install cargo-sort and taplo` step:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>` for type `nodes::Key`
   --> taplo-0.14.0/src/dom/node/nodes.rs:164:1
    = note: conflicting implementation in crate `time`
error: could not compile `taplo` (lib) due to 4 previous errors
error: failed to compile `taplo-cli v0.10.0`
```

This is unrelated to any source change. An unlocked `cargo install taplo-cli` re-resolves taplo's transitive `time` dependency to the newest semver-compatible release. A recent `time` version adds a `From<HourBase>` impl that collides with `taplo 0.14.0`'s blanket `impl<S: Into<String>> From<S> for Key` (and similar), tripping the coherence checker (`E0119`). `taplo-cli` itself never changed — only the resolved `time` version did.

## Fix

Install with `--locked` so Cargo uses the `Cargo.lock` shipped inside the `taplo-cli` package, which pins `time` to a version taplo compiles against.

Verified locally that `cargo install taplo-cli --locked` builds and installs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
