### PR TITLE
fix(monolith-air): guard match-flag batching precondition, correct docs

### DIFF
--- a/monolith-air/src/air.rs
+++ b/monolith-air/src/air.rs
@@ -133,13 +133,20 @@ impl<
     ///
     /// # Match-flag width invariant
     ///
-    /// - `NUM_MATCH_FLAGS` must equal `modulus.count_ones() / 2`: two
-    ///   consecutive modulus one-bits share one committed flag cell via a
-    ///   degree-3 batched step (`m_i = m_prev2 * x_a * x_b`), and a
-    ///   modulus-zero bit needs no cell at all (its flag is a pure copy of
-    ///   the previous one). If the Hamming weight is odd, the final
-    ///   one-bit (always bit 0) is folded directly into the closing
-    ///   `assert_zero` with no committed cell of its own.
+    /// - `NUM_MATCH_FLAGS` must equal `modulus.count_ones() / 2`.
+    /// - The canonical-form walk pairs modulus one-bits two at a time.
+    /// - Each pair commits one flag cell, `m = m_prev * x_a * x_b` (degree 3).
+    /// - A modulus zero-bit commits no cell and reuses the previous flag.
+    /// - An odd Hamming weight leaves bit 0 unpaired, folded into the closing assert.
+    ///
+    /// # Match-flag batching precondition
+    ///
+    /// - A zero-bit reuses the flag from the last completed pair.
+    /// - That flag is correct only when no pair straddles the zero-bit.
+    /// - So every zero-bit must have an even count of one-bits above it.
+    /// - A bad modulus over-rejects valid inputs.
+    /// - It never accepts a non-canonical one, so this is completeness, not soundness.
+    /// - Mersenne31 (no zero-bits) and Goldilocks (32 one-bits, then zeros) both qualify.
     ///
     /// # Chi-cell width invariant
     ///
@@ -157,6 +164,7 @@ impl<
     /// - Trailing limb is outside `3..=8`.
     /// - `NUM_MATCH_FLAGS` does not equal `modulus.count_ones() / 2`.
     /// - `NUM_CHI_CELLS` does not match the trailing limb's width.
+    /// - Some modulus zero-bit has an odd count of one-bits above it.
     pub fn new(
         round_constants: [[F; WIDTH]; NUM_FULL_ROUNDS],
         mds_matrix: [[F; WIDTH]; WIDTH],
@@ -230,6 +238,34 @@ impl<
             NUM_MATCH_FLAGS,
             "NUM_MATCH_FLAGS must equal modulus.count_ones() / 2"
         );
+
+        // Invariant: no fold-pair may straddle a modulus zero-bit.
+        //
+        // - The canonical-form walk descends MSB -> LSB, pairing one-bits.
+        // - At a zero-bit it asserts the running match flag times that bit is 0.
+        // - The running flag covers only one-bits folded through closed pairs.
+        // - It means "prefix still equals p" only if no pair is half-open here.
+        // - A pair is closed exactly when an even count of one-bits sits above.
+        //
+        // - An odd count leaves one one-bit unfolded, so the flag runs too coarse.
+        // - A coarser flag only tightens the side constraint, never loosens it.
+        // - So it never admits a non-canonical encoding.
+        // - But it rejects valid ones, so reject the modulus here instead.
+        //
+        //     Mersenne31 : 1..1 (x31)                 no zero-bits         -> ok
+        //     Goldilocks : 1..1 (x32) 0..0 (x31) 1    even run above zeros -> ok
+        //     KoalaBear  : 1..1 (x7)  0..0 (x23) 1    odd run above zeros  -> rejected
+        let mut ones_above = 0usize;
+        for i in (0..FIELD_BITS).rev() {
+            if modulus_lsb_to_msb[i] {
+                ones_above += 1;
+            } else {
+                assert!(
+                    ones_above.is_multiple_of(2),
+                    "match-flag batching requires an even count of modulus one-bits above every zero-bit"
+                );
+            }
+        }
 
         // The trailing limb's chi is inlined (no committed column) exactly
         // when it uses the narrower 2-input AND variant.

--- a/monolith-air/src/columns.rs
+++ b/monolith-air/src/columns.rs
@@ -141,8 +141,10 @@ pub struct MonolithRoundCols<
     ///
     /// - Without it, integers in `[p, 2^FIELD_BITS - 1]` would forge a second
     ///   bit encoding for field elements already represented canonically.
