### PR TITLE
fix(circle): reject input matrices opened at zero points

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -83,6 +83,31 @@ where
     /// The DEEP-quotient denominator vanishes there, so the row cannot be reduced.
     #[error("opening point coincides with a query point")]
     OpeningPointMatchesQueryPoint,
+    #[error(
+        "batch {batch}, matrix {matrix}: opened at no points; its width cannot be authenticated"
+    )]
+    MatrixWithoutOpeningPoints { batch: usize, matrix: usize },
+}
+
+/// Authenticated dimensions for one input matrix.
+///
+/// The width is pinned to the first opening point's claimed evaluation count.
+/// `check_widths` in the MMCS is the only authenticator of row boundaries in the flattened leaf hash.
+/// A matrix opened at no points carries no such claim, so its width could only come from the proof.
+///
+/// # Returns
+///
+/// - `Some(dims)`: the matrix has an opening point that pins its width.
+/// - `None`: the matrix is opened at no points, so the caller must reject it.
+fn pin_matrix_width<Challenge>(
+    height: usize,
+    points_and_values: &[(Challenge, Vec<Challenge>)],
+) -> Option<Dimensions> {
+    let (_, values) = points_and_values.first()?;
+    Some(Dimensions {
+        width: values.len(),
+        height,
+    })
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -605,8 +630,8 @@ where
                     first_layer_proof,
                 } = input_proof;
 
-                for (batch_opening, (batch_commit, mats)) in
-                    zip_eq(input_openings, &rounds, InputError::InputShapeError)?
+                for (batch, (batch_opening, (batch_commit, mats))) in
+                    zip_eq(input_openings, &rounds, InputError::InputShapeError)?.enumerate()
                 {
                     let batch_heights: Vec<usize> = mats
                         .iter()
@@ -618,19 +643,12 @@ where
                         &batch_opening.opened_values,
                         InputError::InputShapeError,
                     )?
-                    .map(
-                        |((&height, (_, points_and_values)), opened_row)| Dimensions {
-                            // Invariant: the commitment layer rejects opened rows that differ from this width.
-                            //
-                            //     some points → width = claimed evaluation count
-                            //     no points   → width = opened row length (no claim to enforce)
-                            width: points_and_values
-                                .first()
-                                .map_or(opened_row.len(), |(_, values)| values.len()),
-                            height,
-                        },
-                    )
-                    .collect_vec();
+                    .enumerate()
+                    .map(|(matrix, ((&height, (_, points_and_values)), _))| {
+                        pin_matrix_width(height, points_and_values)
+                            .ok_or(InputError::MatrixWithoutOpeningPoints { batch, matrix })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
 
                     let (dims, idx) = batch_heights
                         .iter()
@@ -899,6 +917,27 @@ mod tests {
         // Smoke test: an honestly generated proof must verify successfully.
         let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
         try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof).expect("verify err");
+    }
+
+    #[test]
+    fn pin_matrix_width_rejects_no_opening_points() {
+        // Invariant: a matrix's authenticated width is pinned by its first opening point.
+        //
+        //     no points   ->  None         ->  caller rejects (MatrixWithoutOpeningPoints)
+        //     >= 1 point   ->  Some(width)  ->  width = claimed evaluation count
+        let mut rng = SmallRng::seed_from_u64(0);
+
+        // A matrix opened at no points has no claim to pin its width.
+        let no_points: Vec<(Challenge, Vec<Challenge>)> = vec![];
+        assert!(pin_matrix_width(16, &no_points).is_none());
+
+        // A matrix with one opening point claiming three evaluations.
+        // The values themselves are irrelevant; only their count sets the width.
+        let with_points: Vec<(Challenge, Vec<Challenge>)> =
+            vec![(rng.random(), vec![rng.random(), rng.random(), rng.random()])];
+        let dims = pin_matrix_width(16, &with_points).expect("opening point present");
+        assert_eq!(dims.width, 3);
+        assert_eq!(dims.height, 16);
     }
 
     #[test]

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -89,27 +89,6 @@ where
     MatrixWithoutOpeningPoints { batch: usize, matrix: usize },
 }
 
