### PR TITLE
feat: add sqrt method for `Field`

### DIFF
--- a/baby-bear/benches/bench_field.rs
+++ b/baby-bear/benches/bench_field.rs
@@ -1,3 +1,5 @@
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
 use p3_field::{Field, PrimeCharacteristicRing};
@@ -17,6 +19,16 @@ fn bench_field(c: &mut Criterion) {
     let name = "BabyBear";
     const REPS: usize = 1000;
     benchmark_inv::<F>(c, name);
+    // `BabyBear::try_sqrt` is an inherent method (the two-adic specialization), so
+    // it must be benchmarked through the concrete type rather than the generic
+    // `benchmark_sqrt` helper, which would resolve to the slower trait default.
+    {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let x = rng.random::<F>().square();
+        c.bench_function("BabyBear sqrt", |b| {
+            b.iter(|| black_box(black_box(x).try_sqrt()));
+        });
+    }
     benchmark_iter_sum::<F, 4, REPS>(c, name);
     benchmark_iter_sum::<F, 8, REPS>(c, name);
     benchmark_iter_sum::<F, 12, REPS>(c, name);

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -184,6 +184,28 @@ mod tests {
         test_field_json_serialization(&[f, f_1, f_2, f_p_minus_1, f_p_minus_2, m1, m2]);
     }
 
+    #[test]
+    fn test_baby_bear_inherent_sqrt() {
+        // Exercises the inherent (two-adic) `try_sqrt` which shadows
+        // `Field::try_sqrt` for the concrete `BabyBear` type.
+        let mut residues = 0;
+        let mut non_residues = 0;
+        for i in 0..2000u32 {
+            let x = F::from_u32(i);
+            // The square of any element is a quadratic residue.
+            let square = x.square();
+            assert_eq!(square.try_sqrt().map(|r| r.square()), Some(square));
+            match x.try_sqrt() {
+                Some(r) => {
+                    assert_eq!(r.square(), x);
+                    residues += 1;
+                }
+                None => non_residues += 1,
+            }
+        }
+        assert!(residues > 0 && non_residues > 0);
+    }
+
     // MontyField31's have no redundant representations.
     const ZEROS: [BabyBear; 1] = [BabyBear::ZERO];
     const ONES: [BabyBear; 1] = [BabyBear::ONE];

--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -137,6 +137,7 @@ mod tests {
         test_field_json_serialization, test_prime_field, test_prime_field_32, test_prime_field_64,
         test_two_adic_field,
     };
+    use proptest::prelude::*;
 
     use super::*;
 
@@ -184,26 +185,21 @@ mod tests {
         test_field_json_serialization(&[f, f_1, f_2, f_p_minus_1, f_p_minus_2, m1, m2]);
     }
 
-    #[test]
-    fn test_baby_bear_inherent_sqrt() {
-        // Exercises the inherent (two-adic) `try_sqrt` which shadows
-        // `Field::try_sqrt` for the concrete `BabyBear` type.
-        let mut residues = 0;
-        let mut non_residues = 0;
-        for i in 0..2000u32 {
-            let x = F::from_u32(i);
-            // The square of any element is a quadratic residue.
+    proptest! {
+        /// Exercises the inherent (two-adic) `try_sqrt` which shadows
+        /// `Field::try_sqrt` for the concrete `BabyBear` type.
+        #[test]
+        fn test_baby_bear_inherent_sqrt(x in prop::num::u32::ANY.prop_map(F::from_u32)) {
+            // The square of any element is a quadratic residue, so its root
+            // always exists and squares back to the original square.
             let square = x.square();
-            assert_eq!(square.try_sqrt().map(|r| r.square()), Some(square));
-            match x.try_sqrt() {
-                Some(r) => {
-                    assert_eq!(r.square(), x);
-                    residues += 1;
-                }
-                None => non_residues += 1,
+            prop_assert_eq!(square.try_sqrt().map(|r| r.square()), Some(square));
+
+            // Whenever a root is reported, it must square back to `x`.
+            if let Some(r) = x.try_sqrt() {
+                prop_assert_eq!(r.square(), x);
             }
         }
-        assert!(residues > 0 && non_residues > 0);
     }
 
     // MontyField31's have no redundant representations.

--- a/bn254/benches/bench_field.rs
+++ b/bn254/benches/bench_field.rs
@@ -1,8 +1,8 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use p3_bn254::Bn254;
 use p3_field_testing::bench_func::{
-    benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_sub_latency,
-    benchmark_sub_throughput,
+    benchmark_add_latency, benchmark_add_throughput, benchmark_inv, benchmark_sqrt,
+    benchmark_sub_latency, benchmark_sub_throughput,
 };
 use p3_field_testing::{benchmark_halve, benchmark_mul_latency, benchmark_mul_throughput};
 
@@ -13,6 +13,7 @@ fn bench_field(c: &mut Criterion) {
     const REPS: usize = 100;
     benchmark_halve::<F, REPS>(c, name);
     benchmark_inv::<F>(c, name);
+    benchmark_sqrt::<F>(c, name);
 
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.

--- a/field-testing/src/bench_func.rs
+++ b/field-testing/src/bench_func.rs
@@ -46,6 +46,19 @@ where
     });
 }
 
+pub fn benchmark_sqrt<F: Field>(c: &mut Criterion, name: &str)
+where
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    // Square a random element so the input is always a quadratic residue and the
+    // full square-root computation runs (rather than bailing out early).
+    let x = rng.random::<F>().square();
+    c.bench_function(&format!("{name} sqrt"), |b| {
+        b.iter(|| black_box(black_box(x).try_sqrt()));
+    });
+}
+
 pub fn benchmark_mul_2exp<R: PrimeCharacteristicRing + Copy, const REPS: usize>(
     c: &mut Criterion,
     name: &str,

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -349,6 +349,53 @@ where
     }
 }
 
