### PR TITLE
perf(sumcheck): reuse Poly::unpack for packed-to-scalar conversion

### DIFF
--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -287,16 +287,8 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
             assert_eq!(k, weights.num_variables());
 
             if k == 0 {
-                // Unpack the single packed element into SIMD_WIDTH scalar elements.
-                //
-                // Extract individual extension field elements from the packed representation.
-                let evals =
-                    EF::ExtensionPacking::to_ext_iter(evals.as_slice().iter().copied()).collect();
-                let weights =
-                    EF::ExtensionPacking::to_ext_iter(weights.as_slice().iter().copied()).collect();
-
-                // Replace self with the scalar variant, carrying the same order.
-                *self = Self::new_unpacked(self.order, Poly::new(evals), Poly::new(weights));
+                // Unpack each packed element into its WIDTH scalar lanes, keeping the same order.
+                *self = Self::new_unpacked(self.order, evals.unpack(), weights.unpack());
             }
         }
     }
@@ -468,9 +460,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// A copy of the evaluations in scalar extension field format.
     pub fn evals(&self) -> Poly<EF> {
         match &self.inner {
-            MaybePacked::Packed { evals, .. } => Poly::new(
-                EF::ExtensionPacking::to_ext_iter(evals.as_slice().iter().copied()).collect(),
-            ),
+            MaybePacked::Packed { evals, .. } => evals.unpack(),
             MaybePacked::Unpacked { evals, .. } => evals.clone(),
         }
     }
@@ -484,9 +474,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// A copy of the weights in scalar extension field format.
     pub fn weights(&self) -> Poly<EF> {
         match &self.inner {
-            MaybePacked::Packed { weights, .. } => Poly::new(
-                EF::ExtensionPacking::to_ext_iter(weights.as_slice().iter().copied()).collect(),
-            ),
+            MaybePacked::Packed { weights, .. } => weights.unpack(),
             MaybePacked::Unpacked { weights, .. } => weights.clone(),
         }
     }


### PR DESCRIPTION
## What

`ProductPolynomial::{transition, evals, weights}` rebuilt scalar vectors with `to_ext_iter(...).collect()`. That collect does **not** pre-size: `to_ext_iter` is a `flat_map`, whose `size_hint` lower bound is `0`, so the collected `Vec` reallocates as it grows even though the exact length (`len * WIDTH`) is known.

`Poly::unpack` already performs the identical lane expansion (it calls the same `to_ext_iter`) but writes into a buffer it sizes to `len * WIDTH` up front. Reusing it removes the reallocation churn and the duplicated unpacking logic.

```diff
-    MaybePacked::Packed { evals, .. } => Poly::new(
-        EF::ExtensionPacking::to_ext_iter(evals.as_slice().iter().copied()).collect(),
-    ),
+    MaybePacked::Packed { evals, .. } => evals.unpack::<F, EF>(),
```

## Scope / honesty

This is a **code-quality cleanup** (reuse an existing tested abstraction, pre-size the output), not a measurable speedup: these methods run on the *folded* (small) polynomial at the final sumcheck rounds, and `transition()` unpacks a single packed element. Risk-free and cleaner, so worth landing on its own merits.

## Tests

- `p3-sumcheck` suite (219 tests) passes; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
