### PR TITLE
docs(sumcheck): document Fiat-Shamir binding contract on Constraint::new

### DIFF
--- a/sumcheck/src/constraints/mod.rs
+++ b/sumcheck/src/constraints/mod.rs
@@ -227,6 +227,12 @@ impl<F: Field, EF: ExtensionField<F>> Constraint<F, EF> {
     /// - `num_variables`: shared multilinear arity that every group must match.
     /// - `statements`: groups in the protocol-visible order used by batching.
     ///
+    /// # Fiat-Shamir
+    ///
+    /// - The caller owns the binding of `challenge`; this type does not absorb anything.
+    /// - Every statement's points and evaluations must be observed before `challenge` is sampled.
+    /// - A `challenge` drawn before that binding lets a prover steer it and forge the batch.
+    ///
     /// # Panics
     ///
     /// Panics if any group has a different variable count than the shared arity.


### PR DESCRIPTION
## What

`Constraint::new` takes the RLC batching `challenge` (the `gamma`/`alpha` whose powers weight each statement group) as an argument and absorbs nothing into the transcript itself. The powers-of-gamma batching is sound — exponents are contiguous and disjoint across groups, soundness error ≈ `(total_constraints − 1)/|EF|` — but that soundness rests entirely on the caller having bound all statement data (points, evaluations, arity) into the transcript **before** sampling the challenge.

That contract was implicit. Nothing in `constraints/` enforces or documents it.

## Change

Add a `# Fiat-Shamir` section to `Constraint::new` (matching the established section header already used in `layout/verifier.rs` and `layout/prover/*`) making the precondition explicit:

- the caller owns the binding of `challenge`; this type does not absorb anything;
- every statement's points and evaluations must be observed before `challenge` is sampled;
- a challenge drawn before that binding lets a prover steer it and forge the batch.

Doc-only; no behavior change. The current production caller (WHIR verifier, `whir/src/pcs/verifier/mod.rs`) already honors this ordering.

## Testing

- `cargo doc -p p3-sumcheck --no-deps` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)