### PR TITLE
perf(multilinear-util): parallelize packed single-point eq builder

### DIFF
--- a/multilinear-util/Cargo.toml
+++ b/multilinear-util/Cargo.toml
@@ -37,5 +37,9 @@ harness = false
 name = "compress_kernels"
 harness = false
 
+[[bench]]
+name = "poly"
+harness = false
+
 [lints]
 workspace = true

--- a/multilinear-util/benches/poly.rs
+++ b/multilinear-util/benches/poly.rs
@@ -1,0 +1,37 @@
+//! Benchmarks for [`Poly`] operations.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use p3_multilinear_util::poly::Poly;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+/// Base field type.
+type F = BabyBear;
+
+/// Extension field: a degree-4 binomial extension of the base field.
+type EF4 = BinomialExtensionField<F, 4>;
+
+/// Packed extension field type used by the packed eq builder.
+type Packed = <EF4 as p3_field::ExtensionField<F>>::ExtensionPacking;
+
+/// Benchmarks the packed single-point eq builder over the 2^18..2^24 range.
+fn bench_new_packed_from_point(c: &mut Criterion) {
+    let mut group = c.benchmark_group("new_packed_from_point");
+    let mut rng = SmallRng::seed_from_u64(987654321);
+
+    for num_vars in [18usize, 20, 22, 24] {
+        let point: Vec<EF4> = (0..num_vars).map(|_| rng.random()).collect();
+        let scale: EF4 = rng.random();
+
+        group.bench_with_input(BenchmarkId::from_parameter(num_vars), &num_vars, |b, _| {
+            b.iter(|| Poly::<Packed>::new_packed_from_point::<F, EF4>(&point, scale));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_new_packed_from_point);
+criterion_main!(benches);

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -181,12 +181,15 @@ impl<Packed> Poly<Packed> {
     ///
     /// ## Returns
     /// A packed polynomial containing `scale * eq(point, X)` for all `X` in `{0,1}^n`.
+    ///
+    /// The last `log2(W)` variables fold into one packed seed (filling the SIMD lanes).
+    /// The remaining variables expand across the thread pool, one output chunk per worker.
     #[inline]
     pub fn new_packed_from_point<F, EF>(point: &[EF], scale: EF) -> Self
     where
         F: Field,
         EF: ExtensionField<F, ExtensionPacking = Packed>,
-        Packed: PackedFieldExtension<F, EF> + Copy,
+        Packed: PackedFieldExtension<F, EF> + Copy + Send + Sync,
     {
         /// Computes eq(point, X) * scale for all X in {0,1}^n, writing results into `out`.
         ///
@@ -213,23 +216,42 @@ impl<Packed> Poly<Packed> {
 
         let (point_rest, point_init) = point.split_at(n - n_pack);
 
-        // COMPUTE SUFFIX (Inside the SIMD lanes)
+        // COMPUTE SUFFIX (inside the SIMD lanes)
         //
         // We compute the equality polynomial for the last `n_pack` variables.
         // This forms a single `Packed` element which acts as the seed for the next stage.
         let mut init: Vec<EF> = EF::zero_vec(1 << n_pack);
         eq_serial(&mut init, point_init, scale);
+        let seed = Packed::from_ext_slice(&init);
 
-        // COMPUTE PREFIX (Vector Expansion)
+        // COMPUTE PREFIX (vector expansion over `point_rest`)
         //
         // We expand the seed across the remaining variables using Packed arithmetic.
-        let mut packed = unsafe { uninitialized_vec::<Packed>(1 << (n - n_pack)) };
-        eq_serial(
-            &mut packed,
-            point_rest,
-            // Initialize the first element with the seed computed above
-            Packed::from_ext_slice(&init),
-        );
+        let mut packed = unsafe { uninitialized_vec::<Packed>(1 << point_rest.len()) };
+
+        // Split the prefix into [leading `log_chunks` vars | middle vars].
+        //
+        // The leading vars index the output chunks; the middle vars expand within each chunk.
+        // eq factorizes across this split:
+        //     eq(point_rest, c·2^|mid| + y) = eq(leading, c) * eq(middle, y).
+        let log_chunks = log2_strict_usize(current_num_threads().next_power_of_two());
+        if point_rest.len() <= log_chunks + 1 {
+            // Too small to be worth fanning out: expand serially.
+            eq_serial(&mut packed, point_rest, seed);
+        } else {
+            let (leading, middle) = point_rest.split_at(log_chunks);
+
+            // One packed seed per chunk: buffer[c] = seed * eq(leading, c).
+            let mut buffer = unsafe { uninitialized_vec::<Packed>(1 << log_chunks) };
+            eq_serial(&mut buffer, leading, seed);
+
+            // Each chunk holds 2^|middle| entries and expands independently from its seed.
+            let chunk_size = 1 << middle.len();
+            packed
+                .par_chunks_mut(chunk_size)
+                .zip(buffer.par_iter())
+                .for_each(|(chunk, &chunk_seed)| eq_serial(chunk, middle, chunk_seed));
+        }
 
         Self(packed)
     }
@@ -2095,6 +2117,29 @@ pub(crate) mod test {
             let next = Poly::new_from_point(p0.as_slice(), F::ONE);
             let e1 = next.eval_next_base(&p1);
             assert_eq!(e0, e1);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn new_packed_from_point_matches_scalar_reference(
+            // Sweep across the serial/parallel boundary: the parallel fan-out engages
+            // once `n - log2(W) > log_chunks + 1`, so cover small and large `n`.
+            k in (log2_strict_usize(PackedF::WIDTH))..=18usize,
+            scale_raw in 1u64..F::ORDER_U64,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let point: Vec<EF> = (0..k).map(|_| rng.random()).collect();
+            let scale = EF::from(F::from_u64(scale_raw));
+
+            // Packed builder, unpacked back to scalar extension form.
+            let packed = Poly::new_packed_from_point::<F, EF>(&point, scale).unpack::<F, EF>();
+
+            // Scalar reference: the same eq table built directly.
+            let reference = Poly::new_from_point(&point, scale);
+
+            prop_assert_eq!(packed, reference);
         }
     }
 }


### PR DESCRIPTION
## What

Parallelize `Poly::new_packed_from_point`, the packed single-point equality-table builder.

It already folded the trailing `log2(W)` variables into one packed SIMD seed, then expanded the remaining variables with a **single serial loop**. This splits the prefix into `[leading log_chunks vars | middle vars]` — matching the existing `eq_batch.rs` fan-out convention — builds one packed seed per chunk, and expands each output chunk across the thread pool.

The expansion is exact because `eq` factorizes across the split:

```
eq(point_rest, c·2^|mid| + y) = eq(leading, c) * eq(middle, y)
```

A size guard keeps small inputs on the serial path, and at one thread the behavior degenerates to the original loop.

## Micro-benchmark

`benches/poly.rs`, BabyBear + degree-4 extension, same binary at 1 thread (old serial path) vs all cores (10-core, 8P+2E):

| n (vars) | serial | parallel | speedup |
|---|---|---|---|
| 2^18 | 1.02 ms | 0.35 ms | **2.9×** |
| 2^20 | 4.08 ms | 1.63 ms | **2.5×** |
| 2^22 | 16.30 ms | 3.18 ms | **5.1×** |
| 2^24 | 66.63 ms | 12.28 ms | **5.4×** |

The win grows with table size as the fan-out overhead amortizes.

## Honest scope: no measurable WHIR end-to-end impact

This speeds up the builder *in isolation*, but it does **not** speed up the WHIR PCS prove path. `SplitEq::new_packed` splits the point in half (`split_at(num_variables / 2)`), and SVO + folding shrink the residual further, so WHIR builds eq tables of only ~2^10 elements even at 2^20 — below the parallel threshold, so the serial branch is taken. Clean e2e prove measurements confirm this (within noise):

| n | serial | parallel | change |
|---|---|---|---|
| 2^18 | 79.1 ms | 80.0 ms | +1.1% (noise) |
| 2^20 | 378.9 ms | 380.2 ms | +0.5% (p=0.30, n.s.) |

The change is correct, tested, and regression-free; it benefits any caller that builds **large** eq tables directly (e.g. a future full-trace sumcheck/GKR), which no in-tree caller does today.

## Tests

- New proptest `new_packed_from_point_matches_scalar_reference` pins the parallel builder (unpacked) equal to the scalar `new_from_point` reference across the serial/parallel boundary.
- Full `p3-multilinear-util` suite (142 tests) passes; downstream `p3-whir` / `p3-sumcheck` build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
