### PR TITLE
feat(air,lookup): add serde to symbolic constraint and lookup types

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -12,11 +12,13 @@ categories.workspace = true
 [dependencies]
 p3-field.workspace = true
 p3-matrix.workspace = true
+serde = { workspace = true, features = ["derive", "alloc"] }
 tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-field = { path = "../field" }
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -5,6 +5,7 @@ use core::borrow::Borrow;
 use p3_field::{Algebra, ExtensionField, Field};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::symbolic::SymbolicExpr;
@@ -20,7 +21,7 @@ use crate::{
 ///
 /// Bundles the various width/count parameters needed to construct a
 /// [`SymbolicAirBuilder`].
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct AirLayout {
     /// Width of [`AirBuilder::preprocessed`].
     pub preprocessed_width: usize,
@@ -371,7 +372,7 @@ enum ConstraintType {
 /// When alpha powers are pre-computed in global order `[α^{N−1}, …, α⁰]`,
 /// the layout tells us which powers correspond to base-field constraints (for
 /// `batched_linear_combination`) and which to extension-field constraints.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ConstraintLayout {
     /// Global indices of base-field constraints, in emission order.
     pub base_indices: Vec<usize>,
@@ -1072,5 +1073,34 @@ mod tests {
         for &val in &ext {
             assert_eq!(val, EF::ONE);
         }
+    }
+
+    #[test]
+    fn air_layout_serde_round_trip() {
+        let layout = AirLayout {
+            preprocessed_width: 2,
+            main_width: 5,
+            num_public_values: 3,
+            permutation_width: 4,
+            num_permutation_challenges: 2,
+            num_permutation_values: 1,
+            num_periodic_columns: 6,
+        };
+        let json = serde_json::to_string(&layout).unwrap();
+        let decoded: AirLayout = serde_json::from_str(&json).unwrap();
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), json);
+    }
+
+    #[test]
+    fn constraint_layout_serde_round_trip() {
+        // An interleaved layout drives the base/ext stream separation the verifier folds with.
+        let layout = ConstraintLayout {
+            base_indices: vec![0, 2, 4],
+            ext_indices: vec![1, 3],
+        };
+        let json = serde_json::to_string(&layout).unwrap();
+        let decoded: ConstraintLayout = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.base_indices, layout.base_indices);
+        assert_eq!(decoded.ext_indices, layout.ext_indices);
     }
 }

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -1,4 +1,5 @@
 use p3_field::{Algebra, ExtensionField, Field, InjectiveMonomial};
+use serde::{Deserialize, Serialize};
 
 use crate::symbolic::variable::{BaseEntry, SymbolicVariable};
 use crate::symbolic::{SymLeaf, SymbolicExpr};
@@ -8,7 +9,7 @@ use crate::{AirBuilder, WindowAccess};
 ///
 /// These represent the atomic building blocks of AIR constraint expressions:
 /// trace column references, selectors, and field constants.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BaseLeaf<F> {
     /// A reference to a trace column or public input.
     Variable(SymbolicVariable<F>),
@@ -1017,5 +1018,33 @@ mod tests {
 
         let expr = col0 * p0 + p1;
         assert_eq!(expr.resolve(&b), BabyBear::new(83));
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_resolution() {
+        // A constraint mixing every leaf kind, both row offsets, and all node kinds:
+        //   main[0]·main_next[1] - public[0] + periodic[0]·is_transition - constant
+        let b = test_builder();
+        let main_cur =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0));
+        let main_next =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 1 }, 1));
+        let public =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Public, 0));
+        let periodic =
+            SymbolicExpression::from(SymbolicVariable::<BabyBear>::new(BaseEntry::Periodic, 0));
+        let transition = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
+
+        let expr = main_cur * main_next - public + periodic * transition
+            - SymbolicExpression::from(BabyBear::new(5));
+
+        let json = serde_json::to_string(&expr).unwrap();
+        let decoded: SymbolicExpression<BabyBear> = serde_json::from_str(&json).unwrap();
+
+        // Semantic equality: both trees resolve to the same value.
+        assert_eq!(decoded.resolve(&b), expr.resolve(&b));
+        // Structural equality: the decoded tree re-serializes identically.
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), json);
+        assert_eq!(decoded.degree_multiple(), expr.degree_multiple());
     }
 }

