### PR TITLE
test(sumcheck): de-flake tampered PoW witness rejection under parallel grind

### DIFF
--- a/sumcheck/src/generic_degree/prover.rs
+++ b/sumcheck/src/generic_degree/prover.rs
@@ -284,9 +284,9 @@ mod tests {
         // Fixture state: a valid grinded proof over log_m = 4 rounds.
         //
         // Mutation: corrupt the last round's witness.
-        //
-        //     rounds 0..2 keep valid witnesses, so the transcript stays in sync
-        //     the final round then fails its grinding check
+        //   - rounds 0..2 keep valid witnesses
+        //   - the transcript therefore stays in sync up to the final round
+        //   - the final round then fails its grinding check
         let mut rng = SmallRng::seed_from_u64(99);
         let log_m = 4usize;
         let pow_bits = 4usize;
@@ -297,14 +297,29 @@ mod tests {
         let (mut proof, _) = prover_state.prove::<F, _>(&mut p_ch, log_m, 3, pow_bits, claimed_sum);
 
         let last_round = log_m - 1;
-        proof.pow_witnesses[last_round] += F::ONE;
+        let valid_witness = proof.pow_witnesses[last_round];
 
-        let mut v_ch = fresh_challenger();
-        let err = proof.verify(&mut v_ch, log_m, 3, pow_bits).unwrap_err();
-        match err {
-            // The failure is pinned to the corrupted round.
-            GenericDegreeError::InvalidPowWitness { round } => assert_eq!(round, last_round),
-            other => panic!("expected an invalid pow witness error, got {other:?}"),
+        // Why an offset search instead of a single `+1` tamper:
+        //   - a corrupted witness still clears the grind by chance with probability 2^-pow_bits
+        //   - parallel grinding may return any valid witness, not a fixed smallest one
+        //
+        // Walking successive offsets pins the rejection regardless of the witness grinding picked.
+        let mut offset = F::ONE;
+        loop {
+            // Replace the honest witness with a nearby, almost-certainly-invalid value.
+            proof.pow_witnesses[last_round] = valid_witness + offset;
+
+            let mut v_ch = fresh_challenger();
+            match proof.verify(&mut v_ch, log_m, 3, pow_bits) {
+                // The failure is pinned to the corrupted round.
+                Err(GenericDegreeError::InvalidPowWitness { round }) => {
+                    assert_eq!(round, last_round);
+                    break;
+                }
+                // Rare coincidental grind hit: advance to the next offset.
+                Ok(_) => offset += F::ONE,
+                Err(other) => panic!("expected an invalid pow witness error, got {other:?}"),
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`generic_degree::prover::tests::verify_rejects_tampered_pow_witness` fails intermittently when the `parallel` feature is enabled:

```
called `Result::unwrap_err()` on an `Ok` value
  at sumcheck/src/generic_degree/prover.rs:303
```

This is a flaky test, not a protocol bug.

## Root cause

The test grinds a proof at `pow_bits = 4`, bumps the last round's PoW witness by one, and expects `verify` to reject it.

- A tampered witness still satisfies a 4-bit grind check **by chance with probability 1/16**.
- `GrindingChallenger::grind` searches with `into_par_iter().find_map_any(...)`. Serially this returns the *smallest* valid witness deterministically; under the `parallel` cfg it returns *any* valid witness (whichever thread finds it first). So the parallel run produces a different witness whose `+1` can keep its 4 trailing zero bits.
- `verify` does not check the final sum (that is the caller's job, per its `Closing the protocol` doc), so a coincidental PoW pass makes it return `Ok` — tripping `unwrap_err()`.

The sibling tamper-PoW tests don't flake because they use `pow_bits = 16`/`20`. This one inherited `pow_bits = 4` from the neighboring *positive* test, which chose 4 deliberately for grind speed.

## Fix

Keep `pow_bits = 4` (preserving the module's intentional fast grind) and make the negative test **deterministic in outcome**: walk successive witness offsets until one is genuinely rejected, then assert the failure pins to the corrupted round. Expected ~1 iteration; zero flake regardless of which witness grinding returns or which cfg is active.

## Testing

- `cargo test -p p3-sumcheck generic_degree` — serial: 8 passed.
- `cargo test -p p3-sumcheck --features parallel generic_degree` — 8 passed.
- `cargo fmt -p p3-sumcheck -- --check` — clean.
- `cargo clippy -p p3-sumcheck --all-targets --features parallel` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)