### PR TITLE
perf(poseidon-air): speed-up Poseidon1Air and Poseidon2Air

### DIFF
--- a/mds/src/karatsuba_convolution.rs
+++ b/mds/src/karatsuba_convolution.rs
@@ -47,30 +47,30 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
-use p3_field::{Algebra, Field};
+use p3_field::{Algebra, PrimeCharacteristicRing};
 
 /// Bound alias for the wide operand type (used for both lhs and output).
 ///
 /// Must support addition, subtraction, negation, and in-place variants.
 pub trait ConvolutionElt:
-    Add<Output = Self> + AddAssign + Copy + Neg<Output = Self> + Sub<Output = Self> + SubAssign
+    Add<Output = Self> + AddAssign + Clone + Neg<Output = Self> + Sub<Output = Self> + SubAssign
 {
 }
 
 impl<T> ConvolutionElt for T where
-    T: Add<Output = T> + AddAssign + Copy + Neg<Output = T> + Sub<Output = T> + SubAssign
+    T: Add<Output = T> + AddAssign + Clone + Neg<Output = T> + Sub<Output = T> + SubAssign
 {
 }
 
 /// Bound alias for the narrow operand type (rhs only).
 ///
-/// Requires addition, subtraction, negation, and copy.
+/// Requires addition, subtraction, negation, and clone.
 pub trait ConvolutionRhs:
-    Add<Output = Self> + Copy + Neg<Output = Self> + Sub<Output = Self>
+    Add<Output = Self> + Clone + Neg<Output = Self> + Sub<Output = Self>
 {
 }
 
-impl<T> ConvolutionRhs for T where T: Add<Output = T> + Copy + Neg<Output = T> + Sub<Output = T> {}
+impl<T> ConvolutionRhs for T where T: Add<Output = T> + Clone + Neg<Output = T> + Sub<Output = T> {}
 
 /// Trait for computing cyclic and negacyclic convolutions.
 ///
