### PR TITLE
feat(multi-stark) batch zerocheck

### DIFF
--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -17,6 +17,7 @@ parallel = [
 ]
 
 [dependencies]
+itertools.workspace = true
 p3-air.workspace = true
 p3-challenger.workspace = true
 p3-commit.workspace = true
@@ -30,10 +31,10 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 thiserror.workspace = true
 tracing.workspace = true
 
-
 [dev-dependencies]
 criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
+p3-blake3-air.workspace = true
 p3-dft.workspace = true
 p3-merkle-tree.workspace = true
 p3-poseidon2-air.workspace = true

--- a/multi-stark/benches/poseidon2.rs
+++ b/multi-stark/benches/poseidon2.rs
@@ -70,20 +70,31 @@ fn bench_poseidon2_zerocheck_prove(c: &mut Criterion) {
         let air = poseidon2_air();
         let trace = air.generate_random_trace_rows(num_hashes, 0);
         let table = Table::new(trace.transpose());
-        let zerocheck = AirZerocheck::new(&air, 0);
+        let empty_public_values: &[F] = &[];
+        for num_airs in [1, 5, 10] {
+            let airs = vec![&air; num_airs];
+            let preprocessed = vec![None; num_airs];
+            let tables = vec![&table; num_airs];
+            let public_values = vec![empty_public_values; num_airs];
+            let zerocheck = AirZerocheck::new(&airs, 0);
 
-        group.bench_with_input(
-            BenchmarkId::from_parameter(num_vars),
-            &num_vars,
-            |b, &num_vars| {
-                b.iter(|| {
-                    let mut challenger = fresh_challenger();
-                    let (proof, point) =
-                        zerocheck.prove::<F, EF, _>(&table, None, &[], &mut challenger);
-                    black_box((proof, point, num_vars));
-                });
-            },
-        );
+            group.bench_with_input(
+                BenchmarkId::new(format!("{num_airs}_airs"), num_vars),
+                &num_vars,
+                |b, &num_vars| {
+                    b.iter(|| {
+                        let mut challenger = fresh_challenger();
+                        let (proof, point) = zerocheck.prove::<F, EF, _>(
+                            &preprocessed,
+                            &tables,
+                            &public_values,
+                            &mut challenger,
+                        );
+                        black_box((proof, point, num_vars, num_airs));
+                    });
+                },
+            );
+        }
     }
 
     group.finish();

--- a/multi-stark/benches/zerocheck.rs
+++ b/multi-stark/benches/zerocheck.rs
@@ -138,19 +138,31 @@ fn fresh_challenger() -> Ch {
 
 fn bench_zerocheck(c: &mut Criterion) {
     let mut group = c.benchmark_group("zerocheck_prove");
+    group.sample_size(10);
     for log_height in [16, 18, 20] {
         let n = 1 << log_height;
         let trace = fib_trace(n);
         let last = trace.values[(n - 1) * NUM_COLS + 1];
         let pis = [F::ZERO, F::ONE, last];
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
         let table = Table::new(trace.transpose());
-        group.bench_with_input(BenchmarkId::from_parameter(log_height), &n, |b, _| {
-            b.iter(|| {
-                let mut ch = fresh_challenger();
-                zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut ch)
-            });
-        });
+        let air = FibAir;
+        for num_airs in [1, 5, 10] {
+            let airs = (0..num_airs).map(|_| &air).collect::<Vec<_>>();
+            let preprocessed = vec![None; num_airs];
+            let tables = vec![&table; num_airs];
+            let public_values = vec![&pis[..]; num_airs];
+            let zerocheck = AirZerocheck::new(&airs, 0);
+            group.bench_with_input(
+                BenchmarkId::new(format!("{num_airs}_airs"), log_height),
+                &n,
+                |b, _| {
+                    b.iter(|| {
+                        let mut ch = fresh_challenger();
+                        zerocheck.prove::<F, EF, _>(&preprocessed, &tables, &public_values, &mut ch)
+                    });
+                },
+            );
+        }
     }
     group.finish();
 }
@@ -161,15 +173,31 @@ fn bench_wide_zerocheck(c: &mut Criterion) {
     for log_height in [16, 18, 20] {
         let n = 1 << log_height;
         let table = Table::new(wide_fib_trace(n).transpose());
+        let empty_public_values: &[F] = &[];
         for (label, all_next) in [("all_next", true), ("sparse_next", false)] {
             let air = WideFibAir { all_next };
-            let zerocheck = AirZerocheck::new(&air, 0);
-            group.bench_with_input(BenchmarkId::new(label, log_height), &n, |b, _| {
-                b.iter(|| {
-                    let mut ch = fresh_challenger();
-                    zerocheck.prove::<F, EF, _>(&table, None, &[], &mut ch)
-                });
-            });
+            for num_airs in [1, 5, 10] {
+                let airs = (0..num_airs).map(|_| &air).collect::<Vec<_>>();
+                let preprocessed = vec![None; num_airs];
+                let tables = vec![&table; num_airs];
+                let public_values = vec![empty_public_values; num_airs];
+                let zerocheck = AirZerocheck::new(&airs, 0);
+                group.bench_with_input(
+                    BenchmarkId::new(format!("{label}_{num_airs}_airs"), log_height),
+                    &n,
+                    |b, _| {
+                        b.iter(|| {
+                            let mut ch = fresh_challenger();
+                            zerocheck.prove::<F, EF, _>(
+                                &preprocessed,
+                                &tables,
+                                &public_values,
+                                &mut ch,
+                            )
+                        });
+                    },
+                );
+            }
         }
     }
     group.finish();

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -92,7 +92,7 @@ where
     let log_height = log2_strict_usize(trace.height());
     let width = trace.width;
     let next_columns = air.main_next_row_columns();
-    let preprocessed = proving_key.preprocessed.as_ref();
+    let preprocessed_key = proving_key.preprocessed.as_ref();
 
     // The trace columns are the AIR columns, so their counts must agree.
     assert_eq!(width, air.width(), "trace width must match the AIR width");
@@ -105,7 +105,7 @@ where
     );
 
     // 1. Absorb the reusable preprocessed commitment before any challenge depends on it.