--- a/air/src/symbolic/expression_ext.rs
+++ b/air/src/symbolic/expression_ext.rs
@@ -4,6 +4,7 @@ use p3_field::extension::{
     BinomialExtensionField, CubicTrinomialExtensionField, QuinticTrinomialExtensionField,
 };
 use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing};
+use serde::{Deserialize, Serialize};
 
 use crate::symbolic::expression::BaseLeaf;
 use crate::symbolic::variable::SymbolicVariableExt;
@@ -13,7 +14,7 @@ use crate::symbolic::{SymLeaf, SymbolicExpr, SymbolicExpression, SymbolicVariabl
 ///
 /// These represent the atomic building blocks of extension-field AIR constraints:
 /// lifted base-field sub-trees, extension-field variables, and extension-field constants.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ExtLeaf<F, EF> {
     /// A lifted base-field expression (entire base sub-tree preserved).
     Base(SymbolicExpression<F>),
@@ -803,5 +804,35 @@ mod tests {
 
         // The mixed result cannot be lowered to base.
         assert!(result.to_base().is_none());
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_extension_constraint() {
+        // A constraint over all extension leaf kinds and a lifted base sub-tree:
+        //   perm[0]·challenge - ext_const + base_var
+        let perm = SymbolicExpressionExt::<F, EF>::from(SymbolicVariableExt::<F, EF>::new(
+            ExtEntry::Permutation { offset: 0 },
+            0,
+        ));
+        let challenge = SymbolicExpressionExt::<F, EF>::from(SymbolicVariableExt::<F, EF>::new(
+            ExtEntry::Challenge,
+            0,
+        ));
+        let ext_const = SymbolicExpressionExt::<F, EF>::from(EF::from_basis_coefficients_fn(|i| {
+            if i == 1 { F::ONE } else { F::ZERO }
+        }));
+        let base_var = SymbolicExpressionExt::<F, EF>::from(SymbolicVariable::<F>::new(
+            BaseEntry::Main { offset: 0 },
+            0,
+        ));
+
+        let expr = perm * challenge - ext_const + base_var;
+
+        let json = serde_json::to_string(&expr).unwrap();
+        let decoded: SymbolicExpressionExt<F, EF> = serde_json::from_str(&json).unwrap();
+
+        // Structural equality: the decoded tree re-serializes identically.
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), json);
+        assert_eq!(decoded.degree_multiple(), expr.degree_multiple());
     }
 }

