### PR TITLE
feat(multi-stark): prove AIRs end-to-end via WHIR commitment openings

### DIFF
--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -33,7 +33,11 @@ tracing.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
+p3-dft.workspace = true
+p3-merkle-tree.workspace = true
 p3-poseidon2-air.workspace = true
+p3-symmetric.workspace = true
+p3-whir.workspace = true
 rand = { workspace = true }
 tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
 tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }

--- a/multi-stark/src/commit.rs
+++ b/multi-stark/src/commit.rs
@@ -175,6 +175,11 @@ mod tests {
             &self.pcs
         }
 
+        fn min_num_variables(&self) -> usize {
+            // The mock commits columns directly, with no padding floor.
+            0
+        }
+
         fn build_witness(&self, columns: Vec<Poly<F>>) -> Vec<Poly<F>> {
             // The mock scheme commits columns directly, with no stacking or folding.
             columns

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -29,6 +29,19 @@ pub trait MultiStarkConfig {
     /// Borrow the commitment scheme.
     fn pcs(&self) -> &Self::Pcs;
 
+    /// Smallest table arity the commitment scheme accepts without padding.
+    ///
+    /// A table below this floor is zero-padded before commitment, which breaks the successor view:
+    /// - padding moves the repeated boundary row into the pad,
+    /// - so the repeat-last successor view no longer reads itself,
+    /// - which disagrees with the zerocheck successor convention.
+    ///
+    /// The committed prover therefore requires the trace arity to meet this floor.
+    /// The opening point and the committed table then share one frame.
+    ///
+    /// For a WHIR-backed config this is the first-round folding factor.
+    fn min_num_variables(&self) -> usize;
+
     /// Pack committed column polynomials into the commitment scheme's witness form.
     ///
     /// The witness representation is private to the commitment scheme:
@@ -59,3 +72,15 @@ pub type ProverData<C> = <Pcs<C> as MultilinearPcs<
     <C as MultiStarkConfig>::Challenge,
     <C as MultiStarkConfig>::Challenger,
 >>::ProverData;
+
+/// Opening proof produced by a configuration's commitment scheme.
+pub type PcsProof<C> = <Pcs<C> as MultilinearPcs<
+    <C as MultiStarkConfig>::Challenge,
+    <C as MultiStarkConfig>::Challenger,
+>>::Proof;
+
+/// Opening-verification error produced by a configuration's commitment scheme.
+pub type PcsError<C> = <Pcs<C> as MultilinearPcs<
+    <C as MultiStarkConfig>::Challenge,
+    <C as MultiStarkConfig>::Challenger,
+>>::Error;

--- a/multi-stark/src/lib.rs
+++ b/multi-stark/src/lib.rs
@@ -14,6 +14,13 @@ pub mod config;
 pub mod folder;
 pub mod metadata;
 pub mod opening;
+pub mod proof;
+pub mod prover;
 pub mod rounds;
 pub mod selectors;
+pub mod verifier;
 pub mod zerocheck;
+
+pub use proof::MultiStarkProof;
+pub use prover::prove;
+pub use verifier::{VerificationError, verify};

--- a/multi-stark/src/proof.rs
+++ b/multi-stark/src/proof.rs
@@ -1,0 +1,54 @@
+//! Proof data and opening shapes for multilinear AIR verification.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_sumcheck::generic_degree::GenericDegreeProof;
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+
+use crate::config::{Commitment, MultiStarkConfig, PcsProof};
+
+/// A complete multilinear AIR proof.
+///
+/// The three parts are checked in order against one shared transcript:
+/// - the commitment binds the trace columns.
+/// - the sumcheck reduces the AIR constraint to one bound-point claim.
+/// - the opening proves the trace columns at that point.
+pub struct MultiStarkProof<C: MultiStarkConfig> {
+    /// Commitment to the trace columns.
+    pub commitment: Commitment<C>,
+    /// Zerocheck sumcheck transcript for the alpha-batched constraint.
+    pub sumcheck: GenericDegreeProof<C::Val, C::Challenge>,
+    /// Commitment opening at the bound sumcheck point.
+    pub opening: PcsProof<C>,
+}
+
+/// Build the single-table opening protocol shared by the prover and verifier.
+///
+/// Version one commits a single table.
+/// That table is the whole execution trace.
+///
+/// It opens at the bound sumcheck point:
+/// - every current-row column.
+/// - every successor-view column read by the AIR.
+///
+/// The prover and verifier build this identically, so their opening transcripts agree.
+///
+/// # Arguments
+///
+/// - Trace arity, with one variable per row bit.
+/// - Number of trace columns.
+/// - Column indices read through the successor view.
+pub(crate) fn single_table_protocol(
+    log_height: usize,
+    width: usize,
+    next_columns: &[usize],
+) -> OpeningProtocol {
+    OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(log_height, width),
+        vec![OpeningBatch::new(
+            (0..width).collect::<Vec<_>>(),
+            next_columns.to_vec(),
+        )],
+    )])
+}

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -1,0 +1,108 @@
+//! Prove that an AIR is satisfied by a committed trace.
+
+use p3_air::{Air, BaseAir, SymbolicAirBuilder};
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_field::{ExtensionField, Field};
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_sumcheck::PrescribedPointPcs;
+use p3_util::log2_strict_usize;
+
+use crate::commit::commit_trace;
+use crate::config::{Commitment, MultiStarkConfig};
+use crate::folder::MultilinearFolder;
+use crate::proof::{MultiStarkProof, single_table_protocol};
+use crate::zerocheck::AirZerocheck;
+
+/// Prove that an AIR is satisfied by a committed execution trace.
+///
+/// The three phases share one transcript:
+///
+/// ```text
+///     1. commit(trace)        -> absorb commitment
+///     2. zerocheck reduction  -> bound point r, sumcheck transcript
+///     3. open columns at r    -> opening proof bound to the commitment
+/// ```
+///
+/// # Arguments
+///
+/// - Proof configuration selecting the commitment scheme.
+/// - AIR whose constraints are proved.
+/// - Execution trace with one column per AIR column.
+/// - Public inputs forwarded to the AIR.
+/// - Grinding difficulty per sumcheck round.
+/// - Fiat-Shamir transcript.
+///
+/// # Panics
+///
+/// - The trace width must match the AIR width.
+/// - The trace arity must meet the commitment scheme's padding floor.
+/// - This keeps the committed successor view in the same frame as zerocheck.
+/// - The AIR must declare no preprocessed columns.
+/// - The AIR must declare no periodic columns.
+pub fn prove<C, A>(
+    config: &C,
+    air: &A,
+    trace: &RowMajorMatrix<C::Val>,
+    public_values: &[C::Val],
+    pow_bits: usize,
+    challenger: &mut C::Challenger,
+) -> MultiStarkProof<C>
+where
+    C: MultiStarkConfig,
+    C::Pcs: PrescribedPointPcs<C::Challenge, C::Challenger>,
+    C::Challenger: FieldChallenger<C::Val>
+        + GrindingChallenger<Witness = C::Val>
+        + CanSampleUniformBits<C::Val>
+        + CanObserve<Commitment<C>>,
+    A: for<'b> Air<MultilinearFolder<'b, C::Val, C::Val, C::Challenge>>
+        + for<'b> Air<
+            MultilinearFolder<
+                'b,
+                C::Val,
+                <C::Val as Field>::Packing,
+                <C::Challenge as ExtensionField<C::Val>>::ExtensionPacking,
+            >,
+        > + for<'b> Air<MultilinearFolder<'b, C::Val, C::Challenge, C::Challenge>>
+        + Air<SymbolicAirBuilder<C::Val, C::Challenge>>
+        + BaseAir<C::Val>,
+    <C::Challenge as ExtensionField<C::Val>>::ExtensionPacking:
+        From<C::Challenge> + From<<C::Val as Field>::Packing>,
+{
+    let log_height = log2_strict_usize(trace.height());
+    let width = trace.width;
+    let next_columns = air.main_next_row_columns();
+
+    // The trace columns are the AIR columns, so their counts must agree.
+    assert_eq!(width, air.width(), "trace width must match the AIR width");
+
+    // A padded table would read a pad row as the last row's successor.
+    // The zerocheck's successor repeats the last row, so padding would desync the two.
+    assert!(
+        log_height >= config.min_num_variables(),
+        "trace arity must be at least the commitment scheme's padding floor"
+    );
+
+    // 1. Commit to the trace columns; the scheme absorbs its commitment into the transcript.
+    let (commitment, prover_data) = commit_trace(config, trace, challenger);
+
+    // 2. Reduce the AIR constraint to a single bound point.
+    // The committed prover opens the columns through the commitment scheme,
+    // so the zerocheck's own opened values are not used here.
+    let zerocheck = AirZerocheck::new(air, pow_bits);
+    let (zerocheck_proof, point) =
+        zerocheck.prove::<C::Val, C::Challenge, _>(trace, public_values, challenger);
+    let sumcheck = zerocheck_proof.sumcheck;
+
+    // 3. Open the trace columns at the bound point, binding the opened values to the commitment.
+    let protocol = single_table_protocol(log_height, width, &next_columns);
+    let opening = config
+        .pcs()
+        .open_at(prover_data, &protocol, &[point], challenger);
+
+    MultiStarkProof {
+        commitment,
+        sumcheck,
+        opening,
+    }
+}

