### PR TITLE
feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762)

### DIFF
--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -492,6 +492,51 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         self.0.truncate(mid);
     }
 
+    /// Fixes the prefix variable at a challenge value in the *monomial* basis,
+    /// in place.
+    ///
+    /// The table is interpreted as monomial coefficients (the projective
+    /// `{0, inf}` representation of eprint 2026/762). Writing the polynomial as
+    /// `p(X_0, x') = a0(x') + X_0 * a1(x')`, with `a0` the low half (monomials
+    /// without `X_0`) and `a1` the high half (monomials with `X_0`), binding
+    /// `X_0 = r` gives, by Corollary 3.2:
+    ///
+    /// ```text
+    /// out = p(0, x') + r * p(inf, x') = a0 + r * a1
+    /// ```
+    ///
+    /// Unlike [`Self::fix_prefix_var_mut`], this costs no subtraction per pair.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant (zero free variables).
+    pub fn fix_prefix_var_mut_projective<F: Copy + Send + Sync>(&mut self, r: F)
+    where
+        A: Algebra<F>,
+    {
+        assert!(self.as_constant().is_none(), "no free variables");
+        let num_evals = self.num_evals();
+        let mid = num_evals / 2;
+        // Low half: monomials without x_0 (the constant part a0).
+        // High half: monomials with x_0 (the leading-coefficient part a1).
+        let (p0, p1) = self.0.split_at_mut(mid);
+
+        if num_evals >= PARALLEL_THRESHOLD {
+            // Parallel: fold each pair in place.
+            p0.par_iter_mut()
+                .zip(p1.par_iter())
+                .for_each(|(a0, &a1)| *a0 += a1 * r);
+        } else {
+            // Sequential: fold each pair in place.
+            p0.iter_mut()
+                .zip(p1.iter())
+                .for_each(|(a0, &a1)| *a0 += a1 * r);
+        }
+
+        // Discard the second half; the first half now holds the folded result.
+        self.0.truncate(mid);
+    }
+
     /// In-place version of the suffix-variable fix.
     ///
     /// Folds adjacent pairs and truncates to the first half. The sequential
@@ -1973,6 +2018,46 @@ pub(crate) mod test {
             for s in 0..folded.num_evals() {
                 assert_eq!(poly.fix_prefix_var_at(z, s), folded.as_slice()[s]);
             }
+        }
+    }
+
+    proptest! {
+        /// Projective binding fixes a variable in the *monomial* basis: the table
+        /// holds monomial coefficients (Proposition 3.1, eprint 2026/762), and
+        /// binding x_0 = r maps each pair (a0, a1) to a0 + r * a1, with no
+        /// subtraction. Applied across every variable it evaluates the monomial
+        /// polynomial sum_S a_S * prod_{i in S} z_i at the point z.
+        #[test]
+        fn prop_fix_prefix_var_mut_projective_evaluates_monomial_basis(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            // Interpret the random table as monomial coefficients.
+            let poly = Poly::<F>::rand(&mut rng, k);
+            let point: Point<F> = Point::rand(&mut rng, k);
+            let z = point.as_slice();
+
+            // Reference: evaluate the monomial polynomial directly. Prefix binding
+            // fixes the most-significant variable first, so bit position p of the
+            // index corresponds to challenge z[k - 1 - p].
+            let mut expected = F::ZERO;
+            for (s, &coeff) in poly.as_slice().iter().enumerate() {
+                let mut term = coeff;
+                for p in 0..k {
+                    if (s >> p) & 1 == 1 {
+                        term *= z[k - 1 - p];
+                    }
+                }
+                expected += term;
+            }
+
+            // Projective binding across all variables must agree.
+            let mut compressed = Poly::new(poly.as_slice().to_vec());
+            for &zi in z {
+                compressed.fix_prefix_var_mut_projective(zi);
+            }
+            prop_assert_eq!(compressed.as_constant().unwrap(), expected);
         }
     }
 

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -496,7 +496,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
     /// in place.
     ///
     /// The table is interpreted as monomial coefficients (the projective
-    /// `{0, inf}` representation of eprint 2026/762). Writing the polynomial as
+    /// `{0, inf}` representation of <https://eprint.iacr.org/2026/762> ). Writing the polynomial as
     /// `p(X_0, x') = a0(x') + X_0 * a1(x')`, with `a0` the low half (monomials
     /// without `X_0`) and `a1` the high half (monomials with `X_0`), binding
     /// `X_0 = r` gives, by Corollary 3.2:
@@ -510,7 +510,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
     /// # Panics
     ///
     /// Panics if the polynomial is constant (zero free variables).
-    pub fn fix_prefix_var_mut_projective<F: Copy + Send + Sync>(&mut self, r: F)
+    pub fn fix_prefix_var_mut_monomial<F: Copy + Send + Sync>(&mut self, r: F)
     where
         A: Algebra<F>,
     {
@@ -2028,7 +2028,7 @@ pub(crate) mod test {
         /// subtraction. Applied across every variable it evaluates the monomial
         /// polynomial sum_S a_S * prod_{i in S} z_i at the point z.
         #[test]
-        fn prop_fix_prefix_var_mut_projective_evaluates_monomial_basis(
+        fn prop_fix_prefix_var_mut_monomial_evaluates_monomial_basis(
             k in 1usize..=12,
             seed in any::<u64>(),
         ) {
@@ -2055,7 +2055,7 @@ pub(crate) mod test {
             // Projective binding across all variables must agree.
             let mut compressed = Poly::new(poly.as_slice().to_vec());
             for &zi in z {
-                compressed.fix_prefix_var_mut_projective(zi);
+                compressed.fix_prefix_var_mut_monomial(zi);
             }
             prop_assert_eq!(compressed.as_constant().unwrap(), expected);
         }

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,8 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix, sumcheck_coefficients_suffix,
+    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
 use rand::distr::{Distribution, StandardUniform};
@@ -251,6 +252,19 @@ where
             );
         }
 
+        group.bench_with_input(
+            BenchmarkId::new("base_ext_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        &base_packed,
+                        round_zero_weights.as_slice(),
+                    ))
+                });
+            },
+        );
+
         // Later-round operands: both sides are packed extension elements.
         let packed_evals = rand_ext_packed::<B>(&mut rng, k);
         let packed_weights = rand_ext_packed::<B>(&mut rng, k);
@@ -269,6 +283,19 @@ where
                 },
             );
         }
+
+        group.bench_with_input(
+            BenchmarkId::new("ext_ext_packed_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        packed_evals.as_slice(),
+                        packed_weights.as_slice(),
+                    ))
+                });
+            },
+        );
     }
 
     for &k in SCALAR_SIZES {
@@ -288,6 +315,19 @@ where
                 },
             );
         }
+
+        group.bench_with_input(
+            BenchmarkId::new("ext_ext_scalar_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        evals.as_slice(),
+                        weights.as_slice(),
+                    ))
+                });
+            },
+        );
     }
 
     group.finish();

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -366,6 +366,27 @@ where
                 );
             });
         }
