### PR TITLE
perf(air): make symbolic degree calculation trace-size aware

### DIFF
--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -59,11 +59,11 @@ impl AirLayout {
 /// degree at most `d * (trace_len - 1) + 1` (the `+ 1` covers the linear
 /// transition selector). We therefore return the smallest `d` satisfying
 /// `poly_degree <= d * (trace_len - 1) + 1`.
-pub fn constraint_degree_from_poly_degree(poly_degree: usize, trace_len: usize) -> usize {
+pub const fn constraint_degree_from_poly_degree(poly_degree: usize, trace_len: usize) -> usize {
     if poly_degree == 0 {
         return 0;
     }
-    let denom = trace_len.saturating_sub(1).max(1);
+    let denom = if trace_len > 1 { trace_len - 1 } else { 1 };
     (poly_degree - 1).div_ceil(denom)
 }
 

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -51,13 +51,29 @@ impl AirLayout {
     }
 }
 
+/// Convert an absolute constraint-polynomial degree into the "constraint degree"
+/// used to size the quotient: the number of degree-`(trace_len - 1)` trace
+/// polynomials the constraint behaves like.
+///
+/// The quotient machinery bounds a constraint of degree `d` by a polynomial of
+/// degree at most `d * (trace_len - 1) + 1` (the `+ 1` covers the linear
+/// transition selector). We therefore return the smallest `d` satisfying
+/// `poly_degree <= d * (trace_len - 1) + 1`.
+pub fn constraint_degree_from_poly_degree(poly_degree: usize, trace_len: usize) -> usize {
+    if poly_degree == 0 {
+        return 0;
+    }
+    let denom = trace_len.saturating_sub(1).max(1);
+    (poly_degree - 1).div_ceil(denom)
+}
+
 #[instrument(skip_all, level = "debug")]
-pub fn get_max_constraint_degree<F, A>(air: &A, layout: AirLayout) -> usize
+pub fn get_max_constraint_degree<F, A>(air: &A, layout: AirLayout, trace_len: usize) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
 {
-    get_max_constraint_degree_extension(air, layout)
+    get_max_constraint_degree_extension(air, layout, trace_len)
 }
 
 #[instrument(
@@ -65,7 +81,11 @@ where
     skip_all,
     level = "debug"
 )]
-pub fn get_max_constraint_degree_extension<F, EF, A>(air: &A, layout: AirLayout) -> usize
+pub fn get_max_constraint_degree_extension<F, EF, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_len: usize,
+) -> usize
 where
     F: Field,
     EF: ExtensionField<F>,
@@ -73,18 +93,35 @@ where
 {
     let (base_constraints, extension_constraints) = get_all_symbolic_constraints(air, layout);
 
+    // Without periodic columns the trace-size-aware degree coincides with the cached
+    // degree multiple: the linear transition selector never changes the constraint
+    // degree, and every other leaf scales with `trace_len - 1`. Reuse the cached
+    // degrees and skip the expression walk entirely.
+    if layout.num_periodic_columns == 0 {
+        return base_constraints
+            .iter()
+            .map(|c| c.degree_multiple())
+            .chain(extension_constraints.iter().map(|c| c.degree_multiple()))
+            .max()
+            .unwrap_or(0);
+    }
+
+    // Period (cycle length) of each periodic column, indexed by periodic column index.
+    let periodic_periods: Vec<usize> = air.periodic_columns().iter().map(Vec::len).collect();
+
     let base_degree = base_constraints
         .iter()
-        .map(|c| c.degree_multiple())
+        .map(|c| c.poly_degree(trace_len, &periodic_periods))
         .max()
         .unwrap_or(0);
 
     let extension_degree = extension_constraints
         .iter()
-        .map(|c| c.degree_multiple())
+        .map(|c| c.poly_degree(trace_len, &periodic_periods))
         .max()
         .unwrap_or(0);
-    base_degree.max(extension_degree)
+
+    constraint_degree_from_poly_degree(base_degree.max(extension_degree), trace_len)
 }
 
 #[instrument(
@@ -530,6 +567,55 @@ mod tests {
         }
     }
 
