### PR TITLE
perf(mersenne-31): add deferred-reduction `dot_product` for AVX2/AVX-512

### DIFF
--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -24,6 +24,8 @@ use crate::{Mersenne31, mul_2exp_i};
 
 const WIDTH: usize = 8;
 pub(crate) const P: __m256i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
+/// The low 31 bits of each 64-bit lane, used to mask off the high half during folding.
+const LOW31_64: __m256i = unsafe { transmute::<[u64; 4], _>([0x7fffffff; 4]) };
 
 /// Vectorized AVX2 implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -188,6 +190,11 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX2 {
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
+    }
+
+    #[inline(always)]
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        dot_product::<N>(u, v)
     }
 }
 
@@ -394,6 +401,71 @@ pub(crate) fn exp5(x: __m256i) -> __m256i {
         let u = x86_64::_mm256_sub_epi32(t, corr);
 
         x86_64::_mm256_min_epu32(t, u)
+    }
+}
+
+/// Fold a vector of four 64-bit accumulators once: given `val`, return `res = val (mod P)`
+/// with `res <= (val >> 31) + P` in the low 32 bits of each lane.
+///
+/// Uses `2^31 = 1 (mod P)`: writing `val = hi * 2^31 + lo` with `lo <= P`, we have
+/// `val = hi + lo (mod P)`. Applied twice, any `val < 2^64` is brought to `0..=2 P`.
+#[inline(always)]
+#[must_use]
+fn fold_u64(val: __m256i) -> __m256i {
+    unsafe {
+        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        let lo = x86_64::_mm256_and_si256(val, LOW31_64);
+        let hi = x86_64::_mm256_srli_epi64::<31>(val);
+        x86_64::_mm256_add_epi64(lo, hi)
+    }
+}
+
+/// Compute the dot product of `u` and `v` lanewise, deferring the Mersenne reduction.
+///
+/// Each product fits in 62 bits, so the raw `32x32 -> 64`-bit products are accumulated in
+/// 64-bit lanes (even and odd 32-bit indices kept apart, since `vpmuludq` reads only the
+/// low half of each 64-bit lane). Inputs are in `0..=P`, so a product is at most `P^2`;
+/// folding the accumulators below `2^33` every 3 iterations keeps `2^33 + 3 * P^2 < 2^64`,
+/// so the lanes never overflow.
+#[inline]
+fn dot_product<const N: usize>(
+    u: &[PackedMersenne31AVX2; N],
+    v: &[PackedMersenne31AVX2; N],
+) -> PackedMersenne31AVX2 {
+    unsafe {
+        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        let mut acc_evn = x86_64::_mm256_setzero_si256();
+        let mut acc_odd = x86_64::_mm256_setzero_si256();
+        let mut unreduced = 0;
+        for i in 0..N {
+            let lhs = u[i].to_vector();
+            let rhs = v[i].to_vector();
+            acc_evn = x86_64::_mm256_add_epi64(acc_evn, x86_64::_mm256_mul_epu32(lhs, rhs));
+            acc_odd = x86_64::_mm256_add_epi64(
+                acc_odd,
+                x86_64::_mm256_mul_epu32(movehdup_epi32(lhs), movehdup_epi32(rhs)),
+            );
+            unreduced += 1;
+            if unreduced == 3 {
+                unreduced = 0;
+                acc_evn = fold_u64(acc_evn);
+                acc_odd = fold_u64(acc_odd);
+            }
+        }
+
+        // At most 2 unreduced products sit on top of a folded value: the lanes are below
+        // `2^33 + 2 * P^2 < 2^64`, so two folds bring them to `0..=2 P` in the low 32 bits.
+        let evn = fold_u64(fold_u64(acc_evn));
+        let odd = fold_u64(fold_u64(acc_odd));
+
+        // The even results sit in the low 32 bits of each 64-bit lane (indices 0, 2, 4, 6);
+        // shift the odd results up into the high halves (indices 1, 3, 5, 7) and merge.
+        let odd_shifted = x86_64::_mm256_slli_epi64::<32>(odd);
+        let t = x86_64::_mm256_blend_epi32::<0b10101010>(evn, odd_shifted);
+
+        // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
+        let u = x86_64::_mm256_sub_epi32(t, P);
+        PackedMersenne31AVX2::from_vector(x86_64::_mm256_min_epu32(t, u))
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -464,8 +464,8 @@ fn dot_product<const N: usize>(
         let t = x86_64::_mm256_blend_epi32::<0b10101010>(evn, odd_shifted);
 
         // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
-        let u = x86_64::_mm256_sub_epi32(t, P);
-        PackedMersenne31AVX2::from_vector(x86_64::_mm256_min_epu32(t, u))
+        let t_sub_p = x86_64::_mm256_sub_epi32(t, P);
+        PackedMersenne31AVX2::from_vector(x86_64::_mm256_min_epu32(t, t_sub_p))
     }
 }
 

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -26,6 +26,8 @@ const WIDTH: usize = 16;
 pub(crate) const P: __m512i = unsafe { transmute::<[u32; WIDTH], _>([0x7fffffff; WIDTH]) };
 const EVENS: __mmask16 = 0b0101010101010101;
 const ODDS: __mmask16 = 0b1010101010101010;
+/// The low 31 bits of each 64-bit lane, used to mask off the high half during folding.
+const LOW31_64: __m512i = unsafe { transmute::<[u64; 8], _>([0x7fffffff; 8]) };
 
 /// Vectorized AVX-512F implementation of `Mersenne31` arithmetic.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -190,6 +192,11 @@ impl PrimeCharacteristicRing for PackedMersenne31AVX512 {
             }
             _ => self.exp_u64(POWER),
         }
