### PR TITLE
perf(multi-stark): parallelize the zerocheck round_poly hot loop

### DIFF
--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -9,20 +9,33 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = [
+    "p3-maybe-rayon/parallel",
+    "p3-multilinear-util/parallel",
+    "p3-sumcheck/parallel",
+]
+
 [dependencies]
 p3-air.workspace = true
 p3-challenger.workspace = true
 p3-commit.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
+p3-maybe-rayon.workspace = true
 p3-multilinear-util.workspace = true
 p3-sumcheck.workspace = true
 p3-util.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+criterion = { workspace = true }
 p3-baby-bear = { path = "../baby-bear" }
 rand = { workspace = true }
+
+[[bench]]
+name = "zerocheck"
+harness = false
 
 [lints]
 workspace = true

--- a/multi-stark/benches/zerocheck.rs
+++ b/multi-stark/benches/zerocheck.rs
@@ -1,0 +1,99 @@
+use core::borrow::Borrow;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::DuplexChallenger;
+use p3_field::PrimeCharacteristicRing;
+use p3_field::extension::BinomialExtensionField;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_multi_stark::zerocheck::AirZerocheck;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type Ch = DuplexChallenger<F, Perm, 16, 8>;
+
+const NUM_COLS: usize = 2;
+
+struct FibAir;
+struct FibRow<T> {
+    left: T,
+    right: T,
+}
+
+impl<T> Borrow<FibRow<T>> for [T] {
+    fn borrow(&self) -> &FibRow<T> {
+        let ptr = self.as_ptr() as *const FibRow<T>;
+        unsafe { &*ptr }
+    }
+}
+
+impl<X> BaseAir<X> for FibAir {
+    fn width(&self) -> usize {
+        NUM_COLS
+    }
+    fn num_public_values(&self) -> usize {
+        3
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for FibAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let pis = builder.public_values();
+        let (a, b, x) = (pis[0], pis[1], pis[2]);
+        let local: &FibRow<AB::Var> = main.current_slice().borrow();
+        let next: &FibRow<AB::Var> = main.next_slice().borrow();
+        let mut first = builder.when_first_row();
+        first.assert_eq(local.left, a);
+        first.assert_eq(local.right, b);
+        let mut trans = builder.when_transition();
+        trans.assert_eq(local.right, next.left);
+        trans.assert_eq(local.left + local.right, next.right);
+        builder.when_last_row().assert_eq(local.right, x);
+    }
+}
+
+fn fib_trace(n: usize) -> RowMajorMatrix<F> {
+    let mut left = F::ZERO;
+    let mut right = F::ONE;
+    let mut values = Vec::with_capacity(NUM_COLS * n);
+    for _ in 0..n {
+        values.push(left);
+        values.push(right);
+        let next_right = left + right;
+        left = right;
+        right = next_right;
+    }
+    RowMajorMatrix::new(values, NUM_COLS)
+}
+
+fn fresh_challenger() -> Ch {
+    let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    Ch::new(perm)
+}
+
+fn bench_zerocheck(c: &mut Criterion) {
+    let mut group = c.benchmark_group("zerocheck_prove");
+    for log_height in [16, 18, 20] {
+        let n = 1 << log_height;
+        let trace = fib_trace(n);
+        let last = trace.values[(n - 1) * NUM_COLS + 1];
+        let pis = [F::ZERO, F::ONE, last];
+        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        group.bench_with_input(BenchmarkId::from_parameter(log_height), &n, |b, _| {
+            b.iter(|| {
+                let mut ch = fresh_challenger();
+                zerocheck.prove::<F, EF, _>(&trace, &pis, &mut ch)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_zerocheck);
+criterion_main!(benches);

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -18,6 +18,7 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundProver};
@@ -463,37 +464,38 @@ where
         // hypercube once the active variable is dropped.
         let half = self.eq.num_evals() / 2;
 
-        // Reused per-row buffers handed to the folder.
-        let mut local_row = EF::zero_vec(width);
-        let mut next_row = EF::zero_vec(width);
-
         // Transmit h at nodes 0, 2, 3, ..., degree; the verifier recovers h(1).
         let mut out = Vec::with_capacity(self.degree);
         for node in core::iter::once(0).chain(2..=self.degree) {
             let z = EF::from_usize(node);
 
             // Sum the weighted constraint over the remaining hypercube.
-            let mut acc = EF::ZERO;
-            for s in 0..half {
-                for c in 0..width {
-                    local_row[c] = self.local[c].fix_prefix_var_at(z, s);
-                    next_row[c] = self.next[c].fix_prefix_var_at(z, s);
-                }
-                let boundary = BoundaryEvals {
-                    first: self.first.fix_prefix_var_at(z, s),
-                    last: self.last.fix_prefix_var_at(z, s),
-                    transition: self.transition.fix_prefix_var_at(z, s),
-                };
-                let g = MultilinearFolder::new(
-                    &local_row,
-                    &next_row,
-                    boundary,
-                    self.public_values,
-                    self.alpha,
-                )
-                .eval_air(self.air);
-                acc += self.eq.fix_prefix_var_at(z, s) * g;
-            }
+            // Each worker keeps its own per-row scratch buffers across the fold.
+            let (acc, _, _) = (0..half).into_par_iter().par_fold_reduce(
+                || (EF::ZERO, EF::zero_vec(width), EF::zero_vec(width)),
+                |(mut acc, mut local_row, mut next_row), s| {
+                    for c in 0..width {
+                        local_row[c] = self.local[c].fix_prefix_var_at(z, s);
+                        next_row[c] = self.next[c].fix_prefix_var_at(z, s);
+                    }
+                    let boundary = BoundaryEvals {
+                        first: self.first.fix_prefix_var_at(z, s),
+                        last: self.last.fix_prefix_var_at(z, s),
+                        transition: self.transition.fix_prefix_var_at(z, s),
+                    };
+                    let g = MultilinearFolder::new(
+                        &local_row,
+                        &next_row,
+                        boundary,
+                        self.public_values,
+                        self.alpha,
+                    )
+                    .eval_air(self.air);
+                    acc += self.eq.fix_prefix_var_at(z, s) * g;
+                    (acc, local_row, next_row)
+                },
+                |(a, la, na), (b, _, _)| (a + b, la, na),
+            );
             out.push(acc);
         }
         out


### PR DESCRIPTION
Also added a benchmark file for it. 

On my M4 pro:

```bash
  ┌────────────┬─────────┬──────────┬─────────┐
  │ log₂(rows) │ serial  │ parallel │ speedup │
  ├────────────┼─────────┼──────────┼─────────┤
  │ 16         │ 20.7 ms │ 10.1 ms  │ 2.0×    │
  ├────────────┼─────────┼──────────┼─────────┤
  │ 18         │ 83.3 ms │ 20.7 ms  │ 4.0×    │
  ├────────────┼─────────┼──────────┼─────────┤
  │ 20         │ 338 ms  │ 53.3 ms  │ 6.3×    │
  └────────────┴─────────┴──────────┴─────────┘
  ```