### PR TITLE
fix: patch merkle-tree soundness gap and cleanup some quality findings

### DIFF
--- a/baby-bear/src/poseidon1.rs
+++ b/baby-bear/src/poseidon1.rs
@@ -63,6 +63,15 @@ pub const BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_16: usize = 13;
 /// With the +7.5% security margin: ⌈1.075 × 18.824⌉ = 21.
 pub const BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_24: usize = 21;
 
+const _: () = assert!(
+    BABYBEAR_POSEIDON1_RC_16.len()
+        == 2 * BABYBEAR_POSEIDON1_HALF_FULL_ROUNDS + BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_16
+);
+const _: () = assert!(
+    BABYBEAR_POSEIDON1_RC_24.len()
+        == 2 * BABYBEAR_POSEIDON1_HALF_FULL_ROUNDS + BABYBEAR_POSEIDON1_PARTIAL_ROUNDS_24
+);
+
 /// The Poseidon1 permutation for BabyBear.
 ///
 /// Acts on arrays of the form `[BabyBear; WIDTH]` or `[BabyBear::Packing; WIDTH]`.

--- a/baby-bear/src/poseidon2.rs
+++ b/baby-bear/src/poseidon2.rs
@@ -61,6 +61,25 @@ pub const BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_24: usize = 21;
 /// (matching the Grain LFSR parameters used to generate the round constants below).
 pub const BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_32: usize = 30;
 
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_16_EXTERNAL_INITIAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_16_EXTERNAL_FINAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_16_INTERNAL.len() == BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_16);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_24_EXTERNAL_INITIAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_24_EXTERNAL_FINAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_24_INTERNAL.len() == BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_24);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_32_EXTERNAL_INITIAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_32_EXTERNAL_FINAL.len() == BABYBEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(BABYBEAR_POSEIDON2_RC_32_INTERNAL.len() == BABYBEAR_POSEIDON2_PARTIAL_ROUNDS_32);
+
 /// An implementation of the Poseidon2 hash function specialised to run on the current architecture.
 ///
 /// It acts on arrays of the form either `[BabyBear::Packing; WIDTH]` or `[BabyBear; WIDTH]`. For speed purposes,

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -348,13 +348,21 @@ where
             let log_num_chunks = log_num_quotient_chunks[i];
             let n_chunks = num_quotient_chunks[i];
             let ext_dom = ext_trace_domains[i];
-            let (_, quotient_domain_size) = checked_log_size_sum(ext_db, log_num_chunks)
-                .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
-                    air: Some(i),
-                    maximum: usize::BITS as usize - 1,
-                    got: ext_db.saturating_add(log_num_chunks),
+            let (quotient_domain_log_size, quotient_domain_size) =
+                checked_log_size_sum(ext_db, log_num_chunks).ok_or_else(|| {
+                    InvalidProofShapeError::QuotientDomainTooLarge {
+                        air: Some(i),
+                        maximum: usize::BITS as usize - 1,
+                        got: ext_db.saturating_add(log_num_chunks),
+                    }
                 })?;
-            let qdom = ext_dom.create_disjoint_domain(quotient_domain_size);
+            let qdom = ext_dom
+                .try_create_disjoint_domain(quotient_domain_size)
+                .ok_or(InvalidProofShapeError::QuotientDomainTooLarge {
+                    air: Some(i),
+                    maximum: pcs.log_max_lde_height(),
+                    got: quotient_domain_log_size,
+                })?;
             Ok(qdom.split_domains(n_chunks))
         })
         .collect::<Result<Vec<_>, InvalidProofShapeError>>()?;