@@ -146,48 +146,104 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
 
     #[inline(always)]
     fn conv3(lhs: [T; 3], rhs: [U; 3], output: &mut [T]) {
-        output[0] = Self::parity_dot(lhs, [rhs[0], rhs[2], rhs[1]]);
-        output[1] = Self::parity_dot(lhs, [rhs[1], rhs[0], rhs[2]]);
-        output[2] = Self::parity_dot(lhs, [rhs[2], rhs[1], rhs[0]]);
+        output[0] = Self::parity_dot(
+            lhs.clone(),
+            [rhs[0].clone(), rhs[2].clone(), rhs[1].clone()],
+        );
+        output[1] = Self::parity_dot(
+            lhs.clone(),
+            [rhs[1].clone(), rhs[0].clone(), rhs[2].clone()],
+        );
+        output[2] = Self::parity_dot(lhs, [rhs[2].clone(), rhs[1].clone(), rhs[0].clone()]);
     }
 
     #[inline(always)]
     fn negacyclic_conv3(lhs: [T; 3], rhs: [U; 3], output: &mut [T]) {
-        output[0] = Self::parity_dot(lhs, [rhs[0], -rhs[2], -rhs[1]]);
-        output[1] = Self::parity_dot(lhs, [rhs[1], rhs[0], -rhs[2]]);
-        output[2] = Self::parity_dot(lhs, [rhs[2], rhs[1], rhs[0]]);
+        output[0] = Self::parity_dot(
+            lhs.clone(),
+            [rhs[0].clone(), -rhs[2].clone(), -rhs[1].clone()],
+        );
+        output[1] = Self::parity_dot(
+            lhs.clone(),
+            [rhs[1].clone(), rhs[0].clone(), -rhs[2].clone()],
+        );
+        output[2] = Self::parity_dot(lhs, [rhs[2].clone(), rhs[1].clone(), rhs[0].clone()]);
     }
 
     #[inline(always)]
     fn conv4(lhs: [T; 4], rhs: [U; 4], output: &mut [T]) {
         // NB: This is just explicitly implementing
         // conv_n_recursive::<4, 2, _, _>(lhs, rhs, output, Self::conv2, Self::negacyclic_conv2)
-        let u_p = [lhs[0] + lhs[2], lhs[1] + lhs[3]];
-        let u_m = [lhs[0] - lhs[2], lhs[1] - lhs[3]];
-        let v_p = [rhs[0] + rhs[2], rhs[1] + rhs[3]];
-        let v_m = [rhs[0] - rhs[2], rhs[1] - rhs[3]];
+        let u_p = [
+            lhs[0].clone() + lhs[2].clone(),
+            lhs[1].clone() + lhs[3].clone(),
+        ];
+        let u_m = [
+            lhs[0].clone() - lhs[2].clone(),
+            lhs[1].clone() - lhs[3].clone(),
+        ];
+        let v_p = [
+            rhs[0].clone() + rhs[2].clone(),
+            rhs[1].clone() + rhs[3].clone(),
+        ];
+        let v_m = [
+            rhs[0].clone() - rhs[2].clone(),
+            rhs[1].clone() - rhs[3].clone(),
+        ];
 
-        output[0] = Self::parity_dot(u_m, [v_m[0], -v_m[1]]);
-        output[1] = Self::parity_dot(u_m, [v_m[1], v_m[0]]);
-        output[2] = Self::parity_dot(u_p, v_p);
-        output[3] = Self::parity_dot(u_p, [v_p[1], v_p[0]]);
+        output[0] = Self::parity_dot(u_m.clone(), [v_m[0].clone(), -v_m[1].clone()]);
+        output[1] = Self::parity_dot(u_m, [v_m[1].clone(), v_m[0].clone()]);
+        output[2] = Self::parity_dot(u_p.clone(), v_p.clone());
+        output[3] = Self::parity_dot(u_p, [v_p[1].clone(), v_p[0].clone()]);
 
-        output[0] += output[2];
-        output[1] += output[3];
+        output[0] += output[2].clone();
+        output[1] += output[3].clone();
 
-        output[0] = Self::halve(output[0]);
-        output[1] = Self::halve(output[1]);
+        output[0] = Self::halve(output[0].clone());
+        output[1] = Self::halve(output[1].clone());
 
-        output[2] -= output[0];
-        output[3] -= output[1];
+        output[2] -= output[0].clone();
+        output[3] -= output[1].clone();
     }
 
     #[inline(always)]
     fn negacyclic_conv4(lhs: [T; 4], rhs: [U; 4], output: &mut [T]) {
-        output[0] = Self::parity_dot(lhs, [rhs[0], -rhs[3], -rhs[2], -rhs[1]]);
-        output[1] = Self::parity_dot(lhs, [rhs[1], rhs[0], -rhs[3], -rhs[2]]);
-        output[2] = Self::parity_dot(lhs, [rhs[2], rhs[1], rhs[0], -rhs[3]]);
-        output[3] = Self::parity_dot(lhs, [rhs[3], rhs[2], rhs[1], rhs[0]]);
+        output[0] = Self::parity_dot(
+            lhs.clone(),
+            [
+                rhs[0].clone(),
+                -rhs[3].clone(),
+                -rhs[2].clone(),
+                -rhs[1].clone(),
+            ],
+        );
+        output[1] = Self::parity_dot(
+            lhs.clone(),
+            [
+                rhs[1].clone(),
+                rhs[0].clone(),
+                -rhs[3].clone(),
+                -rhs[2].clone(),
+            ],
+        );
+        output[2] = Self::parity_dot(
+            lhs.clone(),
+            [
+                rhs[2].clone(),
+                rhs[1].clone(),
+                rhs[0].clone(),
+                -rhs[3].clone(),
+            ],
+        );
+        output[3] = Self::parity_dot(
+            lhs,
+            [
+                rhs[3].clone(),
+                rhs[2].clone(),
+                rhs[1].clone(),
+                rhs[0].clone(),
+            ],
+        );
     }
 
     /// Compute output(x) = lhs(x)rhs(x) mod x^N - 1 recursively using
