### PR TITLE
perf(sumcheck): hoist invariant alpha exponentiation out of the SVO round loop

### DIFF
--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -322,6 +322,10 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         let mut sum = self.sum(alpha);
         let mut rs = Vec::new();
 
+        // First alpha power assigned to the virtual claims, sitting just past the concrete claims.
+        // The claim count is fixed for the whole fold, so this exponentiation is loop-invariant.
+        let alpha_base = alpha.exp_u64(n_claims as u64);
+
         for round_idx in 0..self.folding {
             let weights = lagrange_weights_01inf_multi(&rs);
 
@@ -342,7 +346,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
             for (vc, alpha_i) in self
                 .virtual_claims
                 .iter()
-                .zip(alpha.shifted_powers(alpha.exp_u64(n_claims as u64)))
+                .zip(alpha.shifted_powers(alpha_base))
             {
                 let vc_accs = &vc.data;
                 c0 += alpha_i

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -395,6 +395,10 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
         let mut sum = self.sum(alpha);
         let mut rs: Vec<EF> = vec![];
 
+        // First alpha power assigned to the virtual claims, sitting just past the concrete claims.
+        // The claim count is fixed for the whole fold, so this exponentiation is loop-invariant.
+        let alpha_base = alpha.exp_u64(n_claims as u64);
+
         for round_idx in 0..self.folding {
             // Lagrange weights at the challenges sampled so far.
             let weights = lagrange_weights_01inf_multi(&rs);
@@ -426,7 +430,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
             for (vc, alpha_i) in self
                 .virtual_claims
                 .iter()
-                .zip(alpha.shifted_powers(alpha.exp_u64(n_claims as u64)))
+                .zip(alpha.shifted_powers(alpha_base))
             {
                 let vc_accs = &vc.data;
                 c0 += alpha_i


### PR DESCRIPTION
In `into_sumcheck` (both the prefix and suffix provers), the virtual-claim contribution rebuilt `alpha.shifted_powers(alpha.exp_u64(n_claims as u64))` on every round, recomputing the modular exponentiation `alpha.exp_u64(n_claims)` each iteration. `n_claims` is loop-invariant, so this hoists `let alpha_base = alpha.exp_u64(n_claims as u64);` just before the round loop and reuses it inside.

The shifted-powers sequence is byte-for-byte identical, so behavior is unchanged. `cargo test -p p3-sumcheck` (220), clippy, and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)