### PR TITLE
perf(matrix): no-alloc `vertically_packed_row` for `RowIndexMappedView`

### DIFF
--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -47,5 +47,10 @@ name = "vertical_packing"
 path = "benches/vertical_packing.rs"
 harness = false
 
+[[bench]]
+name = "bitrev_vertical_packing"
+path = "benches/bitrev_vertical_packing.rs"
+harness = false
+
 [lints]
 workspace = true

--- a/matrix/benches/bitrev_vertical_packing.rs
+++ b/matrix/benches/bitrev_vertical_packing.rs
@@ -1,0 +1,41 @@
+use core::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::Field;
+use p3_matrix::Matrix;
+use p3_matrix::bitrev::BitReversibleMatrix;
+use p3_matrix::dense::RowMajorMatrix;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BabyBear;
+type Packed = <F as Field>::Packing;
+
+const CONFIGS: &[(usize, usize)] = &[(10, 32), (14, 32), (18, 32)];
+
+fn bitrev_vertically_packed_row(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bitrev_vertically_packed_row");
+    group.sample_size(20);
+
+    for &(log_rows, width) in CONFIGS {
+        let rows = 1usize << log_rows;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let matrix = RowMajorMatrix::<F>::rand_nonzero(&mut rng, rows, width).bit_reverse_rows();
+        let start_row = rows / 2;
+        let param = format!("2^{log_rows}x{width}");
+
+        group.bench_with_input(BenchmarkId::new("row", &param), &(), |b, _| {
+            b.iter(|| {
+                black_box(
+                    matrix
+                        .vertically_packed_row::<Packed>(start_row)
+                        .collect::<Vec<_>>(),
+                )
+            });
+        });
+    }
+}
+
+criterion_group!(benches, bitrev_vertically_packed_row);
+criterion_main!(benches);

--- a/matrix/src/row_index_mapped.rs
+++ b/matrix/src/row_index_mapped.rs
@@ -150,6 +150,26 @@ impl<T: Send + Sync + Clone, IndexMap: RowIndexMap, Inner: Matrix<T>> Matrix<T>
         self.inner
             .padded_horizontally_packed_row(self.index_map.map_row_index(r))
     }
+
+    #[inline]
+    fn vertically_packed_row<P>(&self, r: usize) -> impl Iterator<Item = P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        let height = self.height();
+        let width = self.width();
+        // The row permutation generally scatters `r..r + P::WIDTH` across non-contiguous
+        // inner rows, so unlike `DenseMatrix` we cannot take a contiguous-slice fast path.
+        // Reading elements directly still avoids the `Vec` of row-slice guards that the
+        // default implementation allocates via `wrapping_row_slices`.
+        (0..width).map(move |c| {
+            P::from_fn(|i| unsafe {
+                // Safety: (r + i) % height < height, and c < width (loop bound).
+                self.get_unchecked((r + i) % height, c)
+            })
+        })
+    }
 }
 
 #[cfg(test)]
@@ -354,6 +374,46 @@ mod tests {
                 BabyBear::new(4),
                 BabyBear::new(0),
             ])]
+        );
+    }
+
+    #[test]
+    fn test_vertically_packed_row() {
+        // Define the packed type with width 2
+        type Packed = FieldArray<BabyBear, 2>;
+
+        // Create a 4x2 matrix of BabyBear elements:
+        // [ 1  2 ]
+        // [ 3  4 ]
+        // [ 5  6 ]
+        // [ 7  8 ]
+        let inner = RowMajorMatrix::new((1..=8).map(BabyBear::new).collect::<Vec<_>>(), 2);
+
+        // Reverse row mapping: visible row i maps to inner row (height - 1 - i).
+        // So the view (in inner-row order) is rows [3, 2, 1, 0].
+        let mapped_view = RowIndexMappedView {
+            index_map: ReverseMap(inner.height()),
+            inner,
+        };
+
+        // Non-wrapping gather: visible rows 0 and 1 map to inner rows 3 and 2.
+        let packed: Vec<_> = mapped_view.vertically_packed_row::<Packed>(0).collect();
+        assert_eq!(
+            packed,
+            vec![
+                Packed::from([BabyBear::new(7), BabyBear::new(5)]),
+                Packed::from([BabyBear::new(8), BabyBear::new(6)]),
+            ]
+        );
+
+        // Wrapping gather: visible rows 3 and 0 (wrapping past height=4) map to inner rows 0 and 3.
+        let packed: Vec<_> = mapped_view.vertically_packed_row::<Packed>(3).collect();
+        assert_eq!(
+            packed,
+            vec![
+                Packed::from([BabyBear::new(1), BabyBear::new(7)]),
+                Packed::from([BabyBear::new(2), BabyBear::new(8)]),
+            ]
         );
     }
 

--- a/matrix/src/row_index_mapped.rs
+++ b/matrix/src/row_index_mapped.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::ops::Deref;
 
 use p3_field::PackedValue;
@@ -163,12 +164,49 @@ impl<T: Send + Sync + Clone, IndexMap: RowIndexMap, Inner: Matrix<T>> Matrix<T>
         // inner rows, so unlike `DenseMatrix` we cannot take a contiguous-slice fast path.
         // Reading elements directly still avoids the `Vec` of row-slice guards that the
         // default implementation allocates via `wrapping_row_slices`.
