### PR TITLE
fix(air): account for transition selector degree

### DIFF
--- a/air/src/symbolic/builder.rs
+++ b/air/src/symbolic/builder.rs
@@ -127,10 +127,8 @@ where
 {
     let (base_constraints, extension_constraints) = get_all_symbolic_constraints(air, layout);
 
-    // Without periodic columns the trace-size-aware degree coincides with the cached
-    // degree multiple: the linear transition selector never changes the constraint
-    // degree, and every other leaf scales with `trace_len - 1`. Reuse the cached
-    // degrees and skip the expression walk entirely.
+    // Without periodic columns the cached degree multiple is a conservative
+    // trace-size-independent bound, so we can skip the expression walk entirely.
     if layout.num_periodic_columns == 0 {
         return base_constraints
             .iter()

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -44,8 +44,8 @@ impl<F: Field> SymLeaf for BaseLeaf<F> {
     fn degree_multiple(&self) -> usize {
         match self {
             Self::Variable(v) => v.degree_multiple(),
-            Self::IsFirstRow | Self::IsLastRow => 1,
-            Self::IsTransition | Self::Constant(_) => 0,
+            Self::IsFirstRow | Self::IsLastRow | Self::IsTransition => 1,
+            Self::Constant(_) => 0,
         }
     }
 
@@ -247,8 +247,8 @@ mod tests {
         let is_transition = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
         assert_eq!(
             is_transition.degree_multiple(),
-            0,
-            "IsTransition should have degree 0"
+            1,
+            "IsTransition should have degree 1"
         );
 
         let add_expr = SymbolicExpr::<BaseLeaf<BabyBear>>::Add {

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -93,7 +93,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicVariable};
-    use p3_air::{AirBuilder, BaseAir, BaseEntry};
+    use p3_air::{AirBuilder, BaseAir, BaseEntry, WindowAccess};
     use p3_baby_bear::BabyBear;
 
     use super::*;
@@ -115,6 +115,23 @@ mod tests {
             for constraint in &self.constraints {
                 builder.assert_zero(*constraint);
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TransitionQuadraticAir;
+
+    impl BaseAir<BabyBear> for TransitionQuadraticAir {
+        fn width(&self) -> usize {
+            1
+        }
+    }
+
+    impl Air<SymbolicAirBuilder<BabyBear>> for TransitionQuadraticAir {
+        fn eval(&self, builder: &mut SymbolicAirBuilder<BabyBear>) {
+            let main = builder.main();
+            let x = main.current(0).unwrap();
+            builder.when_transition().assert_zero(x * x);
         }
     }
 
@@ -159,6 +176,14 @@ mod tests {
         };
         let log_degree = get_log_num_quotient_chunks(&air, air_layout(&air, 3), 8, 0);
         assert_eq!(log_degree, log2_ceil_usize(1));
+    }
+
+    #[test]
+    fn transition_selector_contributes_to_quotient_degree() {
+        let air = TransitionQuadraticAir;
+        let log_chunks = get_log_num_quotient_chunks(&air, air_layout(&air, 0), 8, 0);
+
+        assert_eq!(log_chunks, log2_ceil_usize(2));
     }
 
     /// A mock AIR with a configurable `max_constraint_degree` hint.


### PR DESCRIPTION
## Summary

- Make `BaseLeaf::IsTransition` contribute one degree multiple during symbolic degree inference.
- Add a regression test for a transition-gated quadratic constraint, which previously inferred too few quotient chunks.
- Update the no-periodic-columns fast-path comment to describe the cached degree multiple as a conservative bound.

## Motivation

`IsTransition` was treated as degree-multiple `0`, which can understate the quotient degree for Circle STARK constraints guarded by the transition selector. In particular, a transition-gated quadratic constraint could infer `0` quotient chunk bits where `1` is needed.

Fixes #575.

## Testing

- `cargo +1.95.0 test -p p3-air --lib`
- `cargo +1.95.0 test -p p3-uni-stark --lib`
- `cargo +nightly-2026-05-17 fmt --all -- --check`
- `git diff --check`