### PR TITLE
perf: make `periodic_columns()` return a borrow-or-owned `Cow`

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -1,4 +1,4 @@
-use alloc::vec;
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use p3_matrix::dense::RowMajorMatrix;
@@ -54,8 +54,11 @@ pub trait BaseAir<F>: Sync {
     /// Periodic columns are public parameters and must be committed during initialization of
     /// the Fiat-Shamir transcript. The values returned are evaluations over a subgroup;
     /// callers may convert to coefficient form for efficient evaluation if needed.
-    fn periodic_columns(&self) -> Vec<Vec<F>> {
-        vec![]
+    fn periodic_columns(&self) -> Cow<'_, [Vec<F>]>
+    where
+        F: Clone,
+    {
+        Cow::Borrowed(&[])
     }
 
     /// Return the periodic values for the given row index.

--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -499,6 +499,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::borrow::Cow;
+
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
@@ -580,9 +582,9 @@ mod tests {
         fn num_periodic_columns(&self) -> usize {
             2
         }
-        fn periodic_columns(&self) -> Vec<Vec<F>> {
+        fn periodic_columns(&self) -> Cow<'_, [Vec<F>]> {
             // Two columns of period 2.
-            vec![vec![F::ZERO, F::ONE], vec![F::ONE, F::new(2)]]
+            Cow::Owned(vec![vec![F::ZERO, F::ONE], vec![F::ONE, F::new(2)]])
         }
     }
 

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -2,6 +2,7 @@ use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::slice::from_ref;
+use std::borrow::Cow;
 
 use p3_air::{Air, AirBuilder, BaseAir, PermutationAirBuilder, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -223,8 +224,8 @@ impl<F: Field> BaseAir<F> for PeriodicAir<F> {
         self.periodic.len()
     }
 
-    fn periodic_columns(&self) -> Vec<Vec<F>> {
-        self.periodic.clone()
+    fn periodic_columns(&self) -> Cow<'_, [Vec<F>]> {
+        Cow::Borrowed(&self.periodic)
     }
 }
 

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -1,5 +1,6 @@
 use core::fmt::Debug;
 use core::marker::PhantomData;
+use std::borrow::Cow;
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -60,8 +61,8 @@ impl<F: Field> BaseAir<F> for PeriodicAir<F> {
         self.periodic.len()
     }
 
-    fn periodic_columns(&self) -> Vec<Vec<F>> {
-        self.periodic.clone()
+    fn periodic_columns(&self) -> Cow<'_, [Vec<F>]> {
+        Cow::Borrowed(&self.periodic)
     }
 }
 

--- a/uni-stark/tests/periodic_column_shape.rs
+++ b/uni-stark/tests/periodic_column_shape.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
@@ -45,10 +47,10 @@ impl<F: Field> BaseAir<F> for SinglePeriodicAir {
         1
     }
 
-    fn periodic_columns(&self) -> Vec<Vec<F>> {
+    fn periodic_columns(&self) -> Cow<'_, [Vec<F>]> {
         // A single column holding 0, 1, ..., period - 1.
         // A period of zero yields one empty column, which has no valid subdomain.
-        vec![(0..self.period as u64).map(F::from_u64).collect()]
+        Cow::Owned(vec![(0..self.period as u64).map(F::from_u64).collect()])
     }
 }
 


### PR DESCRIPTION
In some side projects I've done, I noticed the double Vec could be sometimes heavy and induce some numbers of unfortunate `clone()` that would go away with `Cow::Borrowed`. Leaving it as potential suggestion if that makes sense