### PR TITLE
perf(multi-stark) dedup trace transpose

### DIFF
--- a/multi-stark/benches/poseidon2.rs
+++ b/multi-stark/benches/poseidon2.rs
@@ -79,7 +79,7 @@ fn bench_poseidon2_zerocheck_prove(c: &mut Criterion) {
                 b.iter(|| {
                     let mut challenger = fresh_challenger();
                     let (proof, point) =
-                        zerocheck.prove::<F, EF, _>(None, &table, &[], &mut challenger);
+                        zerocheck.prove::<F, EF, _>(&table, None, &[], &mut challenger);
                     black_box((proof, point, num_vars));
                 });
             },

--- a/multi-stark/benches/poseidon2.rs
+++ b/multi-stark/benches/poseidon2.rs
@@ -10,6 +10,7 @@ use p3_challenger::DuplexChallenger;
 use p3_field::extension::BinomialExtensionField;
 use p3_multi_stark::zerocheck::AirZerocheck;
 use p3_poseidon2_air::{Poseidon2Air, RoundConstants};
+use p3_sumcheck::layout::Table;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
@@ -68,6 +69,7 @@ fn bench_poseidon2_zerocheck_prove(c: &mut Criterion) {
         let num_hashes = 1 << num_vars;
         let air = poseidon2_air();
         let trace = air.generate_random_trace_rows(num_hashes, 0);
+        let table = Table::new(trace.transpose());
         let zerocheck = AirZerocheck::new(&air, 0);
 
         group.bench_with_input(
@@ -77,7 +79,7 @@ fn bench_poseidon2_zerocheck_prove(c: &mut Criterion) {
                 b.iter(|| {
                     let mut challenger = fresh_challenger();
                     let (proof, point) =
-                        zerocheck.prove::<F, EF, _>(&trace, None, &[], &mut challenger);
+                        zerocheck.prove::<F, EF, _>(None, &table, &[], &mut challenger);
                     black_box((proof, point, num_vars));
                 });
             },

--- a/multi-stark/benches/zerocheck.rs
+++ b/multi-stark/benches/zerocheck.rs
@@ -8,6 +8,7 @@ use p3_field::PrimeCharacteristicRing;
 use p3_field::extension::BinomialExtensionField;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_multi_stark::zerocheck::AirZerocheck;
+use p3_sumcheck::layout::Table;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
@@ -143,10 +144,11 @@ fn bench_zerocheck(c: &mut Criterion) {
         let last = trace.values[(n - 1) * NUM_COLS + 1];
         let pis = [F::ZERO, F::ONE, last];
         let zerocheck = AirZerocheck::new(&FibAir, 0);
+        let table = Table::new(trace.transpose());
         group.bench_with_input(BenchmarkId::from_parameter(log_height), &n, |b, _| {
             b.iter(|| {
                 let mut ch = fresh_challenger();
-                zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut ch)
+                zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut ch)
             });
         });
     }
@@ -158,14 +160,14 @@ fn bench_wide_zerocheck(c: &mut Criterion) {
     group.sample_size(10);
     for log_height in [16, 18, 20] {
         let n = 1 << log_height;
-        let trace = wide_fib_trace(n);
+        let table = Table::new(wide_fib_trace(n).transpose());
         for (label, all_next) in [("all_next", true), ("sparse_next", false)] {
             let air = WideFibAir { all_next };
             let zerocheck = AirZerocheck::new(&air, 0);
             group.bench_with_input(BenchmarkId::new(label, log_height), &n, |b, _| {
                 b.iter(|| {
                     let mut ch = fresh_challenger();
-                    zerocheck.prove::<F, EF, _>(&trace, None, &[], &mut ch)
+                    zerocheck.prove::<F, EF, _>(None, &table, &[], &mut ch)
                 });
             });
         }

--- a/multi-stark/benches/zerocheck.rs
+++ b/multi-stark/benches/zerocheck.rs
@@ -148,7 +148,7 @@ fn bench_zerocheck(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(log_height), &n, |b, _| {
             b.iter(|| {
                 let mut ch = fresh_challenger();
-                zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut ch)
+                zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut ch)
             });
         });
     }
@@ -167,7 +167,7 @@ fn bench_wide_zerocheck(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new(label, log_height), &n, |b, _| {
                 b.iter(|| {
                     let mut ch = fresh_challenger();
-                    zerocheck.prove::<F, EF, _>(None, &table, &[], &mut ch)
+                    zerocheck.prove::<F, EF, _>(&table, None, &[], &mut ch)
                 });
             });
         }

--- a/multi-stark/src/commit.rs
+++ b/multi-stark/src/commit.rs
@@ -1,12 +1,9 @@
 //! Turn an execution trace into the committed multilinear witness.
 
-use alloc::vec::Vec;
-
 use p3_commit::MultilinearPcs;
 use p3_field::Field;
-use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::layout::Table;
 
 use crate::config::{Commitment, MultiStarkConfig, ProverData};
 
@@ -18,22 +15,8 @@ use crate::config::{Commitment, MultiStarkConfig, ProverData};
 /// # Panics
 ///
 /// Panics if the trace height is not a power of two.
