### PR TITLE
fix(circle): reject opening point equal to a query point instead of panicking

### DIFF
--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -82,17 +82,23 @@ pub(crate) fn deep_quotient_vanishing_part<F: ComplexExtendable, EF: ExtensionFi
 ///
 /// # Returns
 ///
-/// The DEEP quotient value for this row.
+/// The DEEP quotient value for this row, or `None` if `x` coincides with `zeta`, where the
+/// denominator would be zero.
 pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<F>>(
     alpha: EF,
     x: Point<F>,
     zeta: Point<EF>,
     ps_at_x: &[F],
     ps_at_zeta: &[EF],
-) -> EF {
+) -> Option<EF> {
     // Compute the vanishing part: handles the (x - zeta) denominator
     let (vp_num, vp_denom) =
         deep_quotient_vanishing_part(x, zeta, alpha.exp_u64(ps_at_x.len() as u64));
+
+    // The denominator |v_p(zeta)|^2 is zero exactly when the query point `x` coincides with the
+    // opening point `zeta`, which would invert zero. Reject instead of panicking, mirroring the
+    // two-adic FRI guard (`OpeningPointMatchesQueryPoint` in `fri/src/verifier.rs`).
+    let vp_denom_inv = vp_denom.try_inverse()?;
 
     // Compute the constraint part: handles the f(x) - f(zeta) numerator
     let constraint_part = dot_product::<EF, _, _>(
@@ -101,7 +107,7 @@ pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<
     );
 
     // Combine vanishing part and constraint part
-    (vp_num / vp_denom) * constraint_part
+    Some(vp_num * vp_denom_inv * constraint_part)
 }
 
 /// The point-dependent part of the DEEP quotient on a fixed domain.
@@ -345,6 +351,7 @@ mod tests {
             .zip(domain.points())
             .map(|(ps_at_x, x)| {
                 deep_quotient_reduce_row(alpha, x, zeta, &ps_at_x.collect_vec(), &ps_at_zeta)
+                    .unwrap()
             })
             .collect_vec();
         assert_eq!(cfft_permute_slice(&mat_reduced), row_reduced);
@@ -471,5 +478,21 @@ mod tests {
                 &coeffs.values[(1 << log_n) + 1..]
             );
         }
+    }
+
+    #[test]
+    fn reduce_row_rejects_opening_point_on_query_point() {
+        let x: Point<F> = Point::from_projective_line(F::from_u8(5));
+        let alpha: EF = EF::from(F::from_u8(7));
+        let ps_at_x = [F::from_u8(1), F::from_u8(2)];
+        let ps_at_zeta = [EF::from(F::from_u8(3)), EF::from(F::from_u8(4))];
+
+        // An opening point equal to the query point makes the denominator |v_p(zeta)|^2 vanish.
+        let zeta_on_x: Point<EF> = Point::new(EF::from(x.x), EF::from(x.y));
+        assert!(deep_quotient_reduce_row(alpha, x, zeta_on_x, &ps_at_x, &ps_at_zeta).is_none());
+
+        // A distinct opening point still reduces normally.
+        let zeta_off: Point<EF> = Point::from_projective_line(EF::from(F::from_u8(9)));
+        assert!(deep_quotient_reduce_row(alpha, x, zeta_off, &ps_at_x, &ps_at_zeta).is_some());
     }
 }

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -82,8 +82,8 @@ pub(crate) fn deep_quotient_vanishing_part<F: ComplexExtendable, EF: ExtensionFi
 ///
 /// # Returns
 ///