@@ -210,16 +266,16 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
         let mut rhs_neg = [Self::U_ZERO; HALF_N]; // rhs_neg = rhs(x) mod x^{N/2} + 1
 
         for i in 0..HALF_N {
-            let s = lhs[i];
-            let t = lhs[i + HALF_N];
+            let s = lhs[i].clone();
+            let t = lhs[i + HALF_N].clone();
 
-            lhs_pos[i] = s + t;
+            lhs_pos[i] = s.clone() + t.clone();
             lhs_neg[i] = s - t;
 
-            let s = rhs[i];
-            let t = rhs[i + HALF_N];
+            let s = rhs[i].clone();
+            let t = rhs[i + HALF_N].clone();
 
-            rhs_pos[i] = s + t;
+            rhs_pos[i] = s.clone() + t.clone();
             rhs_neg[i] = s - t;
         }
 
@@ -232,9 +288,9 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
         inner_conv(lhs_pos, rhs_pos, right);
 
         for i in 0..HALF_N {
-            left[i] += right[i]; // w_0 + w_1
-            left[i] = Self::halve(left[i]); // (w_0 + w_1)/2
-            right[i] -= left[i]; // (w_0 - w_1)/2
+            left[i] += right[i].clone(); // w_0 + w_1
+            left[i] = Self::halve(left[i].clone()); // (w_0 + w_1)/2
+            right[i] -= left[i].clone(); // (w_0 - w_1)/2
         }
     }
 
@@ -258,17 +314,17 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
         let mut rhs_sum = [Self::U_ZERO; HALF_N];
 
         for i in 0..HALF_N {
-            let s = lhs[2 * i];
-            let t = lhs[2 * i + 1];
+            let s = lhs[2 * i].clone();
+            let t = lhs[2 * i + 1].clone();
+            lhs_sum[i] = s.clone() + t.clone();
             lhs_even[i] = s;
             lhs_odd[i] = t;
-            lhs_sum[i] = s + t;
 
-            let s = rhs[2 * i];
-            let t = rhs[2 * i + 1];
+            let s = rhs[2 * i].clone();
+            let t = rhs[2 * i + 1].clone();
+            rhs_sum[i] = s.clone() + t.clone();
             rhs_even[i] = s;
             rhs_odd[i] = t;
-            rhs_sum[i] = s + t;
         }
 
         let mut even_s_conv = [Self::T_ZERO; HALF_N];
@@ -282,18 +338,18 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
 
         // Adjust so that the correct values are in right and
         // even_s_conv respectively:
-        right[0] -= even_s_conv[0] + left[0];
-        even_s_conv[0] -= left[HALF_N - 1];
+        right[0] -= even_s_conv[0].clone() + left[0].clone();
+        even_s_conv[0] -= left[HALF_N - 1].clone();
 
         for i in 1..HALF_N {
-            right[i] -= even_s_conv[i] + left[i];
-            even_s_conv[i] += left[i - 1];
+            right[i] -= even_s_conv[i].clone() + left[i].clone();
+            even_s_conv[i] += left[i - 1].clone();
         }
 
         // Interleave even_s_conv and right in the output:
         for i in 0..HALF_N {
-            output[2 * i] = even_s_conv[i];
-            output[2 * i + 1] = output[i + HALF_N];
+            output[2 * i] = even_s_conv[i].clone();
+            output[2 * i + 1] = output[i + HALF_N].clone();
         }
     }
 
