### PR TITLE
refactor(sumcheck): use assert_eq! for the debug-only SVO fast-path cross-checks

### DIFF
--- a/sumcheck/src/svo/point.rs
+++ b/sumcheck/src/svo/point.rs
@@ -302,7 +302,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
 
         // Fast and dense paths must agree exactly.
         #[cfg(debug_assertions)]
-        debug_assert!(out == expected.as_slice());
+        assert_eq!(out, expected.as_slice());
     }
 
     /// Adds the residual prefix-layout successor weight over the split variables.
@@ -414,7 +414,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
 
         // Fast and dense paths must agree exactly.
         #[cfg(debug_assertions)]
-        debug_assert!(out == expected.as_slice());
+        assert_eq!(out, expected.as_slice());
     }
 
     /// Evaluates a suffix-layout repeat-last-successor opening and caches its SVO rounds.


### PR DESCRIPTION
## Summary

The two SVO fast-path cross-checks in `sumcheck/src/svo/point.rs` (`accumulate_next_suffix_into` and `accumulate_next_prefix_into`) each compute a dense `expected` reference under `#[cfg(debug_assertions)]`, then check it with a `debug_assert!`. Since the statement is already gated by the `#[cfg(debug_assertions)]` attribute, the `debug_assert!` macro double-gated the same condition.

Swap each `debug_assert!(out == expected.as_slice())` for `assert_eq!(out, expected.as_slice())`, keeping the attribute. `assert_eq!` is the right tool here: it prints both sides on mismatch for a far better failure message.

## Behavior

- The `#[cfg(debug_assertions)]` attribute is retained, so the statement is still compiled out in release (the `expected` block is cfg-gated and would not exist otherwise).
- Release behavior is unchanged; the debug check is identical with a better diagnostic.

## Validation

- `cargo build -p p3-sumcheck --all-features` and `--release` both compile (release proves the attribute still strips the statement).
- `cargo test -p p3-sumcheck --all-features svo::` passes (25 tests).
- `cargo clippy -p p3-sumcheck --all-features --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)