### PR TITLE
perf(multi-stark): tighten AIR zerocheck round-poly and degree

### DIFF
--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -445,15 +445,6 @@ where
         let mut local_row = EF::zero_vec(width);
         let mut next_row = EF::zero_vec(width);
 
-        // Interpolate a table's active variable to `z` at residual index `s`,
-        // reading the two halves in place. This matches `fix_prefix_var(z)[s]`
-        // but allocates no folded table per node.
-        let interp = |table: &Poly<EF>, s: usize, z: EF| {
-            let lo = table.as_slice()[s];
-            let hi = table.as_slice()[s + half];
-            lo + (hi - lo) * z
-        };
-
         // Transmit h at nodes 0, 2, 3, ..., degree; the verifier recovers h(1).
         let mut out = Vec::with_capacity(self.degree);
         for node in core::iter::once(0).chain(2..=self.degree) {
@@ -463,13 +454,13 @@ where
             let mut acc = EF::ZERO;
             for s in 0..half {
                 for c in 0..width {
-                    local_row[c] = interp(&self.local[c], s, z);
-                    next_row[c] = interp(&self.next[c], s, z);
+                    local_row[c] = self.local[c].fix_prefix_var_at(z, s);
+                    next_row[c] = self.next[c].fix_prefix_var_at(z, s);
                 }
                 let boundary = BoundaryEvals {
-                    first: interp(&self.first, s, z),
-                    last: interp(&self.last, s, z),
-                    transition: interp(&self.transition, s, z),
+                    first: self.first.fix_prefix_var_at(z, s),
+                    last: self.last.fix_prefix_var_at(z, s),
+                    transition: self.transition.fix_prefix_var_at(z, s),
                 };
                 let g = MultilinearFolder::new(
                     &local_row,
@@ -479,7 +470,7 @@ where
                     self.alpha,
                 )
                 .eval_air(self.air);
-                acc += interp(&self.eq, s, z) * g;
+                acc += self.eq.fix_prefix_var_at(z, s) * g;
             }
             out.push(acc);
         }

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -13,7 +13,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder};
+use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder, get_all_symbolic_constraints};
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
@@ -25,7 +25,6 @@ use p3_util::log2_strict_usize;
 use thiserror::Error;
 
 use crate::folder::MultilinearFolder;
-use crate::metadata::ConstraintMetadata;
 use crate::selectors::BoundaryEvals;
 
 /// Reasons the zerocheck verifier rejects a proof.
