### PR TITLE
refactor: fold MultiOpeningMmcs into Mmcs

### DIFF
--- a/commit/src/adapters/extension_mmcs.rs
+++ b/commit/src/adapters/extension_mmcs.rs
@@ -6,7 +6,7 @@ use p3_field::{ExtensionField, Field};
 use p3_matrix::extension::FlatMatrixView;
 use p3_matrix::{Dimensions, Matrix};
 
-use crate::{BatchOpening, BatchOpeningRef, Mmcs, MultiOpeningMmcs};
+use crate::{BatchOpening, BatchOpeningRef, Mmcs};
 
 /// A wrapper to lift an MMCS from a base field `F` to an extension field `EF`.
 ///
@@ -39,6 +39,7 @@ where
     type ProverData<M> = InnerMmcs::ProverData<FlatMatrixView<F, EF, M>>;
     type Commitment = InnerMmcs::Commitment;
     type Proof = InnerMmcs::Proof;
+    type MultiProof = InnerMmcs::MultiProof;
     type Error = InnerMmcs::Error;
 
     fn commit<M: Matrix<EF>>(&self, inputs: Vec<M>) -> (Self::Commitment, Self::ProverData<M>) {
@@ -94,15 +95,6 @@ where
             BatchOpeningRef::new(&opened_base_values, batch_opening.opening_proof),
         )
     }