-/// Authenticated dimensions for one input matrix.
-///
-/// The width is pinned to the first opening point's claimed evaluation count.
-/// `check_widths` in the MMCS is the only authenticator of row boundaries in the flattened leaf hash.
-/// A matrix opened at no points carries no such claim, so its width could only come from the proof.
-///
-/// # Returns
-///
-/// - `Some(dims)`: the matrix has an opening point that pins its width.
-/// - `None`: the matrix is opened at no points, so the caller must reject it.
-fn pin_matrix_width<Challenge>(
-    height: usize,
-    points_and_values: &[(Challenge, Vec<Challenge>)],
-) -> Option<Dimensions> {
-    let (_, values) = points_and_values.first()?;
-    Some(Dimensions {
-        width: values.len(),
-        height,
-    })
-}
-
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(bound(
     serialize = "Witness: Serialize",
@@ -645,8 +624,22 @@ where
                     )?
                     .enumerate()
                     .map(|(matrix, ((&height, (_, points_and_values)), _))| {
-                        pin_matrix_width(height, points_and_values)
-                            .ok_or(InputError::MatrixWithoutOpeningPoints { batch, matrix })
+                        // Invariant: a matrix's width is fixed by its first opening point.
+                        //
+                        //     >= 1 point  ->  width = number of claimed evaluations
+                        //     no points   ->  reject
+                        //
+                        // Why reject the no-points case:
+                        //   - row boundaries in the flattened leaf hash are authenticated only from claimed widths
+                        //   - a matrix opened at no points claims no width
+                        //   - its width could then come only from the unverified proof
+                        let (_, values) = points_and_values
+                            .first()
+                            .ok_or(InputError::MatrixWithoutOpeningPoints { batch, matrix })?;
+                        Ok(Dimensions {
+                            width: values.len(),
+                            height,
+                        })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
 
@@ -920,24 +913,69 @@ mod tests {
     }
 
     #[test]
-    fn pin_matrix_width_rejects_no_opening_points() {
-        // Invariant: a matrix's authenticated width is pinned by its first opening point.
+    fn reject_matrix_without_opening_points() {
+        // Invariant: every input matrix must be opened at >= 1 point.
         //
-        //     no points   ->  None         ->  caller rejects (MatrixWithoutOpeningPoints)
-        //     >= 1 point   ->  Some(width)  ->  width = claimed evaluation count
+        //     no points  ->  no claimed width  ->  width would come from the proof  ->  reject
+        //
+        // A matrix opened at no points observes nothing into the challenger.
+        // This holds identically on the proving side and the verifying side.
+        //
+        // Fixture state: one batch of two matrices sharing a domain.
+        //   - matrix 0 is opened at one point, keeping the reduced openings non-empty
+        //   - matrix 1 is opened at no points
+        //
+        // Flow:
+        //   - both sides observe only matrix 0  ->  proof-of-work challenge matches
+        //   - the query phase verifies the input opening  ->  matrix 1 rejected
         let mut rng = SmallRng::seed_from_u64(0);
 
-        // A matrix opened at no points has no claim to pin its width.
-        let no_points: Vec<(Challenge, Vec<Challenge>)> = vec![];
-        assert!(pin_matrix_width(16, &no_points).is_none());
+        let byte_hash = ByteHash {};
+        let field_hash = FieldHash::new(byte_hash);
+        let compress = MyCompress::new(byte_hash);
+        let val_mmcs = ValMmcs::new(field_hash, compress, 0);
+        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+        let fri_params = FriParameters::new_testing(challenge_mmcs, 0);
+        let pcs = TestPcs {
+            mmcs: val_mmcs,
+            fri_params,
+            _phantom: PhantomData,
+        };
 
-        // A matrix with one opening point claiming three evaluations.
-        // The values themselves are irrelevant; only their count sets the width.
-        let with_points: Vec<(Challenge, Vec<Challenge>)> =
-            vec![(rng.random(), vec![rng.random(), rng.random(), rng.random()])];
-        let dims = pin_matrix_width(16, &with_points).expect("opening point present");
-        assert_eq!(dims.width, 3);
-        assert_eq!(dims.height, 16);
+        // One batch, two single-column matrices sharing a domain of 2^{10} rows.
+        let log_n = 10;
+        let d =
+            <TestPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_n);
+        let evals_0 = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
+        let evals_1 = RowMajorMatrix::rand(&mut rng, 1 << log_n, 1);
+        let (comm, data) =
+            <TestPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(d, evals_0), (d, evals_1)]);
+
+        // Prove: open matrix 0 at one point, matrix 1 at no points.
+        let zeta: Challenge = rng.random();
+        let mut chal = Challenger::from_hasher(vec![], byte_hash);
+        let (values, proof) = pcs.open(vec![(&data, vec![vec![zeta], vec![]])], &mut chal);
+
+        // Verify with the same shape: matrix 1 carries no opening points.
+        let mut chal = Challenger::from_hasher(vec![], byte_hash);
+        let err = pcs
+            .verify(
+                vec![(
+                    comm,
+                    vec![(d, vec![(zeta, values[0][0][0].clone())]), (d, vec![])],
+                )],
+                &proof,
+                &mut chal,
+            )
+            .expect_err("matrix without opening points must be rejected");
+
+        // The offending matrix is identified by its batch and matrix index.
+        let FriError::InputError(InputError::MatrixWithoutOpeningPoints { batch, matrix }) = err
+        else {
+            panic!("expected MatrixWithoutOpeningPoints, got {err:?}");
+        };
+        assert_eq!(batch, 0);
+        assert_eq!(matrix, 1);
     }
 
     #[test]


### PR DESCRIPTION
Circle's verifier derived each input matrix's `width` for the authenticated MMCS `Dimensions` from the claimed evaluation count when the matrix had opening points, but fell back to the proof-supplied `opened_row.len()` when it had none. `check_widths` in the MMCS is the only authenticator of row boundaries in the flattened leaf hash, so a no-points matrix left its boundary unchecked.

This is the circle analog of #1793, which fixed the identical gap in two-adic FRI. Every input matrix is opened at >= 1 point, so reject the degenerate case with a new `InputError::MatrixWithoutOpeningPoints` error instead of trusting the proof.

The width decision is extracted into a small `pin_matrix_width` helper so it can be unit-tested directly: circle's `verify` observes opening values into the challenger before the proof-of-work check, so stripping a matrix's points fails earlier in the transcript and cannot reach the guard through the full verify path (unlike two-adic, where `run_verify_fri` exercises it end to end).
