### PR TITLE
perf(circle): flatten the fused CFFT pass driver

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -442,29 +442,49 @@ fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
                 CfftLayer::Butterflies(ts) => {
                     let slice_len = 1 << (log_group - e - 1);
                     let slice = &ts[hi * slice_len..][..slice_len];
-                    for (s, &t) in slice.iter().enumerate() {
-                        for u in 0..1usize << e {
-                            let row_lo = first_row + (((s << (e + 1)) | u) << log_stride);
-                            let row_hi = row_lo + (1 << (e + log_stride));
+                    if log_stride == 0 {
+                        // The `2^e` row pairs sharing the twiddle `t` span two contiguous
+                        // row blocks, so they merge into a single call: one twiddle
+                        // broadcast and one long inner loop instead of one per row pair.
+                        for (s, &t) in slice.iter().enumerate() {
+                            let row_lo = first_row + (s << (e + 1));
+                            let row_hi = row_lo + (1 << e);
+                            let len = width << e;
                             // SAFETY: every row index decomposes uniquely as
-                            // `hi << (log_group + log_stride) | t << log_stride | lo`, so the task
-                            // for group `g = (hi, lo)` is the only one touching its rows, and
-                            // within a layer each row appears in exactly one butterfly, so
-                            // `row_lo` and `row_hi` never alias. All indices stay below `h` since
+                            // `hi << (log_group + log_stride) | t << log_stride | lo`, so the
+                            // task for group `g = (hi, lo)` is the only one touching its rows,
+                            // and within a layer each row appears in exactly one butterfly, so
+                            // the two blocks never alias. All indices stay below `h` since
                             // `t < 2^log_group`.
-                            let (row_lo, row_hi) = unsafe {
+                            let (block_lo, block_hi) = unsafe {
                                 (
-                                    core::slice::from_raw_parts_mut(
-                                        base.add(row_lo * width),
-                                        width,
-                                    ),
-                                    core::slice::from_raw_parts_mut(
-                                        base.add(row_hi * width),
-                                        width,
-                                    ),
+                                    core::slice::from_raw_parts_mut(base.add(row_lo * width), len),
+                                    core::slice::from_raw_parts_mut(base.add(row_hi * width), len),
                                 )
                             };
-                            t.apply_to_rows(row_lo, row_hi);
+                            t.apply_to_rows(block_lo, block_hi);
+                        }
+                    } else {
+                        for (s, &t) in slice.iter().enumerate() {
+                            for u in 0..1usize << e {
+                                let row_lo = first_row + (((s << (e + 1)) | u) << log_stride);
+                                let row_hi = row_lo + (1 << (e + log_stride));
+                                // SAFETY: as in the contiguous case above; `row_lo` and
+                                // `row_hi` never alias and stay below `h`.
+                                let (row_lo, row_hi) = unsafe {
+                                    (
+                                        core::slice::from_raw_parts_mut(
+                                            base.add(row_lo * width),
+                                            width,
+                                        ),
+                                        core::slice::from_raw_parts_mut(
+                                            base.add(row_hi * width),
+                                            width,
+                                        ),
+                                    )
+                                };
+                                t.apply_to_rows(row_lo, row_hi);
+                            }
                         }
                     }
                 }

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -122,6 +122,51 @@ impl<F: Field> Butterfly<F> for DifButterfly<F> {
     fn apply<PF: PackedField<Scalar = F>>(&self, x_1: PF, x_2: PF) -> (PF, PF) {
         (x_1 + x_2, (x_1 - x_2) * self.0)
     }
+
+    /// Override `apply_to_rows` to pre-broadcast the twiddle factor into a packed field
+    /// once before the inner loop, and manually unroll it to expose multiple independent
+    /// sub-then-mul chains to the compiler's scheduler, hiding the multiplication latency.
+    /// Mirrors the [`DitButterfly`] override.
+    #[inline]
+    fn apply_to_rows(&self, row_1: &mut [F], row_2: &mut [F]) {
+        let (shorts_1, suffix_1) = F::Packing::pack_slice_with_suffix_mut(row_1);
+        let (shorts_2, suffix_2) = F::Packing::pack_slice_with_suffix_mut(row_2);
+        debug_assert_eq!(shorts_1.len(), shorts_2.len());
+        debug_assert_eq!(suffix_1.len(), suffix_2.len());
+        let twiddle_packed = F::Packing::from(self.0);
+        let mut c1 = shorts_1.chunks_exact_mut(4);
+        let mut c2 = shorts_2.chunks_exact_mut(4);
+        for (p1, p2) in (&mut c1).zip(&mut c2) {
+            let a1 = p1[0];
+            let b1 = p1[1];
+            let c1_ = p1[2];
+            let d1 = p1[3];
+            let a2 = p2[0];
+            let b2 = p2[1];
+            let c2_ = p2[2];
+            let d2 = p2[3];
+            p1[0] = a1 + a2;
+            p1[1] = b1 + b2;
+            p1[2] = c1_ + c2_;
+            p1[3] = d1 + d2;
+            p2[0] = (a1 - a2) * twiddle_packed;
+            p2[1] = (b1 - b2) * twiddle_packed;
+            p2[2] = (c1_ - c2_) * twiddle_packed;
+            p2[3] = (d1 - d2) * twiddle_packed;
+        }
+        for (x_1, x_2) in c1
+            .into_remainder()
+            .iter_mut()
+            .zip(c2.into_remainder().iter_mut())
+        {
+            let sum = *x_1 + *x_2;
+            *x_2 = (*x_1 - *x_2) * twiddle_packed;
+            *x_1 = sum;
+        }
+        for (x_1, x_2) in suffix_1.iter_mut().zip(suffix_2.iter_mut()) {
+            self.apply_in_place(x_1, x_2);
+        }
+    }
 }
 
 /// DIF (Decimation-In-Frequency) butterfly operation where `x_2` is guaranteed to be zero.


### PR DESCRIPTION
Two driver-shape costs sat above the butterfly math itself:

- DifButterfly used the default apply_to_rows, re-broadcasting the scalar twiddle per packed multiplication and exposing a single dependency chain. Give it the same pre-broadcast + unroll-4 override DitButterfly already has.
- Stride-0 passes called apply_to_rows once per row pair even though the 2^e pairs sharing a twiddle span two contiguous row blocks. Merge them into one call per twiddle: one broadcast, one pack-split, and a long inner loop over the whole block.

Shaves off another ~25 ms from `extrapolate` phase