### PR TITLE
perf(m31): eliminate allocation churn in QM31 column conversions and the lambda extraction

### DIFF
--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -16,9 +16,10 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
+use crate::CircleEvaluations;
 use crate::domain::CircleDomain;
+use crate::ordering::cfft_permute_index;
 use crate::point::Point;
-use crate::{CircleEvaluations, cfft_permute_slice};
 
 /// Compute the "vanishing part" of the DEEP quotient numerator and denominator.
 ///
@@ -233,27 +234,31 @@ pub fn extract_lambda<F: ComplexExtendable, EF: ExtensionField<F>>(
 
     // The unique values are repeated over the rest of the domain in the pattern:
     // 0 1 2 .. n-1 n n n-1 .. 1 0 0 1 ..
-    let v_d = v_d_init
-        .iter()
-        .chain(v_d_init.iter().rev())
-        .cycle()
-        .copied();
+    // Look the pattern up through the CFFT permutation instead of materializing
+    // and permuting a domain-sized vector.
+    let b = 1 << log_blowup;
+    let v_d_at = |i: usize| {
+        let m = cfft_permute_index(i, log_lde_size) & (2 * b - 1);
+        v_d_init[if m < b { m } else { 2 * b - 1 - m }]
+    };
 
     // Compute the squared norm <v_d, v_d> of the vanishing polynomial
     let v_d_2 = F::TWO.exp_u64(log_lde_size as u64 - 1);
 
-    // Convert to the correct order and take only the needed length
-    let v_d = v_d.take(lde.len()).collect_vec();
-    let v_d = cfft_permute_slice(&v_d);
-
     // Extract lambda using the orthogonality property: lambda = <lde, v_d> / <v_d, v_d>
-    let lambda =
-        dot_product::<EF, _, _>(lde.iter().copied(), v_d.iter().copied()) * v_d_2.inverse();
+    let lambda = lde
+        .par_iter()
+        .enumerate()
+        .map(|(i, &y)| y * v_d_at(i))
+        .sum::<EF>()
+        * v_d_2.inverse();
 
     // Remove the vanishing polynomial component from the LDE evaluations
-    for (y, v_x) in izip!(lde, v_d) {
-        *y -= lambda * v_x;
-    }
+    let lambda_v_d: Vec<EF> = v_d_init.iter().map(|&v| lambda * v).collect();
+    lde.par_iter_mut().enumerate().for_each(|(i, y)| {
+        let m = cfft_permute_index(i, log_lde_size) & (2 * b - 1);
+        *y -= lambda_v_d[if m < b { m } else { 2 * b - 1 - m }];
+    });
 
     lambda
 }
@@ -268,6 +273,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
+    use crate::ordering::cfft_permute_slice;
 
     type F = Mersenne31;
     type EF = BinomialExtensionField<F, 3>;

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -195,11 +195,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
         let lifted = CircleEvaluations::from_cfft_order(self.domain, flat)
             .extrapolate(target_domain)
             .to_cfft_order();
-        lifted
-            .values
-            .par_chunks_exact(EF::DIMENSION)
-            .map(|coeffs| EF::from_basis_coefficients_slice(coeffs).unwrap())
-            .collect()
+        EF::reconstitute_from_base(lifted.values)
     }
 }
 

--- a/mersenne-31/src/qm31.rs
+++ b/mersenne-31/src/qm31.rs
@@ -22,7 +22,7 @@ use p3_field::{
     Algebra, BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PackedValue, Powers,
     PrimeCharacteristicRing,
 };
-use p3_util::{as_base_slice, reconstitute_from_base};
+use p3_util::{as_base_slice, flatten_to_base, reconstitute_from_base};
 
 use crate::Mersenne31;
 