+
+        // Projective (monomial-basis) binding: the subtraction-free
+        // `a0 + a1 * r` of eprint 2026/762, prefix only.
+        //
+        // This is where the projective basis is expected to pay. The
+        // round-coefficient kernel only trades a subtraction pass for an
+        // addition pass, so it cannot come out ahead; binding drops a pass.
+        group.bench_with_input(
+            BenchmarkId::new("prefix_projective", &label),
+            &(),
+            |b, ()| {
+                b.iter_batched_ref(
+                    || template.clone(),
+                    |poly| {
+                        poly.fix_prefix_var_mut_monomial(black_box(r));
+                        black_box(&*poly);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
     }
 
     group.finish();

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,7 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
     sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
@@ -205,7 +205,7 @@ where
 ///
 /// The constant term and the leading coefficient of the round polynomial.
 #[inline]
-fn coeffs<Base, Acc>(order: VariableOrder, evals: &[Base], weights: &[Acc]) -> (Acc, Acc)
+fn coeffs<Base, Acc>(order: VariableOrder, evals: &[Base], weights: &[Acc]) -> RoundMessage<Acc>
 where
     Base: PrimeCharacteristicRing + Copy + Send + Sync,
     Acc: Algebra<Base> + Copy + Send + Sync,

--- a/sumcheck/src/data.rs
+++ b/sumcheck/src/data.rs
@@ -5,12 +5,15 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_multilinear_util::point::Point;
 use serde::{Deserialize, Serialize};
 
-use crate::{SumcheckError, extrapolate_01inf};
+use crate::SumcheckError;
+use crate::strategy::Basis;
 
 /// Sumcheck polynomial data
 ///
 /// Stores the polynomial evaluations for sumcheck rounds in a compact format.
-/// Each round stores `[h(0), h(inf)]` where `h(1)` is derived as `claimed_sum - h(0)`.
+/// Each round stores two evaluations: `[h(0), h(inf)]` in the evaluation
+/// basis (`h(1)` derived as `claimed_sum - h(0)`), or `[s(1), s(inf)]` in the
+/// projective basis (`s(0)` derived as `claimed_sum - s(inf)`).
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 pub struct SumcheckData<F, EF> {
     /// Polynomial evaluations for each sumcheck round.
@@ -49,17 +52,21 @@ impl<F, EF> SumcheckData<F, EF> {
     /// # Arguments
     ///
     /// * `challenger` - Fiat-Shamir transcript.
-    /// * `c0` - Constant coefficient `h(0)`.
-    /// * `c_inf` - Leading coefficient `h(inf)`.
+    /// * `c_a` - Finite-point value: `h(0)` (evaluation) or `s(1)` (projective).
+    /// * `c_inf` - Leading coefficient `h(inf)` / `s(inf)`.
     /// * `pow_bits` - PoW difficulty (0 to skip grinding).
     ///
     /// # Returns
     ///
     /// The sampled challenge `r`.
+    ///
+    /// The two values are recorded and absorbed verbatim; which basis defines
+    /// them is the caller's business, and must match the [`Basis`] the
+    /// verifier later passes to [`Self::verify_rounds`].
     pub fn observe_and_sample<Challenger, BF>(
         &mut self,
         challenger: &mut Challenger,
-        c0: EF,
+        c_a: EF,
         c_inf: EF,
         pow_bits: usize,
     ) -> EF
@@ -70,12 +77,13 @@ impl<F, EF> SumcheckData<F, EF> {
         Challenger: FieldChallenger<BF> + GrindingChallenger<Witness = F>,
     {
         // Record the polynomial coefficients in the proof.
-        self.polynomial_evaluations.push([c0, c_inf]);
+        self.polynomial_evaluations.push([c_a, c_inf]);
 
         // Absorb coefficients into the transcript.
         //
-        // We send (h(0), h(inf)). The verifier derives h(1) from the sum constraint.
-        challenger.observe_algebra_slice(&[c0, c_inf]);
+        // Two of the quadratic's three values cross the wire; the verifier
+        // derives the third from the basis-dependent round identity.
+        challenger.observe_algebra_slice(&[c_a, c_inf]);
 
         // Optional proof-of-work to increase prover cost.
         //
@@ -113,6 +121,7 @@ impl<F, EF> SumcheckData<F, EF> {
         claimed_sum: &mut EF,
         expected_rounds: usize,
         pow_bits: usize,
+        basis: Basis,
     ) -> Result<Point<EF>, SumcheckError>
     where
         F: TwoAdicField,
@@ -142,18 +151,21 @@ impl<F, EF> SumcheckData<F, EF> {
             });
         }
 
-        for (i, &[c0, c_inf]) in self.polynomial_evaluations.iter().enumerate() {
-            // Observe only the sent polynomial evaluations (h(0) and h(inf)).
-            challenger.observe_algebra_slice(&[c0, c_inf]);
+        for (i, &[c_a, c_inf]) in self.polynomial_evaluations.iter().enumerate() {
+            // Observe only the sent polynomial evaluations; their meaning is
+            // basis-dependent ([h(0), h(inf)] or [s(1), s(inf)]).
+            challenger.observe_algebra_slice(&[c_a, c_inf]);
 
             // Verify PoW (only if pow_bits > 0)
             if pow_bits > 0 && !challenger.check_witness(pow_bits, self.pow_witnesses[i]) {
                 return Err(SumcheckError::InvalidPowWitness);
             }
 
-            // Sample challenge and reconstruct h(r) from (h(0), h(1), h(inf)).
+            // Sample the challenge and reconstruct h(r); the basis-dependent
+            // round identity supplies the third quadratic value (shared with
+            // the prover via Basis::reduce_claim).
             let r: EF = challenger.sample_algebra_element();
-            *claimed_sum = extrapolate_01inf(c0, *claimed_sum - c0, c_inf, r);
+            *claimed_sum = basis.reduce_claim(c_a, c_inf, r, *claimed_sum);
             randomness.push(r);
         }
 
@@ -174,6 +186,7 @@ pub fn verify_final_sumcheck_rounds<F, EF, Challenger>(
     claimed_sum: &mut EF,
     rounds: usize,
     pow_bits: usize,
+    basis: Basis,
 ) -> Result<Point<EF>, SumcheckError>
 where
     F: TwoAdicField,
@@ -189,5 +202,5 @@ where
     })?;
 
     // `verify_rounds` binds the round count to `rounds`.
-    sumcheck.verify_rounds(challenger, claimed_sum, rounds, pow_bits)
+    sumcheck.verify_rounds(challenger, claimed_sum, rounds, pow_bits, basis)
 }

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -207,7 +207,7 @@ pub(super) mod test_utils {
 
     use crate::SumcheckData;
     use crate::layout::{Layout, LayoutStrategy, Table, TableShape, Verifier, Witness};
-    use crate::strategy::VariableOrder;
+    use crate::strategy::{Basis, VariableOrder};
     use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
     use crate::tests::*;
 
@@ -324,7 +324,13 @@ pub(super) mod test_utils {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -339,7 +345,13 @@ pub(super) mod test_utils {
         constraints.push(intermediate_constraint);
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -349,6 +361,7 @@ pub(super) mod test_utils {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );
@@ -637,6 +650,7 @@ mod tests {
         FOLDING, build_tables, run_roundtrip_test, table_shapes, tables_from_shape,
     };
     use crate::layout::{Layout, Verifier};
+    use crate::strategy::Basis;
     use crate::table::OpeningBatch;
     use crate::tests::*;
 
@@ -840,7 +854,13 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -857,7 +877,13 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -867,6 +893,7 @@ mod tests {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );
@@ -956,7 +983,13 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -973,7 +1006,13 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -983,6 +1022,7 @@ mod tests {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -27,9 +27,9 @@ use p3_multilinear_util::poly::{Poly, PolyMaybePacked, PolyMaybePackedView};
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
+use crate::SumcheckData;
 use crate::constraints::Constraint;
-use crate::strategy::{RoundMessage, VariableOrder};
-use crate::{SumcheckData, extrapolate_01inf};
+use crate::strategy::{Basis, RoundMessage, VariableOrder};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
 ///
@@ -339,10 +339,14 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         //
         // The strategy differs based on representation to maximize SIMD utilization.
         let order = self.order;
-        let RoundMessage { c_a: c0, c_inf } = match &self.inner {
+
+        // This prover binds evaluation-basis tables; the projective kernels
+        // are reachable through the same tag, wired up by their consumer.
+        let basis = Basis::Evaluation;
+        let RoundMessage { c_a, c_inf } = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 // Packed round coefficients: SIMD-parallel per-lane accumulation.
-                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice());
 
                 // Horizontal reduction across SIMD lanes.
                 RoundMessage {
@@ -352,21 +356,19 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
             }
             MaybePacked::Unpacked { evals, weights } => {
                 // Scalar round coefficients.
-                order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
+                basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice())
             }
         };
 
         // Step 2-4: Commit to transcript, do PoW, and receive challenge.
-        let r = sumcheck_data.observe_and_sample(challenger, c0, c_inf, pow_bits);
+        let r = sumcheck_data.observe_and_sample(challenger, c_a, c_inf, pow_bits);
 
         // Step 5: Fold both polynomials using the challenge.
         self.compress(r);
 
-        // Step 6: Update the claimed sum.
-        //
-        // h(r) = h(0)*(1-r) + h(1)*r + h(inf)*r*(r-1)
-        // where h(1) = claimed_sum - h(0).
-        *sum = extrapolate_01inf(c0, *sum - c0, c_inf, r);
+        // Step 6: Update the claimed sum, through the same round identity the
+        // verifier will apply to this message.
+        *sum = basis.reduce_claim(c_a, c_inf, r, *sum);
 
         // Sanity check: the updated sum should equal the inner product after folding.
         debug_assert_eq!(*sum, self.dot_product());
@@ -384,16 +386,17 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// touching the transcript or folding the polynomial.
     pub(crate) fn round_coefficients(&self) -> (EF, EF) {
         let order = self.order;
+        let basis = Basis::Evaluation;
         let msg = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
-                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice());
                 RoundMessage {
                     c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
                     c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
                 }
             }
             MaybePacked::Unpacked { evals, weights } => {
-                order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
+                basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice())
             }
         };
         (msg.c_a, msg.c_inf)
@@ -577,6 +580,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
+    use crate::extrapolate_01inf;
     use crate::strategy::{RoundMessage, sumcheck_coefficients_prefix};
 
     type F = BabyBear;

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -28,7 +28,7 @@ use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use crate::constraints::Constraint;
-use crate::strategy::VariableOrder;
+use crate::strategy::{RoundMessage, VariableOrder};
 use crate::{SumcheckData, extrapolate_01inf};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
@@ -339,16 +339,16 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         //
         // The strategy differs based on representation to maximize SIMD utilization.
         let order = self.order;
-        let (c0, c_inf) = match &self.inner {
+        let RoundMessage { c_a: c0, c_inf } = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 // Packed round coefficients: SIMD-parallel per-lane accumulation.
-                let (c0, c_inf) = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
 
                 // Horizontal reduction across SIMD lanes.
-                (
-                    EF::ExtensionPacking::to_ext_iter([c0]).sum(),
-                    EF::ExtensionPacking::to_ext_iter([c_inf]).sum(),
-                )
+                RoundMessage {
+                    c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
+                    c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
+                }
             }
             MaybePacked::Unpacked { evals, weights } => {
                 // Scalar round coefficients.
@@ -384,18 +384,19 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// touching the transcript or folding the polynomial.
     pub(crate) fn round_coefficients(&self) -> (EF, EF) {
         let order = self.order;
-        match &self.inner {
+        let msg = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
-                let (c0, c_inf) = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
-                (
-                    EF::ExtensionPacking::to_ext_iter([c0]).sum(),
-                    EF::ExtensionPacking::to_ext_iter([c_inf]).sum(),
-                )
+                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                RoundMessage {
+                    c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
+                    c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
+                }
             }
             MaybePacked::Unpacked { evals, weights } => {
                 order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
             }
-        }
+        };
+        (msg.c_a, msg.c_inf)
     }
 
     /// Folds both product-polynomial sides by one verifier challenge.
@@ -576,7 +577,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
-    use crate::strategy::sumcheck_coefficients_prefix;
+    use crate::strategy::{RoundMessage, sumcheck_coefficients_prefix};
 
     type F = BabyBear;
     type EF = BinomialExtensionField<BabyBear, 4>;
@@ -646,7 +647,10 @@ mod tests {
         let evals = Poly::new(vec![e0, e1]);
         let weights = Poly::new(vec![w0, w1]);
 
-        let (h0, h_inf) = sumcheck_coefficients_prefix(evals.as_slice(), weights.as_slice());
+        let RoundMessage {
+            c_a: h0,
+            c_inf: h_inf,
+        } = sumcheck_coefficients_prefix(evals.as_slice(), weights.as_slice());
 
         // h(0) = e0 * w0
         let expected_h0 = e0 * w0;
@@ -1226,7 +1230,7 @@ mod tests {
             // Compute sumcheck coefficients before folding.
             // Returns (h(0), h(inf)) where h is the univariate
             // polynomial h(X) = sum_{b in {0,1}^{n-1}} f(X, b) * w(X, b).
-            let (c0, c_inf) = match &poly.inner {
+            let RoundMessage { c_a: c0, c_inf } = match &poly.inner {
                 MaybePacked::Unpacked {
                     evals: small_evals,
                     weights: small_weights,

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -130,27 +130,24 @@ where
     (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
 }
 
-/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+/// Shared prefix round-coefficient scaffold, parameterised over the basis steps.
 ///
-/// # Inputs
-///
-/// - `evals`   — multilinear evaluations of `f(X)` over the hypercube.
-/// - `weights` — multilinear evaluations of `w(X)` over the hypercube.
-///
-/// # Returns
-///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
-/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
-///
-/// # Complexity
-///
-/// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
-/// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
-/// streaming fold.
-pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+/// The tiling, `PAR_THRESHOLD` par-vs-serial split, and `K`-tail fold are
+/// identical across bases; only the per-tile and per-pair MAC differ. The
+/// evaluation and projective kernels supply their `chunk_step` / `pair_step`
+/// pair so this delicate delayed-reduction loop exists exactly once.
+#[inline]
+fn sumcheck_coefficients_prefix_with<B, A, Chunk, Pair>(
+    evals: &[B],
+    weights: &[A],
+    chunk_step: Chunk,
+    pair_step: Pair,
+) -> (A, A)
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
+    Chunk: Fn(&[B; K], &[B; K], &[A; K], &[A; K]) -> (A, A) + Sync,
+    Pair: Fn((A, A), B, B, A, A) -> (A, A),
 {
     // Precondition: paired slices must be aligned; half-and-half split addresses the prefix bit.
     assert_eq!(evals.len(), weights.len());
@@ -178,7 +175,7 @@ where
             .par_fold_reduce(
                 || (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step::<B, A>(
+                    let chunk = chunk_step(
                         e_lo_c.try_into().unwrap(),
                         e_hi_c.try_into().unwrap(),
                         w_lo_c.try_into().unwrap(),
@@ -196,7 +193,7 @@ where
             .fold(
                 (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step::<B, A>(
+                    let chunk = chunk_step(
                         e_lo_c.try_into().unwrap(),
                         e_hi_c.try_into().unwrap(),
                         w_lo_c.try_into().unwrap(),
@@ -213,10 +210,35 @@ where
         .zip(e_hi_tail.iter())
         .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
         .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
-            round_step(acc, e0, e1, w0, w1)
+            pair_step(acc, e0, e1, w0, w1)
         });
 
     round_reduce(main, tail)
+}
+
+/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+///
+/// # Inputs
+///
+/// - `evals`   — multilinear evaluations of `f(X)` over the hypercube.
+/// - `weights` — multilinear evaluations of `w(X)` over the hypercube.
+///
+/// # Returns
+///
+/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
+/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
+///
+/// # Complexity
+///
+/// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
+/// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
+/// streaming fold.
+pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<B> + Copy + Send + Sync,
+{
+    sumcheck_coefficients_prefix_with(evals, weights, chunk_round_step::<B, A>, round_step::<B, A>)
 }
 
 /// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
@@ -236,68 +258,12 @@ where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    assert_eq!(evals.len(), weights.len());
-    assert!(evals.len().is_multiple_of(2));
-    let half = evals.len() / 2;
-    let (e_lo, e_hi) = evals.split_at(half);
-    let (w_lo, w_hi) = weights.split_at(half);
-
-    let body = (half / K) * K;
-    let (e_lo_main, e_lo_tail) = e_lo.split_at(body);
-    let (e_hi_main, e_hi_tail) = e_hi.split_at(body);
-    let (w_lo_main, w_lo_tail) = w_lo.split_at(body);
-    let (w_hi_main, w_hi_tail) = w_hi.split_at(body);
-
-    let main: (A, A) = if half > PAR_THRESHOLD {
-        e_lo_main
-            .par_chunks_exact(K)
-            .zip(e_hi_main.par_chunks_exact(K))
-            .zip(
-                w_lo_main
-                    .par_chunks_exact(K)
-                    .zip(w_hi_main.par_chunks_exact(K)),
-            )
-            .par_fold_reduce(
-                || (A::ZERO, A::ZERO),
-                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step_projective::<B, A>(
-                        e_lo_c.try_into().unwrap(),
-                        e_hi_c.try_into().unwrap(),
-                        w_lo_c.try_into().unwrap(),
-                        w_hi_c.try_into().unwrap(),
-                    );
-                    round_reduce(acc, chunk)
-                },
-                round_reduce,
-            )
-    } else {
-        e_lo_main
-            .chunks_exact(K)
-            .zip(e_hi_main.chunks_exact(K))
-            .zip(w_lo_main.chunks_exact(K).zip(w_hi_main.chunks_exact(K)))
-            .fold(
-                (A::ZERO, A::ZERO),
-                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step_projective::<B, A>(
-                        e_lo_c.try_into().unwrap(),
-                        e_hi_c.try_into().unwrap(),
-                        w_lo_c.try_into().unwrap(),
-                        w_hi_c.try_into().unwrap(),
-                    );
-                    round_reduce(acc, chunk)
-                },
-            )
-    };
-
-    let tail = e_lo_tail
-        .iter()
-        .zip(e_hi_tail.iter())
-        .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
-        .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
-            round_step_projective(acc, e0, e1, w0, w1)
-        });
-
-    round_reduce(main, tail)
+    sumcheck_coefficients_prefix_with(
+        evals,
+        weights,
+        chunk_round_step_projective::<B, A>,
+        round_step_projective::<B, A>,
+    )
 }
 
 /// Computes `(h(0), h(inf))` for a suffix-binding sumcheck round.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -84,6 +84,52 @@ fn round_reduce<A: Copy + PrimeCharacteristicRing>(a: (A, A), b: (A, A)) -> (A, 
     (a.0 + b.0, a.1 + b.1)
 }
 
+/// Projective per-tile MAC (eprint 2026/762, Fig. 3).
+///
+/// Like [`chunk_round_step`], but the tables are interpreted as monomial
+/// coefficients, so the round message is `[s(1), s(inf)]` and the verifier
+/// derives `s(0) := C - s(inf)` from the projective round identity. The
+/// `X = 1` evaluation of a coefficient pair is `lo + hi`, so the differences
+/// of the evaluation basis become sums:
+///
+/// ```text
+///     at_one  += sum_i  (w_lo[i] + w_hi[i]) * (e_lo[i] + e_hi[i])
+///     leading += sum_i  w_hi[i] * e_hi[i]
+/// ```
+#[inline(always)]
+fn chunk_round_step_projective<B, A>(
+    e_lo: &[B; K],
+    e_hi: &[B; K],
+    w_lo: &[A; K],
+    w_hi: &[A; K],
+) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy,
+    A: Algebra<B> + Copy,
+{
+    // Materialise the X = 1 evaluations (lo + hi) tile-locally so they can
+    // feed the same delayed-reduction primitive. `K` base adds, no reductions.
+    let ones_e: [B; K] = core::array::from_fn(|i| e_lo[i] + e_hi[i]);
+    let ones_w: [A; K] = core::array::from_fn(|i| w_lo[i] + w_hi[i]);
+
+    let acc1 = A::mixed_dot_product::<K>(&ones_w, &ones_e);
+
+    // Leading coefficient: dot product of the high (coefficient) faces.
+    let acc_inf = A::mixed_dot_product::<K>(w_hi, e_hi);
+
+    (acc1, acc_inf)
+}
+
+/// Projective per-pair MAC for the streaming tail (no subtraction).
+#[inline(always)]
+fn round_step_projective<B, A>((acc1, acc_inf): (A, A), e0: B, e1: B, w0: A, w1: A) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy,
+    A: Algebra<B> + Copy,
+{
+    (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
+}
+
 /// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
 ///
 /// # Inputs
@@ -168,6 +214,87 @@ where
         .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
         .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
             round_step(acc, e0, e1, w0, w1)
+        });
+
+    round_reduce(main, tail)
+}
+
+/// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
+/// (eprint 2026/762, Fig. 3).
+///
+/// The tables are interpreted as monomial coefficients. The round message is
+/// `[s(1), s(inf)]`; the verifier derives `s(0) := C - s(inf)` from the
+/// projective round identity `s(0) + s(inf) = C`. Returned as:
+///
+/// - `s(1)`   = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
+/// - `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
+///
+/// The evaluation-basis kernel's per-pair subtractions (`hi - lo`) become
+/// additions (`lo + hi`); same `K`-tiled, delayed-reduction structure.
+pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<B> + Copy + Send + Sync,
+{
+    assert_eq!(evals.len(), weights.len());
+    assert!(evals.len().is_multiple_of(2));
+    let half = evals.len() / 2;
+    let (e_lo, e_hi) = evals.split_at(half);
+    let (w_lo, w_hi) = weights.split_at(half);
+
+    let body = (half / K) * K;
+    let (e_lo_main, e_lo_tail) = e_lo.split_at(body);
+    let (e_hi_main, e_hi_tail) = e_hi.split_at(body);
+    let (w_lo_main, w_lo_tail) = w_lo.split_at(body);
+    let (w_hi_main, w_hi_tail) = w_hi.split_at(body);
+
+    let main: (A, A) = if half > PAR_THRESHOLD {
+        e_lo_main
+            .par_chunks_exact(K)
+            .zip(e_hi_main.par_chunks_exact(K))
+            .zip(
+                w_lo_main
+                    .par_chunks_exact(K)
+                    .zip(w_hi_main.par_chunks_exact(K)),
+            )
+            .par_fold_reduce(
+                || (A::ZERO, A::ZERO),
+                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                    let chunk = chunk_round_step_projective::<B, A>(
+                        e_lo_c.try_into().unwrap(),
+                        e_hi_c.try_into().unwrap(),
+                        w_lo_c.try_into().unwrap(),
+                        w_hi_c.try_into().unwrap(),
+                    );
+                    round_reduce(acc, chunk)
+                },
+                round_reduce,
+            )
+    } else {
+        e_lo_main
+            .chunks_exact(K)
+            .zip(e_hi_main.chunks_exact(K))
+            .zip(w_lo_main.chunks_exact(K).zip(w_hi_main.chunks_exact(K)))
+            .fold(
+                (A::ZERO, A::ZERO),
+                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                    let chunk = chunk_round_step_projective::<B, A>(
+                        e_lo_c.try_into().unwrap(),
+                        e_hi_c.try_into().unwrap(),
+                        w_lo_c.try_into().unwrap(),
+                        w_hi_c.try_into().unwrap(),
+                    );
+                    round_reduce(acc, chunk)
+                },
+            )
+    };
+
+    let tail = e_lo_tail
+        .iter()
+        .zip(e_hi_tail.iter())
+        .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
+        .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
+            round_step_projective(acc, e0, e1, w0, w1)
         });
 
     round_reduce(main, tail)
@@ -670,6 +797,35 @@ mod tests {
                 VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge),
                 eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge),
             );
