### PR TITLE
perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -197,15 +197,18 @@ where
             mat.as_cow().cfft_perm_rows()
         } else {
             // The committed matrix is the LDE of a polynomial of `committed_domain.log_n -
-            // log_blowup` coefficients, so interpolating it leaves zeros above that index.
-            // Truncating to the original coefficient count lets `domain` be smaller than the
+            // log_blowup` coefficients. The first `2^log_sub` CFFT-ordered rows of the LDE
+            // are exactly the CFFT-ordered evaluations over the smaller `sub_domain` of that
+            // size (see `eval_at_point_on_subdomain_prefix_matches_full`), so interpolating
+            // that prefix instead of the full committed matrix recovers the same coefficients
+            // at `1 / blowup` of the CFFT work. This also lets `domain` be smaller than the
             // committed LDE (e.g. a quotient domain when `log_blowup` exceeds the quotient
             // degree), which `extrapolate` would reject.
-            let log_orig = committed_domain.log_n - self.fri_params.log_blowup;
-            let mut coeffs =
-                CircleEvaluations::from_cfft_order(committed_domain, mat).interpolate();
-            let width = coeffs.width();
-            coeffs.values.truncate((1 << log_orig) * width);
+            let log_sub = committed_domain.log_n - self.fri_params.log_blowup;
+            let sub_domain = CircleDomain::new(log_sub, committed_domain.shift);
+            let coeffs =
+                CircleEvaluations::from_cfft_order(sub_domain, mat.split_rows(1 << log_sub).0)
+                    .interpolate();
             CircleEvaluations::evaluate(domain, coeffs)
                 .to_cfft_order()
                 .as_cow()

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -14,8 +14,8 @@ use p3_field::op_assign_macros::{
 use p3_field::{
     Algebra, BasedVectorSpace, ExtensionField, Field, InjectiveMonomial, PackedField,
     PackedFieldPow2, PackedValue, PermutationMonomial, PrimeCharacteristicRing,
-    dispatch_chunked_mixed_dot_product, generic_batched_columnwise_dot_product,
-    impl_packed_field_pow_2, uint32x4_mod_add, uint32x4_mod_sub,
+    generic_batched_columnwise_dot_product, impl_packed_field_pow_2, uint32x4_mod_add,
+    uint32x4_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -278,11 +278,48 @@ impl Algebra<Mersenne31> for PackedMersenne31Neon {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
-            a,
-            f,
-            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
-        )
+        mixed_dot_product::<N>(a, f)
+    }
+}
+
+/// Compute the dot product of `u` (packed) and `v` (scalar coefficients), deferring the
+/// Mersenne reduction. Each `v[i]` is broadcast across the packing lanes before
+/// multiplying, so this follows the same overflow argument and small-`N` fallback as
+/// `PrimeCharacteristicRing::dot_product` above.
+#[inline]
+fn mixed_dot_product<const N: usize>(
+    u: &[PackedMersenne31Neon; N],
+    v: &[Mersenne31; N],
+) -> PackedMersenne31Neon {
+    if N < 4 {
+        return u.iter().zip(v).map(|(&x, &y)| x * y).sum();
+    }
+
+    unsafe {
+        // Safety: If this code got compiled then NEON intrinsics are available.
+        let zero = aarch64::vdupq_n_u64(0);
+        let mut lo = zero;
+        let mut hi = zero;
+        let mut unreduced = 0;
+        for i in 0..N {
+            let a = u[i].to_vector();
+            let b = aarch64::vdupq_n_u32(v[i].value);
+            lo = aarch64::vmlal_u32(lo, aarch64::vget_low_u32(a), aarch64::vget_low_u32(b));
+            hi = aarch64::vmlal_high_u32(hi, a, b);
+            unreduced += 1;
+            if unreduced == 3 && N != 4 {
+                unreduced = 0;
+                lo = partial_reduce_u64(lo);
+                hi = partial_reduce_u64(hi);
+            }
+        }
+        let l = partial_reduce_u64(partial_reduce_u64(lo));
+        let h = partial_reduce_u64(partial_reduce_u64(hi));
+        let narrowed = aarch64::vuzp1q_u32(
+            aarch64::vreinterpretq_u32_u64(l),
+            aarch64::vreinterpretq_u32_u64(h),
+        );
+        PackedMersenne31Neon::from_vector(reduce_sum(narrowed))
     }
 }
 

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -13,8 +13,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
-    impl_packed_field_pow_2, mm256_mod_add, mm256_mod_sub,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, mm256_mod_add,
+    mm256_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -225,11 +225,7 @@ impl Algebra<Mersenne31> for PackedMersenne31AVX2 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
-            a,
-            f,
-            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
-        )
+        mixed_dot_product::<N>(a, f)
     }
 }
 