-}
-
-impl<F, EF, InnerMmcs> MultiOpeningMmcs<EF> for ExtensionMmcs<F, EF, InnerMmcs>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    InnerMmcs: MultiOpeningMmcs<F>,
-{
-    type MultiProof = InnerMmcs::MultiProof;
 
     fn open_multi_batch<M: Matrix<EF>>(
         &self,

--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -20,6 +20,12 @@ pub trait Mmcs<T: Send + Sync + Clone>: Clone {
     type ProverData<M>;
     type Commitment: Clone + Serialize + DeserializeOwned;
     type Proof: Clone + Serialize + DeserializeOwned;
+    /// Compact proof covering every index of one multi-opening.
+    ///
+    /// Opening `q` indices through [`Self::open_batch`] costs `q` full authentication paths.
+    /// Those paths overlap wherever two indices share an ancestor.
+    /// A multi-opening sends each shared digest once.
+    type MultiProof: Clone + Serialize + DeserializeOwned;
     type Error: Debug;
 
     /// Commits to a batch of matrices at once and returns both the commitment and associated prover data.
@@ -155,6 +161,41 @@ pub trait Mmcs<T: Send + Sync + Clone>: Clone {
         index: usize,
         batch_opening: BatchOpeningRef<'_, T, Self>,
     ) -> Result<(), Self::Error>;
+
+    /// Opens the given row indices from each committed matrix at once.
+    ///
+    /// Per-matrix index semantics follow [`Self::open_batch`].
+    ///
+    /// # Returns
+    ///
+    /// - `values[q][m]` — the opened row of matrix `m` at `indices[q]`.
+    /// - One [`Self::MultiProof`] authenticating all rows together.
+    fn open_multi_batch<M: Matrix<T>>(
+        &self,
+        indices: &[usize],
+        prover_data: &Self::ProverData<M>,
+    ) -> (Vec<Vec<Vec<T>>>, Self::MultiProof);
+
+    /// Verifies a multi-opening at the given indices.
+    ///
+    /// `indices` must come from verifier-side data (e.g. the transcript).
+    /// A proof opening any other index set is rejected.
+    ///
+    /// `opened_values[q][m]` is the claimed row of matrix `m` at `indices[q]`.
+    ///
+    /// Each row is any `AsRef<[T]>`.
+    /// A caller holding rows as slices verifies without copying them into owned buffers.
+    ///
+    /// Width enforcement follows [`Self::verify_batch`].
+    /// Every opened row must match its verifier-known matrix width.
+    fn verify_multi_batch<R: AsRef<[T]> + PartialEq>(
+        &self,
+        commit: &Self::Commitment,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+        opened_values: &[Vec<R>],
+        proof: &Self::MultiProof,
+    ) -> Result<(), Self::Error>;
 }
 
 /// Lets a shared reference be used wherever an owned [`Mmcs`] is expected.
@@ -162,6 +203,7 @@ impl<T: Send + Sync + Clone, M: Mmcs<T>> Mmcs<T> for &M {
     type ProverData<Mat> = M::ProverData<Mat>;
     type Commitment = M::Commitment;
     type Proof = M::Proof;
+    type MultiProof = M::MultiProof;
     type Error = M::Error;
 
     fn commit<Mat: Matrix<T>>(
@@ -201,55 +243,6 @@ impl<T: Send + Sync + Clone, M: Mmcs<T>> Mmcs<T> for &M {
             BatchOpeningRef::new(batch_opening.opened_values, batch_opening.opening_proof),
         )
     }
-}
-
-/// An [`Mmcs`] whose openings at many indices share one compact proof.
-///
-/// Opening `q` indices through [`Mmcs::open_batch`] costs `q` full authentication paths.
-/// Those paths overlap wherever two indices share an ancestor.
-/// A multi-opening sends each shared digest once.
-pub trait MultiOpeningMmcs<T: Send + Sync + Clone>: Mmcs<T> {
-    /// Compact proof covering every index of one multi-opening.
-    type MultiProof: Clone + Serialize + DeserializeOwned;
-
-    /// Opens the given row indices from each committed matrix at once.
-    ///
-    /// Per-matrix index semantics follow [`Mmcs::open_batch`].
-    ///
-    /// # Returns
-    ///
-    /// - `values[q][m]` — the opened row of matrix `m` at `indices[q]`.
-    /// - One [`Self::MultiProof`] authenticating all rows together.
-    fn open_multi_batch<M: Matrix<T>>(
-        &self,
-        indices: &[usize],
-        prover_data: &Self::ProverData<M>,
-    ) -> (Vec<Vec<Vec<T>>>, Self::MultiProof);
-
-    /// Verifies a multi-opening at the given indices.
-    ///
-    /// `indices` must come from verifier-side data (e.g. the transcript).
-    /// A proof opening any other index set is rejected.
-    ///
-    /// `opened_values[q][m]` is the claimed row of matrix `m` at `indices[q]`.
-    ///
-    /// Each row is any `AsRef<[T]>`.
-    /// A caller holding rows as slices verifies without copying them into owned buffers.
-    ///
-    /// Width enforcement follows [`Mmcs::verify_batch`]:
-    /// every opened row must match its verifier-known matrix width.
-    fn verify_multi_batch<R: AsRef<[T]> + PartialEq>(
-        &self,
-        commit: &Self::Commitment,
-        dimensions: &[Dimensions],
-        indices: &[usize],
-        opened_values: &[Vec<R>],
-        proof: &Self::MultiProof,
-    ) -> Result<(), Self::Error>;
-}
-
-impl<T: Send + Sync + Clone, M: MultiOpeningMmcs<T>> MultiOpeningMmcs<T> for &M {
-    type MultiProof = M::MultiProof;
 
     fn open_multi_batch<Mat: Matrix<T>>(
         &self,

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use spin::Mutex;
 
 use crate::mmcs::check_widths;
+use crate::pruning::PrunedMerklePaths;
 use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 
 /// A vector commitment scheme backed by a `MerkleTree`.
@@ -117,6 +118,12 @@ where
     type Commitment = MerkleCap<P::Value, [PW::Value; DIGEST_ELEMS]>;
     /// The first item is salts; the second is the usual Merkle proof (sibling digests).
     type Proof = (Vec<Vec<P::Value>>, Vec<[PW::Value; DIGEST_ELEMS]>);
+    /// The first item is the per-query salts (`salts[q][m]`).
+    /// The second is the shared pruned multiproof.
+    type MultiProof = (
+        Vec<Vec<Vec<P::Value>>>,
+        PrunedMerklePaths<PW::Value, DIGEST_ELEMS>,
+    );
     type Error = MerkleTreeError;
 
     fn commit<M: Matrix<P::Value>>(
@@ -191,6 +198,81 @@ where
             index,
             BatchOpeningRef::new(&opened_salted_values, siblings),
         )
+    }
+
+    fn open_multi_batch<M: Matrix<P::Value>>(
+        &self,
+        indices: &[usize],
+        prover_data: &Self::ProverData<M>,
+    ) -> (Vec<Vec<Vec<P::Value>>>, Self::MultiProof) {
+        // The inner tree opens salted rows: each row is `real_row ++ salt`.
+        let (salted_values, pruned) = self.inner.open_multi_batch(indices, prover_data);
+
+        // Split every salted row back into its unsalted prefix and its salt suffix.
+        // Salts move into the proof.
+        // The unsalted rows are returned to the caller.
+        let mut salts = Vec::with_capacity(salted_values.len());
+        let opened_values = salted_values
+            .into_iter()
+            .map(|rows_at_index| {
+                let (opened, salts_at_index): (Vec<_>, Vec<_>) = rows_at_index
+                    .into_iter()
+                    .map(|row| {
+                        let (a, b) = row.split_at(row.len() - SALT_ELEMS);
+                        (a.to_vec(), b.to_vec())
+                    })
+                    .unzip();
+                salts.push(salts_at_index);
+                opened
+            })
+            .collect();
+
+        (opened_values, (salts, pruned))
+    }
+
+    fn verify_multi_batch<Row: AsRef<[P::Value]> + PartialEq>(
+        &self,
+        commit: &Self::Commitment,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+        opened_values: &[Vec<Row>],
+        proof: &Self::MultiProof,
+    ) -> Result<(), Self::Error> {
+        let (salts, pruned) = proof;
+
+        // Re-attach salts query by query, mirroring the single-opening path.
+        let mut salted_values = Vec::with_capacity(opened_values.len());
+        for (rows, salts_at_index) in zip_eq(opened_values, salts, MerkleTreeError::WrongBatchSize)?
+        {
+            // Pin each unsalted row to its matrix width before salting.
+            // The inner tree only sees salted widths.
+            // An over-long row could otherwise hide behind an under-long salt.
+            check_widths(dimensions, rows)?;
+
+            let salted_rows = zip_eq(rows, salts_at_index, MerkleTreeError::WrongBatchSize)?
+                .map(|(opened, salt)| {
+                    opened
+                        .as_ref()
+                        .iter()
+                        .chain(salt.iter())
+                        .copied()
+                        .collect_vec()
+                })
+                .collect_vec();
+            salted_values.push(salted_rows);
+        }
+
+        // The inner tree commits to salt-widened rows, so widen the dimensions to match.
+        let salted_dimensions = dimensions
+            .iter()
+            .map(|dims| Dimensions {
+                width: dims.width + SALT_ELEMS,
+                height: dims.height,
+            })
+            .collect_vec();
+
+        self.inner
+            .verify_multi_batch(commit, &salted_dimensions, indices, &salted_values, pruned)
     }
 }
 
@@ -302,5 +384,78 @@ mod tests {
     #[test]
     fn hiding_mmcs_is_sync() {
         assert_sync::<MyMmcs>();
+    }
+
+    #[test]
+    fn multi_opening_round_trip() {
+        let mut rng = SmallRng::seed_from_u64(3);
+        // Three matrices of equal height but widths 2, 3, 4.
+        let mats = (0..3)
+            .map(|i| RowMajorMatrix::<F>::rand(&mut rng, 16, i + 2))
+            .collect_vec();
+        let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let (commit, prover_data) = mmcs.commit(mats);
+
+        // Open four leaves at once.
+        // Indices must be ascending and distinct.
+        let indices = vec![1usize, 4, 9, 15];
+        let (opened, proof) = mmcs.open_multi_batch(&indices, &prover_data);
+
+        // One opened row set per query, one row per committed matrix.
+        assert_eq!(opened.len(), indices.len());
+        assert!(opened.iter().all(|rows| rows.len() == dims.len()));
+
+        // The salt suffix is stripped: each returned row matches its matrix width.
+        for rows in &opened {
+            for (row, dim) in rows.iter().zip(&dims) {
+                assert_eq!(row.len(), dim.width);
+            }
+        }
+
+        // The single shared multiproof authenticates every opened row.
+        mmcs.verify_multi_batch(&commit, &dims, &indices, &opened, &proof)
+            .expect("round-trip multi-opening must verify");
+    }
+
+    #[test]
+    fn verify_multi_rejects_wrong_row_width() {
+        let mut rng = SmallRng::seed_from_u64(4);
+        // Commit to one matrix of width 4 through the hiding wrapper.
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 8, 4);
+        let dims = vec![mat.dimensions()];
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let (commit, prover_data) = mmcs.commit(vec![mat]);
+
+        let indices = vec![2usize, 5];
+        let (mut opened, proof) = mmcs.open_multi_batch(&indices, &prover_data);
+
+        // Mutation: append one extra element to the first query's only row.
+        //
+        //     query 0 row:  [a, b, c, d, EXTRA]   (5 values, width is 4)
+        opened[0][0].push(F::ONE);
+
+        // The unsalted width is checked before salt columns are re-appended.
+        // An over-long row cannot hide behind an under-long salt.
+        //
+        //     expected: 4 (matrix width)
+        //     got:      5 (opened row length)
+        let err = mmcs
+            .verify_multi_batch(&commit, &dims, &indices, &opened, &proof)
+            .expect_err("row longer than the matrix width must be rejected");
+        assert!(matches!(
+            err,
+            MerkleTreeError::WrongWidth {
+                matrix: 0,
+                expected: 4,
+                got: 5,
+            }
+        ));
     }
 }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -210,22 +210,18 @@ where
 
         // Split every salted row back into its unsalted prefix and its salt suffix.
         // Salts move into the proof.
-        // The unsalted rows are returned to the caller.
-        let mut salts = Vec::with_capacity(salted_values.len());
-        let opened_values = salted_values
+        let (opened_values, salts): (Vec<_>, Vec<_>) = salted_values
             .into_iter()
             .map(|rows_at_index| {
-                let (opened, salts_at_index): (Vec<_>, Vec<_>) = rows_at_index
+                rows_at_index
                     .into_iter()
                     .map(|row| {
                         let (a, b) = row.split_at(row.len() - SALT_ELEMS);
                         (a.to_vec(), b.to_vec())
                     })
-                    .unzip();
-                salts.push(salts_at_index);
-                opened
+                    .unzip()
             })
-            .collect();
+            .unzip();
 
         (opened_values, (salts, pruned))
     }

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -209,7 +209,6 @@ where
         let (salted_values, pruned) = self.inner.open_multi_batch(indices, prover_data);
 
         // Split every salted row back into its unsalted prefix and its salt suffix.
