### PR TITLE
feat: make `p3-security` composable over any LDT, and account for batched openings

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,6 @@ p3-monty-31.workspace = true
 p3-poseidon1-air.workspace = true
 p3-poseidon2.workspace = true
 p3-poseidon2-air.workspace = true
-p3-security.workspace = true
 p3-symmetric.workspace = true
 p3-uni-stark.workspace = true
 

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -9,7 +9,6 @@ use p3_field::{ExtensionField, Field, PrimeField32, PrimeField64, TwoAdicField};
 use p3_fri::{FriParameters, TwoAdicFriPcs};
 use p3_keccak::{Keccak256Hash, KeccakF};
 use p3_mersenne_31::{Mersenne31, QM31};
-use p3_security::fri::FriRegime;
 use p3_symmetric::{CryptographicPermutation, PaddingFreeSponge, SerializingHasher};
 use p3_uni_stark::{
     AirLayout, PcsError, Proof, StarkGenericConfig, StarkSecurityParams, VerificationError, prove,
@@ -99,14 +98,7 @@ where
     let fri_params = FriParameters::new_benchmark_high_arity(challenge_mmcs);
 
     let security_params = StarkSecurityParams::from_air::<F, F, _>(
-        FriRegime {
-            log_blowup: fri_params.log_blowup,
-            log_final_poly_len: fri_params.log_final_poly_len,
-            max_log_arity: fri_params.max_log_arity,
-            num_queries: fri_params.num_queries,
-            commit_pow_bits: fri_params.commit_proof_of_work_bits,
-            query_pow_bits: fri_params.query_proof_of_work_bits,
-        },
+        fri_params.security_regime(),
         proof_goal,
         AirLayout::from_air(proof_goal),
         EF::bits(),
@@ -160,14 +152,7 @@ where
     let challenge_mmcs = ExtensionMmcs::<F, EF, _>::new(val_mmcs.clone());
     let fri_params = FriParameters::new_benchmark_high_arity(challenge_mmcs);
     let security_params = StarkSecurityParams::from_air::<F, F, _>(
-        FriRegime {
-            log_blowup: fri_params.log_blowup,
-            log_final_poly_len: fri_params.log_final_poly_len,
-            max_log_arity: fri_params.max_log_arity,
-            num_queries: fri_params.num_queries,
-            commit_pow_bits: fri_params.commit_proof_of_work_bits,
-            query_pow_bits: fri_params.query_proof_of_work_bits,
-        },
+        fri_params.security_regime(),
         proof_goal,
         AirLayout::from_air(proof_goal),
         EF::bits(),
@@ -213,14 +198,7 @@ pub fn prove_m31_keccak<
     // Circle PCS only supports arity 2 (max_log_arity = 1)
     let fri_params = FriParameters::new_benchmark(challenge_mmcs);
     let security_params = StarkSecurityParams::from_air::<F, F, _>(
-        FriRegime {
-            log_blowup: fri_params.log_blowup,
-            log_final_poly_len: fri_params.log_final_poly_len,
-            max_log_arity: fri_params.max_log_arity,
-            num_queries: fri_params.num_queries,
-            commit_pow_bits: fri_params.commit_proof_of_work_bits,
-            query_pow_bits: fri_params.query_proof_of_work_bits,
-        },
+        fri_params.security_regime(),
         proof_goal,
         AirLayout::from_air(proof_goal),
         EF::bits(),
@@ -273,14 +251,7 @@ where
     // Circle PCS only supports arity 2 (max_log_arity = 1)
     let fri_params = FriParameters::new_benchmark(challenge_mmcs);
     let security_params = StarkSecurityParams::from_air::<F, F, _>(
-        FriRegime {
-            log_blowup: fri_params.log_blowup,
-            log_final_poly_len: fri_params.log_final_poly_len,
-            max_log_arity: fri_params.max_log_arity,
-            num_queries: fri_params.num_queries,
-            commit_pow_bits: fri_params.commit_proof_of_work_bits,
-            query_pow_bits: fri_params.query_proof_of_work_bits,
-        },
+        fri_params.security_regime(),
         proof_goal,
         AirLayout::from_air(proof_goal),
         EF::bits(),

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -16,6 +16,7 @@ p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
+p3-security.workspace = true
 p3-util.workspace = true
 
 itertools.workspace = true

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -3,6 +3,7 @@ use core::fmt::Debug;
 
 use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
+use p3_security::fri::FriRegime;
 
 /// A set of parameters defining a specific instance of the FRI protocol.
 #[derive(Clone, Debug)]
@@ -41,6 +42,33 @@ impl<M> FriParameters<M> {
     /// isn't currently supported by this crate.
     pub const fn conjectured_soundness_bits(&self) -> usize {
         self.log_blowup * self.num_queries + self.query_proof_of_work_bits
+    }
+
+    /// Assemble the [`FriRegime`] mirror consumed by `p3-security` for
+    /// soundness analysis.
+    ///
+    /// The exhaustive destructuring is deliberate: adding a field to
+    /// `FriParameters` breaks this method until the new field is either
+    /// mapped into [`FriRegime`] or explicitly ignored, so the runtime config
+    /// and the soundness model cannot drift apart silently.
+    pub const fn security_regime(&self) -> FriRegime {
+        let Self {
+            log_blowup,
+            log_final_poly_len,
+            max_log_arity,
+            num_queries,
+            commit_proof_of_work_bits,
+            query_proof_of_work_bits,
+            mmcs: _,
+        } = self;
+        FriRegime {
+            log_blowup: *log_blowup,
+            num_queries: *num_queries,
+            log_final_poly_len: *log_final_poly_len,
+            max_log_arity: *max_log_arity,
+            commit_pow_bits: *commit_proof_of_work_bits,
+            query_pow_bits: *query_proof_of_work_bits,
+        }
     }
 
     /// Creates a minimal set of `FriParameters` for testing purposes.
@@ -176,4 +204,35 @@ pub fn compute_log_arity_for_round(
     });
 
     max_fold.min(max_log_arity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the field-by-field mapping in [`FriParameters::security_regime`].
+    /// Distinct values per field catch a mis-wired mapping (e.g. swapping the
+    /// commit and query PoW bits); the method's exhaustive destructuring is
+    /// what catches a newly-added `FriParameters` field.
+    #[test]
+    fn security_regime_mirrors_parameters() {
+        let params = FriParameters {
+            log_blowup: 1,
+            log_final_poly_len: 2,
+            max_log_arity: 3,
+            num_queries: 4,
+            commit_proof_of_work_bits: 5,
+            query_proof_of_work_bits: 6,
+            mmcs: (),
+        };
+
+        let regime = params.security_regime();
+
+        assert_eq!(regime.log_blowup, 1);
+        assert_eq!(regime.log_final_poly_len, 2);
+        assert_eq!(regime.max_log_arity, 3);
+        assert_eq!(regime.num_queries, 4);
+        assert_eq!(regime.commit_pow_bits, 5);
+        assert_eq!(regime.query_pow_bits, 6);
+    }
 }

--- a/security/src/assumption.rs
+++ b/security/src/assumption.rs
@@ -25,6 +25,17 @@ use core::str::FromStr;
 
 use serde::Serialize;
 
+/// \[BCSS25\] Theorem 1.5 dominant term, in bits:
+/// `log_2(2·(m + 1/2)⁵ / (3·ρ^{3/2}) · n)`. Shared by
+/// [`SecurityAssumption::prox_gaps_error`] (fixed `m = 10`) and
+/// [`SecurityAssumption::prox_gaps_error_jb_at_m`] (explicit `m`).
+fn jb_prox_gaps_dominant_term_bits(log_degree: usize, log_inv_rate: usize, m: usize) -> f64 {
+    let log_n = (log_degree + log_inv_rate) as f64;
+    let constant = libm::log2(2. * libm::pow(m as f64 + 0.5, 5.) / 3.);
+    let log_rho_neg_3_2 = 1.5 * log_inv_rate as f64;
+    log_n + constant + log_rho_neg_3_2
+}
+
 /// Proximity regime selector for Reed–Solomon-based IOPs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum SecurityAssumption {
@@ -85,10 +96,15 @@ impl SecurityAssumption {
     /// Proximity-gap error in bits for combining `num_functions` functions
     /// at the regime's distance.
     ///
-    /// The Johnson-bound branch uses \[BCSS25\] Theorem 1.5. Only the
-    /// dominant term `2·(m + 1/2)⁵ / (3·ρ^{3/2}) · n` is kept; the
-    /// additive `(m + 1/2)/√ρ` and sub-dominant `3·(m + 1/2)·γ·ρ` terms
-    /// are negligible at `m = 10` (the safety choice η = √ρ/20).
+    /// The Johnson-bound branch uses \[BCSS25\] Theorem 1.5 at the fixed
+    /// safety choice `m = max(ceil(sqrt(rho)/(2*eta)), 3) = 10` (η = √ρ/20,
+    /// see [`Self::log_eta`]). Only the dominant term
+    /// `2·(m + 1/2)⁵ / (3·ρ^{3/2}) · n` is kept; the additive `(m + 1/2)/√ρ`
+    /// and sub-dominant `3·(m + 1/2)·γ·ρ` terms are negligible at `m = 10`.
+    /// Use [`Self::prox_gaps_error_jb_at_m`] when the surrounding regime
+    /// decodes at a different explicit `m` (e.g. FRI's `best_m`) — the
+    /// fixed `m = 10` here is a WHIR-style default, not necessarily the `m`
+    /// the caller's list-decoding regime actually operates at.
     #[must_use]
     pub fn prox_gaps_error(
         &self,
@@ -114,34 +130,9 @@ impl SecurityAssumption {
             //
             // With eta = sqrt(rho)/20 (safe gap), m = max(ceil(sqrt(rho)/(2*eta)), 3) = max(10, 3) = 10.
             //
-            // Only the first (dominant) term is kept.
-            // The second additive term (m + 1/2) / sqrt(rho) is O(1), negligible for large n.
-            // Within the first term, the sub-term 3*(m + 1/2)*gamma*rho is also dropped
-            // because 2*(m + 1/2)^5 dominates it when m = 10.
-            //
-            // This gives the approximation:
-            //
-            //   a ~ (2 * 10.5^5) / (3 * rho^(3/2)) * n
-            //
-            // In log form:
-            //   log_2(a) = log_2(n) + log_2(2 * 10.5^5 / 3) + 1.5 * log_2(1/rho)
-            //            = (log_degree + log_inv_rate) + 16.38 + 1.5 * log_inv_rate
-            //            = log_degree + 2.5 * log_inv_rate + 16.38
-            //
             // This improves over [BCI+20] which had:
             //   log_2(a) = 2*log_degree + 3.5*log_inv_rate + 23.24
-            Self::JohnsonBound => {
-                // n = 2^(log_degree + log_inv_rate)
-                let log_n = (log_degree + log_inv_rate) as f64;
-
-                // Constant from (2 * 10.5^5 / 3)
-                let constant = libm::log2(2. * libm::pow(10.5, 5.) / 3.);
-
-                // rho^(-3/2) contributes 1.5 * log_inv_rate
-                let log_rho_neg_3_2 = 1.5 * log_inv_rate as f64;
-
-                log_n + constant + log_rho_neg_3_2
-            }
+            Self::JohnsonBound => jb_prox_gaps_dominant_term_bits(log_degree, log_inv_rate, 10),
 
             // In CB we assume the error is degree/(eta*rho^2)
             Self::CapacityBound => {
@@ -150,6 +141,39 @@ impl SecurityAssumption {
         };
 
         // Error is (num_functions - 1) * error/|F|;
+        let num_functions_1_log = libm::log2(num_functions as f64 - 1.);
+        field_size_bits as f64 - (error + num_functions_1_log)
+    }
+
+    /// Johnson-bound proximity-gap error (\[BCSS25\] Theorem 1.5, dominant
+    /// term) at an explicit proximity parameter `m`, rather than the fixed
+    /// `m = 10` safety choice [`Self::prox_gaps_error`] uses.
+    ///
+    /// Only the dominant term `2·(m + 1/2)⁵ / (3·ρ^{3/2}) · n` is kept; see
+    /// [`Self::prox_gaps_error`] for the full derivation and the terms this
+    /// drops. Those terms remain negligible for any `m` in FRI's searched
+    /// range (`m ∈ [3, 1000]`): the dropped `3·(m + 1/2)·γ·ρ` sub-term is
+    /// smaller than the kept `2·(m + 1/2)⁵` term by a factor of
+    /// `2·(m + 1/2)⁴ / (3·γ)`, which grows with `m`.
+    ///
+    /// For use when the caller already knows the `m` the surrounding
+    /// list-decoding regime decodes at (e.g. FRI's `best_m` from
+    /// [`crate::fri::best_ldr_m`]) and needs the batch-combination term
+    /// evaluated at that same radius rather than the WHIR-style fixed
+    /// safety margin.
+    #[must_use]
+    pub fn prox_gaps_error_jb_at_m(
+        log_degree: usize,
+        log_inv_rate: usize,
+        field_size_bits: usize,
+        num_functions: usize,
+        m: usize,
+    ) -> f64 {
+        assert!(
+            num_functions >= 2,
+            "num_functions must be >= 2 to compute proximity gaps error",
+        );
+        let error = jb_prox_gaps_dominant_term_bits(log_degree, log_inv_rate, m);
         let num_functions_1_log = libm::log2(num_functions as f64 - 1.);
         field_size_bits as f64 - (error + num_functions_1_log)
     }

--- a/security/src/error.rs
+++ b/security/src/error.rs
@@ -3,9 +3,10 @@
 use alloc::vec::Vec;
 
 use libm::log2;
+use serde::Serialize;
 
 /// `-log2(error_probability)`. Higher = tighter bound.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
 pub struct ErrorBits(pub f64);
 
 impl ErrorBits {

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -245,6 +245,7 @@ mod tests {
             log_trace_length: 20,
             modulus_bits: 252,
             collision_resistance: 128,
+            num_batched_functions: 1,
         }
     }
 
@@ -314,6 +315,7 @@ mod tests {
             log_trace_length: 16,
             modulus_bits: 128,
             collision_resistance: 128,
+            num_batched_functions: 1,
         };
         let bits = conjectured_error(&regime, &shape)
             .bits()

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -18,6 +18,7 @@ use libm::{log2, pow};
 use p3_util::log2_floor_usize;
 
 use crate::error::ErrorBits;
+use crate::ldt::LowDegreeTest;
 use crate::proximity::{LDR_M_CAP, alpha_ldr_m, alpha_udr, compute_upper_m, gamma_ldr_m};
 use crate::shape::{InstanceShape, StarkAirParams};
 
@@ -40,6 +41,24 @@ pub struct FriRegime {
 impl FriRegime {
     const fn folding_factor(self) -> f64 {
         (1usize << self.max_log_arity) as f64
+    }
+}
+
+impl LowDegreeTest for FriRegime {
+    fn log_blowup(&self) -> usize {
+        self.log_blowup
+    }
+
+    fn proven_error_udr(&self, air: &StarkAirParams, shape: &InstanceShape) -> ErrorBits {
+        proven_error_udr(self, air, shape)
+    }
+
+    fn best_ldr(&self, air: &StarkAirParams, shape: &InstanceShape) -> Option<(usize, ErrorBits)> {
+        best_ldr_m(self, air, shape)
+    }
+
+    fn conjectured_error(&self, shape: &InstanceShape) -> ErrorBits {
+        conjectured_error(self, shape)
     }
 }
 

--- a/security/src/ldt.rs
+++ b/security/src/ldt.rs
@@ -1,0 +1,36 @@
+//! Typed low-degree-test boundary.
+//!
+//! [`crate::stark`]'s composite orchestration is generic over the LDT through
+//! this trait: any protocol — FRI, WHIR, or an out-of-tree drop-in —
+//! implements [`LowDegreeTest`] and composes with the AIR + DEEP-ALI bounds
+//! via [`crate::stark::proven_security_report`]. The FRI implementation lives
+//! in [`crate::fri`].
+
+use crate::error::ErrorBits;
+use crate::shape::{InstanceShape, StarkAirParams};
+
+/// A low-degree test whose per-regime error terms compose with the AIR +
+/// DEEP-ALI bounds at the protocol call site.
+///
+/// The proximity regimes mirror [`crate::proximity`]: unique decoding (list
+/// size 1) and list decoding at an explicit proximity parameter `m`. An
+/// implementation reports only the **LDT-only** error for each regime; the
+/// composite ([`crate::stark::proven_security_report`]) folds in the ALI,
+/// DEEP, extra, and commitment-collision terms.
+pub trait LowDegreeTest {
+    /// `log2` of the LDT blowup factor (rate ρ = 2^{−log_blowup}). The
+    /// composite uses it to reconstruct the list-decoding list size for the
+    /// regime returned by [`Self::best_ldr`].
+    fn log_blowup(&self) -> usize;
+
+    /// LDT-only error in the unique-decoding regime.
+    fn proven_error_udr(&self, air: &StarkAirParams, shape: &InstanceShape) -> ErrorBits;
+
+    /// Best list-decoding regime for this instance: the proximity parameter
+    /// `m` maximising LDT-only security together with the error attained.
+    /// `None` when no valid `m` exists (e.g. the trace is too small).
+    fn best_ldr(&self, air: &StarkAirParams, shape: &InstanceShape) -> Option<(usize, ErrorBits)>;
+
+    /// Conjectured LDT error (random-words / heuristic regime).
+    fn conjectured_error(&self, shape: &InstanceShape) -> ErrorBits;
+}

--- a/security/src/ldt.rs
+++ b/security/src/ldt.rs
@@ -1,10 +1,11 @@
 //! Typed low-degree-test boundary.
 //!
 //! [`crate::stark`]'s composite orchestration is generic over the LDT through
-//! this trait: any protocol — FRI, WHIR, or an out-of-tree drop-in —
-//! implements [`LowDegreeTest`] and composes with the AIR + DEEP-ALI bounds
-//! via [`crate::stark::proven_security_report`]. The FRI implementation lives
-//! in [`crate::fri`].
+//! this trait: any protocol — FRI, WHIR, or an out-of-tree drop-in — can
+//! implement [`LowDegreeTest`] and compose with the AIR + DEEP-ALI bounds via
+//! [`crate::stark::proven_security_report`]. The FRI implementation lives in
+//! [`crate::fri`]; [`crate::whir`] currently exposes only the underlying WHIR
+//! error terms, not yet a [`LowDegreeTest`] impl.
 
 use crate::error::ErrorBits;
 use crate::shape::{InstanceShape, StarkAirParams};

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -38,11 +38,14 @@ extern crate alloc;
 pub mod assumption;
 pub mod error;
 pub mod proximity;
+pub mod report;
 pub mod shape;
 
 pub mod air;
 pub mod deep;
 pub mod grinding;
+
+pub mod ldt;
 
 pub mod fri;
 pub mod whir;
@@ -51,4 +54,6 @@ pub mod stark;
 
 pub use assumption::SecurityAssumption;
 pub use error::ErrorBits;
+pub use ldt::LowDegreeTest;
+pub use report::{Regime, RegimeReport, SecurityReport, SecurityTerm};
 pub use shape::{InstanceShape, StarkAirParams};

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -54,10 +54,26 @@ pub enum Regime {
 #[derive(Clone, Debug, Serialize)]
 pub struct RegimeReport {
     pub regime: Regime,
-    pub terms: Vec<SecurityTerm>,
+    terms: Vec<SecurityTerm>,
 }
 
 impl RegimeReport {
+    /// Builds a report from its labeled terms. `terms` must be non-empty —
+    /// every regime carries at least the ALI, DEEP, LDT, and collision terms.
+    pub(crate) fn new(regime: Regime, terms: Vec<SecurityTerm>) -> Self {
+        debug_assert!(
+            !terms.is_empty(),
+            "a regime report must carry at least one term"
+        );
+        Self { regime, terms }
+    }
+
+    /// Every soundness contribution in this regime — ALI, DEEP, LDT, any
+    /// protocol extras, and the commitment-collision cap.
+    pub fn terms(&self) -> &[SecurityTerm] {
+        &self.terms
+    }
+
     /// The binding (minimum-bits) term. `terms` is always non-empty — every
     /// regime carries at least the ALI, DEEP, LDT, and collision terms.
     pub fn binding(&self) -> SecurityTerm {

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -1,0 +1,107 @@
+//! Labeled soundness breakdown produced by the composite orchestration.
+//!
+//! [`SecurityReport`] is the public, audit-facing output of
+//! [`crate::stark::proven_security_report`]. It carries every soundness
+//! contribution as a named [`SecurityTerm`], per proximity regime, so the
+//! binding term is inspectable rather than collapsed into a single number.
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+use serde::Serialize;
+
+use crate::error::ErrorBits;
+
+/// Label for the AIR-composition (ALI) term.
+pub const ALI_LABEL: &str = "air-composition";
+/// Label for the DEEP-ALI out-of-domain term.
+pub const DEEP_LABEL: &str = "deep-ali";
+/// Label for the low-degree-test term.
+pub const LDT_LABEL: &str = "low-degree-test";
+/// Label for the commitment-collision cap term.
+pub const COLLISION_LABEL: &str = "commitment-collision";
+
+/// A single named soundness contribution, in `−log2(error)` bits.
+#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
+pub struct SecurityTerm {
+    pub label: &'static str,
+    pub bits: ErrorBits,
+}
+
+impl SecurityTerm {
+    pub const fn new(label: &'static str, bits: ErrorBits) -> Self {
+        Self { label, bits }
+    }
+}
+
+/// The proximity regime a [`RegimeReport`] was evaluated in.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
+pub enum Regime {
+    /// Unique-decoding regime (list size 1).
+    UniqueDecoding,
+    /// List-decoding regime at proximity parameter `m`.
+    ListDecoding { m: usize },
+}
+
+/// Full soundness breakdown within a single proximity regime.
+///
+/// `terms` holds every contribution — ALI, DEEP, LDT, any protocol extras,
+/// and the commitment-collision cap. The attained security is the minimum
+/// over all terms: a collision, or any single binding error, forges the
+/// proof.
+#[derive(Clone, Debug, Serialize)]
+pub struct RegimeReport {
+    pub regime: Regime,
+    pub terms: Vec<SecurityTerm>,
+}
+
+impl RegimeReport {
+    /// The binding (minimum-bits) term. `terms` is always non-empty — every
+    /// regime carries at least the ALI, DEEP, LDT, and collision terms.
+    pub fn binding(&self) -> SecurityTerm {
+        self.terms
+            .iter()
+            .copied()
+            .min_by(|a, b| {
+                a.bits
+                    .bits()
+                    .partial_cmp(&b.bits.bits())
+                    .unwrap_or(Ordering::Equal)
+            })
+            .expect("a regime report always carries the ALI/DEEP/LDT/collision terms")
+    }
+
+    /// Attained security in this regime, in bits.
+    pub fn security_bits(&self) -> f64 {
+        self.binding().bits.bits()
+    }
+}
+
+/// Proven-soundness report across both proximity regimes.
+///
+/// Each regime is an independent valid lower bound on round-by-round
+/// soundness, so the attained security is the maximum of the two.
+#[derive(Clone, Debug, Serialize)]
+pub struct SecurityReport {
+    pub udr: RegimeReport,
+    /// `None` when no valid list-decoding regime exists for the instance.
+    pub ldr: Option<RegimeReport>,
+}
+
+impl SecurityReport {
+    /// Attained proven security in bits: the better of the two regimes.
+    pub fn security_bits(&self) -> f64 {
+        let ldr = self.ldr.as_ref().map_or(0.0, RegimeReport::security_bits);
+        self.udr.security_bits().max(ldr)
+    }
+
+    /// The winning regime and its binding term.
+    pub fn binding(&self) -> (Regime, SecurityTerm) {
+        match &self.ldr {
+            Some(ldr) if ldr.security_bits() > self.udr.security_bits() => {
+                (ldr.regime, ldr.binding())
+            }
+            _ => (self.udr.regime, self.udr.binding()),
+        }
+    }
+}

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -18,6 +18,8 @@ pub const ALI_LABEL: &str = "air-composition";
 pub const DEEP_LABEL: &str = "deep-ali";
 /// Label for the low-degree-test term.
 pub const LDT_LABEL: &str = "low-degree-test";
+/// Label for the batched-openings random-linear-combination term.
+pub const BATCH_LABEL: &str = "batch-combination";
 /// Label for the commitment-collision cap term.
 pub const COLLISION_LABEL: &str = "commitment-collision";
 

--- a/security/src/shape.rs
+++ b/security/src/shape.rs
@@ -64,4 +64,9 @@ pub struct InstanceShape {
     pub modulus_bits: usize,
     /// Collision resistance of the commitment hash, in bits.
     pub collision_resistance: usize,
+    /// Number of committed codewords random-linear-combined into a single
+    /// low-degree-test instance (trace segments, quotient chunks, …). `1`
+    /// means no batching. Read by the batched-openings proximity term in
+    /// [`crate::stark::proven_security_report`].
+    pub num_batched_functions: usize,
 }

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -102,21 +102,38 @@ pub fn proven_security(
 /// instance, evaluated in `assumption`'s regime (UD in the unique-decoding
 /// regime, JB in the list-decoding regime). Returns `None` when nothing is
 /// batched (fewer than two functions).
+///
+/// `ldr_m` is the proximity parameter the surrounding [`Regime::ListDecoding`]
+/// actually decodes at (e.g. FRI's `best_m`); `None` for the unique-decoding
+/// regime, where it does not apply. The batch RLC must be δ-close at the
+/// same radius the rest of the regime's terms (ALI/DEEP/LDT) are evaluated
+/// at, so the Johnson-bound branch is computed at `ldr_m` rather than the
+/// fixed `m = 10` WHIR safety choice.
 fn batching_term(
     assumption: SecurityAssumption,
     shape: &InstanceShape,
     log_blowup: usize,
+    ldr_m: Option<usize>,
 ) -> Option<SecurityTerm> {
     let num_functions = shape.num_batched_functions;
     if num_functions < 2 {
         return None;
     }
-    let bits = assumption.prox_gaps_error(
-        shape.log_trace_length,
-        log_blowup,
-        shape.modulus_bits,
-        num_functions,
-    );
+    let bits = match (assumption, ldr_m) {
+        (SecurityAssumption::JohnsonBound, Some(m)) => SecurityAssumption::prox_gaps_error_jb_at_m(
+            shape.log_trace_length,
+            log_blowup,
+            shape.modulus_bits,
+            num_functions,
+            m,
+        ),
+        _ => assumption.prox_gaps_error(
+            shape.log_trace_length,
+            log_blowup,
+            shape.modulus_bits,
+            num_functions,
+        ),
+    };
     Some(SecurityTerm::new(
         BATCH_LABEL,
         ErrorBits::from_log2(bits.max(0.0)),
@@ -177,7 +194,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
         shape,
         list_size_udr(),
         udr_ldt,
-        batching_term(SecurityAssumption::UniqueDecoding, shape, log_blowup),
+        batching_term(SecurityAssumption::UniqueDecoding, shape, log_blowup, None),
         extras,
     );
 
@@ -189,7 +206,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
             shape,
             list_size,
             ldr_ldt,
-            batching_term(SecurityAssumption::JohnsonBound, shape, log_blowup),
+            batching_term(SecurityAssumption::JohnsonBound, shape, log_blowup, Some(m)),
             extras,
         )
     });
@@ -392,5 +409,57 @@ mod tests {
         // With 2^20 batched functions over a 64-bit field, the batch term binds.
         let (_, binding) = with_batch.binding();
         assert_eq!(binding.label, BATCH_LABEL);
+    }
+
+    /// The LDR batch term is evaluated at the same `m` the surrounding
+    /// `ListDecoding` regime reports (`best_m`), not the fixed `m = 10`
+    /// WHIR safety choice — at the benchmark shape `best_m` is far from 10,
+    /// so this pins the two diverging.
+    #[test]
+    fn ldr_batch_term_uses_regime_m_not_fixed_ten() {
+        let regime = benchmark_regime();
+        let air = air();
+        let shape = InstanceShape {
+            num_batched_functions: 2,
+            ..shape()
+        };
+
+        let report = proven_security_report(&regime, &air, &shape, &[]);
+        let ldr = report
+            .ldr
+            .as_ref()
+            .expect("benchmark has a valid LDR regime");
+        let Regime::ListDecoding { m } = ldr.regime else {
+            panic!("expected a list-decoding regime");
+        };
+        assert_ne!(m, 10, "test only pins the m != 10 path if best_m != 10");
+
+        let batch_term = ldr
+            .terms()
+            .iter()
+            .find(|t| t.label == BATCH_LABEL)
+            .expect("batching two functions emits a batch-combination term");
+
+        let expected_bits = SecurityAssumption::prox_gaps_error_jb_at_m(
+            shape.log_trace_length,
+            regime.log_blowup,
+            shape.modulus_bits,
+            shape.num_batched_functions,
+            m,
+        )
+        .max(0.0);
+        assert!((batch_term.bits.bits() - expected_bits).abs() < 1e-9);
+
+        // The fixed m = 10 WHIR default would report a tighter (larger)
+        // batch error here, since (m + 1/2)^5 grows with m.
+        let fixed_m_bits = SecurityAssumption::JohnsonBound
+            .prox_gaps_error(
+                shape.log_trace_length,
+                regime.log_blowup,
+                shape.modulus_bits,
+                shape.num_batched_functions,
+            )
+            .max(0.0);
+        assert!(batch_term.bits.bits() < fixed_m_bits);
     }
 }

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -10,12 +10,13 @@
 
 use alloc::vec::Vec;
 
+use crate::assumption::SecurityAssumption;
 use crate::error::ErrorBits;
 use crate::ldt::LowDegreeTest;
 use crate::proximity::{list_size_ldr_m, list_size_udr};
 use crate::report::{
-    ALI_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, Regime, RegimeReport, SecurityReport,
-    SecurityTerm,
+    ALI_LABEL, BATCH_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, Regime, RegimeReport,
+    SecurityReport, SecurityTerm,
 };
 use crate::shape::{InstanceShape, StarkAirParams};
 use crate::{air, deep};
@@ -96,23 +97,53 @@ pub fn proven_security(
     ErrorBits::from_log2(udr.bits().max(ldr.bits()))
 }
 
-/// Labeled term list for one proximity regime: ALI, DEEP, LDT, `extras`, and
-/// the commitment-collision cap. Attained security is the min over these
-/// (see [`RegimeReport::security_bits`]), matching [`proven_security_regime`].
+/// Proximity-gap error of the initial random linear combination that batches
+/// `shape.num_batched_functions` committed codewords into a single LDT
+/// instance, evaluated in `assumption`'s regime (UD in the unique-decoding
+/// regime, JB in the list-decoding regime). Returns `None` when nothing is
+/// batched (fewer than two functions).
+fn batching_term(
+    assumption: SecurityAssumption,
+    shape: &InstanceShape,
+    log_blowup: usize,
+) -> Option<SecurityTerm> {
+    let num_functions = shape.num_batched_functions;
+    if num_functions < 2 {
+        return None;
+    }
+    let bits = assumption.prox_gaps_error(
+        shape.log_trace_length,
+        log_blowup,
+        shape.modulus_bits,
+        num_functions,
+    );
+    Some(SecurityTerm::new(
+        BATCH_LABEL,
+        ErrorBits::from_log2(bits.max(0.0)),
+    ))
+}
+
+/// Labeled term list for one proximity regime: ALI, DEEP, LDT, the optional
+/// batch-combination term, `extras`, and the commitment-collision cap.
+/// Attained security is the min over these (see
+/// [`RegimeReport::security_bits`]), matching [`proven_security_regime`] plus
+/// the batching term.
 fn regime_report(
     regime: Regime,
     air: &StarkAirParams,
     shape: &InstanceShape,
     list_size: f64,
     ldt_error: ErrorBits,
+    batch: Option<SecurityTerm>,
     extras: &[SecurityTerm],
 ) -> RegimeReport {
     let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
     let deep = deep::deep_ali_error(air, shape, list_size);
-    let mut terms = Vec::with_capacity(4 + extras.len());
+    let mut terms = Vec::with_capacity(5 + extras.len());
     terms.push(SecurityTerm::new(ALI_LABEL, ali));
     terms.push(SecurityTerm::new(DEEP_LABEL, deep));
     terms.push(SecurityTerm::new(LDT_LABEL, ldt_error));
+    terms.extend(batch);
     terms.extend_from_slice(extras);
     terms.push(SecurityTerm::new(
         COLLISION_LABEL,
@@ -137,6 +168,8 @@ pub fn proven_security_report<L: LowDegreeTest>(
     shape: &InstanceShape,
     extras: &[SecurityTerm],
 ) -> SecurityReport {
+    let log_blowup = ldt.log_blowup();
+
     let udr_ldt = ldt.proven_error_udr(air, shape);
     let udr = regime_report(
         Regime::UniqueDecoding,
@@ -144,17 +177,19 @@ pub fn proven_security_report<L: LowDegreeTest>(
         shape,
         list_size_udr(),
         udr_ldt,
+        batching_term(SecurityAssumption::UniqueDecoding, shape, log_blowup),
         extras,
     );
 
     let ldr = ldt.best_ldr(air, shape).map(|(m, ldr_ldt)| {
-        let list_size = list_size_ldr_m(ldt.log_blowup(), m);
+        let list_size = list_size_ldr_m(log_blowup, m);
         regime_report(
             Regime::ListDecoding { m },
             air,
             shape,
             list_size,
             ldr_ldt,
+            batching_term(SecurityAssumption::JohnsonBound, shape, log_blowup),
             extras,
         )
     });
@@ -171,6 +206,7 @@ mod tests {
             log_trace_length: 20,
             modulus_bits: 252,
             collision_resistance: 128,
+            num_batched_functions: 1,
         }
     }
 
@@ -221,6 +257,7 @@ mod tests {
             &shape,
             list_size,
             ldt,
+            None,
             &[SecurityTerm::new("extra", extra)],
         );
 
@@ -306,5 +343,54 @@ mod tests {
             LowDegreeTest::conjectured_error(&regime, &shape).bits(),
             conjectured_error(&regime, &shape).bits()
         );
+    }
+
+    fn benchmark_regime() -> crate::fri::FriRegime {
+        crate::fri::FriRegime {
+            log_blowup: 1,
+            num_queries: 100,
+            log_final_poly_len: 0,
+            max_log_arity: 3,
+            commit_pow_bits: 0,
+            query_pow_bits: 16,
+        }
+    }
+
+    /// A single committed function is not batched, so no batch-combination
+    /// term is emitted in either regime.
+    #[test]
+    fn no_batch_term_for_single_function() {
+        let report = proven_security_report(&benchmark_regime(), &air(), &shape(), &[]);
+        assert!(report.udr.terms.iter().all(|t| t.label != BATCH_LABEL));
+        if let Some(ldr) = &report.ldr {
+            assert!(ldr.terms.iter().all(|t| t.label != BATCH_LABEL));
+        }
+    }
+
+    /// Batching many functions over a small field only tightens the bound and,
+    /// once large enough, becomes the binding term.
+    #[test]
+    fn batching_lowers_security_when_binding() {
+        let regime = benchmark_regime();
+        let air = air();
+        let base = InstanceShape {
+            log_trace_length: 20,
+            modulus_bits: 64,
+            collision_resistance: 128,
+            num_batched_functions: 1,
+        };
+        let batched = InstanceShape {
+            num_batched_functions: 1 << 20,
+            ..base
+        };
+
+        let no_batch = proven_security_report(&regime, &air, &base, &[]);
+        let with_batch = proven_security_report(&regime, &air, &batched, &[]);
+
+        // Batching is an extra independent error source: it can only tighten.
+        assert!(with_batch.security_bits() <= no_batch.security_bits());
+        // With 2^20 batched functions over a 64-bit field, the batch term binds.
+        let (_, binding) = with_batch.binding();
+        assert_eq!(binding.label, BATCH_LABEL);
     }
 }

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -149,7 +149,7 @@ fn regime_report(
         COLLISION_LABEL,
         ErrorBits::from_log2(shape.collision_resistance as f64),
     ));
-    RegimeReport { regime, terms }
+    RegimeReport::new(regime, terms)
 }
 
 /// Composite proven-security report, generic over the low-degree test.
@@ -361,9 +361,9 @@ mod tests {
     #[test]
     fn no_batch_term_for_single_function() {
         let report = proven_security_report(&benchmark_regime(), &air(), &shape(), &[]);
-        assert!(report.udr.terms.iter().all(|t| t.label != BATCH_LABEL));
+        assert!(report.udr.terms().iter().all(|t| t.label != BATCH_LABEL));
         if let Some(ldr) = &report.ldr {
-            assert!(ldr.terms.iter().all(|t| t.label != BATCH_LABEL));
+            assert!(ldr.terms().iter().all(|t| t.label != BATCH_LABEL));
         }
     }
 

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -11,7 +11,12 @@
 use alloc::vec::Vec;
 
 use crate::error::ErrorBits;
+use crate::ldt::LowDegreeTest;
 use crate::proximity::{list_size_ldr_m, list_size_udr};
+use crate::report::{
+    ALI_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, Regime, RegimeReport, SecurityReport,
+    SecurityTerm,
+};
 use crate::shape::{InstanceShape, StarkAirParams};
 use crate::{air, deep};
 
@@ -91,6 +96,72 @@ pub fn proven_security(
     ErrorBits::from_log2(udr.bits().max(ldr.bits()))
 }
 
+/// Labeled term list for one proximity regime: ALI, DEEP, LDT, `extras`, and
+/// the commitment-collision cap. Attained security is the min over these
+/// (see [`RegimeReport::security_bits`]), matching [`proven_security_regime`].
+fn regime_report(
+    regime: Regime,
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    list_size: f64,
+    ldt_error: ErrorBits,
+    extras: &[SecurityTerm],
+) -> RegimeReport {
+    let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
+    let deep = deep::deep_ali_error(air, shape, list_size);
+    let mut terms = Vec::with_capacity(4 + extras.len());
+    terms.push(SecurityTerm::new(ALI_LABEL, ali));
+    terms.push(SecurityTerm::new(DEEP_LABEL, deep));
+    terms.push(SecurityTerm::new(LDT_LABEL, ldt_error));
+    terms.extend_from_slice(extras);
+    terms.push(SecurityTerm::new(
+        COLLISION_LABEL,
+        ErrorBits::from_log2(shape.collision_resistance as f64),
+    ));
+    RegimeReport { regime, terms }
+}
+
+/// Composite proven-security report, generic over the low-degree test.
+///
+/// Evaluates the UDR and best-`m` LDR regimes via `ldt`, composes each with
+/// the ALI, DEEP, `extras`, and commitment-collision terms, and returns the
+/// full labeled breakdown. `extras` fold protocol-specific error sources
+/// (lookup arguments, custom DEEP variants, batched openings, …) into every
+/// regime; pass `&[]` for the baseline AIR + DEEP + LDT composite.
+///
+/// [`SecurityReport::security_bits`] reproduces [`proven_security`]; the report
+/// additionally exposes which term binds in each regime.
+pub fn proven_security_report<L: LowDegreeTest>(
+    ldt: &L,
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    extras: &[SecurityTerm],
+) -> SecurityReport {
+    let udr_ldt = ldt.proven_error_udr(air, shape);
+    let udr = regime_report(
+        Regime::UniqueDecoding,
+        air,
+        shape,
+        list_size_udr(),
+        udr_ldt,
+        extras,
+    );
+
+    let ldr = ldt.best_ldr(air, shape).map(|(m, ldr_ldt)| {
+        let list_size = list_size_ldr_m(ldt.log_blowup(), m);
+        regime_report(
+            Regime::ListDecoding { m },
+            air,
+            shape,
+            list_size,
+            ldr_ldt,
+            extras,
+        )
+    });
+
+    SecurityReport { udr, ldr }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +202,109 @@ mod tests {
         assert!((with_tight.bits() - 40.0).abs() < 1e-12);
         // Monotone: extras can only tighten, never loosen.
         assert!(with_tight.bits() <= baseline.bits());
+    }
+
+    /// A regime report's attained bits equal the scalar `proven_security_regime`
+    /// for the same list size, LDT error, and extras.
+    #[test]
+    fn regime_report_matches_proven_security_regime() {
+        let air = air();
+        let shape = shape();
+        let ldt = ErrorBits::from_log2(80.0);
+        let list_size = 1.0;
+
+        let extra = ErrorBits::from_log2(40.0);
+        let expected = proven_security_regime(&air, &shape, list_size, ldt, &[extra]);
+        let report = regime_report(
+            Regime::UniqueDecoding,
+            &air,
+            &shape,
+            list_size,
+            ldt,
+            &[SecurityTerm::new("extra", extra)],
+        );
+
+        assert!((report.security_bits() - expected.bits()).abs() < 1e-12);
+        // The tight extra (40 bits) is the binding term.
+        assert_eq!(report.binding().label, "extra");
+    }
+
+    /// The report path reproduces the scalar composite for the FRI benchmark
+    /// vector and reports the low-degree test as the binding term.
+    #[test]
+    fn proven_security_report_matches_scalar_composite() {
+        use crate::fri::{FriRegime, best_ldr_m, proven_error_udr};
+
+        let regime = FriRegime {
+            log_blowup: 1,
+            num_queries: 100,
+            log_final_poly_len: 0,
+            max_log_arity: 3,
+            commit_pow_bits: 0,
+            query_pow_bits: 16,
+        };
+        let air = air();
+        let shape = shape();
+
+        let report = proven_security_report(&regime, &air, &shape, &[]);
+
+        // Same per-regime and combined numbers as ProvenSecurity / proven_security.
+        assert_eq!(report.udr.security_bits().floor() as usize, 57);
+        let ldr = report
+            .ldr
+            .as_ref()
+            .expect("benchmark has a valid LDR regime");
+        assert_eq!(ldr.security_bits().floor() as usize, 65);
+        assert_eq!(report.security_bits().floor() as usize, 65);
+
+        // The LDR regime wins and the low-degree test binds it.
+        let (regime_kind, binding) = report.binding();
+        assert!(matches!(regime_kind, Regime::ListDecoding { .. }));
+        assert_eq!(binding.label, LDT_LABEL);
+
+        // Cross-check against the untyped composite.
+        let udr_ldt = proven_error_udr(&regime, &air, &shape);
+        let (best_m, ldr_ldt) = best_ldr_m(&regime, &air, &shape).unwrap();
+        let scalar = proven_security(
+            &air,
+            &shape,
+            regime.log_blowup,
+            udr_ldt,
+            best_m,
+            ldr_ldt,
+            &[],
+        );
+        assert_eq!(
+            report.security_bits().floor() as usize,
+            scalar.bits().floor() as usize
+        );
+    }
+
+    /// `FriRegime`'s `LowDegreeTest` methods delegate to the free functions.
+    #[test]
+    fn fri_regime_ldt_impl_delegates() {
+        use crate::fri::{FriRegime, conjectured_error, proven_error_udr};
+        use crate::ldt::LowDegreeTest;
+
+        let regime = FriRegime {
+            log_blowup: 1,
+            num_queries: 100,
+            log_final_poly_len: 0,
+            max_log_arity: 3,
+            commit_pow_bits: 0,
+            query_pow_bits: 16,
+        };
+        let air = air();
+        let shape = shape();
+
+        assert_eq!(LowDegreeTest::log_blowup(&regime), regime.log_blowup);
+        assert_eq!(
+            LowDegreeTest::proven_error_udr(&regime, &air, &shape).bits(),
+            proven_error_udr(&regime, &air, &shape).bits()
+        );
+        assert_eq!(
+            LowDegreeTest::conjectured_error(&regime, &shape).bits(),
+            conjectured_error(&regime, &shape).bits()
+        );
     }
 }

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -9,9 +9,9 @@ use core::cmp::{max, min};
 use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
 use p3_field::{ExtensionField, Field};
-use p3_security::fri::{FriRegime, best_ldr_m, conjectured_error, proven_error_udr};
+use p3_security::fri::{FriRegime, conjectured_error};
 use p3_security::shape::{InstanceShape, StarkAirParams as P3AirShape};
-use p3_security::stark::{proven_security_ldr_m, proven_security_udr};
+use p3_security::stark::proven_security_report;
 use p3_util::log2_floor_usize;
 
 /// Parameters required to compute STARK proof security level.
@@ -49,6 +49,11 @@ pub struct StarkSecurityParams {
     /// (DEEP-ALI's `max_combo`). For a uni-STARK using `local`/`next` rotations this
     /// is `2`; `1` if no transition constraint is present.
     pub max_combo: usize,
+    /// Number of committed codewords random-linear-combined into the single
+    /// FRI instance (trace columns, quotient chunks, …). Defaults to `1` (no
+    /// batching term); set it to the actual count to account for the
+    /// batched-openings proximity error. Leaving it at `1` is optimistic.
+    pub num_batched_functions: usize,
 }
 
 impl StarkSecurityParams {
@@ -76,6 +81,7 @@ impl StarkSecurityParams {
             num_constraints,
             air_max_constraint_degree,
             max_combo,
+            num_batched_functions: 1,
         }
     }
 
@@ -135,6 +141,7 @@ impl StarkSecurityParams {
             log_trace_length,
             modulus_bits: self.num_modulus_bits,
             collision_resistance: self.collision_resistance,
+            num_batched_functions: self.num_batched_functions,
         }
     }
 }
@@ -171,6 +178,7 @@ impl ConjecturedSecurity {
             log_trace_length: 0,
             modulus_bits: num_modulus_bits,
             collision_resistance,
+            num_batched_functions: 1,
         };
         let fri_bits = conjectured_error(&regime, &shape).bits() as usize;
         let bits = min(min(fri_bits, collision_resistance), num_modulus_bits);
@@ -256,19 +264,14 @@ impl ProvenSecurity {
         let air = params.air_shape();
         let shape = params.instance_shape(degree_bits);
 
-        let udr_ldt = proven_error_udr(&regime, &air, &shape);
-        let udr_bits = proven_security_udr(&air, &shape, udr_ldt, &[]).bits() as usize;
-
-        let ldr_bits = match best_ldr_m(&regime, &air, &shape) {
-            Some((m, ldt)) => {
-                proven_security_ldr_m(&air, &shape, regime.log_blowup, m, ldt, &[]).bits() as usize
-            }
-            None => 0,
-        };
+        let report = proven_security_report(&regime, &air, &shape, &[]);
 
         Self {
-            unique_decoding_bits: udr_bits,
-            list_decoding_bits: ldr_bits,
+            unique_decoding_bits: report.udr.security_bits() as usize,
+            list_decoding_bits: report
+                .ldr
+                .as_ref()
+                .map_or(0, |r| r.security_bits() as usize),
         }
     }
 }
@@ -313,6 +316,7 @@ mod tests {
             num_constraints: TEST_NUM_CONSTRAINTS,
             air_max_constraint_degree: TEST_AIR_MAX_DEG,
             max_combo: TEST_MAX_COMBO,
+            num_batched_functions: 1,
         }
     }
 
@@ -387,9 +391,21 @@ mod tests {
         assert!(p_a8.unique_decoding_bits <= p_a2.unique_decoding_bits);
     }
 
+    #[test]
+    fn more_batched_functions_decreases_or_holds_security() {
+        // Over a small field the batched-openings term is active.
+        let mut params = benchmark_high_arity_params(64);
+        params.num_batched_functions = 1;
+        let p1 = ProvenSecurity::compute(&params, 1 << 20);
+        params.num_batched_functions = 1 << 20;
+        let p_batched = ProvenSecurity::compute(&params, 1 << 20);
+        assert!(p_batched.security_bits() <= p1.security_bits());
+    }
+
     // Regression vector pinning the proven-security output for a fixed configuration:
     // log_blowup=1, num_queries=100, query_pow=16, commit_pow=0, max_log_arity=3,
     // |F|=252 bits, trace 2^20, num_constraints=1, max_deg=2, max_combo=2.
+    // num_batched_functions defaults to 1, so no batching term applies.
     #[test]
     fn proven_security_regression_benchmark_high_arity() {
         let params = benchmark_high_arity_params(252);

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -151,6 +151,11 @@ impl StarkSecurityParams {
 ///
 /// The cited paper recommends proven bounds for deployment; users staying with
 /// conjectured bounds should remain above the cutoff.
+///
+/// Unlike [`ProvenSecurity`], this does not model the batched-openings term
+/// (`num_batched_functions`): the conjectured path is optimistic relative to
+/// the proven one for instances that random-linear-combine more than one
+/// committed codeword.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConjecturedSecurity {
     pub security_bits: usize,


### PR DESCRIPTION
Follow-up to #1686. Makes the soundness crate generic enough for out-of-tree protocols and closes a missing error term.

  What's in it
  - `LowDegreeTest` trait + `SecurityReport` — the composite (`stark::proven_security_report`) now composes over any LDT via a trait (`FriRegime` is one impl), and returns a labeled
  per-term breakdown (ALI / DEEP / LDT / batch / collision) that exposes which term binds, instead of two bare usizes.
  - `FriParameters::security_regime()` — one canonical `FriParameters` → `FriRegime` assembler in `p3-fri`, using exhaustive destructuring so a new `FriParameters` field fails to
  compile until it's mapped. Replaces four hand-copied literals in examples.
  - Batched-openings term (B.3) — new `InstanceShape.num_batched_functions` feeds a batch-combination proximity term (prox_gaps_error: UD in the UDR regime, JB in the LDR
  regime). `uni-stark::ProvenSecurity` now routes through the report path so the term is actually applied.