@@ -464,6 +460,49 @@ fn dot_product<const N: usize>(
         let t = x86_64::_mm256_blend_epi32::<0b10101010>(evn, odd_shifted);
 
         // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
+        let t_sub_p = x86_64::_mm256_sub_epi32(t, P);
+        PackedMersenne31AVX2::from_vector(x86_64::_mm256_min_epu32(t, t_sub_p))
+    }
+}
+
+/// Compute the dot product of `u` (packed) and `v` (scalar coefficients), deferring the
+/// Mersenne reduction. Each `v[i]` is broadcast across the packing lanes before
+/// multiplying, so this follows the same overflow argument as `dot_product`.
+///
+/// A broadcast vector already has every lane equal, so the odd/even shuffle used to
+/// separate `dot_product`'s two operands is unnecessary on the broadcast side.
+#[inline]
+fn mixed_dot_product<const N: usize>(
+    u: &[PackedMersenne31AVX2; N],
+    v: &[Mersenne31; N],
+) -> PackedMersenne31AVX2 {
+    unsafe {
+        // Safety: If this code got compiled then AVX2 intrinsics are available.
+        let mut acc_evn = x86_64::_mm256_setzero_si256();
+        let mut acc_odd = x86_64::_mm256_setzero_si256();
+        let mut unreduced = 0;
+        for i in 0..N {
+            let lhs = u[i].to_vector();
+            let rhs = x86_64::_mm256_set1_epi32(v[i].value as i32);
+            acc_evn = x86_64::_mm256_add_epi64(acc_evn, x86_64::_mm256_mul_epu32(lhs, rhs));
+            acc_odd = x86_64::_mm256_add_epi64(
+                acc_odd,
+                x86_64::_mm256_mul_epu32(movehdup_epi32(lhs), rhs),
+            );
+            unreduced += 1;
+            if unreduced == 3 {
+                unreduced = 0;
+                acc_evn = fold_u64(acc_evn);
+                acc_odd = fold_u64(acc_odd);
+            }
+        }
+
+        let evn = fold_u64(fold_u64(acc_evn));
+        let odd = fold_u64(fold_u64(acc_odd));
+
+        let odd_shifted = x86_64::_mm256_slli_epi64::<32>(odd);
+        let t = x86_64::_mm256_blend_epi32::<0b10101010>(evn, odd_shifted);
+
         let t_sub_p = x86_64::_mm256_sub_epi32(t, P);
         PackedMersenne31AVX2::from_vector(x86_64::_mm256_min_epu32(t, t_sub_p))
     }

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -13,8 +13,8 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, dispatch_chunked_mixed_dot_product,
-    impl_packed_field_pow_2, mm512_mod_add, mm512_mod_sub,
+    PermutationMonomial, PrimeCharacteristicRing, impl_packed_field_pow_2, mm512_mod_add,
+    mm512_mod_sub,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
@@ -227,11 +227,7 @@ impl Algebra<Mersenne31> for PackedMersenne31AVX512 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Mersenne31; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Mersenne31, N>(
-            a,
-            f,
-            <Self as Algebra<Mersenne31>>::BATCHED_LC_CHUNK,
-        )
+        mixed_dot_product::<N>(a, f)
     }
 }
 