@@ -134,6 +134,20 @@ impl BasedVectorSpace<Mersenne31> for QM31 {
         mut iter: I,
     ) -> Option<Self> {
         (iter.len() == 4).then(|| Self::from_basis_coefficients_fn(|_| iter.next().unwrap()))
+    }
+
+    #[inline]
+    fn flatten_to_base(vec: Vec<Self>) -> Vec<Mersenne31> {
+        // SAFETY: `QM31` is layout-identical to `[Mersenne31; 4]` (see
+        // `as_basis_coefficients_slice`) and has the same alignment as `Mersenne31`.
+        unsafe { flatten_to_base(vec) }
+    }
+
+    #[inline]
+    fn reconstitute_from_base(vec: Vec<Mersenne31>) -> Vec<Self> {
+        // SAFETY: `QM31` is layout-identical to `[Mersenne31; 4]` (see
+        // `as_basis_coefficients_slice`) and has the same alignment as `Mersenne31`.
+        unsafe { reconstitute_from_base(vec) }
     }
 }
 
@@ -553,5 +567,28 @@ mod tests {
                 xs[lane] * ys[lane]
             );
         }
+    }
+
+    /// The zero-copy `flatten_to_base`/`reconstitute_from_base` overrides must match
+    /// the basis-coefficient view element by element and round-trip exactly.
+    #[test]
+    fn flatten_reconstitute_roundtrip() {
+        use alloc::vec::Vec;
+
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        let mut rng = SmallRng::seed_from_u64(7);
+        let xs: Vec<QM31> = (0..23).map(|_| rng.random()).collect();
+
+        let flat = <QM31 as BasedVectorSpace<F>>::flatten_to_base(xs.clone());
+        let expected: Vec<F> = xs
+            .iter()
+            .flat_map(|x| x.as_basis_coefficients_slice().to_vec())
+            .collect();
+        assert_eq!(flat, expected);
+
+        let back = <QM31 as BasedVectorSpace<F>>::reconstitute_from_base(flat);
+        assert_eq!(back, xs);
     }
 }


### PR DESCRIPTION
  Two allocation-focused cleanups in the Mersenne-31 Circle proving path, one commit each.

  ## QM31 zero-copy `flatten_to_base` / `reconstitute_from_base`

  `QM31` inherited the default `BasedVectorSpace::flatten_to_base`, which goes through `flat_map(|x| x.as_basis_coefficients_slice().to_vec())` — one 16-byte heap allocation **per element**. On a log18 keccak-f prove this
  fires at two hot call sites: flattening the DEEP-quotient lift input (2^17 elements) and flattening the quotient column before commitment in the uni-stark prover (2^19 elements), about 655k allocations per prove in total.

  `QM31` is `repr(transparent)` over `[CM31; 2]`, itself over `[Mersenne31; 2]`, so it is layout- and alignment-identical to `[Mersenne31; 4]`: both directions are now `Vec` transmutes via the existing `p3_util` helpers (the
  same pattern the packed binomial extensions already use). The DEEP lift's rebuild loop is switched to `reconstitute_from_base` so it picks up the override; the generic default is unchanged for every other field.

  Measured in isolation at the prover's sizes (best of 5):

  | operation | default | override |
  |---|---|---|
  | flatten 2^17 QM31 (DEEP lift input) | 2.51 ms | ~0 |
  | flatten 2^19 QM31 (quotient flattening) | 10.05 ms | ~0 |
  | reconstitute 2^21 M31 → 2^19 QM31 (lift output) | 0.13 ms | 0.10 ms |

  ≈ 12 ms per prove, the larger half landing in the quotient-commit stage.

  ## Analytic lambda vanishing column

  `extract_lambda` materialized the domain-sized `v_d` vector — which holds only `2 * blowup` distinct values in a fixed periodic pattern — and ran it through `cfft_permute_slice` (an 8 MB allocation plus a full gather pass
  at log19) before the dot product and the subtraction. The pattern is now looked up through `cfft_permute_index` inline, both passes are parallelized, and the subtraction uses the `lambda`-scaled pattern values precomputed
  once.

  Measured on the keccak-f log18 M31 prove: `extract_lambda` 2.56–2.62 ms → 0.50–0.59 ms.

  ## Test plan

  - [x] `cargo test -p p3-mersenne-31` — includes a new flatten/reconstitute round-trip test against the basis-coefficient view
  - [x] `cargo test -p p3-circle` — `extract_lambda` unit tests and end-to-end M31 circle proofs cover both changes
  - [x] `cargo clippy --all-targets` clean on the touched crates
  - [x] Span measurements above (`RUST_LOG=debug`, alternating A/B binaries)