### PR TITLE
refactor(sumcheck): assert ternary-grid length at SVO consumption sites

### DIFF
--- a/sumcheck/src/layout/opening.rs
+++ b/sumcheck/src/layout/opening.rs
@@ -157,6 +157,10 @@ impl<EF: Field> EqPartials<EF> {
         // Expand the cached payload to the same ternary grid.
         let acc_grid = evals_01inf_grid_prefix(self.poly().as_slice());
 
+        // The grid spans the full ternary cube so the 0-face and inf-face slices are well defined.
+        debug_assert_eq!(eq_grid.len(), 3 * stride);
+        debug_assert_eq!(acc_grid.len(), 3 * stride);
+
         // The first third of the grid fixes the leading active coordinate to 0.
         acc0.iter_mut()
             .zip(eq_grid[..stride].iter().zip(acc_grid[..stride].iter()))
@@ -360,6 +364,14 @@ impl<EF: Field> NextPartials<EF> {
         let done_data_grid = evals_01inf_grid_prefix(self.done().as_slice());
         let carry_data_grid = evals_01inf_grid_prefix(self.carry().as_slice());
         let omega_data_grid = evals_01inf_grid_prefix(self.omega().as_slice());
+
+        // Every grid spans the full ternary cube so the 0-face and inf-face slices are well defined.
+        debug_assert_eq!(carry_grid.len(), 3 * stride);
+        debug_assert_eq!(done_grid.len(), 3 * stride);
+        debug_assert_eq!(omega_grid.len(), 3 * stride);
+        debug_assert_eq!(done_data_grid.len(), 3 * stride);
+        debug_assert_eq!(carry_data_grid.len(), 3 * stride);
+        debug_assert_eq!(omega_data_grid.len(), 3 * stride);
 
         // First grid third: leading active coordinate fixed to 0; sum the three state-data products.
         acc0.iter_mut()

--- a/sumcheck/src/svo/accumulator.rs
+++ b/sumcheck/src/svo/accumulator.rs
@@ -320,6 +320,9 @@ fn calculate_accumulator_general<F: Field, EF: ExtensionField<F>>(
     evals_01inf_grid_into(reduced_evals, &mut reduced_grid, &mut scratch);
 
     let stride = 3usize.pow((l - 1) as u32);
+    // Both grids span the full ternary cube so the 0-face and inf-face slices are well defined.
+    debug_assert_eq!(eq0_grid.len(), 3 * stride);
+    debug_assert_eq!(reduced_grid.len(), 3 * stride);
     let acc0 = eq0_grid[..stride]
         .iter()
         .copied()


### PR DESCRIPTION
## What

Several SVO call sites consume the ternary grid returned by `evals_01inf_grid_prefix` / `evals_01inf_grid_into` by slicing the 0-face `[..stride]` and inf-face `[2*stride..]`, but never assert the grid length is `3 * stride`. A future change to the grid producer's layout convention would silently read the wrong face.

This adds `debug_assert_eq!(<grid>.len(), 3 * stride)` for each grid slice read, right after `stride` is computed and before the slicing.

## Sites guarded

- `sumcheck/src/layout/opening.rs`: `EqPartials::accumulate_suffix` (`eq_grid`, `acc_grid`)
- `sumcheck/src/layout/opening.rs`: `NextPartials::accumulate_suffix` (`carry_grid`, `done_grid`, `omega_grid`, `done_data_grid`, `carry_data_grid`, `omega_data_grid`)
- `sumcheck/src/svo/accumulator.rs`: `calculate_accumulator_general` (`eq0_grid`, `reduced_grid`)

## Why it's behavior-preserving

`stride = 3^(active_len-1)` and each grid is `3^active_len = 3 * stride`, so the asserts hold for all valid inputs. They are `debug_assert`, so no release overhead.

`cargo test -p p3-sumcheck --all-features`: 220 passed, asserts never tripped. `fmt --check` and `clippy --all-features --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)