### PR TITLE
refactor(sumcheck): trim test-only API surface and dedup SVO virtual fold

### DIFF
--- a/sumcheck/src/constraints/statement/eq.rs
+++ b/sumcheck/src/constraints/statement/eq.rs
@@ -191,11 +191,6 @@ impl<F: Field> EqStatement<F> {
         self.points.is_empty()
     }
 
-    /// Returns an iterator over the evaluation constraints in the statement.
-    pub fn iter(&self) -> impl Iterator<Item = (&Point<F>, &F)> {
-        self.points.iter().zip(self.evaluations.iter())
-    }
-
     /// Returns the number of constraints in the statement.
     #[must_use]
     pub const fn len(&self) -> usize {
@@ -220,20 +215,6 @@ impl<F: Field> EqStatement<F> {
             // For each point, evaluate its equality polynomial at the query point.
             // The result is 1 only when the query point equals the stored point on the hypercube.
             .map(|point| Point::eval_eq(point.as_slice(), row.as_slice()))
-    }
-
-    /// Verifies that a given polynomial satisfies all constraints in the statement.
-    #[must_use]
-    pub fn verify(&self, poly: &Poly<F>) -> bool {
-        self.iter()
-            .all(|(point, &expected_eval)| poly.eval_base(point) == expected_eval)
-    }
-
-    /// Concatenates another statement's constraints into this one.
-    pub fn concatenate(&mut self, other: &Self) {
-        assert_eq!(self.num_variables, other.num_variables);
-        self.points.extend_from_slice(&other.points);
-        self.evaluations.extend_from_slice(&other.evaluations);
     }
 
     /// Adds an evaluation constraint `p(z) = s` to the system.
@@ -469,6 +450,15 @@ mod tests {
                 evaluations,
             }
         }
+
+        /// Returns true when `poly` satisfies every stored equality constraint p(z_i) = s_i.
+        pub fn verify(&self, poly: &Poly<F>) -> bool {
+            // Each constraint holds when the polynomial's value at the stored point matches.
+            self.points
+                .iter()
+                .zip(&self.evaluations)
+                .all(|(point, &expected_eval)| poly.eval_base(point) == expected_eval)
+        }
     }
 
     type F = BabyBear;
@@ -589,26 +579,6 @@ mod tests {
         // Test mismatched constraint: f(1) = 5 (but poly has f(1) = 2)
         statement.add_evaluated_constraint(Point::new(vec![F::ONE]), F::from_u64(5));
         assert!(!statement.verify(&poly));
-    }
-
-    #[test]
-    fn test_concatenate() {
-        // Test successful concatenation
-        let mut statement1 = EqStatement::<F>::initialize(1);
-        let mut statement2 = EqStatement::<F>::initialize(1);
-        statement1.add_evaluated_constraint(Point::new(vec![F::ZERO]), F::from_u64(10));
-        statement2.add_evaluated_constraint(Point::new(vec![F::ONE]), F::from_u64(20));
-
-        statement1.concatenate(&statement2);
-        assert_eq!(statement1.len(), 2);
-    }
-
-    #[test]
-    #[should_panic(expected = "assertion `left == right` failed")]
-    fn test_concatenate_mismatched_variables() {
-        let mut statement1 = EqStatement::<F>::initialize(2);
-        let statement2 = EqStatement::<F>::initialize(3);
-        statement1.concatenate(&statement2); // Should panic
     }
 
     #[test]

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -675,12 +675,23 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
             }
         }
 
-        // Virtual claims span the full residual space; accumulate packed.
+        // Each virtual claim spans the full residual space and adds one packed term.
+        //
+        //     virtual point = [ svo vars | residual vars ]
+        //                      \_______/
+        //                      fixed to rs by the SVO rounds
+        //
+        // The packed accumulation folds eq(svo, rs) into a scalar weight.
+        // That weight scales the residual equality table added to the output.
+
+        // Virtual claims take the alpha powers right after the concrete claims.
         let mut alpha_i = alpha.exp_u64(self.num_claims() as u64);
         for claim in &self.virtual_claims {
-            let (svo, rest) = claim.point.split_at(rs.num_variables());
-            let scale = alpha_i * Point::eval_eq(svo.as_slice(), rs.as_slice());
-            SplitEq::new_packed(&rest, scale).accumulate_into_packed(out.as_mut_slice(), None);
+            // Split the claim point into its leading SVO variables and the residual variables.
+            let svo_point = SvoPoint::new_packed(rs.num_variables(), &claim.point);
+            // Add eq(svo, rs) * eq(residual, .) into the packed buffer, scaled by this claim's power.
+            svo_point.accumulate_into_packed(out.as_mut_slice(), rs, alpha_i);
+            // Step to the next power of alpha for the following claim.
             alpha_i *= alpha;
         }
 

--- a/sumcheck/src/layout/verifier.rs
+++ b/sumcheck/src/layout/verifier.rs
@@ -91,7 +91,7 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
     }
 
     /// Returns the arity of the source table at the given index.
-    pub fn num_variables_table(&self, table_idx: usize) -> usize {
+    pub(crate) fn num_variables_table(&self, table_idx: usize) -> usize {
         // Look up this table's placement; every column shares the same selector bit-width.
         let placement = self.placement(table_idx);
         let selector_vars = placement


### PR DESCRIPTION
## What

Three small, behavior-preserving cleanups in the sumcheck `constraints`/`layout` code:

- **`EqStatement`** — move the test-only satisfaction oracle (`verify`) into the test module, and drop the now-unused `iter`/`concatenate` helpers together with the two tests that only exercised `concatenate`. `EqStatement` is consumed by `whir` solely through `initialize` / `add_evaluated_constraint` / `num_variables`, so these helpers were never part of the production surface.
- **`PrefixProver::combine_weights_packed`** — fold virtual claims through `SvoPoint::accumulate_into_packed` instead of re-deriving the point split and equality scale inline. Identical arithmetic, one shared code path, and it turns that method from test-only into a live caller.
- **`Verifier::num_variables_table`** — demote to `pub(crate)`; it has no cross-crate caller.

## What was deliberately *not* changed

While auditing the area I confirmed two things the surface-trim should leave alone:

- **`SelectStatement::verify` stays public** — `whir`'s production verifier calls it on the final STIR statement (`whir/src/pcs/verifier/mod.rs`), so it is not dead.
- **The `layout::opening` claim types stay public** — they appear in the signatures of the public `ZkLayout` trait (`impl Iterator<Item = &ProverMultiClaim<…>>`, etc.), which `whir` consumes as a generic bound. Demoting them to `pub(crate)` breaks the public interface.

This part of the crate is under active construction (next-openings, #1821 and follow-ups), so the change is intentionally limited to what is provably safe today; no protocol code is deleted.

## Testing

- `cargo test -p p3-sumcheck --all-features` — 218 passed.
- `cargo test -p p3-whir --all-features` — 121 passed.
- `cargo clippy -p p3-sumcheck --all-features --all-targets` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)