### PR TITLE
perf(mersenne-31): complex-squaring scalar QM31 square

### DIFF
--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -169,8 +169,7 @@ where
     #[inline(always)]
     fn square(&self) -> Self {
         let mut res = Self::default();
-        let w = F::W;
-        binomial_square(&self.value, &mut res.value, w);
+        <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_square(&self.value, &mut res.value);
         res
     }
 

--- a/field/src/extension/complex.rs
+++ b/field/src/extension/complex.rs
@@ -1,6 +1,6 @@
 use super::{
     Binomial, BinomialExtensionField, BinomiallyExtendable, ExtensionAlgebra,
-    HasTwoAdicBinomialExtension, binomial_mul,
+    HasTwoAdicBinomialExtension, binomial_mul, binomial_square,
 };
 use crate::{Algebra, Field, PrimeCharacteristicRing};
 
@@ -21,6 +21,11 @@ impl<F: ComplexExtendable> ExtensionAlgebra<F, 2, Binomial<F>> for F {
     #[inline]
     fn ext_mul(a: &[Self; 2], b: &[Self; 2], res: &mut [Self; 2]) {
         binomial_mul::<F, Self, Self, 2>(a, b, res, <F as BinomiallyExtendable<2>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_square::<F, Self, 2>(a, res, <F as BinomiallyExtendable<2>>::W);
     }
 }
 
@@ -104,6 +109,16 @@ pub trait HasComplexBinomialExtension<const D: usize>: ComplexExtendable {
     const DTH_ROOT: Complex<Self>;
 
     const EXT_GENERATOR: [Complex<Self>; D];
+
+    /// Multiply a `Complex<Self>` element by `W = Self::W`.
+    ///
+    /// The default is a general complex multiplication. Override when `W` has
+    /// structure that makes multiplication cheaper (e.g. add-only when all
+    /// coefficients of `W` are small).
+    #[inline]
+    fn mul_by_w(z: Complex<Self>) -> Complex<Self> {
+        <Complex<Self> as BinomiallyExtendable<D>>::W * z
+    }
 }
 
 impl<F, const D: usize> ExtensionAlgebra<Self, D, Binomial<Self>> for Complex<F>
@@ -113,6 +128,25 @@ where
     #[inline]
     fn ext_mul(a: &[Self; D], b: &[Self; D], res: &mut [Self; D]) {
         binomial_mul::<Self, Self, Self, D>(a, b, res, <Self as BinomiallyExtendable<D>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; D], res: &mut [Self; D]) {
+        match D {
+            2 => {
+                // QM31-style: (a0, a1) with modulus X² − W.
+                // res[0] = a0² + W·a1²   (two CM31 squares + add-only W-mul)
+                // res[1] = 2·a0·a1        (one CM31 mul)
+                let a0 = a[0];
+                let a1 = a[1];
+                let a0_sq = a0.square();
+                let a1_sq = a1.square();
+                let w_a1_sq = F::mul_by_w(a1_sq);
+                res[0] = a0_sq + w_a1_sq;
+                res[1] = (a0 * a1).double();
+            }
+            _ => binomial_square::<Self, Self, D>(a, res, <Self as BinomiallyExtendable<D>>::W),
+        }
     }
 }
 

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -1,7 +1,7 @@
 use p3_field::extension::{
     Binomial, BinomiallyExtendable, CubicTrinomial, CubicTrinomialExtendable, ExtensionAlgebra,
-    HasTwoAdicBinomialExtension, HasTwoAdicCubicExtension, binomial_mul, cubic_square,
-    trinomial_cubic_mul,
+    HasTwoAdicBinomialExtension, HasTwoAdicCubicExtension, binomial_mul, binomial_square,
+    cubic_square, trinomial_cubic_mul,
 };
 use p3_field::{PrimeCharacteristicRing, TwoAdicField, field_to_array};
 
@@ -11,6 +11,11 @@ impl ExtensionAlgebra<Self, 2, Binomial<Self>> for Goldilocks {
     #[inline]
     fn ext_mul(a: &[Self; 2], b: &[Self; 2], res: &mut [Self; 2]) {
         binomial_mul::<Self, Self, Self, 2>(a, b, res, <Self as BinomiallyExtendable<2>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_square::<Self, Self, 2>(a, res, <Self as BinomiallyExtendable<2>>::W);
     }
 }
 
@@ -106,6 +111,11 @@ impl ExtensionAlgebra<Self, 5, Binomial<Self>> for Goldilocks {
     #[inline]
     fn ext_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
         binomial_mul::<Self, Self, Self, 5>(a, b, res, <Self as BinomiallyExtendable<5>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 5], res: &mut [Self; 5]) {
+        binomial_square::<Self, Self, 5>(a, res, <Self as BinomiallyExtendable<5>>::W);
     }
 }
 