-    /// - The walk works for any prime, including those whose forbidden range
-    ///   covers many bit patterns (e.g. Goldilocks).
+    /// - The walk handles any prime whose one-bits pair cleanly.
+    /// - "Cleanly" means no fold-pair straddles a modulus zero-bit.
+    /// - Mersenne31 and Goldilocks both qualify.
+    /// - The constructor rejects any modulus that does not.
     pub bars_match_flags: [[T; NUM_MATCH_FLAGS]; NUM_BARS],
 
     /// Committed output of each Bar (S-box) application.

--- a/monolith-air/src/lib.rs
+++ b/monolith-air/src/lib.rs
@@ -155,8 +155,11 @@ mod tests {
         };
         let degree = get_max_constraint_degree::<F, _>(&air, layout, 1 << 6);
 
-        // Cap set by the chi AND product binding (degree 3); all other
-        // constraints are degree ≤ 2.
+        // Degree 3 is the cap, reached by three constraint families:
+        //   - 8-bit chi AND-product binding, (1 - x) * x * x
+        //   - batched match-flag step, prev * bits[a] * bits[b]
+        //   - inlined trailing 7-bit limb output, x XOR ((1 - x) * x)
+        // Everything else (booleanity, reconstruction, MDS, Bricks) is degree <= 2.
         assert_eq!(degree, 3, "Expected constraint degree 3 for Monolith-31");
     }
 
@@ -461,6 +464,25 @@ mod tests {
         let actual =
             num_cols::<G_WIDTH, G_FULL, G_BARS, G_BITS, G_NUM_MATCH_FLAGS, G_NUM_CHI_CELLS>();
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_monolith_air_degree_goldilocks() {
+        let (air, _bars) = build_goldilocks_air();
+
+        // Probe the symbolic degree over the full committed width, 64-row trace.
+        let layout = AirLayout {
+            main_width: air.width(),
+            ..Default::default()
+        };
+        let degree = get_max_constraint_degree::<G, _>(&air, layout, 1 << 6);
+
+        // Degree 3 is the cap, reached by two constraint families here:
+        //   - 8-bit chi AND-product binding, (1 - x) * x * x
+        //   - batched match-flag step, prev * bits[a] * bits[b]
+        // All eight limbs are 8 bits wide, so there is no inlined trailing
+        // limb (the third degree-3 family present for Mersenne31 is absent).
+        assert_eq!(degree, 3, "Expected constraint degree 3 for Monolith-64");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1924.

## Context

#1924 batched two modulus one-bits into each committed match-flag cell of the Bar canonical-form walk (`m = m_prev * x_a * x_b`, degree 3). The walk descends MSB → LSB and, at a modulus **zero**-bit, reuses the running flag from the last *completed* pair to enforce the side constraint `flag * bit = 0`.

That reuse is correct only when **no fold-pair straddles a zero-bit** — equivalently, every zero-bit has an even number of one-bits above it. Both supported fields satisfy this:

```
Mersenne31 : 1..1 (x31)                 no zero-bits         -> ok
Goldilocks : 1..1 (x32) 0..0 (x31) 1    even run above zeros -> ok
KoalaBear  : 1..1 (x7)  0..0 (x23) 1    odd run above zeros  -> would over-reject
```

But `MonolithAir` is generic over the field and the invariant was unchecked, while the docs claimed the walk "works for any prime". For a modulus like KoalaBear the batched zero-bit side constraint tests a too-coarse flag and **over-rejects valid canonical inputs**. This is a completeness issue only — it never admits a non-canonical encoding, so it is not a soundness regression — but it should fail loudly at construction rather than silently mis-constrain.

## Changes

- **Guard the precondition** in `MonolithAir::new`: reject any modulus where a zero-bit has an odd count of one-bits above it. Mirrors the eval-walk's pairing logic exactly.
- **Correct the docs**: drop the "works for any prime" claim, state the batching precondition precisely, and rewrite the match-flag documentation one-idea-per-line.
- **Fix the stale degree comment** for Mersenne31: the batched match-flag step and the inlined trailing-limb output are also degree 3 (not "all others ≤ 2").
- **Add a Goldilocks degree test** pinning the degree-3 cap for the second field.

## Testing

- `cargo test -p p3-monolith-air`: 20/20 pass (both new degree tests included; both fields still construct, so the guard does not falsely reject them).
- `cargo fmt --check` and `cargo clippy --all-targets`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)