+    }
+
+    #[inline(always)]
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        dot_product::<N>(u, v)
     }
 }
 
@@ -413,6 +420,71 @@ pub(crate) fn exp5(x: __m512i) -> __m512i {
         let u = x86_64::_mm512_sub_epi32(t, corr);
 
         x86_64::_mm512_min_epu32(t, u)
+    }
+}
+
+/// Fold a vector of eight 64-bit accumulators once: given `val`, return `res = val (mod P)`
+/// with `res <= (val >> 31) + P` in the low 32 bits of each lane.
+///
+/// Uses `2^31 = 1 (mod P)`: writing `val = hi * 2^31 + lo` with `lo <= P`, we have
+/// `val = hi + lo (mod P)`. Applied twice, any `val < 2^64` is brought to `0..=2 P`.
+#[inline(always)]
+#[must_use]
+fn fold_u64(val: __m512i) -> __m512i {
+    unsafe {
+        // Safety: If this code got compiled then AVX-512 intrinsics are available.
+        let lo = x86_64::_mm512_and_si512(val, LOW31_64);
+        let hi = x86_64::_mm512_srli_epi64::<31>(val);
+        x86_64::_mm512_add_epi64(lo, hi)
+    }
+}
+
+/// Compute the dot product of `u` and `v` lanewise, deferring the Mersenne reduction.
+///
+/// Each product fits in 62 bits, so the raw `32x32 -> 64`-bit products are accumulated in
+/// 64-bit lanes (even and odd 32-bit indices kept apart, since `vpmuludq` reads only the
+/// low half of each 64-bit lane). Inputs are in `0..=P`, so a product is at most `P^2`;
+/// folding the accumulators below `2^33` every 3 iterations keeps `2^33 + 3 * P^2 < 2^64`,
+/// so the lanes never overflow.
+#[inline]
+fn dot_product<const N: usize>(
+    u: &[PackedMersenne31AVX512; N],
+    v: &[PackedMersenne31AVX512; N],
+) -> PackedMersenne31AVX512 {
+    unsafe {
+        // Safety: If this code got compiled then AVX-512 intrinsics are available.
+        let mut acc_evn = x86_64::_mm512_setzero_si512();
+        let mut acc_odd = x86_64::_mm512_setzero_si512();
+        let mut unreduced = 0;
+        for i in 0..N {
+            let lhs = u[i].to_vector();
+            let rhs = v[i].to_vector();
+            acc_evn = x86_64::_mm512_add_epi64(acc_evn, x86_64::_mm512_mul_epu32(lhs, rhs));
+            acc_odd = x86_64::_mm512_add_epi64(
+                acc_odd,
+                x86_64::_mm512_mul_epu32(movehdup_epi32(lhs), movehdup_epi32(rhs)),
+            );
+            unreduced += 1;
+            if unreduced == 3 {
+                unreduced = 0;
+                acc_evn = fold_u64(acc_evn);
+                acc_odd = fold_u64(acc_odd);
+            }
+        }
+
+        // At most 2 unreduced products sit on top of a folded value: the lanes are below
+        // `2^33 + 2 * P^2 < 2^64`, so two folds bring them to `0..=2 P` in the low 32 bits.
+        let evn = fold_u64(fold_u64(acc_evn));
+        let odd = fold_u64(fold_u64(acc_odd));
+
+        // The even results sit in the low 32 bits of each 64-bit lane (the even 32-bit
+        // indices); shift the odd results up into the high halves (the odd indices) and merge.
+        let odd_shifted = x86_64::_mm512_slli_epi64::<32>(odd);
+        let t = x86_64::_mm512_mask_blend_epi32(ODDS, evn, odd_shifted);
+
+        // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
+        let u = x86_64::_mm512_sub_epi32(t, P);
+        PackedMersenne31AVX512::from_vector(x86_64::_mm512_min_epu32(t, u))
     }
 }
 

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -483,8 +483,8 @@ fn dot_product<const N: usize>(
         let t = x86_64::_mm512_mask_blend_epi32(ODDS, evn, odd_shifted);
 
         // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
-        let u = x86_64::_mm512_sub_epi32(t, P);
-        PackedMersenne31AVX512::from_vector(x86_64::_mm512_min_epu32(t, u))
+        let t_sub_p = x86_64::_mm512_sub_epi32(t, P);
+        PackedMersenne31AVX512::from_vector(x86_64::_mm512_min_epu32(t, t_sub_p))
     }
 }
 


### PR DESCRIPTION
Override `PrimeCharacteristicRing::dot_product` for the x86 Mersenne31 packings, which previously fell through to the generic default doing one eager reduction per element.

Accumulate raw 32x32->64-bit products in 64-bit lanes (even/odd 32-bit indices kept apart for vpmuludq), folding every 3 iterations to keep 2^33 + 3*P^2 < 2^64, then reduce once at the end. This mirrors the existing M31 NEON deferred kernel and replaces N reductions with a single final reduction.

Note that I can't test it locally as I don't have access to an AVX512 machine.