### PR TITLE
perf(multi-stark) apply Gruen section 3.2 optimization

### DIFF
--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -5,13 +5,14 @@
 use alloc::vec::Vec;
 
 use p3_air::Air;
-use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
+use p3_field::{
+    ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing, dot_product,
+};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
-use p3_sumcheck::generic_degree::RoundProver;
 
 use crate::folder::MultilinearFolder;
 use crate::selectors::BoundaryEvals;
@@ -27,8 +28,8 @@ pub(crate) struct RoundStateBase<'a, A, F, EF> {
     public_values: &'a [F],
     /// Random scalar batching the AIR constraints.
     alpha: EF,
-    /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
-    eq: Poly<EF>,
+    /// Equality weight over the current round's suffix variables.
+    eq_suffix: Poly<EF>,
     /// Main trace columns, stored as a row-major matrix with one original column per row.
     columns: RowMajorMatrix<F>,
     /// Per-round sumcheck degree.
@@ -36,9 +37,6 @@ pub(crate) struct RoundStateBase<'a, A, F, EF> {
 }
 
 /// Extension-field sumcheck state after the first base-field round.
-///
-/// Owns the folded trace columns, equality weights, boundary selectors, and repeat-last next-row
-/// tail values needed by the remaining rounds.
 pub(crate) struct RoundStateExt<'a, A, F, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
@@ -46,8 +44,8 @@ pub(crate) struct RoundStateExt<'a, A, F, EF> {
     public_values: &'a [F],
     /// Random scalar batching the AIR constraints.
     alpha: EF,
-    /// Zerocheck weight `eq(tau, x)` over the remaining hypercube.
-    eq: Poly<EF>,
+    /// Equality weight over the current round's suffix variables.
+    eq_suffix: Poly<EF>,
     /// Folded boundary-selector values at the current sumcheck prefix.
     boundary: BoundaryEvals<EF>,
     /// Main trace columns after the first base-field fold.
@@ -82,8 +80,34 @@ struct PackedScratch<P, EF> {
     local_diff: Vec<P>,
     next_point: Vec<P>,
     next_diff: Vec<P>,
-    eq_value: Vec<EF>,
-    eq_diff: Vec<EF>,
+}
+
+impl<EF: PrimeCharacteristicRing> ExtScratch<EF> {
+    fn new(degree: usize, width: usize) -> Self {
+        Self {
+            out: EF::zero_vec(degree),
+            local_point: EF::zero_vec(width),
+            local_diff: EF::zero_vec(width),
+            next_point: EF::zero_vec(width),
+            next_diff: EF::zero_vec(width),
+        }
+    }
+}
+
+impl<P, EF> PackedScratch<P, EF>
+where
+    P: PrimeCharacteristicRing,
+    EF: PrimeCharacteristicRing,
+{
+    fn new(degree: usize, width: usize) -> Self {
+        Self {
+            out: EF::zero_vec(degree),
+            local_point: P::zero_vec(width),
+            local_diff: P::zero_vec(width),
+            next_point: P::zero_vec(width),
+            next_diff: P::zero_vec(width),
+        }
+    }
 }
 
 impl<'a, A, F, EF> RoundStateBase<'a, A, F, EF>
@@ -107,14 +131,14 @@ where
             air,
             public_values,
             alpha,