--- a/air/src/symbolic/flatten.rs
+++ b/air/src/symbolic/flatten.rs
@@ -1,0 +1,272 @@
+//! Flattened wire format for [`SymbolicExpr`].
+//!
+//! An expression tree is an acyclic DAG whose interior nodes share `Arc`
+//! children. Serializing the `Arc` pointers directly would expand each shared
+//! sub-tree once per parent, so instead the tree is lowered to a topologically
+//! ordered `Vec` of [`FlatNode`]s in which children are referenced by index.
+//! Shared sub-trees collapse to a single node, giving the compact "list of
+//! operations" encoding used as the stable on-wire form.
+
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::symbolic::SymbolicExpr;
+
+/// A single node in the flattened expression arena.
+///
+/// Interior nodes refer to their operands by their position in the node list.
+/// Every operand index is strictly smaller than the node's own index, so the
+/// list is a valid topological (post-order) ordering with the root last.
+#[derive(Debug, Serialize, Deserialize)]
+enum FlatNode<A> {
+    Leaf(A),
+    Add {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+    Sub {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+    Neg {
+        x: usize,
+        degree_multiple: usize,
+    },
+    Mul {
+        x: usize,
+        y: usize,
+        degree_multiple: usize,
+    },
+}
+
+/// Lower `node` into `nodes` in post-order, returning its index.
+///
+/// `seen` maps the address of an already-emitted node to its index so shared
+/// `Arc` children are emitted exactly once. The whole tree is borrowed for the
+/// duration, so addresses stay live and unique while flattening.
+fn flatten_into<'a, A>(
+    node: &'a SymbolicExpr<A>,
+    nodes: &mut Vec<FlatNode<&'a A>>,
+    seen: &mut BTreeMap<*const SymbolicExpr<A>, usize>,
+) -> usize {
+    let key: *const SymbolicExpr<A> = node;
+    if let Some(&idx) = seen.get(&key) {
+        return idx;
+    }
+    let flat = match node {
+        SymbolicExpr::Leaf(a) => FlatNode::Leaf(a),
+        SymbolicExpr::Add {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x = flatten_into(x, nodes, seen);
+            let y = flatten_into(y, nodes, seen);
+            FlatNode::Add {
+                x,
+                y,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpr::Sub {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x = flatten_into(x, nodes, seen);
+            let y = flatten_into(y, nodes, seen);
+            FlatNode::Sub {
+                x,
+                y,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpr::Neg { x, degree_multiple } => {
+            let x = flatten_into(x, nodes, seen);
+            FlatNode::Neg {
+                x,
+                degree_multiple: *degree_multiple,
+            }
+        }
+        SymbolicExpr::Mul {
+            x,
+            y,
+            degree_multiple,
+        } => {
+            let x = flatten_into(x, nodes, seen);
+            let y = flatten_into(y, nodes, seen);
+            FlatNode::Mul {
+                x,
+                y,
+                degree_multiple: *degree_multiple,
+            }
+        }
+    };
+    let idx = nodes.len();
+    nodes.push(flat);
+    seen.insert(key, idx);
+    idx
+}
+
+/// Rebuild a tree from a flattened arena, sharing `Arc`s for repeated indices.
+///
+/// Returns `None` if the list is empty, an operand index is not strictly
+/// smaller than its node's index (a forward or self reference), or the root is
+/// somehow still shared after construction.
+fn unflatten<A>(nodes: Vec<FlatNode<A>>) -> Option<SymbolicExpr<A>> {
+    let mut built: Vec<Arc<SymbolicExpr<A>>> = Vec::with_capacity(nodes.len());
+    for (i, flat) in nodes.into_iter().enumerate() {
+        let expr = match flat {
+            FlatNode::Leaf(a) => SymbolicExpr::Leaf(a),
+            FlatNode::Add {
+                x,
+                y,
+                degree_multiple,
+            } => {
+                if x >= i || y >= i {
+                    return None;
+                }
+                SymbolicExpr::Add {
+                    x: built[x].clone(),
+                    y: built[y].clone(),
+                    degree_multiple,
+                }
+            }
+            FlatNode::Sub {
+                x,
+                y,
+                degree_multiple,
+            } => {
+                if x >= i || y >= i {
+                    return None;
+                }
+                SymbolicExpr::Sub {
+                    x: built[x].clone(),
+                    y: built[y].clone(),
+                    degree_multiple,
+                }
+            }
+            FlatNode::Neg { x, degree_multiple } => {
+                if x >= i {
+                    return None;
+                }
+                SymbolicExpr::Neg {
+                    x: built[x].clone(),
+                    degree_multiple,
+                }
+            }
+            FlatNode::Mul {
+                x,
+                y,
+                degree_multiple,
+            } => {
+                if x >= i || y >= i {
+                    return None;
+                }
+                SymbolicExpr::Mul {
+                    x: built[x].clone(),
+                    y: built[y].clone(),
+                    degree_multiple,
+                }
+            }
+        };
+        built.push(Arc::new(expr));
+    }
+    // The root is the last node emitted; no other node references it, so it is
+    // uniquely owned and can be unwrapped without cloning.
+    Arc::try_unwrap(built.pop()?).ok()
+}
+
+impl<A: Serialize> Serialize for SymbolicExpr<A> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut nodes: Vec<FlatNode<&A>> = Vec::new();
+        let mut seen: BTreeMap<*const Self, usize> = BTreeMap::new();
+        flatten_into(self, &mut nodes, &mut seen);
+        nodes.serialize(serializer)
+    }
+}
+
+impl<'de, A: Deserialize<'de>> Deserialize<'de> for SymbolicExpr<A> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let nodes = Vec::<FlatNode<A>>::deserialize(deserializer)?;
+        unflatten(nodes).ok_or_else(|| D::Error::custom("invalid flattened symbolic expression"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+    use alloc::sync::Arc;
+
+    use p3_baby_bear::BabyBear;
+
+    use crate::symbolic::expression::BaseLeaf;
+    use crate::symbolic::variable::BaseEntry;
+    use crate::symbolic::{SymbolicExpr, SymbolicExpression, SymbolicVariable};
+
+    type F = BabyBear;
+
+    fn var(index: usize) -> SymbolicExpression<F> {
+        SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, index))
+    }
+
+    #[test]
+    fn json_round_trip_preserves_structure() {
+        // A non-trivial tree: (x0 * x1) - x0 + 7, exercising every node kind.
+        let expr = var(0) * var(1) - var(0) + SymbolicExpression::from(F::new(7));
+
+        let json = serde_json::to_string(&expr).unwrap();
+        let decoded: SymbolicExpression<F> = serde_json::from_str(&json).unwrap();
+
+        // Re-serializing the decoded tree must reproduce the original wire form.
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), json);
+        assert_eq!(format!("{decoded:?}"), format!("{expr:?}"));
+    }
+
+    #[test]
+    fn shared_subtree_is_emitted_once() {
+        // Build a node that references the same Arc child twice.
+        let shared = Arc::new(var(0));
+        let expr = SymbolicExpr::Add {
+            x: shared.clone(),
+            y: shared,
+            degree_multiple: 1,
+        };
+
+        // The flattened form is a JSON array; with deduplication the shared leaf
+        // contributes a single node, so the arena holds exactly two nodes.
+        let value: serde_json::Value = serde_json::to_value(&expr).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 2);
+
+        let decoded: SymbolicExpression<F> = serde_json::from_value(value).unwrap();
+        assert_eq!(format!("{decoded:?}"), format!("{expr:?}"));
+    }
+
+    #[test]
+    fn rejects_forward_reference() {
+        // A single Add node whose operands point past itself is not a valid arena.
+        let json = r#"[{"Add":{"x":1,"y":2,"degree_multiple":1}}]"#;
+        let decoded: Result<SymbolicExpression<F>, _> = serde_json::from_str(json);
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn rejects_empty_arena() {
+        let decoded: Result<SymbolicExpression<F>, _> = serde_json::from_str("[]");
+        assert!(decoded.is_err());
+    }
+
+    #[test]
+    fn leaf_round_trips() {
+        let expr = SymbolicExpression::<F>::Leaf(BaseLeaf::Constant(F::new(42)));
+        let json = serde_json::to_string(&expr).unwrap();
+        let decoded: SymbolicExpression<F> = serde_json::from_str(&json).unwrap();
+        assert_eq!(format!("{decoded:?}"), format!("{expr:?}"));
+    }
+}