+    /// A mock AIR with two period-2 periodic columns whose single constraint is
+    /// their product.
+    #[derive(Debug)]
+    struct PeriodicProductAir;
+
+    impl BaseAir<F> for PeriodicProductAir {
+        fn width(&self) -> usize {
+            1
+        }
+        fn num_periodic_columns(&self) -> usize {
+            2
+        }
+        fn periodic_columns(&self) -> Vec<Vec<F>> {
+            // Two columns of period 2.
+            vec![vec![F::ZERO, F::ONE], vec![F::ONE, F::new(2)]]
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<F>> for PeriodicProductAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<F>) {
+            let periodic = builder.periodic_values().to_vec();
+            builder.assert_zero(periodic[0] * periodic[1]);
+        }
+    }
+
+    #[test]
+    fn test_constraint_degree_from_poly_degree() {
+        // A degree-0 (constant) polynomial maps to constraint degree 0.
+        assert_eq!(constraint_degree_from_poly_degree(0, 8), 0);
+        // A single trace column (degree N - 1) is constraint degree 1.
+        assert_eq!(constraint_degree_from_poly_degree(7, 8), 1);
+        // A transition-guarded column (degree N) is still constraint degree 1: the
+        // linear selector is absorbed by the quotient bound's `+ 1` slack.
+        assert_eq!(constraint_degree_from_poly_degree(8, 8), 1);
+        // A degree-`2(N - 1)` polynomial is constraint degree 2.
+        assert_eq!(constraint_degree_from_poly_degree(14, 8), 2);
+    }
+
+    #[test]
+    fn test_get_max_constraint_degree_periodic_is_reduced() {
+        // The product of two period-2 columns has polynomial degree
+        // (N - N/2) + (N - N/2) = N, which is constraint degree 1 — half of the 2
+        // that two regular columns (or the trace-size-independent degree multiple)
+        // would report.
+        let air = PeriodicProductAir;
+        let l = layout(0, 1, 0, 2);
+        assert_eq!(get_max_constraint_degree(&air, l, 8), 1);
+    }
+
     #[test]
     fn test_get_max_constraint_degree_no_constraints() {
         let air = MockAir {
@@ -537,7 +623,7 @@ mod tests {
             width: 4,
         };
         let l = layout(3, air.width, air.num_public_values(), 0);
-        let max_degree = get_max_constraint_degree(&air, l);
+        let max_degree = get_max_constraint_degree(&air, l, 8);
         assert_eq!(
             max_degree, 0,
             "No constraints should result in a degree of 0"
@@ -555,7 +641,7 @@ mod tests {
             width: 4,
         };
         let l = layout(3, air.width, air.num_public_values(), 0);
-        let max_degree = get_max_constraint_degree(&air, l);
+        let max_degree = get_max_constraint_degree(&air, l, 8);
         assert_eq!(max_degree, 1, "Max constraint degree should be 1");
     }
 
@@ -823,7 +909,7 @@ mod tests {
         // The max degree covers both base and extension constraints.
         let air = ExtMockAir { width: 2 };
         let l = layout_with_perm(0, air.width, air.num_public_values(), 3, 1, 0);
-        let max_deg = get_max_constraint_degree_extension::<F, EF, _>(&air, l);
+        let max_deg = get_max_constraint_degree_extension::<F, EF, _>(&air, l, 8);
 
         // Both constraints are single variables with degree 1.
         assert_eq!(max_deg, 1);

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -48,6 +48,18 @@ impl<F: Field> SymLeaf for BaseLeaf<F> {
         }
     }
 
+    fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
+        match self {
+            Self::Variable(v) => v.poly_degree(trace_len, periodic_periods),
+            // Boundary selectors are non-zero at a single row, so they are degree-`(N - 1)`
+            // polynomials, while the transition selector only needs to vanish on the last
+            // row and so is linear.
+            Self::IsFirstRow | Self::IsLastRow => trace_len.saturating_sub(1),
+            Self::IsTransition => 1,
+            Self::Constant(_) => 0,
+        }
+    }
+
     fn as_const(&self) -> Option<&F> {
         match self {
             Self::Constant(c) => Some(c),
@@ -280,6 +292,64 @@ mod tests {
             2,
             "Multiplication should sum degrees"
         );
+    }
+
+    #[test]
+    fn test_symbolic_expression_poly_degree() {
+        const N: usize = 8;
+
+        // The transition selector is linear, unlike the boundary selectors which are
+        // degree-`(N - 1)` polynomials.
+        let is_transition = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
+        assert_eq!(is_transition.poly_degree(N, &[]), 1);
+
+        let is_first_row = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsFirstRow);
+        assert_eq!(is_first_row.poly_degree(N, &[]), N - 1);
+
+        // Constants contribute nothing.
+        let constant = SymbolicExpression::Leaf(BaseLeaf::Constant(BabyBear::new(5)));
+        assert_eq!(constant.poly_degree(N, &[]), 0);
+
+        // `is_transition * main` is degree `1 + (N - 1) = N`.
+        let main = SymbolicExpression::<BabyBear>::from(SymbolicVariable::new(
+            BaseEntry::Main { offset: 0 },
+            0,
+        ));
+        let guarded = is_transition * main.clone();
+        assert_eq!(guarded.poly_degree(N, &[]), N);
+
+        // Products of periodic columns sum their reduced degrees: two period-2
+        // columns give `(N - N/2) + (N - N/2) = N`, versus `2(N - 1)` for two
+        // regular columns.
+        let p0 =
+            SymbolicExpression::<BabyBear>::from(SymbolicVariable::new(BaseEntry::Periodic, 0));
+        let p1 =
+            SymbolicExpression::<BabyBear>::from(SymbolicVariable::new(BaseEntry::Periodic, 1));
+        let periodic_product = p0 * p1;
+        assert_eq!(periodic_product.poly_degree(N, &[2, 2]), N);
+
+        // Sums take the max degree of their operands.
+        let sum = main + SymbolicExpression::Leaf(BaseLeaf::IsTransition);
+        assert_eq!(sum.poly_degree(N, &[]), N - 1);
+    }
+
+    #[test]
+    fn poly_degree_handles_shared_dag_in_linear_time() {
+        // Repeated squaring builds a DAG of depth `d` whose flattened tree has
+        // `2^d` leaves but only `O(d)` distinct nodes. `poly_degree` must run in
+        // time proportional to the distinct nodes; without memoization this test
+        // would take `O(2^d)` and never finish.
+        const DEPTH: usize = 30;
+        const N: usize = 1 << 10;
+
+        let mut expr =
+            SymbolicExpression::<BabyBear>::from(SymbolicVariable::new(BaseEntry::Periodic, 0));
+        for _ in 0..DEPTH {
+            expr = expr.clone() * expr.clone();
+        }
+
+        // The period-2 column has degree `N - N/2 = N/2`; each squaring doubles it.
+        assert_eq!(expr.poly_degree(N, &[2]), (N / 2) << DEPTH);
     }
 
     #[test]

--- a/air/src/symbolic/expression_ext.rs
+++ b/air/src/symbolic/expression_ext.rs
@@ -47,6 +47,14 @@ impl<F: Field, EF: ExtensionField<F>> SymLeaf for ExtLeaf<F, EF> {
         }
     }
 
