### PR TITLE
perf(keccak-air): cut redundant packed muls in `eval()` and dedupe padding trace gen

### DIFF
--- a/keccak-air/src/air.rs
+++ b/keccak-air/src/air.rs
@@ -46,6 +46,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         let first_step = local.step_flags[0];
         let final_step = local.step_flags[NUM_ROUNDS_MIN_1];
         let not_final_step = AB::Expr::ONE - final_step;
+        let transition_and_not_final = builder.is_transition() * not_final_step.clone();
 
         // If this is the first step, the input A must match the preimage.
         for y in 0..5 {
@@ -62,8 +63,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for y in 0..5 {
             for x in 0..5 {
                 builder
-                    .when(not_final_step.clone())
-                    .when_transition()
+                    .when(transition_and_not_final.clone())
                     .assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
                         local.preimage[y][x][limb] - next.preimage[y][x][limb]
                     }));
@@ -74,9 +74,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         builder.assert_bool(local.export);
 
         // If this is not the final step, the export flag must be off.
-        builder
-            .when(not_final_step.clone())
-            .assert_zero(local.export);
+        builder.when(not_final_step).assert_zero(local.export);
 
         // C'[x, z] = xor(C[x, z], C[x - 1, z], C[x + 1, z - 1]).
         // Note that if all entries of C are boolean, the arithmetic generalization
@@ -101,13 +99,12 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         // It isn't required, but makes this check a bit cleaner.
         // We also check that all entries of A' are bools.
         // This has the side effect of also range checking the limbs of A.
-        for y in 0..5 {
-            for x in 0..5 {
-                let get_bit = |z: usize| {
-                    local.a_prime[y][x][z]
-                        .into()
-                        .xor3(&local.c[x][z].into(), &local.c_prime[x][z].into())
-                };
+        for x in 0..5 {
+            let c_xor_c_prime: [AB::Expr; 64] =
+                array::from_fn(|z| local.c[x][z].into().xor(&local.c_prime[x][z].into()));
+
+            for y in 0..5 {
+                let get_bit = |z: usize| local.a_prime[y][x][z].into().xor(&c_xor_c_prime[z]);
 
                 // Check that all entries of A'[y][x] are boolean.
                 builder.assert_bools(local.a_prime[y][x]);
@@ -171,11 +168,13 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         }));
 
         let get_xored_bit = |i| {
-            let mut rc_bit_i = AB::Expr::ZERO;
-            for (rc_bits_r, &step_flag) in RC_BITS.iter().zip(local.step_flags.iter()) {
-                let this_round_constant = AB::Expr::from_bool(rc_bits_r[i] != 0);
-                rc_bit_i += step_flag * this_round_constant;
-            }
+            let rc_bit_i: AB::Expr = local
+                .step_flags
+                .iter()
+                .zip(RC_BITS.iter())
+                .filter(|(_, rc_bits_r)| rc_bits_r[i] != 0)
+                .map(|(&step_flag, _)| step_flag.into())
+                .sum();
 
             rc_bit_i.xor(&AB::Expr::from(local.a_prime_prime_0_0_bits[i]))
         };
@@ -192,8 +191,7 @@ impl<AB: AirBuilder> Air<AB> for KeccakAir {
         for x in 0..5 {
             for y in 0..5 {
                 builder
-                    .when_transition()
-                    .when(not_final_step.clone())
+                    .when(transition_and_not_final.clone())
                     .assert_zeros::<U64_LIMBS, _>(array::from_fn(|limb| {
                         local.a_prime_prime_prime(y, x, limb) - next.a[y][x][limb]
                     }));

--- a/keccak-air/src/generation.rs
+++ b/keccak-air/src/generation.rs
@@ -5,7 +5,6 @@ use core::mem::transmute;
 use p3_air::utils::{u64_to_16_bit_limbs, u64_to_bits_le};
 use p3_field::PrimeField64;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_maybe_rayon::iter::repeat_n;
 use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
@@ -31,16 +30,35 @@ pub fn generate_trace_rows<F: PrimeField64>(
     assert!(suffix.is_empty(), "Alignment should match");
     assert_eq!(rows.len(), num_rows);
 
-    let num_padding_inputs = num_rows.div_ceil(NUM_ROUNDS) - inputs.len();
-    let padded_inputs = inputs
-        .into_par_iter()
-        .chain(repeat_n([0; 25], num_padding_inputs));
+    let (real_rows, padding_rows) = rows.split_at_mut(inputs.len() * NUM_ROUNDS);
 
-    rows.par_chunks_mut(NUM_ROUNDS)
-        .zip(padded_inputs)
+    real_rows
+        .par_chunks_mut(NUM_ROUNDS)
+        .zip(inputs.into_par_iter())
         .for_each(|(row, input)| {
             generate_trace_rows_for_perm(row, input);
         });
+
+    // All padding chunks share the same all-zero input, so their trace is
+    // byte-identical. Generate it once and broadcast it into every padding
+    // chunk instead of re-running the permutation for each of them.
+    if !padding_rows.is_empty() {
+        let mut zero_block = F::zero_vec(NUM_ROUNDS * NUM_KECCAK_COLS);
+        {
+            let (prefix, zero_rows, suffix) = unsafe { zero_block.align_to_mut::<KeccakCols<F>>() };
+            assert!(prefix.is_empty(), "Alignment should match");
+            assert!(suffix.is_empty(), "Alignment should match");
+            generate_trace_rows_for_perm(zero_rows, [0; 25]);
+        }
+
+        let (prefix, padding_flat, suffix) = unsafe { padding_rows.align_to_mut::<F>() };
+        assert!(prefix.is_empty(), "Alignment should match");
+        assert!(suffix.is_empty(), "Alignment should match");
+
+        padding_flat
+            .par_chunks_mut(NUM_ROUNDS * NUM_KECCAK_COLS)
+            .for_each(|chunk| chunk.copy_from_slice(&zero_block[..chunk.len()]));
+    }
 
     trace
 }


### PR DESCRIPTION
## Summary

- get_xored_bit only sums step_flags for RC bit positions that are actually set, instead of multiplying every step_flag by from_bool(bit) across all 64 positions.
- Hoist xor(c, c_prime) out of the y-loop in the A' consistency check so it's computed once per x instead of once per (x, y) pair, and merge the two doubly-gated transition blocks into a single combined condition.
- generate_trace_rows now generates the all-zero padding permutation once and copies it into every padding chunk instead of recomputing it per chunk.

Yields around 3.5% savings E2E on my M4 pro when running `cargo run --example prove_prime_field_31 --profile optimized
  --features parallel -- --field mersenne-31 --objective keccak-f-permutations --log-trace-length 17 --merkle-hash keccak-f`