### PR TITLE
perf(uni-stark): reuse per-thread buffers in quotient_values

### DIFF
--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -835,16 +835,21 @@ where
         .into_par_iter()
         .step_by(pack_width)
         .for_each_init(
-            // Per-task initialization: allocate constraint and permutation buffers once.
-            // These are cleared (without deallocating) and reused on every iteration.
+            // Per-task initialization: allocate constraint, permutation and
+            // packed-row buffers once. These are cleared (without
+            // deallocating) and reused on every iteration.
             || {
                 (
                     Vec::with_capacity(n_base),
                     Vec::with_capacity(n_ext),
                     Vec::with_capacity(2 * perm_cols),
+                    Vec::with_capacity(2 * main_width),
+                    Vec::with_capacity(
+                        2 * preprocessed_on_quotient_domain.map_or(0, |p| p.width()),
+                    ),
                 )
             },
-            |(base_buf, ext_buf, perm_buf), i_start| {
+            |(base_buf, ext_buf, perm_buf, main_buf, prep_buf), i_start| {
                 let chunk_emit = pack_width.min(quotient_size - i_start);
                 // Load SIMD-packed selector values for this chunk.
                 let i_range = i_start..i_start + pack_width;
@@ -856,19 +861,30 @@ where
                 let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
 
                 // Pack the main trace rows (current + next) for this chunk.
-                let main = RowMajorMatrix::new(
-                    trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
-                    main_width,
+                main_buf.clear();
+                main_buf.extend(
+                    trace_on_quotient_domain.vertically_packed_row::<PackedVal<SC>>(i_start),
                 );
+                main_buf.extend(
+                    trace_on_quotient_domain
+                        .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                );
+                let main = RowMajorMatrixView::new(main_buf.as_slice(), main_width);
 
                 // Pack preprocessed rows if the AIR has preprocessed columns.
-                let preprocessed = preprocessed_on_quotient_domain.map(|preprocessed| {
-                    let preprocessed_width = preprocessed.width();
-                    RowMajorMatrix::new(
-                        preprocessed.vertically_packed_row_pair(i_start, next_step),
-                        preprocessed_width,
-                    )
-                });
+                let preprocessed_view = preprocessed_on_quotient_domain.map_or_else(
+                    || RowMajorMatrixView::new(&[], 0),
+                    |preprocessed| {
+                        prep_buf.clear();
+                        prep_buf
+                            .extend(preprocessed.vertically_packed_row::<PackedVal<SC>>(i_start));
+                        prep_buf.extend(
+                            preprocessed
+                                .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                        );
+                        RowMajorMatrixView::new(prep_buf.as_slice(), preprocessed.width())
+                    },
+                );
 
                 // Build a packed permutation matrix from element-wise reads.
                 // The buffer is cleared and refilled each iteration without reallocating.
@@ -899,10 +915,6 @@ where
                 }
                 let permutation = RowMajorMatrixView::new(perm_buf.as_slice(), perm_cols);
 
-                let preprocessed_view = preprocessed
-                    .as_ref()
-                    .map_or_else(|| RowMajorMatrixView::new(&[], 0), |m| m.as_view());
-
                 // Swap in the reusable constraint buffers (already cleared).
                 base_buf.clear();
                 ext_buf.clear();
@@ -912,7 +924,7 @@ where
                     &periodic_packed[i_start / pack_width]
                 };
                 let inner_folder = ProverConstraintFolder {
-                    main: main.as_view(),
+                    main,
                     preprocessed: preprocessed_view,
                     preprocessed_window: RowWindow::from_view(&preprocessed_view),
                     periodic_values,

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -537,6 +537,9 @@ where
                 // quotient(x) = constraints(x) / Z_H(x)
                 let quotient = folder.finalize_constraints() * inv_vanishing;
 
+                // The contents were folded into `quotient` above; reclaim the Vecs and
+                // `clear` them (`len = 0`, capacity kept) so the next row group reuses
+                // the allocations.
                 bufs.base_constraints = folder.base_constraints;
                 bufs.base_constraints.clear();
                 bufs.ext_constraints = folder.ext_constraints;

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -14,7 +14,7 @@ use p3_util::log2_strict_usize;
 use tracing::{debug_span, info_span, instrument};
 
 use crate::{
-    Commitments, Domain, OpenedValues, PackedVal, PreprocessedProverData, Proof,
+    Commitments, Domain, OpenedValues, PackedChallenge, PackedVal, PreprocessedProverData, Proof,
     ProverConstraintFolder, StarkGenericConfig, Val, get_constraint_layout,
     get_log_num_quotient_chunks,
 };
@@ -454,62 +454,99 @@ where
             .collect()
     };
 
-    (0..quotient_size)
-        .into_par_iter()
-        .step_by(PackedVal::<SC>::WIDTH)
-        .flat_map_iter(|i_start| {
-            let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
+    // Buffers reused across row-groups on each worker thread: allocating the
+    // packed row pairs and constraint accumulators fresh per group costs
+    // ~20% of this function's runtime on wide traces.
+    struct GroupBuffers<SC: StarkGenericConfig> {
+        main: Vec<PackedVal<SC>>,
+        preprocessed: Vec<PackedVal<SC>>,
+        base_constraints: Vec<PackedVal<SC>>,
+        ext_constraints: Vec<PackedChallenge<SC>>,
+    }
 
-            let is_first_row = *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
-            let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
-            let is_transition = *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
-            let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
-
-            let main = RowMajorMatrix::new(
-                trace_on_quotient_domain.vertically_packed_row_pair(i_start, next_step),
-                width,
-            );
-
-            let preprocessed = preprocessed_on_quotient_domain.map(|preprocessed| {
-                let preprocessed_width = preprocessed.width();
-                RowMajorMatrix::new(
-                    preprocessed.vertically_packed_row_pair(i_start, next_step),
-                    preprocessed_width,
-                )
-            });
-
-            let preprocessed_view = preprocessed
-                .as_ref()
-                .map_or_else(|| RowMajorMatrixView::new(&[], 0), |m| m.as_view());
-            let periodic_values: &[PackedVal<SC>] = if periodic_packed.is_empty() {
-                &[]
-            } else {
-                &periodic_packed[i_start / pack_width]
-            };
-            let mut folder = ProverConstraintFolder {
-                main: main.as_view(),
-                preprocessed: preprocessed_view,
-                preprocessed_window: RowWindow::from_view(&preprocessed_view),
-                periodic_values,
-                public_values,
-                is_first_row,
-                is_last_row,
-                is_transition,
-                base_alpha_powers: &base_alpha_powers,
-                ext_alpha_powers: &ext_alpha_powers,
+    let mut quotient_values = SC::Challenge::zero_vec(quotient_size);
+    quotient_values
+        .par_chunks_mut(PackedVal::<SC>::WIDTH)
+        .enumerate()
+        .for_each_init(
+            || GroupBuffers::<SC> {
+                main: Vec::with_capacity(2 * width),
+                preprocessed: Vec::with_capacity(
+                    2 * preprocessed_on_quotient_domain.map_or(0, |p| p.width()),
+                ),
                 base_constraints: Vec::with_capacity(constraint_layout.base_indices.len()),
                 ext_constraints: Vec::with_capacity(constraint_layout.ext_indices.len()),
-                constraint_index: 0,
-                constraint_count: constraint_layout.total_constraints(),
-            };
-            air.eval(&mut folder);
+            },
+            |bufs, (group, quotient_chunk)| {
+                let i_start = group * PackedVal::<SC>::WIDTH;
+                let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
 
-            // quotient(x) = constraints(x) / Z_H(x)
-            let quotient = folder.finalize_constraints() * inv_vanishing;
+                let is_first_row =
+                    *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+                let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+                let is_transition =
+                    *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+                let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
 
-            // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
-            (0..core::cmp::min(quotient_size, PackedVal::<SC>::WIDTH))
-                .map(move |idx_in_packing| quotient.extract(idx_in_packing))
-        })
-        .collect()
+                bufs.main.clear();
+                bufs.main.extend(
+                    trace_on_quotient_domain.vertically_packed_row::<PackedVal<SC>>(i_start),
+                );
+                bufs.main.extend(
+                    trace_on_quotient_domain
+                        .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                );
+                let main = RowMajorMatrixView::new(&bufs.main, width);
+
+                let preprocessed_view = match preprocessed_on_quotient_domain {
+                    Some(preprocessed) => {
+                        bufs.preprocessed.clear();
+                        bufs.preprocessed
+                            .extend(preprocessed.vertically_packed_row::<PackedVal<SC>>(i_start));
+                        bufs.preprocessed.extend(
+                            preprocessed
+                                .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                        );
+                        RowMajorMatrixView::new(&bufs.preprocessed, preprocessed.width())
+                    }
+                    None => RowMajorMatrixView::new(&[], 0),
+                };
+                let periodic_values: &[PackedVal<SC>] = if periodic_packed.is_empty() {
+                    &[]
+                } else {
+                    &periodic_packed[i_start / pack_width]
+                };
+                let mut folder = ProverConstraintFolder {
+                    main,
+                    preprocessed: preprocessed_view,
+                    preprocessed_window: RowWindow::from_view(&preprocessed_view),
+                    periodic_values,
+                    public_values,
+                    is_first_row,
+                    is_last_row,
+                    is_transition,
+                    base_alpha_powers: &base_alpha_powers,
+                    ext_alpha_powers: &ext_alpha_powers,
+                    base_constraints: core::mem::take(&mut bufs.base_constraints),
+                    ext_constraints: core::mem::take(&mut bufs.ext_constraints),
+                    constraint_index: 0,
+                    constraint_count: constraint_layout.total_constraints(),
+                };
+                air.eval(&mut folder);
+
+                // quotient(x) = constraints(x) / Z_H(x)
+                let quotient = folder.finalize_constraints() * inv_vanishing;
+
+                bufs.base_constraints = folder.base_constraints;
+                bufs.base_constraints.clear();
+                bufs.ext_constraints = folder.ext_constraints;
+                bufs.ext_constraints.clear();
+
+                // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
+                for (idx_in_packing, q) in quotient_chunk.iter_mut().enumerate() {
+                    *q = quotient.extract(idx_in_packing);
+                }
+            },
+        );
+    quotient_values
 }


### PR DESCRIPTION
Each packed row-group previously allocated three fresh Vecs (the vertically-packed main row pair and the folder's base/ext constraint accumulators); on wide traces this allocation traffic costs ~20% of quotient evaluation. Write quotient values directly into a preallocated output and keep the group buffers in rayon for_each_init state.

Keccak-f log18 (2633 cols, Apple Silicon, 14 cores): quotient_values 397-451 -> 340-347 ms (M31 circle) and 423-492 -> 354-373 ms (KB two-adic).