### PR TITLE
refactor(sumcheck): consistent expect message for concrete opening column index

### DIFF
--- a/sumcheck/src/layout/verifier.rs
+++ b/sumcheck/src/layout/verifier.rs
@@ -311,7 +311,10 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
                 // Next group: one repeat-last successor statement per claim's next openings.
                 let mut next_statement = NextStatement::initialize(self.k);
                 for opening in claim.next_openings() {
-                    let col = opening.poly_idx().unwrap();
+                    // Recorded concrete openings always bind a column, never virtual.
+                    let col = opening
+                        .poly_idx()
+                        .expect("concrete claims only hold column-bound openings");
                     // The successor weight depends on which end the folded variables sit.
                     let var_order = if self.strategy.reverse_selectors {
                         VariableOrder::Suffix


### PR DESCRIPTION
In `Verifier::constraint`, the next-openings loop used a bare `.unwrap()` on `opening.poly_idx()`, while the current-openings loop used a descriptive `.expect(...)` for the identical invariant (a concrete opening always carries `Some(column_index)`). This unifies them on the same message so an impossible-state failure reads the same in both groups.

Behavior-preserving. `cargo test -p p3-sumcheck`, clippy, and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)