@@ -121,13 +120,15 @@ impl<'a, A> AirZerocheck<'a, A> {
 
     /// Per-round degree of the zerocheck sumcheck.
     ///
-    /// The summed integrand `eq(tau, x) * g(x)` has per-variable degree `max_constraint_degree + 2`.
+    /// The summed integrand `eq(tau, x) * g(x)` has per-variable degree
+    /// `deg(g) + 1`, where the `+ 1` is the multilinear `eq(tau, x)`.
     ///
-    /// The `+ 2` is two single-degree corrections:
-    /// - `eq(tau, x)` is multilinear, so it adds one,
-    /// - the transition selector is degree one but counts as zero symbolically, so it adds one.
-    ///
-    /// Sound only while every column and selector has per-variable degree at most one, which standard AIRs satisfy.
+    /// `deg(g)` is the largest per-variable degree among the asserted constraints,
+    /// read from `poly_degree` at domain size two. At that domain size every leaf
+    /// scores its per-variable degree, so each column and each selector — including
+    /// the transition selector, which `degree_multiple` undercounts as zero — is
+    /// degree one. This is exact, provided columns and selectors are per-variable
+    /// degree at most one, which standard AIRs satisfy.
     ///
     /// # Arguments
     ///
@@ -138,9 +139,17 @@ impl<'a, A> AirZerocheck<'a, A> {
         EF: ExtensionField<F>,
         A: Air<SymbolicAirBuilder<F, EF>>,
     {
-        // Symbolic max constraint degree, then the plus-two integrand correction.
-        let metadata = ConstraintMetadata::from_air::<F, EF, A>(self.air, layout);
-        metadata.max_constraint_degree + 2
+        // Per-variable degree of g from the symbolic constraints (domain size two),
+        // then the `+ 1` for the multilinear eq weight. No periodic columns reach
+        // this point (the layout check rejects them), so the periods are empty.
+        let (base, ext) = get_all_symbolic_constraints::<F, EF, A>(self.air, layout);
+        let base_degree = base
+            .iter()
+            .map(|c| c.poly_degree(2, &[]))
+            .max()
+            .unwrap_or(0);
+        let ext_degree = ext.iter().map(|c| c.poly_degree(2, &[])).max().unwrap_or(0);
+        base_degree.max(ext_degree) + 1
     }
 
     /// Prove that the AIR's alpha-batched constraint vanishes on every trace row.
@@ -428,35 +437,39 @@ where
 
     fn round_poly(&self) -> Vec<EF> {
         let width = self.local.len();
+        // Each table currently spans `2 * half` evaluations; `half` is the residual
+        // hypercube once the active variable is dropped.
+        let half = self.eq.num_evals() / 2;
 
         // Reused per-row buffers handed to the folder.
         let mut local_row = EF::zero_vec(width);
         let mut next_row = EF::zero_vec(width);
+
+        // Interpolate a table's active variable to `z` at residual index `s`,
+        // reading the two halves in place. This matches `fix_prefix_var(z)[s]`
+        // but allocates no folded table per node.
+        let interp = |table: &Poly<EF>, s: usize, z: EF| {
+            let lo = table.as_slice()[s];
+            let hi = table.as_slice()[s + half];
+            lo + (hi - lo) * z
+        };
 
         // Transmit h at nodes 0, 2, 3, ..., degree; the verifier recovers h(1).
         let mut out = Vec::with_capacity(self.degree);
         for node in core::iter::once(0).chain(2..=self.degree) {
             let z = EF::from_usize(node);
 
-            // Bind the current variable to z in every table.
-            let eq_z = self.eq.fix_prefix_var(z);
-            let first_z = self.first.fix_prefix_var(z);
-            let last_z = self.last.fix_prefix_var(z);
-            let transition_z = self.transition.fix_prefix_var(z);
-            let local_z: Vec<Poly<EF>> = self.local.iter().map(|p| p.fix_prefix_var(z)).collect();
-            let next_z: Vec<Poly<EF>> = self.next.iter().map(|p| p.fix_prefix_var(z)).collect();
-
             // Sum the weighted constraint over the remaining hypercube.
             let mut acc = EF::ZERO;
-            for s in 0..eq_z.num_evals() {
+            for s in 0..half {
                 for c in 0..width {
-                    local_row[c] = local_z[c].as_slice()[s];
-                    next_row[c] = next_z[c].as_slice()[s];
+                    local_row[c] = interp(&self.local[c], s, z);
+                    next_row[c] = interp(&self.next[c], s, z);
                 }
                 let boundary = BoundaryEvals {
-                    first: first_z.as_slice()[s],
-                    last: last_z.as_slice()[s],
-                    transition: transition_z.as_slice()[s],
+                    first: interp(&self.first, s, z),
+                    last: interp(&self.last, s, z),
+                    transition: interp(&self.transition, s, z),
                 };
                 let g = MultilinearFolder::new(
                     &local_row,
@@ -466,7 +479,7 @@ where
                     self.alpha,
                 )
                 .eval_air(self.air);
-                acc += eq_z.as_slice()[s] * g;
+                acc += interp(&self.eq, s, z) * g;
             }
             out.push(acc);
         }
@@ -607,10 +620,11 @@ mod tests {
         let mut challenger = fresh_challenger();
         let proof = AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&trace, &pis, &mut challenger);
 
-        // Fibonacci has symbolic max degree 2, so the per-round degree is 4.
+        // Each Fibonacci constraint is per-variable degree 2 (a degree-1 selector
+        // times a degree-1 column), so the eq-weighted integrand is degree 3.
         let layout = AirLayout::from_air::<F>(&FibAir);
         let degree = AirZerocheck::new(&FibAir, 0).sumcheck_degree::<F, EF>(layout);
-        assert_eq!(degree, 4);
+        assert_eq!(degree, 3);
         assert_eq!(proof.sumcheck.num_rounds(), log2_strict_usize(n));
         for round in &proof.sumcheck.round_polys {
             assert_eq!(round.len(), degree);

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -525,6 +525,29 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         }
     }
 
+    /// Evaluates the prefix-variable fix at a single residual index, without
+    /// allocating the folded polynomial.
+    ///
+    /// Equivalent to `self.fix_prefix_var(r)[index]`:
+    /// ```text
+    /// out = (1 - r) * p(0, index) + r * p(1, index)
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of range for the residual hypercube
+    /// (`index >= self.num_evals() / 2`).
+    pub fn fix_prefix_var_at<F>(&self, r: F, index: usize) -> F
+    where
+        F: Algebra<A> + Copy,
+    {
+        // The residual hypercube is the x_0 = 0 half; the x_0 = 1 half starts at `half`.
+        let half = self.num_evals() / 2;
+        let lo = self.as_slice()[index];
+        let hi = self.as_slice()[index + half];
+        r * (hi - lo) + lo
+    }
+
     /// Fixes the prefix variable at a challenge value, returning a folded polynomial
     /// in SIMD-packed form.
     ///
@@ -1828,6 +1851,22 @@ pub(crate) mod test {
                 compressed.fix_prefix_var_mut(zi);
             }
             assert_eq!(compressed.as_constant().unwrap(), poly.eval_base(&point));
+        }
+    }
+
+    #[test]
+    fn test_fix_prefix_var_at() {
+        let mut rng = SmallRng::seed_from_u64(0);
+        for k in 1..=12 {
+            let poly = Poly::<F>::rand(&mut rng, k);
+            let point: Point<EF> = Point::rand(&mut rng, 1);
+            let z = point.as_slice()[0];
+
+            // The pointwise variant must agree with the full folded table.
+            let folded = poly.fix_prefix_var(z);
+            for s in 0..folded.num_evals() {
+                assert_eq!(poly.fix_prefix_var_at(z, s), folded.as_slice()[s]);
+            }
         }
     }
 


### PR DESCRIPTION
## Changes
- round_poly: interpolate each table's active variable in place instead of allocating a folded Poly per node, removing O(degree * tables) allocations per round (behavior-identical).
- sumcheck_degree: use poly_degree at domain size two for the exact per-variable degree (transition selector counted as degree one) instead of the max_constraint_degree + 2 upper bound, saving one evaluation per round when a boundary constraint dominates.