-pub(crate) fn trace_to_columns<F: Field>(trace: &RowMajorMatrix<F>) -> Vec<Poly<F>> {
-    let width = trace.width;
-    let height = trace.height();
-
-    // Build one polynomial per column.
-    (0..width)
-        .map(|col| {
-            // Row-major storage places entry (row, col) at index `row * width + col`.
-            //
-            //     column `col` evaluations = trace[col], trace[width + col], trace[2*width + col], ...
-            let evals = (0..height)
-                .map(|row| trace.values[row * width + col])
-                .collect();
-            Poly::new(evals)
-        })
-        .collect()
+pub(crate) fn trace_to_table<F: Field>(trace: &RowMajorMatrix<F>) -> Table<F> {
+    Table::new(tracing::info_span!("transpose").in_scope(|| trace.transpose()))
 }
 
 /// Commit to a trace through the configured commitment scheme.
@@ -62,20 +45,11 @@ pub fn commit_trace<C: MultiStarkConfig>(
     trace: &RowMajorMatrix<C::Val>,
     challenger: &mut C::Challenger,
 ) -> (Commitment<C>, ProverData<C>) {
-    // One multilinear polynomial per trace column.
-    let columns = trace_to_columns(trace);
-
-    // The witness builder lays each column into a slot sized by its arity.
-    // Every column must therefore share the same number of variables.
-    debug_assert!(
-        columns
-            .windows(2)
-            .all(|pair| pair[0].num_variables() == pair[1].num_variables()),
-        "all trace columns must share the same arity"
-    );
+    // One multilinear polynomial per trace column, stored as one table row per column.
+    let table = trace_to_table(trace);
 
     // Pack the columns into the scheme's witness form (slot layout and folding live in the config).
-    let witness = config.build_witness(columns);
+    let witness = config.build_witness(table);
 
     // Commit; the scheme observes its commitment into the transcript.
     config.pcs().commit(witness, challenger)
@@ -91,7 +65,7 @@ mod tests {
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_matrix::dense::RowMajorMatrix;
-    use p3_multilinear_util::poly::Poly;
+    use p3_sumcheck::layout::Table;
 
     use super::*;
     use crate::config::MultiStarkConfig;
@@ -116,10 +90,10 @@ mod tests {
     impl MultilinearPcs<EF, RecordingChallenger> for MockPcs {
         type Val = F;
         type Commitment = Vec<F>;
-        type ProverData = Vec<Poly<F>>;
+        type ProverData = Table<F>;
         type Proof = ();
         type Error = ();
-        type Witness = Vec<Poly<F>>;
+        type Witness = Table<F>;
         type OpeningProtocol = ();
 
         fn num_vars(&self) -> usize {
@@ -133,8 +107,8 @@ mod tests {
         ) -> (Self::Commitment, Self::ProverData) {
             // One checksum per column: the sum of that column's evaluations.
             let commitment: Vec<F> = witness
-                .iter()
-                .map(|column| column.as_slice().iter().copied().sum())
+                .iter_polys()
+                .map(|column| column.iter().copied().sum())
                 .collect();
             // Absorb the commitment so any later transcript draw depends on it.
             challenger.observed.extend_from_slice(&commitment);
@@ -180,14 +154,18 @@ mod tests {
             0
         }
 
-        fn build_witness(&self, columns: Vec<Poly<F>>) -> Vec<Poly<F>> {
+        fn build_witness(&self, table: Table<F>) -> Table<F> {
             // The mock scheme commits columns directly, with no stacking or folding.
-            columns
+            table
+        }
+
+        fn committed_table<'a>(&self, prover_data: &'a Table<F>) -> &'a Table<F> {
+            prover_data
         }
     }
 
     #[test]
-    fn trace_to_columns_extracts_each_column() {
+    fn trace_to_table_extracts_each_column() {
         // Fixture state: a width-2, height-4 row-major trace.
         //
         //     row 0: [1, 5]
@@ -199,16 +177,16 @@ mod tests {
         let values = [1, 5, 2, 6, 3, 7, 4, 8].map(F::from_u64).to_vec();
         let trace = RowMajorMatrix::new(values, 2);
 
-        let columns = trace_to_columns(&trace);
+        let table = trace_to_table(&trace);
 
         // One polynomial per column.
-        assert_eq!(columns.len(), 2);
+        assert_eq!(table.num_polys(), 2);
         // Each column has height-4 evaluations, so two variables.
-        assert_eq!(columns[0].num_variables(), 2);
+        assert_eq!(table.poly(0).num_variables(), 2);
         // Column 0 read in row order.
-        assert_eq!(columns[0].as_slice(), &[1, 2, 3, 4].map(F::from_u64));
+        assert_eq!(table.poly(0).as_slice(), &[1, 2, 3, 4].map(F::from_u64));
         // Column 1 read in row order.
-        assert_eq!(columns[1].as_slice(), &[5, 6, 7, 8].map(F::from_u64));
+        assert_eq!(table.poly(1).as_slice(), &[5, 6, 7, 8].map(F::from_u64));
     }
 
     #[test]
@@ -231,7 +209,7 @@ mod tests {
         // The commitment carries one checksum per column.
         assert_eq!(commitment, vec![F::from_u64(10), F::from_u64(26)]);
         // Prover data retains all committed columns.
-        assert_eq!(prover_data.len(), 2);
+        assert_eq!(prover_data.num_polys(), 2);
         // The commitment was absorbed into the transcript.
         assert_eq!(challenger.observed, vec![F::from_u64(10), F::from_u64(26)]);
     }

--- a/multi-stark/src/commit.rs
+++ b/multi-stark/src/commit.rs
@@ -1,23 +1,10 @@
 //! Turn an execution trace into the committed multilinear witness.
 
 use p3_commit::MultilinearPcs;
-use p3_field::Field;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_sumcheck::layout::Table;
 
 use crate::config::{Commitment, MultiStarkConfig, ProverData};
-
-/// Split a trace matrix into one multilinear polynomial per column.
-///
-/// A column of height `2^k` becomes the evaluations of a `k`-variable multilinear polynomial.
-/// The evaluations are taken in row order over the Boolean hypercube.
-///
-/// # Panics
-///
-/// Panics if the trace height is not a power of two.
-pub(crate) fn trace_to_table<F: Field>(trace: &RowMajorMatrix<F>) -> Table<F> {
-    Table::new(tracing::info_span!("transpose").in_scope(|| trace.transpose()))
-}
 
 /// Commit to a trace through the configured commitment scheme.
 ///
@@ -46,7 +33,8 @@ pub fn commit_trace<C: MultiStarkConfig>(
     challenger: &mut C::Challenger,
 ) -> (Commitment<C>, ProverData<C>) {
     // One multilinear polynomial per trace column, stored as one table row per column.
-    let table = trace_to_table(trace);
+    // Transposing lays each column out contiguously as a table row.
+    let table = Table::new(tracing::info_span!("transpose").in_scope(|| trace.transpose()));
 
     // Pack the columns into the scheme's witness form (slot layout and folding live in the config).
     let witness = config.build_witness(table);
@@ -165,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    fn trace_to_table_extracts_each_column() {
+    fn transposed_trace_extracts_each_column() {
         // Fixture state: a width-2, height-4 row-major trace.
         //
         //     row 0: [1, 5]
@@ -177,7 +165,8 @@ mod tests {
         let values = [1, 5, 2, 6, 3, 7, 4, 8].map(F::from_u64).to_vec();
         let trace = RowMajorMatrix::new(values, 2);
 
-        let table = trace_to_table(&trace);
+        // Transposing lays each column out contiguously as a table row.
+        let table = Table::new(trace.transpose());
 
         // One polynomial per column.
         assert_eq!(table.num_polys(), 2);

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -1,10 +1,8 @@
 //! Configuration tying together the commitment scheme, challenge field, and transcript.
 
-use alloc::vec::Vec;
-
 use p3_commit::MultilinearPcs;
 use p3_field::{ExtensionField, Field};
-use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::layout::Table;
 
 /// The wiring a multilinear AIR proof depends on.
 ///
@@ -59,7 +57,7 @@ pub trait MultiStarkConfig {
     /// For a WHIR-backed config this is the first-round folding factor.
     fn min_num_variables(&self) -> usize;
 
-    /// Pack committed column polynomials into the commitment scheme's witness form.
+    /// Pack the committed trace table into the commitment scheme's witness form.
     ///
     /// The witness representation is private to the commitment scheme:
     /// - it folds in the slot layout and preprocessing depth that scheme expects,
@@ -68,11 +66,14 @@ pub trait MultiStarkConfig {
     ///
     /// # Arguments
     ///
-    /// - `columns`: one multilinear polynomial per committed trace column.
+    /// - `table`: one source table whose rows are trace-column polynomials.
     fn build_witness(
         &self,
-        columns: Vec<Poly<Self::Val>>,
+        table: Table<Self::Val>,
     ) -> <Self::Pcs as MultilinearPcs<Self::Challenge, Self::Challenger>>::Witness;
+
+    /// Borrows the committed trace table retained between commit and open.
+    fn committed_table<'a>(&self, prover_data: &'a ProverData<Self>) -> &'a Table<Self::Val>;
 }
 
 /// Commitment scheme selected by a configuration.

--- a/multi-stark/src/keys.rs
+++ b/multi-stark/src/keys.rs
@@ -12,10 +12,9 @@ use alloc::vec::Vec;
 use p3_air::BaseAir;
 use p3_commit::MultilinearPcs;
 use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrix;
+use p3_sumcheck::layout::Table;
 use p3_util::log2_strict_usize;
 
-use crate::commit::trace_to_columns;
 use crate::config::{Commitment, MultiStarkConfig, ProverData};
 
 /// Preprocessed data the prover reuses across proofs.
@@ -25,18 +24,10 @@ use crate::config::{Commitment, MultiStarkConfig, ProverData};
 pub struct PreprocessedProverData<C: MultiStarkConfig> {
     /// The preprocessed trace, one column per preprocessed AIR column.
     ///
-    /// Retained so the zerocheck round state can fold it alongside the main trace.
-    pub(crate) trace: RowMajorMatrix<C::Val>,
     /// Commitment to the stacked preprocessed columns.
     pub(crate) commitment: Commitment<C>,
     /// Committed prover data behind the commitment, cloned per proof to open.
     pub(crate) prover_data: ProverData<C>,
-    /// Number of preprocessed columns.
-    pub(crate) width: usize,
-    /// Preprocessed columns whose next row the AIR reads.
-    pub(crate) next_columns: Vec<usize>,
-    /// Base-two logarithm of the preprocessed trace height.
-    pub(crate) log_height: usize,
 }
 
 /// The prover's key for a fixed AIR and trace height.
@@ -106,19 +97,14 @@ where
     let next_columns = air.preprocessed_next_row_columns();
 
     // Turn the trace into one multilinear per column, then commit the stacked columns once.
-    let columns = trace_to_columns(&trace);
-    let witness = config.build_witness(columns);
+    let witness = config.build_witness(Table::new(trace.transpose()));
     let (commitment, prover_data) = config.preprocessed_pcs().commit(witness, challenger);
 
     // The prover key keeps the trace to fold and the committed data to open each proof.
     let proving = ProvingKey {
         preprocessed: Some(PreprocessedProverData {
-            trace,
             commitment: commitment.clone(),
             prover_data,
-            width,
-            next_columns: next_columns.clone(),
-            log_height,
         }),
     };
     // The verifier key keeps only the commitment and the shape facts.

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -122,8 +122,8 @@ where
     let committed_preprocessed =
         preprocessed.map(|preprocessed| config.committed_table(&preprocessed.prover_data));
     let (zerocheck_proof, point) = zerocheck.prove::<C::Val, C::Challenge, _>(
-        committed_preprocessed,
         committed_trace,
+        committed_preprocessed,
         public_values,
         challenger,
     );

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -104,22 +104,6 @@ where
         "trace arity must be at least the commitment scheme's padding floor"
     );
 
-    // Invariant: committed preprocessed column count == AIR's declared preprocessed width.
-    // A key with no preprocessed data pairs with an AIR that declares none (width 0).
-    assert_eq!(
-        preprocessed.map_or(0, |p| p.width),
-        air.preprocessed_width(),
-        "preprocessed key width must match the AIR's declared preprocessed width"
-    );
-
-    // Preprocessed and main columns share the bound point, so they must share a height.
-    if let Some(preprocessed) = preprocessed {
-        assert_eq!(
-            preprocessed.log_height, log_height,
-            "preprocessed trace height must match the main trace height"
-        );
-    }
-
     // 1. Absorb the reusable preprocessed commitment before any challenge depends on it.
     if let Some(preprocessed) = preprocessed {
         challenger.observe(preprocessed.commitment.clone());
@@ -133,9 +117,13 @@ where
     // The committed prover opens the columns through the commitment scheme,
     // so the zerocheck's own opened values are not used here.
     let zerocheck = AirZerocheck::new(air, pow_bits);
+
+    let committed_trace = config.committed_table(&prover_data);
+    let committed_preprocessed =
+        preprocessed.map(|preprocessed| config.committed_table(&preprocessed.prover_data));
     let (zerocheck_proof, point) = zerocheck.prove::<C::Val, C::Challenge, _>(
-        trace,
-        preprocessed.map(|p| &p.trace),
+        committed_preprocessed,
+        committed_trace,
         public_values,
         challenger,
     );
@@ -154,9 +142,9 @@ where
     // Cloning the committed data reuses the setup encoding and Merkle tree, skipping a rebuild.
     let preprocessed_opening = preprocessed.map(|preprocessed| {
         let protocol = single_table_protocol(
-            preprocessed.log_height,
-            preprocessed.width,
-            &preprocessed.next_columns,
+            log_height,
+            air.preprocessed_width(),
+            &air.preprocessed_next_row_columns(),
         );
         config.preprocessed_pcs().open_at(
             preprocessed.prover_data.clone(),

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -4,13 +4,12 @@
 
 use alloc::vec::Vec;
 
-use p3_air::Air;
+use p3_air::{Air, BaseAir};
 use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
-use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::Poly;
+use p3_multilinear_util::poly::{Poly, PolyView};
+use p3_sumcheck::layout::Table;
 
 use crate::folder::MultilinearFolder;
 use crate::packed_ext::PackedExt;
@@ -24,7 +23,7 @@ use crate::selectors::BoundaryEvals;
 /// They are laid out immediately after the main columns in the same matrix.
 /// A stored split index separates the two views when a folder is built.
 #[derive(Debug)]
-pub(crate) struct RoundStateBase<'a, A, F, EF> {
+pub(crate) struct RoundStateBase<'a, A, F: Field, EF> {
     /// AIR whose alpha-batched constraint is being evaluated.
     air: &'a A,
     /// Public inputs forwarded to the AIR.
@@ -33,11 +32,10 @@ pub(crate) struct RoundStateBase<'a, A, F, EF> {
     alpha: EF,
     /// Equality weight over the current round's suffix variables.
     eq_suffix: Poly<EF>,
-    /// Main columns then preprocessed columns, one original column per matrix row.
-    columns: RowMajorMatrix<F>,
-    /// Count of leading rows that are main columns.
-    /// Every later row is a preprocessed column.
-    main_width: usize,
+    /// Main trace columns, stored as one table row per original trace column.
+    table: &'a Table<F>,
+    /// Preprocessed columns
+    preprocessed: Option<&'a Table<F>>,
     /// Per-round sumcheck degree.
     degree: usize,
 }
@@ -193,16 +191,12 @@ struct ExtScratch<EF> {
     next_diff: Vec<EF>,
 }
 
-/// Per-worker scratch for the packed base-field first-round fold.
+/// Per-worker scratch for round-polynomial folds.
 ///
-/// Mirrors [`ExtScratch`] with packed base-field row buffers and a pair of
-/// per-lane equality-weight buffers. One instance is allocated per worker and
-/// reused across that worker's packed blocks.
-///
-/// `out` accumulates each round-polynomial evaluation as a packed extension
-/// value, one SIMD lane per row in the current chunk, deferring the
-/// horizontal lane reduction to a single pass after all chunks are folded in.
-struct PackedScratch<P, Acc> {
+/// `out` accumulates the round-polynomial evaluations; the row buffers hold one
+/// interpolation point and its per-step difference. One instance is allocated per
+/// worker and reused across that worker's rows or packed blocks.
+struct RoundScratch<P, Acc> {
     out: Vec<Acc>,
     local_point: Vec<P>,
     local_diff: Vec<P>,
@@ -222,9 +216,16 @@ impl<EF: PrimeCharacteristicRing> ExtScratch<EF> {
     }
 }
 
-impl<P, Acc> PackedScratch<P, Acc>
+impl<EF: Field> ExtScratch<EF> {
+    fn add_diffs(&mut self) {
+        EF::add_slices(&mut self.local_point, &self.local_diff);
+        EF::add_slices(&mut self.next_point, &self.next_diff);
+    }
+}
+
+impl<P, Acc> RoundScratch<P, Acc>
 where
-    P: PrimeCharacteristicRing,
+    P: PrimeCharacteristicRing + Copy,
     Acc: PrimeCharacteristicRing,
 {
     fn new(degree: usize, width: usize) -> Self {
@@ -236,80 +237,59 @@ where
             next_diff: P::zero_vec(width),
         }
     }
+
+    fn add_diffs(&mut self) {
+        self.local_point
+            .iter_mut()
+            .zip(self.local_diff.iter())
+            .zip(self.next_point.iter_mut())
+            .zip(self.next_diff.iter())
+            .for_each(|(((local, local_diff), next), next_diff)| {
+                *local += *local_diff;
+                *next += *next_diff;
+            });
+    }
 }
 
 impl<'a, A, F, EF> RoundStateBase<'a, A, F, EF>
 where
     F: Field,
     EF: ExtensionField<F>,
+    A: BaseAir<F>,
 {
-    /// Build the prover state from a trace and a sampled zerocheck point.
-    ///
-    /// The preprocessed columns, when present, are appended after the main columns.
-    /// Both traces must share the same height, so every column has the same arity.
-    ///
-    /// # Arguments
-    ///
-    /// - `air`: the AIR whose alpha-batched constraint is evaluated.
-    /// - `public_values`: public inputs forwarded to the AIR.
-    /// - `alpha`: random scalar batching the constraints.
-    /// - `tau`: the sampled zerocheck point.
-    /// - `trace`: the main execution trace, one column per main AIR column.
-    /// - `preprocessed`: the preprocessed trace, or `None` when the AIR declares none.
-    /// - `degree`: the per-round sumcheck degree.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the preprocessed trace height differs from the main trace height.
+    /// Build the prover state from trace columns and a sampled zerocheck point.
     #[tracing::instrument(skip_all)]
     pub(crate) fn new(
         air: &'a A,
         public_values: &'a [F],
         alpha: EF,
         tau: &Point<EF>,
-        trace: &'a RowMajorMatrix<F>,
-        preprocessed: Option<&RowMajorMatrix<F>>,
+        preprocessed: Option<&'a Table<F>>,
+        table: &'a Table<F>,
         degree: usize,
     ) -> Self {
-        // TODO: we may want to send cm_trace directly since PCS needs Vec<Poly> representation of witneses
-        // One matrix row per column: transpose lays each column out contiguously.
-        let main_width = trace.width;
-        let columns = tracing::info_span!("transpose").in_scope(|| {
-            let main = trace.transpose();
-            match preprocessed {
-                // No preprocessed trace: the main columns are the whole matrix.
-                None => main,
-                // Append the preprocessed columns as extra rows of the same width.
-                Some(preprocessed) => {
-                    let trace_height = main.width;
-                    let prep = preprocessed.transpose();
-                    assert_eq!(
-                        prep.width, trace_height,
-                        "preprocessed trace height must match the main trace height"
-                    );
-                    let mut values = main.values;
-                    values.extend_from_slice(&prep.values);
-                    RowMajorMatrix::new(values, trace_height)
-                }
-            }
-        });
+        assert_eq!(tau.num_variables(), table.num_variables());
+        assert_eq!(air.width(), table.num_polys());
+        assert_eq!(
+            air.preprocessed_width(),
+            preprocessed.map_or(0, Table::num_polys)
+        );
+        if let Some(air_degree) = air.max_constraint_degree() {
+            assert_eq!(degree, air_degree);
+        }
         Self {
             air,
             public_values,
             alpha,
             eq_suffix: Poly::new_from_point(&tau.as_slice()[1..], EF::ONE),
-            columns,
-            main_width,
+            preprocessed,
+            table,
             degree,
         }
     }
 
-    const fn num_evals(&self) -> usize {
+    fn num_evals(&self) -> usize {
         self.eq_suffix.num_evals() * 2
-    }
-
-    fn width(&self) -> usize {
-        self.columns.height()
     }
 
     #[tracing::instrument(skip_all)]
@@ -329,12 +309,12 @@ where
     #[tracing::instrument(skip_all)]
     fn round_poly_packed(&self) -> Vec<EF>
     where
-        A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
-            + for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
+        A: for<'b> Air<MultilinearFolder<'b, F, F::Packing, EF::ExtensionPacking>>,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
-        let width = self.width();
-        let main_width = self.main_width;
+        let main_width = self.table.num_polys();
+        let preprocessed_width = self.preprocessed.map_or(0, Table::num_polys);
+        let width = main_width + preprocessed_width;
         let height = self.num_evals();
         let scalar_half = height / 2;
         let packing_width = F::Packing::WIDTH;
@@ -348,73 +328,71 @@ where
             .par_chunks_exact(packing_width)
             .enumerate()
             .par_fold_reduce(
-                || PackedScratch::<F::Packing, EF::ExtensionPacking>::new(degree, width),
+                || RoundScratch::<F::Packing, EF::ExtensionPacking>::new(degree, width),
                 |mut scratch, (packed_s, eq_suffix)| {
                     let s = packed_s * packing_width;
                     let eq_suffix = EF::ExtensionPacking::from_ext_slice(eq_suffix);
+                    let fill_columns =
+                        |scratch: &mut RoundScratch<F::Packing, EF::ExtensionPacking>,
+                         offset: usize,
+                         columns: &Table<F>| {
+                            let end = offset + columns.num_polys();
+                            let local_point = &mut scratch.local_point[offset..end];
+                            let local_diff = &mut scratch.local_diff[offset..end];
+                            let next_point = &mut scratch.next_point[offset..end];
+                            let next_diff = &mut scratch.next_diff[offset..end];
 
-                    for ((((local, local_delta), next), next_delta), column) in scratch
-                        .local_point
-                        .iter_mut()
-                        .zip(scratch.local_diff.iter_mut())
-                        .zip(scratch.next_point.iter_mut())
-                        .zip(scratch.next_diff.iter_mut())
-                        .zip(self.columns.row_slices())
-                    {
-                        let local_lo = *F::Packing::from_slice(&column[s..s + packing_width]);
-                        let local_hi = *F::Packing::from_slice(
-                            &column[s + scalar_half..s + scalar_half + packing_width],
-                        );
-                        *local = local_lo;
-                        *local_delta = local_hi - local_lo;
+                            for ((((local, local_diff), next), next_diff), column) in local_point
+                                .iter_mut()
+                                .zip(local_diff.iter_mut())
+                                .zip(next_point.iter_mut())
+                                .zip(next_diff.iter_mut())
+                                .zip(columns.iter_polys())
+                            {
+                                let local_lo =
+                                    *F::Packing::from_slice(&column[s..s + packing_width]);
+                                let local_hi = *F::Packing::from_slice(
+                                    &column[s + scalar_half..s + scalar_half + packing_width],
+                                );
+                                *local = local_lo;
+                                *local_diff = local_hi - local_lo;
 
-                        let next_lo =
-                            *F::Packing::from_slice(&column[s + 1..s + 1 + packing_width]);
-                        let next_hi_start = s + scalar_half + 1;
-                        let next_hi = if next_hi_start + packing_width <= height {
-                            *F::Packing::from_slice(
-                                &column[next_hi_start..next_hi_start + packing_width],
-                            )
-                        } else {
-                            F::Packing::from_fn(|lane| {
-                                let row = next_hi_start + lane;
-                                if row < height {
-                                    column[row]
+                                let next_lo =
+                                    *F::Packing::from_slice(&column[s + 1..s + 1 + packing_width]);
+                                let next_hi_start = s + scalar_half + 1;
+                                let next_hi = if next_hi_start + packing_width <= height {
+                                    *F::Packing::from_slice(
+                                        &column[next_hi_start..next_hi_start + packing_width],
+                                    )
                                 } else {
-                                    column[height - 1]
-                                }
-                            })
+                                    F::Packing::from_fn(|lane| {
+                                        let row = next_hi_start + lane;
+                                        if row < height {
+                                            column[row]
+                                        } else {
+                                            column[height - 1]
+                                        }
+                                    })
+                                };
+                                *next = next_lo;
+                                *next_diff = next_hi - next_lo;
+                            }
                         };
-                        *next = next_lo;
-                        *next_delta = next_hi - next_lo;
+
+                    fill_columns(&mut scratch, 0, self.table);
+
+                    if let Some(preprocessed) = self.preprocessed {
+                        fill_columns(&mut scratch, main_width, preprocessed);
                     }
 
                     let (mut boundary, boundary_diff) =
                         BoundaryEvals::<F::Packing>::row_pair_packed(s, scalar_half, height);
 
-                    scratch
-                        .local_point
-                        .iter_mut()
-                        .zip(scratch.local_diff.iter())
-                        .zip(scratch.next_point.iter_mut())
-                        .zip(scratch.next_diff.iter())
-                        .for_each(|(((local, local_diff), next), next_diff)| {
-                            *local += *local_diff;
-                            *next += *next_diff;
-                        });
+                    scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc in &mut scratch.out[1..] {
-                        scratch
-                            .local_point
-                            .iter_mut()
-                            .zip(scratch.local_diff.iter())
-                            .zip(scratch.next_point.iter_mut())
-                            .zip(scratch.next_diff.iter())
-                            .for_each(|(((local, local_diff), next), next_diff)| {
-                                *local += *local_diff;
-                                *next += *next_diff;
-                            });
+                    for acc_idx in 1..scratch.out.len() {
+                        scratch.add_diffs();
                         boundary += boundary_diff;
 
                         let g = MultilinearFolder::new(
@@ -429,7 +407,7 @@ where
                             &scratch.next_point[main_width..],
                         )
                         .eval_air(self.air);
-                        *acc += g * eq_suffix;
+                        scratch.out[acc_idx] += g * eq_suffix;
                     }
 
                     scratch
@@ -453,74 +431,88 @@ where
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
     {
-        let width = self.width();
-        let main_width = self.main_width;
+        let main_width = self.table.num_polys();
+        let preprocessed_width = self.preprocessed.map_or(0, Table::num_polys);
+        let width = main_width + preprocessed_width;
         let height = self.num_evals();
         let half = height / 2;
 
-        let mut out = EF::zero_vec(self.degree);
-        let mut local_point = F::zero_vec(width);
-        let mut local_diff = F::zero_vec(width);
-        let mut next_point = F::zero_vec(width);
-        let mut next_diff = F::zero_vec(width);
+        let mut scratch = RoundScratch::<F, EF>::new(self.degree, width);
 
         for (s, &eq_suffix) in self.eq_suffix.as_slice().iter().enumerate() {
-            local_point
-                .iter_mut()
-                .zip(local_diff.iter_mut())
-                .zip(next_point.iter_mut())
-                .zip(next_diff.iter_mut())
-                .zip(self.columns.row_slices())
-                .for_each(|((((local, local_delta), next), next_delta), column)| {
-                    let local_lo = column[s];
-                    let local_hi = column[s + half];
-                    *local = local_lo;
-                    *local_delta = local_hi - local_lo;
+            let fill_columns =
+                |scratch: &mut RoundScratch<F, EF>, offset: usize, columns: &Table<F>| {
+                    let end = offset + columns.num_polys();
+                    let local_point = &mut scratch.local_point[offset..end];
+                    let local_diff = &mut scratch.local_diff[offset..end];
+                    let next_point = &mut scratch.next_point[offset..end];
+                    let next_diff = &mut scratch.next_diff[offset..end];
 
-                    let next_lo = column[s + 1];
-                    let next_hi = if s + half + 1 < height {
-                        column[s + half + 1]
-                    } else {
-                        column[height - 1]
-                    };
-                    *next = next_lo;
-                    *next_delta = next_hi - next_lo;
-                });
+                    for ((((local, local_diff), next), next_diff), column) in local_point
+                        .iter_mut()
+                        .zip(local_diff.iter_mut())
+                        .zip(next_point.iter_mut())
+                        .zip(next_diff.iter_mut())
+                        .zip(columns.iter_polys())
+                    {
+                        let local_lo = column[s];
+                        let local_hi = column[s + half];
+                        *local = local_lo;
+                        *local_diff = local_hi - local_lo;
+
+                        let next_lo = column[s + 1];
+                        let next_hi = if s + half + 1 < height {
+                            column[s + half + 1]
+                        } else {
+                            column[height - 1]
+                        };
+                        *next = next_lo;
+                        *next_diff = next_hi - next_lo;
+                    }
+                };
+
+            fill_columns(&mut scratch, 0, self.table);
+
+            if let Some(preprocessed) = self.preprocessed {
+                fill_columns(&mut scratch, main_width, preprocessed);
+            }
 
             let (mut boundary, boundary_diff) = BoundaryEvals::<F>::row_pair(s, half, height);
 
-            F::add_slices(&mut local_point, &local_diff);
-            F::add_slices(&mut next_point, &next_diff);
+            scratch.add_diffs();
             boundary += boundary_diff;
 
-            for acc in &mut out[1..] {
-                F::add_slices(&mut local_point, &local_diff);
-                F::add_slices(&mut next_point, &next_diff);
+            for acc_idx in 1..scratch.out.len() {
+                scratch.add_diffs();
                 boundary += boundary_diff;
 
                 let g = MultilinearFolder::new(
-                    &local_point[..main_width],
-                    &next_point[..main_width],
+                    &scratch.local_point[..main_width],
+                    &scratch.next_point[..main_width],
                     boundary,
                     self.public_values,
                     self.alpha,
                 )
-                .with_preprocessed(&local_point[main_width..], &next_point[main_width..])
+                .with_preprocessed(
+                    &scratch.local_point[main_width..],
+                    &scratch.next_point[main_width..],
+                )
                 .eval_air(self.air);
-                *acc += eq_suffix * g;
+                scratch.out[acc_idx] += eq_suffix * g;
             }
         }
 
-        out
+        scratch.out
     }
 
     #[tracing::instrument(skip_all)]
     pub(crate) fn fold(self, r: EF) -> RoundStateExt<'a, A, F, EF> {
+        let main_width = self.table.num_polys();
         let num_evals = self.num_evals();
         let half = num_evals / 2;
-        let next_tail = self
-            .columns
-            .row_slices()
+        let mut next_tail = self
+            .table
+            .iter_polys()
             .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half]))
             .collect::<Vec<_>>();
 
@@ -529,20 +521,44 @@ where
 
         let want_packed = (half / 2) >= F::Packing::WIDTH;
         let columns = if want_packed {
-            ExtColumns::Packed(
-                self.columns
-                    .par_row_slices()
-                    .map(|col| Poly::fix_prefix_var_to_packed_from_evals(col, r))
-                    .collect(),
-            )
+            let mut columns = self
+                .table
+                .par_iter_polys()
+                .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
+                .collect::<Vec<_>>();
+            if let Some(preprocessed) = self.preprocessed {
+                columns.extend(
+                    preprocessed
+                        .par_iter_polys()
+                        .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
+                        .collect::<Vec<_>>(),
+                );
+            }
+            ExtColumns::Packed(columns)
         } else {
-            ExtColumns::Scalar(
-                self.columns
-                    .par_row_slices()
-                    .map(|col| Poly::fix_prefix_var_from_evals(col, r))
-                    .collect(),
-            )
+            let mut columns = self
+                .table
+                .par_iter_polys()
+                .map(|col| PolyView::new(col).fix_prefix_var(r))
+                .collect::<Vec<_>>();
+            if let Some(preprocessed) = self.preprocessed {
+                columns.extend(
+                    preprocessed
+                        .par_iter_polys()
+                        .map(|col| PolyView::new(col).fix_prefix_var(r))
+                        .collect::<Vec<_>>(),
+                );
+            }
+            ExtColumns::Scalar(columns)
         };
+
+        if let Some(preprocessed) = self.preprocessed {
+            next_tail.extend(
+                preprocessed
+                    .iter_polys()
+                    .map(|col| EF::from(col[half]) + r * (col[num_evals - 1] - col[half])),
+            );
+        }
 
         RoundStateExt {
             air: self.air,
@@ -551,7 +567,7 @@ where
             eq_suffix,
             degree: self.degree,
             columns,
-            main_width: self.main_width,
+            main_width,
             next_tail,
             boundary: BoundaryEvals::new(EF::ONE - r, r, EF::ONE - r),
         }
@@ -563,12 +579,8 @@ where
     F: Field,
     EF: ExtensionField<F>,
 {
-    const fn num_evals(&self) -> usize {
+    fn num_evals(&self) -> usize {
         self.eq_suffix.num_evals() * 2
-    }
-
-    const fn width(&self) -> usize {
-        self.columns.len()
     }
 
     /// Extracts the final scalar value of each column.
@@ -617,7 +629,7 @@ where
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
     {
-        let width = self.width();
+        let width = self.columns.len();
         let main_width = self.main_width;
         let num_evals = self.num_evals();
         let half = num_evals / 2;
@@ -630,7 +642,7 @@ where
             .par_fold_reduce(
                 || ExtScratch::new(degree, width),
                 |mut scratch, (s, &eq_suffix)| {
-                    for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
+                    for (((((local, local_diff), next), next_diff), column), next_tail) in scratch
                         .local_point
                         .iter_mut()
                         .zip(scratch.local_diff.iter_mut())
@@ -643,7 +655,7 @@ where
                         let local_lo = column[s];
                         let local_hi = column[s + half];
                         *local = local_lo;
-                        *local_delta = local_hi - local_lo;
+                        *local_diff = local_hi - local_lo;
 
                         let next_lo = column[s + 1];
                         let next_hi_row = s + half;
@@ -653,7 +665,7 @@ where
                             *next_tail
                         };
                         *next = next_lo;
-                        *next_delta = next_hi - next_lo;
+                        *next_diff = next_hi - next_lo;
                     }
 
                     let (mut boundary, boundary_diff) =
@@ -673,13 +685,11 @@ where
                     .eval_air(self.air);
                     scratch.out[0] += eq_suffix * g;
 
-                    EF::add_slices(&mut scratch.local_point, &scratch.local_diff);
-                    EF::add_slices(&mut scratch.next_point, &scratch.next_diff);
+                    scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc in &mut scratch.out[1..] {
-                        EF::add_slices(&mut scratch.local_point, &scratch.local_diff);
-                        EF::add_slices(&mut scratch.next_point, &scratch.next_diff);
+                    for acc_idx in 1..scratch.out.len() {
+                        scratch.add_diffs();
                         boundary += boundary_diff;
 
                         let g = MultilinearFolder::new(
@@ -694,7 +704,7 @@ where
                             &scratch.next_point[main_width..],
                         )
                         .eval_air(self.air);
-                        *acc += eq_suffix * g;
+                        scratch.out[acc_idx] += eq_suffix * g;
                     }
 
                     scratch
@@ -733,7 +743,7 @@ where
         >,
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
     {
-        let width = self.width();
+        let width = self.columns.len();
         let main_width = self.main_width;
         let height = self.num_evals();
         let scalar_half = height / 2;
@@ -749,7 +759,7 @@ where
             .enumerate()
             .par_fold_reduce(
                 || {
-                    PackedScratch::<PackedExt<F, EF::ExtensionPacking>, EF::ExtensionPacking>::new(
+                    RoundScratch::<PackedExt<F, EF::ExtensionPacking>, EF::ExtensionPacking>::new(
                         degree, width,
                     )
                 },
@@ -757,7 +767,7 @@ where
                     let s = packed_s * packing_width;
                     let eq_suffix = EF::ExtensionPacking::from_ext_slice(eq_suffix);
 
-                    for (((((local, local_delta), next), next_delta), column), next_tail) in scratch
+                    for (((((local, local_diff), next), next_diff), column), next_tail) in scratch
                         .local_point
                         .iter_mut()
                         .zip(scratch.local_diff.iter_mut())
@@ -771,7 +781,7 @@ where
                         let local_lo = PackedExt::new(column[packed_s]);
                         let local_hi = PackedExt::new(column[packed_s + packed_half]);
                         *local = local_lo;
-                        *local_delta = local_hi - local_lo;
+                        *local_diff = local_hi - local_lo;
 
                         // Shifted-by-one reads cross packed-group boundaries, so they
                         // reconstruct their window lane by lane instead of indexing directly.
@@ -788,7 +798,7 @@ where
                             *next_tail,
                         ));
                         *next = next_lo;
-                        *next_delta = next_hi - next_lo;
+                        *next_diff = next_hi - next_lo;
                     }
 
                     let (raw_boundary, raw_boundary_diff) =
@@ -823,29 +833,11 @@ where
                     .eval_air(self.air);
                     scratch.out[0] += g.0 * eq_suffix;
 
-                    scratch
-                        .local_point
-                        .iter_mut()
-                        .zip(scratch.local_diff.iter())
-                        .zip(scratch.next_point.iter_mut())
-                        .zip(scratch.next_diff.iter())
-                        .for_each(|(((local, local_diff), next), next_diff)| {
-                            *local += *local_diff;
-                            *next += *next_diff;
-                        });
+                    scratch.add_diffs();
                     boundary += boundary_diff;
 
-                    for acc in &mut scratch.out[1..] {
-                        scratch
-                            .local_point
-                            .iter_mut()
-                            .zip(scratch.local_diff.iter())
-                            .zip(scratch.next_point.iter_mut())
-                            .zip(scratch.next_diff.iter())
-                            .for_each(|(((local, local_diff), next), next_diff)| {
-                                *local += *local_diff;
-                                *next += *next_diff;
-                            });
+                    for acc_idx in 1..scratch.out.len() {
+                        scratch.add_diffs();
                         boundary += boundary_diff;
 
                         let g = MultilinearFolder::new(
@@ -860,7 +852,7 @@ where
                             &scratch.next_point[main_width..],
                         )
                         .eval_air(self.air);
-                        *acc += g.0 * eq_suffix;
+                        scratch.out[acc_idx] += g.0 * eq_suffix;
                     }
 
                     scratch

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -264,8 +264,8 @@ where
         public_values: &'a [F],
         alpha: EF,
         tau: &Point<EF>,
-        preprocessed: Option<&'a Table<F>>,
         table: &'a Table<F>,
+        preprocessed: Option<&'a Table<F>>,
         degree: usize,
     ) -> Self {
         assert_eq!(tau.num_variables(), table.num_variables());
@@ -274,6 +274,15 @@ where
             air.preprocessed_width(),
             preprocessed.map_or(0, Table::num_polys)
         );
+        // Both traces bind the same zerocheck point, so they must share an arity.
+        // The fold reads preprocessed columns at offsets derived from the main height.
+        if let Some(preprocessed) = preprocessed {
+            assert_eq!(
+                preprocessed.num_variables(),
+                table.num_variables(),
+                "preprocessed trace height must match the main trace height"
+            );
+        }
         if let Some(air_degree) = air.max_constraint_degree() {
             assert_eq!(degree, air_degree);
         }
@@ -527,11 +536,10 @@ where
                 .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
                 .collect::<Vec<_>>();
             if let Some(preprocessed) = self.preprocessed {
-                columns.extend(
+                columns.par_extend(
                     preprocessed
                         .par_iter_polys()
-                        .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
-                        .collect::<Vec<_>>(),
+                        .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r)),
                 );
             }
             ExtColumns::Packed(columns)
@@ -542,11 +550,10 @@ where
                 .map(|col| PolyView::new(col).fix_prefix_var(r))
                 .collect::<Vec<_>>();
             if let Some(preprocessed) = self.preprocessed {
-                columns.extend(
+                columns.par_extend(
                     preprocessed
                         .par_iter_polys()
-                        .map(|col| PolyView::new(col).fix_prefix_var(r))
-                        .collect::<Vec<_>>(),
+                        .map(|col| PolyView::new(col).fix_prefix_var(r)),
                 );
             }
             ExtColumns::Scalar(columns)

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -536,10 +536,11 @@ where
                 .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
                 .collect::<Vec<_>>();
             if let Some(preprocessed) = self.preprocessed {
-                columns.par_extend(
+                columns.extend(
                     preprocessed
                         .par_iter_polys()
-                        .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r)),
+                        .map(|col| PolyView::new(col).fix_prefix_var_to_packed(r))
+                        .collect::<Vec<_>>(),
                 );
             }
             ExtColumns::Packed(columns)
@@ -550,10 +551,11 @@ where
                 .map(|col| PolyView::new(col).fix_prefix_var(r))
                 .collect::<Vec<_>>();
             if let Some(preprocessed) = self.preprocessed {
-                columns.par_extend(
+                columns.extend(
                     preprocessed
                         .par_iter_polys()
-                        .map(|col| PolyView::new(col).fix_prefix_var(r)),
+                        .map(|col| PolyView::new(col).fix_prefix_var(r))
+                        .collect::<Vec<_>>(),
                 );
             }
             ExtColumns::Scalar(columns)

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -215,8 +215,8 @@ impl<'a, A> AirZerocheck<'a, A> {
     ///
     /// # Arguments
     ///
-    /// - `preprocessed`: the preprocessed trace, or `None` when the AIR declares none.
     /// - `table`: committed trace table, one original trace column per table row.
+    /// - `preprocessed`: the preprocessed trace, or `None` when the AIR declares none.
     /// - `public_values`: public inputs forwarded to the AIR.
     /// - `challenger`: the Fiat-Shamir transcript.
     ///
@@ -230,8 +230,8 @@ impl<'a, A> AirZerocheck<'a, A> {
     #[tracing::instrument(skip_all)]
     pub fn prove<F, EF, Challenger>(
         &self,
-        preprocessed: Option<&Table<F>>,
         table: &Table<F>,
+        preprocessed: Option<&Table<F>>,
         public_values: &[F],
         challenger: &mut Challenger,
     ) -> (ZerocheckProof<F, EF>, Point<EF>)
@@ -286,8 +286,8 @@ impl<'a, A> AirZerocheck<'a, A> {
             public_values,
             alpha,
             &tau,
-            preprocessed,
             table,
+            preprocessed,
             degree - 1,
         );
 
@@ -874,7 +874,7 @@ mod tests {
 
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         zerocheck
@@ -893,7 +893,7 @@ mod tests {
         let mut challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
         let (proof, point) =
-            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(None, &table, &pis, &mut challenger);
+            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&table, None, &pis, &mut challenger);
 
         // Each Fibonacci constraint is per-variable degree 2 (a degree-1 selector
         // times a degree-1 column), so the eq-weighted integrand is degree 3.
@@ -929,7 +929,7 @@ mod tests {
         // Prove with grinding enabled.
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
 
         // Grinding emits exactly one witness per sumcheck round.
         assert_eq!(proof.sumcheck.pow_witnesses.len(), log2_strict_usize(n));
@@ -953,7 +953,7 @@ mod tests {
 
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         let err = zerocheck
@@ -973,7 +973,7 @@ mod tests {
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
         proof.local[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -995,7 +995,7 @@ mod tests {
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
         proof.next[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -1018,7 +1018,7 @@ mod tests {
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
 
         // Declare a nonzero sum; the verifier must reject before any further work.
         proof.sumcheck.claimed_sum += EF::ONE;
@@ -1049,7 +1049,7 @@ mod tests {
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(&table, None, &pis, &mut prover_challenger);
 
         // Remove one opened value so the count no longer matches the AIR width.
         proof.local.pop();
@@ -1119,7 +1119,7 @@ mod tests {
 
         let mut prover_challenger = fresh_challenger();
         let table = Table::new(trace.transpose());
-        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &[], &mut prover_challenger);
+        let (proof, _) = zerocheck.prove::<F, EF, _>(&table, None, &[], &mut prover_challenger);
 
         // Two committed columns yield two current-row claims.
         assert_eq!(proof.local.len(), 2);
@@ -1160,7 +1160,7 @@ mod tests {
             let mut prover_challenger = fresh_challenger();
             let table = Table::new(trace.transpose());
             let (proof, point_prover) =
-                zerocheck.prove::<F, EF, _>(None, &table, &[], &mut prover_challenger);
+                zerocheck.prove::<F, EF, _>(&table, None, &[], &mut prover_challenger);
 
             // Reference columns: one multilinear per trace column, in row order.
             //
@@ -1258,8 +1258,8 @@ mod tests {
             let table = Table::new(trace.transpose());
             let preprocessed_table = Table::new(preprocessed.transpose());
             let (proof, point) = zerocheck.prove::<F, EF, _>(
-                Some(&preprocessed_table),
                 &table,
+                Some(&preprocessed_table),
                 &[],
                 &mut prover_challenger,
             );
@@ -1293,8 +1293,8 @@ mod tests {
         let table = Table::new(trace.transpose());
         let preprocessed_table = Table::new(preprocessed.transpose());
         let (mut proof, _) = zerocheck.prove::<F, EF, _>(
-            Some(&preprocessed_table),
             &table,
+            Some(&preprocessed_table),
             &[],
             &mut prover_challenger,
         );
@@ -1318,8 +1318,8 @@ mod tests {
         let table = Table::new(trace.transpose());
         let preprocessed_table = Table::new(preprocessed.transpose());
         let (mut proof, _) = zerocheck.prove::<F, EF, _>(
-            Some(&preprocessed_table),
             &table,
+            Some(&preprocessed_table),
             &[],
             &mut prover_challenger,
         );

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -15,11 +15,9 @@ use alloc::vec::Vec;
 use p3_air::{Air, AirLayout, BaseAir, SymbolicAirBuilder, get_all_symbolic_constraints};
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field};
-use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_multilinear_util::point::Point;
 use p3_sumcheck::generic_degree::{GenericDegreeError, GenericDegreeProof, RoundPolyInterpolator};
-use p3_util::log2_strict_usize;
+use p3_sumcheck::layout::Table;
 use thiserror::Error;
 
 use crate::folder::MultilinearFolder;
@@ -210,13 +208,15 @@ impl<'a, A> AirZerocheck<'a, A> {
 
     /// Prove that the AIR's alpha-batched constraint vanishes on every trace row.
     ///
+    /// The `table` must have one original trace column per table row.
+    ///
     /// The caller must observe the trace commitment into the challenger before this call.
     /// The public values are observed here, so the caller need not observe them.
     ///
     /// # Arguments
     ///
-    /// - `trace`: the execution trace, one column per main AIR column, height a power of two.
     /// - `preprocessed`: the preprocessed trace, or `None` when the AIR declares none.
+    /// - `table`: committed trace table, one original trace column per table row.
     /// - `public_values`: public inputs forwarded to the AIR.
     /// - `challenger`: the Fiat-Shamir transcript.
     ///
@@ -230,8 +230,8 @@ impl<'a, A> AirZerocheck<'a, A> {
     #[tracing::instrument(skip_all)]
     pub fn prove<F, EF, Challenger>(
         &self,
-        trace: &RowMajorMatrix<F>,
-        preprocessed: Option<&RowMajorMatrix<F>>,
+        preprocessed: Option<&Table<F>>,
+        table: &Table<F>,
         public_values: &[F],
         challenger: &mut Challenger,
     ) -> (ZerocheckProof<F, EF>, Point<EF>)
@@ -252,10 +252,15 @@ impl<'a, A> AirZerocheck<'a, A> {
         EF::ExtensionPacking: From<EF> + From<F::Packing>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        let log_height = log2_strict_usize(trace.height());
+        let log_height = table.num_variables();
 
         // Reject column kinds this version cannot prove, and read the layout once.
         let layout = self.layout::<F>();
+        assert_eq!(
+            table.num_polys(),
+            layout.main_width,
+            "trace width must match the AIR width"
+        );
 
         // Per-round sumcheck degree from the symbolic constraint degree.
         let degree = self.sumcheck_degree::<F, EF>(layout);
@@ -281,8 +286,8 @@ impl<'a, A> AirZerocheck<'a, A> {
             public_values,
             alpha,
             &tau,
-            trace,
             preprocessed,
+            table,
             degree - 1,
         );
 
@@ -749,6 +754,7 @@ mod tests {
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
     use p3_poseidon2_air::{Poseidon2Air, RoundConstants};
+    use p3_util::log2_strict_usize;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -867,7 +873,8 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         zerocheck
@@ -884,8 +891,9 @@ mod tests {
         let pis = fib_public_values(n);
 
         let mut challenger = fresh_challenger();
+        let table = Table::new(trace.transpose());
         let (proof, point) =
-            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(&trace, None, &pis, &mut challenger);
+            AirZerocheck::new(&FibAir, 0).prove::<F, EF, _>(None, &table, &pis, &mut challenger);
 
         // Each Fibonacci constraint is per-variable degree 2 (a degree-1 selector
         // times a degree-1 column), so the eq-weighted integrand is degree 3.
@@ -920,7 +928,8 @@ mod tests {
 
         // Prove with grinding enabled.
         let mut prover_challenger = fresh_challenger();
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
 
         // Grinding emits exactly one witness per sumcheck round.
         assert_eq!(proof.sumcheck.pow_witnesses.len(), log2_strict_usize(n));
@@ -943,7 +952,8 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
 
         let mut verifier_challenger = fresh_challenger();
         let err = zerocheck
@@ -961,8 +971,9 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
+        let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
         proof.local[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -982,8 +993,9 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
+        let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
         proof.next[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -1004,8 +1016,9 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
+        let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
 
         // Declare a nonzero sum; the verifier must reject before any further work.
         proof.sumcheck.claimed_sum += EF::ONE;
@@ -1034,8 +1047,9 @@ mod tests {
         let zerocheck = AirZerocheck::new(&FibAir, 0);
 
         let mut prover_challenger = fresh_challenger();
+        let table = Table::new(trace.transpose());
         let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, None, &pis, &mut prover_challenger);
+            zerocheck.prove::<F, EF, _>(None, &table, &pis, &mut prover_challenger);
 
         // Remove one opened value so the count no longer matches the AIR width.
         proof.local.pop();
@@ -1104,7 +1118,8 @@ mod tests {
         let zerocheck = AirZerocheck::new(&ConstColAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let (proof, _) = zerocheck.prove::<F, EF, _>(&trace, None, &[], &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let (proof, _) = zerocheck.prove::<F, EF, _>(None, &table, &[], &mut prover_challenger);
 
         // Two committed columns yield two current-row claims.
         assert_eq!(proof.local.len(), 2);
@@ -1143,15 +1158,15 @@ mod tests {
             // Prove the alpha-batched constraint vanishes on every row.
             let zerocheck = AirZerocheck::new(&air, 0);
             let mut prover_challenger = fresh_challenger();
+            let table = Table::new(trace.transpose());
             let (proof, point_prover) =
-                zerocheck.prove::<F, EF, _>(&trace, None, &[], &mut prover_challenger);
+                zerocheck.prove::<F, EF, _>(None, &table, &[], &mut prover_challenger);
 
             // Reference columns: one multilinear per trace column, in row order.
             //
             //     row-major trace --transpose--> one row per column
-            let columns = trace.transpose();
-            let columns = columns
-                .row_slices()
+            let columns = table
+                .iter_polys()
                 .map(|col| Poly::new(col.to_vec()))
                 .collect::<Vec<_>>();
 
@@ -1240,15 +1255,17 @@ mod tests {
             let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
 
             let mut prover_challenger = fresh_challenger();
+            let table = Table::new(trace.transpose());
+            let preprocessed_table = Table::new(preprocessed.transpose());
             let (proof, point) = zerocheck.prove::<F, EF, _>(
-                &trace,
-                Some(&preprocessed),
+                Some(&preprocessed_table),
+                &table,
                 &[],
                 &mut prover_challenger,
             );
 
             // The preprocessed openings must match the preprocessed column at the bound point.
-            let preprocessed_col = Poly::new(preprocessed.values.clone());
+            let preprocessed_col = preprocessed_table.poly(0);
             assert_eq!(
                 proof.preprocessed_local,
                 [preprocessed_col.eval_base(&point)]
@@ -1273,8 +1290,14 @@ mod tests {
         let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, Some(&preprocessed), &[], &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let preprocessed_table = Table::new(preprocessed.transpose());
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(
+            Some(&preprocessed_table),
+            &table,
+            &[],
+            &mut prover_challenger,
+        );
         proof.preprocessed_local[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();
@@ -1292,8 +1315,14 @@ mod tests {
         let zerocheck = AirZerocheck::new(&PreprocessedAir, 0);
 
         let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) =
-            zerocheck.prove::<F, EF, _>(&trace, Some(&preprocessed), &[], &mut prover_challenger);
+        let table = Table::new(trace.transpose());
+        let preprocessed_table = Table::new(preprocessed.transpose());
+        let (mut proof, _) = zerocheck.prove::<F, EF, _>(
+            Some(&preprocessed_table),
+            &table,
+            &[],
+            &mut prover_challenger,
+        );
         proof.preprocessed_next[0] += EF::ONE;
 
         let mut verifier_challenger = fresh_challenger();

--- a/multi-stark/tests/whir_fibonacci.rs
+++ b/multi-stark/tests/whir_fibonacci.rs
@@ -13,7 +13,6 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multi_stark::config::MultiStarkConfig;
 use p3_multi_stark::zerocheck::ZerocheckError;
 use p3_multi_stark::{VerificationError, prove, setup, verify};
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::OpeningBatch;
 use p3_sumcheck::layout::{Layout, PrefixProver, Table, Witness};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -64,9 +63,16 @@ impl MultiStarkConfig for WhirConfigForTest {
         FOLDING
     }
 
-    fn build_witness(&self, columns: Vec<Poly<F>>) -> Witness<F> {
+    fn build_witness(&self, table: Table<F>) -> Witness<F> {
         // Version one commits a single table: the whole trace.
-        L::new_witness(vec![Table::new(columns)], FOLDING)
+        L::new_witness(vec![table], FOLDING)
+    }
+
+    fn committed_table<'a>(
+        &self,
+        prover_data: &'a p3_whir::WhirProverData<F, EF, MyMmcs, L>,
+    ) -> &'a Table<F> {
+        prover_data.table(0)
     }
 }
 

--- a/multi-stark/tests/whir_preprocessed.rs
+++ b/multi-stark/tests/whir_preprocessed.rs
@@ -17,7 +17,6 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multi_stark::config::MultiStarkConfig;
 use p3_multi_stark::zerocheck::ZerocheckError;
 use p3_multi_stark::{VerificationError, prove, setup, verify};
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::OpeningBatch;
 use p3_sumcheck::layout::{Layout, PrefixProver, Table, Witness};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -83,9 +82,16 @@ impl MultiStarkConfig for WhirConfigForTest {
         FOLDING
     }
 
-    fn build_witness(&self, columns: Vec<Poly<F>>) -> Witness<F> {
+    fn build_witness(&self, table: Table<F>) -> Witness<F> {
         // Each trace, main or preprocessed, commits as a single stacked table.
-        L::new_witness(vec![Table::new(columns)], FOLDING)
+        L::new_witness(vec![table], FOLDING)
+    }
+
+    fn committed_table<'a>(
+        &self,
+        prover_data: &'a p3_whir::WhirProverData<F, EF, MyMmcs, L>,
+    ) -> &'a Table<F> {
+        prover_data.table(0)
     }
 }
 

--- a/multilinear-util/benches/compress_kernels.rs
+++ b/multilinear-util/benches/compress_kernels.rs
@@ -53,13 +53,13 @@ fn bench_compress_suffix_dot(c: &mut Criterion) {
         // Packed-eq path: hits the SIMD kernel from PR #1574.
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
             let mut out = EF::zero_vec(1 << (k_total - split_packed.num_variables()));
-            b.iter(|| split_packed.compress_suffix_into(&mut out, &poly));
+            b.iter(|| split_packed.compress_suffix_into(&mut out, poly.as_view()));
         });
 
         // Unpacked-eq path: scalar reference for the same operation.
         group.bench_with_input(BenchmarkId::new("unpacked", label), &label, |b, _| {
             let mut out = EF::zero_vec(1 << (k_total - split_unpacked.num_variables()));
-            b.iter(|| split_unpacked.compress_suffix_into(&mut out, &poly));
+            b.iter(|| split_unpacked.compress_suffix_into(&mut out, poly.as_view()));
         });
     }
 
@@ -93,7 +93,7 @@ fn bench_compress_prefix(c: &mut Criterion) {
         let split_packed = SplitEq::<F, EF>::new_packed(&point, EF::ONE);
 
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
-            b.iter(|| split_packed.compress_prefix(&poly));
+            b.iter(|| split_packed.compress_prefix(poly.as_view()));
         });
     }
 
@@ -127,7 +127,7 @@ fn bench_compress_prefix_to_packed(c: &mut Criterion) {
         let split_packed = SplitEq::<F, EF>::new_packed(&point, EF::ONE);
 
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
-            b.iter(|| split_packed.compress_prefix_to_packed(&poly));
+            b.iter(|| split_packed.compress_prefix_to_packed(poly.as_view()));
         });
     }
 
@@ -150,7 +150,7 @@ fn bench_dot_with_base(c: &mut Criterion) {
         let split_packed = SplitEq::<F, EF>::new_packed(&point, EF::ONE);
 
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
-            b.iter(|| split_packed.eval_base(&poly));
+            b.iter(|| split_packed.eval_base(poly.as_view()));
         });
     }
 
@@ -174,7 +174,7 @@ fn bench_dot_with_ext_packed(c: &mut Criterion) {
         let split_packed = SplitEq::<F, EF>::new_packed(&point, EF::ONE);
 
         group.bench_with_input(BenchmarkId::new("packed", label), &label, |b, _| {
-            b.iter(|| split_packed.eval_packed(&packed_poly));
+            b.iter(|| split_packed.eval_packed(packed_poly.as_view()));
         });
     }
 

--- a/multilinear-util/src/poly.rs
+++ b/multilinear-util/src/poly.rs
@@ -1,5 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
 
 use p3_field::{
     Algebra, ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
@@ -58,9 +60,82 @@ unsafe fn uninitialized_vec<A>(len: usize) -> Vec<A> {
 /// order. The number of variables `n` is inferred from the length of this vector, where
 /// `self.len() = 2^n`.
 #[allow(clippy::unsafe_derive_deserialize)]
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[must_use]
-pub struct Poly<F>(pub(crate) Vec<F>);
+pub struct Poly<F, S = Vec<F>>(pub(crate) S, PhantomData<F>);
+
+/// Borrowed view of a multilinear polynomial's evaluation table.
+pub type PolyView<'a, F> = Poly<F, &'a [F]>;
+
+impl<F, S> Poly<F, S>
+where
+    S: Borrow<[F]>,
+{
+    /// Constructs a polynomial from a backing store of evaluations.
+    ///
+    /// The evaluations must be ordered lexicographically over the boolean hypercube.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of evaluations is not a power of two.
+    #[inline]
+    pub fn new(evals: S) -> Self {
+        assert!(
+            evals.borrow().len().is_power_of_two(),
+            "Evaluation list length must be a power of two."
+        );
+
+        Self(evals, PhantomData)
+    }
+
+    /// Returns the total number of stored evaluations.
+    #[must_use]
+    #[inline]
+    pub fn num_evals(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Returns the number of variables in the multilinear polynomial.
+    #[must_use]
+    #[inline]
+    pub fn num_variables(&self) -> usize {
+        // Safety: The length is guaranteed to be a power of two.
+        log2_strict_usize(self.num_evals())
+    }
+
+    /// Returns a borrowed polynomial view over these evaluations.
+    #[inline]
+    pub fn as_view(&self) -> PolyView<'_, F> {
+        PolyView::new(self.as_slice())
+    }
+
+    /// Returns a reference to the underlying slice of evaluations.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[F] {
+        self.0.borrow()
+    }
+
+    /// Returns an iterator over the evaluations.
+    #[inline]
+    pub fn iter(&self) -> core::slice::Iter<'_, F> {
+        self.as_slice().iter()
+    }
+
+    /// Evaluates the polynomial as a constant.
+    ///
+    /// This is only valid for constant polynomials (i.e., when `num_variables` is 0).
+    ///
+    /// Returns `None` in other cases.
+    #[must_use]
+    #[inline]
+    pub fn as_constant(&self) -> Option<F>
+    where
+        F: Copy,
+    {
+        (self.as_slice().len() == 1).then_some(self.as_slice()[0])
+    }
+}
 
 impl<F> Poly<F> {
     /// Initializes the zero polynomial in `num_variables` variables.
@@ -69,49 +144,7 @@ impl<F> Poly<F> {
     where
         F: PrimeCharacteristicRing,
     {
-        Self(F::zero_vec(1 << num_variables))
-    }
-
-    /// Constructs a polynomial from a vector of evaluations.
-    ///
-    /// The `evals` vector must adhere to the following constraints:
-    /// - Its length must be a power of two, as it represents evaluations over a
-    ///   binary hypercube of some dimension `n`.
-    /// - The evaluations must be ordered lexicographically corresponding to the points
-    ///   on the hypercube.
-    ///
-    /// # Panics
-    /// Panics if `evals.len()` is not a power of two.
-    #[inline]
-    pub const fn new(evals: Vec<F>) -> Self {
-        assert!(
-            evals.len().is_power_of_two(),
-            "Evaluation list length must be a power of two."
-        );
-
-        Self(evals)
-    }
-
-    /// Returns the total number of stored evaluations.
-    #[must_use]
-    #[inline]
-    pub const fn num_evals(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns the number of variables in the multilinear polynomial.
-    #[must_use]
-    #[inline]
-    pub const fn num_variables(&self) -> usize {
-        // Safety: The length is guaranteed to be a power of two.
-        self.0.len().ilog2() as usize
-    }
-
-    /// Returns a reference to the underlying slice of evaluations.
-    #[inline]
-    #[must_use]
-    pub fn as_slice(&self) -> &[F] {
-        &self.0
+        Self(F::zero_vec(1 << num_variables), PhantomData)
     }
 
     /// Returns a mutable reference to the underlying slice of evaluations.
@@ -142,32 +175,12 @@ impl<F> Poly<F> {
         self.0.resize(1 << num_variables, F::ZERO);
     }
 
-    /// Returns an iterator over the evaluations.
-    #[inline]
-    pub fn iter(&self) -> core::slice::Iter<'_, F> {
-        self.0.iter()
-    }
-
-    /// Evaluates the polynomial as a constant.
-    ///
-    /// This is only valid for constant polynomials (i.e., when `num_variables` is 0).
-    ///
-    /// Returns `None` in other cases.
-    #[must_use]
-    #[inline]
-    pub fn as_constant(&self) -> Option<F>
-    where
-        F: Copy,
-    {
-        (self.num_evals() == 1).then_some(self.0[0])
-    }
-
     /// Samples all `2^k` evaluations independently at random.
     pub fn rand(rng: &mut impl rand::Rng, k: usize) -> Self
     where
         StandardUniform: Distribution<F>,
     {
-        Self(rng.random_iter().take(1 << k).collect())
+        Self(rng.random_iter().take(1 << k).collect(), PhantomData)
     }
 }
 
@@ -253,29 +266,14 @@ impl<Packed> Poly<Packed> {
                 .for_each(|(chunk, &chunk_seed)| eq_serial(chunk, middle, chunk_seed));
         }
 
-        Self(packed)
+        Self(packed, PhantomData)
     }
+}
 
-    /// Evaluates the multilinear polynomial at `point ∈ EF^n`.
-    /// Polynomial evaluations are in packed form.
-    ///
-    /// Computes
-    /// ```text
-    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
-    /// ```
-    /// where
-    /// ```text
-    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
-    /// ```
-    pub fn eval_packed<F, EF>(&self, point: &Point<EF>) -> EF
-    where
-        F: Field,
-        EF: ExtensionField<F, ExtensionPacking = Packed>,
-        Packed: PackedFieldExtension<F, EF>,
-    {
-        SplitEq::new_packed(point, EF::ONE).eval_packed(self)
-    }
-
+impl<Packed, S> Poly<Packed, S>
+where
+    S: Borrow<[Packed]>,
+{
     /// Converts a SIMD-packed polynomial back to scalar extension-field form.
     ///
     /// Expands each packed element into W scalar evaluations,
@@ -287,9 +285,13 @@ impl<Packed> Poly<Packed> {
         Packed: PackedFieldExtension<F, EF> + Copy,
     {
         // Allocate uninitialized output; every entry will be written by the unpacking.
-        let mut out = Poly(unsafe {
-            uninitialized_vec(1 << (self.num_variables() + log2_strict_usize(F::Packing::WIDTH)))
-        });
+        let num_variables = self.num_variables();
+        let mut out = Poly(
+            unsafe {
+                uninitialized_vec(1 << (num_variables + log2_strict_usize(F::Packing::WIDTH)))
+            },
+            PhantomData,
+        );
         self.unpack_into(&mut out);
         out
     }
@@ -317,6 +319,26 @@ impl<Packed> Poly<Packed> {
                 *out = packed;
             });
     }
+
+    /// Evaluates the multilinear polynomial at `point ∈ EF^n`.
+    /// Polynomial evaluations are in packed form.
+    ///
+    /// Computes
+    /// ```text
+    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
+    /// ```
+    /// where
+    /// ```text
+    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
+    /// ```
+    pub fn eval_packed<F, EF>(&self, point: &Point<EF>) -> EF
+    where
+        F: Field,
+        EF: ExtensionField<F, ExtensionPacking = Packed>,
+        Packed: PackedFieldExtension<F, EF>,
+    {
+        SplitEq::new_packed(point, EF::ONE).eval_packed(self.as_view())
+    }
 }
 
 impl<F: Field> Poly<F> {
@@ -333,7 +355,7 @@ impl<F: Field> Poly<F> {
     pub fn new_from_point(point: &[F], scale: F) -> Self {
         let n = point.len();
         if n == 0 {
-            return Self(vec![scale]);
+            return Self(vec![scale], PhantomData);
         }
         let len: usize = 1_usize
             .checked_shl(n as u32)
@@ -344,7 +366,7 @@ impl<F: Field> Poly<F> {
         );
         let mut evals = F::zero_vec(len);
         eval_eq_batch::<_, _, false>(RowMajorMatrixView::new_col(point), &mut evals, &[scale]);
-        Self(evals)
+        Self(evals, PhantomData)
     }
 
     /// Materializes the dense repeat-last successor weight table for a point.
@@ -381,280 +403,9 @@ impl<F: Field> Poly<F> {
 
         Self::new(res)
     }
-
-    /// Evaluates the multilinear polynomial at `point ∈ F^n`.
-    ///
-    /// Computes
-    /// ```text
-    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
-    /// ```
-    /// where
-    /// ```text
-    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn eval_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
-        if point.num_variables() < mle_recursion_threshold::<F>() {
-            eval_multilinear_recursive(&self.0, point.as_slice())
-        } else {
-            SplitEq::new_packed(point, EF::ONE).eval_base(self)
-        }
-    }
-
-    /// Evaluates this polynomial against the repeat-last successor weights at a point.
-    ///
-    /// Each hypercube row is read at its successor, with the maximal row repeating itself:
-    /// ```text
-    ///     sum_{x in {0,1}^n} eq(point, x) * self(succ_repeat_last(x))
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn eval_next_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
-        // Build the factored equality table for the point and let the split form
-        // contract it against the successor view without materializing the dense table.
-        SplitEq::new_packed(point, EF::ONE).eval_next_base(self)
-    }
-
-    /// Evaluates the multilinear polynomial at `point ∈ F^n`.
-    ///
-    /// Computes
-    /// ```text
-    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
-    /// ```
-    /// where
-    /// ```text
-    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn eval_ext<BaseField: Field>(&self, point: &Point<F>) -> F
-    where
-        F: ExtensionField<BaseField>,
-    {
-        if point.num_variables() < mle_recursion_threshold::<BaseField>() {
-            eval_multilinear_recursive(&self.0, point.as_slice())
-        } else {
-            SplitEq::new_packed(point, F::ONE).eval_ext(self)
-        }
-    }
-
-    /// Fixes the prefix variables of a multilinear polynomial using the split eq
-    /// tables, returning a reduced polynomial over the remaining suffix variables.
-    ///
-    /// Given `poly` with `n` variables and split eq with `m ≤ n` variables, computes:
-    /// ```text
-    ///   out(x_suffix) = Σ_{y_prefix ∈ {0,1}^m} eq(point, y_prefix) · poly(y_prefix, x_suffix)
-    /// ```
-    pub fn compress_prefix<EF>(&self, point: &Point<EF>, scale: EF) -> Poly<EF>
-    where
-        EF: ExtensionField<F>,
-    {
-        SplitEq::<F, EF>::new_packed(point, scale).compress_prefix(self)
-    }
-
-    /// Like [`compress_prefix`](Self::compress_prefix), but returns the result in packed
-    /// extension-field representation. Requires that `poly` has enough variables
-    /// to fill at least one packed element after compression.
-    ///
-    /// ```text
-    ///   out(x_suffix) = Σ_{y_prefix ∈ {0,1}^m} eq(point, y_prefix) · poly(y_prefix, x_suffix)
-    /// ```
-    pub fn compress_prefix_to_packed<EF>(
-        &self,
-        point: &Point<EF>,
-        scale: EF,
-    ) -> Poly<EF::ExtensionPacking>
-    where
-        EF: ExtensionField<F>,
-    {
-        SplitEq::<F, EF>::new_packed(point, scale).compress_prefix_to_packed(self)
-    }
-
-    /// Fixes the suffix variables of a multilinear polynomial using the split eq
-    /// tables, returning a reduced polynomial over the remaining prefix variables.
-    ///
-    /// Given `poly` with `n` variables and split eq with `m ≤ n` variables, computes:
-    /// ```text
-    ///   out(x_prefix) = Σ_{y_suffix ∈ {0,1}^m} eq(point, y_suffix) · poly(x_prefix, y_suffix)
-    /// ```
-    pub fn compress_suffix<EF>(&self, point: &Point<EF>, scale: EF) -> Poly<EF>
-    where
-        EF: ExtensionField<F>,
-    {
-        SplitEq::<F, EF>::new_packed(point, scale).compress_suffix(self)
-    }
 }
 
 impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
-    /// Folds the most significant variable of an evaluation table into a new polynomial.
-    ///
-    /// The input is the evaluation table over the boolean hypercube.
-    /// The most significant variable splits it into a low half and a high half.
-    /// The challenge collapses that variable by linear interpolation between the halves:
-    /// ```text
-    /// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
-    /// ```
-    ///
-    /// The result has one fewer variable.
-    /// The element type may widen, so a base-field table folds into an extension-field polynomial.
-    ///
-    /// Takes a borrowed slice rather than a polynomial.
-    /// This folds a trace column straight from its matrix row, with no wrapping copy.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the table has at most one entry, since then there is no variable to fold.
-    pub fn fix_prefix_var_from_evals<F>(evals: &[A], r: F) -> Poly<F>
-    where
-        F: Algebra<A> + Copy + Send + Sync,
-    {
-        // A single value is already constant, so no variable remains to fold.
-        assert!(evals.len() > 1, "no free variables");
-
-        // The most significant variable splits the table into equal halves:
-        //
-        //     p0 = evaluations at x_0 = 0
-        //     p1 = evaluations at x_0 = 1
-        let (p0, p1) = evals.split_at(evals.len() / 2);
-
-        // Each output entry interpolates one (low, high) pair at the challenge:
-        //
-        //     p'(x') = p0(x') + (p1(x') - p0(x')) * r
-        if evals.len() >= PARALLEL_THRESHOLD {
-            // Parallel path: the table is large enough to amortize thread fan-out.
-            Poly::new(
-                p0.par_iter()
-                    .zip(p1.par_iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        } else {
-            // Sequential path: small tables where threads would not pay off.
-            Poly::new(
-                p0.iter()
-                    .zip(p1.iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        }
-    }
-
-    /// Fixes the prefix variable at a challenge value, returning a folded polynomial.
-    ///
-    /// Computes:
-    /// ```text
-    /// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
-    /// ```
-    ///
-    /// The result has one fewer variable (n - 1).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the polynomial is constant (zero free variables).
-    pub fn fix_prefix_var<F>(&self, r: F) -> Poly<F>
-    where
-        F: Algebra<A> + Copy + Send + Sync,
-    {
-        assert!(self.as_constant().is_none(), "no free variables");
-        Self::fix_prefix_var_from_evals(self.as_slice(), r)
-    }
-
-    /// Evaluates the prefix-variable fix at a single residual index, without
-    /// allocating the folded polynomial.
-    ///
-    /// Equivalent to `self.fix_prefix_var(r)[index]`:
-    /// ```text
-    /// out = (1 - r) * p(0, index) + r * p(1, index)
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index` is out of range for the residual hypercube
-    /// (`index >= self.num_evals() / 2`).
-    pub fn fix_prefix_var_at<F>(&self, r: F, index: usize) -> F
-    where
-        F: Algebra<A> + Copy,
-    {
-        // The residual hypercube is the x_0 = 0 half; the x_0 = 1 half starts at `half`.
-        let half = self.num_evals() / 2;
-        let lo = self.as_slice()[index];
-        let hi = self.as_slice()[index + half];
-        r * (hi - lo) + lo
-    }
-
-    /// Fixes the prefix variable at a challenge value from a borrowed evaluation slice,
-    /// returning a folded polynomial in SIMD-packed form.
-    ///
-    /// Computes:
-    /// ```text
-    ///     p'(x') = (1 - r) * p(0, x') + r * p(1, x')
-    /// ```
-    ///
-    /// The result has one fewer variable (n - 1).
-    ///
-    /// Takes a borrowed slice rather than a polynomial.
-    /// This folds a trace column straight from its matrix row, with no wrapping copy.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `evals.len()` is at most one, since then there is no variable to fold.
-    pub fn fix_prefix_var_to_packed_from_evals<Ext>(
-        evals: &[A],
-        r: Ext,
-    ) -> Poly<Ext::ExtensionPacking>
-    where
-        A: Field,
-        Ext: ExtensionField<A>,
-    {
-        assert!(evals.len() > 1, "no free variables");
-        // Broadcast the scalar challenge into every SIMD lane.
-        let r = Ext::ExtensionPacking::from(r);
-        // Reinterpret the base-field scalars as packed elements.
-        let poly = A::Packing::pack_slice(evals);
-        // Split evaluations into the x_0 = 0 half (p0) and x_0 = 1 half (p1).
-        let (p0, p1) = poly.split_at(poly.len() / 2);
-        if evals.len() >= PARALLEL_THRESHOLD {
-            // Parallel: linear interpolation between (p0, p1) pairs.
-            Poly::new(
-                p0.par_iter()
-                    .zip(p1.par_iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        } else {
-            // Sequential: same interpolation.
-            Poly::new(
-                p0.iter()
-                    .zip(p1.iter())
-                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
-                    .collect(),
-            )
-        }
-    }
-
-    /// Fixes the prefix variable at a challenge value, returning a folded polynomial
-    /// in SIMD-packed form.
-    ///
-    /// Computes:
-    /// ```text
-    ///     p'(x') = (1 - r) * p(0, x') + r * p(1, x')
-    /// ```
-    ///
-    /// The result has one fewer variable (n - 1).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the polynomial is constant (zero free variables).
-    pub fn fix_prefix_var_to_packed<Ext>(&self, r: Ext) -> Poly<Ext::ExtensionPacking>
-    where
-        A: Field,
-        Ext: ExtensionField<A>,
-    {
-        assert!(self.as_constant().is_none(), "no free variables");
-        Self::fix_prefix_var_to_packed_from_evals(self.as_slice(), r)
-    }
-
     /// In-place version of the prefix-variable fix.
     ///
     /// Folds the first half in place using:
@@ -733,38 +484,6 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         self.0.truncate(mid);
     }
 
-    /// Fixes the suffix variable at a challenge value, returning a folded polynomial.
-    ///
-    /// Computes:
-    /// ```text
-    /// p'(x') = (1 - r) * p(x', 0) + r * p(x', 1)
-    /// ```
-    ///
-    /// The result has one fewer variable (n - 1).
-    /// Unlike the prefix-variable version, consecutive pairs are adjacent in memory.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the polynomial is constant (zero free variables).
-    pub fn fix_suffix_var<F>(&self, r: F) -> Poly<F>
-    where
-        F: Algebra<A> + Copy + Send + Sync,
-    {
-        assert!(self.as_constant().is_none(), "no free variables");
-        if self.num_evals() >= PARALLEL_THRESHOLD {
-            // Parallel: interpolate each adjacent pair [p(x',0), p(x',1)].
-            Poly::new(
-                self.0
-                    .par_chunks(2)
-                    .map(|a| r * (a[1] - a[0]) + a[0])
-                    .collect(),
-            )
-        } else {
-            // Sequential: same interpolation over adjacent pairs.
-            Poly::new(self.0.chunks(2).map(|a| r * (a[1] - a[0]) + a[0]).collect())
-        }
-    }
-
     /// In-place version of the suffix-variable fix.
     ///
     /// Folds adjacent pairs and truncates to the first half. The sequential
@@ -798,6 +517,147 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
             self.0 = folded;
         }
     }
+}
+
+impl<A, S> Poly<A, S>
+where
+    A: Copy + Send + Sync + PrimeCharacteristicRing,
+    S: Borrow<[A]>,
+{
+    /// Fixes the prefix variable at a challenge value, returning a folded polynomial.
+    ///
+    /// Computes:
+    /// ```text
+    /// p'(x') = (1 - r) * p(0, x') + r * p(1, x')
+    /// ```
+    ///
+    /// The result has one fewer variable (n - 1).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant (zero free variables).
+    pub fn fix_prefix_var<F>(&self, r: F) -> Poly<F>
+    where
+        F: Algebra<A> + Copy + Send + Sync,
+    {
+        let evals = self.as_slice();
+        assert!(evals.len() > 1, "no free variables");
+
+        let (p0, p1) = evals.split_at(evals.len() / 2);
+        if evals.len() >= PARALLEL_THRESHOLD {
+            Poly::new(
+                p0.par_iter()
+                    .zip(p1.par_iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        } else {
+            Poly::new(
+                p0.iter()
+                    .zip(p1.iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        }
+    }
+
+    /// Evaluates the prefix-variable fix at a single residual index, without
+    /// allocating the folded polynomial.
+    ///
+    /// Equivalent to `self.fix_prefix_var(r)[index]`:
+    /// ```text
+    /// out = (1 - r) * p(0, index) + r * p(1, index)
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of range for the residual hypercube
+    /// (`index >= self.num_evals() / 2`).
+    pub fn fix_prefix_var_at<F>(&self, r: F, index: usize) -> F
+    where
+        F: Algebra<A> + Copy,
+    {
+        let evals = self.as_slice();
+        // The residual hypercube is the x_0 = 0 half; the x_0 = 1 half starts at `half`.
+        let half = evals.len() / 2;
+        let lo = evals[index];
+        let hi = evals[index + half];
+        r * (hi - lo) + lo
+    }
+
+    /// Fixes the prefix variable at a challenge value, returning a folded polynomial
+    /// in SIMD-packed form.
+    ///
+    /// Computes:
+    /// ```text
+    ///     p'(x') = (1 - r) * p(0, x') + r * p(1, x')
+    /// ```
+    ///
+    /// The result has one fewer variable (n - 1).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant (zero free variables).
+    pub fn fix_prefix_var_to_packed<Ext>(&self, r: Ext) -> Poly<Ext::ExtensionPacking>
+    where
+        A: Field,
+        Ext: ExtensionField<A>,
+    {
+        let evals = self.as_slice();
+        assert!(evals.len() > 1, "no free variables");
+
+        let r = Ext::ExtensionPacking::from(r);
+        let poly = A::Packing::pack_slice(evals);
+        let (p0, p1) = poly.split_at(poly.len() / 2);
+        if evals.len() >= PARALLEL_THRESHOLD {
+            Poly::new(
+                p0.par_iter()
+                    .zip(p1.par_iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        } else {
+            Poly::new(
+                p0.iter()
+                    .zip(p1.iter())
+                    .map(|(&a0, &a1)| r * (a1 - a0) + a0)
+                    .collect(),
+            )
+        }
+    }
+
+    /// Fixes the suffix variable at a challenge value, returning a folded polynomial.
+    ///
+    /// Computes:
+    /// ```text
+    /// p'(x') = (1 - r) * p(x', 0) + r * p(x', 1)
+    /// ```
+    ///
+    /// The result has one fewer variable (n - 1).
+    /// Unlike the prefix-variable version, consecutive pairs are adjacent in memory.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant (zero free variables).
+    pub fn fix_suffix_var<F>(&self, r: F) -> Poly<F>
+    where
+        F: Algebra<A> + Copy + Send + Sync,
+    {
+        assert!(self.as_constant().is_none(), "no free variables");
+        let evals = self.as_slice();
+        if evals.len() >= PARALLEL_THRESHOLD {
+            // Parallel: interpolate each adjacent pair [p(x',0), p(x',1)].
+            Poly::new(
+                evals
+                    .par_chunks(2)
+                    .map(|a| r * (a[1] - a[0]) + a[0])
+                    .collect(),
+            )
+        } else {
+            // Sequential: same interpolation over adjacent pairs.
+            Poly::new(evals.chunks(2).map(|a| r * (a[1] - a[0]) + a[0]).collect())
+        }
+    }
 
     /// Converts a scalar extension-field polynomial into SIMD-packed form.
     ///
@@ -812,15 +672,126 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         F: Field,
         A: ExtensionField<F>,
     {
+        let evals = self.as_slice();
         // Require at least W evaluations to fill one packed element.
         assert!(self.num_variables() >= log2_strict_usize(F::Packing::WIDTH));
         // Group W consecutive extension-field elements into each packed element.
         Poly(
-            self.0
+            evals
                 .par_chunks(F::Packing::WIDTH)
                 .map(|ext| A::ExtensionPacking::from_ext_slice(ext))
                 .collect(),
+            PhantomData,
         )
+    }
+}
+
+impl<F, S> Poly<F, S>
+where
+    F: Field,
+    S: Borrow<[F]>,
+{
+    /// Evaluates the multilinear polynomial at `point ∈ F^n`.
+    ///
+    /// Computes
+    /// ```text
+    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
+    /// ```
+    /// where
+    /// ```text
+    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn eval_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
+        if point.num_variables() < mle_recursion_threshold::<F>() {
+            eval_multilinear_recursive(self.as_slice(), point.as_slice())
+        } else {
+            SplitEq::new_packed(point, EF::ONE).eval_base(self.as_view())
+        }
+    }
+
+    /// Evaluates this polynomial against the repeat-last successor weights at a point.
+    ///
+    /// Each hypercube row is read at its successor, with the maximal row repeating itself:
+    /// ```text
+    ///     sum_{x in {0,1}^n} eq(point, x) * self(succ_repeat_last(x))
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn eval_next_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
+        // Build the factored equality table for the point and let the split form
+        // contract it against the successor view without materializing the dense table.
+        SplitEq::new_packed(point, EF::ONE).eval_next_base(self.as_view())
+    }
+
+    /// Evaluates the multilinear polynomial at `point ∈ F^n`.
+    ///
+    /// Computes
+    /// ```text
+    ///     f(point) = \sum_{x ∈ {0,1}^n} eq(x, point) * f(x),
+    /// ```
+    /// where
+    /// ```text
+    ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn eval_ext<BaseField: Field>(&self, point: &Point<F>) -> F
+    where
+        F: ExtensionField<BaseField>,
+    {
+        if point.num_variables() < mle_recursion_threshold::<BaseField>() {
+            eval_multilinear_recursive(self.as_slice(), point.as_slice())
+        } else {
+            SplitEq::new_packed(point, F::ONE).eval_ext(self.as_view())
+        }
+    }
+
+    /// Fixes the prefix variables of a multilinear polynomial using the split eq
+    /// tables, returning a reduced polynomial over the remaining suffix variables.
+    ///
+    /// Given `poly` with `n` variables and split eq with `m ≤ n` variables, computes:
+    /// ```text
+    ///   out(x_suffix) = Σ_{y_prefix ∈ {0,1}^m} eq(point, y_prefix) · poly(y_prefix, x_suffix)
+    /// ```
+    pub fn compress_prefix<EF>(&self, point: &Point<EF>, scale: EF) -> Poly<EF>
+    where
+        EF: ExtensionField<F>,
+    {
+        SplitEq::<F, EF>::new_packed(point, scale).compress_prefix(self.as_view())
+    }
+
+    /// Like [`compress_prefix`](Self::compress_prefix), but returns the result in packed
+    /// extension-field representation. Requires that `poly` has enough variables
+    /// to fill at least one packed element after compression.
+    ///
+    /// ```text
+    ///   out(x_suffix) = Σ_{y_prefix ∈ {0,1}^m} eq(point, y_prefix) · poly(y_prefix, x_suffix)
+    /// ```
+    pub fn compress_prefix_to_packed<EF>(
+        &self,
+        point: &Point<EF>,
+        scale: EF,
+    ) -> Poly<EF::ExtensionPacking>
+    where
+        EF: ExtensionField<F>,
+    {
+        SplitEq::<F, EF>::new_packed(point, scale).compress_prefix_to_packed(self.as_view())
+    }
+
+    /// Fixes the suffix variables of a multilinear polynomial using the split eq
+    /// tables, returning a reduced polynomial over the remaining prefix variables.
+    ///
+    /// Given `poly` with `n` variables and split eq with `m ≤ n` variables, computes:
+    /// ```text
+    ///   out(x_prefix) = Σ_{y_suffix ∈ {0,1}^m} eq(point, y_suffix) · poly(x_prefix, y_suffix)
+    /// ```
+    pub fn compress_suffix<EF>(&self, point: &Point<EF>, scale: EF) -> Poly<EF>
+    where
+        EF: ExtensionField<F>,
+    {
+        SplitEq::<F, EF>::new_packed(point, scale).compress_suffix(self.as_view())
     }
 }
 
@@ -1057,7 +1028,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_sum_prefix_var_mut() {
-        let mut evals = Poly::new((1..=8).map(F::from_u64).collect());
+        let mut evals = Poly::new((1..=8).map(F::from_u64).collect::<Vec<_>>());
 
         evals.sum_prefix_var_mut();
 
@@ -1432,7 +1403,9 @@ pub(crate) mod test {
     #[test]
     fn test_folding_and_evaluation() {
         let num_variables = 10;
-        let evals = (0..(1 << num_variables)).map(F::from_u64).collect();
+        let evals = (0..(1 << num_variables))
+            .map(F::from_u64)
+            .collect::<Vec<_>>();
         let evals_list = Poly::new(evals);
         let randomness: Vec<_> = (0..num_variables)
             .map(|i| F::from_u64(35 * i as u64))
@@ -1778,7 +1751,7 @@ pub(crate) mod test {
 
     #[test]
     fn test_fold_batch_single_variable() {
-        let poly = Poly::new((1..=8).map(F::from_u64).collect());
+        let poly = Poly::new((1..=8).map(F::from_u64).collect::<Vec<_>>());
         let r2 = EF::from_u64(3);
         let challenges = vec![r2];
         let result = poly.compress_prefix(&Point::new(challenges), EF::ONE);

--- a/multilinear-util/src/split_eq/eq.rs
+++ b/multilinear-util/src/split_eq/eq.rs
@@ -66,7 +66,7 @@ impl<F: Field, EF: ExtensionField<F>> EqMaybePacked<F, EF> {
     ///
     /// For packed tables, this accounts for the log_2(W) variables
     /// absorbed into each SIMD lane.
-    pub const fn num_variables(&self) -> usize {
+    pub fn num_variables(&self) -> usize {
         match self {
             Self::Unpacked(poly) => poly.num_variables(),
             // Packed polynomial has k - log_2(W) stored entries,
@@ -82,7 +82,7 @@ impl<F: Field, EF: ExtensionField<F>> EqMaybePacked<F, EF> {
     ///
     /// This is used to determine chunk sizes when iterating over
     /// a polynomial paired with this eq table.
-    pub const fn scalar_chunk_size(&self) -> usize {
+    pub fn scalar_chunk_size(&self) -> usize {
         match self {
             Self::Unpacked(eq1) => eq1.num_evals(),
             Self::Packed(eq1) => eq1.num_evals() * F::Packing::WIDTH,

--- a/multilinear-util/src/split_eq/mod.rs
+++ b/multilinear-util/src/split_eq/mod.rs
@@ -28,7 +28,7 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
 use crate::point::Point;
-use crate::poly::{PARALLEL_THRESHOLD, Poly};
+use crate::poly::{PARALLEL_THRESHOLD, Poly, PolyView};
 
 /// Factored eq polynomial table for scale * eq(z, .).
 ///
@@ -80,7 +80,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     }
 
     /// Total number of variables: k = k_prefix + k_suffix.
-    pub const fn num_variables(&self) -> usize {
+    pub fn num_variables(&self) -> usize {
         self.eq0.num_variables() + self.eq1.num_variables()
     }
 
@@ -104,7 +104,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the polynomial and eq table have different numbers of variables.
-    pub fn eval_base(&self, poly: &Poly<F>) -> EF {
+    pub fn eval_base(&self, poly: PolyView<'_, F>) -> EF {
         assert_eq!(poly.num_variables(), self.num_variables());
 
         // Short-circuit: a constant polynomial evaluates to itself
@@ -119,14 +119,14 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
             // Sequential: chunk poly by eq1 block size, pair with eq0 weights.
             // For each chunk, compute the inner dot product with eq1,
             // then multiply by the corresponding eq0 weight.
-            poly.0
+            poly.as_slice()
                 .chunks(cs)
                 .zip_eq(self.eq0.iter())
                 .map(|(chunk, &w0)| self.eq1.dot_with_base(chunk) * w0)
                 .sum::<EF>()
         } else {
             // Parallel: same logic with parallel iterators.
-            poly.0
+            poly.as_slice()
                 .par_chunks(cs)
                 .zip_eq(self.eq0.as_slice().par_iter())
                 .map(|(chunk, &w0)| self.eq1.dot_with_base(chunk) * w0)
@@ -144,7 +144,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the polynomial and eq table have different numbers of variables.
-    pub fn eval_ext(&self, poly: &Poly<EF>) -> EF {
+    pub fn eval_ext(&self, poly: PolyView<'_, EF>) -> EF {
         assert_eq!(poly.num_variables(), self.num_variables());
 
         // Short-circuit for constant polynomials.
@@ -155,14 +155,14 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
         let cs = self.eq1.scalar_chunk_size();
         if (1 << self.num_variables()) < PARALLEL_THRESHOLD {
             // Sequential outer loop: dot each chunk with eq1, weight by eq0.
-            poly.0
+            poly.as_slice()
                 .chunks(cs)
                 .zip_eq(self.eq0.iter())
                 .map(|(chunk, &w0)| self.eq1.dot_with_ext(chunk) * w0)
                 .sum::<EF>()
         } else {
             // Parallel path.
-            poly.0
+            poly.as_slice()
                 .par_chunks(cs)
                 .zip_eq(self.eq0.as_slice().par_iter())
                 .map(|(chunk, &w0)| self.eq1.dot_with_ext(chunk) * w0)
@@ -182,7 +182,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the packed polynomial size is inconsistent with the eq table.
-    pub fn eval_packed(&self, poly: &Poly<EF::ExtensionPacking>) -> EF {
+    pub fn eval_packed(&self, poly: PolyView<'_, EF::ExtensionPacking>) -> EF {
         assert_eq!(
             poly.num_variables() + log2_strict_usize(F::Packing::WIDTH),
             self.num_variables()
@@ -194,13 +194,13 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
                 if (1 << (self.num_variables() - log2_strict_usize(F::Packing::WIDTH)))
                     < PARALLEL_THRESHOLD
                 {
-                    poly.0
+                    poly.as_slice()
                         .chunks(cs)
                         .zip_eq(self.eq0.iter())
                         .map(|(chunk, &w0)| self.eq1.dot_with_ext_packed(chunk) * w0)
                         .sum::<EF>()
                 } else {
-                    poly.0
+                    poly.as_slice()
                         .par_chunks(cs)
                         .zip_eq(self.eq0.as_slice().par_iter())
                         .map(|(chunk, &w0)| self.eq1.dot_with_ext_packed(chunk) * w0)
@@ -209,9 +209,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
             }
             EqMaybePacked::Unpacked(_) => {
                 // eq1 is scalar; unpack the polynomial and delegate to the scalar path.
-                self.eval_ext(&Poly::new(
-                    EF::ExtensionPacking::to_ext_iter(poly.iter().copied()).collect(),
-                ))
+                self.eval_ext(poly.unpack().as_view())
             }
         }
     }
@@ -309,7 +307,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the eq table has more variables than the polynomial.
-    pub fn compress_prefix(&self, poly: &Poly<F>) -> Poly<EF> {
+    pub fn compress_prefix(&self, poly: PolyView<'_, F>) -> Poly<EF> {
         assert!(self.num_variables() <= poly.num_variables());
         // Number of remaining (output) variables.
         let k_inner = poly.num_variables() - self.num_variables();
@@ -319,7 +317,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
         if (1 << poly.num_variables()) < PARALLEL_THRESHOLD {
             // Sequential: accumulate each eq0 chunk into a shared output buffer.
             let mut out = Poly::<EF>::zero(k_inner);
-            poly.0
+            poly.as_slice()
                 .chunks(size_outer)
                 .zip_eq(self.eq0.iter())
                 .for_each(|(chunk, &w0)| {
@@ -329,7 +327,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
             out
         } else {
             // Parallel: each thread accumulates into a local buffer, then reduce.
-            poly.0
+            poly.as_slice()
                 .par_chunks(size_outer)
                 .zip_eq(self.eq0.as_slice().par_iter())
                 .par_fold_reduce(
@@ -359,7 +357,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     ///
     /// - Panics if the eq table has more variables than the polynomial.
     /// - Panics if the remaining variables are fewer than log_2(W).
-    pub fn compress_prefix_to_packed(&self, poly: &Poly<F>) -> Poly<EF::ExtensionPacking> {
+    pub fn compress_prefix_to_packed(&self, poly: PolyView<'_, F>) -> Poly<EF::ExtensionPacking> {
         assert!(self.num_variables() <= poly.num_variables());
         assert!(
             poly.num_variables() >= (self.num_variables() + log2_strict_usize(F::Packing::WIDTH))
@@ -371,7 +369,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
 
         if (1 << poly.num_variables()) < PARALLEL_THRESHOLD {
             let mut out = Poly::<EF::ExtensionPacking>::zero(k_inner);
-            poly.0
+            poly.as_slice()
                 .chunks(size_outer)
                 .zip_eq(self.eq0.iter())
                 .for_each(|(chunk, &w0)| {
@@ -380,7 +378,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
                 });
             out
         } else {
-            poly.0
+            poly.as_slice()
                 .par_chunks(size_outer)
                 .zip_eq(self.eq0.as_slice().par_iter())
                 .par_fold_reduce(
@@ -414,7 +412,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the eq table has more variables than the polynomial.
-    pub fn compress_suffix(&self, poly: &Poly<F>) -> Poly<EF> {
+    pub fn compress_suffix(&self, poly: PolyView<'_, F>) -> Poly<EF> {
         // Allocate output and delegate to the in-place version.
         let mut out = Poly::zero(poly.num_variables() - self.num_variables());
         self.compress_suffix_into(out.as_mut_slice(), poly);
@@ -427,7 +425,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     ///
     /// - Panics if the eq table has more variables than the polynomial.
     /// - Panics if the output buffer length != 2^{n-m}.
-    pub fn compress_suffix_into(&self, out: &mut [EF], poly: &Poly<F>) {
+    pub fn compress_suffix_into(&self, out: &mut [EF], poly: PolyView<'_, F>) {
         assert!(self.num_variables() <= poly.num_variables());
         assert_eq!(out.len(), poly.num_evals() >> self.num_variables());
 
@@ -435,14 +433,14 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
             // Sequential: each output element is a full dot product of one row
             // against the factored eq tables.
             out.iter_mut()
-                .zip_eq(poly.0.chunks(1 << self.num_variables()))
+                .zip_eq(poly.as_slice().chunks(1 << self.num_variables()))
                 .for_each(|(out, chunk)| {
                     *out = self.eq1.compress_suffix_dot(chunk, &self.eq0);
                 });
         } else {
             // Parallel: each output element is independent.
             out.par_iter_mut()
-                .zip(poly.0.par_chunks(1 << self.num_variables()))
+                .zip(poly.as_slice().par_chunks(1 << self.num_variables()))
                 .for_each(|(out, chunk)| {
                     *out = self.eq1.compress_suffix_dot(chunk, &self.eq0);
                 });
@@ -462,7 +460,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// # Panics
     ///
     /// Panics if the polynomial and the equality table have different numbers of variables.
-    pub fn eval_next_base(&self, poly: &Poly<F>) -> EF {
+    pub fn eval_next_base(&self, poly: PolyView<'_, F>) -> EF {
         // The contraction pairs one polynomial row with one equality weight.
         assert_eq!(poly.num_variables(), self.num_variables());
 
@@ -523,7 +521,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// out(x_suffix) = sum_{y_prefix != 0}
     ///     eq(point, y_prefix - 1) * poly(y_prefix, x_suffix)
     /// ```
-    pub fn compress_prefix_shifted(&self, poly: &Poly<F>) -> Poly<EF> {
+    pub fn compress_prefix_shifted(&self, poly: PolyView<'_, F>) -> Poly<EF> {
         // The prefix variables fixed here must be a subset of the polynomial's variables.
         assert!(self.num_variables() <= poly.num_variables());
 
@@ -612,7 +610,7 @@ impl<F: Field, EF: ExtensionField<F>> SplitEq<F, EF> {
     /// out(x_prefix) = sum_{y_suffix != 0}
     ///     eq(point, y_suffix - 1) * poly(x_prefix, y_suffix)
     /// ```
-    pub fn compress_suffix_shifted(&self, poly: &Poly<F>) -> Poly<EF> {
+    pub fn compress_suffix_shifted(&self, poly: PolyView<'_, F>) -> Poly<EF> {
         // The suffix variables fixed here must be a subset of the polynomial's variables.
         assert!(self.num_variables() <= poly.num_variables());
 
@@ -716,11 +714,11 @@ mod tests {
             // Both scalar and packed construction must match the reference.
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_base(&poly),
+                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_base(poly.as_view()),
             );
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_base(&poly),
+                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_base(poly.as_view()),
             );
         }
 
@@ -733,11 +731,11 @@ mod tests {
 
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_ext(&poly),
+                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_ext(poly.as_view()),
             );
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_ext(&poly),
+                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_ext(poly.as_view()),
             );
         }
 
@@ -756,11 +754,11 @@ mod tests {
             // Both packed and unpacked eq tables must produce the same result.
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_packed(&packed),
+                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_packed(packed.as_view()),
             );
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_packed(&packed),
+                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_packed(packed.as_view()),
             );
         }
     }
@@ -855,8 +853,8 @@ mod tests {
             let split_hi = SplitEq::<F, EF>::new_unpacked(&point_hi, EF::ONE);
 
             // Compress prefix variables, then evaluate the remainder.
-            let compressed = split_lo.compress_prefix(&poly);
-            prop_assert_eq!(expected, split_hi.eval_ext(&compressed));
+            let compressed = split_lo.compress_prefix(poly.as_view());
+            prop_assert_eq!(expected, split_hi.eval_ext(compressed.as_view()));
         }
 
         #[test]
@@ -878,16 +876,18 @@ mod tests {
             let split_hi = SplitEq::<F, EF>::new_packed(&point_hi, EF::ONE);
 
             // Scalar compress then eval.
-            let compressed = split_lo.compress_prefix(&poly);
-            prop_assert_eq!(expected, split_hi.eval_ext(&compressed));
+            let compressed = split_lo.compress_prefix(poly.as_view());
+            prop_assert_eq!(expected, split_hi.eval_ext(compressed.as_view()));
 
             // Packed compress, unpack, then eval.
-            let compressed = split_lo.compress_prefix_to_packed(&poly).unpack::<F, EF>();
-            prop_assert_eq!(expected, split_hi.eval_ext(&compressed));
+            let compressed = split_lo
+                .compress_prefix_to_packed(poly.as_view())
+                .unpack::<F, EF>();
+            prop_assert_eq!(expected, split_hi.eval_ext(compressed.as_view()));
 
             // Compress suffix variables, then evaluate in the other direction.
-            let compressed = split_hi.compress_suffix(&poly);
-            prop_assert_eq!(expected, split_lo.eval_ext(&compressed));
+            let compressed = split_hi.compress_suffix(poly.as_view());
+            prop_assert_eq!(expected, split_lo.eval_ext(compressed.as_view()));
         }
     }
 
@@ -900,7 +900,7 @@ mod tests {
             let point = Point::<EF>::rand(&mut rng, k);
             // All evaluations are 2; eq(z,.) sums to 1, so the result should be 2.
             let poly = Poly::new(vec![F::TWO; 1 << k]);
-            let result = SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_base(&poly);
+            let result = SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_base(poly.as_view());
             assert_eq!(result, EF::TWO);
         }
     }
@@ -928,7 +928,7 @@ mod tests {
 
         // Compressing all variables should produce a 0-variable (scalar) result.
         let split = SplitEq::<F, EF>::new_unpacked(&point, EF::ONE);
-        let compressed = split.compress_prefix(&poly);
+        let compressed = split.compress_prefix(poly.as_view());
         assert_eq!(compressed.num_variables(), 0);
         assert_eq!(compressed.as_constant().unwrap(), expected);
     }
@@ -943,7 +943,7 @@ mod tests {
 
         // Compressing zero variables should return the polynomial lifted to the extension field.
         let split = SplitEq::<F, EF>::new_unpacked(&point, EF::ONE);
-        let compressed = split.compress_suffix(&poly);
+        let compressed = split.compress_suffix(poly.as_view());
         assert_eq!(compressed.num_variables(), k);
         // Each element should equal its base-field counterpart promoted to the extension.
         for (c, &p) in compressed.iter().zip(poly.iter()) {
@@ -1025,12 +1025,12 @@ mod tests {
             // Scalar storage must match the golden value.
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_next_base(&poly),
+                SplitEq::<F, EF>::new_unpacked(&point, EF::ONE).eval_next_base(poly.as_view()),
             );
             // Packed storage must match the golden value.
             prop_assert_eq!(
                 expected,
-                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_next_base(&poly),
+                SplitEq::<F, EF>::new_packed(&point, EF::ONE).eval_next_base(poly.as_view()),
             );
         }
 
@@ -1053,7 +1053,7 @@ mod tests {
             prop_assert_eq!(
                 expected,
                 SplitEq::<F, EF>::new_packed(&point, EF::ONE)
-                    .compress_prefix_shifted(&base_poly),
+                    .compress_prefix_shifted(base_poly.as_view()),
             );
 
             // Extension-field input: exercises the all-extension storage path.
@@ -1062,7 +1062,7 @@ mod tests {
             prop_assert_eq!(
                 expected,
                 SplitEq::<EF, EF>::new_packed(&point, EF::ONE)
-                    .compress_prefix_shifted(&ext_poly),
+                    .compress_prefix_shifted(ext_poly.as_view()),
             );
         }
 
@@ -1085,7 +1085,7 @@ mod tests {
             prop_assert_eq!(
                 expected,
                 SplitEq::<F, EF>::new_packed(&point, EF::ONE)
-                    .compress_suffix_shifted(&base_poly),
+                    .compress_suffix_shifted(base_poly.as_view()),
             );
 
             // Extension-field input: exercises the all-extension storage path.
@@ -1094,7 +1094,7 @@ mod tests {
             prop_assert_eq!(
                 expected,
                 SplitEq::<EF, EF>::new_packed(&point, EF::ONE)
-                    .compress_suffix_shifted(&ext_poly),
+                    .compress_suffix_shifted(ext_poly.as_view()),
             );
         }
     }

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -555,7 +555,7 @@ where
         let mut rng = rng_for(0x0007, k);
 
         // Single source table, one column of `2^k` base-field evaluations.
-        let table = Table::new(vec![rand_base::<B>(&mut rng, k)]);
+        let table = Table::rand(&mut rng, 1, k);
 
         group.bench_with_input(BenchmarkId::new("prefix", &label), &table, |b, table| {
             b.iter_batched(

--- a/sumcheck/src/layout/prover/claims.rs
+++ b/sumcheck/src/layout/prover/claims.rs
@@ -82,6 +82,11 @@ impl<F: Field, EF: ExtensionField<F>> StackedClaims<F, EF> {
         self.tables[id].num_variables()
     }
 
+    /// Returns source table `id`.
+    pub fn table(&self, id: usize) -> &Table<F> {
+        &self.tables[id]
+    }
+
     /// Returns the total number of concrete openings recorded so far.
     pub(crate) fn num_claims(&self) -> usize {
         self.claim_map
@@ -163,7 +168,6 @@ mod tests {
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_multilinear_util::point::Point;
-    use p3_multilinear_util::poly::Poly;
 
     use super::*;
     use crate::layout::opening::{EqSvoPartials, NextSvoPartials, Opening};
@@ -175,7 +179,7 @@ mod tests {
 
     // A single zero column of the given arity, enough to drive the table getters.
     fn table(arity: usize) -> Table<F> {
-        Table::new(vec![Poly::<F>::zero(arity)])
+        Table::zero(1, arity)
     }
 
     // Placement pointing back at source table `idx`.

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -104,6 +104,11 @@ pub trait Layout<F: TwoAdicField, EF: ExtensionField<F>>: Sized {
         self.claims().num_variables_table(id)
     }
 
+    /// Returns source table `id`.
+    fn table(&self, id: usize) -> &Table<F> {
+        self.claims().table(id)
+    }
+
     /// Records opening claims for the selected columns of one table at a sampled point.
     ///
     /// - The local-frame opening point is drawn from the transcript.
@@ -196,7 +201,6 @@ pub(super) mod test_utils {
     use p3_challenger::FieldChallenger;
     use p3_field::PrimeCharacteristicRing;
     use p3_multilinear_util::point::Point;
-    use p3_multilinear_util::poly::Poly;
     use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
@@ -235,12 +239,10 @@ pub(super) mod test_utils {
     pub(crate) fn build_tables() -> Vec<Table<F>> {
         let mut rng = SmallRng::seed_from_u64(1);
         // Table at index 1 in the insertion order: arity 10, two columns.
-        let a0 = Poly::<F>::rand(&mut rng, 10);
-        let a1 = Poly::<F>::rand(&mut rng, 10);
+        let a = Table::rand(&mut rng, 2, 10);
         // Table at index 0 in the insertion order: arity 9, two columns.
-        let b0 = Poly::<F>::rand(&mut rng, 9);
-        let b1 = Poly::<F>::rand(&mut rng, 9);
-        vec![Table::new(vec![b0, b1]), Table::new(vec![a0, a1])]
+        let b = Table::rand(&mut rng, 2, 9);
+        vec![b, a]
     }
 
     /// Returns the per-table shape used by the verifier side.
@@ -535,12 +537,7 @@ pub(super) mod test_utils {
         // One table per (arity, column_count) pair; each column is a random polynomial.
         shape
             .iter()
-            .map(|&(arity, num_cols)| {
-                let polys: Vec<Poly<F>> = (0..num_cols)
-                    .map(|_| Poly::<F>::rand(&mut rng, arity))
-                    .collect();
-                Table::new(polys)
-            })
+            .map(|&(arity, num_cols)| Table::rand(&mut rng, num_cols, arity))
             .collect()
     }
 

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -629,11 +629,9 @@ mod tests {
         // Builds a four-column table and opens the first `open` of them.
         // Four columns tile a power-of-two space, so `open` columns is `open/4` occupancy.
         let mut routed = |open: usize| {
-            let mut prover =
-                PrefixProver::<F, EF>::from_witness(PrefixProver::<F, EF>::new_witness(
-                    vec![Table::new((0..4).map(|_| Poly::<F>::zero(8)).collect())],
-                    FOLDING,
-                ));
+            let mut prover = PrefixProver::<F, EF>::from_witness(
+                PrefixProver::<F, EF>::new_witness(vec![Table::zero(4, 8)], FOLDING),
+            );
             let cols: Vec<usize> = (0..open).collect();
             prover.eval(0, &OpeningBatch::new(cols, Vec::new()), &mut ch);
             prover.scatter_beats_pack(&rs)
@@ -646,7 +644,7 @@ mod tests {
 
         // A holey layout (one of five columns) sits far below the threshold.
         let mut sparse = PrefixProver::<F, EF>::from_witness(PrefixProver::<F, EF>::new_witness(
-            vec![Table::new((0..5).map(|_| Poly::<F>::zero(8)).collect())],
+            vec![Table::zero(5, 8)],
             FOLDING,
         ));
         sparse.eval(0, &OpeningBatch::new(vec![2], Vec::new()), &mut ch);

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -255,7 +255,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
                 &point,
                 VariableOrder::Suffix,
             );
-            let (ref_eval, ref_partials) = ref_svo.eval(poly);
+            let (ref_eval, ref_partials) = ref_svo.eval(poly.as_view());
             let opening = Opening {
                 poly_idx: None,
                 eval: ref_eval,
@@ -476,7 +476,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> SuffixProver<F, EF> {
                 rs.compress_suffix_into(
                     &mut out.as_mut_slice()
                         [off..off + (1 << (poly.num_variables() - rs.num_variables()))],
-                    poly,
+                    poly.as_view(),
                 );
             }
         }

--- a/sumcheck/src/layout/witness.rs
+++ b/sumcheck/src/layout/witness.rs
@@ -1,6 +1,5 @@
 //! Physical placement of source tables inside the stacked committed polynomial.
 
-use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_field::Field;
@@ -118,7 +117,7 @@ impl<F: Field> Table<F> {
     /// - `num_polys` must be nonzero.
     pub fn zero(num_polys: usize, num_variables: usize) -> Self {
         Self::new(RowMajorMatrix::new(
-            vec![F::ZERO; num_polys * (1 << num_variables)],
+            F::zero_vec(num_polys * (1 << num_variables)),
             1 << num_variables,
         ))
     }
@@ -550,7 +549,7 @@ mod tests {
         //
         // Fixture state:
         //     one row of width 3 → not a power of two → must panic.
-        let _ = Table::new(RowMajorMatrix::new(vec![F::ZERO; 3], 3));
+        let _ = Table::new(RowMajorMatrix::new(F::zero_vec(3), 3));
     }
 
     #[test]

--- a/sumcheck/src/layout/witness.rs
+++ b/sumcheck/src/layout/witness.rs
@@ -1,12 +1,17 @@
 //! Physical placement of source tables inside the stacked committed polynomial.
 
+use alloc::vec;
 use alloc::vec::Vec;
 
-use itertools::Itertools;
 use p3_field::Field;
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::Poly;
+use p3_multilinear_util::poly::{Poly, PolyView};
 use p3_util::reverse_bits_len;
+use rand::Rng;
+use rand::distr::{Distribution, StandardUniform};
 
 use crate::layout::plan::{LayoutShape, plan_layout};
 use crate::table::TableShape;
@@ -80,45 +85,98 @@ impl Selector {
 
 /// A column-major table of multilinear polynomials sharing a common arity.
 ///
+/// The backing matrix is row-major, with one row per polynomial. Each row is
+/// therefore one trace column in evaluation order.
+///
 /// # Invariants
 ///
 /// - At least one column.
 /// - Every column has the same number of variables.
 #[derive(Debug, Clone)]
-pub struct Table<F: Field>(Vec<Poly<F>>);
+pub struct Table<F: Field>(RowMajorMatrix<F>);
 
 impl<F: Field> Table<F> {
-    /// Creates a table from one or more polynomials.
+    /// Creates a table from a row-major matrix with one polynomial per row.
+    ///
+    /// # Panics
+    ///
+    /// - Matrix must have at least one row.
+    pub fn new(columns: RowMajorMatrix<F>) -> Self {
+        assert!(columns.width > 0, "table row width must be positive");
+        Self(columns)
+    }
+
+    /// Creates a table from one or more owned polynomials.
     ///
     /// # Panics
     ///
     /// - Column list must not be empty.
     /// - Every column must share the same arity.
-    pub fn new(polys: Vec<Poly<F>>) -> Self {
-        // Structural precondition: at least one column.
+    #[cfg(test)]
+    pub fn from_polys(polys: Vec<Poly<F>>) -> Self {
         assert!(!polys.is_empty());
-        // Consistency precondition: every column shares the same arity.
+        let num_variables = polys[0].num_variables();
         assert!(
-            polys.iter().map(Poly::num_variables).all_equal(),
+            polys
+                .iter()
+                .all(|poly| poly.num_variables() == num_variables),
             "every column of a table must share the same arity",
         );
-        Self(polys)
+
+        let width = polys[0].num_evals();
+        let values = polys.into_iter().flat_map(Poly::into_evals).collect();
+        Self::new(RowMajorMatrix::new(values, width))
+    }
+
+    /// Creates a zero-filled table.
+    ///
+    /// # Panics
+    ///
+    /// - `num_polys` must be nonzero.
+    pub fn zero(num_polys: usize, num_variables: usize) -> Self {
+        Self::new(RowMajorMatrix::new(
+            vec![F::ZERO; num_polys * (1 << num_variables)],
+            1 << num_variables,
+        ))
+    }
+
+    /// Samples a table whose rows are independent random polynomials.
+    ///
+    /// # Panics
+    ///
+    /// - `num_polys` must be nonzero.
+    pub fn rand<R: Rng>(rng: &mut R, num_polys: usize, num_variables: usize) -> Self
+    where
+        StandardUniform: Distribution<F>,
+    {
+        Self::new(RowMajorMatrix::rand(rng, num_polys, 1 << num_variables))
+    }
+
+    /// Iterates over the table rows, one polynomial evaluation slice per row.
+    pub fn iter_polys(&self) -> impl DoubleEndedIterator<Item = &[F]> {
+        self.0.row_slices()
+    }
+
+    /// Iterates over the table rows in parallel, one polynomial evaluation slice per row.
+    pub fn par_iter_polys(&self) -> impl IndexedParallelIterator<Item = &[F]> {
+        self.0.par_row_slices()
     }
 
     /// Returns the polynomial at column `id`.
-    pub fn poly(&self, id: usize) -> &Poly<F> {
-        &self.0[id]
+    pub fn poly(&self, id: usize) -> PolyView<'_, F> {
+        let start = id * self.0.width;
+        PolyView::new(&self.0.values[start..start + self.0.width])
     }
 
     /// Returns the number of columns.
-    pub const fn num_polys(&self) -> usize {
-        self.0.len()
+    pub fn num_polys(&self) -> usize {
+        self.0.height()
     }
 
     /// Returns the shared number of variables.
     pub fn num_variables(&self) -> usize {
         // Invariant (set by the constructor): every column shares this value.
-        self.0[0].num_variables()
+        self.poly(0).num_variables()
     }
 
     /// Returns the verifier shape of this table.
@@ -131,8 +189,7 @@ impl<F: Field> Table<F> {
         let current_num_variables = self.num_variables();
         if current_num_variables < num_variables {
             self.0
-                .iter_mut()
-                .for_each(|poly| poly.pad_zeros(num_variables));
+                .widen_right((1 << num_variables) - (1 << current_num_variables), F::ZERO);
         }
     }
 }
@@ -503,34 +560,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn table_new_panics_on_empty_polys() {
-        // Invariant:
-        //     A table with no columns is rejected.
-        let _: Table<F> = Table::new(vec![]);
-    }
-
-    #[test]
-    #[should_panic(expected = "must share the same arity")]
-    fn table_new_panics_on_mixed_arities() {
-        // Invariant:
-        //     Mixing columns of different arities is rejected.
-        //
-        // Fixture state:
-        //     poly_a: 3 variables, poly_b: 4 variables → must panic.
-        let poly_a = Poly::<F>::zero(3);
-        let poly_b = Poly::<F>::zero(4);
-        let _ = Table::new(vec![poly_a, poly_b]);
-    }
-
-    #[test]
     fn table_accessors_report_shape() {
         // Invariant:
         //     num_polys, num_variables, size, and poly(id) all agree with the input.
         //
         // Fixture state:
         //     two columns of arity 3 → num_polys = 2, num_variables = 3, size = 2^3 * 2 = 16.
-        let table = Table::new(vec![Poly::<F>::zero(3), Poly::<F>::zero(3)]);
+        let table = Table::<F>::zero(2, 3);
 
         // Check: all shape queries match the fixture.
         assert_eq!(table.num_polys(), 2);
@@ -595,11 +631,7 @@ mod tests {
         //
         // Fixture state:
         //     three columns of arity 4 → expected shape: (4, 3).
-        let table = Table::new(vec![
-            Poly::<F>::zero(4),
-            Poly::<F>::zero(4),
-            Poly::<F>::zero(4),
-        ]);
+        let table = Table::<F>::zero(3, 4);
 
         let shape = table.shape();
 
@@ -612,15 +644,9 @@ mod tests {
     fn fixture_witness() -> Witness<F> {
         let mut rng = SmallRng::seed_from_u64(1);
         // Table 0: arity 3, two columns.
-        let t0 = Table::new(vec![
-            Poly::<F>::rand(&mut rng, 3),
-            Poly::<F>::rand(&mut rng, 3),
-        ]);
+        let t0 = Table::rand(&mut rng, 2, 3);
         // Table 1: arity 4, two columns.
-        let t1 = Table::new(vec![
-            Poly::<F>::rand(&mut rng, 4),
-            Poly::<F>::rand(&mut rng, 4),
-        ]);
+        let t1 = Table::rand(&mut rng, 2, 4);
         Witness::new(vec![t0, t1], 1)
     }
 
@@ -692,8 +718,8 @@ mod tests {
         let b0 = F::from_u64(20);
         let b1 = F::from_u64(21);
 
-        let table_a = Table::new(vec![Poly::new(vec![a0, a1, a2, a3])]);
-        let table_b = Table::new(vec![Poly::new(vec![b0, b1])]);
+        let table_a = Table::from_polys(vec![Poly::new(vec![a0, a1, a2, a3])]);
+        let table_b = Table::from_polys(vec![Poly::new(vec![b0, b1])]);
         let witness = Witness::new_interleaved(vec![table_a, table_b], 0);
 
         assert_eq!(witness.num_variables(), 3);
@@ -710,7 +736,7 @@ mod tests {
         //     zero-padded polynomial with arity equal to folding.
         let a0 = F::from_u64(10);
         let a1 = F::from_u64(11);
-        let table = Table::new(vec![Poly::new(vec![a0, a1])]);
+        let table = Table::from_polys(vec![Poly::new(vec![a0, a1])]);
 
         let witness = Witness::new(vec![table], 3);
 
@@ -860,8 +886,7 @@ mod tests {
             let tables: Vec<Table<F>> = shapes
                 .iter()
                 .map(|&(arity, width)| {
-                    let polys = (0..width).map(|_| Poly::<F>::rand(&mut rng, arity)).collect();
-                    Table::new(polys)
+                    Table::rand(&mut rng, width, arity)
                 })
                 .collect();
 

--- a/sumcheck/src/layout/witness.rs
+++ b/sumcheck/src/layout/witness.rs
@@ -100,9 +100,14 @@ impl<F: Field> Table<F> {
     ///
     /// # Panics
     ///
-    /// - Matrix must have at least one row.
+    /// - Matrix must have at least one row (one polynomial).
+    /// - Row width must be a power of two, since each row is a hypercube evaluation table.
     pub fn new(columns: RowMajorMatrix<F>) -> Self {
-        assert!(columns.width > 0, "table row width must be positive");
+        assert!(
+            columns.width.is_power_of_two(),
+            "table row width must be a power of two"
+        );
+        assert!(columns.height() > 0, "table must have at least one column");
         Self(columns)
     }
 
@@ -557,6 +562,28 @@ mod tests {
 
         assert_eq!(sel.num_variables(), 5);
         assert_eq!(sel.index(), original_index);
+    }
+
+    #[test]
+    #[should_panic(expected = "power of two")]
+    fn table_new_panics_on_non_power_of_two_width() {
+        // Invariant:
+        //     Each row is a hypercube evaluation table, so its width must be 2^k.
+        //
+        // Fixture state:
+        //     one row of width 3 → not a power of two → must panic.
+        let _ = Table::new(RowMajorMatrix::new(vec![F::ZERO; 3], 3));
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one column")]
+    fn table_new_panics_on_zero_columns() {
+        // Invariant:
+        //     A table with no columns (no rows) is rejected.
+        //
+        // Fixture state:
+        //     empty buffer with width 2 → height 0 → must panic.
+        let _ = Table::new(RowMajorMatrix::new(Vec::<F>::new(), 2));
     }
 
     #[test]

--- a/sumcheck/src/layout/witness.rs
+++ b/sumcheck/src/layout/witness.rs
@@ -111,28 +111,6 @@ impl<F: Field> Table<F> {
         Self(columns)
     }
 
-    /// Creates a table from one or more owned polynomials.
-    ///
-    /// # Panics
-    ///
-    /// - Column list must not be empty.
-    /// - Every column must share the same arity.
-    #[cfg(test)]
-    pub fn from_polys(polys: Vec<Poly<F>>) -> Self {
-        assert!(!polys.is_empty());
-        let num_variables = polys[0].num_variables();
-        assert!(
-            polys
-                .iter()
-                .all(|poly| poly.num_variables() == num_variables),
-            "every column of a table must share the same arity",
-        );
-
-        let width = polys[0].num_evals();
-        let values = polys.into_iter().flat_map(Poly::into_evals).collect();
-        Self::new(RowMajorMatrix::new(values, width))
-    }
-
     /// Creates a zero-filled table.
     ///
     /// # Panics
@@ -745,8 +723,8 @@ mod tests {
         let b0 = F::from_u64(20);
         let b1 = F::from_u64(21);
 
-        let table_a = Table::from_polys(vec![Poly::new(vec![a0, a1, a2, a3])]);
-        let table_b = Table::from_polys(vec![Poly::new(vec![b0, b1])]);
+        let table_a = Table::new(RowMajorMatrix::new(vec![a0, a1, a2, a3], 4));
+        let table_b = Table::new(RowMajorMatrix::new(vec![b0, b1], 2));
         let witness = Witness::new_interleaved(vec![table_a, table_b], 0);
 
         assert_eq!(witness.num_variables(), 3);
@@ -763,7 +741,7 @@ mod tests {
         //     zero-padded polynomial with arity equal to folding.
         let a0 = F::from_u64(10);
         let a1 = F::from_u64(11);
-        let table = Table::from_polys(vec![Poly::new(vec![a0, a1])]);
+        let table = Table::new(RowMajorMatrix::new(vec![a0, a1], 2));
 
         let witness = Witness::new(vec![table], 3);
 

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -116,16 +116,16 @@ enum MaybePacked<F: Field, EF: ExtensionField<F>> {
 /// Reads the current evaluations with no scalar copy.
 /// Works directly on the SIMD-packed buffer the prover still holds.
 #[derive(Debug, Clone, Copy)]
-pub enum PolyView<'a, F: Field, EF: ExtensionField<F>> {
+pub enum PolyMaybePacked<'a, F: Field, EF: ExtensionField<F>> {
     /// SIMD-packed evaluations; each element holds `F::Packing::WIDTH` lanes.
     Packed(&'a Poly<EF::ExtensionPacking>),
     /// Scalar evaluations.
     Scalar(&'a Poly<EF>),
 }
 
-impl<F: Field, EF: ExtensionField<F>> PolyView<'_, F, EF> {
+impl<F: Field, EF: ExtensionField<F>> PolyMaybePacked<'_, F, EF> {
     /// Returns the logical number of variables, accounting for SIMD packing.
-    pub const fn num_variables(&self) -> usize {
+    pub fn num_variables(&self) -> usize {
         match self {
             Self::Packed(poly) => poly.num_variables() + log2_strict_usize(F::Packing::WIDTH),
             Self::Scalar(poly) => poly.num_variables(),
@@ -133,7 +133,7 @@ impl<F: Field, EF: ExtensionField<F>> PolyView<'_, F, EF> {
     }
 
     /// Returns the logical number of evaluations, `2^num_variables`.
-    pub const fn num_evals(&self) -> usize {
+    pub fn num_evals(&self) -> usize {
         1 << self.num_variables()
     }
 
@@ -500,10 +500,10 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// Borrows the evaluation polynomial in its live representation.
     ///
     /// No unpacking or copying takes place.
-    pub const fn evals_view(&self) -> PolyView<'_, F, EF> {
+    pub const fn evals_view(&self) -> PolyMaybePacked<'_, F, EF> {
         match &self.inner {
-            MaybePacked::Packed { evals, .. } => PolyView::Packed(evals),
-            MaybePacked::Unpacked { evals, .. } => PolyView::Scalar(evals),
+            MaybePacked::Packed { evals, .. } => PolyMaybePacked::Packed(evals),
+            MaybePacked::Unpacked { evals, .. } => PolyMaybePacked::Scalar(evals),
         }
     }
 
@@ -1097,7 +1097,7 @@ mod tests {
         let poly = ProductPolynomial::<F, EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
 
         let view = poly.evals_view();
-        assert!(matches!(view, PolyView::Scalar(_)));
+        assert!(matches!(view, PolyMaybePacked::Scalar(_)));
         assert_eq!(view.num_variables(), 2);
         assert_eq!(view.num_evals(), 4);
 
@@ -1135,7 +1135,7 @@ mod tests {
         );
 
         let view = poly.evals_view();
-        assert!(matches!(view, PolyView::Packed(_)));
+        assert!(matches!(view, PolyMaybePacked::Packed(_)));
         assert_eq!(view.num_variables(), num_variables);
 
         // The view must unpack to the same scalars as the copying extraction.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -13,7 +13,7 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 
 use crate::constraints::{Constraint, Statements};
-use crate::product_polynomial::{PolyView, ProductPolynomial};
+use crate::product_polynomial::{PolyMaybePacked, ProductPolynomial};
 use crate::{SumcheckData, extrapolate_01inf};
 
 /// Input size at which the round-coefficient routines switch from serial to parallel execution.
@@ -423,7 +423,7 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     /// Borrows the current evaluation polynomial in its live representation.
     ///
     /// No unpacking or copying takes place.
-    pub const fn evals_view(&self) -> PolyView<'_, F, EF> {
+    pub const fn evals_view(&self) -> PolyMaybePacked<'_, F, EF> {
         self.poly.evals_view()
     }
 

--- a/sumcheck/src/svo/accumulator.rs
+++ b/sumcheck/src/svo/accumulator.rs
@@ -383,7 +383,7 @@ mod test {
                 .map(|poly| {
                     // Virtual opening: evaluate the column at the SVO point and
                     // carry the per-round partial evaluations as payload.
-                    let (eval, partial_evals) = svo_point.eval(poly);
+                    let (eval, partial_evals) = svo_point.eval(poly.as_view());
                     let opening = Opening {
                         poly_idx: None,
                         eval,
@@ -445,7 +445,7 @@ mod test {
             let openings = polys
                 .iter()
                 .map(|poly| {
-                    let (eval, partial_evals) = svo_point.eval(poly);
+                    let (eval, partial_evals) = svo_point.eval(poly.as_view());
                     let opening = Opening {
                         poly_idx: None,
                         eval,
@@ -551,13 +551,13 @@ mod test {
         #[test]
         fn prop_accumulators_specialization_matches_general(k in 10usize..=14) {
             let mut rng = SmallRng::seed_from_u64(k as u64);
-            let poly = Poly::new((0..1 << k).map(|_| rng.random()).collect());
+            let poly = Poly::new((0..1 << k).map(|_| rng.random()).collect::<Vec<_>>());
             let point = Point::<EF>::rand(&mut rng, k);
 
             // Split the point at half to get partial evaluations.
             let (z_svo, z_rest) = point.split_at(k / 2);
             let split_eq = SplitEq::<F, EF>::new_packed(&z_rest, EF::ONE);
-            let partial_evals = split_eq.compress_suffix(&poly);
+            let partial_evals = split_eq.compress_suffix(poly.as_view());
 
             // Compare the dispatch path (which uses straightline specializations
             // for l <= 3) against the general grid-expansion path.

--- a/sumcheck/src/svo/point.rs
+++ b/sumcheck/src/svo/point.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use p3_field::{ExtensionField, Field, add_scaled_slice_in_place};
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::Poly;
+use p3_multilinear_util::poly::{Poly, PolyView};
 use p3_multilinear_util::split_eq::SplitEq;
 use p3_util::log2_strict_usize;
 
@@ -145,12 +145,12 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
     /// polynomial only in the SVO variables, which is then:
     /// - evaluated at `z_svo` to obtain the opening value
     /// - partially compressed after each SVO round to feed the accumulator path
-    pub fn eval(&self, poly: &Poly<F>) -> (EF, EqSvoPartials<EF>) {
+    pub fn eval(&self, poly: PolyView<'_, F>) -> (EF, EqSvoPartials<EF>) {
         assert_eq!(self.num_variables(), poly.num_variables());
         // Each per-round compression is wrapped as an equality payload as it is produced.
         let (compressed, partial_evals) = match self.var_order {
             VariableOrder::Prefix => {
-                let compressed = self.z_split.compress_suffix(poly);
+                let compressed = self.z_split.compress_suffix(poly.as_view());
                 let partial_evals = (1..=self.num_variables_svo())
                     .map(|i| {
                         let (_svo_active, svo_rest) = self.z_svo.split_at(i);
@@ -160,7 +160,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
                 (compressed, partial_evals)
             }
             VariableOrder::Suffix => {
-                let compressed = self.z_split.compress_prefix(poly);
+                let compressed = self.z_split.compress_prefix(poly.as_view());
                 let partial_evals = (1..=self.num_variables_svo())
                     .map(|i| {
                         let (svo_rest, _svo_active) =
@@ -186,7 +186,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
     }
 
     /// Returns the number of variables of the represented point.
-    pub const fn num_variables(&self) -> usize {
+    pub fn num_variables(&self) -> usize {
         self.z_svo.num_variables() + self.z_split.num_variables()
     }
 
@@ -459,7 +459,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
     /// - If a supplied equality payload does not span the SVO variables.
     pub fn eval_next_suffix(
         &self,
-        poly: &Poly<F>,
+        poly: PolyView<'_, F>,
         d_eq: Option<&Poly<EF>>,
     ) -> (EF, NextSvoPartials<EF>) {
         // The polynomial must cover both the split and SVO variables.
@@ -471,14 +471,16 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
         );
 
         // Compress the equality payload over the split prefix unless the caller supplied it.
-        let d_eq_owned = d_eq.is_none().then(|| self.z_split.compress_prefix(poly));
+        let d_eq_owned = d_eq
+            .is_none()
+            .then(|| self.z_split.compress_prefix(poly.as_view()));
         let d_eq = d_eq.unwrap_or_else(|| d_eq_owned.as_ref().unwrap());
         assert_eq!(d_eq.num_variables(), self.num_variables_svo());
 
         // A caller-supplied payload must equal the freshly computed one.
         #[cfg(debug_assertions)]
         if d_eq_owned.is_none() {
-            debug_assert_eq!(*d_eq, self.z_split.compress_prefix(poly));
+            debug_assert_eq!(*d_eq, self.z_split.compress_prefix(poly.as_view()));
         }
         // Carry payload: compress the polynomial over the split prefix with a one-row shift.
         let d_t = self.z_split.compress_prefix_shifted(poly);
@@ -534,7 +536,7 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
     ///
     /// - If the polynomial does not span all point variables.
     /// - If the point is not in prefix layout.
-    pub fn eval_next_prefix(&self, poly: &Poly<F>) -> (EF, NextSvoPartials<EF>) {
+    pub fn eval_next_prefix(&self, poly: PolyView<'_, F>) -> (EF, NextSvoPartials<EF>) {
         // The polynomial must cover both the split and SVO variables.
         assert_eq!(self.num_variables(), poly.num_variables());
         // This routine derives its compressions only for prefix layout.
@@ -686,9 +688,9 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
         let rest_eq = SplitEq::<EF, EF>::new_packed(&p_rest, EF::ONE);
 
         // Done state: contract the equality payload over the prefix at the matching active row.
-        let done = rest_eq.compress_prefix(d_eq);
+        let done = rest_eq.compress_prefix(d_eq.as_view());
         // Carry state: contract the equality payload over the prefix shifted by one successor step.
-        let mut carry = rest_eq.compress_prefix_shifted(d_eq);
+        let mut carry = rest_eq.compress_prefix_shifted(d_eq.as_view());
 
         // The all-ones prefix corner carries the full product of prefix coordinates.
         let carry_scale = p_rest.iter().copied().product::<EF>();
@@ -767,9 +769,9 @@ impl<F: Field, EF: ExtensionField<F>> SvoPoint<F, EF> {
         let rest_eq = SplitEq::<EF, EF>::new_packed(&p_rest, EF::ONE);
 
         // Done state: contract the shifted-done payload over the suffix.
-        let mut done = rest_eq.compress_suffix(d_done);
+        let mut done = rest_eq.compress_suffix(d_done.as_view());
         // Carry crossing a row boundary lands one suffix step over, so contract it shifted.
-        let carry_done = rest_eq.compress_suffix_shifted(d_carry);
+        let carry_done = rest_eq.compress_suffix_shifted(d_carry.as_view());
 
         // Fold the boundary-crossing carry contribution into the done state.
         done.as_mut_slice()
@@ -837,7 +839,7 @@ mod test {
         let assert_eval = |svo_point: &SvoPoint<F, EF>, poly: &Poly<F>, point: &Point<EF>| {
             let e0 = poly.eval_base(point);
 
-            let (e1, partial_evals) = svo_point.eval(poly);
+            let (e1, partial_evals) = svo_point.eval(poly.as_view());
             assert_eq!(e0, e1);
             assert_eq!(partial_evals.rounds().len(), svo_point.num_variables_svo());
 
@@ -971,7 +973,7 @@ mod test {
             // Ground truth: the full successor evaluation over all variables.
             let expected = poly.eval_next_base(point);
             // Fast path: the SVO opening value plus per-round cached tables.
-            let (actual, partials) = svo_point.eval_next_suffix(poly, None);
+            let (actual, partials) = svo_point.eval_next_suffix(poly.as_view(), None);
             assert_eq!(actual, expected);
             assert_eq!(partials.rounds().len(), svo_point.num_variables_svo());
 
@@ -1026,7 +1028,7 @@ mod test {
             // Ground truth: the full successor evaluation over all variables.
             let expected = poly.eval_next_base(point);
             // Fast path: the SVO opening value plus per-round cached tables.
-            let (actual, partials) = svo_point.eval_next_prefix(poly);
+            let (actual, partials) = svo_point.eval_next_prefix(poly.as_view());
             assert_eq!(actual, expected);
             assert_eq!(partials.rounds().len(), svo_point.num_variables_svo());
 

--- a/sumcheck/src/test_util.rs
+++ b/sumcheck/src/test_util.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 
 use p3_baby_bear::BabyBear;
 use p3_field::{Field, PackedValue};
-use p3_multilinear_util::poly::Poly;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -81,11 +80,6 @@ pub fn table_specs_to_tables(specs: &[TableSpec]) -> Vec<Table<F>> {
     let mut rng = SmallRng::seed_from_u64(3);
     specs
         .iter()
-        .map(|spec| {
-            let polys = (0..spec.shape().width())
-                .map(|_| Poly::<F>::rand(&mut rng, spec.shape().num_variables()))
-                .collect();
-            Table::new(polys)
-        })
+        .map(|spec| Table::rand(&mut rng, spec.shape().width(), spec.shape().num_variables()))
         .collect()
 }

--- a/sumcheck/src/zk/test_helpers.rs
+++ b/sumcheck/src/zk/test_helpers.rs
@@ -120,7 +120,7 @@ where
 
     // One-column table built from the witness polynomial.
     let poly = Poly::new(evals);
-    let table = Table::new(vec![poly]);
+    let table = Table::from_polys(vec![poly]);
 
     // Witness shape comes from the layout factory; binding mode is encoded
     // in the layout type itself.

--- a/sumcheck/src/zk/test_helpers.rs
+++ b/sumcheck/src/zk/test_helpers.rs
@@ -9,8 +9,8 @@ use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
+use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_multilinear_util::poly::Poly;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_zk_codes::reed_solomon::ReedSolomonZkEncoding;
 use rand::rngs::SmallRng;
@@ -119,8 +119,7 @@ where
     let n_vars = p3_util::log2_strict_usize(evals.len());
 
     // One-column table built from the witness polynomial.
-    let poly = Poly::new(evals);
-    let table = Table::from_polys(vec![poly]);
+    let table = Table::new(RowMajorMatrix::new(evals, 1 << n_vars));
 
     // Witness shape comes from the layout factory; binding mode is encoded
     // in the layout type itself.

--- a/whir/benches/fri_vs_whir.rs
+++ b/whir/benches/fri_vs_whir.rs
@@ -65,7 +65,6 @@ use p3_koala_bear::{
 };
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, SuffixProver, Table, Witness};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -350,10 +349,7 @@ where
     );
 
     // One table of `width` random columns, each a `log_height`-variable multilinear.
-    let columns = (0..width)
-        .map(|_| Poly::<F>::rand(&mut rng, log_height))
-        .collect();
-    let table = Table::new(columns);
+    let table = Table::rand(&mut rng, width, log_height);
     // Stack the columns into the single committed multilinear in `num_variables` variables.
     let witness = WhirLayout::new_witness(vec![table], folding);
 

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -85,9 +85,7 @@ fn make_challenger() -> Challenger {
 
 fn make_table(num_variables: usize) -> Table<F> {
     let mut rng = SmallRng::seed_from_u64(num_variables as u64);
-    Table::new(vec![Poly::new(
-        (0..1 << num_variables).map(|_| rng.random()).collect(),
-    )])
+    Table::rand(&mut rng, 1, num_variables)
 }
 
 fn setup_prefix(table: &Table<F>, folding: usize) -> (PrefixProver<F, EF>, Challenger) {

--- a/whir/benches/whir_pcs.rs
+++ b/whir/benches/whir_pcs.rs
@@ -13,7 +13,6 @@ use p3_field::Field;
 use p3_field::extension::QuinticTrinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, PointSchedule, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -171,7 +170,7 @@ impl<L: Layout<F, EF>> Bench<L> {
 
         // Single random table of one column committed by every iteration.
         let mut data_rng = SmallRng::seed_from_u64(0xD157A1B);
-        let table = Table::new(vec![Poly::<F>::rand(&mut data_rng, opts.num_variables)]);
+        let table = Table::rand(&mut data_rng, 1, opts.num_variables);
         let witness = L::new_witness(vec![table], opts.folding);
 
         // Open the single column NUM_EVALUATIONS times at fresh sampled points.

--- a/whir/benches/zk_overhead.rs
+++ b/whir/benches/zk_overhead.rs
@@ -79,7 +79,7 @@ fn bench_plain(group: &mut BenchmarkGroup<'_, WallTime>, num_variables: usize) {
     let pcs = PlainPcs::new(config, Dft::default(), mmcs());
 
     let mut rng = SmallRng::seed_from_u64(3);
-    let table = Table::new(vec![Poly::<F>::rand(&mut rng, num_variables)]);
+    let table = Table::rand(&mut rng, 1, num_variables);
     let protocol = OpeningProtocol::new(vec![TableSpec::new(
         TableShape::new(num_variables, 1),
         vec![OpeningBatch::new(vec![0], Vec::new())],
@@ -147,7 +147,7 @@ fn report_proof_sizes(num_variables: usize) {
     let config = WhirConfig::new(num_variables, protocol_params()).unwrap();
     let pcs = PlainPcs::new(config, Dft::default(), mmcs());
     let mut rng = SmallRng::seed_from_u64(3);
-    let table = Table::new(vec![Poly::<F>::rand(&mut rng, num_variables)]);
+    let table = Table::rand(&mut rng, 1, num_variables);
     let protocol = OpeningProtocol::new(vec![TableSpec::new(
         TableShape::new(num_variables, 1),
         vec![OpeningBatch::new(vec![0], Vec::new())],

--- a/whir/examples/whir.rs
+++ b/whir/examples/whir.rs
@@ -15,7 +15,6 @@ use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout as _, SuffixProver, Table};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, PointSchedule, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -24,8 +23,8 @@ use p3_whir::parameters::{
     DEFAULT_MAX_POW, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig,
 };
 use p3_whir::pcs::prover::WhirProver;
+use rand::SeedableRng;
 use rand::rngs::SmallRng;
-use rand::{RngExt, SeedableRng};
 use tracing::{info, warn};
 use tracing_forest::ForestLayer;
 use tracing_forest::util::LevelFilter;
@@ -170,11 +169,9 @@ fn main() {
         "WHIR PCS"
     );
 
-    // Generate one random multilinear polynomial f: {0,1}^m -> F and expose it
-    // as a single-column table.
+    // Generate one random single-column table.
     let mut rng = SmallRng::seed_from_u64(0);
-    let polynomial = Poly::<F>::new((0..1 << num_variables).map(|_| rng.random()).collect());
-    let table = Table::new(vec![polynomial]);
+    let table = Table::rand(&mut rng, 1, num_variables);
     let witness = Layout::new_witness(vec![table], folding_factor.at_round(0));
 
     let point_schedule: PointSchedule = (0..num_evaluations)

--- a/whir/src/pcs/adapter.rs
+++ b/whir/src/pcs/adapter.rs
@@ -9,7 +9,7 @@ use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
 use p3_multilinear_util::point::Point;
-use p3_sumcheck::layout::{Layout, Verifier, Witness};
+use p3_sumcheck::layout::{Layout, Table, Verifier, Witness};
 use p3_sumcheck::{OpeningEvals, OpeningProtocol, PrescribedPointPcs};
 
 use super::prover::WhirProver;
@@ -29,6 +29,7 @@ use crate::pcs::proof::PcsProof;
 /// Each opening then receives a clone instead of a freshly committed copy.
 /// Cloning copies only the committed data.
 /// It skips the codeword re-encode and the Merkle rebuild.
+#[derive(Clone)]
 pub struct WhirProverData<F, EF, MT, L>
 where
     F: TwoAdicField,
@@ -44,20 +45,16 @@ where
     _marker: PhantomData<EF>,
 }
 
-impl<F, EF, MT, L> Clone for WhirProverData<F, EF, MT, L>
+impl<F, EF, MT, L> WhirProverData<F, EF, MT, L>
 where
     F: TwoAdicField,
     EF: ExtensionField<F>,
     MT: Mmcs<F>,
-    L: Layout<F, EF> + Clone,
-    MT::ProverData<DenseMatrix<F>>: Clone,
+    L: Layout<F, EF>,
 {
-    fn clone(&self) -> Self {
-        Self {
-            layout: self.layout.clone(),
-            merkle_data: self.merkle_data.clone(),
-            _marker: PhantomData,
-        }
+    /// Returns source table `id` retained by the committed layout.
+    pub fn table(&self, id: usize) -> &Table<F> {
+        self.layout.table(id)
     }
 }
 

--- a/whir/src/pcs/committer/writer.rs
+++ b/whir/src/pcs/committer/writer.rs
@@ -4,7 +4,7 @@ use p3_field::{ExtensionField, PackedFieldExtension, TwoAdicField};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixView, RowMajorMatrixViewMut};
 use p3_matrix::extension::FlatMatrixView;
-use p3_sumcheck::product_polynomial::PolyView;
+use p3_sumcheck::product_polynomial::PolyMaybePacked;
 use p3_sumcheck::strategy::VariableOrder;
 use tracing::info_span;
 
@@ -15,14 +15,14 @@ use tracing::info_span;
 /// - the DFT runs over extension-field values;
 /// - the extension MMCS views each extension row as base-field data for the Merkle tree.
 ///
-/// `poly` is borrowed as a [`PolyView`] over the live sumcheck buffer.
+/// `poly` is borrowed as a [`PolyMaybePacked`] over the live sumcheck buffer.
 /// No intermediate scalar copy is materialized.
 #[allow(clippy::type_complexity)]
 pub(crate) fn commit_extension<F, EF, Dft, MT>(
     order: VariableOrder,
     dft: &Dft,
     extension_mmcs: &ExtensionMmcs<F, EF, MT>,
-    poly: PolyView<'_, F, EF>,
+    poly: PolyMaybePacked<'_, F, EF>,
     folding: usize,
     inv_rate: usize,
 ) -> (
@@ -51,7 +51,7 @@ where
                 // Transpose the folding blocks straight into the leading rows.
                 match poly {
                     // Packed source: fuse the lane unpacking with the transpose; no scalar staging.
-                    PolyView::Packed(packed) => {
+                    PolyMaybePacked::Packed(packed) => {
                         EF::ExtensionPacking::unpack_transpose_into(
                             packed.as_slice(),
                             leading,
@@ -59,7 +59,7 @@ where
                         );
                     }
                     // Scalar source: reuse the cache-blocked transpose directly.
-                    PolyView::Scalar(scalar) => {
+                    PolyMaybePacked::Scalar(scalar) => {
                         RowMajorMatrixView::new(scalar.as_slice(), src_width)
                             .transpose_into(&mut RowMajorMatrixViewMut::new(leading, width));
                     }

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -11,7 +11,6 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
-use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table, Witness};
 use p3_sumcheck::test_util::{random_table_specs, table_specs_to_tables};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
@@ -493,10 +492,7 @@ fn test_whir_end_to_end_mixed_current_next_openings() {
         const FOLDING: usize = 3;
 
         let mut rng = SmallRng::seed_from_u64(42);
-        let table = Table::new(vec![
-            Poly::<F>::rand(&mut rng, NUM_VARIABLES),
-            Poly::<F>::rand(&mut rng, NUM_VARIABLES),
-        ]);
+        let table = Table::rand(&mut rng, 2, NUM_VARIABLES);
         let witness = L::new_witness(vec![table], FOLDING);
         let protocol = OpeningProtocol::new(vec![TableSpec::new(
             TableShape::new(NUM_VARIABLES, 2),
@@ -681,10 +677,7 @@ mod error_variant_tests {
     ) {
         // Random table of two columns; deterministic seed for reproducibility.
         let mut rng = SmallRng::seed_from_u64(1);
-        let table = Table::new(vec![
-            Poly::<F>::rand(&mut rng, NUM_VARIABLES),
-            Poly::<F>::rand(&mut rng, NUM_VARIABLES),
-        ]);
+        let table = Table::rand(&mut rng, 2, NUM_VARIABLES);
         let witness = L::new_witness(vec![table], FOLDING);
         // Two opening batches: (cols [0, 1]) and (col [0]).
         let protocol = OpeningProtocol::new(vec![TableSpec::new(
@@ -1100,7 +1093,6 @@ mod keccak_tests {
     use p3_keccak::{Keccak256Hash, KeccakF};
     use p3_koala_bear::KoalaBear;
     use p3_merkle_tree::MerkleTreeMmcs;
-    use p3_multilinear_util::poly::Poly;
     use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
     use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
     use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
@@ -1138,7 +1130,7 @@ mod keccak_tests {
 
         // Build one random table, stack it through the chosen layout mode.
         let mut rng = SmallRng::seed_from_u64(1);
-        let table = Table::new(vec![Poly::<F>::rand(&mut rng, NUM_VARIABLES)]);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
         let witness = L::new_witness(vec![table], FOLDING);
         // Public protocol: open the single column at one point.
         let protocol = OpeningProtocol::new(vec![TableSpec::new(


### PR DESCRIPTION
Air generates trace in row major order. To commit in multilinear pcs we transpose the trace to column major order with `trace_to_columns`. And currently the same tranpose operation is duplicated in `RoundStateBase::new`. With this PR transposed trace is preserved as `RowMajorMatrix` type but practically in column major order, so each row is a column. To support that we introduced PolyView where eval list storage is `&[F]` to be able to use row slices as polynomials. And now we are able to use committed trace directly in zerocheck, more precicely in `RoundStateBase`. Also transposition in `trace_to_columns` switched to native `RowMajorMatrix::transpose` which is 3x times faster than the manuel operation.

Benchmakrs for poseidon2 air:

```
ZEROCHECK_POSEIDON2_NUM_VARS=10,15,20 cargo bench poseidon2 --features parallel
```

num_vars | main | this PR
-- | -- | --
10 | 3.1022 ms | 2.9672 ms
15 | 65.612 ms | 55.975 ms
20 | 2.1601 s | 1.6838 s