+        }
+    }
+
+    proptest! {
+        // Projective (monomial-basis) prefix round message (eprint 2026/762,
+        // Fig. 3) is [s(1), s(inf)] = [dot(lo + hi, lo + hi), dot(hi, hi)];
+        // the per-pair subtractions of the evaluation basis become additions.
+        #[test]
+        fn prop_sumcheck_coefficients_prefix_projective_matches_reference(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = 1usize << k;
+            let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+
+            let (h1, h_inf) = super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+
+            let half = n / 2;
+            // s(1): the X = 1 evaluation of each coefficient pair is lo + hi.
+            let h1_ref: EF = (0..half)
+                .map(|i| (weights[i] + weights[half + i]) * (evals[i] + evals[half + i]))
+                .sum();
+            // s(inf): dot product of the high (leading-coefficient) faces.
+            let h_inf_ref: EF = (0..half).map(|i| weights[half + i] * evals[half + i]).sum();
+
+            prop_assert_eq!(h1, h1_ref);
+            prop_assert_eq!(h_inf, h_inf_ref);
         }
     }
 }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -141,8 +141,11 @@ where
 /// | evaluation | `h(0)` | `h(inf)` | `h(1) = C - h(0)`   |
 /// | projective | `s(1)` | `s(inf)` | `s(0) = C - s(inf)` |
 ///
