### PR TITLE
refactor(util): replace hand-rolled assume with core::hint::assert_unchecked

### DIFF
--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -2,6 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
+use core::hint::assert_unchecked;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::{array, fmt};
@@ -19,7 +20,7 @@ use p3_field::{
     quotient_map_large_iint, quotient_map_large_uint, quotient_map_small_int,
     tonelli_shanks_two_adic,
 };
-use p3_util::{assume, branch_hint, flatten_to_base, gcd_inner};
+use p3_util::{branch_hint, flatten_to_base, gcd_inner};
 use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
 use serde::de::Error;
@@ -582,13 +583,13 @@ impl Add for Goldilocks {
         if over {
             // NB: self.value > Self::ORDER && rhs.value > Self::ORDER is necessary but not
             // sufficient for double-overflow.
-            // This assume does two things:
+            // This hint does two things:
             //  1. If compiler knows that either self.value or rhs.value <= ORDER, then it can skip
             //     this check.
             //  2. Hints to the compiler how rare this double-overflow is (thus handled better with
             //     a branch).
             unsafe {
-                assume(self.value > Self::ORDER_U64 && rhs.value > Self::ORDER_U64);
+                assert_unchecked(self.value > Self::ORDER_U64 && rhs.value > Self::ORDER_U64);
             }
             branch_hint();
             sum += Self::NEG_ORDER; // Cannot overflow.
@@ -607,13 +608,13 @@ impl Sub for Goldilocks {
         if under {
             // NB: self.value < NEG_ORDER - 1 && rhs.value > ORDER is necessary but not
             // sufficient for double-underflow.
-            // This assume does two things:
+            // This hint does two things:
             //  1. If compiler knows that either self.value >= NEG_ORDER - 1 or rhs.value <= ORDER,
             //     then it can skip this check.
             //  2. Hints to the compiler how rare this double-underflow is (thus handled better
             //     with a branch).
             unsafe {
-                assume(self.value < Self::NEG_ORDER - 1 && rhs.value > Self::ORDER_U64);
+                assert_unchecked(self.value < Self::NEG_ORDER - 1 && rhs.value > Self::ORDER_U64);
             }
             branch_hint();
             diff -= Self::NEG_ORDER; // Cannot underflow.
@@ -705,8 +706,8 @@ unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
             inlateout(reg) y => adjustment,
             options(pure, nomem, nostack),
         );
-        assume(x != 0 || (res_wrapped == y && adjustment == 0));
-        assume(y != 0 || (res_wrapped == x && adjustment == 0));
+        assert_unchecked(x != 0 || (res_wrapped == y && adjustment == 0));
+        assert_unchecked(y != 0 || (res_wrapped == x && adjustment == 0));
         // Add NEG_ORDER == subtract ORDER.
         // Cannot overflow unless the assumption if x + y < 2**64 + ORDER is incorrect.
         res_wrapped + adjustment

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::slice;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::any::type_name;
-use core::hint::unreachable_unchecked;
+use core::hint::assert_unchecked;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::{iter, mem};
 
@@ -81,7 +81,7 @@ pub const fn log2_strict_usize(n: usize) -> usize {
     // Tell the optimizer about the semantics of `log2_strict`. i.e. it can replace `n` with
     // `1 << res` and vice versa.
     unsafe {
-        assume(n == 1 << res);
+        assert_unchecked(n == 1 << res);
     }
     res as usize
 }
@@ -369,21 +369,6 @@ unsafe fn reverse_slice_index_bits_chunks<F>(
                     1 << lb_chunk_size,
                 );
             }
-        }
-    }
-}
-
-/// Allow the compiler to assume that the given predicate `p` is always `true`.
-///
-/// # Safety
-///
-/// Callers must ensure that `p` is true. If this is not the case, the behavior is undefined.
-#[inline(always)]
-pub const unsafe fn assume(p: bool) {
-    debug_assert!(p);
-    if !p {
-        unsafe {
-            unreachable_unchecked();
         }
     }
 }


### PR DESCRIPTION
## Summary

`p3_util::assume` predates `core::hint::assert_unchecked`, which is now stable (and `const`-stable). The std intrinsic gives the same optimizer promise — \"this predicate always holds\" — plus a debug-time precondition check, so the hand-rolled wrapper no longer earns its place:

```rust
// before
pub const unsafe fn assume(p: bool) {
    debug_assert!(p);
    if !p { unsafe { unreachable_unchecked(); } }
}
```

This deletes `assume` and calls `core::hint::assert_unchecked` directly.

## Changes

- **`util/src/lib.rs`**: remove the `assume` function; swap the `unreachable_unchecked` import (only `assume` used it) for `assert_unchecked`; call it directly in `log2_strict_usize`.
- **`goldilocks/src/goldilocks.rs`** (the only external user): drop `assume` from the `p3_util` import, add `use core::hint::assert_unchecked;`, and update all 4 call sites (they remain inside their existing `unsafe` blocks, since `assert_unchecked` is also `unsafe`). Two nearby comments referencing the old name were reworded.

## Behavior

Identical optimizer contract. The only nuance: the old `assume` used `debug_assert!` (unwinding panic in debug), whereas `assert_unchecked` uses std's precondition check (aborts in debug). No release-mode difference.

## Testing

On nightly `1.98.0`: `cargo build`, `cargo clippy` (no warnings), and `cargo test` for `p3-util` and `p3-goldilocks` all pass (340 + 55 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)