### PR TITLE
fix(sumcheck): assert accumulator length in scalar combine paths

### DIFF
--- a/sumcheck/src/constraints/statement/eq.rs
+++ b/sumcheck/src/constraints/statement/eq.rs
@@ -289,6 +289,9 @@ impl<F: Field> EqStatement<F> {
             return;
         }
 
+        // Invariant: the scalar accumulator spans the full hypercube of this statement.
+        assert_eq!(acc_weights.num_variables(), self.num_variables());
+
         let num_constraints = self.len();
         // Build the batching weights gamma^shift, gamma^{shift+1}, ..., one per constraint.
         // Starting at the shift keeps this group's powers disjoint from earlier groups.
@@ -848,6 +851,21 @@ mod tests {
             prop_assert_eq!(s_wt.as_slice(), &unpacked[..]);
             prop_assert_eq!(s_sum, p_sum);
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn combine_hypercube_rejects_mis_sized_accumulator() {
+        // Fixture state: a 2-variable statement carrying one constraint.
+        let mut statement = EqStatement::<F>::initialize(2);
+        statement.add_evaluated_constraint(Point::new(vec![F::ONE, F::ZERO]), F::from_u64(5));
+
+        // Fixture state: accumulator over 3 variables, not the required 2.
+        let mut acc_weights = Poly::zero(3);
+        let mut acc_sum = F::ZERO;
+
+        // Invariant: the accumulator must span the statement's hypercube, so this panics.
+        statement.combine_hypercube::<F, false>(&mut acc_weights, &mut acc_sum, F::from_u64(2), 0);
     }
 
     #[test]

--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -388,6 +388,9 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
             return;
         }
 
+        // Invariant: the scalar accumulator spans the full hypercube of this statement.
+        assert_eq!(acc_weights.num_variables(), self.num_variables());
+
         // Extract dimensions for clarity.
         //
         // Number of constraints
@@ -1240,6 +1243,21 @@ mod tests {
             prop_assert_eq!(s_wt.as_slice(), &unpacked[..]);
             prop_assert_eq!(s_sum, p_sum);
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    fn combine_rejects_mis_sized_accumulator() {
+        // Fixture state: a 2-variable statement carrying one constraint.
+        let mut statement = SelectStatement::<F, F>::initialize(2);
+        statement.add_constraint(F::from_u64(5), F::from_u64(100));
+
+        // Fixture state: accumulator over 3 variables, not the required 2.
+        let mut acc_weights = Poly::zero(3);
+        let mut acc_sum = F::ZERO;
+
+        // Invariant: the accumulator must span the statement's hypercube, so this panics.
+        statement.combine(&mut acc_weights, &mut acc_sum, F::from_u64(2), 0);
     }
 
     #[test]


### PR DESCRIPTION
The SIMD-packed weight-combine paths assert their accumulator shape, but the scalar `EqStatement::combine_hypercube` and `SelectStatement::combine` did not. A mis-sized `acc_weights` would therefore silently produce a wrong or truncated weight polynomial instead of failing loudly.

This adds a symmetric up-front `assert_eq!(acc_weights.num_variables(), self.num_variables())` to both scalar paths (a once-per-call check, negligible cost), mirroring the packed paths, plus a `#[should_panic]` unit test for each. Every existing valid caller already sizes the accumulator to `2^k`, so no legitimate workflow trips the assertion.

`cargo test -p p3-sumcheck` (222, incl. the 2 new tests), clippy, and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)