### PR TITLE
perf(monolith-air): more efficient AIR layout and trace generation

### DIFF
--- a/monolith-air/benches/monolith-air.rs
+++ b/monolith-air/benches/monolith-air.rs
@@ -36,9 +36,8 @@ const M31_WIDTH: usize = 16;
 const M31_NUM_FULL_ROUNDS: usize = 5;
 const M31_NUM_BARS: usize = 8;
 const M31_FIELD_BITS: usize = 31;
-// Mersenne31's modulus (0x7FFFFFFF) is all ones, so NUM_MATCH_FLAGS equals
-// FIELD_BITS exactly (every bit position needs a committed flag).
-const M31_NUM_MATCH_FLAGS: usize = 31;
+const M31_NUM_MATCH_FLAGS: usize = 15;
+const M31_NUM_CHI_CELLS: usize = 24;
 
 fn build_monolith_air_m31() -> (
     MonolithAir<
@@ -48,6 +47,7 @@ fn build_monolith_air_m31() -> (
         M31_NUM_BARS,
         M31_FIELD_BITS,
         M31_NUM_MATCH_FLAGS,
+        M31_NUM_CHI_CELLS,
     >,
     MonolithBarsM31,
 ) {
@@ -60,6 +60,7 @@ fn build_monolith_air_m31() -> (
         M31_NUM_BARS,
         M31_FIELD_BITS,
         M31_NUM_MATCH_FLAGS,
+        M31_NUM_CHI_CELLS,
     >::extract_mds_matrix(&mds);
     let monolith = MonolithMersenne31::new(bars, mds);
     let air = MonolithAir::new(monolith.round_constants, mds_matrix, MERSENNE31_LIMB_BITS);
@@ -142,6 +143,7 @@ fn bench_trace_generation_m31(c: &mut Criterion) {
                         M31_NUM_BARS,
                         M31_FIELD_BITS,
                         M31_NUM_MATCH_FLAGS,
+                        M31_NUM_CHI_CELLS,
                     >(inputs, &air, &bars, 0)
                 });
             },
@@ -208,9 +210,8 @@ const GL_WIDTH: usize = 8;
 const GL_NUM_FULL_ROUNDS: usize = 5;
 const GL_NUM_BARS: usize = 4;
 const GL_FIELD_BITS: usize = 64;
-// Goldilocks's modulus (0xFFFFFFFF00000001) has Hamming weight 33, so 31 of
-// its 64 bit positions need no committed match-flag cell.
-const GL_NUM_MATCH_FLAGS: usize = 33;
+const GL_NUM_MATCH_FLAGS: usize = 16;
+const GL_NUM_CHI_CELLS: usize = 64;
 
 fn build_monolith_air_goldilocks() -> (
     MonolithAir<
@@ -220,6 +221,7 @@ fn build_monolith_air_goldilocks() -> (
         GL_NUM_BARS,
         GL_FIELD_BITS,
         GL_NUM_MATCH_FLAGS,
+        GL_NUM_CHI_CELLS,
     >,
     MonolithBarsGoldilocks<8>,
 ) {
@@ -232,6 +234,7 @@ fn build_monolith_air_goldilocks() -> (
         GL_NUM_BARS,
         GL_FIELD_BITS,
         GL_NUM_MATCH_FLAGS,
+        GL_NUM_CHI_CELLS,
     >::extract_mds_matrix(&mds);
     let monolith: MonolithGoldilocks8<_, GL_WIDTH, 5> = MonolithGoldilocks8::new(bars, mds);
     let air = MonolithAir::new(monolith.round_constants, mds_matrix, GOLDILOCKS_8_LIMB_BITS);
@@ -321,6 +324,7 @@ fn bench_trace_generation_goldilocks(c: &mut Criterion) {
                         GL_NUM_BARS,
                         GL_FIELD_BITS,
                         GL_NUM_MATCH_FLAGS,
+                        GL_NUM_CHI_CELLS,
                     >(inputs, &air, &bars, 0)
                 });
             },

--- a/monolith-air/benches/monolith-air.rs
+++ b/monolith-air/benches/monolith-air.rs
@@ -36,9 +36,19 @@ const M31_WIDTH: usize = 16;
 const M31_NUM_FULL_ROUNDS: usize = 5;
 const M31_NUM_BARS: usize = 8;
 const M31_FIELD_BITS: usize = 31;
+// Mersenne31's modulus (0x7FFFFFFF) is all ones, so NUM_MATCH_FLAGS equals
+// FIELD_BITS exactly (every bit position needs a committed flag).
+const M31_NUM_MATCH_FLAGS: usize = 31;
 
 fn build_monolith_air_m31() -> (
-    MonolithAir<M31Val, M31_WIDTH, M31_NUM_FULL_ROUNDS, M31_NUM_BARS, M31_FIELD_BITS>,
+    MonolithAir<
+        M31Val,
+        M31_WIDTH,
+        M31_NUM_FULL_ROUNDS,
+        M31_NUM_BARS,
+        M31_FIELD_BITS,
+        M31_NUM_MATCH_FLAGS,
+    >,
     MonolithBarsM31,
 ) {
     let bars = MonolithBarsM31;
@@ -49,6 +59,7 @@ fn build_monolith_air_m31() -> (
         M31_NUM_FULL_ROUNDS,
         M31_NUM_BARS,
         M31_FIELD_BITS,
+        M31_NUM_MATCH_FLAGS,
     >::extract_mds_matrix(&mds);
     let monolith = MonolithMersenne31::new(bars, mds);
     let air = MonolithAir::new(monolith.round_constants, mds_matrix, MERSENNE31_LIMB_BITS);
@@ -130,6 +141,7 @@ fn bench_trace_generation_m31(c: &mut Criterion) {
                         M31_NUM_FULL_ROUNDS,
                         M31_NUM_BARS,
                         M31_FIELD_BITS,
+                        M31_NUM_MATCH_FLAGS,
                     >(inputs, &air, &bars, 0)
                 });
             },
@@ -196,9 +208,19 @@ const GL_WIDTH: usize = 8;
 const GL_NUM_FULL_ROUNDS: usize = 5;
 const GL_NUM_BARS: usize = 4;
 const GL_FIELD_BITS: usize = 64;
+// Goldilocks's modulus (0xFFFFFFFF00000001) has Hamming weight 33, so 31 of
+// its 64 bit positions need no committed match-flag cell.
+const GL_NUM_MATCH_FLAGS: usize = 33;
 
 fn build_monolith_air_goldilocks() -> (
-    MonolithAir<GlVal, GL_WIDTH, GL_NUM_FULL_ROUNDS, GL_NUM_BARS, GL_FIELD_BITS>,
+    MonolithAir<
+        GlVal,
+        GL_WIDTH,
+        GL_NUM_FULL_ROUNDS,
+        GL_NUM_BARS,
+        GL_FIELD_BITS,
+        GL_NUM_MATCH_FLAGS,
+    >,
     MonolithBarsGoldilocks<8>,
 ) {
     let bars = MonolithBarsGoldilocks::<8>;
@@ -209,6 +231,7 @@ fn build_monolith_air_goldilocks() -> (
         GL_NUM_FULL_ROUNDS,
         GL_NUM_BARS,
         GL_FIELD_BITS,
+        GL_NUM_MATCH_FLAGS,
     >::extract_mds_matrix(&mds);
     let monolith: MonolithGoldilocks8<_, GL_WIDTH, 5> = MonolithGoldilocks8::new(bars, mds);
     let air = MonolithAir::new(monolith.round_constants, mds_matrix, GOLDILOCKS_8_LIMB_BITS);
@@ -297,6 +320,7 @@ fn bench_trace_generation_goldilocks(c: &mut Criterion) {
                         GL_NUM_FULL_ROUNDS,
                         GL_NUM_BARS,
                         GL_FIELD_BITS,
+                        GL_NUM_MATCH_FLAGS,
                     >(inputs, &air, &bars, 0)
                 });
             },

--- a/monolith-air/src/air.rs
+++ b/monolith-air/src/air.rs
@@ -76,6 +76,7 @@ pub struct MonolithAir<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 > {
     /// Round constants for each of the `NUM_FULL_ROUNDS` rounds.
     ///
@@ -109,7 +110,8 @@ impl<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
-> MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
+    const NUM_CHI_CELLS: usize,
+> MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>
 {
     /// Build the AIR from a permutation's parameters.
     ///
@@ -131,9 +133,20 @@ impl<
     ///
     /// # Match-flag width invariant
     ///
-    /// - `NUM_MATCH_FLAGS` must equal the modulus's Hamming weight: a
-    ///   committed flag is stored only at modulus one-bits, since a
-    ///   modulus-zero bit's flag is a pure copy of the previous one.
+    /// - `NUM_MATCH_FLAGS` must equal `modulus.count_ones() / 2`: two
+    ///   consecutive modulus one-bits share one committed flag cell via a
+    ///   degree-3 batched step (`m_i = m_prev2 * x_a * x_b`), and a
+    ///   modulus-zero bit needs no cell at all (its flag is a pure copy of
+    ///   the previous one). If the Hamming weight is odd, the final
+    ///   one-bit (always bit 0) is folded directly into the closing
+    ///   `assert_zero` with no committed cell of its own.
+    ///
+    /// # Chi-cell width invariant
+    ///
+    /// - `NUM_CHI_CELLS` must equal `FIELD_BITS` minus the trailing limb's
+    ///   width when that limb uses the 2-input chi variant (width `< 8`):
+    ///   its AND term is cheap enough (degree 2) to inline directly into
+    ///   the output XOR without a committed column of its own.
     ///
     /// # Panics
     ///
@@ -142,7 +155,8 @@ impl<
     /// - Bar applications exceed the state width.
     /// - Any non-trailing limb is not 8.
     /// - Trailing limb is outside `3..=8`.
-    /// - `NUM_MATCH_FLAGS` does not equal the modulus's Hamming weight.
+    /// - `NUM_MATCH_FLAGS` does not equal `modulus.count_ones() / 2`.
+    /// - `NUM_CHI_CELLS` does not match the trailing limb's width.
     pub fn new(
         round_constants: [[F; WIDTH]; NUM_FULL_ROUNDS],
         mds_matrix: [[F; WIDTH]; WIDTH],
@@ -207,11 +221,26 @@ impl<
         let modulus_lsb_to_msb: [bool; FIELD_BITS] =
             core::array::from_fn(|i| (modulus >> i) & 1 == 1);
 
-        // Only modulus one-bits get a committed match-flag cell.
+        // Two modulus one-bits share one committed flag cell; an odd
+        // leftover (always bit 0) folds into the closing assert with no
+        // cell of its own.
+        let num_ones = modulus_lsb_to_msb.iter().filter(|&&b| b).count();
         assert_eq!(
-            modulus_lsb_to_msb.iter().filter(|&&b| b).count(),
+            num_ones / 2,
             NUM_MATCH_FLAGS,
-            "NUM_MATCH_FLAGS must equal the modulus's Hamming weight"
+            "NUM_MATCH_FLAGS must equal modulus.count_ones() / 2"
+        );
+
+        // The trailing limb's chi is inlined (no committed column) exactly
+        // when it uses the narrower 2-input AND variant.
+        let reduced_width = limb_bits
+            .split_last()
+            .map(|(&last, _)| if last < 8 { last } else { 0 })
+            .unwrap_or(0);
+        assert_eq!(
+            FIELD_BITS - reduced_width,
+            NUM_CHI_CELLS,
+            "NUM_CHI_CELLS must equal FIELD_BITS minus the inlined trailing limb's width"
         );
 
         Self {
@@ -272,11 +301,13 @@ impl<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
-> BaseAir<F> for MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
+    const NUM_CHI_CELLS: usize,
+> BaseAir<F>
+    for MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>
 {
     /// Returns the number of trace columns (the AIR width).
     fn width(&self) -> usize {
-        num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>()
+        num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>()
     }
 
     /// No next-row columns. Each permutation is fully constrained within one row.
@@ -292,7 +323,17 @@ impl<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
-> Air<AB> for MonolithAir<AB::F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
+    const NUM_CHI_CELLS: usize,
+> Air<AB>
+    for MonolithAir<
+        AB::F,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    >
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
@@ -303,6 +344,7 @@ impl<
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         > = main.current_slice().borrow();
 
         // Initialize the running state from the committed input columns.
@@ -314,7 +356,7 @@ impl<
 
         // Full rounds: Bars → Bricks → Concrete → AddRoundConstants.
         for round_idx in 0..NUM_FULL_ROUNDS {
-            eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
+            eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>(
                 &mut state,
                 &local.full_rounds[round_idx],
                 &self.mds_matrix,
@@ -326,7 +368,7 @@ impl<
         }
 
         // Final round: Bars → Bricks → Concrete (no round constants).
-        eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
+        eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>(
             &mut state,
             &local.final_round,
             &self.mds_matrix,
@@ -356,9 +398,10 @@ fn eval_round<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 >(
     state: &mut [AB::Expr; WIDTH],
-    round: &MonolithRoundCols<AB::Var, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+    round: &MonolithRoundCols<AB::Var, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>,
     mds_matrix: &[[AB::F; WIDTH]; WIDTH],
     round_constants: Option<&[AB::F; WIDTH]>,
     limb_bits: &[usize],
@@ -385,50 +428,63 @@ fn eval_round<
 
         // Lift committed cells to expressions for symbolic algebra.
         let bits: [AB::Expr; FIELD_BITS] = input_bits.map(|b| b.into());
-        let chi: [AB::Expr; FIELD_BITS] = chi_products.map(|b| b.into());
+        let chi: [AB::Expr; NUM_CHI_CELLS] = chi_products.map(|b| b.into());
         let mflag: [AB::Expr; NUM_MATCH_FLAGS] = match_flags.map(|b| b.into());
 
         // Reconstruction:  sum_i bits[i] * 2^i  ==  state[bar_idx].
         let reconstructed: AB::Expr = pack_bits_le(bits.iter().cloned());
         builder.assert_eq(reconstructed, state[bar_idx].clone());
 
-        // S-box: committed Bar output == chi(bits), degree 2 thanks to the
-        // committed AND product witnesses.
-        let sbox_output = eval_bar_sbox::<AB, FIELD_BITS>(&bits, &chi, limb_bits, builder);
+        // S-box: committed Bar output == chi(bits), degree ≤ 3 thanks to the
+        // committed AND product witnesses (or an inlined one, for the
+        // trailing 2-input limb).
+        let sbox_output =
+            eval_bar_sbox::<AB, FIELD_BITS, NUM_CHI_CELLS>(&bits, &chi, limb_bits, builder);
         builder.assert_eq(AB::Expr::from(bar_out), sbox_output);
 
-        // Canonical bit-pattern walk (MSB → LSB).
+        // Canonical bit-pattern walk (MSB → LSB), with two modulus one-bits
+        // batched into each committed flag.
         //
         // Define `m_i` = "bits[i..FIELD_BITS] still match the modulus prefix".
         // Start above the MSB with `m_top = 1` (no info yet):
         //
-        //     p_i = 1 : m_i = m_{i+1} * bits[i]           (committed cell)
-        //     p_i = 0 : m_i = m_{i+1}                     (no cell; reuse m_{i+1})
-        //               assert m_{i+1} * bits[i] = 0      (a 1 here would force X > p)
+        //     p_i = p_{i-1} = 1 : m_{i-1} = m_{i+1} * bits[i] * bits[i-1]   (committed, degree 3)
+        //     p_i = 0           : m_i = m_{i+1}                            (no cell; reuse m_{i+1})
+        //                         assert m_{i+1} * bits[i] = 0             (a 1 here would force X > p)
         //
-        // Only modulus one-bits commit a flag cell, so `mflag` has
-        // `NUM_MATCH_FLAGS` entries (the modulus's Hamming weight) rather
-        // than one per bit position; `flag_idx` walks it in step with the
-        // one-bits encountered from the MSB down.
+        // Modulus one-bits are paired as encountered (`pending` holds the
+        // first bit of an unfinished pair); a modulus-zero bit needs no
+        // cell at all. If the Hamming weight is odd, the final one-bit
+        // (always bit 0, since any prime modulus is odd) never pairs — its
+        // check is folded directly into the closing assertion below instead
+        // of getting its own committed cell.
         //
-        // Final assertion `prev = 0` rejects the encoding `bits == p`, which
-        // is the only forbidden one in `[p, 2^FIELD_BITS - 1]` that survives
+        // The closing assertion rejects the encoding `bits == p`, which is
+        // the only forbidden one in `[p, 2^FIELD_BITS - 1]` that survives
         // the side-constraints above.
         let mut prev = AB::Expr::ONE;
         let mut flag_idx = 0;
+        let mut pending: Option<AB::Expr> = None;
         for i in (0..FIELD_BITS).rev() {
             let x_i = bits[i].clone();
             if modulus_lsb_to_msb[i] {
-                let m_i = mflag[flag_idx].clone();
-                builder.assert_eq(m_i.clone(), prev * x_i);
-                prev = m_i;
-                flag_idx += 1;
+                if let Some(first) = pending.take() {
+                    let m_i = mflag[flag_idx].clone();
+                    builder.assert_eq(m_i.clone(), prev * first * x_i);
+                    prev = m_i;
+                    flag_idx += 1;
+                } else {
+                    pending = Some(x_i);
+                }
             } else {
                 builder.assert_zero(prev.clone() * x_i);
             }
         }
         debug_assert_eq!(flag_idx, NUM_MATCH_FLAGS);
-        builder.assert_zero(prev);
+        match pending {
+            Some(last) => builder.assert_zero(prev * last),
+            None => builder.assert_zero(prev),
+        }
     }
 
     // Phase 2: Build the post-Bars state.
@@ -477,57 +533,61 @@ fn eval_round<
 ///
 /// - Apply chi independently to each limb (widths from the input slice).
 /// - Recombine output bits via little-endian packing.
-/// - Use the committed AND product witnesses to cap degree at 3.
+/// - Use a committed AND product witness to cap degree at 3 for 8-bit
+///   limbs; the trailing 2-input limb's AND term is cheap enough (degree
+///   2) to inline directly into the XOR instead, so it commits nothing.
 ///
 /// # Chi per limb (width n, indices mod n)
 ///
 /// ```text
-///   8-bit:  out[j] = x[j-1] XOR ((NOT x[j-2]) AND x[j-3] AND x[j-4])
-///   7-bit:  out[j] = x[j-1] XOR ((NOT x[j-2]) AND x[j-3])
+///   8-bit:  out[j] = x[j-1] XOR ((NOT x[j-2]) AND x[j-3] AND x[j-4])   — degree 3, chi[j] committed
+///   7-bit:  out[j] = x[j-1] XOR ((NOT x[j-2]) AND x[j-3])              — degree 3, inlined
 /// ```
-fn eval_bar_sbox<AB: AirBuilder, const FIELD_BITS: usize>(
+fn eval_bar_sbox<AB: AirBuilder, const FIELD_BITS: usize, const NUM_CHI_CELLS: usize>(
     bits: &[AB::Expr; FIELD_BITS],
-    chi_products: &[AB::Expr; FIELD_BITS],
+    chi_products: &[AB::Expr; NUM_CHI_CELLS],
     limb_bits: &[usize],
     builder: &mut AB,
 ) -> AB::Expr {
     // Accumulator for the recombined field element.
     let mut result = AB::Expr::ZERO;
 
-    // Running offset into the global bit array; advances by limb width.
+    // Running offsets: `bit_offset` spans the full bit array (every limb),
+    // `chi_offset` spans only the committed chi cells (skips the inlined
+    // trailing limb, if any).
     let mut bit_offset = 0;
+    let mut chi_offset = 0;
 
     for (limb_idx, &n) in limb_bits.iter().enumerate() {
-        // Slice the input bits and committed AND products for this limb.
+        // Slice the input bits for this limb.
         let x = &bits[bit_offset..bit_offset + n];
-        let chi = &chi_products[bit_offset..bit_offset + n];
 
         // Only the trailing limb may be narrower than 8 bits; it uses the
-        // 2-input AND variant of chi.
+        // 2-input AND variant of chi, inlined rather than committed.
         let is_last_reduced = limb_idx == limb_bits.len() - 1 && n < 8;
 
         //     sub(j, k) = (j - k) mod n
         let sub = |base: usize, offset: usize| (base + n - (offset % n)) % n;
 
-        // Bind each AND product witness:
-        //
-        //     8-bit:  chi[j] = (1 - x[j-2]) * x[j-3] * x[j-4]
-        //     7-bit:  chi[j] = (1 - x[j-2]) * x[j-3]
-        for j in 0..n {
-            let andn = x[sub(j, 2)].clone().andn(&x[sub(j, 3)].clone());
-            let expected = if is_last_reduced {
-                andn
-            } else {
-                andn * x[sub(j, 4)].clone()
-            };
-            builder.assert_eq(chi[j].clone(), expected);
-        }
+        let limb_value: AB::Expr = if is_last_reduced {
+            // Output bit:  out[j] = x[j-1] XOR ((1 - x[j-2]) * x[j-3])  (degree 3).
+            pack_bits_le((0..n).map(|j| {
+                let andn = x[sub(j, 2)].clone().andn(&x[sub(j, 3)].clone());
+                x[sub(j, 1)].clone().xor(&andn)
+            }))
+        } else {
+            let chi = &chi_products[chi_offset..chi_offset + n];
 
-        // Output bit:  out[j] = x[j-1] XOR chi[j]  (degree 2).
-        let get_out_bit = |j: usize| -> AB::Expr { x[sub(j, 1)].clone().xor(&chi[j].clone()) };
+            // Bind each AND product witness:  chi[j] = (1 - x[j-2]) * x[j-3] * x[j-4].
+            for j in 0..n {
+                let andn = x[sub(j, 2)].clone().andn(&x[sub(j, 3)].clone());
+                builder.assert_eq(chi[j].clone(), andn * x[sub(j, 4)].clone());
+            }
+            chi_offset += n;
 
-        // Pack the limb's bits into one field element (Horner).
-        let limb_value: AB::Expr = pack_bits_le((0..n).map(get_out_bit));
+            // Output bit:  out[j] = x[j-1] XOR chi[j]  (degree 2).
+            pack_bits_le((0..n).map(|j| x[sub(j, 1)].clone().xor(&chi[j].clone())))
+        };
 
         // Shift into global position and accumulate:  result += limb * 2^offset.
         let limb_shift = AB::F::from_u64(1u64 << bit_offset);

--- a/monolith-air/src/air.rs
+++ b/monolith-air/src/air.rs
@@ -75,6 +75,7 @@ pub struct MonolithAir<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 > {
     /// Round constants for each of the `NUM_FULL_ROUNDS` rounds.
     ///
@@ -107,7 +108,8 @@ impl<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
-> MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>
+    const NUM_MATCH_FLAGS: usize,
+> MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
 {
     /// Build the AIR from a permutation's parameters.
     ///
@@ -127,6 +129,12 @@ impl<
     /// - Every non-trailing entry equals 8.
     /// - Trailing entry lies in `3..=8`.
     ///
+    /// # Match-flag width invariant
+    ///
+    /// - `NUM_MATCH_FLAGS` must equal the modulus's Hamming weight: a
+    ///   committed flag is stored only at modulus one-bits, since a
+    ///   modulus-zero bit's flag is a pure copy of the previous one.
+    ///
     /// # Panics
     ///
     /// - Field-bit parameter exceeds 63.
@@ -134,6 +142,7 @@ impl<
     /// - Bar applications exceed the state width.
     /// - Any non-trailing limb is not 8.
     /// - Trailing limb is outside `3..=8`.
+    /// - `NUM_MATCH_FLAGS` does not equal the modulus's Hamming weight.
     pub fn new(
         round_constants: [[F; WIDTH]; NUM_FULL_ROUNDS],
         mds_matrix: [[F; WIDTH]; WIDTH],
@@ -195,7 +204,15 @@ impl<
         //
         //     modulus_lsb_to_msb[i] = (ORDER >> i) & 1 == 1
         let modulus = F::ORDER_U64;
-        let modulus_lsb_to_msb = core::array::from_fn(|i| (modulus >> i) & 1 == 1);
+        let modulus_lsb_to_msb: [bool; FIELD_BITS] =
+            core::array::from_fn(|i| (modulus >> i) & 1 == 1);
+
+        // Only modulus one-bits get a committed match-flag cell.
+        assert_eq!(
+            modulus_lsb_to_msb.iter().filter(|&&b| b).count(),
+            NUM_MATCH_FLAGS,
+            "NUM_MATCH_FLAGS must equal the modulus's Hamming weight"
+        );
 
         Self {
             round_constants,
@@ -254,11 +271,12 @@ impl<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
-> BaseAir<F> for MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>
+    const NUM_MATCH_FLAGS: usize,
+> BaseAir<F> for MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
 {
     /// Returns the number of trace columns (the AIR width).
     fn width(&self) -> usize {
-        num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>()
+        num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>()
     }
 
     /// No next-row columns. Each permutation is fully constrained within one row.
@@ -273,12 +291,19 @@ impl<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
-> Air<AB> for MonolithAir<AB::F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>
+    const NUM_MATCH_FLAGS: usize,
+> Air<AB> for MonolithAir<AB::F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>
 {
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
-        let local: &MonolithCols<AB::Var, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> =
-            main.current_slice().borrow();
+        let local: &MonolithCols<
+            AB::Var,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        > = main.current_slice().borrow();
 
         // Initialize the running state from the committed input columns.
         let mut state: [AB::Expr; WIDTH] = local.inputs.map(|x| x.into());
@@ -289,7 +314,7 @@ impl<
 
         // Full rounds: Bars → Bricks → Concrete → AddRoundConstants.
         for round_idx in 0..NUM_FULL_ROUNDS {
-            eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS>(
+            eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
                 &mut state,
                 &local.full_rounds[round_idx],
                 &self.mds_matrix,
@@ -301,7 +326,7 @@ impl<
         }
 
         // Final round: Bars → Bricks → Concrete (no round constants).
-        eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS>(
+        eval_round::<AB, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
             &mut state,
             &local.final_round,
             &self.mds_matrix,
@@ -330,9 +355,10 @@ fn eval_round<
     const WIDTH: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 >(
     state: &mut [AB::Expr; WIDTH],
-    round: &MonolithRoundCols<AB::Var, WIDTH, NUM_BARS, FIELD_BITS>,
+    round: &MonolithRoundCols<AB::Var, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
     mds_matrix: &[[AB::F; WIDTH]; WIDTH],
     round_constants: Option<&[AB::F; WIDTH]>,
     limb_bits: &[usize],
@@ -360,7 +386,7 @@ fn eval_round<
         // Lift committed cells to expressions for symbolic algebra.
         let bits: [AB::Expr; FIELD_BITS] = input_bits.map(|b| b.into());
         let chi: [AB::Expr; FIELD_BITS] = chi_products.map(|b| b.into());
-        let mflag: [AB::Expr; FIELD_BITS] = match_flags.map(|b| b.into());
+        let mflag: [AB::Expr; NUM_MATCH_FLAGS] = match_flags.map(|b| b.into());
 
         // Reconstruction:  sum_i bits[i] * 2^i  ==  state[bar_idx].
         let reconstructed: AB::Expr = pack_bits_le(bits.iter().cloned());
@@ -376,25 +402,32 @@ fn eval_round<
         // Define `m_i` = "bits[i..FIELD_BITS] still match the modulus prefix".
         // Start above the MSB with `m_top = 1` (no info yet):
         //
-        //     p_i = 1 : m_i = m_{i+1} * bits[i]
-        //     p_i = 0 : m_i = m_{i+1}                  (linear pass-through)
-        //               assert m_{i+1} * bits[i] = 0   (a 1 here would force X > p)
+        //     p_i = 1 : m_i = m_{i+1} * bits[i]           (committed cell)
+        //     p_i = 0 : m_i = m_{i+1}                     (no cell; reuse m_{i+1})
+        //               assert m_{i+1} * bits[i] = 0      (a 1 here would force X > p)
         //
-        // Final assertion `m_0 = 0` rejects the encoding `bits == p`, which
+        // Only modulus one-bits commit a flag cell, so `mflag` has
+        // `NUM_MATCH_FLAGS` entries (the modulus's Hamming weight) rather
+        // than one per bit position; `flag_idx` walks it in step with the
+        // one-bits encountered from the MSB down.
+        //
+        // Final assertion `prev = 0` rejects the encoding `bits == p`, which
         // is the only forbidden one in `[p, 2^FIELD_BITS - 1]` that survives
         // the side-constraints above.
         let mut prev = AB::Expr::ONE;
+        let mut flag_idx = 0;
         for i in (0..FIELD_BITS).rev() {
-            let m_i = mflag[i].clone();
             let x_i = bits[i].clone();
             if modulus_lsb_to_msb[i] {
-                builder.assert_eq(m_i.clone(), prev.clone() * x_i);
+                let m_i = mflag[flag_idx].clone();
+                builder.assert_eq(m_i.clone(), prev * x_i);
+                prev = m_i;
+                flag_idx += 1;
             } else {
-                builder.assert_eq(m_i.clone(), prev.clone());
                 builder.assert_zero(prev.clone() * x_i);
             }
-            prev = m_i;
         }
+        debug_assert_eq!(flag_idx, NUM_MATCH_FLAGS);
         builder.assert_zero(prev);
     }
 

--- a/monolith-air/src/columns.rs
+++ b/monolith-air/src/columns.rs
@@ -18,8 +18,8 @@
 //!
 //! - **Inputs**: `WIDTH` columns.
 //! - **Per round** (NUM_FULL_ROUNDS + 1 total rounds):
-//!   `NUM_BARS * (2 * FIELD_BITS + NUM_MATCH_FLAGS)` (bit decomposition,
-//!   chi products, and match flags)
+//!   `NUM_BARS * (FIELD_BITS + NUM_CHI_CELLS + NUM_MATCH_FLAGS)` (bit
+//!   decomposition, chi products, and match flags)
 //!   + `NUM_BARS` (bar outputs)
 //!   + `WIDTH` (post-state).
 //!
@@ -49,6 +49,7 @@ pub struct MonolithCols<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 > {
     /// The initial permutation state before any operations are applied.
     pub inputs: [T; WIDTH],
@@ -58,13 +59,15 @@ pub struct MonolithCols<
     /// Each round applies: Bars → Bricks → Concrete → AddRoundConstants.
     /// The `post` field in each round stores the state after all four operations.
     pub full_rounds:
-        [MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>; NUM_FULL_ROUNDS],
+        [MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>;
+            NUM_FULL_ROUNDS],
 
     /// Columns for the final round (no round constants).
     ///
     /// The final round applies: Bars → Bricks → Concrete.
     /// The `post` field stores the final permutation output.
-    pub final_round: MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+    pub final_round:
+        MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>,
 }
 
 /// Columns for a single Monolith round.
@@ -77,6 +80,7 @@ pub struct MonolithRoundCols<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 > {
     /// Bit decomposition of the input to each Bar application (LSB first).
     ///
@@ -90,41 +94,48 @@ pub struct MonolithRoundCols<
     /// Each bit is constrained to be boolean: `b * (1 - b) = 0`.
     pub bars_input_bits: [[T; FIELD_BITS]; NUM_BARS],
 
-    /// Committed chi AND product, one cell per output bit.
+    /// Committed chi AND product, one cell per output bit of every 8-bit
+    /// limb. The trailing limb, when narrower than 8 bits, uses a cheaper
+    /// 2-input AND that's inlined directly into the output XOR instead of
+    /// committed here — so `NUM_CHI_CELLS` is `FIELD_BITS` minus that
+    /// trailing limb's width (or `FIELD_BITS` unchanged when every limb is
+    /// 8 bits wide, e.g. Goldilocks).
     ///
-    /// # Binding equation (limb of width n)
+    /// # Binding equation (8-bit limb, indices mod 8)
     ///
-    /// - Width 8: `chi[j] = (1 - x_{j-2}) * x_{j-3} * x_{j-4}` — degree 3.
-    /// - Width 7: `chi[j] = (1 - x_{j-2}) * x_{j-3}`           — degree 2.
-    ///
-    /// All indices are taken mod n.
+    /// `chi[j] = (1 - x_{j-2}) * x_{j-3} * x_{j-4}` — degree 3.
     ///
     /// # Why this column exists
     ///
     /// - Inlining the chi XOR makes the limb output degree 4.
     /// - Committing the AND product splits it into a degree-3 binding
     ///   and a degree-2 XOR, capping the AIR at degree 3.
-    pub bars_chi_products: [[T; FIELD_BITS]; NUM_BARS],
+    /// - The narrower 2-input AND (width `< 8`) is only degree 2, so
+    ///   inlining it into the XOR directly still caps at degree 3 without
+    ///   needing a committed cell.
+    pub bars_chi_products: [[T; NUM_CHI_CELLS]; NUM_BARS],
 
-    /// Running "still matches the modulus prefix" flag, one cell per
-    /// modulus **one**-bit.
+    /// Running "still matches the modulus prefix" flag, one cell per pair
+    /// of modulus **one**-bits.
     ///
     /// # Walk (MSB to LSB)
     ///
     /// - Start with `m = 1` above the most significant bit.
-    /// - For each bit position i from MSB down to LSB:
-    ///   - If the modulus has 1 at i: commit the next flag cell,
-    ///     `m_i = m_{i+1} * x_i`.
-    ///   - If the modulus has 0 at i: no cell is committed; `m_i = m_{i+1}`
-    ///     is enforced only through the side constraint
-    ///     `m_{i+1} * x_i = 0` (any 1 in x while still matching means
-    ///     `x > p`), with `m_{i+1}` reused directly from the previous step.
-    /// - Final: the last committed flag is `0`, ruling out the encoding
+    /// - Modulus one-bits are consumed two at a time: the second one-bit
+    ///   of each pair commits the next flag cell,
+    ///   `m = m_prev * bits[first] * bits[second]` (degree 3).
+    /// - A modulus-zero bit commits no cell; `m` passes through unchanged,
+    ///   enforced only through the side constraint `m * bits[i] = 0` (any 1
+    ///   in x while still matching means `x > p`).
+    /// - If the modulus's Hamming weight is odd, the final one-bit (always
+    ///   bit 0, since every prime modulus is odd) never pairs: its check is
+    ///   folded directly into the closing assertion instead of getting its
+    ///   own committed cell.
+    /// - Final: the closing assertion is `0`, ruling out the encoding
     ///   `x == p`.
     ///
-    /// A modulus-zero bit is a pure copy of the previous flag, so it needs
-    /// no committed column of its own — only `NUM_MATCH_FLAGS` cells (the
-    /// modulus's Hamming weight) are stored per Bar, one per one-bit.
+    /// `NUM_MATCH_FLAGS` therefore equals `modulus.count_ones() / 2`
+    /// (integer division) per Bar, rather than one cell per bit position.
     ///
     /// # Why this column exists
     ///
@@ -161,8 +172,19 @@ pub const fn num_cols<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 >() -> usize {
-    size_of::<MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
+    size_of::<
+        MonolithCols<
+            u8,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >,
+    >()
 }
 
 impl<
@@ -172,16 +194,44 @@ impl<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
-> Borrow<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>> for [T]
+    const NUM_CHI_CELLS: usize,
+>
+    Borrow<
+        MonolithCols<
+            T,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >,
+    > for [T]
 {
     fn borrow(
         &self,
-    ) -> &MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> {
+    ) -> &MonolithCols<
+        T,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    > {
         // Reinterpret the flat slice as the column struct.
         // Safety: `#[repr(C)]` guarantees predictable layout and `T` has
         // alignment 1 for the `u8` case used in `num_cols`.
         let (prefix, shorts, suffix) = unsafe {
-            self.align_to::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
+            self.align_to::<MonolithCols<
+                T,
+                WIDTH,
+                NUM_FULL_ROUNDS,
+                NUM_BARS,
+                FIELD_BITS,
+                NUM_MATCH_FLAGS,
+                NUM_CHI_CELLS,
+            >>()
         };
 
         // No padding before or after the struct.
@@ -201,14 +251,41 @@ impl<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
-> BorrowMut<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>
-    for [T]
+    const NUM_CHI_CELLS: usize,
+>
+    BorrowMut<
+        MonolithCols<
+            T,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >,
+    > for [T]
 {
     fn borrow_mut(
         &mut self,
-    ) -> &mut MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> {
+    ) -> &mut MonolithCols<
+        T,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    > {
         let (prefix, shorts, suffix) = unsafe {
-            self.align_to_mut::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
+            self.align_to_mut::<MonolithCols<
+                T,
+                WIDTH,
+                NUM_FULL_ROUNDS,
+                NUM_BARS,
+                FIELD_BITS,
+                NUM_MATCH_FLAGS,
+                NUM_CHI_CELLS,
+            >>()
         };
         debug_assert!(prefix.is_empty(), "Alignment should match");
         debug_assert!(suffix.is_empty(), "Alignment should match");

--- a/monolith-air/src/columns.rs
+++ b/monolith-air/src/columns.rs
@@ -18,7 +18,8 @@
 //!
 //! - **Inputs**: `WIDTH` columns.
 //! - **Per round** (NUM_FULL_ROUNDS + 1 total rounds):
-//!   `NUM_BARS * FIELD_BITS` (bit decomposition)
+//!   `NUM_BARS * (2 * FIELD_BITS + NUM_MATCH_FLAGS)` (bit decomposition,
+//!   chi products, and match flags)
 //!   + `NUM_BARS` (bar outputs)
 //!   + `WIDTH` (post-state).
 //!
@@ -47,6 +48,7 @@ pub struct MonolithCols<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 > {
     /// The initial permutation state before any operations are applied.
     pub inputs: [T; WIDTH],
@@ -55,21 +57,27 @@ pub struct MonolithCols<
     ///
     /// Each round applies: Bars → Bricks → Concrete → AddRoundConstants.
     /// The `post` field in each round stores the state after all four operations.
-    pub full_rounds: [MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS>; NUM_FULL_ROUNDS],
+    pub full_rounds:
+        [MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>; NUM_FULL_ROUNDS],
 
     /// Columns for the final round (no round constants).
     ///
     /// The final round applies: Bars → Bricks → Concrete.
     /// The `post` field stores the final permutation output.
-    pub final_round: MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS>,
+    pub final_round: MonolithRoundCols<T, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
 }
 
 /// Columns for a single Monolith round.
 ///
 /// Each round applies: Bars → Bricks → Concrete (→ AddRC for non-final rounds).
 #[repr(C)]
-pub struct MonolithRoundCols<T, const WIDTH: usize, const NUM_BARS: usize, const FIELD_BITS: usize>
-{
+pub struct MonolithRoundCols<
+    T,
+    const WIDTH: usize,
+    const NUM_BARS: usize,
+    const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
+> {
     /// Bit decomposition of the input to each Bar application (LSB first).
     ///
     /// For each of the `NUM_BARS` elements entering the Bars layer, we store
@@ -98,16 +106,25 @@ pub struct MonolithRoundCols<T, const WIDTH: usize, const NUM_BARS: usize, const
     ///   and a degree-2 XOR, capping the AIR at degree 3.
     pub bars_chi_products: [[T; FIELD_BITS]; NUM_BARS],
 
-    /// Running "still matches the modulus prefix" flag, one cell per input bit.
+    /// Running "still matches the modulus prefix" flag, one cell per
+    /// modulus **one**-bit.
     ///
     /// # Walk (MSB to LSB)
     ///
     /// - Start with `m = 1` above the most significant bit.
     /// - For each bit position i from MSB down to LSB:
-    ///   - If the modulus has 1 at i: `m_i = m_{i+1} * x_i`.
-    ///   - If the modulus has 0 at i: `m_i = m_{i+1}` plus the side constraint
-    ///     `m_{i+1} * x_i = 0` (any 1 in x while still matching means `x > p`).
-    /// - Final: `m_0 = 0`, ruling out the encoding `x == p`.
+    ///   - If the modulus has 1 at i: commit the next flag cell,
+    ///     `m_i = m_{i+1} * x_i`.
+    ///   - If the modulus has 0 at i: no cell is committed; `m_i = m_{i+1}`
+    ///     is enforced only through the side constraint
+    ///     `m_{i+1} * x_i = 0` (any 1 in x while still matching means
+    ///     `x > p`), with `m_{i+1}` reused directly from the previous step.
+    /// - Final: the last committed flag is `0`, ruling out the encoding
+    ///   `x == p`.
+    ///
+    /// A modulus-zero bit is a pure copy of the previous flag, so it needs
+    /// no committed column of its own — only `NUM_MATCH_FLAGS` cells (the
+    /// modulus's Hamming weight) are stored per Bar, one per one-bit.
     ///
     /// # Why this column exists
     ///
@@ -115,7 +132,7 @@ pub struct MonolithRoundCols<T, const WIDTH: usize, const NUM_BARS: usize, const
     ///   bit encoding for field elements already represented canonically.
     /// - The walk works for any prime, including those whose forbidden range
     ///   covers many bit patterns (e.g. Goldilocks).
-    pub bars_match_flags: [[T; FIELD_BITS]; NUM_BARS],
+    pub bars_match_flags: [[T; NUM_MATCH_FLAGS]; NUM_BARS],
 
     /// Committed output of each Bar (S-box) application.
     ///
@@ -143,8 +160,9 @@ pub const fn num_cols<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 >() -> usize {
-    size_of::<MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>>()
+    size_of::<MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
 }
 
 impl<
@@ -153,14 +171,17 @@ impl<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
-> Borrow<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>> for [T]
+    const NUM_MATCH_FLAGS: usize,
+> Borrow<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>> for [T]
 {
-    fn borrow(&self) -> &MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> {
+    fn borrow(
+        &self,
+    ) -> &MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> {
         // Reinterpret the flat slice as the column struct.
         // Safety: `#[repr(C)]` guarantees predictable layout and `T` has
         // alignment 1 for the `u8` case used in `num_cols`.
         let (prefix, shorts, suffix) = unsafe {
-            self.align_to::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>>()
+            self.align_to::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
         };
 
         // No padding before or after the struct.
@@ -179,11 +200,15 @@ impl<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
-> BorrowMut<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>> for [T]
+    const NUM_MATCH_FLAGS: usize,
+> BorrowMut<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>
+    for [T]
 {
-    fn borrow_mut(&mut self) -> &mut MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> {
+    fn borrow_mut(
+        &mut self,
+    ) -> &mut MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> {
         let (prefix, shorts, suffix) = unsafe {
-            self.align_to_mut::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>>()
+            self.align_to_mut::<MonolithCols<T, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>>()
         };
         debug_assert!(prefix.is_empty(), "Alignment should match");
         debug_assert!(suffix.is_empty(), "Alignment should match");

--- a/monolith-air/src/generation.rs
+++ b/monolith-air/src/generation.rs
@@ -59,9 +59,10 @@ pub fn generate_trace_rows<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 >(
     inputs: Vec<[F; WIDTH]>,
-    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>,
+    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
     bars: &B,
     extra_capacity_bits: usize,
 ) -> RowMajorMatrix<F> {
@@ -72,7 +73,7 @@ pub fn generate_trace_rows<
     );
 
     // One permutation per row.
-    let ncols = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>();
+    let ncols = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
 
     // Allocate with extra capacity for LDE blowup.
     let mut vec = Vec::with_capacity((n * ncols) << extra_capacity_bits);
@@ -89,6 +90,7 @@ pub fn generate_trace_rows<
             NUM_FULL_ROUNDS,
             NUM_BARS,
             FIELD_BITS,
+            NUM_MATCH_FLAGS,
         >>()
     };
     assert!(prefix.is_empty(), "Alignment should match");
@@ -134,10 +136,18 @@ pub fn generate_trace_rows_for_perm<
     const NUM_FULL_ROUNDS: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 >(
-    perm: &mut MonolithCols<MaybeUninit<F>, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>,
+    perm: &mut MonolithCols<
+        MaybeUninit<F>,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+    >,
     mut state: [F; WIDTH],
-    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>,
+    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
     bars: &B,
 ) {
     // Step 1: Write the initial state into the `inputs` columns.
@@ -153,7 +163,7 @@ pub fn generate_trace_rows_for_perm<
 
     // Step 3: Full rounds (NUM_FULL_ROUNDS rounds with round constants).
     for (round_idx, round_cols) in perm.full_rounds.iter_mut().enumerate() {
-        generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS>(
+        generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
             &mut state,
             round_cols,
             &air.mds_matrix,
@@ -165,7 +175,7 @@ pub fn generate_trace_rows_for_perm<
     }
 
     // Step 4: Final round (no round constants).
-    generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS>(
+    generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
         &mut state,
         &mut perm.final_round,
         &air.mds_matrix,
@@ -189,9 +199,10 @@ fn generate_round<
     const WIDTH: usize,
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
+    const NUM_MATCH_FLAGS: usize,
 >(
     state: &mut [F; WIDTH],
-    round: &mut MonolithRoundCols<MaybeUninit<F>, WIDTH, NUM_BARS, FIELD_BITS>,
+    round: &mut MonolithRoundCols<MaybeUninit<F>, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
     mds_matrix: &[[F; WIDTH]; WIDTH],
     round_constants: Option<&[F; WIDTH]>,
     limb_bits: &[usize],
@@ -216,48 +227,64 @@ fn generate_round<
             bit_col.write(bit_val);
         }
 
-        // Per-bit AND products, walking limbs left to right.
+        // All chi/walk witnesses below are boolean functions of the input's
+        // bit pattern, so they're computed as word-level bit ops on the
+        // canonical integer instead of field multiplications.
+        let val = state[bar_idx].as_canonical_u64();
+
+        // Per-limb AND products, walking limbs left to right.
+        //
+        // Bit j of `rot(k)` is `x[(j - k) mod n]` (a left rotation by k
+        // within the n-bit limb), matching the `sub(k) = (j - k) mod n`
+        // indexing of the field-arithmetic formulation this replaces:
+        //
+        //     andn   = (NOT x[j-2]) AND x[j-3]
+        //     8-bit  : chi[j] = andn AND x[j-4]
+        //     7-bit  : chi[j] = andn
         let mut bit_offset = 0;
         for (limb_idx, &n) in limb_bits.iter().enumerate() {
             // Only the trailing limb may be narrower than 8 bits.
             let is_last_reduced = limb_idx == limb_bits.len() - 1 && n < 8;
-            let limb = &bits[bit_offset..bit_offset + n];
+            let mask = (1u64 << n) - 1;
+            let limb = (val >> bit_offset) & mask;
+            let rot = |k: usize| ((limb << k) | (limb >> (n - k))) & mask;
 
-            //     sub(k) = (j - k) mod n
+            let chi_word = if is_last_reduced {
+                !rot(2) & rot(3)
+            } else {
+                !rot(2) & rot(3) & rot(4)
+            };
             for j in 0..n {
-                let sub = |offset: usize| (j + n - (offset % n)) % n;
-
-                //     andn   = (1 - x[j-2]) * x[j-3]
-                //     8-bit  : chi = andn * x[j-4]
-                //     7-bit  : chi = andn
-                let andn = limb[sub(2)].andn(&limb[sub(3)]);
-                let chi_product = if is_last_reduced {
-                    andn
-                } else {
-                    andn * limb[sub(4)]
-                };
-                bar_chi[bit_offset + j].write(chi_product);
+                bar_chi[bit_offset + j].write(F::from_bool((chi_word >> j) & 1 != 0));
             }
             bit_offset += n;
         }
 
         // Canonical-pattern walk (MSB → LSB):
         //
-        //     prev = 1
+        //     prev = true
         //     for i from FIELD_BITS-1 down to 0:
-        //         if p_bit[i]: prev *= bits[i]
-        //         else       : prev stays                 (and prev * bits[i] must be 0)
-        //         match_flag[i] = prev
+        //         if p_bit[i]: prev &= bit[i]; commit prev as the next flag cell
+        //         else       : prev stays                 (and prev AND bit[i] must be false)
         //
-        // Canonical inputs always end with prev = 0 (some bit position must
-        // make them strictly less than p).
-        let mut prev = F::ONE;
+        // Only modulus one-bits commit a flag cell (a zero-bit's flag is a
+        // pure copy of the previous one, so the AIR reuses `prev` directly
+        // instead of reading a redundant column). `bar_mflag` therefore has
+        // `NUM_MATCH_FLAGS` cells — the modulus's Hamming weight — filled in
+        // MSB-to-LSB order as one-bits are encountered.
+        //
+        // Canonical inputs always end with prev = false (some bit position
+        // must make them strictly less than p).
+        let mut prev = true;
+        let mut flag_idx = 0;
         for i in (0..FIELD_BITS).rev() {
             if modulus_lsb_to_msb[i] {
-                prev *= bits[i];
+                prev &= (val >> i) & 1 != 0;
+                bar_mflag[flag_idx].write(F::from_bool(prev));
+                flag_idx += 1;
             }
-            bar_mflag[i].write(prev);
         }
+        debug_assert_eq!(flag_idx, NUM_MATCH_FLAGS);
     }
 
     // Phase 2: Bars S-box (overwrites positions 0..u; u..t pass through).

--- a/monolith-air/src/generation.rs
+++ b/monolith-air/src/generation.rs
@@ -60,9 +60,18 @@ pub fn generate_trace_rows<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 >(
     inputs: Vec<[F; WIDTH]>,
-    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+    air: &MonolithAir<
+        F,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    >,
     bars: &B,
     extra_capacity_bits: usize,
 ) -> RowMajorMatrix<F> {
@@ -73,7 +82,8 @@ pub fn generate_trace_rows<
     );
 
     // One permutation per row.
-    let ncols = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
+    let ncols =
+        num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>();
 
     // Allocate with extra capacity for LDE blowup.
     let mut vec = Vec::with_capacity((n * ncols) << extra_capacity_bits);
@@ -91,6 +101,7 @@ pub fn generate_trace_rows<
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >>()
     };
     assert!(prefix.is_empty(), "Alignment should match");
@@ -137,6 +148,7 @@ pub fn generate_trace_rows_for_perm<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 >(
     perm: &mut MonolithCols<
         MaybeUninit<F>,
@@ -145,9 +157,18 @@ pub fn generate_trace_rows_for_perm<
         NUM_BARS,
         FIELD_BITS,
         NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
     >,
     mut state: [F; WIDTH],
-    air: &MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+    air: &MonolithAir<
+        F,
+        WIDTH,
+        NUM_FULL_ROUNDS,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    >,
     bars: &B,
 ) {
     // Step 1: Write the initial state into the `inputs` columns.
@@ -163,7 +184,7 @@ pub fn generate_trace_rows_for_perm<
 
     // Step 3: Full rounds (NUM_FULL_ROUNDS rounds with round constants).
     for (round_idx, round_cols) in perm.full_rounds.iter_mut().enumerate() {
-        generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
+        generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>(
             &mut state,
             round_cols,
             &air.mds_matrix,
@@ -175,7 +196,7 @@ pub fn generate_trace_rows_for_perm<
     }
 
     // Step 4: Final round (no round constants).
-    generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>(
+    generate_round::<F, B, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS>(
         &mut state,
         &mut perm.final_round,
         &air.mds_matrix,
@@ -200,9 +221,17 @@ fn generate_round<
     const NUM_BARS: usize,
     const FIELD_BITS: usize,
     const NUM_MATCH_FLAGS: usize,
+    const NUM_CHI_CELLS: usize,
 >(
     state: &mut [F; WIDTH],
-    round: &mut MonolithRoundCols<MaybeUninit<F>, WIDTH, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+    round: &mut MonolithRoundCols<
+        MaybeUninit<F>,
+        WIDTH,
+        NUM_BARS,
+        FIELD_BITS,
+        NUM_MATCH_FLAGS,
+        NUM_CHI_CELLS,
+    >,
     mds_matrix: &[[F; WIDTH]; WIDTH],
     round_constants: Option<&[F; WIDTH]>,
     limb_bits: &[usize],
@@ -232,56 +261,62 @@ fn generate_round<
         // canonical integer instead of field multiplications.
         let val = state[bar_idx].as_canonical_u64();
 
-        // Per-limb AND products, walking limbs left to right.
+        // Per-limb AND products, walking limbs left to right. The trailing
+        // limb, when narrower than 8 bits, is inlined by the AIR instead of
+        // committed, so its AND term isn't written here at all.
         //
         // Bit j of `rot(k)` is `x[(j - k) mod n]` (a left rotation by k
-        // within the n-bit limb), matching the `sub(k) = (j - k) mod n`
-        // indexing of the field-arithmetic formulation this replaces:
+        // within the n-bit limb):
         //
-        //     andn   = (NOT x[j-2]) AND x[j-3]
-        //     8-bit  : chi[j] = andn AND x[j-4]
-        //     7-bit  : chi[j] = andn
+        //     chi[j] = (NOT x[j-2]) AND x[j-3] AND x[j-4]
         let mut bit_offset = 0;
+        let mut chi_offset = 0;
         for (limb_idx, &n) in limb_bits.iter().enumerate() {
-            // Only the trailing limb may be narrower than 8 bits.
             let is_last_reduced = limb_idx == limb_bits.len() - 1 && n < 8;
-            let mask = (1u64 << n) - 1;
-            let limb = (val >> bit_offset) & mask;
-            let rot = |k: usize| ((limb << k) | (limb >> (n - k))) & mask;
-
-            let chi_word = if is_last_reduced {
-                !rot(2) & rot(3)
-            } else {
-                !rot(2) & rot(3) & rot(4)
-            };
-            for j in 0..n {
-                bar_chi[bit_offset + j].write(F::from_bool((chi_word >> j) & 1 != 0));
+            if !is_last_reduced {
+                let mask = (1u64 << n) - 1;
+                let limb = (val >> bit_offset) & mask;
+                let rot = |k: usize| ((limb << k) | (limb >> (n - k))) & mask;
+                let chi_word = !rot(2) & rot(3) & rot(4);
+                for j in 0..n {
+                    bar_chi[chi_offset + j].write(F::from_bool((chi_word >> j) & 1 != 0));
+                }
+                chi_offset += n;
             }
             bit_offset += n;
         }
+        debug_assert_eq!(chi_offset, NUM_CHI_CELLS);
 
-        // Canonical-pattern walk (MSB → LSB):
+        // Canonical-pattern walk (MSB → LSB), batching two modulus one-bits
+        // into each committed flag:
         //
         //     prev = true
         //     for i from FIELD_BITS-1 down to 0:
-        //         if p_bit[i]: prev &= bit[i]; commit prev as the next flag cell
+        //         if p_bit[i]: pair with the pending one-bit (if any) and
+        //                      commit `prev &= pending_bit & bit[i]`;
+        //                      otherwise stash bit[i] as pending
         //         else       : prev stays                 (and prev AND bit[i] must be false)
         //
-        // Only modulus one-bits commit a flag cell (a zero-bit's flag is a
-        // pure copy of the previous one, so the AIR reuses `prev` directly
-        // instead of reading a redundant column). `bar_mflag` therefore has
-        // `NUM_MATCH_FLAGS` cells — the modulus's Hamming weight — filled in
-        // MSB-to-LSB order as one-bits are encountered.
-        //
-        // Canonical inputs always end with prev = false (some bit position
-        // must make them strictly less than p).
+        // A modulus-zero bit's flag is a pure copy of the previous one, so
+        // the AIR reuses `prev` directly instead of reading a column; two
+        // modulus one-bits share one committed cell. `bar_mflag` therefore
+        // has `NUM_MATCH_FLAGS` cells (`modulus.count_ones() / 2`) filled in
+        // MSB-to-LSB order. If the Hamming weight is odd, the final one-bit
+        // (always bit 0) never pairs and needs no cell — the AIR folds its
+        // check directly into the closing assertion instead.
         let mut prev = true;
         let mut flag_idx = 0;
+        let mut pending: Option<bool> = None;
         for i in (0..FIELD_BITS).rev() {
             if modulus_lsb_to_msb[i] {
-                prev &= (val >> i) & 1 != 0;
-                bar_mflag[flag_idx].write(F::from_bool(prev));
-                flag_idx += 1;
+                let bit_i = (val >> i) & 1 != 0;
+                if let Some(first) = pending.take() {
+                    prev = prev && first && bit_i;
+                    bar_mflag[flag_idx].write(F::from_bool(prev));
+                    flag_idx += 1;
+                } else {
+                    pending = Some(bit_i);
+                }
             }
         }
         debug_assert_eq!(flag_idx, NUM_MATCH_FLAGS);

--- a/monolith-air/src/lib.rs
+++ b/monolith-air/src/lib.rs
@@ -49,13 +49,25 @@ mod tests {
     const NUM_FULL_ROUNDS: usize = 5;
     const NUM_BARS: usize = 8;
     const FIELD_BITS: usize = 31;
-    // Mersenne31's modulus (0x7FFFFFFF) is all ones, so every bit is a
-    // "match" position and NUM_MATCH_FLAGS equals FIELD_BITS exactly.
-    const NUM_MATCH_FLAGS: usize = 31;
+    // Mersenne31's modulus (0x7FFFFFFF) is all ones (Hamming weight 31, all
+    // "one" positions), so pairing two one-bits per flag gives 31/2 = 15
+    // committed flags (the odd leftover, bit 0, folds into the final assert).
+    const NUM_MATCH_FLAGS: usize = 15;
+    // Three leading 8-bit limbs commit chi (24 cells); the trailing 7-bit
+    // limb's chi is inlined into the XOR instead of committed.
+    const NUM_CHI_CELLS: usize = 24;
 
     /// Build a Monolith-31 AIR instance and return it with the Bars impl.
     fn build_monolith_air() -> (
-        MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+        MonolithAir<
+            F,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >,
         MonolithBarsM31,
     ) {
         let bars = MonolithBarsM31;
@@ -69,6 +81,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >::extract_mds_matrix(&mds);
 
         let monolith = MonolithMersenne31::new(bars, mds);
@@ -80,11 +93,26 @@ mod tests {
     #[test]
     fn test_column_layout() {
         // num_cols() computes the expected column count from const generics.
-        let expected = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
+        let expected = num_cols::<
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >();
 
         // size_of with T=u8 gives the actual struct size in bytes = number of fields.
         let actual = size_of::<
-            MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+            MonolithCols<
+                u8,
+                WIDTH,
+                NUM_FULL_ROUNDS,
+                NUM_BARS,
+                FIELD_BITS,
+                NUM_MATCH_FLAGS,
+                NUM_CHI_CELLS,
+            >,
         >();
 
         assert_eq!(expected, actual);
@@ -95,16 +123,25 @@ mod tests {
         // Per round (Mersenne31, width 16):
         //
         //     FIELD_BITS * NUM_BARS       (input bits)
-        //   + FIELD_BITS * NUM_BARS       (chi AND-product witnesses)
+        //   + NUM_CHI_CELLS * NUM_BARS    (chi AND-product witnesses: 24 of
+        //                                  31 bits, since the trailing 7-bit
+        //                                  limb's chi is inlined, not committed)
         //   + NUM_MATCH_FLAGS * NUM_BARS  (canonical-pattern match flags:
-        //                                  one per modulus one-bit, not
-        //                                  FIELD_BITS — M31's modulus is
-        //                                  all ones, so this equals FIELD_BITS)
+        //                                  one per PAIR of modulus one-bits,
+        //                                  15 = 31/2, not FIELD_BITS)
         //   + NUM_BARS                    (Bar outputs)
         //   + WIDTH                       (post-state)
-        let per_round = (2 * FIELD_BITS + NUM_MATCH_FLAGS) * NUM_BARS + NUM_BARS + WIDTH;
+        let per_round =
+            (FIELD_BITS + NUM_CHI_CELLS + NUM_MATCH_FLAGS) * NUM_BARS + NUM_BARS + WIDTH;
         let expected = WIDTH + (NUM_FULL_ROUNDS + 1) * per_round;
-        let actual = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
+        let actual = num_cols::<
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        >();
         assert_eq!(expected, actual);
     }
 
@@ -138,6 +175,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(inputs, &air, &bars, 0);
 
         // One input → one row in the trace.
@@ -151,8 +189,15 @@ mod tests {
 
         // Extract the final post-state from the trace (last round's post).
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> =
-            (*local).borrow();
+        let row: &MonolithCols<
+            F,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        > = (*local).borrow();
         let final_post = &row.final_round.post;
 
         // The AIR trace output must match the reference implementation.
@@ -177,11 +222,19 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(inputs, &air, &bars, 0);
 
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> =
-            (*local).borrow();
+        let row: &MonolithCols<
+            F,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
+        > = (*local).borrow();
 
         // Expected output from the Monolith-31 reference test vector
         // (validated against the HorizenLabs reference implementation).
@@ -214,6 +267,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
@@ -233,6 +287,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
@@ -253,6 +308,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
@@ -280,13 +336,14 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         >(vec![input], &air, &bars, 0);
 
         // Mutation on the first Bar of the first round:
         //
         //     bits           : 0...0  -->  1...1
         //     chi[j]         : 0      -->  0     ((1 - 1) * 1 * 1 = 0)
-        //     match_flag[i]  : 0      -->  1     (forced by walk:  m *= 1)
+        //     match_flag[i]  : 0      -->  1     (forced by walk pairing:  m &= 1 & 1)
         //
         // chi fixed points keep the S-box equation satisfied:
         //
@@ -294,8 +351,10 @@ mod tests {
         //     chi(0x7F) = 0x7F   (7-bit limb)
         //     packed    = p = 0  (mod p)
         //
-        // But the walk now ends with match_flag[0] = 1, which the
-        // `assert_zero(match_flag[0])` constraint rejects.
+        // The walk's every paired step still holds (`m = 1` throughout,
+        // since every bit is 1), but the final bit (index 0) never pairs
+        // and its check is folded directly into the closing assertion,
+        // which rejects it.
         let row_slice = trace.row_mut(0);
         let row: &mut MonolithCols<
             F,
@@ -304,6 +363,7 @@ mod tests {
             NUM_BARS,
             FIELD_BITS,
             NUM_MATCH_FLAGS,
+            NUM_CHI_CELLS,
         > = row_slice.borrow_mut();
         let bar = &mut row.full_rounds[0];
         for b in bar.bars_input_bits[0].iter_mut() {
@@ -348,7 +408,7 @@ mod tests {
             ].map(F::from_u32);
 
             let trace = generate_trace_rows::<
-                _, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS,
+                _, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS, NUM_CHI_CELLS,
             >(vec![input], &air, &bars, 0);
 
             check_constraints(&air, &trace, &[]);
@@ -362,18 +422,28 @@ mod tests {
     const G_BARS: usize = 4;
     const G_BITS: usize = 64;
     // Goldilocks's modulus (0xFFFFFFFF00000001) has Hamming weight 33 (32
-    // leading one-bits plus bit 0), so 31 of its 64 bit positions need no
-    // committed match-flag cell.
-    const G_NUM_MATCH_FLAGS: usize = 33;
+    // leading one-bits plus bit 0): pairing two one-bits per flag gives
+    // 33/2 = 16 committed flags (the odd leftover, bit 0, folds into the
+    // final assert).
+    const G_NUM_MATCH_FLAGS: usize = 16;
+    // All eight limbs are 8 bits wide, so every chi cell is committed.
+    const G_NUM_CHI_CELLS: usize = 64;
 
     fn build_goldilocks_air() -> (
-        MonolithAir<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>,
+        MonolithAir<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS, G_NUM_CHI_CELLS>,
         MonolithBarsGoldilocks<8>,
     ) {
         let bars = MonolithBarsGoldilocks::<8>;
         let mds = MonolithMdsMatrixGoldilocks;
-        let mds_matrix =
-            MonolithAir::<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>::extract_mds_matrix(&mds);
+        let mds_matrix = MonolithAir::<
+            G,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        >::extract_mds_matrix(&mds);
         let monolith = MonolithGoldilocks8::new(bars, mds);
         let air = MonolithAir::new(monolith.round_constants, mds_matrix, GOLDILOCKS_8_LIMB_BITS);
         (air, bars)
@@ -382,20 +452,15 @@ mod tests {
     #[test]
     fn test_column_count_goldilocks_8() {
         // Per round (Goldilocks, width 8): same shape as
-        // `test_column_count_mersenne31_16`, but here NUM_MATCH_FLAGS (33)
-        // is strictly less than FIELD_BITS (64), since 31 of the modulus's
-        // bit positions are zero and need no committed flag cell.
-        let per_round = (2 * G_BITS + G_NUM_MATCH_FLAGS) * G_BARS + G_BARS + G_WIDTH;
+        // `test_column_count_mersenne31_16`. NUM_CHI_CELLS equals FIELD_BITS
+        // since all eight limbs are 8 bits wide, but NUM_MATCH_FLAGS (16) is
+        // one committed cell per pair of modulus one-bits, well below
+        // FIELD_BITS (64).
+        let per_round = (G_BITS + G_NUM_CHI_CELLS + G_NUM_MATCH_FLAGS) * G_BARS + G_BARS + G_WIDTH;
         let expected = G_WIDTH + (G_FULL + 1) * per_round;
-        let actual = num_cols::<G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>();
+        let actual =
+            num_cols::<G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS, G_NUM_CHI_CELLS>();
         assert_eq!(expected, actual);
-
-        // Against the FIELD_BITS-wide match-flag layout this replaces:
-        // 4,688 columns, a 744-column (15.9%) reduction.
-        let per_round_before_perf1a = 3 * G_BITS * G_BARS + G_BARS + G_WIDTH;
-        let before = G_WIDTH + (G_FULL + 1) * per_round_before_perf1a;
-        assert_eq!(before, 4688);
-        assert_eq!(before - actual, 744);
     }
 
     #[test]
@@ -404,9 +469,16 @@ mod tests {
         // high-bit activity.
         let (air, bars) = build_goldilocks_air();
         let inputs = vec![[G::ZERO; G_WIDTH]];
-        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        >(inputs, &air, &bars, 0);
         check_constraints(&air, &trace, &[]);
     }
 
@@ -419,12 +491,16 @@ mod tests {
         //     modulus bit 0          = 1       ->  final multiplicative step
         let (air, bars) = build_goldilocks_air();
         let input: [G; G_WIDTH] = core::array::from_fn(|i| G::from_u64(i as u64 * 0x9E37));
-        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
-            vec![input],
-            &air,
-            &bars,
-            0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        >(vec![input], &air, &bars, 0);
         check_constraints(&air, &trace, &[]);
     }
 
@@ -445,17 +521,27 @@ mod tests {
         // all-ones forgery test above.
         let (air, bars) = build_goldilocks_air();
         let input: [G; G_WIDTH] = [G::ZERO; G_WIDTH];
-        let mut trace =
-            generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
-                vec![input],
-                &air,
-                &bars,
-                0,
-            );
+        let mut trace = generate_trace_rows::<
+            _,
+            _,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        >(vec![input], &air, &bars, 0);
 
         let row_slice = trace.row_mut(0);
-        let row: &mut MonolithCols<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS> =
-            row_slice.borrow_mut();
+        let row: &mut MonolithCols<
+            G,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        > = row_slice.borrow_mut();
         let bar = &mut row.full_rounds[0];
         for b in bar.bars_input_bits[0].iter_mut() {
             *b = G::ONE;
@@ -484,7 +570,7 @@ mod tests {
         ) {
             let (air, bars) = build_goldilocks_air();
             let input: [G; G_WIDTH] = [s0, s1, s2, s3, s4, s5, s6, s7].map(G::from_u64);
-            let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
+            let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS, G_NUM_CHI_CELLS>(
                 vec![input], &air, &bars, 0,
             );
             check_constraints(&air, &trace, &[]);
@@ -496,12 +582,16 @@ mod tests {
         // AIR trace's final post-state must match the reference permutation.
         let (air, bars) = build_goldilocks_air();
         let input: [G; G_WIDTH] = core::array::from_fn(G::from_usize);
-        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
-            vec![input],
-            &air,
-            &bars,
-            0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        >(vec![input], &air, &bars, 0);
 
         let monolith: MonolithGoldilocks8<_, G_WIDTH, G_FULL> =
             MonolithGoldilocks8::new(MonolithBarsGoldilocks::<8>, MonolithMdsMatrixGoldilocks);
@@ -509,8 +599,15 @@ mod tests {
         monolith.permute_mut(&mut expected);
 
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS> =
-            (*local).borrow();
+        let row: &MonolithCols<
+            G,
+            G_WIDTH,
+            G_FULL,
+            G_BARS,
+            G_BITS,
+            G_NUM_MATCH_FLAGS,
+            G_NUM_CHI_CELLS,
+        > = (*local).borrow();
         assert_eq!(row.final_round.post, expected);
     }
 }

--- a/monolith-air/src/lib.rs
+++ b/monolith-air/src/lib.rs
@@ -28,7 +28,7 @@ mod tests {
 
     use p3_air::symbolic::{AirLayout, get_max_constraint_degree};
     use p3_air::{BaseAir, check_constraints};
-    use p3_field::{PrimeCharacteristicRing, PrimeField32};
+    use p3_field::{PrimeCharacteristicRing, PrimeField32, PrimeField64};
     use p3_goldilocks::Goldilocks;
     use p3_matrix::Matrix;
     use p3_mersenne_31::Mersenne31;
@@ -49,20 +49,27 @@ mod tests {
     const NUM_FULL_ROUNDS: usize = 5;
     const NUM_BARS: usize = 8;
     const FIELD_BITS: usize = 31;
+    // Mersenne31's modulus (0x7FFFFFFF) is all ones, so every bit is a
+    // "match" position and NUM_MATCH_FLAGS equals FIELD_BITS exactly.
+    const NUM_MATCH_FLAGS: usize = 31;
 
     /// Build a Monolith-31 AIR instance and return it with the Bars impl.
     fn build_monolith_air() -> (
-        MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>,
+        MonolithAir<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
         MonolithBarsM31,
     ) {
         let bars = MonolithBarsM31;
         let mds = MonolithMdsMatrixMersenne31::<6>;
 
         // Extract MDS matrix before moving mds into the Monolith constructor.
-        let mds_matrix =
-            MonolithAir::<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>::extract_mds_matrix(
-                &mds,
-            );
+        let mds_matrix = MonolithAir::<
+            F,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >::extract_mds_matrix(&mds);
 
         let monolith = MonolithMersenne31::new(bars, mds);
 
@@ -73,10 +80,12 @@ mod tests {
     #[test]
     fn test_column_layout() {
         // num_cols() computes the expected column count from const generics.
-        let expected = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>();
+        let expected = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
 
         // size_of with T=u8 gives the actual struct size in bytes = number of fields.
-        let actual = size_of::<MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>>();
+        let actual = size_of::<
+            MonolithCols<u8, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>,
+        >();
 
         assert_eq!(expected, actual);
     }
@@ -85,14 +94,17 @@ mod tests {
     fn test_column_count_mersenne31_16() {
         // Per round (Mersenne31, width 16):
         //
-        //     FIELD_BITS * NUM_BARS  (input bits)
-        //   + FIELD_BITS * NUM_BARS  (chi AND-product witnesses)
-        //   + FIELD_BITS * NUM_BARS  (canonical-pattern match flags)
-        //   + NUM_BARS               (Bar outputs)
-        //   + WIDTH                  (post-state)
-        let per_round = 3 * FIELD_BITS * NUM_BARS + NUM_BARS + WIDTH;
+        //     FIELD_BITS * NUM_BARS       (input bits)
+        //   + FIELD_BITS * NUM_BARS       (chi AND-product witnesses)
+        //   + NUM_MATCH_FLAGS * NUM_BARS  (canonical-pattern match flags:
+        //                                  one per modulus one-bit, not
+        //                                  FIELD_BITS — M31's modulus is
+        //                                  all ones, so this equals FIELD_BITS)
+        //   + NUM_BARS                    (Bar outputs)
+        //   + WIDTH                       (post-state)
+        let per_round = (2 * FIELD_BITS + NUM_MATCH_FLAGS) * NUM_BARS + NUM_BARS + WIDTH;
         let expected = WIDTH + (NUM_FULL_ROUNDS + 1) * per_round;
-        let actual = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>();
+        let actual = num_cols::<WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS>();
         assert_eq!(expected, actual);
     }
 
@@ -118,9 +130,15 @@ mod tests {
         // Generate a single permutation trace with sequential input [0..15].
         let input: [F; WIDTH] = core::array::from_fn(F::from_usize);
         let inputs = vec![input];
-        let trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(inputs, &air, &bars, 0);
 
         // One input → one row in the trace.
         assert_eq!(trace.height(), 1);
@@ -133,7 +151,8 @@ mod tests {
 
         // Extract the final post-state from the trace (last round's post).
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> = (*local).borrow();
+        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> =
+            (*local).borrow();
         let final_post = &row.final_round.post;
 
         // The AIR trace output must match the reference implementation.
@@ -150,12 +169,19 @@ mod tests {
         // Input: [0, 1, 2, ..., 15] — standard test vector.
         let input: [F; WIDTH] = core::array::from_fn(F::from_usize);
         let inputs = vec![input];
-        let trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(inputs, &air, &bars, 0);
 
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> = (*local).borrow();
+        let row: &MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS> =
+            (*local).borrow();
 
         // Expected output from the Monolith-31 reference test vector
         // (validated against the HorizenLabs reference implementation).
@@ -180,9 +206,15 @@ mod tests {
         let inputs: alloc::vec::Vec<[F; WIDTH]> = (0..16)
             .map(|batch| core::array::from_fn(|i| F::from_usize(batch * WIDTH + i)))
             .collect();
-        let trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
     }
@@ -193,9 +225,15 @@ mod tests {
 
         // Test with all-zero input (edge case for Bars fixed points).
         let inputs = vec![[F::ZERO; WIDTH]];
-        let trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
     }
@@ -207,9 +245,15 @@ mod tests {
         // Test with maximum field values (p-1 = 2^31 - 2).
         let max_val = F::from_u32(0x7FFF_FFFE);
         let inputs = vec![[max_val; WIDTH]];
-        let trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            inputs, &air, &bars, 0,
-        );
+        let trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(inputs, &air, &bars, 0);
 
         check_constraints(&air, &trace, &[]);
     }
@@ -228,12 +272,15 @@ mod tests {
         // Fixture: honest trace over a 16-word all-zero input.
         let (air, bars) = build_monolith_air();
         let input: [F; WIDTH] = [F::ZERO; WIDTH];
-        let mut trace = generate_trace_rows::<_, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS>(
-            vec![input],
-            &air,
-            &bars,
-            0,
-        );
+        let mut trace = generate_trace_rows::<
+            _,
+            _,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        >(vec![input], &air, &bars, 0);
 
         // Mutation on the first Bar of the first round:
         //
@@ -250,8 +297,14 @@ mod tests {
         // But the walk now ends with match_flag[0] = 1, which the
         // `assert_zero(match_flag[0])` constraint rejects.
         let row_slice = trace.row_mut(0);
-        let row: &mut MonolithCols<F, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS> =
-            row_slice.borrow_mut();
+        let row: &mut MonolithCols<
+            F,
+            WIDTH,
+            NUM_FULL_ROUNDS,
+            NUM_BARS,
+            FIELD_BITS,
+            NUM_MATCH_FLAGS,
+        > = row_slice.borrow_mut();
         let bar = &mut row.full_rounds[0];
         for b in bar.bars_input_bits[0].iter_mut() {
             *b = F::ONE;
@@ -295,7 +348,7 @@ mod tests {
             ].map(F::from_u32);
 
             let trace = generate_trace_rows::<
-                _, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS,
+                _, _, WIDTH, NUM_FULL_ROUNDS, NUM_BARS, FIELD_BITS, NUM_MATCH_FLAGS,
             >(vec![input], &air, &bars, 0);
 
             check_constraints(&air, &trace, &[]);
@@ -308,18 +361,41 @@ mod tests {
     const G_FULL: usize = 5;
     const G_BARS: usize = 4;
     const G_BITS: usize = 64;
+    // Goldilocks's modulus (0xFFFFFFFF00000001) has Hamming weight 33 (32
+    // leading one-bits plus bit 0), so 31 of its 64 bit positions need no
+    // committed match-flag cell.
+    const G_NUM_MATCH_FLAGS: usize = 33;
 
     fn build_goldilocks_air() -> (
-        MonolithAir<G, G_WIDTH, G_FULL, G_BARS, G_BITS>,
+        MonolithAir<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>,
         MonolithBarsGoldilocks<8>,
     ) {
         let bars = MonolithBarsGoldilocks::<8>;
         let mds = MonolithMdsMatrixGoldilocks;
         let mds_matrix =
-            MonolithAir::<G, G_WIDTH, G_FULL, G_BARS, G_BITS>::extract_mds_matrix(&mds);
+            MonolithAir::<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>::extract_mds_matrix(&mds);
         let monolith = MonolithGoldilocks8::new(bars, mds);
         let air = MonolithAir::new(monolith.round_constants, mds_matrix, GOLDILOCKS_8_LIMB_BITS);
         (air, bars)
+    }
+
+    #[test]
+    fn test_column_count_goldilocks_8() {
+        // Per round (Goldilocks, width 8): same shape as
+        // `test_column_count_mersenne31_16`, but here NUM_MATCH_FLAGS (33)
+        // is strictly less than FIELD_BITS (64), since 31 of the modulus's
+        // bit positions are zero and need no committed flag cell.
+        let per_round = (2 * G_BITS + G_NUM_MATCH_FLAGS) * G_BARS + G_BARS + G_WIDTH;
+        let expected = G_WIDTH + (G_FULL + 1) * per_round;
+        let actual = num_cols::<G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>();
+        assert_eq!(expected, actual);
+
+        // Against the FIELD_BITS-wide match-flag layout this replaces:
+        // 4,688 columns, a 744-column (15.9%) reduction.
+        let per_round_before_perf1a = 3 * G_BITS * G_BARS + G_BARS + G_WIDTH;
+        let before = G_WIDTH + (G_FULL + 1) * per_round_before_perf1a;
+        assert_eq!(before, 4688);
+        assert_eq!(before - actual, 744);
     }
 
     #[test]
@@ -328,8 +404,9 @@ mod tests {
         // high-bit activity.
         let (air, bars) = build_goldilocks_air();
         let inputs = vec![[G::ZERO; G_WIDTH]];
-        let trace =
-            generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS>(inputs, &air, &bars, 0);
+        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
+            inputs, &air, &bars, 0,
+        );
         check_constraints(&air, &trace, &[]);
     }
 
@@ -342,7 +419,7 @@ mod tests {
         //     modulus bit 0          = 1       ->  final multiplicative step
         let (air, bars) = build_goldilocks_air();
         let input: [G; G_WIDTH] = core::array::from_fn(|i| G::from_u64(i as u64 * 0x9E37));
-        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS>(
+        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
             vec![input],
             &air,
             &bars,
@@ -352,11 +429,74 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "constraints not satisfied")]
+    fn test_goldilocks_canonical_constraint_rejects_zero_bit_side_constraint_forgery() {
+        // Goldilocks modulus p = 0xFFFFFFFF00000001: bits 63..32 are all 1
+        // (matching the "all-ones" forgery through the top 32 bits), bits
+        // 31..1 are all 0, bit 0 is 1.
+        //
+        // Forging bits = all-ones keeps chi's fixed point (chi(0xFF) = 0xFF,
+        // since `1 - x[j-2] = 0` whenever `x[j-2] = 1`), so the S-box
+        // equation stays satisfied. The walk carries `prev = 1` through the
+        // top 32 one-bits (matching p), then hits the first modulus-zero
+        // bit (index 31) with `prev = 1` and `x_31 = 1`: the side constraint
+        // `assert_zero(prev * x_i)` fires there, before the walk ever
+        // reaches the final `assert_zero(m_0)` check exercised by the M31
+        // all-ones forgery test above.
+        let (air, bars) = build_goldilocks_air();
+        let input: [G; G_WIDTH] = [G::ZERO; G_WIDTH];
+        let mut trace =
+            generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
+                vec![input],
+                &air,
+                &bars,
+                0,
+            );
+
+        let row_slice = trace.row_mut(0);
+        let row: &mut MonolithCols<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS> =
+            row_slice.borrow_mut();
+        let bar = &mut row.full_rounds[0];
+        for b in bar.bars_input_bits[0].iter_mut() {
+            *b = G::ONE;
+        }
+        for c in bar.bars_chi_products[0].iter_mut() {
+            *c = G::ZERO;
+        }
+        for m in bar.bars_match_flags[0].iter_mut() {
+            *m = G::ONE;
+        }
+
+        check_constraints(&air, &trace, &[]);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_goldilocks_constraint_satisfaction_random(
+            s0 in 0u64..Goldilocks::ORDER_U64,
+            s1 in 0u64..Goldilocks::ORDER_U64,
+            s2 in 0u64..Goldilocks::ORDER_U64,
+            s3 in 0u64..Goldilocks::ORDER_U64,
+            s4 in 0u64..Goldilocks::ORDER_U64,
+            s5 in 0u64..Goldilocks::ORDER_U64,
+            s6 in 0u64..Goldilocks::ORDER_U64,
+            s7 in 0u64..Goldilocks::ORDER_U64,
+        ) {
+            let (air, bars) = build_goldilocks_air();
+            let input: [G; G_WIDTH] = [s0, s1, s2, s3, s4, s5, s6, s7].map(G::from_u64);
+            let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
+                vec![input], &air, &bars, 0,
+            );
+            check_constraints(&air, &trace, &[]);
+        }
+    }
+
+    #[test]
     fn test_goldilocks_trace_matches_reference_permutation() {
         // AIR trace's final post-state must match the reference permutation.
         let (air, bars) = build_goldilocks_air();
         let input: [G; G_WIDTH] = core::array::from_fn(G::from_usize);
-        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS>(
+        let trace = generate_trace_rows::<_, _, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS>(
             vec![input],
             &air,
             &bars,
@@ -369,7 +509,8 @@ mod tests {
         monolith.permute_mut(&mut expected);
 
         let local = trace.row_slice(0).expect("Trace is empty");
-        let row: &MonolithCols<G, G_WIDTH, G_FULL, G_BARS, G_BITS> = (*local).borrow();
+        let row: &MonolithCols<G, G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS> =
+            (*local).borrow();
         assert_eq!(row.final_round.post, expected);
     }
 }


### PR DESCRIPTION
Optimize trace generation and reduce column count.

Results on my M4 pro:

```bash
  ┌───────────────────┬──────────────────────────┬──────────────────────────┐
  │                   │        Mersenne31        │        Goldilocks        │
  ├───────────────────┼──────────────────────────┼──────────────────────────┤
  │ Trace-gen 2^14    │ 112.0ms → 27.8ms (−75%)  │ 118.5ms → 24.3ms (−80%)  │
  ├───────────────────┼──────────────────────────┼──────────────────────────┤
  │ Trace-gen 2^16    │ 394.7ms → 113.2ms (−71%) │ 487.8ms → 97.9ms (−80%)  │
  ├───────────────────┼──────────────────────────┼──────────────────────────┤
  │ Prove 2^10        │ 111.8ms → 90.5ms (−30%)  │ 184.2ms → 148.5ms (−18%) │
  ├───────────────────┼──────────────────────────┼──────────────────────────┤
  │ Prove 2^14        │ 1.42s → 1.07s (−25%)     │ 3.48s → 2.75s (−21%)     │
  ├───────────────────┼──────────────────────────┼──────────────────────────┤
  │ Prove+verify 2^14 │ 1.70s → 1.08s (−36%)     │ 3.35s → 2.57s (−24%)     │
  └───────────────────┴──────────────────────────┴──────────────────────────┘
  ```