### PR TITLE
perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels

### DIFF
--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1040,6 +1040,28 @@ pub trait Field:
         }
     }
 
+    /// Accumulate `result[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
+    ///
+    /// Each item provides one matrix row as `packed_width` packed base-field words,
+    /// together with the row's `N` extension-field weights. Returns the
+    /// `packed_width * N` packed accumulators, laid out with the `N` weights of each
+    /// word group adjacent.
+    ///
+    /// This is the inner kernel of batched columnwise (weighted-sum-of-rows) dot
+    /// products. Fields may override it to defer modular reductions across rows.
+    #[must_use]
+    fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
+        packed_width: usize,
+        items: I,
+    ) -> Vec<EF::ExtensionPacking>
+    where
+        EF: ExtensionField<Self>,
+        R: Iterator<Item = Self::Packing>,
+        I: Iterator<Item = (R, [EF; N])>,
+    {
+        generic_batched_columnwise_dot_product::<Self, EF, R, I, N>(packed_width, items)
+    }
+
     /// The number of elements in the field.
     ///
     /// This will either be prime if the field is a PrimeField or a power of a
@@ -1056,6 +1078,34 @@ pub trait Field:
     fn bits() -> usize {
         Self::order().bits() as usize
     }
+}
+
+/// The generic accumulation behind [`Field::batched_columnwise_dot_product`]:
+/// `result[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
+///
+/// Kept as a free function so that specialized `Field` implementations can fall back
+/// to it for extension degrees their kernels do not cover.
+#[must_use]
+pub fn generic_batched_columnwise_dot_product<F, EF, R, I, const N: usize>(
+    packed_width: usize,
+    items: I,
+) -> Vec<EF::ExtensionPacking>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    R: Iterator<Item = F::Packing>,
+    I: Iterator<Item = (R, [EF; N])>,
+{
+    let mut acc = EF::ExtensionPacking::zero_vec(packed_width * N);
+    for (row, scales) in items {
+        let packed_scales = scales.map(EF::ExtensionPacking::from);
+        for (acc_c, r) in acc.chunks_exact_mut(N).zip(row) {
+            for (a, &s) in acc_c.iter_mut().zip(&packed_scales) {
+                *a += s * r;
+            }
+        }
+    }
+    acc
 }
 
 /// A field isomorphic to `ℤ/p` for some prime `p`.

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1040,26 +1040,23 @@ pub trait Field:
         }
     }
 
-    /// Accumulate `result[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
+    /// Accumulate `acc[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
     ///
-    /// Each item provides one matrix row as `packed_width` packed base-field words,
-    /// together with the row's `N` extension-field weights. Returns the
-    /// `packed_width * N` packed accumulators, laid out with the `N` weights of each
-    /// word group adjacent.
+    /// Each item provides one matrix row as `acc.len() / N` packed base-field words,
+    /// together with the row's `N` extension-field weights. `acc` is laid out with the
+    /// `N` weights of each word group adjacent, and its length must be a multiple of `N`.
     ///
     /// This is the inner kernel of batched columnwise (weighted-sum-of-rows) dot
     /// products. Fields may override it to defer modular reductions across rows.
-    #[must_use]
     fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
-        packed_width: usize,
+        acc: &mut [EF::ExtensionPacking],
         items: I,
-    ) -> Vec<EF::ExtensionPacking>
-    where
+    ) where
         EF: ExtensionField<Self>,
         R: Iterator<Item = Self::Packing>,
         I: Iterator<Item = (R, [EF; N])>,
     {
-        generic_batched_columnwise_dot_product::<Self, EF, R, I, N>(packed_width, items)
+        generic_batched_columnwise_dot_product::<Self, EF, R, I, N>(acc, items);
     }
 
     /// The number of elements in the field.
@@ -1081,22 +1078,19 @@ pub trait Field:
 }
 
 /// The generic accumulation behind [`Field::batched_columnwise_dot_product`]:
-/// `result[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
+/// `acc[c * N + j] += scales[j] * row[c]` over a stream of packed rows.
 ///
 /// Kept as a free function so that specialized `Field` implementations can fall back
 /// to it for extension degrees their kernels do not cover.
-#[must_use]
 pub fn generic_batched_columnwise_dot_product<F, EF, R, I, const N: usize>(
-    packed_width: usize,
+    acc: &mut [EF::ExtensionPacking],
     items: I,
-) -> Vec<EF::ExtensionPacking>
-where
+) where
     F: Field,
     EF: ExtensionField<F>,
     R: Iterator<Item = F::Packing>,
     I: Iterator<Item = (R, [EF; N])>,
 {
-    let mut acc = EF::ExtensionPacking::zero_vec(packed_width * N);
     for (row, scales) in items {
         let packed_scales = scales.map(EF::ExtensionPacking::from);
         for (acc_c, r) in acc.chunks_exact_mut(N).zip(row) {
@@ -1105,7 +1099,6 @@ where
             }
         }
     }
-    acc
 }
 
 /// A field isomorphic to `ℤ/p` for some prime `p`.

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -308,6 +308,36 @@ pub unsafe trait PackedField:
             current,
         }
     }
