### PR TITLE
perf(monolith): precompute Cauchy MDS matrix, use Karatsuba for Goldilocks Concrete

### DIFF
--- a/monolith-air/benches/monolith-air.rs
+++ b/monolith-air/benches/monolith-air.rs
@@ -42,7 +42,7 @@ fn build_monolith_air_m31() -> (
     MonolithBarsM31,
 ) {
     let bars = MonolithBarsM31;
-    let mds = MonolithMdsMatrixMersenne31::<6>;
+    let mds = MonolithMdsMatrixMersenne31::<16, 6>::new();
     let mds_matrix = MonolithAir::<
         M31Val,
         M31_WIDTH,

--- a/monolith-air/src/lib.rs
+++ b/monolith-air/src/lib.rs
@@ -56,7 +56,7 @@ mod tests {
         MonolithBarsM31,
     ) {
         let bars = MonolithBarsM31;
-        let mds = MonolithMdsMatrixMersenne31::<6>;
+        let mds = MonolithMdsMatrixMersenne31::<16, 6>::new();
 
         // Extract MDS matrix before moving mds into the Monolith constructor.
         let mds_matrix =
@@ -127,7 +127,7 @@ mod tests {
 
         // Compute the expected output using the reference Monolith permutation.
         let monolith: MonolithMersenne31<_, WIDTH, NUM_FULL_ROUNDS> =
-            MonolithMersenne31::new(MonolithBarsM31, MonolithMdsMatrixMersenne31::<6>);
+            MonolithMersenne31::new(MonolithBarsM31, MonolithMdsMatrixMersenne31::<16, 6>::new());
         let mut expected_state = input;
         monolith.permute_mut(&mut expected_state);
 

--- a/monolith/benches/monolith.rs
+++ b/monolith/benches/monolith.rs
@@ -14,8 +14,16 @@ use p3_symmetric::Permutation;
 fn bench_monolith(c: &mut Criterion) {
     // Mersenne31 with WIDTH=16 and WIDTH=24.
     monolith_m31::<_, 16>(c, "MdsMatrixMersenne31", MdsMatrixMersenne31);
-    monolith_m31::<_, 16>(c, "MonolithMds", MonolithMdsMatrixMersenne31::<6>);
-    monolith_m31::<_, 24>(c, "MonolithMds", MonolithMdsMatrixMersenne31::<6>);
+    monolith_m31::<_, 16>(
+        c,
+        "MonolithMds",
+        MonolithMdsMatrixMersenne31::<16, 6>::new(),
+    );
+    monolith_m31::<_, 24>(
+        c,
+        "MonolithMds",
+        MonolithMdsMatrixMersenne31::<24, 6>::new(),
+    );
 
     // Goldilocks with WIDTH=8 and WIDTH=12.
     monolith_gl8::<_, 8>(c, "MdsMatrixGoldilocks", MdsMatrixGoldilocks);

--- a/monolith/src/mds/goldilocks.rs
+++ b/monolith/src/mds/goldilocks.rs
@@ -1,8 +1,9 @@
 //! Concrete (MDS) layer for Monolith-64.
 
-use p3_goldilocks::Goldilocks;
+use p3_goldilocks::{Goldilocks, SmallConvolveGoldilocks};
 use p3_mds::MdsPermutation;
-use p3_mds::util::apply_circulant;
+use p3_mds::karatsuba_convolution::Convolve;
+use p3_mds::util::first_row_to_first_col;
 use p3_symmetric::Permutation;
 
 /// MDS matrix implementation for the Monolith-64 Concrete layer.
@@ -13,25 +14,68 @@ pub struct MonolithMdsMatrixGoldilocks;
 ///
 /// From Section 4.5 of the paper:
 /// M = circ(23, 8, 13, 10, 7, 6, 21, 8)
-const MATRIX_CIRC_MDS_8_GOLDILOCKS_MONOLITH: [u64; 8] = [23, 8, 13, 10, 7, 6, 21, 8];
+///
+/// Row sum is 96, well within the 2^51 "small RHS" bound required by
+/// `SmallConvolveGoldilocks`.
+const MATRIX_CIRC_MDS_8_GOLDILOCKS_MONOLITH: [i64; 8] = [23, 8, 13, 10, 7, 6, 21, 8];
 
 /// First row of the 12x12 circulant MDS matrix for Monolith-64 sponge mode.
 ///
 /// From Section 4.5 of the paper:
 /// M = circ(7, 23, 8, 26, 13, 10, 9, 7, 6, 22, 21, 8)
-const MATRIX_CIRC_MDS_12_GOLDILOCKS_MONOLITH: [u64; 12] =
+///
+/// Row sum is 160, well within the 2^51 "small RHS" bound required by
+/// `SmallConvolveGoldilocks`.
+const MATRIX_CIRC_MDS_12_GOLDILOCKS_MONOLITH: [i64; 12] =
     [7, 23, 8, 26, 13, 10, 9, 7, 6, 22, 21, 8];
 
 impl Permutation<[Goldilocks; 8]> for MonolithMdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 8]) -> [Goldilocks; 8] {
-        apply_circulant(&MATRIX_CIRC_MDS_8_GOLDILOCKS_MONOLITH, &input)
+        const COL: [i64; 8] = first_row_to_first_col(&MATRIX_CIRC_MDS_8_GOLDILOCKS_MONOLITH);
+        SmallConvolveGoldilocks::apply(input, COL, SmallConvolveGoldilocks::conv8)
     }
 }
 impl MdsPermutation<Goldilocks, 8> for MonolithMdsMatrixGoldilocks {}
 
 impl Permutation<[Goldilocks; 12]> for MonolithMdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 12]) -> [Goldilocks; 12] {
-        apply_circulant(&MATRIX_CIRC_MDS_12_GOLDILOCKS_MONOLITH, &input)
+        const COL: [i64; 12] = first_row_to_first_col(&MATRIX_CIRC_MDS_12_GOLDILOCKS_MONOLITH);
+        SmallConvolveGoldilocks::apply(input, COL, SmallConvolveGoldilocks::conv12)
     }
 }
 impl MdsPermutation<Goldilocks, 12> for MonolithMdsMatrixGoldilocks {}
