### PR TITLE
fix(whir): reject non-redundant code rates in WhirConfig::new

### DIFF
--- a/whir/src/parameters/soundness.rs
+++ b/whir/src/parameters/soundness.rs
@@ -205,6 +205,15 @@ impl SecurityAssumption {
     /// Compute the number of queries to match the security level
     /// The error to drive down is (1-delta)^t < 2^-lambda.
     /// Where delta is set as in the `log_1_delta` function.
+    ///
+    /// Requires a redundant code rate, at most `1/2`:
+    /// - A redundant rate keeps the proximity parameter `delta > 0`.
+    /// - With `delta > 0` the term `log2(1 - delta)` is negative.
+    /// - Dividing `-lambda` by a negative number gives a positive, finite count.
+    /// - A rate of `1` forces `delta <= 0` and rounds the count down to zero.
+    /// - Zero queries would make the proximity test check nothing.
+    ///
+    /// Configuration construction rejects rate `1`, so the precondition holds.
     #[must_use]
     pub(crate) fn queries(&self, protocol_security_level: usize, log_inv_rate: usize) -> usize {
         let num_queries_f = -(protocol_security_level as f64) / self.log_1_delta(log_inv_rate);

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -58,6 +58,31 @@ pub enum WhirConfigError {
     #[error("round {round}: requested codeword rate would require growing the RS domain")]
     RateGrowsDomain { round: usize },
 
+    /// The starting code rate is not redundant.
+    ///
+    /// - A rate of `2^-0 = 1` adds no Reed-Solomon redundancy.
+    /// - A proximity test needs redundancy, so there is nothing to check.
+    /// - At rate `1` the proximity parameter `delta` is `<= 0`.
+    /// - The query count `ceil(-lambda / log2(1 - delta))` is then non-positive.
+    /// - A non-positive count rounds down to zero queries.
+    /// - With zero queries the verifier accepts any committed function.
+    ///
+    /// Every code rate must be redundant: rate `<= 1/2`.
+    #[error(
+        "starting_log_inv_rate must be >= 1 (rate <= 1/2); got 2^-{log_inv_rate}, a non-redundant code whose proximity test makes zero queries"
+    )]
+    NonRedundantStartingRate { log_inv_rate: usize },
+
+    /// A per-round code rate is not redundant.
+    ///
+    /// - The codeword committed after one intermediate round has rate `1`.
+    /// - A rate of `1` drives that round's query count to zero.
+    /// - The failure matches a non-redundant starting rate.
+    #[error(
+        "round {round}: log_inv_rate must be >= 1 (rate <= 1/2); got 2^-{log_inv_rate}, a non-redundant code whose proximity test makes zero queries"
+    )]
+    NonRedundantRoundRate { round: usize, log_inv_rate: usize },
+
     /// No out-of-domain sample count reaches the requested security level.
     ///
     /// - The field is too small for the requested security level.
@@ -182,6 +207,18 @@ where
         // tracks the remaining variables as we consume them round by round.
         let initial_num_variables = num_variables;
 
+        // Invariant: the Reed-Solomon code must be redundant, rate <= 1/2.
+        //
+        //     rate 1             -> proximity parameter delta <= 0
+        //     delta <= 0         -> query count ceil(-lambda / log2(1 - delta)) <= 0
+        //     non-positive count -> rounds down to zero STIR queries
+        //     zero queries       -> verifier accepts any committed function
+        if whir_parameters.starting_log_inv_rate == 0 {
+            return Err(WhirConfigError::NonRedundantStartingRate {
+                log_inv_rate: whir_parameters.starting_log_inv_rate,
+            });
+        }
+
         // Derive the concrete folding schedule once. Validation is a property
         // of this derivation, so all later code uses the same source of truth.
         let folding_schedule = whir_parameters
@@ -259,6 +296,18 @@ where
             }
             whir_parameters.round_log_inv_rates.clone()
         };