--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -1,0 +1,135 @@
+//! Verify a multilinear AIR SNARK against a trace commitment.
+
+use core::fmt::{self, Debug, Display, Formatter};
+
+use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder};
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_sumcheck::PrescribedPointPcs;
+
+use crate::config::{Commitment, MultiStarkConfig, PcsError};
+use crate::folder::MultilinearFolder;
+use crate::proof::{MultiStarkProof, single_table_protocol};
+use crate::zerocheck::{AirZerocheck, ZerocheckError};
+
+/// Reasons the multilinear AIR verifier rejects a proof.
+#[derive(Debug)]
+pub enum VerificationError<E> {
+    /// The zerocheck reduction or its closing constraint check failed.
+    Zerocheck(ZerocheckError),
+    /// The commitment opening failed to verify.
+    Opening(E),
+}
+
+impl<E: Debug> Display for VerificationError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Zerocheck(e) => write!(f, "zerocheck: {e}"),
+            Self::Opening(e) => write!(f, "opening: {e:?}"),
+        }
+    }
+}
+
+impl<E: Debug> core::error::Error for VerificationError<E> {}
+
+/// Verify a complete multilinear AIR proof.
+///
+/// The verifier replays the prover's transcript in the same order:
+///
+/// ```text
+///     1. absorb commitment
+///     2. verify zerocheck sumcheck -> bound point r, reduced sum
+///     3. open columns at r         -> opened values bound to the commitment
+///     4. recompute g at r          -> match the reduced sum
+/// ```
+///
+/// # Soundness
+///
+/// - Opened values come from the commitment proof.
+/// - The proof body never supplies those values directly.
+/// - The closing check therefore uses committed trace values.
+/// - The point is the bound point returned by zerocheck.
+///
+/// # Arguments
+///
+/// - Proof configuration selecting the commitment scheme.
+/// - AIR whose constraints are checked.
+/// - Proof to verify.
+/// - Public inputs forwarded to the AIR.
+/// - Grinding difficulty per sumcheck round.
+/// - Fiat-Shamir transcript.
+///
+/// # Errors
+///
+/// Returns an error when the sumcheck fails.
+/// Returns an error when the closing check fails.
+/// Returns an error when the commitment opening fails.
+///
+/// # Panics
+///
+/// Panics if the AIR declares preprocessed columns.
+/// Panics if the AIR declares periodic columns.
+pub fn verify<C, A>(
+    config: &C,
+    air: &A,
+    proof: &MultiStarkProof<C>,
+    public_values: &[C::Val],
+    pow_bits: usize,
+    challenger: &mut C::Challenger,
+) -> Result<(), VerificationError<PcsError<C>>>
+where
+    C: MultiStarkConfig,
+    C::Pcs: PrescribedPointPcs<C::Challenge, C::Challenger>,
+    C::Challenger: FieldChallenger<C::Val>
+        + GrindingChallenger<Witness = C::Val>
+        + CanSampleUniformBits<C::Val>
+        + CanObserve<Commitment<C>>,
+    A: for<'b> Air<MultilinearFolder<'b, C::Val, C::Challenge, C::Challenge>>
+        + Air<SymbolicAirBuilder<C::Val, C::Challenge>>
+        + BaseAir<C::Val>,
+{
+    // The sumcheck has one round per trace variable, so it fixes the trace arity.
+    let log_height = proof.sumcheck.num_rounds();
+    let width = AirLayout::from_air::<C::Val>(air).main_width;
+    let next_columns = air.main_next_row_columns();
+
+    // 1. Absorb the commitment; the prover absorbed it during the commit phase.
+    challenger.observe(proof.commitment.clone());
+
+    // 2. Verify the zerocheck sumcheck, yielding the bound point and the reduced sum.
+    let zerocheck = AirZerocheck::new(air, pow_bits);
+    let reduction = zerocheck
+        .verify_reduction::<C::Val, C::Challenge, _>(
+            &proof.sumcheck,
+            log_height,
+            public_values,
+            challenger,
+        )
+        .map_err(VerificationError::Zerocheck)?;
+
+    // 3. Open the committed columns at the bound point; the returned values are commitment-bound.
+    let protocol = single_table_protocol(log_height, width, &next_columns);
+    let evals = config
+        .pcs()
+        .verify_at(
+            &proof.commitment,
+            &proof.opening,
+            &protocol,
+            core::slice::from_ref(&reduction.point),
+            challenger,
+        )
+        .map_err(VerificationError::Opening)?;
+
+    // Single table, single point: one batch of current values then successor values.
+    let batch = &evals[0];
+
+    // 4. Close the zerocheck: recompute g from the commitment-bound values and match the sum.
+    zerocheck
+        .check_constraint(
+            &reduction,
+            batch.current(),
+            &next_columns,
+            batch.next(),
+            public_values,
+        )
+        .map_err(VerificationError::Zerocheck)
+}

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -355,12 +355,66 @@ impl<'a, A> AirZerocheck<'a, A> {
             });
         }
 