+
+#[cfg(test)]
+mod tests {
+    use core::array;
+
+    use p3_mds::util::apply_circulant;
+
+    use super::*;
+
+    #[test]
+    fn width_8_matches_naive_circulant() {
+        let input: [Goldilocks; 8] = array::from_fn(|i| Goldilocks::new(i as u64 + 1));
+
+        let fast = MonolithMdsMatrixGoldilocks.permute(input);
+        let naive = apply_circulant(
+            &MATRIX_CIRC_MDS_8_GOLDILOCKS_MONOLITH.map(|x| x as u64),
+            &input,
+        );
+
+        assert_eq!(fast, naive);
+    }
+
+    #[test]
+    fn width_12_matches_naive_circulant() {
+        let input: [Goldilocks; 12] = array::from_fn(|i| Goldilocks::new(i as u64 + 1));
+
+        let fast = MonolithMdsMatrixGoldilocks.permute(input);
+        let naive = apply_circulant(
+            &MATRIX_CIRC_MDS_12_GOLDILOCKS_MONOLITH.map(|x| x as u64),
+            &input,
+        );
+
+        assert_eq!(fast, naive);
+    }
+}

--- a/monolith/src/mds/mersenne31.rs
+++ b/monolith/src/mds/mersenne31.rs
@@ -1,9 +1,12 @@
 //! Concrete (MDS) layer for Monolith-31.
 
-use p3_field::{PrimeCharacteristicRing, PrimeField32};
+use p3_field::integers::QuotientMap;
+use p3_field::{
+    Field, PrimeCharacteristicRing, PrimeField32, batch_multiplicative_inverse_general,
+};
 use p3_mds::MdsPermutation;
 use p3_mds::karatsuba_convolution::Convolve;
-use p3_mds::util::{dot_product, first_row_to_first_col};
+use p3_mds::util::{dot_product, first_row_to_first_col, mds_multiply};
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::Permutation;
 use shake::digest::{ExtendableOutput, Update};
@@ -12,8 +15,40 @@ use shake::{Shake128, Shake128Reader};
 use crate::util::get_random_u32;
 
 /// MDS matrix implementation for the Monolith-31 Concrete layer.
+///
+/// For `WIDTH == 16` this uses the fast Karatsuba-convolution path over the
+/// paper's circulant matrix. For any other width, the matrix is a dense
+/// Cauchy matrix derived from SHAKE-128, precomputed once in [`Self::new`]
+/// rather than rebuilt on every permutation.
 #[derive(Clone, Debug)]
