### PR TITLE
fix(sumcheck): bind round count inside verify_rounds

### DIFF
--- a/sumcheck/src/data.rs
+++ b/sumcheck/src/data.rs
@@ -90,13 +90,28 @@ impl<F, EF> SumcheckData<F, EF> {
 
     /// Verifies standard sumcheck rounds and extracts folding randomness from the transcript.
     ///
+    /// # Arguments
+    ///
+    /// * `challenger` - Fiat-Shamir transcript.
+    /// * `claimed_sum` - Running claim, folded in place to `h(r)` after each round.
+    /// * `expected_rounds` - Protocol-fixed number of rounds this proof must carry.
+    /// * `pow_bits` - PoW difficulty (0 to skip grinding).
+    ///
     /// # Returns
     ///
-    /// A `Point` of folding randomness values.
+    /// A `Point` of folding randomness values, one per round.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RoundCountMismatch` if the proof does not carry exactly `expected_rounds` rounds.
+    ///
+    /// The folding-challenge count is derived from the proof itself.
+    /// A wrong count would desync Fiat-Shamir rather than reject, so it is bound here.
     pub fn verify_rounds<Challenger>(
         &self,
         challenger: &mut Challenger,
         claimed_sum: &mut EF,
+        expected_rounds: usize,
         pow_bits: usize,
     ) -> Result<Point<EF>, SumcheckError>
     where
@@ -104,6 +119,17 @@ impl<F, EF> SumcheckData<F, EF> {
         EF: ExtensionField<F> + TwoAdicField,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
+        // Bind the round count to the protocol-fixed value before folding anything.
+        //
+        // Centralizing the check here makes the safe path the only path:
+        // every caller is forced to declare how many rounds it expects.
+        if self.polynomial_evaluations.len() != expected_rounds {
+            return Err(SumcheckError::RoundCountMismatch {
+                expected: expected_rounds,
+                actual: self.polynomial_evaluations.len(),
+            });
+        }
+
         let mut randomness = Vec::with_capacity(self.polynomial_evaluations.len());
 
         // Grinding pushes one witness per round;
@@ -162,11 +188,6 @@ where
         expected_rounds: rounds,
     })?;
 
-    if sumcheck.polynomial_evaluations.len() != rounds {
-        return Err(SumcheckError::RoundCountMismatch {
-            expected: rounds,
-            actual: sumcheck.polynomial_evaluations.len(),
-        });
-    }
-    sumcheck.verify_rounds(challenger, claimed_sum, pow_bits)
+    // `verify_rounds` binds the round count to `rounds`.
+    sumcheck.verify_rounds(challenger, claimed_sum, rounds, pow_bits)
 }

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -250,7 +250,7 @@ pub(super) mod test_utils {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
                 .unwrap(),
         );
 
@@ -265,12 +265,17 @@ pub(super) mod test_utils {
         constraints.push(intermediate_constraint);
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, POW_BITS)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
                 .unwrap(),
         );
         verifier_challenge.extend(
             &proof2
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    stacked_num_variables - 2 * FOLDING,
+                    0,
+                )
                 .unwrap(),
         );
 
@@ -766,7 +771,7 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
                 .unwrap(),
         );
 
@@ -783,12 +788,17 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, POW_BITS)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
                 .unwrap(),
         );
         verifier_challenge.extend(
             &proof2
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    stacked_num_variables - 2 * FOLDING,
+                    0,
+                )
                 .unwrap(),
         );
 
@@ -877,7 +887,7 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
                 .unwrap(),
         );
 