+    fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
+        match self {
+            Self::Base(e) => e.poly_degree(trace_len, periodic_periods),
+            Self::ExtVariable(v) => v.poly_degree(trace_len),
+            Self::ExtConstant(_) => 0,
+        }
+    }
+
     fn as_const(&self) -> Option<&F> {
         match self {
             Self::Base(SymbolicExpression::Leaf(BaseLeaf::Constant(c))) => Some(c),

--- a/air/src/symbolic/mod.rs
+++ b/air/src/symbolic/mod.rs
@@ -5,6 +5,7 @@ mod expression;
 pub(crate) mod expression_ext;
 mod variable;
 
+use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use core::iter::{Product, Sum};
 use core::ops;
@@ -32,6 +33,10 @@ pub trait SymLeaf: Clone + core::fmt::Debug {
 
     /// Returns the degree multiple of this leaf.
     fn degree_multiple(&self) -> usize;
+
+    /// Returns the exact polynomial degree of this leaf over a trace of length
+    /// `trace_len`, given the period of each periodic column.
+    fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize;
 
     /// Try to view this leaf as a base-field constant.
     fn as_const(&self) -> Option<&Self::F>;
@@ -100,6 +105,59 @@ impl<A: SymLeaf> SymbolicExpr<A> {
                 degree_multiple, ..
             } => *degree_multiple,
         }
+    }
+
+    /// Returns the exact polynomial degree of this expression over a trace of
+    /// length `trace_len`, given the period of each periodic column (indexed by
+    /// periodic column index).
+    ///
+    /// This is trace-size aware: it treats the transition selector as the linear
+    /// polynomial it is and accounts for the reduced degree of periodic columns,
+    /// unlike the trace-size-independent [`Self::degree_multiple`].
+    pub fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
+        // The expression is a DAG: arithmetic nodes share `Arc` children, so a naive
+        // recursion would revisit shared subtrees exponentially. Memoize on node
+        // identity to keep this linear in the number of distinct nodes.
+        let mut cache: BTreeMap<*const Self, usize> = BTreeMap::new();
+        self.poly_degree_memo(trace_len, periodic_periods, &mut cache)
+    }
+
+    fn poly_degree_memo(
+        &self,
+        trace_len: usize,
+        periodic_periods: &[usize],
+        cache: &mut BTreeMap<*const Self, usize>,
+    ) -> usize {
+        match self {
+            Self::Leaf(a) => a.poly_degree(trace_len, periodic_periods),
+            Self::Add { x, y, .. } | Self::Sub { x, y, .. } => {
+                Self::child_poly_degree(x, trace_len, periodic_periods, cache).max(
+                    Self::child_poly_degree(y, trace_len, periodic_periods, cache),
+                )
+            }
+            Self::Neg { x, .. } => Self::child_poly_degree(x, trace_len, periodic_periods, cache),
+            Self::Mul { x, y, .. } => {
+                Self::child_poly_degree(x, trace_len, periodic_periods, cache)
+                    + Self::child_poly_degree(y, trace_len, periodic_periods, cache)
+            }
+        }
+    }
+
+    /// Degree of an `Arc`-shared child, looked up by pointer identity so each
+    /// distinct node is evaluated at most once.
+    fn child_poly_degree(
+        node: &Arc<Self>,
+        trace_len: usize,
+        periodic_periods: &[usize],
+        cache: &mut BTreeMap<*const Self, usize>,
+    ) -> usize {
+        let key = Arc::as_ptr(node);
+        if let Some(&degree) = cache.get(&key) {
+            return degree;
+        }
+        let degree = node.poly_degree_memo(trace_len, periodic_periods, cache);
+        cache.insert(key, degree);
+        degree
     }
 
     /// Try to view this expression as a base-field constant.

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -64,12 +64,7 @@ impl<F> SymbolicVariable<F> {
                     .min(trace_len);
                 match period {
                     0 => trace_len.saturating_sub(1),
-                    p => {
-                        // `trace_len` is a power of two, so a valid period (which must
-                        // divide it) is too; this guards the `trace_len / p` exactness.
-                        debug_assert!(p.is_power_of_two());
-                        trace_len - trace_len / p
-                    }
+                    p => trace_len - trace_len / p,
                 }
             }
             BaseEntry::Public => 0,

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -36,12 +36,37 @@ impl<F> SymbolicVariable<F> {
 
     pub const fn degree_multiple(&self) -> usize {
         match self.entry {
-            BaseEntry::Preprocessed { .. }
-            | BaseEntry::Main { .. }
-            // TODO: Periodic columns use degree 1 as an approximation. In Winterfell's model,
-            // a periodic column with period `p` over trace length `n` contributes degree `n/p - 1`.
-            // See: https://github.com/facebook/winterfell/blob/main/air/src/air/transition/degree.rs
-            | BaseEntry::Periodic => 1,
+            // Periodic columns are bounded by degree 1 here; the exact, trace-size-aware
+            // degree is computed by [`Self::poly_degree`].
+            BaseEntry::Preprocessed { .. } | BaseEntry::Main { .. } | BaseEntry::Periodic => 1,
+            BaseEntry::Public => 0,
+        }
+    }
+
+    /// Returns the exact degree of the polynomial this variable resolves to over a
+    /// trace of length `trace_len`, given the period of each periodic column
+    /// (indexed by periodic column index).
+    ///
+    /// Unlike [`Self::degree_multiple`], which measures degree in multiples of the
+    /// degree-`(trace_len - 1)` trace polynomials, this returns the absolute
+    /// polynomial degree, so it accounts for the reduced degree of periodic columns.
+    pub fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
+        match self.entry {
+            BaseEntry::Preprocessed { .. } | BaseEntry::Main { .. } => trace_len.saturating_sub(1),
+            BaseEntry::Periodic => {
+                // A periodic column of period `p` (with `p | trace_len`) is the evaluation
+                // of `f'(X) = f(X^(trace_len/p))` with `deg f < p`, so its degree is
+                // `(p - 1) * (trace_len / p) = trace_len - trace_len / p`.
+                let period = periodic_periods
+                    .get(self.index)
+                    .copied()
+                    .unwrap_or(trace_len)
+                    .min(trace_len);
+                match period {
+                    0 => trace_len.saturating_sub(1),
+                    p => trace_len - trace_len / p,
+                }
+            }
             BaseEntry::Public => 0,
         }
     }