-pub struct MonolithMdsMatrixMersenne31<const NUM_ROUNDS: usize>;
+pub struct MonolithMdsMatrixMersenne31<const WIDTH: usize, const NUM_ROUNDS: usize> {
+    /// Dense Cauchy MDS matrix, indexed `matrix[row][col]`.
+    ///
+    /// Left as all-zero and unused when `WIDTH == 16`, which takes the
+    /// circulant Karatsuba path instead.
+    matrix: [[Mersenne31; WIDTH]; WIDTH],
+}
+
+impl<const WIDTH: usize, const NUM_ROUNDS: usize> Default
+    for MonolithMdsMatrixMersenne31<WIDTH, NUM_ROUNDS>
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const WIDTH: usize, const NUM_ROUNDS: usize> MonolithMdsMatrixMersenne31<WIDTH, NUM_ROUNDS> {
+    /// Construct a new Monolith-31 MDS matrix, precomputing the dense Cauchy
+    /// matrix once (skipped for `WIDTH == 16`, which uses the circulant path).
+    pub fn new() -> Self {
+        let matrix = if WIDTH == 16 {
+            [[Mersenne31::ZERO; WIDTH]; WIDTH]
+        } else {
+            derive_cauchy_mds_matrix::<WIDTH, NUM_ROUNDS>()
+        };
+        Self { matrix }
+    }
+}
 
 /// Precomputed first row of the 16x16 circulant MDS matrix for Mersenne31.
 ///
@@ -59,7 +94,7 @@ impl Convolve<Mersenne31, i64, i64> for MonolithConvolveMersenne31 {
 }
 
 impl<const WIDTH: usize, const NUM_ROUNDS: usize> Permutation<[Mersenne31; WIDTH]>
-    for MonolithMdsMatrixMersenne31<NUM_ROUNDS>
+    for MonolithMdsMatrixMersenne31<WIDTH, NUM_ROUNDS>
 {
     fn permute(&self, input: [Mersenne31; WIDTH]) -> [Mersenne31; WIDTH] {
         if WIDTH == 16 {
@@ -74,62 +109,61 @@ impl<const WIDTH: usize, const NUM_ROUNDS: usize> Permutation<[Mersenne31; WIDTH
             );
             out_16[..].try_into().unwrap()
         } else {
-            // For non-standard widths, derive a Cauchy MDS matrix from SHAKE-128.
-            let mut shake = Shake128::default();
-            shake.update(b"Monolith");
-            shake.update(&[WIDTH as u8, NUM_ROUNDS as u8]);
-            shake.update(&Mersenne31::ORDER_U32.to_le_bytes());
-            // The [16, 15] encodes the bit parameters for the Cauchy construction.
-            shake.update(&[16, 15]);
-            shake.update(b"MDS");
-            let mut shake_finalized = shake.finalize_xof();
-            apply_cauchy_mds_matrix(&mut shake_finalized, input)
+            let mut state = input;
+            mds_multiply(&mut state, &self.matrix);
+            state
         }
     }
 }
 
 impl<const WIDTH: usize, const NUM_ROUNDS: usize> MdsPermutation<Mersenne31, WIDTH>
-    for MonolithMdsMatrixMersenne31<NUM_ROUNDS>
+    for MonolithMdsMatrixMersenne31<WIDTH, NUM_ROUNDS>
 {
 }
 
-/// Multiply a state vector by a Cauchy MDS matrix derived from SHAKE-128.
+/// Derive the dense Cauchy MDS matrix from SHAKE-128.
 ///
 /// A Cauchy matrix has entries 1 / (x_i + y_j) where x and y are vectors
 /// with distinct x-components. The vectors are derived from the SHAKE
 /// stream with careful masking to ensure no overflow when computing
