### PR TITLE
perf(multi-stark): prune the zerocheck successor table to declared next-row columns

### DIFF
--- a/multi-stark/benches/zerocheck.rs
+++ b/multi-stark/benches/zerocheck.rs
@@ -18,6 +18,9 @@ type Ch = DuplexChallenger<F, Perm, 16, 8>;
 
 const NUM_COLS: usize = 2;
 
+/// Width of the wide trace whose columns are mostly current-row-only filler.
+const WIDE_COLS: usize = 64;
+
 struct FibAir;
 struct FibRow<T> {
     left: T,
@@ -71,6 +74,61 @@ fn fib_trace(n: usize) -> RowMajorMatrix<F> {
     RowMajorMatrix::new(values, NUM_COLS)
 }
 
+/// Wide AIR carrying a Fibonacci recurrence in columns 0 and 1, with the
+/// remaining `WIDE_COLS - 2` columns committed but read only on the current row.
+///
+/// `all_next` selects the declared next-row footprint: `true` declares every
+/// column (the conservative default for an AIR that does not override
+/// [`BaseAir::main_next_row_columns`]), `false` declares just the two columns
+/// the constraints read on the next row. Both share one [`Air::eval`], so the
+/// prover-time gap between them reflects the successor-table cost of the
+/// undeclared columns.
+struct WideFibAir {
+    all_next: bool,
+}
+
+impl<X> BaseAir<X> for WideFibAir {
+    fn width(&self) -> usize {
+        WIDE_COLS
+    }
+    fn main_next_row_columns(&self) -> Vec<usize> {
+        if self.all_next {
+            (0..WIDE_COLS).collect()
+        } else {
+            vec![0, 1]
+        }
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for WideFibAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
+        let next = main.next_slice();
+        let mut trans = builder.when_transition();
+        trans.assert_eq(local[1], next[0]);
+        trans.assert_eq(local[0] + local[1], next[1]);
+    }
+}
+
+fn wide_fib_trace(n: usize) -> RowMajorMatrix<F> {
+    let mut left = F::ZERO;
+    let mut right = F::ONE;
+    let mut values = Vec::with_capacity(WIDE_COLS * n);
+    for i in 0..n {
+        values.push(left);
+        values.push(right);
+        // Filler columns: committed and opened at the current row, never read ahead.
+        for c in 2..WIDE_COLS {
+            values.push(F::from_u64((i + c) as u64));
+        }
+        let next_right = left + right;
+        left = right;
+        right = next_right;
+    }
+    RowMajorMatrix::new(values, WIDE_COLS)
+}
+
 fn fresh_challenger() -> Ch {
     let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
     let perm = Perm::new_from_rng_128(&mut rng);
@@ -95,5 +153,25 @@ fn bench_zerocheck(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_zerocheck);
+fn bench_wide_zerocheck(c: &mut Criterion) {
+    let mut group = c.benchmark_group("zerocheck_prove_wide");
+    group.sample_size(10);
+    for log_height in [16, 18, 20] {
+        let n = 1 << log_height;
+        let trace = wide_fib_trace(n);
+        for (label, all_next) in [("all_next", true), ("sparse_next", false)] {
+            let air = WideFibAir { all_next };
+            let zerocheck = AirZerocheck::new(&air, 0);
+            group.bench_with_input(BenchmarkId::new(label, log_height), &n, |b, _| {
+                b.iter(|| {
+                    let mut ch = fresh_challenger();
+                    zerocheck.prove::<F, EF, _>(&trace, &[], &mut ch)
+                });
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_zerocheck, bench_wide_zerocheck);
 criterion_main!(benches);

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -220,13 +220,8 @@ impl<'a, A> AirZerocheck<'a, A> {
         // After every variable is bound, each table holds its evaluation at the point.
         let local = state.local.iter().map(|p| p.as_slice()[0]).collect();
 
-        // Only the columns the AIR reads on the next row need a successor claim.
-        let next = self
-            .air
-            .main_next_row_columns()
-            .iter()
-            .map(|&column| state.next[column].as_slice()[0])
-            .collect();
+        // Each successor table holds one next-row column's opening, in the AIR's declared order.
+        let next = state.next.iter().map(|p| p.as_slice()[0]).collect();
 
         ZerocheckProof {
             sumcheck,
@@ -375,7 +370,9 @@ struct RoundState<'a, A, F, EF> {
     transition: Poly<EF>,
     /// Current-row values of each main column.
     local: Vec<Poly<EF>>,
-    /// Next-row values of each main column, with repeat-last at the final row.
+    /// Main columns the AIR reads on the next row, in its declared order.
+    next_columns: Vec<usize>,
+    /// Next-row values of the `next_columns`, with repeat-last at the final row.
     next: Vec<Poly<EF>>,
     /// Per-round sumcheck degree.
     degree: usize,
@@ -385,6 +382,7 @@ impl<'a, A, F, EF> RoundState<'a, A, F, EF>
 where
     F: Field,
     EF: ExtensionField<F>,
+    A: BaseAir<F>,
 {
     /// Build the prover state from a trace and a sampled zerocheck point.
     fn new(
@@ -398,20 +396,30 @@ where
         let height = trace.height();
         let width = trace.width;
 
-        let mut local = Vec::with_capacity(width);
-        let mut next = Vec::with_capacity(width);
-        for c in 0..width {
-            // Lift column `c` into the extension field in row order.
-            let column: Vec<EF> = (0..height)
-                .map(|i| EF::from(trace.values[i * width + c]))
-                .collect();
-            // Successor column: row i reads row i+1, and the final row repeats itself.
-            let mut successor = Vec::with_capacity(height);
-            successor.extend_from_slice(&column[1..]);
-            successor.push(column[height - 1]);
-            local.push(Poly::new(column));
-            next.push(Poly::new(successor));
-        }
+        // Lift every main column into the extension field in row order.
+        let local: Vec<Poly<EF>> = (0..width)
+            .map(|c| {
+                Poly::new(
+                    (0..height)
+                        .map(|i| EF::from(trace.values[i * width + c]))
+                        .collect(),
+                )
+            })
+            .collect();
+
+        // Only the columns the AIR reads on the next row need a successor table.
+        let next_columns = air.main_next_row_columns();
+        let next: Vec<Poly<EF>> = next_columns
+            .iter()
+            .map(|&c| {
+                // Successor column: row i reads row i+1, and the final row repeats itself.
+                let column = local[c].as_slice();
+                let mut successor = Vec::with_capacity(height);
+                successor.extend_from_slice(&column[1..]);
+                successor.push(column[height - 1]);
+                Poly::new(successor)
+            })
+            .collect();
 
         // eq(tau, x) over the hypercube.
         let eq = Poly::new_from_point(tau, EF::ONE);
@@ -433,6 +441,7 @@ where
             last: Poly::new(last),
             transition: Poly::new(transition),
             local,
+            next_columns,
             next,
             degree,
         }
@@ -474,9 +483,12 @@ where
             let (acc, _, _) = (0..half).into_par_iter().par_fold_reduce(
                 || (EF::ZERO, EF::zero_vec(width), EF::zero_vec(width)),
                 |(mut acc, mut local_row, mut next_row), s| {
-                    for c in 0..width {
-                        local_row[c] = self.local[c].fix_prefix_var_at(z, s);
-                        next_row[c] = self.next[c].fix_prefix_var_at(z, s);
+                    for (dst, poly) in local_row.iter_mut().zip(&self.local) {
+                        *dst = poly.fix_prefix_var_at(z, s);
+                    }
+                    // Undeclared next-row entries stay zero; the AIR never reads them.
+                    for (&c, poly) in self.next_columns.iter().zip(&self.next) {
+                        next_row[c] = poly.fix_prefix_var_at(z, s);
                     }
                     let boundary = BoundaryEvals {
                         first: self.first.fix_prefix_var_at(z, s),


### PR DESCRIPTION
  ### Summary

  The zerocheck prover built and folded a full next-row (successor) table for **every** trace column, even though an AIR only reads the columns reported by `BaseAir::main_next_row_columns()` on the next row. `RoundState` now
  builds, folds, and fills successor tables only for those declared columns; undeclared `next_row` scratch entries stay at their zero init, and the AIR provably never reads them.

  This stacks on top of the `round_poly` parallelization from #1895 — it trims a constant factor off the same hot loop, plus the `RoundState::new` build and the per-round `fold`.

  ### Correctness

  - **Proof output is byte-identical.** `proof.next` carries the same values in the same declared order; nothing in the transcript or verifier changes. This is a pure prover-internal optimization.
  - The existing end-to-end test `next_claims_cover_only_declared_columns` (a width-2 AIR declaring only column 0, leaving column 1's next-row zero-filled) is the correctness guard and passes — along with all 22 crate tests.
  `clippy` is clean.

  ### Performance

  Measured drift-free by comparing two declared-footprint settings of one width-64 AIR (2 columns read on the next row) **within the same binary**, interleaved by criterion so machine drift cancels. `all_next` reproduces the
  pre-change cost (declares all 64 columns); `sparse_next` is the optimized path. Both share an identical `Air::eval`.

  | log₂(rows) | `all_next` (pre-change) | `sparse_next` (optimized) | Speedup |
  |---:|---:|---:|---:|
  | 16 | 204.8 ms | 116.3 ms | **1.76×** (−43%) |
  | 18 | 912.1 ms | 523.0 ms | **1.74×** (−43%) |
  | 20 | 4.876 s | 2.146 s | **2.27×** (−56%) |

  The win grows with trace size as the all-column successor build/fold becomes memory-bandwidth bound.

  **Scope:** the speedup is proportional to next-row sparsity. An AIR that reads all columns on the next row — including any AIR that does not override `main_next_row_columns()` (the default declares all columns) — gets
  **0%**; the change is provably a no-op there. The benefit is real and large precisely for wide AIRs with a sparse next-row footprint.

  ### Changes

  - `multi-stark/src/zerocheck.rs` — `RoundState` carries `next_columns` and builds/folds/fills successors only for those; prover reads the next-row openings straight off the pruned tables.
  - `multi-stark/benches/zerocheck.rs` — added a wide AIR with `all_next` / `sparse_next` variants as a reproducible measurement and regression guard.

  ### Test plan

  - [x] `cargo test -p p3-multi-stark` — 22 passed
  - [x] `cargo clippy -p p3-multi-stark --benches --tests` — clean
  - [x] `cargo bench -p p3-multi-stark --bench zerocheck -- zerocheck_prove_wide` — table above