### PR TITLE
perf(circle): precompute per-query FRI twiddle chain, hoist verifier-side redundant work

### DIFF
--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -13,9 +13,11 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_ceil_usize, log2_strict_usize, reverse_slice_index_bits};
 use tracing::{debug_span, instrument};
 
+#[cfg(test)]
+use crate::cfft_permute_index;
 use crate::domain::CircleDomain;
 use crate::point::{Point, compute_lagrange_den_batched};
-use crate::{CfftPermutable, CfftView, cfft_permute_index, cfft_permute_slice};
+use crate::{CfftPermutable, CfftView, cfft_permute_slice};
 
 #[derive(Clone)]
 pub struct CircleEvaluations<F, M = RowMajorMatrix<F>> {
@@ -514,6 +516,9 @@ impl<F: ComplexExtendable> CircleDomain<F> {
         reverse_slice_index_bits(&mut ys);
         ys
     }
+    /// Used only by [`crate::folding::fold_y_row`], the test-only reference implementation
+    /// of [`crate::folding::fold_y`]; see that function's doc comment.
+    #[cfg(test)]
     pub(crate) fn nth_y_twiddle(&self, index: usize) -> F {
         self.nth_point(cfft_permute_index(index << 1, self.log_n)).y
     }

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -13,8 +13,6 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_ceil_usize, log2_strict_usize, reverse_slice_index_bits};
 use tracing::{debug_span, instrument};
 
-#[cfg(test)]
-use crate::cfft_permute_index;
 use crate::domain::CircleDomain;
 use crate::point::{Point, compute_lagrange_den_batched};
 use crate::{CfftPermutable, CfftView, cfft_permute_slice};
@@ -516,12 +514,7 @@ impl<F: ComplexExtendable> CircleDomain<F> {
         reverse_slice_index_bits(&mut ys);
         ys
     }