-/// Named fields keep the two bases' different finite points from being
-/// swapped silently at dispatch sites.
+/// The struct itself is basis-agnostic: `c_a` has the same name and type in
+/// both rows, so it carries no evidence of which kernel produced it. What
+/// keeps the rows from being crossed is that a message is only ever produced
+/// by [`Basis::sumcheck_coefficients`] and only ever consumed by
+/// [`Basis::reduce_claim`], each under the same tag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RoundMessage<A> {
     /// The finite-point value: `h(0)` (evaluation basis) or `s(1)` (projective).
@@ -372,6 +375,101 @@ where
 
     let (c_a, c_inf) = round_reduce(main, tail);
     RoundMessage { c_a, c_inf }
+}
+
+/// How the sumcheck tables are interpreted, and with it the round arithmetic.
+///
+/// The table bytes are identical in both bases; the tag selects which
+/// polynomial those bytes describe, and one round arithmetic follows from
+/// each choice (eprint 2026/762, Section 3):
+///
+/// | per round                  | [`Basis::Evaluation`]              | [`Basis::Projective`]                           |
+/// |----------------------------|------------------------------------|-------------------------------------------------|
+/// | a table entry is           | a value on the hypercube `{0,1}^n` | a monomial coefficient (a value on `{0,inf}^n`) |
+/// | binding `X = r`            | `a0 + (a1 - a0) * r`               | `a0 + a1 * r`                                   |
+/// | message sent               | `[h(0), h(inf)]`                   | `[s(1), s(inf)]`                                |
+/// | value the verifier derives | `h(1) := C - h(0)`                 | `s(0) := C - s(inf)`                            |
+///
+/// The rows are one package per column: a consumer must take an entire
+/// column, never a mix. That is what the tag buys. A [`RoundMessage`] alone
+/// cannot say which column produced it, so the two values only ever leave or
+/// re-enter the transcript through the basis that defines them.
+///
+/// The claim invariant `C = dot(evals, weights)` is the same in both bases:
+/// the `{0,1}`-sum of products in the evaluation basis and the `{0,inf}`-sum
+/// in the projective basis are both the dot product of the two tables, so
+/// the running-sum bookkeeping does not change. Like [`VariableOrder`], the
+/// tag is consulted once per round in the outer frame, never inside the
+/// O(2^n) inner loops.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Basis {
+    /// The tables hold values over the boolean hypercube `{0,1}^n`; rounds
+    /// sum over `{0,1}` and bind by linear interpolation. The default.
+    #[default]
+    Evaluation,
+    /// The tables hold monomial coefficients, equivalently values over
+    /// `{0,inf}^n`; rounds sum over `{0,inf}` and bind subtraction-free
+    /// (eprint 2026/762).
+    ///
+    /// Prefix order only: the projective kernels are implemented for
+    /// prefix-bound variables (WHIR's path).
+    Projective,
+}
+
+impl Basis {
+    /// Computes the two-element round message for one quadratic sumcheck round.
+    ///
+    /// - [`Basis::Evaluation`]: `[h(0), h(inf)]`, dispatching on `order`.
+    /// - [`Basis::Projective`]: `[s(1), s(inf)]` (prefix only); the verifier
+    ///   derives `s(0) := C - s(inf)` from the projective round identity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding.
+    pub fn sumcheck_coefficients<B, A>(
+        self,
+        order: VariableOrder,
+        evals: &[B],
+        weights: &[A],
+    ) -> RoundMessage<A>
+    where
+        B: PrimeCharacteristicRing + Copy + Send + Sync,
+        A: Algebra<B> + Copy + Send + Sync,
+    {
+        match self {
+            Self::Evaluation => order.sumcheck_coefficients(evals, weights),
+            Self::Projective => {
+                assert_eq!(
+                    order,
+                    VariableOrder::Prefix,
+                    "the projective basis is prefix-only"
+                );
+                sumcheck_coefficients_prefix_projective(evals, weights)
+            }
+        }
+    }
+
+    /// Reduces the running claim to the round polynomial at `r`, from the two
+    /// sent message elements.
+    ///
+    /// One source of truth for the round identity, shared by the prover and
+    /// the verifier:
+    ///
+    /// - [`Basis::Evaluation`]: message `[h(0), h(inf)]`; the identity
+    ///   `h(0) + h(1) = C` supplies `h(1) = C - h(0)`.
+    /// - [`Basis::Projective`]: message `[s(1), s(inf)]`; the identity
+    ///   `s(0) + s(inf) = C` supplies `s(0) = C - s(inf)`
+    ///   (eprint 2026/762, Fig. 3).
+    ///
+    /// Both reconstruct the quadratic through `{0, 1, inf}` and evaluate it
+    /// at `r`. Pairing a message with the wrong basis reduces to the wrong
+    /// claim, so this is the only place either identity is written down.
+    pub fn reduce_claim<EF: Field>(self, c_a: EF, c_inf: EF, r: EF, claimed_sum: EF) -> EF {
+        match self {
+            Self::Evaluation => extrapolate_01inf(c_a, claimed_sum - c_a, c_inf, r),
+            Self::Projective => extrapolate_01inf(claimed_sum - c_inf, c_a, c_inf, r),
+        }
+    }
 }
 
 /// Which side of the variable order is bound first by the sumcheck rounds.