--- a/air/src/symbolic/mod.rs
+++ b/air/src/symbolic/mod.rs
@@ -3,6 +3,7 @@
 mod builder;
 mod expression;
 pub(crate) mod expression_ext;
+mod flatten;
 mod variable;
 
 use alloc::sync::Arc;

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -1,7 +1,9 @@
 use core::marker::PhantomData;
 
+use serde::{Deserialize, Serialize};
+
 /// Entry kinds for base-field trace columns and public inputs.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BaseEntry {
     Preprocessed { offset: usize },
     Main { offset: usize },
@@ -10,7 +12,7 @@ pub enum BaseEntry {
 }
 
 /// Entry kinds for extension-field columns (permutation trace, challenges, and permutation values).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ExtEntry {
     Permutation { offset: usize },
     Challenge,
@@ -18,10 +20,11 @@ pub enum ExtEntry {
 }
 
 /// A variable within the evaluation window for base-field columns.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct SymbolicVariable<F> {
     pub entry: BaseEntry,
     pub index: usize,
+    #[serde(skip)]
     pub(crate) _phantom: PhantomData<F>,
 }
 
@@ -48,10 +51,11 @@ impl<F> SymbolicVariable<F> {
 }
 
 /// A variable within the evaluation window for extension-field columns.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct SymbolicVariableExt<F, EF> {
     pub entry: ExtEntry,
     pub index: usize,
