### PR TITLE
perf: add NEON vectorization for RPO on 31bit fields

### DIFF
--- a/rescue/src/rpo/baby_bear.rs
+++ b/rescue/src/rpo/baby_bear.rs
@@ -1,7 +1,11 @@
 use alloc::vec::Vec;
 
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_baby_bear::PackedBabyBearNeon;
 use p3_baby_bear::{BabyBear, MdsMatrixBabyBear};
-use p3_field::InjectiveMonomial;
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_field::PackedValue;
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 
 use super::Rpo;
@@ -82,34 +86,55 @@ impl Permutation<[BabyBear; RPO_BB_WIDTH]> for RpoBabyBear {
 
 impl CryptographicPermutation<[BabyBear; RPO_BB_WIDTH]> for RpoBabyBear {}
 
-/// Width-parallel inverse S-box `x -> x^(1/7)` over `[BabyBear; 24]`.
+/// Inverse S-box `x -> x^(1/7)` over `[BabyBear; 24]`.
 ///
-/// Computes `x^1725656503` via the same addition chain as
-/// [`p3_field::exponentiation::exp_1725656503`], but applied across all 24
-/// lanes step-by-step. Each step issues 24 independent multiplications,
-/// exposing 24-way ILP to the CPU.
+/// On aarch64 the 24-element state reinterprets as six packed NEON vectors so
+/// the addition chain runs four lanes per multiply; on other targets it runs
+/// lane-by-lane.
 #[inline]
 fn apply_inv_sbox_x7(state: &mut [BabyBear; RPO_BB_WIDTH]) {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        // `RPO_BB_WIDTH` is a multiple of the NEON packing width (4), so the
+        // whole state reinterprets as packed vectors with no remainder.
+        let packed: &mut [PackedBabyBearNeon; RPO_BB_WIDTH / 4] =
+            PackedBabyBearNeon::pack_slice_mut(state)
+                .try_into()
+                .unwrap();
+        inv_sbox_x7(packed);
+    }
+    #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+    inv_sbox_x7(state);
+}
+
+/// Width-parallel inverse S-box `x -> x^(1/7)` over `[R; N]`.
+///
+/// Computes `x^1725656503` via the same addition chain as
+/// [`p3_field::exponentiation::exp_1725656503`], applied across all `N`
+/// lanes step-by-step. Each step issues `N` independent multiplications,
+/// exposing `N`-way ILP to the CPU.
+#[inline]
+fn inv_sbox_x7<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R; N]) {
     // Binary expansion of 1725656503 (29 squares + 8 mults):
     //   1100110110110110110110110110111
     let p1 = *state;
 
-    let p10 = square_n::<_, RPO_BB_WIDTH, 1>(p1);
+    let p10 = square_n::<_, N, 1>(p1);
 
     let mut p11 = p10;
     p11.iter_mut().zip(p1).for_each(|(t, x)| *t *= x);
 
-    let p110 = square_n::<_, RPO_BB_WIDTH, 1>(p11);
+    let p110 = square_n::<_, N, 1>(p11);
 
     let mut p111 = p110;
     p111.iter_mut().zip(p1).for_each(|(t, x)| *t *= x);
 
-    let p11000 = square_n::<_, RPO_BB_WIDTH, 2>(p110);
+    let p11000 = square_n::<_, N, 2>(p110);
 
     let mut p11011 = p11000;
     p11011.iter_mut().zip(p11).for_each(|(t, x)| *t *= x);
 
-    let p11000000 = square_n::<_, RPO_BB_WIDTH, 3>(p11000);
+    let p11000000 = square_n::<_, N, 3>(p11000);
 
     let mut p11011011 = p11000000;
     p11011011.iter_mut().zip(p11011).for_each(|(t, x)| *t *= x);
@@ -120,11 +145,9 @@ fn apply_inv_sbox_x7(state: &mut [BabyBear; RPO_BB_WIDTH]) {
         .zip(p11000000)
         .for_each(|(t, x)| *t *= x);
 
-    let p110011011011011011 = exp_acc::<_, RPO_BB_WIDTH, 9>(p110011011, p11011011);
-    let p110011011011011011011011011 =
-        exp_acc::<_, RPO_BB_WIDTH, 9>(p110011011011011011, p11011011);
-    let p1100110110110110110110110110000 =
-        square_n::<_, RPO_BB_WIDTH, 4>(p110011011011011011011011011);
+    let p110011011011011011 = exp_acc::<_, N, 9>(p110011011, p11011011);
+    let p110011011011011011011011011 = exp_acc::<_, N, 9>(p110011011011011011, p11011011);
+    let p1100110110110110110110110110000 = square_n::<_, N, 4>(p110011011011011011011011011);
 
     state
         .iter_mut()

--- a/rescue/src/rpo/koala_bear.rs
+++ b/rescue/src/rpo/koala_bear.rs
@@ -1,6 +1,10 @@
 use alloc::vec::Vec;
 
-use p3_field::InjectiveMonomial;
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_field::PackedValue;
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_koala_bear::PackedKoalaBearNeon;
 use p3_koala_bear::{KoalaBear, MdsMatrixKoalaBear};
 use p3_symmetric::{CryptographicPermutation, Permutation};
 
@@ -82,29 +86,50 @@ impl Permutation<[KoalaBear; RPO_KB_WIDTH]> for RpoKoalaBear {
 
 impl CryptographicPermutation<[KoalaBear; RPO_KB_WIDTH]> for RpoKoalaBear {}
 
-/// Width-parallel inverse S-box `x -> x^(1/3)` over `[KoalaBear; 24]`.
+/// Inverse S-box `x -> x^(1/3)` over `[KoalaBear; 24]`.
 ///
-/// Computes `x^1420470955` via the same addition chain as
-/// [`p3_field::exponentiation::exp_1420470955`], but applied across all 24
-/// lanes step-by-step. Each step issues 24 independent multiplications,
-/// exposing 24-way ILP to the CPU.
+/// On aarch64 the 24-element state reinterprets as six packed NEON vectors so
+/// the addition chain runs four lanes per multiply; on other targets it runs
+/// lane-by-lane.
 #[inline]
 fn apply_inv_sbox_x3(state: &mut [KoalaBear; RPO_KB_WIDTH]) {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        // `RPO_KB_WIDTH` is a multiple of the NEON packing width (4), so the
+        // whole state reinterprets as packed vectors with no remainder.
+        let packed: &mut [PackedKoalaBearNeon; RPO_KB_WIDTH / 4] =
+            PackedKoalaBearNeon::pack_slice_mut(state)
+                .try_into()
+                .unwrap();
+        inv_sbox_x3(packed);
+    }
+    #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+    inv_sbox_x3(state);
+}
+
+/// Width-parallel inverse S-box `x -> x^(1/3)` over `[R; N]`.
+///
+/// Computes `x^1420470955` via the same addition chain as
+/// [`p3_field::exponentiation::exp_1420470955`], applied across all `N`
+/// lanes step-by-step. Each step issues `N` independent multiplications,
+/// exposing `N`-way ILP to the CPU.
+#[inline]
+fn inv_sbox_x3<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R; N]) {
     // Binary expansion of 1420470955 (29 squares + 7 mults):
     //   1010100101010101010101010101011
     let p1 = *state;
 
-    let p100 = square_n::<_, RPO_KB_WIDTH, 2>(p1);
+    let p100 = square_n::<_, N, 2>(p1);
 
     let mut p101 = p100;
     p101.iter_mut().zip(p1).for_each(|(t, x)| *t *= x);
 
-    let p10000 = square_n::<_, RPO_KB_WIDTH, 2>(p100);
+    let p10000 = square_n::<_, N, 2>(p100);
 
     let mut p10101 = p10000;
     p10101.iter_mut().zip(p101).for_each(|(t, x)| *t *= x);
 
-    let p10101000000 = square_n::<_, RPO_KB_WIDTH, 6>(p10101);
+    let p10101000000 = square_n::<_, N, 6>(p10101);
 
     let mut p10101010101 = p10101000000;
     p10101010101
@@ -118,11 +143,9 @@ fn apply_inv_sbox_x3(state: &mut [KoalaBear; RPO_KB_WIDTH]) {
         .zip(p10101010101)
         .for_each(|(t, x)| *t *= x);
 
-    let p101010010101010101010101 = exp_acc::<_, RPO_KB_WIDTH, 12>(p101010010101, p10101010101);
-    let p101010010101010101010101010101 =
-        exp_acc::<_, RPO_KB_WIDTH, 6>(p101010010101010101010101, p10101);
-    let p1010100101010101010101010101010 =
-        square_n::<_, RPO_KB_WIDTH, 1>(p101010010101010101010101010101);
+    let p101010010101010101010101 = exp_acc::<_, N, 12>(p101010010101, p10101010101);
+    let p101010010101010101010101010101 = exp_acc::<_, N, 6>(p101010010101010101010101, p10101);
+    let p1010100101010101010101010101010 = square_n::<_, N, 1>(p101010010101010101010101010101);
 
     state
         .iter_mut()

--- a/rescue/src/rpo/mersenne_31.rs
+++ b/rescue/src/rpo/mersenne_31.rs
@@ -1,9 +1,13 @@
 use alloc::vec::Vec;
 
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_field::PackedValue;
 use p3_field::integers::QuotientMap;
 use p3_field::{InjectiveMonomial, PrimeCharacteristicRing, PrimeField32};
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_mersenne_31::PackedMersenne31Neon;
 use p3_symmetric::{CryptographicPermutation, Permutation};
 
 use super::Rpo;
@@ -173,14 +177,35 @@ impl Permutation<[Mersenne31; RPO_M31_WIDTH]> for RpoMersenne31 {
 
 impl CryptographicPermutation<[Mersenne31; RPO_M31_WIDTH]> for RpoMersenne31 {}
 
-/// Width-parallel inverse S-box `x -> x^(1/5)` over `[Mersenne31; 24]`.
+/// Inverse S-box `x -> x^(1/5)` over `[Mersenne31; 24]`.
 ///
-/// Computes `x^1717986917` via the same addition chain as
-/// [`p3_field::exponentiation::exp_1717986917`], but applied across all 24
-/// lanes step-by-step. Each step issues 24 independent multiplications,
-/// exposing 24-way ILP to the CPU.
+/// On aarch64 the 24-element state reinterprets as six packed NEON vectors so
+/// the addition chain runs four lanes per multiply; on other targets it runs
+/// lane-by-lane.
 #[inline]
 fn apply_inv_sbox_x5(state: &mut [Mersenne31; RPO_M31_WIDTH]) {
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        // `RPO_M31_WIDTH` is a multiple of the NEON packing width (4), so the
+        // whole state reinterprets as packed vectors with no remainder.
+        let packed: &mut [PackedMersenne31Neon; RPO_M31_WIDTH / 4] =
+            PackedMersenne31Neon::pack_slice_mut(state)
+                .try_into()
+                .unwrap();
+        inv_sbox_x5(packed);
+    }
+    #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+    inv_sbox_x5(state);
+}
+
+/// Width-parallel inverse S-box `x -> x^(1/5)` over `[R; N]`.
+///
+/// Computes `x^1717986917` via the same addition chain as
+/// [`p3_field::exponentiation::exp_1717986917`], applied across all `N`
+/// lanes step-by-step. Each step issues `N` independent multiplications,
+/// exposing `N`-way ILP to the CPU.
+#[inline]
+fn inv_sbox_x5<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R; N]) {
     // Binary expansion of 1717986917 (30 squares + 7 mults):
     //   1100110011001100110011001100101
     let p1 = *state;
@@ -194,8 +219,8 @@ fn apply_inv_sbox_x5(state: &mut [Mersenne31; RPO_M31_WIDTH]) {
     let mut p101 = p10;
     p101.iter_mut().zip(p11).for_each(|(t, x)| *t *= x);
 
-    let p110011 = exp_acc::<_, RPO_M31_WIDTH, 4>(p11, p11);
-    let p11001100000000 = square_n::<_, RPO_M31_WIDTH, 8>(p110011);
+    let p110011 = exp_acc::<_, N, 4>(p11, p11);
+    let p11001100000000 = square_n::<_, N, 8>(p110011);
 
     let mut p11001100110011 = p11001100000000;
     p11001100110011
@@ -203,10 +228,9 @@ fn apply_inv_sbox_x5(state: &mut [Mersenne31; RPO_M31_WIDTH]) {
         .zip(p110011)
         .for_each(|(t, x)| *t *= x);
 
-    let p1100110011001100110011 = exp_acc::<_, RPO_M31_WIDTH, 8>(p11001100000000, p11001100110011);
-    let p11001100110011001100110011 = exp_acc::<_, RPO_M31_WIDTH, 4>(p1100110011001100110011, p11);
-    let p1100110011001100110011001100000 =
-        square_n::<_, RPO_M31_WIDTH, 5>(p11001100110011001100110011);
+    let p1100110011001100110011 = exp_acc::<_, N, 8>(p11001100000000, p11001100110011);
+    let p11001100110011001100110011 = exp_acc::<_, N, 4>(p1100110011001100110011, p11);
+    let p1100110011001100110011001100000 = square_n::<_, N, 5>(p11001100110011001100110011);
 
     state
         .iter_mut()

--- a/rescue/src/rpo/mersenne_31.rs
+++ b/rescue/src/rpo/mersenne_31.rs
@@ -1,9 +1,10 @@
 use alloc::vec::Vec;
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-use p3_field::PackedValue;
-use p3_field::integers::QuotientMap;
-use p3_field::{InjectiveMonomial, PrimeCharacteristicRing, PrimeField32};
+use p3_field::{Algebra, PackedValue};
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+use p3_field::{PrimeField32, integers::QuotientMap};
 use p3_mds::MdsPermutation;
 use p3_mersenne_31::Mersenne31;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
@@ -66,39 +67,87 @@ const MDS_FIRST_ROW_32: [u32; 32] = [
 /// RPO-M31 MDS: the 24x24 top-left sub-block of the 32x32 circulant defined
 /// by `MDS_FIRST_ROW_32`.
 ///
-/// Not itself circulant, so applied as a dense matrix-vector product. Inputs
-/// and coefficients fit in `u32`; their products in `u64`; the row sum of 24
-/// products in `u128`. Reduction back to M31 happens once per row.
+/// Applied as a dense matrix-vector product. On aarch64 each block of four
+/// output rows is one packed `mixed_dot_product` of the input with that block's
+/// column coefficients; elsewhere each row accumulates 24 `u64` products in a
+/// `u128` and reduces once.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct MdsMatrixRpoMersenne31;
 
 impl Permutation<[Mersenne31; RPO_M31_WIDTH]> for MdsMatrixRpoMersenne31 {
     fn permute_mut(&self, state: &mut [Mersenne31; RPO_M31_WIDTH]) {
-        let lifted: [u64; RPO_M31_WIDTH] =
-            core::array::from_fn(|i| state[i].as_canonical_u32() as u64);
-
-        for row in 0..RPO_M31_WIDTH {
-            // Each (coeff, input) is < 2^31 so the product fits in u64; the
-            // sum of 24 such products is < 24 * 2^62 < 2^67, so we accumulate
-            // in u128 and reduce once at the end.
-            let mut acc: u128 = 0;
-            for col in 0..RPO_M31_WIDTH {
-                let coeff = MDS_FIRST_ROW_32[(col + 32 - row) % 32] as u64;
-                acc += (coeff * lifted[col]) as u128;
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            // Output row `r = 4*block + lane` is `sum_col coeff[r][col] * x[col]`.
+            // Packing four rows per lane turns each block into a single dot
+            // product of the input vector with the block's column coefficients.
+            let input = *state;
+            for block in 0..RPO_M31_WIDTH / 4 {
+                let rows = PackedMersenne31Neon::mixed_dot_product::<RPO_M31_WIDTH>(
+                    &MDS_PACKED_COLUMNS[block],
+                    &input,
+                );
+                state[4 * block..4 * block + 4].copy_from_slice(&rows.0);
             }
-            // SAFETY: `acc` < 2^67.
-            state[row] = unsafe { reduce_u128_to_m31(acc) };
+        }
+        #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+        {
+            let lifted: [u64; RPO_M31_WIDTH] =
+                core::array::from_fn(|i| state[i].as_canonical_u32() as u64);
+
+            for row in 0..RPO_M31_WIDTH {
+                // Each (coeff, input) is < 2^31 so the product fits in u64; the
+                // sum of 24 such products is < 24 * 2^62 < 2^67, so we accumulate
+                // in u128 and reduce once at the end.
+                let mut acc: u128 = 0;
+                for col in 0..RPO_M31_WIDTH {
+                    let coeff = MDS_FIRST_ROW_32[(col + 32 - row) % 32] as u64;
+                    acc += (coeff * lifted[col]) as u128;
+                }
+                // SAFETY: `acc` < 2^67.
+                state[row] = unsafe { reduce_u128_to_m31(acc) };
+            }
         }
     }
 }
 
 impl MdsPermutation<Mersenne31, RPO_M31_WIDTH> for MdsMatrixRpoMersenne31 {}
 
+/// Column-major packed coefficients of the RPO-M31 MDS, grouped into blocks of
+/// four output rows.
+///
+/// `MDS_PACKED_COLUMNS[block][col]` holds in its four lanes the coefficients
+/// `coeff[4*block + lane][col]`, where `coeff[row][col] =
+/// MDS_FIRST_ROW_32[(col + 32 - row) % 32]`.
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const MDS_PACKED_COLUMNS: [[PackedMersenne31Neon; RPO_M31_WIDTH]; RPO_M31_WIDTH / 4] = {
+    let mut table =
+        [[PackedMersenne31Neon(Mersenne31::new_array([0; 4])); RPO_M31_WIDTH]; RPO_M31_WIDTH / 4];
+    let mut block = 0;
+    while block < RPO_M31_WIDTH / 4 {
+        let mut col = 0;
+        while col < RPO_M31_WIDTH {
+            let mut lanes = [0u32; 4];
+            let mut lane = 0;
+            while lane < 4 {
+                let row = 4 * block + lane;
+                lanes[lane] = MDS_FIRST_ROW_32[(col + 32 - row) % 32];
+                lane += 1;
+            }
+            table[block][col] = PackedMersenne31Neon(Mersenne31::new_array(lanes));
+            col += 1;
+        }
+        block += 1;
+    }
+    table
+};
+
 /// Reduce a value in `[0, 2^67)` modulo `p = 2^31 - 1` using the identity
 /// `2^31 ≡ 1 (mod p)`.
 ///
 /// The bound `v < 2^67` is the caller's responsibility; for `MdsMatrixRpoMersenne31`
 /// it follows from `24 * (2^31 - 1)^2 < 2^67`.
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 #[inline]
 unsafe fn reduce_u128_to_m31(v: u128) -> Mersenne31 {
     const M: u64 = (1u64 << 31) - 1;
@@ -243,8 +292,29 @@ fn inv_sbox_x5<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R
 mod tests {
     use p3_field::PrimeCharacteristicRing;
     use p3_symmetric::Permutation;
+    use proptest::prelude::*;
 
     use super::*;
+
+    /// Reference dense matrix-vector product against the circulant coefficients.
+    fn mds_naive(input: [Mersenne31; RPO_M31_WIDTH]) -> [Mersenne31; RPO_M31_WIDTH] {
+        core::array::from_fn(|row| {
+            (0..RPO_M31_WIDTH)
+                .map(|col| {
+                    Mersenne31::from_u32(MDS_FIRST_ROW_32[(col + 32 - row) % 32]) * input[col]
+                })
+                .sum()
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_mds_matches_naive(seeds in prop::array::uniform24(any::<u32>())) {
+            let input: [Mersenne31; RPO_M31_WIDTH] =
+                core::array::from_fn(|i| Mersenne31::from_u32(seeds[i]));
+            prop_assert_eq!(MdsMatrixRpoMersenne31.permute(input), mds_naive(input));
+        }
+    }
 
     #[test]
     fn rpo_mersenne31_test_vector() {


### PR DESCRIPTION
On my M4 pro:

  ```bash
  ┌────────────┬─────────┬─────────┬────────────────────────────┐
  │   Field    │ Before  │  After  │          Speedup           │
  ├────────────┼─────────┼─────────┼────────────────────────────┤
  │ BabyBear   │ 3.83 µs │ 2.26 µs │ 1.70×                      │
  ├────────────┼─────────┼─────────┼────────────────────────────┤
  │ KoalaBear  │ 3.57 µs │ 2.14 µs │ 1.67×                      │
  ├────────────┼─────────┼─────────┼────────────────────────────┤
  │ Mersenne31 │ 3.50 µs │ 2.02 µs │ 1.74×                      │  
  └────────────┴─────────┴─────────┴────────────────────────────┘
  ```