+        let no_wrap = P::WIDTH != 1 && r + P::WIDTH <= height;
         (0..width).map(move |c| {
-            P::from_fn(|i| unsafe {
+            if no_wrap {
+                // Safety: r + i < height (fast-path guard), and c < width (loop bound).
+                P::from_fn(|i| unsafe { self.get_unchecked(r + i, c) })
+            } else {
                 // Safety: (r + i) % height < height, and c < width (loop bound).
-                self.get_unchecked((r + i) % height, c)
-            })
+                P::from_fn(|i| unsafe { self.get_unchecked((r + i) % height, c) })
+            }
         })
+    }
+
+    #[inline]
+    fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        let height = self.height();
+        let width = self.width();
+        let no_wrap = P::WIDTH != 1 && r + P::WIDTH <= height;
+        let next_no_wrap = P::WIDTH != 1 && r + step + P::WIDTH <= height;
+
+        (0..width)
+            .map(move |c| {
+                if no_wrap {
+                    // Safety: r + i < height (fast-path guard), and c < width (loop bound).
+                    P::from_fn(|i| unsafe { self.get_unchecked(r + i, c) })
+                } else {
+                    // Safety: (r + i) % height < height, and c < width (loop bound).
+                    P::from_fn(|i| unsafe { self.get_unchecked((r + i) % height, c) })
+                }
+            })
+            .chain((0..width).map(move |c| {
+                if next_no_wrap {
+                    // Safety: r + step + i < height (fast-path guard), and c < width (loop bound).
+                    P::from_fn(|i| unsafe { self.get_unchecked(r + step + i, c) })
+                } else {
+                    // Safety: (r + step + i) % height < height, and c < width (loop bound).
+                    P::from_fn(|i| unsafe { self.get_unchecked((r + step + i) % height, c) })
+                }
+            }))
+            .collect()
     }
 }
 
@@ -413,6 +451,62 @@ mod tests {
             vec![
                 Packed::from([BabyBear::new(1), BabyBear::new(7)]),
                 Packed::from([BabyBear::new(2), BabyBear::new(8)]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_vertically_packed_row_pair() {
+        // Define the packed type with width 2
+        type Packed = FieldArray<BabyBear, 2>;
+
+        // Create a 4x2 matrix of BabyBear elements:
+        // [ 1  2 ]
+        // [ 3  4 ]
+        // [ 5  6 ]
+        // [ 7  8 ]
+        let inner = RowMajorMatrix::new((1..=8).map(BabyBear::new).collect::<Vec<_>>(), 2);
+
+        // Reverse row mapping: visible row i maps to inner row (height - 1 - i).
+        // So the view (in inner-row order) is rows [3, 2, 1, 0].
+        let mapped_view = RowIndexMappedView {
+            index_map: ReverseMap(inner.height()),
+            inner,
+        };
+
+        // Both halves non-wrapping: visible rows [0, 1] and [2, 3] map to inner rows [3, 2] and [1, 0].
+        let packed = mapped_view.vertically_packed_row_pair::<Packed>(0, 2);
+        assert_eq!(
+            packed,
+            vec![
+                Packed::from([BabyBear::new(7), BabyBear::new(5)]),
+                Packed::from([BabyBear::new(8), BabyBear::new(6)]),
+                Packed::from([BabyBear::new(3), BabyBear::new(1)]),
+                Packed::from([BabyBear::new(4), BabyBear::new(2)]),
+            ]
+        );
+
+        // First half non-wrapping, second half wrapping past height=4.
+        let packed = mapped_view.vertically_packed_row_pair::<Packed>(1, 2);
+        assert_eq!(
+            packed,
+            vec![
+                Packed::from([BabyBear::new(5), BabyBear::new(3)]),
+                Packed::from([BabyBear::new(6), BabyBear::new(4)]),
+                Packed::from([BabyBear::new(1), BabyBear::new(7)]),
+                Packed::from([BabyBear::new(2), BabyBear::new(8)]),
+            ]
+        );
+
+        // Both halves wrapping past height=4.
+        let packed = mapped_view.vertically_packed_row_pair::<Packed>(3, 2);
+        assert_eq!(
+            packed,
+            vec![
+                Packed::from([BabyBear::new(1), BabyBear::new(7)]),
+                Packed::from([BabyBear::new(2), BabyBear::new(8)]),
+                Packed::from([BabyBear::new(5), BabyBear::new(3)]),
+                Packed::from([BabyBear::new(6), BabyBear::new(4)]),
             ]
         );
     }


### PR DESCRIPTION
`BitReversedMatrixView` never overrode `vertically_packed_row`, so it fell back to the generic `Matrix` default which allocates a `Vec` via `wrapping_row_slices` on every call. This is on the hot path of `uni_stark::prover::quotient_values`, called twice per SIMD-packed group.

Override it to gather each packed lane directly through get_unchecked, avoiding the intermediate `Vec` allocation. Benchmarked on a `BitReversedMatrixView`: ~57-59% faster across 2^10-2^18 row matrices.