### PR TITLE
Fix BCHKS25 theorem citation in FRI security calculation

### DIFF
--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -101,7 +101,7 @@ pub fn commit_phase_error_udr(regime: &FriRegime, shape: &InstanceShape) -> Opti
 }
 
 /// FRI commit-phase per-round error in LDR with explicit proximity
-/// parameter `m`. BCHKS25 Theorem 4.2 (`error_powers`):
+/// parameter `m`. BCHKS25 Theorem 1.5 (Equation (1)):
 ///
 /// ε_lin   = ((2·m'⁵ + 3·m'·γρ)·n / (3·ρ^{3/2}) + m'/√ρ) / |F|,
 /// ε_round = ε_lin · (folding − 1).


### PR DESCRIPTION
## What changed

Correct the BCHKS25 citation above `commit_phase_error_ldr_m` from Theorem 4.2 to Theorem 1.5, Equation (1).

## Why

The implementation uses the Theorem 1.5 normalization

```text
m = max(ceil(sqrt(rho) / (2 eta)), 3)
```

and Equation (1) contains the exceptional-set expression reproduced by the comment. Theorem 4.2 instead defines its curve parameter with `sqrt(rho) / eta`, so citing it here makes the implementation's `m` look off by a factor of two.

This is a comment-only correction; it does not change the security calculation. Thomas requested the PR so the intended citation can be double-checked upstream.

Source: [BCHKS25, Theorem 1.5 and Equation (1)](https://eprint.iacr.org/2025/2055).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p p3-security --lib` — 23 passed