@@ -67,6 +92,15 @@ impl<F, EF> SymbolicVariableExt<F, EF> {
     pub const fn degree_multiple(&self) -> usize {
         match self.entry {
             ExtEntry::Permutation { .. } => 1,
+            ExtEntry::Challenge | ExtEntry::PermutationValue => 0,
+        }
+    }
+
+    /// Returns the exact polynomial degree of this extension variable over a trace
+    /// of length `trace_len`. See [`SymbolicVariable::poly_degree`].
+    pub const fn poly_degree(&self, trace_len: usize) -> usize {
+        match self.entry {
+            ExtEntry::Permutation { .. } => trace_len.saturating_sub(1),
             ExtEntry::Challenge | ExtEntry::PermutationValue => 0,
         }
     }
@@ -141,6 +175,53 @@ mod tests {
         let var = SymbolicVariableExt::<F, EF>::new(ExtEntry::Challenge, 4);
         assert_eq!(var.entry, ExtEntry::Challenge);
         assert_eq!(var.index, 4);
+    }
+
+    #[test]
+    fn symbolic_variable_poly_degree_main_and_preprocessed() {
+        // Main and preprocessed columns are degree-`(N - 1)` trace polynomials.
+        let main = SymbolicVariable::<F>::new(BaseEntry::Main { offset: 1 }, 0);
+        let prep = SymbolicVariable::<F>::new(BaseEntry::Preprocessed { offset: 0 }, 0);
+        assert_eq!(main.poly_degree(8, &[]), 7);
+        assert_eq!(prep.poly_degree(8, &[]), 7);
+    }
+
+    #[test]
+    fn symbolic_variable_poly_degree_public_is_constant() {
+        // Public inputs are constants, regardless of trace length.
+        let var = SymbolicVariable::<F>::new(BaseEntry::Public, 0);
+        assert_eq!(var.poly_degree(8, &[]), 0);
+    }
+
+    #[test]
+    fn symbolic_variable_poly_degree_periodic() {
+        // A periodic column of period `p` over a trace of length `N` has degree
+        // `N - N / p`, strictly below the `N - 1` of a regular column for `p < N`.
+        let var = SymbolicVariable::<F>::new(BaseEntry::Periodic, 0);
+        // Period 2 over N = 8: degree 8 - 4 = 4.
+        assert_eq!(var.poly_degree(8, &[2]), 4);
+        // Period 4 over N = 8: degree 8 - 2 = 6.
+        assert_eq!(var.poly_degree(8, &[4]), 6);
+        // Period equal to N behaves like a regular column: degree N - 1.
+        assert_eq!(var.poly_degree(8, &[8]), 7);
+        // Period 1 is a true constant column: degree 0.
+        assert_eq!(var.poly_degree(8, &[1]), 0);
+    }
+
+    #[test]
+    fn symbolic_variable_poly_degree_periodic_missing_period_is_conservative() {
+        // With no period recorded for the column, fall back to a full-degree column.
+        let var = SymbolicVariable::<F>::new(BaseEntry::Periodic, 3);
+        assert_eq!(var.poly_degree(8, &[]), 7);
+    }
+
+    #[test]
+    fn symbolic_variable_ext_poly_degree() {
+        // Permutation columns are degree-`(N - 1)` polynomials; challenges are constants.
+        let perm = SymbolicVariableExt::<F, EF>::new(ExtEntry::Permutation { offset: 0 }, 0);
+        let challenge = SymbolicVariableExt::<F, EF>::new(ExtEntry::Challenge, 0);
+        assert_eq!(perm.poly_degree(8), 7);
+        assert_eq!(challenge.poly_degree(8), 0);
     }
 
     #[test]

--- a/air/src/symbolic/variable.rs
+++ b/air/src/symbolic/variable.rs
@@ -64,7 +64,12 @@ impl<F> SymbolicVariable<F> {
                     .min(trace_len);
                 match period {
                     0 => trace_len.saturating_sub(1),
-                    p => trace_len - trace_len / p,
+                    p => {
+                        // `trace_len` is a power of two, so a valid period (which must
+                        // divide it) is too; this guards the `trace_len / p` exactness.
+                        debug_assert!(p.is_power_of_two());
+                        trace_len - trace_len / p
+                    }
                 }
             }
             BaseEntry::Public => 0,

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -265,7 +265,11 @@ where
         let lookup_gadget = LogUpGadget::new();
         let lookups: Vec<Lookups<Val<SC>>> = airs
             .iter()
-            .map(|air| {
+            .zip(trace_ext_degree_bits.iter())
+            .map(|(air, &ext_db)| {
+                // Base trace length `N` (before any ZK extension), matching what the
+                // prover and verifier feed the degree model for this instance.
+                let trace_len = 1usize << (ext_db - is_zk);
                 let unpacked = Lookups::<Val<SC>>::from_air::<SC::Challenge, A>(air);
 
                 // `log_chunks` fixes the quotient bucket: n_chunks = 2^log_chunks.
@@ -273,6 +277,7 @@ where
                     get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
                         air,
                         AirLayout::from_air(air),
+                        trace_len,
                         &unpacked,
                         is_zk,
                         &lookup_gadget,
@@ -290,6 +295,7 @@ where
                     get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
                         air,
                         AirLayout::from_air(air),
+                        trace_len,
                         &packed,
                         is_zk,
                         &lookup_gadget,

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -185,6 +185,7 @@ where
                     get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
                         air,
                         layout,
+                        degrees[i],
                         all_lookups[i],
                         config.is_zk(),
                         &lookup_gadget,

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -1,7 +1,10 @@
 use alloc::vec::Vec;
 
 use p3_air::Air;
-use p3_air::symbolic::{AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt};
+use p3_air::symbolic::{
+    AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt,
+    constraint_degree_from_poly_degree,
+};
 use p3_field::{Algebra, ExtensionField, Field};
 use p3_lookup::{InteractionSymbolicBuilder, Lookup, LookupProtocol};
 use p3_util::log2_ceil_usize;
@@ -49,6 +52,7 @@ where
 pub fn get_log_num_quotient_chunks<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
+    trace_len: usize,
     contexts: &[Lookup<F>],
     is_zk: usize,
     lookup_gadget: &LG,
@@ -77,7 +81,8 @@ where
         // a different hint than the verifier computes for itself.
         debug_assert!(
             {
-                let actual = get_max_constraint_degree(air, layout, contexts, lookup_gadget);
+                let actual =
+                    get_max_constraint_degree(air, layout, trace_len, contexts, lookup_gadget);
                 max_degree >= actual
             },
             "max_constraint_degree() hint {} with lookup degree {} is too small; \
@@ -91,7 +96,7 @@ where
 
     // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
     let constraint_degree =
-        (get_max_constraint_degree(air, layout, contexts, lookup_gadget) + is_zk).max(2);
+        (get_max_constraint_degree(air, layout, trace_len, contexts, lookup_gadget) + is_zk).max(2);
 
     // The quotient's actual degree is approximately (max_constraint_degree - 1) n,
     // where subtracting 1 comes from division by the vanishing polynomial.
@@ -103,6 +108,7 @@ where
 pub fn get_max_constraint_degree<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,
+    trace_len: usize,
     contexts: &[Lookup<F>],
     lookup_gadget: &LG,
 ) -> usize
@@ -114,13 +120,32 @@ where
     LG: LookupProtocol,
 {
     let (base, extension) = get_symbolic_constraints(air, layout, contexts, lookup_gadget);
-    let base_degree = base.iter().map(|c| c.degree_multiple()).max().unwrap_or(0);
-    let extension_degree = extension
+
+    // Without periodic columns the trace-size-aware degree coincides with the cached
+    // degree multiple, so reuse it and skip the expression walk entirely.
+    if layout.num_periodic_columns == 0 {
+        return base
+            .iter()
+            .map(|c| c.degree_multiple())
+            .chain(extension.iter().map(|c| c.degree_multiple()))
+            .max()
+            .unwrap_or(0);
+    }
+
+    // Period (cycle length) of each periodic column, indexed by periodic column index.
+    let periodic_periods: Vec<usize> = air.periodic_columns().iter().map(Vec::len).collect();
+
+    let base_degree = base
         .iter()
-        .map(|c| c.degree_multiple())
+        .map(|c| c.poly_degree(trace_len, &periodic_periods))
         .max()
         .unwrap_or(0);
-    base_degree.max(extension_degree)
+    let extension_degree = extension
+        .iter()
+        .map(|c| c.poly_degree(trace_len, &periodic_periods))
+        .max()
+        .unwrap_or(0);
+    constraint_degree_from_poly_degree(base_degree.max(extension_degree), trace_len)
 }
 
 #[instrument(name = "evaluate constraints symbolically", skip_all, level = "debug")]

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -125,6 +125,7 @@ where
                 get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
                     air,
                     layout,
+                    1usize << base_db,
                     &all_lookups[i],
                     config.is_zk(),
                     &lookup_gadget,

--- a/monolith-air/src/lib.rs
+++ b/monolith-air/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
             main_width: air.width(),
             ..Default::default()
         };
-        let degree = get_max_constraint_degree::<F, _>(&air, layout);
+        let degree = get_max_constraint_degree::<F, _>(&air, layout, 1 << 6);
 
         // Cap set by the chi AND product binding (degree 3); all other
         // constraints are degree ≤ 2.

--- a/poseidon1-air/src/lib.rs
+++ b/poseidon1-air/src/lib.rs
@@ -151,7 +151,7 @@ mod tests {
             main_width: air.width(),
             ..Default::default()
         };
-        let degree = get_max_constraint_degree::<F, _>(&air, layout);
+        let degree = get_max_constraint_degree::<F, _>(&air, layout, 1 << 6);
         assert_eq!(
             degree, 3,
             "Expected constraint degree 3 for BabyBear (7, 1)"
@@ -176,7 +176,7 @@ mod tests {
             main_width: air.width(),
             ..Default::default()
         };
-        let degree = get_max_constraint_degree::<F, _>(&air, layout);
+        let degree = get_max_constraint_degree::<F, _>(&air, layout, 1 << 6);
         assert_eq!(degree, 5, "Expected constraint degree 5 for (11, 1)");
     }
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -122,7 +122,7 @@ where
     // of quotient polynomials we will split Q(x) into. This is chosen to
     // always be a power of 2.
     let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, degree, config.is_zk());
 
     let num_quotient_chunks = 1 << (log_num_quotient_chunks + config.is_zk());
 

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -7,7 +7,12 @@ use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
 #[instrument(skip_all, level = "debug")]
-pub fn get_log_num_quotient_chunks<F, A>(air: &A, layout: AirLayout, is_zk: usize) -> usize
+pub fn get_log_num_quotient_chunks<F, A>(
+    air: &A,
+    layout: AirLayout,
+    trace_len: usize,
+    is_zk: usize,
+) -> usize
 where
     F: Field,
     A: Air<SymbolicAirBuilder<F>>,
@@ -23,7 +28,8 @@ where
         // a different hint than the verifier computes for itself.
         debug_assert!(
             {
-                let symbolic = get_log_quotient_degree_extension::<F, F, A>(air, layout, is_zk);
+                let symbolic =
+                    get_log_quotient_degree_extension::<F, F, A>(air, layout, trace_len, is_zk);
                 result >= symbolic
             },
             "max_constraint_degree() hint {} is too small; actual log quotient degree is larger",
@@ -33,7 +39,7 @@ where
         return result;
     }
 
-    get_log_quotient_degree_extension(air, layout, is_zk)
+    get_log_quotient_degree_extension(air, layout, trace_len, is_zk)
 }
 
 #[instrument(
@@ -44,6 +50,7 @@ where
 pub fn get_log_quotient_degree_extension<F, EF, A>(
     air: &A,
     layout: AirLayout,
+    trace_len: usize,
     is_zk: usize,
 ) -> usize
 where
@@ -59,7 +66,8 @@ where
 
         debug_assert!(
             {
-                let actual = get_max_constraint_degree_extension::<F, EF, A>(air, layout);
+                let actual =
+                    get_max_constraint_degree_extension::<F, EF, A>(air, layout, trace_len);
                 degree_hint >= actual
             },
             "max_constraint_degree() hint {} is too small; symbolic evaluation found a larger degree",
@@ -71,7 +79,7 @@ where
 
     // We pad to at least degree 2, since a quotient argument doesn't make sense with smaller degrees.
     let constraint_degree =
-        (get_max_constraint_degree_extension::<F, EF, A>(air, layout) + is_zk).max(2);
+        (get_max_constraint_degree_extension::<F, EF, A>(air, layout, trace_len) + is_zk).max(2);
 
     // We bound the degree of the quotient polynomial by constraint_degree - 1,
     // then choose the number of quotient chunks as the smallest power of two
@@ -125,7 +133,7 @@ mod tests {
             constraints: vec![],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 8, 0);
         assert_eq!(log_degree, 0);
     }
 
@@ -135,7 +143,7 @@ mod tests {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 8, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -149,7 +157,7 @@ mod tests {
             ],
             width: 4,
         };
-        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 0);
+        let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 8, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
     }
 