-    /// Used only by [`crate::folding::fold_y_row`], the test-only reference implementation
-    /// of [`crate::folding::fold_y`]; see that function's doc comment.
-    #[cfg(test)]
-    pub(crate) fn nth_y_twiddle(&self, index: usize) -> F {
-        self.nth_point(cfft_permute_index(index << 1, self.log_n)).y
-    }
+
     pub(crate) fn x_twiddles(&self, layer: usize) -> Vec<F> {
         let generator = self.subgroup_generator() * (1 << layer);
         let shift = self.shift * (1 << layer);
@@ -583,6 +576,15 @@ mod tests {
 
     type F = Mersenne31;
     type EF = BinomialExtensionField<F, 3>;
+
+    impl<F: ComplexExtendable> CircleDomain<F> {
+        /// Used only by [`crate::folding::fold_y_row`], the test-only reference implementation
+        /// of [`crate::folding::fold_y`]; see that function's doc comment.
+        pub(crate) fn nth_y_twiddle(&self, index: usize) -> F {
+            self.nth_point(crate::cfft_permute_index(index << 1, self.log_n))
+                .y
+        }
+    }
 
     #[test]
     fn test_cfft_icfft() {

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -74,7 +74,8 @@ pub(crate) fn deep_quotient_vanishing_part<F: ComplexExtendable, EF: ExtensionFi
 ///
 /// # Parameters
 ///
-/// - `alpha`: The random challenge scalar
+/// - `alpha_pow_width`: `alpha` raised to the power of the matrix width (`ps_at_x.len()`)
+/// - `alpha_powers`: `alpha^0, alpha^1, ..`, at least `ps_at_x.len()` of them
 /// - `x`: A point on the circle domain
 /// - `zeta`: The random challenge point (outside the original domain)
 /// - `ps_at_x`: Polynomial evaluations at point `x` (one per polynomial)
@@ -85,15 +86,15 @@ pub(crate) fn deep_quotient_vanishing_part<F: ComplexExtendable, EF: ExtensionFi
 /// - `Some(value)`: the DEEP quotient value for this row.
 /// - `None`: the opening point coincides with this query point, so the denominator vanishes.
 pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<F>>(
-    alpha: EF,
+    alpha_pow_width: EF,
+    alpha_powers: &[EF],
     x: Point<F>,
     zeta: Point<EF>,
     ps_at_x: &[F],
     ps_at_zeta: &[EF],
 ) -> Option<EF> {
     // Compute the vanishing part: handles the (x - zeta) denominator
-    let (vp_num, vp_denom) =
-        deep_quotient_vanishing_part(x, zeta, alpha.exp_u64(ps_at_x.len() as u64));
+    let (vp_num, vp_denom) = deep_quotient_vanishing_part(x, zeta, alpha_pow_width);
 
     // On the circle, the denominator `|v_p(zeta)|^2` reduces to `2 * (1 - (x - zeta).x)`.
     // This is zero exactly when `x == zeta`.
@@ -102,7 +103,7 @@ pub(crate) fn deep_quotient_reduce_row<F: ComplexExtendable, EF: ExtensionField<
 
     // Compute the constraint part: handles the f(x) - f(zeta) numerator
     let constraint_part = dot_product::<EF, _, _>(
-        alpha.powers(),
+        alpha_powers.iter().copied(),
         izip!(ps_at_x, ps_at_zeta).map(|(&p_at_x, &p_at_zeta)| -p_at_zeta + p_at_x),
     );
 
@@ -345,13 +346,23 @@ mod tests {
         let ps_at_zeta = evals.evaluate_at_point(zeta);
 
         let mat_reduced = evals.deep_quotient_reduce(alpha, zeta, &ps_at_zeta);
+        let width = ps_at_zeta.len();
+        let alpha_pow_width = alpha.exp_u64(width as u64);
+        let alpha_powers = alpha.powers().collect_n(width);
         let row_reduced = evals
             .to_natural_order()
             .rows()
             .zip(domain.points())
             .map(|(ps_at_x, x)| {
-                deep_quotient_reduce_row(alpha, x, zeta, &ps_at_x.collect_vec(), &ps_at_zeta)
-                    .unwrap()
+                deep_quotient_reduce_row(
+                    alpha_pow_width,
+                    &alpha_powers,
+                    x,
+                    zeta,
+                    &ps_at_x.collect_vec(),
+                    &ps_at_zeta,
+                )
+                .unwrap()
             })
             .collect_vec();
         assert_eq!(cfft_permute_slice(&mat_reduced), row_reduced);
@@ -497,13 +508,36 @@ mod tests {
         let ps_at_x = [F::from_u8(1), F::from_u8(2)];
         let ps_at_zeta = [EF::from_u8(3), EF::from_u8(4)];
 
+        let alpha_pow_width = alpha.exp_u64(ps_at_x.len() as u64);
+        let alpha_powers = alpha.powers().collect_n(ps_at_x.len());
+
         // Lift the query point's coordinates into the extension field.
         // The opening point is now the same point, so `x - zeta` is the group identity.
         let zeta_on_x: Point<EF> = Point::new(EF::from(x.x), EF::from(x.y));
-        assert!(deep_quotient_reduce_row(alpha, x, zeta_on_x, &ps_at_x, &ps_at_zeta).is_none());
+        assert!(
+            deep_quotient_reduce_row(
+                alpha_pow_width,
+                &alpha_powers,
+                x,
+                zeta_on_x,
+                &ps_at_x,
+                &ps_at_zeta
+            )
+            .is_none()
+        );
 
         // A distinct opening point keeps the denominator nonzero and reduces normally.
         let zeta_off: Point<EF> = Point::from_projective_line(EF::from_u8(9));
-        assert!(deep_quotient_reduce_row(alpha, x, zeta_off, &ps_at_x, &ps_at_zeta).is_some());
+        assert!(
+            deep_quotient_reduce_row(
+                alpha_pow_width,
+                &alpha_powers,
+                x,
+                zeta_off,
+                &ps_at_x,
+                &ps_at_zeta
+            )
+            .is_some()
+        );
     }
 }

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -73,6 +73,16 @@ impl<F: ComplexExtendable> CircleDomain<F> {
     pub(crate) fn points(&self) -> impl Iterator<Item = Point<F>> {
         self.coset0().interleave(self.coset1())
     }
+    /// Same points as [`Self::points`], materialized eagerly. Each half-coset's sequential
+    /// point-addition chain is split into chunks (reseeded via a scalar multiplication) that
+    /// run in parallel, instead of walking the whole chain on a single thread.
+    pub(crate) fn points_vec(&self) -> Vec<Point<F>> {
+        let half = 1usize << (self.log_n - 1);
+        let g = self.subgroup_generator();
+        let c0 = parallel_point_chain(self.shift, g, half);
+        let c1 = parallel_point_chain(g - self.shift, g, half);
+        c0.into_iter().interleave(c1).collect()
+    }
     pub(crate) fn nth_point(&self, idx: usize) -> Point<F> {
         let (idx, lsb) = (idx >> 1, idx & 1);
         if lsb == 0 {
@@ -84,14 +94,6 @@ impl<F: ComplexExtendable> CircleDomain<F> {
 
     pub(crate) fn vanishing_poly<EF: ExtensionField<F>>(&self, at: Point<EF>) -> EF {
         at.v_n(self.log_n) - self.shift.v_n(self.log_n)
-    }
-
-    pub(crate) fn s_p<EF: ExtensionField<F>>(&self, p: Point<F>, at: Point<EF>) -> EF {
-        self.vanishing_poly(at) / p.v_tilde_p(at)
-    }
-
-    pub(crate) fn s_p_normalized<EF: ExtensionField<F>>(&self, p: Point<F>, at: Point<EF>) -> EF {
-        self.vanishing_poly(at) / (p.v_tilde_p(at) * p.s_p_at_p(self.log_n))
     }
 
     /// `log_period`, `log_repetitions` with `trace_len / period = 2^log_repetitions`.
@@ -107,6 +109,33 @@ impl<F: ComplexExtendable> CircleDomain<F> {
         let log_repetitions = log2_strict_usize(trace_len / period);
         (log_period, log_repetitions)
     }
+}
+
+/// Materialize `len` points of the sequential chain `iterate(seed, |&p| p + g)`, splitting it
+/// into chunks that run in parallel. Each chunk reseeds itself with one scalar multiplication
+/// (`g * chunk_start`) instead of walking the prefix of the chain that precedes it.
+fn parallel_point_chain<F: ComplexExtendable>(
+    seed: Point<F>,
+    g: Point<F>,
+    len: usize,
+) -> Vec<Point<F>> {
+    if len == 0 {
+        return Vec::new();
+    }
+    let num_chunks = current_num_threads().max(1).min(len);
+    let chunk_len = len.div_ceil(num_chunks);
+    (0..len.div_ceil(chunk_len))
+        .into_par_iter()
+        .map(|c| {
+            let chunk_start = c * chunk_len;
+            let this_len = chunk_len.min(len - chunk_start);
+            let chunk_seed = seed + g * chunk_start;
+            iterate(chunk_seed, move |&p| p + g)
+                .take(this_len)
+                .collect_vec()
+        })
+        .collect::<Vec<_>>()
+        .concat()
 }
 
 impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
@@ -189,11 +218,25 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
         point: Ext,
     ) -> LagrangeSelectors<Ext> {
         let point = Point::from_projective_line(point);
+
+        // Single-point specialization of the fused pass in `selectors_on_coset`: one
+        // shared `vanishing_poly` evaluation and one batch inversion instead of four
+        // separate `log_n`-step squaring chains and three separate inversions.
+        let neg_shift = -self.shift;
+        let k = neg_shift.s_p_at_p(self.log_n);
+        let z = self.vanishing_poly(point);
+        let den_shift = self.shift.v_tilde_p(point);
+        let den_negshift_k = neg_shift.v_tilde_p(point) * k;
+
+        let inv = batch_multiplicative_inverse(&[den_shift, den_negshift_k, z]);
+        let (inv_den_shift, inv_den_negshift_k, inv_z) = (inv[0], inv[1], inv[2]);
+
+        let z_inv_dk = z * inv_den_negshift_k;
         LagrangeSelectors {
-            is_first_row: self.s_p(self.shift, point),
-            is_last_row: self.s_p(-self.shift, point),
-            is_transition: Ext::ONE - self.s_p_normalized(-self.shift, point),
-            inv_vanishing: self.vanishing_poly(point).inverse(),
+            is_first_row: z * inv_den_shift,
+            is_last_row: z_inv_dk * k,
+            is_transition: Ext::ONE - z_inv_dk,
+            inv_vanishing: inv_z,
         }
     }
 
@@ -220,6 +263,10 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
 
         let neg_shift = -self.shift;
         let k = neg_shift.s_p_at_p(self.log_n);
+        // `vanishing_poly(at) = at.v_n(log_n) - shift.v_n(log_n)`; the second term is the
+        // same constant for every point in the coset, so it is hoisted out of the loop
+        // below instead of being recomputed (as a `log_n`-step squaring chain) per point.
+        let shift_v_n = self.shift.v_n(self.log_n);
 
         // Fused parallel pass over the coset points: `vanishing_poly`,
         // `shift.v_tilde_p` and `(-shift).v_tilde_p * k` are independent per
@@ -234,7 +281,7 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
             .zip(den_negshift_k.par_iter_mut())
             .zip(pts.par_iter())
             .for_each(|(((z, ds), dnk), &at)| {
-                *z = self.vanishing_poly(at);
+                *z = at.v_n(self.log_n) - shift_v_n;
                 *ds = self.shift.v_tilde_p(at);
                 *dnk = neg_shift.v_tilde_p(at) * k;
             });
@@ -494,5 +541,14 @@ mod tests {
     fn test_circle_domain() {
         do_test_circle_domain(4, 8);
         do_test_circle_domain(10, 32);
+    }
+
+    #[test]
+    fn points_vec_matches_points() {
+        type F = Mersenne31;
+        for log_n in 1..8 {
+            let d = CircleDomain::<F>::standard(log_n);
+            assert_eq!(d.points_vec(), d.points().collect_vec());
+        }
     }
 }

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -111,6 +111,10 @@ impl<F: ComplexExtendable> CircleDomain<F> {
     }
 }
 
+/// Below this length, chunking overhead (each chunk reseeds via a scalar multiplication costing
+/// `O(log len)` point operations) outweighs the benefit of splitting the chain across threads.
+const PARALLEL_THRESHOLD: usize = 1 << 10;
+
 /// Materialize `len` points of the sequential chain `iterate(seed, |&p| p + g)`, splitting it
 /// into chunks that run in parallel. Each chunk reseeds itself with one scalar multiplication
 /// (`g * chunk_start`) instead of walking the prefix of the chain that precedes it.
@@ -119,8 +123,8 @@ fn parallel_point_chain<F: ComplexExtendable>(
     g: Point<F>,
     len: usize,
 ) -> Vec<Point<F>> {
-    if len == 0 {
-        return Vec::new();
+    if len < PARALLEL_THRESHOLD {
+        return iterate(seed, move |&p| p + g).take(len).collect_vec();
     }
     let num_chunks = current_num_threads().max(1).min(len);
     let chunk_len = len.div_ceil(num_chunks);

--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use itertools::Itertools;
 use p3_commit::Mmcs;
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, batch_multiplicative_inverse};
+use p3_field::{ExtensionField, Field, batch_multiplicative_inverse};
 use p3_fri::FriFoldingStrategy;
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
@@ -93,6 +93,10 @@ pub(crate) fn fold_y<F: ComplexExtendable, EF: ExtensionField<F>>(
     )
 }
 
+/// Reference implementation for [`fold_y`], kept only to cross-check it against row-wise
+/// folding in tests; the verifier reuses the lambda-correction point instead (see
+/// `CirclePcs::open`'s `open_input` closure) rather than recomputing this per-row twiddle.
+#[cfg(test)]
 pub(crate) fn fold_y_row<F: ComplexExtendable, EF: ExtensionField<F>>(
     index: usize,
     log_folded_height: usize,
@@ -147,9 +151,65 @@ pub(crate) fn fold_x_row<F: ComplexExtendable, EF: ExtensionField<F>>(
     (sum + beta * diff).halve()
 }
 
+/// Fold a pair of sibling evaluations given an already-inverted twiddle, shared by both the
+/// first-layer (y) fold and every FRI (x) fold round: `fold_*_row` differ only in how `t` is
+/// derived, not in this arithmetic.
+pub(crate) fn fold_row_with_inv_twiddle<F: Field, EF: ExtensionField<F>>(
+    inv_twiddle: F,
+    beta: EF,
+    evals: impl Iterator<Item = EF>,
+) -> EF {
+    let evals = evals.collect_vec();
+    assert_eq!(evals.len(), 2);
+    let sum = evals[0] + evals[1];
+    let diff = (evals[0] - evals[1]) * inv_twiddle;
+    (sum + beta * diff).halve()
+}
+
+/// Precompute the per-query chain of x-fold twiddles, already batch-inverted.
+///
+/// `top_level_index` is the FRI-domain index (the query index with
+/// [`FriFoldingStrategy::extra_query_index_bits`] shifted off), and `log_max_height` is
+/// [`crate::verifier::verify`]'s own top height (one less than the tallest committed matrix's
+/// LDE height, since the first-layer bivariate fold has already consumed one bit of height by
+/// this point).
+///
+/// Round `r`'s twiddle is exactly what `fold_x_row` recomputes from scratch on every call
+/// (`CircleDomain::standard(log_max_height - r + 1).nth_x_twiddle(..)`). After the first round,
+/// each successive twiddle is the circle's squaring map applied to the previous one
+/// (`x -> 2x^2 - 1`), with a sign flip determined by a fixed bit of `top_level_index` - no
+/// further scalar multiplications or domain constructions are needed. All `num_rounds`
+/// twiddles are inverted in a single batch instead of one inversion per round.
+pub(crate) fn query_x_twiddles_inv<F: ComplexExtendable>(
+    top_level_index: usize,
+    log_max_height: usize,
+    num_rounds: usize,
+) -> Vec<F> {
+    if num_rounds == 0 {
+        return Vec::new();
+    }
+
+    let seed_log_folded_height = log_max_height - 1;
+    let seed_idx = reverse_bits_len(top_level_index >> 1, seed_log_folded_height);
+    let mut x = CircleDomain::<F>::standard(log_max_height + 1).nth_x_twiddle(seed_idx);
+
+    let mut twiddles = Vec::with_capacity(num_rounds);
+    twiddles.push(x);
+    for r in 0..num_rounds - 1 {
+        x = x.square().double() - F::ONE;
+        if (top_level_index >> (r + 1)) & 1 == 1 {
+            x = -x;
+        }
+        twiddles.push(x);
+    }
+
+    batch_multiplicative_inverse(&twiddles)
+}
+
 #[cfg(test)]
 mod tests {
     use itertools::iproduct;
+    use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_mersenne_31::Mersenne31;
@@ -158,9 +218,115 @@ mod tests {
 
     use super::*;
     use crate::CircleEvaluations;
+    use crate::ordering::cfft_permute_index;
 
     type F = Mersenne31;
     type EF = BinomialExtensionField<F, 3>;
+
+    /// Exhaustively checks the closed-form twiddle chain that `verify_query`'s fold loop
+    /// could use instead of recomputing `nth_point`/`nth_x_twiddle` from scratch each round.
+    ///
+    /// Reproduces, bit-for-bit, the index arithmetic in `CirclePcs::open`'s `open_input`
+    /// closure (the `p`/`orig_idx`/`bits_reduced` computation feeding the lambda correction
+    /// and the first-layer `fold_y_row` call) and in `verify_query` (the FRI round loop's
+    /// `index >>= log_arity` bookkeeping feeding `fold_x_row`), for a matrix committed at
+    /// `log_height` inside a global FRI instance of `log_max_height`.
+    ///
+    /// Claims checked, for `p = CircleDomain::standard(log_height).nth_point(orig_idx)`:
+    /// - the first-layer (bivariate) y-twiddle is `p.y`, sign-flipped when the query's bit
+    ///   at `bits_reduced` is 1 (the two members of a fold pair are negations of each other).
+    /// - the x-twiddle chain for every FRI round this matrix participates in is exactly
+    ///   `p.x, 2p.x^2-1, 2(2p.x^2-1)^2-1, ..`, i.e. repeated application of the circle's
+    ///   squaring map with no further scalar multiplications.
+    #[test]
+    fn scratch_generator_doubling() {
+        use crate::point::Point;
+        for k in 2..8 {
+            let g = Point::<F>::generator(k);
+            assert_eq!(g.double(), Point::<F>::generator(k - 1), "k={k}");
+        }
+        // nth_x_twiddle doubling identity, same idx, domain one size smaller.
+        for log_n in 4..8 {
+            let d = CircleDomain::<F>::standard(log_n);
+            let d2 = CircleDomain::<F>::standard(log_n - 1);
+            for idx in 0..(1usize << (log_n - 2)) {
+                let t = d.nth_x_twiddle(idx);
+                let doubled_x = t.square().double() - F::ONE;
+                let t2 = d2.nth_x_twiddle(idx);
+                assert_eq!(doubled_x, t2, "log_n={log_n} idx={idx}");
+            }
+        }
+    }
+
+    #[test]
+    fn query_twiddle_chain_matches_naive_recomputation() {
+        for log_blowup in 1..4 {
+            for matrix_log_n in 2..5 {
+                for extra_rounds_above in 0..3 {
+                    let log_height = matrix_log_n + log_blowup;
+                    // The first-layer (bivariate) fold always consumes one bit of height
+                    // before FRI's own x-folding rounds begin, even for the tallest matrix.
+                    let log_max_height = log_height - 1 + extra_rounds_above;
+                    let log_global_max_height = log_max_height + 1;
+                    let total_rounds = log_max_height - log_blowup;
+
+                    let lde_domain = CircleDomain::<F>::standard(log_height);
+                    let bits_reduced = log_global_max_height - log_height;
+
+                    for global_sampled_index in 0..(1usize << log_global_max_height) {
+                        let m = global_sampled_index >> bits_reduced;
+                        let orig_idx = cfft_permute_index(m, log_height);
+                        let p = lde_domain.nth_point(orig_idx);
+
+                        // First-layer (bivariate) y-twiddle: shared across the fold pair,
+                        // canonically the "b=0" member's y-coordinate.
+                        let idx_y_true = global_sampled_index >> (bits_reduced + 1);
+                        let t_y_true = lde_domain.nth_y_twiddle(idx_y_true);
+                        let b = m & 1;
+                        let y_twiddle_hyp = if b == 0 { p.y } else { -p.y };
+                        assert_eq!(
+                            y_twiddle_hyp, t_y_true,
+                            "y-twiddle mismatch: log_blowup={log_blowup} matrix_log_n={matrix_log_n} \
+                             extra_rounds_above={extra_rounds_above} global_sampled_index={global_sampled_index}"
+                        );
+
+                        // x-twiddle chain: shared by the whole query (independent of which
+                        // matrix rolls in where), seeded once at FRI round 0.
+                        let top_level_index = global_sampled_index >> 1;
+
+                        let seed_index_r = top_level_index >> 1;
+                        let seed_log_folded_height = log_max_height - 1;
+                        let seed_domain_log_n = seed_log_folded_height + 2;
+                        let seed_idx = reverse_bits_len(seed_index_r, seed_log_folded_height);
+                        let mut x_closed =
+                            CircleDomain::<F>::standard(seed_domain_log_n).nth_x_twiddle(seed_idx);
+
+                        for r in 0..total_rounds {
+                            let index_r = top_level_index >> (r + 1);
+                            let log_current_height_r = log_max_height - r;
+                            let log_folded_height_r = log_current_height_r - 1;
+                            let domain_log_n = log_folded_height_r + 2; // + log_arity(1) + 1
+                            let idx_for_twiddle = reverse_bits_len(index_r, log_folded_height_r);
+                            let t_x_true = CircleDomain::<F>::standard(domain_log_n)
+                                .nth_x_twiddle(idx_for_twiddle);
+
+                            assert_eq!(
+                                x_closed, t_x_true,
+                                "x-twiddle mismatch at round {r}: log_blowup={log_blowup} \
+                                 matrix_log_n={matrix_log_n} extra_rounds_above={extra_rounds_above} \
+                                 global_sampled_index={global_sampled_index}"
+                            );
+                            x_closed = x_closed.square().double() - F::ONE;
+                            if (top_level_index >> (r + 1)) & 1 == 1 {
+                                x_closed = -x_closed;
+                            }
+                        }
+                        let _ = p;
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn fold_matrix_same_as_row() {

--- a/circle/src/folding.rs
+++ b/circle/src/folding.rs
@@ -159,10 +159,12 @@ pub(crate) fn fold_row_with_inv_twiddle<F: Field, EF: ExtensionField<F>>(
     beta: EF,
     evals: impl Iterator<Item = EF>,
 ) -> EF {
-    let evals = evals.collect_vec();
-    assert_eq!(evals.len(), 2);
-    let sum = evals[0] + evals[1];
-    let diff = (evals[0] - evals[1]) * inv_twiddle;
+    let mut it = evals;
+    let (e0, e1) = (it.next().unwrap(), it.next().unwrap());
+    assert!(it.next().is_none());
+
+    let sum = e0 + e1;
+    let diff = (e0 - e1) * inv_twiddle;
     (sum + beta * diff).halve()
 }
 

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -10,7 +10,7 @@ use p3_commit::{
     PeriodicLdeTable, PolynomialSpace,
 };
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field, dot_product};
+use p3_field::{ExtensionField, Field, batch_multiplicative_inverse, dot_product};
 use p3_fri::FriParameters;
 use p3_fri::verifier::FriError;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixCow};
@@ -27,7 +27,9 @@ use crate::deep_quotient::{
     extract_lambda,
 };
 use crate::domain::CircleDomain;
-use crate::folding::{CircleFriFolding, CircleFriFoldingForMmcs, fold_y, fold_y_row};
+use crate::folding::{
+    CircleFriFolding, CircleFriFoldingForMmcs, fold_row_with_inv_twiddle, fold_y,
+};
 use crate::point::{Point, compute_lagrange_den_batched};
 use crate::prover::prove;
 use crate::verifier::verify;
@@ -238,9 +240,7 @@ where
                 for mat in self.mmcs.get_matrices(data) {
                     let log_height = log2_strict_usize(mat.height());
                     permuted_points.entry(log_height).or_insert_with(|| {
-                        cfft_permute_slice(
-                            &CircleDomain::standard(log_height).points().collect_vec(),
-                        )
+                        cfft_permute_slice(&CircleDomain::standard(log_height).points_vec())
                     });
                 }
             }
@@ -559,6 +559,32 @@ where
 
         // Batch combination challenge
         let alpha: Challenge = challenger.sample_algebra_element();
+
+        // Per (batch, matrix) `alpha^width` and `alpha^(2*width)`, plus a shared table of
+        // `alpha`'s powers up to the widest matrix. A matrix's width is fixed by the
+        // verifier's own claimed evaluations (`rounds`), independent of the query, so
+        // computing these once here replaces recomputing them on every (query, matrix)
+        // or (query, matrix, point) inside the per-query closure below.
+        let matrix_alpha_pows: Vec<Vec<(Challenge, Challenge)>> = rounds
+            .iter()
+            .map(|(_, mats)| {
+                mats.iter()
+                    .map(|(_, points_and_values)| {
+                        let width = points_and_values.first().map_or(0, |(_, v)| v.len());
+                        let alpha_pow_width = alpha.exp_u64(width as u64);
+                        (alpha_pow_width, alpha_pow_width.square())
+                    })
+                    .collect()
+            })
+            .collect();
+        let max_width = rounds
+            .iter()
+            .flat_map(|(_, mats)| mats.iter())
+            .flat_map(|(_, points_and_values)| points_and_values.iter().map(|(_, v)| v.len()))
+            .max()
+            .unwrap_or(0);
+        let alpha_powers: Vec<Challenge> = alpha.powers().collect_n(max_width);
+
         challenger.observe(proof.first_layer_commitment.clone());
         let bivariate_beta: Challenge = challenger.sample_algebra_element();
 
@@ -666,11 +692,13 @@ where
                         .verify_batch(batch_commit, dims, idx, batch_opening.into())
                         .map_err(InputError::InputMmcsError)?;
 
-                    for (ps_at_x, (mat_domain, mat_points_and_values)) in zip_eq(
+                    for (matrix, (ps_at_x, (mat_domain, mat_points_and_values))) in zip_eq(
                         &batch_opening.opened_values,
                         mats,
                         InputError::InputShapeError,
-                    )? {
+                    )?
+                    .enumerate()
+                    {
                         let log_height = mat_domain.log_n + self.fri_params.log_blowup;
                         let bits_reduced = log_global_max_height - log_height;
                         let orig_idx = cfft_permute_index(index >> bits_reduced, log_height);
@@ -681,7 +709,7 @@ where
                         let (alpha_offset, ro) = reduced_openings
                             .entry(log_height)
                             .or_insert((Challenge::ONE, Challenge::ZERO));
-                        let alpha_pow_width_2 = alpha.exp_u64(ps_at_x.len() as u64).square();
+                        let (alpha_pow_width, alpha_pow_width_2) = matrix_alpha_pows[batch][matrix];
 
                         for (zeta_uni, ps_at_zeta) in mat_points_and_values {
                             // The claimed opening must have exactly as many
@@ -694,8 +722,15 @@ where
                             // A vanishing denominator means this opening point lands on the
                             // query point; reject the proof rather than dividing by zero.
                             *ro += *alpha_offset
-                                * deep_quotient_reduce_row(alpha, x, zeta, ps_at_x, ps_at_zeta)
-                                    .ok_or(InputError::OpeningPointMatchesQueryPoint)?;
+                                * deep_quotient_reduce_row(
+                                    alpha_pow_width,
+                                    &alpha_powers,
+                                    x,
+                                    zeta,
+                                    ps_at_x,
+                                    ps_at_zeta,
+                                )
+                                .ok_or(InputError::OpeningPointMatchesQueryPoint)?;
 
                             *alpha_offset *= alpha_pow_width_2;
                         }
@@ -704,7 +739,14 @@ where
 
                 // Verify bivariate fold and lambda correction
 
-                let (mut fri_input, fl_dims, fl_leaves): (Vec<_>, Vec<_>, Vec<_>) = zip_eq(
+                // First pass: derive the lambda-corrected leaf values and each height's
+                // first-layer (y) twiddle, without folding yet. The fold pairs a point with
+                // its negation, so the canonical (b=0) twiddle is `p.y` (sign-flipped when
+                // this query landed on the b=1 member) - the same point `p` already computed
+                // for the lambda correction, with no separate `nth_y_twiddle` scalar
+                // multiplication. All these per-height twiddles are then inverted in a single
+                // batch instead of one inversion per height.
+                let per_height: Vec<_> = zip_eq(
                     zip_eq(
                         reduced_openings,
                         first_layer_siblings,
@@ -718,6 +760,7 @@ where
 
                     let orig_size = log_height - self.fri_params.log_blowup;
                     let bits_reduced = log_global_max_height - log_height;
+                    let b = (index >> bits_reduced) & 1;
                     let orig_idx = cfft_permute_index(index >> bits_reduced, log_height);
 
                     let lde_domain = CircleDomain::standard(log_height);
@@ -726,19 +769,9 @@ where
                     let lambda_corrected = ro - lambda * p.v_n(orig_size);
 
                     let mut fl_values = vec![lambda_corrected; 2];
-                    fl_values[((index >> bits_reduced) & 1) ^ 1] = fl_sib;
+                    fl_values[b ^ 1] = fl_sib;
 
-                    let fri_input = (
-                        // - 1 here is because we have already folded a layer.
-                        log_height - 1,
-                        fold_y_row(
-                            index >> (bits_reduced + 1),
-                            // - 1 here is log_arity.
-                            log_height - 1,
-                            bivariate_beta,
-                            fl_values.iter().copied(),
-                        ),
-                    );
+                    let y_twiddle = if b == 0 { p.y } else { -p.y };
 
                     let fl_dims = Dimensions {
                         // First-layer leaves hold the queried value and its sibling.
@@ -746,9 +779,30 @@ where
                         height: 1 << (log_height - 1),
                     };
 
-                    (fri_input, fl_dims, fl_values)
+                    (log_height, y_twiddle, fl_values, fl_dims)
                 })
-                .multiunzip();
+                .collect();
+
+                let y_twiddles_inv = batch_multiplicative_inverse(
+                    &per_height.iter().map(|&(_, t, _, _)| t).collect_vec(),
+                );
+
+                let (mut fri_input, fl_dims, fl_leaves): (Vec<_>, Vec<_>, Vec<_>) = per_height
+                    .into_iter()
+                    .zip(y_twiddles_inv)
+                    .map(|((log_height, _, fl_values, fl_dims), y_twiddle_inv)| {
+                        let fri_input = (
+                            // - 1 here is because we have already folded a layer.
+                            log_height - 1,
+                            fold_row_with_inv_twiddle(
+                                y_twiddle_inv,
+                                bivariate_beta,
+                                fl_values.iter().copied(),
+                            ),
+                        );
+                        (fri_input, fl_dims, fl_values)
+                    })
+                    .multiunzip();
 
                 // sort descending
                 fri_input.reverse();

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -3,12 +3,13 @@ use alloc::vec::Vec;
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, Mmcs};
+use p3_field::ExtensionField;
 use p3_field::extension::ComplexExtendable;
-use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
 use p3_fri::{FriFoldingStrategy, FriParameters};
 use p3_matrix::Dimensions;
 
+use crate::folding::{fold_row_with_inv_twiddle, query_x_twiddles_inv};
 use crate::{CircleCommitPhaseProofStep, CircleFriProof};
 
 pub fn verify<Folding, Val, Challenge, M, Challenger>(
@@ -207,16 +208,23 @@ where
             .zip(proof.commit_phase_commits.iter())
             .zip(qp.commit_phase_openings.iter());
 
+        // The whole x-fold chain for this query is index-derived (no Merkle or proof data
+        // needed), so it is precomputed and batch-inverted once up front instead of each
+        // round recomputing its own twiddle from scratch.
+        let top_level_index = index >> folding.extra_query_index_bits();
+        let x_twiddle_inv =
+            query_x_twiddles_inv::<Val>(top_level_index, log_max_height, log_arities.len());
+
         // Walk the FRI folding chain: at each round, verify the Merkle
         // opening against the commitment, then fold the sibling evaluations
         // using the challenge beta to produce the next-round evaluation.
         let folded_eval = verify_query(
-            folding,
             params,
-            index >> folding.extra_query_index_bits(),
+            top_level_index,
             fold_data_iter,
             ro,
             log_max_height,
+            &x_twiddle_inv,
         )?;
 
         // After all rounds, the polynomial has been folded to a constant.
@@ -265,19 +273,19 @@ type CommitStep<'a, F, M> = (
 ///
 /// The final folded evaluation, which the caller checks against
 /// the prover's claimed constant.
-fn verify_query<'a, Folding, F, EF, M>(
-    folding: &Folding,
+fn verify_query<'a, F, EF, M, InputError>(
     params: &FriParameters<M>,
     mut index: usize,
     steps: impl ExactSizeIterator<Item = CommitStep<'a, EF, M>>,
     reduced_openings: Vec<(usize, EF)>,
     log_max_height: usize,
-) -> Result<EF, FriError<M::Error, Folding::InputError>>
+    x_twiddle_inv: &[F],
+) -> Result<EF, FriError<M::Error, InputError>>
 where
-    F: Field,
+    F: ComplexExtendable,
     EF: ExtensionField<F>,
     M: Mmcs<EF> + 'a,
-    Folding: FriFoldingStrategy<F, EF>,
+    InputError: core::fmt::Debug,
 {
     // Running accumulator: starts at zero and accumulates reduced openings
     // and folding results as we walk up the tree.
@@ -368,10 +376,13 @@ where
             )
             .map_err(FriError::CommitPhaseMmcsError)?;
 
-        // Fold the full sibling group down to a single evaluation using
-        // the random challenge beta. This is the core FRI step.
-        folded_eval =
-            folding.fold_row(index, log_folded_height, log_arity, beta, evals.into_iter());
+        // Fold the full sibling group down to a single evaluation using the random
+        // challenge beta. Circle PCS only ever folds by arity 2 (`CircleFriFolding::fold_row`
+        // asserts this too); the twiddle for this round was already precomputed for the
+        // whole query chain, so this is now pure arithmetic with no domain construction,
+        // scalar multiplication, or inversion left to do.
+        assert_eq!(log_arity, 1, "Circle PCS currently only supports arity 2");
+        folded_eval = fold_row_with_inv_twiddle(x_twiddle_inv[round], beta, evals.into_iter());
 
         // Advance to the next (smaller) domain.
         log_current_height = log_folded_height;


### PR DESCRIPTION
## Summary

- verifier: precompute and batch-invert the per-query FRI x-fold twiddle chain (squaring recurrence with a per-round sign flip) instead of recomputing each round's twiddle from scratch via a fresh scalar multiplication; reuse the lambda-correction point for the first-layer y-twiddle instead of re-deriving it
- verifier: hoist per-matrix alpha^width/alpha^(2*width) and a shared alpha-powers table out of the per-query closure
- domain: hoist the per-coset-point constant out of selectors_on_coset, and fuse selectors_at_point's four vanishing-poly evaluations and three inversions into one plus a batch inversion
- domain: parallelize CircleDomain point materialization via chunked scalar-mul seeding instead of a single serial point-addition chain

## Performance

Verifier is ~22% faster and prover is ~4% faster E2E.