### PR TITLE
perf(whir, sumcheck): used packing in constraint combination and HZVK initial sumcheck relation

### DIFF
--- a/multi-stark/src/lib.rs
+++ b/multi-stark/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod folder;
 pub mod metadata;
 pub mod opening;
+pub mod packed_ext;
 pub mod rounds;
 pub mod selectors;
 pub mod zerocheck;

--- a/multi-stark/src/packed_ext.rs
+++ b/multi-stark/src/packed_ext.rs
@@ -1,0 +1,189 @@
+//! Local wrapper granting a packed extension-field value arithmetic against
+//! the base field directly.
+
+use core::fmt;
+use core::iter::{Product, Sum};
+use core::marker::PhantomData;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use p3_field::{Algebra, Field, PrimeCharacteristicRing};
+
+/// Wraps a packed extension-field value so it supports arithmetic against
+/// the base field `F` directly, i.e. implements `Algebra<F>`.
+///
+/// `P` (typically `EF::ExtensionPacking`) only implements `Algebra<EF>` and
+/// `Algebra<F::Packing>` — never `Algebra<F>` — because a direct `From<F>`
+/// impl on `P` itself would conflict under orphan/coherence rules with the
+/// existing `From<F::Packing>` impl: a field's fallback (non-SIMD) packing
+/// can have `F::Packing = F`, so the compiler cannot prove the two impls
+/// are disjoint. This type is local to this crate, so implementing
+/// `Algebra<F>` for it here is not subject to that conflict.
+///
+/// Only the trait items required to satisfy `p3_air::AirBuilder`'s bounds
+/// are overridden; every other [`PrimeCharacteristicRing`] method falls
+/// back to its default (mathematically correct, not necessarily as fast as
+/// `P`'s own overrides for that operation).
+#[repr(transparent)]
+pub struct PackedExt<F, P>(pub P, PhantomData<fn() -> F>);
+
+impl<F, P> PackedExt<F, P> {
+    #[inline]
+    pub const fn new(p: P) -> Self {
+        Self(p, PhantomData)
+    }
+}
+
+impl<F, P: Copy> Clone for PackedExt<F, P> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<F, P: Copy> Copy for PackedExt<F, P> {}
+
+impl<F, P: fmt::Debug> fmt::Debug for PackedExt<F, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<F, P: Default> Default for PackedExt<F, P> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(P::default())
+    }
+}
+
+impl<F, P: Add<Output = P>> Add for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        Self::new(self.0 + rhs.0)
+    }
+}
+
+impl<F, P: AddAssign> AddAssign for PackedExt<F, P> {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl<F, P: Sub<Output = P>> Sub for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(self.0 - rhs.0)
+    }
+}
+
+impl<F, P: SubAssign> SubAssign for PackedExt<F, P> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl<F, P: Neg<Output = P>> Neg for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        Self::new(-self.0)
+    }
+}
+
+impl<F, P: Mul<Output = P>> Mul for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self::new(self.0 * rhs.0)
+    }
+}
+
+impl<F, P: MulAssign> MulAssign for PackedExt<F, P> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl<F, P: PrimeCharacteristicRing + Copy> Sum for PackedExt<F, P> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        Self::new(iter.map(|x| x.0).sum())
+    }
+}
+
+impl<F, P: PrimeCharacteristicRing + Copy> Product for PackedExt<F, P> {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        Self::new(iter.map(|x| x.0).product())
+    }
+}
+
+impl<F, P: PrimeCharacteristicRing + Copy> PrimeCharacteristicRing for PackedExt<F, P> {
+    type PrimeSubfield = P::PrimeSubfield;
+
+    const ZERO: Self = Self::new(P::ZERO);
+    const ONE: Self = Self::new(P::ONE);
+    const TWO: Self = Self::new(P::TWO);
+    const NEG_ONE: Self = Self::new(P::NEG_ONE);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        Self::new(P::from_prime_subfield(f))
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> From<F> for PackedExt<F, P> {
+    #[inline]
+    fn from(f: F) -> Self {
+        Self::new(P::from(F::Packing::from(f)))
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> Add<F> for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: F) -> Self {
+        self + Self::from(rhs)
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> AddAssign<F> for PackedExt<F, P> {
+    #[inline]
+    fn add_assign(&mut self, rhs: F) {
+        *self += Self::from(rhs);
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> Sub<F> for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: F) -> Self {
+        self - Self::from(rhs)
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> SubAssign<F> for PackedExt<F, P> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F) {
+        *self -= Self::from(rhs);
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> Mul<F> for PackedExt<F, P> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: F) -> Self {
+        self * Self::from(rhs)
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> MulAssign<F> for PackedExt<F, P> {
+    #[inline]
+    fn mul_assign(&mut self, rhs: F) {
+        *self *= Self::from(rhs);
+    }
+}
+
+impl<F: Field, P: Algebra<F::Packing> + Copy> Algebra<F> for PackedExt<F, P> {}

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -15,6 +15,7 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 
 use crate::folder::MultilinearFolder;
+use crate::packed_ext::PackedExt;
 use crate::selectors::BoundaryEvals;
 
 /// Sumcheck prover state for the AIR zerocheck.
@@ -393,8 +394,32 @@ where
         (columns, self.next_tail, self.boundary)
     }
 
+    /// Computes the round polynomial evaluations, dispatching to the
+    /// SIMD-packed kernel once there are enough residual rows to fill a
+    /// packed lane, mirroring [`RoundStateBase::round_poly`].
     #[tracing::instrument(skip_all)]
     pub(crate) fn round_poly(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
+            + for<'b> Air<
+                MultilinearFolder<
+                    'b,
+                    F,
+                    PackedExt<F, EF::ExtensionPacking>,
+                    PackedExt<F, EF::ExtensionPacking>,
+                >,
+            >,
+        EF::ExtensionPacking: From<EF> + From<F::Packing>,
+    {
+        if self.num_evals() / 2 < F::Packing::WIDTH {
+            self.round_poly_unpacked()
+        } else {
+            self.round_poly_packed()
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn round_poly_unpacked(&self) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
     {
@@ -467,6 +492,171 @@ where
                         )
                         .eval_air(self.air);
                         *acc += eq_suffix * g;
+                    }
+
+                    scratch
+                },
+                |mut lhs, rhs| {
+                    lhs.out
+                        .iter_mut()
+                        .zip(rhs.out)
+                        .for_each(|(lhs, rhs)| *lhs += rhs);
+                    lhs
+                },
+            )
+            .out
+    }
+
+    /// SIMD-packed twin of [`Self::round_poly_unpacked`].
+    ///
+    /// Every column is already extension-valued (folded by earlier rounds),
+    /// so packing groups `F::Packing::WIDTH` consecutive residual rows of
+    /// each `Poly<EF>` column into one `EF::ExtensionPacking`, via an
+    /// unaligned [`PackedFieldExtension::from_ext_slice`] read exactly like
+    /// [`RoundStateBase::round_poly_packed`] does for its base-field
+    /// columns. The AIR is driven through [`PackedExt`], which wraps the
+    /// packed extension value so it supports arithmetic against the base
+    /// field `F` directly (see that type's docs for why this is needed).
+    #[tracing::instrument(skip_all)]
+    fn round_poly_packed(&self) -> Vec<EF>
+    where
+        A: for<'b> Air<
+            MultilinearFolder<
+                'b,
+                F,
+                PackedExt<F, EF::ExtensionPacking>,
+                PackedExt<F, EF::ExtensionPacking>,
+            >,
+        >,
+        EF::ExtensionPacking: From<EF> + From<F::Packing>,
+    {
+        let width = self.width();
+        let height = self.num_evals();
+        let scalar_half = height / 2;
+        let packing_width = F::Packing::WIDTH;
+        let packed_half = scalar_half / packing_width;
+        let degree = self.degree;
+        let alpha = PackedExt::new(EF::ExtensionPacking::from(self.alpha));
+        assert_ne!(packed_half, 0);
+
+        self.eq_suffix
+            .as_slice()
+            .par_chunks_exact(packing_width)
+            .enumerate()
+            .par_fold_reduce(
+                || PackedScratch::<PackedExt<F, EF::ExtensionPacking>, EF>::new(degree, width),
+                |mut scratch, (packed_s, eq_suffix)| {
+                    let s = packed_s * packing_width;
+
+                    for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
+                        .local_point
+                        .iter_mut()
+                        .zip(scratch.local_diff.iter_mut())
+                        .zip(scratch.next_point.iter_mut())
+                        .zip(scratch.next_diff.iter_mut())
+                        .zip(self.columns.iter())
+                        .zip(self.next_tail.iter())
+                    {
+                        let column = column.as_slice();
+                        let local_lo = PackedExt::new(EF::ExtensionPacking::from_ext_slice(
+                            &column[s..s + packing_width],
+                        ));
+                        let local_hi = PackedExt::new(EF::ExtensionPacking::from_ext_slice(
+                            &column[s + scalar_half..s + scalar_half + packing_width],
+                        ));
+                        *local = local_lo;
+                        *local_delta = local_hi - local_lo;
+
+                        let next_lo = PackedExt::new(EF::ExtensionPacking::from_ext_slice(
+                            &column[s + 1..s + 1 + packing_width],
+                        ));
+                        let next_hi_start = s + scalar_half + 1;
+                        let next_hi = if next_hi_start + packing_width <= height {
+                            PackedExt::new(EF::ExtensionPacking::from_ext_slice(
+                                &column[next_hi_start..next_hi_start + packing_width],
+                            ))
+                        } else {
+                            PackedExt::new(EF::ExtensionPacking::from_ext_fn(|lane| {
+                                let row = next_hi_start + lane;
+                                if row < height {
+                                    column[row]
+                                } else {
+                                    *next_tail
+                                }
+                            }))
+                        };
+                        *next = next_lo;
+                        *next_delta = next_hi - next_lo;
+                    }
+
+                    let (raw_boundary, raw_boundary_diff) =
+                        BoundaryEvals::row_pair_with_prefix_packed::<F>(
+                            s,
+                            scalar_half,
+                            height,
+                            self.boundary,
+                        );
+                    let mut boundary = BoundaryEvals::new(
+                        PackedExt::new(raw_boundary.first),
+                        PackedExt::new(raw_boundary.last),
+                        PackedExt::new(raw_boundary.transition),
+                    );
+                    let boundary_diff = BoundaryEvals::new(
+                        PackedExt::new(raw_boundary_diff.first),
+                        PackedExt::new(raw_boundary_diff.last),
+                        PackedExt::new(raw_boundary_diff.transition),
+                    );
+
+                    let g = MultilinearFolder::new(
+                        &scratch.local_point,
+                        &scratch.next_point,
+                        boundary,
+                        self.public_values,
+                        alpha,
+                    )
+                    .eval_air(self.air);
+                    scratch.out[0] += dot_product::<EF, _, _>(
+                        eq_suffix.iter().copied(),
+                        EF::ExtensionPacking::to_ext_iter([g.0]),
+                    );
+
+                    scratch
+                        .local_point
+                        .iter_mut()
+                        .zip(scratch.local_diff.iter())
+                        .zip(scratch.next_point.iter_mut())
+                        .zip(scratch.next_diff.iter())
+                        .for_each(|(((local, local_diff), next), next_diff)| {
+                            *local += *local_diff;
+                            *next += *next_diff;
+                        });
+                    boundary += boundary_diff;
+
+                    for acc in &mut scratch.out[1..] {
+                        scratch
+                            .local_point
+                            .iter_mut()
+                            .zip(scratch.local_diff.iter())
+                            .zip(scratch.next_point.iter_mut())
+                            .zip(scratch.next_diff.iter())
+                            .for_each(|(((local, local_diff), next), next_diff)| {
+                                *local += *local_diff;
+                                *next += *next_diff;
+                            });
+                        boundary += boundary_diff;
+
+                        let g = MultilinearFolder::new(
+                            &scratch.local_point,
+                            &scratch.next_point,
+                            boundary,
+                            self.public_values,
+                            alpha,
+                        )
+                        .eval_air(self.air);
+                        *acc += dot_product::<EF, _, _>(
+                            eq_suffix.iter().copied(),
+                            EF::ExtensionPacking::to_ext_iter([g.0]),
+                        );
                     }
 
                     scratch

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -2,7 +2,7 @@
 
 use core::ops::{AddAssign, Sub};
 
-use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
+use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
 
 /// Boundary selectors evaluated at a sumcheck challenge.
 #[derive(Copy, Clone, Debug)]
@@ -234,6 +234,69 @@ impl<EF: Field> BoundaryEvals<EF> {
         (
             boundary,
             Self::new(
+                hi_boundary.first - boundary.first,
+                hi_boundary.last - boundary.last,
+                hi_boundary.transition - boundary.transition,
+            ),
+        )
+    }
+
+    /// The full selector values at a residual-cube row, combined with the
+    /// bound-coordinate prefix, spread across `WIDTH` SIMD lanes — one lane
+    /// per consecutive residual row starting at `row`.
+    ///
+    /// Same construction as [`Self::from_row_with_prefix`], but every
+    /// per-row indicator is built lane-by-lane via
+    /// [`PackedFieldExtension::from_ext_fn`] instead of once for a single row.
+    fn from_ext_packed_row_with_prefix<F>(
+        row: usize,
+        height: usize,
+        prefix: Self,
+    ) -> BoundaryEvals<EF::ExtensionPacking>
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+    {
+        BoundaryEvals::new(
+            EF::ExtensionPacking::from_ext_fn(|lane| prefix.first * EF::from_bool(row + lane == 0)),
+            EF::ExtensionPacking::from_ext_fn(|lane| {
+                prefix.last * EF::from_bool(row + lane + 1 == height)
+            }),
+            EF::ExtensionPacking::from_ext_fn(|lane| {
+                let suffix_last = EF::from_bool(row + lane + 1 == height);
+                EF::from_bool(row + lane + 1 < height) + suffix_last * prefix.transition
+            }),
+        )
+    }
+
+    /// Packed `(value, per-step difference)` pair for folding one variable,
+    /// with a bound-coordinate prefix — the SIMD-packed extension-field twin
+    /// of [`Self::row_pair_with_prefix`].
+    ///
+    /// # Arguments
+    ///
+    /// - `row`: index of the first low-half row in this packed block.
+    /// - `half`: distance from a low row to its matching high row.
+    /// - `height`: number of rows in the residual cube.
+    /// - `prefix`: partial products over the coordinates bound so far.
+    pub(super) fn row_pair_with_prefix_packed<F>(
+        row: usize,
+        half: usize,
+        height: usize,
+        prefix: Self,
+    ) -> (
+        BoundaryEvals<EF::ExtensionPacking>,
+        BoundaryEvals<EF::ExtensionPacking>,
+    )
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+    {
+        let boundary = Self::from_ext_packed_row_with_prefix::<F>(row, height, prefix);
+        let hi_boundary = Self::from_ext_packed_row_with_prefix::<F>(row + half, height, prefix);
+        (
+            boundary,
+            BoundaryEvals::new(
                 hi_boundary.first - boundary.first,
                 hi_boundary.last - boundary.last,
                 hi_boundary.transition - boundary.transition,

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -24,6 +24,7 @@ use thiserror::Error;
 
 use crate::folder::MultilinearFolder;
 use crate::opening::OpeningClaims;
+use crate::packed_ext::PackedExt;
 use crate::rounds::RoundStateBase;
 use crate::selectors::BoundaryEvals;
 
@@ -215,7 +216,14 @@ impl<'a, A> AirZerocheck<'a, A> {
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
             + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>
             + for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
-            + Air<SymbolicAirBuilder<F, EF>>,
+            + for<'b> Air<
+                MultilinearFolder<
+                    'b,
+                    F,
+                    PackedExt<F, EF::ExtensionPacking>,
+                    PackedExt<F, EF::ExtensionPacking>,
+                >,
+            > + Air<SymbolicAirBuilder<F, EF>>,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -27,7 +27,7 @@ use p3_field::{
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
-use p3_sumcheck::constraints::statement::EqStatement;
+use p3_sumcheck::constraints::statement::{EqStatement, SelectStatement};
 use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
@@ -420,8 +420,6 @@ fn bench_combine<B: BenchField>(c: &mut Criterion)
 where
     StandardUniform: Distribution<B::F> + Distribution<B::EF>,
 {
-    use p3_sumcheck::constraints::statement::SelectStatement;
-
     let mut group = c.benchmark_group(format!("sumcheck/{}/combine", B::NAME));
     group.sample_size(10);
 

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -414,6 +414,47 @@ where
     Constraint::new(rng.random(), k, vec![Statements::Eq(eq)])
 }
 
+/// Benches folding a large `SelectStatement` (STIR-query-shaped) into an
+/// unpacked weight accumulator, isolated from any round-folding cost.
+fn bench_combine<B: BenchField>(c: &mut Criterion)
+where
+    StandardUniform: Distribution<B::F> + Distribution<B::EF>,
+{
+    use p3_sumcheck::constraints::statement::SelectStatement;
+
+    let mut group = c.benchmark_group(format!("sumcheck/{}/combine", B::NAME));
+    group.sample_size(10);
+
+    let k = 20;
+    let n = 80;
+    let mut rng = rng_for(0x000C, k);
+
+    let evals = rand_ext::<B>(&mut rng, k);
+    let weights = Poly::<B::EF>::new(vec![B::EF::ZERO; 1 << k]);
+    let poly =
+        ProductPolynomial::<B::F, B::EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
+
+    let mut statement = SelectStatement::<B::F, B::EF>::initialize(k);
+    for _ in 0..n {
+        statement.add_constraint(rng.random(), rng.random());
+    }
+    let constraint = Constraint::new(rng.random(), k, vec![Statements::Select(statement)]);
+
+    group.throughput(Throughput::Elements(1 << k));
+    group.bench_function("select", |b| {
+        b.iter_batched(
+            || (poly.clone(), B::EF::ZERO, constraint.clone()),
+            |(mut poly, mut sum, constraint)| {
+                poly.combine(&mut sum, &constraint);
+                black_box((poly, sum));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
 /// Benches the multi-round driver folding every variable to a constant.
 ///
 /// Two arms isolate the cost of absorbing a constraint:
@@ -600,6 +641,12 @@ fn prover(c: &mut Criterion) {
     bench_prover::<KoalaBear4>(c);
 }
 
+/// Select-statement combine for every field.
+fn combine(c: &mut Criterion) {
+    bench_combine::<BabyBear4>(c);
+    bench_combine::<KoalaBear4>(c);
+}
+
 /// Stacked-layout handoff for every field.
 fn layout(c: &mut Criterion) {
     bench_layout::<BabyBear4>(c);
@@ -613,6 +660,7 @@ criterion_group!(
     dot_product,
     product_round,
     prover,
+    combine,
     layout,
 );
 criterion_main!(benches);

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -549,7 +549,28 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
                 constraint.combine_packed(weights, sum);
             }
             MaybePacked::Unpacked { weights, .. } => {
-                constraint.combine(weights, sum);
+                // The scalar `Constraint::combine` builds an explicit `2^k` weight
+                // table via a full select-matrix construction. `combine_packed`
+                // computes the same table with O(sqrt(2^k)) working memory via a
+                // split-and-dot construction; route through it whenever there are
+                // enough variables to pack, then unpack-add the packed delta into
+                // the scalar accumulator.
+                let k_pack = log2_strict_usize(F::Packing::WIDTH);
+                if weights.num_variables() >= k_pack {
+                    let mut packed_delta = Poly::zero(weights.num_variables() - k_pack);
+                    let mut packed_sum = EF::ZERO;
+                    constraint.combine_packed(&mut packed_delta, &mut packed_sum);
+                    *sum += packed_sum;
+                    weights
+                        .as_mut_slice()
+                        .iter_mut()
+                        .zip(EF::ExtensionPacking::to_ext_iter(
+                            packed_delta.iter().copied(),
+                        ))
+                        .for_each(|(out, delta)| *out += delta);
+                } else {
+                    constraint.combine(weights, sum);
+                }
             }
         }
     }

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -18,11 +18,10 @@ use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, PackedValue, PrimeCharacteristicRing, TwoAdicField, dot_product};
 use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrixView;
 use p3_maybe_rayon::prelude::*;
-use p3_multilinear_util::eq_batch::eval_eq_batch;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
+use p3_multilinear_util::split_eq::SplitEq;
 use p3_sumcheck::constraints::statement::SelectStatement;
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{SumcheckProver, VariableOrder};
@@ -136,40 +135,47 @@ where
         //
         //     W = sum_i alpha^i eq(z_i, .)        claim = sum_i alpha^i v_i
         let alpha: EF = challenger.sample_algebra_element();
-        let mut weights = EF::zero_vec(1 << num_variables);
+        let coeffs: Vec<EF> = alpha.powers().collect_n(claims.len());
         let mut claim = EF::ZERO;
-        if !claims.is_empty() {
-            let coeffs: Vec<EF> = alpha.powers().collect_n(claims.len());
-            // All claim tables land in one batched parallel sweep.
-            // Row `var` of the point matrix holds variable `var` across claims.
-            let mut points_flat = Vec::with_capacity(num_variables * claims.len());
-            for var in 0..num_variables {
-                for (point, _) in claims {
-                    assert_eq!(point.num_variables(), num_variables);
-                    points_flat.push(point.as_slice()[var]);
-                }
-            }
-            eval_eq_batch::<F, EF, false>(
-                RowMajorMatrixView::new(&points_flat, claims.len()),
-                &mut weights,
-                &coeffs,
-            );
-            for ((_, eval), coeff) in claims.iter().zip(&coeffs) {
-                claim += *coeff * *eval;
-            }
+        for ((point, eval), coeff) in claims.iter().zip(&coeffs) {
+            assert_eq!(point.num_variables(), num_variables);
+            claim += *coeff * *eval;
         }
-        // Lift the base-field message into the extension once, in parallel.
-        let evals: Vec<EF> = prover_data
-            .message
-            .as_slice()
-            .par_iter()
-            .map(|&v| v.into())
-            .collect();
-        let product = ProductPolynomial::new_unpacked(
-            VariableOrder::Prefix,
-            Poly::new(evals),
-            Poly::new(weights),
-        );
+
+        // Build the weight and evaluation polynomials in SIMD-packed form
+        // whenever the hypercube is large enough, mirroring the non-ZK
+        // sumcheck's packed construction; the eq table is accumulated
+        // per-claim through the split-eq factorization instead of a full
+        // 2^n scalar materialization.
+        let k_pack = log2_strict_usize(F::Packing::WIDTH);
+        let product = if num_variables >= k_pack {
+            let mut weights = Poly::<EF::ExtensionPacking>::zero(num_variables - k_pack);
+            for ((point, _), &coeff) in claims.iter().zip(&coeffs) {
+                SplitEq::new_packed(point, coeff)
+                    .accumulate_into_packed(weights.as_mut_slice(), None);
+            }
+            let evals = Poly::new(
+                F::Packing::pack_slice(prover_data.message.as_slice())
+                    .par_iter()
+                    .map(|&p| EF::ExtensionPacking::from(p))
+                    .collect(),
+            );
+            ProductPolynomial::new_packed(VariableOrder::Prefix, evals, weights)
+        } else {
+            let mut weights = Poly::<EF>::zero(num_variables);
+            for ((point, _), &coeff) in claims.iter().zip(&coeffs) {
+                SplitEq::new_unpacked(point, coeff).accumulate_into(weights.as_mut_slice(), None);
+            }
+            let evals = Poly::new(
+                prover_data
+                    .message
+                    .as_slice()
+                    .par_iter()
+                    .map(|&v| v.into())
+                    .collect(),
+            );
+            ProductPolynomial::new_unpacked(VariableOrder::Prefix, evals, weights)
+        };
         let sumcheck_prover = SumcheckProver::new(product, claim);
 
         // Initial masked sumcheck batch.


### PR DESCRIPTION
Added a `combine` benchmark in the `p3-sumcheck` crate. Compared to `main`, I'm getting ~60% improvement for this step on my M4 pro.