### PR TITLE
perf(merkle-tree): hash single-matrix injected rows without flat_map

### DIFF
--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -390,11 +390,18 @@ where
             });
             let mut packed_digest = c.compress(children);
 
-            let tallest_digest = h.hash_iter(
-                matrices_to_inject
-                    .iter()
-                    .flat_map(|m| m.vertically_packed_row(first_row)),
-            );
+            // As in `first_digest_layer`, the single-matrix case feeds `h` the
+            // row iterator directly: a `flat_map` compound iterator defeats the
+            // optimizer's vectorization of the absorb loop.
+            let tallest_digest: [PW; DIGEST_ELEMS] = if let [m] = matrices_to_inject {
+                h.hash_iter(m.vertically_packed_row(first_row))
+            } else {
+                h.hash_iter(
+                    matrices_to_inject
+                        .iter()
+                        .flat_map(|m| m.vertically_packed_row(first_row)),
+                )
+            };
             let inject_inputs: [[PW; DIGEST_ELEMS]; N] = array::from_fn(|n| {
                 if n == 0 {
                     packed_digest


### PR DESCRIPTION
Apply the same specialization as first_digest_layer (#1813) to the injection hash in compress_and_inject: when exactly one matrix is injected at a level — the common case for batch commits of distinct-height traces — feed the hasher its packed row iterator directly instead of a flat_map compound iterator.

Keccak-f leaves, [2633 x 2^19, 2633 x 2^18] commit (Apple Silicon,
14 cores): incremental cost of the injected matrix ~215-250 ms ->
~120-140 ms, its permutation-compute floor.