+        // Verify the sumcheck reduction, then close on the proof's own opened values.
+        let reduction = self.verify_reduction::<F, EF, _>(
+            &proof.sumcheck,
+            log_height,
+            public_values,
+            challenger,
+        )?;
+        self.check_constraint::<F, EF>(
+            &reduction,
+            &proof.local,
+            &next_columns,
+            &proof.next,
+            public_values,
+        )?;
+        Ok(reduction.point)
+    }
+
+    /// Verify the zerocheck sumcheck and return the data the final check needs.
+    ///
+    /// This stops short of recomputing the constraint.
+    /// The opened column values are not yet known.
+    /// The committed verifier opens them through a commitment scheme.
+    ///
+    /// The caller must observe the trace commitment into the challenger before this call.
+    /// The public values are observed here.
+    /// The caller therefore does not observe them separately.
+    ///
+    /// # Arguments
+    ///
+    /// - Zerocheck sumcheck transcript.
+    /// - Base-two logarithm of the trace height.
+    /// - Public inputs forwarded to the AIR.
+    /// - Fiat-Shamir transcript.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the claimed sum is nonzero.
+    /// Returns an error when the sumcheck transcript fails to verify.
+    pub fn verify_reduction<F, EF, Challenger>(
+        &self,
+        sumcheck: &GenericDegreeProof<F, EF>,
+        log_height: usize,
+        public_values: &[F],
+        challenger: &mut Challenger,
+    ) -> Result<ZerocheckReduction<EF>, ZerocheckError>
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+        A: Air<SymbolicAirBuilder<F, EF>> + BaseAir<F>,
+        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
         // A zerocheck always claims the sum is zero.
         // A nonzero claim is a forgery vector: it would let an unsatisfied trace pass.
