### PR TITLE
perf(monty-31): pack the coset-shift scale in the RecursiveDft LDE

### DIFF
--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 
 use itertools::izip;
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::{BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::RowMajorMatrix;
@@ -35,12 +35,19 @@ fn coset_shift_and_scale_rows<F: Field>(
     debug_assert!(out_ncols >= ncols);
     debug_assert_eq!(out.len() / out_ncols, mat.len() / ncols);
     let powers = shift.shifted_powers(scale).collect_n(ncols);
+    // Pack the shared per-column weights once; every row reuses the same split.
+    let (powers_packed, powers_suffix) = F::Packing::pack_slice_with_suffix(&powers);
     out.par_chunks_exact_mut(out_ncols)
         .zip(mat.par_chunks_exact(ncols))
         .for_each(|(out_row, in_row)| {
-            izip!(out_row.iter_mut(), in_row, &powers).for_each(|(out, &coeff, &weight)| {
-                *out = coeff * weight;
-            });
+            // Only the first `ncols` entries carry data; the rest stays zero-padded.
+            let (out_packed, out_suffix) =
+                F::Packing::pack_slice_with_suffix_mut(&mut out_row[..ncols]);
+            let (in_packed, in_suffix) = F::Packing::pack_slice_with_suffix(in_row);
+            izip!(out_packed.iter_mut(), in_packed, powers_packed)
+                .for_each(|(out, &coeff, &weight)| *out = coeff * weight);
+            izip!(out_suffix.iter_mut(), in_suffix, powers_suffix)
+                .for_each(|(out, &coeff, &weight)| *out = coeff * weight);
         });
 }
 


### PR DESCRIPTION
## Root cause
`coset_shift_and_scale_rows` (the per-column scale in `RecursiveDft::coset_lde_batch`) multiplied each element by its weight with a **scalar** field multiply. It is the only un-packed `O(n)` pass in `coset_lde_batch`: both DFTs, the pre/post transposes, and the sibling `Matrix::scale` (`par_scale_slice_in_place`) are SIMD-packed. #888 packed the weight *generation* (`collect_n`) but left the consuming multiply scalar.

## Fix
Pre-pack the shared per-column weights once, then multiply each row with a packed lane-wise product plus a scalar suffix tail, mirroring `scale_slice_in_place_single_core`. Generic over `F: Field`; no API change.

## Correctness
Output is identical to the scalar path (lane-wise product equals the scalar one). `nrows` is a power of two, so the three slices (`out_row[..ncols]`, `in_row`, `powers`) pack identically, and `nrows < WIDTH` falls back to the scalar suffix. Verified: `p3-monty-31`, `p3-dft` (RecursiveDft vs naive reference), and `p3-uni-stark` prove/verify all pass; clippy + fmt clean.

## Measured
~17% faster on the `coset_shift_and_scale_rows` span (BabyBear, `2^19` trace, M3/NEON, 4 warm reps: ~167ms to ~138ms). The pass is largely memory-bound, so the end-to-end prove delta is small on NEON; the scalar multiply is a larger share of per-element cost on AVX2/AVX-512, where the win should be at least as large (measured on NEON only). Reproducible via the existing `dft/benches/fft.rs` `coset_lde` benchmark.

## Scope
`monty-31/src/dft/mod.rs` only.