+/// Test that [`Field::try_sqrt`] agrees with squaring.
+///
+/// Assumes the field has characteristic `!= 2`, so that roughly half of all
+/// elements are quadratic non-residues.
+pub fn test_sqrt<F: Field>()
+where
+    StandardUniform: Distribution<F>,
+{
+    // `0` is its own square root and `1` is always a square.
+    assert_eq!(F::ZERO.try_sqrt(), Some(F::ZERO));
+    assert_eq!(
+        F::ONE.try_sqrt().map(|r| r.square()),
+        Some(F::ONE),
+        "1 must be a square"
+    );
+
+    let mut rng = SmallRng::seed_from_u64(0x59A7);
+    let mut residues = 0;
+    let mut non_residues = 0;
+    for _ in 0..1000 {
+        let x = rng.random::<F>();
+
+        // The square of any element is a quadratic residue, and any returned
+        // root must square back to it.
+        let square = x.square();
+        let root = square.try_sqrt().expect("x^2 is always a square");
+        assert_eq!(root.square(), square, "sqrt(x^2)^2 == x^2");
+
+        // A random element is a residue iff `try_sqrt` succeeds; when it does,
+        // the result must be a genuine square root.
+        match x.try_sqrt() {
+            Some(r) => {
+                assert_eq!(r.square(), x, "try_sqrt(x)^2 == x");
+                residues += 1;
+            }
+            None => non_residues += 1,
+        }
+    }
+
+    // With 1000 samples both branches are hit with overwhelming probability.
+    assert!(residues > 0, "expected to sample a quadratic residue");
+    assert!(
+        non_residues > 0,
+        "expected to sample a quadratic non-residue"
+    );
+}
+
 /// Verify [`batch_multiplicative_inverse`] against the naive per-element inverse
 /// across a range of input lengths.
 ///
