### PR TITLE
cleanup(m31): drop redundant Distribution bound on PackedQM31 sampler

### DIFF
--- a/mersenne-31/src/qm31.rs
+++ b/mersenne-31/src/qm31.rs
@@ -437,10 +437,7 @@ impl BasedVectorSpace<PackedM31> for PackedQM31 {
     }
 }
 
-impl rand::distr::Distribution<PackedQM31> for rand::distr::StandardUniform
-where
-    Self: rand::distr::Distribution<PackedM31>,
-{
+impl rand::distr::Distribution<PackedQM31> for rand::distr::StandardUniform {
     #[inline]
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedQM31 {
         PackedQM31(core::array::from_fn(|_| {


### PR DESCRIPTION
## Summary

Minor follow-up cleanup to #1817.

The `StandardUniform` sampler for `PackedQM31` carried a `where Self: Distribution<PackedM31>` clause:

```rust
impl rand::distr::Distribution<PackedQM31> for rand::distr::StandardUniform
where
    Self: rand::distr::Distribution<PackedM31>,
{ ... }
```

The bound is always satisfied and never constrains anything: `PackedM31` is a *concrete* type with a per-platform `Distribution` impl. (The generic `PackedBinomialExtensionField` impl genuinely needs the analogous bound because its packing type `PF` is a type parameter — not the case here.) Removed for clarity; the closure's `self.sample(rng)` still resolves to `PackedM31` via the concrete impl.

## Test plan

- `cargo check -p p3-mersenne-31 --all-features --tests` — clean
- `cargo test -p p3-mersenne-31 qm31` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)