@@ -653,7 +751,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::{RoundMessage, VariableOrder};
+    use super::{Basis, RoundMessage, VariableOrder};
     use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
     use crate::constraints::{Constraint, Statements};
 
@@ -851,6 +949,9 @@ mod tests {
             let s0 = claim - s_inf;
             let s_at_r = s0 + (s1 - s0 - s_inf) * r + s_inf * r.square();
 
+            // The shipped reduction must agree with the identity written out above.
+            prop_assert_eq!(Basis::Projective.reduce_claim(s1, s_inf, r, claim), s_at_r);
+
             // Prover side: bind the round variable at r in the monomial basis.
             let (mut bound_evals, mut bound_weights) = (Poly::new(evals), Poly::new(weights));
             bound_evals.fix_prefix_var_mut_monomial(r);
@@ -864,5 +965,38 @@ mod tests {
                 )
             );
         }
+
+        // A `RoundMessage` carries no evidence of its basis, so the tag is the
+        // only thing keeping the two round identities apart. Pin that they are
+        // genuinely different reductions: reading a projective message with the
+        // evaluation identity (or the reverse) lands on another claim entirely,
+        // which is why production only ever pairs the two through `Basis`.
+        #[test]
+        fn prop_the_two_round_identities_disagree_on_the_same_message(
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let (c_a, c_inf, r, claim): (EF, EF, EF, EF) =
+                (rng.random(), rng.random(), rng.random(), rng.random());
+
+            // Both reductions are quadratics through {0, 1, inf}; they differ
+            // in which of the three values the round identity supplies.
+            prop_assume!(c_a + c_inf != claim);
+
+            prop_assert_ne!(
+                Basis::Evaluation.reduce_claim(c_a, c_inf, r, claim),
+                Basis::Projective.reduce_claim(c_a, c_inf, r, claim),
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "the projective basis is prefix-only")]
+    fn projective_basis_rejects_suffix_binding() {
+        // The projective kernels are prefix-only; pairing them with suffix
+        // binding would silently run prefix math on suffix-laid-out data.
+        let evals = [EF::ONE; 4];
+        let weights = [EF::ONE; 4];
+        let _ = Basis::Projective.sumcheck_coefficients(VariableOrder::Suffix, &evals, &weights);
     }
 }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -130,6 +130,27 @@ where
     (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
 }
 