-/// x_i + y_j (which must stay below p).
-fn apply_cauchy_mds_matrix<F: PrimeField32, const WIDTH: usize>(
-    shake: &mut Shake128Reader,
-    to_multiply: [F; WIDTH],
-) -> [F; WIDTH] {
-    let mut output: [F; WIDTH] = [F::ZERO; WIDTH];
+/// x_i + y_j (which must stay below p). Denominators are inverted a row
+/// at a time via Montgomery's batch-inversion trick, replacing WIDTH^2
+/// individual field inversions with WIDTH batched ones.
+fn derive_cauchy_mds_matrix<const WIDTH: usize, const NUM_ROUNDS: usize>()
+-> [[Mersenne31; WIDTH]; WIDTH] {
+    let mut shake = Shake128::default();
+    shake.update(b"Monolith");
+    shake.update(&[WIDTH as u8, NUM_ROUNDS as u8]);
+    shake.update(&Mersenne31::ORDER_U32.to_le_bytes());
+    // The [16, 15] encodes the bit parameters for the Cauchy construction.
+    shake.update(&[16, 15]);
+    shake.update(b"MDS");
+    let mut shake = shake.finalize_xof();
 
     // Compute masks that ensure x_i + y_j < p.
     // - x_mask keeps the value well below p (by ~8 bits).
     // - y_mask keeps the value below p/4 so x + y < p.
-    let bits = F::bits();
+    let bits = Mersenne31::bits();
     let x_mask = (1 << (bits - 9)) - 1;
     let y_mask = ((1 << bits) - 1) >> 2;
 
     // Sample y values with distinct x-components (x = y & x_mask).
-    let y = get_random_y_i::<WIDTH>(shake, x_mask, y_mask);
+    let y = get_random_y_i::<WIDTH>(&mut shake, x_mask, y_mask);
     let mut x = y;
     x.iter_mut().for_each(|x_i| *x_i &= x_mask);
 
-    // Compute output[i] = sum_j (1/(x_i + y_j)) * input[j].
-    for (i, x_i) in x.iter().enumerate() {
-        for (j, y_j) in y.iter().enumerate() {
-            let val = unsafe {
-                // Safety: x_i < x_mask < p/256 and y_j < y_mask < p/4,
-                // so x_i + y_j < p and from_canonical_unchecked is valid.
-                F::from_canonical_unchecked(x_i + y_j).inverse()
-            };
-            output[i] += val * to_multiply[j];
-        }
+    // matrix[i][j] = 1 / (x_i + y_j).
+    let mut matrix = [[Mersenne31::ZERO; WIDTH]; WIDTH];
+    for (x_i, row) in x.iter().zip(matrix.iter_mut()) {
+        let denominators: [Mersenne31; WIDTH] = core::array::from_fn(|j| unsafe {
+            // Safety: x_i < x_mask < p/256 and y_j < y_mask < p/4,
+            // so x_i + y_j < p and from_canonical_unchecked is valid.
+            Mersenne31::from_canonical_unchecked(x_i + y[j])
+        });
+        batch_multiplicative_inverse_general(&denominators, row, |v| v.inverse());
     }
 
-    output
+    matrix
 }
 
 /// Sample WIDTH random y-values from SHAKE such that their x-components
@@ -153,4 +187,82 @@ fn get_random_y_i<const WIDTH: usize>(
     }
 
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use core::array;
+
+    use super::*;
+
+    /// Independent, naive re-implementation of the original per-entry Cauchy
+    /// derivation (one `.inverse()` call per matrix entry), used as an oracle
+    /// to confirm the batched-inversion path in [`derive_cauchy_mds_matrix`]
+    /// is bit-identical.
+    fn naive_cauchy_mds_matrix<const WIDTH: usize, const NUM_ROUNDS: usize>()
+    -> [[Mersenne31; WIDTH]; WIDTH] {
+        let mut shake = Shake128::default();
+        shake.update(b"Monolith");
+        shake.update(&[WIDTH as u8, NUM_ROUNDS as u8]);
+        shake.update(&Mersenne31::ORDER_U32.to_le_bytes());
+        shake.update(&[16, 15]);
+        shake.update(b"MDS");
+        let mut shake = shake.finalize_xof();
+
+        let bits = Mersenne31::bits();
+        let x_mask = (1 << (bits - 9)) - 1;
+        let y_mask = ((1 << bits) - 1) >> 2;
+
+        let y = get_random_y_i::<WIDTH>(&mut shake, x_mask, y_mask);
+        let mut x = y;
+        x.iter_mut().for_each(|x_i| *x_i &= x_mask);
+
+        array::from_fn(|i| {
+            array::from_fn(|j| unsafe {
+                // Safety: x[i] < x_mask < p/256 and y[j] < y_mask < p/4,
+                // so x[i] + y[j] < p and from_canonical_unchecked is valid.
+                Mersenne31::from_canonical_unchecked(x[i] + y[j]).inverse()
+            })
+        })
+    }
+
+    #[test]
+    fn cauchy_matrix_width24_matches_naive_oracle() {
+        let fast = derive_cauchy_mds_matrix::<24, 6>();
+        let naive = naive_cauchy_mds_matrix::<24, 6>();
+        assert_eq!(fast, naive);
+    }
+
+    #[test]
+    fn cauchy_matrix_is_deterministic() {
+        let a = derive_cauchy_mds_matrix::<24, 6>();
+        let b = derive_cauchy_mds_matrix::<24, 6>();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn permute_width24_matches_stored_matrix() {
+        // permute() on standard basis vectors must reconstruct the same
+        // dense matrix stored in the struct (mirrors monolith-air's
+        // extract_mds_matrix, scoped here to this crate's own type).
+        let mds = MonolithMdsMatrixMersenne31::<24, 6>::new();
+        for col in 0..24 {
+            let mut basis = [Mersenne31::ZERO; 24];
+            basis[col] = Mersenne31::ONE;
+            let output = mds.permute(basis);
+            for (row, &expected) in output.iter().enumerate() {
+                assert_eq!(expected, mds.matrix[row][col]);
+            }
+        }
+    }
+
+    #[test]
+    fn permute_width24_is_deterministic() {
+        let mds = MonolithMdsMatrixMersenne31::<24, 6>::new();
+        let input: [Mersenne31; 24] = array::from_fn(Mersenne31::from_usize);
+
+        let out1 = mds.permute(input);
+        let out2 = mds.permute(input);
+        assert_eq!(out1, out2);
+    }
 }

--- a/monolith/src/monolith.rs
+++ b/monolith/src/monolith.rs
@@ -200,7 +200,7 @@ mod tests {
         // Known-answer test from the paper / reference implementation.
         // Input: [0, 1, 2, ..., 15], Width: 16, Rounds: 6 (NUM_FULL_ROUNDS=5).
         let bars = MonolithBarsM31;
-        let mds = MonolithMdsMatrixMersenne31::<6>;
+        let mds = MonolithMdsMatrixMersenne31::<16, 6>::new();
         let monolith: MonolithMersenne31<_, 16, 5> = MonolithMersenne31::new(bars, mds);
 
         let mut input: [Mersenne31; 16] = array::from_fn(Mersenne31::from_usize);
@@ -239,7 +239,7 @@ mod tests {
         // The Feistel Type-3 Bricks layer leaves the first element unchanged.
         let mut state: [Mersenne31; 16] = array::from_fn(Mersenne31::from_usize);
         let first = state[0];
-        Monolith::<Mersenne31, MonolithBarsM31, MonolithMdsMatrixMersenne31<6>, 16, 5>::bricks(
+        Monolith::<Mersenne31, MonolithBarsM31, MonolithMdsMatrixMersenne31<16, 6>, 16, 5>::bricks(
             &mut state,
         );
         assert_eq!(state[0], first);
@@ -250,7 +250,7 @@ mod tests {
         // For Bricks, state[1] should become state[1] + state[0]^2.
         let mut state: [Mersenne31; 16] = array::from_fn(Mersenne31::from_usize);
         let expected_1 = state[1] + state[0] * state[0];
-        Monolith::<Mersenne31, MonolithBarsM31, MonolithMdsMatrixMersenne31<6>, 16, 5>::bricks(
+        Monolith::<Mersenne31, MonolithBarsM31, MonolithMdsMatrixMersenne31<16, 6>, 16, 5>::bricks(
             &mut state,
         );
         assert_eq!(state[1], expected_1);
@@ -260,7 +260,7 @@ mod tests {
     fn test_permutation_deterministic() {
         // Two invocations with the same input must produce the same output.
         let bars = MonolithBarsM31;
-        let mds = MonolithMdsMatrixMersenne31::<6>;
+        let mds = MonolithMdsMatrixMersenne31::<16, 6>::new();
         let monolith: MonolithMersenne31<_, 16, 5> = MonolithMersenne31::new(bars, mds);
 
         let input: [Mersenne31; 16] = array::from_fn(Mersenne31::from_usize);


### PR DESCRIPTION
## Summary

MonolithMdsMatrixMersenne31 now takes a WIDTH const param and a new() constructor. For WIDTH == 16 the existing circulant Karatsuba path is unchanged; for other widths (WIDTH = 24 in practice) the Cauchy matrix is derived from SHAKE-128 once in the constructor instead of on every permute call, with its WIDTH^2 denominators batch-inverted a row at a time via Montgomery's trick. permute() then reduces to a single dense mat-vec multiply.

MonolithMdsMatrixGoldilocks's width-8 and width-12 Concrete layers now go through SmallConvolveGoldilocks (the same Karatsuba engine MdsMatrixGoldilocks already uses for Plonky2) instead of apply_circulant's per-call O(N^2) matrix rebuild.

## Performance 


Benchmarked in isolation (Concrete layer only):
- Mersenne31 width 24: 225.09 us -> 1.315 us (~171x)
- Goldilocks width 8:  281.89 ns -> 226.30 ns (~1.25x)
- Goldilocks width 12: 411.57 ns -> 277.08 ns (~1.48x)
- Mersenne31 width 16: unchanged (still the circulant path)


## Tests

Added oracle-equivalence tests confirming both changes are bit-identical to the prior algorithms (naive per-entry Cauchy inversion for width 24, apply_circulant for Goldilocks width 8/12), plus determinism checks.