### PR TITLE
perf(matrix): pack rows through composition wrappers

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -656,15 +656,21 @@ impl<T: Clone + Default + Send + Sync> DenseMatrix<T> {
         let new_values = T::zero_vec(new_w * self.height());
         let mut result = Self::new(new_values, new_w);
 
-        // - Copy original data into the left portion of each row,
-        // - Then fill the right portion with independent random samples.
+        // Copy original data into the left portion of each row in parallel; this is a plain
+        // memcpy per row with no dependency on the (necessarily serial) RNG stream below.
         result
-            .rows_mut()
-            .zip(self.row_slices())
+            .par_rows_mut()
+            .zip(self.par_row_slices())
             .for_each(|(new_row, old_row)| {
                 new_row[..old_w].copy_from_slice(old_row);
-                new_row[old_w..].iter_mut().for_each(|v| *v = rng.random());
             });
+
+        // Fill the trailing random columns as a separate serial pass, since `rng` is a single
+        // sequential stream.
+        result.rows_mut().for_each(|new_row| {
+            new_row[old_w..].iter_mut().for_each(|v| *v = rng.random());
+        });
+
         result
     }
 

--- a/matrix/src/horizontally_truncated.rs
+++ b/matrix/src/horizontally_truncated.rs
@@ -1,5 +1,8 @@
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::ops::Range;
+
+use p3_field::PackedValue;
 
 use crate::Matrix;
 use crate::bitrev::BitReversibleMatrix;
@@ -128,6 +131,29 @@ where
                 self.column_range.start + end,
             )
         }
+    }
+
+    #[inline]
+    fn vertically_packed_row<P>(&self, r: usize) -> impl Iterator<Item = P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        self.inner
+            .vertically_packed_row::<P>(r)
+            .skip(self.column_range.start)
+            .take(self.width())
+    }
+
+    #[inline]
+    fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        self.vertically_packed_row::<P>(r)
+            .chain(self.vertically_packed_row::<P>(r + step))
+            .collect()
     }
 }
 
@@ -439,5 +465,54 @@ mod tests {
         // The constructor must reject it rather than return a view.
         let inverted = Range { start: 2, end: 1 };
         assert!(HorizontallyTruncated::new_with_range(inner, inverted).is_none());
+    }
+
+    #[test]
+    fn test_vertically_packed_row_scalar_width_1() {
+        use p3_baby_bear::BabyBear;
+
+        type Packed = BabyBear;
+
+        // Full matrix (4x4):
+        // [  1   2   3   4  ]  <-- Row 0
+        // [  5   6   7   8  ]  <-- Row 1
+        // [  9  10  11  12  ]  <-- Row 2
+        // [ 13  14  15  16  ]  <-- Row 3
+        let inner = RowMajorMatrix::new((1..17).map(BabyBear::new).collect::<Vec<_>>(), 4);
+
+        // Truncate to the first two columns.
+        let truncated = HorizontallyTruncated::new(inner, 2).unwrap();
+
+        let packed = truncated
+            .vertically_packed_row::<Packed>(2)
+            .collect::<Vec<_>>();
+
+        assert_eq!(packed, vec![BabyBear::new(9), BabyBear::new(10)]);
+    }
+
+    #[test]
+    fn test_vertically_packed_row_pair_middle_column_range() {
+        use p3_baby_bear::BabyBear;
+        use p3_field::FieldArray;
+
+        type Packed = FieldArray<BabyBear, 2>;
+
+        let inner = RowMajorMatrix::new((1..17).map(BabyBear::new).collect::<Vec<_>>(), 4);
+
+        // Select the middle two columns (1, 2), so the packed-row skip/take logic is exercised
+        // with a non-zero `column_range.start`.
+        let view = HorizontallyTruncated::new_with_range(inner, 1..3).unwrap();
+
+        let packed = view.vertically_packed_row_pair::<Packed>(0, 2);
+
+        assert_eq!(
+            packed,
+            vec![
+                [BabyBear::new(2), BabyBear::new(6)].into(),
+                [BabyBear::new(3), BabyBear::new(7)].into(),
+                [BabyBear::new(10), BabyBear::new(14)].into(),
+                [BabyBear::new(11), BabyBear::new(15)].into(),
+            ]
+        );
     }
 }

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -428,10 +428,12 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
-        // Below this height, the rayon fork-join and SIMD-packing machinery costs more than
-        // the dot product itself; fall back to a plain scalar accumulation.
-        const SMALL_HEIGHT: usize = 16;
-        if self.height() <= SMALL_HEIGHT {
+        // Below this many total elements, the rayon fork-join and SIMD-packing machinery
+        // costs more than the dot product itself; fall back to a plain scalar accumulation.
+        // Gating on total elements (rather than height alone) also covers wide-but-short
+        // matrices, where a per-row cost proportional to width still adds up.
+        const SMALL_ELEMS: usize = 256;
+        if self.height().saturating_mul(self.width()) <= SMALL_ELEMS {
             let mut acc = EF::zero_vec(self.width());
             for (row, &scale) in self.rows().zip(v) {
                 for (l, r) in acc.iter_mut().zip(row) {

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -428,6 +428,19 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
+        // Below this height, the rayon fork-join and SIMD-packing machinery costs more than
+        // the dot product itself; fall back to a plain scalar accumulation.
+        const SMALL_HEIGHT: usize = 16;
+        if self.height() <= SMALL_HEIGHT {
+            let mut acc = EF::zero_vec(self.width());
+            for (row, &scale) in self.rows().zip(v) {
+                for (l, r) in acc.iter_mut().zip(row) {
+                    *l += scale * r;
+                }
+            }
+            return acc;
+        }
+
         let packed_width = self.width().div_ceil(T::Packing::WIDTH);
 
         let packed_result = self
@@ -582,6 +595,29 @@ mod tests {
         }
 
         assert_eq!(m.columnwise_dot_product(&v), expected);
+    }
+
+    #[test]
+    fn test_columnwise_dot_product_small_height() {
+        type F = BabyBear;
+        type EF = BinomialExtensionField<BabyBear, 4>;
+
+        let mut rng = SmallRng::seed_from_u64(2);
+
+        // Cover heights below, at, and just above the small-height serial threshold.
+        for height in [0, 1, 3, 16, 17] {
+            let m = RowMajorMatrix::<F>::rand(&mut rng, height, 1 << 4);
+            let v = RowMajorMatrix::<EF>::rand(&mut rng, height, 1).values;
+
+            let mut expected = EF::zero_vec(m.width());
+            for (row, &scale) in izip!(m.rows(), &v) {
+                for (l, r) in izip!(&mut expected, row) {
+                    *l += scale * r;
+                }
+            }
+
+            assert_eq!(m.columnwise_dot_product(&v), expected, "height = {height}");
+        }
     }
 
     #[test]

--- a/matrix/src/stack.rs
+++ b/matrix/src/stack.rs
@@ -1,4 +1,7 @@
+use alloc::vec::Vec;
 use core::ops::Deref;
+
+use p3_field::PackedValue;
 
 use crate::Matrix;
 use crate::bitrev::BitReversibleMatrix;
@@ -209,6 +212,28 @@ impl<T: Send + Sync + Clone, Left: Matrix<T>, Right: Matrix<T>> Matrix<T>
                 .chain(self.right.row_unchecked(r))
         }
     }
+
+    #[inline]
+    fn vertically_packed_row<P>(&self, r: usize) -> impl Iterator<Item = P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        self.left
+            .vertically_packed_row::<P>(r)
+            .chain(self.right.vertically_packed_row::<P>(r))
+    }
+
+    #[inline]
+    fn vertically_packed_row_pair<P>(&self, r: usize, step: usize) -> Vec<P>
+    where
+        T: Copy,
+        P: PackedValue<Value = T>,
+    {
+        self.vertically_packed_row::<P>(r)
+            .chain(self.vertically_packed_row::<P>(r + step))
+            .collect()
+    }
 }
 
 /// We use this to wrap both the row iterator and the row slice.