-        if proof.sumcheck.claimed_sum != EF::ZERO {
+        if sumcheck.claimed_sum != EF::ZERO {
             return Err(ZerocheckError::NonZeroClaimedSum);
         }
 
+        // Reject column kinds this version cannot prove.
+        // Size the symbolic pass from the AIR layout.
+        let layout = self.layout::<F>();
         let degree = self.sumcheck_degree::<F, EF>(layout);
 
         // Bind the public values before any challenge depends on them.
@@ -370,27 +424,98 @@ impl<'a, A> AirZerocheck<'a, A> {
         // Draw the same batching scalar and zerocheck point the prover drew.
         let (alpha, tau) = sample_zerocheck_challenges(challenger, log_height);
 
-        let (point, final_sum) = proof
-            .sumcheck
+        let (point, final_sum) = sumcheck
             .verify(challenger, log_height, degree, self.pow_bits)
             .map_err(ZerocheckError::Sumcheck)?;
 
-        // Reduce the proof to opening claims at the bound point.
-        let claims = OpeningClaims::new(point, proof.local.clone(), &next_columns, &proof.next);
+        Ok(ZerocheckReduction {
+            alpha,
+            tau,
+            point,
+            final_sum,
+        })
+    }
+
+    /// Close the zerocheck: recompute the alpha-batched constraint and match the reduced sum.
+    ///
+    /// The opened values may come from the proof itself.
+    /// The opened values may instead come from a commitment opening.
+    /// Either way the final identity is the same.
+    ///
+    /// # Arguments
+    ///
+    /// - Verified sumcheck reduction data.
+    /// - Current-row value of each main column.
+    /// - Column indices read on the next row.
+    /// - Successor values aligned with those column indices.
+    /// - Public inputs forwarded to the AIR.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the reduced sum does not match the constraint.
+    /// The constraint is evaluated at the bound point.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the successor column list and value list have different lengths.
+    pub fn check_constraint<F, EF>(
+        &self,
+        reduction: &ZerocheckReduction<EF>,
+        local: &[EF],
+        next_columns: &[usize],
+        next_values: &[EF],
+        public_values: &[F],
+    ) -> Result<(), ZerocheckError>
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
+    {
+        let width = local.len();
+
+        // Reduce to opening claims at the bound point.
+        let claims = OpeningClaims::new(
+            reduction.point.clone(),
+            local.to_vec(),
+            next_columns,
+            next_values,
+        );
 
         // Reconstruct the rows the folder reads, then recompute the alpha-batched constraint.
         let next_row = claims.next_row(width);
         let boundary = BoundaryEvals::at(claims.point.as_slice());
-        let g = MultilinearFolder::new(&claims.local, &next_row, boundary, public_values, alpha)
-            .eval_air(self.air);
-        let eq_at_point = Point::eval_eq(&tau, claims.point.as_slice());
+        let g = MultilinearFolder::new(
+            &claims.local,
+            &next_row,
+            boundary,
+            public_values,
+            reduction.alpha,
+        )
+        .eval_air(self.air);
+        let eq_at_point = Point::eval_eq(&reduction.tau, claims.point.as_slice());
 
         // Close the protocol: the reduced sum must equal the integrand at the point.
-        if final_sum != eq_at_point * g {
+        if reduction.final_sum != eq_at_point * g {
             return Err(ZerocheckError::FinalSumMismatch);
         }
-        Ok(claims.point)
+        Ok(())
     }
+}
+
+/// Data yielded before the opened values are known.
+///
+/// The reduction verifier produces it from the sumcheck transcript.
+/// The closing check consumes it together with the opened column values.
+#[derive(Clone, Debug)]
+pub struct ZerocheckReduction<EF> {
+    /// Random scalar batching the AIR constraints.
+    pub alpha: EF,
+    /// Zerocheck point sampled before the sumcheck.
+    pub tau: Vec<EF>,
+    /// Bound sumcheck point with every variable fixed to one challenge.
+    pub point: Point<EF>,
+    /// Reduced sum bound by the sumcheck.
+    pub final_sum: EF,
 }
 
 /// Draw the constraint-batching scalar and the zerocheck point, in that order.

--- a/multi-stark/tests/whir_fibonacci.rs
+++ b/multi-stark/tests/whir_fibonacci.rs
@@ -1,0 +1,300 @@
+//! End-to-end multilinear AIR SNARK over WHIR: commit, zerocheck, open, verify.
+
+use core::borrow::Borrow;
+
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::DuplexChallenger;
+use p3_dft::Radix2DFTSmallBatch;
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_multi_stark::config::MultiStarkConfig;
+use p3_multi_stark::zerocheck::ZerocheckError;
+use p3_multi_stark::{VerificationError, prove, verify};
+use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::OpeningBatch;
+use p3_sumcheck::layout::{Layout, PrefixProver, Table, Witness};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_util::{log2_ceil_usize, log2_strict_usize};
+use p3_whir::{
+    DomainSeparator, FoldingFactor, ProtocolParameters, SecurityAssumption,
+    VerifierError as WhirVerifierError, WhirConfig, WhirProver,
+};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 4>;
+type Perm = Poseidon2BabyBear<16>;
+
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
+
+type PackedF = <F as Field>::Packing;
+type MyMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
+
+type MyDft = Radix2DFTSmallBatch<F>;
+type L = PrefixProver<F, EF>;
+type TestPcs = WhirProver<EF, F, MyDft, MyMmcs, MyChallenger, L>;
+
+/// First-round folding factor; also the per-table padding floor.
+const FOLDING: usize = 2;
+
+/// A WHIR-backed multilinear AIR configuration over BabyBear.
+struct WhirConfigForTest {
+    /// The WHIR commitment scheme, fixed to one stacked-table arity.
+    pcs: TestPcs,
+}
+
+impl MultiStarkConfig for WhirConfigForTest {
+    type Val = F;
+    type Challenge = EF;
+    type Challenger = MyChallenger;
+    type Pcs = TestPcs;
+
+    fn pcs(&self) -> &TestPcs {
+        &self.pcs
+    }
+
+    fn min_num_variables(&self) -> usize {
+        // The witness pads each table to the first-round folding factor.
+        FOLDING
+    }
+
+    fn build_witness(&self, columns: Vec<Poly<F>>) -> Witness<F> {
+        // Version one commits a single table: the whole trace.
+        L::new_witness(vec![Table::new(columns)], FOLDING)
+    }
+}
+
+/// Fixed permutation so prover and verifier transcripts match exactly.
+fn perm() -> Perm {
+    let mut rng = SmallRng::seed_from_u64(0xD15EA5E);
+    Perm::new_from_rng_128(&mut rng)
+}
+
+/// Per-round log-inverse rates for a stacked polynomial.
+fn default_round_log_inv_rates(num_variables: usize, folding_factor: &FoldingFactor) -> Vec<usize> {
+    let folding_schedule = folding_factor
+        .compute_folding_schedule(num_variables)
+        .expect("valid folding schedule");
+    let num_rounds = folding_schedule.len() - 1;
+    let mut rates = Vec::with_capacity(num_rounds);
+    let mut rate = 1;
+    for &folding in folding_schedule.iter().take(num_rounds) {
+        rate += folding - 1;
+        rates.push(rate);
+    }
+    rates
+}
+
+/// Build a configuration sized for a trace shape.
+///
+/// The committed polynomial stacks every trace column.
+/// The WHIR configuration must match that stacked arity.
+fn config_for(log_height: usize, width: usize) -> WhirConfigForTest {
+    let stacked_num_variables = log_height + log2_ceil_usize(width);
+    let folding_factor = FoldingFactor::Constant(FOLDING);
+
+    let mmcs = MyMmcs::new(MyHash::new(perm()), MyCompress::new(perm()), 0);
+    let params = ProtocolParameters {
+        security_level: 32,
+        pow_bits: 0,
+        round_log_inv_rates: default_round_log_inv_rates(stacked_num_variables, &folding_factor),
+        folding_factor,
+        soundness_type: SecurityAssumption::CapacityBound,
+        starting_log_inv_rate: 1,
+    };
+    let whir_config = WhirConfig::new(stacked_num_variables, params).unwrap();
+    WhirConfigForTest {
+        pcs: TestPcs::new(whir_config, MyDft::default(), mmcs),
+    }
+}
+
+/// A challenger seeded with the same domain separator on both proof and verify sides.
+fn challenger(config: &WhirConfigForTest) -> MyChallenger {
+    let mut challenger = MyChallenger::new(perm());
+    let mut ds = DomainSeparator::new(vec![]);
+    config.pcs.add_domain_separator::<8>(&mut ds);
+    ds.observe_domain_separator(&mut challenger);
+    challenger
+}
+
+const NUM_COLS: usize = 2;
+
+/// Fibonacci AIR.
+///
+/// - The first row equals the first two public values.
+/// - Each transition advances the Fibonacci recurrence.
+/// - The final row equals the output public value.
+struct FibAir;
+
+struct FibRow<T> {
+    left: T,
+    right: T,
+}
+
+impl<T> Borrow<FibRow<T>> for [T] {
+    fn borrow(&self) -> &FibRow<T> {
+        // Safety: two fields of type T in declaration order match the layout of [T; 2].
+        debug_assert_eq!(self.len(), NUM_COLS);
+        let ptr = self.as_ptr() as *const FibRow<T>;
+        unsafe { &*ptr }
+    }
+}
+
+impl<X> BaseAir<X> for FibAir {
+    fn width(&self) -> usize {
+        NUM_COLS
+    }
+    fn num_public_values(&self) -> usize {
+        3
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for FibAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let pis = builder.public_values();
+        let (a, b, x) = (pis[0], pis[1], pis[2]);
+
+        let local: &FibRow<AB::Var> = main.current_slice().borrow();
+        let next: &FibRow<AB::Var> = main.next_slice().borrow();
+
+        let mut first = builder.when_first_row();
+        first.assert_eq(local.left, a);
+        first.assert_eq(local.right, b);
+
+        let mut trans = builder.when_transition();
+        trans.assert_eq(local.right, next.left);
+        trans.assert_eq(local.left + local.right, next.right);
+
+        builder.when_last_row().assert_eq(local.right, x);
+    }
+}
+
+/// Build a Fibonacci trace seeded with zero and one.
+fn fib_trace(n: usize) -> RowMajorMatrix<F> {
+    let mut left = F::ZERO;
+    let mut right = F::ONE;
+    let mut values = Vec::with_capacity(NUM_COLS * n);
+    for _ in 0..n {
+        values.push(left);
+        values.push(right);
+        let next_left = right;
+        let next_right = left + right;
+        left = next_left;
+        right = next_right;
+    }
+    RowMajorMatrix::new(values, NUM_COLS)
+}
+
+/// Public inputs for the first row and final output.
+fn fib_public_values(n: usize) -> [F; 3] {
+    let trace = fib_trace(n);
+    let last = trace.values[(n - 1) * NUM_COLS + 1];
+    [F::ZERO, F::ONE, last]
+}
+
+#[test]
+fn prove_verify_fibonacci_roundtrips() {
+    // A satisfying trace must prove and verify end to end through WHIR.
+    let n = 256;
+    let trace = fib_trace(n);
+    let pis = fib_public_values(n);
+    let config = config_for(log2_strict_usize(n), NUM_COLS);
+
+    let proof = prove(&config, &FibAir, &trace, &pis, 0, &mut challenger(&config));
+
+    verify(&config, &FibAir, &proof, &pis, 0, &mut challenger(&config))
+        .expect("honest Fibonacci proof must verify");
+}
+
+#[test]
+fn verify_rejects_tampered_opening() {
+    // Fixture state: the proof carries commitment-bound trace openings.
+    let n = 256;
+    let trace = fib_trace(n);
+    let pis = fib_public_values(n);
+    let config = config_for(log2_strict_usize(n), NUM_COLS);
+
+    let mut proof = prove(&config, &FibAir, &trace, &pis, 0, &mut challenger(&config));
+
+    // Mutation: shift the first claimed current-row value by one field element.
+    let batch = &proof.opening.evals[0];
+    let mut current = batch.current().to_vec();
+    current[0] += EF::ONE;
+    proof.opening.evals[0] = OpeningBatch::new(current, batch.next().to_vec());
+
+    // Expected rejection: the tampered value is no longer bound to the commitment.
+    // The verifier derives query positions from the absorbed value and opens one the
+    // prover never authenticated, so a Merkle path check rejects the proof.
+    let err = verify(&config, &FibAir, &proof, &pis, 0, &mut challenger(&config)).unwrap_err();
+    match err {
+        VerificationError::Opening(WhirVerifierError::MerkleProofInvalid { position, reason }) => {
+            assert_eq!(position, 10);
+            assert_eq!(reason, "Base field Merkle proof verification failed");
+        }
+        other => panic!("expected a Merkle opening rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn verify_rejects_violated_constraint() {
+    // Fixture state: a satisfying trace obeys every Fibonacci transition.
+    let n = 256;
+    let mut trace = fib_trace(n);
+    // Mutation: shift one row value used by the transition constraints.
+    trace.values[2 * NUM_COLS] += F::ONE;
+    let pis = fib_public_values(n);
+    let config = config_for(log2_strict_usize(n), NUM_COLS);
+
+    let proof = prove(&config, &FibAir, &trace, &pis, 0, &mut challenger(&config));
+
+    // Expected rejection: the zerocheck closes on a nonzero constraint value.
+    let err = verify(&config, &FibAir, &proof, &pis, 0, &mut challenger(&config)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            VerificationError::Zerocheck(ZerocheckError::FinalSumMismatch)
+        ),
+        "expected zerocheck final-sum mismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn verify_rejects_tampered_public_values() {
+    // Fixture state: the public output equals the final trace row.
+    let n = 256;
+    let trace = fib_trace(n);
+    let pis = fib_public_values(n);
+    let config = config_for(log2_strict_usize(n), NUM_COLS);
+
+    let proof = prove(&config, &FibAir, &trace, &pis, 0, &mut challenger(&config));
+
+    // Mutation: shift the claimed output by one field element.
+    let mut wrong = pis;
+    wrong[2] += F::ONE;
+    // Expected rejection: the wrong public value desyncs the transcript.
+    // The verifier then derives a different opening point than the prover used,
+    // so it opens a Merkle position the prover never authenticated.
+    let err = verify(
+        &config,
+        &FibAir,
+        &proof,
+        &wrong,
+        0,
+        &mut challenger(&config),
+    )
+    .unwrap_err();
+    match err {
+        VerificationError::Opening(WhirVerifierError::MerkleProofInvalid { position, reason }) => {
+            assert_eq!(position, 2);
+            assert_eq!(reason, "Base field Merkle proof verification failed");
+        }
+        other => panic!("expected a Merkle opening rejection, got {other:?}"),
+    }
+}

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -104,15 +104,54 @@ pub trait Layout<F: TwoAdicField, EF: ExtensionField<F>>: Sized {
         self.claims().num_variables_table(id)
     }
 
-    /// Records opening claims for the selected columns of one table.
+    /// Records opening claims for the selected columns of one table at a sampled point.
     ///
-    /// - Current openings evaluate a column at the sampled point.
+    /// - The local-frame opening point is drawn from the transcript.
+    /// - Current openings evaluate a column at that point.
     /// - Next openings evaluate the repeat-last successor view at the same point.
-    /// - Returned evaluations list all current openings first, then all next openings.
+    /// - Returned evaluations list all current openings first.
+    /// - Returned evaluations list all next openings second.
     fn eval<Ch>(
         &mut self,
         table_idx: usize,
         batch: &OpeningRequest,
+        challenger: &mut Ch,
+    ) -> OpeningEvals<EF>
+    where
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        // Draw the local-frame opening point as powers of one challenge.
+        // This is the standalone-PCS convention: the verifier picks the evaluation point.
+        let point = Point::expand_from_univariate(
+            challenger.sample_algebra_element(),
+            self.num_variables_table(table_idx),
+        );
+        self.eval_at(table_idx, batch, &point, challenger)
+    }
+
+    /// Records opening claims for the selected columns of one table at a prescribed point.
+    ///
+    /// The caller supplies the local-frame opening point instead of sampling it.
+    /// An outer protocol that fixes the point opens its columns here.
+    ///
+    /// - Current openings evaluate a column at the supplied point.
+    /// - Next openings evaluate the repeat-last successor view at the same point.
+    /// - The claimed evaluations are absorbed into the transcript.
+    /// - The current group is absorbed first.
+    /// - Returned evaluations list all current openings first.
+    /// - Returned evaluations list all next openings second.
+    ///
+    /// # Arguments
+    ///
+    /// - Index of the table whose columns are opened.
+    /// - Column indices opened directly and through the successor view.
+    /// - Local-frame opening point.
+    /// - Fiat-Shamir transcript.
+    fn eval_at<Ch>(
+        &mut self,
+        table_idx: usize,
+        batch: &OpeningRequest,
+        point: &Point<EF>,
         challenger: &mut Ch,
     ) -> OpeningEvals<EF>
     where

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -86,10 +86,11 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
     ///
     /// - At least one current or next column must be requested.
     #[tracing::instrument(skip_all)]
-    fn eval<Ch>(
+    fn eval_at<Ch>(
         &mut self,
         table_idx: usize,
         batch: &OpeningRequest,
+        point: &Point<EF>,
         challenger: &mut Ch,
     ) -> OpeningEvals<EF>
     where
@@ -103,15 +104,12 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
             !batch.is_empty(),
             "opening schedule must name at least one column"
         );
-        // Sample the local-frame opening point from the transcript.
         let table = &self.claims.tables[table_idx];
-        let point = Point::expand_from_univariate(
-            challenger.sample_algebra_element(),
-            table.num_variables(),
-        );
+        // The opening point lives in the table's local frame, one coordinate per variable.
+        debug_assert_eq!(point.num_variables(), table.num_variables());
 
         // Factorise the point once; every selected column reuses it.
-        let point = SvoPoint::new_packed(self.claims.folding, &point);
+        let point = SvoPoint::new_packed(self.claims.folding, point);
 
         // Current group: evaluate each column at the point.
         // Each entry yields an opening (carrying preprocessing residuals) plus the bare eval.

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -84,10 +84,11 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
     ///
     /// - At least one current or next column must be requested.
     #[tracing::instrument(skip_all)]
-    fn eval<Ch>(
+    fn eval_at<Ch>(
         &mut self,
         table_idx: usize,
         batch: &OpeningRequest,
+        point: &Point<EF>,
         challenger: &mut Ch,
     ) -> OpeningEvals<EF>
     where
@@ -102,15 +103,12 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
             "opening schedule must name at least one column"
         );
 
-        // Sample the local-frame opening point from the transcript.
         let table = &self.claims.tables[table_idx];
-        let point = Point::expand_from_univariate(
-            challenger.sample_algebra_element(),
-            table.num_variables(),
-        );
+        // The opening point lives in the table's local frame, one coordinate per variable.
+        debug_assert_eq!(point.num_variables(), table.num_variables());
 
         // Factorise the point with the suffix split; every selected column reuses it.
-        let point = SvoPoint::new_unpacked(self.claims.folding, &point, VariableOrder::Suffix);
+        let point = SvoPoint::new_unpacked(self.claims.folding, point, VariableOrder::Suffix);
 
         // Current group: evaluate each column at the point.
         // Each entry yields an opening (carrying preprocessing residuals) plus the bare eval.

--- a/sumcheck/src/layout/verifier.rs
+++ b/sumcheck/src/layout/verifier.rs
@@ -137,6 +137,48 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
     where
         Ch: p3_challenger::FieldChallenger<F> + p3_challenger::GrindingChallenger<Witness = F>,
     {
+        // Draw the local-frame opening point as powers of one challenge.
+        // This is the standalone-PCS convention: the verifier picks the evaluation point.
+        let point = Point::expand_from_univariate(
+            challenger.sample_algebra_element(),
+            self.num_variables_table(table_idx),
+        );
+        self.add_claim_at(table_idx, batch, &point, evals, challenger)
+    }
+
+    /// Records an opening claim at a prescribed point.
+    ///
+    /// The caller supplies the local-frame opening point instead of sampling it.
+    /// An outer protocol that fixes the point opens its columns through this entry.
+    ///
+    /// # Arguments
+    ///
+    /// - Index of the table whose columns are opened.
+    /// - Column indices opened directly and through the successor view.
+    /// - Local-frame opening point.
+    /// - Claimed evaluations matching the batch shape.
+    /// - Fiat-Shamir transcript.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error when the evaluations do not match the requested shape.
+    ///
+    /// # Panics
+    ///
+    /// - At least one current or next column must be requested.
+    /// - Every column index must be in range for this table.
+    /// - The point must carry one coordinate per table variable.
+    pub fn add_claim_at<Ch>(
+        &mut self,
+        table_idx: usize,
+        batch: &OpeningRequest,
+        point: &Point<EF>,
+        evals: &OpeningEvals<EF>,
+        challenger: &mut Ch,
+    ) -> Result<(), SumcheckError>
+    where
+        Ch: p3_challenger::FieldChallenger<F> + p3_challenger::GrindingChallenger<Witness = F>,
+    {
         let placement = self.placement(table_idx);
         // Split the request into its two column groups.
         let current = batch.current();
@@ -147,6 +189,9 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
             !batch.is_empty(),
             "opening schedule must name at least one column"
         );
+        // The point lives in the table's local frame.
+        // It carries one coordinate per variable.
+        assert_eq!(point.num_variables(), self.num_variables_table(table_idx));
         // The evaluations come from the proof, so a shape mismatch is a malformed
         // proof and must be rejected rather than aborting the verifier.
         if !batch.has_same_shape(evals) {
@@ -167,12 +212,6 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
         assert!(
             next.iter()
                 .all(|&poly_idx| poly_idx < placement.num_polys())
-        );
-
-        // Sample the local-frame opening point from the transcript.
-        let point = Point::expand_from_univariate(
-            challenger.sample_algebra_element(),
-            self.num_variables_table(table_idx),
         );
 
         // Absorb the evals in the same current-then-next order as the prover.
@@ -196,7 +235,7 @@ impl<F: Field, EF: ExtensionField<F>> Verifier<F, EF> {
 
         // Store the batch under this table's claim list.
         self.claim_map[table_idx].push(VerifierMultiClaim::new(
-            point,
+            point.clone(),
             current_openings,
             next_openings,
         ));

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -33,6 +33,7 @@ pub mod error;
 pub mod generic_degree;
 pub mod lagrange;
 pub mod layout;
+pub mod prescribed_pcs;
 pub mod product_polynomial;
 pub mod strategy;
 pub mod svo;
@@ -47,6 +48,7 @@ pub use data::{SumcheckData, verify_final_sumcheck_rounds};
 pub use error::SumcheckError;
 pub(crate) use lagrange::extrapolate_01inf;
 use p3_field::Field;
+pub use prescribed_pcs::PrescribedPointPcs;
 pub use table::{
     OpeningBatch, OpeningEvals, OpeningProtocol, OpeningRequest, PointSchedule, TableShape,
     TableSpec,

--- a/sumcheck/src/prescribed_pcs.rs
+++ b/sumcheck/src/prescribed_pcs.rs
@@ -1,0 +1,85 @@
+//! Opening committed columns at caller-prescribed points.
+
+use alloc::vec::Vec;
+
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_commit::MultilinearPcs;
+use p3_field::ExtensionField;
+use p3_multilinear_util::point::Point;
+
+use crate::table::{OpeningEvals, OpeningProtocol};
+
+/// A multilinear commitment scheme that opens columns at caller-chosen points.
+///
+/// The base opening path draws each evaluation point from the transcript.
+/// An AIR proof fixes the point during its zerocheck.
+/// The opening phase then opens the columns at that fixed point.
+///
+/// Shape agreement uses one table spec per committed table.
+/// Each table spec carries its point-local column batches.
+/// The caller supplies one point per batch instead of letting the transcript pick it.
+///
+/// The prescribed-point verifier does not absorb the commitment.
+/// The outer protocol absorbs the commitment once.
+/// That absorption happens before the outer protocol samples challenges.
+pub trait PrescribedPointPcs<Challenge, Challenger>: MultilinearPcs<Challenge, Challenger>
+where
+    Challenge: ExtensionField<Self::Val>,
+    Challenger: FieldChallenger<Self::Val>
+        + GrindingChallenger<Witness = Self::Val>
+        + CanSampleUniformBits<Self::Val>
+        + CanObserve<Self::Commitment>,
+{
+    /// Open the committed columns at caller-prescribed points instead of sampled ones.
+    ///
+    /// # Arguments
+    ///
+    /// - Prover data returned by the commitment phase.
+    /// - Table shapes and per-point column batches.
+    /// - One prescribed point per batch.
+    /// - Fiat-Shamir transcript with the commitment already absorbed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of points differs from the number of opening batches.
+    fn open_at(
+        &self,
+        prover_data: Self::ProverData,
+        protocol: &OpeningProtocol,
+        points: &[Point<Challenge>],
+        challenger: &mut Challenger,
+    ) -> Self::Proof;
+
+    /// Verify a prescribed-point opening and return the opened column values.
+    ///
+    /// # Arguments
+    ///
+    /// - Commitment to the columns.
+    /// - Opening proof.
+    /// - Table shapes and column batches.
+    /// - Prescribed points in opening order.
+    /// - Fiat-Shamir transcript with the commitment already absorbed.
+    ///
+    /// # Returns
+    ///
+    /// One evaluation batch per opening batch.
+    /// Each lists the direct column values, then the repeat-last successor-view values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any count disagrees.
+    /// Returns an error if any shape disagrees.
+    /// Returns an error if the proof fails to verify.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of points differs from the number of opening batches.
+    fn verify_at(
+        &self,
+        commitment: &Self::Commitment,
+        proof: &Self::Proof,
+        protocol: &OpeningProtocol,
+        points: &[Point<Challenge>],
+        challenger: &mut Challenger,
+    ) -> Result<Vec<OpeningEvals<Challenge>>, Self::Error>;
+}

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -8,8 +8,9 @@ use p3_commit::{Mmcs, MultilinearPcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
-use p3_sumcheck::OpeningProtocol;
+use p3_multilinear_util::point::Point;
 use p3_sumcheck::layout::{Layout, Verifier, Witness};
+use p3_sumcheck::{OpeningEvals, OpeningProtocol, PrescribedPointPcs};
 
 use super::prover::WhirProver;
 use super::verifier::WhirVerifier;
@@ -178,5 +179,131 @@ where
         )?;
 
         Ok(())
+    }
+}
+
+impl<EF, F, Dft, MT, Challenger, L> PrescribedPointPcs<EF, Challenger>
+    for WhirProver<EF, F, Dft, MT, Challenger, L>
+where
+    F: TwoAdicField + Ord,
+    EF: ExtensionField<F> + TwoAdicField,
+    Dft: TwoAdicSubgroupDft<F>,
+    MT: Mmcs<F>,
+    Challenger: FieldChallenger<F>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>
+        + CanObserve<MT::Commitment>,
+    L: Layout<F, EF>,
+{
+    /// Open each batch at its supplied point.
+    ///
+    /// The out-of-domain commitment samples are still drawn from the transcript.
+    /// Those samples belong to the WHIR proximity argument.
+    /// They do not belong to the prescribed openings.
+    fn open_at(
+        &self,
+        prover_data: Self::ProverData,
+        protocol: &OpeningProtocol,
+        points: &[Point<EF>],
+        challenger: &mut Challenger,
+    ) -> Self::Proof {
+        // One prescribed point per opening batch.
+        assert_eq!(protocol.num_openings(), points.len());
+
+        let mut prover_data = prover_data;
+        let mut whir_proof = self.config.empty_proof();
+        whir_proof.initial_ood_answers = (0..self.commitment_ood_samples)
+            .map(|_| prover_data.layout.add_virtual_eval(challenger))
+            .collect::<Vec<_>>();
+
+        // Record each batch at its prescribed point rather than a sampled one.
+        let evals = protocol
+            .iter_openings()
+            .zip(points)
+            .map(|((table_idx, batch), point)| {
+                prover_data
+                    .layout
+                    .eval_at(table_idx, batch, point, challenger)
+            })
+            .collect::<Vec<_>>();
+
+        self.prove(
+            &mut whir_proof,
+            challenger,
+            prover_data.layout,
+            prover_data.merkle_data,
+        );
+
+        PcsProof {
+            whir: whir_proof,
+            evals,
+        }
+    }
+
+    /// Verify each batch at its supplied point.
+    ///
+    /// The commitment is not absorbed here.
+    /// The caller absorbs it once before its own challenges.
+    fn verify_at(
+        &self,
+        commitment: &Self::Commitment,
+        proof: &Self::Proof,
+        protocol: &OpeningProtocol,
+        points: &[Point<EF>],
+        challenger: &mut Challenger,
+    ) -> Result<Vec<OpeningEvals<EF>>, Self::Error> {
+        // One prescribed point per opening batch.
+        assert_eq!(protocol.num_openings(), points.len());
+
+        let mut layout_verifier = Verifier::<F, EF>::new(&protocol.table_shapes(), L::strategy());
+
+        // The commitment fixes how many initial OOD answers exist.
+        // A wrong count desyncs Fiat-Shamir.
+        if proof.whir.initial_ood_answers.len() != self.commitment_ood_samples {
+            return Err(VerifierError::InitialOodAnswerCountMismatch {
+                expected: self.commitment_ood_samples,
+                actual: proof.whir.initial_ood_answers.len(),
+            });
+        }
+        for &eval in &proof.whir.initial_ood_answers {
+            layout_verifier.add_virtual_eval(eval, challenger);
+        }
+        if protocol.num_openings() != proof.evals.len() {
+            return Err(VerifierError::OpeningBatchCountMismatch {
+                expected: protocol.num_openings(),
+                actual: proof.evals.len(),
+            });
+        }
+        for (((table_idx, batch), evals), point) in
+            protocol.iter_openings().zip(&proof.evals).zip(points)
+        {
+            // The supplied evaluations must match the schedule entry on both list lengths.
+            if !batch.has_same_shape(evals) {
+                return Err(VerifierError::OpeningBatchSizeMismatch {
+                    table_idx,
+                    expected: batch.len(),
+                    actual: evals.len(),
+                });
+            }
+            layout_verifier.add_claim_at(table_idx, batch, point, evals, challenger)?;
+        }
+
+        let alpha = challenger.sample_algebra_element();
+        let constraint = layout_verifier.constraint(alpha);
+        let mut claimed_eval = EF::ZERO;
+        constraint.combine_evals(&mut claimed_eval);
+
+        let verifier = WhirVerifier::new(&self.config, &self.mmcs, L::variable_order());
+        verifier.verify(
+            &proof.whir,
+            challenger,
+            commitment,
+            constraint,
+            claimed_eval,
+        )?;
+
+        // The opening verified.
+        // Hand back the values bound to the commitment.
+        Ok(proof.evals.clone())
     }
 }

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -4,16 +4,17 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_challenger::DuplexChallenger;
+use p3_challenger::{CanObserve, DuplexChallenger};
 use p3_commit::MultilinearPcs;
 use p3_dft::Radix2DFTSmallBatch;
-use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_merkle_tree::MerkleTreeMmcs;
+use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table, Witness};
 use p3_sumcheck::test_util::{random_table_specs, table_specs_to_tables};
-use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
@@ -21,6 +22,7 @@ use rand::rngs::SmallRng;
 use crate::fiat_shamir::domain_separator::DomainSeparator;
 use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
 use crate::pcs::prover::WhirProver;
+use crate::pcs::verifier::errors::VerifierError;
 
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
@@ -150,10 +152,222 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
     }
 }
 