--- a/mersenne-31/src/extension.rs
+++ b/mersenne-31/src/extension.rs
@@ -1,6 +1,6 @@
 use p3_field::extension::{
     Binomial, BinomiallyExtendable, Complex, ExtensionAlgebra, HasComplexBinomialExtension,
-    HasTwoAdicComplexBinomialExtension, binomial_mul,
+    HasTwoAdicComplexBinomialExtension, binomial_mul, binomial_square,
 };
 use p3_field::{PrimeCharacteristicRing, TwoAdicField, field_to_array};
 
@@ -10,6 +10,11 @@ impl ExtensionAlgebra<Self, 3, Binomial<Self>> for Mersenne31 {
     #[inline]
     fn ext_mul(a: &[Self; 3], b: &[Self; 3], res: &mut [Self; 3]) {
         binomial_mul::<Self, Self, Self, 3>(a, b, res, <Self as BinomiallyExtendable<3>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 3], res: &mut [Self; 3]) {
+        binomial_square::<Self, Self, 3>(a, res, <Self as BinomiallyExtendable<3>>::W);
     }
 }
 
@@ -57,6 +62,15 @@ impl HasComplexBinomialExtension<2> for Mersenne31 {
     //   assert g^((p^4-1) // f) != 1
     // ```
     const EXT_GENERATOR: [Complex<Self>; 2] = [Complex::new_real(Self::new(6)), Complex::ONE];
+
+    /// Multiply a `Complex<Mersenne31>` element by `W = 2 + i` using only additions:
+    /// `(a + bi)(2 + i) = (2a - b) + (a + 2b)i`.
+    #[inline(always)]
+    fn mul_by_w(z: Complex<Self>) -> Complex<Self> {
+        let re = z.real();
+        let im = z.imag();
+        Complex::new_complex(re + re - im, re + im + im)
+    }
 }
 
 impl HasTwoAdicComplexBinomialExtension<2> for Mersenne31 {

--- a/monty-31/src/extension.rs
+++ b/monty-31/src/extension.rs
@@ -1,6 +1,6 @@
 use p3_field::extension::{
     Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension,
-    HasTwoAdicQuinticExtension, QuinticTrinomial, QuinticTrinomialExtendable,
+    HasTwoAdicQuinticExtension, QuinticTrinomial, QuinticTrinomialExtendable, binomial_square,
 };
 use p3_field::{
     PrimeCharacteristicRing, TwoAdicField, field_to_array, packed_mod_add, packed_mod_sub,
@@ -65,6 +65,11 @@ where
         let mut res = [Self::ZERO; WIDTH];
         base_mul_packed(lhs, rhs, &mut res);
         res
+    }
+
+    #[inline(always)]
+    fn ext_square(a: &[Self; WIDTH], res: &mut [Self; WIDTH]) {
+        binomial_square::<Self, Self, WIDTH>(a, res, <Self as BinomiallyExtendable<WIDTH>>::W);
     }
 }
 


### PR DESCRIPTION
Route BinomialExtensionField::square() through A::ext_square (matching CubicTrinomialExtensionField and QuinticTrinomialExtensionField), then add an optimised ext_square for Complex<F> D=2 that exploits the algebraic structure:

  res[0] = a0² + W·a1²   (two CM31 squares + add-only W-mul)
  res[1] = 2·a0·a1        (one CM31 mul)

For QM31 (W = 2+i) the W-multiplication is free (only additions via the mul_by_w hook added to HasComplexBinomialExtension and overridden for Mersenne31). This reduces the scalar QM31 square from ~16 M31 multiplications to ~10, a ~37% reduction.

Companion changes prevent regressions on other BinomialExtensionField users: ext_square overrides calling binomial_square are added for ComplexExtendable prime-field D=2, Goldilocks D=2 and D=5, Mersenne31 D=3, and MontyField31 (all widths).

Yields about −12.4% on my machine