### PR TITLE
perf(circle): cache exponentiation for `two_adic_generator`

### DIFF
--- a/mersenne-31/src/complex.rs
+++ b/mersenne-31/src/complex.rs
@@ -9,6 +9,46 @@ use p3_field::extension::{Complex, ComplexExtendable, HasTwoAdicBinomialExtensio
 
 use crate::Mersenne31;
 
+impl Mersenne31 {
+    /// Precomputed table of generators for two-adic subgroups of the circle group
+    /// (the norm-1 subgroup of the degree two extension field over Mersenne31).
+    /// The `i`'th element is a generator of the subgroup of order `2^i`.
+    const CIRCLE_TWO_ADIC_GENERATORS: [Complex<Self>; 32] = [
+        Complex::new_complex(Self::new(1), Self::new(0)),
+        Complex::new_complex(Self::new(2_147_483_646), Self::new(0)),
+        Complex::new_complex(Self::new(0), Self::new(2_147_483_646)),
+        Complex::new_complex(Self::new(32_768), Self::new(2_147_450_879)),
+        Complex::new_complex(Self::new(590_768_354), Self::new(978_592_373)),
+        Complex::new_complex(Self::new(1_179_735_656), Self::new(1_241_207_368)),
+        Complex::new_complex(Self::new(1_567_857_810), Self::new(456_695_729)),
+        Complex::new_complex(Self::new(1_774_253_895), Self::new(1_309_288_441)),
+        Complex::new_complex(Self::new(736_262_640), Self::new(1_553_669_210)),
+        Complex::new_complex(Self::new(1_819_216_575), Self::new(1_662_816_114)),
+        Complex::new_complex(Self::new(1_323_191_254), Self::new(1_936_974_060)),
+        Complex::new_complex(Self::new(605_622_498), Self::new(1_964_232_216)),
+        Complex::new_complex(Self::new(343_674_985), Self::new(501_786_993)),
+        Complex::new_complex(Self::new(1_995_316_534), Self::new(149_306_621)),
+        Complex::new_complex(Self::new(2_107_600_913), Self::new(1_378_821_388)),
+        Complex::new_complex(Self::new(541_476_169), Self::new(2_101_081_972)),
+        Complex::new_complex(Self::new(2_135_874_973), Self::new(483_411_332)),
+        Complex::new_complex(Self::new(2_097_144_245), Self::new(1_684_033_590)),
+        Complex::new_complex(Self::new(1_662_322_247), Self::new(670_236_780)),
+        Complex::new_complex(Self::new(1_172_215_635), Self::new(595_888_646)),
+        Complex::new_complex(Self::new(241_940_101), Self::new(323_856_519)),
+        Complex::new_complex(Self::new(1_957_194_259), Self::new(2_139_647_100)),
+        Complex::new_complex(Self::new(1_957_419_629), Self::new(1_541_039_442)),
+        Complex::new_complex(Self::new(1_062_045_235), Self::new(1_824_580_421)),
+        Complex::new_complex(Self::new(1_929_382_196), Self::new(1_664_698_822)),
+        Complex::new_complex(Self::new(1_889_294_251), Self::new(331_248_939)),
+        Complex::new_complex(Self::new(1_214_231_414), Self::new(1_646_302_518)),
+        Complex::new_complex(Self::new(1_765_392_370), Self::new(461_136_547)),
+        Complex::new_complex(Self::new(1_629_751_483), Self::new(66_485_474)),
+        Complex::new_complex(Self::new(1_501_355_827), Self::new(1_439_063_420)),
+        Complex::new_complex(Self::new(509_778_402), Self::new(800_467_507)),
+        Complex::new_complex(Self::new(311_014_874), Self::new(1_584_694_829)),
+    ];
+}
+
 impl ComplexExtendable for Mersenne31 {
     const CIRCLE_TWO_ADICITY: usize = 31;
 
@@ -31,11 +71,7 @@ impl ComplexExtendable for Mersenne31 {
         // sage: assert(g.multiplicative_order() == 2^31)
         // sage: assert(g.norm() == 1)
         assert!(bits <= Self::CIRCLE_TWO_ADICITY);
-        let base = Complex::new_complex(
-            Self::new_reduced(311_014_874),
-            Self::new_reduced(1_584_694_829),
-        );
-        base.exp_power_of_2(Self::CIRCLE_TWO_ADICITY - bits)
+        Self::CIRCLE_TWO_ADIC_GENERATORS[bits]
     }
 }
 
@@ -159,6 +195,17 @@ mod tests {
             Fi::new_imag(F::new(5)).mul_2exp_u64(2),
             Fi::new_imag(F::new(20))
         );
+    }
+
+    #[test]
+    fn circle_two_adic_generators_table_matches_repeated_squaring() {
+        let base = Fi::new_complex(F::new(311_014_874), F::new(1_584_694_829));
+        for bits in 0..=Mersenne31::CIRCLE_TWO_ADICITY {
+            assert_eq!(
+                Mersenne31::CIRCLE_TWO_ADIC_GENERATORS[bits],
+                base.exp_power_of_2(Mersenne31::CIRCLE_TWO_ADICITY - bits)
+            );
+        }
     }
 
     // There is a redundant representation of zero but we already tested it


### PR DESCRIPTION
Similarly to what's done in `mersenne31.rs`