-        // Salts move into the proof.
         let (opened_values, salts): (Vec<_>, Vec<_>) = salted_values
             .into_iter()
             .map(|rows_at_index| {

--- a/merkle-tree/src/mmcs/batch.rs
+++ b/merkle-tree/src/mmcs/batch.rs
@@ -1,4 +1,4 @@
-//! The standard [`Mmcs`] interface: commit, open, and verify a single index.
+//! The [`Mmcs`] trait implementation: commit, then open and verify one index or many.
 
 use alloc::vec::Vec;
 use core::cmp::Reverse;
@@ -16,6 +16,7 @@ use crate::MerkleTreeError::{
     CapMismatch, EmptyBatch, IndexOutOfBounds, WrongBatchSize, WrongHeight,
 };
 use crate::merkle_tree::padded_len;
+use crate::pruning::PrunedMerklePaths;
 use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 
 impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize> Mmcs<P::Value>
@@ -35,6 +36,7 @@ where
     type ProverData<M> = MerkleTree<P::Value, PW::Value, M, N, DIGEST_ELEMS>;
     type Commitment = MerkleCap<P::Value, [PW::Value; DIGEST_ELEMS]>;
     type Proof = Vec<[PW::Value; DIGEST_ELEMS]>;
+    type MultiProof = PrunedMerklePaths<PW::Value, DIGEST_ELEMS>;
     type Error = MerkleTreeError;
 
     fn commit<M: Matrix<P::Value>>(
@@ -268,6 +270,28 @@ where
         } else {
             Err(CapMismatch)
         }
+    }
+
+    fn open_multi_batch<M: Matrix<P::Value>>(
+        &self,
+        indices: &[usize],
+        prover_data: &Self::ProverData<M>,
+    ) -> (Vec<Vec<Vec<P::Value>>>, Self::MultiProof) {
+        // Open every index against one shared, pruned authentication path.
+        let opening = self.open_batch_pruned(indices, prover_data);
+        // Return the opened rows and that shared proof as separate values.
+        (opening.opened_values, opening.pruned_proof)
+    }
+
+    fn verify_multi_batch<R: AsRef<[P::Value]> + PartialEq>(
+        &self,
+        commit: &Self::Commitment,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+        opened_values: &[Vec<R>],
+        proof: &Self::MultiProof,
+    ) -> Result<(), Self::Error> {
+        self.verify_batch_pruned(commit, dimensions, indices, opened_values, proof)
     }
 }
 