@@ -364,7 +420,7 @@ pub trait Convolve<F, T: ConvolutionElt, U: ConvolutionRhs> {
 /// Used by the public Karatsuba entry points for generic field/algebra pairs.
 struct FieldConvolve<F, A>(PhantomData<(F, A)>);
 
-impl<F: Field, A: Algebra<F> + Copy> Convolve<A, A, F> for FieldConvolve<F, A> {
+impl<F: PrimeCharacteristicRing, A: Algebra<F> + Clone> Convolve<A, A, F> for FieldConvolve<F, A> {
     const T_ZERO: A = A::ZERO;
     const U_ZERO: F = F::ZERO;
 
@@ -391,39 +447,42 @@ impl<F: Field, A: Algebra<F> + Copy> Convolve<A, A, F> for FieldConvolve<F, A> {
 
 /// Circulant matrix-vector multiply for width 8 via Karatsuba convolution.
 #[inline]
-pub fn mds_circulant_karatsuba_8<F: Field, A: Algebra<F> + Copy>(state: &mut [A; 8], col: &[F; 8]) {
-    let input = *state;
-    FieldConvolve::<F, A>::conv8(input, *col, state.as_mut_slice());
+pub fn mds_circulant_karatsuba_8<F: PrimeCharacteristicRing, A: Algebra<F> + Clone>(
+    state: &mut [A; 8],
+    col: &[F; 8],
+) {
+    let input = state.clone();
+    FieldConvolve::<F, A>::conv8(input, col.clone(), state.as_mut_slice());
 }
 
 /// Circulant matrix-vector multiply for width 12 via Karatsuba convolution.
 #[inline]
-pub fn mds_circulant_karatsuba_12<F: Field, A: Algebra<F> + Copy>(
+pub fn mds_circulant_karatsuba_12<F: PrimeCharacteristicRing, A: Algebra<F> + Clone>(
     state: &mut [A; 12],
     col: &[F; 12],
 ) {
-    let input = *state;
-    FieldConvolve::<F, A>::conv12(input, *col, state.as_mut_slice());
+    let input = state.clone();
+    FieldConvolve::<F, A>::conv12(input, col.clone(), state.as_mut_slice());
 }
 
 /// Circulant matrix-vector multiply for width 16 via Karatsuba convolution.
 #[inline]
-pub fn mds_circulant_karatsuba_16<F: Field, A: Algebra<F> + Copy>(
+pub fn mds_circulant_karatsuba_16<F: PrimeCharacteristicRing, A: Algebra<F> + Clone>(
     state: &mut [A; 16],
     col: &[F; 16],
 ) {
-    let input = *state;
-    FieldConvolve::<F, A>::conv16(input, *col, state.as_mut_slice());
+    let input = state.clone();
+    FieldConvolve::<F, A>::conv16(input, col.clone(), state.as_mut_slice());
 }
 
 /// Circulant matrix-vector multiply for width 24 via Karatsuba convolution.
 #[inline]
-pub fn mds_circulant_karatsuba_24<F: Field, A: Algebra<F> + Copy>(
+pub fn mds_circulant_karatsuba_24<F: PrimeCharacteristicRing, A: Algebra<F> + Clone>(
     state: &mut [A; 24],
     col: &[F; 24],
 ) {
-    let input = *state;
-    FieldConvolve::<F, A>::conv24(input, *col, state.as_mut_slice());
+    let input = state.clone();
+    FieldConvolve::<F, A>::conv24(input, col.clone(), state.as_mut_slice());
 }
 
 #[cfg(test)]

--- a/poseidon1-air/src/air.rs
+++ b/poseidon1-air/src/air.rs
@@ -34,7 +34,7 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
-use p3_field::{PrimeCharacteristicRing, PrimeField, dot_product};
+use p3_field::{Algebra, PrimeCharacteristicRing, PrimeField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon1::external::mds_multiply;
 use rand::distr::{Distribution, StandardUniform};
@@ -42,6 +42,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use crate::columns::{Poseidon1Cols, num_cols};
+use crate::mds_dispatch::mds_dispatch;
 use crate::{
     FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox, generate_trace_rows,
 };
@@ -250,6 +251,10 @@ pub(crate) fn eval<
     // Initialize the running state from the committed input columns.
     let mut state: [_; WIDTH] = local.inputs.map(|x| x.into());
 
+    // Circulant first column of the dense MDS matrix, for the Karatsuba fast path.
+    let circ_col: [AB::F; WIDTH] =
+        core::array::from_fn(|i| air.full_constants.dense_mds[i][0].clone());
+
     // Phase 1: Beginning full rounds (RF/2 rounds)
     //
     // Each round: add constants → S-box on all elements → MDS multiply.
@@ -258,6 +263,7 @@ pub(crate) fn eval<
             &mut state,
             &local.beginning_full_rounds[round],
             &air.full_constants.initial[round],
+            &circ_col,
             &air.full_constants.dense_mds,
             builder,
         );
@@ -303,6 +309,7 @@ pub(crate) fn eval<
             &mut state,
             &local.ending_full_rounds[round],
             &air.full_constants.terminal[round],
+            &circ_col,
             &air.full_constants.dense_mds,
             builder,
         );
@@ -352,6 +359,7 @@ fn eval_full_round<
     state: &mut [AB::Expr; WIDTH],
     full_round: &FullRound<AB::Var, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constants: &[AB::F; WIDTH],
+    circ_col: &[AB::F; WIDTH],
     mds_matrix: &[[AB::F; WIDTH]; WIDTH],
     builder: &mut AB,
 ) {
@@ -365,8 +373,8 @@ fn eval_full_round<
         eval_sbox(&full_round.sbox[i], s, builder);
     }
 
-    // Step 3: Multiply by the dense MDS matrix.
-    mds_multiply(state, mds_matrix);
+    // Step 3: Multiply by the dense MDS matrix (circulant Karatsuba for supported widths).
+    mds_dispatch(state, circ_col, mds_matrix);
 
     // Constrain: computed state must equal committed post-state.
     // Then reset state to the committed values (degree 1).
@@ -411,7 +419,7 @@ fn eval_sparse_partial_round<
 
     // Sparse matrix multiply.
     let old_s0 = state[0].clone();
-    state[0] = dot_product(state.iter().cloned(), first_row.iter().cloned());
+    state[0] = AB::Expr::mixed_dot_product(state, first_row);
 
     for i in 1..WIDTH {
         state[i] += old_s0.clone() * v[i - 1].clone();

--- a/poseidon1-air/src/generation.rs
+++ b/poseidon1-air/src/generation.rs
@@ -24,41 +24,15 @@
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-use p3_field::{PrimeField, dot_product};
+use p3_field::PrimeField;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_maybe_rayon::prelude::*;
-use p3_mds::karatsuba_convolution::{mds_circulant_karatsuba_16, mds_circulant_karatsuba_24};
 use p3_poseidon1::external::mds_multiply;
 use tracing::instrument;
 
 use crate::columns::{Poseidon1Cols, num_cols};
+use crate::mds_dispatch::mds_dispatch;
 use crate::{FullRound, FullRoundConstants, PartialRound, PartialRoundConstants, SBox};
-
-/// Karatsuba MDS multiply for trace generation.
-///
-/// Uses Karatsuba convolution for supported widths (16, 24), falling back
-/// to dense O(t²) multiplication otherwise. Concrete field types satisfy
-/// the `Copy` bound required by the Karatsuba implementation.
-#[inline]
-fn mds_for_trace_gen<F: PrimeField, const WIDTH: usize>(
-    state: &mut [F; WIDTH],
-    circ_col: &[F; WIDTH],
-    dense_mds: &[[F; WIDTH]; WIDTH],
-) {
-    match WIDTH {
-        16 => {
-            let state_16: &mut [F; 16] = state.as_mut_slice().try_into().unwrap();
-            let col_16: &[F; 16] = circ_col.as_slice().try_into().unwrap();
-            mds_circulant_karatsuba_16(state_16, col_16);
-        }
-        24 => {
-            let state_24: &mut [F; 24] = state.as_mut_slice().try_into().unwrap();
-            let col_24: &[F; 24] = circ_col.as_slice().try_into().unwrap();
-            mds_circulant_karatsuba_24(state_24, col_24);
-        }
-        _ => mds_multiply(state, dense_mds),
-    }
-}
 
 /// Generate a trace for multiple Poseidon1 permutations (vectorized layout).
 ///
@@ -375,7 +349,7 @@ fn generate_full_round<
 
     // MDS multiply: state = MDS * state.
     // Karatsuba MDS for supported widths, dense fallback otherwise.
-    mds_for_trace_gen(state, circ_col, dense_mds);
+    mds_dispatch(state, circ_col, dense_mds);
 
     // Write the post-state to the trace.
     full_round
@@ -419,7 +393,7 @@ fn generate_sparse_partial_round<
 
     // Sparse matrix multiply.
     let old_s0 = state[0];
-    state[0] = dot_product(state.iter().copied(), first_row.iter().copied());
+    state[0] = F::dot_product(state, first_row);
     for i in 1..WIDTH {
         state[i] += old_s0 * v[i - 1];
     }

--- a/poseidon1-air/src/lib.rs
+++ b/poseidon1-air/src/lib.rs
@@ -62,6 +62,7 @@ extern crate alloc;
 mod air;
 mod columns;
 mod generation;
+mod mds_dispatch;
 mod vectorized;
 
 pub use air::*;

--- a/poseidon1-air/src/mds_dispatch.rs
+++ b/poseidon1-air/src/mds_dispatch.rs
@@ -1,0 +1,33 @@
+//! Shared circulant-Karatsuba dispatch for the dense Poseidon1 full-round MDS matrix.
+//!
+//! Used by both constraint evaluation ([`crate::air`]) and trace generation
+//! ([`crate::generation`]), so the two share the same width-16/24 fast path.
+
+use p3_field::{Algebra, PrimeCharacteristicRing};
+use p3_mds::karatsuba_convolution::{mds_circulant_karatsuba_16, mds_circulant_karatsuba_24};
+use p3_poseidon1::external::mds_multiply;
+
+/// Multiply `state` by the dense MDS matrix.
+///
+/// Dispatches to a circulant Karatsuba convolution for supported widths (16, 24),
+/// falling back to the dense `O(WIDTH^2)` multiply otherwise.
+#[inline]
+pub(crate) fn mds_dispatch<F: PrimeCharacteristicRing, A: Algebra<F>, const WIDTH: usize>(
+    state: &mut [A; WIDTH],
+    circ_col: &[F; WIDTH],
+    dense_mds: &[[F; WIDTH]; WIDTH],
+) {
+    match WIDTH {
+        16 => {
+            let state_16: &mut [A; 16] = state.as_mut_slice().try_into().unwrap();
+            let col_16: &[F; 16] = circ_col.as_slice().try_into().unwrap();
+            mds_circulant_karatsuba_16(state_16, col_16);
+        }
+        24 => {
+            let state_24: &mut [A; 24] = state.as_mut_slice().try_into().unwrap();
+            let col_24: &[F; 24] = circ_col.as_slice().try_into().unwrap();
+            mds_circulant_karatsuba_24(state_24, col_24);
+        }
+        _ => mds_multiply(state, dense_mds),
+    }
+}

--- a/poseidon2-air/src/generation.rs
+++ b/poseidon2-air/src/generation.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
-use p3_field::PrimeField;
+use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixViewMut};
 use p3_maybe_rayon::prelude::*;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
@@ -52,17 +52,15 @@ pub fn generate_vectorized_trace_rows<
     assert!(suffix.is_empty(), "Alignment should match");
     assert_eq!(perms.len(), n);
 
-    perms.par_iter_mut().zip(inputs).for_each(|(perm, input)| {
-        generate_trace_rows_for_perm::<
-            F,
-            LinearLayers,
-            WIDTH,
-            SBOX_DEGREE,
-            SBOX_REGISTERS,
-            HALF_FULL_ROUNDS,
-            PARTIAL_ROUNDS,
-        >(perm, input, round_constants);
-    });
+    generate_perms::<
+        F,
+        LinearLayers,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >(perms, inputs, round_constants);
 
     unsafe {
         vec.set_len(nrows * ncols);
@@ -111,23 +109,77 @@ pub fn generate_trace_rows<
     assert!(suffix.is_empty(), "Alignment should match");
     assert_eq!(perms.len(), n);
 
-    perms.par_iter_mut().zip(inputs).for_each(|(perm, input)| {
-        generate_trace_rows_for_perm::<
-            F,
-            LinearLayers,
-            WIDTH,
-            SBOX_DEGREE,
-            SBOX_REGISTERS,
-            HALF_FULL_ROUNDS,
-            PARTIAL_ROUNDS,
-        >(perm, input, constants);
-    });
+    generate_perms::<
+        F,
+        LinearLayers,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >(perms, inputs, constants);
 
     unsafe {
         vec.set_len(n * ncols);
     }
 
     RowMajorMatrix::new(vec, ncols)
+}
+
+/// Fill every permutation's trace columns from its input.
+///
+/// Runs `F::Packing::WIDTH` permutations at a time through the packed round functions when
+/// the input count divides evenly into that width, falling back to one permutation at a time
+/// (via [`generate_trace_rows_for_perm`]) otherwise.
+fn generate_perms<
+    F: PrimeField,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+>(
+    perms: &mut [Poseidon2Cols<
+        MaybeUninit<F>,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >],
+    inputs: Vec<[F; WIDTH]>,
+    constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
+) {
+    let packing_width = F::Packing::WIDTH;
+    if packing_width > 1 && inputs.len().is_multiple_of(packing_width) {
+        perms
+            .par_chunks_mut(packing_width)
+            .zip(inputs.par_chunks(packing_width))
+            .for_each(|(perm_chunk, input_chunk)| {
+                generate_trace_rows_for_perm_batch::<
+                    F,
+                    LinearLayers,
+                    WIDTH,
+                    SBOX_DEGREE,
+                    SBOX_REGISTERS,
+                    HALF_FULL_ROUNDS,
+                    PARTIAL_ROUNDS,
+                >(perm_chunk, input_chunk, constants);
+            });
+    } else {
+        perms.par_iter_mut().zip(inputs).for_each(|(perm, input)| {
+            generate_trace_rows_for_perm::<
+                F,
+                LinearLayers,
+                WIDTH,
+                SBOX_DEGREE,
+                SBOX_REGISTERS,
+                HALF_FULL_ROUNDS,
+                PARTIAL_ROUNDS,
+            >(perm, input, constants);
+        });
+    }
 }
 
 /// `rows` will normally consist of 24 rows, with an exception for the final row.
@@ -191,6 +243,220 @@ pub fn generate_trace_rows_for_perm<
             &mut state, full_round, constants,
         );
     }
+}
+
+/// Generate `F::Packing::WIDTH` permutations at once, running the round functions over
+/// `F::Packing` so that every state element processes all lanes with one field operation
+/// instead of one permutation at a time.
+#[inline]
+fn generate_trace_rows_for_perm_batch<
+    F: PrimeField,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+>(
+    perms: &mut [Poseidon2Cols<
+        MaybeUninit<F>,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >],
+    inputs: &[[F; WIDTH]],
+    constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
+) {
+    let width = F::Packing::WIDTH;
+    debug_assert_eq!(perms.len(), width);
+    debug_assert_eq!(inputs.len(), width);
+
+    for (perm, input) in perms.iter_mut().zip(inputs) {
+        perm.inputs.iter_mut().zip(input).for_each(|(c, &x)| {
+            c.write(x);
+        });
+    }
+
+    let mut state: [F::Packing; WIDTH] = F::Packing::pack_columns(inputs);
+
+    LinearLayers::external_linear_layer(&mut state);
+
+    for (round, round_constants) in constants.beginning_full_round_constants.iter().enumerate() {
+        generate_full_round_packed::<
+            F,
+            LinearLayers,
+            WIDTH,
+            SBOX_DEGREE,
+            SBOX_REGISTERS,
+            HALF_FULL_ROUNDS,
+            PARTIAL_ROUNDS,
+        >(
+            &mut state,
+            perms,
+            |p| &mut p.beginning_full_rounds[round],
+            round_constants,
+        );
+    }
+
+    for (round, &round_constant) in constants.partial_round_constants.iter().enumerate() {
+        generate_partial_round_packed::<
+            F,
+            LinearLayers,
+            WIDTH,
+            SBOX_DEGREE,
+            SBOX_REGISTERS,
+            HALF_FULL_ROUNDS,
+            PARTIAL_ROUNDS,
+        >(&mut state, perms, round, round_constant);
+    }
+
+    for (round, round_constants) in constants.ending_full_round_constants.iter().enumerate() {
+        generate_full_round_packed::<
+            F,
+            LinearLayers,
+            WIDTH,
+            SBOX_DEGREE,
+            SBOX_REGISTERS,
+            HALF_FULL_ROUNDS,
+            PARTIAL_ROUNDS,
+        >(
+            &mut state,
+            perms,
+            |p| &mut p.ending_full_rounds[round],
+            round_constants,
+        );
+    }
+}
+
+#[inline]
+fn generate_full_round_packed<
+    F: PrimeField,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+>(
+    state: &mut [F::Packing; WIDTH],
+    perms: &mut [Poseidon2Cols<
+        MaybeUninit<F>,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >],
+    full_round: impl Fn(
+        &mut Poseidon2Cols<
+            MaybeUninit<F>,
+            WIDTH,
+            SBOX_DEGREE,
+            SBOX_REGISTERS,
+            HALF_FULL_ROUNDS,
+            PARTIAL_ROUNDS,
+        >,
+    ) -> &mut FullRound<MaybeUninit<F>, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
+    round_constants: &[F; WIDTH],
+) {
+    let mut sbox_registers = [[F::Packing::ZERO; SBOX_REGISTERS]; WIDTH];
+    for ((s, &rc), regs) in state
+        .iter_mut()
+        .zip(round_constants.iter())
+        .zip(sbox_registers.iter_mut())
+    {
+        *s += rc;
+        *regs = generate_sbox_packed::<F, SBOX_DEGREE, SBOX_REGISTERS>(s);
+    }
+
+    LinearLayers::external_linear_layer(state);
+
+    for (lane, perm) in perms.iter_mut().enumerate() {
+        let full_round = full_round(perm);
+        for i in 0..WIDTH {
+            for (r, reg) in sbox_registers[i].iter().enumerate() {
+                full_round.sbox[i].0[r].write(reg.as_slice()[lane]);
+            }
+            full_round.post[i].write(state[i].as_slice()[lane]);
+        }
+    }
+}
+
+#[inline]
+fn generate_partial_round_packed<
+    F: PrimeField,
+    LinearLayers: GenericPoseidon2LinearLayers<WIDTH>,
+    const WIDTH: usize,
+    const SBOX_DEGREE: u64,
+    const SBOX_REGISTERS: usize,
+    const HALF_FULL_ROUNDS: usize,
+    const PARTIAL_ROUNDS: usize,
+>(
+    state: &mut [F::Packing; WIDTH],
+    perms: &mut [Poseidon2Cols<
+        MaybeUninit<F>,
+        WIDTH,
+        SBOX_DEGREE,
+        SBOX_REGISTERS,
+        HALF_FULL_ROUNDS,
+        PARTIAL_ROUNDS,
+    >],
+    round: usize,
+    round_constant: F,
+) {
+    state[0] += round_constant;
+    let sbox_registers = generate_sbox_packed::<F, SBOX_DEGREE, SBOX_REGISTERS>(&mut state[0]);
+
+    for (lane, perm) in perms.iter_mut().enumerate() {
+        let partial_round = &mut perm.partial_rounds[round];
+        for (r, reg) in sbox_registers.iter().enumerate() {
+            partial_round.sbox.0[r].write(reg.as_slice()[lane]);
+        }
+        partial_round.post_sbox.write(state[0].as_slice()[lane]);
+    }
+
+    LinearLayers::internal_linear_layer(state);
+}
+
+/// Packed analog of [`generate_sbox`]: computes `x -> x^{DEGREE}` over `F::Packing::WIDTH`
+/// permutations at once, returning the packed intermediate registers instead of writing them
+/// directly (the caller unpacks them into each lane's own trace columns).
+#[inline]
+fn generate_sbox_packed<F: PrimeField, const DEGREE: u64, const REGISTERS: usize>(
+    x: &mut F::Packing,
+) -> [F::Packing; REGISTERS] {
+    let mut registers = [F::Packing::ZERO; REGISTERS];
+    *x = match (DEGREE, REGISTERS) {
+        (3, 0) => x.cube(),
+        (5, 0) => x.exp_const_u64::<5>(),
+        (7, 0) => x.exp_const_u64::<7>(),
+        (5, 1) => {
+            let x2 = x.square();
+            let x3 = x2 * *x;
+            registers[0] = x3;
+            x3 * x2
+        }
+        (7, 1) => {
+            let x3 = x.cube();
+            registers[0] = x3;
+            x3 * x3 * *x
+        }
+        (11, 2) => {
+            let x2 = x.square();
+            let x3 = x2 * *x;
+            let x9 = x3.cube();
+            registers[0] = x3;
+            registers[1] = x9;
+            x9 * x2
+        }
+        _ => panic!(
+            "Unexpected (DEGREE, REGISTERS) of ({}, {})",
+            DEGREE, REGISTERS
+        ),
+    };
+    registers
 }
 
 #[inline]


### PR DESCRIPTION
On my M4 pro, 

- `poseidon1-air` prove at 2^14 rows is ~8% faster
- `poseidon2-air` trace generation is ~2.3x faster