### PR TITLE
perf(sumcheck): build eval_next state tables once instead of per row

### DIFF
--- a/sumcheck/src/svo/point.rs
+++ b/sumcheck/src/svo/point.rs
@@ -481,16 +481,15 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
                 .collect(),
         );
 
+        // Closed-form successor state tables of the SVO point over all rows, built once.
+        let states = NextPartials::from_point(self.z_svo.as_slice());
+
         // Opening value: sum the three-state successor weight against the payloads over every SVO row.
         let eval = (0..svo_rows)
             .map(|svo_idx| {
-                // Boolean assignment of the SVO variables for this row.
-                let row = Point::hypercube(svo_idx, self.z_svo.num_variables());
-                // Closed-form successor states of the SVO point at this row.
-                let (carry, done, omega) = Point::eval_next(self.z_svo.as_slice(), row.as_slice());
-                done * d_eq.as_slice()[svo_idx]
-                    + carry * d_t.as_slice()[svo_idx]
-                    + omega * d_omega.as_slice()[svo_idx]
+                states.done().as_slice()[svo_idx] * d_eq.as_slice()[svo_idx]
+                    + states.carry().as_slice()[svo_idx] * d_t.as_slice()[svo_idx]
+                    + states.omega().as_slice()[svo_idx] * d_omega.as_slice()[svo_idx]
             })
             .sum();
 
@@ -561,17 +560,17 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
         let d_carry = Poly::new(d_carry);
         let d_omega = Poly::new(d_omega);
 
+        // Closed-form successor state tables of the SVO point over all rows, built once.
+        let states = NextPartials::from_point(self.z_svo.as_slice());
+        // Plain equality weights of the SVO point over all rows, indexed by hypercube row.
+        let eq = Poly::new_from_point(self.z_svo.as_slice(), EF::ONE);
+
         // Opening value: sum the three-state successor weight against the payloads over every SVO row.
         let eval = (0..svo_rows)
             .map(|svo_idx| {
-                // Boolean assignment of the SVO variables for this row.
-                let row = Point::hypercube(svo_idx, self.z_svo.num_variables());
-                // Closed-form successor states and equality weight of the SVO point at this row.
-                let (_carry, done, omega) = Point::eval_next(self.z_svo.as_slice(), row.as_slice());
-                let eq = Point::eval_eq(self.z_svo.as_slice(), row.as_slice());
-                eq * d_done.as_slice()[svo_idx]
-                    + done * d_carry.as_slice()[svo_idx]
-                    + omega * d_omega.as_slice()[svo_idx]
+                eq.as_slice()[svo_idx] * d_done.as_slice()[svo_idx]
+                    + states.done().as_slice()[svo_idx] * d_carry.as_slice()[svo_idx]
+                    + states.omega().as_slice()[svo_idx] * d_omega.as_slice()[svo_idx]
             })
             .sum();
 


### PR DESCRIPTION
## What

The opening loops in `eval_next_suffix` and `eval_next_prefix` (`sumcheck/src/svo/point.rs`) rebuilt the successor state decomposition one row at a time: each of the `2^l0` SVO rows called `Point::hypercube` (a fresh `Vec` allocation per row) and then `Point::eval_next` / `Point::eval_eq` (each `O(l0)`). That is `O(l0 \cdot 2^{l0})` work with `2^{l0}` small allocations.

The three successor-state tables (carry, done, omega) the loop reconstructs are exactly what `NextPartials::from_point` builds once in `O(2^{l0})` with no per-row allocation, and the prefix equality table is `Poly::new_from_point(z_svo, 1)`. Both use the same big-endian hypercube indexing the loop relied on, so the per-row build is replaced by a single table build dotted against the payloads.

## Why it is safe

The dot products are unchanged term by term and in the same order, so the result is byte-for-byte identical:

- `from_point` is proven to equal the per-row `eval_next` decomposition by `next_partials_from_point_matches_reference`.
- `Point::eval_eq` on a Boolean row equals the matching `Poly::new_from_point` entry.

## Framing

This is a work and allocation reduction, **not** a measured speedup. The SVO grid path is not the prover bottleneck, so no benchmark is included; correctness is confirmed by the existing tests.

## Validation

- `cargo fmt -p p3-sumcheck --check`: clean
- `cargo build -p p3-sumcheck --all-features`: ok
- `cargo test -p p3-sumcheck --all-features svo::`: 25 passed (incl. `test_svo_point_eval_next_prefix`/`_suffix`, `test_svo_point_accumulate_next_*`, and the ternary-reference test)
- `cargo clippy -p p3-sumcheck --all-features --all-targets`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)