-/// The DEEP quotient value for this row, or `None` if `x` coincides with `zeta`, where the
-/// denominator would be zero.
+/// - `Some(value)`: the DEEP quotient value for this row.
+/// - `None`: the opening point coincides with this query point, so the denominator vanishes.
 pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<F>>(
     alpha: EF,
     x: Point<F>,
@@ -95,9 +95,9 @@ pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<
     let (vp_num, vp_denom) =
         deep_quotient_vanishing_part(x, zeta, alpha.exp_u64(ps_at_x.len() as u64));
 
-    // The denominator |v_p(zeta)|^2 is zero exactly when the query point `x` coincides with the
-    // opening point `zeta`, which would invert zero. Reject instead of panicking, mirroring the
-    // two-adic FRI guard (`OpeningPointMatchesQueryPoint` in `fri/src/verifier.rs`).
+    // On the circle, the denominator `|v_p(zeta)|^2` reduces to `2 * (1 - (x - zeta).x)`.
+    // This is zero exactly when `x == zeta`.
+    // Return `None` there so the caller rejects the opening instead of dividing by zero.
     let vp_denom_inv = vp_denom.try_inverse()?;
 
     // Compute the constraint part: handles the f(x) - f(zeta) numerator
@@ -482,17 +482,28 @@ mod tests {
 
     #[test]
     fn reduce_row_rejects_opening_point_on_query_point() {
-        let x: Point<F> = Point::from_projective_line(F::from_u8(5));
-        let alpha: EF = EF::from(F::from_u8(7));
-        let ps_at_x = [F::from_u8(1), F::from_u8(2)];
-        let ps_at_zeta = [EF::from(F::from_u8(3)), EF::from(F::from_u8(4))];
+        // Invariant: the DEEP-quotient denominator is `2 * (1 - (x - zeta).x)`.
+        // It vanishes exactly when the opening point `zeta` equals the query point `x`.
+        //
+        //     x == zeta  ->  denominator 0     ->  None
+        //     x != zeta  ->  denominator != 0  ->  Some(quotient)
 
-        // An opening point equal to the query point makes the denominator |v_p(zeta)|^2 vanish.
+        // A query point on the circle domain, in the base field.
+        let x: Point<F> = Point::from_projective_line(F::from_u8(5));
+
+        // Challenge scalar and dummy column evaluations.
+        // Their values never affect whether the denominator vanishes.
+        let alpha = EF::from_u8(7);
+        let ps_at_x = [F::from_u8(1), F::from_u8(2)];
+        let ps_at_zeta = [EF::from_u8(3), EF::from_u8(4)];
+
+        // Lift the query point's coordinates into the extension field.
+        // The opening point is now the same point, so `x - zeta` is the group identity.
         let zeta_on_x: Point<EF> = Point::new(EF::from(x.x), EF::from(x.y));
         assert!(deep_quotient_reduce_row(alpha, x, zeta_on_x, &ps_at_x, &ps_at_zeta).is_none());
 
-        // A distinct opening point still reduces normally.
-        let zeta_off: Point<EF> = Point::from_projective_line(EF::from(F::from_u8(9)));
+        // A distinct opening point keeps the denominator nonzero and reduces normally.
+        let zeta_off: Point<EF> = Point::from_projective_line(EF::from_u8(9));
         assert!(deep_quotient_reduce_row(alpha, x, zeta_off, &ps_at_x, &ps_at_zeta).is_some());
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -78,6 +78,8 @@ where
     FirstLayerMmcsError(FriMmcsError),
     #[error("input shape error: mismatched dimensions")]
     InputShapeError,
+    #[error("opening point coincides with a query point")]
+    OpeningPointMatchesQueryPoint,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -673,7 +675,8 @@ where
                             let zeta = Point::from_projective_line(*zeta_uni);
 
                             *ro += *alpha_offset
-                                * deep_quotient_reduce_row(alpha, x, zeta, ps_at_x, ps_at_zeta);
+                                * deep_quotient_reduce_row(alpha, x, zeta, ps_at_x, ps_at_zeta)
+                                    .ok_or(InputError::OpeningPointMatchesQueryPoint)?;
 
                             *alpha_offset *= alpha_pow_width_2;
                         }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -78,6 +78,9 @@ where
     FirstLayerMmcsError(FriMmcsError),
     #[error("input shape error: mismatched dimensions")]
     InputShapeError,
+    /// The opening point coincides with a queried domain point.
+    ///
+    /// The DEEP-quotient denominator vanishes there, so the row cannot be reduced.
     #[error("opening point coincides with a query point")]
     OpeningPointMatchesQueryPoint,
 }
@@ -674,6 +677,8 @@ where
                             }
                             let zeta = Point::from_projective_line(*zeta_uni);
 
+                            // A vanishing denominator means this opening point lands on the
+                            // query point; reject the proof rather than dividing by zero.
                             *ro += *alpha_offset
                                 * deep_quotient_reduce_row(alpha, x, zeta, ps_at_x, ps_at_zeta)
                                     .ok_or(InputError::OpeningPointMatchesQueryPoint)?;


### PR DESCRIPTION
The circle DEEP-quotient verifier inverts the denominator `|v_p(zeta)|^2` for each (query point `x`, opening point `zeta`) pair. That denominator equals `2 * (1 - (x - zeta).x)`, which is zero exactly when `x == zeta`. In that case `deep_quotient_reduce_row` inverted zero and panicked with "Tried to invert zero" instead of returning an error.

This is the same case two-adic FRI already rejects in #1762 (`OpeningPointMatchesQueryPoint`). This change adds the matching guard to the circle path: `deep_quotient_reduce_row` returns `None` when the denominator vanishes, and the verifier maps that to a new `InputError::OpeningPointMatchesQueryPoint`.

Scope and compatibility:

- Verifier side only, matching #1762, which left the prover unchanged.
- For any `zeta` distinct from `x` the result is unchanged: `vp_num / vp_denom` becomes `vp_num * vp_denom.try_inverse().unwrap()`, the same value. The existing `reduce_row_same_as_reduce_matrix` and the circle prove/verify integration tests confirm valid proofs verify identically.
- Added a unit test asserting `None` on the collision and `Some` otherwise. The circle verify path is an inline closure rather than a standalone function like two-adic `open_input`, so the guard is tested at the reduce function.