--- a/merkle-tree/src/mmcs/mod.rs
+++ b/merkle-tree/src/mmcs/mod.rs
@@ -29,7 +29,7 @@ use core::marker::PhantomData;
 
 use geometry::ArityAndPositions;
 use itertools::Itertools;
-use p3_commit::{Mmcs, MultiOpeningMmcs};
+use p3_commit::Mmcs;
 use p3_field::PackedValue;
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
@@ -775,42 +775,5 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         }
 
         Ok(())
-    }
-}
-
-impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize> MultiOpeningMmcs<P::Value>
-    for MerkleTreeMmcs<P, PW, H, C, N, DIGEST_ELEMS>
-where
-    P: PackedValue,
-    PW: PackedValue,
-    H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
-        + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
-        + Sync,
-    C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
-        + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
-        + Sync,
-    PW::Value: Eq + Clone,
-    [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
-{
-    type MultiProof = PrunedMerklePaths<PW::Value, DIGEST_ELEMS>;
-
-    fn open_multi_batch<M: Matrix<P::Value>>(
-        &self,
-        indices: &[usize],
-        prover_data: &Self::ProverData<M>,
-    ) -> (Vec<Vec<Vec<P::Value>>>, Self::MultiProof) {
-        let opening = self.open_batch_pruned(indices, prover_data);
-        (opening.opened_values, opening.pruned_proof)
-    }
-
-    fn verify_multi_batch<R: AsRef<[P::Value]> + PartialEq>(
-        &self,
-        commit: &Self::Commitment,
-        dimensions: &[Dimensions],
-        indices: &[usize],
-        opened_values: &[Vec<R>],
-        proof: &Self::MultiProof,
-    ) -> Result<(), Self::Error> {
-        self.verify_batch_pruned(commit, dimensions, indices, opened_values, proof)
     }
 }

--- a/whir/benches/fri_vs_whir.rs
+++ b/whir/benches/fri_vs_whir.rs
@@ -54,7 +54,7 @@ use itertools::Itertools;
 use p3_challenger::{
     CanObserve, CanSampleUniformBits, DuplexChallenger, FieldChallenger, GrindingChallenger,
 };
-use p3_commit::{BatchOpening, ExtensionMmcs, Mmcs, MultiOpeningMmcs, MultilinearPcs, Pcs};
+use p3_commit::{BatchOpening, ExtensionMmcs, Mmcs, MultilinearPcs, Pcs};
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
@@ -202,9 +202,9 @@ const BENCH_SEED: u64 = 0xA17_5C0DE;
 /// Bound bundle the WHIR helpers require on the Merkle MMCS type.
 ///
 /// Every concrete hash backend in this bench satisfies these bounds.
-trait WhirMmcs: MultiOpeningMmcs<F> + Clone + Send + Sync {}
+trait WhirMmcs: Mmcs<F> + Clone + Send + Sync {}
 
-impl<T: MultiOpeningMmcs<F> + Clone + Send + Sync> WhirMmcs for T {}
+impl<T: Mmcs<F> + Clone + Send + Sync> WhirMmcs for T {}
 
 /// Bound bundle the WHIR helpers require on the Fiat-Shamir challenger.
 trait WhirChallenger<MT: Mmcs<F>>:

--- a/whir/benches/whir_pcs.rs
+++ b/whir/benches/whir_pcs.rs
@@ -7,7 +7,7 @@ use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 use p3_challenger::DuplexChallenger;
-use p3_commit::{MultiOpeningMmcs, MultilinearPcs};
+use p3_commit::{Mmcs, MultilinearPcs};
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
 use p3_field::extension::QuinticTrinomialExtensionField;
@@ -34,11 +34,11 @@ type MerkleHash = PaddingFreeSponge<Poseidon24, 24, 16, 8>;
 type MerkleCompress = TruncatedPermutation<Poseidon16, 2, 8, 16>;
 type Challenger = DuplexChallenger<F, Poseidon16, 16, 8>;
 type PackedF = <F as Field>::Packing;
-type Mmcs = MerkleTreeMmcs<PackedF, PackedF, MerkleHash, MerkleCompress, 2, 8>;
+type MerkleMmcs = MerkleTreeMmcs<PackedF, PackedF, MerkleHash, MerkleCompress, 2, 8>;
 type Dft = Radix2DFTSmallBatch<F>;
 
 /// Concrete PCS instantiation parameterized by the sumcheck layout mode.
-type Pcs<L> = WhirProver<EF, F, Dft, Mmcs, Challenger, L>;
+type Pcs<L> = WhirProver<EF, F, Dft, MerkleMmcs, Challenger, L>;
 
 // Polynomial sizes (log_2 of coefficient count).
 const SMALL: usize = 14;
@@ -147,7 +147,7 @@ impl<L: Layout<F, EF>> Bench<L> {
         let poseidon24 = Poseidon24::new_from_rng_128(&mut perm_rng);
 
         // Wire the Merkle hash (24-wide) and 2-to-1 compress (16-wide).
-        let mmcs = Mmcs::new(
+        let mmcs = MerkleMmcs::new(
             MerkleHash::new(poseidon24),
             MerkleCompress::new(poseidon16.clone()),
             0,
@@ -285,7 +285,7 @@ impl<L: Layout<F, EF>> Bench<L> {
     }
 
     /// Produce one honest proof outside any timing window.
-    fn build_proof(&self) -> PcsProof<F, EF, Mmcs> {
+    fn build_proof(&self) -> PcsProof<F, EF, MerkleMmcs> {
         let mut challenger = self.challenger();
         let (_, prover_data) = <Pcs<L> as MultilinearPcs<EF, Challenger>>::commit(
             &self.pcs,
@@ -311,23 +311,21 @@ impl<L: Layout<F, EF>> Bench<L> {
         // The pruned digest count is the length of the flat boundary-sibling list.
         //   queries = rows.len()   (one opened row per STIR query)
         //   pruned  = sibling_hashes.len()   (boundary digests, shared once)
-        let round_stats =
-            |openings: &QueryOpenings<F, EF, <Mmcs as MultiOpeningMmcs<F>>::MultiProof>| {
-                let (queries, proof) = match openings {
-                    QueryOpenings::Base(opening) => (opening.rows.len(), &opening.proof),
-                    QueryOpenings::Extension(opening) => (opening.rows.len(), &opening.proof),
-                };
-                (queries, proof.sibling_hashes.len())
+        let round_stats = |openings: &QueryOpenings<F, EF, <MerkleMmcs as Mmcs<F>>::MultiProof>| {
+            let (queries, proof) = match openings {
+                QueryOpenings::Base(opening) => (opening.rows.len(), &opening.proof),
+                QueryOpenings::Extension(opening) => (opening.rows.len(), &opening.proof),
             };
+            (queries, proof.sibling_hashes.len())
+        };
 
         let mut stir_queries = 0;
         let mut pruned_digests = 0;
-        let mut accumulate =
-            |o: &QueryOpenings<F, EF, <Mmcs as MultiOpeningMmcs<F>>::MultiProof>| {
-                let (q, pruned) = round_stats(o);
-                stir_queries += q;
-                pruned_digests += pruned;
-            };
+        let mut accumulate = |o: &QueryOpenings<F, EF, <MerkleMmcs as Mmcs<F>>::MultiProof>| {
+            let (q, pruned) = round_stats(o);
+            stir_queries += q;
+            pruned_digests += pruned;
+        };
         for round in &proof.whir.rounds {
             accumulate(&round.openings);
         }

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, MultiOpeningMmcs, MultilinearPcs};
+use p3_commit::{Mmcs, MultilinearPcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
@@ -45,7 +45,7 @@ where
     F: TwoAdicField + Ord,
     EF: ExtensionField<F> + TwoAdicField,
     Dft: TwoAdicSubgroupDft<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F>
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>
@@ -184,7 +184,7 @@ where
     F: TwoAdicField + Ord,
     EF: ExtensionField<F> + TwoAdicField,
     Dft: TwoAdicSubgroupDft<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F>
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>

--- a/whir/src/pcs/committer/reader.rs
+++ b/whir/src/pcs/committer/reader.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::MultiOpeningMmcs;
+use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_multilinear_util::point::Point;
 use p3_sumcheck::constraints::statement::EqStatement;
@@ -31,7 +31,7 @@ where
     ///
     /// - Round index is past the last round carried by the proof.
     /// - Round entry is present but its Merkle-root slot is empty.
-    pub fn parse_with_round<EF, MT: MultiOpeningMmcs<F>, Challenger>(
+    pub fn parse_with_round<EF, MT: Mmcs<F>, Challenger>(
         proof: &WhirProof<F, EF, MT>,
         challenger: &mut Challenger,
         num_variables: usize,

--- a/whir/src/pcs/proof.rs
+++ b/whir/src/pcs/proof.rs
@@ -1,7 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_commit::MultiOpeningMmcs;
+use p3_commit::Mmcs;
 use p3_matrix::{Dimensions, Matrix};
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::OpeningBatch;
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
     serialize = "F: Serialize, EF: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct WhirProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct WhirProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Initial OOD evaluations.
     pub initial_ood_answers: Vec<EF>,
     /// Initial sumcheck data.
@@ -55,7 +55,7 @@ pub struct WhirProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
     serialize = "F: Serialize, EF: Serialize, MT::Commitment: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct PcsProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct PcsProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Proximity transcript: initial commitment, sumcheck rounds, per-round
     /// commitments, STIR query openings, and the final polynomial.
     pub whir: WhirProof<F, EF, MT>,
@@ -71,7 +71,7 @@ pub struct PcsProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
     serialize = "F: Serialize, EF: Serialize, MT::Commitment: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct WhirRoundProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct WhirRoundProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Round commitment (Merkle root).
     pub commitment: Option<MT::Commitment>,
     /// OOD evaluations for this round.
@@ -104,7 +104,7 @@ impl<T: Send + Sync + Clone, P> SharedProofOpening<T, P> {
     /// Opens `indices` on a commitment holding exactly one matrix.
     pub(crate) fn open<MT, M>(mmcs: &MT, indices: &[usize], prover_data: &MT::ProverData<M>) -> Self
     where
-        MT: MultiOpeningMmcs<T, MultiProof = P>,
+        MT: Mmcs<T, MultiProof = P>,
         M: Matrix<T>,
     {
         let (values, proof) = mmcs.open_multi_batch(indices, prover_data);
@@ -135,7 +135,7 @@ impl<T: Send + Sync + Clone, P> SharedProofOpening<T, P> {
         indices: &[usize],
     ) -> Result<(), MT::Error>
     where
-        MT: MultiOpeningMmcs<T, MultiProof = P>,
+        MT: Mmcs<T, MultiProof = P>,
         T: PartialEq,
     {
         // WHIR commits one matrix per round, so each query opens one row.
@@ -158,7 +158,7 @@ pub enum QueryOpenings<F, EF, P> {
     Extension(SharedProofOpening<EF, P>),
 }
 
-impl<F: Clone + Send + Sync, EF, MT: MultiOpeningMmcs<F>> WhirProof<F, EF, MT> {
+impl<F: Clone + Send + Sync, EF, MT: Mmcs<F>> WhirProof<F, EF, MT> {
     /// Retrieve the PoW witness at a given round index.
     pub(crate) fn get_pow_after_commitment(&self, round_index: usize) -> Option<F> {
         self.rounds

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -5,7 +5,7 @@ use core::mem;
 use core::ops::Deref;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, Mmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
@@ -105,7 +105,7 @@ where
     EF: ExtensionField<F> + TwoAdicField,
     Dft: TwoAdicSubgroupDft<F>,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanSampleUniformBits<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     L: Layout<F, EF>,
 {
     /// Builds a prover from a derived config, an FFT engine, and a base-field MMCS.

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -623,7 +623,7 @@ mod error_variant_tests {
     //! Lock the precise error variant emitted on each opening-shape mismatch.
     use alloc::vec;
 
-    use p3_commit::{MultiOpeningMmcs, MultilinearPcs};
+    use p3_commit::{Mmcs, MultilinearPcs};
     use p3_multilinear_util::poly::Poly;
     use p3_sumcheck::layout::{Layout, SuffixProver, Table};
     use p3_sumcheck::{OpeningBatch, OpeningProtocol, SumcheckError, TableShape, TableSpec};
@@ -645,7 +645,7 @@ mod error_variant_tests {
     ///
     /// Returns the original row count, so the caller can assert the mismatch.
     fn drop_last_opened_row(
-        openings: &mut QueryOpenings<F, EF, <MyMmcs as MultiOpeningMmcs<F>>::MultiProof>,
+        openings: &mut QueryOpenings<F, EF, <MyMmcs as Mmcs<F>>::MultiProof>,
     ) -> usize {
         match openings {
             QueryOpenings::Base(opening) => {

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -5,7 +5,7 @@ use core::ops::Deref;
 
 use errors::VerifierError;
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_multilinear_util::point::Point;
@@ -47,7 +47,7 @@ pub struct WhirVerifier<'a, EF, F, MT, Challenger>
 where
     F: Field,
     EF: ExtensionField<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
 {
     /// Derived per-protocol parameters and per-round configuration.
     pub(crate) config: &'a WhirConfig<EF, F, Challenger>,
@@ -61,7 +61,7 @@ impl<'a, EF, F, MT, Challenger> WhirVerifier<'a, EF, F, MT, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanSampleUniformBits<F>,
 {
     /// Wraps the verifier-side dependencies into a single replay context.
@@ -410,7 +410,7 @@ impl<EF, F, MT, Challenger> Deref for WhirVerifier<'_, EF, F, MT, Challenger>
 where
     F: Field,
     EF: ExtensionField<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
 {
     type Target = WhirConfig<EF, F, Challenger>;
 

--- a/whir/src/pcs/zk/adapter.rs
+++ b/whir/src/pcs/zk/adapter.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{MultiOpeningMmcs, MultilinearPcs};
+use p3_commit::{Mmcs, MultilinearPcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_multilinear_util::point::Point;
@@ -86,7 +86,7 @@ where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Dft: TwoAdicSubgroupDft<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F>
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>

--- a/whir/src/pcs/zk/base_case/prover.rs
+++ b/whir/src/pcs/zk/base_case/prover.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, Mmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField, dot_product};
 use p3_matrix::dense::RowMajorMatrix;
@@ -34,7 +34,7 @@ impl<F, EF, MT> BaseCaseZkProver<'_, F, EF, MT>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     StandardUniform: Distribution<EF>,
 {
     /// Runs Construction 7.2 and returns the proof payload.

--- a/whir/src/pcs/zk/base_case/verifier.rs
+++ b/whir/src/pcs/zk/base_case/verifier.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::iter::repeat_n;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, Mmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, TwoAdicField, dot_product};
 use p3_matrix::Dimensions;
 use p3_util::log2_strict_usize;
@@ -34,7 +34,7 @@ impl<F, EF, MT> BaseCaseZkVerifier<'_, F, EF, MT>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
 {
     /// Replays Construction 7.2 against the carried claim.
     ///

--- a/whir/src/pcs/zk/proof.rs
+++ b/whir/src/pcs/zk/proof.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec;
 
-use p3_commit::MultiOpeningMmcs;
+use p3_commit::Mmcs;
 use p3_sumcheck::zk::ZkSumcheckData;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +14,7 @@ use crate::pcs::proof::{QueryOpenings, SharedProofOpening};
     serialize = "F: Serialize, EF: Serialize, MT::Commitment: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct ZkWhirProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct ZkWhirProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Claimed opening evaluations, one per requested point.
     pub evals: Vec<EF>,
     /// Masked sumcheck transcripts, one per fold batch (`n_rounds + 1` batches).
@@ -33,7 +33,7 @@ pub struct ZkWhirProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
     serialize = "F: Serialize, EF: Serialize, MT::Commitment: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct ZkRoundProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct ZkRoundProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Commitment to the next interleaved ZK oracle.
     pub commitment: MT::Commitment,
     /// Commitment to the fresh code-switch mask `(folded randomness || pad)`.
@@ -56,7 +56,7 @@ pub struct ZkRoundProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
     serialize = "F: Serialize, EF: Serialize, MT::Commitment: Serialize, MT::MultiProof: Serialize",
     deserialize = "F: Deserialize<'de>, EF: Deserialize<'de>, MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
 ))]
-pub struct BaseCaseZkProof<F: Send + Sync + Clone, EF, MT: MultiOpeningMmcs<F>> {
+pub struct BaseCaseZkProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Commitment to the fresh main mask `g`, in the folded source code.
     pub fresh_main_commitment: MT::Commitment,
     /// Commitments to the fresh blinds, one per carried mask group, in chronological group order.

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -14,7 +14,7 @@ pub use data::HidingWhirProverData;
 use data::ZkRoundData;
 use masks::{ProverMasks, fold_limb_chunks};
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, Mmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, PackedValue, PrimeCharacteristicRing, TwoAdicField, dot_product};
 use p3_matrix::Matrix;
@@ -64,7 +64,7 @@ where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Dft: TwoAdicSubgroupDft<F>,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F>
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>

--- a/whir/src/pcs/zk/verifier/mod.rs
+++ b/whir/src/pcs/zk/verifier/mod.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 
 use masks::VerifierMasks;
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{ExtensionMmcs, Mmcs, MultiOpeningMmcs};
+use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_multilinear_util::point::Point;
@@ -119,7 +119,7 @@ impl<'a, EF, F, MT, Challenger> HidingWhirVerifier<'a, EF, F, MT, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    MT: MultiOpeningMmcs<F>,
+    MT: Mmcs<F>,
     Challenger: FieldChallenger<F>
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>


### PR DESCRIPTION
## What

Removes the separate `MultiOpeningMmcs` trait introduced in #1805 and moves its three members onto the existing `Mmcs` trait:

- `type MultiProof`
- `fn open_multi_batch`
- `fn verify_multi_batch`

Call sites change only in the bound name (`MultiOpeningMmcs<F>` → `Mmcs<F>`). Every code path keeps its pruned/amortized behaviour — the method bodies are unchanged, just relocated into the single `Mmcs` impl block of each type.

## Why

The extra trait was confusing and not needed. There are only four `Mmcs` implementors:

- the `&M` blanket impl
- `ExtensionMmcs`
- `MerkleTreeMmcs`
- `MerkleTreeHidingMmcs`

The first three already implemented `MultiOpeningMmcs`, so folding is a pure move. Associated-type defaults are unstable on stable Rust, so `MultiProof` cannot be defaulted — but every implementor declares it, so requiring it on the base trait costs nothing.

## The one real cost, handled properly

`MerkleTreeHidingMmcs` previously implemented only `Mmcs`, so folding forces it to gain multi-opening. Rather than a `todo!()`/panic footgun, it gets a real implementation: it delegates to the inner tree's pruned multi-opening and splits/re-appends the salt suffix exactly the way its single-opening path already does — including the load-bearing unsalted-width check (`check_widths` before salting) that prevents an over-long row hiding behind an under-long salt.

Two tests cover this newly reachable path:
- a multi-opening round trip
- a width-rejection test

## Rebase note

This is a rebase of tcoratger#35 onto current `main`. The only delta beyond the original refactor: #1915 (`fix(whir): update prescribed-point adapter to pruned multiproof API`) landed after #1805 and added a second `MultiOpeningMmcs<F>` bound on the `PrescribedPointPcs` impl in `whir/src/pcs/adapter.rs`. That bound is renamed to `Mmcs<F>` here too, so nothing references the removed trait.

## Verification

- `cargo build -p p3-commit -p p3-merkle-tree -p p3-whir --all-targets` ✅
- `cargo clippy -p p3-commit -p p3-merkle-tree -p p3-whir --all-targets` ✅ (no warnings)
- tests: commit (3) + merkle-tree (105, incl. the two new hiding tests) + whir (131, default and `parallel`) + multi-stark `whir_fibonacci` (4) pass
- `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