-            eq: Poly::new_from_point(tau.as_slice(), EF::ONE),
+            eq_suffix: Poly::new_from_point(&tau.as_slice()[1..], EF::ONE),
             columns,
             degree,
         }
     }
 
     const fn num_evals(&self) -> usize {
-        self.eq.num_evals()
+        self.eq_suffix.num_evals() * 2
     }
 
     fn width(&self) -> usize {
@@ -151,19 +175,13 @@ where
         let alpha = EF::ExtensionPacking::from(self.alpha);
         assert_ne!(packed_half, 0);
 
-        (0..packed_half)
-            .into_par_iter()
+        self.eq_suffix
+            .as_slice()
+            .par_chunks_exact(packing_width)
+            .enumerate()
             .par_fold_reduce(
-                || PackedScratch {
-                    out: EF::zero_vec(degree),
-                    local_point: F::Packing::zero_vec(width),
-                    local_diff: F::Packing::zero_vec(width),
-                    next_point: F::Packing::zero_vec(width),
-                    next_diff: F::Packing::zero_vec(width),
-                    eq_value: EF::zero_vec(packing_width),
-                    eq_diff: EF::zero_vec(packing_width),
-                },
-                |mut scratch, packed_s| {
+                || PackedScratch::new(degree, width),
+                |mut scratch, (packed_s, eq_suffix)| {
                     let s = packed_s * packing_width;
 
                     for ((((local, local_delta), next), next_delta), column) in scratch
@@ -202,28 +220,8 @@ where
                         *next_delta = next_hi - next_lo;
                     }
 
-                    for lane in 0..packing_width {
-                        let lo = self.eq.as_slice()[s + lane];
-                        scratch.eq_value[lane] = lo;
-                        scratch.eq_diff[lane] = self.eq.as_slice()[s + scalar_half + lane] - lo;
-                    }
-
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::<F::Packing>::row_pair_packed(s, scalar_half, height);
-
-                    let g = MultilinearFolder::new(
-                        &scratch.local_point,
-                        &scratch.next_point,
-                        boundary,
-                        self.public_values,
-                        alpha,
-                    )
-                    .eval_air(self.air);
-
-                    scratch.out[0] += EF::ExtensionPacking::to_ext_iter([g])
-                        .zip(&scratch.eq_value)
-                        .map(|(g, &eq)| eq * g)
-                        .sum::<EF>();
 
                     scratch
                         .local_point
@@ -235,14 +233,9 @@ where
                             *local += *local_diff;
                             *next += *next_diff;
                         });
-                    scratch
-                        .eq_value
-                        .iter_mut()
-                        .zip(scratch.eq_diff.iter())
-                        .for_each(|(value, diff)| *value += *diff);
                     boundary += boundary_diff;
 
-                    for node in 1..degree {
+                    for acc in &mut scratch.out[1..] {
                         scratch
                             .local_point
                             .iter_mut()
@@ -253,11 +246,6 @@ where
                                 *local += *local_diff;
                                 *next += *next_diff;
                             });
-                        scratch
-                            .eq_value
-                            .iter_mut()
-                            .zip(scratch.eq_diff.iter())
-                            .for_each(|(value, diff)| *value += *diff);
                         boundary += boundary_diff;
 
                         let g = MultilinearFolder::new(
@@ -268,10 +256,10 @@ where
                             alpha,
                         )
                         .eval_air(self.air);
-                        scratch.out[node] += EF::ExtensionPacking::to_ext_iter([g])
-                            .zip(&scratch.eq_value)
-                            .map(|(g, &eq)| eq * g)
-                            .sum::<EF>();
+                        *acc += dot_product::<EF, _, _>(
+                            eq_suffix.iter().copied(),
+                            EF::ExtensionPacking::to_ext_iter([g]),
+                        );
                     }
 
                     scratch
@@ -302,7 +290,7 @@ where
         let mut next_point = F::zero_vec(width);
         let mut next_diff = F::zero_vec(width);
 