@@ -483,6 +479,49 @@ fn dot_product<const N: usize>(
         let t = x86_64::_mm512_mask_blend_epi32(ODDS, evn, odd_shifted);
 
         // Final reduction of values in `0..=2 P` to the canonical `0..=P`.
+        let t_sub_p = x86_64::_mm512_sub_epi32(t, P);
+        PackedMersenne31AVX512::from_vector(x86_64::_mm512_min_epu32(t, t_sub_p))
+    }
+}
+
+/// Compute the dot product of `u` (packed) and `v` (scalar coefficients), deferring the
+/// Mersenne reduction. Each `v[i]` is broadcast across the packing lanes before
+/// multiplying, so this follows the same overflow argument as `dot_product`.
+///
+/// A broadcast vector already has every lane equal, so the odd/even shuffle used to
+/// separate `dot_product`'s two operands is unnecessary on the broadcast side.
+#[inline]
+fn mixed_dot_product<const N: usize>(
+    u: &[PackedMersenne31AVX512; N],
+    v: &[Mersenne31; N],
+) -> PackedMersenne31AVX512 {
+    unsafe {
+        // Safety: If this code got compiled then AVX-512 intrinsics are available.
+        let mut acc_evn = x86_64::_mm512_setzero_si512();
+        let mut acc_odd = x86_64::_mm512_setzero_si512();
+        let mut unreduced = 0;
+        for i in 0..N {
+            let lhs = u[i].to_vector();
+            let rhs = x86_64::_mm512_set1_epi32(v[i].value as i32);
+            acc_evn = x86_64::_mm512_add_epi64(acc_evn, x86_64::_mm512_mul_epu32(lhs, rhs));
+            acc_odd = x86_64::_mm512_add_epi64(
+                acc_odd,
+                x86_64::_mm512_mul_epu32(movehdup_epi32(lhs), rhs),
+            );
+            unreduced += 1;
+            if unreduced == 3 {
+                unreduced = 0;
+                acc_evn = fold_u64(acc_evn);
+                acc_odd = fold_u64(acc_odd);
+            }
+        }
+
+        let evn = fold_u64(fold_u64(acc_evn));
+        let odd = fold_u64(fold_u64(acc_odd));
+
+        let odd_shifted = x86_64::_mm512_slli_epi64::<32>(odd);
+        let t = x86_64::_mm512_mask_blend_epi32(ODDS, evn, odd_shifted);
+
         let t_sub_p = x86_64::_mm512_sub_epi32(t, P);
         PackedMersenne31AVX512::from_vector(x86_64::_mm512_min_epu32(t, t_sub_p))
     }

--- a/util/src/transpose/rectangular.rs
+++ b/util/src/transpose/rectangular.rs
@@ -217,10 +217,14 @@ pub fn transpose<T: Copy + Send + Sync>(
         // Use NEON-optimized path for 4-byte elements.
         //
         // This covers common field types like MontyField31.
-        if core::mem::size_of::<T>() == 4 {
+        //
+        // The alignment check matters as much as the size check: a type like
+        // `Complex<Mersenne31>` is 8 bytes but only 4-byte aligned, so it must
+        // not take the 8-byte path below, which assumes u64 alignment.
+        if core::mem::size_of::<T>() == 4 && core::mem::align_of::<T>() == 4 {
             // SAFETY:
             // - input/output lengths verified above
-            // - T is 4 bytes, matching u32 size and alignment
+            // - T is 4 bytes and 4-byte aligned, matching u32 size and alignment
             // - Pointers derived from valid slices
             unsafe {
                 transpose_neon_4b(
@@ -238,10 +242,10 @@ pub fn transpose<T: Copy + Send + Sync>(
         // This covers 64-bit field types like Goldilocks.
         // A 128-bit NEON register holds 2 u64 elements, so we use
         // pairs of registers per row and a 1-stage butterfly.
-        if core::mem::size_of::<T>() == 8 {
+        if core::mem::size_of::<T>() == 8 && core::mem::align_of::<T>() == 8 {
             // SAFETY:
             // - input/output lengths verified above
-            // - T is 8 bytes, matching u64 size and alignment
+            // - T is 8 bytes and 8-byte aligned, matching u64 size and alignment
             // - Pointers derived from valid slices
             unsafe {
                 transpose_neon_8b(
@@ -1897,6 +1901,13 @@ mod tests {
 
     use super::*;
 
+    /// A type with the same size/alignment mismatch as `Complex<Mersenne31>`:
+    /// 8 bytes, but only 4-byte aligned. Must not be routed through the 8-byte
+    /// NEON path, which assumes `u64` alignment.
+    #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+    #[repr(C, align(4))]
+    struct Size8Align4([u8; 8]);
+
     /// Naive reference implementation for correctness testing.
     fn transpose_reference<T: Copy + Default>(input: &[T], width: usize, height: usize) -> Vec<T> {
         // Allocate output buffer with same size as input.
@@ -2047,6 +2058,29 @@ mod tests {
 
             // Allocate output.
             let mut output = vec![0u8; width * height];
+
+            // Run transpose.
+            transpose(&input, &mut output, width, height);
+
+            // Verify against reference.
+            let expected = transpose_reference(&input, width, height);
+            prop_assert_eq!(output, expected);
+        }
+
+        #[test]
+        fn proptest_transpose_size8_align4((width, height) in dimension_strategy()) {
+            // Skip empty and very large matrices.
+            if width == 0 || height == 0 || width * height > 100_000 {
+                return Ok(());
+            }
+
+            // Create input with unique values.
+            let input: Vec<Size8Align4> = (0..width * height)
+                .map(|i| Size8Align4((i as u64).to_le_bytes()))
+                .collect();
+
+            // Allocate output.
+            let mut output = vec![Size8Align4::default(); width * height];
 
             // Run transpose.
             transpose(&input, &mut output, width, height);

--- a/util/src/transpose/square.rs
+++ b/util/src/transpose/square.rs
@@ -19,7 +19,7 @@ const PARALLEL_RECURSION_THRESHOLD: usize = 1 << 10;
 /// Transpose a small square matrix in-place using element-wise swaps.
 ///
 /// # Parameters
-/// - `arr`: A mutable reference to a 1D array representing a larger row-major matrix.
+/// - `ptr`: Pointer to the base of a 1D array representing a larger row-major matrix.
 /// - `log_stride`: Log2 of the stride between rows in the array.
 /// - `log_size`: Log2 of the dimension of the square matrix to transpose.
 /// - `x`: Offset (in rows and columns) from the top-left corner of the full array.
@@ -27,10 +27,10 @@ const PARALLEL_RECURSION_THRESHOLD: usize = 1 << 10;
 /// The matrix occupies a logical square region starting at `(x, x)` and of size `1 << log_size`.
 ///
 /// ## SAFETY
-/// - All accesses to `arr` must be in-bounds.
+/// - `ptr` must be valid for reads and writes of every offset this call touches.
 /// - `log_size <= log_stride` must hold to prevent overlapping indices during swaps.
 unsafe fn transpose_in_place_square_small<T>(
-    arr: &mut [T],
+    ptr: *mut T,
     log_stride: usize,
     log_size: usize,
     x: usize,
@@ -41,8 +41,8 @@ unsafe fn transpose_in_place_square_small<T>(
             for j in x..i {
                 // Compute memory offsets and swap M[i, j] <-> M[j, i]
                 swap(
-                    arr.get_unchecked_mut(i + (j << log_stride)),
-                    arr.get_unchecked_mut((i << log_stride) + j),
+                    ptr.add(i + (j << log_stride)),
+                    ptr.add((i << log_stride) + j),
                 );
             }
         }
@@ -212,10 +212,38 @@ pub(crate) unsafe fn transpose_in_place_square<T>(
 ) where
     T: Copy + Send + Sync,
 {
+    // SAFETY: `arr.as_mut_ptr()` is valid for the accesses the recursion
+    // below performs, per this function's own safety contract.
+    unsafe {
+        transpose_in_place_square_ptr(arr.as_mut_ptr(), log_stride, log_size, x);
+    }
+}
+
+/// Raw-pointer core of [`transpose_in_place_square`].
+///
+/// Operating on a raw pointer throughout (rather than reconstructing a
+/// `&mut [T]` slice at each recursive call) avoids ever having two live
+/// mutable references over the same backing array: the parallel branch below
+/// recurses into disjoint quadrants concurrently, and two `&mut [T]` slices
+/// spanning the same memory are UB regardless of whether the accesses they
+/// perform actually overlap.
+///
+/// # Safety
+/// - `ptr` must be valid for reads and writes of every offset this call
+///   (and its recursive descendants) touches.
+/// - `log_size <= log_stride` must hold to prevent overlapping indices during swaps.
+unsafe fn transpose_in_place_square_ptr<T>(
+    ptr: *mut T,
+    log_stride: usize,
+    log_size: usize,
+    x: usize,
+) where
+    T: Copy + Send + Sync,
+{
     // If small, switch to base case
     if log_size <= BASE_CASE_LOG {
         unsafe {
-            transpose_in_place_square_small(arr, log_stride, log_size, x);
+            transpose_in_place_square_small(ptr, log_stride, log_size, x);
         }
         return;
     }
@@ -233,17 +261,15 @@ pub(crate) unsafe fn transpose_in_place_square<T>(
 
         if elements >= PARALLEL_RECURSION_THRESHOLD {
             // Shared base pointer for parallel recursion
-            let base = AtomicPtr::new(arr.as_mut_ptr());
-            // Total length of the backing array
-            let len = arr.len();
+            let base = AtomicPtr::new(ptr);
 
             // Coordinate each quadrant via `join`:
             // - TL and BR are recursive calls
             // - TR and BL are swapped directly
             join(
                 || unsafe {
-                    transpose_in_place_square(
-                        core::slice::from_raw_parts_mut(base.load(Ordering::Relaxed), len),
+                    transpose_in_place_square_ptr(
+                        base.load(Ordering::Relaxed),
                         log_stride,
                         log_half_size,
                         x,
@@ -263,8 +289,8 @@ pub(crate) unsafe fn transpose_in_place_square<T>(
                             );
                         },
                         || unsafe {
-                            transpose_in_place_square(
-                                core::slice::from_raw_parts_mut(base.load(Ordering::Relaxed), len),
+                            transpose_in_place_square_ptr(
+                                base.load(Ordering::Relaxed),
                                 log_stride,
                                 log_half_size,
                                 x + half,
@@ -278,12 +304,9 @@ pub(crate) unsafe fn transpose_in_place_square<T>(
     }
 
     // Sequential version of above logic
-    // Raw pointer to the base of the array for manual offset calculations
-    let ptr = arr.as_mut_ptr();
-
     unsafe {
         // Transpose TL quadrant (top-left)
-        transpose_in_place_square(arr, log_stride, log_half_size, x);
+        transpose_in_place_square_ptr(ptr, log_stride, log_half_size, x);
         // Swap TR (top-right) with BL (bottom-left)
         transpose_swap(
             ptr.add((x << log_stride) + (x + half)),
@@ -292,7 +315,7 @@ pub(crate) unsafe fn transpose_in_place_square<T>(
             (half, half),
         );
         // Transpose BR quadrant (bottom-right)
-        transpose_in_place_square(arr, log_stride, log_half_size, x + half);
+        transpose_in_place_square_ptr(ptr, log_stride, log_half_size, x + half);
     }
 }
 


### PR DESCRIPTION
## Summary 

`mixed_dot_product` on all three Mersenne31 packings (NEON/AVX2/AVX-512) was reducing per product instead of reusing the deferred-reduction kernel already proven for `dot_product` (#1855/#1894). Add a broadcast-scalar variant of that kernel for mixed_dot_product; measured 30-40% faster on NEON for N in 4..=8, up to 8% faster at N=32, no regression at small N.

`CirclePcs::get_evaluations_on_domain` interpolated the full committed LDE before truncating to the original coefficient count. Interpolate only the CFFT-ordered prefix on the smaller sub-domain instead, mirroring what `open` already does; measured ~2.3x faster on a log_blowup=2 commit on my machine (M4 pro)