### PR TITLE
perf(multi-stark) optimize round evaluation

### DIFF
--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -27,11 +27,20 @@ p3-multilinear-util.workspace = true
 p3-sumcheck.workspace = true
 p3-util.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
+
 
 [dev-dependencies]
-criterion = { workspace = true }
+criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
+p3-poseidon2-air.workspace = true
 rand = { workspace = true }
+tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
+
+[[bench]]
+name = "poseidon2"
+harness = false
 
 [[bench]]
 name = "zerocheck"

--- a/multi-stark/benches/poseidon2.rs
+++ b/multi-stark/benches/poseidon2.rs
@@ -1,0 +1,94 @@
+use core::time::Duration;
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::{
+    BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS, BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16,
+    BABYBEAR_S_BOX_DEGREE, BabyBear, GenericPoseidon2LinearLayersBabyBear, Poseidon2BabyBear,
+};
+use p3_challenger::DuplexChallenger;
+use p3_field::extension::BinomialExtensionField;
+use p3_multi_stark::zerocheck::AirZerocheck;
+use p3_poseidon2_air::{Poseidon2Air, RoundConstants};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type Ch = DuplexChallenger<F, Perm, 16, 8>;
+
+const POSEIDON2_WIDTH: usize = 16;
+const POSEIDON2_SBOX_DEGREE: u64 = BABYBEAR_S_BOX_DEGREE;
+const POSEIDON2_SBOX_REGISTERS: usize = 1;
+const POSEIDON2_HALF_FULL_ROUNDS: usize = BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS;
+const POSEIDON2_PARTIAL_ROUNDS: usize = BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16;
+
+type BabyBearPoseidon2Air = Poseidon2Air<
+    F,
+    GenericPoseidon2LinearLayersBabyBear,
+    POSEIDON2_WIDTH,
+    POSEIDON2_SBOX_DEGREE,
+    POSEIDON2_SBOX_REGISTERS,
+    POSEIDON2_HALF_FULL_ROUNDS,
+    POSEIDON2_PARTIAL_ROUNDS,
+>;
+
+fn fresh_challenger() -> Ch {
+    let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    Ch::new(perm)
+}
+
+fn poseidon2_air() -> BabyBearPoseidon2Air {
+    let mut rng = SmallRng::seed_from_u64(1);
+    Poseidon2Air::new(RoundConstants::from_rng(&mut rng))
+}
+
+fn bench_num_vars() -> Vec<usize> {
+    let value = std::env::var("ZEROCHECK_POSEIDON2_NUM_VARS")
+        .ok()
+        .unwrap_or_else(|| "15".to_string());
+
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.parse().expect("invalid num_vars"))
+        .collect()
+}
+
+fn bench_poseidon2_zerocheck_prove(c: &mut Criterion) {
+    let mut group = c.benchmark_group("poseidon2_zerocheck_prove");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(10));
+
+    for num_vars in bench_num_vars() {
+        let num_hashes = 1 << num_vars;
+        let air = poseidon2_air();
+        let trace = air.generate_trace_rows(num_hashes, 0);
+        let zerocheck = AirZerocheck::new(&air, 0);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |b, &num_vars| {
+                b.iter(|| {
+                    let mut challenger = fresh_challenger();
+                    let (proof, point) = zerocheck.prove::<F, EF, _>(&trace, &[], &mut challenger);
+                    black_box((proof, point, num_vars));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_poseidon2_zerocheck_prove
+);
+criterion_main!(benches);

--- a/multi-stark/src/folder.rs
+++ b/multi-stark/src/folder.rs
@@ -8,43 +8,42 @@
 use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, RowWindow};
-use p3_field::{ExtensionField, Field};
+use p3_field::{Algebra, Field, PrimeCharacteristicRing};
 
 use crate::selectors::BoundaryEvals;
 
 /// Folder shared by the prover and the verifier.
 #[derive(Debug)]
-pub struct MultilinearFolder<'a, F, EF>
+pub struct MultilinearFolder<'a, F, Var, Acc, PublicVar = F>
 where
-    F: Field,
-    EF: ExtensionField<F>,
+    F: PrimeCharacteristicRing,
 {
     /// Two-row main window holding the current and shifted-by-one rows.
     ///
     /// The shifted row carries zero in its last position.
-    pub main_window: RowWindow<'a, EF>,
+    pub main_window: RowWindow<'a, Var>,
     /// Boundary-selector values shared by all selector accessors.
-    pub boundary: BoundaryEvals<EF>,
+    pub boundary: BoundaryEvals<Var>,
     /// Public inputs forwarded to the AIR.
-    pub public_values: &'a [F],
+    pub public_values: &'a [PublicVar],
     /// Random scalar driving alpha-batching of constraints.
-    pub alpha: EF,
+    pub alpha: Acc,
     /// Running alpha-batched accumulator capturing every asserted-zero constraint.
-    pub accumulator: EF,
+    pub accumulator: Acc,
     /// Two-row preprocessed window; zero-width when the AIR has no preprocessed columns.
-    pub preprocessed_window: RowWindow<'a, EF>,
+    pub preprocessed_window: RowWindow<'a, Var>,
     /// Periodic column values at the current evaluation point, one per declared periodic column.
     ///
     /// Empty when the AIR declares no periodic columns.
-    pub periodic_values: &'a [EF],
+    pub periodic_values: &'a [Var],
     /// Type witness for the base field; no runtime storage.
     pub _phantom: PhantomData<F>,
 }
 
-impl<'a, F, EF> MultilinearFolder<'a, F, EF>
+impl<'a, F, Var, Acc, PublicVar> MultilinearFolder<'a, F, Var, Acc, PublicVar>
 where
-    F: Field,
-    EF: ExtensionField<F>,
+    F: PrimeCharacteristicRing,
+    Acc: PrimeCharacteristicRing,
 {
     /// Build a folder for a single AIR evaluation.
     ///
@@ -63,11 +62,11 @@ where
     /// - `alpha`: random scalar driving constraint batching.
     #[inline]
     pub fn new(
-        local: &'a [EF],
-        next: &'a [EF],
-        boundary: BoundaryEvals<EF>,
-        public_values: &'a [F],
-        alpha: EF,
+        local: &'a [Var],
+        next: &'a [Var],
+        boundary: BoundaryEvals<Var>,
+        public_values: &'a [PublicVar],
+        alpha: Acc,
     ) -> Self {
         Self {
             // Pair the two borrowed rows into the window the AIR reads from.
@@ -75,8 +74,8 @@ where
             boundary,
             public_values,
             alpha,
-            accumulator: EF::ZERO,
             // Zero-width preprocessed window covers AIRs without a preprocessed trace.
+            accumulator: Acc::ZERO,
             preprocessed_window: RowWindow::from_two_rows(&[], &[]),
             // No periodic columns until attached.
             periodic_values: &[],
@@ -92,7 +91,7 @@ where
     /// - `next`: preprocessed column values at the shifted-by-one row.
     #[inline]
     #[must_use]
-    pub fn with_preprocessed(mut self, current: &'a [EF], next: &'a [EF]) -> Self {
+    pub fn with_preprocessed(mut self, current: &'a [Var], next: &'a [Var]) -> Self {
         self.preprocessed_window = RowWindow::from_two_rows(current, next);
         self
     }
@@ -104,7 +103,7 @@ where
     /// - `periodic_values`: one entry per declared periodic column, in declaration order.
     #[inline]
     #[must_use]
-    pub const fn with_periodic(mut self, periodic_values: &'a [EF]) -> Self {
+    pub const fn with_periodic(mut self, periodic_values: &'a [Var]) -> Self {
         self.periodic_values = periodic_values;
         self
     }
@@ -119,7 +118,7 @@ where
     /// - `n` is the total number of asserted constraints.
     #[inline]
     #[must_use]
-    pub const fn into_accumulator(self) -> EF {
+    pub fn into_accumulator(self) -> Acc {
         self.accumulator
     }
 
@@ -140,29 +139,30 @@ where
     /// - `n` is the total number of asserted constraints.
     #[inline]
     #[must_use]
-    pub fn eval_air<A>(mut self, air: &A) -> EF
+    pub fn eval_air<A>(mut self, air: &A) -> Acc
     where
         A: Air<Self>,
+        Self: AirBuilder,
     {
-        // Drive every asserted constraint into the accumulator.
         air.eval(&mut self);
-        // The accumulator now holds the alpha-batched constraint value.
         self.into_accumulator()
     }
 }
 
-impl<'a, F, EF> AirBuilder for MultilinearFolder<'a, F, EF>
+impl<'a, F, Var, Acc, PublicVar> AirBuilder for MultilinearFolder<'a, F, Var, Acc, PublicVar>
 where
     F: Field,
-    EF: ExtensionField<F>,
+    Var: Algebra<F> + Algebra<Var> + Copy + Send + Sync,
+    Acc: Algebra<Var> + Copy,
+    PublicVar: Into<Var> + Copy,
 {
     type F = F;
-    type Expr = EF;
-    type Var = EF;
-    type MainWindow = RowWindow<'a, EF>;
-    type PreprocessedWindow = RowWindow<'a, EF>;
-    type PublicVar = F;
-    type PeriodicVar = EF;
+    type Expr = Var;
+    type Var = Var;
+    type MainWindow = RowWindow<'a, Var>;
+    type PreprocessedWindow = RowWindow<'a, Var>;
+    type PublicVar = PublicVar;
+    type PeriodicVar = Var;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
@@ -227,6 +227,7 @@ mod tests {
 
     type F = BabyBear;
     type EF = BinomialExtensionField<F, 4>;
+    type TestFolder<'a> = MultilinearFolder<'a, F, EF, EF>;
 
     /// Mini Fibonacci AIR used to exercise every selector path.
     ///
@@ -349,8 +350,7 @@ mod tests {
             };
             let boundary = boundary_at_row(i, n);
 
-            let value =
-                MultilinearFolder::new(&local, &next, boundary, &pis, alpha).eval_air(&FibAir);
+            let value = TestFolder::new(&local, &next, boundary, &pis, alpha).eval_air(&FibAir);
             assert_eq!(value, EF::ZERO, "row {i}: folder returned {value:?}");
         }
     }
@@ -374,8 +374,7 @@ mod tests {
         let next = row_in_ef(&trace, 1);
         let boundary = boundary_at_row(0, n);
 
-        let value =
-            MultilinearFolder::new(&local, &next, boundary, &bad_pis, alpha).eval_air(&FibAir);
+        let value = TestFolder::new(&local, &next, boundary, &bad_pis, alpha).eval_air(&FibAir);
         assert_ne!(value, EF::ZERO);
     }
 
@@ -409,7 +408,7 @@ mod tests {
             transition: EF::ONE,
         };
 
-        let value = MultilinearFolder::new(&local, &next, boundary, &pis, alpha).eval_air(&FibAir);
+        let value = TestFolder::new(&local, &next, boundary, &pis, alpha).eval_air(&FibAir);
 
         // Active constraints (the two transition checks), in declaration order:
         //
@@ -475,7 +474,7 @@ mod tests {
         let periodic = [EF::from_u64(5)];
 
         // Matching auxiliary columns -> both constraints are zero.
-        let value = MultilinearFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
+        let value = TestFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
             .with_preprocessed(&prep_local, &prep_next)
             .with_periodic(&periodic)
             .eval_air(&AuxAir);
@@ -483,7 +482,7 @@ mod tests {
 
         // Perturbed preprocessed column -> the first constraint is non-zero.
         let bad_prep = [EF::from_u64(6)];
-        let value = MultilinearFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
+        let value = TestFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
             .with_preprocessed(&bad_prep, &prep_next)
             .with_periodic(&periodic)
             .eval_air(&AuxAir);
@@ -491,7 +490,7 @@ mod tests {
 
         // Perturbed periodic column -> the second constraint is non-zero.
         let bad_periodic = [EF::from_u64(6)];
-        let value = MultilinearFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
+        let value = TestFolder::new(&main_local, &main_next, boundary, &[] as &[F], alpha)
             .with_preprocessed(&prep_local, &prep_next)
             .with_periodic(&bad_periodic)
             .eval_air(&AuxAir);

--- a/multi-stark/src/folder.rs
+++ b/multi-stark/src/folder.rs
@@ -5,8 +5,6 @@
 //!   - the prover walks the boolean hypercube row by row,
 //!   - the verifier evaluates at the random sumcheck challenge.
 
-use core::marker::PhantomData;
-
 use p3_air::{Air, AirBuilder, RowWindow};
 use p3_field::{Algebra, PrimeCharacteristicRing};
 
@@ -14,15 +12,15 @@ use crate::selectors::BoundaryEvals;
 
 /// Folder shared by the prover and the verifier.
 #[derive(Debug)]
-pub struct MultilinearFolder<'a, F, Var, Acc, PublicVar = F> {
+pub struct MultilinearFolder<'a, F, Var, Acc> {
     /// Two-row main window holding the current and shifted-by-one rows.
     ///
     /// The shifted row carries zero in its last position.
     pub main_window: RowWindow<'a, Var>,
     /// Boundary-selector values shared by all selector accessors.
     pub boundary: BoundaryEvals<Var>,
-    /// Public inputs forwarded to the AIR.
-    pub public_values: &'a [PublicVar],
+    /// Public inputs forwarded to the AIR, always in the base field.
+    pub public_values: &'a [F],
     /// Random scalar driving alpha-batching of constraints.
     pub alpha: Acc,
     /// Running alpha-batched accumulator capturing every asserted-zero constraint.
@@ -33,11 +31,9 @@ pub struct MultilinearFolder<'a, F, Var, Acc, PublicVar = F> {
     ///
     /// Empty when the AIR declares no periodic columns.
     pub periodic_values: &'a [Var],
-    /// Type witness for the base field; no runtime storage.
-    pub _phantom: PhantomData<F>,
 }
 
-impl<'a, F, Var, Acc, PublicVar> MultilinearFolder<'a, F, Var, Acc, PublicVar>
+impl<'a, F, Var, Acc> MultilinearFolder<'a, F, Var, Acc>
 where
     Acc: PrimeCharacteristicRing,
 {
@@ -61,7 +57,7 @@ where
         local: &'a [Var],
         next: &'a [Var],
         boundary: BoundaryEvals<Var>,
-        public_values: &'a [PublicVar],
+        public_values: &'a [F],
         alpha: Acc,
     ) -> Self {
         Self {
@@ -75,7 +71,6 @@ where
             preprocessed_window: RowWindow::from_two_rows(&[], &[]),
             // No periodic columns until attached.
             periodic_values: &[],
-            _phantom: PhantomData,
         }
     }
 
@@ -145,19 +140,19 @@ where
     }
 }
 
-impl<'a, F, Var, Acc, PublicVar> AirBuilder for MultilinearFolder<'a, F, Var, Acc, PublicVar>
+impl<'a, F, Var, Acc> AirBuilder for MultilinearFolder<'a, F, Var, Acc>
 where
-    F: PrimeCharacteristicRing + Sync,
+    F: PrimeCharacteristicRing + Into<Var> + Copy + Sync,
     Var: Algebra<F> + Algebra<Var> + Copy + Send + Sync,
     Acc: Algebra<Var> + Copy,
-    PublicVar: Into<Var> + Copy,
 {
     type F = F;
     type Expr = Var;
     type Var = Var;
     type MainWindow = RowWindow<'a, Var>;
     type PreprocessedWindow = RowWindow<'a, Var>;
-    type PublicVar = PublicVar;
+    // Public values stay in the base field and lift into the expression type on read.
+    type PublicVar = F;
     type PeriodicVar = Var;
 
     #[inline]

--- a/multi-stark/src/folder.rs
+++ b/multi-stark/src/folder.rs
@@ -8,16 +8,13 @@
 use core::marker::PhantomData;
 
 use p3_air::{Air, AirBuilder, RowWindow};
-use p3_field::{Algebra, Field, PrimeCharacteristicRing};
+use p3_field::{Algebra, PrimeCharacteristicRing};
 
 use crate::selectors::BoundaryEvals;
 
 /// Folder shared by the prover and the verifier.
 #[derive(Debug)]
-pub struct MultilinearFolder<'a, F, Var, Acc, PublicVar = F>
-where
-    F: PrimeCharacteristicRing,
-{
+pub struct MultilinearFolder<'a, F, Var, Acc, PublicVar = F> {
     /// Two-row main window holding the current and shifted-by-one rows.
     ///
     /// The shifted row carries zero in its last position.
@@ -42,7 +39,6 @@ where
 
 impl<'a, F, Var, Acc, PublicVar> MultilinearFolder<'a, F, Var, Acc, PublicVar>
 where
-    F: PrimeCharacteristicRing,
     Acc: PrimeCharacteristicRing,
 {
     /// Build a folder for a single AIR evaluation.
@@ -151,7 +147,7 @@ where
 
 impl<'a, F, Var, Acc, PublicVar> AirBuilder for MultilinearFolder<'a, F, Var, Acc, PublicVar>
 where
-    F: Field,
+    F: PrimeCharacteristicRing + Sync,
     Var: Algebra<F> + Algebra<Var> + Copy + Send + Sync,
     Acc: Algebra<Var> + Copy,
     PublicVar: Into<Var> + Copy,

--- a/multi-stark/src/lib.rs
+++ b/multi-stark/src/lib.rs
@@ -14,5 +14,6 @@ pub mod config;
 pub mod folder;
 pub mod metadata;
 pub mod opening;
+pub mod rounds;
 pub mod selectors;
 pub mod zerocheck;

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -20,7 +20,7 @@ use crate::selectors::BoundaryEvals;
 ///
 /// Stores the base trace as one transposed row-major matrix: each matrix row is one trace column.
 #[derive(Debug, Clone)]
-pub(crate) struct RoundStateBase<'a, A, F: Field, EF: ExtensionField<F>> {
+pub(crate) struct RoundStateBase<'a, A, F, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
     /// Public inputs forwarded to the AIR.
@@ -39,7 +39,7 @@ pub(crate) struct RoundStateBase<'a, A, F: Field, EF: ExtensionField<F>> {
 ///
 /// Owns the folded trace columns, equality weights, boundary selectors, and repeat-last next-row
 /// tail values needed by the remaining rounds.
-pub(crate) struct RoundStateExt<'a, A, F: Field, EF: ExtensionField<F>> {
+pub(crate) struct RoundStateExt<'a, A, F, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
     /// Public inputs forwarded to the AIR, lifted into the extension field.
@@ -398,7 +398,7 @@ where
     #[tracing::instrument(skip_all)]
     pub(crate) fn round_poly(&self) -> Vec<EF>
     where
-        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>> + Sync,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>,
     {
         let width = self.width();
         let num_evals = self.num_evals();

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -1,0 +1,518 @@
+//! Per-round AIR zerocheck state.
+//!
+//! Builds round polynomials for `sum_x eq(tau, x) * g(x)` and folds state across challenges.
+
+use alloc::vec::Vec;
+
+use p3_air::Air;
+use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::{Poly, fix_prefix_var};
+use p3_sumcheck::generic_degree::RoundProver;
+
+use crate::folder::MultilinearFolder;
+use crate::selectors::BoundaryEvals;
+
+/// Sumcheck prover state for the AIR zerocheck.
+///
+/// Stores the base trace as one transposed row-major matrix: each matrix row is one trace column.
+#[derive(Debug, Clone)]
+pub(crate) struct RoundStateBase<'a, A, F: Field, EF: ExtensionField<F>> {
+    /// AIR whose alpha-batched constraint is being evaluated.
+    air: &'a A,
+    /// Public inputs forwarded to the AIR.
+    public_values: &'a [F],
+    /// Random scalar batching the AIR constraints.
+    alpha: EF,
+    /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
+    eq: Poly<EF>,
+    /// Main trace columns, stored as a row-major matrix with one original column per row.
+    columns: RowMajorMatrix<F>,
+    /// Per-round sumcheck degree.
+    degree: usize,
+}
+
+/// Extension-field sumcheck state after the first base-field round.
+///
+/// Owns the folded trace columns, equality weights, boundary selectors, and repeat-last next-row
+/// tail values needed by the remaining rounds.
+pub(crate) struct RoundStateExt<'a, A, F: Field, EF: ExtensionField<F>> {
+    /// AIR whose alpha-batched constraint is being evaluated.
+    air: &'a A,
+    /// Public inputs forwarded to the AIR, lifted into the extension field.
+    public_values: Vec<EF>,
+    /// Random scalar batching the AIR constraints.
+    alpha: EF,
+    /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
+    eq: Poly<EF>,
+    /// Folded boundary-selector values at the current sumcheck prefix.
+    boundary: BoundaryEvals<EF>,
+    /// Main trace columns after the first base-field fold.
+    columns: Vec<Poly<EF>>,
+    /// Repeat-last successor values for each main column at the folded tail row.
+    next_tail: Vec<EF>,
+    /// Per-round sumcheck degree.
+    degree: usize,
+    /// Type witness for the base field; no runtime storage.
+    _marker: core::marker::PhantomData<F>,
+}
+
+impl<'a, A, F, EF> RoundStateBase<'a, A, F, EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    /// Build the prover state from a trace and a sampled zerocheck point.
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn new(
+        air: &'a A,
+        public_values: &'a [F],
+        alpha: EF,
+        tau: &Point<EF>,
+        trace: &'a RowMajorMatrix<F>,
+        degree: usize,
+    ) -> Self {
+        // TODO: we may want to send cm_trace directly since PCS needs Vec<Poly> representation of witneses
+        let columns = tracing::info_span!("transpose").in_scope(|| trace.transpose());
+        Self {
+            air,
+            public_values,
+            alpha,
+            eq: Poly::new_from_point(tau.as_slice(), EF::ONE),
+            columns,
+            degree,
+        }
+    }
+
+    const fn num_evals(&self) -> usize {
+        self.eq.num_evals()
+    }
+
+    fn width(&self) -> usize {
+        self.columns.height()
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn round_poly(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
+            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
+        EF::ExtensionPacking: From<EF> + From<F::Packing>,
+    {
+        if self.num_evals() / 2 < F::Packing::WIDTH {
+            self.round_poly_unpacked()
+        } else {
+            self.round_poly_packed()
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn round_poly_packed(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
+            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
+        EF::ExtensionPacking: From<EF> + From<F::Packing>,
+    {
+        let width = self.width();
+        let height = self.num_evals();
+        let scalar_half = height / 2;
+        let packing_width = F::Packing::WIDTH;
+        let packed_half = scalar_half / packing_width;
+        let degree = self.degree;
+        let alpha = EF::ExtensionPacking::from(self.alpha);
+        assert_ne!(packed_half, 0);
+
+        (0..packed_half).into_par_iter().par_fold_reduce(
+            || EF::zero_vec(degree),
+            |mut out, packed_s| {
+                let s = packed_s * packing_width;
+                let mut local_point = F::Packing::zero_vec(width);
+                let mut local_diff = F::Packing::zero_vec(width);
+                let mut next_point = F::Packing::zero_vec(width);
+                let mut next_diff = F::Packing::zero_vec(width);
+                let mut eq_value = EF::zero_vec(packing_width);
+                let mut eq_diff = EF::zero_vec(packing_width);
+
+                for ((((local, local_delta), next), next_delta), column) in local_point
+                    .iter_mut()
+                    .zip(local_diff.iter_mut())
+                    .zip(next_point.iter_mut())
+                    .zip(next_diff.iter_mut())
+                    .zip(self.columns.row_slices())
+                {
+                    let local_lo = *F::Packing::from_slice(&column[s..s + packing_width]);
+                    let local_hi = *F::Packing::from_slice(
+                        &column[s + scalar_half..s + scalar_half + packing_width],
+                    );
+                    *local = local_lo;
+                    *local_delta = local_hi - local_lo;
+
+                    let next_lo = *F::Packing::from_slice(&column[s + 1..s + 1 + packing_width]);
+                    let next_hi_start = s + scalar_half + 1;
+                    let next_hi = if next_hi_start + packing_width <= height {
+                        *F::Packing::from_slice(
+                            &column[next_hi_start..next_hi_start + packing_width],
+                        )
+                    } else {
+                        F::Packing::from_fn(|lane| {
+                            let row = next_hi_start + lane;
+                            if row < height {
+                                column[row]
+                            } else {
+                                column[height - 1]
+                            }
+                        })
+                    };
+                    *next = next_lo;
+                    *next_delta = next_hi - next_lo;
+                }
+
+                for lane in 0..packing_width {
+                    let lo = self.eq.as_slice()[s + lane];
+                    eq_value[lane] = lo;
+                    eq_diff[lane] = self.eq.as_slice()[s + scalar_half + lane] - lo;
+                }
+
+                let (mut boundary, boundary_diff) =
+                    BoundaryEvals::<F::Packing>::row_pair_packed::<F>(s, scalar_half, height);
+
+                let g = MultilinearFolder::new(
+                    &local_point,
+                    &next_point,
+                    boundary,
+                    self.public_values,
+                    alpha,
+                )
+                .eval_air(self.air);
+
+                out[0] += EF::ExtensionPacking::to_ext_iter([g])
+                    .zip(&eq_value)
+                    .map(|(g, &eq)| eq * g)
+                    .sum::<EF>();
+
+                local_point
+                    .iter_mut()
+                    .zip(local_diff.iter())
+                    .zip(next_point.iter_mut())
+                    .zip(next_diff.iter())
+                    .for_each(|(((local, local_diff), next), next_diff)| {
+                        *local += *local_diff;
+                        *next += *next_diff;
+                    });
+                eq_value
+                    .iter_mut()
+                    .zip(eq_diff.iter())
+                    .for_each(|(value, diff)| *value += *diff);
+                boundary += boundary_diff;
+
+                for acc in &mut out[1..] {
+                    local_point
+                        .iter_mut()
+                        .zip(local_diff.iter())
+                        .zip(next_point.iter_mut())
+                        .zip(next_diff.iter())
+                        .for_each(|(((local, local_diff), next), next_diff)| {
+                            *local += *local_diff;
+                            *next += *next_diff;
+                        });
+                    eq_value
+                        .iter_mut()
+                        .zip(eq_diff.iter())
+                        .for_each(|(value, diff)| *value += *diff);
+                    boundary += boundary_diff;
+
+                    let g = MultilinearFolder::new(
+                        &local_point,
+                        &next_point,
+                        boundary,
+                        self.public_values,
+                        alpha,
+                    )
+                    .eval_air(self.air);
+                    *acc += EF::ExtensionPacking::to_ext_iter([g])
+                        .zip(&eq_value)
+                        .map(|(g, &eq)| eq * g)
+                        .sum::<EF>();
+                }
+
+                out
+            },
+            |mut lhs, rhs| {
+                lhs.iter_mut().zip(rhs).for_each(|(lhs, rhs)| *lhs += rhs);
+                lhs
+            },
+        )
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn round_poly_unpacked(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
+    {
+        let width = self.width();
+        let height = self.num_evals();
+        let half = height / 2;
+
+        let mut out = EF::zero_vec(self.degree);
+        let mut local_point = F::zero_vec(width);
+        let mut local_diff = F::zero_vec(width);
+        let mut next_point = F::zero_vec(width);
+        let mut next_diff = F::zero_vec(width);
+
+        for s in 0..half {
+            local_point
+                .iter_mut()
+                .zip(local_diff.iter_mut())
+                .zip(next_point.iter_mut())
+                .zip(next_diff.iter_mut())
+                .zip(self.columns.row_slices())
+                .for_each(|((((local, local_delta), next), next_delta), column)| {
+                    let local_lo = column[s];
+                    let local_hi = column[s + half];
+                    *local = local_lo;
+                    *local_delta = local_hi - local_lo;
+
+                    let next_lo = column[s + 1];
+                    let next_hi = if s + half + 1 < height {
+                        column[s + half + 1]
+                    } else {
+                        column[height - 1]
+                    };
+                    *next = next_lo;
+                    *next_delta = next_hi - next_lo;
+                });
+
+            let (mut boundary, boundary_diff) = BoundaryEvals::<F>::row_pair(s, half, height);
+
+            let mut eq_value = self.eq.as_slice()[s];
+            let eq_diff = self.eq.as_slice()[s + half] - eq_value;
+
+            let g = MultilinearFolder::new(
+                &local_point,
+                &next_point,
+                boundary,
+                self.public_values,
+                self.alpha,
+            )
+            .eval_air(self.air);
+            out[0] += eq_value * g;
+
+            F::add_slices(&mut local_point, &local_diff);
+            F::add_slices(&mut next_point, &next_diff);
+            boundary += boundary_diff;
+            eq_value += eq_diff;
+
+            for acc in &mut out[1..] {
+                F::add_slices(&mut local_point, &local_diff);
+                F::add_slices(&mut next_point, &next_diff);
+                boundary += boundary_diff;
+                eq_value += eq_diff;
+
+                let g = MultilinearFolder::new(
+                    &local_point,
+                    &next_point,
+                    boundary,
+                    self.public_values,
+                    self.alpha,
+                )
+                .eval_air(self.air);
+                *acc += eq_value * g;
+            }
+        }
+
+        out
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn fold(mut self, r: EF) -> RoundStateExt<'a, A, F, EF> {
+        let num_evals = self.eq.num_evals();
+        let half = num_evals / 2;
+        let next_tail = self
+            .columns
+            .row_slices()
+            .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half]))
+            .collect::<Vec<_>>();
+
+        self.eq.fix_prefix_var_mut(r);
+
+        let columns = self
+            .columns
+            .par_row_slices()
+            .map(|col| fix_prefix_var(col, r))
+            .collect::<Vec<_>>();
+
+        RoundStateExt {
+            air: self.air,
+            public_values: self.public_values.iter().copied().map(EF::from).collect(),
+            alpha: self.alpha,
+            eq: self.eq,
+            degree: self.degree,
+            columns,
+            next_tail,
+            boundary: BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, A, F, EF> RoundProver<EF> for RoundStateExt<'a, A, F, EF>
+where
+    A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>,
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    fn round_poly(&self) -> Vec<EF> {
+        RoundStateExt::round_poly(self)
+    }
+
+    fn fold(&mut self, r: EF) {
+        RoundStateExt::fold(self, r);
+    }
+}
+
+impl<'a, A, F, EF> RoundStateExt<'a, A, F, EF>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    const fn num_evals(&self) -> usize {
+        self.eq.num_evals()
+    }
+
+    const fn width(&self) -> usize {
+        self.columns.len()
+    }
+
+    pub(crate) fn evals(self) -> (Vec<EF>, Vec<EF>, BoundaryEvals<EF>) {
+        let columns = self
+            .columns
+            .iter()
+            .map(|poly| poly.as_constant().unwrap())
+            .collect();
+        (columns, self.next_tail, self.boundary)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn round_poly(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>> + Sync,
+    {
+        let width = self.width();
+        let num_evals = self.num_evals();
+        let half = num_evals / 2;
+        let degree = self.degree;
+        let (eq_lo, eq_hi) = self.eq.as_slice().split_at(half);
+
+        (0..half)
+            .into_par_iter()
+            .zip(eq_lo.par_iter().zip(eq_hi.par_iter()))
+            .par_fold_reduce(
+                || EF::zero_vec(degree),
+                |mut out, (s, (&eq_lo_value, &eq_hi_value))| {
+                    let mut local_point = EF::zero_vec(width);
+                    let mut local_diff = EF::zero_vec(width);
+                    let mut next_point = EF::zero_vec(width);
+                    let mut next_diff = EF::zero_vec(width);
+
+                    for (((((local, local_delta), next), next_delta), column), next_tail) in
+                        local_point
+                            .iter_mut()
+                            .zip(local_diff.iter_mut())
+                            .zip(next_point.iter_mut())
+                            .zip(next_diff.iter_mut())
+                            .zip(self.columns.iter())
+                            .zip(self.next_tail.iter())
+                    {
+                        let column = column.as_slice();
+                        let local_lo = column[s];
+                        let local_hi = column[s + half];
+                        *local = local_lo;
+                        *local_delta = local_hi - local_lo;
+
+                        let next_lo = column[s + 1];
+                        let next_hi_row = s + half;
+                        let next_hi = if next_hi_row + 1 < num_evals {
+                            column[next_hi_row + 1]
+                        } else {
+                            *next_tail
+                        };
+                        *next = next_lo;
+                        *next_delta = next_hi - next_lo;
+                    }
+
+                    let (mut boundary, boundary_diff) =
+                        BoundaryEvals::row_pair_with_prefix(s, half, num_evals, self.boundary);
+
+                    let mut eq_value = eq_lo_value;
+                    let eq_diff = eq_hi_value - eq_value;
+
+                    let g = MultilinearFolder::new(
+                        &local_point,
+                        &next_point,
+                        boundary,
+                        &self.public_values,
+                        self.alpha,
+                    )
+                    .eval_air(self.air);
+                    out[0] += eq_value * g;
+
+                    EF::add_slices(&mut local_point, &local_diff);
+                    EF::add_slices(&mut next_point, &next_diff);
+                    boundary += boundary_diff;
+                    eq_value += eq_diff;
+
+                    for acc in &mut out[1..] {
+                        EF::add_slices(&mut local_point, &local_diff);
+                        EF::add_slices(&mut next_point, &next_diff);
+                        boundary += boundary_diff;
+                        eq_value += eq_diff;
+
+                        let g = MultilinearFolder::new(
+                            &local_point,
+                            &next_point,
+                            boundary,
+                            &self.public_values,
+                            self.alpha,
+                        )
+                        .eval_air(self.air);
+                        *acc += eq_value * g;
+                    }
+
+                    out
+                },
+                |mut lhs, rhs| {
+                    lhs.iter_mut().zip(rhs).for_each(|(lhs, rhs)| *lhs += rhs);
+                    lhs
+                },
+            )
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn fold(&mut self, r: EF) {
+        let num_evals = self.eq.num_evals();
+        let half = num_evals / 2;
+
+        self.next_tail = self
+            .columns
+            .iter()
+            .zip(self.next_tail.iter())
+            .map(|(col, &next_tail)| {
+                let lo = col.as_slice()[half];
+                lo + r * (next_tail - lo)
+            })
+            .collect();
+
+        self.eq.fix_prefix_var_mut(r);
+
+        self.columns = self
+            .columns
+            .par_iter()
+            .map(|col| fix_prefix_var(col.as_slice(), r))
+            .collect();
+
+        self.boundary.apply(r);
+    }
+}

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -42,8 +42,8 @@ pub(crate) struct RoundStateBase<'a, A, F, EF> {
 pub(crate) struct RoundStateExt<'a, A, F, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
-    /// Public inputs forwarded to the AIR, lifted into the extension field.
-    public_values: Vec<EF>,
+    /// Public inputs forwarded to the AIR, in the base field.
+    public_values: &'a [F],
     /// Random scalar batching the AIR constraints.
     alpha: EF,
     /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
@@ -56,8 +56,6 @@ pub(crate) struct RoundStateExt<'a, A, F, EF> {
     next_tail: Vec<EF>,
     /// Per-round sumcheck degree.
     degree: usize,
-    /// Type witness for the base field; no runtime storage.
-    _marker: core::marker::PhantomData<F>,
 }
 
 impl<'a, A, F, EF> RoundStateBase<'a, A, F, EF>
@@ -346,21 +344,20 @@ where
 
         RoundStateExt {
             air: self.air,
-            public_values: self.public_values.iter().copied().map(EF::from).collect(),
+            public_values: self.public_values,
             alpha: self.alpha,
             eq: self.eq,
             degree: self.degree,
             columns,
             next_tail,
             boundary: BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
-            _marker: core::marker::PhantomData,
         }
     }
 }
 
 impl<'a, A, F, EF> RoundProver<EF> for RoundStateExt<'a, A, F, EF>
 where
-    A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>,
+    A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
     F: Field,
     EF: ExtensionField<F>,
 {
@@ -398,7 +395,7 @@ where
     #[tracing::instrument(skip_all)]
     pub(crate) fn round_poly(&self) -> Vec<EF>
     where
-        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
     {
         let width = self.width();
         let num_evals = self.num_evals();
@@ -453,7 +450,7 @@ where
                         &local_point,
                         &next_point,
                         boundary,
-                        &self.public_values,
+                        self.public_values,
                         self.alpha,
                     )
                     .eval_air(self.air);
@@ -474,7 +471,7 @@ where
                             &local_point,
                             &next_point,
                             boundary,
-                            &self.public_values,
+                            self.public_values,
                             self.alpha,
                         )
                         .eval_air(self.air);

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -19,7 +19,7 @@ use crate::selectors::BoundaryEvals;
 /// Sumcheck prover state for the AIR zerocheck.
 ///
 /// Stores the base trace as one transposed row-major matrix: each matrix row is one trace column.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct RoundStateBase<'a, A, F, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
@@ -177,7 +177,7 @@ where
                 }
 
                 let (mut boundary, boundary_diff) =
-                    BoundaryEvals::<F::Packing>::row_pair_packed::<F>(s, scalar_half, height);
+                    BoundaryEvals::<F::Packing>::row_pair_packed(s, scalar_half, height);
 
                 let g = MultilinearFolder::new(
                     &local_point,
@@ -342,7 +342,7 @@ where
             .columns
             .par_row_slices()
             .map(|col| fix_prefix_var(col, r))
-            .collect::<Vec<_>>();
+            .collect();
 
         RoundStateExt {
             air: self.air,
@@ -507,11 +507,12 @@ where
 
         self.eq.fix_prefix_var_mut(r);
 
-        self.columns = self
-            .columns
-            .par_iter()
-            .map(|col| fix_prefix_var(col.as_slice(), r))
-            .collect();
+        // Both halves already live in the extension field.
+        // So each column folds in place, reusing its buffer.
+        // No per-round reallocation is needed.
+        self.columns
+            .par_iter_mut()
+            .for_each(|col| col.fix_prefix_var_mut(r));
 
         self.boundary.apply(r);
     }

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -10,7 +10,7 @@ use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::{Poly, fix_prefix_var};
+use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::generic_degree::RoundProver;
 
 use crate::folder::MultilinearFolder;
@@ -339,7 +339,7 @@ where
         let columns = self
             .columns
             .par_row_slices()
-            .map(|col| fix_prefix_var(col, r))
+            .map(|col| Poly::fix_prefix_var_from_evals(col, r))
             .collect();
 
         RoundStateExt {

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -92,7 +92,7 @@ impl<EF: Field> BoundaryEvals<EF> {
     /// # Arguments
     ///
     /// - `rs`: challenge coordinates, one per binary trace variable.
-    pub(super) fn at(rs: &[EF]) -> Self {
+    pub fn at(rs: &[EF]) -> Self {
         // Thread both running products through the same loop:
         //
         //     first := first * (1 - r)

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -41,7 +41,7 @@ impl<Packed> BoundaryEvals<Packed> {
     pub(super) fn row_pair_packed<F>(row: usize, half: usize, height: usize) -> (Self, Self)
     where
         F: Field<Packing = Packed>,
-        Packed: PackedValue<Value = F> + Sub<Output = Packed> + Copy,
+        Packed: PackedValue<Value = F> + Sub<Output = Packed>,
     {
         let boundary = Self::from_packed_row::<F>(row, height);
         let hi_boundary = Self::from_packed_row::<F>(row + half, height);

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -1,6 +1,8 @@
 //! Closed-form multilinear extensions used by the multilinear AIR prover.
 
-use p3_field::Field;
+use core::ops::{AddAssign, Sub};
+
+use p3_field::{Field, PackedValue};
 
 /// Boundary selectors evaluated at a sumcheck challenge.
 #[derive(Copy, Clone, Debug)]
@@ -13,13 +15,54 @@ pub struct BoundaryEvals<EF> {
     pub transition: EF,
 }
 
+impl<EF> BoundaryEvals<EF> {
+    pub(super) const fn new(first: EF, last: EF, transition: EF) -> Self {
+        Self {
+            first,
+            last,
+            transition,
+        }
+    }
+}
+
+impl<Packed> BoundaryEvals<Packed> {
+    pub(super) fn from_packed_row<F>(row: usize, height: usize) -> Self
+    where
+        F: Field<Packing = Packed>,
+        Packed: PackedValue<Value = F>,
+    {
+        Self::new(
+            Packed::from_fn(|lane| F::from_bool(row + lane == 0)),
+            Packed::from_fn(|lane| F::from_bool(row + lane + 1 == height)),
+            Packed::from_fn(|lane| F::from_bool(row + lane + 1 < height)),
+        )
+    }
+
+    pub(super) fn row_pair_packed<F>(row: usize, half: usize, height: usize) -> (Self, Self)
+    where
+        F: Field<Packing = Packed>,
+        Packed: PackedValue<Value = F> + Sub<Output = Packed> + Copy,
+    {
+        let boundary = Self::from_packed_row::<F>(row, height);
+        let hi_boundary = Self::from_packed_row::<F>(row + half, height);
+        (
+            boundary,
+            Self::new(
+                hi_boundary.first - boundary.first,
+                hi_boundary.last - boundary.last,
+                hi_boundary.transition - boundary.transition,
+            ),
+        )
+    }
+}
+
 impl<EF: Field> BoundaryEvals<EF> {
     /// Evaluate all three boundary selectors at the same challenge point.
     ///
     /// # Arguments
     ///
     /// - `rs`: challenge coordinates, one per binary trace variable.
-    pub fn at(rs: &[EF]) -> Self {
+    pub(super) fn at(rs: &[EF]) -> Self {
         // Thread both running products through the same loop:
         //
         //     first := first * (1 - r)
@@ -35,6 +78,71 @@ impl<EF: Field> BoundaryEvals<EF> {
             last,
             transition: EF::ONE - last,
         }
+    }
+
+    pub(super) fn apply(&mut self, r: EF) {
+        self.first *= EF::ONE - r;
+        self.last *= r;
+        self.transition = EF::ONE - self.last;
+    }
+
+    pub(super) fn from_row(row: usize, height: usize) -> Self {
+        Self::new(
+            EF::from_bool(row == 0),
+            EF::from_bool(row + 1 == height),
+            EF::from_bool(row + 1 < height),
+        )
+    }
+
+    pub(super) fn from_row_with_prefix(row: usize, height: usize, prefix: Self) -> Self {
+        let suffix = Self::from_row(row, height);
+        Self::new(
+            prefix.first * suffix.first,
+            prefix.last * suffix.last,
+            suffix.transition + suffix.last * prefix.transition,
+        )
+    }
+
+    pub(super) fn row_pair(row: usize, half: usize, height: usize) -> (Self, Self) {
+        let boundary = Self::from_row(row, height);
+        let hi_boundary = Self::from_row(row + half, height);
+        (
+            boundary,
+            Self::new(
+                hi_boundary.first - boundary.first,
+                hi_boundary.last - boundary.last,
+                hi_boundary.transition - boundary.transition,
+            ),
+        )
+    }
+
+    pub(super) fn row_pair_with_prefix(
+        row: usize,
+        half: usize,
+        height: usize,
+        prefix: Self,
+    ) -> (Self, Self) {
+        let boundary = Self::from_row_with_prefix(row, height, prefix);
+        let hi_boundary = Self::from_row_with_prefix(row + half, height, prefix);
+        (
+            boundary,
+            Self::new(
+                hi_boundary.first - boundary.first,
+                hi_boundary.last - boundary.last,
+                hi_boundary.transition - boundary.transition,
+            ),
+        )
+    }
+}
+
+impl<EF> AddAssign for BoundaryEvals<EF>
+where
+    EF: AddAssign,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        self.first += rhs.first;
+        self.last += rhs.last;
+        self.transition += rhs.transition;
     }
 }
 

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{AddAssign, Sub};
 
-use p3_field::{Field, PackedValue};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 
 /// Boundary selectors evaluated at a sumcheck challenge.
 #[derive(Copy, Clone, Debug)]
@@ -16,6 +16,7 @@ pub struct BoundaryEvals<EF> {
 }
 
 impl<EF> BoundaryEvals<EF> {
+    /// Bundle three already-computed selector values.
     pub(super) const fn new(first: EF, last: EF, transition: EF) -> Self {
         Self {
             first,
@@ -25,26 +26,55 @@ impl<EF> BoundaryEvals<EF> {
     }
 }
 
-impl<Packed> BoundaryEvals<Packed> {
-    pub(super) fn from_packed_row<F>(row: usize, height: usize) -> Self
-    where
-        F: Field<Packing = Packed>,
-        Packed: PackedValue<Value = F>,
-    {
+impl<Packed> BoundaryEvals<Packed>
+where
+    Packed: PackedValue,
+    Packed::Value: PrimeCharacteristicRing,
+{
+    /// Build the three selectors for a packed block of consecutive rows, one lane per row.
+    ///
+    /// Lane `lane` carries the selector value at global row `row + lane`:
+    /// ```text
+    ///     first      = 1 iff row + lane == 0
+    ///     last       = 1 iff row + lane == height - 1
+    ///     transition = 1 iff row + lane <  height - 1
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index of the first row in this packed block.
+    /// - `height`: total number of trace rows.
+    pub(super) fn from_packed_row(row: usize, height: usize) -> Self {
         Self::new(
-            Packed::from_fn(|lane| F::from_bool(row + lane == 0)),
-            Packed::from_fn(|lane| F::from_bool(row + lane + 1 == height)),
-            Packed::from_fn(|lane| F::from_bool(row + lane + 1 < height)),
+            Packed::from_fn(|lane| Packed::Value::from_bool(row + lane == 0)),
+            Packed::from_fn(|lane| Packed::Value::from_bool(row + lane + 1 == height)),
+            Packed::from_fn(|lane| Packed::Value::from_bool(row + lane + 1 < height)),
         )
     }
 
-    pub(super) fn row_pair_packed<F>(row: usize, half: usize, height: usize) -> (Self, Self)
+    /// Packed `(value, per-step difference)` pair for folding one variable.
+    ///
+    /// The active variable splits the residual cube into a low half and a high half.
+    /// The first element is the selector block at the low rows.
+    /// The second is the lane-wise difference to the matching high rows:
+    /// ```text
+    ///     value(t) = low + t * (high - low)
+    /// ```
+    /// Adding the difference once advances each lane from the low row to the high row.
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index of the first low-half row in this packed block.
+    /// - `half`: distance from a low row to its matching high row.
+    /// - `height`: total number of trace rows.
+    pub(super) fn row_pair_packed(row: usize, half: usize, height: usize) -> (Self, Self)
     where
-        F: Field<Packing = Packed>,
-        Packed: PackedValue<Value = F> + Sub<Output = Packed>,
+        Packed: Sub<Output = Packed>,
     {
-        let boundary = Self::from_packed_row::<F>(row, height);
-        let hi_boundary = Self::from_packed_row::<F>(row + half, height);
+        // Selector block at the low rows row .. row + WIDTH.
+        let boundary = Self::from_packed_row(row, height);
+        // Selector block at the matching high rows row + half .. row + half + WIDTH.
+        let hi_boundary = Self::from_packed_row(row + half, height);
         (
             boundary,
             Self::new(
@@ -80,12 +110,39 @@ impl<EF: Field> BoundaryEvals<EF> {
         }
     }
 
+    /// Fold one more bound coordinate into the running prefix accumulator.
+    ///
+    /// The accumulator tracks the partial products over the coordinates bound so far:
+    /// ```text
+    ///     first = prod_j (1 - r_j)
+    ///     last  = prod_j r_j
+    /// ```
+    ///
+    /// The transition value is kept as the dependent quantity `1 - last`.
+    /// This invariant is what makes the prefix-aware row evaluation exact.
+    ///
+    /// # Arguments
+    ///
+    /// - `r`: the challenge that binds the next coordinate.
     pub(super) fn apply(&mut self, r: EF) {
         self.first *= EF::ONE - r;
         self.last *= r;
         self.transition = EF::ONE - self.last;
     }
 
+    /// The three selector values at a single residual-cube row, with no prefix applied.
+    ///
+    /// Each value is the indicator of that row over the residual cube:
+    /// ```text
+    ///     first      = 1 iff row == 0
+    ///     last       = 1 iff row == height - 1
+    ///     transition = 1 iff row <  height - 1
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index into the residual cube.
+    /// - `height`: number of rows in the residual cube.
     pub(super) fn from_row(row: usize, height: usize) -> Self {
         Self::new(
             EF::from_bool(row == 0),
@@ -94,6 +151,30 @@ impl<EF: Field> BoundaryEvals<EF> {
         )
     }
 
+    /// The full selector values at a residual-cube row, combined with the bound-coordinate prefix.
+    ///
+    /// The first-row and last-row selectors factor across bound and residual coordinates:
+    /// ```text
+    ///     first = prefix.first * [row == 0]
+    ///     last  = prefix.last  * [row == height - 1]
+    /// ```
+    ///
+    /// The transition selector is `1 - last` over all coordinates:
+    /// ```text
+    ///     transition = 1 - prefix.last * [row == height - 1]
+    /// ```
+    ///
+    /// The implementation form reaches the same value through the residual indicators:
+    /// ```text
+    ///     transition = [row < height - 1] + [row == height - 1] * prefix.transition
+    /// ```
+    /// The two forms agree exactly because the prefix maintains `transition = 1 - last`.
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index into the residual cube.
+    /// - `height`: number of rows in the residual cube.
+    /// - `prefix`: partial products over the coordinates bound so far.
     pub(super) fn from_row_with_prefix(row: usize, height: usize, prefix: Self) -> Self {
         let suffix = Self::from_row(row, height);
         Self::new(
@@ -103,6 +184,19 @@ impl<EF: Field> BoundaryEvals<EF> {
         )
     }
 
+    /// `(value, per-step difference)` pair for folding one variable, with no prefix.
+    ///
+    /// - The first element is the selector at the low-half row.
+    /// - The second is the difference to the matching high-half row:
+    /// ```text
+    ///     value(t) = low + t * (high - low)
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index of the low-half row in the residual cube.
+    /// - `half`: distance from a low row to its matching high row.
+    /// - `height`: number of rows in the residual cube.
     pub(super) fn row_pair(row: usize, half: usize, height: usize) -> (Self, Self) {
         let boundary = Self::from_row(row, height);
         let hi_boundary = Self::from_row(row + half, height);
@@ -116,6 +210,19 @@ impl<EF: Field> BoundaryEvals<EF> {
         )
     }
 
+    /// `(value, per-step difference)` pair for folding one variable, with a bound-coordinate prefix.
+    ///
+    /// Same interpolation shape as the prefix-free pair, with the prefix folded in:
+    /// ```text
+    ///     value(t) = low + t * (high - low)
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index of the low-half row in the residual cube.
+    /// - `half`: distance from a low row to its matching high row.
+    /// - `height`: number of rows in the residual cube.
+    /// - `prefix`: partial products over the coordinates bound so far.
     pub(super) fn row_pair_with_prefix(
         row: usize,
         half: usize,
@@ -139,6 +246,9 @@ impl<EF> AddAssign for BoundaryEvals<EF>
 where
     EF: AddAssign,
 {
+    /// Advance all three selectors by one interpolation step.
+    ///
+    /// Adding the per-step difference moves each selector to the next integer node.
     fn add_assign(&mut self, rhs: Self) {
         self.first += rhs.first;
         self.last += rhs.last;
@@ -148,10 +258,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
     use p3_multilinear_util::point::Point;
+    use p3_multilinear_util::poly::Poly;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
 
@@ -187,6 +302,122 @@ mod tests {
                 if idx == last_idx { EF::ZERO } else { EF::ONE },
                 "transition idx={idx}"
             );
+        }
+    }
+
+    #[test]
+    fn virtual_selectors_match_materialized_fold() {
+        // Invariant: the closed-form selectors equal the materialized indicator columns folded the same way.
+        //
+        // Fixture state:
+        //   cube of k variables, height = 2^k.
+        //   interpolation nodes {0, 1, 2, 3}.
+        //
+        // The nodes mirror how the prover steps a round polynomial by adding the per-step difference.
+        let mut rng = SmallRng::seed_from_u64(0x5E1EC7);
+        let nodes = [EF::ZERO, EF::ONE, EF::from_u64(2), EF::from_u64(3)];
+
+        for k in 1..=6usize {
+            let height = 1usize << k;
+
+            // Materialized indicator columns over the full cube:
+            //
+            //     first      = [1, 0, ..., 0]
+            //     last       = [0, ..., 0, 1]
+            //     transition = [1, ..., 1, 0]
+            let mut first = vec![EF::ZERO; height];
+            first[0] = EF::ONE;
+            let mut last = vec![EF::ZERO; height];
+            last[height - 1] = EF::ONE;
+            let mut transition = vec![EF::ONE; height];
+            transition[height - 1] = EF::ZERO;
+            let mut first = Poly::new(first);
+            let mut last = Poly::new(last);
+            let mut transition = Poly::new(transition);
+
+            // Round 0 binds no coordinate yet; later rounds carry a prefix accumulator.
+            let mut prefix: Option<BoundaryEvals<EF>> = None;
+            let mut num_evals = height;
+
+            while num_evals > 1 {
+                // The active variable splits the residual cube into matching halves.
+                let half = num_evals / 2;
+
+                for s in 0..half {
+                    // Closed-form value at the low row, plus the step to the high row.
+                    // Round 0 has no prefix; later rounds fold the accumulator in.
+                    let (mut value, diff) = prefix.map_or_else(
+                        || BoundaryEvals::row_pair(s, half, num_evals),
+                        |p| BoundaryEvals::row_pair_with_prefix(s, half, num_evals, p),
+                    );
+
+                    // value(t) = low + t * (high - low), checked against the folded columns.
+                    for &t in &nodes {
+                        assert_eq!(value.first, first.fix_prefix_var_at(t, s));
+                        assert_eq!(value.last, last.fix_prefix_var_at(t, s));
+                        assert_eq!(value.transition, transition.fix_prefix_var_at(t, s));
+                        value += diff;
+                    }
+                }
+
+                // Bind this round with a random challenge on both representations.
+                let r: EF = rng.random();
+                first.fix_prefix_var_mut(r);
+                last.fix_prefix_var_mut(r);
+                transition.fix_prefix_var_mut(r);
+
+                // First fold seeds the accumulator; later folds extend it.
+                prefix = Some(prefix.map_or_else(
+                    || BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
+                    |mut p| {
+                        p.apply(r);
+                        p
+                    },
+                ));
+
+                num_evals = half;
+            }
+        }
+    }
+
+    #[test]
+    fn packed_row_pair_matches_scalar_lanes() {
+        // Invariant: each lane of the packed selector pair equals the scalar pair at that lane's row.
+        //
+        // Fixture state:
+        //   height = 64 rows.
+        //   one packed block per WIDTH consecutive low-half rows.
+        let height = 1usize << 6;
+        let half = height / 2;
+        let width = <F as Field>::Packing::WIDTH;
+
+        for block in 0..(half / width) {
+            // First low-half row covered by this packed block.
+            let row = block * width;
+
+            // Packed pair over WIDTH lanes at once.
+            let (packed_value, packed_diff) =
+                BoundaryEvals::<<F as Field>::Packing>::row_pair_packed(row, half, height);
+
+            for lane in 0..width {
+                // Scalar pair at the single global row this lane represents.
+                let (scalar_value, scalar_diff) =
+                    BoundaryEvals::<F>::row_pair(row + lane, half, height);
+
+                assert_eq!(packed_value.first.as_slice()[lane], scalar_value.first);
+                assert_eq!(packed_value.last.as_slice()[lane], scalar_value.last);
+                assert_eq!(
+                    packed_value.transition.as_slice()[lane],
+                    scalar_value.transition
+                );
+
+                assert_eq!(packed_diff.first.as_slice()[lane], scalar_diff.first);
+                assert_eq!(packed_diff.last.as_slice()[lane], scalar_diff.last);
+                assert_eq!(
+                    packed_diff.transition.as_slice()[lane],
+                    scalar_diff.transition
+                );
+            }
         }
     }
 }

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -214,7 +214,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         EF: ExtensionField<F>,
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
             + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>
-            + for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>
+            + for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
             + Air<SymbolicAirBuilder<F, EF>>,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -329,7 +329,7 @@ impl<'a, A> AirZerocheck<'a, A> {
     where
         F: Field,
         EF: ExtensionField<F>,
-        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, F>> + Air<SymbolicAirBuilder<F, EF>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>> + Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Reject column kinds this version cannot prove, and read the layout once.

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -132,15 +132,21 @@ impl<'a, A> AirZerocheck<'a, A> {
 
     /// Per-round degree of the zerocheck sumcheck.
     ///
-    /// The summed integrand `eq(tau, x) * g(x)` has per-variable degree
-    /// `deg(g) + 1`, where the `+ 1` is the multilinear `eq(tau, x)`.
+    /// The summed integrand is `eq(tau, x) * g(x)`.
+    /// Its per-variable degree is the constraint per-variable degree, plus one for the multilinear weight.
     ///
-    /// `deg(g)` is the largest per-variable degree among the asserted constraints,
-    /// read from `poly_degree` at domain size two. At that domain size every leaf
-    /// scores its per-variable degree, so each column and each selector — including
-    /// the transition selector, which `degree_multiple` undercounts as zero — is
-    /// degree one. This is exact, provided columns and selectors are per-variable
-    /// degree at most one, which standard AIRs satisfy.
+    /// The constraint degree comes from one of two sources:
+    /// - a constant-time hint supplied by the AIR, when present;
+    /// - otherwise a symbolic pass that scores each constraint at domain size two.
+    ///
+    /// At domain size two every column and every boundary selector scores degree one, so the symbolic value is exact.
+    ///
+    /// The prover and the verifier both call this, so they always agree on the degree.
+    /// The hint must be at least the true per-variable degree:
+    /// - a smaller value under-determines the round polynomial and breaks soundness;
+    /// - a larger value only inflates the proof and the per-row work.
+    ///
+    /// A debug assertion pins the hint against the symbolic value.
     ///
     /// # Arguments
     ///
@@ -151,21 +157,31 @@ impl<'a, A> AirZerocheck<'a, A> {
         EF: ExtensionField<F>,
         A: Air<SymbolicAirBuilder<F, EF>>,
     {
+        // Largest per-variable degree among the asserted constraints, scored at domain size two.
+        // No periodic columns reach this point, so the periodic-column lengths are empty.
+        let symbolic_constraint_degree = || {
+            let (base, ext) = get_all_symbolic_constraints::<F, EF, A>(self.air, layout);
+            let base_degree = base
+                .iter()
+                .map(|c| c.poly_degree(2, &[]))
+                .max()
+                .unwrap_or(0);
+            let ext_degree = ext.iter().map(|c| c.poly_degree(2, &[])).max().unwrap_or(0);
+            base_degree.max(ext_degree)
+        };
+
         if let Some(degree) = self.air.max_constraint_degree() {
+            // A hint below the true constraint degree drops evaluations from each round polynomial.
+            // Reject such a hint in debug builds.
+            debug_assert!(
+                degree >= symbolic_constraint_degree(),
+                "max_constraint_degree hint is below the symbolic constraint degree"
+            );
             return degree + 1;
         }
 
-        // Per-variable degree of g from the symbolic constraints (domain size two),
-        // then the `+ 1` for the multilinear eq weight. No periodic columns reach
-        // this point (the layout check rejects them), so the periods are empty.
-        let (base, ext) = get_all_symbolic_constraints::<F, EF, A>(self.air, layout);
-        let base_degree = base
-            .iter()
-            .map(|c| c.poly_degree(2, &[]))
-            .max()
-            .unwrap_or(0);
-        let ext_degree = ext.iter().map(|c| c.poly_degree(2, &[])).max().unwrap_or(0);
-        base_degree.max(ext_degree) + 1
+        // Add one for the multilinear eq weight.
+        symbolic_constraint_degree() + 1
     }
 
     /// Prove that the AIR's alpha-batched constraint vanishes on every trace row.
@@ -748,27 +764,42 @@ mod tests {
 
     #[test]
     fn zerocheck_poseidon2() {
+        // Invariant on the Poseidon2 permutation AIR:
+        //   - each current-row opening equals the column multilinear at the bound point;
+        //   - each next-row opening equals the shifted column at that point;
+        //   - prover and verifier bind the same sumcheck point.
+        //
+        // Trace height is the only axis, swept exhaustively over 1..10.
         for num_vars in 1..10 {
+            // Trace height 2^num_vars, i.e. one hashed input per row.
             let num_hashes = 1 << num_vars;
 
+            // Deterministic round constants, so the trace and transcript are reproducible.
             let mut rng = SmallRng::seed_from_u64(1);
             let constants = RoundConstants::from_rng(&mut rng);
             let air: BabyBearPoseidon2Air = Poseidon2Air::new(constants);
+
+            // Witness trace: each row is one full permutation, satisfying every constraint.
             let trace =
                 tracing::info_span!("zerocheck_poseidon2_generate_trace", num_vars, num_hashes)
                     .in_scope(|| air.generate_trace_rows(num_hashes, 0));
 
+            // Prove the alpha-batched constraint vanishes on every row.
             let zerocheck = AirZerocheck::new(&air, 0);
             let mut prover_challenger = fresh_challenger();
             let (proof, point_prover) =
                 zerocheck.prove::<F, EF, _>(&trace, &[], &mut prover_challenger);
 
+            // Reference columns: one multilinear per trace column, in row order.
+            //
+            //     row-major trace --transpose--> one row per column
             let columns = trace.transpose();
             let columns = columns
                 .row_slices()
                 .map(|col| Poly::new(col.to_vec()))
                 .collect::<Vec<_>>();
 
+            // Each current-row opening must equal the column multilinear at the bound point.
             columns
                 .iter()
                 .zip(proof.local.iter())
@@ -776,6 +807,7 @@ mod tests {
                     assert_eq!(col.eval_base(&point_prover), local);
                 });
 
+            // Each next-row opening must equal the same column shifted by one row.
             air.main_next_row_columns()
                 .iter()
                 .zip(proof.next.iter())
@@ -783,6 +815,7 @@ mod tests {
                     assert_eq!(columns[column].eval_next_base(&point_prover), next);
                 });
 
+            // Replaying the transcript must reproduce the prover's bound point exactly.
             let mut verifier_challenger = fresh_challenger();
             let point_verifier = zerocheck
                 .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -17,7 +17,6 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundProver};
 use p3_util::log2_strict_usize;

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -10,7 +10,6 @@
 //! The generic-degree sumcheck proves that sum.
 //! A zerocheck always claims zero, so the verifier rejects any proof that claims a different sum.
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder, get_all_symbolic_constraints};
@@ -20,13 +19,13 @@ use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundProver};
 use p3_util::log2_strict_usize;
 use thiserror::Error;
 
 use crate::folder::MultilinearFolder;
 use crate::opening::OpeningClaims;
+use crate::rounds::RoundStateBase;
 use crate::selectors::BoundaryEvals;
 
 /// Reasons the zerocheck verifier rejects a proof.
@@ -153,6 +152,10 @@ impl<'a, A> AirZerocheck<'a, A> {
         EF: ExtensionField<F>,
         A: Air<SymbolicAirBuilder<F, EF>>,
     {
+        if let Some(degree) = self.air.max_constraint_degree() {
+            return degree + 1;
+        }
+
         // Per-variable degree of g from the symbolic constraints (domain size two),
         // then the `+ 1` for the multilinear eq weight. No periodic columns reach
         // this point (the layout check rejects them), so the periods are empty.
@@ -184,16 +187,21 @@ impl<'a, A> AirZerocheck<'a, A> {
     /// # Panics
     ///
     /// Panics if the AIR declares preprocessed or periodic columns, which this version does not support.
+    #[tracing::instrument(skip_all)]
     pub fn prove<F, EF, Challenger>(
         &self,
         trace: &RowMajorMatrix<F>,
         public_values: &[F],
         challenger: &mut Challenger,
-    ) -> ZerocheckProof<F, EF>
+    ) -> (ZerocheckProof<F, EF>, Point<EF>)
     where
         F: Field,
         EF: ExtensionField<F>,
-        A: for<'b> Air<MultilinearFolder<'b, F, EF>> + Air<SymbolicAirBuilder<F, EF>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
+            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>
+            + for<'b> Air<MultilinearFolder<'b, F, EF, EF, EF>>
+            + Air<SymbolicAirBuilder<F, EF>>,
+        EF::ExtensionPacking: From<EF> + From<F::Packing>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         let log_height = log2_strict_usize(trace.height());
@@ -211,23 +219,62 @@ impl<'a, A> AirZerocheck<'a, A> {
         // Draw the batching scalar then the zerocheck point, in that fixed order.
         let (alpha, tau) = sample_zerocheck_challenges(challenger, log_height);
 
-        let mut state = RoundState::new(self.air, public_values, alpha, &tau, trace, degree);
+        let state = RoundStateBase::<'_, _, F, EF>::new(
+            self.air,
+            public_values,
+            alpha,
+            &Point::new(tau),
+            trace,
+            degree,
+        );
 
-        // The claim is zero: every constraint must vanish on the hypercube.
-        let (sumcheck, _point) =
-            state.prove::<F, _>(challenger, log_height, degree, self.pow_bits, EF::ZERO);
+        // Bind the transcript to the claimed sum so the challenges depend on the statement.
+        challenger.observe_algebra_element(EF::ZERO);
 
-        // After every variable is bound, each table holds its evaluation at the point.
-        let local = state.local.iter().map(|p| p.as_slice()[0]).collect();
+        let mut sumcheck = GenericDegreeProof {
+            claimed_sum: EF::ZERO,
+            round_polys: Vec::with_capacity(log_height),
+            pow_witnesses: Vec::with_capacity(if self.pow_bits > 0 { log_height } else { 0 }),
+        };
+        let mut challenges = Vec::with_capacity(log_height);
 
-        // Each successor table holds one next-row column's opening, in the AIR's declared order.
-        let next = state.next.iter().map(|p| p.as_slice()[0]).collect();
+        let evals = state.round_poly();
+        challenger.observe_algebra_slice(&evals);
 
-        ZerocheckProof {
-            sumcheck,
-            local,
-            next,
+        // Optional proof-of-work; raises the cost of grinding a favorable challenge.
+        if self.pow_bits > 0 {
+            sumcheck.pow_witnesses.push(challenger.grind(self.pow_bits));
         }
+
+        let r: EF = challenger.sample_algebra_element();
+        let mut state = state.fold(r);
+
+        sumcheck.round_polys.push(evals);
+        challenges.push(r);
+
+        let (proof_rest, point_rest) =
+            state.prove(challenger, log_height - 1, degree, self.pow_bits, EF::ZERO);
+        challenges.extend_from_slice(point_rest.as_slice());
+
+        sumcheck.round_polys.extend(proof_rest.round_polys);
+        sumcheck.pow_witnesses.extend(proof_rest.pow_witnesses);
+
+        let (local, next, _) = state.evals();
+        let next = self
+            .air
+            .main_next_row_columns()
+            .iter()
+            .map(|&column| next[column])
+            .collect();
+
+        (
+            ZerocheckProof {
+                sumcheck,
+                local,
+                next,
+            },
+            Point::new(challenges),
+        )
     }
 
     /// Verify a zerocheck proof.
@@ -263,11 +310,11 @@ impl<'a, A> AirZerocheck<'a, A> {
         log_height: usize,
         public_values: &[F],
         challenger: &mut Challenger,
-    ) -> Result<(), ZerocheckError>
+    ) -> Result<Point<EF>, ZerocheckError>
     where
         F: Field,
         EF: ExtensionField<F>,
-        A: for<'b> Air<MultilinearFolder<'b, F, EF>> + Air<SymbolicAirBuilder<F, EF>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF, F>> + Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Reject column kinds this version cannot prove, and read the layout once.
@@ -327,7 +374,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         if final_sum != eq_at_point * g {
             return Err(ZerocheckError::FinalSumMismatch);
         }
-        Ok(())
+        Ok(claims.point)
     }
 }
 
@@ -350,181 +397,24 @@ where
     (alpha, tau)
 }
 
-/// Sumcheck prover state for the AIR zerocheck.
-///
-/// Every table shares the same hypercube and is bound one variable per round.
-struct RoundState<'a, A, F, EF> {
-    /// AIR whose alpha-batched constraint is being evaluated.
-    air: &'a A,
-    /// Public inputs forwarded to the AIR.
-    public_values: &'a [F],
-    /// Random scalar batching the AIR constraints.
-    alpha: EF,
-    /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
-    eq: Poly<EF>,
-    /// First-row selector table, `1` at row zero and `0` elsewhere.
-    first: Poly<EF>,
-    /// Last-row selector table, `1` at the final row and `0` elsewhere.
-    last: Poly<EF>,
-    /// Transition selector table, `0` at the final row and `1` elsewhere.
-    transition: Poly<EF>,
-    /// Current-row values of each main column.
-    local: Vec<Poly<EF>>,
-    /// Main columns the AIR reads on the next row, in its declared order.
-    next_columns: Vec<usize>,
-    /// Next-row values of the `next_columns`, with repeat-last at the final row.
-    next: Vec<Poly<EF>>,
-    /// Per-round sumcheck degree.
-    degree: usize,
-}
-
-impl<'a, A, F, EF> RoundState<'a, A, F, EF>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    A: BaseAir<F>,
-{
-    /// Build the prover state from a trace and a sampled zerocheck point.
-    fn new(
-        air: &'a A,
-        public_values: &'a [F],
-        alpha: EF,
-        tau: &[EF],
-        trace: &RowMajorMatrix<F>,
-        degree: usize,
-    ) -> Self {
-        let height = trace.height();
-        let width = trace.width;
-
-        // Lift every main column into the extension field in row order.
-        let local: Vec<Poly<EF>> = (0..width)
-            .map(|c| {
-                Poly::new(
-                    (0..height)
-                        .map(|i| EF::from(trace.values[i * width + c]))
-                        .collect(),
-                )
-            })
-            .collect();
-
-        // Only the columns the AIR reads on the next row need a successor table.
-        let next_columns = air.main_next_row_columns();
-        let next: Vec<Poly<EF>> = next_columns
-            .iter()
-            .map(|&c| {
-                // Successor column: row i reads row i+1, and the final row repeats itself.
-                let column = local[c].as_slice();
-                let mut successor = Vec::with_capacity(height);
-                successor.extend_from_slice(&column[1..]);
-                successor.push(column[height - 1]);
-                Poly::new(successor)
-            })
-            .collect();
-
-        // eq(tau, x) over the hypercube.
-        let eq = Poly::new_from_point(tau, EF::ONE);
-
-        // Selector tables as plain indicators over the hypercube.
-        let mut first = EF::zero_vec(height);
-        first[0] = EF::ONE;
-        let mut last = EF::zero_vec(height);
-        last[height - 1] = EF::ONE;
-        let mut transition = vec![EF::ONE; height];
-        transition[height - 1] = EF::ZERO;
-
-        Self {
-            air,
-            public_values,
-            alpha,
-            eq,
-            first: Poly::new(first),
-            last: Poly::new(last),
-            transition: Poly::new(transition),
-            local,
-            next_columns,
-            next,
-            degree,
-        }
-    }
-}
-
-impl<'a, A, F, EF> RoundProver<EF> for RoundState<'a, A, F, EF>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    A: for<'b> Air<MultilinearFolder<'b, F, EF>>,
-{
-    fn fold(&mut self, r: EF) {
-        self.eq.fix_prefix_var_mut(r);
-        self.first.fix_prefix_var_mut(r);
-        self.last.fix_prefix_var_mut(r);
-        self.transition.fix_prefix_var_mut(r);
-        for p in &mut self.local {
-            p.fix_prefix_var_mut(r);
-        }
-        for p in &mut self.next {
-            p.fix_prefix_var_mut(r);
-        }
-    }
-
-    fn round_poly(&self) -> Vec<EF> {
-        let width = self.local.len();
-        // Each table currently spans `2 * half` evaluations; `half` is the residual
-        // hypercube once the active variable is dropped.
-        let half = self.eq.num_evals() / 2;
-
-        // Transmit h at nodes 0, 2, 3, ..., degree; the verifier recovers h(1).
-        let mut out = Vec::with_capacity(self.degree);
-        for node in core::iter::once(0).chain(2..=self.degree) {
-            let z = EF::from_usize(node);
-
-            // Sum the weighted constraint over the remaining hypercube.
-            // Each worker keeps its own per-row scratch buffers across the fold.
-            let (acc, _, _) = (0..half).into_par_iter().par_fold_reduce(
-                || (EF::ZERO, EF::zero_vec(width), EF::zero_vec(width)),
-                |(mut acc, mut local_row, mut next_row), s| {
-                    for (dst, poly) in local_row.iter_mut().zip(&self.local) {
-                        *dst = poly.fix_prefix_var_at(z, s);
-                    }
-                    // Undeclared next-row entries stay zero; the AIR never reads them.
-                    for (&c, poly) in self.next_columns.iter().zip(&self.next) {
-                        next_row[c] = poly.fix_prefix_var_at(z, s);
-                    }
-                    let boundary = BoundaryEvals {
-                        first: self.first.fix_prefix_var_at(z, s),
-                        last: self.last.fix_prefix_var_at(z, s),
-                        transition: self.transition.fix_prefix_var_at(z, s),
-                    };
-                    let g = MultilinearFolder::new(
-                        &local_row,
-                        &next_row,
-                        boundary,
-                        self.public_values,
-                        self.alpha,
-                    )
-                    .eval_air(self.air);
-                    acc += self.eq.fix_prefix_var_at(z, s) * g;
-                    (acc, local_row, next_row)
-                },
-                |(a, la, na), (b, _, _)| (a + b, la, na),
-            );
-            out.push(acc);
-        }
-        out
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use alloc::vec::Vec;
     use core::borrow::Borrow;
 
     use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
-    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_baby_bear::{
+        BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS, BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16,
+        BABYBEAR_S_BOX_DEGREE, BabyBear, GenericPoseidon2LinearLayersBabyBear, Poseidon2BabyBear,
+    };
     use p3_challenger::DuplexChallenger;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
+    use p3_multilinear_util::poly::Poly;
+    use p3_poseidon2_air::{Poseidon2Air, RoundConstants};
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -536,6 +426,21 @@ mod tests {
     type Ch = DuplexChallenger<F, Perm, 16, 8>;
 
     const NUM_COLS: usize = 2;
+    const POSEIDON2_WIDTH: usize = 16;
+    const POSEIDON2_SBOX_DEGREE: u64 = BABYBEAR_S_BOX_DEGREE;
+    const POSEIDON2_SBOX_REGISTERS: usize = 1;
+    const POSEIDON2_HALF_FULL_ROUNDS: usize = BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS;
+    const POSEIDON2_PARTIAL_ROUNDS: usize = BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16;
+
+    type BabyBearPoseidon2Air = Poseidon2Air<
+        F,
+        GenericPoseidon2LinearLayersBabyBear,
+        POSEIDON2_WIDTH,
+        POSEIDON2_SBOX_DEGREE,
+        POSEIDON2_SBOX_REGISTERS,
+        POSEIDON2_HALF_FULL_ROUNDS,
+        POSEIDON2_PARTIAL_ROUNDS,
+    >;
 
     fn fresh_challenger() -> Ch {
         // Fixed seed so prover and verifier transcripts match exactly.
@@ -628,7 +533,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         zerocheck
@@ -645,7 +550,8 @@ mod tests {
         let pis = fib_public_values(n);
 
         let mut challenger = fresh_challenger();
-        let proof = AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&trace, &pis, &mut challenger);
+        let (proof, point) =
+            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&trace, &pis, &mut challenger);
 
         // Each Fibonacci constraint is per-variable degree 2 (a degree-1 selector
         // times a degree-1 column), so the eq-weighted integrand is degree 3.
@@ -653,6 +559,7 @@ mod tests {
         let degree = AirZerocheck::new(&FibAir, 0).sumcheck_degree::<F, EF>(layout);
         assert_eq!(degree, 3);
         assert_eq!(proof.sumcheck.num_rounds(), log2_strict_usize(n));
+        assert_eq!(point.num_variables(), log2_strict_usize(n));
         for round in &proof.sumcheck.round_polys {
             assert_eq!(round.len(), degree);
         }
@@ -669,7 +576,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         let err = zerocheck
@@ -687,7 +594,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let mut proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
         proof.local[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -707,7 +614,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let mut proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
         proof.next[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -728,7 +635,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let mut proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
 
         // Declare a nonzero sum; the verifier must reject before any further work.
         proof.sumcheck.claimed_sum += EF::ONE;
@@ -757,7 +664,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let mut proof = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
 
         // Remove one opened value so the count no longer matches the AIR width.
         proof.local.pop();
@@ -826,7 +733,7 @@ mod tests {
         let zerocheck = AirZerocheck::new(&ConstColAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let proof = zerocheck.prove::<F, EF, _>(&trace, &[], &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, &[], &mut prover_challenger);
 
         // Two committed columns yield two current-row claims.
         assert_eq!(proof.local.len(), 2);
@@ -838,5 +745,50 @@ mod tests {
         zerocheck
             .verify::<F, EF, _>(&proof, log2_strict_usize(n), &[], &mut verifier_challenger)
             .expect("subset-next AIR must verify");
+    }
+
+    #[test]
+    fn zerocheck_poseidon2() {
+        for num_vars in 1..10 {
+            let num_hashes = 1 << num_vars;
+
+            let mut rng = SmallRng::seed_from_u64(1);
+            let constants = RoundConstants::from_rng(&mut rng);
+            let air: BabyBearPoseidon2Air = Poseidon2Air::new(constants);
+            let trace =
+                tracing::info_span!("zerocheck_poseidon2_generate_trace", num_vars, num_hashes)
+                    .in_scope(|| air.generate_trace_rows(num_hashes, 0));
+
+            let zerocheck = AirZerocheck::new(&air, 0);
+            let mut prover_challenger = fresh_challenger();
+            let (proof, point_prover) =
+                zerocheck.prove::<F, EF, _>(&trace, &[], &mut prover_challenger);
+
+            let columns = trace.transpose();
+            let columns = columns
+                .row_slices()
+                .map(|col| Poly::new(col.to_vec()))
+                .collect::<Vec<_>>();
+
+            columns
+                .iter()
+                .zip(proof.local.iter())
+                .for_each(|(col, &local)| {
+                    assert_eq!(col.eval_base(&point_prover), local);
+                });
+
+            air.main_next_row_columns()
+                .iter()
+                .zip(proof.next.iter())
+                .for_each(|(&column, &next)| {
+                    assert_eq!(columns[column].eval_next_base(&point_prover), next);
+                });
+
+            let mut verifier_challenger = fresh_challenger();
+            let point_verifier = zerocheck
+                .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)
+                .unwrap();
+            assert_eq!(point_prover, point_verifier);
+        }
     }
 }

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -17,6 +17,48 @@ use crate::split_eq::SplitEq;
 
 pub(crate) const PARALLEL_THRESHOLD: usize = 4096;
 
+/// Fixes the prefix variable at a challenge value, returning a folded polynomial.
+///
+/// Computes:
+/// ```text
+/// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
+/// ```
+///
+/// The result has one fewer variable (n - 1).
+///
+/// # Panics
+///
+/// Panics if the polynomial is constant (zero free variables).
+pub fn fix_prefix_var<A, F>(poly: &[A], r: F) -> Poly<F>
+where
+    A: Copy + Send + Sync + PrimeCharacteristicRing,
+    F: Algebra<A> + Copy + Send + Sync,
+{
+    assert!(poly.len() > 1, "no free variables");
+
+    let num_evals = poly.len();
+    // assert!(poly.as_constant().is_none(), "no free variables");
+    // Split evaluations into the x_0 = 0 half (p0) and x_0 = 1 half (p1).
+    let (p0, p1) = poly.split_at(num_evals / 2);
+    if num_evals >= PARALLEL_THRESHOLD {
+        // Parallel: linear interpolation between each (p0, p1) pair.
+        Poly::new(
+            p0.par_iter()
+                .zip(p1.par_iter())
+                .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                .collect(),
+        )
+    } else {
+        // Sequential: same linear interpolation.
+        Poly::new(
+            p0.iter()
+                .zip(p1.iter())
+                .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                .collect(),
+        )
+    }
+}
+
 /// Number of variables at which we switch from recursive scalar evaluation to the
 /// SIMD-packed `SplitEq` path.
 ///
@@ -504,25 +546,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         F: Algebra<A> + Copy + Send + Sync,
     {
         assert!(self.as_constant().is_none(), "no free variables");
-        // Split evaluations into the x_0 = 0 half (p0) and x_0 = 1 half (p1).
-        let (p0, p1) = self.0.split_at(self.num_evals() / 2);
-        if self.num_evals() >= PARALLEL_THRESHOLD {
-            // Parallel: linear interpolation between each (p0, p1) pair.
-            Poly::new(
-                p0.par_iter()
-                    .zip(p1.par_iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        } else {
-            // Sequential: same linear interpolation.
-            Poly::new(
-                p0.iter()
-                    .zip(p1.iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        }
+        fix_prefix_var(self.as_slice(), r)
     }
 
     /// Evaluates the prefix-variable fix at a single residual index, without

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -17,31 +17,39 @@ use crate::split_eq::SplitEq;
 
 pub(crate) const PARALLEL_THRESHOLD: usize = 4096;
 
-/// Fixes the prefix variable at a challenge value, returning a folded polynomial.
+/// Folds the most significant variable of a multilinear polynomial at a challenge.
 ///
-/// Computes:
+/// The input is the evaluation table over the boolean hypercube.
+/// The most significant variable splits it into a low half and a high half.
+/// The challenge collapses that variable by linear interpolation between the halves:
 /// ```text
 /// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
 /// ```
 ///
-/// The result has one fewer variable (n - 1).
+/// The result is the evaluation table of a polynomial with one fewer variable.
 ///
 /// # Panics
 ///
-/// Panics if the polynomial is constant (zero free variables).
+/// Panics if the table has at most one entry, since then there is no variable to fold.
 pub fn fix_prefix_var<A, F>(poly: &[A], r: F) -> Poly<F>
 where
     A: Copy + Send + Sync + PrimeCharacteristicRing,
     F: Algebra<A> + Copy + Send + Sync,
 {
+    // A single value is already constant, so no variable remains to fold.
     assert!(poly.len() > 1, "no free variables");
 
-    let num_evals = poly.len();
-    // assert!(poly.as_constant().is_none(), "no free variables");
-    // Split evaluations into the x_0 = 0 half (p0) and x_0 = 1 half (p1).
-    let (p0, p1) = poly.split_at(num_evals / 2);
-    if num_evals >= PARALLEL_THRESHOLD {
-        // Parallel: linear interpolation between each (p0, p1) pair.
+    // The most significant variable splits the table into equal halves:
+    //
+    //     p0 = evaluations at x_0 = 0
+    //     p1 = evaluations at x_0 = 1
+    let (p0, p1) = poly.split_at(poly.len() / 2);
+
+    // Each output entry interpolates one (low, high) pair at the challenge:
+    //
+    //     p'(x') = p0(x') + (p1(x') - p0(x')) * r
+    if poly.len() >= PARALLEL_THRESHOLD {
+        // Parallel path: the table is large enough to amortize thread fan-out.
         Poly::new(
             p0.par_iter()
                 .zip(p1.par_iter())
@@ -49,7 +57,7 @@ where
                 .collect(),
         )
     } else {
-        // Sequential: same linear interpolation.
+        // Sequential path: small tables where threads would not pay off.
         Poly::new(
             p0.iter()
                 .zip(p1.iter())

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -17,56 +17,6 @@ use crate::split_eq::SplitEq;
 
 pub(crate) const PARALLEL_THRESHOLD: usize = 4096;
 
-/// Folds the most significant variable of a multilinear polynomial at a challenge.
-///
-/// The input is the evaluation table over the boolean hypercube.
-/// The most significant variable splits it into a low half and a high half.
-/// The challenge collapses that variable by linear interpolation between the halves:
-/// ```text
-/// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
-/// ```
-///
-/// The result is the evaluation table of a polynomial with one fewer variable.
-///
-/// # Panics
-///
-/// Panics if the table has at most one entry, since then there is no variable to fold.
-pub fn fix_prefix_var<A, F>(poly: &[A], r: F) -> Poly<F>
-where
-    A: Copy + Send + Sync + PrimeCharacteristicRing,
-    F: Algebra<A> + Copy + Send + Sync,
-{
-    // A single value is already constant, so no variable remains to fold.
-    assert!(poly.len() > 1, "no free variables");
-
-    // The most significant variable splits the table into equal halves:
-    //
-    //     p0 = evaluations at x_0 = 0
-    //     p1 = evaluations at x_0 = 1
-    let (p0, p1) = poly.split_at(poly.len() / 2);
-
-    // Each output entry interpolates one (low, high) pair at the challenge:
-    //
-    //     p'(x') = p0(x') + (p1(x') - p0(x')) * r
-    if poly.len() >= PARALLEL_THRESHOLD {
-        // Parallel path: the table is large enough to amortize thread fan-out.
-        Poly::new(
-            p0.par_iter()
-                .zip(p1.par_iter())
-                .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                .collect(),
-        )
-    } else {
-        // Sequential path: small tables where threads would not pay off.
-        Poly::new(
-            p0.iter()
-                .zip(p1.iter())
-                .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                .collect(),
-        )
-    }
-}
-
 /// Number of variables at which we switch from recursive scalar evaluation to the
 /// SIMD-packed `SplitEq` path.
 ///
@@ -537,6 +487,59 @@ impl<F: Field> Poly<F> {
 }
 
 impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
+    /// Folds the most significant variable of an evaluation table into a new polynomial.
+    ///
+    /// The input is the evaluation table over the boolean hypercube.
+    /// The most significant variable splits it into a low half and a high half.
+    /// The challenge collapses that variable by linear interpolation between the halves:
+    /// ```text
+    /// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
+    /// ```
+    ///
+    /// The result has one fewer variable.
+    /// The element type may widen, so a base-field table folds into an extension-field polynomial.
+    ///
+    /// Takes a borrowed slice rather than a polynomial.
+    /// This folds a trace column straight from its matrix row, with no wrapping copy.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the table has at most one entry, since then there is no variable to fold.
+    pub fn fix_prefix_var_from_evals<F>(evals: &[A], r: F) -> Poly<F>
+    where
+        F: Algebra<A> + Copy + Send + Sync,
+    {
+        // A single value is already constant, so no variable remains to fold.
+        assert!(evals.len() > 1, "no free variables");
+
+        // The most significant variable splits the table into equal halves:
+        //
+        //     p0 = evaluations at x_0 = 0
+        //     p1 = evaluations at x_0 = 1
+        let (p0, p1) = evals.split_at(evals.len() / 2);
+
+        // Each output entry interpolates one (low, high) pair at the challenge:
+        //
+        //     p'(x') = p0(x') + (p1(x') - p0(x')) * r
+        if evals.len() >= PARALLEL_THRESHOLD {
+            // Parallel path: the table is large enough to amortize thread fan-out.
+            Poly::new(
+                p0.par_iter()
+                    .zip(p1.par_iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        } else {
+            // Sequential path: small tables where threads would not pay off.
+            Poly::new(
+                p0.iter()
+                    .zip(p1.iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        }
+    }
+
     /// Fixes the prefix variable at a challenge value, returning a folded polynomial.
     ///
     /// Computes:
@@ -554,7 +557,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         F: Algebra<A> + Copy + Send + Sync,
     {
         assert!(self.as_constant().is_none(), "no free variables");
-        fix_prefix_var(self.as_slice(), r)
+        Self::fix_prefix_var_from_evals(self.as_slice(), r)
     }
 
     /// Evaluates the prefix-variable fix at a single residual index, without

--- a/sumcheck/src/generic_degree/prover.rs
+++ b/sumcheck/src/generic_degree/prover.rs
@@ -222,6 +222,7 @@ mod tests {
         // Prover side.
         let mut prover_state = prover_from(&columns);
         let mut p_ch = fresh_challenger();
+        p_ch.observe_algebra_element(claimed_sum);
         let (proof, prover_challenges) =
             prover_state.prove::<F, _>(&mut p_ch, log_m, 3, 0, claimed_sum);
 
@@ -256,6 +257,7 @@ mod tests {
 
         let mut prover_state = prover_from(&columns);
         let mut p_ch = fresh_challenger();
+        p_ch.observe_algebra_element(claimed_sum);
         let (proof, prover_challenges) =
             prover_state.prove::<F, _>(&mut p_ch, log_m, 3, pow_bits, claimed_sum);
 
@@ -291,6 +293,7 @@ mod tests {
 
         let mut prover_state = prover_from(&columns);
         let mut p_ch = fresh_challenger();
+        p_ch.observe_algebra_element(claimed_sum);
         let (mut proof, _) = prover_state.prove::<F, _>(&mut p_ch, log_m, 3, pow_bits, claimed_sum);
 
         let last_round = log_m - 1;

--- a/sumcheck/src/generic_degree/prover.rs
+++ b/sumcheck/src/generic_degree/prover.rs
@@ -64,9 +64,6 @@ pub trait RoundProver<EF> {
         // A degree-zero polynomial would carry no information.
         assert!(degree > 0, "generic-degree sumcheck: degree must be > 0");
 
-        // Bind the transcript to the claimed sum so the challenges depend on the statement.
-        challenger.observe_algebra_element(claimed_sum);
-
         let mut proof = GenericDegreeProof {
             claimed_sum,
             round_polys: Vec::with_capacity(num_rounds),


### PR DESCRIPTION
This PR updates AIR zerocheck round evaluation to use a separate base-field first round, followed by extension-field rounds, while avoiding large materialized helper columns.

- Add `RoundStateBase` and `RoundStateExt` for optimized zerocheck round state.
- Avoid `F -> EF` conversion in the first round.
- Use packed/SIMD first-round evaluation for large traces.
- Use one transposed column-major trace view via `RowMajorMatrix::transpose()`; currently this happens inside zerocheck, but we may later transpose outside for WHIR/PCS commitment and pass the same view here.
- Keep next-row values and boundary selectors virtual instead of materializing full columns/polys.
- Parallelize round polynomial accumulation.
- Generalize `MultilinearFolder` for base, packed base, and extension evaluation.
- Add a Criterion Poseidon2 zerocheck benchmark.

Benchmarks for 289-column Poseidon2:

| Num hashes | Current | This PR | Speedup |
|---:|---:|---:|---:|
| `2^10` | 67 ms | 4.2 ms | 16.0x |
| `2^15` | 2.6 s | 98.5 ms | 26.4x |
| `2^18` | 21.4 s | 831 ms | 25.8x |

Further work:
- Apply SVO-style optimizations similar to WHIR PCS.
- Investigate univariate skip for this AIR sumcheck shape.
- Add coefficient-form round polynomial evaluation to process each row in one AIR pass and skip redundant work for lower-degree constraints.
- Make `AirBuilder` / folder bounds more friendly to `EF::ExtensionPacking`.