+/// The two prover-sent values of a quadratic sumcheck round.
+///
+/// The round polynomial has three unknowns; the verifier recovers the third
+/// from the running claim `C`, so only two values cross the transcript. Which
+/// finite point is sent differs by basis:
+///
+/// | basis      | `c_a`  | `c_inf`  | derived             |
+/// |------------|--------|----------|---------------------|
+/// | evaluation | `h(0)` | `h(inf)` | `h(1) = C - h(0)`   |
+/// | projective | `s(1)` | `s(inf)` | `s(0) = C - s(inf)` |
+///
+/// Named fields keep the two bases' different finite points from being
+/// swapped silently at dispatch sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoundMessage<A> {
+    /// The finite-point value: `h(0)` (evaluation basis) or `s(1)` (projective).
+    pub c_a: A,
+    /// The leading coefficient of the round polynomial: `h(inf)` / `s(inf)`.
+    pub c_inf: A,
+}
+
 /// Shared prefix round-coefficient scaffold, parameterised over the basis steps.
 ///
 /// The tiling, `PAR_THRESHOLD` par-vs-serial split, and `K`-tail fold are
@@ -216,7 +237,7 @@ where
     round_reduce(main, tail)
 }
 
-/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+/// Computes the round message for a prefix-binding sumcheck round.
 ///
 /// # Inputs
 ///
@@ -225,20 +246,26 @@ where
 ///
 /// # Returns
 ///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
-/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
+/// - `c_a` = `h(0)`     = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
+/// - `c_inf` = `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
 ///
 /// # Complexity
 ///
 /// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
 /// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
 /// streaming fold.
-pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    sumcheck_coefficients_prefix_with(evals, weights, chunk_round_step::<B, A>, round_step::<B, A>)
+    let (c_a, c_inf) = sumcheck_coefficients_prefix_with(
+        evals,
+        weights,
+        chunk_round_step::<B, A>,
+        round_step::<B, A>,
+    );
+    RoundMessage { c_a, c_inf }
 }
 
 /// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
@@ -248,25 +275,26 @@ where
 /// `[s(1), s(inf)]`; the verifier derives `s(0) := C - s(inf)` from the
 /// projective round identity `s(0) + s(inf) = C`. Returned as:
 ///
-/// - `s(1)`   = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
-/// - `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
+/// - `c_a` = `s(1)`     = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
+/// - `c_inf` = `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
 ///
 /// The evaluation-basis kernel's per-pair subtractions (`hi - lo`) become
 /// additions (`lo + hi`); same `K`-tiled, delayed-reduction structure.
-pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    sumcheck_coefficients_prefix_with(
+    let (c_a, c_inf) = sumcheck_coefficients_prefix_with(
         evals,
         weights,
         chunk_round_step_projective::<B, A>,
         round_step_projective::<B, A>,
-    )
+    );
+    RoundMessage { c_a, c_inf }
 }
 
-/// Computes `(h(0), h(inf))` for a suffix-binding sumcheck round.
+/// Computes the round message for a suffix-binding sumcheck round.
 ///
 /// # Inputs
 ///
@@ -275,8 +303,8 @@ where
 ///
 /// # Returns
 ///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(b, 0) * w(b, 0)
-/// - `h(inf)` = sum_{b} (f(b, 1) - f(b, 0)) * (w(b, 1) - w(b, 0))
+/// - `c_a` = `h(0)`     = sum_{b in {0,1}^{n-1}} f(b, 0) * w(b, 0)
+/// - `c_inf` = `h(inf)` = sum_{b} (f(b, 1) - f(b, 0)) * (w(b, 1) - w(b, 0))
 ///
 /// # Complexity
 ///
@@ -284,7 +312,7 @@ where
 /// buffer in `2K`-wide chunks: each chunk gathers `K` adjacent
 /// `(b_n=0, b_n=1)` pairs and dispatches to a delayed-reduction dot
 /// product.
-pub fn sumcheck_coefficients_suffix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_suffix<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
@@ -342,7 +370,8 @@ where
             round_step(acc, e[0], e[1], w[0], w[1])
         });
 
-    round_reduce(main, tail)
+    let (c_a, c_inf) = round_reduce(main, tail);
+    RoundMessage { c_a, c_inf }
 }
 
 /// Which side of the variable order is bound first by the sumcheck rounds.
@@ -364,8 +393,8 @@ pub enum VariableOrder {
 }
 
 impl VariableOrder {
-    /// Computes `(h(0), h(inf))` for one quadratic sumcheck round.
-    pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> (A, A)
+    /// Computes the [`RoundMessage`] for one quadratic sumcheck round.
+    pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> RoundMessage<A>
     where
         B: PrimeCharacteristicRing + Copy + Send + Sync,
         A: Algebra<B> + Copy + Send + Sync,
@@ -624,7 +653,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::VariableOrder;
+    use super::{RoundMessage, VariableOrder};
     use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
     use crate::constraints::{Constraint, Statements};
 
@@ -780,7 +809,8 @@ mod tests {
             let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
             let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
 
-            let (h1, h_inf) = super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+            let RoundMessage { c_a: h1, c_inf: h_inf } =
+                super::sumcheck_coefficients_prefix_projective(&evals, &weights);
 
             let half = n / 2;
             // s(1): the X = 1 evaluation of each coefficient pair is lo + hi.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -645,8 +645,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::{PrimeCharacteristicRing, dot_product};
     use p3_multilinear_util::point::Point;
     use p3_multilinear_util::poly::Poly;
     use proptest::prelude::*;
@@ -822,6 +822,47 @@ mod tests {
 
             prop_assert_eq!(h1, h1_ref);
             prop_assert_eq!(h_inf, h_inf_ref);
+        }
+
+        // The projective round identity, both protocol sides together: derive
+        // s(0) := C - s(inf) as the verifier does, evaluate the quadratic at
+        // the challenge, and compare against the dot product of the tables
+        // bound in the monomial basis. Unlike the reference check above, this
+        // fails if the sent message did not determine the round polynomial
+        // (e.g. the insufficient [s(0), s(inf)] message passes the reference
+        // check but not this one).
+        #[test]
+        fn prop_projective_round_message_satisfies_round_identity(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = 1usize << k;
+            let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let r: EF = rng.random();
+
+            let claim: EF = dot_product(evals.iter().copied(), weights.iter().copied());
+            let RoundMessage { c_a: s1, c_inf: s_inf } =
+                super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+
+            // Verifier side: s(0) is derived, never sent. The quadratic is
+            // s(X) = s(0) + (s(1) - s(0) - s(inf)) * X + s(inf) * X^2.
+            let s0 = claim - s_inf;
+            let s_at_r = s0 + (s1 - s0 - s_inf) * r + s_inf * r.square();
+
+            // Prover side: bind the round variable at r in the monomial basis.
+            let (mut bound_evals, mut bound_weights) = (Poly::new(evals), Poly::new(weights));
+            bound_evals.fix_prefix_var_mut_monomial(r);
+            bound_weights.fix_prefix_var_mut_monomial(r);
+
+            prop_assert_eq!(
+                s_at_r,
+                dot_product(
+                    bound_evals.as_slice().iter().copied(),
+                    bound_weights.as_slice().iter().copied(),
+                )
+            );
         }
     }
 }