+/// How a prescribed-point run deviates from the honest transcript.
+///
+/// Each non-honest mode attacks one opening binding.
+#[derive(Clone, Copy)]
+enum Tamper {
+    /// Verify honestly, at the prover's points and claimed values.
+    None,
+    /// Verify at a point the prover never opened.
+    ///
+    /// The claimed value belongs to the prover's point, so the WHIR proof must reject.
+    VerifierPoint,
+    /// Corrupt a claimed opened value before verifying.
+    ///
+    /// The commitment fixes the true value, so the WHIR proof must reject.
+    ProofEval,
+}
+
+/// Drive the prescribed-point opening path: open and verify at caller-chosen points.
+///
+/// Returns the verifier result so a test can assert acceptance.
+/// Optionally applies one mutation to check that the broken binding is rejected.
+fn run_whir_pcs_at_prescribed_points<L: Layout<F, EF>>(
+    specs: &[TableSpec],
+    folding_factor: FoldingFactor,
+    soundness_type: SecurityAssumption,
+    pow_bits: usize,
+    tamper: Tamper,
+) -> Result<(), VerifierError> {
+    let folding = folding_factor.at_round(0);
+    let tables = table_specs_to_tables(specs);
+    let witness = L::new_witness(tables, folding);
+    let protocol = OpeningProtocol::new(specs.to_vec()).pad_to_min_num_variables(folding);
+    let shapes = protocol.table_shapes();
+
+    // One arbitrary non-boolean point per opening batch, sized to its table's local frame.
+    // A frame or ordering mistake would change the opened values, so the test would catch it.
+    let points: Vec<Point<EF>> = protocol
+        .iter_openings()
+        .enumerate()
+        .map(|(b, (table_idx, _batch))| {
+            let n = shapes[table_idx].num_variables();
+            Point::new(
+                (0..n)
+                    .map(|c| EF::from_u64((7 + b * 13 + c * 3) as u64))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    // Merkle and protocol parameters mirror the sampled-point lifecycle runner.
+    let num_variables = witness.num_variables();
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let mmcs = MyMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
+    let params = ProtocolParameters {
+        security_level: 32,
+        pow_bits,
+        round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+        folding_factor,
+        soundness_type,
+        starting_log_inv_rate: 1,
+    };
+    let config = WhirConfig::new(num_variables, params).unwrap();
+    let pcs = TestWhirPcs::<L>::new(config, MyDft::default(), mmcs);
+
+    // Prover: commit, then open every batch at its prescribed point.
+    let (commitment, mut proof) = {
+        let mut challenger = challenger();
+        let mut ds = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut ds);
+        ds.observe_domain_separator(&mut challenger);
+
+        let (commitment, prover_data) =
+            <TestWhirPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+                &pcs,
+                witness,
+                &mut challenger,
+            );
+        let proof = pcs.open_at(prover_data, &protocol, &points, &mut challenger);
+        (commitment, proof)
+    };
+
+    // Verifier: replay the transcript and check the openings at the same points,
+    // unless a tamper variant breaks one of the bindings first.
+    let verify_points = if matches!(tamper, Tamper::VerifierPoint) {
+        // Shift the first batch's first coordinate so the claimed value no longer matches.
+        let mut perturbed = points;
+        let mut coords = perturbed[0].as_slice().to_vec();
+        coords[0] += EF::ONE;
+        perturbed[0] = Point::new(coords);
+        perturbed
+    } else {
+        points
+    };
+
+    if matches!(tamper, Tamper::ProofEval) {
+        // Bump the first claimed current-point value off the committed one.
+        let batch = &proof.evals[0];
+        let mut current = batch.current().to_vec();
+        current[0] += EF::ONE;
+        proof.evals[0] = OpeningBatch::new(current, batch.next().to_vec());
+    }
+
+    let mut challenger = challenger();
+    let mut ds = DomainSeparator::new(vec![]);
+    pcs.add_domain_separator::<8>(&mut ds);
+    ds.observe_domain_separator(&mut challenger);
+    // The prescribed-point verifier does not absorb the commitment.
+    // The caller absorbs it once, matching the prover's commit phase.
+    challenger.observe(commitment.clone());
+    pcs.verify_at(
+        &commitment,
+        &proof,
+        &protocol,
+        &verify_points,
+        &mut challenger,
+    )
+    .map(|_evals| ())
+}
+
+#[test]
+fn prescribed_point_open_verify_roundtrips() {
+    // Fixture state: one arity-8 table with two columns, opened at two prescribed points.
+    //
+    //     point 0: current columns {0, 1}
+    //     point 1: current column  {0}
+    //
+    // The arity is kept comfortably above the SIMD packing width.
+    // A polynomial smaller than the packing width cannot drive the packed sumcheck.
+    //
+    // Opening at caller-chosen points and verifying at the same points must accept.
+    let specs = [TableSpec::new(
+        TableShape::new(8, 2),
+        vec![
+            OpeningBatch::new(vec![0, 1], Vec::new()),
+            OpeningBatch::new(vec![0], Vec::new()),
+        ],
+    )];
+    run_whir_pcs_at_prescribed_points::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(2),
+        SecurityAssumption::CapacityBound,
+        0,
+        Tamper::None,
+    )
+    .expect("prescribed-point round-trip must verify");
+}
+
+#[test]
+fn prescribed_point_verify_rejects_wrong_point() {
+    // Fixture state: one batch opens current and successor values.
+    let specs = [TableSpec::new(
+        TableShape::new(8, 2),
+        vec![OpeningBatch::new(vec![0, 1], vec![0])],
+    )];
+    // Mutation: verify at a point the prover did not open.
+    let err = run_whir_pcs_at_prescribed_points::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(2),
+        SecurityAssumption::CapacityBound,
+        0,
+        Tamper::VerifierPoint,
+    )
+    .unwrap_err();
+    match err {
+        VerifierError::SumcheckFailed {
+            round,
+            expected,
+            actual,
+        } => {
+            // The opening sumcheck binds the claim to the prover's point.
+            // Verifying at a different point first disagrees at round 5.
+            assert_eq!(round, 5);
+            assert_eq!(
+                expected,
+                "1841252927 + 394466335 X + 1831684817 X^2 + 521830660 X^3"
+            );
+            assert_eq!(
+                actual,
+                "1535800973 + 1619442985 X + 1493239317 X^2 + 1782746132 X^3"
+            );
+        }
+        other => panic!("expected round-polynomial mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn prescribed_point_verify_rejects_tampered_eval() {
+    // Fixture state: one batch opens current and successor values.
+    let specs = [TableSpec::new(
+        TableShape::new(8, 2),
+        vec![OpeningBatch::new(vec![0, 1], vec![0])],
+    )];
+    // Mutation: shift one claimed current value by one field element.
+    let err = run_whir_pcs_at_prescribed_points::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(2),
+        SecurityAssumption::CapacityBound,
+        0,
+        Tamper::ProofEval,
+    )
+    .unwrap_err();
+    match err {
+        VerifierError::MerkleProofInvalid { position, reason } => {
+            // The tampered eval is absorbed, so the verifier derives different query
+            // positions than the prover authenticated, and opens an unauthenticated one.
+            assert_eq!(position, 9);
+            assert_eq!(reason, "Base field Merkle proof verification failed");
+        }
+        other => panic!("expected a Merkle opening rejection, got {other:?}"),
+    }
+}
+
 /// Smoke matrix covering each WHIR parameter axis at least once.
 ///
