### PR TITLE
perf(monty-31): use dedicated `quintic_square` kernel for `QuinticTrinomial` `ext_square`

### DIFF
--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -1,6 +1,6 @@
 use p3_field::extension::{
     Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension,
-    HasTwoAdicQuinticExtension, QuinticTrinomial, QuinticTrinomialExtendable,
+    HasTwoAdicQuinticExtension, QuinticTrinomial, QuinticTrinomialExtendable, quintic_square,
 };
 use p3_field::{
     PrimeCharacteristicRing, TwoAdicField, field_to_array, packed_mod_add, packed_mod_sub,
@@ -105,6 +105,11 @@ where
     #[inline(always)]
     fn ext_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
         quintic_mul_packed_trinomial(a, b, res);
+    }
+
+    #[inline(always)]
+    fn ext_square(a: &[Self; 5], res: &mut [Self; 5]) {
+        quintic_square(a, res);
     }
 
     #[inline(always)]


### PR DESCRIPTION
We already quintic_square but it wasn't wired in

Yields about −6.9%  improvements on my machine