+    #[serde(skip)]
     pub(crate) _phantom: PhantomData<(F, EF)>,
 }
 

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -36,6 +36,7 @@ p3-symmetric = { path = "../symmetric" }
 
 criterion.workspace = true
 rand.workspace = true
+serde_json.workspace = true
 
 [[bench]]
 name = "logup"

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -17,7 +17,7 @@ use crate::protocol::LookupProtocol;
 use crate::symbolic::InteractionSymbolicBuilder;
 
 /// Whether a lookup is confined to one AIR or shared across AIRs on a named bus.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Kind {
     /// Intra-AIR lookup.
     ///
@@ -34,7 +34,8 @@ pub enum Kind {
 
 /// A single lookup argument: element tuples, multiplicities, and one
 /// auxiliary column in the permutation trace.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct Lookup<F: Field> {
     /// Local or global (with bus name).
     pub kind: Kind,
@@ -59,7 +60,8 @@ pub struct Lookup<F: Field> {
 }
 
 /// All lookups for one AIR, with column indices assigned.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(transparent, bound = "")]
 pub struct Lookups<F: Field>(Vec<Lookup<F>>);
 
 impl<F: Field> Lookups<F> {
@@ -621,5 +623,44 @@ mod tests {
                 assert_contiguous_columns(&packed);
             }
         }
+    }
+
+    #[test]
+    fn lookups_serde_round_trip() {
+        // A representative LogUp set: one local lookup followed by two same-bus globals.
+        let local = vec![SymbolicLocalInteraction {
+            tuples: vec![(
+                vec![SymbolicExpression::from(SymbolicVariable::<F>::new(
+                    BaseEntry::Main { offset: 0 },
+                    0,
+                ))],
+                SymbolicExpression::from(F::ONE),
+            )],
+        }];
+        let global = vec![global_payload("bus", 1), global_payload("bus", 0)];
+        let lookups = Lookups::from_interactions(&global, &local);
+
+        let json = serde_json::to_string(&lookups).unwrap();
+        let decoded: Lookups<F> = serde_json::from_str(&json).unwrap();
+
+        // Structural equality: the decoded set re-serializes identically.
+        assert_eq!(serde_json::to_string(&decoded).unwrap(), json);
+
+        // Spot-check the decoded fields against the original.
+        assert_eq!(decoded.len(), lookups.len());
+        assert_eq!(decoded.total_count_weight(), lookups.total_count_weight());
+        for (a, b) in decoded.iter().zip(lookups.iter()) {
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.column, b.column);
+            assert_eq!(a.count_weight, b.count_weight);
+        }
+    }
+
+    #[test]
+    fn lookup_terminal_serde_round_trip() {
+        let terminal = LookupTerminal(F::new(123));
+        let json = serde_json::to_string(&terminal).unwrap();
+        let decoded: LookupTerminal<F> = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.0, terminal.0);
     }
 }


### PR DESCRIPTION
Serialize the symbolic-expression tree, AIR/constraint layout metadata, and lookup declaration types so a verifying key can carry constraints as data.

The Arc-based `SymbolicExpr` tree is lowered to a flattened, index- referenced `Vec` of nodes (root last, shared subtrees deduplicated) as a stable, compact wire format, with validation rejecting forward and self references on decode. Leaf, variable, entry, layout, and lookup types derive serde directly. Round-trip tests cover base and extension constraints, layouts, and a LogUp lookup set.