@@ -188,7 +196,7 @@ mod tests {
             width: 4,
             degree_hint: Some(3),
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 8, 0);
         assert_eq!(log_chunks, log2_ceil_usize(2));
     }
 
@@ -201,7 +209,7 @@ mod tests {
             width: 4,
             degree_hint: None,
         };
-        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 8, 0);
         assert_eq!(log_chunks, 0);
     }
 
@@ -213,7 +221,7 @@ mod tests {
             width: 4,
             degree_hint: Some(1),
         };
-        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let with_hint = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 8, 0);
 
         let air_no_hint = HintedMockAir {
             constraints: vec![SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0)],
@@ -221,7 +229,7 @@ mod tests {
             degree_hint: None,
         };
         let without_hint =
-            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), 0);
+            get_log_num_quotient_chunks(&air_no_hint, air_layout(&air_no_hint, 0), 8, 0);
 
         assert_eq!(with_hint, without_hint);
     }
@@ -236,6 +244,6 @@ mod tests {
             width: 4,
             degree_hint: Some(0),
         };
-        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 0);
+        let _ = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 8, 0);
     }
 }

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -330,8 +330,12 @@ where
         num_periodic_columns: air.num_periodic_columns(),
         ..Default::default()
     };
+    // Base trace length `N` (before any ZK extension); the quotient degree model
+    // measures trace columns as degree-`(N - 1)` polynomials and accounts for ZK
+    // separately via `is_zk`.
+    let base_degree = 1usize << base_degree_bits;
     let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, config.is_zk());
