### PR TITLE
test(sumcheck): reuse production dispatch in the accumulator test reference

### DIFF
--- a/sumcheck/src/svo/accumulator.rs
+++ b/sumcheck/src/svo/accumulator.rs
@@ -539,22 +539,8 @@ mod test {
             .map(|chunk| dot_product::<EF, _, _>(eq1.iter().copied(), chunk.iter().copied()))
             .collect::<Vec<_>>();
 
-        // For small l, use straightline specializations that avoid loop/buffer overhead.
-        match l {
-            1 => calculate_accumulator_1(
-                eq0.as_slice().try_into().unwrap(),
-                reduced_evals.as_slice().try_into().unwrap(),
-            ),
-            2 => calculate_accumulator_2(
-                eq0.as_slice().try_into().unwrap(),
-                reduced_evals.as_slice().try_into().unwrap(),
-            ),
-            3 => calculate_accumulator_3(
-                eq0.as_slice().try_into().unwrap(),
-                reduced_evals.as_slice().try_into().unwrap(),
-            ),
-            _ => calculate_accumulator_general(l, eq0.as_slice(), &reduced_evals),
-        }
+        // Dispatch through the production path so this reference exercises the same specializations.
+        calculate_product_accumulator(l, eq0.as_slice(), &reduced_evals)
     }
 
     proptest! {


### PR DESCRIPTION
The `#[cfg(test)]` `calculate_accumulator` reference in `sumcheck/src/svo/accumulator.rs` re-implemented the same `match l {1,2,3,_}` dispatch as the production `calculate_product_accumulator`, over the same `calculate_accumulator_{1,2,3,general}` primitives.

This replaces that duplicated match with a direct call to `calculate_product_accumulator`, keeping only the test-specific `eq0`/`reduced_evals` setup. The reference stays a thin oracle and the per-`l` proptests plus `test_batch_svo_accumulators` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)