### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,50 +99,50 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.6.0" }
-p3-baby-bear = { path = "baby-bear", version = "0.6.0" }
-p3-blake3 = { path = "blake3", version = "0.6.0" }
-p3-blake3-air = { path = "blake3-air", version = "0.6.0" }
-p3-bn254 = { path = "bn254", version = "0.6.0" }
-p3-challenger = { path = "challenger", version = "0.6.0" }
-p3-circle = { path = "circle", version = "0.6.0" }
-p3-commit = { path = "commit", version = "0.6.0" }
-p3-dft = { path = "dft", version = "0.6.0" }
+p3-air = { path = "air", version = "0.6.1" }
+p3-baby-bear = { path = "baby-bear", version = "0.6.1" }
+p3-blake3 = { path = "blake3", version = "0.6.1" }
+p3-blake3-air = { path = "blake3-air", version = "0.6.1" }
+p3-bn254 = { path = "bn254", version = "0.6.1" }
+p3-challenger = { path = "challenger", version = "0.6.1" }
+p3-circle = { path = "circle", version = "0.6.1" }
+p3-commit = { path = "commit", version = "0.6.1" }
+p3-dft = { path = "dft", version = "0.6.1" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.6.0" }
-p3-field-testing = { path = "field-testing", version = "0.6.0" }
-p3-fri = { path = "fri", version = "0.6.0" }
-p3-goldilocks = { path = "goldilocks", version = "0.6.0" }
-p3-keccak = { path = "keccak", version = "0.6.0" }
-p3-keccak-air = { path = "keccak-air", version = "0.6.0" }
-p3-koala-bear = { path = "koala-bear", version = "0.6.0" }
-p3-lookup = { path = "lookup", version = "0.6.0" }
-p3-matrix = { path = "matrix", version = "0.6.0" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.0" }
-p3-mds = { path = "mds", version = "0.6.0" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.6.0" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.6.0" }
-p3-monolith = { path = "monolith", version = "0.6.0" }
-p3-monolith-air = { path = "monolith-air", version = "0.6.0" }
-p3-monty-31 = { path = "monty-31", version = "0.6.0" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.6.0" }
-p3-poseidon1 = { path = "poseidon1", version = "0.6.0" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.0" }
-p3-poseidon2 = { path = "poseidon2", version = "0.6.0" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.0" }
-p3-rescue = { path = "rescue", version = "0.6.0" }
-p3-sha256 = { path = "sha256", version = "0.6.0" }
-p3-sumcheck = { path = "sumcheck", version = "0.6.0" }
-p3-symmetric = { path = "symmetric", version = "0.6.0" }
-p3-uni-stark = { path = "uni-stark", version = "0.6.0" }
-p3-util = { path = "util", version = "0.6.0" }
-p3-whir = { path = "whir", version = "0.6.0" }
-p3-zk-codes = { path = "zk-codes", version = "0.6.0" }
+p3-field = { path = "field", version = "0.6.1" }
+p3-field-testing = { path = "field-testing", version = "0.6.1" }
+p3-fri = { path = "fri", version = "0.6.1" }
+p3-goldilocks = { path = "goldilocks", version = "0.6.1" }
+p3-keccak = { path = "keccak", version = "0.6.1" }
+p3-keccak-air = { path = "keccak-air", version = "0.6.1" }
+p3-koala-bear = { path = "koala-bear", version = "0.6.1" }
+p3-lookup = { path = "lookup", version = "0.6.1" }
+p3-matrix = { path = "matrix", version = "0.6.1" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.1" }
+p3-mds = { path = "mds", version = "0.6.1" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.6.1" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.6.1" }
+p3-monolith = { path = "monolith", version = "0.6.1" }
+p3-monolith-air = { path = "monolith-air", version = "0.6.1" }
+p3-monty-31 = { path = "monty-31", version = "0.6.1" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.6.1" }
+p3-poseidon1 = { path = "poseidon1", version = "0.6.1" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.1" }
+p3-poseidon2 = { path = "poseidon2", version = "0.6.1" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.1" }
+p3-rescue = { path = "rescue", version = "0.6.1" }
+p3-sha256 = { path = "sha256", version = "0.6.1" }
+p3-sumcheck = { path = "sumcheck", version = "0.6.1" }
+p3-symmetric = { path = "symmetric", version = "0.6.1" }
+p3-uni-stark = { path = "uni-stark", version = "0.6.1" }
+p3-util = { path = "util", version = "0.6.1" }
+p3-whir = { path = "whir", version = "0.6.1" }
+p3-zk-codes = { path = "zk-codes", version = "0.6.1" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Air: some debugging improvements (#1431)

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Make batched_linear_combination chunk size per-impl tunable (#1451)

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Uni-stark: richer verification errors (#1453)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Ci: tighten doc/release/TOML checks (#1689)

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Ci: tighten doc/release/TOML checks (#1689)

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix(bn254): add Poseidon2 round-number constants and fix benchmark (#1557)

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(circle): parallelize the FRI fold kernels (#1809)
+- Perf(circle): evaluate out-of-domain openings on a trace-size subdomain (#1810)
+- Perf(circle): kill data-movement passes across `extrapolate` (#1811)
+- Perf(circle): alpha-reduce the trace-size subdomain prefix and lift the column (#1818)
+- Perf(m31): eliminate allocation churn in QM31 column conversions and the lambda extraction (#1823)
+- Perf(circle): flatten the fused CFFT pass driver (#1819)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(circle): flatten the fused CFFT pass driver (#1819)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Dft: testing for internals (#1494)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Field: reinforcement of tests with edge cases and proptests (#1435)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: more const assertions (#1441)

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore(deps): update sha2 requirement from 0.10.9 to 0.11.0 (#1503)

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: remove needless_range_loop allows across the workspace (#1632)

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(lookup): flag-zero skip for sparse rows + dot_product tuple combine (#1812)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix(batch-stark): validate per-instance global lookup data count (#1458)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Matrix: add pad_to_min_power_of_two_height (#1448)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Batch-stark: more efficient prover (#1470)

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Mds: small improvements and more testing (#1459)

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(merkle-tree): hash single-matrix leaf rows without flat_map (#1813)
+- Perf(merkle-tree): hash single-matrix injected rows without flat_map (#1816)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: expose arity schedule (#1433)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(m31): use the degree-4 extension field for `Mersenne31` Circle proofs (#1817)
+- Cleanup(m31): drop redundant Distribution bound on PackedQM31 sampler (#1820)
+- Perf(m31): eliminate allocation churn in QM31 column conversions and the lambda extraction (#1823)
+- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Make batched_linear_combination chunk size per-impl tunable (#1451)

--- a/monolith-air/CHANGELOG.md
+++ b/monolith-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add p3-monolith-air crate for Monolith permutation arithmetization (#1516)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Monolith: implement Monolith for Mersenne31 and Goldilocks (#1478)

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Poseidon1: speedup monty-31 packed version on avx (#1420)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Multilinear util: integrate poly utils (#1379)

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Improved poseidon1 air (Karatsuba + Sparse partial rounds) (#1480)

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Improved poseidon1 air (Karatsuba + Sparse partial rounds) (#1480)

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Perf: abstract away Copy vs Clone (#1463)

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: more const assertions (#1441)

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore(deps): update sha2 requirement from 0.10.9 to 0.11.0 (#1503)

--- a/sumcheck/CHANGELOG.md
+++ b/sumcheck/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Refactor: move sumcheck to an independent crate (#1672)

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
+### Merged PRs
+- Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Uni-stark: richer verification errors (#1453)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Utils: add `log3_strict_usize` (#1444)

--- a/whir/CHANGELOG.md
+++ b/whir/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Whir: integration of all the required primitives (#1477)

--- a/zk-codes/CHANGELOG.md
+++ b/zk-codes/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: extract ZK encoding traits to p3-zk-codes (#1601)


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.6.0 -> 0.6.1
* `p3-util`: 0.6.0 -> 0.6.1
* `p3-field`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-matrix`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-air`: 0.6.0 -> 0.6.1
* `p3-dft`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-symmetric`: 0.6.0 -> 0.6.1
* `p3-mds`: 0.6.0 -> 0.6.1
* `p3-poseidon1`: 0.6.0 -> 0.6.1
* `p3-poseidon2`: 0.6.0 -> 0.6.1
* `p3-monty-31`: 0.6.0 -> 0.6.1
* `p3-challenger`: 0.6.0 -> 0.6.1
* `p3-baby-bear`: 0.6.0 -> 0.6.1
* `p3-goldilocks`: 0.6.0 -> 0.6.1
* `p3-koala-bear`: 0.6.0 -> 0.6.1
* `p3-mersenne-31`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-bn254`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-field-testing`: 0.6.0 -> 0.6.1
* `p3-multilinear-util`: 0.6.0 -> 0.6.1
* `p3-commit`: 0.6.0 -> 0.6.1
* `p3-fri`: 0.6.0 -> 0.6.1
* `p3-uni-stark`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-lookup`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-batch-stark`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-circle`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-keccak`: 0.6.0 -> 0.6.1
* `p3-merkle-tree`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `p3-blake3`: 0.6.0 -> 0.6.1
* `p3-rescue`: 0.6.0 -> 0.6.1
* `p3-blake3-air`: 0.6.0 -> 0.6.1
* `p3-keccak-air`: 0.6.0 -> 0.6.1
* `p3-poseidon2-air`: 0.6.0 -> 0.6.1
* `p3-sha256`: 0.6.0 -> 0.6.1
* `p3-monolith`: 0.6.0 -> 0.6.1
* `p3-monolith-air`: 0.6.0 -> 0.6.1
* `p3-poseidon1-air`: 0.6.0 -> 0.6.1
* `p3-zk-codes`: 0.6.0 -> 0.6.1
* `p3-sumcheck`: 0.6.0 -> 0.6.1
* `p3-whir`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>



## `p3-field`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
</blockquote>

## `p3-matrix`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
</blockquote>


## `p3-dft`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(circle): flatten the fused CFFT pass driver (#1819)
</blockquote>










## `p3-mersenne-31`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(m31): use the degree-4 extension field for `Mersenne31` Circle proofs (#1817)
- Cleanup(m31): drop redundant Distribution bound on PackedQM31 sampler (#1820)
- Perf(m31): eliminate allocation churn in QM31 column conversions and the lambda extraction (#1823)
- Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)
</blockquote>






## `p3-uni-stark`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)
</blockquote>

## `p3-lookup`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(lookup): flag-zero skip for sparse rows + dot_product tuple combine (#1812)
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)
</blockquote>

## `p3-circle`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(circle): parallelize the FRI fold kernels (#1809)
- Perf(circle): evaluate out-of-domain openings on a trace-size subdomain (#1810)
- Perf(circle): kill data-movement passes across `extrapolate` (#1811)
- Perf(circle): alpha-reduce the trace-size subdomain prefix and lift the column (#1818)
- Perf(m31): eliminate allocation churn in QM31 column conversions and the lambda extraction (#1823)
- Perf(circle): flatten the fused CFFT pass driver (#1819)
</blockquote>


## `p3-merkle-tree`

<blockquote>

## [0.6.1] - 2026-06-13

### Merged PRs
- Perf(merkle-tree): hash single-matrix leaf rows without flat_map (#1813)
- Perf(merkle-tree): hash single-matrix injected rows without flat_map (#1816)
</blockquote>














</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).