-        for s in 0..half {
+        for (s, &eq_suffix) in self.eq_suffix.as_slice().iter().enumerate() {
             local_point
                 .iter_mut()
                 .zip(local_diff.iter_mut())
@@ -327,29 +315,14 @@ where
 
             let (mut boundary, boundary_diff) = BoundaryEvals::<F>::row_pair(s, half, height);
 
-            let mut eq_value = self.eq.as_slice()[s];
-            let eq_diff = self.eq.as_slice()[s + half] - eq_value;
-
-            let g = MultilinearFolder::new(
-                &local_point,
-                &next_point,
-                boundary,
-                self.public_values,
-                self.alpha,
-            )
-            .eval_air(self.air);
-            out[0] += eq_value * g;
-
             F::add_slices(&mut local_point, &local_diff);
             F::add_slices(&mut next_point, &next_diff);
             boundary += boundary_diff;
-            eq_value += eq_diff;
 
             for acc in &mut out[1..] {
                 F::add_slices(&mut local_point, &local_diff);
                 F::add_slices(&mut next_point, &next_diff);
                 boundary += boundary_diff;
-                eq_value += eq_diff;
 
                 let g = MultilinearFolder::new(
                     &local_point,
@@ -359,7 +332,7 @@ where
                     self.alpha,
                 )
                 .eval_air(self.air);
-                *acc += eq_value * g;
+                *acc += eq_suffix * g;
             }
         }
 
@@ -367,8 +340,8 @@ where
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn fold(mut self, r: EF) -> RoundStateExt<'a, A, F, EF> {
-        let num_evals = self.eq.num_evals();
+    pub(crate) fn fold(self, r: EF) -> RoundStateExt<'a, A, F, EF> {
+        let num_evals = self.num_evals();
         let half = num_evals / 2;
         let next_tail = self
             .columns
@@ -376,7 +349,8 @@ where
             .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half]))
             .collect::<Vec<_>>();
 
-        self.eq.fix_prefix_var_mut(r);
+        let mut eq_suffix = self.eq_suffix;
+        eq_suffix.sum_prefix_var_mut();
 
         let columns = self
             .columns
@@ -388,27 +362,12 @@ where
             air: self.air,
             public_values: self.public_values,
             alpha: self.alpha,
-            eq: self.eq,
+            eq_suffix,
             degree: self.degree,
             columns,
             next_tail,
             boundary: BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
         }
-    }
-}
-
-impl<'a, A, F, EF> RoundProver<EF> for RoundStateExt<'a, A, F, EF>
-where
-    A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
-    F: Field,
-    EF: ExtensionField<F>,
-{
-    fn round_poly(&self) -> Vec<EF> {
-        RoundStateExt::round_poly(self)
-    }
-
-    fn fold(&mut self, r: EF) {
-        RoundStateExt::fold(self, r);
     }
 }
 