@@ -894,12 +904,17 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, POW_BITS)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
                 .unwrap(),
         );
         verifier_challenge.extend(
             &proof2
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    stacked_num_variables - 2 * FOLDING,
+                    0,
+                )
                 .unwrap(),
         );
 

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -348,7 +348,7 @@ where
 
         verifier_randomness.extend(
             &proof[0]
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -367,7 +367,7 @@ where
 
         verifier_randomness.extend(
             &proof[round]
-                .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -377,7 +377,7 @@ where
         &proof
             .last()
             .unwrap()
-            .verify_rounds(&mut verifier_challenger, &mut sum, 0)
+            .verify_rounds(&mut verifier_challenger, &mut sum, num_variables_inter, 0)
             .unwrap(),
     );
 
@@ -500,6 +500,34 @@ fn test_round_count_mismatch() {
 }
 
 #[test]
+fn test_verify_rounds_rejects_wrong_round_count() {
+    // Invariant: verify_rounds binds the round count itself, before observing or folding.
+    //
+    //     evaluations: 3     expected: 4     -> expected=4, actual=3
+    let mut chal = challenger();
+    let mut sum = EF::ZERO;
+    let expected_rounds = 4;
+    let actual_rounds = 3;
+    let data = SumcheckData::<F, EF> {
+        // Values are unread; the count check fires first.
+        polynomial_evaluations: vec![[EF::ZERO, EF::ZERO]; actual_rounds],
+        pow_witnesses: vec![],
+    };
+
+    let err = data
+        .verify_rounds(&mut chal, &mut sum, expected_rounds, 0)
+        .expect_err("wrong round count must error");
+
+    match err {
+        SumcheckError::RoundCountMismatch { expected, actual } => {
+            assert_eq!(expected, expected_rounds);
+            assert_eq!(actual, actual_rounds);
+        }
+        other => panic!("expected RoundCountMismatch, got: {other}"),
+    }
+}
+
+#[test]
 fn test_pow_witness_count_mismatch() {
     // Invariant: when PoW is enabled, witness count must match round count.
     let mut chal = challenger();
@@ -512,7 +540,7 @@ fn test_pow_witness_count_mismatch() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, 20)
+        .verify_rounds(&mut chal, &mut sum, expected, 20)
         .expect_err("witness-count mismatch must error before indexing");
 
     match err {
@@ -541,7 +569,7 @@ fn test_invalid_pow_witness() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, pow_bits)
+        .verify_rounds(&mut chal, &mut sum, data.num_rounds(), pow_bits)
         .expect_err("zeroed witness must fail");
 
     assert!(matches!(err, SumcheckError::InvalidPowWitness));

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -14,7 +14,7 @@ use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::constraints::statement::SelectStatement;
 use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::strategy::VariableOrder;
-use p3_sumcheck::{SumcheckError, verify_final_sumcheck_rounds};
+use p3_sumcheck::verify_final_sumcheck_rounds;
 use tracing::instrument;
 
 use super::committer::reader::ParsedCommitment;
@@ -118,17 +118,11 @@ where
         constraints.push(initial_constraint);
 
         // Initial sumcheck rounds == first-round folding factor.
-        let expected_initial_rounds = self.round_folding_factor(0);
-        let actual_initial_rounds = proof.initial_sumcheck.polynomial_evaluations().len();
-        if actual_initial_rounds != expected_initial_rounds {
-            return Err(VerifierError::Sumcheck(SumcheckError::RoundCountMismatch {
-                expected: expected_initial_rounds,
-                actual: actual_initial_rounds,
-            }));
-        }
+        // `verify_rounds` rejects a proof that carries the wrong number of rounds.
         let folding_randomness = proof.initial_sumcheck.verify_rounds(
             challenger,
             &mut claimed_eval,
+            self.round_folding_factor(0),
             self.starting_folding_pow_bits,
         )?;
         round_folding_randomness.push(folding_randomness);
@@ -177,22 +171,11 @@ where
             constraints.push(constraint);
 
             // Intermediate-round sumcheck rounds == next-round folding factor.
-            // Mirrors the initial and final sumcheck guards;
-            // Without it a wrong count desyncs Fiat-Shamir instead of rejecting cleanly.
-            let expected_round_rounds = self.round_folding_factor(round_index + 1);
-            let actual_round_rounds = proof.rounds[round_index]
-                .sumcheck
-                .polynomial_evaluations()
-                .len();
-            if actual_round_rounds != expected_round_rounds {
-                return Err(VerifierError::Sumcheck(SumcheckError::RoundCountMismatch {
-                    expected: expected_round_rounds,
-                    actual: actual_round_rounds,
-                }));
-            }
+            // `verify_rounds` rejects a wrong count instead of desyncing Fiat-Shamir.
             let folding_randomness = proof.rounds[round_index].sumcheck.verify_rounds(
                 challenger,
                 &mut claimed_eval,
+                self.round_folding_factor(round_index + 1),
                 round_params.folding_pow_bits,
             )?;
             round_folding_randomness.push(folding_randomness);


### PR DESCRIPTION
## What

`SumcheckData::verify_rounds` derived the number of folding challenges from `polynomial_evaluations.len()` — i.e. from the proof — with **no check** that it matched the protocol-fixed round count. It simply folded however many rounds the proof carried.

The round-count guard lived only in the separate `verify_final_sumcheck_rounds`. Every production caller (the WHIR verifier) does guard the count manually right before calling, so this is **not exploitable today** — but `verify_rounds` is `pub` and unsafe-by-default: the next caller that forgets the guard would desync Fiat-Shamir instead of rejecting cleanly.

## Change

Fold the check into `verify_rounds` itself via a new `expected_rounds` argument, rejecting with `RoundCountMismatch` *before* observing or folding anything. This makes the safe path the only path.

- `verify_final_sumcheck_rounds` drops its now-redundant length check and delegates to `verify_rounds`.
- WHIR verifier drops its two manual round-count guards (initial + intermediate rounds); behavior is identical, just centralized (and the now-unused `SumcheckError` import is removed).
- Test harness call sites pass the protocol-fixed counts.
- Adds `test_verify_rounds_rejects_wrong_round_count`, pinning the new contract directly on `verify_rounds` (previously only covered transitively via `verify_final_sumcheck_rounds`).

No behavior change for honest proofs; the only difference is that a malformed round count is now rejected by `verify_rounds` regardless of caller diligence.

## Testing

- `cargo test -p p3-sumcheck` — 219 passed
- `cargo test -p p3-whir` — 121 passed
- `cargo fmt --check` clean, `cargo clippy --all-targets` no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)