### PR TITLE
perf(util): stripe the 8-byte parallel transpose along the longer dimension

### DIFF
--- a/util/src/transpose/rectangular.rs
+++ b/util/src/transpose/rectangular.rs
@@ -1258,7 +1258,46 @@ unsafe fn transpose_neon_8b(input: *const u64, output: *mut u64, width: usize, h
 
 /// Parallel transpose for very large matrices of 8-byte elements.
 ///
-/// Divides the matrix into horizontal stripes, one per thread.
+/// The work is split into stripes, one per thread, along the longer input dimension.
+///
+/// # Stripe Division
+///
+/// The output holds the transpose in row-major order.
+/// Input element `(r, c)` lands at output index `c * height + r`.
+///
+/// A wide input (more columns than rows) is split by columns.
+/// - Each thread owns a column band over every row.
+/// - Its writes form one contiguous block of output rows.
+///
+/// A tall or square input is split by rows.
+/// - Each thread owns a row band over every column.
+/// - Its input reads stay contiguous, one full row at a time.
+///
+/// ```text
+///     wide input: split by columns        tall input: split by rows
+///     ┌──────┬──────┬──────┐              ┌────────────────────┐
+///     │  t0  │  t1  │  t2  │              │         t0         │
+///     │ cols │ cols │ cols │              ├────────────────────┤
+///     └──────┴──────┴──────┘              │         t1         │
+///                                         ├────────────────────┤
+///                                         │         t2         │
+///                                         └────────────────────┘
+/// ```
+///
+/// # Why the longer dimension
+///
+/// Splitting a wide input by rows would scatter each thread's writes:
+/// - Each thread gets a thin column band, written down the tall output
+///   with stride `height`.
+/// - Scattered stores stall on read-for-ownership and TLB traffic.
+///
+/// Splitting by columns keeps each thread's writes in one contiguous block.
+///
+/// # Data Race Safety
+///
+/// Each thread writes a disjoint output region, so no synchronization is needed.
+/// - A column band maps to a contiguous run of output rows, unique per thread.
+/// - A row band maps to a unique set of output columns.
 ///
 /// # Safety
 ///
@@ -1273,23 +1312,58 @@ unsafe fn transpose_neon_8b_parallel(
 ) {
     use p3_maybe_rayon::prelude::*;
 
+    // Number of available threads in the rayon thread pool.
     let num_threads = current_num_threads();
-    let rows_per_thread = height.div_ceil(num_threads);
 
+    // We use `AtomicUsize` to pass pointer addresses to threads.
+    //
+    // This is safe because:
+    // 1. We only read the addresses (Relaxed ordering is fine)
+    // 2. Each thread writes to a disjoint output region
     let inp = AtomicUsize::new(input as usize);
     let out = AtomicUsize::new(output as usize);
 
-    (0..num_threads).into_par_iter().for_each(|thread_idx| {
-        let row_start = thread_idx * rows_per_thread;
-        let row_end = (row_start + rows_per_thread).min(height);
+    // Split the longer input dimension so each thread's output stays contiguous.
+    //
+    // A wide input is split by columns, a tall or square input by rows.
+    let split_cols = width > height;
 
-        if row_start < row_end {
+    // Length of the dimension being split.
+    let stripe_len = if split_cols { width } else { height };
+
+    // Share handed to each thread.
+    //
+    // The ceiling keeps the final thread from getting an oversized chunk.
+    let stripe_per_thread = stripe_len.div_ceil(num_threads);
+
+    (0..num_threads).into_par_iter().for_each(|thread_idx| {
+        // Half-open stripe `[start, end)` of the split dimension owned here.
+        let start = thread_idx * stripe_per_thread;
+        let end = (start + stripe_per_thread).min(stripe_len);
+
+        // Empty when there are more threads than stripe units.
+        if start < end {
+            // Recover the pointers from their atomic addresses.
             let input_ptr = inp.load(Ordering::Relaxed) as *const u64;
             let output_ptr = out.load(Ordering::Relaxed) as *mut u64;
 
+            // Map the stripe to an input region.
+            //
+            // A column stripe spans every row.
+            // A row stripe spans every column.
+            let (row_start, row_end, col_start, col_end) = if split_cols {
+                (0, height, start, end)
+            } else {
+                (start, end, 0, width)
+            };
+
+            // SAFETY:
+            // - Pointers are valid for `width * height` elements (from caller).
+            // - Stripes partition one dimension, so the per-thread output
+            //   regions are disjoint and never aliased.
             unsafe {
                 transpose_region_tiled_8b(
-                    input_ptr, output_ptr, row_start, row_end, 0, width, width, height,
+                    input_ptr, output_ptr, row_start, row_end, col_start, col_end, width, height,
                 );
             }
         }
@@ -2034,17 +2108,25 @@ mod tests {
         for (width, height) in shapes {
             // Distinct values 0..size, so a misplaced element is caught.
             let size = width * height;
-            let input: Vec<u32> = (0..size as u32).collect();
 
-            // Run the transpose under test into a zeroed buffer.
+            // 4-byte path.
+            let input: Vec<u32> = (0..size as u32).collect();
             let mut output = vec![0u32; size];
             transpose(&input, &mut output, width, height);
-
-            // Must match the naive reference transpose elementwise.
             assert_eq!(
                 output,
                 transpose_reference(&input, width, height),
-                "parallel transpose mismatch for {width}×{height}"
+                "4-byte parallel transpose mismatch for {width}×{height}"
+            );
+
+            // 8-byte path.
+            let input: Vec<u64> = (0..size as u64).collect();
+            let mut output = vec![0u64; size];
+            transpose(&input, &mut output, width, height);
+            assert_eq!(
+                output,
+                transpose_reference(&input, width, height),
+                "8-byte parallel transpose mismatch for {width}×{height}"
             );
         }
     }


### PR DESCRIPTION
## What

Follow-up to #1888, which striped the 4-byte NEON parallel transpose along the longer dimension. The 8-byte path (`transpose_neon_8b_parallel`) still split work by input rows only, so a wide input made each thread scatter its writes across the whole tall output (stride = `height`), stalling on RFO and TLB traffic.

Same fix: split the longer input dimension, so a wide input is striped by columns and each thread writes a contiguous block of output rows. Mirrors the 4-byte path; the tall/square path is unchanged.

## Numbers

Apple M3 Pro, Goldilocks (8-byte), criterion:

| benchmark | baseline | this PR | |
|---|---|---|---|
| `large_wide_4096x2048` | 3.6 ms | 2.2 ms | 1.6x (p < 0.05) |
| `large_tall_2048x4096` | 2.9 ms | 2.9 ms | no change (p = 0.57) |

repro: `cargo bench -p p3-util --bench transpose --features parallel`

## Correctness

Same writes reordered across threads, so the result is bit-identical. The parallel test now checks both the 4-byte and 8-byte paths against the naive reference (wide, tall, and degenerate two-row shapes past the parallel threshold).