+        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, base_degree, config.is_zk());
     let (_, num_quotient_chunks) = checked_log_size_sum(log_num_quotient_chunks, config.is_zk())
         .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
             air: None,


### PR DESCRIPTION
Resolves #1382.

The SymbolicAir degree calculation was slightly off in a trace-size-dependent way: it treated the transition selector as a constant (it is linear) and overestimated the degree of periodic columns.

Add `SymbolicExpr::poly_degree(trace_len, periodic_periods)` computing the exact constraint-polynomial degree over a trace of length N: the transition selector contributes degree 1, and a periodic column of period p contributes N - N/p (versus the N-1 of a regular column). `constraint_degree_from_poly_degree` converts that absolute degree back into the unit constraint degree the existing quotient/ZK/security pipeline consumes, so the proven chunk-sizing math is untouched. The result is provably never larger than the previous degree and is tighter when periodic reductions cross a power-of-two quotient-chunk boundary.

Thread the base trace length N through get_max_constraint_degree[_extension], get_log_quotient_degree_extension and get_log_num_quotient_chunks in both uni-stark and batch-stark, passing it consistently from the prover, verifier (1 << base_degree_bits, not the ZK-extended length) and the batch keygen path so all three agree on the chunk count.

`poly_degree` is memoized on Arc pointer identity, keeping it linear in the number of distinct DAG nodes (the symbolic expression shares Arc children, so a naive walk is exponential). When an AIR has no periodic columns the trace-aware degree equals the cached degree_multiple, so that case short-circuits and skips the walk entirely.