@@ -1054,6 +1101,10 @@ macro_rules! test_field {
             #[test]
             fn test_batch_multiplicative_inverse() {
                 $crate::test_batch_multiplicative_inverse::<$field>();
+            }
+            #[test]
+            fn test_sqrt() {
+                $crate::test_sqrt::<$field>();
             }
             #[test]
             fn test_generator() {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1013,6 +1013,20 @@ pub trait Field:
         self.try_inverse().expect("Tried to invert zero")
     }
 
+    /// A square root of this field element, if one exists.
+    ///
+    /// Returns `Some(r)` with `r * r == *self` when this element is a quadratic
+    /// residue, and `None` when it is a quadratic non-residue. `ZERO` returns
+    /// `Some(ZERO)`. When two square roots exist, which one is returned is
+    /// unspecified.
+    ///
+    /// The default implementation uses the Tonelli–Shanks algorithm. Fields with
+    /// a more direct formula (e.g. those with `|F| ≡ 3 mod 4`) may override it.
+    #[must_use]
+    fn try_sqrt(&self) -> Option<Self> {
+        crate::sqrt::tonelli_shanks(*self)
+    }
+
     /// Add two slices of field elements together, returning the result in the first slice.
     ///
     /// Makes use of packing to speed up the addition.

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -14,6 +14,7 @@ mod helpers;
 pub mod integers;
 pub mod op_assign_macros;
 mod packed;
+mod sqrt;
 
 pub use array::*;
 pub use batch_inverse::*;
@@ -21,3 +22,4 @@ pub use dup::Dup;
 pub use field::*;
 pub use helpers::*;
 pub use packed::*;
+pub use sqrt::{tonelli_shanks, tonelli_shanks_two_adic};

--- a/field/src/sqrt.rs
+++ b/field/src/sqrt.rs
@@ -1,0 +1,113 @@
+//! Square roots in finite fields via the Tonelli–Shanks algorithm.
+
+use num_bigint::BigUint;
+
+use crate::{Field, TwoAdicField};
+
+/// Compute `base^exponent` for an arbitrarily large exponent.
+///
+/// Uses the standard square-and-multiply approach over the bits of `exponent`.
+/// Unlike [`Field::exp_u64`] this accepts exponents which do not fit in a `u64`,
+/// as required by fields whose order exceeds `2^64`.
+fn exp_biguint<F: Field>(base: F, exponent: &BigUint) -> F {
+    let mut product = F::ONE;
+    let mut current = base;
+    for j in 0..exponent.bits() {
+        if exponent.bit(j) {
+            product *= current;
+        }
+        current = current.square();
+    }
+    product
+}
+
+/// The core of the Tonelli–Shanks algorithm.
+///
+/// Given a nonzero `a`, the decomposition `|F| - 1 = q * 2^s` with `q` odd, and a
+/// primitive `2^s`-th root of unity `c` (the `2`-Sylow generator), return a square
+/// root of `a` if one exists.
+///
+/// `c` must be a quadratic non-residue raised to the `q`-th power; both
+/// [`tonelli_shanks`] and [`tonelli_shanks_two_adic`] provide such a value.
+fn tonelli_shanks_inner<F: Field>(a: F, s: usize, q: &BigUint, mut c: F) -> Option<F> {
+    // A single exponentiation yields both candidates: with `u = a^((q-1)/2)`,
+    // `r = u * a = a^((q+1)/2)` is the prospective root and `t = r * u = a^q`
+    // tracks the residue's `2`-power component.
+    let u = exp_biguint(a, &((q - 1u32) >> 1));
+    let mut r = u * a;
+    let mut t = r * u;
+    let mut m = s;
+
+    while !t.is_one() {
+        // Find the least `i`, with `0 < i < m`, such that `t^(2^i) == 1`.
+        let mut i = 0;
+        let mut t2i = t;
+        while !t2i.is_one() {
+            t2i = t2i.square();
+            i += 1;
+            if i == m {
+                // `t` has order `2^m`, which only happens when `a` is a
+                // quadratic non-residue, so no square root exists.
+                return None;
+            }
+        }
+
+        let b = c.exp_power_of_2(m - i - 1);
+        m = i;
+        c = b.square();
+        t *= c;
+        r *= b;
+    }
+
+    Some(r)
+}
+
+/// Return a square root of `a` if one exists, otherwise `None`.
+///
+/// This is the generic Tonelli–Shanks algorithm. Writing the multiplicative
+/// group order as `|F| - 1 = q * 2^s` with `q` odd, it uses [`Field::GENERATOR`]
+/// (a generator of `F^*`, hence a quadratic non-residue) to seed the `2`-Sylow
+/// subgroup via `c = GENERATOR^q`.
+///
+/// For a quadratic residue this returns one of its two square roots; which one
+/// is unspecified. `ZERO` maps to `ZERO`.
+pub fn tonelli_shanks<F: Field>(a: F) -> Option<F> {
+    // Zero is its own square root and would otherwise break the logic below.
+    if a.is_zero() {
+        return Some(F::ZERO);
+    }
+
+    // Write `|F| - 1 = q * 2^s` with `q` odd.
+    let order_minus_one = F::order() - BigUint::from(1u8);
+    // `|F| >= 2`, so `order_minus_one >= 1` and `trailing_zeros` is never `None`.
+    let s = order_minus_one
+        .trailing_zeros()
+        .expect("field order must be at least two") as usize;
+    let q = &order_minus_one >> s;
+
+    let c = exp_biguint(F::GENERATOR, &q);
+    tonelli_shanks_inner(a, s, &q, c)
+}
+
+/// Return a square root of `a` if one exists, otherwise `None`.
+///
+/// A variant of [`tonelli_shanks`] for two-adic fields. It seeds the `2`-Sylow
+/// subgroup directly from [`TwoAdicField::two_adic_generator`] (a primitive
+/// `2^TWO_ADICITY`-th root of unity), avoiding the `GENERATOR^q` exponentiation
+/// that the generic version performs on every call.
+///
+/// For a quadratic residue this returns one of its two square roots; which one
+/// is unspecified. `ZERO` maps to `ZERO`.
+pub fn tonelli_shanks_two_adic<F: TwoAdicField>(a: F) -> Option<F> {
+    // Zero is its own square root and would otherwise break the logic below.
+    if a.is_zero() {
+        return Some(F::ZERO);
+    }
+
+    // For a two-adic field, `s` is exactly `TWO_ADICITY` and the `2`-Sylow
+    // generator is available as a constant.
+    let s = F::TWO_ADICITY;
+    let q = (F::order() - BigUint::from(1u8)) >> s;
+    let c = F::two_adic_generator(s);
+    tonelli_shanks_inner(a, s, &q, c)
+}

--- a/field/src/sqrt.rs
+++ b/field/src/sqrt.rs
@@ -7,8 +7,8 @@ use crate::{Field, TwoAdicField};
 /// Compute `base^exponent` for an arbitrarily large exponent.
 ///
 /// Uses the standard square-and-multiply approach over the bits of `exponent`.
-/// Unlike [`Field::exp_u64`] this accepts exponents which do not fit in a `u64`,
-/// as required by fields whose order exceeds `2^64`.
+/// This accepts exponents which do not fit in a `u64`, as required by fields
+/// whose order exceeds `2^64`.
 fn exp_biguint<F: Field>(base: F, exponent: &BigUint) -> F {
     let mut product = F::ONE;
     let mut current = base;

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -6,7 +6,8 @@ use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_chunked_linear_combination,
     benchmark_div_2exp, benchmark_double_latency, benchmark_double_throughput, benchmark_halve,
     benchmark_inv, benchmark_iter_sum, benchmark_mul_2exp, benchmark_neg_latency,
-    benchmark_neg_throughput, benchmark_square, benchmark_sub_latency, benchmark_sub_throughput,
+    benchmark_neg_throughput, benchmark_sqrt, benchmark_square, benchmark_sub_latency,
+    benchmark_sub_throughput,
 };
 use p3_field_testing::{
     benchmark_dot_array, benchmark_mixed_dot_array, benchmark_mul_latency,
@@ -25,6 +26,7 @@ fn bench_field(c: &mut Criterion) {
     benchmark_mul_throughput::<F, 25>(c, name);
     benchmark_square::<F>(c, name);
     benchmark_inv::<F>(c, name);
+    benchmark_sqrt::<F>(c, name);
     benchmark_iter_sum::<F, 4, REPS>(c, name);
 
     benchmark_sum_array::<F, 4, REPS>(c, name);

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -17,6 +17,7 @@ use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField64, RawDataSerializable, TwoAdicField, impl_raw_serializable_primefield64,
     quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int,
+    tonelli_shanks_two_adic,
 };
 use p3_util::{assume, branch_hint, flatten_to_base, gcd_inner};
 use rand::Rng;
@@ -434,6 +435,11 @@ impl Field for Goldilocks {
     #[inline]
     fn order() -> BigUint {
         P.into()
+    }
+
+    #[inline]
+    fn try_sqrt(&self) -> Option<Self> {
+        tonelli_shanks_two_adic(*self)
     }
 }
 

--- a/koala-bear/benches/bench_field.rs
+++ b/koala-bear/benches/bench_field.rs
@@ -1,3 +1,5 @@
+use std::hint::black_box;
+
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
@@ -18,6 +20,16 @@ fn bench_field(c: &mut Criterion) {
     let name = "KoalaBear";
     const REPS: usize = 500;
     benchmark_inv::<F>(c, name);
+    // `KoalaBear::try_sqrt` is an inherent method (the two-adic specialization), so
+    // it must be benchmarked through the concrete type rather than the generic
+    // `benchmark_sqrt` helper, which would resolve to the slower trait default.
+    {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let x = rng.random::<F>().square();
+        c.bench_function("KoalaBear sqrt", |b| {
+            b.iter(|| black_box(black_box(x).try_sqrt()));
+        });
+    }
     benchmark_mul_2exp::<F, 100>(c, name, 16);
     benchmark_mul_2exp::<F, 100>(c, name, 64);
     benchmark_mul_2exp::<F, 100>(c, name, (1 << 63) - 1);

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -189,6 +189,28 @@ mod tests {
         test_field_json_serialization(&[f, f_1, f_2, f_p_minus_1, f_p_minus_2, m1, m2]);
     }
 
+    #[test]
+    fn test_koala_bear_inherent_sqrt() {
+        // Exercises the inherent (two-adic) `try_sqrt` which shadows
+        // `Field::try_sqrt` for the concrete `KoalaBear` type.
+        let mut residues = 0;
+        let mut non_residues = 0;
+        for i in 0..2000u32 {
+            let x = F::from_u32(i);
+            // The square of any element is a quadratic residue.
+            let square = x.square();
+            assert_eq!(square.try_sqrt().map(|r| r.square()), Some(square));
+            match x.try_sqrt() {
+                Some(r) => {
+                    assert_eq!(r.square(), x);
+                    residues += 1;
+                }
+                None => non_residues += 1,
+            }
+        }
+        assert!(residues > 0 && non_residues > 0);
+    }
+
     // MontyField31's have no redundant representations.
     const ZEROS: [KoalaBear; 1] = [KoalaBear::ZERO];
     const ONES: [KoalaBear; 1] = [KoalaBear::ONE];

--- a/mersenne-31/benches/bench_field.rs
+++ b/mersenne-31/benches/bench_field.rs
@@ -4,7 +4,7 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_chunked_linear_combination,
-    benchmark_dot_array, benchmark_inv, benchmark_iter_sum, benchmark_sub_latency,
+    benchmark_dot_array, benchmark_inv, benchmark_iter_sum, benchmark_sqrt, benchmark_sub_latency,
     benchmark_sub_throughput, benchmark_sum_array,
 };
 use p3_mersenne_31::Mersenne31;
@@ -17,6 +17,7 @@ fn bench_field(c: &mut Criterion) {
     let name = "Mersenne31";
     const REPS: usize = 500;
     benchmark_inv::<F>(c, name);
+    benchmark_sqrt::<F>(c, name);
     benchmark_iter_sum::<F, 4, REPS>(c, name);
     benchmark_sum_array::<F, 4, REPS>(c, name);
     benchmark_iter_sum::<F, 6, REPS>(c, name);

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -388,6 +388,14 @@ impl Field for Mersenne31 {
         P.into()
     }
 
+    #[inline]
+    fn try_sqrt(&self) -> Option<Self> {
+        // Mersenne31 has `p = 2^31 - 1 ≡ 3 (mod 4)`, so `a^((p+1)/4)` is a square
+        // root of `a` whenever one exists. Here `(p + 1)/4 = 2^29`.
+        let candidate = self.exp_power_of_2(29);
+        (candidate.square() == *self).then_some(candidate)
+    }
+
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     #[inline]
     fn batched_columnwise_dot_product<EF, R, I, const N: usize>(

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -17,7 +17,7 @@ use p3_field::op_assign_macros::{
 use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField32, PrimeField64, RawDataSerializable, TwoAdicField,
-    impl_raw_serializable_primefield32, quotient_map_small_int,
+    impl_raw_serializable_primefield32, quotient_map_small_int, tonelli_shanks_two_adic,
 };
 use p3_util::{flatten_to_base, gcd_inversion_prime_field_32};
 use rand::Rng;
@@ -466,6 +466,24 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
     #[inline]
     fn order() -> BigUint {
         FP::PRIME.into()
+    }
+}
+
+impl<FP: FieldParameters + TwoAdicData> MontyField31<FP> {
+    /// A square root of this field element, if one exists.
+    ///
+    /// This specializes the generic [`Field::try_sqrt`] for two-adic Monty-31
+    /// fields: it seeds Tonelli–Shanks from the precomputed
+    /// [`TwoAdicField::two_adic_generator`] instead of recomputing `GENERATOR^q`.
+    /// As an inherent method it shadows the trait method for concrete field types
+    /// such as `BabyBear` and `KoalaBear`; generic `Field` callers still use the
+    /// trait default.
+    ///
+    /// See [`Field::try_sqrt`] for the returned-root semantics.
+    #[inline]
+    #[must_use]
+    pub fn try_sqrt(&self) -> Option<Self> {
+        tonelli_shanks_two_adic(*self)
     }
 }
 


### PR DESCRIPTION
  ### Summary

  Adds a `Field::try_sqrt` method that returns a square root of a field element when one exists (`None` for quadratic non-residues, `Some(ZERO)` for zero; one of the two roots is returned, unspecified which). The default is
  a generic Tonelli–Shanks implementation that works for every field — prime fields and extension fields alike — and individual fields override it with faster routines where their structure allows.

closes #719 

  ### Algorithm overview

  **Generic default — Tonelli–Shanks** (`field/src/sqrt.rs`)

  Writing the multiplicative group order as `|F| − 1 = q · 2^s` with `q` odd:

  - A single exponentiation `u = a^((q−1)/2)` yields both candidates: `r = u·a = a^((q+1)/2)` (the prospective root) and `t = r·u = a^q` (the 2-power-torsion component).
  - The 2-Sylow subgroup is seeded with `c = GENERATOR^q` (`GENERATOR` generates `F*`, so it is a quadratic non-residue).
  - The standard fix-up loop walks the 2-power torsion; a non-residue is detected when `t` has full order `2^s`, returning `None`.

  This applies unchanged to all fields (BabyBear, KoalaBear, Goldilocks, BN254, and all extension fields).

  ### Per-field overrides

  | Field | Override | Algorithm |
  |---|---|---|
  | **Mersenne31** | `try_sqrt` (trait) | `p = 2³¹−1 ≡ 3 (mod 4)`, so `a^((p+1)/4) = a^(2²⁹)` is a root whenever one exists. Computed as `a.exp_power_of_2(29)`, then verified with `r² == a` to reject non-residues. |
  | **Goldilocks** | `try_sqrt` (trait) | Two-adic-seeded Tonelli–Shanks: seeds the 2-Sylow subgroup from the precomputed `two_adic_generator(TWO_ADICITY)` instead of recomputing `GENERATOR^q`, saving one full `log₂ p`-bit exponentiation. |
  | **BabyBear / KoalaBear** | `try_sqrt` (inherent) | Same two-adic-seeded Tonelli–Shanks (`tonelli_shanks_two_adic`). Implemented as an **inherent** method on `MontyField31<FP: FieldParameters + TwoAdicData>` |

  ### Note on the BabyBear/KoalaBear override

  `MontyField31`'s `Field` impl is `impl<FP: FieldParameters>`, but the two-adic generator constant lives behind the extra `TwoAdicData` bound. Adding that bound to the `Field` impl cascades into 29 compile errors (it would
  force `TwoAdicData` across the whole monty public API — `PrimeField`, `inverse`, packing, …), so it isn't viable.

  Instead, the override is an **inherent** `try_sqrt` on the `TwoAdicData`-bounded inherent impl. It shadows the trait method for concrete `BabyBear`/`KoalaBear` values (the common case); generic `F: Field` callers fall back
  to the trait default. Both paths return identical results — only speed differs. Dedicated `test_*_inherent_sqrt` tests cover the inherent path, since the generic `test_sqrt` harness exercises the trait path.

  ### Performance

  `cargo bench --bench bench_field -- sqrt` (random quadratic residue):

  | Field | sqrt runtime |
  |---|---|
  | Mersenne31 | 27 ns |
  | KoalaBear | 300 ns |
  | BabyBear | 360 ns |
  | Goldilocks | 640 ns |

  For reference, the generic Tonelli–Shanks default (before per-field overrides) measured ~210 ns for Mersenne31 and ~715 ns for Goldilocks — the overrides give ~8× and ~10% respectively, and the two-adic seed saves ~25% on
  BabyBear / ~16% on KoalaBear vs. the generic `GENERATOR^q` seed.

  ### API additions

  - `Field::try_sqrt(&self) -> Option<Self>` — default method, overridable.
  - `p3_field::tonelli_shanks` and `p3_field::tonelli_shanks_two_adic` — public free functions.
  - `MontyField31::try_sqrt` — inherent method for two-adic monty fields.

  ### Testing

  - New generic `test_sqrt` wired into the shared `test_field!` macro, so every field (and extension field) is covered: checks `sqrt(x²)² == x²`, validates returned roots, and confirms both residues and non-residues are
  sampled.
  - Concrete `test_baby_bear_inherent_sqrt` / `test_koala_bear_inherent_sqrt` pin the inherent two-adic path.
  - `benchmark_sqrt` added to `bench_func` and wired into all five `bench_field` benches.

  ### Test plan

  - [x] `cargo test` across `p3-field`, `p3-baby-bear`, `p3-koala-bear`, `p3-goldilocks`, `p3-mersenne-31`, `p3-bn254`
  - [x] `cargo clippy` clean on all touched crates
  - [x] `cargo fmt --all --check`