-    if let Some(preprocessed) = preprocessed {
+    if let Some(preprocessed) = preprocessed_key {
         challenger.observe(preprocessed.commitment.clone());
     }
 
@@ -116,15 +116,18 @@ where
     // 3. Reduce the AIR constraint to a single bound point.
     // The committed prover opens the columns through the commitment scheme,
     // so the zerocheck's own opened values are not used here.
-    let zerocheck = AirZerocheck::new(air, pow_bits);
-
+    let airs = [air];
     let committed_trace = config.committed_table(&prover_data);
     let committed_preprocessed =
-        preprocessed.map(|preprocessed| config.committed_table(&preprocessed.prover_data));
+        preprocessed_key.map(|preprocessed| config.committed_table(&preprocessed.prover_data));
+    let preprocessed = [committed_preprocessed];
+    let tables = [committed_trace];
+    let public_values = [public_values];
+    let zerocheck = AirZerocheck::new(&airs, pow_bits);
     let (zerocheck_proof, point) = zerocheck.prove::<C::Val, C::Challenge, _>(
-        committed_trace,
-        committed_preprocessed,
-        public_values,
+        &preprocessed,
+        &tables,
+        &public_values,
         challenger,
     );
     let sumcheck = zerocheck_proof.sumcheck;
@@ -140,7 +143,7 @@ where
 
     // 5. Open the preprocessed columns at the same point against the reused commitment.
     // Cloning the committed data reuses the setup encoding and Merkle tree, skipping a rebuild.
-    let preprocessed_opening = preprocessed.map(|preprocessed| {
+    let preprocessed_opening = preprocessed_key.map(|preprocessed| {
         let protocol = single_table_protocol(
             log_height,
             air.preprocessed_width(),

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -446,6 +446,59 @@ struct DegreeGroup<EF> {
 }
 
 impl<EF: Field> DegreeGroup<EF> {
+    /// Bucket AIRs by degree and assign each AIR its column span in the merged buffer.
+    ///
+    /// Columns are laid out per AIR as main columns then preprocessed columns, in caller order:
+    ///
+    /// ```text
+    ///     [ air0 main | air0 preproc | air1 main | air1 preproc | ... ]
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `degrees`: per-variable constraint degree of each AIR, in stage-local order.
+    /// - `main_widths`: main column count of each AIR, in stage-local order.
+    /// - `preprocessed_widths`: preprocessed column count of each AIR, in stage-local order.
+    fn build(degrees: &[usize], main_widths: &[usize], preprocessed_widths: &[usize]) -> Vec<Self> {
+        // A btree keyed by degree gives deterministic group order across prover and verifier.
+        let mut groups = BTreeMap::<usize, Vec<DegreeGroupAir>>::new();
+        // Running column cursor into the merged buffer, advanced AIR by AIR.
+        let mut column_offset = 0;
+        for (air_index, ((&degree, &main_width), &preprocessed_width)) in degrees
+            .iter()
+            .zip(main_widths)
+            .zip(preprocessed_widths)
+            .enumerate()
+        {
+            // Main columns come first for this AIR.
+            let main_offset = column_offset;
+            column_offset += main_width;
+            // Preprocessed columns follow immediately after.
+            let preprocessed_offset = column_offset;
+            column_offset += preprocessed_width;
+            // File the AIR under its degree, keeping its column span.
+            groups.entry(degree).or_default().push(DegreeGroupAir {
+                air_index,
+                main_offset,
+                main_width,
+                preprocessed_offset,
+                preprocessed_width,
+            });
+        }
+
+        // Each degree becomes one group with a zero starting claim and a prebuilt interpolator.
+        groups
+            .into_iter()
+            .map(|(degree, airs)| Self {
+                degree,
+                airs,
+                claim: EF::ZERO,
+                last_evals: EF::zero_vec(degree),
+                interpolator: RoundPolyInterpolator::new(degree),
+            })
+            .collect()
+    }
+
     /// Evaluate this group's eq-stripped round polynomial `q` at an interpolation node.
     ///
     /// The prover never stores `q(1)`; it is recovered from the sumcheck claim relation:
@@ -529,63 +582,6 @@ impl<EF: Field> DegreeGroup<EF> {
     }
 }
 
-/// Bucket AIRs by degree and assign each AIR its column span in the merged buffer.
-///
-/// Columns are laid out per AIR as main columns then preprocessed columns, in caller order:
-///
-/// ```text
-///     [ air0 main | air0 preproc | air1 main | air1 preproc | ... ]
-/// ```
-///
-/// # Arguments
-///
-/// - `degrees`: per-variable constraint degree of each AIR, in stage-local order.
-/// - `main_widths`: main column count of each AIR, in stage-local order.
-/// - `preprocessed_widths`: preprocessed column count of each AIR, in stage-local order.
-fn build_degree_groups<EF: Field>(
-    degrees: &[usize],
-    main_widths: &[usize],
-    preprocessed_widths: &[usize],
-) -> Vec<DegreeGroup<EF>> {
-    // A btree keyed by degree gives deterministic group order across prover and verifier.
-    let mut groups = BTreeMap::<usize, Vec<DegreeGroupAir>>::new();
-    // Running column cursor into the merged buffer, advanced AIR by AIR.
-    let mut column_offset = 0;
-    for (air_index, ((&degree, &main_width), &preprocessed_width)) in degrees
-        .iter()
-        .zip(main_widths)
-        .zip(preprocessed_widths)
-        .enumerate()
-    {
-        // Main columns come first for this AIR.
-        let main_offset = column_offset;
-        column_offset += main_width;
-        // Preprocessed columns follow immediately after.
-        let preprocessed_offset = column_offset;
-        column_offset += preprocessed_width;
-        // File the AIR under its degree, keeping its column span.
-        groups.entry(degree).or_default().push(DegreeGroupAir {
-            air_index,
-            main_offset,
-            main_width,
-            preprocessed_offset,
-            preprocessed_width,
-        });
-    }
-
-    // Each degree becomes one group with a zero starting claim and a prebuilt interpolator.
-    groups
-        .into_iter()
-        .map(|(degree, airs)| DegreeGroup {
-            degree,
-            airs,
-            claim: EF::ZERO,
-            last_evals: EF::zero_vec(degree),
-            interpolator: RoundPolyInterpolator::new(degree),
-        })
-        .collect()
-}
-
 impl<'air, 'data, A, F, EF> RoundStateBase<'air, 'data, A, F, EF>
 where
     F: Field,
@@ -659,7 +655,7 @@ where
         }
 
         // Build the degree grouping once, then flatten it into the AIR-ordered fold view.
-        let degree_groups = build_degree_groups(&stage.degrees, &main_widths, &preprocessed_widths);
+        let degree_groups = DegreeGroup::build(&stage.degrees, &main_widths, &preprocessed_widths);
         let slots = AirSlot::flatten(&degree_groups);
 
         Self {

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -102,6 +102,10 @@ pub(crate) struct RoundStateBase<'air, 'data, A, F: Field, EF> {
     betas: Vec<EF>,
     /// AIRs grouped by their internal round-polynomial degree.
     degree_groups: Vec<DegreeGroup<EF>>,
+    /// Per-AIR column spans and degrees, in stage-local order, driving the per-round column fold.
+    ///
+    /// Derived once from the degree groups, since the layout is fixed for the state's lifetime.
+    slots: Vec<AirSlot>,
     /// Zerocheck point coordinates, used to recover the omitted node one for each AIR.
     tau: Point<EF>,
 }
@@ -261,6 +265,10 @@ pub(crate) struct RoundStateExt<'air, 'data, A, F: Field, EF: ExtensionField<F>>
     betas: Vec<EF>,
     /// AIRs grouped by their internal round-polynomial degree.
     degree_groups: Vec<DegreeGroup<EF>>,
+    /// Per-AIR column spans and degrees, in stage-local order, driving the per-round column fold.
+    ///
+    /// Derived once from the degree groups, since the layout is fixed for the state's lifetime.
+    slots: Vec<AirSlot>,
     /// Zerocheck point coordinates, used to recover the omitted node one for each AIR.
     tau: Point<EF>,
     /// Number of already-bound prefix coordinates.
@@ -358,10 +366,9 @@ where
 
 /// Per-AIR fold metadata, in stage-local order.
 ///
-/// Flattens the degree groups.
-/// The hot loop then drives one AIR at a time.
+/// Flattens the degree groups so the hot loop drives one AIR at a time.
 /// Interpolation nodes above an AIR's own degree are still skipped.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct AirSlot {
     /// Position of this AIR within its stage, in caller order.
     air_index: usize,
@@ -377,35 +384,31 @@ struct AirSlot {
     degree: usize,
 }
 
-/// Flatten the degree groups into per-AIR slots, ordered by stage-local index.
-fn air_slots<EF>(degree_groups: &[DegreeGroup<EF>], num_airs: usize) -> Vec<AirSlot> {
-    // One placeholder slot per AIR; scattered into place in group order below.
-    let mut slots = alloc::vec![
-        AirSlot {
-            air_index: 0,
-            main_offset: 0,
-            main_width: 0,
-            preprocessed_offset: 0,
-            preprocessed_width: 0,
-            degree: 0,
-        };
-        num_airs
-    ];
-    // A group fixes the degree; each AIR in it fixes its own column span.
-    for group in degree_groups {
-        for air in &group.airs {
-            // Store at the stage-local position so callers index by AIR, not group.
-            slots[air.air_index] = AirSlot {
-                air_index: air.air_index,
-                main_offset: air.main_offset,
-                main_width: air.main_width,
-                preprocessed_offset: air.preprocessed_offset,
-                preprocessed_width: air.preprocessed_width,
-                degree: group.degree,
-            };
+impl AirSlot {
+    /// Flatten the degree groups into one slot per AIR, indexed by stage-local position.
+    ///
+    /// The groups iterate in degree order, but the hot loop wants AIR order.
+    /// Each AIR belongs to exactly one group, so every output slot is written exactly once.
+    fn flatten<EF>(degree_groups: &[DegreeGroup<EF>]) -> Vec<Self> {
+        // The stage-local indices run `0..num_airs`, so the total AIR count sizes the output.
+        let num_airs = degree_groups.iter().map(|group| group.airs.len()).sum();
+        let mut slots = alloc::vec![Self::default(); num_airs];
+        // A group fixes the degree; each AIR in it fixes its own column span.
+        for group in degree_groups {
+            for air in &group.airs {
+                // Scatter to the stage-local position so callers index by AIR, not group.
+                slots[air.air_index] = Self {
+                    air_index: air.air_index,
+                    main_offset: air.main_offset,
+                    main_width: air.main_width,
+                    preprocessed_offset: air.preprocessed_offset,
+                    preprocessed_width: air.preprocessed_width,
+                    degree: group.degree,
+                };
+            }
         }
+        slots
     }
-    slots
 }
 
 /// Beta-weight each AIR's evaluations and reduce them into its degree group.
@@ -667,6 +670,10 @@ where
             assert_eq!(public_values.len(), air.num_public_values());
         }
 
+        // Build the degree grouping once, then flatten it into the AIR-ordered fold view.
+        let degree_groups = build_degree_groups(&stage.degrees, &main_widths, &preprocessed_widths);
+        let slots = AirSlot::flatten(&degree_groups);
+
         Self {
             airs: stage.airs.clone(),
             public_values: stage.public_values.clone(),
@@ -674,7 +681,8 @@ where
             preprocessed: stage.preprocessed.clone(),
             tables: stage.tables.clone(),
             betas,
-            degree_groups: build_degree_groups(&stage.degrees, &main_widths, &preprocessed_widths),
+            degree_groups,
+            slots,
             tau: tau.clone(),
         }
     }
@@ -735,8 +743,11 @@ where
         let packed_half = scalar_half / packing_width;
         let degree = self.degree();
         let alpha = EF::ExtensionPacking::from(self.alpha);
-        let slots = air_slots(&self.degree_groups, self.airs.len());
-        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
+        let air_degrees = self
+            .slots
+            .iter()
+            .map(|slot| slot.degree)
+            .collect::<Vec<_>>();
         assert_ne!(packed_half, 0);
 
         let air_evals = eq_suffix
@@ -788,7 +799,7 @@ where
                             *next_delta = next_hi - next_lo;
                         }
                     };
-                    for slot in &slots {
+                    for slot in &self.slots {
                         fill_columns(&mut scratch, slot.main_offset, self.tables[slot.air_index]);
                         if let Some(preprocessed) = self.preprocessed[slot.air_index] {
                             fill_columns(&mut scratch, slot.preprocessed_offset, preprocessed);
@@ -812,7 +823,7 @@ where
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        slots
+                        self.slots
                             .iter()
                             .zip(scratch.air_evals.iter_mut())
                             .for_each(|(slot, evals)| {
@@ -871,8 +882,11 @@ where
         let half = height / 2;
         let degree = self.degree();
 
-        let slots = air_slots(&self.degree_groups, self.airs.len());
-        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
+        let air_degrees = self
+            .slots
+            .iter()
+            .map(|slot| slot.degree)
+            .collect::<Vec<_>>();
         let mut scratch = Scratch::<F, EF>::new(&air_degrees, width);
 
         for (s, &eq_suffix) in eq_suffix.as_slice().iter().enumerate() {
@@ -900,7 +914,7 @@ where
                         *next_delta = next_hi - next_lo;
                     });
             };
-            for slot in &slots {
+            for slot in &self.slots {
                 fill_columns(&mut scratch, slot.main_offset, self.tables[slot.air_index]);
                 if let Some(preprocessed) = self.preprocessed[slot.air_index] {
                     fill_columns(&mut scratch, slot.preprocessed_offset, preprocessed);
@@ -923,7 +937,7 @@ where
                 scratch.add_diffs();
                 boundary += boundary_diff;
 
-                slots
+                self.slots
                     .iter()
                     .zip(scratch.air_evals.iter_mut())
                     .for_each(|(slot, evals)| {
@@ -971,10 +985,9 @@ where
 
         let num_evals = self.num_evals();
         let half = num_evals / 2;
-        let slots = air_slots(&self.degree_groups, self.airs.len());
         let width = self.total_width();
         let mut next_tail = Vec::with_capacity(width);
-        for slot in &slots {
+        for slot in &self.slots {
             next_tail.extend(
                 self.tables[slot.air_index]
                     .iter_polys()
@@ -992,7 +1005,7 @@ where
         let want_packed = (half / 2) >= F::Packing::WIDTH;
         let columns = if want_packed {
             let mut columns = Vec::with_capacity(width);
-            for slot in &slots {
+            for slot in &self.slots {
                 columns.extend(
                     self.tables[slot.air_index]
                         .par_iter_polys()
@@ -1011,7 +1024,7 @@ where
             ExtColumns::Packed(columns)
         } else {
             let mut columns = Vec::with_capacity(width);
-            for slot in &slots {
+            for slot in &self.slots {
                 columns.extend(
                     self.tables[slot.air_index]
                         .par_iter_polys()
@@ -1036,6 +1049,7 @@ where
             alpha: self.alpha,
             betas: self.betas,
             degree_groups: self.degree_groups,
+            slots: self.slots,
             tau: self.tau,
             round: 1,
             columns,
@@ -1109,8 +1123,11 @@ where
         let num_evals = self.num_evals();
         let half = num_evals / 2;
         let degree = self.degree();
-        let slots = air_slots(&self.degree_groups, self.airs.len());
-        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
+        let air_degrees = self
+            .slots
+            .iter()
+            .map(|slot| slot.degree)
+            .collect::<Vec<_>>();
 
         let air_evals = eq_suffix
             .as_slice()
@@ -1148,7 +1165,7 @@ where
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::row_pair_with_prefix(s, half, num_evals, self.boundary);
 
-                    slots
+                    self.slots
                         .iter()
                         .zip(scratch.air_evals.iter_mut())
                         .for_each(|(slot, evals)| {
@@ -1179,7 +1196,7 @@ where
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        slots
+                        self.slots
                             .iter()
                             .zip(scratch.air_evals.iter_mut())
                             .for_each(|(slot, evals)| {
@@ -1256,8 +1273,11 @@ where
         let packed_half = scalar_half / packing_width;
         let degree = self.degree();
         let alpha = PackedExt::new(EF::ExtensionPacking::from(self.alpha));
-        let slots = air_slots(&self.degree_groups, self.airs.len());
-        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
+        let air_degrees = self
+            .slots
+            .iter()
+            .map(|slot| slot.degree)
+            .collect::<Vec<_>>();
         assert_ne!(packed_half, 0);
 
         let air_evals = eq_suffix
@@ -1323,7 +1343,7 @@ where
                         PackedExt::new(raw_boundary_diff.transition),
                     );
 
-                    slots
+                    self.slots
                         .iter()
                         .zip(scratch.air_evals.iter_mut())
                         .for_each(|(slot, evals)| {
@@ -1357,7 +1377,7 @@ where
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        slots
+                        self.slots
                             .iter()
                             .zip(scratch.air_evals.iter_mut())
                             .for_each(|(slot, evals)| {

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -2,51 +2,95 @@
 //!
 //! Builds round polynomials for `sum_x eq(tau, x) * g(x)` and folds state across challenges.
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
+use itertools::Itertools;
 use p3_air::{Air, BaseAir};
-use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
+use p3_field::{
+    ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing, dot_product,
+};
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::{Poly, PolyView};
+use p3_sumcheck::generic_degree::RoundPolyInterpolator;
 use p3_sumcheck::layout::Table;
 
 use crate::folder::MultilinearFolder;
 use crate::packed_ext::PackedExt;
 use crate::selectors::BoundaryEvals;
 
+pub(super) struct Stage<'air, 'data, A, F: Field> {
+    pub(super) indices: Vec<usize>,
+    pub(super) airs: Vec<&'air A>,
+    pub(super) public_values: Vec<&'data [F]>,
+    pub(super) preprocessed: Vec<Option<&'data Table<F>>>,
+    pub(super) tables: Vec<&'data Table<F>>,
+    pub(super) degrees: Vec<usize>,
+    pub(super) num_vars: usize,
+}
+
+impl<'air, 'data, A, F: Field> Stage<'air, 'data, A, F> {
+    pub(super) fn new(
+        airs: &[&'air A],
+        public_values: &[&'data [F]],
+        indices: &[usize],
+        preprocessed: &[Option<&'data Table<F>>],
+        tables: &[&'data Table<F>],
+        degrees: &[usize],
+    ) -> Self {
+        let num_vars = tables
+            .iter()
+            .map(|table| table.num_variables())
+            .all_equal_value()
+            .expect("all tables must have the same height");
+
+        assert!(
+            preprocessed
+                .iter()
+                .flatten()
+                .all(|table| table.num_variables() == num_vars),
+            "preprocessed tables must match the stage height"
+        );
+
+        Self {
+            num_vars,
+            indices: indices.to_vec(),
+            airs: airs.to_vec(),
+            public_values: public_values.to_vec(),
+            preprocessed: preprocessed.to_vec(),
+            tables: tables.to_vec(),
+            degrees: degrees.to_vec(),
+        }
+    }
+}
+
 /// Sumcheck prover state for the AIR zerocheck.
 ///
-/// Stores the trace as one transposed row-major matrix: each matrix row is one trace column.
-///
-/// Preprocessed columns fold exactly like main columns.
-/// They are laid out immediately after the main columns in the same matrix.
-/// A stored split index separates the two views when a folder is built.
-#[derive(Debug)]
-pub(crate) struct RoundStateBase<'a, A, F: Field, EF> {
+/// Stores already-transposed trace tables.
+pub(crate) struct RoundStateBase<'air, 'data, A, F: Field, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
-    air: &'a A,
+    airs: Vec<&'air A>,
     /// Public inputs forwarded to the AIR.
-    public_values: &'a [F],
+    public_values: Vec<&'data [F]>,
     /// Random scalar batching the AIR constraints.
     alpha: EF,
-    /// Equality weight over the current round's suffix variables.
-    eq_suffix: Poly<EF>,
-    /// Main trace columns, stored as one table row per original trace column.
-    table: &'a Table<F>,
-    /// Preprocessed columns
-    preprocessed: Option<&'a Table<F>>,
-    /// Per-round sumcheck degree.
-    degree: usize,
+    /// Optional preprocessed tables, one per AIR.
+    preprocessed: Vec<Option<&'data Table<F>>>,
+    /// Main trace tables, one row per original trace column.
+    tables: Vec<&'data Table<F>>,
+    /// Beta power for each AIR in canonical input order.
+    betas: Vec<EF>,
+    /// AIRs grouped by their internal round-polynomial degree.
+    degree_groups: Vec<DegreeGroup<EF>>,
+    /// Zerocheck point coordinates, used to recover the omitted node one for each AIR.
+    tau: Point<EF>,
 }
 
 /// Extension-round column storage.
 ///
-/// Columns stay SIMD-packed (one lane per residual row) as long as there are
-/// enough residual rows left to fill a packed lane. Once a round's fold would
-/// leave fewer than `F::Packing::WIDTH` residual rows, columns unpack to
-/// scalar form; that transition happens at most once, since the residual row
-/// count only ever shrinks.
+/// Columns stay SIMD-packed as long as there are enough residual rows to fill a packed lane.
+/// Once a fold would leave fewer rows than a lane, columns unpack to scalar form.
 enum ExtColumns<F: Field, EF: ExtensionField<F>> {
     Packed(Vec<Poly<EF::ExtensionPacking>>),
     Scalar(Vec<Poly<EF>>),
@@ -60,13 +104,21 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
-    /// Column view expected by [`RoundStateExt::round_poly_packed`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the columns have already unpacked to scalar form. Callers
-    /// gate on the same width threshold that decides the storage variant, so
-    /// this never fires.
+    fn num_evals(&self) -> usize {
+        match self {
+            Self::Packed(cols) => {
+                cols.first()
+                    .expect("round state requires at least one column")
+                    .num_evals()
+                    * F::Packing::WIDTH
+            }
+            Self::Scalar(cols) => cols
+                .first()
+                .expect("round state requires at least one column")
+                .num_evals(),
+        }
+    }
+
     fn as_packed(&self) -> &[Poly<EF::ExtensionPacking>] {
         match self {
             Self::Packed(cols) => cols,
@@ -74,12 +126,6 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
-    /// Column view expected by [`RoundStateExt::round_poly_unpacked`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the columns are still packed. Callers gate on the same
-    /// width threshold that decides the storage variant, so this never fires.
     fn as_scalar(&self) -> &[Poly<EF>] {
         match self {
             Self::Scalar(cols) => cols,
@@ -87,14 +133,6 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
-    /// Folds the prefix variable of every column at `r`, unpacking to scalar
-    /// form when `want_packed` is false.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `want_packed` is true while the columns are already scalar:
-    /// the residual row count only shrinks round to round, so a fold can
-    /// never make packed storage viable again once it stopped being viable.
     fn fold(self, r: EF, want_packed: bool) -> Self {
         match self {
             Self::Packed(mut cols) => {
@@ -124,13 +162,6 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
     }
 }
 
-/// Reads `F::Packing::WIDTH` consecutive residual rows of a packed column
-/// starting at scalar row `start`, falling back to `tail` past `len`.
-///
-/// The packed groups in `column` are aligned to multiples of the packing
-/// width, so an offset window generally spans two adjacent groups; each lane
-/// is reconstructed independently via [`PackedFieldExtension::extract`]
-/// rather than assuming any particular memory layout.
 #[inline]
 fn packed_window<F: Field, EF: ExtensionField<F>>(
     column: &[EF::ExtensionPacking],
@@ -150,81 +181,89 @@ fn packed_window<F: Field, EF: ExtensionField<F>>(
 }
 
 /// Extension-field sumcheck state after the first base-field round.
-pub(crate) struct RoundStateExt<'a, A, F: Field, EF: ExtensionField<F>> {
+///
+/// Owns the folded trace columns, boundary selectors, and repeat-last next-row tail values needed
+/// by the remaining rounds.
+pub(crate) struct RoundStateExt<'air, 'data, A, F: Field, EF: ExtensionField<F>> {
     /// AIR whose alpha-batched constraint is being evaluated.
-    air: &'a A,
-    /// Public inputs forwarded to the AIR, in the base field.
-    public_values: &'a [F],
+    airs: Vec<&'air A>,
+    /// Public inputs forwarded to the AIR.
+    public_values: Vec<&'data [F]>,
     /// Random scalar batching the AIR constraints.
     alpha: EF,
-    /// Equality weight over the current round's suffix variables.
-    eq_suffix: Poly<EF>,
     /// Folded boundary-selector values at the current sumcheck prefix.
     boundary: BoundaryEvals<EF>,
-    /// Main columns then preprocessed columns, after the first base-field fold.
+    /// Main and preprocessed columns after the first base-field fold.
     columns: ExtColumns<F, EF>,
-    /// Count of leading columns that are main columns.
-    /// Every later column is a preprocessed column.
-    main_width: usize,
-    /// Repeat-last successor value for each column at the folded tail row.
+    /// Beta power for each AIR in canonical input order.
+    betas: Vec<EF>,
+    /// AIRs grouped by their internal round-polynomial degree.
+    degree_groups: Vec<DegreeGroup<EF>>,
+    /// Zerocheck point coordinates, used to recover the omitted node one for each AIR.
+    tau: Point<EF>,
+    /// Number of already-bound prefix coordinates.
+    round: usize,
+    /// Repeat-last successor values for each main column at the folded tail row.
     next_tail: Vec<EF>,
-    /// Per-round sumcheck degree.
-    degree: usize,
 }
 
-/// Per-worker scratch for the extension-field round-polynomial fold.
+/// Scratch for scalar round-polynomial folds.
 ///
-/// `out` accumulates the round-polynomial evaluations; the row buffers hold one
-/// residual row's interpolation node and its per-step difference. One instance
-/// is allocated per worker and reused across that worker's rows.
-struct ExtScratch<EF> {
-    out: Vec<EF>,
-    local_point: Vec<EF>,
-    local_diff: Vec<EF>,
-    next_point: Vec<EF>,
-    next_diff: Vec<EF>,
+/// Holds one unweighted evaluation accumulator per AIR.
+/// The row buffers carry one residual row's interpolation node and its step difference.
+/// The base path uses one instance; the extension path allocates one per worker.
+struct Scratch<F, EF> {
+    air_evals: Vec<Vec<EF>>,
+    local_point: Vec<F>,
+    local_diff: Vec<F>,
+    next_point: Vec<F>,
+    next_diff: Vec<F>,
 }
 
-/// Per-worker scratch for round-polynomial folds.
+/// Per-worker scratch for the packed base-field first-round fold.
 ///
-/// `out` accumulates the round-polynomial evaluations; the row buffers hold one
-/// interpolation point and its per-step difference. One instance is allocated per
-/// worker and reused across that worker's rows or packed blocks.
-struct RoundScratch<P, Acc> {
-    out: Vec<Acc>,
+/// Mirrors [`Scratch`] with packed base-field row buffers and a pair of
+/// per-lane equality-weight buffers. One instance is allocated per worker and
+/// reused across that worker's packed blocks.
+struct PackedScratch<P, EF> {
+    air_evals: Vec<Vec<EF>>,
     local_point: Vec<P>,
     local_diff: Vec<P>,
     next_point: Vec<P>,
     next_diff: Vec<P>,
 }
 
-impl<EF: PrimeCharacteristicRing> ExtScratch<EF> {
-    fn new(degree: usize, width: usize) -> Self {
+impl<F, EF> Scratch<F, EF>
+where
+    F: PrimeCharacteristicRing,
+    EF: PrimeCharacteristicRing,
+{
+    fn new(air_degrees: &[usize], width: usize) -> Self {
         Self {
-            out: EF::zero_vec(degree),
-            local_point: EF::zero_vec(width),
-            local_diff: EF::zero_vec(width),
-            next_point: EF::zero_vec(width),
-            next_diff: EF::zero_vec(width),
+            air_evals: air_degrees.iter().copied().map(EF::zero_vec).collect(),
+            local_point: F::zero_vec(width),
+            local_diff: F::zero_vec(width),
+            next_point: F::zero_vec(width),
+            next_diff: F::zero_vec(width),
         }
     }
 }
 
-impl<EF: Field> ExtScratch<EF> {
+impl<F: Field, EF> Scratch<F, EF> {
     fn add_diffs(&mut self) {
-        EF::add_slices(&mut self.local_point, &self.local_diff);
-        EF::add_slices(&mut self.next_point, &self.next_diff);
+        F::add_slices(&mut self.local_point, &self.local_diff);
+        F::add_slices(&mut self.next_point, &self.next_diff);
     }
 }
 
-impl<P, Acc> RoundScratch<P, Acc>
+impl<P, EF> PackedScratch<P, EF>
 where
-    P: PrimeCharacteristicRing + Copy,
-    Acc: PrimeCharacteristicRing,
+    P: PrimeCharacteristicRing,
+    EF: PrimeCharacteristicRing,
 {
-    fn new(degree: usize, width: usize) -> Self {
+    fn new(air_degrees: &[usize], width: usize) -> Self {
         Self {
-            out: Acc::zero_vec(degree),
+            air_evals: air_degrees.iter().copied().map(EF::zero_vec).collect(),
             local_point: P::zero_vec(width),
             local_diff: P::zero_vec(width),
             next_point: P::zero_vec(width),
@@ -232,7 +271,10 @@ where
         }
     }
 
-    fn add_diffs(&mut self) {
+    fn add_diffs(&mut self)
+    where
+        P: Copy,
+    {
         self.local_point
             .iter_mut()
             .zip(self.local_diff.iter())
@@ -245,354 +287,654 @@ where
     }
 }
 
-impl<'a, A, F, EF> RoundStateBase<'a, A, F, EF>
+/// Per-AIR fold metadata, in stage-local order.
+///
+/// Flattens the degree groups.
+/// The hot loop then drives one AIR at a time.
+/// Interpolation nodes above an AIR's own degree are still skipped.
+#[derive(Clone, Copy)]
+struct AirSlot {
+    /// Position of this AIR within its stage, in caller order.
+    air_index: usize,
+    /// First main column of this AIR inside the merged column buffer.
+    main_offset: usize,
+    /// Number of main columns this AIR owns.
+    main_width: usize,
+    /// First preprocessed column of this AIR inside the merged column buffer.
+    preprocessed_offset: usize,
+    /// Number of preprocessed columns this AIR owns.
+    preprocessed_width: usize,
+    /// Per-variable degree of this AIR's eq-stripped round polynomial.
+    degree: usize,
+}
+
+/// Flatten the degree groups into per-AIR slots, ordered by stage-local index.
+fn air_slots<EF>(degree_groups: &[DegreeGroup<EF>], num_airs: usize) -> Vec<AirSlot> {
+    // One placeholder slot per AIR; scattered into place in group order below.
+    let mut slots = alloc::vec![
+        AirSlot {
+            air_index: 0,
+            main_offset: 0,
+            main_width: 0,
+            preprocessed_offset: 0,
+            preprocessed_width: 0,
+            degree: 0,
+        };
+        num_airs
+    ];
+    // A group fixes the degree; each AIR in it fixes its own column span.
+    for group in degree_groups {
+        for air in &group.airs {
+            // Store at the stage-local position so callers index by AIR, not group.
+            slots[air.air_index] = AirSlot {
+                air_index: air.air_index,
+                main_offset: air.main_offset,
+                main_width: air.main_width,
+                preprocessed_offset: air.preprocessed_offset,
+                preprocessed_width: air.preprocessed_width,
+                degree: group.degree,
+            };
+        }
+    }
+    slots
+}
+
+/// Beta-weight each AIR's evaluations and reduce them into its degree group.
+///
+/// The per-row fold accumulates `sum_x eq(x) * g_air(x)` with no beta factor.
+/// Beta enters here, once per AIR per node, since the sum is linear:
+///
+/// ```text
+///     sum_x beta * eq(x) * g(x) = beta * sum_x eq(x) * g(x)
+/// ```
+///
+/// This keeps beta out of the row loop.
+/// It saves one extension multiply per node per row.
+/// That multiply dominates the fold for cheap AIRs.
+fn write_last_evals<EF: Field>(
+    degree_groups: &mut [DegreeGroup<EF>],
+    betas: &[EF],
+    air_evals: &[Vec<EF>],
+) {
+    for group in degree_groups.iter_mut() {
+        // One accumulator per interpolation node this group carries.
+        let mut last = EF::zero_vec(group.degree);
+        for air in &group.airs {
+            // beta^i for this AIR, applied once here rather than per row.
+            let beta = betas[air.air_index];
+            // Fold the AIR's unweighted per-node sums in, scaled by beta.
+            last.iter_mut()
+                .zip(air_evals[air.air_index].iter())
+                .for_each(|(acc, &value)| *acc += beta * value);
+        }
+        // The group's beta-weighted round polynomial for this round.
+        group.last_evals = last;
+    }
+}
+
+/// AIRs with the same internal degree share one beta-weighted round polynomial.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DegreeGroupAir {
+    air_index: usize,
+    main_offset: usize,
+    main_width: usize,
+    preprocessed_offset: usize,
+    preprocessed_width: usize,
+}
+
+struct DegreeGroup<EF> {
+    degree: usize,
+    airs: Vec<DegreeGroupAir>,
+    claim: EF,
+    last_evals: Vec<EF>,
+    interpolator: RoundPolyInterpolator<EF>,
+}
+
+impl<EF: Field> DegreeGroup<EF> {
+    fn eval(&self, tau: EF, point: EF) -> EF {
+        debug_assert_eq!(self.last_evals.len(), self.degree);
+        assert!(self.degree > 0, "round polynomial degree must be positive");
+        if point.is_zero() {
+            return self.last_evals[0];
+        }
+
+        let q1 = (self.claim - (EF::ONE - tau) * self.last_evals[0]) * tau.inverse();
+        if point == EF::ONE {
+            return q1;
+        }
+
+        self.interpolator
+            .eval(&self.last_evals, self.last_evals[0] + q1, point)
+    }
+
+    fn combine_evals(&self, out: &mut [EF], tau: EF) {
+        for (idx, acc) in out.iter_mut().enumerate() {
+            let node = if idx == 0 { 0 } else { idx + 1 };
+            let value = if node == 0 || node <= self.degree {
+                let index = if node == 0 { 0 } else { node - 1 };
+                self.last_evals[index]
+            } else {
+                self.eval(tau, EF::from_usize(node))
+            };
+            *acc += value;
+        }
+    }
+
+    fn update_claim(&mut self, tau: EF, r: EF) {
+        self.claim = self.eval(tau, r);
+    }
+}
+
+fn build_degree_groups<EF: Field>(
+    degrees: &[usize],
+    main_widths: &[usize],
+    preprocessed_widths: &[usize],
+) -> Vec<DegreeGroup<EF>> {
+    let mut groups = BTreeMap::<usize, Vec<DegreeGroupAir>>::new();
+    let mut column_offset = 0;
+    for (air_index, ((&degree, &main_width), &preprocessed_width)) in degrees
+        .iter()
+        .zip(main_widths)
+        .zip(preprocessed_widths)
+        .enumerate()
+    {
+        let main_offset = column_offset;
+        column_offset += main_width;
+        let preprocessed_offset = column_offset;
+        column_offset += preprocessed_width;
+        groups.entry(degree).or_default().push(DegreeGroupAir {
+            air_index,
+            main_offset,
+            main_width,
+            preprocessed_offset,
+            preprocessed_width,
+        });
+    }
+
+    groups
+        .into_iter()
+        .map(|(degree, airs)| DegreeGroup {
+            degree,
+            airs,
+            claim: EF::ZERO,
+            last_evals: EF::zero_vec(degree),
+            interpolator: RoundPolyInterpolator::new(degree),
+        })
+        .collect()
+}
+
+impl<'air, 'data, A, F, EF> RoundStateBase<'air, 'data, A, F, EF>
 where
     F: Field,
     EF: ExtensionField<F>,
     A: BaseAir<F>,
 {
-    /// Build the prover state from trace columns and a sampled zerocheck point.
+    /// Build the prover state when different AIRs have different internal degrees.
+    ///
+    /// `degrees[i]` is the degree of AIR `i` after stripping the active eq factor.
+    /// Every entry must be positive. The round degree is the maximum AIR degree.
     #[tracing::instrument(skip_all)]
     pub(crate) fn new(
-        air: &'a A,
-        public_values: &'a [F],
+        stage: &Stage<'air, 'data, A, F>,
         alpha: EF,
+        betas: Vec<EF>,
         tau: &Point<EF>,
-        table: &'a Table<F>,
-        preprocessed: Option<&'a Table<F>>,
-        degree: usize,
     ) -> Self {
-        assert_eq!(tau.num_variables(), table.num_variables());
-        assert_eq!(air.width(), table.num_polys());
-        assert_eq!(
-            air.preprocessed_width(),
-            preprocessed.map_or(0, Table::num_polys)
+        assert!(!stage.tables.is_empty(),);
+        assert_eq!(stage.airs.len(), stage.tables.len(),);
+        assert_eq!(stage.preprocessed.len(), stage.tables.len(),);
+        assert_eq!(stage.public_values.len(), stage.tables.len(),);
+        assert_eq!(stage.degrees.len(), stage.tables.len(),);
+        assert!(stage.degrees.iter().all(|&degree| degree > 0),);
+
+        let num_vars = stage
+            .tables
+            .iter()
+            .map(|table| table.num_variables())
+            .all_equal_value()
+            .expect("all tables in a RoundStateBase must have the same height");
+        assert!(
+            stage
+                .preprocessed
+                .iter()
+                .flatten()
+                .all(|table| table.num_variables() == num_vars),
+            "preprocessed tables must match the main trace height"
         );
-        // Both traces bind the same zerocheck point, so they must share an arity.
-        // The fold reads preprocessed columns at offsets derived from the main height.
-        if let Some(preprocessed) = preprocessed {
+
+        let main_widths = stage
+            .tables
+            .iter()
+            .map(|table| table.num_polys())
+            .collect::<Vec<_>>();
+        let preprocessed_widths = stage
+            .preprocessed
+            .iter()
+            .map(|table| table.map_or(0, Table::num_polys))
+            .collect::<Vec<_>>();
+        let num_airs = stage.airs.len();
+        assert_eq!(
+            betas.len(),
+            num_airs,
+            "one beta power is required for each AIR"
+        );
+
+        for (((air, public_values), &main_width), &preprocessed_width) in stage
+            .airs
+            .iter()
+            .zip(stage.public_values.iter())
+            .zip(main_widths.iter())
+            .zip(preprocessed_widths.iter())
+        {
+            assert_eq!(main_width, air.width(), "trace width must match AIR width");
             assert_eq!(
-                preprocessed.num_variables(),
-                table.num_variables(),
-                "preprocessed trace height must match the main trace height"
+                preprocessed_width,
+                air.preprocessed_width(),
+                "preprocessed width must match AIR preprocessed width"
             );
+            assert_eq!(public_values.len(), air.num_public_values());
         }
-        if let Some(air_degree) = air.max_constraint_degree() {
-            assert_eq!(degree, air_degree);
-        }
+
         Self {
-            air,
-            public_values,
+            airs: stage.airs.clone(),
+            public_values: stage.public_values.clone(),
             alpha,
-            eq_suffix: Poly::new_from_point(&tau.as_slice()[1..], EF::ONE),
-            preprocessed,
-            table,
-            degree,
+            preprocessed: stage.preprocessed.clone(),
+            tables: stage.tables.clone(),
+            betas,
+            degree_groups: build_degree_groups(&stage.degrees, &main_widths, &preprocessed_widths),
+            tau: tau.clone(),
         }
     }
 
     fn num_evals(&self) -> usize {
-        self.eq_suffix.num_evals() * 2
+        1 << self
+            .tables
+            .first()
+            .expect("round state requires at least one table")
+            .num_variables()
+    }
+
+    fn total_width(&self) -> usize {
+        self.tables
+            .iter()
+            .map(|table| table.num_polys())
+            .sum::<usize>()
+            + self
+                .preprocessed
+                .iter()
+                .map(|table| table.map_or(0, Table::num_polys))
+                .sum::<usize>()
+    }
+
+    fn degree(&self) -> usize {
+        self.degree_groups
+            .iter()
+            .map(|group| group.degree)
+            .max()
+            .unwrap()
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn round_poly(&self) -> Vec<EF>
+    pub(crate) fn round_poly(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
             + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
         if self.num_evals() / 2 < F::Packing::WIDTH {
-            self.round_poly_unpacked()
+            self.round_poly_unpacked(eq_suffix)
         } else {
-            self.round_poly_packed()
+            self.round_poly_packed(eq_suffix)
         }
     }
 
     #[tracing::instrument(skip_all)]
-    fn round_poly_packed(&self) -> Vec<EF>
+    fn round_poly_packed(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
-        A: for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
+            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
-        let main_width = self.table.num_polys();
-        let preprocessed_width = self.preprocessed.map_or(0, Table::num_polys);
-        let width = main_width + preprocessed_width;
+        let width = self.total_width();
         let height = self.num_evals();
         let scalar_half = height / 2;
         let packing_width = F::Packing::WIDTH;
         let packed_half = scalar_half / packing_width;
-        let degree = self.degree;
+        let degree = self.degree();
         let alpha = EF::ExtensionPacking::from(self.alpha);
+        let slots = air_slots(&self.degree_groups, self.airs.len());
+        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
         assert_ne!(packed_half, 0);
 
-        self.eq_suffix
+        let air_evals = eq_suffix
             .as_slice()
             .par_chunks_exact(packing_width)
             .enumerate()
             .par_fold_reduce(
-                || RoundScratch::<F::Packing, EF::ExtensionPacking>::new(degree, width),
+                || PackedScratch::new(&air_degrees, width),
                 |mut scratch, (packed_s, eq_suffix)| {
                     let s = packed_s * packing_width;
-                    let eq_suffix = EF::ExtensionPacking::from_ext_slice(eq_suffix);
-                    let fill_columns =
-                        |scratch: &mut RoundScratch<F::Packing, EF::ExtensionPacking>,
-                         offset: usize,
-                         columns: &Table<F>| {
-                            let end = offset + columns.num_polys();
-                            let local_point = &mut scratch.local_point[offset..end];
-                            let local_diff = &mut scratch.local_diff[offset..end];
-                            let next_point = &mut scratch.next_point[offset..end];
-                            let next_diff = &mut scratch.next_diff[offset..end];
 
-                            for ((((local, local_diff), next), next_diff), column) in local_point
-                                .iter_mut()
-                                .zip(local_diff.iter_mut())
-                                .zip(next_point.iter_mut())
-                                .zip(next_diff.iter_mut())
-                                .zip(columns.iter_polys())
-                            {
-                                let local_lo =
-                                    *F::Packing::from_slice(&column[s..s + packing_width]);
-                                let local_hi = *F::Packing::from_slice(
-                                    &column[s + scalar_half..s + scalar_half + packing_width],
-                                );
-                                *local = local_lo;
-                                *local_diff = local_hi - local_lo;
+                    let fill_columns = |scratch: &mut PackedScratch<F::Packing, EF>,
+                                        offset: usize,
+                                        table: &Table<F>| {
+                        let end = offset + table.num_polys();
+                        for ((((local, local_delta), next), next_delta), column) in scratch
+                            .local_point[offset..end]
+                            .iter_mut()
+                            .zip(scratch.local_diff[offset..end].iter_mut())
+                            .zip(scratch.next_point[offset..end].iter_mut())
+                            .zip(scratch.next_diff[offset..end].iter_mut())
+                            .zip(table.iter_polys())
+                        {
+                            let local_lo = *F::Packing::from_slice(&column[s..s + packing_width]);
+                            let local_hi = *F::Packing::from_slice(
+                                &column[s + scalar_half..s + scalar_half + packing_width],
+                            );
+                            *local = local_lo;
+                            *local_delta = local_hi - local_lo;
 
-                                let next_lo =
-                                    *F::Packing::from_slice(&column[s + 1..s + 1 + packing_width]);
-                                let next_hi_start = s + scalar_half + 1;
-                                let next_hi = if next_hi_start + packing_width <= height {
-                                    *F::Packing::from_slice(
-                                        &column[next_hi_start..next_hi_start + packing_width],
-                                    )
-                                } else {
-                                    F::Packing::from_fn(|lane| {
-                                        let row = next_hi_start + lane;
-                                        if row < height {
-                                            column[row]
-                                        } else {
-                                            column[height - 1]
-                                        }
-                                    })
-                                };
-                                *next = next_lo;
-                                *next_diff = next_hi - next_lo;
-                            }
-                        };
-
-                    fill_columns(&mut scratch, 0, self.table);
-
-                    if let Some(preprocessed) = self.preprocessed {
-                        fill_columns(&mut scratch, main_width, preprocessed);
+                            let next_lo =
+                                *F::Packing::from_slice(&column[s + 1..s + 1 + packing_width]);
+                            let next_hi_start = s + scalar_half + 1;
+                            let next_hi = if next_hi_start + packing_width <= height {
+                                *F::Packing::from_slice(
+                                    &column[next_hi_start..next_hi_start + packing_width],
+                                )
+                            } else {
+                                F::Packing::from_fn(|lane| {
+                                    let row = next_hi_start + lane;
+                                    if row < height {
+                                        column[row]
+                                    } else {
+                                        column[height - 1]
+                                    }
+                                })
+                            };
+                            *next = next_lo;
+                            *next_delta = next_hi - next_lo;
+                        }
+                    };
+                    for slot in &slots {
+                        fill_columns(&mut scratch, slot.main_offset, self.tables[slot.air_index]);
+                        if let Some(preprocessed) = self.preprocessed[slot.air_index] {
+                            fill_columns(&mut scratch, slot.preprocessed_offset, preprocessed);
+                        }
                     }
 
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::<F::Packing>::row_pair_packed(s, scalar_half, height);
 
+                    // Node 0 is skipped.
+                    // Invariant: a stage's first round runs on an unfolded trace.
+                    //     X = 0 and X = 1 are then real boolean rows.
+                    //     A satisfying trace makes g vanish on every row.
+                    //     So q(0) = q(1) = 0.
+                    // The node-0 accumulator stays zero.
+                    // The sweep below starts at node 2.
                     scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc_idx in 1..scratch.out.len() {
+                    for node in 2..=degree {
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        let g = MultilinearFolder::new(
-                            &scratch.local_point[..main_width],
-                            &scratch.next_point[..main_width],
-                            boundary,
-                            self.public_values,
-                            alpha,
-                        )
-                        .with_preprocessed(
-                            &scratch.local_point[main_width..],
-                            &scratch.next_point[main_width..],
-                        )
-                        .eval_air(self.air);
-                        scratch.out[acc_idx] += g * eq_suffix;
+                        slots
+                            .iter()
+                            .zip(scratch.air_evals.iter_mut())
+                            .for_each(|(slot, evals)| {
+                                if node <= slot.degree {
+                                    let g = MultilinearFolder::new(
+                                        &scratch.local_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        &scratch.next_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        boundary,
+                                        self.public_values[slot.air_index],
+                                        alpha,
+                                    )
+                                    .with_preprocessed(
+                                        &scratch.local_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                        &scratch.next_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                    )
+                                    .eval_air(self.airs[slot.air_index]);
+                                    evals[node - 1] += dot_product::<EF, _, _>(
+                                        eq_suffix.iter().copied(),
+                                        EF::ExtensionPacking::to_ext_iter([g]),
+                                    );
+                                }
+                            });
                     }
 
                     scratch
                 },
                 |mut lhs, rhs| {
-                    lhs.out
+                    lhs.air_evals
                         .iter_mut()
-                        .zip(rhs.out)
-                        .for_each(|(lhs, rhs)| *lhs += rhs);
+                        .zip(rhs.air_evals)
+                        .for_each(|(lhs, rhs)| EF::add_slices(lhs, &rhs));
                     lhs
                 },
             )
-            .out
-            .into_iter()
-            .map(|acc| EF::ExtensionPacking::to_ext_iter([acc]).sum())
-            .collect()
+            .air_evals;
+        let mut out = EF::zero_vec(degree);
+        let tau = self.tau.as_slice()[0];
+        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        self.degree_groups
+            .iter()
+            .for_each(|group| group.combine_evals(&mut out, tau));
+        out
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn round_poly_unpacked(&self) -> Vec<EF>
+    pub(crate) fn round_poly_unpacked(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
     {
-        let main_width = self.table.num_polys();
-        let preprocessed_width = self.preprocessed.map_or(0, Table::num_polys);
-        let width = main_width + preprocessed_width;
+        let width = self.total_width();
         let height = self.num_evals();
         let half = height / 2;
+        let degree = self.degree();
 
-        let mut scratch = RoundScratch::<F, EF>::new(self.degree, width);
+        let slots = air_slots(&self.degree_groups, self.airs.len());
+        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
+        let mut scratch = Scratch::<F, EF>::new(&air_degrees, width);
 
-        for (s, &eq_suffix) in self.eq_suffix.as_slice().iter().enumerate() {
+        for (s, &eq_suffix) in eq_suffix.as_slice().iter().enumerate() {
             let fill_columns =
-                |scratch: &mut RoundScratch<F, EF>, offset: usize, columns: &Table<F>| {
-                    let end = offset + columns.num_polys();
-                    let local_point = &mut scratch.local_point[offset..end];
-                    let local_diff = &mut scratch.local_diff[offset..end];
-                    let next_point = &mut scratch.next_point[offset..end];
-                    let next_diff = &mut scratch.next_diff[offset..end];
-
-                    for ((((local, local_diff), next), next_diff), column) in local_point
+                |scratch: &mut Scratch<F, EF>, offset: usize, table: &Table<F>| {
+                    let end = offset + table.num_polys();
+                    scratch.local_point[offset..end]
                         .iter_mut()
-                        .zip(local_diff.iter_mut())
-                        .zip(next_point.iter_mut())
-                        .zip(next_diff.iter_mut())
-                        .zip(columns.iter_polys())
-                    {
-                        let local_lo = column[s];
-                        let local_hi = column[s + half];
-                        *local = local_lo;
-                        *local_diff = local_hi - local_lo;
+                        .zip(scratch.local_diff[offset..end].iter_mut())
+                        .zip(scratch.next_point[offset..end].iter_mut())
+                        .zip(scratch.next_diff[offset..end].iter_mut())
+                        .zip(table.iter_polys())
+                        .for_each(|((((local, local_delta), next), next_delta), column)| {
+                            let local_lo = column[s];
+                            let local_hi = column[s + half];
+                            *local = local_lo;
+                            *local_delta = local_hi - local_lo;
 
-                        let next_lo = column[s + 1];
-                        let next_hi = if s + half + 1 < height {
-                            column[s + half + 1]
-                        } else {
-                            column[height - 1]
-                        };
-                        *next = next_lo;
-                        *next_diff = next_hi - next_lo;
-                    }
+                            let next_lo = column[s + 1];
+                            let next_hi = if s + half + 1 < height {
+                                column[s + half + 1]
+                            } else {
+                                column[height - 1]
+                            };
+                            *next = next_lo;
+                            *next_delta = next_hi - next_lo;
+                        });
                 };
-
-            fill_columns(&mut scratch, 0, self.table);
-
-            if let Some(preprocessed) = self.preprocessed {
-                fill_columns(&mut scratch, main_width, preprocessed);
+            for slot in &slots {
+                fill_columns(&mut scratch, slot.main_offset, self.tables[slot.air_index]);
+                if let Some(preprocessed) = self.preprocessed[slot.air_index] {
+                    fill_columns(&mut scratch, slot.preprocessed_offset, preprocessed);
+                }
             }
 
             let (mut boundary, boundary_diff) = BoundaryEvals::<F>::row_pair(s, half, height);
 
+            // Node 0 is skipped.
+            // Invariant: a stage's first round runs on an unfolded trace.
+            //     X = 0 and X = 1 are then real boolean rows.
+            //     A satisfying trace makes g vanish on every row.
+            //     So q(0) = q(1) = 0.
+            // The node-0 accumulator stays zero.
+            // The sweep below starts at node 2.
             scratch.add_diffs();
             boundary += boundary_diff;
 
-            for acc_idx in 1..scratch.out.len() {
+            for node in 2..=degree {
                 scratch.add_diffs();
                 boundary += boundary_diff;
 
-                let g = MultilinearFolder::new(
-                    &scratch.local_point[..main_width],
-                    &scratch.next_point[..main_width],
-                    boundary,
-                    self.public_values,
-                    self.alpha,
-                )
-                .with_preprocessed(
-                    &scratch.local_point[main_width..],
-                    &scratch.next_point[main_width..],
-                )
-                .eval_air(self.air);
-                scratch.out[acc_idx] += eq_suffix * g;
+                slots
+                    .iter()
+                    .zip(scratch.air_evals.iter_mut())
+                    .for_each(|(slot, evals)| {
+                        if node <= slot.degree {
+                            let g = MultilinearFolder::new(
+                                &scratch.local_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                &scratch.next_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                boundary,
+                                self.public_values[slot.air_index],
+                                self.alpha,
+                            )
+                            .with_preprocessed(
+                                &scratch.local_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                                &scratch.next_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                            )
+                            .eval_air(self.airs[slot.air_index]);
+                            evals[node - 1] += eq_suffix * g;
+                        }
+                    });
             }
         }
 
-        scratch.out
+        let mut out = EF::zero_vec(degree);
+        let tau = self.tau.as_slice()[0];
+        write_last_evals(&mut self.degree_groups, &self.betas, &scratch.air_evals);
+        self.degree_groups
+            .iter()
+            .for_each(|group| group.combine_evals(&mut out, tau));
+        out
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn fold(self, r: EF) -> RoundStateExt<'a, A, F, EF> {
-        let main_width = self.table.num_polys();
+    pub(crate) fn fold(mut self, r: EF) -> RoundStateExt<'air, 'data, A, F, EF>
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
+    {
+        let tau = self.tau.as_slice()[0];
+        self.degree_groups
+            .iter_mut()
+            .for_each(|group| group.update_claim(tau, r));
+
         let num_evals = self.num_evals();
         let half = num_evals / 2;
-        let mut next_tail = self
-            .table
-            .iter_polys()
-            .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half]))
-            .collect::<Vec<_>>();
-
-        let mut eq_suffix = self.eq_suffix;
-        eq_suffix.sum_prefix_var_mut();
+        let slots = air_slots(&self.degree_groups, self.airs.len());
+        let width = self.total_width();
+        let mut next_tail = Vec::with_capacity(width);
+        for slot in &slots {
+            next_tail.extend(
+                self.tables[slot.air_index]
+                    .iter_polys()
+                    .map(|col| r * (col[num_evals - 1] - col[half]) + col[half]),
+            );
+            if let Some(preprocessed) = self.preprocessed[slot.air_index] {
+                next_tail.extend(
+                    preprocessed
+                        .iter_polys()
+                        .map(|col| r * (col[num_evals - 1] - col[half]) + col[half]),
+                );
+            }
+        }
 
         let want_packed = (half / 2) >= F::Packing::WIDTH;
         let columns = if want_packed {
-            let mut columns = self
-                .table
-                .par_iter_polys()
-                .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
-                .collect::<Vec<_>>();
-            if let Some(preprocessed) = self.preprocessed {
+            let mut columns = Vec::with_capacity(width);
+            for slot in &slots {
                 columns.extend(
-                    preprocessed
+                    self.tables[slot.air_index]
                         .par_iter_polys()
                         .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
                         .collect::<Vec<_>>(),
                 );
+                if let Some(preprocessed) = self.preprocessed[slot.air_index] {
+                    columns.extend(
+                        preprocessed
+                            .par_iter_polys()
+                            .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
+                            .collect::<Vec<_>>(),
+                    );
+                }
             }
             ExtColumns::Packed(columns)
         } else {
-            let mut columns = self
-                .table
-                .par_iter_polys()
-                .map(|col| PolyView::new(col).fix_prefix_var(r))
-                .collect::<Vec<_>>();
-            if let Some(preprocessed) = self.preprocessed {
+            let mut columns = Vec::with_capacity(width);
+            for slot in &slots {
                 columns.extend(
-                    preprocessed
+                    self.tables[slot.air_index]
                         .par_iter_polys()
                         .map(|col| PolyView::new(col).fix_prefix_var(r))
                         .collect::<Vec<_>>(),
                 );
+                if let Some(preprocessed) = self.preprocessed[slot.air_index] {
+                    columns.extend(
+                        preprocessed
+                            .par_iter_polys()
+                            .map(|col| PolyView::new(col).fix_prefix_var(r))
+                            .collect::<Vec<_>>(),
+                    );
+                }
             }
             ExtColumns::Scalar(columns)
         };
 
-        if let Some(preprocessed) = self.preprocessed {
-            next_tail.extend(
-                preprocessed
-                    .iter_polys()
-                    .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half])),
-            );
-        }
-
         RoundStateExt {
-            air: self.air,
+            airs: self.airs,
             public_values: self.public_values,
             alpha: self.alpha,
-            eq_suffix,
-            degree: self.degree,
+            betas: self.betas,
+            degree_groups: self.degree_groups,
+            tau: self.tau,
+            round: 1,
             columns,
-            main_width,
             next_tail,
             boundary: BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
         }
     }
 }
 
-impl<'a, A, F, EF> RoundStateExt<'a, A, F, EF>
+impl<'air, 'data, A, F, EF> RoundStateExt<'air, 'data, A, F, EF>
 where
     F: Field,
     EF: ExtensionField<F>,
 {
     fn num_evals(&self) -> usize {
-        self.eq_suffix.num_evals() * 2
+        self.columns.num_evals()
     }
 
-    /// Extracts the final scalar value of each column.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the columns are still SIMD-packed. Callers only reach this
-    /// once the sumcheck has bound every variable (`num_evals() == 1`), well
-    /// below the packing width, so the columns have always unpacked by then.
+    const fn width(&self) -> usize {
+        self.columns.len()
+    }
+
+    fn degree(&self) -> usize {
+        self.degree_groups
+            .iter()
+            .map(|group| group.degree)
+            .max()
+            .unwrap()
+    }
+
     pub(crate) fn evals(self) -> (Vec<EF>, Vec<EF>, BoundaryEvals<EF>) {
         let columns = self
             .columns
@@ -607,7 +949,7 @@ where
     /// SIMD-packed kernel once there are enough residual rows to fill a
     /// packed lane, mirroring [`RoundStateBase::round_poly`].
     #[tracing::instrument(skip_all)]
-    pub(crate) fn round_poly(&self) -> Vec<EF>
+    pub(crate) fn round_poly(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
             + for<'b> Air<
@@ -621,31 +963,32 @@ where
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
         if self.num_evals() / 2 < F::Packing::WIDTH {
-            self.round_poly_unpacked()
+            self.round_poly_unpacked(eq_suffix)
         } else {
-            self.round_poly_packed()
+            self.round_poly_packed(eq_suffix)
         }
     }
 
     #[tracing::instrument(skip_all)]
-    fn round_poly_unpacked(&self) -> Vec<EF>
+    fn round_poly_unpacked(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
     {
-        let width = self.columns.len();
-        let main_width = self.main_width;
+        let width = self.width();
         let num_evals = self.num_evals();
         let half = num_evals / 2;
-        let degree = self.degree;
+        let degree = self.degree();
+        let slots = air_slots(&self.degree_groups, self.airs.len());
+        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
 
-        self.eq_suffix
+        let air_evals = eq_suffix
             .as_slice()
             .par_iter()
             .enumerate()
             .par_fold_reduce(
-                || ExtScratch::new(degree, width),
+                || Scratch::<EF, EF>::new(&air_degrees, width),
                 |mut scratch, (s, &eq_suffix)| {
-                    for (((((local, local_diff), next), next_diff), column), next_tail) in scratch
+                    for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
                         .local_point
                         .iter_mut()
                         .zip(scratch.local_diff.iter_mut())
@@ -658,7 +1001,7 @@ where
                         let local_lo = column[s];
                         let local_hi = column[s + half];
                         *local = local_lo;
-                        *local_diff = local_hi - local_lo;
+                        *local_delta = local_hi - local_lo;
 
                         let next_lo = column[s + 1];
                         let next_hi_row = s + half;
@@ -668,59 +1011,88 @@ where
                             *next_tail
                         };
                         *next = next_lo;
-                        *next_diff = next_hi - next_lo;
+                        *next_delta = next_hi - next_lo;
                     }
 
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::row_pair_with_prefix(s, half, num_evals, self.boundary);
 
-                    let g = MultilinearFolder::new(
-                        &scratch.local_point[..main_width],
-                        &scratch.next_point[..main_width],
-                        boundary,
-                        self.public_values,
-                        self.alpha,
-                    )
-                    .with_preprocessed(
-                        &scratch.local_point[main_width..],
-                        &scratch.next_point[main_width..],
-                    )
-                    .eval_air(self.air);
-                    scratch.out[0] += eq_suffix * g;
+                    slots
+                        .iter()
+                        .zip(scratch.air_evals.iter_mut())
+                        .for_each(|(slot, evals)| {
+                            let g = MultilinearFolder::new(
+                                &scratch.local_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                &scratch.next_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                boundary,
+                                self.public_values[slot.air_index],
+                                self.alpha,
+                            )
+                            .with_preprocessed(
+                                &scratch.local_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                                &scratch.next_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                            )
+                            .eval_air(self.airs[slot.air_index]);
+                            evals[0] += eq_suffix * g;
+                            debug_assert!(slot.degree > 0);
+                        });
 
                     scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc_idx in 1..scratch.out.len() {
+                    for node in 2..=degree {
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        let g = MultilinearFolder::new(
-                            &scratch.local_point[..main_width],
-                            &scratch.next_point[..main_width],
-                            boundary,
-                            self.public_values,
-                            self.alpha,
-                        )
-                        .with_preprocessed(
-                            &scratch.local_point[main_width..],
-                            &scratch.next_point[main_width..],
-                        )
-                        .eval_air(self.air);
-                        scratch.out[acc_idx] += eq_suffix * g;
+                        slots
+                            .iter()
+                            .zip(scratch.air_evals.iter_mut())
+                            .for_each(|(slot, evals)| {
+                                if node <= slot.degree {
+                                    let g = MultilinearFolder::new(
+                                        &scratch.local_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        &scratch.next_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        boundary,
+                                        self.public_values[slot.air_index],
+                                        self.alpha,
+                                    )
+                                    .with_preprocessed(
+                                        &scratch.local_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                        &scratch.next_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                    )
+                                    .eval_air(self.airs[slot.air_index]);
+                                    evals[node - 1] += eq_suffix * g;
+                                }
+                            });
                     }
 
                     scratch
                 },
                 |mut lhs, rhs| {
-                    lhs.out
+                    lhs.air_evals
                         .iter_mut()
-                        .zip(rhs.out)
-                        .for_each(|(lhs, rhs)| *lhs += rhs);
+                        .zip(rhs.air_evals)
+                        .for_each(|(lhs, rhs)| EF::add_slices(lhs, &rhs));
                     lhs
                 },
             )
-            .out
+            .air_evals;
+        let mut out = EF::zero_vec(degree);
+        let tau = self.tau.as_slice()[self.round];
+        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        self.degree_groups
+            .iter()
+            .for_each(|group| group.combine_evals(&mut out, tau));
+
+        out
     }
 
     /// SIMD-packed twin of [`Self::round_poly_unpacked`].
@@ -734,7 +1106,7 @@ where
     /// packed extension value so it supports arithmetic against the base
     /// field `F` directly (see that type's docs for why this is needed).
     #[tracing::instrument(skip_all)]
-    fn round_poly_packed(&self) -> Vec<EF>
+    fn round_poly_packed(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<
             MultilinearFolder<
@@ -746,31 +1118,32 @@ where
         >,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
-        let width = self.columns.len();
-        let main_width = self.main_width;
+        let width = self.width();
         let height = self.num_evals();
         let scalar_half = height / 2;
         let packing_width = F::Packing::WIDTH;
         let packed_half = scalar_half / packing_width;
-        let degree = self.degree;
+        let degree = self.degree();
         let alpha = PackedExt::new(EF::ExtensionPacking::from(self.alpha));
+        let slots = air_slots(&self.degree_groups, self.airs.len());
+        let air_degrees = slots.iter().map(|slot| slot.degree).collect::<Vec<_>>();
         assert_ne!(packed_half, 0);
 
-        self.eq_suffix
+        let air_evals = eq_suffix
             .as_slice()
             .par_chunks_exact(packing_width)
             .enumerate()
             .par_fold_reduce(
                 || {
-                    RoundScratch::<PackedExt<F, EF::ExtensionPacking>, EF::ExtensionPacking>::new(
-                        degree, width,
+                    PackedScratch::<PackedExt<F, EF::ExtensionPacking>, EF>::new(
+                        &air_degrees,
+                        width,
                     )
                 },
                 |mut scratch, (packed_s, eq_suffix)| {
                     let s = packed_s * packing_width;
-                    let eq_suffix = EF::ExtensionPacking::from_ext_slice(eq_suffix);
 
-                    for (((((local, local_diff), next), next_diff), column), next_tail) in scratch
+                    for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
                         .local_point
                         .iter_mut()
                         .zip(scratch.local_diff.iter_mut())
@@ -780,14 +1153,11 @@ where
                         .zip(self.next_tail.iter())
                     {
                         let column = column.as_slice();
-                        // Aligned reads: `packed_s` indexes this chunk's own packed group directly.
                         let local_lo = PackedExt::new(column[packed_s]);
                         let local_hi = PackedExt::new(column[packed_s + packed_half]);
                         *local = local_lo;
-                        *local_diff = local_hi - local_lo;
+                        *local_delta = local_hi - local_lo;
 
-                        // Shifted-by-one reads cross packed-group boundaries, so they
-                        // reconstruct their window lane by lane instead of indexing directly.
                         let next_lo = PackedExt::new(packed_window::<F, EF>(
                             column,
                             s + 1,
@@ -801,7 +1171,7 @@ where
                             *next_tail,
                         ));
                         *next = next_lo;
-                        *next_diff = next_hi - next_lo;
+                        *next_delta = next_hi - next_lo;
                     }
 
                     let (raw_boundary, raw_boundary_diff) =
@@ -822,60 +1192,99 @@ where
                         PackedExt::new(raw_boundary_diff.transition),
                     );
 
-                    let g = MultilinearFolder::new(
-                        &scratch.local_point[..main_width],
-                        &scratch.next_point[..main_width],
-                        boundary,
-                        self.public_values,
-                        alpha,
-                    )
-                    .with_preprocessed(
-                        &scratch.local_point[main_width..],
-                        &scratch.next_point[main_width..],
-                    )
-                    .eval_air(self.air);
-                    scratch.out[0] += g.0 * eq_suffix;
+                    slots
+                        .iter()
+                        .zip(scratch.air_evals.iter_mut())
+                        .for_each(|(slot, evals)| {
+                            let g = MultilinearFolder::new(
+                                &scratch.local_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                &scratch.next_point
+                                    [slot.main_offset..slot.main_offset + slot.main_width],
+                                boundary,
+                                self.public_values[slot.air_index],
+                                alpha,
+                            )
+                            .with_preprocessed(
+                                &scratch.local_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                                &scratch.next_point[slot.preprocessed_offset
+                                    ..slot.preprocessed_offset + slot.preprocessed_width],
+                            )
+                            .eval_air(self.airs[slot.air_index]);
+                            evals[0] += dot_product::<EF, _, _>(
+                                eq_suffix.iter().copied(),
+                                EF::ExtensionPacking::to_ext_iter([g.0]),
+                            );
+                            debug_assert!(slot.degree > 0);
+                        });
 
                     scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc_idx in 1..scratch.out.len() {
+                    for node in 2..=degree {
                         scratch.add_diffs();
                         boundary += boundary_diff;
 
-                        let g = MultilinearFolder::new(
-                            &scratch.local_point[..main_width],
-                            &scratch.next_point[..main_width],
-                            boundary,
-                            self.public_values,
-                            alpha,
-                        )
-                        .with_preprocessed(
-                            &scratch.local_point[main_width..],
-                            &scratch.next_point[main_width..],
-                        )
-                        .eval_air(self.air);
-                        scratch.out[acc_idx] += g.0 * eq_suffix;
+                        slots
+                            .iter()
+                            .zip(scratch.air_evals.iter_mut())
+                            .for_each(|(slot, evals)| {
+                                if node <= slot.degree {
+                                    let g = MultilinearFolder::new(
+                                        &scratch.local_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        &scratch.next_point
+                                            [slot.main_offset..slot.main_offset + slot.main_width],
+                                        boundary,
+                                        self.public_values[slot.air_index],
+                                        alpha,
+                                    )
+                                    .with_preprocessed(
+                                        &scratch.local_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                        &scratch.next_point[slot.preprocessed_offset
+                                            ..slot.preprocessed_offset + slot.preprocessed_width],
+                                    )
+                                    .eval_air(self.airs[slot.air_index]);
+                                    evals[node - 1] += dot_product::<EF, _, _>(
+                                        eq_suffix.iter().copied(),
+                                        EF::ExtensionPacking::to_ext_iter([g.0]),
+                                    );
+                                }
+                            });
                     }
 
                     scratch
                 },
                 |mut lhs, rhs| {
-                    lhs.out
+                    lhs.air_evals
                         .iter_mut()
-                        .zip(rhs.out)
-                        .for_each(|(lhs, rhs)| *lhs += rhs);
+                        .zip(rhs.air_evals)
+                        .for_each(|(lhs, rhs)| EF::add_slices(lhs, &rhs));
                     lhs
                 },
             )
-            .out
-            .into_iter()
-            .map(|acc| EF::ExtensionPacking::to_ext_iter([acc]).sum())
-            .collect()
+            .air_evals;
+        let mut out = EF::zero_vec(degree);
+        let tau = self.tau.as_slice()[self.round];
+        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        self.degree_groups
+            .iter()
+            .for_each(|group| group.combine_evals(&mut out, tau));
+        out
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn fold(&mut self, r: EF) {
+    pub(crate) fn fold(&mut self, r: EF)
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
+    {
+        let tau = self.tau.as_slice()[self.round];
+        self.degree_groups
+            .iter_mut()
+            .for_each(|group| group.update_claim(tau, r));
+
         let num_evals = self.num_evals();
         let half = num_evals / 2;
 
@@ -898,15 +1307,11 @@ where
             }
         }
 
-        self.eq_suffix.sum_prefix_var_mut();
-
-        // Packed columns fold in packed form (one SIMD op per lane group instead
-        // of one scalar EF mul per row), unpacking to scalar once residual rows
-        // drop below the packing width.
         let want_packed = (half / 2) >= F::Packing::WIDTH;
         self.columns = core::mem::replace(&mut self.columns, ExtColumns::Scalar(Vec::new()))
             .fold(r, want_packed);
 
         self.boundary.apply(r);
+        self.round += 1;
     }
 }

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -111,11 +111,14 @@ pub(crate) struct RoundStateBase<'air, 'data, A, F: Field, EF> {
 /// Columns stay SIMD-packed as long as there are enough residual rows to fill a packed lane.
 /// Once a fold would leave fewer rows than a lane, columns unpack to scalar form.
 enum ExtColumns<F: Field, EF: ExtensionField<F>> {
+    /// One SIMD lane per residual row, holding several rows per stored element.
     Packed(Vec<Poly<EF::ExtensionPacking>>),
+    /// One extension element per residual row.
     Scalar(Vec<Poly<EF>>),
 }
 
 impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
+    /// Number of stored columns.
     const fn len(&self) -> usize {
         match self {
             Self::Packed(cols) => cols.len(),
@@ -123,6 +126,14 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
+    /// Number of residual rows across every column.
+    ///
+    /// A packed column stores one lane group per `F::Packing::WIDTH` rows.
+    /// Multiplying the stored-element count by the packing width recovers the scalar row count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no columns, since the row count is read from the first column.
     fn num_evals(&self) -> usize {
         match self {
             Self::Packed(cols) => {
@@ -138,6 +149,12 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
+    /// Borrow the columns as packed lanes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the columns have already unpacked to scalar form.
+    /// Callers gate on the same width threshold that decides the storage variant, so this never fires.
     fn as_packed(&self) -> &[Poly<EF::ExtensionPacking>] {
         match self {
             Self::Packed(cols) => cols,
@@ -145,6 +162,12 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
+    /// Borrow the columns as scalar extension elements.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the columns are still packed.
+    /// Callers gate on the same width threshold that decides the storage variant, so this never fires.
     fn as_scalar(&self) -> &[Poly<EF>] {
         match self {
             Self::Scalar(cols) => cols,
@@ -152,6 +175,16 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
         }
     }
 
+    /// Fold the prefix variable of every column at `r`.
+    ///
+    /// Stays packed when `want_packed` holds; otherwise unpacks to scalar form in the same pass.
+    ///
+    /// The residual row count only shrinks round to round.
+    /// So a fold can never make packed storage viable again once it stopped being viable.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `want_packed` is true while the columns are already scalar.
     fn fold(self, r: EF, want_packed: bool) -> Self {
         match self {
             Self::Packed(mut cols) => {
@@ -181,6 +214,13 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
     }
 }
 
+/// Read one packed lane group of consecutive residual rows, starting at scalar row `start`.
+///
+/// Rows at or past `len` fall back to `tail`, the repeat-last successor value.
+///
+/// The stored groups are aligned to multiples of the packing width.
+/// An offset window generally straddles two adjacent groups.
+/// So each lane is reconstructed independently rather than assuming a contiguous layout.
 #[inline]
 fn packed_window<F: Field, EF: ExtensionField<F>>(
     column: &[EF::ExtensionPacking],
@@ -190,10 +230,13 @@ fn packed_window<F: Field, EF: ExtensionField<F>>(
 ) -> EF::ExtensionPacking {
     let packing_width = F::Packing::WIDTH;
     EF::ExtensionPacking::from_ext_fn(|lane| {
+        // Scalar row this lane maps to inside the window.
         let row = start + lane;
         if row < len {
+            // Locate the row's group, then pull its lane out of that group.
             column[row / packing_width].extract(row % packing_width)
         } else {
+            // Past the last real row: repeat the tail value.
             tail
         }
     })
@@ -228,27 +271,34 @@ pub(crate) struct RoundStateExt<'air, 'data, A, F: Field, EF: ExtensionField<F>>
 
 /// Scratch for scalar round-polynomial folds.
 ///
-/// Holds one unweighted evaluation accumulator per AIR.
-/// The row buffers carry one residual row's interpolation node and its step difference.
 /// The base path uses one instance; the extension path allocates one per worker.
 struct Scratch<F, EF> {
+    /// Unweighted per-node evaluation accumulator for each AIR.
     air_evals: Vec<Vec<EF>>,
+    /// Current-row value of each column at the active interpolation node.
     local_point: Vec<F>,
+    /// Step added to advance each current-row value to the next node.
     local_diff: Vec<F>,
+    /// Successor-row value of each column at the active interpolation node.
     next_point: Vec<F>,
+    /// Step added to advance each successor-row value to the next node.
     next_diff: Vec<F>,
 }
 
 /// Per-worker scratch for the packed base-field first-round fold.
 ///
-/// Mirrors [`Scratch`] with packed base-field row buffers and a pair of
-/// per-lane equality-weight buffers. One instance is allocated per worker and
-/// reused across that worker's packed blocks.
+/// Mirrors the scalar scratch with packed row buffers, so each element covers one SIMD lane group.
+/// One instance is allocated per worker and reused across that worker's packed blocks.
 struct PackedScratch<P, EF> {
+    /// Unweighted per-node evaluation accumulator for each AIR.
     air_evals: Vec<Vec<EF>>,
+    /// Current-row lanes of each column at the active interpolation node.
     local_point: Vec<P>,
+    /// Step added to advance each current-row lane to the next node.
     local_diff: Vec<P>,
+    /// Successor-row lanes of each column at the active interpolation node.
     next_point: Vec<P>,
+    /// Step added to advance each successor-row lane to the next node.
     next_diff: Vec<P>,
 }
 

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -411,39 +411,6 @@ impl AirSlot {
     }
 }
 
-/// Beta-weight each AIR's evaluations and reduce them into its degree group.
-///
-/// The per-row fold accumulates `sum_x eq(x) * g_air(x)` with no beta factor.
-/// Beta enters here, once per AIR per node, since the sum is linear:
-///
-/// ```text
-///     sum_x beta * eq(x) * g(x) = beta * sum_x eq(x) * g(x)
-/// ```
-///
-/// This keeps beta out of the row loop.
-/// It saves one extension multiply per node per row.
-/// That multiply dominates the fold for cheap AIRs.
-fn write_last_evals<EF: Field>(
-    degree_groups: &mut [DegreeGroup<EF>],
-    betas: &[EF],
-    air_evals: &[Vec<EF>],
-) {
-    for group in degree_groups.iter_mut() {
-        // One accumulator per interpolation node this group carries.
-        let mut last = EF::zero_vec(group.degree);
-        for air in &group.airs {
-            // beta^i for this AIR, applied once here rather than per row.
-            let beta = betas[air.air_index];
-            // Fold the AIR's unweighted per-node sums in, scaled by beta.
-            last.iter_mut()
-                .zip(air_evals[air.air_index].iter())
-                .for_each(|(acc, &value)| *acc += beta * value);
-        }
-        // The group's beta-weighted round polynomial for this round.
-        group.last_evals = last;
-    }
-}
-
 /// One AIR's column placement inside its degree group.
 ///
 /// The group fixes the degree; this records where the AIR's columns live in the merged buffer.
@@ -535,9 +502,30 @@ impl<EF: Field> DegreeGroup<EF> {
         }
     }
 
-    /// Reduce this group's claim to the value of its round polynomial at the sampled challenge.
-    fn update_claim(&mut self, tau: EF, r: EF) {
-        self.claim = self.eval(tau, r);
+    /// Beta-weight each AIR's per-node sums and store them as this round's evaluations.
+    ///
+    /// The per-row fold accumulates `sum_x eq(x) * g_air(x)` with no beta factor.
+    /// Beta enters here, once per AIR per node, since the sum is linear:
+    ///
+    /// ```text
+    ///     sum_x beta * eq(x) * g(x) = beta * sum_x eq(x) * g(x)
+    /// ```
+    ///
+    /// This keeps beta out of the row loop.
+    /// It saves one extension multiply per node per row.
+    /// That multiply dominates the fold for cheap AIRs.
+    fn write_last_evals(&mut self, betas: &[EF], air_evals: &[Vec<EF>]) {
+        // One accumulator per interpolation node this group carries.
+        let mut last = EF::zero_vec(self.degree);
+        for air in &self.airs {
+            // beta^i for this AIR, applied once here rather than per row.
+            let beta = betas[air.air_index];
+            // Fold the AIR's unweighted per-node sums in, scaled by beta.
+            last.iter_mut()
+                .zip(air_evals[air.air_index].iter())
+                .for_each(|(acc, &value)| *acc += beta * value);
+        }
+        self.last_evals = last;
     }
 }
 
@@ -865,7 +853,9 @@ where
             .air_evals;
         let mut out = EF::zero_vec(degree);
         let tau = self.tau.as_slice()[0];
-        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        for group in &mut self.degree_groups {
+            group.write_last_evals(&self.betas, &air_evals);
+        }
         self.degree_groups
             .iter()
             .for_each(|group| group.combine_evals(&mut out, tau));
@@ -966,7 +956,9 @@ where
 
         let mut out = EF::zero_vec(degree);
         let tau = self.tau.as_slice()[0];
-        write_last_evals(&mut self.degree_groups, &self.betas, &scratch.air_evals);
+        for group in &mut self.degree_groups {
+            group.write_last_evals(&self.betas, &scratch.air_evals);
+        }
         self.degree_groups
             .iter()
             .for_each(|group| group.combine_evals(&mut out, tau));
@@ -981,7 +973,7 @@ where
         let tau = self.tau.as_slice()[0];
         self.degree_groups
             .iter_mut()
-            .for_each(|group| group.update_claim(tau, r));
+            .for_each(|group| group.claim = group.eval(tau, r));
 
         let num_evals = self.num_evals();
         let half = num_evals / 2;
@@ -1235,7 +1227,9 @@ where
             .air_evals;
         let mut out = EF::zero_vec(degree);
         let tau = self.tau.as_slice()[self.round];
-        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        for group in &mut self.degree_groups {
+            group.write_last_evals(&self.betas, &air_evals);
+        }
         self.degree_groups
             .iter()
             .for_each(|group| group.combine_evals(&mut out, tau));
@@ -1419,7 +1413,9 @@ where
             .air_evals;
         let mut out = EF::zero_vec(degree);
         let tau = self.tau.as_slice()[self.round];
-        write_last_evals(&mut self.degree_groups, &self.betas, &air_evals);
+        for group in &mut self.degree_groups {
+            group.write_last_evals(&self.betas, &air_evals);
+        }
         self.degree_groups
             .iter()
             .for_each(|group| group.combine_evals(&mut out, tau));
@@ -1434,7 +1430,7 @@ where
         let tau = self.tau.as_slice()[self.round];
         self.degree_groups
             .iter_mut()
-            .for_each(|group| group.update_claim(tau, r));
+            .for_each(|group| group.claim = group.eval(tau, r));
 
         let num_evals = self.num_evals();
         let half = num_evals / 2;

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -744,31 +744,30 @@ where
         let mut scratch = Scratch::<F, EF>::new(&air_degrees, width);
 
         for (s, &eq_suffix) in eq_suffix.as_slice().iter().enumerate() {
-            let fill_columns =
-                |scratch: &mut Scratch<F, EF>, offset: usize, table: &Table<F>| {
-                    let end = offset + table.num_polys();
-                    scratch.local_point[offset..end]
-                        .iter_mut()
-                        .zip(scratch.local_diff[offset..end].iter_mut())
-                        .zip(scratch.next_point[offset..end].iter_mut())
-                        .zip(scratch.next_diff[offset..end].iter_mut())
-                        .zip(table.iter_polys())
-                        .for_each(|((((local, local_delta), next), next_delta), column)| {
-                            let local_lo = column[s];
-                            let local_hi = column[s + half];
-                            *local = local_lo;
-                            *local_delta = local_hi - local_lo;
+            let fill_columns = |scratch: &mut Scratch<F, EF>, offset: usize, table: &Table<F>| {
+                let end = offset + table.num_polys();
+                scratch.local_point[offset..end]
+                    .iter_mut()
+                    .zip(scratch.local_diff[offset..end].iter_mut())
+                    .zip(scratch.next_point[offset..end].iter_mut())
+                    .zip(scratch.next_diff[offset..end].iter_mut())
+                    .zip(table.iter_polys())
+                    .for_each(|((((local, local_delta), next), next_delta), column)| {
+                        let local_lo = column[s];
+                        let local_hi = column[s + half];
+                        *local = local_lo;
+                        *local_delta = local_hi - local_lo;
 
-                            let next_lo = column[s + 1];
-                            let next_hi = if s + half + 1 < height {
-                                column[s + half + 1]
-                            } else {
-                                column[height - 1]
-                            };
-                            *next = next_lo;
-                            *next_delta = next_hi - next_lo;
-                        });
-                };
+                        let next_lo = column[s + 1];
+                        let next_hi = if s + half + 1 < height {
+                            column[s + half + 1]
+                        } else {
+                            column[height - 1]
+                        };
+                        *next = next_lo;
+                        *next_delta = next_hi - next_lo;
+                    });
+            };
             for slot in &slots {
                 fill_columns(&mut scratch, slot.main_offset, self.tables[slot.air_index]);
                 if let Some(preprocessed) = self.preprocessed[slot.air_index] {

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -20,17 +20,34 @@ use crate::folder::MultilinearFolder;
 use crate::packed_ext::PackedExt;
 use crate::selectors::BoundaryEvals;
 
+/// One batch of AIRs that share a single trace height.
+///
+/// A stage activates when the global sumcheck cube shrinks to its height.
+/// Every table inside a stage has the same number of variables.
 pub(super) struct Stage<'air, 'data, A, F: Field> {
+    /// Original caller indices of these AIRs, used to return openings in caller order.
     pub(super) indices: Vec<usize>,
+    /// The AIRs in this stage.
     pub(super) airs: Vec<&'air A>,
+    /// Public inputs forwarded to each AIR.
     pub(super) public_values: Vec<&'data [F]>,
+    /// Optional preprocessed table for each AIR.
     pub(super) preprocessed: Vec<Option<&'data Table<F>>>,
+    /// Transposed main trace table for each AIR.
     pub(super) tables: Vec<&'data Table<F>>,
+    /// Per-variable constraint degree of each AIR, with the eq factor stripped.
     pub(super) degrees: Vec<usize>,
+    /// Shared variable count, equal to the base-two logarithm of the common height.
     pub(super) num_vars: usize,
 }
 
 impl<'air, 'data, A, F: Field> Stage<'air, 'data, A, F> {
+    /// Build a stage from AIRs that all share one trace height.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tables do not all have the same height.
+    /// Panics if a preprocessed table's height differs from the stage height.
     pub(super) fn new(
         airs: &[&'air A],
         public_values: &[&'data [F]],
@@ -39,12 +56,14 @@ impl<'air, 'data, A, F: Field> Stage<'air, 'data, A, F> {
         tables: &[&'data Table<F>],
         degrees: &[usize],
     ) -> Self {
+        // Every table in a stage binds the same zerocheck variables, so heights must agree.
         let num_vars = tables
             .iter()
             .map(|table| table.num_variables())
             .all_equal_value()
             .expect("all tables must have the same height");
 
+        // Preprocessed columns fold alongside the main columns, so they share the height.
         assert!(
             preprocessed
                 .iter()
@@ -372,65 +391,124 @@ fn write_last_evals<EF: Field>(
     }
 }
 
-/// AIRs with the same internal degree share one beta-weighted round polynomial.
+/// One AIR's column placement inside its degree group.
+///
+/// The group fixes the degree; this records where the AIR's columns live in the merged buffer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct DegreeGroupAir {
+    /// Position of this AIR within its stage, in caller order.
     air_index: usize,
+    /// First main column of this AIR inside the merged column buffer.
     main_offset: usize,
+    /// Number of main columns this AIR owns.
     main_width: usize,
+    /// First preprocessed column of this AIR inside the merged column buffer.
     preprocessed_offset: usize,
+    /// Number of preprocessed columns this AIR owns.
     preprocessed_width: usize,
 }
 
+/// AIRs sharing one per-variable degree, folded into a single beta-weighted round polynomial.
+///
+/// Grouping by degree lets a lower-degree AIR skip the interpolation nodes that only a
+/// higher-degree AIR needs.
 struct DegreeGroup<EF> {
+    /// Common per-variable degree of every AIR in this group, with the eq factor stripped.
     degree: usize,
+    /// The AIRs in this group, each carrying its own column span.
     airs: Vec<DegreeGroupAir>,
+    /// Current reduced sumcheck claim for this group's round polynomial.
     claim: EF,
+    /// This round's beta-weighted evaluations at nodes `0, 2, 3, ..., degree`.
     last_evals: Vec<EF>,
+    /// Barycentric helper for this group's degree, reused across rounds.
     interpolator: RoundPolyInterpolator<EF>,
 }
 
 impl<EF: Field> DegreeGroup<EF> {
+    /// Evaluate this group's eq-stripped round polynomial `q` at an interpolation node.
+    ///
+    /// The prover never stores `q(1)`; it is recovered from the sumcheck claim relation:
+    ///
+    /// ```text
+    ///     claim = (1 - tau) * q(0) + tau * q(1)
+    ///  => q(1)  = (claim - (1 - tau) * q(0)) / tau
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the group degree is zero, since a constant has no round polynomial.
     fn eval(&self, tau: EF, point: EF) -> EF {
         debug_assert_eq!(self.last_evals.len(), self.degree);
         assert!(self.degree > 0, "round polynomial degree must be positive");
+        // Node 0 is stored directly as the first evaluation.
         if point.is_zero() {
             return self.last_evals[0];
         }
 
+        // Recover the dropped node 1 from the inter-round claim relation.
         let q1 = (self.claim - (EF::ONE - tau) * self.last_evals[0]) * tau.inverse();
         if point == EF::ONE {
             return q1;
         }
 
+        // Any higher node is a barycentric extrapolation of the stored evaluations.
         self.interpolator
             .eval(&self.last_evals, self.last_evals[0] + q1, point)
     }
 
+    /// Add this group's per-node evaluations into the stage's shared accumulator.
+    ///
+    /// The accumulator carries the stage's max degree, so a lower-degree group is
+    /// extrapolated up to the missing top nodes.
+    ///
+    /// ```text
+    ///     out index : 0    1    2    3    ...
+    ///     node      : 0    2    3    4    ...   (node 1 is never stored)
+    /// ```
     fn combine_evals(&self, out: &mut [EF], tau: EF) {
         for (idx, acc) in out.iter_mut().enumerate() {
+            // Map the dense output index onto the sparse node set {0, 2, 3, ...}.
             let node = if idx == 0 { 0 } else { idx + 1 };
             let value = if node == 0 || node <= self.degree {
+                // Within this group's own degree: read the stored evaluation directly.
                 let index = if node == 0 { 0 } else { node - 1 };
                 self.last_evals[index]
             } else {
+                // Above this group's degree: extrapolate to the stage's top nodes.
                 self.eval(tau, EF::from_usize(node))
             };
             *acc += value;
         }
     }
 
+    /// Reduce this group's claim to the value of its round polynomial at the sampled challenge.
     fn update_claim(&mut self, tau: EF, r: EF) {
         self.claim = self.eval(tau, r);
     }
 }
 
+/// Bucket AIRs by degree and assign each AIR its column span in the merged buffer.
+///
+/// Columns are laid out per AIR as main columns then preprocessed columns, in caller order:
+///
+/// ```text
+///     [ air0 main | air0 preproc | air1 main | air1 preproc | ... ]
+/// ```
+///
+/// # Arguments
+///
+/// - `degrees`: per-variable constraint degree of each AIR, in stage-local order.
+/// - `main_widths`: main column count of each AIR, in stage-local order.
+/// - `preprocessed_widths`: preprocessed column count of each AIR, in stage-local order.
 fn build_degree_groups<EF: Field>(
     degrees: &[usize],
     main_widths: &[usize],
     preprocessed_widths: &[usize],
 ) -> Vec<DegreeGroup<EF>> {
+    // A btree keyed by degree gives deterministic group order across prover and verifier.
     let mut groups = BTreeMap::<usize, Vec<DegreeGroupAir>>::new();
+    // Running column cursor into the merged buffer, advanced AIR by AIR.
     let mut column_offset = 0;
     for (air_index, ((&degree, &main_width), &preprocessed_width)) in degrees
         .iter()
@@ -438,10 +516,13 @@ fn build_degree_groups<EF: Field>(
         .zip(preprocessed_widths)
         .enumerate()
     {
+        // Main columns come first for this AIR.
         let main_offset = column_offset;
         column_offset += main_width;
+        // Preprocessed columns follow immediately after.
         let preprocessed_offset = column_offset;
         column_offset += preprocessed_width;
+        // File the AIR under its degree, keeping its column span.
         groups.entry(degree).or_default().push(DegreeGroupAir {
             air_index,
             main_offset,
@@ -451,6 +532,7 @@ fn build_degree_groups<EF: Field>(
         });
     }
 
+    // Each degree becomes one group with a zero starting claim and a prebuilt interpolator.
     groups
         .into_iter()
         .map(|(degree, airs)| DegreeGroup {

--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -145,12 +145,15 @@ where
     challenger.observe(proof.commitment.clone());
 
     // 3. Verify the zerocheck sumcheck, yielding the bound point and the reduced sum.
-    let zerocheck = AirZerocheck::new(air, pow_bits);
+    let airs = [air];
+    let log_heights = [log_height];
+    let public_values = [public_values];
+    let zerocheck = AirZerocheck::new(&airs, pow_bits);
     let reduction = zerocheck
         .verify_reduction::<C::Val, C::Challenge, _>(
             &proof.sumcheck,
-            log_height,
-            public_values,
+            &log_heights,
+            &public_values,
             challenger,
         )
         .map_err(VerificationError::Zerocheck)?;
@@ -207,12 +210,19 @@ where
     };
 
     // 6. Close the zerocheck: recompute g from the commitment-bound values and match the sum.
+    let main_opening = [TableOpening::new(
+        main.current(),
+        &next_columns,
+        main.next(),
+    )];
+    let preprocessed_opening = [preprocessed_opening];
     zerocheck
         .check_constraint(
             &reduction,
-            TableOpening::new(main.current(), &next_columns, main.next()),
-            preprocessed_opening,
-            public_values,
+            &main_opening,
+            &preprocessed_opening,
+            &log_heights,
+            &public_values,
         )
         .map_err(VerificationError::Zerocheck)
 }

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -10,12 +10,14 @@
 //! The generic-degree sumcheck proves that sum.
 //! A zerocheck always claims zero, so the verifier rejects any proof that claims a different sum.
 
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
-use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder, get_all_symbolic_constraints};
+use p3_air::{Air, AirLayout, SymbolicAirBuilder, get_all_symbolic_constraints};
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundPolyInterpolator};
 use p3_sumcheck::layout::Table;
 use thiserror::Error;
@@ -23,7 +25,7 @@ use thiserror::Error;
 use crate::folder::MultilinearFolder;
 use crate::opening::{OpeningClaims, TableOpening};
 use crate::packed_ext::PackedExt;
-use crate::rounds::RoundStateBase;
+use crate::rounds::{RoundStateBase, RoundStateExt, Stage};
 use crate::selectors::BoundaryEvals;
 
 /// Reasons the zerocheck verifier rejects a proof.
@@ -81,299 +83,409 @@ pub enum ZerocheckError {
 pub struct ZerocheckProof<F, EF> {
     /// Generic-degree sumcheck transcript for `sum_x eq(tau, x) * g(x) = 0`.
     pub sumcheck: GenericDegreeProof<F, EF>,
-    /// Current-row value of every main column at the sumcheck point, in column order.
+    /// Current-row values at the sumcheck point, grouped by input AIR order.
     ///
-    /// These are the main-trace `Eq` opening claims.
-    pub local: Vec<EF>,
-    /// Repeat-last successor value of each main column the AIR reads on the next row.
+    /// `local[i]` contains one value per main column of `airs[i]`.
+    pub local: Vec<Vec<EF>>,
+    /// Repeat-last successor values at the sumcheck point, grouped by input AIR order.
     ///
-    /// These are the main-trace `Next` opening claims, in the AIR's declared next-row order.
-    pub next: Vec<EF>,
-    /// Current-row value of every preprocessed column at the sumcheck point, in column order.
-    ///
-    /// Empty when the AIR declares no preprocessed columns.
-    pub preprocessed_local: Vec<EF>,
-    /// Repeat-last successor value of each preprocessed column the AIR reads on the next row.
-    ///
-    /// In the AIR's declared preprocessed next-row order.
-    /// Empty when the AIR declares no preprocessed columns.
-    pub preprocessed_next: Vec<EF>,
+    /// `next[i]` contains one value per column declared by `airs[i].main_next_row_columns()`.
+    pub next: Vec<Vec<EF>>,
+    /// Current-row preprocessed values at the sumcheck point, grouped by input AIR order.
+    pub preprocessed_local: Vec<Vec<EF>>,
+    /// Repeat-last preprocessed successor values, grouped by input AIR order.
+    pub preprocessed_next: Vec<Vec<EF>>,
 }
 
-/// An AIR zerocheck instance.
-///
-/// Bundles the AIR and the grinding parameter shared by the prover and verifier.
-/// The field and transcript are chosen per call, so one instance serves any field.
 #[derive(Debug)]
 pub struct AirZerocheck<'a, A> {
-    /// AIR whose alpha-batched constraint is checked.
-    air: &'a A,
+    /// AIRs whose alpha-batched constraints are checked.
+    airs: &'a [&'a A],
     /// Grinding difficulty per sumcheck round, or `0` to skip.
     pow_bits: usize,
 }
 
-impl<'a, A> AirZerocheck<'a, A> {
-    /// Create a zerocheck instance for an AIR.
-    ///
-    /// # Arguments
-    ///
-    /// - `air`: the AIR whose constraints are checked.
-    /// - `pow_bits`: grinding difficulty per sumcheck round, or `0` to skip.
-    pub const fn new(air: &'a A, pow_bits: usize) -> Self {
-        Self { air, pow_bits }
-    }
+fn sumcheck_degree<F, EF, A>(air: &A) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
+{
+    air_degree(air) + 1
+}
 
-    /// Derive the AIR layout and reject column kinds this version cannot prove.
-    ///
-    /// Main and preprocessed columns are supported.
-    /// Periodic columns are not wired in yet.
-    /// An AIR that declared periodic columns would be evaluated against empty data and silently mis-proved.
-    ///
-    /// # Returns
-    ///
-    /// The AIR layout, carrying the main width, preprocessed width, and public-value count.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the AIR declares any periodic columns.
-    fn layout<F>(&self) -> AirLayout
-    where
-        F: Field,
-        A: BaseAir<F>,
-    {
-        let layout = AirLayout::from_air::<F>(self.air);
+fn air_degree<F, EF, A>(air: &A) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<SymbolicAirBuilder<F, EF>>,
+{
+    let layout = AirLayout::from_air::<F>(air);
 
-        // Periodic columns need closed-form evaluation threaded into the folder.
-        assert_eq!(
-            layout.num_periodic_columns, 0,
-            "zerocheck does not support periodic columns yet"
+    // Largest per-variable degree among the asserted constraints, scored at domain size two.
+    // No periodic columns reach this point, so the periodic-column lengths are empty.
+    let symbolic_constraint_degree = || {
+        let (base, ext) = get_all_symbolic_constraints::<F, EF, A>(air, layout);
+        let base_degree = base
+            .iter()
+            .map(|c| c.poly_degree(2, &[]))
+            .max()
+            .unwrap_or(0);
+        let ext_degree = ext.iter().map(|c| c.poly_degree(2, &[])).max().unwrap_or(0);
+        base_degree.max(ext_degree)
+    };
+
+    if let Some(degree) = air.max_constraint_degree() {
+        // A hint below the true constraint degree drops evaluations from each round polynomial.
+        // Reject such a hint in debug builds.
+        debug_assert!(
+            degree >= symbolic_constraint_degree(),
+            "max_constraint_degree hint is below the symbolic constraint degree"
         );
-
-        layout
+        return degree;
     }
 
-    /// Per-round degree of the zerocheck sumcheck.
-    ///
-    /// The summed integrand is `eq(tau, x) * g(x)`.
-    /// Its per-variable degree is the constraint per-variable degree, plus one for the multilinear weight.
-    ///
-    /// The constraint degree comes from one of two sources:
-    /// - a constant-time hint supplied by the AIR, when present;
-    /// - otherwise a symbolic pass that scores each constraint at domain size two.
-    ///
-    /// At domain size two every column and every boundary selector scores degree one, so the symbolic value is exact.
-    ///
-    /// The prover and the verifier both call this, so they always agree on the degree.
-    /// The hint must be at least the true per-variable degree:
-    /// - a smaller value under-determines the round polynomial and breaks soundness;
-    /// - a larger value only inflates the proof and the per-row work.
-    ///
-    /// A debug assertion pins the hint against the symbolic value.
-    ///
-    /// # Arguments
-    ///
-    /// - `layout`: column widths and public-value counts sizing the symbolic pass.
-    fn sumcheck_degree<F, EF>(&self, layout: AirLayout) -> usize
-    where
-        F: Field,
-        EF: ExtensionField<F>,
-        A: Air<SymbolicAirBuilder<F, EF>>,
-    {
-        // Largest per-variable degree among the asserted constraints, scored at domain size two.
-        // No periodic columns reach this point, so the periodic-column lengths are empty.
-        let symbolic_constraint_degree = || {
-            let (base, ext) = get_all_symbolic_constraints::<F, EF, A>(self.air, layout);
-            let base_degree = base
-                .iter()
-                .map(|c| c.poly_degree(2, &[]))
-                .max()
-                .unwrap_or(0);
-            let ext_degree = ext.iter().map(|c| c.poly_degree(2, &[])).max().unwrap_or(0);
-            base_degree.max(ext_degree)
-        };
+    // Add one for the multilinear eq weight.
+    symbolic_constraint_degree()
+}
 
-        if let Some(degree) = self.air.max_constraint_degree() {
-            // A hint below the true constraint degree drops evaluations from each round polynomial.
-            // Reject such a hint in debug builds.
-            debug_assert!(
-                degree >= symbolic_constraint_degree(),
-                "max_constraint_degree hint is below the symbolic constraint degree"
-            );
-            return degree + 1;
-        }
-
-        // Add one for the multilinear eq weight.
-        symbolic_constraint_degree() + 1
+impl<'a, A> AirZerocheck<'a, A> {
+    /// Create a zerocheck instance for AIRs that may have different trace heights.
+    ///
+    /// AIRs are batched in the order supplied here; proof opening claims use the same order.
+    pub const fn new(airs: &'a [&'a A], pow_bits: usize) -> Self {
+        Self { airs, pow_bits }
     }
 
-    /// Prove that the AIR's alpha-batched constraint vanishes on every trace row.
+    /// Prove that every AIR in the batch vanishes on its trace.
     ///
-    /// The `table` must have one original trace column per table row.
-    ///
-    /// The caller must observe the trace commitment into the challenger before this call.
-    /// The public values are observed here, so the caller need not observe them.
-    ///
-    /// # Arguments
-    ///
-    /// - `table`: committed trace table, one original trace column per table row.
-    /// - `preprocessed`: the preprocessed trace, or `None` when the AIR declares none.
-    /// - `public_values`: public inputs forwarded to the AIR.
-    /// - `challenger`: the Fiat-Shamir transcript.
-    ///
-    /// # Returns
-    ///
-    /// The sumcheck transcript and the column opening claims at the sumcheck point.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the AIR declares periodic columns, which this version does not support.
+    /// `tables[i]`, `preprocessed[i]`, and `public_values[i]` correspond to `airs[i]`.
     #[tracing::instrument(skip_all)]
     pub fn prove<F, EF, Challenger>(
         &self,
-        table: &Table<F>,
-        preprocessed: Option<&Table<F>>,
-        public_values: &[F],
+        preprocessed: &[Option<&Table<F>>],
+        tables: &[&Table<F>],
+        public_values: &[&[F]],
         challenger: &mut Challenger,
     ) -> (ZerocheckProof<F, EF>, Point<EF>)
     where
         F: Field,
         EF: ExtensionField<F>,
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
-            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>
-            + for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
             + for<'b> Air<
                 MultilinearFolder<
                     'b,
                     F,
-                    PackedExt<F, EF::ExtensionPacking>,
-                    PackedExt<F, EF::ExtensionPacking>,
+                    <F as Field>::Packing,
+                    <EF as ExtensionField<F>>::ExtensionPacking,
+                >,
+            > + for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
+            + for<'b> Air<
+                MultilinearFolder<
+                    'b,
+                    F,
+                    PackedExt<F, <EF as ExtensionField<F>>::ExtensionPacking>,
+                    PackedExt<F, <EF as ExtensionField<F>>::ExtensionPacking>,
                 >,
             > + Air<SymbolicAirBuilder<F, EF>>,
-        EF::ExtensionPacking: From<EF> + From<F::Packing>,
+        <EF as ExtensionField<F>>::ExtensionPacking: From<EF> + From<<F as Field>::Packing>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        let log_height = table.num_variables();
+        assert!(!self.airs.is_empty());
+        assert_eq!(self.airs.len(), tables.len(),);
+        assert_eq!(self.airs.len(), preprocessed.len(),);
+        assert_eq!(self.airs.len(), public_values.len(),);
 
-        // Reject column kinds this version cannot prove, and read the layout once.
-        let layout = self.layout::<F>();
-        assert_eq!(
-            table.num_polys(),
-            layout.main_width,
-            "trace width must match the AIR width"
-        );
+        let degrees = self
+            .airs
+            .iter()
+            .zip(tables.iter())
+            .zip(preprocessed.iter())
+            .zip(public_values.iter())
+            .map(|(((&air, table), preprocessed), public_values)| {
+                let layout = AirLayout::from_air::<F>(air);
+                assert_eq!(
+                    layout.num_periodic_columns, 0,
+                    "zerocheck does not support periodic columns yet"
+                );
+                assert_eq!(table.num_polys(), layout.main_width);
+                assert_eq!(
+                    preprocessed.map_or(0, |table| table.num_polys()),
+                    layout.preprocessed_width
+                );
+                if let Some(preprocessed) = preprocessed {
+                    assert_eq!(preprocessed.num_variables(), table.num_variables());
+                }
+                assert_eq!(public_values.len(), air.num_public_values());
+                air_degree::<F, EF, A>(air)
+            })
+            .collect::<Vec<_>>();
+        let max_degree = degrees.iter().copied().max().unwrap();
 
-        // Per-round sumcheck degree from the symbolic constraint degree.
-        let degree = self.sumcheck_degree::<F, EF>(layout);
+        // Bucket AIR indices by trace height.
+        // The map gives deterministic height order; stages are built largest-first below.
+        let mut indices_by_height = BTreeMap::<usize, Vec<usize>>::new();
+        tables.iter().enumerate().for_each(|(index, table)| {
+            indices_by_height
+                .entry(table.num_variables())
+                .or_default()
+                .push(index);
+        });
 
-        // The optimized prover strips one degree from each round polynomial.
-        // That leaves one fewer internal evaluation, so the constraint must be at least degree one.
-        // A degree-zero constraint is constant and has no meaningful zerocheck.
-        assert!(
-            degree >= 2,
-            "zerocheck requires a constraint of per-variable degree at least one"
-        );
+        let log_height = indices_by_height.keys().copied().max().unwrap();
 
-        // Bind the public values before any challenge depends on them.
-        // The trace commitment must already be in the transcript.
-        challenger.observe_algebra_slice(public_values);
+        // Each stage contains the AIRs sharing one trace height.
+        // Original AIR indices stay attached so final openings can return in caller order.
+        let stages = indices_by_height
+            .into_iter()
+            .rev()
+            .map(|(_, indices)| {
+                let tables = indices.iter().map(|&i| tables[i]).collect::<Vec<_>>();
+                let preprocessed = indices.iter().map(|&i| preprocessed[i]).collect::<Vec<_>>();
+                let airs = indices.iter().map(|&i| self.airs[i]).collect::<Vec<_>>();
+                let public_values = indices
+                    .iter()
+                    .map(|&i| public_values[i])
+                    .collect::<Vec<_>>();
+                let degrees = indices.iter().map(|&i| degrees[i]).collect::<Vec<_>>();
+                Stage::new(
+                    &airs,
+                    &public_values,
+                    &indices,
+                    &preprocessed,
+                    &tables,
+                    &degrees,
+                )
+            })
+            .collect::<Vec<_>>();
 
-        // Draw the batching scalar then the zerocheck point, in that fixed order.
-        let (alpha, tau) = sample_zerocheck_challenges(challenger, log_height);
+        // Bind all public values before any challenge depends on them.
+        // Trace commitments must already be in the transcript.
+        for values in public_values {
+            challenger.observe_algebra_slice(values);
+        }
+
+        let (alpha, beta, tau) =
+            sample_zerocheck_challenges::<F, EF, Challenger>(challenger, log_height);
         let tau = Point::new(tau);
-
-        let state = RoundStateBase::<'_, _, F, EF>::new(
-            self.air,
-            public_values,
-            alpha,
-            &tau,
-            table,
-            preprocessed,
-            degree - 1,
-        );
+        // Beta batches AIR contributions in caller order.
+        // When a stage activates, it selects the beta powers for its original AIR indices.
+        let beta_powers = beta.powers().collect_n(self.airs.len());
 
         // Bind the transcript to the claimed sum so the challenges depend on the statement.
         challenger.observe_algebra_element(EF::ZERO);
 
-        let mut sumcheck = GenericDegreeProof {
+        let mut proof = GenericDegreeProof {
             claimed_sum: EF::ZERO,
             round_polys: Vec::with_capacity(log_height),
             pow_witnesses: Vec::with_capacity(if self.pow_bits > 0 { log_height } else { 0 }),
         };
+
         let mut challenges = Vec::with_capacity(log_height);
+        // Active stages live as folded extension states.
+        // claims[i] is the current reduced claim for states[i].
+        let mut states = Vec::<RoundStateExt<'_, '_, A, F, EF>>::new();
+        let mut claims = Vec::<EF>::new();
+
+        // All stages share the same global sumcheck point.
+        // eq_prefix covers folded rounds; eq_suffix covers the tail still inside each state.
         let mut eq_prefix = EF::ONE;
-        let mut claim = EF::ZERO;
-        let interpolator = RoundPolyInterpolator::new(degree - 1);
+        let mut eq_suffix = Poly::new_from_point(&tau.as_slice()[1..], EF::ONE);
 
-        let evals = state.round_poly();
+        let interpolator = RoundPolyInterpolator::new(max_degree);
 
-        let (standard_evals, q_unweighted_sum) =
-            standard_round_from_q_evals(&interpolator, &evals, claim, eq_prefix, tau.as_slice()[0]);
+        // Barycentric interpolators, indexed by internal degree, built once.
+        // A lower-degree stage is extrapolated up to the batch's max degree.
+        // Reusing prebuilt weights avoids recomputing them every round.
+        let interpolators = (0..=max_degree)
+            .map(RoundPolyInterpolator::<EF>::new)
+            .collect::<Vec<_>>();
 
-        challenger.observe_algebra_slice(&standard_evals);
+        let mut next_stage = 0;
+        for round in 0..log_height {
+            let num_vars = log_height - round;
+            let tau_round = tau.as_slice()[round];
+            let tau_round_inv = tau_round.inverse();
 
-        // Optional proof-of-work; raises the cost of grinding a favorable challenge.
-        if self.pow_bits > 0 {
-            sumcheck.pow_witnesses.push(challenger.grind(self.pow_bits));
-        }
+            let mut round_poly_acc = EF::zero_vec(max_degree);
+            let mut round_polys = Vec::with_capacity(states.len());
 
-        let r: EF = challenger.sample_algebra_element();
-        claim = interpolator.eval(&evals, q_unweighted_sum, r);
-        eq_prefix *= Point::eval_eq(&[tau.as_slice()[0]], &[r]);
-        let mut state = state.fold(r);
+            // Existing stages already live over the extension field.
+            // Extend each stage's internal round polynomial to the global degree and accumulate it.
+            for (state, &claim) in states.iter_mut().zip(claims.iter()) {
+                let round_poly = state.round_poly(&eq_suffix);
+                let q1 = (claim - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
+                let unweighted_claim = round_poly[0] + q1;
+                let interpolator = &interpolators[round_poly.len()];
+                let round_poly = round_poly
+                    .iter()
+                    .map(Some)
+                    .chain(core::iter::repeat(None))
+                    .take(max_degree)
+                    .enumerate()
+                    .map(|(i, value)| match value {
+                        Some(&value) => value,
+                        None => {
+                            interpolator.eval(&round_poly, unweighted_claim, EF::from_usize(i + 1))
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                EF::add_slices(&mut round_poly_acc, &round_poly);
+                round_polys.push(round_poly);
+            }
 
-        sumcheck.round_polys.push(standard_evals);
-        challenges.push(r);
+            // A stage activates when the global cube reaches its trace height.
+            // Its base-field trace is evaluated once, extended to the global degree, then folded.
+            let mut new_state = None;
+            if next_stage < stages.len() && num_vars == stages[next_stage].num_vars {
+                let stage = &stages[next_stage];
+                let tau = Point::new(tau.as_slice()[round..].to_vec());
+                let betas = stage
+                    .indices
+                    .iter()
+                    .map(|&air_index| beta_powers[air_index])
+                    .collect::<Vec<_>>();
+                let mut state = RoundStateBase::new(&stages[next_stage], alpha, betas, &tau);
+                let round_poly = state.round_poly(&eq_suffix);
+                let q1 = (EF::ZERO - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
+                let unweighted_claim = round_poly[0] + q1;
+                let interpolator = &interpolators[round_poly.len()];
+                let round_poly = round_poly
+                    .iter()
+                    .map(Some)
+                    .chain(core::iter::repeat(None))
+                    .take(max_degree)
+                    .enumerate()
+                    .map(|(i, value)| match value {
+                        Some(&value) => value,
+                        None => {
+                            interpolator.eval(&round_poly, unweighted_claim, EF::from_usize(i + 1))
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                EF::add_slices(&mut round_poly_acc, &round_poly);
+                new_state = Some((state, round_poly));
+                next_stage += 1;
+            }
 
-        for round in 1..log_height {
-            let evals = state.round_poly();
-            let (standard_evals, unweighted_sum) = standard_round_from_q_evals(
+            // The verifier sees one global sumcheck round.
+            // Convert the accumulated internal q-evals back to eq-weighted standard evals.
+            let claim = claims.iter().copied().sum::<EF>();
+            let (standard_evals, _) = standard_round_from_q_evals(
                 &interpolator,
-                &evals,
+                &round_poly_acc,
                 claim,
                 eq_prefix,
                 tau.as_slice()[round],
             );
+
             challenger.observe_algebra_slice(&standard_evals);
+            proof.round_polys.push(standard_evals);
 
             if self.pow_bits > 0 {
-                sumcheck.pow_witnesses.push(challenger.grind(self.pow_bits));
+                proof.pow_witnesses.push(challenger.grind(self.pow_bits));
             }
 
             let r: EF = challenger.sample_algebra_element();
-            claim = interpolator.eval(&evals, unweighted_sum, r);
-            eq_prefix *= Point::eval_eq(&[tau.as_slice()[round]], &[r]);
-            state.fold(r);
-
-            sumcheck.round_polys.push(standard_evals);
             challenges.push(r);
+
+            // Fold every already-active state at the sampled challenge.
+            // Update its reduced claim using the same internal round polynomial used above.
+            for ((state, claim), round_poly) in states
+                .iter_mut()
+                .zip(claims.iter_mut())
+                .zip(round_polys.iter())
+            {
+                let q1 = (*claim - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
+                let unweighted_claim = round_poly[0] + q1;
+                *claim = interpolator.eval(round_poly, unweighted_claim, r);
+                state.fold(r);
+            }
+
+            // The newly activated stage joins the active list only after this round.
+            // Its first claim starts from the zerocheck claim, which is zero.
+            if let Some((state, round_poly)) = new_state {
+                let q1 = (EF::ZERO - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
+                let unweighted_claim = round_poly[0] + q1;
+                claims.push(interpolator.eval(&round_poly, unweighted_claim, r));
+                states.push(state.fold(r));
+            }
+
+            // Advance the shared equality factors to the next round.
+            // The prefix absorbs r; the suffix drops the variable just bound.
+            eq_prefix *= Point::eval_eq(&[tau_round], &[r]);
+            if round + 1 < log_height {
+                eq_suffix.sum_prefix_var_mut();
+            }
         }
 
-        // The state holds main columns then preprocessed columns.
-        // Split the two groups at the main width before forming opening claims.
-        let (local, next_tail, _) = state.evals();
-        let (main_local, preprocessed_local) = local.split_at(layout.main_width);
-        let (main_next_tail, preprocessed_next_tail) = next_tail.split_at(layout.main_width);
+        // States are ordered by activation height, not caller AIR order.
+        // Scatter final local/next openings back through the original AIR indices.
+        let mut local_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
+        let mut next_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
+        let mut preprocessed_local_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
+        let mut preprocessed_next_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
 
-        // Keep only the successor claims for the columns the AIR reads on the next row.
-        let next = self
-            .air
-            .main_next_row_columns()
-            .iter()
-            .map(|&column| main_next_tail[column])
+        for (stage, state) in stages.iter().zip(states) {
+            let (local, all_next, _) = state.evals();
+            let mut column_offset = 0;
+            for (((&air_index, table), preprocessed), &air) in stage
+                .indices
+                .iter()
+                .zip(stage.tables.iter())
+                .zip(stage.preprocessed.iter())
+                .zip(stage.airs.iter())
+            {
+                let main_offset = column_offset;
+                let main_width = table.num_polys();
+                let main_end = main_offset + main_width;
+                local_by_air[air_index] = Some(local[main_offset..main_end].to_vec());
+                next_by_air[air_index] = Some(
+                    air.main_next_row_columns()
+                        .into_iter()
+                        .map(|column| all_next[main_offset + column])
+                        .collect::<Vec<_>>(),
+                );
+                column_offset = main_end;
+
+                let preprocessed_offset = column_offset;
+                let preprocessed_width = preprocessed.map_or(0, |table| table.num_polys());
+                let preprocessed_end = preprocessed_offset + preprocessed_width;
+                preprocessed_local_by_air[air_index] =
+                    Some(local[preprocessed_offset..preprocessed_end].to_vec());
+                preprocessed_next_by_air[air_index] = Some(
+                    air.preprocessed_next_row_columns()
+                        .into_iter()
+                        .map(|column| all_next[preprocessed_offset + column])
+                        .collect::<Vec<_>>(),
+                );
+                column_offset = preprocessed_end;
+            }
+        }
+
+        let local = local_by_air
+            .into_iter()
+            .map(|values| values.expect("every AIR must have local openings"))
             .collect();
-        let preprocessed_next = self
-            .air
-            .preprocessed_next_row_columns()
-            .iter()
-            .map(|&column| preprocessed_next_tail[column])
+        let next = next_by_air
+            .into_iter()
+            .map(|values| values.expect("every AIR must have next openings"))
+            .collect();
+        let preprocessed_local = preprocessed_local_by_air
+            .into_iter()
+            .map(|values| values.expect("every AIR must have preprocessed local openings"))
+            .collect();
+        let preprocessed_next = preprocessed_next_by_air
+            .into_iter()
+            .map(|values| values.expect("every AIR must have preprocessed next openings"))
             .collect();
 
         (
             ZerocheckProof {
-                sumcheck,
-                local: main_local.to_vec(),
+                sumcheck: proof,
+                local,
                 next,
-                preprocessed_local: preprocessed_local.to_vec(),
+                preprocessed_local,
                 preprocessed_next,
             },
             Point::new(challenges),
@@ -398,20 +510,20 @@ impl<'a, A> AirZerocheck<'a, A> {
     /// # Errors
     ///
     /// Returns an error when:
-    /// - a table's current-row openings do not carry one value per column,
-    /// - a table's next-row openings do not carry one value per next-row column,
+    /// - the current-row openings do not carry one value per main column,
+    /// - the next-row openings do not carry one value per next-row column,
     /// - the claimed sum is nonzero,
     /// - the inner sumcheck transcript fails to verify,
     /// - the reduced sum does not match the constraint at the random point.
     ///
     /// # Panics
     ///
-    /// Panics if the AIR declares periodic columns, which this version does not support.
+    /// Panics if the AIR declares preprocessed or periodic columns, which this version does not support.
     pub fn verify<F, EF, Challenger>(
         &self,
         proof: &ZerocheckProof<F, EF>,
-        log_height: usize,
-        public_values: &[F],
+        log_heights: &[usize],
+        public_values: &[&[F]],
         challenger: &mut Challenger,
     ) -> Result<Point<EF>, ZerocheckError>
     where
@@ -420,37 +532,53 @@ impl<'a, A> AirZerocheck<'a, A> {
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>> + Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        // Reject column kinds this version cannot prove, and read the layout once.
-        let layout = self.layout::<F>();
+        assert!(!self.airs.is_empty(), "zerocheck requires at least one AIR");
+        assert_eq!(self.airs.len(), public_values.len(),);
+        assert_eq!(self.airs.len(), log_heights.len(),);
+        assert!(log_heights.iter().all(|&log_height| log_height > 0),);
 
-        // Only the columns the AIR reads on the next row carry a successor claim.
-        let next_columns = self.air.main_next_row_columns();
-        let preprocessed_next_columns = self.air.preprocessed_next_row_columns();
+        for (&air, public_values) in self.airs.iter().zip(public_values.iter()) {
+            let layout = AirLayout::from_air::<F>(air);
+            assert_eq!(
+                layout.num_periodic_columns, 0,
+                "zerocheck does not support periodic columns yet"
+            );
+            assert_ne!(layout.main_width, 0);
+            assert_eq!(public_values.len(), air.num_public_values());
+        }
 
-        // Every column of each table must contribute exactly one current-row opening.
-        if proof.local.len() != layout.main_width {
+        let next_columns = self
+            .airs
+            .iter()
+            .map(|&air| air.main_next_row_columns())
+            .collect::<Vec<_>>();
+        let preprocessed_next_columns = self
+            .airs
+            .iter()
+            .map(|&air| air.preprocessed_next_row_columns())
+            .collect::<Vec<_>>();
+        if proof.local.len() != self.airs.len() {
             return Err(ZerocheckError::OpeningCountMismatch {
-                expected: layout.main_width,
+                expected: self.airs.len(),
                 actual: proof.local.len(),
             });
         }
-        if proof.preprocessed_local.len() != layout.preprocessed_width {
-            return Err(ZerocheckError::PreprocessedOpeningCountMismatch {
-                expected: layout.preprocessed_width,
-                actual: proof.preprocessed_local.len(),
-            });
-        }
-
-        // Every next-row column of each table must contribute exactly one successor opening.
-        if proof.next.len() != next_columns.len() {
+        // Every next-row column must contribute exactly one successor opening.
+        if proof.next.len() != self.airs.len() {
             return Err(ZerocheckError::NextOpeningCountMismatch {
-                expected: next_columns.len(),
+                expected: self.airs.len(),
                 actual: proof.next.len(),
             });
         }
-        if proof.preprocessed_next.len() != preprocessed_next_columns.len() {
+        if proof.preprocessed_local.len() != self.airs.len() {
+            return Err(ZerocheckError::PreprocessedOpeningCountMismatch {
+                expected: self.airs.len(),
+                actual: proof.preprocessed_local.len(),
+            });
+        }
+        if proof.preprocessed_next.len() != self.airs.len() {
             return Err(ZerocheckError::PreprocessedNextOpeningCountMismatch {
-                expected: preprocessed_next_columns.len(),
+                expected: self.airs.len(),
                 actual: proof.preprocessed_next.len(),
             });
         }
@@ -458,18 +586,33 @@ impl<'a, A> AirZerocheck<'a, A> {
         // Verify the sumcheck reduction, then close on the proof's own opened values.
         let reduction = self.verify_reduction::<F, EF, _>(
             &proof.sumcheck,
-            log_height,
+            log_heights,
             public_values,
             challenger,
         )?;
+        let main = proof
+            .local
+            .iter()
+            .zip(next_columns.iter())
+            .zip(proof.next.iter())
+            .map(|((local, next_columns), next_values)| {
+                TableOpening::new(local, next_columns, next_values)
+            })
+            .collect::<Vec<_>>();
+        let preprocessed = proof
+            .preprocessed_local
+            .iter()
+            .zip(preprocessed_next_columns.iter())
+            .zip(proof.preprocessed_next.iter())
+            .map(|((local, next_columns), next_values)| {
+                TableOpening::new(local, next_columns, next_values)
+            })
+            .collect::<Vec<_>>();
         self.check_constraint::<F, EF>(
             &reduction,
-            TableOpening::new(&proof.local, &next_columns, &proof.next),
-            TableOpening::new(
-                &proof.preprocessed_local,
-                &preprocessed_next_columns,
-                &proof.preprocessed_next,
-            ),
+            &main,
+            &preprocessed,
+            log_heights,
             public_values,
         )?;
         Ok(reduction.point)
@@ -499,110 +642,167 @@ impl<'a, A> AirZerocheck<'a, A> {
     pub fn verify_reduction<F, EF, Challenger>(
         &self,
         sumcheck: &GenericDegreeProof<F, EF>,
-        log_height: usize,
-        public_values: &[F],
+        log_heights: &[usize],
+        public_values: &[&[F]],
         challenger: &mut Challenger,
     ) -> Result<ZerocheckReduction<EF>, ZerocheckError>
     where
         F: Field,
         EF: ExtensionField<F>,
-        A: Air<SymbolicAirBuilder<F, EF>> + BaseAir<F>,
+        A: Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        // A zerocheck always claims the sum is zero.
-        // A nonzero claim is a forgery vector: it would let an unsatisfied trace pass.
+        assert!(!self.airs.is_empty(), "zerocheck requires at least one AIR");
+        assert_eq!(self.airs.len(), public_values.len(),);
+        assert_eq!(self.airs.len(), log_heights.len(),);
+        assert!(log_heights.iter().all(|&log_height| log_height > 0),);
+
         if sumcheck.claimed_sum != EF::ZERO {
             return Err(ZerocheckError::NonZeroClaimedSum);
         }
 
-        // Reject column kinds this version cannot prove.
-        // Size the symbolic pass from the AIR layout.
-        let layout = self.layout::<F>();
-        let degree = self.sumcheck_degree::<F, EF>(layout);
+        let max_log_height = log_heights.iter().copied().max().unwrap();
+        let degree = self
+            .airs
+            .iter()
+            .map(|&air| sumcheck_degree::<F, EF, A>(air))
+            .max()
+            .unwrap();
 
         // Bind the public values before any challenge depends on them.
         // The trace commitment must already be in the transcript.
-        challenger.observe_algebra_slice(public_values);
+        for values in public_values {
+            challenger.observe_algebra_slice(values);
+        }
 
-        // Draw the same batching scalar and zerocheck point the prover drew.
-        let (alpha, tau) = sample_zerocheck_challenges(challenger, log_height);
+        // Draw the same constraint scalar, AIR batching scalar, and zerocheck point the prover drew.
+        let (alpha, beta, tau) =
+            sample_zerocheck_challenges::<F, EF, Challenger>(challenger, max_log_height);
 
         let (point, final_sum) = sumcheck
-            .verify(challenger, log_height, degree, self.pow_bits)
+            .verify(challenger, max_log_height, degree, self.pow_bits)
             .map_err(ZerocheckError::Sumcheck)?;
 
         Ok(ZerocheckReduction {
             alpha,
+            beta,
             tau,
             point,
             final_sum,
         })
     }
 
-    /// Close the zerocheck: recompute the alpha-batched constraint and match the reduced sum.
+    /// Close the zerocheck: recompute the alpha-batched constraints and match the reduced sum.
     ///
-    /// The opened values may come from the proof itself.
-    /// The opened values may instead come from a commitment opening.
-    /// Either way the final identity is the same.
-    ///
-    /// # Arguments
-    ///
-    /// - Verified sumcheck reduction data.
-    /// - Main-trace opened values at the bound point.
-    /// - Preprocessed-trace opened values at the bound point, empty when the AIR declares none.
-    /// - Public inputs forwarded to the AIR.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the reduced sum does not match the constraint.
-    /// The constraint is evaluated at the bound point.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a table's successor column list and value list have different lengths.
+    /// Opened values are grouped in the same order as `self.airs`.
+    /// They may come from the proof itself or from commitment openings.
     pub fn check_constraint<F, EF>(
         &self,
         reduction: &ZerocheckReduction<EF>,
-        main: TableOpening<'_, EF>,
-        preprocessed: TableOpening<'_, EF>,
-        public_values: &[F],
+        main: &[TableOpening<'_, EF>],
+        preprocessed: &[TableOpening<'_, EF>],
+        log_heights: &[usize],
+        public_values: &[&[F]],
     ) -> Result<(), ZerocheckError>
     where
         F: Field,
         EF: ExtensionField<F>,
-        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>> + Air<SymbolicAirBuilder<F, EF>>,
     {
-        // Reduce each table to opening claims at the bound point, then rebuild its two rows.
-        let main_claims = OpeningClaims::new(
-            reduction.point.clone(),
-            main.local.to_vec(),
-            main.next_columns,
-            main.next_values,
-        );
-        let main_next_row = main_claims.next_row(main.local.len());
+        assert!(!self.airs.is_empty(), "zerocheck requires at least one AIR");
+        assert_eq!(self.airs.len(), public_values.len(),);
+        assert_eq!(self.airs.len(), log_heights.len(),);
+        assert!(log_heights.iter().all(|&log_height| log_height > 0),);
 
-        let preprocessed_claims = OpeningClaims::new(
-            reduction.point.clone(),
-            preprocessed.local.to_vec(),
-            preprocessed.next_columns,
-            preprocessed.next_values,
-        );
-        let preprocessed_next_row = preprocessed_claims.next_row(preprocessed.local.len());
+        if main.len() != self.airs.len() {
+            return Err(ZerocheckError::OpeningCountMismatch {
+                expected: self.airs.len(),
+                actual: main.len(),
+            });
+        }
+        if preprocessed.len() != self.airs.len() {
+            return Err(ZerocheckError::PreprocessedOpeningCountMismatch {
+                expected: self.airs.len(),
+                actual: preprocessed.len(),
+            });
+        }
 
-        // Recompute the alpha-batched constraint from the committed values at the point.
-        let boundary = BoundaryEvals::at(main_claims.point.as_slice());
-        let g = MultilinearFolder::new(
-            &main_claims.local,
-            &main_next_row,
-            boundary,
-            public_values,
-            reduction.alpha,
-        )
-        .with_preprocessed(&preprocessed_claims.local, &preprocessed_next_row)
-        .eval_air(self.air);
-        let eq_at_point = Point::eval_eq(&reduction.tau, main_claims.point.as_slice());
+        let max_log_height = reduction.tau.len();
+        assert_eq!(reduction.point.as_slice().len(), max_log_height);
 
-        // Close the protocol: the reduced sum must equal the integrand at the point.
+        let mut g = EF::ZERO;
+        for (air_index, ((((&air, &log_height), main), preprocessed), beta)) in self
+            .airs
+            .iter()
+            .zip(log_heights.iter())
+            .zip(main.iter())
+            .zip(preprocessed.iter())
+            .zip(reduction.beta.powers())
+            .enumerate()
+        {
+            let layout = AirLayout::from_air::<F>(air);
+            assert_eq!(
+                layout.num_periodic_columns, 0,
+                "zerocheck does not support periodic columns yet"
+            );
+            assert_ne!(layout.main_width, 0);
+            assert_eq!(public_values[air_index].len(), air.num_public_values());
+
+            if main.local.len() != layout.main_width {
+                return Err(ZerocheckError::OpeningCountMismatch {
+                    expected: layout.main_width,
+                    actual: main.local.len(),
+                });
+            }
+            if main.next_values.len() != main.next_columns.len() {
+                return Err(ZerocheckError::NextOpeningCountMismatch {
+                    expected: main.next_columns.len(),
+                    actual: main.next_values.len(),
+                });
+            }
+            if preprocessed.local.len() != layout.preprocessed_width {
+                return Err(ZerocheckError::PreprocessedOpeningCountMismatch {
+                    expected: layout.preprocessed_width,
+                    actual: preprocessed.local.len(),
+                });
+            }
+            if preprocessed.next_values.len() != preprocessed.next_columns.len() {
+                return Err(ZerocheckError::PreprocessedNextOpeningCountMismatch {
+                    expected: preprocessed.next_columns.len(),
+                    actual: preprocessed.next_values.len(),
+                });
+            }
+
+            let activation_round = max_log_height - log_height;
+            let point = Point::new(reduction.point.as_slice()[activation_round..].to_vec());
+            let boundary = BoundaryEvals::at(point.as_slice());
+            let claims = OpeningClaims::new(
+                point.clone(),
+                main.local.to_vec(),
+                main.next_columns,
+                main.next_values,
+            );
+            let next_row = claims.next_row(layout.main_width);
+            let preprocessed_claims = OpeningClaims::new(
+                point,
+                preprocessed.local.to_vec(),
+                preprocessed.next_columns,
+                preprocessed.next_values,
+            );
+            let preprocessed_next_row = preprocessed_claims.next_row(layout.preprocessed_width);
+            let air_g = MultilinearFolder::new(
+                &claims.local,
+                &next_row,
+                boundary,
+                public_values[air_index],
+                reduction.alpha,
+            )
+            .with_preprocessed(&preprocessed_claims.local, &preprocessed_next_row)
+            .eval_air(air);
+            g += beta * air_g;
+        }
+
+        let eq_at_point = Point::eval_eq(&reduction.tau, reduction.point.as_slice());
         if reduction.final_sum != eq_at_point * g {
             return Err(ZerocheckError::FinalSumMismatch);
         }
@@ -618,6 +818,8 @@ impl<'a, A> AirZerocheck<'a, A> {
 pub struct ZerocheckReduction<EF> {
     /// Random scalar batching the AIR constraints.
     pub alpha: EF,
+    /// Random scalar batching AIRs together in caller order.
+    pub beta: EF,
     /// Zerocheck point sampled before the sumcheck.
     pub tau: Vec<EF>,
     /// Bound sumcheck point with every variable fixed to one challenge.
@@ -704,7 +906,7 @@ where
     (standard_evals, unweighted_sum)
 }
 
-/// Draw the constraint-batching scalar and the zerocheck point, in that order.
+/// Draw the constraint-batching scalar, AIR-batching scalar, and zerocheck point, in that order.
 ///
 /// Prover and verifier call this identically so their transcripts stay in lockstep.
 ///
@@ -714,7 +916,7 @@ where
 fn sample_zerocheck_challenges<F, EF, Challenger>(
     challenger: &mut Challenger,
     log_height: usize,
-) -> (EF, Vec<EF>)
+) -> (EF, EF, Vec<EF>)
 where
     F: Field,
     EF: ExtensionField<F>,
@@ -722,6 +924,7 @@ where
 {
     // The batching scalar may take any value.
     let alpha = challenger.sample_algebra_element();
+    let beta = challenger.sample_algebra_element();
 
     // Draw each point coordinate, resampling past a zero.
     let tau = (0..log_height)
@@ -733,7 +936,7 @@ where
             coord
         })
         .collect();
-    (alpha, tau)
+    (alpha, beta, tau)
 }
 
 #[cfg(test)]
@@ -748,9 +951,11 @@ mod tests {
         BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS, BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16,
         BABYBEAR_S_BOX_DEGREE, BabyBear, GenericPoseidon2LinearLayersBabyBear, Poseidon2BabyBear,
     };
+    use p3_blake3_air::Blake3Air;
     use p3_challenger::DuplexChallenger;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
     use p3_poseidon2_air::{Poseidon2Air, RoundConstants};
@@ -787,6 +992,41 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
         let perm = Perm::new_from_rng_128(&mut rng);
         Ch::new(perm)
+    }
+
+    fn prove_traces<A>(
+        zerocheck: &AirZerocheck<'_, A>,
+        traces: &[&RowMajorMatrix<F>],
+        public_values: &[&[F]],
+        challenger: &mut Ch,
+    ) -> (ZerocheckProof<F, EF>, Point<EF>)
+    where
+        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
+            + for<'b> Air<
+                MultilinearFolder<
+                    'b,
+                    F,
+                    <F as Field>::Packing,
+                    <EF as ExtensionField<F>>::ExtensionPacking,
+                >,
+            > + for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
+            + for<'b> Air<
+                MultilinearFolder<
+                    'b,
+                    F,
+                    PackedExt<F, <EF as ExtensionField<F>>::ExtensionPacking>,
+                    PackedExt<F, <EF as ExtensionField<F>>::ExtensionPacking>,
+                >,
+            > + Air<SymbolicAirBuilder<F, EF>>,
+        <EF as ExtensionField<F>>::ExtensionPacking: From<EF> + From<<F as Field>::Packing>,
+    {
+        let tables = traces
+            .iter()
+            .map(|trace| Table::new(trace.transpose()))
+            .collect::<Vec<_>>();
+        let preprocessed = tables.iter().map(|_| None).collect::<Vec<_>>();
+        let table_refs = tables.iter().collect::<Vec<_>>();
+        zerocheck.prove::<F, EF, _>(&preprocessed, &table_refs, public_values, challenger)
     }
 
     /// Fibonacci AIR.
@@ -870,15 +1110,24 @@ mod tests {
         let n = 8;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
+        let traces = [&trace];
+        let public_values = [&pis[..]];
+        let (proof, _) = prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .expect("valid trace must verify");
     }
 
@@ -891,14 +1140,16 @@ mod tests {
         let pis = fib_public_values(n);
 
         let mut challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let (proof, point) =
-            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&table, None, &pis, &mut challenger);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
+        let traces = [&trace];
+        let public_values = [&pis[..]];
+        let (proof, point) = prove_traces(&zerocheck, &traces, &public_values, &mut challenger);
 
         // Each Fibonacci constraint is per-variable degree 2 (a degree-1 selector
         // times a degree-1 column), so the eq-weighted integrand is degree 3.
-        let layout = AirLayout::from_air::<F>(&FibAir);
-        let degree = AirZerocheck::new(&FibAir, 0).sumcheck_degree::<F, EF>(layout);
+        let degree = sumcheck_degree::<F, EF, FibAir>(&air);
         assert_eq!(degree, 3);
         assert_eq!(proof.sumcheck.num_rounds(), log2_strict_usize(n));
         assert_eq!(point.num_variables(), log2_strict_usize(n));
@@ -924,20 +1175,29 @@ mod tests {
         let pow_bits = 4;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, pow_bits);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, pow_bits);
 
         // Prove with grinding enabled.
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
+        let traces = [&trace];
+        let public_values = [&pis[..]];
+        let (proof, _) = prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         // Grinding emits exactly one witness per sumcheck round.
         assert_eq!(proof.sumcheck.pow_witnesses.len(), log2_strict_usize(n));
 
         // The verifier re-checks each round's witness while replaying the transcript.
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .expect("valid trace must verify with grinding");
     }
 
@@ -949,15 +1209,24 @@ mod tests {
         let mut trace = fib_trace(n);
         trace.values[2 * NUM_COLS] += F::ONE;
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
+        let traces = [&trace];
+        let public_values = [&pis[..]];
+        let (proof, _) = prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         let err = zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .unwrap_err();
         assert!(matches!(err, ZerocheckError::FinalSumMismatch));
     }
@@ -968,17 +1237,26 @@ mod tests {
         let n = 8;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
+        let traces = [&trace];
+        let public_values = [&pis[..]];
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
-        proof.local[0] += EF::ONE;
+            prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
+        proof.local[0][0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         let err = zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .unwrap_err();
         assert!(matches!(err, ZerocheckError::FinalSumMismatch));
     }
@@ -990,17 +1268,26 @@ mod tests {
         let n = 8;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
+        let traces = [&trace];
+        let public_values = [&pis[..]];
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
-        proof.next[0] += EF::ONE;
+            prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
+        proof.next[0][0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         let err = zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .unwrap_err();
         assert!(matches!(err, ZerocheckError::FinalSumMismatch));
     }
@@ -1013,19 +1300,28 @@ mod tests {
         let n = 8;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
+        let traces = [&trace];
+        let public_values = [&pis[..]];
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
+            prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         // Declare a nonzero sum; the verifier must reject before any further work.
         proof.sumcheck.claimed_sum += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         let err = zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .unwrap_err();
         assert!(matches!(err, ZerocheckError::NonZeroClaimedSum));
     }
@@ -1044,19 +1340,28 @@ mod tests {
         let n = 8;
         let trace = fib_trace(n);
         let pis = fib_public_values(n);
-        let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
+        let traces = [&trace];
+        let public_values = [&pis[..]];
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
+            prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         // Remove one opened value so the count no longer matches the AIR width.
-        proof.local.pop();
+        proof.local[0].pop();
 
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         let err = zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &pis, &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .unwrap_err();
         assert!(matches!(
             err,
@@ -1115,21 +1420,32 @@ mod tests {
         //     next-row    (Next) claim: column 0              -> 1
         let n = 8;
         let trace = const_col_trace(n);
-        let zerocheck = AirZerocheck::new(&ConstColAir, 0);
+        let air = ConstColAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &[], &mut prover_challenger);
+        let traces = [&trace];
+        let public_values = [&[] as &[F]];
+        let (proof, _) = prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
         // Two committed columns yield two current-row claims.
-        assert_eq!(proof.local.len(), 2);
+        assert_eq!(proof.local.len(), 1);
+        assert_eq!(proof.local[0].len(), 2);
         // Only the read-ahead column yields a next-row claim.
         assert_eq!(proof.next.len(), 1);
+        assert_eq!(proof.next[0].len(), 1);
 
         // The reduction still verifies end to end.
         let mut verifier_challenger = fresh_challenger();
+        let log_heights = [log2_strict_usize(n)];
         zerocheck
-            .verify::<F, EF, _>(&proof, log2_strict_usize(n), &[], &mut verifier_challenger)
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
             .expect("subset-next AIR must verify");
     }
 
@@ -1156,24 +1472,27 @@ mod tests {
                     .in_scope(|| air.generate_random_trace_rows(num_hashes, 0));
 
             // Prove the alpha-batched constraint vanishes on every row.
-            let zerocheck = AirZerocheck::new(&air, 0);
+            let airs = [&air];
+            let zerocheck = AirZerocheck::new(&airs, 0);
             let mut prover_challenger = fresh_challenger();
-            let table = Table::new(trace.transpose());
+            let traces = [&trace];
+            let public_values = [&[] as &[F]];
             let (proof, point_prover) =
-                zerocheck.prove::<F, EF, _>(&table, None, &[], &mut prover_challenger);
+                prove_traces(&zerocheck, &traces, &public_values, &mut prover_challenger);
 
             // Reference columns: one multilinear per trace column, in row order.
             //
             //     row-major trace --transpose--> one row per column
-            let columns = table
-                .iter_polys()
+            let columns = trace.transpose();
+            let columns = columns
+                .row_slices()
                 .map(|col| Poly::new(col.to_vec()))
                 .collect::<Vec<_>>();
 
             // Each current-row opening must equal the column multilinear at the bound point.
             columns
                 .iter()
-                .zip(proof.local.iter())
+                .zip(proof.local[0].iter())
                 .for_each(|(col, &local)| {
                     assert_eq!(col.eval_base(&point_prover), local);
                 });
@@ -1181,154 +1500,236 @@ mod tests {
             // Each next-row opening must equal the same column shifted by one row.
             air.main_next_row_columns()
                 .iter()
-                .zip(proof.next.iter())
+                .zip(proof.next[0].iter())
                 .for_each(|(&column, &next)| {
                     assert_eq!(columns[column].eval_next_base(&point_prover), next);
                 });
 
             // Replaying the transcript must reproduce the prover's bound point exactly.
             let mut verifier_challenger = fresh_challenger();
+            let log_heights = [num_vars];
             let point_verifier = zerocheck
-                .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)
+                .verify::<F, EF, _>(
+                    &proof,
+                    &log_heights,
+                    &public_values,
+                    &mut verifier_challenger,
+                )
                 .unwrap();
             assert_eq!(point_prover, point_verifier);
         }
     }
 
-    /// Width-1 main AIR tied to a fixed width-1 preprocessed column.
-    ///
-    /// With the main trace equal to the preprocessed trace on every row, both constraints vanish:
-    ///
-    /// - first row: `main.local[0] == preprocessed.local[0]`
-    /// - transition: `main.next[0] == preprocessed.next[0]`
-    ///
-    /// The transition reads both the main and the preprocessed next row, so every opening path runs.
-    struct PreprocessedAir;
+    #[allow(clippy::large_enum_variant)]
+    enum MixedAir {
+        Poseidon2(BabyBearPoseidon2Air),
+        Blake3(Blake3Air),
+        Fib(FibAir),
+    }
 
-    impl<X> BaseAir<X> for PreprocessedAir {
+    impl BaseAir<F> for MixedAir {
         fn width(&self) -> usize {
-            1
+            match self {
+                Self::Poseidon2(air) => <BabyBearPoseidon2Air as BaseAir<F>>::width(air),
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::width(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::width(air),
+            }
         }
+
+        fn num_public_values(&self) -> usize {
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::num_public_values(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::num_public_values(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::num_public_values(air),
+            }
+        }
+
+        fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::preprocessed_trace(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::preprocessed_trace(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::preprocessed_trace(air),
+            }
+        }
+
         fn preprocessed_width(&self) -> usize {
-            1
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::preprocessed_width(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::preprocessed_width(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::preprocessed_width(air),
+            }
+        }
+
+        fn main_next_row_columns(&self) -> Vec<usize> {
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::main_next_row_columns(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::main_next_row_columns(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::main_next_row_columns(air),
+            }
+        }
+
+        fn preprocessed_next_row_columns(&self) -> Vec<usize> {
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::preprocessed_next_row_columns(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::preprocessed_next_row_columns(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::preprocessed_next_row_columns(air),
+            }
+        }
+
+        fn num_constraints(&self) -> Option<usize> {
+            match self {
+                Self::Poseidon2(air) => <BabyBearPoseidon2Air as BaseAir<F>>::num_constraints(air),
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::num_constraints(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::num_constraints(air),
+            }
+        }
+
+        fn max_constraint_degree(&self) -> Option<usize> {
+            match self {
+                Self::Poseidon2(air) => {
+                    <BabyBearPoseidon2Air as BaseAir<F>>::max_constraint_degree(air)
+                }
+                Self::Blake3(air) => <Blake3Air as BaseAir<F>>::max_constraint_degree(air),
+                Self::Fib(air) => <FibAir as BaseAir<F>>::max_constraint_degree(air),
+            }
         }
     }
 
-    impl<AB: AirBuilder> Air<AB> for PreprocessedAir {
+    impl<AB> Air<AB> for MixedAir
+    where
+        AB: AirBuilder<F = F>,
+        BabyBearPoseidon2Air: Air<AB>,
+        Blake3Air: Air<AB>,
+        FibAir: Air<AB>,
+    {
         fn eval(&self, builder: &mut AB) {
-            // Bind the current and next entry of each single-column window.
-            let main = builder.main();
-            let main_local = main.current_slice()[0];
-            let main_next = main.next_slice()[0];
-            let preprocessed = builder.preprocessed();
-            let preprocessed_local = preprocessed.current_slice()[0];
-            let preprocessed_next = preprocessed.next_slice()[0];
-
-            // The main column equals the fixed column at the boundary and along every step.
-            builder
-                .when_first_row()
-                .assert_eq(main_local, preprocessed_local);
-            builder
-                .when_transition()
-                .assert_eq(main_next, preprocessed_next);
+            match self {
+                Self::Poseidon2(air) => air.eval(builder),
+                Self::Blake3(air) => air.eval(builder),
+                Self::Fib(air) => air.eval(builder),
+            }
         }
-    }
-
-    /// A satisfying main / preprocessed pair: both columns hold the same fixed values.
-    fn preprocessed_pair(n: usize) -> (RowMajorMatrix<F>, RowMajorMatrix<F>) {
-        let values: Vec<F> = (0..n).map(|i| F::from_u64(3 + 2 * i as u64)).collect();
-        (
-            RowMajorMatrix::new(values.clone(), 1),
-            RowMajorMatrix::new(values, 1),
-        )
     }
 
     #[test]
-    fn zerocheck_accepts_preprocessed() {
-        // Invariant on the preprocessed AIR, swept over trace heights 1..10:
-        //   - each preprocessed current-row opening equals its column multilinear at the point;
-        //   - each preprocessed next-row opening equals that column shifted by one row;
-        //   - a satisfying trace proves and verifies.
+    fn staged_zerocheck_mixed_poseidon2_blake3_fib() {
         for num_vars in 1..10 {
-            let n = 1 << num_vars;
-            let (trace, preprocessed) = preprocessed_pair(n);
-            let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
+            let mut rng = SmallRng::seed_from_u64(1);
+            let poseidon_constants = RoundConstants::from_rng(&mut rng);
+            let poseidon_air: BabyBearPoseidon2Air = Poseidon2Air::new(poseidon_constants);
+
+            let mut airs = Vec::<MixedAir>::with_capacity(3 * num_vars);
+            let mut traces = Vec::with_capacity(3 * num_vars);
+            let mut public_values = Vec::<Vec<F>>::with_capacity(3 * num_vars);
+            let mut log_heights = Vec::with_capacity(3 * num_vars);
+
+            for log_height in (1..=num_vars).rev() {
+                let height = 1 << log_height;
+
+                airs.push(MixedAir::Poseidon2(poseidon_air.clone()));
+                traces.push(
+                    tracing::info_span!(
+                        "staged_zerocheck_poseidon2_stage_trace",
+                        num_vars,
+                        log_height
+                    )
+                    .in_scope(|| poseidon_air.generate_random_trace_rows(height, 0)),
+                );
+                public_values.push(Vec::new());
+                log_heights.push(log_height);
+
+                airs.push(MixedAir::Blake3(Blake3Air {}));
+                traces.push(
+                    tracing::info_span!(
+                        "staged_zerocheck_blake3_stage_trace",
+                        num_vars,
+                        log_height
+                    )
+                    .in_scope(|| Blake3Air {}.generate_random_trace_rows(height, 0)),
+                );
+                public_values.push(Vec::new());
+                log_heights.push(log_height);
+
+                airs.push(MixedAir::Fib(FibAir));
+                traces.push(fib_trace(height));
+                public_values.push(fib_public_values(height).to_vec());
+                log_heights.push(log_height);
+            }
+
+            let air_refs = airs.iter().collect::<Vec<_>>();
+            let trace_refs = traces.iter().collect::<Vec<_>>();
+            let public_refs = public_values
+                .iter()
+                .map(|values| &values[..])
+                .collect::<Vec<_>>();
+            let zerocheck = AirZerocheck::new(&air_refs, 0);
 
             let mut prover_challenger = fresh_challenger();
-            let table = Table::new(trace.transpose());
-            let preprocessed_table = Table::new(preprocessed.transpose());
-            let (proof, point) = zerocheck.prove::<F, EF, _>(
-                &table,
-                Some(&preprocessed_table),
-                &[],
+            let (proof, point_prover) = prove_traces(
+                &zerocheck,
+                &trace_refs,
+                &public_refs,
                 &mut prover_challenger,
             );
 
-            // The preprocessed openings must match the preprocessed column at the bound point.
-            let preprocessed_col = preprocessed_table.poly(0);
-            assert_eq!(
-                proof.preprocessed_local,
-                [preprocessed_col.eval_base(&point)]
-            );
-            assert_eq!(
-                proof.preprocessed_next,
-                [preprocessed_col.eval_next_base(&point)]
-            );
+            assert_eq!(proof.sumcheck.num_rounds(), num_vars);
+            let max_degree = airs
+                .iter()
+                .map(sumcheck_degree::<F, EF, MixedAir>)
+                .max()
+                .unwrap();
+            for round in &proof.sumcheck.round_polys {
+                assert_eq!(round.len(), max_degree);
+            }
+            assert_eq!(proof.local.len(), airs.len());
+            assert_eq!(proof.next.len(), airs.len());
+
+            for ((((air, trace), &log_height), local), next) in airs
+                .iter()
+                .zip(traces.iter())
+                .zip(log_heights.iter())
+                .zip(proof.local.iter())
+                .zip(proof.next.iter())
+            {
+                let activation_round = num_vars - log_height;
+                let point = Point::new(point_prover.as_slice()[activation_round..].to_vec());
+                assert_eq!(local.len(), trace.width());
+
+                let columns = trace.transpose();
+                let columns = columns
+                    .row_slices()
+                    .map(|col| Poly::new(col.to_vec()))
+                    .collect::<Vec<_>>();
+
+                columns.iter().zip(local.iter()).for_each(|(col, &local)| {
+                    assert_eq!(col.eval_base(&point), local);
+                });
+
+                let next_columns = air.main_next_row_columns();
+                assert_eq!(next.len(), next_columns.len());
+                next_columns
+                    .iter()
+                    .zip(next.iter())
+                    .for_each(|(&column, &next)| {
+                        assert_eq!(columns[column].eval_next_base(&point), next);
+                    });
+            }
 
             let mut verifier_challenger = fresh_challenger();
-            zerocheck
-                .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)
-                .expect("preprocessed AIR must verify");
+            let point_verifier = zerocheck
+                .verify::<F, EF, _>(&proof, &log_heights, &public_refs, &mut verifier_challenger)
+                .unwrap();
+            assert_eq!(point_prover, point_verifier);
         }
-    }
-
-    #[test]
-    fn zerocheck_rejects_tampered_preprocessed_opening() {
-        // Corrupt a preprocessed current-row opening, so the final check must reject.
-        let num_vars = 4;
-        let (trace, preprocessed) = preprocessed_pair(1 << num_vars);
-        let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
-
-        let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let preprocessed_table = Table::new(preprocessed.transpose());
-        let (mut proof, _) = zerocheck.prove::<F, EF, _>(
-            &table,
-            Some(&preprocessed_table),
-            &[],
-            &mut prover_challenger,
-        );
-        proof.preprocessed_local[0] += EF::ONE;
-
-        let mut verifier_challenger = fresh_challenger();
-        let err = zerocheck
-            .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)
-            .unwrap_err();
-        assert!(matches!(err, ZerocheckError::FinalSumMismatch));
-    }
-
-    #[test]
-    fn zerocheck_rejects_tampered_preprocessed_next_opening() {
-        // Corrupt a preprocessed next-row opening, so the final check must reject.
-        let num_vars = 4;
-        let (trace, preprocessed) = preprocessed_pair(1 << num_vars);
-        let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
-
-        let mut prover_challenger = fresh_challenger();
-        let table = Table::new(trace.transpose());
-        let preprocessed_table = Table::new(preprocessed.transpose());
-        let (mut proof, _) = zerocheck.prove::<F, EF, _>(
-            &table,
-            Some(&preprocessed_table),
-            &[],
-            &mut prover_challenger,
-        );
-        proof.preprocessed_next[0] += EF::ONE;
-
-        let mut verifier_challenger = fresh_challenger();
-        let err = zerocheck
-            .verify::<F, EF, _>(&proof, num_vars, &[], &mut verifier_challenger)
-            .unwrap_err();
-        assert!(matches!(err, ZerocheckError::FinalSumMismatch));
     }
 }

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -97,6 +97,19 @@ pub struct ZerocheckProof<F, EF> {
     pub preprocessed_next: Vec<Vec<EF>>,
 }
 
+/// One AIR's opening values at its sub-point, held together while scattering back to caller order.
+#[derive(Clone)]
+struct AirOpenings<EF> {
+    /// Current-row value of each main column.
+    local: Vec<EF>,
+    /// Successor value of each main column the AIR reads on the next row.
+    next: Vec<EF>,
+    /// Current-row value of each preprocessed column.
+    preprocessed_local: Vec<EF>,
+    /// Successor value of each preprocessed column the AIR reads on the next row.
+    preprocessed_next: Vec<EF>,
+}
+
 /// A batched AIR zerocheck instance.
 ///
 /// Bundles the AIRs and the grinding parameter shared by the prover and verifier.
@@ -353,20 +366,11 @@ impl<'a, A> AirZerocheck<'a, A> {
                 let round_poly = state.round_poly(&eq_suffix);
                 let q1 = (claim - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
                 let unweighted_claim = round_poly[0] + q1;
-                let interpolator = &interpolators[round_poly.len()];
-                let round_poly = round_poly
-                    .iter()
-                    .map(Some)
-                    .chain(core::iter::repeat(None))
-                    .take(max_degree)
-                    .enumerate()
-                    .map(|(i, value)| match value {
-                        Some(&value) => value,
-                        None => {
-                            interpolator.eval(&round_poly, unweighted_claim, EF::from_usize(i + 1))
-                        }
-                    })
-                    .collect::<Vec<_>>();
+                let round_poly = interpolators[round_poly.len()].extend_evals(
+                    &round_poly,
+                    unweighted_claim,
+                    max_degree,
+                );
                 EF::add_slices(&mut round_poly_acc, &round_poly);
                 round_polys.push(round_poly);
             }
@@ -384,22 +388,14 @@ impl<'a, A> AirZerocheck<'a, A> {
                     .collect::<Vec<_>>();
                 let mut state = RoundStateBase::new(&stages[next_stage], alpha, betas, &tau);
                 let round_poly = state.round_poly(&eq_suffix);
+                // A stage's first round runs on an unfolded trace, so its claim starts at zero.
                 let q1 = (EF::ZERO - (EF::ONE - tau_round) * round_poly[0]) * tau_round_inv;
                 let unweighted_claim = round_poly[0] + q1;
-                let interpolator = &interpolators[round_poly.len()];
-                let round_poly = round_poly
-                    .iter()
-                    .map(Some)
-                    .chain(core::iter::repeat(None))
-                    .take(max_degree)
-                    .enumerate()
-                    .map(|(i, value)| match value {
-                        Some(&value) => value,
-                        None => {
-                            interpolator.eval(&round_poly, unweighted_claim, EF::from_usize(i + 1))
-                        }
-                    })
-                    .collect::<Vec<_>>();
+                let round_poly = interpolators[round_poly.len()].extend_evals(
+                    &round_poly,
+                    unweighted_claim,
+                    max_degree,
+                );
                 EF::add_slices(&mut round_poly_acc, &round_poly);
                 new_state = Some((state, round_poly));
                 next_stage += 1;
@@ -457,12 +453,8 @@ impl<'a, A> AirZerocheck<'a, A> {
         }
 
         // States are ordered by activation height, not caller AIR order.
-        // Scatter final local/next openings back through the original AIR indices.
-        let mut local_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
-        let mut next_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
-        let mut preprocessed_local_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
-        let mut preprocessed_next_by_air = (0..self.airs.len()).map(|_| None).collect::<Vec<_>>();
-
+        // Scatter each AIR's openings back to its original index, then read them out in order.
+        let mut openings: Vec<Option<AirOpenings<EF>>> = alloc::vec![None; self.airs.len()];
         for (stage, state) in stages.iter().zip(states) {
             let (local, all_next, _) = state.evals();
             let mut column_offset = 0;
@@ -473,49 +465,48 @@ impl<'a, A> AirZerocheck<'a, A> {
                 .zip(stage.preprocessed.iter())
                 .zip(stage.airs.iter())
             {
+                // Main columns occupy the first span of this AIR's merged block.
                 let main_offset = column_offset;
-                let main_width = table.num_polys();
-                let main_end = main_offset + main_width;
-                local_by_air[air_index] = Some(local[main_offset..main_end].to_vec());
-                next_by_air[air_index] = Some(
-                    air.main_next_row_columns()
-                        .into_iter()
-                        .map(|column| all_next[main_offset + column])
-                        .collect::<Vec<_>>(),
-                );
+                let main_end = main_offset + table.num_polys();
+                let next = air
+                    .main_next_row_columns()
+                    .into_iter()
+                    .map(|column| all_next[main_offset + column])
+                    .collect();
                 column_offset = main_end;
 
+                // Preprocessed columns follow immediately after the main columns.
                 let preprocessed_offset = column_offset;
-                let preprocessed_width = preprocessed.map_or(0, |table| table.num_polys());
-                let preprocessed_end = preprocessed_offset + preprocessed_width;
-                preprocessed_local_by_air[air_index] =
-                    Some(local[preprocessed_offset..preprocessed_end].to_vec());
-                preprocessed_next_by_air[air_index] = Some(
-                    air.preprocessed_next_row_columns()
-                        .into_iter()
-                        .map(|column| all_next[preprocessed_offset + column])
-                        .collect::<Vec<_>>(),
-                );
+                let preprocessed_end =
+                    preprocessed_offset + preprocessed.map_or(0, |table| table.num_polys());
+                let preprocessed_next = air
+                    .preprocessed_next_row_columns()
+                    .into_iter()
+                    .map(|column| all_next[preprocessed_offset + column])
+                    .collect();
                 column_offset = preprocessed_end;
+
+                openings[air_index] = Some(AirOpenings {
+                    local: local[main_offset..main_end].to_vec(),
+                    next,
+                    preprocessed_local: local[preprocessed_offset..preprocessed_end].to_vec(),
+                    preprocessed_next,
+                });
             }
         }
 
-        let local = local_by_air
-            .into_iter()
-            .map(|values| values.expect("every AIR must have local openings"))
-            .collect();
-        let next = next_by_air
-            .into_iter()
-            .map(|values| values.expect("every AIR must have next openings"))
-            .collect();
-        let preprocessed_local = preprocessed_local_by_air
-            .into_iter()
-            .map(|values| values.expect("every AIR must have preprocessed local openings"))
-            .collect();
-        let preprocessed_next = preprocessed_next_by_air
-            .into_iter()
-            .map(|values| values.expect("every AIR must have preprocessed next openings"))
-            .collect();
+        // Split the per-AIR openings into the four proof vectors, in caller order.
+        let mut local = Vec::with_capacity(self.airs.len());
+        let mut next = Vec::with_capacity(self.airs.len());
+        let mut preprocessed_local = Vec::with_capacity(self.airs.len());
+        let mut preprocessed_next = Vec::with_capacity(self.airs.len());
+        for opening in openings {
+            let opening = opening.expect("every AIR must have openings");
+            local.push(opening.local);
+            next.push(opening.next);
+            preprocessed_local.push(opening.preprocessed_local);
+            preprocessed_next.push(opening.preprocessed_next);
+        }
 
         (
             ZerocheckProof {

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -97,6 +97,10 @@ pub struct ZerocheckProof<F, EF> {
     pub preprocessed_next: Vec<Vec<EF>>,
 }
 
+/// A batched AIR zerocheck instance.
+///
+/// Bundles the AIRs and the grinding parameter shared by the prover and verifier.
+/// The field and transcript are chosen per call, so one instance serves any field.
 #[derive(Debug)]
 pub struct AirZerocheck<'a, A> {
     /// AIRs whose alpha-batched constraints are checked.
@@ -105,6 +109,10 @@ pub struct AirZerocheck<'a, A> {
     pow_bits: usize,
 }
 
+/// Per-round degree of an AIR's zerocheck sumcheck.
+///
+/// The integrand is `eq(tau, x) * g(x)`.
+/// Its per-variable degree is the constraint degree plus one for the multilinear eq weight.
 fn sumcheck_degree<F, EF, A>(air: &A) -> usize
 where
     F: Field,
@@ -114,6 +122,20 @@ where
     air_degree(air) + 1
 }
 
+/// Per-variable constraint degree of an AIR, with the eq weight not yet applied.
+///
+/// The degree comes from one of two sources:
+/// - a constant-time hint supplied by the AIR, when present;
+/// - otherwise a symbolic pass that scores each constraint at domain size two.
+///
+/// At domain size two every column and boundary selector scores degree one, so the symbolic value
+/// is exact.
+///
+/// The hint must be at least the true degree:
+/// - a smaller hint drops evaluations from each round polynomial and breaks soundness;
+/// - a larger hint only inflates the proof and the per-row work.
+///
+/// A debug assertion pins the hint against the symbolic value.
 fn air_degree<F, EF, A>(air: &A) -> usize
 where
     F: Field,
@@ -145,7 +167,7 @@ where
         return degree;
     }
 
-    // Add one for the multilinear eq weight.
+    // No hint: fall back to the symbolic constraint degree.
     symbolic_constraint_degree()
 }
 
@@ -160,6 +182,15 @@ impl<'a, A> AirZerocheck<'a, A> {
     /// Prove that every AIR in the batch vanishes on its trace.
     ///
     /// `tables[i]`, `preprocessed[i]`, and `public_values[i]` correspond to `airs[i]`.
+    ///
+    /// The caller must observe every trace commitment into the challenger before this call.
+    /// The public values are observed here, so the caller need not observe them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input lengths disagree with the number of AIRs.
+    /// Panics if any AIR declares periodic columns, which this version does not support.
+    /// Panics if any trace height is less than two.
     #[tracing::instrument(skip_all)]
     pub fn prove<F, EF, Challenger>(
         &self,
@@ -207,6 +238,12 @@ impl<'a, A> AirZerocheck<'a, A> {
                 assert_eq!(
                     layout.num_periodic_columns, 0,
                     "zerocheck does not support periodic columns yet"
+                );
+                // A height-1 trace has zero variables and never activates a stage.
+                // Reject it here, matching the verifier's `log_height > 0` guard.
+                assert!(
+                    table.num_variables() > 0,
+                    "zerocheck requires each trace height to be at least two"
                 );
                 assert_eq!(table.num_polys(), layout.main_width);
                 assert_eq!(
@@ -497,28 +534,29 @@ impl<'a, A> AirZerocheck<'a, A> {
     /// The opened column values are trusted at this layer.
     /// Binding them to a commitment is the job of the polynomial commitment scheme in a later step.
     ///
-    /// The caller must observe the trace commitment into the challenger before this call.
+    /// The caller must observe every trace commitment into the challenger before this call.
     /// The public values are observed here, so the caller need not observe them.
     ///
     /// # Arguments
     ///
     /// - `proof`: the zerocheck proof.
-    /// - `log_height`: base-two logarithm of the trace height.
-    /// - `public_values`: public inputs forwarded to the AIR.
+    /// - `log_heights`: base-two logarithm of each AIR's trace height, in caller order.
+    /// - `public_values`: public inputs forwarded to each AIR, in caller order.
     /// - `challenger`: the Fiat-Shamir transcript.
     ///
     /// # Errors
     ///
     /// Returns an error when:
-    /// - the current-row openings do not carry one value per main column,
-    /// - the next-row openings do not carry one value per next-row column,
+    /// - the per-AIR opening groups do not number one per AIR,
+    /// - an AIR's current-row openings do not carry one value per main column,
+    /// - an AIR's next-row openings do not carry one value per next-row column,
     /// - the claimed sum is nonzero,
     /// - the inner sumcheck transcript fails to verify,
-    /// - the reduced sum does not match the constraint at the random point.
+    /// - the reduced sum does not match the constraints at the random point.
     ///
     /// # Panics
     ///
-    /// Panics if the AIR declares preprocessed or periodic columns, which this version does not support.
+    /// Panics if any AIR declares periodic columns, which this version does not support.
     pub fn verify<F, EF, Challenger>(
         &self,
         proof: &ZerocheckProof<F, EF>,
@@ -624,15 +662,15 @@ impl<'a, A> AirZerocheck<'a, A> {
     /// The opened column values are not yet known.
     /// The committed verifier opens them through a commitment scheme.
     ///
-    /// The caller must observe the trace commitment into the challenger before this call.
+    /// The caller must observe every trace commitment into the challenger before this call.
     /// The public values are observed here.
     /// The caller therefore does not observe them separately.
     ///
     /// # Arguments
     ///
     /// - Zerocheck sumcheck transcript.
-    /// - Base-two logarithm of the trace height.
-    /// - Public inputs forwarded to the AIR.
+    /// - Base-two logarithm of each AIR's trace height, in caller order.
+    /// - Public inputs forwarded to each AIR, in caller order.
     /// - Fiat-Shamir transcript.
     ///
     /// # Errors
@@ -1731,5 +1769,294 @@ mod tests {
                 .unwrap();
             assert_eq!(point_prover, point_verifier);
         }
+    }
+
+    /// Width-1 main AIR tied to a fixed width-1 preprocessed column.
+    ///
+    /// With the main trace equal to the preprocessed trace on every row, both constraints vanish:
+    ///
+    /// - first row: main current value equals preprocessed current value
+    /// - transition: main next value equals preprocessed next value
+    ///
+    /// The transition reads both the main and the preprocessed next row, so every opening path runs.
+    struct PreprocessedAir;
+
+    impl<X> BaseAir<X> for PreprocessedAir {
+        fn width(&self) -> usize {
+            1
+        }
+        fn preprocessed_width(&self) -> usize {
+            1
+        }
+    }
+
+    impl<AB: AirBuilder> Air<AB> for PreprocessedAir {
+        fn eval(&self, builder: &mut AB) {
+            // Read the current and next entry of each single-column window.
+            let main = builder.main();
+            let main_local = main.current_slice()[0];
+            let main_next = main.next_slice()[0];
+            let preprocessed = builder.preprocessed();
+            let preprocessed_local = preprocessed.current_slice()[0];
+            let preprocessed_next = preprocessed.next_slice()[0];
+
+            // The main column equals the fixed column at the boundary and along every step.
+            builder
+                .when_first_row()
+                .assert_eq(main_local, preprocessed_local);
+            builder
+                .when_transition()
+                .assert_eq(main_next, preprocessed_next);
+        }
+    }
+
+    /// A satisfying main / preprocessed pair: both columns hold the same fixed values.
+    fn preprocessed_pair(n: usize) -> (RowMajorMatrix<F>, RowMajorMatrix<F>) {
+        // Any injective column works; an odd arithmetic progression keeps the values distinct.
+        let values: Vec<F> = (0..n).map(|i| F::from_u64(3 + 2 * i as u64)).collect();
+        (
+            RowMajorMatrix::new(values.clone(), 1),
+            RowMajorMatrix::new(values, 1),
+        )
+    }
+
+    /// Build a preprocessed batch of two tall AIRs plus one short AIR.
+    ///
+    /// The two tall AIRs land in one stage, so the second carries nonzero column offsets.
+    /// The short AIR activates one round later, exercising staging with preprocessed columns.
+    ///
+    /// ```text
+    ///     stage tall (num_vars):     air0, air1
+    ///     stage short (num_vars-1):  air2   (activates one round later)
+    /// ```
+    fn preprocessed_batch(
+        num_vars: usize,
+    ) -> ([usize; 3], Vec<RowMajorMatrix<F>>, Vec<RowMajorMatrix<F>>) {
+        // Two AIRs at the tall height share a stage; one AIR sits one height below.
+        let log_heights = [num_vars, num_vars, num_vars - 1];
+        // Split each satisfying pair into its main matrix and its preprocessed matrix.
+        let (mains, preprocessed) = log_heights
+            .iter()
+            .map(|&log_height| preprocessed_pair(1 << log_height))
+            .unzip();
+        (log_heights, mains, preprocessed)
+    }
+
+    #[test]
+    fn staged_zerocheck_preprocessed_multi_air() {
+        for num_vars in 2..6 {
+            // Fixture: three preprocessed AIRs, two sharing the tall stage, one activating late.
+            let (log_heights, mains, preprocessed) = preprocessed_batch(num_vars);
+            let air = PreprocessedAir;
+            let airs = [&air, &air, &air];
+
+            // Transpose each main and preprocessed matrix into the column-major table layout.
+            let main_tables = mains
+                .iter()
+                .map(|main| Table::new(main.transpose()))
+                .collect::<Vec<_>>();
+            let preprocessed_tables = preprocessed
+                .iter()
+                .map(|preprocessed| Table::new(preprocessed.transpose()))
+                .collect::<Vec<_>>();
+            let table_refs = main_tables.iter().collect::<Vec<_>>();
+            let preprocessed_refs = preprocessed_tables.iter().map(Some).collect::<Vec<_>>();
+            let empty: &[F] = &[];
+            let public_values = alloc::vec![empty; 3];
+
+            let zerocheck = AirZerocheck::new(&airs, 0);
+            let mut prover_challenger = fresh_challenger();
+            let (proof, point) = zerocheck.prove::<F, EF, _>(
+                &preprocessed_refs,
+                &table_refs,
+                &public_values,
+                &mut prover_challenger,
+            );
+
+            // One opening group per AIR, in caller order.
+            assert_eq!(proof.preprocessed_local.len(), 3);
+            assert_eq!(proof.preprocessed_next.len(), 3);
+
+            // Each preprocessed opening equals the preprocessed column at that AIR's sub-point.
+            for (air_index, &log_height) in log_heights.iter().enumerate() {
+                // A shorter AIR binds only the last `log_height` coordinates of the global point.
+                let activation_round = num_vars - log_height;
+                let sub_point = Point::new(point.as_slice()[activation_round..].to_vec());
+                let column = preprocessed_tables[air_index].poly(0);
+                assert_eq!(
+                    proof.preprocessed_local[air_index],
+                    [column.eval_base(&sub_point)]
+                );
+                assert_eq!(
+                    proof.preprocessed_next[air_index],
+                    [column.eval_next_base(&sub_point)]
+                );
+            }
+
+            // The whole batch verifies end to end.
+            let mut verifier_challenger = fresh_challenger();
+            zerocheck
+                .verify::<F, EF, _>(
+                    &proof,
+                    &log_heights,
+                    &public_values,
+                    &mut verifier_challenger,
+                )
+                .expect("preprocessed batch must verify");
+        }
+    }
+
+    #[test]
+    fn staged_zerocheck_rejects_tampered_preprocessed_in_batch() {
+        // Invariant: corrupting one AIR's preprocessed opening in a batch must fail the close.
+        //
+        // Mutation: bump the current-row preprocessed opening of the second tall AIR.
+        //
+        //     air1 shares the tall stage with air0, so its columns sit at a nonzero offset.
+        let num_vars = 4;
+        let (log_heights, mains, preprocessed) = preprocessed_batch(num_vars);
+        let air = PreprocessedAir;
+        let airs = [&air, &air, &air];
+
+        let main_tables = mains
+            .iter()
+            .map(|main| Table::new(main.transpose()))
+            .collect::<Vec<_>>();
+        let preprocessed_tables = preprocessed
+            .iter()
+            .map(|preprocessed| Table::new(preprocessed.transpose()))
+            .collect::<Vec<_>>();
+        let table_refs = main_tables.iter().collect::<Vec<_>>();
+        let preprocessed_refs = preprocessed_tables.iter().map(Some).collect::<Vec<_>>();
+        let empty: &[F] = &[];
+        let public_values = alloc::vec![empty; 3];
+
+        let zerocheck = AirZerocheck::new(&airs, 0);
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(
+            &preprocessed_refs,
+            &table_refs,
+            &public_values,
+            &mut prover_challenger,
+        );
+
+        // Corrupt the second AIR's preprocessed current-row opening.
+        proof.preprocessed_local[1][0] += EF::ONE;
+
+        let mut verifier_challenger = fresh_challenger();
+        let err = zerocheck
+            .verify::<F, EF, _>(
+                &proof,
+                &log_heights,
+                &public_values,
+                &mut verifier_challenger,
+            )
+            .unwrap_err();
+        assert!(matches!(err, ZerocheckError::FinalSumMismatch));
+    }
+
+    /// Build a Fibonacci batch of two tall AIRs plus one short AIR.
+    ///
+    /// The two tall AIRs share a stage; the short one activates a round later.
+    fn fib_batch(num_vars: usize) -> ([usize; 3], Vec<RowMajorMatrix<F>>, Vec<Vec<F>>) {
+        let log_heights = [num_vars, num_vars, num_vars - 1];
+        let traces = log_heights
+            .iter()
+            .map(|&log_height| fib_trace(1 << log_height))
+            .collect::<Vec<_>>();
+        let public_values = log_heights
+            .iter()
+            .map(|&log_height| fib_public_values(1 << log_height).to_vec())
+            .collect::<Vec<_>>();
+        (log_heights, traces, public_values)
+    }
+
+    #[test]
+    fn staged_zerocheck_rejects_violated_air_in_batch() {
+        // Invariant: one unsatisfied AIR in a batch makes the batched final check reject.
+        //
+        // Mutation: break a transition row of the second tall AIR, leaving the others valid.
+        //
+        //     beta batches the AIRs, so a single nonzero constraint sum survives w.h.p.
+        let num_vars = 4;
+        let (log_heights, mut traces, public_values) = fib_batch(num_vars);
+
+        // Break the transition constraint at row 2 of the second AIR.
+        traces[1].values[2 * NUM_COLS] += F::ONE;
+
+        let air = FibAir;
+        let airs = [&air, &air, &air];
+        let trace_refs = traces.iter().collect::<Vec<_>>();
+        let public_refs = public_values
+            .iter()
+            .map(|values| &values[..])
+            .collect::<Vec<_>>();
+        let zerocheck = AirZerocheck::new(&airs, 0);
+
+        let mut prover_challenger = fresh_challenger();
+        let (proof, _) = prove_traces(
+            &zerocheck,
+            &trace_refs,
+            &public_refs,
+            &mut prover_challenger,
+        );
+
+        let mut verifier_challenger = fresh_challenger();
+        let err = zerocheck
+            .verify::<F, EF, _>(&proof, &log_heights, &public_refs, &mut verifier_challenger)
+            .unwrap_err();
+        assert!(matches!(err, ZerocheckError::FinalSumMismatch));
+    }
+
+    #[test]
+    fn staged_zerocheck_rejects_tampered_opening_in_late_stage() {
+        // Invariant: tampering a late-activating AIR's opening is caught at its own sub-point.
+        //
+        // Mutation: bump a current-row opening of the short AIR, which activates one round late.
+        let num_vars = 4;
+        let (log_heights, traces, public_values) = fib_batch(num_vars);
+
+        let air = FibAir;
+        let airs = [&air, &air, &air];
+        let trace_refs = traces.iter().collect::<Vec<_>>();
+        let public_refs = public_values
+            .iter()
+            .map(|values| &values[..])
+            .collect::<Vec<_>>();
+        let zerocheck = AirZerocheck::new(&airs, 0);
+
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = prove_traces(
+            &zerocheck,
+            &trace_refs,
+            &public_refs,
+            &mut prover_challenger,
+        );
+
+        // The short AIR is the last entry; corrupt its first current-row opening.
+        proof.local[2][0] += EF::ONE;
+
+        let mut verifier_challenger = fresh_challenger();
+        let err = zerocheck
+            .verify::<F, EF, _>(&proof, &log_heights, &public_refs, &mut verifier_challenger)
+            .unwrap_err();
+        assert!(matches!(err, ZerocheckError::FinalSumMismatch));
+    }
+
+    #[test]
+    #[should_panic = "at least two"]
+    fn zerocheck_rejects_height_one_trace() {
+        // A single-row trace has zero sumcheck variables, so no stage ever activates.
+        // The prover rejects it up front rather than failing deep inside the fold.
+        let trace = fib_trace(1);
+        let pis = fib_public_values(1);
+        let air = FibAir;
+        let airs = [&air];
+        let zerocheck = AirZerocheck::new(&airs, 0);
+
+        let traces = [&trace];
+        let public_values = [&pis[..]];
+        let mut challenger = fresh_challenger();
+        let _ = prove_traces(&zerocheck, &traces, &public_values, &mut challenger);
     }
 }

--- a/sumcheck/src/generic_degree/util.rs
+++ b/sumcheck/src/generic_degree/util.rs
@@ -75,6 +75,27 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
         RowMajorMatrix::new_col(full)
             .interpolate_arbitrary_with_precomputation(&self.weights, &diff_invs)[0]
     }
+
+    /// Extend a round polynomial's transmitted evaluations up to `target_len` entries.
+    ///
+    /// The layout matches [`Self::eval`]: entry `0` is `h(0)`, entry `i >= 1` is `h(i + 1)`.
+    /// Entries past the input are the same polynomial extrapolated at the higher nodes.
+    ///
+    /// # Arguments
+    ///
+    /// - `evals`: transmitted evaluations `h(0), h(2), …, h(degree)`.
+    /// - `sum_constraint`: the running claimed sum, equal to `h(0) + h(1)`.
+    /// - `target_len`: length of the returned vector; must be at least the input length.
+    pub fn extend_evals(&self, evals: &[EF], sum_constraint: EF, target_len: usize) -> Vec<EF> {
+        let mut extended = Vec::with_capacity(target_len);
+        extended.extend_from_slice(evals);
+        // Each appended entry `i` carries node `i + 1`, extrapolated from the input.
+        extended.extend(
+            (evals.len()..target_len)
+                .map(|i| self.eval(evals, sum_constraint, EF::from_usize(i + 1))),
+        );
+        extended
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR replaces the old single-AIR zerocheck path with a staged multi-AIR zerocheck.

### Main changes:
- Supports batching AIRs with different trace heights in one zerocheck.
- Stages AIRs by height; a stage activates when the sumcheck cube reaches that height.
- All stages share the same `eq` challenge structure and Fiat-Shamir transcript.
- Inside each stage, AIRs are grouped by constraint degree, so lower-degree AIRs are not evaluated at interpolation nodes required only by higher-degree AIRs.
- Proof openings are returned per input AIR, preserving caller order.

### Benefits:
- Proof size is reduced because multiple AIRs share one zerocheck sumcheck transcript instead of producing one transcript per AIR.
- WHIR/PCS opening points are shared across AIRs, reducing opening overhead compared to proving each AIR independently.

### Performance note:
- Prover time can slightly regress in small or single-AIR cases because the staged path has extra bookkeeping and glues AIRs together.
- The main expected wins are proof-size reduction and shared PCS opening points.

### Benchmarks

Baseline, main branch, with single air

benchmark | height | time
-- | -- | --
zerocheck_prove | 16 | 3.5056 ms
zerocheck_prove | 18 | 8.5169 ms
zerocheck_prove | 20 | 26.190 ms
zerocheck_prove_wide | 16 | 13.838 ms
zerocheck_prove_wide | 18 | 51.177 ms
zerocheck_prove_wide | 20 | 197.55 ms
poseidon2_zerocheck_prove | 10 | 3.4750 ms
poseidon2_zerocheck_prove | 15 | 67.811 ms
poseidon2_zerocheck_prove | 20 | 2.0742 s

Multi air benchmarks

benchmark | num_airs | height | time
-- | -- | -- | --
**zerocheck_prove** | **1** | **16** | **3.6115 ms**
zerocheck_prove | 5 | 16 | 8.5148 ms
zerocheck_prove | 10 | 16 | 13.700 ms
**zerocheck_prove** | **1** | **18** | **9.0173 ms**
zerocheck_prove | 5 | 18 | 25.071 ms
zerocheck_prove | 10 | 18 | 44.732 ms
**zerocheck_prove** | **1** | **20** | **29.101 ms**
zerocheck_prove | 5 | 20 | 89.618 ms
zerocheck_prove | 10 | 20 | 168.06 ms
**zerocheck_prove_wide** | **1** | **16** | **14.215 ms**
zerocheck_prove_wide | 5 | 16 | 77.057 ms
zerocheck_prove_wide | 10 | 16 | 182.84 ms
**zerocheck_prove_wide** | **1** | **18** | **52.166 ms**
zerocheck_prove_wide | 5 | 18 | 307.98 ms
zerocheck_prove_wide | 10 | 18 | 694.90 ms
**zerocheck_prove_wide** | **1** | **20** | **197.47 ms**
zerocheck_prove_wide | 5 | 20 | 1.2326 s
zerocheck_prove_wide | 10 | 20 | 2.7837 s
**poseidon2_zerocheck_prove** | **1** | **10** | **3.5303 ms**
poseidon2_zerocheck_prove | 5 | 10 | 14.688 ms
poseidon2_zerocheck_prove | 10 | 10 | 32.798 ms
**poseidon2_zerocheck_prove** | **1** | **15** | **65.186 ms**
poseidon2_zerocheck_prove | 5 | 15 | 342.89 ms
poseidon2_zerocheck_prove | 10 | 15 | 697.80 ms
**poseidon2_zerocheck_prove** | **1** | **20** | **2.0650 s**
poseidon2_zerocheck_prove | 5 | 20 | 10.920 s
poseidon2_zerocheck_prove | 10 | 20 | 23.688 s