+
+        // Same redundancy invariant, applied to each intermediate-round rate.
+        //
+        //     derived rates  : inherit the starting rate and only grow -> always >= 1
+        //     explicit rates : caller-supplied, so a 0 entry must be rejected here
+        if let Some(round) = round_log_inv_rates.iter().position(|&rate| rate == 0) {
+            return Err(WhirConfigError::NonRedundantRoundRate {
+                round,
+                log_inv_rate: round_log_inv_rates[round],
+            });
+        }
+
         if let FoldingFactor::PerRound(factors) = &whir_parameters.folding_factor
             && factors.len() != num_rounds + 1
         {
@@ -597,11 +646,13 @@ mod tests {
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
     use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
 
     use super::*;
     use crate::parameters::{FoldingFactor, SecurityAssumption};
 
     type F = BabyBear;
+    type EF4 = BinomialExtensionField<F, 4>;
     type Perm = Poseidon2BabyBear<16>;
     type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 
@@ -737,6 +788,94 @@ mod tests {
                 assert_eq!(threshold, 6);
             }
             other => panic!("expected InsufficientFolding, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_rejects_zero_starting_rate() {
+        // Invariant: a code rate of 2^-0 = 1 has no Reed-Solomon redundancy.
+        //
+        //     rate 1 -> delta <= 0 -> zero queries -> proximity test checks nothing
+        //
+        // Mutation: drop the starting rate to 0.
+        let mut params = default_whir_params();
+        params.starting_log_inv_rate = 0;
+
+        // Construction must reject a zero starting rate before deriving rounds.
+        let err = WhirConfig::<F, F, MyChallenger>::new(10, params)
+            .expect_err("rate 2^-0 = 1 must be rejected");
+        assert!(
+            matches!(
+                err,
+                WhirConfigError::NonRedundantStartingRate { log_inv_rate: 0 }
+            ),
+            "expected NonRedundantStartingRate, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn new_rejects_zero_explicit_round_rate() {
+        // Invariant: an explicit per-round rate of 2^-0 = 1 is rejected.
+        //
+        //     16 variables, fold 4 per round -> 2 intermediate rounds
+        //     per-round rates [3, 0]         -> round 1 gets rate 1
+        //
+        // Mutation: set the second round's rate to 0.
+        let mut params = default_whir_params();
+        params.folding_factor = FoldingFactor::Constant(4);
+        params.round_log_inv_rates = vec![3, 0];
+
+        // Rejection names the offending round and its rate.
+        let err = WhirConfig::<F, F, MyChallenger>::new(16, params)
+            .expect_err("explicit round rate 2^-0 = 1 must be rejected");
+        assert!(
+            matches!(
+                err,
+                WhirConfigError::NonRedundantRoundRate {
+                    round: 1,
+                    log_inv_rate: 0
+                }
+            ),
+            "expected NonRedundantRoundRate at round 1, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn valid_rates_yield_positive_query_counts() {
+        // Invariant: a redundant rate keeps delta > 0, so every phase queries.
+        //
+        //     rate <= 1/2 -> delta > 0 -> positive query count per phase
+        //
+        // A quartic extension keeps out-of-domain sampling feasible.
+        // So all three soundness regimes reach the query derivation.
+        for soundness_type in [
+            SecurityAssumption::UniqueDecoding,
+            SecurityAssumption::JohnsonBound,
+            SecurityAssumption::CapacityBound,
+        ] {
+            // Valid, redundant config at rate 2^-1 = 1/2.
+            let params = ProtocolParameters {
+                security_level: 100,
+                pow_bits: 20,
+                round_log_inv_rates: vec![],
+                folding_factor: FoldingFactor::Constant(4),
+                soundness_type,
+                starting_log_inv_rate: 1,
+            };
+            let config = WhirConfig::<EF4, F, MyChallenger>::new(10, params).unwrap();
+
+            // Final proximity phase must spot-check at least one position.
+            assert!(
+                config.final_queries > 0,
+                "{soundness_type:?}: final_queries must be positive"
+            );
+            // Every intermediate round must spot-check at least one position.
+            for (round, cfg) in config.round_parameters.iter().enumerate() {
+                assert!(
+                    cfg.num_queries > 0,
+                    "{soundness_type:?} round {round}: num_queries must be positive"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

A WHIR code rate of `2^-0 = 1` leaves the Reed-Solomon code with no redundancy. In that case the proximity parameter `delta` collapses to `<= 0`, so the derived STIR query count `ceil(-lambda / log2(1 - delta))` is non-positive and the `as usize` cast turns it into **0**. The verifier then makes zero proximity queries and accepts any committed function, while `WhirConfig::new` still returns `Ok` and reports the full target security.

This was found during a soundness review of the WHIR implementation. It requires a misconfiguration (rate `1`, e.g. a typo of `0` for `1` in `starting_log_inv_rate`), but the failure is silent and catastrophic — a config with no proximity test at all that still claims `security_level` bits.

## Fix

Reject `log_inv_rate == 0` at construction, the natural boundary for validating a domain parameter:

- `starting_log_inv_rate == 0` → `NonRedundantStartingRate`.
- any explicit `round_log_inv_rates` entry `== 0` → `NonRedundantRoundRate` (derived per-round rates inherit from the starting rate and only grow, so only caller-supplied rates can trip this).

For every soundness regime, `delta > 0` is equivalent to rate `<= 1/2` (`log_inv_rate >= 1`):
- UD: `delta = (1 - rho)/2 > 0  <=>  rho < 1`
- JB: `delta = 1 - sqrt(rho) - sqrt(rho)/20 > 0  <=>  rho < (20/21)^2 ~ 0.907`
- CB: `delta = 1 - rho - rho/2 > 0  <=>  rho < 2/3`

All hold at `log_inv_rate = 1` and fail at `log_inv_rate = 0`, so the rate check is exactly the right precondition. `ZkWhirConfig::new` delegates to `WhirConfig::new`, so the hiding variant is covered too.

## Tests

- `new_rejects_zero_starting_rate`
- `new_rejects_zero_explicit_round_rate`
- `valid_rates_yield_positive_query_counts` — confirms the guard does not over-reject: a redundant rate yields a positive query count for every phase across UD/JB/CB.

`cargo fmt --check`, `cargo clippy --lib --all-features`, and `cargo test --lib` (124 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)