@@ -418,7 +377,7 @@ where
     EF: ExtensionField<F>,
 {
     const fn num_evals(&self) -> usize {
-        self.eq.num_evals()
+        self.eq_suffix.num_evals() * 2
     }
 
     const fn width(&self) -> usize {
@@ -443,20 +402,14 @@ where
         let num_evals = self.num_evals();
         let half = num_evals / 2;
         let degree = self.degree;
-        let (eq_lo, eq_hi) = self.eq.as_slice().split_at(half);
 
-        (0..half)
-            .into_par_iter()
-            .zip(eq_lo.par_iter().zip(eq_hi.par_iter()))
+        self.eq_suffix
+            .as_slice()
+            .par_iter()
+            .enumerate()
             .par_fold_reduce(
-                || ExtScratch {
-                    out: EF::zero_vec(degree),
-                    local_point: EF::zero_vec(width),
-                    local_diff: EF::zero_vec(width),
-                    next_point: EF::zero_vec(width),
-                    next_diff: EF::zero_vec(width),
-                },
-                |mut scratch, (s, (&eq_lo_value, &eq_hi_value))| {
+                || ExtScratch::new(degree, width),
+                |mut scratch, (s, &eq_suffix)| {
                     for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
                         .local_point
                         .iter_mut()
@@ -486,9 +439,6 @@ where
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::row_pair_with_prefix(s, half, num_evals, self.boundary);
 
-                    let mut eq_value = eq_lo_value;
-                    let eq_diff = eq_hi_value - eq_value;
-
                     let g = MultilinearFolder::new(
                         &scratch.local_point,
                         &scratch.next_point,
@@ -497,18 +447,16 @@ where
                         self.alpha,
                     )
                     .eval_air(self.air);
-                    scratch.out[0] += eq_value * g;
+                    scratch.out[0] += eq_suffix * g;
 
                     EF::add_slices(&mut scratch.local_point, &scratch.local_diff);
                     EF::add_slices(&mut scratch.next_point, &scratch.next_diff);
                     boundary += boundary_diff;
-                    eq_value += eq_diff;
 
-                    for node in 1..degree {
+                    for acc in &mut scratch.out[1..] {
                         EF::add_slices(&mut scratch.local_point, &scratch.local_diff);
                         EF::add_slices(&mut scratch.next_point, &scratch.next_diff);
                         boundary += boundary_diff;
-                        eq_value += eq_diff;
 
                         let g = MultilinearFolder::new(
                             &scratch.local_point,
@@ -518,7 +466,7 @@ where
                             self.alpha,
                         )
                         .eval_air(self.air);
-                        scratch.out[node] += eq_value * g;
+                        *acc += eq_suffix * g;
                     }
 
                     scratch
@@ -536,7 +484,7 @@ where
 
     #[tracing::instrument(skip_all)]
     pub(crate) fn fold(&mut self, r: EF) {
-        let num_evals = self.eq.num_evals();
+        let num_evals = self.num_evals();
         let half = num_evals / 2;
 
         self.next_tail = self
@@ -549,7 +497,7 @@ where
             })
             .collect();
 
-        self.eq.fix_prefix_var_mut(r);
+        self.eq_suffix.sum_prefix_var_mut();
 
         // Both halves already live in the extension field.
         // So each column folds in place, reusing its buffer.

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -18,7 +18,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_multilinear_util::point::Point;
-use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundProver};
+use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundPolyInterpolator};
 use p3_util::log2_strict_usize;
 use thiserror::Error;
 
@@ -233,14 +233,15 @@ impl<'a, A> AirZerocheck<'a, A> {
 
         // Draw the batching scalar then the zerocheck point, in that fixed order.
         let (alpha, tau) = sample_zerocheck_challenges(challenger, log_height);
+        let tau = Point::new(tau);
 
         let state = RoundStateBase::<'_, _, F, EF>::new(
             self.air,
             public_values,
             alpha,
-            &Point::new(tau),
+            &tau,
             trace,
-            degree,
+            degree - 1,
         );
 
         // Bind the transcript to the claimed sum so the challenges depend on the statement.
@@ -252,9 +253,16 @@ impl<'a, A> AirZerocheck<'a, A> {
             pow_witnesses: Vec::with_capacity(if self.pow_bits > 0 { log_height } else { 0 }),
         };
         let mut challenges = Vec::with_capacity(log_height);
+        let mut eq_prefix = EF::ONE;
+        let mut claim = EF::ZERO;
+        let interpolator = RoundPolyInterpolator::new(degree - 1);
 
         let evals = state.round_poly();
-        challenger.observe_algebra_slice(&evals);
+
+        let (standard_evals, q_unweighted_sum) =
+            standard_round_from_q_evals(&interpolator, &evals, claim, eq_prefix, tau.as_slice()[0]);
+
+        challenger.observe_algebra_slice(&standard_evals);
 
         // Optional proof-of-work; raises the cost of grinding a favorable challenge.
         if self.pow_bits > 0 {
@@ -262,17 +270,36 @@ impl<'a, A> AirZerocheck<'a, A> {
         }
 
         let r: EF = challenger.sample_algebra_element();
+        claim = interpolator.eval(&evals, q_unweighted_sum, r);
+        eq_prefix *= Point::eval_eq(&[tau.as_slice()[0]], &[r]);
         let mut state = state.fold(r);
 
-        sumcheck.round_polys.push(evals);
+        sumcheck.round_polys.push(standard_evals);
         challenges.push(r);
 
-        let (proof_rest, point_rest) =
-            state.prove(challenger, log_height - 1, degree, self.pow_bits, EF::ZERO);
-        challenges.extend_from_slice(point_rest.as_slice());
+        for round in 1..log_height {
+            let evals = state.round_poly();
+            let (standard_evals, unweighted_sum) = standard_round_from_q_evals(
+                &interpolator,
+                &evals,
+                claim,
+                eq_prefix,
+                tau.as_slice()[round],
+            );
+            challenger.observe_algebra_slice(&standard_evals);
 
-        sumcheck.round_polys.extend(proof_rest.round_polys);
-        sumcheck.pow_witnesses.extend(proof_rest.pow_witnesses);
+            if self.pow_bits > 0 {
+                sumcheck.pow_witnesses.push(challenger.grind(self.pow_bits));
+            }
+
+            let r: EF = challenger.sample_algebra_element();
+            claim = interpolator.eval(&evals, unweighted_sum, r);
+            eq_prefix *= Point::eval_eq(&[tau.as_slice()[round]], &[r]);
+            state.fold(r);
+
+            sumcheck.round_polys.push(standard_evals);
+            challenges.push(r);
+        }
 
         let (local, next, _) = state.evals();
         let next = self
@@ -391,6 +418,38 @@ impl<'a, A> AirZerocheck<'a, A> {
         }
         Ok(claims.point)
     }
+}
+
+/// Build the standard generic-degree round message from lower-degree internal `q` evals.
+///
+/// The optimized prover computes `q(X)` with the active equality factor removed.
+/// This reconstructs the omitted `q(1)` from
+/// `q_claim = (1 - tau) * q(0) + tau * q(1)`, extrapolates `q(d + 1)`,
+/// and returns the standard wire evals `[s(0), s(2), ..., s(d + 1)]` for
+/// `s(X) = eq_prefix * eq(tau, X) * q(X)`, plus the unweighted `q(0) + q(1)`
+/// sum needed to evaluate `q` with the standard interpolator.
+pub(crate) fn standard_round_from_q_evals<EF>(
+    interpolator: &RoundPolyInterpolator<EF>,
+    evals: &[EF],
+    claim: EF,
+    eq_prefix: EF,
+    tau: EF,
+) -> (Vec<EF>, EF)
+where
+    EF: Field,
+{
+    let unweighted_sum = evals[0] + (claim - (EF::ONE - tau) * evals[0]) * tau.inverse();
+
+    let degree = evals.len() + 1;
+    let last = interpolator.eval(evals, unweighted_sum, EF::from_usize(degree));
+
+    let standard_evals = (0..=degree)
+        .filter(|&node| node != 1)
+        .zip(evals.iter().copied().chain(core::iter::once(last)))
+        .map(|(node, q)| eq_prefix * Point::eval_eq(&[tau], &[EF::from_usize(node)]) * q)
+        .collect();
+
+    (standard_evals, unweighted_sum)
 }
 
 /// Draw the constraint-batching scalar and the zerocheck point, in that order.

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -227,6 +227,14 @@ impl<'a, A> AirZerocheck<'a, A> {
         // Per-round sumcheck degree from the symbolic constraint degree.
         let degree = self.sumcheck_degree::<F, EF>(layout);
 
+        // The optimized prover strips one degree from each round polynomial.
+        // That leaves one fewer internal evaluation, so the constraint must be at least degree one.
+        // A degree-zero constraint is constant and has no meaningful zerocheck.
+        assert!(
+            degree >= 2,
+            "zerocheck requires a constraint of per-variable degree at least one"
+        );
+
         // Bind the public values before any challenge depends on them.
         // The trace commitment must already be in the transcript.
         challenger.observe_algebra_slice(public_values);
@@ -420,15 +428,48 @@ impl<'a, A> AirZerocheck<'a, A> {
     }
 }
 
-/// Build the standard generic-degree round message from lower-degree internal `q` evals.
+/// Rebuild the verifier-facing round message from the prover's internal evaluations.
 ///
-/// The optimized prover computes `q(X)` with the active equality factor removed.
-/// This reconstructs the omitted `q(1)` from
-/// `q_claim = (1 - tau) * q(0) + tau * q(1)`, extrapolates `q(d + 1)`,
-/// and returns the standard wire evals `[s(0), s(2), ..., s(d + 1)]` for
-/// `s(X) = eq_prefix * eq(tau, X) * q(X)`, plus the unweighted `q(0) + q(1)`
-/// sum needed to evaluate `q` with the standard interpolator.
-pub(crate) fn standard_round_from_q_evals<EF>(
+/// # Overview
+///
+/// The optimized prover evaluates an internal polynomial with the active equality
+/// factor stripped out, which lowers its degree by one:
+/// ```text
+/// q(X) = sum over x of eq(suffix, x) * g(prefix, X, x)
+/// ```
+///
+/// The verifier still expects the full weighted round polynomial:
+/// ```text
+/// s(X) = eq_prefix * eq(tau, X) * q(X)
+/// ```
+///
+/// This restores `s` from the transmitted internal evaluations.
+///
+/// # Why this lives here
+///
+/// The weighting and the inter-round claim relation are specific to this zerocheck.
+/// The generic interpolator stays unaware of equality factors, so this glue stays out of it.
+///
+/// Node one is dropped from the message because the verifier recovers it from the claim.
+///
+/// # Arguments
+///
+/// - `interpolator`: barycentric helper for the internal degree, reused across rounds.
+/// - `evals`: internal evaluations at nodes `0, 2, 3, ..., deg - 1`.
+/// - `claim`: previous round's reduced value, tying `q(0)` and `q(1)` together.
+/// - `eq_prefix`: product of equality factors at the already-bound challenges.
+/// - `tau`: this round's zerocheck point coordinate; must be nonzero.
+///
+/// # Returns
+///
+/// - the weighted evaluations `s(0), s(2), ..., s(deg)` sent to the verifier;
+/// - the unweighted sum `q(0) + q(1)` used to reduce the internal claim next round.
+///
+/// # Panics
+///
+/// Panics if `tau` is zero, since recovering `q(1)` divides by it.
+/// The caller samples `tau` from the nonzero elements, so this does not occur.
+fn standard_round_from_q_evals<EF>(
     interpolator: &RoundPolyInterpolator<EF>,
     evals: &[EF],
     claim: EF,
@@ -438,11 +479,24 @@ pub(crate) fn standard_round_from_q_evals<EF>(
 where
     EF: Field,
 {
+    // Recover the dropped node one from the inter-round relation.
+    //
+    //     claim = (1 - tau) * q(0) + tau * q(1)
+    //  => q(1)  = (claim - (1 - tau) * q(0)) / tau
+    //
+    // The unweighted sum q(0) + q(1) is what reduces the internal claim next round.
     let unweighted_sum = evals[0] + (claim - (EF::ONE - tau) * evals[0]) * tau.inverse();
 
+    // The weighted message carries one extra degree from the equality factor.
+    // Extrapolate the internal polynomial to that top node.
     let degree = evals.len() + 1;
     let last = interpolator.eval(evals, unweighted_sum, EF::from_usize(degree));
 
+    // Weight every transmitted node, skipping node one as the verifier rebuilds it.
+    //
+    //     nodes : 0, 2, 3, ..., deg
+    //     values: q(0), q(2), ..., q(deg - 1), q(deg)
+    //     s(node) = eq_prefix * eq(tau, node) * q(node)
     let standard_evals = (0..=degree)
         .filter(|&node| node != 1)
         .zip(evals.iter().copied().chain(core::iter::once(last)))
@@ -455,6 +509,10 @@ where
 /// Draw the constraint-batching scalar and the zerocheck point, in that order.
 ///
 /// Prover and verifier call this identically so their transcripts stay in lockstep.
+///
+/// Each zerocheck point coordinate is drawn nonzero.
+/// The prover divides by a coordinate when rebuilding a round message, so a zero would divide by zero.
+/// Resampling on both sides keeps the transcripts aligned, and a zero draw has negligible probability.
 fn sample_zerocheck_challenges<F, EF, Challenger>(
     challenger: &mut Challenger,
     log_height: usize,
@@ -464,9 +522,18 @@ where
     EF: ExtensionField<F>,
     Challenger: FieldChallenger<F>,
 {
+    // The batching scalar may take any value.
     let alpha = challenger.sample_algebra_element();
+
+    // Draw each point coordinate, resampling past a zero.
     let tau = (0..log_height)
-        .map(|_| challenger.sample_algebra_element())
+        .map(|_| {
+            let mut coord: EF = challenger.sample_algebra_element();
+            while coord.is_zero() {
+                coord = challenger.sample_algebra_element();
+            }
+            coord
+        })
         .collect();
     (alpha, tau)
 }
@@ -637,6 +704,39 @@ mod tests {
         for round in &proof.sumcheck.round_polys {
             assert_eq!(round.len(), degree);
         }
+    }
+
+    #[test]
+    fn zerocheck_round_trip_with_grinding() {
+        // The prover inlines its own grind / observe / sample loop per round.
+        // Every test above runs with pow_bits = 0, so the grinding branch is otherwise unexercised.
+        //
+        // Fixture state:
+        //
+        //     trace height : 8  -> log_height = 3 rounds
+        //     pow_bits     : 4  -> one witness ground per round
+        //
+        // Invariant:
+        //
+        //     a valid trace proves and verifies, and the proof carries one witness per round.
+        let n = 8;
+        let pow_bits = 4;
+        let trace = fib_trace(n);
+        let pis = fib_public_values(n);
+        let zerocheck = AirZerocheck::new(&FibAir, pow_bits);
+
+        // Prove with grinding enabled.
+        let mut prover_challenger = fresh_challenger();
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, &pis, &mut prover_challenger);
+
+        // Grinding emits exactly one witness per sumcheck round.
+        assert_eq!(proof.sumcheck.pow_witnesses.len(), log2_strict_usize(n));
+
+        // The verifier re-checks each round's witness while replaying the transcript.
+        let mut verifier_challenger = fresh_challenger();
+        zerocheck
+            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .expect("valid trace must verify with grinding");
     }
 
     #[test]

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -664,6 +664,45 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         self.0.truncate(mid);
     }
 
+    /// Sums out the prefix variable, reducing the polynomial by one variable.
+    ///
+    /// Computes:
+    /// ```text
+    /// p'(x') = p(0, x') + p(1, x')
+    /// ```
+    ///
+    /// This is the `r = 1` plus `r = 0` aggregate of
+    /// [`fix_prefix_var_mut`](Self::fix_prefix_var_mut), and is useful for
+    /// dropping one factor from an equality table:
+    /// ```text
+    /// Eq((a, tail), (x, y)) summed over x = Eq(tail, y)
+    /// ```
+    ///
+    /// If the polynomial is already constant, this is a no-op.
+    pub fn sum_prefix_var_mut(&mut self) {
+        let num_evals = self.num_evals();
+        if num_evals == 1 {
+            return;
+        }
+
+        let mid = num_evals / 2;
+        // Split into x_0 = 0 (mutable) and x_0 = 1 (read-only) halves.
+        let (p0, p1) = self.0.split_at_mut(mid);
+
+        if num_evals >= PARALLEL_THRESHOLD {
+            // Parallel: sum each low/high pair in place.
+            p0.par_iter_mut()
+                .zip(p1.par_iter())
+                .for_each(|(a0, &a1)| *a0 += a1);
+        } else {
+            // Sequential: sum each low/high pair in place.
+            p0.iter_mut().zip(p1.iter()).for_each(|(a0, &a1)| *a0 += a1);
+        }
+
+        // Discard the second half; the first half now holds the summed result.
+        self.0.truncate(mid);
+    }
+
     /// Fixes the suffix variable at a challenge value, returning a folded polynomial.
     ///
     /// Computes:
@@ -984,6 +1023,27 @@ pub(crate) mod test {
         evals.0[1] = F::from_u64(5);
 
         assert_eq!(evals.0[1], F::from_u64(5));
+    }
+
+    #[test]
+    fn test_sum_prefix_var_mut() {
+        let mut evals = Poly::new((1..=8).map(F::from_u64).collect());
+
+        evals.sum_prefix_var_mut();
+
+        assert_eq!(
+            evals.as_slice(),
+            &[
+                F::from_u64(1 + 5),
+                F::from_u64(2 + 6),
+                F::from_u64(3 + 7),
+                F::from_u64(4 + 8),
+            ],
+        );
+
+        let mut constant = Poly::new(vec![F::from_u64(11)]);
+        constant.sum_prefix_var_mut();
+        assert_eq!(constant.as_slice(), &[F::from_u64(11)]);
     }
 
     #[test]

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -671,14 +671,15 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
     /// p'(x') = p(0, x') + p(1, x')
     /// ```
     ///
-    /// This is the `r = 1` plus `r = 0` aggregate of
-    /// [`fix_prefix_var_mut`](Self::fix_prefix_var_mut), and is useful for
-    /// dropping one factor from an equality table:
+    /// This is the prefix-variable fix evaluated at `r = 0` and `r = 1` and added.
+    ///
+    /// One use is dropping the leading factor of an equality table.
+    /// Summing the boolean values of the leading variable collapses its factor to one:
     /// ```text
-    /// Eq((a, tail), (x, y)) summed over x = Eq(tail, y)
+    /// sum over x of Eq((a, tail), (x, y)) = Eq(tail, y)
     /// ```
     ///
-    /// If the polynomial is already constant, this is a no-op.
+    /// A constant polynomial has no prefix variable, so this is a no-op.
     pub fn sum_prefix_var_mut(&mut self) {
         let num_evals = self.num_evals();
         if num_evals == 1 {

--- a/sumcheck/src/generic_degree/mod.rs
+++ b/sumcheck/src/generic_degree/mod.rs
@@ -8,3 +8,4 @@ mod util;
 pub use error::GenericDegreeError;
 pub use proof::GenericDegreeProof;
 pub use prover::RoundProver;
+pub use util::RoundPolyInterpolator;

--- a/sumcheck/src/generic_degree/util.rs
+++ b/sumcheck/src/generic_degree/util.rs
@@ -13,7 +13,7 @@ use p3_matrix::interpolation::{InterpolateArbitrary, barycentric_weights};
 /// - The barycentric weights depend only on that domain.
 /// - They are precomputed once and reused across all rounds.
 /// - Each round then contributes only the per-challenge difference inverses.
-pub(super) struct RoundPolyInterpolator<EF> {
+pub struct RoundPolyInterpolator<EF> {
     /// Integer domain nodes `0, 1, …, degree`, lifted into the field.
     x_coords: Vec<EF>,
     /// Barycentric weight `w_i = 1 / prod_{j != i} (x_i - x_j)` of each node.
@@ -26,7 +26,7 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
     /// # Arguments
     ///
     /// - `degree`: the per-variable degree, so the domain has `degree + 1` nodes.
-    pub(super) fn new(degree: usize) -> Self {
+    pub fn new(degree: usize) -> Self {
         // Domain: the integer nodes 0, 1, …, degree lifted into the field.
         let x_coords: Vec<EF> = (0..=degree).map(EF::from_usize).collect();
 
@@ -47,7 +47,7 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
     /// # Returns
     ///
     /// `h(r)`, computed by barycentric Lagrange interpolation over the precomputed domain.
-    pub(super) fn eval(&self, evals: &[EF], sum_constraint: EF, r: EF) -> EF {
+    pub fn eval(&self, evals: &[EF], sum_constraint: EF, r: EF) -> EF {
         debug_assert_eq!(evals.len() + 1, self.x_coords.len());
 
         // Reconstruct the full evaluation vector at the integer nodes 0, 1, …, degree.


### PR DESCRIPTION
Apply the prover-side zerocheck optimization from [Gruen section 3.2](https://eprint.iacr.org/2024/108).

The prover now computes suffix-weighted internal round polynomials with one lower sumcheck degree, then reconstructs the standard verifier-facing round messages. This keeps the verifier protocol unchanged while reducing prover work.

This also adds `Poly::sum_prefix_var_mut` for dropping the leading equality suffix variable, and skips the first-round `eq * lo` contribution since it is zero for a valid zerocheck trace.

| Benchmark | Cur | New | Speedup |
|---|---:|---:|---:|
| `poseidon2_zerocheck_prove/10` | 4.1765 ms | 3.7076 ms | 1.13x |
| `poseidon2_zerocheck_prove/15` | 99.126 ms | 76.062 ms | 1.30x |
| `poseidon2_zerocheck_prove/20` | 3.1349 s | 2.5212 s | 1.24x |