-/// The full randomized sweep lives in [`test_whir_end_to_end_exhaustive`] and
-/// runs from the Heavy CI workflow.
+/// The full randomized sweep runs from the Heavy CI workflow.
 #[test]
 fn test_whir_end_to_end() {
     let table_spec_sets = [
@@ -438,8 +652,9 @@ mod error_variant_tests {
     /// - Single table of arity 12 with two columns.
     /// - Two opening batches: first opens both columns; second opens column 0.
     ///
-    /// Yields `protocol.num_openings() == 2` and the inner batch sizes
-    /// `(2, 1)`. Both axes can be tampered independently.
+    /// The fixture has two opening batches.
+    /// The inner batch sizes are two and one.
+    /// Both axes can be tampered independently.
     #[allow(clippy::type_complexity)]
     fn commit_and_open() -> (
         TestWhirPcs<L>,


### PR DESCRIPTION
Continues the multilinear SuperSpartan-flavored AIR prover (after #1879, #1885, #1886). This is the step where the system stops trusting the prover's claimed column values and binds them to a real polynomial commitment, yielding the first complete multilinear AIR SNARK over WHIR.

## What it does

The AIR zerocheck reduces the `alpha`-batched constraint to a single claim at one bound point `r`:

```text
    sum_x eq(tau, x) * g(x) = 0      (g = alpha-batched AIR constraint)
```

Previously the verifier closed this check using column values handed over in the proof body. Now WHIR opens the committed trace columns at `r`, so the values closing the zerocheck are bound to the commitment instead of trusted.

```text
    1. commit(trace)        -> absorb commitment
    2. zerocheck reduction  -> bound point r, reduced sum
    3. open columns at r     -> values bound to the commitment
    4. recompute g at r      -> match the reduced sum
```

## Changes

- **Prescribed-point opening interface** on the multilinear PCS: open and verify at a caller-supplied point and return the opened values, for an outer protocol (the AIR sumcheck) that fixes the point itself rather than sampling it.
- **WHIR implementation** of that interface. WHIR still draws its own out-of-domain samples (they belong to its proximity argument), but the evaluation point comes from the sumcheck. The commitment is absorbed once, by the caller.
- **Split the zerocheck verifier** into a sumcheck-reduction step (yields the point and target sum) and a constraint-closing step (recomputes `g` from opened values), so the commitment opening slots in between.
- **Top-level `prove` / `verify`** over one shared transcript, mirroring the uni-stark public API.
- The trace columns are committed as one stacked WHIR table (arity `log_height + ceil(log2 width)`). Current-row columns open as plain claims; transition reads open the same columns through a repeat-last successor view (no second commitment).

## Soundness / tests

- End-to-end Fibonacci proof over WHIR (`commit -> zerocheck -> open -> verify`).
- Rejection tests asserting the exact error variant for: tampered opening value, violated transition constraint, and tampered public values.
- WHIR-level prescribed-point tests: round-trip, wrong verifier point, tampered claimed evaluation.

All touched crates green: `p3-multi-stark` (22 + 4), `p3-sumcheck` (237), `p3-whir` (131, 1 heavy-CI ignored); `fmt` and `clippy` clean.

## Out of scope (later in the series)

Preprocessed and periodic columns, public-values-as-committed-IO, multi-table batching, packed/SIMD zerocheck, low-degree split, SVO, ZK, and the logup+GKR lookup track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)