### PR TITLE
perf(multi): fuse ext-round fold into a single pass over columns

### DIFF
--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -100,12 +100,20 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
     fn fold(self, r: EF, want_packed: bool) -> Self {
         match self {
             Self::Packed(mut cols) => {
-                cols.par_iter_mut()
-                    .for_each(|col| col.fix_prefix_var_mut(r));
                 if want_packed {
+                    cols.par_iter_mut()
+                        .for_each(|col| col.fix_prefix_var_mut(r));
                     Self::Packed(cols)
                 } else {
-                    Self::Scalar(cols.par_iter().map(Poly::unpack::<F, EF>).collect())
+                    // Fold and unpack each column in a single pass.
+                    Self::Scalar(
+                        cols.into_par_iter()
+                            .map(|mut col| {
+                                col.fix_prefix_var_mut(r);
+                                col.unpack::<F, EF>()
+                            })
+                            .collect(),
+                    )
                 }
             }
             Self::Scalar(mut cols) => {
@@ -113,20 +121,6 @@ impl<F: Field, EF: ExtensionField<F>> ExtColumns<F, EF> {
                 cols.par_iter_mut()
                     .for_each(|col| col.fix_prefix_var_mut(r));
                 Self::Scalar(cols)
-            }
-        }
-    }
-
-    /// Reads the scalar value at flat residual index `idx` from every column.
-    fn scalar_row_at(&self, idx: usize) -> Vec<EF> {
-        match self {
-            Self::Scalar(cols) => cols.iter().map(|col| col.as_slice()[idx]).collect(),
-            Self::Packed(cols) => {
-                let packing_width = F::Packing::WIDTH;
-                let (group, lane) = (idx / packing_width, idx % packing_width);
-                cols.iter()
-                    .map(|col| col.as_slice()[group].extract(lane))
-                    .collect()
             }
         }
     }
@@ -884,13 +878,24 @@ where
         let num_evals = self.num_evals();
         let half = num_evals / 2;
 
-        self.next_tail = self
-            .columns
-            .scalar_row_at(half)
-            .into_iter()
-            .zip(self.next_tail.iter())
-            .map(|(lo, &next_tail)| lo + r * (next_tail - lo))
-            .collect();
+        // Fold each column's repeat-last tail in place with the value at row `half`.
+        // Read that row straight from the current storage, no per-column temporary.
+        match &self.columns {
+            ExtColumns::Scalar(cols) => {
+                for (next_tail, col) in self.next_tail.iter_mut().zip(cols) {
+                    let lo = col.as_slice()[half];
+                    *next_tail = lo + r * (*next_tail - lo);
+                }
+            }
+            ExtColumns::Packed(cols) => {
+                let packing_width = F::Packing::WIDTH;
+                let (group, lane) = (half / packing_width, half % packing_width);
+                for (next_tail, col) in self.next_tail.iter_mut().zip(cols) {
+                    let lo = col.as_slice()[group].extract(lane);
+                    *next_tail = lo + r * (*next_tail - lo);
+                }
+            }
+        }
 
         self.eq_suffix.sum_prefix_var_mut();
 


### PR DESCRIPTION
Follow-up to #1935, which packed the extension-round columns of the `multi-stark` AIR zerocheck sumcheck. This PR tidies two spots in the fold that #1935 left doing more work than they need to. No behaviour changes — it is a pure refactor, validated by the existing round-trip tests.

## What the fold does

Each sumcheck round binds one variable and halves the residual domain. `RoundStateExt::fold` does two things per round:

1. Folds every column at the challenge `r`, i.e. `col <- (1 - r) * col_lo + r * col_hi`.
2. Updates `next_tail`, the repeat-last successor value each column reports at its folded tail row.

While the residual domain is still wide enough to fill a SIMD lane, the columns live in packed form; once a fold would drop them below `F::Packing::WIDTH`, they unpack to scalar for the rest of the run.

## Change 1 — one pass instead of two on the packed → scalar transition

On the round where packed columns unpack, the old code walked the columns twice: once with `par_iter_mut` to fold in place, then again with `par_iter().map(Poly::unpack)` to convert to scalar.

The two steps are independent per column, so they fuse into a single `into_par_iter` pass that folds then unpacks each column in one visit. `into_par_iter` consumes the packed `Vec` (which was going to be dropped anyway), so the packed buffers free as they are consumed and nothing is borrowed twice.

The `want_packed` branch (staying packed) keeps `par_iter_mut`, since it folds in place with no unpack to fuse.

## Change 2 — fold `next_tail` in place, no temporary Vec

`next_tail` was rebuilt each round by collecting a temporary `Vec<EF>` from a `scalar_row_at(half)` helper, then zipping it back against the previous `next_tail` to interpolate at `r`.

The temporary is unnecessary: the update `next_tail <- lo + r * (next_tail - lo)` only needs row `half` of each column, read straight from the current storage. It now updates `next_tail` in place — matching on packed vs scalar storage to read row `half` correctly — and the `scalar_row_at` helper is removed.

## Testing

- `cargo test -p p3-multi-stark` — all pass.
- `RUSTFLAGS="-Ctarget-cpu=native" cargo test -p p3-multi-stark` — all pass, exercising the real AVX2 packed path (`WIDTH = 8`) rather than only the trivial `WIDTH = 1` fallback.
- `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)