### PR TITLE
perf(mersenne-31): specialize PackedMersenne31Neon dot_product with deferred reduction

### DIFF
--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -201,6 +201,54 @@ impl PrimeCharacteristicRing for PackedMersenne31Neon {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Mersenne31::zero_vec(len * WIDTH)) }
     }
+
+    #[inline]
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        // For small `N` the deferred-reduction setup (two final folds plus the narrowing)
+        // is not amortized, and NEON's `sqdmulh`-based reduced multiply is cheap enough that
+        // a plain reduced-multiply sum wins. Measured on NEON: deferral regresses ~10% at
+        // `N = 2` but improves 10-32% from `N = 4` upward.
+        if N < 4 {
+            return u.iter().zip(v).map(|(&x, &y)| x * y).sum();
+        }
+
+        // Single-accumulator form of the `coeffwise_dot_product` scheme: widen each
+        // 32x32 -> 64-bit product into `lo` (lanes 0-1) and `hi` (lanes 2-3) with
+        // multiply-accumulates, deferring the Mersenne reduction. Inputs are in `0..=P`,
+        // so a product is at most `P^2 < 2^62`. `N == 4` accumulates all four without an
+        // intermediate fold (`4 * P^2 < 2^64`); larger `N` fold every 3 products, keeping
+        // `2^33 + 3 * P^2 < 2^64`, so the u64 lanes never overflow.
+        unsafe {
+            // Safety: If this code got compiled then NEON intrinsics are available.
+            let zero = aarch64::vdupq_n_u64(0);
+            let mut lo = zero;
+            let mut hi = zero;
+            let mut unreduced = 0;
+            for i in 0..N {
+                let a = u[i].to_vector();
+                let b = v[i].to_vector();
+                lo = aarch64::vmlal_u32(lo, aarch64::vget_low_u32(a), aarch64::vget_low_u32(b));
+                hi = aarch64::vmlal_high_u32(hi, a, b);
+                unreduced += 1;
+                // `N == 4` is the only size here whose products all fit without an
+                // intermediate fold, so skip it; larger `N` fold every 3.
+                if unreduced == 3 && N != 4 {
+                    unreduced = 0;
+                    lo = partial_reduce_u64(lo);
+                    hi = partial_reduce_u64(hi);
+                }
+            }
+            // At most 2 unreduced products on top of a folded value (< 2^33 + 2 * P^2 < 2^64);
+            // two folds bring each lane to <= 2 P, then `reduce_sum` canonicalizes to 0..=P.
+            let l = partial_reduce_u64(partial_reduce_u64(lo));
+            let h = partial_reduce_u64(partial_reduce_u64(hi));
+            let narrowed = aarch64::vuzp1q_u32(
+                aarch64::vreinterpretq_u32_u64(l),
+                aarch64::vreinterpretq_u32_u64(h),
+            );
+            Self::from_vector(reduce_sum(narrowed))
+        }
+    }
 }
 
 // Degree of the smallest permutation polynomial for Mersenne31.


### PR DESCRIPTION
## Root cause
`PackedMersenne31Neon` was the only Mersenne31 packing without a `dot_product` override. AVX2/AVX-512 specialize it (#1855) and `monty-31` NEON does too, but the M31 NEON path fell back to the generic per-multiply-then-reduce default. `binomial_extension` calls `R::dot_product` over the packed base, so this is on the M31 extension-field hot path.

## Fix
For `N >= 4`, use the single-accumulator form of the existing `coeffwise_dot_product` kernel: widening multiply-accumulates (`vmlal`) into u64 lanes with the Mersenne reduction deferred and folded every 3 products, then two final folds and a canonical reduce. `N == 4` (the QM31 case) accumulates all four products without an intermediate fold (`4 * P^2 < 2^64`). For `N < 4` it keeps the plain reduced-multiply sum, because NEON's `sqdmulh` multiply is cheap enough that the deferral setup is a net loss for tiny `N`.

## Correctness
`test_packed_field_dot_product_boundary` (wired, sweeps N=1..16) covers the overflow boundaries; all paths pass. Full `p3-mersenne-31` suite (227 tests) plus clippy and fmt are clean.

## Measured (M3 / NEON, criterion, p < 0.05)
vs the scalar default: `N = 2` no change, `N >= 4` faster 9.5-32%. The `N = 4` no-fold path is a further ~14% over an every-3 fold schedule. Measured on NEON only; AVX2/AVX-512 already had the specialization.

## Scope
`mersenne-31/src/aarch64_neon/packing.rs` only.