--- a/sumcheck/src/svo/accumulator.rs
+++ b/sumcheck/src/svo/accumulator.rs
@@ -427,11 +427,11 @@ mod test {
                 let cinf =
                     dot_product::<EF, _, _>(acc_inf.iter().copied(), weights.iter().copied());
 
-                let (c0_ref, cinf_ref) =
+                let msg =
                     VariableOrder::Suffix.sumcheck_coefficients(poly.as_slice(), eq.as_slice());
 
-                assert_eq!(c0, c0_ref);
-                assert_eq!(cinf, cinf_ref);
+                assert_eq!(c0, msg.c_a);
+                assert_eq!(cinf, msg.c_inf);
 
                 let r: EF = rng.random();
                 poly.fix_suffix_var_mut(r);
@@ -489,11 +489,11 @@ mod test {
                 let cinf =
                     dot_product::<EF, _, _>(acc_inf.iter().copied(), weights.iter().copied());
 
-                let (c0_ref, cinf_ref) =
+                let msg =
                     VariableOrder::Prefix.sumcheck_coefficients(poly.as_slice(), eq.as_slice());
 
-                assert_eq!(c0, c0_ref);
-                assert_eq!(cinf, cinf_ref);
+                assert_eq!(c0, msg.c_a);
+                assert_eq!(cinf, msg.c_inf);
 
                 let r: EF = rng.random();
                 poly.fix_prefix_var_mut(r);

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -15,7 +15,7 @@ use rand::rngs::SmallRng;
 use crate::constraints::statement::{EqStatement, SelectStatement};
 use crate::constraints::{Constraint, Statements};
 use crate::layout::{Layout, PrefixProver, SuffixProver, TableShape, Verifier};
-use crate::strategy::VariableOrder;
+use crate::strategy::{Basis, VariableOrder};
 use crate::test_util::{stacked_num_variables, table_point_schedule, table_specs_to_tables};
 use crate::{
     OpeningBatch, OpeningEvals, OpeningProtocol, SumcheckData, SumcheckError, TableSpec,
@@ -348,7 +348,13 @@ where
 
         verifier_randomness.extend(
             &proof[0]
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -367,7 +373,13 @@ where
 
         verifier_randomness.extend(
             &proof[round]
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -377,7 +389,13 @@ where
         &proof
             .last()
             .unwrap()
-            .verify_rounds(&mut verifier_challenger, &mut sum, num_variables_inter, 0)
+            .verify_rounds(
+                &mut verifier_challenger,
+                &mut sum,
+                num_variables_inter,
+                0,
+                Basis::Evaluation,
+            )
             .unwrap(),
     );
 
@@ -437,8 +455,15 @@ fn test_zero_rounds_returns_empty_point() {
     // Case 1: no data.
     let mut chal = challenger();
     let mut sum = EF::ZERO;
-    let point = verify_final_sumcheck_rounds::<F, EF, _>(None, &mut chal, &mut sum, 0, 0)
-        .expect("0 rounds + None must succeed");
+    let point = verify_final_sumcheck_rounds::<F, EF, _>(
+        None,
+        &mut chal,
+        &mut sum,
+        0,
+        0,
+        Basis::Evaluation,
+    )
+    .expect("0 rounds + None must succeed");
     assert!(point.as_slice().is_empty());
 
     // Case 2: data supplied but ignored.
@@ -448,8 +473,9 @@ fn test_zero_rounds_returns_empty_point() {
     };
     let mut chal = challenger();
     let mut sum = EF::ZERO;
-    let point = verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, 0, 0)
-        .expect("0 rounds + Some must succeed");
+    let point =
+        verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, 0, 0, Basis::Evaluation)
+            .expect("0 rounds + Some must succeed");
     assert!(point.as_slice().is_empty());
 }
 
@@ -460,8 +486,15 @@ fn test_missing_sumcheck_data() {
     let mut sum = EF::ZERO;
     let rounds = 3;
 
-    let err = verify_final_sumcheck_rounds::<F, EF, _>(None, &mut chal, &mut sum, rounds, 0)
-        .expect_err("None + rounds > 0 must error");
+    let err = verify_final_sumcheck_rounds::<F, EF, _>(
+        None,
+        &mut chal,
+        &mut sum,
+        rounds,
+        0,
+        Basis::Evaluation,
+    )
+    .expect_err("None + rounds > 0 must error");
 
     match err {
         // Inner field must echo the requested round count.
@@ -487,8 +520,15 @@ fn test_round_count_mismatch() {
         pow_witnesses: vec![],
     };
 
-    let err = verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, expected_rounds, 0)
-        .expect_err("length mismatch must error");
+    let err = verify_final_sumcheck_rounds(
+        Some(&data),
+        &mut chal,
+        &mut sum,
+        expected_rounds,
+        0,
+        Basis::Evaluation,
+    )
+    .expect_err("length mismatch must error");
 
     match err {
         SumcheckError::RoundCountMismatch { expected, actual } => {
@@ -515,7 +555,7 @@ fn test_verify_rounds_rejects_wrong_round_count() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, expected_rounds, 0)
+        .verify_rounds(&mut chal, &mut sum, expected_rounds, 0, Basis::Evaluation)
         .expect_err("wrong round count must error");
 
     match err {
@@ -540,7 +580,7 @@ fn test_pow_witness_count_mismatch() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, expected, 20)
+        .verify_rounds(&mut chal, &mut sum, expected, 20, Basis::Evaluation)
         .expect_err("witness-count mismatch must error before indexing");
 
     match err {
@@ -569,7 +609,13 @@ fn test_invalid_pow_witness() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, data.num_rounds(), pow_bits)
+        .verify_rounds(
+            &mut chal,
+            &mut sum,
+            data.num_rounds(),
+            pow_bits,
+            Basis::Evaluation,
+        )
         .expect_err("zeroed witness must fail");
 
     assert!(matches!(err, SumcheckError::InvalidPowWitness));

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -244,9 +244,10 @@ fn bench_round_coefficients(c: &mut Criterion) {
         &n,
         |b, _| {
             b.iter(|| {
-                let (c0, c_inf) =
-                    sumcheck_coefficients_prefix(black_box(&evals), black_box(&weights));
-                black_box((c0, c_inf))
+                black_box(sumcheck_coefficients_prefix(
+                    black_box(&evals),
+                    black_box(&weights),
+                ))
             });
         },
     );

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -12,7 +12,7 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::constraints::statement::SelectStatement;
 use p3_sumcheck::constraints::{Constraint, Statements};
-use p3_sumcheck::strategy::VariableOrder;
+use p3_sumcheck::strategy::{Basis, VariableOrder};
 use p3_sumcheck::verify_final_sumcheck_rounds;
 use tracing::instrument;
 
@@ -123,6 +123,7 @@ where
             &mut claimed_eval,
             self.round_folding_factor(0),
             self.starting_folding_pow_bits,
+            Basis::Evaluation,
         )?;
         round_folding_randomness.push(folding_randomness);
 
@@ -176,6 +177,7 @@ where
                 &mut claimed_eval,
                 self.round_folding_factor(round_index + 1),
                 round_params.folding_pow_bits,
+                Basis::Evaluation,
             )?;
             round_folding_randomness.push(folding_randomness);
 
@@ -227,6 +229,7 @@ where
             &mut claimed_eval,
             self.final_sumcheck_rounds,
             self.final_folding_pow_bits,
+            Basis::Evaluation,
         )?;
         round_folding_randomness.push(final_sumcheck_randomness.clone());
 


### PR DESCRIPTION
Closes part of #1890.

> **Edit (2026-06-26):** reworked per @tcoratger's review (thanks for the careful read). Tightened the PR to the two subtraction-free kernels and dropped everything the kernels do not yet need:
> - Removed the `Basis { Eval, Projective }` dispatch on `ProductPolynomial`; nothing routes to the projective kernels yet, so there is no second basis to keep alive. `ProductPolynomial` is back to upstream verbatim.
> - Removed the full sum-check prover bench. As flagged in review, `ProductPolynomial::round()` never read `self.basis`, so that bench timed eval coefficients + projective binding + eval reduction, not a coherent projective prover. The ~5-6% "end-to-end" row is retracted.
> - Removed `tests/projective_equivalence.rs`. It re-implemented the protocol and checked itself, so it would pass even with the production kernel deleted. The end-to-end equivalence/soundness checks move to the §4.3 follow-up where the protocol actually runs in the projective basis.
> - The binding unit test is now a proptest.
> - The projective and eval round-coefficient kernels now share one tiling scaffold (`sumcheck_coefficients_prefix_with`) instead of duplicating it. This is its own behaviour-preserving `refactor` commit, so the one change to the eval path is isolated and reviewable on its own.
>
> What lands here is the two kernels, each proptested against an independent reference, plus the round-coefficient bench. Fresh single-threaded numbers below. History was rewritten (5 commits -> 4), so the diff reflects the tightened scope directly.

## What

Adds the two subtraction-free prover kernels from "The Sum-Check Protocol over the Monomial Basis" (eprint 2026/762). Running sum-check with the interpolating set `{0, inf}^n` instead of `{0, 1}^n` makes both per-round operations subtraction-free:

- **Binding** (`multilinear-util`): `a0 += (a1 - a0) * r` becomes `a0 += a1 * r` (`Poly::fix_prefix_var_mut_projective`).
-  **Round coefficients** (`sumcheck`): the monomial-basis round message is `[s(1), s(inf)]` with `s(1) = dot(lo+hi, lo+hi)` and `s(inf) = dot(hi, hi)`; the verifier derives `s(0)` from the projective round identity `s(0) + s(inf) = C` (eprint 2026/762, Fig. 3). Both bases share one `K`-tiled delayed-reduction scaffold (`sumcheck_coefficients_prefix_with`), parameterised over the per-tile and per-pair MAC.


This PR adds the kernels and their tests/bench. Nothing dispatches to the projective kernels yet, so the default prover and WHIR are unchanged in behaviour. The one change to the existing path is the scaffold extraction in the `refactor` commit, which is behaviour-preserving (output identical, full sumcheck suite green) and isolated for review. The wiring that makes the kernels load-bearing (threading the projective representation through the prover and the WHIR commitment, the paper's §4.3 alignment) is the follow-up below.

## Scope

In:
- Projective binding + round-coefficient kernels, prover-internal, **prefix order only** (WHIR's path).
- A proptest per kernel against an independent reference, and a before/after bench on the round-coefficient kernel.

Not in (deliberately):
- No dispatch, no `ProductPolynomial` change, no verifier/transcript/proof-format change. The kernels are added alongside the existing ones; the default path's behaviour does not move (the eval kernel is refactored to share the scaffold, output identical).
- Suffix-order projective kernels.
- The end-to-end change that runs the prover in one representation throughout and aligns the WHIR commitment basis (§4.3). That is where these kernels become live, and it is a separate follow-up.

## Correctness

Each kernel is proptested against an independent reference over random instances:

- **Binding** (`multilinear-util`): `fix_prefix_var_mut_projective` applied across every variable evaluates the monomial polynomial `sum_S a_S * prod_{i in S} z_i` at a random point, for random variable counts.
- **Round coefficients** (`sumcheck`): `sumcheck_coefficients_prefix_projective` matches a direct reference computation of `(h(0), h(inf))` over random tables and weights.

Why the basis change is sound, for context (not exercised by this PR, which ships only the kernels): by Proposition 3.1 the projective `{0, inf}`-sum and the standard `{0, 1}`-sum are the same dot product of the same table, so the value being proved is unchanged; Theorem 3.3 keeps the round-by-round soundness error at `d/|F|`. The end-to-end equivalence and soundness checks belong with the §4.3 follow-up, where the full protocol actually runs in the projective basis.

## Numbers

Apple M3 Pro MacBook Pro (12-core, `aarch64-apple-darwin`), `cargo bench`, **single-threaded**, `-Ctarget-cpu=native`. Single-threaded matches the paper's methodology (§6.1: gains are reported for a single performance core).

Reproduce (requires Rust >= 1.93; leave the `parallel` feature off; the filter catches both the eval and `_projective` variants):

```bash
RUSTFLAGS="-Ctarget-cpu=native" cargo +1.93.0 bench -p p3-sumcheck --bench sumcheck \
  -- "round_coefficients/ext_ext_packed_prefix" --warm-up-time 5 --measurement-time 10
```

### Round-coefficient kernel (`p3-sumcheck`, packed extension, prefix)

The complete projective message spends an addition pass where the evaluation kernel spends a subtraction pass, so parity is the expected and measured outcome (speedup = eval / projective):

| Size | BabyBear | KoalaBear |
|---|---|---|
| k16 | 0.99x | 0.98x |
| k18 | 0.98x | 0.98x |
| k20 | 0.99x | 0.99x |
| k22 | 0.98x | 0.99x |

The subtraction-free **binding** kernel is where the per-round win lives; it is measured standalone in the follow-up PR (a consistent ~1.13x).

## Honest caveats

- **Single-threaded only.** The kernel is memory-bandwidth-bound once parallelised, where the subtraction saving largely hides. This matches the paper, which also reports single-threaded gains and leaves multi-threaded to future work.
- **Kernel parity is the expected outcome on any field.** The complete projective message spends an addition pass where the evaluation kernel spends a subtraction pass. The basis' real per-round saving is the subtraction-free binding, measured standalone in the follow-up PR (#1949) at a consistent ~1.13x.

## Follow-up

These kernels are the prover-side primitives. The change that makes them load-bearing runs the whole prover in the projective basis and aligns the WHIR commitment basis (§4.3), so the prover holds one representation throughout instead of converting. That is where end-to-end equivalence and soundness get exercised and where the full-prover win shows up. Landing the kernels first keeps that change small and reviewable. Happy to keep this as a draft until that lands if you would rather review them together.

## Test plan

- [x] `cargo test -p p3-sumcheck`: full suite passes (round-coefficient kernel proptest included)
- [x] `cargo test -p p3-multilinear-util`: passes (binding kernel evaluates the monomial polynomial)
- [x] `cargo check -p p3-whir`: no change (kernels are not yet wired in)
- [x] `cargo clippy -p p3-sumcheck -p p3-multilinear-util --all-targets`: clean
- [x] `cargo fmt --all --check`: clean