--- a/challenger/src/duplex_challenger.rs
+++ b/challenger/src/duplex_challenger.rs
@@ -73,7 +73,7 @@ where
         F: Default,
     {
         const {
-            assert!(RATE > 0 && RATE < WIDTH);
+            assert!(RATE > 0 && RATE < WIDTH && RATE <= 255);
         }
         Self {
             sponge_state: [F::default(); WIDTH],

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -83,14 +83,19 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
         let h_inv = F::ONE.div_2exp_u64(domain.log_n as u64);
 
         let mut buf: Vec<F> = Vec::with_capacity(capacity.max(len));
-        cfft_layers(
-            buf.as_mut_ptr(),
-            domain.size(),
-            w,
-            &twiddles,
-            Some(&values),
-            Some(h_inv),
-        );
+        // SAFETY: `buf` has capacity for at least `len = domain.size() * w` elements, and
+        // `ingest` is set so `cfft_layers` initialises all of them from `values` before
+        // transforming.
+        unsafe {
+            cfft_layers(
+                buf.as_mut_ptr(),
+                domain.size(),
+                w,
+                &twiddles,
+                Some(&values),
+                Some(h_inv),
+            );
+        }
         // SAFETY: the first pass of `cfft_layers` copied every row of `values` into
         // `buf` before transforming it, so all `len` elements are initialised, and the
         // reservation above covers them.
@@ -219,14 +224,19 @@ impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
             .chain(twiddles)
             .collect_vec();
 
-        cfft_layers(
-            coeffs.values.as_mut_ptr(),
-            domain.size(),
-            w,
-            &layers,
-            None::<&RowMajorMatrix<F>>,
-            None,
-        );
+        // SAFETY: `coeffs.values` was reserved above to hold at least `target_len` elements,
+        // and every row beyond the original (lowest-index) block is written by a
+        // duplication layer before any butterfly layer reads it.
+        unsafe {
+            cfft_layers(
+                coeffs.values.as_mut_ptr(),
+                domain.size(),
+                w,
+                &layers,
+                None::<&RowMajorMatrix<F>>,
+                None,
+            );
+        }
 
         // SAFETY: every row with one of the top `added_bits` index bits set is written by
         // the duplication layer of its highest such bit (later duplication layers rewrite
@@ -305,13 +315,13 @@ fn log_group_rows<F>(log_h: usize, width: usize) -> usize {
 /// arithmetic, each one widens the window budget of its run by one bit instead of consuming it,
 /// keeping the number of passes unchanged.
 ///
-/// # Safety-relevant contract (not `unsafe fn` to keep call sites readable)
+/// # Safety
 ///
 /// `base` must be valid for reads and writes of `h * width` elements. Elements must be
 /// initialised, except (without `ingest`) rows whose index has a [`CfftLayer::Dup`] flipped
 /// bit set, and (with `ingest`) the whole buffer. `layers` must not be empty if `ingest` or
 /// `scale` is set (otherwise no pass would perform the copy or the scaling).
-fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
+unsafe fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
     base: *mut F,
     h: usize,
     width: usize,
@@ -360,16 +370,21 @@ fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
             log_stride
         )
         .in_scope(|| {
-            par_group_pass(
-                base,
-                h,
-                width,
-                &layers[start..end],
-                log_group_run,
-                log_stride,
-                pass_ingest,
-                pass_scale,
-            );
+            // SAFETY: `base` is valid for reads and writes of `h * width` elements per
+            // this function's contract, and the run `[start, end)` was chosen so its
+            // `flipped_bit`s fit within `[log_stride, log_stride + log_group_run)`.
+            unsafe {
+                par_group_pass(
+                    base,
+                    h,
+                    width,
+                    &layers[start..end],
+                    log_group_run,
+                    log_stride,
+                    pass_ingest,
+                    pass_scale,
+                );
+            }
         });
         start = end;
     }
@@ -383,9 +398,14 @@ fn cfft_layers<F: Field, B: Butterfly<F>, M: Matrix<F>>(
 /// `e = flipped_bit - log_stride` of `t` and applies the twiddle `b * j / h`, which reduces to
 /// index `t >> (e + 1)` into the contiguous twiddle slice for `hi`.
 ///
-/// See [`cfft_layers`] for the `ingest` and `scale` semantics and the safety contract.
+/// See [`cfft_layers`] for the `ingest` and `scale` semantics.
+///
+/// # Safety
+///
+/// `base` must be valid for reads and writes of `h * width` elements, per the same
+/// initialisation contract as [`cfft_layers`], restricted to the rows this pass touches.
 #[allow(clippy::too_many_arguments)]
-fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
+unsafe fn par_group_pass<F: Field, B: Butterfly<F>, M: Matrix<F>>(
     base: *mut F,
     h: usize,
     width: usize,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -129,22 +129,21 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
         }
     }
 
-    fn create_disjoint_domain(&self, min_size: usize) -> Self {
+    fn try_create_disjoint_domain(&self, min_size: usize) -> Option<Self> {
         // Right now we simply guarantee the domain is disjoint by returning a
         // larger standard position coset, which is fine because we always ask for a larger
         // domain. If we wanted good performance for a disjoint domain of the same size,
         // we could change the shift. Also we could support nonstandard twin cosets.
-        assert!(
-            self.is_standard(),
-            "create_disjoint_domain not currently supported for nonstandard twin cosets"
-        );
+        if !self.is_standard() {
+            return None;
+        }
         let log_n = log2_ceil_usize(min_size);
         // Any standard position coset that is not the same size as us will be disjoint.
-        Self::standard(if log_n == self.log_n {
+        Some(Self::standard(if log_n == self.log_n {
             log_n + 1
         } else {
             log_n
-        })
+        }))
     }
 
     /// Decompose a domain into disjoint twin-cosets.

--- a/circle/src/ordering.rs
+++ b/circle/src/ordering.rs
@@ -32,19 +32,9 @@ pub(crate) fn cfft_permute_slice_chunked_in_place<T>(xs: &mut [T], chunk_size: u
     for i in 0..n_chunks {
         let j = cfft_permute_index(i, log_n);
         if i < j {
-            // somehow this is slightly faster than the unsafe block below
             for k in 0..chunk_size {
                 xs.swap(i * chunk_size + k, j * chunk_size + k);
             }
-            /*
-            unsafe {
-                core::ptr::swap_nonoverlapping(
-                    xs.as_mut_ptr().add(i * chunk_size),
-                    xs.as_mut_ptr().add(j * chunk_size),
-                    chunk_size,
-                );
-            }
-            */
         }
     }
 }

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -133,7 +133,7 @@ where
     }
 
     fn log_max_lde_height(&self) -> usize {
-        Val::CIRCLE_TWO_ADICITY
+        Val::CIRCLE_TWO_ADICITY - 1
     }
 
     fn commit(

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-default = ["test-utils"]
+default = []
 test-utils = ["p3-challenger", "p3-dft"]
 
 [dependencies]

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -78,7 +78,26 @@ pub trait PolynomialSpace: Copy {
     /// smaller than the `2`-adicity of the field.
     ///
     /// This fixes a canonical choice for prover/verifier determinism and LDE caching.
-    fn create_disjoint_domain(&self, min_size: usize) -> Self;
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min_size` is too large for a disjoint domain to be constructed. Verifier-side
+    /// code processing untrusted input should prefer [`Self::try_create_disjoint_domain`], which
+    /// reports this condition as `None` instead of panicking.
+    fn create_disjoint_domain(&self, min_size: usize) -> Self {
+        self.try_create_disjoint_domain(min_size)
+            .unwrap_or_else(|| {
+                panic!("cannot construct a domain of size at least {min_size} disjoint from `self`")
+            })
+    }
+
+    /// The non-panicking counterpart to [`Self::create_disjoint_domain`].
+    ///
+    /// Returns `None` instead of panicking when `min_size` is too large for a disjoint domain
+    /// to be constructed (for two-adic domains, this happens when `log_2(min_size)` is not
+    /// smaller than the field's `2`-adicity). Intended for verifier-side code, which must
+    /// reject malformed or adversarial input rather than panic on it.
+    fn try_create_disjoint_domain(&self, min_size: usize) -> Option<Self>;
 
     /// Split the `PolynomialSpace` into `num_chunks` smaller `PolynomialSpaces` of equal size.
     ///
@@ -143,6 +162,15 @@ pub trait PolynomialSpace: Copy {
     /// gets value `col[i % col.len()]`. The default expands to trace size and
     /// delegates to [`Self::evaluate_polynomial_at`]; domains with algebraic
     /// structure (e.g. two-adic cosets) can override for O(period) work.
+    ///
+    /// # Performance
+    ///
+    /// This default is O(`self.size()`) time and allocates a `self.size()`-length
+    /// vector, versus O(`col.len()`) for an override that exploits the domain's
+    /// algebraic structure (e.g. two-adic cosets folding onto a sub-coset). For a
+    /// small period on a large trace this is a large (potentially many-orders-of-
+    /// magnitude) verifier slowdown. Any new `PolynomialSpace` implementor should
+    /// override this method rather than rely on the default.
     fn evaluate_periodic_column_at<Ext: ExtensionField<Self::Val>>(
         &self,
         col: &[Self::Val],
@@ -192,10 +220,8 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
     /// is a fixed generator of `F^*` and `K` is the unique two-adic subgroup
     /// of with size `2^(ceil(log_2(min_size)))`.
     ///
-    /// # Panics
-    ///
-    /// This will panic if `min_size` > `1 << Val::TWO_ADICITY`.
-    fn create_disjoint_domain(&self, min_size: usize) -> Self {
+    /// Returns `None` if `min_size` > `1 << Val::TWO_ADICITY`.
+    fn try_create_disjoint_domain(&self, min_size: usize) -> Option<Self> {
         // We provide a short proof that these cosets are always disjoint:
         //
         // Assume without loss of generality that `|H| <= min_size <= |K|`.
@@ -206,8 +232,8 @@ impl<Val: TwoAdicField> PolynomialSpace for TwoAdicMultiplicativeCoset<Val> {
         //
         // Thus `gH` and `gfK` are disjoint.
 
-        // This panics if (and only if) `min_size` > `1 << Val::TWO_ADICITY`.
-        Self::new(self.shift() * Val::GENERATOR, log2_ceil_usize(min_size)).unwrap()
+        // This is `None` if (and only if) `min_size` > `1 << Val::TWO_ADICITY`.
+        Self::new(self.shift() * Val::GENERATOR, log2_ceil_usize(min_size))
     }
 
     /// Given the coset `gH` and generator `h` of `H`, let `K = H^{num_chunks}`

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -247,7 +247,7 @@ where
         fiat_shamir_challenger: &mut Challenger,
         _is_preprocessing: bool,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
-        debug_assert!(
+        assert!(
             !Self::ZK,
             "open_with_preprocessing should have a different implementation when ZK is enabled"
         );

--- a/commit/src/periodic.rs
+++ b/commit/src/periodic.rs
@@ -222,18 +222,19 @@ impl<F: Field, D: PolynomialSpace<Val = F>> PeriodicEvaluator<F, D> for () {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-
-    use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
-
-    use super::*;
-
-    type F = BabyBear;
-
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "PeriodicLdeTable height must be a power of two")]
     fn new_panics_on_non_power_of_two_height() {
+        use alloc::vec;
+
+        use p3_baby_bear::BabyBear;
+        use p3_field::PrimeCharacteristicRing;
+
+        use super::*;
+
+        type F = BabyBear;
+
         let (a, b, c) = (F::ONE, F::TWO, F::from_u8(3));
         let _ = PeriodicLdeTable::new(RowMajorMatrix::new(vec![a, b, c], 1));
     }

--- a/dft/src/radix_2_small_batch.rs
+++ b/dft/src/radix_2_small_batch.rs
@@ -173,11 +173,12 @@ where
         // If the total number of layers is not a multiple of `LAYERS_PER_GROUP`,
         // we need to handle the remaining layers separately.
         let corr = (log_h - log_num_par_rows) % LAYERS_PER_GROUP;
-        dft_layer_par_extra_layers(
-            &mut mat.as_view_mut(),
-            &root_table[log_num_par_rows..log_num_par_rows + corr],
-            multi_layer_dit,
-        );
+        let extra_layers: Vec<&[DitButterfly<F>]> = root_table
+            [log_num_par_rows..log_num_par_rows + corr]
+            .iter()
+            .map(|slice| unsafe { as_base_slice::<DitButterfly<F>, F>(slice) }) // Safe as DitButterfly is #[repr(transparent)]
+            .collect();
+        dft_layer_par_extra_layers(&mut mat.as_view_mut(), &extra_layers, multi_layer_dit);
 
         // Once the blocks are small enough, we can split the matrix
         // into chunks of size `chunk_size` and process them in parallel.
@@ -234,11 +235,12 @@ where
         // If the total number of layers is not a multiple of `LAYERS_PER_GROUP`,
         // we need to handle the initial layers separately.
         let corr = (log_h - log_num_par_rows) % LAYERS_PER_GROUP;
-        dft_layer_par_extra_layers(
-            &mut mat.as_view_mut(),
-            &root_table[log_num_par_rows..log_num_par_rows + corr],
-            multi_layer_dif,
-        );
+        let extra_layers: Vec<&[DifButterfly<F>]> = root_table
+            [log_num_par_rows..log_num_par_rows + corr]
+            .iter()
+            .map(|slice| unsafe { as_base_slice::<DifButterfly<F>, F>(slice) }) // Safe as DifButterfly is #[repr(transparent)]
+            .collect();
+        dft_layer_par_extra_layers(&mut mat.as_view_mut(), &extra_layers, multi_layer_dif);
 
         // We do `LAYERS_PER_GROUP` layers of the DFT at once, to minimize how much data we need to transfer
         // between threads.
@@ -318,11 +320,12 @@ where
         // If the total number of layers is not a multiple of `LAYERS_PER_GROUP`,
         // we need to handle the remaining layers separately.
         let corr = (log_h - num_inner_dit_layers) % LAYERS_PER_GROUP;
-        dft_layer_par_extra_layers(
-            &mut mat.as_view_mut(),
-            &inv_root_table[num_inner_dit_layers..num_inner_dit_layers + corr],
-            multi_layer_dit,
-        );
+        let extra_layers: Vec<&[DitButterfly<F>]> = inv_root_table
+            [num_inner_dit_layers..num_inner_dit_layers + corr]
+            .iter()
+            .map(|slice| unsafe { as_base_slice::<DitButterfly<F>, F>(slice) }) // Safe as DitButterfly is #[repr(transparent)]
+            .collect();
+        dft_layer_par_extra_layers(&mut mat.as_view_mut(), &extra_layers, multi_layer_dit);
 
         // Now do all the inner layers at once. This does the final `log_num_par_rows` of
         // the initial transformation, then copies the values of mat to output, scales then
@@ -342,11 +345,12 @@ where
 
         // If the total number of layers is not a multiple of `LAYERS_PER_GROUP`,
         // we need to handle the remaining layers separately.
-        dft_layer_par_extra_layers(
-            &mut out.as_view_mut(),
-            &root_table[num_inner_dif_layers..num_inner_dif_layers + corr],
-            multi_layer_dif,
-        );
+        let extra_layers: Vec<&[DifButterfly<F>]> = root_table
+            [num_inner_dif_layers..num_inner_dif_layers + corr]
+            .iter()
+            .map(|slice| unsafe { as_base_slice::<DifButterfly<F>, F>(slice) }) // Safe as DifButterfly is #[repr(transparent)]
+            .collect();
+        dft_layer_par_extra_layers(&mut out.as_view_mut(), &extra_layers, multi_layer_dif);
 
         // We do `LAYERS_PER_GROUP` layers of the DFT at once, to minimize how much data we need to transfer
         // between threads.
@@ -362,11 +366,11 @@ where
     }
 }
 
-/// Applies one layer of the Radix-2 DIF FFT butterfly network making use of parallelization.
+/// Applies one layer of the Radix-2 FFT butterfly network making use of parallelization.
 ///
 /// Splits the matrix into blocks of rows and performs in-place butterfly operations
-/// on each block. Uses a `TwiddleFreeButterfly` for the first pair and `DifButterfly`
-/// with precomputed twiddles for the rest.
+/// on each block. Uses a `TwiddleFreeButterfly` for the first pair and the given
+/// `Butterfly` implementation with precomputed twiddles for the rest.
 ///
 /// Each block is processed in parallel, if the blocks are large enough they themselves
 /// are split into parallel sub-blocks.
@@ -408,7 +412,7 @@ fn dft_layer_par<F: Field, B: Butterfly<F>>(
                         // The first pair doesn't require a twiddle factor
                         TwiddleFreeButterfly.apply_to_rows(hi_chunk, lo_chunk);
                     } else {
-                        // Apply DIT butterfly using the twiddle factor at index `ind - 1`
+                        // Apply the butterfly using the twiddle factor at index `ind`
                         twiddles[ind].apply_to_rows(hi_chunk, lo_chunk);
                     }
                 });
@@ -699,22 +703,18 @@ fn dft_layer_par_triple<F: Field, B: Butterfly<F>, M: MultiLayerButterfly<F, B>>
 /// may not be a multiple of `LAYERS_PER_GROUP`.
 fn dft_layer_par_extra_layers<F: Field, B: Butterfly<F>, M: MultiLayerButterfly<F, B>>(
     mat: &mut RowMajorMatrixViewMut<'_, F>,
-    root_table: &[Vec<F>],
+    root_table: &[&[B]],
     multi_layer: M,
 ) {
     match root_table.len() {
         1 => {
-            // Safe as DitButterfly is #[repr(transparent)]
-            let fft_layer: &[B] = unsafe { as_base_slice(&root_table[0]) };
-            dft_layer_par(&mut mat.as_view_mut(), fft_layer);
+            dft_layer_par(&mut mat.as_view_mut(), root_table[0]);
         }
         2 => {
-            let fft_layer_0: &[B] = unsafe { as_base_slice(&root_table[0]) };
-            let fft_layer_1: &[B] = unsafe { as_base_slice(&root_table[1]) };
             dft_layer_par_double(
                 &mut mat.as_view_mut(),
-                fft_layer_1,
-                fft_layer_0,
+                root_table[1],
+                root_table[0],
                 multi_layer,
             );
         }

--- a/dft/src/traits.rs
+++ b/dft/src/traits.rs
@@ -251,14 +251,9 @@ pub trait TwoAdicSubgroupDft<F: TwoAdicField>: Clone + Default {
         let mut coeffs = self.idft_batch(mat);
         transform(&mut coeffs.as_view_mut(), Layout::Natural);
         // PANICS: possible panic if the new resized length overflows
-        coeffs.values.resize(
-            coeffs
-                .values
-                .len()
-                .checked_shl(added_bits.try_into().unwrap())
-                .unwrap(),
-            F::ZERO,
-        );
+        let scale = 1usize.checked_shl(added_bits.try_into().unwrap()).unwrap();
+        let new_len = coeffs.values.len().checked_mul(scale).unwrap();
+        coeffs.values.resize(new_len, F::ZERO);
         self.coset_dft_batch(coeffs, shift)
     }
 

--- a/field/src/extension/binomial_extension.rs
+++ b/field/src/extension/binomial_extension.rs
@@ -462,9 +462,6 @@ where
         let b = rhs.value;
         let mut res = Self::default();
 
-        // Migrated to the unified shape-parameterized `ExtensionAlgebra` trait.
-        // `W` is now reached through the bridge impl (which projects `F::W`),
-        // so callers no longer pass it explicitly.
         <A as ExtensionAlgebra<F, D, Binomial<F>>>::ext_mul(&a, &b, &mut res.value);
 
         res

--- a/field/src/helpers.rs
+++ b/field/src/helpers.rs
@@ -102,6 +102,8 @@ pub const fn field_to_array<R: PrimeCharacteristicRing, const D: usize>(x: R) ->
         arr[i] = MaybeUninit::new(R::ZERO);
         i += 1;
     }
+    // SAFETY: every element of `arr` has been initialized above, so reinterpreting
+    // `[MaybeUninit<R>; D]` as `[R; D]` is sound.
     unsafe { core::mem::transmute_copy::<_, [R; D]>(&arr) }
 }
 

--- a/field/src/packed/packed_traits.rs
+++ b/field/src/packed/packed_traits.rs
@@ -89,6 +89,8 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
         );
         let buf_ptr = buf.as_ptr().cast::<Self>();
         let n = buf.len() / Self::WIDTH;
+        // SAFETY: `buf_ptr` is valid for `n * WIDTH` values of `Self::Value`, which is
+        // the same region as `n` values of `Self` given the alignment and length checks above.
         unsafe { slice::from_raw_parts(buf_ptr, n) }
     }
 
@@ -110,6 +112,8 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
         );
         let buf_ptr = buf.as_mut_ptr().cast::<Self>();
         let n = buf.len() / Self::WIDTH;
+        // SAFETY: `buf_ptr` is valid for `n * WIDTH` values of `Self::Value`, which is
+        // the same region as `n` values of `Self` given the alignment and length checks above.
         unsafe { slice::from_raw_parts_mut(buf_ptr, n) }
     }
 
@@ -134,6 +138,9 @@ pub unsafe trait PackedValue: 'static + Copy + Send + Sync {
         );
         let buf_ptr = buf.as_mut_ptr().cast::<MaybeUninit<Self>>();
         let n = buf.len() / Self::WIDTH;
+        // SAFETY: `buf_ptr` is valid for `n * WIDTH` values of `MaybeUninit<Self::Value>`,
+        // which is the same region as `n` values of `MaybeUninit<Self>` given the
+        // alignment and length checks above.
         unsafe { slice::from_raw_parts_mut(buf_ptr, n) }
     }
 

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -14,7 +14,7 @@ use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixCow};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 use p3_matrix::row_index_mapped::RowIndexMappedView;
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, RngExt};
+use rand::{Rng, RngExt, SeedableRng};
 use spin::Mutex;
 use tracing::info_span;
 
@@ -30,19 +30,21 @@ pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
     rng: Mutex<R>,
 }
 
+/// Cloning forks the RNG stream by drawing a fresh seed from the source RNG,
+/// so the clone and the original never produce the same sequence of masks.
 impl<Val, Dft, InputMmcs, FriMmcs, R> Clone for HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R>
 where
     Val: Clone,
     Dft: Clone,
     InputMmcs: Clone,
     FriMmcs: Clone,
-    R: Clone,
+    R: Rng + SeedableRng,
 {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
             num_random_codewords: self.num_random_codewords,
-            rng: Mutex::new(self.rng.lock().clone()),
+            rng: Mutex::new(R::from_rng(&mut *self.rng.lock())),
         }
     }
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -79,7 +79,7 @@ where
     );
 
     // Index sampling and `open_input` must agree on the height; the caller's value is canonical.
-    debug_assert_eq!(
+    assert_eq!(
         log_global_max_height,
         log2_strict_usize(inputs[0].len()),
         "log_global_max_height must match the largest input length"

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -595,14 +595,14 @@ where
         // we may need to revisit this and to ensure it is safe to batch them together.
 
         // num_reduced records the number of (function, opening point) pairs for each `log_height`.
-        // TODO: This should really be `[0; Val::TWO_ADICITY]` but that runs into issues with generics.
-        let mut num_reduced = [0; 32];
+        // TODO: This should really be `[0; Val::TWO_ADICITY + 1]` but that runs into issues with generics.
+        let mut num_reduced = [0; 33];
 
         // For each `log_height` from 2^1 -> 2^32, reduced_openings will contain either `None`
         // if there are no matrices of that height, or `Some(vec)` where `vec` is equal to
         // a weighted sum of `(f(zeta) - f(x))/(zeta - x)` over all `f`'s of that height and
         // for each `f`, all opening points `zeta`. The sum is weighted by powers of the challenge alpha.
-        let mut reduced_openings: [_; 32] = core::array::from_fn(|_| None);
+        let mut reduced_openings: [_; 33] = core::array::from_fn(|_| None);
 
         for ((mats, points), openings_for_round) in
             mats_and_points.iter().zip(all_opened_values.iter())

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -1164,9 +1164,20 @@ pub fn external_terminal_permute_dual_w8(
 // Each operates on both packed lanes simultaneously using uint64x2_t.
 
 #[inline(always)]
+unsafe fn canonicalize_neon(x: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        let p_vec = vdupq_n_u64(P);
+        let ge_p = vcgeq_u64(x, p_vec);
+        let sub = vandq_u64(ge_p, p_vec);
+        vsubq_u64(x, sub)
+    }
+}
+
+#[inline(always)]
 unsafe fn add_neon(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
     unsafe {
-        let res = vaddq_u64(a, b);
+        let b_canon = canonicalize_neon(b);
+        let res = vaddq_u64(a, b_canon);
         let overflow = vcgtq_u64(a, res);
         let adj = vshrq_n_u64::<32>(overflow);
         vaddq_u64(res, adj)
@@ -1176,8 +1187,9 @@ unsafe fn add_neon(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
 #[inline(always)]
 unsafe fn sub_neon(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
     unsafe {
-        let res = vsubq_u64(a, b);
-        let underflow = vcgtq_u64(b, a);
+        let b_canon = canonicalize_neon(b);
+        let res = vsubq_u64(a, b_canon);
+        let underflow = vcgtq_u64(b_canon, a);
         let adj = vshrq_n_u64::<32>(underflow);
         vsubq_u64(res, adj)
     }
@@ -2635,6 +2647,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_add_neon_second_order_overflow() {
+        unsafe {
+            let (r0, r1) = read_neon(add_neon(
+                make_neon(u64::MAX, u64::MAX),
+                make_neon(u64::MAX, u64::MAX),
+            ));
+            let expected = add_asm(u64::MAX, u64::MAX);
+            assert_eq!(canon(r0), canon(expected));
+            assert_eq!(canon(r1), canon(expected));
+            assert_eq!(canon(expected), (1u64 << 33) - 4);
+        }
+    }
+
+    #[test]
+    fn test_sub_neon_second_order_underflow() {
+        unsafe {
+            let (r0, r1) = read_neon(sub_neon(make_neon(0, 0), make_neon(u64::MAX, u64::MAX)));
+            let expected = sub_asm(0, u64::MAX);
+            assert_eq!(canon(r0), canon(expected));
+            assert_eq!(canon(r1), canon(expected));
+        }
+    }
+
     fn test_internal_neon_matches_scalar<const WIDTH: usize>(
         diag: [F; WIDTH],
         neon_fn: fn(&mut [uint64x2_t; WIDTH], &[u64]),
@@ -2868,6 +2904,30 @@ mod tests {
             for i in 0..8 {
                 prop_assert_eq!(canon(got[i]), canon(ref_state[i]));
             }
+        }
+
+        #[test]
+        fn test_add_neon_danger(a in danger_u64(), b in danger_u64()) {
+            let expected = (F::new(a) + F::new(b)).as_canonical_u64();
+            let got = unsafe { read_neon(add_neon(make_neon(a, a), make_neon(b, b))) };
+            prop_assert_eq!(canon(got.0), expected);
+            prop_assert_eq!(canon(got.1), expected);
+        }
+
+        #[test]
+        fn test_sub_neon_danger(a in danger_u64(), b in danger_u64()) {
+            let expected = (F::new(a) - F::new(b)).as_canonical_u64();
+            let got = unsafe { read_neon(sub_neon(make_neon(a, a), make_neon(b, b))) };
+            prop_assert_eq!(canon(got.0), expected);
+            prop_assert_eq!(canon(got.1), expected);
+        }
+
+        #[test]
+        fn test_double_neon_danger(a in danger_u64()) {
+            let expected = (F::new(a) + F::new(a)).as_canonical_u64();
+            let got = unsafe { read_neon(double_neon(make_neon(a, a))) };
+            prop_assert_eq!(canon(got.0), expected);
+            prop_assert_eq!(canon(got.1), expected);
         }
     }
 

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -413,7 +413,7 @@ impl Field for Goldilocks {
             not(target_feature = "avx512f")
         ),
         all(target_arch = "x86_64", target_feature = "avx512f"),
-        target_arch = "aarch64",
+        all(target_arch = "aarch64", target_feature = "neon"),
         all(target_arch = "wasm32", target_feature = "simd128"),
     )))]
     type Packing = Self;

--- a/goldilocks/src/poseidon1.rs
+++ b/goldilocks/src/poseidon1.rs
@@ -103,7 +103,7 @@ pub type Poseidon1Goldilocks<const WIDTH: usize> = crate::Poseidon1GoldilocksDis
 /// Karatsuba MDS convolution.
 ///
 /// Supports both scalar and packed state representations transparently.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub type Poseidon1Goldilocks<const WIDTH: usize> = Poseidon1GoldilocksGeneric<WIDTH>;
 
 /// Round constants for width-8 Poseidon1 on Goldilocks.
@@ -876,7 +876,7 @@ pub fn default_goldilocks_poseidon1_8() -> Poseidon1Goldilocks<8> {
 ///
 /// Returns the platform-optimal implementation: fused ASM on aarch64,
 /// generic Karatsuba on all other platforms.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub fn default_goldilocks_poseidon1_8() -> Poseidon1Goldilocks<8> {
     Poseidon1::new(&Poseidon1Constants {
         rounds_f: 2 * GOLDILOCKS_POSEIDON_HALF_FULL_ROUNDS,
@@ -908,7 +908,7 @@ pub fn default_goldilocks_poseidon1_12() -> Poseidon1Goldilocks<12> {
 ///
 /// Returns the platform-optimal implementation: fused ASM on aarch64,
 /// generic Karatsuba on all other platforms.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub fn default_goldilocks_poseidon1_12() -> Poseidon1Goldilocks<12> {
     Poseidon1::new(&Poseidon1Constants {
         rounds_f: 2 * GOLDILOCKS_POSEIDON_HALF_FULL_ROUNDS,

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use p3_field::{Algebra, InjectiveMonomial, PrimeCharacteristicRing};
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 use p3_poseidon2::Poseidon2;
 use p3_poseidon2::{
     ExternalLayer, ExternalLayerConstants, ExternalLayerConstructor, GenericPoseidon2LinearLayers,
@@ -55,7 +55,7 @@ pub type Poseidon2Goldilocks<const WIDTH: usize> = crate::Poseidon2GoldilocksFus
 /// An implementation of the Poseidon2 hash function for the Goldilocks field.
 ///
 /// It acts on arrays of the form `[Goldilocks; WIDTH]`.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
     Goldilocks,
     Poseidon2ExternalLayerGoldilocks<WIDTH>,
@@ -566,7 +566,7 @@ pub const GOLDILOCKS_POSEIDON2_RC_16_INTERNAL: [Goldilocks; 22] = Goldilocks::ne
 ]);
 
 /// Create a default width-8 Poseidon2 permutation for Goldilocks.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub fn default_goldilocks_poseidon2_8() -> Poseidon2Goldilocks<8> {
     Poseidon2::new(
         ExternalLayerConstants::new(
@@ -590,7 +590,7 @@ pub fn default_goldilocks_poseidon2_8() -> Poseidon2Goldilocks<8> {
 }
 
 /// Create a default width-12 Poseidon2 permutation for Goldilocks.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub fn default_goldilocks_poseidon2_12() -> Poseidon2Goldilocks<12> {
     Poseidon2::new(
         ExternalLayerConstants::new(
@@ -614,7 +614,7 @@ pub fn default_goldilocks_poseidon2_12() -> Poseidon2Goldilocks<12> {
 }
 
 /// Create a default width-16 Poseidon2 permutation for Goldilocks.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 pub fn default_goldilocks_poseidon2_16() -> Poseidon2Goldilocks<16> {
     Poseidon2::new(
         ExternalLayerConstants::new(

--- a/koala-bear/src/poseidon1.rs
+++ b/koala-bear/src/poseidon1.rs
@@ -62,6 +62,15 @@ pub const KOALABEAR_POSEIDON_PARTIAL_ROUNDS_16: usize = 20;
 /// With the +7.5% security margin: ⌈1.075 × 20.230⌉ = 23.
 pub const KOALABEAR_POSEIDON_PARTIAL_ROUNDS_24: usize = 23;
 
+const _: () = assert!(
+    KOALABEAR_POSEIDON1_RC_16.len()
+        == 2 * KOALABEAR_POSEIDON_HALF_FULL_ROUNDS + KOALABEAR_POSEIDON_PARTIAL_ROUNDS_16
+);
+const _: () = assert!(
+    KOALABEAR_POSEIDON1_RC_24.len()
+        == 2 * KOALABEAR_POSEIDON_HALF_FULL_ROUNDS + KOALABEAR_POSEIDON_PARTIAL_ROUNDS_24
+);
+
 /// The Poseidon1 permutation for KoalaBear.
 ///
 /// Acts on arrays of the form `[KoalaBear; WIDTH]` or `[KoalaBear::Packing; WIDTH]`.

--- a/koala-bear/src/poseidon2.rs
+++ b/koala-bear/src/poseidon2.rs
@@ -66,6 +66,28 @@ pub const KOALABEAR_POSEIDON2_PARTIAL_ROUNDS_24: usize = 23;
 /// (matching the Grain LFSR parameters used to generate the round constants below).
 pub const KOALABEAR_POSEIDON2_PARTIAL_ROUNDS_32: usize = 31;
 
+const _: () = assert!(
+    KOALABEAR_POSEIDON2_RC_16_EXTERNAL_INITIAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS
+);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_16_EXTERNAL_FINAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_16_INTERNAL.len() == KOALABEAR_POSEIDON2_PARTIAL_ROUNDS_16);
+const _: () = assert!(
+    KOALABEAR_POSEIDON2_RC_24_EXTERNAL_INITIAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS
+);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_24_EXTERNAL_FINAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_24_INTERNAL.len() == KOALABEAR_POSEIDON2_PARTIAL_ROUNDS_24);
+const _: () = assert!(
+    KOALABEAR_POSEIDON2_RC_32_EXTERNAL_INITIAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS
+);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_32_EXTERNAL_FINAL.len() == KOALABEAR_POSEIDON2_HALF_FULL_ROUNDS);
+const _: () =
+    assert!(KOALABEAR_POSEIDON2_RC_32_INTERNAL.len() == KOALABEAR_POSEIDON2_PARTIAL_ROUNDS_32);
+
 /// An implementation of the Poseidon2 hash function specialised to run on the current architecture.
 ///
 /// It acts on arrays of the form either `[KoalaBear::Packing; WIDTH]` or `[KoalaBear; WIDTH]`. For speed purposes,

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -229,7 +229,10 @@ impl<F: Field> Lookups<F> {
                         if gadget.constraint_degree(&cur) <= max_degree {
                             // Within budget: keep the merge.
                             // Each tuple holds its own per-row query bound, so the bounds add.
-                            cur.count_weight = cur.count_weight.saturating_add(member.count_weight);
+                            cur.count_weight = cur
+                                .count_weight
+                                .checked_add(member.count_weight)
+                                .expect("count_weight overflow: aggregate lookup weight exceeds u32::MAX");
                             current = Some(cur);
                         } else {
                             // Over budget: undo the trial, seal the column, start a new one.
@@ -298,15 +301,18 @@ pub fn check_multiplicity_height_bound<F: PrimeField>(
         "lookups and heights must be aligned per AIR"
     );
 
-    // Accumulate `sum_i w_i * h_i` in 128 bits.
-    // A saturating add only caps far past any field size, where the bound already fails.
-    let weighted_height_sum = lookups.iter().zip(heights).fold(0u128, |acc, (air, &h)| {
-        let term = u128::from(air.total_count_weight()).saturating_mul(h as u128);
-        acc.saturating_add(term)
-    });
+    // Accumulate `sum_i w_i * h_i` exactly via `BigUint`, since this sum
+    // feeds the soundness comparison below and must stay exact for every
+    // supported field, including large ones like BN254 (`p ~ 2^254`).
+    let weighted_height_sum = lookups
+        .iter()
+        .zip(heights)
+        .fold(BigUint::ZERO, |acc, (air, &h)| {
+            acc + BigUint::from(air.total_count_weight()) * BigUint::from(h)
+        });
 
     // Compare against the exact characteristic `p`, valid for any prime size.
-    if BigUint::from(weighted_height_sum) >= F::order() {
+    if weighted_height_sum >= F::order() {
         return Err(LookupError::MultiplicityHeightBoundExceeded {
             weighted_height_sum,
             field_bits: F::bits(),
@@ -386,7 +392,7 @@ pub enum LookupError {
         "LogUp multiplicity height-bound exceeded: weighted height sum {weighted_height_sum} reaches the ~2^{field_bits} field characteristic"
     )]
     MultiplicityHeightBoundExceeded {
-        weighted_height_sum: u128,
+        weighted_height_sum: BigUint,
         field_bits: usize,
     },
 }
@@ -578,7 +584,7 @@ mod tests {
                 weighted_height_sum,
                 field_bits,
             } => {
-                assert_eq!(weighted_height_sum, 1u128 << 31);
+                assert_eq!(weighted_height_sum, BigUint::from(1u128 << 31));
                 assert_eq!(field_bits, F::bits());
             }
             other => panic!("wrong error variant: {other:?}"),

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -428,6 +428,8 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
+        assert_eq!(v.len(), self.height());
+
         // Below this many total elements, the rayon fork-join and SIMD-packing machinery
         // costs more than the dot product itself; fall back to a plain scalar accumulation.
         // Gating on total elements (rather than height alone) also covers wide-but-short
@@ -481,8 +483,10 @@ pub trait Matrix<T: Send + Sync + Clone>: Send + Sync {
         T: Field,
         EF: ExtensionField<T>,
     {
+        assert_eq!(vs.len(), self.height());
+
         let packed_width = self.width().div_ceil(T::Packing::WIDTH);
-        let height = self.height().min(vs.len());
+        let height = self.height();
 
         // Split the rows into a bounded number of contiguous chunks; each task runs the
         // field's columnwise kernel serially over its chunk (letting it defer modular

--- a/maybe-rayon/Cargo.toml
+++ b/maybe-rayon/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-parallel = ["rayon"]
+parallel = ["dep:rayon"]
 
 [dependencies]
 rayon = { workspace = true, optional = true }

--- a/maybe-rayon/src/serial.rs
+++ b/maybe-rayon/src/serial.rs
@@ -205,6 +205,6 @@ where
     (result_a, result_b)
 }
 
-pub const fn current_num_threads() -> usize {
+pub fn current_num_threads() -> usize {
     1
 }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -21,8 +21,9 @@ use tracing::instrument;
 /// * `DIGEST_ELEMS` – number of `W` words in one digest.
 ///
 /// The tree is **balanced only at the digest layer**.
-/// Leaf matrices may have arbitrary heights as long as any two heights
-/// that round **up** to the same power-of-two are equal.
+/// Leaf matrices may have arbitrary heights, but every height must sit on the
+/// `ceil(max_height / 2^k)` ladder anchored at the tallest matrix — the same
+/// requirement `Mmcs::commit` enforces before building a tree.
 ///
 /// Use [`Self::root`] to fetch the final digest once the tree is built.
 ///
@@ -76,18 +77,19 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const N: usize, const DIGES
     /// * `c` – N-to-1 compression function used on digests.
     /// * `leaves` – matrices to commit to. Must be non-empty.
     ///
-    /// Matrices do **not** need to have power-of-two heights. However, any two matrices
-    /// whose heights **round up** to the same power-of-two must have **equal actual height**.
-    /// This ensures proper balancing when folding digests layer-by-layer.
+    /// Matrices do **not** need to have power-of-two heights. However, every height must sit
+    /// on the `ceil(max_height / 2^k)` ladder anchored at the tallest matrix — i.e. at `k`
+    /// halvings above the leaves, the only admissible height is `ceil(max_height / 2^k)`. This
+    /// ensures proper balancing when folding digests layer-by-layer, and that every global leaf
+    /// index maps to a row in every committed matrix.
     ///
     /// All matrices are hashed row-by-row with `h`. The resulting digests are
     /// then folded upwards with `c` until a single root remains.
     ///
     /// # Panics
-    /// * If `leaves` is empty.
+    /// * If `leaves` is empty, or every leaf has height 0.
     /// * If the packing widths of `P` and `PW` differ.
-    /// * If two leaf heights *round up* to the same power-of-two but are not
-    ///   equal (violates balancing rule).
+    /// * If any leaf height is off the `ceil(max_height / 2^k)` ladder.
     #[instrument(name = "build merkle tree", level = "debug", skip_all,
                  fields(dimensions = alloc::format!("{:?}", leaves.iter().map(|l| l.dimensions()).collect::<Vec<_>>())))]
     pub fn new<P, PW, H, C>(h: &H, c: &C, leaves: Vec<M>) -> Self
@@ -108,21 +110,21 @@ impl<F: Clone + Send + Sync, W: Clone, M: Matrix<F>, const N: usize, const DIGES
             assert!(P::WIDTH == PW::WIDTH, "Packing widths must match");
         }
 
+        // Geometry gate: every height must sit on the `ceil(max_height / 2^k)`
+        // ladder anchored at the tallest matrix, or no tree can be built from
+        // them. `Mmcs::commit` enforces the same gate; this constructor is
+        // public, so it must enforce it too rather than fail later with an
+        // out-of-bounds panic deep inside layer construction.
+        if let Err(err) =
+            crate::mmcs::validate_commit_reachable_heights(leaves.iter().map(|l| l.height()))
+        {
+            panic!("{err}");
+        }
+
         let mut leaves_largest_first = leaves
             .iter()
             .sorted_by_key(|l| Reverse(l.height()))
             .peekable();
-
-        // check height property
-        assert!(
-            leaves_largest_first
-                .clone()
-                .map(|m| m.height())
-                .tuple_windows()
-                .all(|(curr, next)| curr == next
-                    || curr.next_power_of_two() != next.next_power_of_two()),
-            "matrix heights that round up to the same power of two must be equal"
-        );
 
         let max_height = leaves_largest_first.peek().unwrap().height();
         let leaf_height_npt = max_height.next_power_of_two();
@@ -694,5 +696,73 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "matrix height 4 incompatible with tallest height 6")]
+    fn new_rejects_heights_off_ladder() {
+        // `MerkleTree::new` is a public constructor that bypasses `Mmcs::commit`'s
+        // geometry gate. Heights 6 and 4 pass the weaker "equal within the same
+        // power-of-two bucket" rule (next_power_of_two(6) = 8, next_power_of_two(4) = 4
+        // — different buckets), but 4 is off the ceil(6 / 2^k) ladder: at k = 1 the
+        // only admissible height is ceil(6 / 2) = 3. Building a tree from these would
+        // panic later, out of bounds, inside a rayon closure — the constructor must
+        // reject it up front instead.
+        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+        use p3_field::Field;
+        use p3_matrix::dense::RowMajorMatrix;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+        use rand::rngs::SmallRng;
+
+        type F = BabyBear;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let mat6 = RowMajorMatrix::<F>::rand(&mut rng, 6, 1);
+        let mat4 = RowMajorMatrix::<F>::rand(&mut rng, 4, 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![mat6, mat4],
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_rejects_single_zero_height_matrix() {
+        // A single height-0 matrix used to build `digest_layers == [[]]`,
+        // and `root()` would panic later. The constructor must reject it directly.
+        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+        use p3_field::Field;
+        use p3_matrix::dense::RowMajorMatrix;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+        use rand::rngs::SmallRng;
+
+        type F = BabyBear;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let empty_mat = RowMajorMatrix::<F>::new(Vec::new(), 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![empty_mat],
+        );
     }
 }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -539,79 +539,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p3_symmetric::PseudoCompressionFunction;
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_field::Field;
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_symmetric::{PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation};
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
     use super::*;
 
-    #[test]
-    #[should_panic(expected = "matrix height 4 incompatible with tallest height 6")]
-    fn new_rejects_heights_off_ladder() {
-        // `MerkleTree::new` is a public constructor that bypasses `Mmcs::commit`'s
-        // geometry gate. Heights 6 and 4 pass the weaker "equal within the same
-        // power-of-two bucket" rule (next_power_of_two(6) = 8, next_power_of_two(4) = 4
-        // — different buckets), but 4 is off the ceil(6 / 2^k) ladder: at k = 1 the
-        // only admissible height is ceil(6 / 2) = 3. Building a tree from these would
-        // panic later, out of bounds, inside a rayon closure — the constructor must
-        // reject it up front instead.
-        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-        use p3_field::Field;
-        use p3_matrix::dense::RowMajorMatrix;
-        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-        use rand::SeedableRng;
-        use rand::rngs::SmallRng;
-
-        type F = BabyBear;
-        type Perm = Poseidon2BabyBear<16>;
-        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-
-        let mut rng = SmallRng::seed_from_u64(0);
-        let perm = Perm::new_from_rng_128(&mut rng);
-        let hash = MyHash::new(perm.clone());
-        let compress = MyCompress::new(perm);
-
-        let mat6 = RowMajorMatrix::<F>::rand(&mut rng, 6, 1);
-        let mat4 = RowMajorMatrix::<F>::rand(&mut rng, 4, 1);
-
-        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
-            &hash,
-            &compress,
-            vec![mat6, mat4],
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn new_rejects_single_zero_height_matrix() {
-        // A single height-0 matrix used to build `digest_layers == [[]]`,
-        // and `root()` would panic later. The constructor must reject it directly.
-        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-        use p3_field::Field;
-        use p3_matrix::dense::RowMajorMatrix;
-        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-        use rand::SeedableRng;
-        use rand::rngs::SmallRng;
-
-        type F = BabyBear;
-        type Perm = Poseidon2BabyBear<16>;
-        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-
-        let mut rng = SmallRng::seed_from_u64(0);
-        let perm = Perm::new_from_rng_128(&mut rng);
-        let hash = MyHash::new(perm.clone());
-        let compress = MyCompress::new(perm);
-
-        let empty_mat = RowMajorMatrix::<F>::new(Vec::new(), 1);
-
-        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
-            &hash,
-            &compress,
-            vec![empty_mat],
-        );
-    }
+    type F = BabyBear;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
 
     #[derive(Clone, Copy)]
     struct DummyCompressionFunction;
@@ -766,5 +706,49 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "matrix height 4 incompatible with tallest height 6")]
+    fn new_rejects_heights_off_ladder() {
+        // `MerkleTree::new` is a public constructor that bypasses `Mmcs::commit`'s
+        // geometry gate. Heights 6 and 4 pass the weaker "equal within the same
+        // power-of-two bucket" rule (next_power_of_two(6) = 8, next_power_of_two(4) = 4
+        // — different buckets), but 4 is off the ceil(6 / 2^k) ladder: at k = 1 the
+        // only admissible height is ceil(6 / 2) = 3. Building a tree from these would
+        // panic later, out of bounds, inside a rayon closure — the constructor must
+        // reject it up front instead.
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let mat6 = RowMajorMatrix::<F>::rand(&mut rng, 6, 1);
+        let mat4 = RowMajorMatrix::<F>::rand(&mut rng, 4, 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![mat6, mat4],
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_rejects_single_zero_height_matrix() {
+        // A single height-0 matrix used to build `digest_layers == [[]]`,
+        // and `root()` would panic later. The constructor must reject it directly.
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let empty_mat = RowMajorMatrix::<F>::new(Vec::new(), 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![empty_mat],
+        );
     }
 }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -545,6 +545,74 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    #[should_panic(expected = "matrix height 4 incompatible with tallest height 6")]
+    fn new_rejects_heights_off_ladder() {
+        // `MerkleTree::new` is a public constructor that bypasses `Mmcs::commit`'s
+        // geometry gate. Heights 6 and 4 pass the weaker "equal within the same
+        // power-of-two bucket" rule (next_power_of_two(6) = 8, next_power_of_two(4) = 4
+        // — different buckets), but 4 is off the ceil(6 / 2^k) ladder: at k = 1 the
+        // only admissible height is ceil(6 / 2) = 3. Building a tree from these would
+        // panic later, out of bounds, inside a rayon closure — the constructor must
+        // reject it up front instead.
+        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+        use p3_field::Field;
+        use p3_matrix::dense::RowMajorMatrix;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+        use rand::rngs::SmallRng;
+
+        type F = BabyBear;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let mat6 = RowMajorMatrix::<F>::rand(&mut rng, 6, 1);
+        let mat4 = RowMajorMatrix::<F>::rand(&mut rng, 4, 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![mat6, mat4],
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_rejects_single_zero_height_matrix() {
+        // A single height-0 matrix used to build `digest_layers == [[]]`,
+        // and `root()` would panic later. The constructor must reject it directly.
+        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+        use p3_field::Field;
+        use p3_matrix::dense::RowMajorMatrix;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+        use rand::rngs::SmallRng;
+
+        type F = BabyBear;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+
+        let mut rng = SmallRng::seed_from_u64(0);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let empty_mat = RowMajorMatrix::<F>::new(Vec::new(), 1);
+
+        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
+            &hash,
+            &compress,
+            vec![empty_mat],
+        );
+    }
+
     #[derive(Clone, Copy)]
     struct DummyCompressionFunction;
 
@@ -698,73 +766,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    #[should_panic(expected = "matrix height 4 incompatible with tallest height 6")]
-    fn new_rejects_heights_off_ladder() {
-        // `MerkleTree::new` is a public constructor that bypasses `Mmcs::commit`'s
-        // geometry gate. Heights 6 and 4 pass the weaker "equal within the same
-        // power-of-two bucket" rule (next_power_of_two(6) = 8, next_power_of_two(4) = 4
-        // — different buckets), but 4 is off the ceil(6 / 2^k) ladder: at k = 1 the
-        // only admissible height is ceil(6 / 2) = 3. Building a tree from these would
-        // panic later, out of bounds, inside a rayon closure — the constructor must
-        // reject it up front instead.
-        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-        use p3_field::Field;
-        use p3_matrix::dense::RowMajorMatrix;
-        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-        use rand::SeedableRng;
-        use rand::rngs::SmallRng;
-
-        type F = BabyBear;
-        type Perm = Poseidon2BabyBear<16>;
-        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-
-        let mut rng = SmallRng::seed_from_u64(0);
-        let perm = Perm::new_from_rng_128(&mut rng);
-        let hash = MyHash::new(perm.clone());
-        let compress = MyCompress::new(perm);
-
-        let mat6 = RowMajorMatrix::<F>::rand(&mut rng, 6, 1);
-        let mat4 = RowMajorMatrix::<F>::rand(&mut rng, 4, 1);
-
-        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
-            &hash,
-            &compress,
-            vec![mat6, mat4],
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn new_rejects_single_zero_height_matrix() {
-        // A single height-0 matrix used to build `digest_layers == [[]]`,
-        // and `root()` would panic later. The constructor must reject it directly.
-        use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-        use p3_field::Field;
-        use p3_matrix::dense::RowMajorMatrix;
-        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-        use rand::SeedableRng;
-        use rand::rngs::SmallRng;
-
-        type F = BabyBear;
-        type Perm = Poseidon2BabyBear<16>;
-        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-
-        let mut rng = SmallRng::seed_from_u64(0);
-        let perm = Perm::new_from_rng_128(&mut rng);
-        let hash = MyHash::new(perm.clone());
-        let compress = MyCompress::new(perm);
-
-        let empty_mat = RowMajorMatrix::<F>::new(Vec::new(), 1);
-
-        let _ = MerkleTree::new::<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress>(
-            &hash,
-            &compress,
-            vec![empty_mat],
-        );
     }
 }

--- a/merkle-tree/src/mmcs/error.rs
+++ b/merkle-tree/src/mmcs/error.rs
@@ -152,4 +152,16 @@ pub enum PrunedProofError {
         /// Leaf index the proof actually opens for this query.
         got: usize,
     },
+
+    /// A non-lead member of a merged path group disagrees with the group's
+    /// lead on the opened row of a matrix injected at their shared layer.
+    #[error(
+        "unique path slot {slot} disagrees with its group's lead on matrix {matrix}'s opened row"
+    )]
+    InconsistentGroupOpening {
+        /// Unique-path slot of the disagreeing group member.
+        slot: usize,
+        /// Index (into the caller-supplied `dimensions`) of the matrix whose opened row diverges.
+        matrix: usize,
+    },
 }

--- a/merkle-tree/src/mmcs/geometry.rs
+++ b/merkle-tree/src/mmcs/geometry.rs
@@ -502,6 +502,38 @@ mod tests {
         }
     }
 
+    #[test]
+    fn replay_arity_and_positions_rejects_oversized_proof_len() {
+        // Once the walk reaches the root, there is no level left to replay.
+        // An oversized `num_opening_proofs` must be rejected, not answered
+        // with fabricated trailing schedule entries.
+        let mut rng = SmallRng::seed_from_u64(321);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0);
+
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 32, 4);
+        let dims = vec![mat.dimensions()];
+        let (_commit, prover_data) = mmcs.commit(vec![mat]);
+
+        let index = 5usize;
+        let opening = mmcs.open_batch(index, &prover_data);
+        let (_opened_values, proof) = opening.unpack();
+
+        let result = mmcs.replay_arity_and_positions(&dims, index, proof.len() + 1);
+        assert!(
+            matches!(
+                result,
+                Err(MerkleTreeError::WrongHeight {
+                    expected_proof_len,
+                    num_siblings,
+                }) if expected_proof_len == proof.len() && num_siblings == proof.len() + 1
+            ),
+            "an oversized proof length must be rejected instead of fabricating levels, got {result:?}"
+        );
+    }
+
     mod proptests {
         use alloc::vec::Vec;
 

--- a/merkle-tree/src/mmcs/mod.rs
+++ b/merkle-tree/src/mmcs/mod.rs
@@ -132,73 +132,34 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         PW: PackedValue,
     {
         // Geometry gate: the claimed heights must form a tree the commitment can build.
-        // The tallest height anchors the index bound and the leaf layer width below.
+        // The tallest height bounds the index below.
         let max_height =
             validate_commit_reachable_heights(dimensions.iter().map(|dims| dims.height))?;
-
-        let mut heights_tallest_first = dimensions
-            .iter()
-            .enumerate()
-            .sorted_by_key(|(_, dims)| Reverse(dims.height))
-            .peekable();
-
-        // Leaf layer width before the walk starts, padded to a full N-ary group.
-        let mut curr_height_padded = padded_len(max_height, N);
 
         if index >= max_height {
             return Err(IndexOutOfBounds { max_height, index });
         }
 
-        let leaf_height_npt = max_height.next_power_of_two();
+        // The authoritative schedule, derived the same way `verify_batch` derives
+        // it: it already stops at the root and excludes cap layers, so there is
+        // no level left to fabricate once it is exhausted.
+        let arity_schedule = self.proof_arity_schedule(dimensions)?;
+        let expected_proof_len: usize = arity_schedule.iter().map(|step| step - 1).sum();
+        if num_opening_proofs != expected_proof_len {
+            return Err(WrongHeight {
+                expected_proof_len,
+                num_siblings: num_opening_proofs,
+            });
+        }
 
-        // Consume tallest matrices (mirrors verify_batch's initial hash step).
-        heights_tallest_first
-            .peeking_take_while(|(_, dims)| dims.height.next_power_of_two() == leaf_height_npt)
-            .for_each(|_| {});
-
-        let mut proof_pos: usize = 0;
-        let mut steps = Vec::new();
-        let mut positions = Vec::new();
-
-        while proof_pos < num_opening_proofs {
-            let step = select_arity_step::<N>(
-                curr_height_padded,
-                leaf_height_npt,
-                heights_tallest_first.clone().map(|(_, dims)| dims.height),
-            );
-
-            let num_siblings = step - 1;
-            if proof_pos + num_siblings > num_opening_proofs {
-                return Err(WrongHeight {
-                    expected_proof_len: proof_pos + num_siblings,
-                    num_siblings: num_opening_proofs,
-                });
-            }
-            proof_pos += num_siblings;
-
-            let pos_in_group = index % step;
-            steps.push(step);
-            positions.push(pos_in_group);
-
+        let mut positions = Vec::with_capacity(arity_schedule.len());
+        for &step in &arity_schedule {
+            positions.push(index % step);
             index /= step;
-            let logical_next = curr_height_padded / step;
-            curr_height_padded = padded_len(logical_next, N);
-
-            // Mimic `verify_batch` but skip hashing values
-            let logical_next_npt = logical_next.next_power_of_two();
-            let next_height = heights_tallest_first
-                .peek()
-                .map(|(_, dims)| dims.height)
-                .filter(|h| h.next_power_of_two() == logical_next_npt);
-            if let Some(next_height) = next_height {
-                heights_tallest_first
-                    .peeking_take_while(|(_, dims)| dims.height == next_height)
-                    .for_each(|_| {});
-            }
         }
 
         Ok(ArityAndPositions {
-            arity_schedule: steps,
+            arity_schedule,
             query_positions: positions,
         })
     }
@@ -707,6 +668,13 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         let mut lead: Vec<usize> = (0..n_unique).collect();
         let mut sibling_cursor: Vec<usize> = vec![0usize; n_unique];
 
+        // Sorted-path-slot range `[group_lo[g], group_hi[g])` merged into
+        // group `g` so far. Sorted paths only ever merge with contiguous
+        // neighbors, so a group's original members always form a contiguous
+        // slot range — no need to track a full member list.
+        let mut group_lo: Vec<usize> = (0..n_unique).collect();
+        let mut group_hi: Vec<usize> = (1..=n_unique).collect();
+
         let default_digest = [PW::Value::default(); DIGEST_ELEMS];
 
         // Reusable scratch — refilled inside the inner loop, never read across iterations.
@@ -714,6 +682,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         let mut new_indices: Vec<usize> = Vec::with_capacity(n_unique);
         let mut new_lead: Vec<usize> = Vec::with_capacity(n_unique);
         let mut new_cursor: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_group_lo: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_group_hi: Vec<usize> = Vec::with_capacity(n_unique);
 
         // Phase 8: Walk up the tree. At each layer we collapse contiguous
         // groups of unique paths that share a parent, replacing each group
@@ -725,6 +695,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
             new_indices.clear();
             new_lead.clear();
             new_cursor.clear();
+            new_group_lo.clear();
+            new_group_hi.clear();
 
             let mut i = 0;
             while i < digests.len() {
@@ -778,6 +750,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
                 new_indices.push(parent_idx);
                 new_lead.push(lead_path);
                 new_cursor.push(cursor_start + num_siblings_per_path);
+                new_group_lo.push(group_lo[i]);
+                new_group_hi.push(group_hi[j - 1]);
 
                 i = j;
             }
@@ -786,6 +760,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
             core::mem::swap(&mut node_indices, &mut new_indices);
             core::mem::swap(&mut lead, &mut new_lead);
             core::mem::swap(&mut sibling_cursor, &mut new_cursor);
+            core::mem::swap(&mut group_lo, &mut new_group_lo);
+            core::mem::swap(&mut group_hi, &mut new_group_hi);
 
             // Layer geometry update mirrors `verify_batch`.
             let logical_next = curr_height_padded / step;
@@ -807,6 +783,29 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
 
                 for g in 0..digests.len() {
                     let rep_orig = reps[lead[g]];
+
+                    // Every sorted-path slot merged into this group shares the
+                    // same reduced row index into the injected matrices, so an
+                    // honest prover reports the same row for all of them. Only
+                    // the lead's row is hashed below, so every other member
+                    // must be checked explicitly against it here.
+                    for (slot, &member_orig) in
+                        reps.iter().enumerate().take(group_hi[g]).skip(group_lo[g])
+                    {
+                        if slot == lead[g] {
+                            continue;
+                        }
+                        for &mi in &inject_matrix_indices {
+                            if opened_values[member_orig][mi] != opened_values[rep_orig][mi] {
+                                return Err(PrunedProofError::InconsistentGroupOpening {
+                                    slot,
+                                    matrix: mi,
+                                }
+                                .into());
+                            }
+                        }
+                    }
+
                     let next_height_digest = self.hash.hash_iter_slices(
                         inject_matrix_indices
                             .iter()

--- a/merkle-tree/src/mmcs/pruned.rs
+++ b/merkle-tree/src/mmcs/pruned.rs
@@ -428,6 +428,43 @@ mod tests {
     }
 
     #[test]
+    fn pruned_amortized_rejects_tampered_non_lead_group_injection() {
+        // Two distinct leaves (0 and 1) merge into one path-sharing group at
+        // the very first layer above the leaves, exactly where the shorter
+        // matrix gets injected. Only the group's lead path hashes its row of
+        // the injected matrix into the tree; every other member's claimed
+        // row for that matrix must still be checked against the lead's,
+        // or a prover could substitute an arbitrary row for it.
+        let seed = 61u64;
+        let mmcs = make_binary_mmcs(seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mat1 = RowMajorMatrix::<F>::rand(&mut rng, 8, 4);
+        let mat2 = RowMajorMatrix::<F>::rand(&mut rng, 4, 6);
+        let dims = vec![mat1.dimensions(), mat2.dimensions()];
+        let (commit, prover_data) = mmcs.commit(vec![mat1, mat2]);
+
+        let indices: Vec<usize> = vec![0, 1];
+        let mut pruned = mmcs.open_batch_pruned(&indices, &prover_data);
+
+        // Query index 1 is the non-lead member of the group. Tamper with its
+        // claimed row for the injected (shorter) matrix, index 1.
+        pruned.opened_values[1][1][0] = F::from_u32(999999);
+
+        let result = mmcs.verify_batch_pruned(
+            &commit,
+            &dims,
+            &indices,
+            &pruned.opened_values,
+            &pruned.pruned_proof,
+        );
+        assert!(
+            result.is_err(),
+            "a tampered non-lead group member's injected-matrix row must be rejected"
+        );
+    }
+
+    #[test]
     fn pruned_amortized_cap_height_nonzero_binary() {
         // Invariant: surviving group digests land in cap[idx >> 4], not the root.
         //

--- a/mersenne-31/src/x86_64_avx2/packing.rs
+++ b/mersenne-31/src/x86_64_avx2/packing.rs
@@ -365,8 +365,10 @@ fn square_unred(x: __m256i) -> __m256i {
 }
 
 /// Compute the permutation x -> x^5 on Mersenne-31 field elements
-/// represented as values in {0, ..., P}. If the inputs do not conform
-/// to this representation, the result is undefined.
+/// represented as signed values in {-P, ..., P}, producing output in {0, ..., P}.
+/// If the inputs do not conform to this representation, the result is undefined.
+/// The Poseidon2 round-constant addition in `input_plus_rc` (utils.rs) relies on
+/// this signed input range, since round constants are added in their negative form.
 #[inline(always)]
 pub(crate) fn exp5(x: __m256i) -> __m256i {
     unsafe {

--- a/mersenne-31/src/x86_64_avx512/packing.rs
+++ b/mersenne-31/src/x86_64_avx512/packing.rs
@@ -379,8 +379,10 @@ fn square_unred(x: __m512i) -> __m512i {
 }
 
 /// Compute the permutation x -> x^5 on Mersenne-31 field elements
-/// represented as values in {0, ..., P}. If the inputs do not conform
-/// to this representation, the result is undefined.
+/// represented as signed values in {-P, ..., P}, producing output in {0, ..., P}.
+/// If the inputs do not conform to this representation, the result is undefined.
+/// The Poseidon2 round-constant addition in `input_plus_rc` (utils.rs) relies on
+/// this signed input range, since round constants are added in their negative form.
 #[inline(always)]
 pub(crate) fn exp5(x: __m512i) -> __m512i {
     unsafe {

--- a/rescue/src/rescue.rs
+++ b/rescue/src/rescue.rs
@@ -22,11 +22,13 @@ impl<F, Mds, const WIDTH: usize, const ALPHA: u64> Rescue<F, Mds, WIDTH, ALPHA>
 where
     F: PrimeField + PermutationMonomial<ALPHA>,
 {
-    pub const fn new(num_rounds: usize, round_constants: Vec<F>, mds: Mds) -> Self {
+    /// `round_constants` must have length `2 * WIDTH * num_rounds`.
+    pub fn new(num_rounds: usize, round_constants: Vec<F>, mds: Mds) -> Self {
         const {
             assert!(WIDTH > 0);
             assert!(ALPHA > 1);
         }
+        assert_eq!(round_constants.len(), 2 * WIDTH * num_rounds);
         Self {
             num_rounds,
             mds,
@@ -90,6 +92,7 @@ where
     {
         let num_constants = 2 * WIDTH * num_rounds;
         let bytes_per_constant = F::bits().div_ceil(8) + 1;
+        assert!((1..=16).contains(&bytes_per_constant));
         let num_bytes = bytes_per_constant * num_constants;
 
         let seed_string = format!(
@@ -107,8 +110,8 @@ where
                 let integer = chunk
                     .iter()
                     .rev()
-                    .fold(0, |acc, &byte| (acc << 8) + byte as u64);
-                F::from_u64(integer)
+                    .fold(0u128, |acc, &byte| (acc << 8) | byte as u128);
+                F::from_u128(integer)
             })
             .collect()
     }

--- a/rescue/src/rpo/baby_bear.rs
+++ b/rescue/src/rpo/baby_bear.rs
@@ -158,11 +158,23 @@ fn inv_sbox_x7<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
+    use p3_field::{PrimeCharacteristicRing, PrimeField64};
     use p3_symmetric::Permutation;
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn seed_matches_consts() {
+        let expected = alloc::format!(
+            "RPO-BB:p={},m={},c={},n={}",
+            BabyBear::ORDER_U64,
+            RPO_BB_WIDTH,
+            RPO_BB_CAPACITY,
+            RPO_BB_NUM_ROUNDS,
+        );
+        assert_eq!(RPO_BB_SEED, expected);
+    }
 
     /// Permutation regression vector for input `[0, 1, …, 23]`.
     ///

--- a/rescue/src/rpo/koala_bear.rs
+++ b/rescue/src/rpo/koala_bear.rs
@@ -156,11 +156,23 @@ fn inv_sbox_x3<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
+    use p3_field::{PrimeCharacteristicRing, PrimeField64};
     use p3_symmetric::Permutation;
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn seed_matches_consts() {
+        let expected = alloc::format!(
+            "RPO-KB:p={},m={},c={},n={}",
+            KoalaBear::ORDER_U64,
+            RPO_KB_WIDTH,
+            RPO_KB_CAPACITY,
+            RPO_KB_NUM_ROUNDS,
+        );
+        assert_eq!(RPO_KB_SEED, expected);
+    }
 
     /// Permutation regression vector for input `[0, 1, …, 23]`.
     ///

--- a/rescue/src/rpo/mersenne_31.rs
+++ b/rescue/src/rpo/mersenne_31.rs
@@ -290,11 +290,23 @@ fn inv_sbox_x5<R: PrimeCharacteristicRing + Copy, const N: usize>(state: &mut [R
 
 #[cfg(test)]
 mod tests {
-    use p3_field::PrimeCharacteristicRing;
+    use p3_field::{PrimeCharacteristicRing, PrimeField64};
     use p3_symmetric::Permutation;
     use proptest::prelude::*;
 
     use super::*;
+
+    #[test]
+    fn seed_matches_consts() {
+        let expected = alloc::format!(
+            "RPO\u{2011}M31:p={},m={},c={},n={}",
+            Mersenne31::ORDER_U64,
+            RPO_M31_WIDTH,
+            RPO_M31_CAPACITY,
+            RPO_M31_NUM_ROUNDS,
+        );
+        assert_eq!(RPO_M31_SEED, expected);
+    }
 
     /// Reference dense matrix-vector product against the circulant coefficients.
     fn mds_naive(input: [Mersenne31; RPO_M31_WIDTH]) -> [Mersenne31; RPO_M31_WIDTH] {

--- a/sumcheck/src/constraints/statement/eq.rs
+++ b/sumcheck/src/constraints/statement/eq.rs
@@ -162,9 +162,9 @@ pub struct EqStatement<F> {
     /// Number of variables in the multilinear polynomial space.
     num_variables: usize,
     /// List of evaluation points.
-    pub points: Vec<Point<F>>,
+    points: Vec<Point<F>>,
     /// List of target evaluations.
-    pub evaluations: Vec<F>,
+    evaluations: Vec<F>,
 }
 
 impl<F: Field> EqStatement<F> {

--- a/sumcheck/src/constraints/statement/next.rs
+++ b/sumcheck/src/constraints/statement/next.rs
@@ -34,7 +34,7 @@ pub struct NextStatement<F> {
     /// The slot-local successor constraints in their stored order.
     constraints: Vec<NextConstraint<F>>,
     /// Claimed successor evaluation of each constraint, aligned with the constraints above.
-    pub evaluations: Vec<F>,
+    evaluations: Vec<F>,
 }
 
 impl<F: Field> NextStatement<F> {

--- a/symmetric/src/sponge.rs
+++ b/symmetric/src/sponge.rs
@@ -109,11 +109,20 @@ use crate::permutation::{CryptographicPermutation, Derangement};
 /// holds as long as the stored increment is non-zero.
 ///
 /// ```ignore
-/// Increment(BabyBear::ONE)   // d(x) = x + 1  for field elements
-/// Increment(1u64)            // d(x) = x + 1  for raw integers
+/// Increment::new(BabyBear::ONE)   // d(x) = x + 1  for field elements
+/// Increment::new(1u64)            // d(x) = x + 1  for raw integers
 /// ```
 #[derive(Copy, Clone, Debug)]
-pub struct Increment<T>(pub T);
+pub struct Increment<T>(T);
+
+impl<T: Default + PartialEq> Increment<T> {
+    /// Builds an increment padding function, panicking if `inc` is the
+    /// additive identity (which would make `d(x) = x`, not a derangement).
+    pub fn new(inc: T) -> Self {
+        assert!(inc != T::default());
+        Self(inc)
+    }
+}
 
 impl<T: Clone + Sync + Send + Add<Output = T>> Permutation<T> for Increment<T> {
     fn permute(&self, input: T) -> T {
@@ -157,7 +166,8 @@ impl<P, const WIDTH: usize, const RATE: usize, const OUT: usize>
         const {
             assert!(RATE > 0);
             assert!(RATE < WIDTH);
-            assert!(OUT <= WIDTH);
+            assert!(OUT > 0);
+            assert!(OUT <= RATE);
         }
         Self { permutation }
     }
@@ -254,8 +264,8 @@ where
 /// points). The standard choice is `Increment` which computes d(x) = x + 1:
 ///
 /// ```ignore
-/// Pad10Sponge::new(permutation, Increment(BabyBear::ONE))  // field
-/// Pad10Sponge::new(permutation, Increment(1u64))           // integer
+/// Pad10Sponge::new(permutation, Increment::new(BabyBear::ONE))  // field
+/// Pad10Sponge::new(permutation, Increment::new(1u64))           // integer
 /// ```
 ///
 /// The derangement **must have no fixed points** (d(x) != x for all x).
@@ -309,7 +319,8 @@ impl<T, P, D, const WIDTH: usize, const RATE: usize, const OUT: usize>
         const {
             assert!(RATE > 0);
             assert!(RATE < WIDTH);
-            assert!(OUT <= WIDTH);
+            assert!(OUT > 0);
+            assert!(OUT <= RATE);
         }
         Self {
             permutation,
@@ -421,7 +432,8 @@ where
         const {
             assert!(RATE > 0);
             assert!(RATE < WIDTH);
-            assert!(OUT <= WIDTH);
+            assert!(OUT > 0);
+            assert!(OUT <= RATE);
         }
         if F::order() >= PF::order() {
             return Err(String::from("F::order() must be less than PF::order()"));
@@ -453,7 +465,8 @@ where
         const {
             assert!(RATE > 0);
             assert!(RATE < WIDTH);
-            assert!(OUT <= WIDTH);
+            assert!(OUT > 0);
+            assert!(OUT <= RATE);
         }
         let mut state = [PF::default(); WIDTH];
 
@@ -534,7 +547,8 @@ where
         const {
             assert!(RATE > 0);
             assert!(RATE < WIDTH);
-            assert!(OUT <= WIDTH);
+            assert!(OUT > 0);
+            assert!(OUT <= RATE);
         }
         if F::order() >= PF::order() {
             return Err(String::from("F::order() must be less than PF::order()"));
@@ -771,7 +785,7 @@ mod tests {
         let sponge =
             Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
         let a = KoalaBear::new(42);
@@ -791,7 +805,7 @@ mod tests {
         let sponge =
             Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
         let a = KoalaBear::new(1);
@@ -814,7 +828,7 @@ mod tests {
         let sponge =
             Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
         let output = sponge.hash_iter(core::iter::empty::<KoalaBear>());
@@ -852,7 +866,7 @@ mod tests {
         let sponge =
             Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
         let input = [1u32, 2, 3, 4, 5].map(KoalaBear::new);
@@ -878,7 +892,7 @@ mod tests {
         let sponge =
             Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 6, 3, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
         let input = [10u32, 20, 30].map(KoalaBear::new);
@@ -903,7 +917,7 @@ mod tests {
             // This is the exact attack that padding prevents.
             let sponge = Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
             // Hash the base message.
@@ -932,7 +946,7 @@ mod tests {
             // Invariant: hash(x) == hash(x). No hidden mutable state.
             let sponge = Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
             // Hash the input twice with independent iterator clones.
@@ -952,7 +966,7 @@ mod tests {
             // Tests collision resistance across arbitrary length gaps.
             let sponge = Pad10Sponge::<KoalaBear, WeightedSumPermutation, Increment<KoalaBear>, 4, 2, 2>::new(
                 WeightedSumPermutation,
-                Increment(KoalaBear::ONE),
+                Increment::new(KoalaBear::ONE),
             );
 
             // Hash the full input.

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -345,13 +345,21 @@ where
     let mut challenger = config.initialise_challenger();
     let init_trace_domain = pcs.natural_domain_for_degree(degree >> config.is_zk());
 
-    let (_, quotient_domain_size) = checked_log_size_sum(degree_bits, log_num_quotient_chunks)
-        .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
-            air: None,
-            maximum: usize::BITS as usize - 1,
-            got: degree_bits.saturating_add(log_num_quotient_chunks),
+    let (quotient_domain_log_size, quotient_domain_size) =
+        checked_log_size_sum(degree_bits, log_num_quotient_chunks).ok_or_else(|| {
+            InvalidProofShapeError::QuotientDomainTooLarge {
+                air: None,
+                maximum: usize::BITS as usize - 1,
+                got: degree_bits.saturating_add(log_num_quotient_chunks),
+            }
         })?;
-    let quotient_domain = trace_domain.create_disjoint_domain(quotient_domain_size);
+    let quotient_domain = trace_domain
+        .try_create_disjoint_domain(quotient_domain_size)
+        .ok_or(InvalidProofShapeError::QuotientDomainTooLarge {
+            air: None,
+            maximum: pcs.log_max_lde_height(),
+            got: quotient_domain_log_size,
+        })?;
     let quotient_chunks_domains = quotient_domain.split_domains(num_quotient_chunks);
 
     let randomized_quotient_chunks_domains = quotient_chunks_domains

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -215,7 +215,7 @@ pub const fn reverse_bits_len(x: usize, bit_len: usize) -> usize {
 
 // Lookup table of 6-bit reverses.
 // NB: 2^6=64 bytes is a cache line. A smaller table wastes cache space.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 #[rustfmt::skip]
 const BIT_REVERSE_6BIT: &[u8] = &[
     0o00, 0o40, 0o20, 0o60, 0o10, 0o50, 0o30, 0o70,
@@ -301,7 +301,7 @@ where
 // where reverse_bits(i, n_power) computes the n_power-bit reverse. The complications are there
 // to guide the compiler to generate optimal assembly.
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     if lb_n <= 6 {
         // BIT_REVERSE_6BIT holds 6-bit reverses. This shift makes them lb_n-bit reverses.
@@ -334,9 +334,8 @@ fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-const fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
+fn reverse_slice_index_bits_small<F>(vals: &mut [F], lb_n: usize) {
     // Aarch64 can reverse bits in one instruction, so the trivial version works best.
-    // use manual `while` loop to enable `const`
     let mut src = 0;
     while src < vals.len() {
         let dst = src.reverse_bits().wrapping_shr(usize::BITS - lb_n as u32);
@@ -891,9 +890,10 @@ impl<T> DisjointMutPtr<T> {
     /// # Safety
     ///
     /// The caller must ensure the range `[offset, offset+len)` is within bounds
-    /// and does not overlap with any other concurrent access.
+    /// and does not overlap with any other concurrent access. The returned
+    /// slice must not outlive the buffer passed to [`Self::new`].
     #[inline]
-    pub const unsafe fn slice_mut(self, offset: usize, len: usize) -> &'static mut [T] {
+    pub const unsafe fn slice_mut<'a>(self, offset: usize, len: usize) -> &'a mut [T] {
         unsafe { core::slice::from_raw_parts_mut(self.0.add(offset), len) }
     }
 }

--- a/whir/src/fiat_shamir/domain_separator.rs
+++ b/whir/src/fiat_shamir/domain_separator.rs
@@ -50,16 +50,23 @@ pub(crate) struct ZkSumcheckParams {
 ///
 /// # Transcript Operation Encoding
 ///
-/// Each transcript step is encoded as a single field element:
+/// Each transcript step is encoded as a single field element with
+/// non-overlapping bit ranges for each component:
 ///
 /// ```text
-///     element = pattern_tag + sub_label + count
+///     element = (pattern_tag << (COUNT_BITS + LABEL_BITS))
+///              | (sub_label << COUNT_BITS)
+///              | count
 /// ```
 ///
 /// where:
 /// - `pattern_tag` distinguishes observe / sample / hint.
 /// - `sub_label` identifies the semantic role (e.g., Merkle digest, folding randomness).
-/// - `count` is the number of field elements involved (omitted for hints).
+/// - `count` is the number of field elements involved (zero for hints).
+///
+/// Packing into disjoint bit ranges (rather than summing the three values)
+/// keeps the encoding injective: distinct `(tag, label, count)` triples
+/// always produce distinct field elements.
 ///
 /// # Evaluation Claims Are Not Absorbed Here
 ///
@@ -94,6 +101,25 @@ pub struct DomainSeparator<EF, F> {
     _extension_field: PhantomData<EF>,
 }
 
+/// Number of bits allotted to the `count` component of an encoded entry.
+const COUNT_BITS: u32 = 16;
+
+/// Number of bits allotted to the `sub_label` component of an encoded entry.
+const LABEL_BITS: u32 = 8;
+
+/// Packs a pattern tag, sub-label, and count into one field element using
+/// disjoint bit ranges, so that distinct `(tag, label, count)` triples
+/// always produce distinct field elements.
+fn encode_entry<F: Field>(tag: Pattern, label: u8, count: usize) -> F {
+    debug_assert!(
+        count < (1 << COUNT_BITS),
+        "domain separator count exceeds the {COUNT_BITS}-bit budget"
+    );
+    let packed =
+        ((tag as usize) << (COUNT_BITS + LABEL_BITS)) | ((label as usize) << COUNT_BITS) | count;
+    F::from_usize(packed)
+}
+
 impl<EF, F> DomainSeparator<EF, F>
 where
     EF: ExtensionField<F>,
@@ -110,20 +136,14 @@ where
 
     /// Record that the prover observes `count` field elements into the sponge.
     pub(crate) fn observe(&mut self, count: usize, pattern: Observe) {
-        self.pattern.push(
-            pattern.as_field_element::<F>()
-                + F::from_usize(count)
-                + Pattern::Observe.as_field_element::<F>(),
-        );
+        self.pattern
+            .push(encode_entry::<F>(Pattern::Observe, pattern as u8, count));
     }
 
     /// Record that the verifier samples `count` field elements from the sponge.
     pub(crate) fn sample(&mut self, count: usize, pattern: Sample) {
-        self.pattern.push(
-            pattern.as_field_element::<F>()
-                + F::from_usize(count)
-                + Pattern::Sample.as_field_element::<F>(),
-        );
+        self.pattern
+            .push(encode_entry::<F>(Pattern::Sample, pattern as u8, count));
     }
 
     /// Encode a public protocol parameter into the domain separator.
@@ -136,10 +156,11 @@ where
     /// configuration, preventing cross-protocol transcript reuse.
     fn protocol_param(&mut self, value: usize) {
         // Constant marker: observe tag + protocol-param sub-label.
-        self.pattern.push(
-            Observe::ProtocolParam.as_field_element::<F>()
-                + Pattern::Observe.as_field_element::<F>(),
-        );
+        self.pattern.push(encode_entry::<F>(
+            Pattern::Observe,
+            Observe::ProtocolParam as u8,
+            0,
+        ));
         // Raw parameter value.
         self.pattern.push(F::from_usize(value));
     }
@@ -147,7 +168,7 @@ where
     /// Record a non-binding hint from the prover.
     pub(crate) fn hint(&mut self, pattern: Hint) {
         self.pattern
-            .push(pattern.as_field_element::<F>() + Pattern::Hint.as_field_element::<F>());
+            .push(encode_entry::<F>(Pattern::Hint, pattern as u8, 0));
     }
 
     /// Absorb the entire domain separator pattern into the challenger.
@@ -516,15 +537,19 @@ where
     /// Optionally append a proof-of-work challenge.
     ///
     /// When `bits` is positive, encodes:
-    /// 1. Sampling a 32-byte challenge from the sponge.
-    /// 2. Observing an 8-byte nonce that satisfies the grinding condition.
+    /// 1. A `Sample::PowQueries` entry marking the grinding challenge.
+    /// 2. A `Observe::PowNonce` entry marking the nonce that solves it.
+    ///
+    /// The accompanying counts are fixed shape descriptors for domain
+    /// separation; they do not correspond to a literal number of bytes or
+    /// field elements sampled/observed by `grind`/`check_witness`.
     ///
     /// When `bits` is zero, nothing is appended.
     pub(crate) fn pow(&mut self, bits: usize) {
         if bits > 0 {
-            // Sample a 32-byte PoW challenge preimage.
+            // Mark the PoW challenge (see doc comment above for the count's meaning).
             self.sample(32, Sample::PowQueries);
-            // Observe the nonce that solves the challenge.
+            // Mark the nonce that solves the challenge.
             self.observe(8, Observe::PowNonce);
         }
     }
@@ -535,7 +560,6 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
 
     use super::*;
@@ -544,15 +568,11 @@ mod tests {
     type EF = BinomialExtensionField<F, 4>;
 
     fn observe_entry(count: usize, observe: Observe) -> F {
-        observe.as_field_element::<F>()
-            + F::from_usize(count)
-            + Pattern::Observe.as_field_element::<F>()
+        encode_entry::<F>(Pattern::Observe, observe as u8, count)
     }
 
     fn sample_entry(count: usize, sample: Sample) -> F {
-        sample.as_field_element::<F>()
-            + F::from_usize(count)
-            + Pattern::Sample.as_field_element::<F>()
+        encode_entry::<F>(Pattern::Sample, sample as u8, count)
     }
 
     #[test]

--- a/whir/src/fiat_shamir/pattern.rs
+++ b/whir/src/fiat_shamir/pattern.rs
@@ -1,7 +1,5 @@
 //! Transcript pattern labels for the Fiat-Shamir domain separator.
 
-use p3_field::Field;
-
 /// Top-level classification of a transcript operation.
 ///
 /// Each step in the protocol transcript is one of three kinds:
@@ -21,14 +19,6 @@ pub enum Pattern {
     Hint,
 }
 
-impl Pattern {
-    /// Convert to a field element using the enum discriminant.
-    #[must_use]
-    pub fn as_field_element<F: Field>(self) -> F {
-        F::from_u8(self as u8)
-    }
-}
-
 /// Sub-labels for sampled (verifier-drawn) transcript items.
 ///
 /// Each variant identifies the semantic role of a challenge or
@@ -41,11 +31,23 @@ pub enum Sample {
     FoldingRandomness,
     /// Randomness for combining quotient polynomials after each round.
     CombinationRandomness,
-    /// Byte-encoded query positions for STIR proximity tests.
+    /// Query positions for STIR proximity tests.
+    ///
+    /// The accompanying count is a shape descriptor (query count times the
+    /// domain's bit-length in bytes), sized only to vary with the query
+    /// geometry for domain separation. It does not equal the number of
+    /// field elements the challenger actually draws (queries are sampled
+    /// via `sample_uniform_bits`, one to two field samples per index).
     StirQueries,
-    /// Byte-encoded query positions for the final proximity test.
+    /// Query positions for the final proximity test.
+    ///
+    /// See [`Self::StirQueries`]: the count is a shape descriptor, not a
+    /// literal field-sample count.
     FinalQueries,
-    /// Challenge bytes for proof-of-work grinding.
+    /// Proof-of-work grinding challenge.
+    ///
+    /// The accompanying count is a shape descriptor, not the literal number
+    /// of field elements sampled by `grind`.
     PowQueries,
     /// Out-of-domain evaluation point.
     OodQuery,
@@ -57,14 +59,6 @@ pub enum Sample {
     TranscriptCheckpoint,
     /// Combining challenge `eps` in the HVZK sumcheck overlay.
     ZkSumcheckCombinationRandomness,
-}
-
-impl Sample {
-    /// Convert to a field element using the enum discriminant.
-    #[must_use]
-    pub fn as_field_element<F: Field>(self) -> F {
-        F::from_u8(self as u8)
-    }
 }
 
 /// Sub-labels for observed (prover-absorbed) transcript items.
@@ -107,14 +101,6 @@ pub enum Observe {
     ZkBaseCaseReveal,
 }
 
-impl Observe {
-    /// Convert to a field element using the enum discriminant.
-    #[must_use]
-    pub fn as_field_element<F: Field>(self) -> F {
-        F::from_u8(self as u8)
-    }
-}
-
 /// Sub-labels for hint (non-binding auxiliary) transcript items.
 ///
 /// Hints are data the prover sends to help the verifier reconstruct
@@ -130,12 +116,4 @@ pub enum Hint {
     MerkleProof,
     /// Precomputed weight evaluations deferred from earlier rounds.
     DeferredWeightEvaluations,
-}
-
-impl Hint {
-    /// Convert to a field element using the enum discriminant.
-    #[must_use]
-    pub fn as_field_element<F: Field>(self) -> F {
-        F::from_u8(self as u8)
-    }
 }

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -667,8 +667,8 @@ where
                 log_inv_rate: last.log_inv_rate,
                 domain_size,
                 folded_domain_gen,
-                // Inherit OOD count from the last intermediate round.
-                ood_samples: last.ood_samples,
+                // The final phase has no OOD step; this field is unused here.
+                ood_samples: 0,
                 folding_pow_bits: self.final_folding_pow_bits,
             }
         }

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -324,15 +324,11 @@ fn prescribed_point_verify_rejects_wrong_point() {
         } => {
             // The opening sumcheck binds the claim to the prover's point.
             // Verifying at a different point first disagrees at round 5.
+            // The exact coefficients are transcript-derived and not pinned here,
+            // since any Fiat-Shamir transcript change would otherwise force an
+            // update to this test despite the property under test being unaffected.
             assert_eq!(round, 5);
-            assert_eq!(
-                expected,
-                "1841252927 + 394466335 X + 1831684817 X^2 + 521830660 X^3"
-            );
-            assert_eq!(
-                actual,
-                "1535800973 + 1619442985 X + 1493239317 X^2 + 1782746132 X^3"
-            );
+            assert_ne!(expected, actual);
         }
         other => panic!("expected round-polynomial mismatch, got {other:?}"),
     }

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -347,13 +347,12 @@ where
         let openings = if round_index == self.n_rounds() {
             &proof.final_openings
         } else {
+            // `verify` pins `proof.rounds.len() == n_rounds` at entry and only
+            // ever calls this with `round_index < n_rounds`, so this is always in bounds.
             &proof
                 .rounds
                 .get(round_index)
-                .ok_or_else(|| VerifierError::MerkleProofInvalid {
-                    position: 0,
-                    reason: format!("Round {round_index} missing from proof"),
-                })?
+                .expect("round_index is in bounds: verify() pins proof.rounds.len() == n_rounds")
                 .openings
         };
 


### PR DESCRIPTION
  Fixes a soundness issue in `verify_batch_pruned` (non-lead group members' injected-matrix rows went unauthenticated, reachable via WHIR's verifier) and a NEON add/sub overflow causing potential goldilocks Poseidon2 hash divergence on aarch64. Also resolves a couple code quality issues: silent truncation/overflow guards, cfg-gating gaps, const-assertion hardening, and non-injective transcript encoding in whir's domain separator.