+
+    /// Accumulate the products of `d` coefficient streams against a shared stream of
+    /// packed base values.
+    ///
+    /// For each `(coeffs, base)` pair produced by the iterator, performs
+    /// `acc[k] += coeffs[k] * base` for all `k < d`, and returns the accumulators
+    /// (entries at `d..` are zero). Coefficient slices shorter than `d` only
+    /// contribute their available entries.
+    ///
+    /// This is the inner kernel of mixed base-times-extension dot products, where each
+    /// extension element contributes `d` base-field coefficient words. Implementations
+    /// may override it to defer modular reductions across iterations.
+    ///
+    /// # Panics
+    /// Debug builds panic if `d > 8`.
+    #[must_use]
+    fn coeffwise_dot_product<'a, I>(d: usize, pairs: I) -> [Self; 8]
+    where
+        Self: 'a,
+        I: Iterator<Item = (&'a [Self], Self)>,
+    {
+        debug_assert!(d <= 8, "Extension degree > 8 not supported");
+        let mut acc = [Self::ZERO; 8];
+        for (coeffs, base) in pairs {
+            for (acc_k, &coeff) in acc[..d].iter_mut().zip(coeffs) {
+                *acc_k += coeff * base;
+            }
+        }
+        acc
+    }
 }
 
 /// # Safety

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -480,8 +480,8 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
                 || EF::ExtensionPacking::zero_vec(packed_width * N),
                 |mut acc, chunk| {
                     let rows = chunk * chunk_rows..((chunk + 1) * chunk_rows).min(height);
-                    let partial = T::batched_columnwise_dot_product::<EF, _, _, N>(
-                        packed_width,
+                    T::batched_columnwise_dot_product::<EF, _, _, N>(
+                        &mut acc,
                         rows.map(|r| {
                             (
                                 self.padded_horizontally_packed_row::<T::Packing>(r),
@@ -489,7 +489,6 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
                             )
                         }),
                     );
-                    acc.iter_mut().zip(partial).for_each(|(a, p)| *a += p);
                     acc
                 },
                 |mut acc_l, acc_r| {

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -9,8 +9,8 @@ use core::ops::Deref;
 
 use itertools::Itertools;
 use p3_field::{
-    BasedVectorSpace, ExtensionField, Field, FieldArray, PackedFieldExtension, PackedValue,
-    PrimeCharacteristicRing,
+    BasedVectorSpace, ExtensionField, Field, FieldArray, PackedField, PackedFieldExtension,
+    PackedValue, PrimeCharacteristicRing,
 };
 use p3_maybe_rayon::prelude::*;
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
@@ -530,18 +530,13 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
                 // Get the extension dimension from the first vec element's coefficients
                 let d = <EF::ExtensionPacking as BasedVectorSpace<T::Packing>>::DIMENSION;
 
-                // Initialize D accumulators for each coefficient of the extension
-                // In practice, we set D to 8, which is the maximum degree of the extension field supported.
-                let mut coeff_accs: [T::Packing; 8] = [T::Packing::ZERO; 8];
-                debug_assert!(d <= 8, "Extension degree > 8 not supported");
-
                 // Accumulate coefficient-wise: for each (v, r) pair, acc[i] += v.coefficient(i) * r
-                for (v, r) in vec.iter().zip(row_packed) {
-                    let v_coeffs = v.as_basis_coefficients_slice();
-                    for (acc, &v_coeff) in coeff_accs[..d].iter_mut().zip(v_coeffs) {
-                        *acc += v_coeff * r;
-                    }
-                }
+                let coeff_accs = T::Packing::coeffwise_dot_product(
+                    d,
+                    vec.iter()
+                        .zip(row_packed)
+                        .map(|(v, r)| (v.as_basis_coefficients_slice(), r)),
+                );
 
                 // Construct the result ExtPacking from the accumulators and sum the coefficients.
                 let packed_result =

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -467,23 +467,29 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
         EF: ExtensionField<T>,
     {
         let packed_width = self.width().div_ceil(T::Packing::WIDTH);
+        let height = self.height().min(vs.len());
 
-        let packed_results: Vec<EF::ExtensionPacking> = self
-            .par_padded_horizontally_packed_rows::<T::Packing>()
-            .zip(vs)
-            .par_fold_reduce(
+        // Split the rows into a bounded number of contiguous chunks; each task runs the
+        // field's columnwise kernel serially over its chunk (letting it defer modular
+        // reductions across rows) and the per-task accumulators are summed at the end.
+        let num_chunks = (4 * current_num_threads()).clamp(1, height.max(1));
+        let chunk_rows = height.div_ceil(num_chunks);
+
+        let packed_results: Vec<EF::ExtensionPacking> =
+            (0..num_chunks).into_par_iter().par_fold_reduce(
                 || EF::ExtensionPacking::zero_vec(packed_width * N),
-                |mut acc, (packed_row, scales)| {
-                    // Broadcast each scalar scale to all SIMD lanes
-                    let packed_scales: [EF::ExtensionPacking; N] =
-                        scales.map_into_array(EF::ExtensionPacking::from);
-
-                    // acc[c][j] += scales[j] · row[c] for column batch c, point j
-                    for (acc_c, row_c) in acc.chunks_exact_mut(N).zip(packed_row) {
-                        for j in 0..N {
-                            acc_c[j] += packed_scales[j] * row_c;
-                        }
-                    }
+                |mut acc, chunk| {
+                    let rows = chunk * chunk_rows..((chunk + 1) * chunk_rows).min(height);
+                    let partial = T::batched_columnwise_dot_product::<EF, _, _, N>(
+                        packed_width,
+                        rows.map(|r| {
+                            (
+                                self.padded_horizontally_packed_row::<T::Packing>(r),
+                                vs[r].0,
+                            )
+                        }),
+                    );
+                    acc.iter_mut().zip(partial).for_each(|(a, p)| *a += p);
                     acc
                 },
                 |mut acc_l, acc_r| {

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -412,20 +412,19 @@ unsafe impl PackedField for PackedMersenne31Neon {
 /// Dispatches the extension degree to a monomorphized kernel so the per-word loops
 /// fully unroll; degrees without a kernel fall back to the generic accumulation.
 pub(crate) fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
-    packed_width: usize,
+    acc: &mut [EF::ExtensionPacking],
     items: I,
-) -> Vec<EF::ExtensionPacking>
-where
+) where
     EF: ExtensionField<Mersenne31>,
     R: Iterator<Item = PackedMersenne31Neon>,
     I: Iterator<Item = (R, [EF; N])>,
 {
     match EF::DIMENSION {
-        1 => columnwise_kernel::<EF, R, I, N, 1>(packed_width, items),
-        2 => columnwise_kernel::<EF, R, I, N, 2>(packed_width, items),
-        4 => columnwise_kernel::<EF, R, I, N, 4>(packed_width, items),
-        8 => columnwise_kernel::<EF, R, I, N, 8>(packed_width, items),
-        _ => generic_batched_columnwise_dot_product::<Mersenne31, EF, R, I, N>(packed_width, items),
+        1 => columnwise_kernel::<EF, R, I, N, 1>(acc, items),
+        2 => columnwise_kernel::<EF, R, I, N, 2>(acc, items),
+        4 => columnwise_kernel::<EF, R, I, N, 4>(acc, items),
+        8 => columnwise_kernel::<EF, R, I, N, 8>(acc, items),
+        _ => generic_batched_columnwise_dot_product::<Mersenne31, EF, R, I, N>(acc, items),
     }
 }
 
@@ -454,21 +453,22 @@ fn mac_up_to_3(vs: &[uint32x4_t], svs: [uint32x4_t; 3]) -> (uint64x2_t, uint64x2
 /// triples keeps them below `2^62` for any stream length, so the final two folds
 /// plus `reduce_sum` always produce canonical values.
 fn columnwise_kernel<EF, R, I, const N: usize, const D: usize>(
-    packed_width: usize,
+    out: &mut [EF::ExtensionPacking],
     mut items: I,
-) -> Vec<EF::ExtensionPacking>
-where
+) where
     EF: ExtensionField<Mersenne31>,
     R: Iterator<Item = PackedMersenne31Neon>,
     I: Iterator<Item = (R, [EF; N])>,
 {
     debug_assert_eq!(EF::DIMENSION, D);
+    debug_assert_eq!(out.len() % N, 0);
+    let packed_width = out.len() / N;
     let zero64 = unsafe { aarch64::vdupq_n_u64(0) };
     let zero32 = unsafe { aarch64::vdupq_n_u32(0) };
 
-    // Accumulator layout: word-major, with the `(weight j, coefficient k)` pair of
+    // Word accumulator layout: word-major, with the `(weight j, coefficient k)` pair of
     // `(lanes 0-1, lanes 2-3)` u64x2 vectors of word `c` at `c * N * D * 2 + (j * D + k) * 2`.
-    let mut acc = alloc::vec![zero64; packed_width * N * D * 2];
+    let mut words = alloc::vec![zero64; packed_width * N * D * 2];
     let broadcast = |scales: &[EF; N]| -> [[uint32x4_t; D]; N] {
         let mut out = [[zero32; D]; N];
         for (row, scale) in out.iter_mut().zip(scales) {
@@ -485,7 +485,7 @@ where
         let sv0 = broadcast(&s0);
         let Some((r1, s1)) = items.next() else {
             // Single trailing row.
-            for (aw, m0) in acc.chunks_exact_mut(N * D * 2).zip(r0) {
+            for (aw, m0) in words.chunks_exact_mut(N * D * 2).zip(r0) {
                 let v0 = m0.to_vector();
                 for (j, sv0_j) in sv0.iter().enumerate() {
                     for (k, &s) in sv0_j.iter().enumerate() {
@@ -503,7 +503,7 @@ where
         let sv1 = broadcast(&s1);
         let Some((r2, s2)) = items.next() else {
             // Trailing row pair.
-            for (aw, (m0, m1)) in acc.chunks_exact_mut(N * D * 2).zip(r0.zip(r1)) {
+            for (aw, (m0, m1)) in words.chunks_exact_mut(N * D * 2).zip(r0.zip(r1)) {
                 let (v0, v1) = (m0.to_vector(), m1.to_vector());
                 for j in 0..N {
                     for k in 0..D {
@@ -520,7 +520,7 @@ where
         };
         let sv2 = broadcast(&s2);
 
-        for (aw, ((m0, m1), m2)) in acc.chunks_exact_mut(N * D * 2).zip(r0.zip(r1).zip(r2)) {
+        for (aw, ((m0, m1), m2)) in words.chunks_exact_mut(N * D * 2).zip(r0.zip(r1).zip(r2)) {
             let (v0, v1, v2) = (m0.to_vector(), m1.to_vector(), m2.to_vector());
             for j in 0..N {
                 for k in 0..D {
@@ -537,28 +537,26 @@ where
         triples += 1;
         if triples == 1 << 28 {
             triples = 0;
-            for a in &mut acc {
-                *a = partial_reduce_u64(*a);
+            for w in &mut words {
+                *w = partial_reduce_u64(*w);
             }
         }
     }
 
-    (0..packed_width * N)
-        .map(|cj| {
-            EF::ExtensionPacking::from_basis_coefficients_fn(|k| {
-                let idx = (cj * D + k) * 2;
-                let l = partial_reduce_u64(partial_reduce_u64(acc[idx]));
-                let h = partial_reduce_u64(partial_reduce_u64(acc[idx + 1]));
-                unsafe {
-                    let narrowed = aarch64::vuzp1q_u32(
-                        aarch64::vreinterpretq_u32_u64(l),
-                        aarch64::vreinterpretq_u32_u64(h),
-                    );
-                    PackedMersenne31Neon::from_vector(reduce_sum(narrowed))
-                }
-            })
-        })
-        .collect()
+    for (out_cj, words_c) in out.iter_mut().zip(words.chunks_exact(D * 2)) {
+        let reduced = EF::ExtensionPacking::from_basis_coefficients_fn(|k| {
+            let l = partial_reduce_u64(partial_reduce_u64(words_c[k * 2]));
+            let h = partial_reduce_u64(partial_reduce_u64(words_c[k * 2 + 1]));
+            unsafe {
+                let narrowed = aarch64::vuzp1q_u32(
+                    aarch64::vreinterpretq_u32_u64(l),
+                    aarch64::vreinterpretq_u32_u64(h),
+                );
+                PackedMersenne31Neon::from_vector(reduce_sum(narrowed))
+            }
+        });
+        *out_cj += reduced;
+    }
 }
 
 /// Compute the permutation x -> x^5 on Mersenne-31 field elements.
@@ -727,7 +725,8 @@ mod tests {
                 }
             }
 
-            let got = super::batched_columnwise_dot_product::<EF, _, _, N>(packed_width, items());
+            let mut got = EF::ExtensionPacking::zero_vec(packed_width * N);
+            super::batched_columnwise_dot_product::<EF, _, _, N>(&mut got, items());
             let expected: Vec<EF> = EF::ExtensionPacking::to_ext_iter(expected).collect();
             let got: Vec<EF> = EF::ExtensionPacking::to_ext_iter(got).collect();
             assert_eq!(expected, got, "rows = {}, N = {N}", rows.len());

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -12,8 +12,9 @@ use p3_field::op_assign_macros::{
     impl_sum_prod_base_field, ring_sum,
 };
 use p3_field::{
-    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
+    Algebra, BasedVectorSpace, ExtensionField, Field, InjectiveMonomial, PackedField,
+    PackedFieldPow2, PackedValue, PermutationMonomial, PrimeCharacteristicRing,
+    dispatch_chunked_mixed_dot_product, generic_batched_columnwise_dot_product,
     impl_packed_field_pow_2, uint32x4_mod_add, uint32x4_mod_sub,
 };
 use p3_util::reconstitute_from_base;
@@ -405,6 +406,161 @@ unsafe impl PackedField for PackedMersenne31Neon {
     }
 }
 
+/// Columnwise dot-product kernel with deferred Mersenne reductions, implementing
+/// [`Field::batched_columnwise_dot_product`] for `Mersenne31`.
+///
+/// Dispatches the extension degree to a monomorphized kernel so the per-word loops
+/// fully unroll; degrees without a kernel fall back to the generic accumulation.
+pub(crate) fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
+    packed_width: usize,
+    items: I,
+) -> Vec<EF::ExtensionPacking>
+where
+    EF: ExtensionField<Mersenne31>,
+    R: Iterator<Item = PackedMersenne31Neon>,
+    I: Iterator<Item = (R, [EF; N])>,
+{
+    match <EF as BasedVectorSpace<Mersenne31>>::DIMENSION {
+        1 => columnwise_kernel::<EF, R, I, N, 1>(packed_width, items),
+        2 => columnwise_kernel::<EF, R, I, N, 2>(packed_width, items),
+        4 => columnwise_kernel::<EF, R, I, N, 4>(packed_width, items),
+        8 => columnwise_kernel::<EF, R, I, N, 8>(packed_width, items),
+        _ => generic_batched_columnwise_dot_product::<Mersenne31, EF, R, I, N>(packed_width, items),
+    }
+}
+
+/// Accumulate up to 3 products into a fresh (lanes 0-1, lanes 2-3) pair of u64x2
+/// vectors and fold it once, leaving both results below `2^33` (`3 * P^2 < 2^64`).
+#[inline(always)]
+fn mac_up_to_3(vs: &[uint32x4_t], svs: [uint32x4_t; 3]) -> (uint64x2_t, uint64x2_t) {
+    unsafe {
+        // Safety: If this code got compiled then NEON intrinsics are available.
+        let mut lo =
+            aarch64::vmull_u32(aarch64::vget_low_u32(vs[0]), aarch64::vget_low_u32(svs[0]));
+        let mut hi = aarch64::vmull_high_u32(vs[0], svs[0]);
+        for (&v, &s) in vs[1..].iter().zip(&svs[1..]) {
+            lo = aarch64::vmlal_u32(lo, aarch64::vget_low_u32(v), aarch64::vget_low_u32(s));
+            hi = aarch64::vmlal_high_u32(hi, v, s);
+        }
+        (partial_reduce_u64(lo), partial_reduce_u64(hi))
+    }
+}
+
+/// Monomorphized body of [`batched_columnwise_dot_product`] for extension degree `D`.
+///
+/// Rows are consumed three at a time: each triple of raw 32x32 -> 64-bit products is
+/// accumulated in registers with widening MACs, folded once below `2^33`, and added
+/// into u64 lane accumulators. A safety fold of the accumulators every `2^28` row
+/// triples keeps them below `2^62` for any stream length, so the final two folds
+/// plus `reduce_sum` always produce canonical values.
+fn columnwise_kernel<EF, R, I, const N: usize, const D: usize>(
+    packed_width: usize,
+    mut items: I,
+) -> Vec<EF::ExtensionPacking>
+where
+    EF: ExtensionField<Mersenne31>,
+    R: Iterator<Item = PackedMersenne31Neon>,
+    I: Iterator<Item = (R, [EF; N])>,
+{
+    debug_assert_eq!(<EF as BasedVectorSpace<Mersenne31>>::DIMENSION, D);
+    let zero64 = unsafe { aarch64::vdupq_n_u64(0) };
+    let zero32 = unsafe { aarch64::vdupq_n_u32(0) };
+
+    // Accumulator layout: word-major, with the `(weight j, coefficient k)` pair of
+    // `(lanes 0-1, lanes 2-3)` u64x2 vectors of word `c` at `c * N * D * 2 + (j * D + k) * 2`.
+    let mut acc = alloc::vec![zero64; packed_width * N * D * 2];
+    let broadcast = |scales: &[EF; N]| -> [[uint32x4_t; D]; N] {
+        let mut out = [[zero32; D]; N];
+        for (row, scale) in out.iter_mut().zip(scales) {
+            let coeffs = scale.as_basis_coefficients_slice();
+            for (v, &coeff) in row.iter_mut().zip(coeffs) {
+                *v = PackedMersenne31Neon::from(coeff).to_vector();
+            }
+        }
+        out
+    };
+
+    let mut triples = 0u32;
+    while let Some((r0, s0)) = items.next() {
+        let sv0 = broadcast(&s0);
+        let Some((r1, s1)) = items.next() else {
+            // Single trailing row.
+            for (aw, m0) in acc.chunks_exact_mut(N * D * 2).zip(r0) {
+                let v0 = m0.to_vector();
+                for (j, sv0_j) in sv0.iter().enumerate() {
+                    for (k, &s) in sv0_j.iter().enumerate() {
+                        let (lo, hi) = mac_up_to_3(&[v0], [s; 3]);
+                        let idx = (j * D + k) * 2;
+                        unsafe {
+                            aw[idx] = aarch64::vaddq_u64(aw[idx], lo);
+                            aw[idx + 1] = aarch64::vaddq_u64(aw[idx + 1], hi);
+                        }
+                    }
+                }
+            }
+            break;
+        };
+        let sv1 = broadcast(&s1);
+        let Some((r2, s2)) = items.next() else {
+            // Trailing row pair.
+            for (aw, (m0, m1)) in acc.chunks_exact_mut(N * D * 2).zip(r0.zip(r1)) {
+                let (v0, v1) = (m0.to_vector(), m1.to_vector());
+                for j in 0..N {
+                    for k in 0..D {
+                        let (lo, hi) = mac_up_to_3(&[v0, v1], [sv0[j][k], sv1[j][k], sv1[j][k]]);
+                        let idx = (j * D + k) * 2;
+                        unsafe {
+                            aw[idx] = aarch64::vaddq_u64(aw[idx], lo);
+                            aw[idx + 1] = aarch64::vaddq_u64(aw[idx + 1], hi);
+                        }
+                    }
+                }
+            }
+            break;
+        };
+        let sv2 = broadcast(&s2);
+
+        for (aw, ((m0, m1), m2)) in acc.chunks_exact_mut(N * D * 2).zip(r0.zip(r1).zip(r2)) {
+            let (v0, v1, v2) = (m0.to_vector(), m1.to_vector(), m2.to_vector());
+            for j in 0..N {
+                for k in 0..D {
+                    let (lo, hi) = mac_up_to_3(&[v0, v1, v2], [sv0[j][k], sv1[j][k], sv2[j][k]]);
+                    let idx = (j * D + k) * 2;
+                    unsafe {
+                        aw[idx] = aarch64::vaddq_u64(aw[idx], lo);
+                        aw[idx + 1] = aarch64::vaddq_u64(aw[idx + 1], hi);
+                    }
+                }
+            }
+        }
+
+        triples += 1;
+        if triples == 1 << 28 {
+            triples = 0;
+            for a in &mut acc {
+                *a = partial_reduce_u64(*a);
+            }
+        }
+    }
+
+    (0..packed_width * N)
+        .map(|cj| {
+            EF::ExtensionPacking::from_basis_coefficients_fn(|k| {
+                let idx = (cj * D + k) * 2;
+                let l = partial_reduce_u64(partial_reduce_u64(acc[idx]));
+                let h = partial_reduce_u64(partial_reduce_u64(acc[idx + 1]));
+                unsafe {
+                    let narrowed = aarch64::vuzp1q_u32(
+                        aarch64::vreinterpretq_u32_u64(l),
+                        aarch64::vreinterpretq_u32_u64(h),
+                    );
+                    PackedMersenne31Neon::from_vector(reduce_sum(narrowed))
+                }
+            })
+        })
+        .collect()
+}
+
 /// Compute the permutation x -> x^5 on Mersenne-31 field elements.
 ///
 /// # Safety
@@ -515,6 +671,90 @@ mod tests {
                 );
                 assert_eq!(expected, got, "d = {d}, len = {len}");
             }
+        }
+    }
+
+    /// The NEON columnwise kernel must agree with the generic accumulation for every
+    /// row-count phase of the 3-row blocking (0, 1 and 2 trailing rows), on boundary
+    /// values, for both the trivial and a degree-4 extension.
+    #[test]
+    fn batched_columnwise_dot_product_matches_generic() {
+        use p3_field::{
+            BasedVectorSpace, ExtensionField, PackedFieldExtension, PrimeCharacteristicRing,
+        };
+
+        use crate::QM31;
+
+        const P: u32 = 0x7fffffff;
+        let val = |i: u32| -> u32 {
+            match i % 7 {
+                0 => 0,
+                1 => 1,
+                2 => P - 1,
+                3 => P,
+                _ => i.wrapping_mul(0x9e3779b9) % P,
+            }
+        };
+        let packed = |i: u32| {
+            PackedMersenne31Neon(Mersenne31::new_array([
+                val(i),
+                val(i.wrapping_add(1)),
+                val(i.wrapping_add(2)),
+                val(i.wrapping_add(3)),
+            ]))
+        };
+        let scalar = |i: u32| Mersenne31::new_checked(val(i) % P).unwrap();
+
+        fn check<EF: ExtensionField<Mersenne31>, const N: usize>(
+            packed_width: usize,
+            rows: &[Vec<PackedMersenne31Neon>],
+            scales: &[[EF; N]],
+        ) {
+            let items = || {
+                rows.iter()
+                    .zip(scales)
+                    .map(|(row, &s)| (row.iter().copied(), s))
+            };
+
+            let mut expected = EF::ExtensionPacking::zero_vec(packed_width * N);
+            for (row, s) in items() {
+                let packed_scales = s.map(EF::ExtensionPacking::from);
+                for (acc_c, r) in expected.chunks_exact_mut(N).zip(row) {
+                    for (a, &ps) in acc_c.iter_mut().zip(&packed_scales) {
+                        *a += ps * r;
+                    }
+                }
+            }
+
+            let got = super::batched_columnwise_dot_product::<EF, _, _, N>(packed_width, items());
+            let expected: Vec<EF> = EF::ExtensionPacking::to_ext_iter(expected).collect();
+            let got: Vec<EF> = EF::ExtensionPacking::to_ext_iter(got).collect();
+            assert_eq!(expected, got, "rows = {}, N = {N}", rows.len());
+        }
+
+        let packed_width = 5;
+        for height in [0usize, 1, 2, 3, 4, 5, 6, 100] {
+            let rows: Vec<Vec<PackedMersenne31Neon>> = (0..height)
+                .map(|r| {
+                    (0..packed_width)
+                        .map(|c| packed((r * 64 + c * 4) as u32))
+                        .collect()
+                })
+                .collect();
+
+            let scales_m31: Vec<[Mersenne31; 2]> = (0..height)
+                .map(|r| core::array::from_fn(|j| scalar((r * 2 + j) as u32)))
+                .collect();
+            check::<Mersenne31, 2>(packed_width, &rows, &scales_m31);
+
+            let scales_qm31: Vec<[QM31; 2]> = (0..height)
+                .map(|r| {
+                    core::array::from_fn(|j| {
+                        QM31::from_basis_coefficients_fn(|k| scalar((r * 8 + j * 4 + k) as u32))
+                    })
+                })
+                .collect();
+            check::<QM31, 2>(packed_width, &rows, &scales_qm31);
         }
     }
 }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use core::arch::aarch64::{self, uint32x4_t};
+use core::arch::aarch64::{self, uint32x4_t, uint64x2_t};
 use core::iter::{Product, Sum};
 use core::mem::transmute;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -306,6 +306,21 @@ fn mul(lhs: uint32x4_t, rhs: uint32x4_t) -> uint32x4_t {
     }
 }
 
+/// Fold a vector of 64-bit accumulators once: given `val`, return `res = val (mod P)`
+/// with `res <= (val >> 31) + P`.
+///
+/// Uses `2^31 = 1 (mod P)`: writing `val = hi * 2^31 + lo` with `lo <= P`, we have
+/// `val = hi + lo (mod P)`. Two applications bring any `val < 2^64` to `0..=P + 3`.
+#[inline]
+#[must_use]
+fn partial_reduce_u64(val: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        // Safety: If this code got compiled then NEON intrinsics are available.
+        let p64 = aarch64::vdupq_n_u64(0x7fffffff);
+        aarch64::vaddq_u64(aarch64::vandq_u64(val, p64), aarch64::vshrq_n_u64(val, 31))
+    }
+}
+
 /// Negate a vector of Mersenne-31 field elements that fit in 31 bits.
 /// If the inputs do not fit in 31 bits, the result is undefined.
 #[inline]
@@ -328,6 +343,66 @@ impl_packed_value!(PackedMersenne31Neon, Mersenne31, WIDTH);
 
 unsafe impl PackedField for PackedMersenne31Neon {
     type Scalar = Mersenne31;
+
+    #[inline]
+    fn coeffwise_dot_product<'a, I>(d: usize, pairs: I) -> [Self; 8]
+    where
+        Self: 'a,
+        I: Iterator<Item = (&'a [Self], Self)>,
+    {
+        // Accumulate the raw 32x32 -> 64-bit products with widening multiply-accumulates
+        // (2 instructions per product), deferring the Mersenne reduction, instead of
+        // paying the 8-instruction reduced multiply-add per product.
+        //
+        // Each coefficient accumulator is a pair of u64x2 vectors: `lo` holds lanes 0-1
+        // and `hi` lanes 2-3. Inputs are in `0..=P`, so a product is at most
+        // `P^2 < 2^62`; folding the accumulators below `2^33` every 3 iterations keeps
+        // `2^33 + 3 * P^2 < 2^64`, so the u64 lanes never overflow.
+        debug_assert!(d <= 8, "Extension degree > 8 not supported");
+        unsafe {
+            // Safety: If this code got compiled then NEON intrinsics are available.
+            let zero = aarch64::vdupq_n_u64(0);
+            let mut lo = [zero; 8];
+            let mut hi = [zero; 8];
+            let mut unreduced = 0;
+            for (coeffs, base) in pairs {
+                let b = base.to_vector();
+                for (k, coeff) in coeffs.iter().take(d).enumerate() {
+                    let c = coeff.to_vector();
+                    lo[k] = aarch64::vmlal_u32(
+                        lo[k],
+                        aarch64::vget_low_u32(c),
+                        aarch64::vget_low_u32(b),
+                    );
+                    hi[k] = aarch64::vmlal_high_u32(hi[k], c, b);
+                }
+                unreduced += 1;
+                if unreduced == 3 {
+                    unreduced = 0;
+                    for k in 0..d {
+                        lo[k] = partial_reduce_u64(lo[k]);
+                        hi[k] = partial_reduce_u64(hi[k]);
+                    }
+                }
+            }
+            core::array::from_fn(|k| {
+                if k < d {
+                    // At most 2 unreduced products on top of a folded value: the lanes
+                    // are below 2^33 + 2 * P^2 < 2^64, so two folds bring them to
+                    // P + 3 <= 2 P, and `reduce_sum` yields a canonical value in 0..=P.
+                    let l = partial_reduce_u64(partial_reduce_u64(lo[k]));
+                    let h = partial_reduce_u64(partial_reduce_u64(hi[k]));
+                    let narrowed = aarch64::vuzp1q_u32(
+                        aarch64::vreinterpretq_u32_u64(l),
+                        aarch64::vreinterpretq_u32_u64(h),
+                    );
+                    Self::from_vector(reduce_sum(narrowed))
+                } else {
+                    Self::ZERO
+                }
+            })
+        }
+    }
 }
 
 /// Compute the permutation x -> x^5 on Mersenne-31 field elements.
@@ -368,6 +443,8 @@ impl_packed_field_pow_2!(
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use p3_field_testing::{test_packed_field, test_packed_field_dot_product_boundary};
 
     use super::{Mersenne31, PackedMersenne31Neon};
@@ -389,4 +466,55 @@ mod tests {
     );
 
     test_packed_field_dot_product_boundary!(crate::PackedMersenne31Neon);
+
+    /// The NEON `coeffwise_dot_product` must agree with the generic coefficient-wise
+    /// accumulation, including on boundary values (0, 1, P - 1 and the redundant
+    /// representation P of zero) and on stream lengths exercising every deferred
+    /// reduction phase.
+    #[test]
+    fn coeffwise_dot_product_matches_generic() {
+        use p3_field::{PackedField, PrimeCharacteristicRing};
+
+        const P: u32 = 0x7fffffff;
+        let val = |i: u32| -> u32 {
+            match i % 7 {
+                0 => 0,
+                1 => 1,
+                2 => P - 1,
+                3 => P,
+                _ => i.wrapping_mul(0x9e3779b9) % P,
+            }
+        };
+        let packed = |i: u32| {
+            PackedMersenne31Neon(Mersenne31::new_array([
+                val(i),
+                val(i.wrapping_add(1)),
+                val(i.wrapping_add(2)),
+                val(i.wrapping_add(3)),
+            ]))
+        };
+
+        for d in 1..=8usize {
+            for len in [0usize, 1, 2, 3, 4, 6, 7, 100] {
+                let coeffs: Vec<[PackedMersenne31Neon; 8]> = (0..len)
+                    .map(|i| core::array::from_fn(|k| packed((i * 8 + k) as u32)))
+                    .collect();
+                let bases: Vec<PackedMersenne31Neon> =
+                    (0..len).map(|i| packed((i + 1000) as u32)).collect();
+
+                let mut expected = [PackedMersenne31Neon::ZERO; 8];
+                for (c, &b) in coeffs.iter().zip(&bases) {
+                    for k in 0..d {
+                        expected[k] += c[k] * b;
+                    }
+                }
+
+                let got = PackedMersenne31Neon::coeffwise_dot_product(
+                    d,
+                    coeffs.iter().zip(&bases).map(|(c, &b)| (&c[..], b)),
+                );
+                assert_eq!(expected, got, "d = {d}, len = {len}");
+            }
+        }
+    }
 }

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -420,7 +420,7 @@ where
     R: Iterator<Item = PackedMersenne31Neon>,
     I: Iterator<Item = (R, [EF; N])>,
 {
-    match <EF as BasedVectorSpace<Mersenne31>>::DIMENSION {
+    match EF::DIMENSION {
         1 => columnwise_kernel::<EF, R, I, N, 1>(packed_width, items),
         2 => columnwise_kernel::<EF, R, I, N, 2>(packed_width, items),
         4 => columnwise_kernel::<EF, R, I, N, 4>(packed_width, items),
@@ -462,7 +462,7 @@ where
     R: Iterator<Item = PackedMersenne31Neon>,
     I: Iterator<Item = (R, [EF; N])>,
 {
-    debug_assert_eq!(<EF as BasedVectorSpace<Mersenne31>>::DIMENSION, D);
+    debug_assert_eq!(EF::DIMENSION, D);
     let zero64 = unsafe { aarch64::vdupq_n_u64(0) };
     let zero32 = unsafe { aarch64::vdupq_n_u32(0) };
 
@@ -679,6 +679,7 @@ mod tests {
     /// values, for both the trivial and a degree-4 extension.
     #[test]
     fn batched_columnwise_dot_product_matches_generic() {
+        use p3_field::extension::Complex;
         use p3_field::{
             BasedVectorSpace, ExtensionField, PackedFieldExtension, PrimeCharacteristicRing,
         };
@@ -746,6 +747,15 @@ mod tests {
                 .map(|r| core::array::from_fn(|j| scalar((r * 2 + j) as u32)))
                 .collect();
             check::<Mersenne31, 2>(packed_width, &rows, &scales_m31);
+
+            let scales_cm31: Vec<[Complex<Mersenne31>; 2]> = (0..height)
+                .map(|r| {
+                    core::array::from_fn(|j| {
+                        Complex::from_basis_coefficients_fn(|k| scalar((r * 4 + j * 2 + k) as u32))
+                    })
+                })
+                .collect();
+            check::<Complex<Mersenne31>, 2>(packed_width, &rows, &scales_cm31);
 
             let scales_qm31: Vec<[QM31; 2]> = (0..height)
                 .map(|r| {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -387,6 +387,20 @@ impl Field for Mersenne31 {
     fn order() -> BigUint {
         P.into()
     }
+
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[inline]
+    fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
+        packed_width: usize,
+        items: I,
+    ) -> Vec<EF::ExtensionPacking>
+    where
+        EF: p3_field::ExtensionField<Self>,
+        R: Iterator<Item = Self::Packing>,
+        I: Iterator<Item = (R, [EF; N])>,
+    {
+        crate::aarch64_neon::batched_columnwise_dot_product::<EF, R, I, N>(packed_width, items)
+    }
 }
 
 // We can use some macros to implement QuotientMap<Int> for all integer types except for u32 and i32's.

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -391,15 +391,14 @@ impl Field for Mersenne31 {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     #[inline]
     fn batched_columnwise_dot_product<EF, R, I, const N: usize>(
-        packed_width: usize,
+        acc: &mut [EF::ExtensionPacking],
         items: I,
-    ) -> Vec<EF::ExtensionPacking>
-    where
+    ) where
         EF: p3_field::ExtensionField<Self>,
         R: Iterator<Item = Self::Packing>,
         I: Iterator<Item = (R, [EF; N])>,
     {
-        crate::aarch64_neon::batched_columnwise_dot_product::<EF, R, I, N>(packed_width, items)
+        crate::aarch64_neon::batched_columnwise_dot_product::<EF, R, I, N>(acc, items);
     }
 }
 


### PR DESCRIPTION
## Description

The two big mixed base×QM31 passes of the Circle open phase (the fused two-point
  out-of-domain evaluation and the rowwise alpha-reduction) execute 4 (resp. 8)
  independent `PackedM31` multiply-accumulates per packed word, each paying the full
  5-instruction reduced multiply plus 3-instruction modular add. On NEON, the raw
  32×32→64-bit products can instead be accumulated with widening MACs
  (`vmlal_u32`/`vmlal_high_u32`, 2 instructions per product) and the Mersenne
  reduction deferred: inputs lie in `0..=P`, so three unreduced products plus a
  folded carry fit a u64 lane (`3·P² + 2³³ < 2⁶⁴`), and one fold
  (`(x & P) + (x >> 31)`, using `2³¹ ≡ 1 (mod P)`) restores headroom.

  This PR adds two overridable hooks for these inner kernels — generic defaults are
  identical to the previous inline loops, so all other fields and targets are
  unaffected — and specializes both for `Mersenne31` on NEON:

  - `PackedField::coeffwise_dot_product` (rowwise shape, accumulators in registers):
    straight substitution, folding every 3 iterations.
  - `Field::batched_columnwise_dot_product` (columnwise shape, accumulators in
    memory): `columnwise_dot_product_batched` now feeds bounded row chunks to the
    field's kernel, which consumes rows three at a time — each product triple is
    accumulated in registers, folded once, then added into u64 lane accumulators,
    which absorb 2³¹ triples without overflow. The kernel is monomorphized over the
    extension degree (1/2/4/8, generic fallback otherwise) so the per-word loops
    fully unroll; a naive runtime-degree version recovers almost none of the win.

  Both kernels carry equivalence tests against the generic accumulation, covering
  the boundary values (0, 1, P−1 and the redundant representation P of zero), every
  deferred-reduction phase of the stream length, and the trivial as well as a
  degree-4 extension.
  
  ## Benchmarks

On my machine, M4 pro NEON activated, this shaves off 4% of the full E2E prover when running `cargo run --release --features parallel --example prove_prime_field_31 -q -- --field mersenne31 --objective poseidon2-permutations --log-trace-length 17 --merkle-hash keccak-f`.

  ## Test plan

  - [x] `cargo test -p p3-field -p p3-matrix -p p3-mersenne-31` (incl. new
        equivalence tests for both kernels)
  - [x] `cargo test -p p3-circle -p p3-fri -p p3-uni-stark -p p3-baby-bear
        -p p3-koala-bear` (end-to-end M31 circle proofs exercise both NEON kernels)
  - [x] `cargo clippy --all-targets` clean on the touched crates
  - [x] A/B benchmarks above