@@ -403,5 +428,59 @@ mod tests {
         let a = RowMajorMatrix::new(vec![1, 2, 3], 3); // 1x3
         let b = RowMajorMatrix::new(vec![4, 5], 1); // 2x1
         let _ = HorizontalPair::new::<i32>(a, b);
+    }
+
+    #[test]
+    fn test_horizontal_pair_vertically_packed_row_scalar_width_1() {
+        use p3_baby_bear::BabyBear;
+
+        type Packed = BabyBear;
+
+        // Full matrix (4x4), split into two 4x2 halves:
+        // [  1   2 |  3   4  ]  <-- Row 0
+        // [  5   6 |  7   8  ]  <-- Row 1
+        // [  9  10 | 11  12  ]  <-- Row 2
+        // [ 13  14 | 15  16  ]  <-- Row 3
+        let left = RowMajorMatrix::new([1, 2, 5, 6, 9, 10, 13, 14].map(BabyBear::new).to_vec(), 2);
+        let right =
+            RowMajorMatrix::new([3, 4, 7, 8, 11, 12, 15, 16].map(BabyBear::new).to_vec(), 2);
+        let horizontal = HorizontalPair::new::<BabyBear>(left, right);
+
+        let packed = horizontal
+            .vertically_packed_row::<Packed>(2)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            packed,
+            vec![
+                BabyBear::new(9),
+                BabyBear::new(10),
+                BabyBear::new(11),
+                BabyBear::new(12),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_horizontal_pair_vertically_packed_row_pair() {
+        use p3_baby_bear::BabyBear;
+        use p3_field::FieldArray;
+
+        type Packed = FieldArray<BabyBear, 2>;
+
+        let left = RowMajorMatrix::new([1, 2, 5, 6, 9, 10, 13, 14].map(BabyBear::new).to_vec(), 2);
+        let right =
+            RowMajorMatrix::new([3, 4, 7, 8, 11, 12, 15, 16].map(BabyBear::new).to_vec(), 2);
+        let horizontal = HorizontalPair::new::<BabyBear>(left, right);
+
+        let packed = horizontal.vertically_packed_row_pair::<Packed>(0, 2);
+
+        assert_eq!(
+            packed,
+            (1..5)
+                .chain(9..13)
+                .map(|i| [BabyBear::new(i), BabyBear::new(i + 4)].into())
+                .collect::<Vec<_>>(),
+        );
     }
 }


### PR DESCRIPTION
I didn't include additional benchmark files, but they yield ~60/~70% savings on vertically_packed_row() / vertically_packed_row_pair().