### PR TITLE
perf(whir): drop redundant to_row_major_matrix after dft_algebra_batch

### DIFF
--- a/whir/src/pcs/committer/writer.rs
+++ b/whir/src/pcs/committer/writer.rs
@@ -56,7 +56,7 @@ where
                 RowMajorMatrix::new(values, width)
             });
             info_span!("dft", height = padded.height(), width = padded.width())
-                .in_scope(|| dft.dft_algebra_batch(padded).to_row_major_matrix())
+                .in_scope(|| dft.dft_algebra_batch(padded))
         }
         VariableOrder::Suffix => {
             let padded = info_span!("pad").in_scope(|| {
@@ -68,7 +68,7 @@ where
                 RowMajorMatrix::new(values, width)
             });
             info_span!("dft", height = padded.height(), width = padded.width())
-                .in_scope(|| dft.dft_algebra_batch(padded).to_row_major_matrix())
+                .in_scope(|| dft.dft_algebra_batch(padded))
         }
     };
 

--- a/whir/src/pcs/zk/committer.rs
+++ b/whir/src/pcs/zk/committer.rs
@@ -17,7 +17,6 @@ use alloc::vec::Vec;
 
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_util::log2_strict_usize;
 
@@ -151,7 +150,6 @@ impl<F: TwoAdicField> FoldedRsCode<F> {
         coeffs.extend_from_slice(randomness);
         coeffs.resize(self.domain_size, EF::ZERO);
         dft.dft_algebra_batch(RowMajorMatrix::new_col(coeffs))
-            .to_row_major_matrix()
     }
 }
 
@@ -206,7 +204,7 @@ mod tests {
         let dft = MyDft::default();
         let height = inv_rate << (num_variables - folding);
         let padded = zk_padded_matrix(message.as_slice(), &randomness, folding, height);
-        let encoded = dft.dft_algebra_batch(padded).to_row_major_matrix();
+        let encoded = dft.dft_algebra_batch(padded);
 
         let gamma = Point::<EF>::rand(&mut rng, folding);
         let folded_message =

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -226,7 +226,7 @@ where
             let height = config.inv_rate(round) * (1 << (message.num_variables() - folding_next));
             let padded =
                 zk_padded_matrix(message.as_slice(), &fresh_randomness, folding_next, height);
-            let encoded = self.dft.dft_algebra_batch(padded).to_row_major_matrix();
+            let encoded = self.dft.dft_algebra_batch(padded);
             let (commitment, merkle) = self.extension_mmcs.commit_matrix(encoded);
             challenger.observe(commitment.clone());
 


### PR DESCRIPTION
dft_algebra_batch already returns an owned RowMajorMatrix, so the trailing to_row_major_matrix() was a full to_vec() clone of the folded extension-field codeword on the commit path. Remove it at the base/ZK committer and ZK prover sites (the dft_batch view conversions are left untouched, as those genuinely need it). The now-unused Matrix trait import in the ZK committer is dropped.