### PR TITLE
feat(whir): projective (monomial-basis) WHIR end to end

### DIFF
--- a/multilinear-util/src/point.rs
+++ b/multilinear-util/src/point.rs
@@ -123,6 +123,29 @@ where
             .product()
     }
 
+    /// Evaluates the equality-weight tensor as *monomial coefficients* at `q`.
+    ///
+    /// The projective counterpart of [`Self::eval_eq`]: the same per-variable
+    /// pairs `(1 - p_i, p_i)` are read as coefficient pairs, so the value at
+    /// `q` is the monomial evaluation
+    ///
+    /// ```text
+    /// prod_i ((1 - p_i) + p_i * q_i)
+    /// ```
+    pub fn eval_eq_projective<EF: ExtensionField<F>>(p: &[F], q: &[EF]) -> EF {
+        assert_eq!(
+            p.len(),
+            q.len(),
+            "Points must have the same number of variables"
+        );
+
+        // Per-variable factor: (1 - p) + p * q = p * (q - 1) + 1.
+        p.iter()
+            .zip(q)
+            .map(|(&l, &r)| (r - EF::ONE) * l + EF::ONE)
+            .product()
+    }
+
     /// Evaluates the selection polynomial of a point against a univariate domain element.
     ///
     /// The univariate element is expanded into the square-power vector
@@ -150,6 +173,33 @@ where
                 term
             })
             // Multiply all per-coordinate factors into the selection value.
+            .product()
+    }
+
+    /// Evaluates the selection-weight tensor as *monomial coefficients* at `point`.
+    ///
+    /// The projective counterpart of [`Self::eval_select`]: the selection
+    /// weight table is the tensor with per-variable pairs `(1, var^(2^i))` in
+    /// both bases, but read as coefficient pairs its value at `point` is the
+    /// monomial evaluation
+    ///
+    /// ```text
+    /// prod_i (1 + var^(2^i) * point_i)
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn eval_select_projective<EF: ExtensionField<F>>(mut var: F, point: &[EF]) -> EF {
+        // Same descending-power walk as `eval_select`; only the per-variable
+        // factor changes from interpolation to the monomial rule.
+        point
+            .iter()
+            .rev()
+            .map(|&r| {
+                // Per-coordinate factor: 1 + var * r.
+                let term = r * var + EF::ONE;
+                var = var.square();
+                term
+            })
             .product()
     }
 

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -282,6 +282,41 @@ impl<Packed, S> Poly<Packed, S>
 where
     S: Borrow<[Packed]>,
 {
+    /// Evaluates the packed table as *monomial coefficients* at `point`.
+    ///
+    /// Packed counterpart of [`Poly::eval_monomial`]: the stored (prefix)
+    /// variables fold in packed form, then the SIMD lanes (the last
+    /// `log2(W)` variables) finish in scalar form.
+    ///
+    /// Kept for representation parity with [`Poly::eval_packed`]; the
+    /// production protocol reads final openings in scalar form, so this is
+    /// exercised by the packed equivalence tests rather than the prover.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the point arity does not match the logical variable count.
+    pub fn eval_monomial_packed<F, EF>(&self, point: &Point<EF>) -> EF
+    where
+        F: Field,
+        EF: ExtensionField<F, ExtensionPacking = Packed>,
+        Packed: PackedFieldExtension<F, EF> + Copy,
+    {
+        let lane_vars = log2_strict_usize(F::Packing::WIDTH);
+        assert_eq!(
+            self.num_variables() + lane_vars,
+            point.num_variables(),
+            "point arity must match the logical variable count"
+        );
+        let (stored, lanes) = point.as_slice().split_at(self.num_variables());
+
+        // Fold the stored prefix variables down to one packed element.
+        let seed = eval_monomial_rec(self.as_slice(), stored);
+
+        // Unpack the lanes (the last `lane_vars` variables) and finish scalar.
+        let scalars: Vec<EF> = Packed::to_ext_iter([seed]).collect();
+        eval_monomial_rec(&scalars, lanes)
+    }
+
     /// Converts a SIMD-packed polynomial back to scalar extension-field form.
     ///
     /// Expands each packed element into W scalar evaluations,
@@ -490,6 +525,31 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
 
         // Discard the second half; the first half now holds the summed result.
         self.0.truncate(mid);
+    }
+
+    /// Evaluates the table as *monomial coefficients* at `point`.
+    ///
+    /// The table is interpreted in the projective basis of eprint 2026/762:
+    /// entry `a_S` is the coefficient of the monomial `prod_{i in S} X_i`, and
+    ///
+    /// ```text
+    ///     g(z) = sum_S a_S * prod_{i in S} z_i.
+    /// ```
+    ///
+    /// The prefix variable is the most significant one, matching
+    /// [`Self::fix_prefix_var_mut_monomial`]: binding `z_0`, then `z_1`, and
+    /// so on down to a constant produces the same value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the point arity does not match the polynomial.
+    pub fn eval_monomial<Ch>(&self, point: &Point<Ch>) -> A
+    where
+        A: Algebra<Ch>,
+        Ch: Field,
+    {
+        assert_eq!(self.num_variables(), point.num_variables());
+        eval_monomial_rec(self.as_slice(), point.as_slice())
     }
 
     /// Fixes the prefix variable at a challenge value in the *monomial* basis,
@@ -951,6 +1011,36 @@ where
             // Perform the final linear interpolation for the first variable `x`.
             f0_eval + (f1_eval - f0_eval) * *x
         }
+    }
+}
+
+/// Evaluates a table of *monomial coefficients* at a point, recursively.
+///
+/// Writing the polynomial as `g(X_0, x') = lo(x') + X_0 * hi(x')` (the prefix
+/// variable is the most significant one, splitting the table into halves):
+///
+/// ```text
+///     g(z_0, z') = lo(z') + z_0 * hi(z')
+/// ```
+///
+/// Subtraction-free, mirroring `fix_prefix_var_mut_monomial`. Serial: the
+/// callers evaluate once per protocol round, so the O(2^n) pass is not worth
+/// fan-out overhead.
+fn eval_monomial_rec<A, Ch>(coeffs: &[A], zs: &[Ch]) -> A
+where
+    A: Algebra<Ch> + Copy,
+    Ch: Copy,
+{
+    match (coeffs, zs) {
+        ([c], []) => *c,
+        (_, [z, sub_point @ ..]) => {
+            // Low half: monomials without X_0; high half: monomials with X_0.
+            let (lo, hi) = coeffs.split_at(coeffs.len() / 2);
+            let lo = eval_monomial_rec(lo, sub_point);
+            let hi = eval_monomial_rec(hi, sub_point);
+            lo + hi * *z
+        }
+        _ => unreachable!("coefficient count must be 2^|zs|"),
     }
 }
 
@@ -2058,6 +2148,49 @@ pub(crate) mod test {
                 compressed.fix_prefix_var_mut_monomial(zi);
             }
             prop_assert_eq!(compressed.as_constant().unwrap(), expected);
+
+            // The monomial evaluation is the same sum computed without binding.
+            prop_assert_eq!(poly.eval_monomial(&point), expected);
+        }
+
+        /// Packed monomial evaluation agrees with the scalar one on the same
+        /// logical table, across the packed/scalar variable boundary.
+        #[test]
+        fn prop_eval_monomial_packed_matches_scalar(
+            extra in 0usize..=6,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let k_pack = log2_strict_usize(PackedF::WIDTH);
+            let k = k_pack + extra;
+
+            let poly = Poly::<EF>::rand(&mut rng, k);
+            let point: Point<EF> = Point::rand(&mut rng, k);
+
+            let packed_poly = poly.pack::<F, EF>();
+            prop_assert_eq!(
+                packed_poly.eval_monomial_packed(&point),
+                poly.eval_monomial(&point)
+            );
+        }
+
+        /// Binding all variables projectively, one challenge at a time, gives
+        /// the same value as one monomial evaluation at the challenge point.
+        #[test]
+        fn prop_projective_binding_equals_eval_monomial(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let poly = Poly::<EF>::rand(&mut rng, k);
+            let point: Point<EF> = Point::rand(&mut rng, k);
+
+            let mut bound = Poly::new(poly.as_slice().to_vec());
+            for &zi in point.as_slice() {
+                bound.fix_prefix_var_mut_monomial(zi);
+            }
+
+            prop_assert_eq!(bound.as_constant().unwrap(), poly.eval_monomial(&point));
         }
     }
 

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -492,6 +492,51 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
         self.0.truncate(mid);
     }
 
+    /// Fixes the prefix variable at a challenge value in the *monomial* basis,
+    /// in place.
+    ///
+    /// The table is interpreted as monomial coefficients (the projective
+    /// `{0, inf}` representation of eprint 2026/762). Writing the polynomial as
+    /// `p(X_0, x') = a0(x') + X_0 * a1(x')`, with `a0` the low half (monomials
+    /// without `X_0`) and `a1` the high half (monomials with `X_0`), binding
+    /// `X_0 = r` gives, by Corollary 3.2:
+    ///
+    /// ```text
+    /// out = p(0, x') + r * p(inf, x') = a0 + r * a1
+    /// ```
+    ///
+    /// Unlike [`Self::fix_prefix_var_mut`], this costs no subtraction per pair.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant (zero free variables).
+    pub fn fix_prefix_var_mut_projective<F: Copy + Send + Sync>(&mut self, r: F)
+    where
+        A: Algebra<F>,
+    {
+        assert!(self.as_constant().is_none(), "no free variables");
+        let num_evals = self.num_evals();
+        let mid = num_evals / 2;
+        // Low half: monomials without x_0 (the constant part a0).
+        // High half: monomials with x_0 (the leading-coefficient part a1).
+        let (p0, p1) = self.0.split_at_mut(mid);
+
+        if num_evals >= PARALLEL_THRESHOLD {
+            // Parallel: fold each pair in place.
+            p0.par_iter_mut()
+                .zip(p1.par_iter())
+                .for_each(|(a0, &a1)| *a0 += a1 * r);
+        } else {
+            // Sequential: fold each pair in place.
+            p0.iter_mut()
+                .zip(p1.iter())
+                .for_each(|(a0, &a1)| *a0 += a1 * r);
+        }
+
+        // Discard the second half; the first half now holds the folded result.
+        self.0.truncate(mid);
+    }
+
     /// In-place version of the suffix-variable fix.
     ///
     /// Folds adjacent pairs and truncates to the first half. The sequential
@@ -1973,6 +2018,46 @@ pub(crate) mod test {
             for s in 0..folded.num_evals() {
                 assert_eq!(poly.fix_prefix_var_at(z, s), folded.as_slice()[s]);
             }
+        }
+    }
+
+    proptest! {
+        /// Projective binding fixes a variable in the *monomial* basis: the table
+        /// holds monomial coefficients (Proposition 3.1, eprint 2026/762), and
+        /// binding x_0 = r maps each pair (a0, a1) to a0 + r * a1, with no
+        /// subtraction. Applied across every variable it evaluates the monomial
+        /// polynomial sum_S a_S * prod_{i in S} z_i at the point z.
+        #[test]
+        fn prop_fix_prefix_var_mut_projective_evaluates_monomial_basis(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            // Interpret the random table as monomial coefficients.
+            let poly = Poly::<F>::rand(&mut rng, k);
+            let point: Point<F> = Point::rand(&mut rng, k);
+            let z = point.as_slice();
+
+            // Reference: evaluate the monomial polynomial directly. Prefix binding
+            // fixes the most-significant variable first, so bit position p of the
+            // index corresponds to challenge z[k - 1 - p].
+            let mut expected = F::ZERO;
+            for (s, &coeff) in poly.as_slice().iter().enumerate() {
+                let mut term = coeff;
+                for p in 0..k {
+                    if (s >> p) & 1 == 1 {
+                        term *= z[k - 1 - p];
+                    }
+                }
+                expected += term;
+            }
+
+            // Projective binding across all variables must agree.
+            let mut compressed = Poly::new(poly.as_slice().to_vec());
+            for &zi in z {
+                compressed.fix_prefix_var_mut_projective(zi);
+            }
+            prop_assert_eq!(compressed.as_constant().unwrap(), expected);
         }
     }
 

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -824,6 +824,20 @@ where
         }
     }
 
+    /// Evaluates the base-field table as *monomial coefficients* at an
+    /// extension-field point.
+    ///
+    /// Widening counterpart of [`Poly::eval_monomial`]; see there for the
+    /// convention (prefix variable most significant).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the point arity does not match the polynomial.
+    pub fn eval_monomial_base<EF: ExtensionField<F>>(&self, point: &Point<EF>) -> EF {
+        assert_eq!(self.num_variables(), point.num_variables());
+        eval_monomial_rec_wide(self.as_slice(), point.as_slice())
+    }
+
     /// Evaluates this polynomial against the repeat-last successor weights at a point.
     ///
     /// Each hypercube row is read at its successor, with the maximal row repeating itself:
@@ -1011,6 +1025,25 @@ where
             // Perform the final linear interpolation for the first variable `x`.
             f0_eval + (f1_eval - f0_eval) * *x
         }
+    }
+}
+
+/// Widening variant of [`eval_monomial_rec`]: base-field coefficients
+/// evaluated at an extension-field point, returning an extension value.
+fn eval_monomial_rec_wide<A, Ch>(coeffs: &[A], zs: &[Ch]) -> Ch
+where
+    A: Copy,
+    Ch: Algebra<A> + Copy,
+{
+    match (coeffs, zs) {
+        ([c], []) => Ch::ZERO + *c,
+        (_, [z, sub_point @ ..]) => {
+            let (lo, hi) = coeffs.split_at(coeffs.len() / 2);
+            let lo = eval_monomial_rec_wide(lo, sub_point);
+            let hi = eval_monomial_rec_wide(hi, sub_point);
+            lo + hi * *z
+        }
+        _ => unreachable!("coefficient count must be 2^|zs|"),
     }
 }
 

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -496,7 +496,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
     /// in place.
     ///
     /// The table is interpreted as monomial coefficients (the projective
-    /// `{0, inf}` representation of eprint 2026/762). Writing the polynomial as
+    /// `{0, inf}` representation of <https://eprint.iacr.org/2026/762> ). Writing the polynomial as
     /// `p(X_0, x') = a0(x') + X_0 * a1(x')`, with `a0` the low half (monomials
     /// without `X_0`) and `a1` the high half (monomials with `X_0`), binding
     /// `X_0 = r` gives, by Corollary 3.2:
@@ -510,7 +510,7 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> Poly<A> {
     /// # Panics
     ///
     /// Panics if the polynomial is constant (zero free variables).
-    pub fn fix_prefix_var_mut_projective<F: Copy + Send + Sync>(&mut self, r: F)
+    pub fn fix_prefix_var_mut_monomial<F: Copy + Send + Sync>(&mut self, r: F)
     where
         A: Algebra<F>,
     {
@@ -2028,7 +2028,7 @@ pub(crate) mod test {
         /// subtraction. Applied across every variable it evaluates the monomial
         /// polynomial sum_S a_S * prod_{i in S} z_i at the point z.
         #[test]
-        fn prop_fix_prefix_var_mut_projective_evaluates_monomial_basis(
+        fn prop_fix_prefix_var_mut_monomial_evaluates_monomial_basis(
             k in 1usize..=12,
             seed in any::<u64>(),
         ) {
@@ -2055,7 +2055,7 @@ pub(crate) mod test {
             // Projective binding across all variables must agree.
             let mut compressed = Poly::new(poly.as_slice().to_vec());
             for &zi in z {
-                compressed.fix_prefix_var_mut_projective(zi);
+                compressed.fix_prefix_var_mut_monomial(zi);
             }
             prop_assert_eq!(compressed.as_constant().unwrap(), expected);
         }

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,8 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix, sumcheck_coefficients_suffix,
+    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
 use rand::distr::{Distribution, StandardUniform};
@@ -251,6 +252,19 @@ where
             );
         }
 
+        group.bench_with_input(
+            BenchmarkId::new("base_ext_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        &base_packed,
+                        round_zero_weights.as_slice(),
+                    ))
+                });
+            },
+        );
+
         // Later-round operands: both sides are packed extension elements.
         let packed_evals = rand_ext_packed::<B>(&mut rng, k);
         let packed_weights = rand_ext_packed::<B>(&mut rng, k);
@@ -269,6 +283,19 @@ where
                 },
             );
         }
+
+        group.bench_with_input(
+            BenchmarkId::new("ext_ext_packed_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        packed_evals.as_slice(),
+                        packed_weights.as_slice(),
+                    ))
+                });
+            },
+        );
     }
 
     for &k in SCALAR_SIZES {
@@ -288,6 +315,19 @@ where
                 },
             );
         }
+
+        group.bench_with_input(
+            BenchmarkId::new("ext_ext_scalar_prefix_projective", &label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    black_box(sumcheck_coefficients_prefix_projective(
+                        evals.as_slice(),
+                        weights.as_slice(),
+                    ))
+                });
+            },
+        );
     }
 
     group.finish();

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,7 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    Basis, RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
     sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
@@ -645,7 +645,7 @@ where
     let mut data = SumcheckData::<B::F, B::EF>::default();
 
     // Consume the prover, yielding the residual prover and the sampled challenges.
-    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger);
+    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger, Basis::Evaluation);
     black_box((data, residual, randomness));
 }
 

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,7 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    Basis, RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
     sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
@@ -666,7 +666,7 @@ where
     let mut data = SumcheckData::<B::F, B::EF>::default();
 
     // Consume the prover, yielding the residual prover and the sampled challenges.
-    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger);
+    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger, Basis::Evaluation);
     black_box((data, residual, randomness));
 }
 

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -366,6 +366,23 @@ where
                 );
             });
         }
+
+        // Projective (monomial-basis) binding: the subtraction-free
+        // a0 + a1 * r of eprint 2026/762, prefix only.
+        group.bench_with_input(
+            BenchmarkId::new("prefix_projective", &label),
+            &(),
+            |b, ()| {
+                b.iter_batched_ref(
+                    || template.clone(),
+                    |poly| {
+                        poly.fix_prefix_var_mut_monomial(black_box(r));
+                        black_box(&*poly);
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
     }
 
     group.finish();

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -32,7 +32,7 @@ use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
-    SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
+    RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
     sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
 use p3_sumcheck::{OpeningBatch, SumcheckData};
@@ -205,7 +205,7 @@ where
 ///
 /// The constant term and the leading coefficient of the round polynomial.
 #[inline]
-fn coeffs<Base, Acc>(order: VariableOrder, evals: &[Base], weights: &[Acc]) -> (Acc, Acc)
+fn coeffs<Base, Acc>(order: VariableOrder, evals: &[Base], weights: &[Acc]) -> RoundMessage<Acc>
 where
     Base: PrimeCharacteristicRing + Copy + Send + Sync,
     Acc: Algebra<Base> + Copy + Send + Sync,

--- a/sumcheck/src/constraints/statement/eq.rs
+++ b/sumcheck/src/constraints/statement/eq.rs
@@ -222,6 +222,17 @@ impl<F: Field> EqStatement<F> {
             .map(|point| Point::eval_eq(point.as_slice(), row.as_slice()))
     }
 
+    /// Projective counterpart of [`Self::weights_at`]: the same stored weight
+    /// tensors read as monomial coefficients (see [`Point::eval_eq_projective`]).
+    pub fn weights_at_projective<'a, EF: ExtensionField<F>>(
+        &'a self,
+        row: &'a Point<EF>,
+    ) -> impl Iterator<Item = EF> + 'a {
+        self.points
+            .iter()
+            .map(|point| Point::eval_eq_projective(point.as_slice(), row.as_slice()))
+    }
+
     /// Verifies that a given polynomial satisfies all constraints in the statement.
     #[must_use]
     pub fn verify(&self, poly: &Poly<F>) -> bool {

--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -283,6 +283,18 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
             .map(|&var| Point::eval_select(var, row.as_slice()))
     }
 
+    /// Projective counterpart of [`Self::weights_at`]: the same stored weight
+    /// tensors read as monomial coefficients (see
+    /// [`Point::eval_select_projective`]).
+    pub fn weights_at_projective<'a>(
+        &'a self,
+        row: &'a Point<EF>,
+    ) -> impl Iterator<Item = EF> + 'a {
+        self.vars
+            .iter()
+            .map(|&var| Point::eval_select_projective(var, row.as_slice()))
+    }
+
     /// Verifies that a given polynomial satisfies all constraints in the statement.
     ///
     /// For each constraint `(z_i, s_i)`, this method interprets the evaluation table as

--- a/sumcheck/src/data.rs
+++ b/sumcheck/src/data.rs
@@ -5,12 +5,15 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_multilinear_util::point::Point;
 use serde::{Deserialize, Serialize};
 
-use crate::{SumcheckError, extrapolate_01inf};
+use crate::SumcheckError;
+use crate::strategy::Basis;
 
 /// Sumcheck polynomial data
 ///
 /// Stores the polynomial evaluations for sumcheck rounds in a compact format.
-/// Each round stores `[h(0), h(inf)]` where `h(1)` is derived as `claimed_sum - h(0)`.
+/// Each round stores two evaluations: `[h(0), h(inf)]` in the evaluation
+/// basis (`h(1)` derived as `claimed_sum - h(0)`), or `[s(1), s(inf)]` in the
+/// projective basis (`s(0)` derived as `claimed_sum - s(inf)`).
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
 pub struct SumcheckData<F, EF> {
     /// Polynomial evaluations for each sumcheck round.
@@ -113,6 +116,7 @@ impl<F, EF> SumcheckData<F, EF> {
         claimed_sum: &mut EF,
         expected_rounds: usize,
         pow_bits: usize,
+        basis: Basis,
     ) -> Result<Point<EF>, SumcheckError>
     where
         F: TwoAdicField,
@@ -142,18 +146,21 @@ impl<F, EF> SumcheckData<F, EF> {
             });
         }
 
-        for (i, &[c0, c_inf]) in self.polynomial_evaluations.iter().enumerate() {
-            // Observe only the sent polynomial evaluations (h(0) and h(inf)).
-            challenger.observe_algebra_slice(&[c0, c_inf]);
+        for (i, &[c_a, c_inf]) in self.polynomial_evaluations.iter().enumerate() {
+            // Observe only the sent polynomial evaluations; their meaning is
+            // basis-dependent ([h(0), h(inf)] or [s(1), s(inf)]).
+            challenger.observe_algebra_slice(&[c_a, c_inf]);
 
             // Verify PoW (only if pow_bits > 0)
             if pow_bits > 0 && !challenger.check_witness(pow_bits, self.pow_witnesses[i]) {
                 return Err(SumcheckError::InvalidPowWitness);
             }
 
-            // Sample challenge and reconstruct h(r) from (h(0), h(1), h(inf)).
+            // Sample the challenge and reconstruct h(r); the basis-dependent
+            // round identity supplies the third quadratic value (shared with
+            // the prover via Basis::reduce_claim).
             let r: EF = challenger.sample_algebra_element();
-            *claimed_sum = extrapolate_01inf(c0, *claimed_sum - c0, c_inf, r);
+            *claimed_sum = basis.reduce_claim(c_a, c_inf, r, *claimed_sum);
             randomness.push(r);
         }
 
@@ -174,6 +181,7 @@ pub fn verify_final_sumcheck_rounds<F, EF, Challenger>(
     claimed_sum: &mut EF,
     rounds: usize,
     pow_bits: usize,
+    basis: Basis,
 ) -> Result<Point<EF>, SumcheckError>
 where
     F: TwoAdicField,
@@ -189,5 +197,5 @@ where
     })?;
 
     // `verify_rounds` binds the round count to `rounds`.
-    sumcheck.verify_rounds(challenger, claimed_sum, rounds, pow_bits)
+    sumcheck.verify_rounds(challenger, claimed_sum, rounds, pow_bits, basis)
 }

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -207,7 +207,7 @@ pub(super) mod test_utils {
 
     use crate::SumcheckData;
     use crate::layout::{Layout, LayoutStrategy, Table, TableShape, Verifier, Witness};
-    use crate::strategy::VariableOrder;
+    use crate::strategy::{Basis, VariableOrder};
     use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
     use crate::tests::*;
 
@@ -324,7 +324,13 @@ pub(super) mod test_utils {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -339,7 +345,13 @@ pub(super) mod test_utils {
         constraints.push(intermediate_constraint);
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -349,6 +361,7 @@ pub(super) mod test_utils {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );
@@ -637,6 +650,7 @@ mod tests {
         FOLDING, build_tables, run_roundtrip_test, table_shapes, tables_from_shape,
     };
     use crate::layout::{Layout, Verifier};
+    use crate::strategy::Basis;
     use crate::table::OpeningBatch;
     use crate::tests::*;
 
@@ -840,7 +854,13 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -857,7 +877,13 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -867,6 +893,7 @@ mod tests {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );
@@ -956,7 +983,13 @@ mod tests {
         let mut verifier_challenge = Point::new(vec![]);
         verifier_challenge.extend(
             &proof0
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
 
@@ -973,7 +1006,13 @@ mod tests {
         // The grinding stage carries proof-of-work bits; the final stage none.
         verifier_challenge.extend(
             &proof1
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, POW_BITS)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    POW_BITS,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         verifier_challenge.extend(
@@ -983,6 +1022,7 @@ mod tests {
                     &mut sum,
                     stacked_num_variables - 2 * FOLDING,
                     0,
+                    Basis::Evaluation,
                 )
                 .unwrap(),
         );

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -24,7 +24,7 @@ pub use suffix::SuffixProver;
 use crate::SumcheckData;
 use crate::commit::commit_base;
 use crate::layout::{LayoutStrategy, Table, Witness};
-use crate::strategy::{SumcheckProver, VariableOrder};
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::table::{OpeningEvals, OpeningRequest};
 
 /// Stacked-sumcheck prover layout
@@ -182,6 +182,7 @@ pub trait Layout<F: TwoAdicField, EF: ExtensionField<F>>: Sized {
         sumcheck_data: &mut SumcheckData<F, EF>,
         pow_bits: usize,
         challenger: &mut Ch,
+        basis: Basis,
     ) -> (SumcheckProver<F, EF>, Point<EF>)
     where
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>;
@@ -370,9 +371,11 @@ pub(super) mod test_utils {
         //     - Prover and verifier agreed on the same randomness.
         //     - Batched sum equals the final folded value times the batched weights.
         assert_eq!(expected_randomness, &verifier_challenge);
-        let weights = strategy
-            .variable_order
-            .eval_constraints_poly(&constraints, &verifier_challenge);
+        let weights = strategy.variable_order.eval_constraints_poly(
+            &constraints,
+            &verifier_challenge,
+            Basis::Evaluation,
+        );
         assert_eq!(sum, final_folded_value * weights);
     }
 
@@ -478,7 +481,7 @@ pub(super) mod test_utils {
         // Preprocessing: consume FOLDING rounds, hand off the residual prover.
         let mut proof0 = SumcheckData::<F, EF>::default();
         let (mut prover, mut prover_randomness) =
-            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger);
+            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger, Basis::Evaluation);
         assert_eq!(proof0.num_rounds(), FOLDING);
         assert_eq!(prover.num_variables(), stacked_num_variables - FOLDING);
 
@@ -814,7 +817,7 @@ mod tests {
         // First sumcheck stage folds the SVO rounds and writes their proof.
         let mut proof0 = SumcheckData::<F, EF>::default();
         let (mut prover, mut prover_randomness) =
-            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger);
+            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger, Basis::Evaluation);
         // The first stage consumes exactly the folding-depth rounds.
         assert_eq!(proof0.num_rounds(), FOLDING);
         assert_eq!(prover.num_variables(), stacked_num_variables - FOLDING);
@@ -901,9 +904,11 @@ mod tests {
         // Both sides must have folded the identical challenge vector.
         assert_eq!(prover_randomness, verifier_challenge);
         // Final identity: running sum equals folded value times the constraint weights.
-        let weights = strategy
-            .variable_order
-            .eval_constraints_poly(&constraints, &verifier_challenge);
+        let weights = strategy.variable_order.eval_constraints_poly(
+            &constraints,
+            &verifier_challenge,
+            Basis::Evaluation,
+        );
         assert_eq!(sum, final_folded_value * weights);
     }
 
@@ -944,7 +949,7 @@ mod tests {
         // First sumcheck stage folds the SVO rounds and writes their proof.
         let mut proof0 = SumcheckData::<F, EF>::default();
         let (mut prover, mut prover_randomness) =
-            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger);
+            prover_state.into_sumcheck(&mut proof0, 0, &mut prover_challenger, Basis::Evaluation);
         assert_eq!(proof0.num_rounds(), FOLDING);
         assert_eq!(prover.num_variables(), stacked_num_variables - FOLDING);
 
@@ -1030,9 +1035,11 @@ mod tests {
         // Both sides must have folded the identical challenge vector.
         assert_eq!(prover_randomness, verifier_challenge);
         // Final identity: running sum equals folded value times the constraint weights.
-        let weights = strategy
-            .variable_order
-            .eval_constraints_poly(&constraints, &verifier_challenge);
+        let weights = strategy.variable_order.eval_constraints_poly(
+            &constraints,
+            &verifier_challenge,
+            Basis::Evaluation,
+        );
         assert_eq!(sum, final_folded_value * weights);
     }
 

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -4,20 +4,23 @@ use alloc::vec::Vec;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{
-    ExtensionField, Field, PackedFieldExtension, PackedValue, TwoAdicField, dot_product,
+    ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
+    TwoAdicField, dot_product,
 };
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_multilinear_util::split_eq::SplitEq;
 use p3_util::log2_strict_usize;
 
+use crate::constraints::statement::EqStatement;
+use crate::constraints::{Constraint, Statements};
 use crate::lagrange::lagrange_weights_01inf_multi;
 use crate::layout::opening::Opening;
 use crate::layout::prover::{Layout, StackedClaims};
 use crate::layout::witness::Table;
 use crate::layout::{LayoutStrategy, ProverMultiClaim, Witness};
 use crate::product_polynomial::ProductPolynomial;
-use crate::strategy::{SumcheckProver, VariableOrder};
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::svo::{SvoPoint, calculate_accumulators_batch};
 use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
 use crate::{Claim, SumcheckData, extrapolate_01inf};
@@ -37,6 +40,26 @@ pub struct PrefixProver<F: Field, EF: ExtensionField<F>> {
     /// - Prefix binding folds this polynomial directly.
     /// - It is kept here, beside the shared claim state.
     pub(crate) poly: Poly<F>,
+    /// Plain lifted claim points and evals, in record order.
+    ///
+    /// The SVO machinery factorises claim points immediately, so the raw
+    /// stacked-coordinate points are stashed here at record time for the
+    /// projective initial rounds, which absorb them as one flat constraint.
+    ///
+    /// Recorded unconditionally: the layout does not know the basis until
+    /// `into_sumcheck`, and the cost is one point clone per opening, which
+    /// is negligible against the evaluation work at record time.
+    pub(crate) projective_eq_claims: Vec<(Point<EF>, EF)>,
+    /// Plain virtual (out-of-domain) claim points and evals, in record order.
+    ///
+    /// Kept separate from the concrete claims: the alpha-power assignment
+    /// places every concrete opening before every virtual claim.
+    pub(crate) projective_virtual_claims: Vec<(Point<EF>, EF)>,
+    /// Whether any repeat-last successor (next) opening was recorded.
+    ///
+    /// Next claims have no projective weight semantics; the projective
+    /// initial rounds reject them.
+    pub(crate) has_next_claims: bool,
 }
 
 impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, EF> {
@@ -51,6 +74,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
                 parts.folding,
             ),
             poly: parts.poly,
+            projective_eq_claims: Vec::new(),
+            projective_virtual_claims: Vec::new(),
+            has_next_claims: false,
         }
     }
 
@@ -108,7 +134,19 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         // The opening point lives in the table's local frame, one coordinate per variable.
         debug_assert_eq!(point.num_variables(), table.num_variables());
 
+        // Stash the plain lifted points before factorisation: the projective
+        // initial rounds rebuild the batched claim constraint from them.
+        // The prefix layout uses reversed selectors, so claims lift as suffix.
+        let placement = self
+            .claims
+            .placements
+            .iter()
+            .find(|p| p.idx() == table_idx)
+            .expect("every table has a placement");
+        self.has_next_claims |= !next.is_empty();
+
         // Factorise the point once; every selected column reuses it.
+        let raw_point = point.clone();
         let point = SvoPoint::new_packed(self.claims.folding, point);
 
         // Current group: evaluate each column at the point.
@@ -132,6 +170,13 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
                 (Opening::new_with_data(poly_idx, eval, partial_evals), eval)
             })
             .unzip();
+
+        // Record the plain lifted claim points with their evals, in the same
+        // flat order the verifier walks (and the alpha powers follow).
+        for (&poly_idx, &eval) in current.iter().zip(&current_evals) {
+            let lifted = placement.selectors()[poly_idx].lift_suffix(&raw_point);
+            self.projective_eq_claims.push((lifted, eval));
+        }
 
         // Bind the evaluations into the transcript, current group first then next.
         // The verifier absorbs the same bytes in the same order.
@@ -205,6 +250,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
 
         // Commit the evaluation to the transcript.
         challenger.observe_algebra_element(eval);
+        // Stash the plain point for the projective initial rounds.
+        self.projective_virtual_claims.push((point.clone(), eval));
+
         self.claims.virtual_claims.push(Claim {
             point,
             eval,
@@ -243,12 +291,17 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         sumcheck_data: &mut SumcheckData<F, EF>,
         pow_bits: usize,
         challenger: &mut Ch,
+        basis: Basis,
     ) -> (SumcheckProver<F, EF>, Point<EF>)
     where
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Sanity: preprocessing cannot consume more rounds than the stacked arity.
         assert!(self.claims.folding <= self.claims.num_variables);
+
+        if basis == Basis::Projective {
+            return self.into_sumcheck_projective(sumcheck_data, pow_bits, challenger);
+        }
 
         let alpha: EF = challenger.sample_algebra_element();
         let n_claims = self.num_claims();
@@ -329,6 +382,92 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
 }
 
 impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
+    /// Projective initial folding rounds: the generic (non-SVO) path.
+    ///
+    /// Widens the stacked base table to the extension field, absorbs the
+    /// alpha-batched claim constraint into zero weights, and drives the
+    /// initial folds through the generic projective rounds of
+    /// [`ProductPolynomial`]. The flat statement order (concrete claims, then
+    /// virtual claims) mirrors the alpha-power assignment of the SVO path and
+    /// the verifier's constraint walk.
+    ///
+    /// Slower than the SVO fast path: the widening is an O(2^n) pass and the
+    /// full-size weight table is materialised. A projective SVO variant is
+    /// possible (the projective grid values are linear combinations of the
+    /// existing accumulator slots) but needs the accumulators' X = 1 slot
+    /// materialised; it is left as a follow-up, and benchmarks report the
+    /// initial-round phase separately so the asymmetry stays visible.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any repeat-last successor (next) opening was recorded; next
+    /// claims have no projective weight semantics.
+    fn into_sumcheck_projective<Ch>(
+        self,
+        sumcheck_data: &mut SumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+    ) -> (SumcheckProver<F, EF>, Point<EF>)
+    where
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        assert!(
+            !self.has_next_claims,
+            "next claims are not supported projectively"
+        );
+        let num_variables = self.claims.num_variables;
+        let alpha: EF = challenger.sample_algebra_element();
+
+        // One flat equality statement per group, in alpha-power order.
+        let mut statements = Vec::new();
+        let mut concrete = EqStatement::initialize(num_variables);
+        for (point, eval) in &self.projective_eq_claims {
+            concrete.add_evaluated_constraint(point.clone(), *eval);
+        }
+        if !concrete.is_empty() {
+            statements.push(Statements::Eq(concrete));
+        }
+        let mut virtuals = EqStatement::initialize(num_variables);
+        for (point, eval) in &self.projective_virtual_claims {
+            virtuals.add_evaluated_constraint(point.clone(), *eval);
+        }
+        if !virtuals.is_empty() {
+            statements.push(Statements::Eq(virtuals));
+        }
+        let constraint = Constraint::new(alpha, num_variables, statements);
+
+        // Widen the stacked base table to the extension field, packed when
+        // large enough to fill SIMD lanes.
+        let k_pack = log2_strict_usize(F::Packing::WIDTH);
+        let wide: Vec<EF> = self.poly.iter().map(|&x| EF::from(x)).collect();
+        let mut prover = if num_variables > k_pack {
+            let evals = Poly::new(wide).pack::<F, EF>();
+            let weights = Poly::new(EF::ExtensionPacking::zero_vec(evals.num_evals()));
+            SumcheckProver::new(
+                ProductPolynomial::new_packed(VariableOrder::Prefix, evals, weights)
+                    .with_basis(Basis::Projective),
+                EF::ZERO,
+            )
+        } else {
+            let weights = Poly::new(EF::zero_vec(1 << num_variables));
+            SumcheckProver::new(
+                ProductPolynomial::new_unpacked(VariableOrder::Prefix, Poly::new(wide), weights)
+                    .with_basis(Basis::Projective),
+                EF::ZERO,
+            )
+        };
+
+        // Absorb the claim constraint and run the initial folds generically.
+        let rs = prover.compute_sumcheck_polynomials(
+            sumcheck_data,
+            challenger,
+            self.claims.folding,
+            pow_bits,
+            Some(constraint),
+        );
+        (prover, rs)
+    }
+
     /// Builds the residual equality weights in packed form.
     ///
     /// Two routes produce the identical polynomial; each call takes the cheaper one:

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -4,7 +4,8 @@ use alloc::vec::Vec;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{
-    ExtensionField, Field, PackedFieldExtension, PackedValue, TwoAdicField, dot_product,
+    ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
+    TwoAdicField, dot_product,
 };
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
@@ -12,13 +13,15 @@ use p3_multilinear_util::poly::Poly;
 use p3_multilinear_util::split_eq::SplitEq;
 use p3_util::log2_strict_usize;
 
+use crate::constraints::statement::EqStatement;
+use crate::constraints::{Constraint, Statements};
 use crate::lagrange::lagrange_weights_01inf_multi;
 use crate::layout::opening::Opening;
 use crate::layout::prover::{Layout, StackedClaims};
 use crate::layout::witness::Table;
 use crate::layout::{LayoutStrategy, ProverMultiClaim, Witness};
 use crate::product_polynomial::ProductPolynomial;
-use crate::strategy::{SumcheckProver, VariableOrder};
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::svo::{SvoPoint, calculate_accumulators_batch};
 use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
 use crate::{Claim, SumcheckData, extrapolate_01inf};
@@ -38,6 +41,26 @@ pub struct PrefixProver<F: Field, EF: ExtensionField<F>> {
     /// - Prefix binding folds this polynomial directly.
     /// - It is kept here, beside the shared claim state.
     pub(crate) poly: Poly<F>,
+    /// Plain lifted claim points and evals, in record order.
+    ///
+    /// The SVO machinery factorises claim points immediately, so the raw
+    /// stacked-coordinate points are stashed here at record time for the
+    /// projective initial rounds, which absorb them as one flat constraint.
+    ///
+    /// Recorded unconditionally: the layout does not know the basis until
+    /// `into_sumcheck`, and the cost is one point clone per opening, which
+    /// is negligible against the evaluation work at record time.
+    pub(crate) projective_eq_claims: Vec<(Point<EF>, EF)>,
+    /// Plain virtual (out-of-domain) claim points and evals, in record order.
+    ///
+    /// Kept separate from the concrete claims: the alpha-power assignment
+    /// places every concrete opening before every virtual claim.
+    pub(crate) projective_virtual_claims: Vec<(Point<EF>, EF)>,
+    /// Whether any repeat-last successor (next) opening was recorded.
+    ///
+    /// Next claims have no projective weight semantics; the projective
+    /// initial rounds reject them.
+    pub(crate) has_next_claims: bool,
 }
 
 impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, EF> {
@@ -52,6 +75,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
                 parts.folding,
             ),
             poly: parts.poly,
+            projective_eq_claims: Vec::new(),
+            projective_virtual_claims: Vec::new(),
+            has_next_claims: false,
         }
     }
 
@@ -109,7 +135,19 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         // The opening point lives in the table's local frame, one coordinate per variable.
         debug_assert_eq!(point.num_variables(), table.num_variables());
 
+        // Stash the plain lifted points before factorisation: the projective
+        // initial rounds rebuild the batched claim constraint from them.
+        // The prefix layout uses reversed selectors, so claims lift as suffix.
+        let placement = self
+            .claims
+            .placements
+            .iter()
+            .find(|p| p.idx() == table_idx)
+            .expect("every table has a placement");
+        self.has_next_claims |= !next.is_empty();
+
         // Factorise the point once; every selected column reuses it.
+        let raw_point = point.clone();
         let point = SvoPoint::new_packed(self.claims.folding, point);
 
         // Current group: evaluate each column at the point.
@@ -134,6 +172,13 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
                 (Opening::new_with_data(poly_idx, eval, partial_evals), eval)
             })
             .unzip();
+
+        // Record the plain lifted claim points with their evals, in the same
+        // flat order the verifier walks (and the alpha powers follow).
+        for (&poly_idx, &eval) in current.iter().zip(&current_evals) {
+            let lifted = placement.selectors()[poly_idx].lift_suffix(&raw_point);
+            self.projective_eq_claims.push((lifted, eval));
+        }
 
         // Bind the evaluations into the transcript, current group first then next.
         // The verifier absorbs the same bytes in the same order.
@@ -207,6 +252,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
 
         // Commit the evaluation to the transcript.
         challenger.observe_algebra_element(eval);
+        // Stash the plain point for the projective initial rounds.
+        self.projective_virtual_claims.push((point.clone(), eval));
+
         self.claims.virtual_claims.push(Claim {
             point,
             eval,
@@ -245,12 +293,17 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         sumcheck_data: &mut SumcheckData<F, EF>,
         pow_bits: usize,
         challenger: &mut Ch,
+        basis: Basis,
     ) -> (SumcheckProver<F, EF>, Point<EF>)
     where
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Sanity: preprocessing cannot consume more rounds than the stacked arity.
         assert!(self.claims.folding <= self.claims.num_variables);
+
+        if basis == Basis::Projective {
+            return self.into_sumcheck_projective(sumcheck_data, pow_bits, challenger);
+        }
 
         let alpha: EF = challenger.sample_algebra_element();
         let n_claims = self.num_claims();
@@ -331,6 +384,92 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
 }
 
 impl<F: TwoAdicField, EF: ExtensionField<F>> PrefixProver<F, EF> {
+    /// Projective initial folding rounds: the generic (non-SVO) path.
+    ///
+    /// Widens the stacked base table to the extension field, absorbs the
+    /// alpha-batched claim constraint into zero weights, and drives the
+    /// initial folds through the generic projective rounds of
+    /// [`ProductPolynomial`]. The flat statement order (concrete claims, then
+    /// virtual claims) mirrors the alpha-power assignment of the SVO path and
+    /// the verifier's constraint walk.
+    ///
+    /// Slower than the SVO fast path: the widening is an O(2^n) pass and the
+    /// full-size weight table is materialised. A projective SVO variant is
+    /// possible (the projective grid values are linear combinations of the
+    /// existing accumulator slots) but needs the accumulators' X = 1 slot
+    /// materialised; it is left as a follow-up, and benchmarks report the
+    /// initial-round phase separately so the asymmetry stays visible.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any repeat-last successor (next) opening was recorded; next
+    /// claims have no projective weight semantics.
+    fn into_sumcheck_projective<Ch>(
+        self,
+        sumcheck_data: &mut SumcheckData<F, EF>,
+        pow_bits: usize,
+        challenger: &mut Ch,
+    ) -> (SumcheckProver<F, EF>, Point<EF>)
+    where
+        Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        assert!(
+            !self.has_next_claims,
+            "next claims are not supported projectively"
+        );
+        let num_variables = self.claims.num_variables;
+        let alpha: EF = challenger.sample_algebra_element();
+
+        // One flat equality statement per group, in alpha-power order.
+        let mut statements = Vec::new();
+        let mut concrete = EqStatement::initialize(num_variables);
+        for (point, eval) in &self.projective_eq_claims {
+            concrete.add_evaluated_constraint(point.clone(), *eval);
+        }
+        if !concrete.is_empty() {
+            statements.push(Statements::Eq(concrete));
+        }
+        let mut virtuals = EqStatement::initialize(num_variables);
+        for (point, eval) in &self.projective_virtual_claims {
+            virtuals.add_evaluated_constraint(point.clone(), *eval);
+        }
+        if !virtuals.is_empty() {
+            statements.push(Statements::Eq(virtuals));
+        }
+        let constraint = Constraint::new(alpha, num_variables, statements);
+
+        // Widen the stacked base table to the extension field, packed when
+        // large enough to fill SIMD lanes.
+        let k_pack = log2_strict_usize(F::Packing::WIDTH);
+        let wide: Vec<EF> = self.poly.iter().map(|&x| EF::from(x)).collect();
+        let mut prover = if num_variables > k_pack {
+            let evals = Poly::new(wide).pack::<F, EF>();
+            let weights = Poly::new(EF::ExtensionPacking::zero_vec(evals.num_evals()));
+            SumcheckProver::new(
+                ProductPolynomial::new_packed(VariableOrder::Prefix, evals, weights)
+                    .with_basis(Basis::Projective),
+                EF::ZERO,
+            )
+        } else {
+            let weights = Poly::new(EF::zero_vec(1 << num_variables));
+            SumcheckProver::new(
+                ProductPolynomial::new_unpacked(VariableOrder::Prefix, Poly::new(wide), weights)
+                    .with_basis(Basis::Projective),
+                EF::ZERO,
+            )
+        };
+
+        // Absorb the claim constraint and run the initial folds generically.
+        let rs = prover.compute_sumcheck_polynomials(
+            sumcheck_data,
+            challenger,
+            self.claims.folding,
+            pow_bits,
+            Some(constraint),
+        );
+        (prover, rs)
+    }
+
     /// Builds the residual equality weights in packed form.
     ///
     /// Two routes produce the identical polynomial; each call takes the cheaper one:

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -15,7 +15,7 @@ use crate::layout::prover::{Layout, StackedClaims};
 use crate::layout::witness::Table;
 use crate::layout::{LayoutStrategy, Witness};
 use crate::product_polynomial::ProductPolynomial;
-use crate::strategy::{SumcheckProver, VariableOrder};
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::svo::{SvoPoint, calculate_accumulators_batch};
 use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
 use crate::{Claim, SumcheckData, extrapolate_01inf};
@@ -313,10 +313,17 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
         sumcheck_data: &mut SumcheckData<F, EF>,
         pow_bits: usize,
         challenger: &mut Ch,
+        basis: Basis,
     ) -> (SumcheckProver<F, EF>, Point<EF>)
     where
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
+        // The projective basis is prefix-only.
+        assert_eq!(
+            basis,
+            Basis::Evaluation,
+            "the suffix layout has no projective path"
+        );
         // Sanity: preprocessing cannot consume more rounds than the stacked arity.
         assert!(self.claims.folding <= self.claims.num_variables);
         let alpha: EF = challenger.sample_algebra_element();

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -16,7 +16,7 @@ use crate::layout::prover::{Layout, StackedClaims};
 use crate::layout::witness::Table;
 use crate::layout::{LayoutStrategy, Witness};
 use crate::product_polynomial::ProductPolynomial;
-use crate::strategy::{SumcheckProver, VariableOrder};
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::svo::{SvoPoint, calculate_accumulators_batch};
 use crate::table::{OpeningBatch, OpeningEvals, OpeningRequest};
 use crate::{Claim, SumcheckData, extrapolate_01inf};
@@ -317,10 +317,17 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
         sumcheck_data: &mut SumcheckData<F, EF>,
         pow_bits: usize,
         challenger: &mut Ch,
+        basis: Basis,
     ) -> (SumcheckProver<F, EF>, Point<EF>)
     where
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
+        // The projective basis is prefix-only.
+        assert_eq!(
+            basis,
+            Basis::Evaluation,
+            "the suffix layout has no projective path"
+        );
         // Sanity: preprocessing cannot consume more rounds than the stacked arity.
         assert!(self.claims.folding <= self.claims.num_variables);
         let alpha: EF = challenger.sample_algebra_element();

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -133,6 +133,11 @@ pub struct ProductPolynomial<F: Field, EF: ExtensionField<F>> {
     inner: MaybePacked<F, EF>,
     /// Variable-binding direction consulted once per round.
     order: VariableOrder,
+    /// Table interpretation consulted once per round (see [`Basis`]).
+    ///
+    /// Defaults to [`Basis::Evaluation`]; [`Self::with_basis`] opts into the
+    /// projective (monomial-basis) round arithmetic of eprint 2026/762.
+    basis: Basis,
 }
 
 impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
@@ -159,6 +164,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         let mut poly = Self {
             inner: MaybePacked::Packed { evals, weights },
             order,
+            basis: Basis::Evaluation,
         };
 
         // Corner case: if the input is already small, switch to scalar mode.
@@ -177,12 +183,34 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         Self {
             inner: MaybePacked::Unpacked { evals, weights },
             order,
+            basis: Basis::Evaluation,
         }
     }
 
     /// Returns the variable-binding order used by this polynomial.
     pub const fn order(&self) -> VariableOrder {
         self.order
+    }
+
+    /// Returns the table interpretation used by this polynomial.
+    pub const fn basis(&self) -> Basis {
+        self.basis
+    }
+
+    /// Opts this polynomial into a table interpretation (see [`Basis`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding; the
+    /// projective kernels are prefix-only.
+    #[must_use]
+    pub fn with_basis(mut self, basis: Basis) -> Self {
+        assert!(
+            basis == Basis::Evaluation || self.order == VariableOrder::Prefix,
+            "the projective basis is prefix-only"
+        );
+        self.basis = basis;
+        self
     }
 
     /// Returns the number of variables in the multilinear polynomials.
@@ -245,18 +273,18 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     ///
     /// * `r` - The verifier's challenge for this round.
     fn compress(&mut self, r: EF) {
-        // Read the order once; the inner arms share the same dispatch target.
-        let order = self.order;
+        // Read the tags once; the inner arms share the same dispatch target.
+        let (order, basis) = (self.order, self.basis);
         match &mut self.inner {
             // Apply folding to both packed polynomials.
             MaybePacked::Packed { evals, weights } => {
-                order.fix_var(evals, r);
-                order.fix_var(weights, r);
+                basis.fix_var(order, evals, r);
+                basis.fix_var(order, weights, r);
             }
             // Apply folding to both scalar polynomials.
             MaybePacked::Unpacked { evals, weights } => {
-                order.fix_var(evals, r);
-                order.fix_var(weights, r);
+                basis.fix_var(order, evals, r);
+                basis.fix_var(order, weights, r);
             }
         }
     }
@@ -335,14 +363,13 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     where
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        // Step 1: Compute sumcheck polynomial coefficients.
+        // Step 1: Compute the two-element round message.
         //
-        // The strategy differs based on representation to maximize SIMD utilization.
-        let order = self.order;
-
-        // This prover binds evaluation-basis tables; the projective kernels
-        // are reachable through the same tag, wired up by their consumer.
-        let basis = Basis::Evaluation;
+        // The representation arm maximizes SIMD utilization; the basis picks
+        // the message semantics (see [`RoundMessage`]): `c_a` is `h(0)` in the
+        // evaluation basis and `s(1)` in the projective basis, `c_inf` is the
+        // leading coefficient in both.
+        let (order, basis) = (self.order, self.basis);
         let RoundMessage { c_a, c_inf } = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 // Packed round coefficients: SIMD-parallel per-lane accumulation.
@@ -385,8 +412,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// Computes the plain quadratic coefficients for the current round without
     /// touching the transcript or folding the polynomial.
     pub(crate) fn round_coefficients(&self) -> (EF, EF) {
-        let order = self.order;
-        let basis = Basis::Evaluation;
+        let (order, basis) = (self.order, self.basis);
         let msg = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 let msg = basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice());
@@ -978,6 +1004,94 @@ mod tests {
     }
 
     #[test]
+    fn test_projective_round_multiple_rounds() {
+        // Drive full projective rounds through `round()`: message [s(1), s(inf)],
+        // reduction s(0) := C - s(inf), subtraction-free binding. The claim
+        // invariant is the same dot product as the evaluation basis, so
+        // dot_product() == sum must hold after every round (and the
+        // debug_assert inside round() checks the same).
+        let mut rng = SmallRng::seed_from_u64(123);
+        let num_variables = 4;
+        let num_evals = 1 << num_variables;
+
+        let evals: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+        let weights: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+
+        let mut poly = ProductPolynomial::<F, EF>::new_unpacked(
+            VariableOrder::Prefix,
+            Poly::new(evals),
+            Poly::new(weights),
+        )
+        .with_basis(Basis::Projective);
+
+        let mut sum = poly.dot_product();
+        let mut sumcheck_data = SumcheckData::default();
+        let mut challenger = make_challenger();
+
+        for expected_vars in (1..=num_variables).rev() {
+            assert_eq!(poly.num_variables(), expected_vars);
+
+            let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+
+            // Invariant: dot_product == sum after each projective round.
+            assert_eq!(poly.dot_product(), sum);
+        }
+
+        assert_eq!(poly.num_variables(), 0);
+    }
+
+    #[test]
+    fn test_projective_round_packed_through_transition() {
+        // Same invariant as above, but starting packed and folding through the
+        // packed -> scalar transition, so both representation arms of the
+        // projective round path are exercised.
+        type EP = <EF as ExtensionField<F>>::ExtensionPacking;
+
+        let simd_width = <F as Field>::Packing::WIDTH;
+        let num_variables = log2_strict_usize(simd_width) + 2;
+        let num_evals = 1 << num_variables;
+
+        let mut rng = SmallRng::seed_from_u64(321);
+        let evals: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+        let weights: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+
+        let packed_evals: Vec<EP> = evals.chunks(simd_width).map(EP::from_ext_slice).collect();
+        let packed_weights: Vec<EP> = weights.chunks(simd_width).map(EP::from_ext_slice).collect();
+
+        let mut poly = ProductPolynomial::<F, EF>::new_packed(
+            VariableOrder::Prefix,
+            Poly::new(packed_evals),
+            Poly::new(packed_weights),
+        )
+        .with_basis(Basis::Projective);
+
+        let mut sum = poly.dot_product();
+        let mut sumcheck_data = SumcheckData::default();
+        let mut challenger = make_challenger();
+
+        for expected_vars in (1..=num_variables).rev() {
+            assert_eq!(poly.num_variables(), expected_vars);
+            let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+            assert_eq!(poly.dot_product(), sum);
+        }
+
+        assert_eq!(poly.num_variables(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix-only")]
+    fn test_projective_rejects_suffix_order() {
+        let evals: Vec<EF> = vec![EF::ONE; 4];
+        let weights: Vec<EF> = vec![EF::ONE; 4];
+        let _ = ProductPolynomial::<F, EF>::new_unpacked(
+            VariableOrder::Suffix,
+            Poly::new(evals),
+            Poly::new(weights),
+        )
+        .with_basis(Basis::Projective);
+    }
+
+    #[test]
     fn test_dot_product_packed_matches_scalar() {
         // Verify that Packed and Small variants compute the same dot product.
         type EP = <EF as ExtensionField<F>>::ExtensionPacking;
@@ -1210,6 +1324,40 @@ mod tests {
                 .sum();
 
             prop_assert_eq!(poly.dot_product(), expected);
+        }
+
+        /// The projective round path preserves the dot-product claim invariant
+        /// across full rounds, for random tables and variable counts.
+        #[test]
+        fn prop_projective_rounds_maintain_invariant(
+            k in 1usize..=6,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let num_evals = 1usize << k;
+
+            let evals: Vec<EF> = (0..num_evals)
+                .map(|_| EF::from_u64(u64::from(rng.random::<u32>())))
+                .collect();
+            let weights: Vec<EF> = (0..num_evals)
+                .map(|_| EF::from_u64(u64::from(rng.random::<u32>())))
+                .collect();
+
+            let mut poly = ProductPolynomial::<F, EF>::new_unpacked(
+                VariableOrder::Prefix,
+                Poly::new(evals),
+                Poly::new(weights),
+            )
+            .with_basis(Basis::Projective);
+
+            let mut sum = poly.dot_product();
+            let mut sumcheck_data = SumcheckData::default();
+            let mut challenger = make_challenger();
+
+            for _ in 0..k {
+                let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+                prop_assert_eq!(poly.dot_product(), sum);
+            }
         }
 
         /// Verify that compress maintains the sumcheck invariant.

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -321,7 +321,10 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
 
             if k == 0 {
                 // Unpack each packed element into its WIDTH scalar lanes, keeping the same order.
-                *self = Self::new_unpacked(self.order, evals.unpack(), weights.unpack());
+                // The basis must survive the representation change: dropping it here would
+                // silently switch the remaining rounds back to evaluation arithmetic.
+                *self = Self::new_unpacked(self.order, evals.unpack(), weights.unpack())
+                    .with_basis(self.basis);
             }
         }
     }
@@ -1050,6 +1053,13 @@ mod tests {
         // Same invariant as above, but starting packed and folding through the
         // packed -> scalar transition, so both representation arms of the
         // projective round path are exercised.
+        //
+        // The dot-product invariant alone cannot catch a basis dropped at the
+        // transition seam: the post-reset rounds stay internally coherent,
+        // just in the wrong basis. The final assertion below can: the fully
+        // bound table must equal the monomial evaluation of the ORIGINAL
+        // table at the sampled challenges, which only holds if every round
+        // bound projectively.
         type EP = <EF as ExtensionField<F>>::ExtensionPacking;
 
         let simd_width = <F as Field>::Packing::WIDTH;
@@ -1059,6 +1069,8 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(321);
         let evals: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
         let weights: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+
+        let original_evals = Poly::new(evals.clone());
 
         let packed_evals: Vec<EP> = evals.chunks(simd_width).map(EP::from_ext_slice).collect();
         let packed_weights: Vec<EP> = weights.chunks(simd_width).map(EP::from_ext_slice).collect();
@@ -1074,13 +1086,21 @@ mod tests {
         let mut sumcheck_data = SumcheckData::default();
         let mut challenger = make_challenger();
 
+        let mut challenges = Vec::new();
         for expected_vars in (1..=num_variables).rev() {
             assert_eq!(poly.num_variables(), expected_vars);
-            let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+            challenges.push(poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0));
             assert_eq!(poly.dot_product(), sum);
         }
 
         assert_eq!(poly.num_variables(), 0);
+
+        // The transition-seam probe: ties every bind, before and after the
+        // packed -> scalar switch, to one monomial evaluation.
+        assert_eq!(
+            poly.evals().as_constant().unwrap(),
+            original_evals.eval_monomial(&Point::new(challenges)),
+        );
     }
 
     #[test]

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -28,7 +28,7 @@ use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use crate::constraints::Constraint;
-use crate::strategy::{RoundMessage, VariableOrder};
+use crate::strategy::{Basis, RoundMessage, VariableOrder};
 use crate::{SumcheckData, extrapolate_01inf};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
@@ -133,6 +133,11 @@ pub struct ProductPolynomial<F: Field, EF: ExtensionField<F>> {
     inner: MaybePacked<F, EF>,
     /// Variable-binding direction consulted once per round.
     order: VariableOrder,
+    /// Table interpretation consulted once per round (see [`Basis`]).
+    ///
+    /// Defaults to [`Basis::Evaluation`]; [`Self::with_basis`] opts into the
+    /// projective (monomial-basis) round arithmetic of eprint 2026/762.
+    basis: Basis,
 }
 
 impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
@@ -159,6 +164,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         let mut poly = Self {
             inner: MaybePacked::Packed { evals, weights },
             order,
+            basis: Basis::Evaluation,
         };
 
         // Corner case: if the input is already small, switch to scalar mode.
@@ -177,12 +183,34 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         Self {
             inner: MaybePacked::Unpacked { evals, weights },
             order,
+            basis: Basis::Evaluation,
         }
     }
 
     /// Returns the variable-binding order used by this polynomial.
     pub const fn order(&self) -> VariableOrder {
         self.order
+    }
+
+    /// Returns the table interpretation used by this polynomial.
+    pub const fn basis(&self) -> Basis {
+        self.basis
+    }
+
+    /// Opts this polynomial into a table interpretation (see [`Basis`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding; the
+    /// projective kernels are prefix-only.
+    #[must_use]
+    pub fn with_basis(mut self, basis: Basis) -> Self {
+        assert!(
+            basis == Basis::Evaluation || self.order == VariableOrder::Prefix,
+            "the projective basis is prefix-only"
+        );
+        self.basis = basis;
+        self
     }
 
     /// Returns the number of variables in the multilinear polynomials.
@@ -245,18 +273,18 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     ///
     /// * `r` - The verifier's challenge for this round.
     fn compress(&mut self, r: EF) {
-        // Read the order once; the inner arms share the same dispatch target.
-        let order = self.order;
+        // Read the tags once; the inner arms share the same dispatch target.
+        let (order, basis) = (self.order, self.basis);
         match &mut self.inner {
             // Apply folding to both packed polynomials.
             MaybePacked::Packed { evals, weights } => {
-                order.fix_var(evals, r);
-                order.fix_var(weights, r);
+                basis.fix_var(order, evals, r);
+                basis.fix_var(order, weights, r);
             }
             // Apply folding to both scalar polynomials.
             MaybePacked::Unpacked { evals, weights } => {
-                order.fix_var(evals, r);
-                order.fix_var(weights, r);
+                basis.fix_var(order, evals, r);
+                basis.fix_var(order, weights, r);
             }
         }
     }
@@ -335,14 +363,17 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     where
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
-        // Step 1: Compute sumcheck polynomial coefficients.
+        // Step 1: Compute the two-element round message.
         //
-        // The strategy differs based on representation to maximize SIMD utilization.
-        let order = self.order;
-        let RoundMessage { c_a: c0, c_inf } = match &self.inner {
+        // The representation arm maximizes SIMD utilization; the basis picks
+        // the message semantics (see [`RoundMessage`]): `c_a` is `h(0)` in the
+        // evaluation basis and `s(1)` in the projective basis, `c_inf` is the
+        // leading coefficient in both.
+        let (order, basis) = (self.order, self.basis);
+        let RoundMessage { c_a, c_inf } = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 // Packed round coefficients: SIMD-parallel per-lane accumulation.
-                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice());
 
                 // Horizontal reduction across SIMD lanes.
                 RoundMessage {
@@ -352,21 +383,27 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
             }
             MaybePacked::Unpacked { evals, weights } => {
                 // Scalar round coefficients.
-                order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
+                basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice())
             }
         };
 
         // Step 2-4: Commit to transcript, do PoW, and receive challenge.
-        let r = sumcheck_data.observe_and_sample(challenger, c0, c_inf, pow_bits);
+        let r = sumcheck_data.observe_and_sample(challenger, c_a, c_inf, pow_bits);
 
         // Step 5: Fold both polynomials using the challenge.
         self.compress(r);
 
-        // Step 6: Update the claimed sum.
+        // Step 6: Update the claimed sum to h(r) via the {0, 1, inf} weights.
         //
-        // h(r) = h(0)*(1-r) + h(1)*r + h(inf)*r*(r-1)
-        // where h(1) = claimed_sum - h(0).
-        *sum = extrapolate_01inf(c0, *sum - c0, c_inf, r);
+        // Evaluation basis: the message is [h(0), h(inf)] and the round
+        // identity h(0) + h(1) = C supplies h(1) = C - h(0).
+        // Projective basis: the message is [s(1), s(inf)] and the round
+        // identity s(0) + s(inf) = C supplies s(0) = C - s(inf)
+        // (eprint 2026/762, Fig. 3).
+        *sum = match basis {
+            Basis::Evaluation => extrapolate_01inf(c_a, *sum - c_a, c_inf, r),
+            Basis::Projective => extrapolate_01inf(*sum - c_inf, c_a, c_inf, r),
+        };
 
         // Sanity check: the updated sum should equal the inner product after folding.
         debug_assert_eq!(*sum, self.dot_product());
@@ -383,17 +420,17 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// Computes the plain quadratic coefficients for the current round without
     /// touching the transcript or folding the polynomial.
     pub(crate) fn round_coefficients(&self) -> (EF, EF) {
-        let order = self.order;
+        let (order, basis) = (self.order, self.basis);
         let msg = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
-                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice());
                 RoundMessage {
                     c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
                     c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
                 }
             }
             MaybePacked::Unpacked { evals, weights } => {
-                order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
+                basis.sumcheck_coefficients(order, evals.as_slice(), weights.as_slice())
             }
         };
         (msg.c_a, msg.c_inf)
@@ -974,6 +1011,94 @@ mod tests {
     }
 
     #[test]
+    fn test_projective_round_multiple_rounds() {
+        // Drive full projective rounds through `round()`: message [s(1), s(inf)],
+        // reduction s(0) := C - s(inf), subtraction-free binding. The claim
+        // invariant is the same dot product as the evaluation basis, so
+        // dot_product() == sum must hold after every round (and the
+        // debug_assert inside round() checks the same).
+        let mut rng = SmallRng::seed_from_u64(123);
+        let num_variables = 4;
+        let num_evals = 1 << num_variables;
+
+        let evals: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+        let weights: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+
+        let mut poly = ProductPolynomial::<F, EF>::new_unpacked(
+            VariableOrder::Prefix,
+            Poly::new(evals),
+            Poly::new(weights),
+        )
+        .with_basis(Basis::Projective);
+
+        let mut sum = poly.dot_product();
+        let mut sumcheck_data = SumcheckData::default();
+        let mut challenger = make_challenger();
+
+        for expected_vars in (1..=num_variables).rev() {
+            assert_eq!(poly.num_variables(), expected_vars);
+
+            let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+
+            // Invariant: dot_product == sum after each projective round.
+            assert_eq!(poly.dot_product(), sum);
+        }
+
+        assert_eq!(poly.num_variables(), 0);
+    }
+
+    #[test]
+    fn test_projective_round_packed_through_transition() {
+        // Same invariant as above, but starting packed and folding through the
+        // packed -> scalar transition, so both representation arms of the
+        // projective round path are exercised.
+        type EP = <EF as ExtensionField<F>>::ExtensionPacking;
+
+        let simd_width = <F as Field>::Packing::WIDTH;
+        let num_variables = log2_strict_usize(simd_width) + 2;
+        let num_evals = 1 << num_variables;
+
+        let mut rng = SmallRng::seed_from_u64(321);
+        let evals: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+        let weights: Vec<EF> = (0..num_evals).map(|_| EF::from_u64(rng.random())).collect();
+
+        let packed_evals: Vec<EP> = evals.chunks(simd_width).map(EP::from_ext_slice).collect();
+        let packed_weights: Vec<EP> = weights.chunks(simd_width).map(EP::from_ext_slice).collect();
+
+        let mut poly = ProductPolynomial::<F, EF>::new_packed(
+            VariableOrder::Prefix,
+            Poly::new(packed_evals),
+            Poly::new(packed_weights),
+        )
+        .with_basis(Basis::Projective);
+
+        let mut sum = poly.dot_product();
+        let mut sumcheck_data = SumcheckData::default();
+        let mut challenger = make_challenger();
+
+        for expected_vars in (1..=num_variables).rev() {
+            assert_eq!(poly.num_variables(), expected_vars);
+            let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+            assert_eq!(poly.dot_product(), sum);
+        }
+
+        assert_eq!(poly.num_variables(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix-only")]
+    fn test_projective_rejects_suffix_order() {
+        let evals: Vec<EF> = vec![EF::ONE; 4];
+        let weights: Vec<EF> = vec![EF::ONE; 4];
+        let _ = ProductPolynomial::<F, EF>::new_unpacked(
+            VariableOrder::Suffix,
+            Poly::new(evals),
+            Poly::new(weights),
+        )
+        .with_basis(Basis::Projective);
+    }
+
+    #[test]
     fn test_dot_product_packed_matches_scalar() {
         // Verify that Packed and Small variants compute the same dot product.
         type EP = <EF as ExtensionField<F>>::ExtensionPacking;
@@ -1206,6 +1331,40 @@ mod tests {
                 .sum();
 
             prop_assert_eq!(poly.dot_product(), expected);
+        }
+
+        /// The projective round path preserves the dot-product claim invariant
+        /// across full rounds, for random tables and variable counts.
+        #[test]
+        fn prop_projective_rounds_maintain_invariant(
+            k in 1usize..=6,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let num_evals = 1usize << k;
+
+            let evals: Vec<EF> = (0..num_evals)
+                .map(|_| EF::from_u64(u64::from(rng.random::<u32>())))
+                .collect();
+            let weights: Vec<EF> = (0..num_evals)
+                .map(|_| EF::from_u64(u64::from(rng.random::<u32>())))
+                .collect();
+
+            let mut poly = ProductPolynomial::<F, EF>::new_unpacked(
+                VariableOrder::Prefix,
+                Poly::new(evals),
+                Poly::new(weights),
+            )
+            .with_basis(Basis::Projective);
+
+            let mut sum = poly.dot_product();
+            let mut sumcheck_data = SumcheckData::default();
+            let mut challenger = make_challenger();
+
+            for _ in 0..k {
+                let _ = poly.round(&mut sumcheck_data, &mut challenger, &mut sum, 0);
+                prop_assert_eq!(poly.dot_product(), sum);
+            }
         }
 
         /// Verify that compress maintains the sumcheck invariant.

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -397,8 +397,9 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         // Step 5: Fold both polynomials using the challenge.
         self.compress(r);
 
-        // Step 6: Update the claimed sum, through the same round identity the
-        // verifier will apply to this message.
+        // Step 6: Update the claimed sum to h(r); the round identity that
+        // supplies the third quadratic value is basis-dependent and lives in
+        // one place, shared with the verifier.
         *sum = basis.reduce_claim(c_a, c_inf, r, *sum);
 
         // Sanity check: the updated sum should equal the inner product after folding.

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -27,9 +27,9 @@ use p3_multilinear_util::poly::{Poly, PolyMaybePacked, PolyMaybePackedView};
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
+use crate::SumcheckData;
 use crate::constraints::Constraint;
 use crate::strategy::{Basis, RoundMessage, VariableOrder};
-use crate::{SumcheckData, extrapolate_01inf};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
 ///
@@ -397,17 +397,10 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         // Step 5: Fold both polynomials using the challenge.
         self.compress(r);
 
-        // Step 6: Update the claimed sum to h(r) via the {0, 1, inf} weights.
-        //
-        // Evaluation basis: the message is [h(0), h(inf)] and the round
-        // identity h(0) + h(1) = C supplies h(1) = C - h(0).
-        // Projective basis: the message is [s(1), s(inf)] and the round
-        // identity s(0) + s(inf) = C supplies s(0) = C - s(inf)
-        // (eprint 2026/762, Fig. 3).
-        *sum = match basis {
-            Basis::Evaluation => extrapolate_01inf(c_a, *sum - c_a, c_inf, r),
-            Basis::Projective => extrapolate_01inf(*sum - c_inf, c_a, c_inf, r),
-        };
+        // Step 6: Update the claimed sum to h(r); the round identity that
+        // supplies the third quadratic value is basis-dependent and lives in
+        // one place, shared with the verifier.
+        *sum = basis.reduce_claim(c_a, c_inf, r, *sum);
 
         // Sanity check: the updated sum should equal the inner product after folding.
         debug_assert_eq!(*sum, self.dot_product());
@@ -618,6 +611,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
+    use crate::extrapolate_01inf;
     use crate::strategy::{RoundMessage, sumcheck_coefficients_prefix};
 
     type F = BabyBear;

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -28,7 +28,7 @@ use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use crate::constraints::Constraint;
-use crate::strategy::VariableOrder;
+use crate::strategy::{RoundMessage, VariableOrder};
 use crate::{SumcheckData, extrapolate_01inf};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
@@ -339,16 +339,16 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
         //
         // The strategy differs based on representation to maximize SIMD utilization.
         let order = self.order;
-        let (c0, c_inf) = match &self.inner {
+        let RoundMessage { c_a: c0, c_inf } = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
                 // Packed round coefficients: SIMD-parallel per-lane accumulation.
-                let (c0, c_inf) = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
 
                 // Horizontal reduction across SIMD lanes.
-                (
-                    EF::ExtensionPacking::to_ext_iter([c0]).sum(),
-                    EF::ExtensionPacking::to_ext_iter([c_inf]).sum(),
-                )
+                RoundMessage {
+                    c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
+                    c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
+                }
             }
             MaybePacked::Unpacked { evals, weights } => {
                 // Scalar round coefficients.
@@ -384,18 +384,19 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// touching the transcript or folding the polynomial.
     pub(crate) fn round_coefficients(&self) -> (EF, EF) {
         let order = self.order;
-        match &self.inner {
+        let msg = match &self.inner {
             MaybePacked::Packed { evals, weights } => {
-                let (c0, c_inf) = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
-                (
-                    EF::ExtensionPacking::to_ext_iter([c0]).sum(),
-                    EF::ExtensionPacking::to_ext_iter([c_inf]).sum(),
-                )
+                let msg = order.sumcheck_coefficients(evals.as_slice(), weights.as_slice());
+                RoundMessage {
+                    c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
+                    c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
+                }
             }
             MaybePacked::Unpacked { evals, weights } => {
                 order.sumcheck_coefficients(evals.as_slice(), weights.as_slice())
             }
-        }
+        };
+        (msg.c_a, msg.c_inf)
     }
 
     /// Folds both product-polynomial sides by one verifier challenge.
@@ -576,7 +577,7 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
-    use crate::strategy::sumcheck_coefficients_prefix;
+    use crate::strategy::{RoundMessage, sumcheck_coefficients_prefix};
 
     type F = BabyBear;
     type EF = BinomialExtensionField<BabyBear, 4>;
@@ -646,7 +647,10 @@ mod tests {
         let evals = Poly::new(vec![e0, e1]);
         let weights = Poly::new(vec![w0, w1]);
 
-        let (h0, h_inf) = sumcheck_coefficients_prefix(evals.as_slice(), weights.as_slice());
+        let RoundMessage {
+            c_a: h0,
+            c_inf: h_inf,
+        } = sumcheck_coefficients_prefix(evals.as_slice(), weights.as_slice());
 
         // h(0) = e0 * w0
         let expected_h0 = e0 * w0;
@@ -1226,7 +1230,7 @@ mod tests {
             // Compute sumcheck coefficients before folding.
             // Returns (h(0), h(inf)) where h is the univariate
             // polynomial h(X) = sum_{b in {0,1}^{n-1}} f(X, b) * w(X, b).
-            let (c0, c_inf) = match &poly.inner {
+            let RoundMessage { c_a: c0, c_inf } = match &poly.inner {
                 MaybePacked::Unpacked {
                     evals: small_evals,
                     weights: small_weights,

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -247,6 +247,10 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     ///
     /// * `point` - The evaluation point as a [`Point`].
     pub fn eval(&self, point: &Point<EF>) -> EF {
+        // The MLE of the table at `point`, in BOTH bases: the out-of-domain
+        // anchor is a binding linear functional of the committed bytes, so it
+        // is deliberately basis-independent. Monomial evaluation lives on
+        // `Poly` and serves the final opening instead.
         match &self.inner {
             MaybePacked::Packed { evals, .. } => evals.eval_packed(point),
             MaybePacked::Unpacked { evals, .. } => evals.eval_ext::<F>(point),

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -130,27 +130,24 @@ where
     (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
 }
 
-/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+/// Shared prefix round-coefficient scaffold, parameterised over the basis steps.
 ///
-/// # Inputs
-///
-/// - `evals`   — multilinear evaluations of `f(X)` over the hypercube.
-/// - `weights` — multilinear evaluations of `w(X)` over the hypercube.
-///
-/// # Returns
-///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
-/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
-///
-/// # Complexity
-///
-/// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
-/// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
-/// streaming fold.
-pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+/// The tiling, `PAR_THRESHOLD` par-vs-serial split, and `K`-tail fold are
+/// identical across bases; only the per-tile and per-pair MAC differ. The
+/// evaluation and projective kernels supply their `chunk_step` / `pair_step`
+/// pair so this delicate delayed-reduction loop exists exactly once.
+#[inline]
+fn sumcheck_coefficients_prefix_with<B, A, Chunk, Pair>(
+    evals: &[B],
+    weights: &[A],
+    chunk_step: Chunk,
+    pair_step: Pair,
+) -> (A, A)
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
+    Chunk: Fn(&[B; K], &[B; K], &[A; K], &[A; K]) -> (A, A) + Sync,
+    Pair: Fn((A, A), B, B, A, A) -> (A, A),
 {
     // Precondition: paired slices must be aligned; half-and-half split addresses the prefix bit.
     assert_eq!(evals.len(), weights.len());
@@ -178,7 +175,7 @@ where
             .par_fold_reduce(
                 || (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step::<B, A>(
+                    let chunk = chunk_step(
                         e_lo_c.try_into().unwrap(),
                         e_hi_c.try_into().unwrap(),
                         w_lo_c.try_into().unwrap(),
@@ -196,7 +193,7 @@ where
             .fold(
                 (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step::<B, A>(
+                    let chunk = chunk_step(
                         e_lo_c.try_into().unwrap(),
                         e_hi_c.try_into().unwrap(),
                         w_lo_c.try_into().unwrap(),
@@ -213,10 +210,35 @@ where
         .zip(e_hi_tail.iter())
         .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
         .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
-            round_step(acc, e0, e1, w0, w1)
+            pair_step(acc, e0, e1, w0, w1)
         });
 
     round_reduce(main, tail)
+}
+
+/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+///
+/// # Inputs
+///
+/// - `evals`   — multilinear evaluations of `f(X)` over the hypercube.
+/// - `weights` — multilinear evaluations of `w(X)` over the hypercube.
+///
+/// # Returns
+///
+/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
+/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
+///
+/// # Complexity
+///
+/// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
+/// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
+/// streaming fold.
+pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<B> + Copy + Send + Sync,
+{
+    sumcheck_coefficients_prefix_with(evals, weights, chunk_round_step::<B, A>, round_step::<B, A>)
 }
 
 /// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
@@ -236,68 +258,12 @@ where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    assert_eq!(evals.len(), weights.len());
-    assert!(evals.len().is_multiple_of(2));
-    let half = evals.len() / 2;
-    let (e_lo, e_hi) = evals.split_at(half);
-    let (w_lo, w_hi) = weights.split_at(half);
-
-    let body = (half / K) * K;
-    let (e_lo_main, e_lo_tail) = e_lo.split_at(body);
-    let (e_hi_main, e_hi_tail) = e_hi.split_at(body);
-    let (w_lo_main, w_lo_tail) = w_lo.split_at(body);
-    let (w_hi_main, w_hi_tail) = w_hi.split_at(body);
-
-    let main: (A, A) = if half > PAR_THRESHOLD {
-        e_lo_main
-            .par_chunks_exact(K)
-            .zip(e_hi_main.par_chunks_exact(K))
-            .zip(
-                w_lo_main
-                    .par_chunks_exact(K)
-                    .zip(w_hi_main.par_chunks_exact(K)),
-            )
-            .par_fold_reduce(
-                || (A::ZERO, A::ZERO),
-                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step_projective::<B, A>(
-                        e_lo_c.try_into().unwrap(),
-                        e_hi_c.try_into().unwrap(),
-                        w_lo_c.try_into().unwrap(),
-                        w_hi_c.try_into().unwrap(),
-                    );
-                    round_reduce(acc, chunk)
-                },
-                round_reduce,
-            )
-    } else {
-        e_lo_main
-            .chunks_exact(K)
-            .zip(e_hi_main.chunks_exact(K))
-            .zip(w_lo_main.chunks_exact(K).zip(w_hi_main.chunks_exact(K)))
-            .fold(
-                (A::ZERO, A::ZERO),
-                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step_projective::<B, A>(
-                        e_lo_c.try_into().unwrap(),
-                        e_hi_c.try_into().unwrap(),
-                        w_lo_c.try_into().unwrap(),
-                        w_hi_c.try_into().unwrap(),
-                    );
-                    round_reduce(acc, chunk)
-                },
-            )
-    };
-
-    let tail = e_lo_tail
-        .iter()
-        .zip(e_hi_tail.iter())
-        .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
-        .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
-            round_step_projective(acc, e0, e1, w0, w1)
-        });
-
-    round_reduce(main, tail)
+    sumcheck_coefficients_prefix_with(
+        evals,
+        weights,
+        chunk_round_step_projective::<B, A>,
+        round_step_projective::<B, A>,
+    )
 }
 
 /// Computes `(h(0), h(inf))` for a suffix-binding sumcheck round.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -84,6 +84,52 @@ fn round_reduce<A: Copy + PrimeCharacteristicRing>(a: (A, A), b: (A, A)) -> (A, 
     (a.0 + b.0, a.1 + b.1)
 }
 
+/// Projective per-tile MAC (eprint 2026/762, Fig. 3).
+///
+/// Like [`chunk_round_step`], but the tables are interpreted as monomial
+/// coefficients, so the round message is `[s(1), s(inf)]` and the verifier
+/// derives `s(0) := C - s(inf)` from the projective round identity. The
+/// `X = 1` evaluation of a coefficient pair is `lo + hi`, so the differences
+/// of the evaluation basis become sums:
+///
+/// ```text
+///     at_one  += sum_i  (w_lo[i] + w_hi[i]) * (e_lo[i] + e_hi[i])
+///     leading += sum_i  w_hi[i] * e_hi[i]
+/// ```
+#[inline(always)]
+fn chunk_round_step_projective<B, A>(
+    e_lo: &[B; K],
+    e_hi: &[B; K],
+    w_lo: &[A; K],
+    w_hi: &[A; K],
+) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy,
+    A: Algebra<B> + Copy,
+{
+    // Materialise the X = 1 evaluations (lo + hi) tile-locally so they can
+    // feed the same delayed-reduction primitive. `K` base adds, no reductions.
+    let ones_e: [B; K] = core::array::from_fn(|i| e_lo[i] + e_hi[i]);
+    let ones_w: [A; K] = core::array::from_fn(|i| w_lo[i] + w_hi[i]);
+
+    let acc1 = A::mixed_dot_product::<K>(&ones_w, &ones_e);
+
+    // Leading coefficient: dot product of the high (coefficient) faces.
+    let acc_inf = A::mixed_dot_product::<K>(w_hi, e_hi);
+
+    (acc1, acc_inf)
+}
+
+/// Projective per-pair MAC for the streaming tail (no subtraction).
+#[inline(always)]
+fn round_step_projective<B, A>((acc1, acc_inf): (A, A), e0: B, e1: B, w0: A, w1: A) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy,
+    A: Algebra<B> + Copy,
+{
+    (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
+}
+
 /// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
 ///
 /// # Inputs
@@ -168,6 +214,87 @@ where
         .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
         .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
             round_step(acc, e0, e1, w0, w1)
+        });
+
+    round_reduce(main, tail)
+}
+
+/// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
+/// (eprint 2026/762, Fig. 3).
+///
+/// The tables are interpreted as monomial coefficients. The round message is
+/// `[s(1), s(inf)]`; the verifier derives `s(0) := C - s(inf)` from the
+/// projective round identity `s(0) + s(inf) = C`. Returned as:
+///
+/// - `s(1)`   = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
+/// - `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
+///
+/// The evaluation-basis kernel's per-pair subtractions (`hi - lo`) become
+/// additions (`lo + hi`); same `K`-tiled, delayed-reduction structure.
+pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+where
+    B: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<B> + Copy + Send + Sync,
+{
+    assert_eq!(evals.len(), weights.len());
+    assert!(evals.len().is_multiple_of(2));
+    let half = evals.len() / 2;
+    let (e_lo, e_hi) = evals.split_at(half);
+    let (w_lo, w_hi) = weights.split_at(half);
+
+    let body = (half / K) * K;
+    let (e_lo_main, e_lo_tail) = e_lo.split_at(body);
+    let (e_hi_main, e_hi_tail) = e_hi.split_at(body);
+    let (w_lo_main, w_lo_tail) = w_lo.split_at(body);
+    let (w_hi_main, w_hi_tail) = w_hi.split_at(body);
+
+    let main: (A, A) = if half > PAR_THRESHOLD {
+        e_lo_main
+            .par_chunks_exact(K)
+            .zip(e_hi_main.par_chunks_exact(K))
+            .zip(
+                w_lo_main
+                    .par_chunks_exact(K)
+                    .zip(w_hi_main.par_chunks_exact(K)),
+            )
+            .par_fold_reduce(
+                || (A::ZERO, A::ZERO),
+                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                    let chunk = chunk_round_step_projective::<B, A>(
+                        e_lo_c.try_into().unwrap(),
+                        e_hi_c.try_into().unwrap(),
+                        w_lo_c.try_into().unwrap(),
+                        w_hi_c.try_into().unwrap(),
+                    );
+                    round_reduce(acc, chunk)
+                },
+                round_reduce,
+            )
+    } else {
+        e_lo_main
+            .chunks_exact(K)
+            .zip(e_hi_main.chunks_exact(K))
+            .zip(w_lo_main.chunks_exact(K).zip(w_hi_main.chunks_exact(K)))
+            .fold(
+                (A::ZERO, A::ZERO),
+                |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                    let chunk = chunk_round_step_projective::<B, A>(
+                        e_lo_c.try_into().unwrap(),
+                        e_hi_c.try_into().unwrap(),
+                        w_lo_c.try_into().unwrap(),
+                        w_hi_c.try_into().unwrap(),
+                    );
+                    round_reduce(acc, chunk)
+                },
+            )
+    };
+
+    let tail = e_lo_tail
+        .iter()
+        .zip(e_hi_tail.iter())
+        .zip(w_lo_tail.iter().zip(w_hi_tail.iter()))
+        .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
+            round_step_projective(acc, e0, e1, w0, w1)
         });
 
     round_reduce(main, tail)
@@ -670,6 +797,35 @@ mod tests {
                 VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge),
                 eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge),
             );
+        }
+    }
+
+    proptest! {
+        // Projective (monomial-basis) prefix round message (eprint 2026/762,
+        // Fig. 3) is [s(1), s(inf)] = [dot(lo + hi, lo + hi), dot(hi, hi)];
+        // the per-pair subtractions of the evaluation basis become additions.
+        #[test]
+        fn prop_sumcheck_coefficients_prefix_projective_matches_reference(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = 1usize << k;
+            let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+
+            let (h1, h_inf) = super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+
+            let half = n / 2;
+            // s(1): the X = 1 evaluation of each coefficient pair is lo + hi.
+            let h1_ref: EF = (0..half)
+                .map(|i| (weights[i] + weights[half + i]) * (evals[i] + evals[half + i]))
+                .sum();
+            // s(inf): dot product of the high (leading-coefficient) faces.
+            let h_inf_ref: EF = (0..half).map(|i| weights[half + i] * evals[half + i]).sum();
+
+            prop_assert_eq!(h1, h1_ref);
+            prop_assert_eq!(h_inf, h_inf_ref);
         }
     }
 }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -432,6 +432,67 @@ pub enum Basis {
     Projective,
 }
 
+impl Basis {
+    /// Computes the two-element round message for one quadratic sumcheck round.
+    ///
+    /// - [`Basis::Evaluation`]: `[h(0), h(inf)]`, dispatching on `order`.
+    /// - [`Basis::Projective`]: `[s(1), s(inf)]` (prefix only); the verifier
+    ///   derives `s(0) := C - s(inf)` from the projective round identity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding.
+    pub fn sumcheck_coefficients<B, A>(
+        self,
+        order: VariableOrder,
+        evals: &[B],
+        weights: &[A],
+    ) -> RoundMessage<A>
+    where
+        B: PrimeCharacteristicRing + Copy + Send + Sync,
+        A: Algebra<B> + Copy + Send + Sync,
+    {
+        match self {
+            Self::Evaluation => order.sumcheck_coefficients(evals, weights),
+            Self::Projective => {
+                assert_eq!(
+                    order,
+                    VariableOrder::Prefix,
+                    "the projective basis is prefix-only"
+                );
+                sumcheck_coefficients_prefix_projective(evals, weights)
+            }
+        }
+    }
+
+    /// Binds the active round variable of `poly` to challenge `r`.
+    ///
+    /// - [`Basis::Evaluation`]: `a0 + (a1 - a0) * r`, dispatching on `order`.
+    /// - [`Basis::Projective`]: the subtraction-free `a0 + a1 * r` (prefix
+    ///   only).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding.
+    pub fn fix_var<A, Ch>(self, order: VariableOrder, poly: &mut Poly<A>, r: Ch)
+    where
+        A: Algebra<Ch> + Copy + Send + Sync,
+        Ch: Copy + Send + Sync,
+    {
+        match self {
+            Self::Evaluation => order.fix_var(poly, r),
+            Self::Projective => {
+                assert_eq!(
+                    order,
+                    VariableOrder::Prefix,
+                    "the projective basis is prefix-only"
+                );
+                poly.fix_prefix_var_mut_monomial(r);
+            }
+        }
+    }
+}
+
 impl VariableOrder {
     /// Computes the [`RoundMessage`] for one quadratic sumcheck round.
     pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> RoundMessage<A>

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -693,6 +693,15 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     /// Folds the residual product polynomial by one challenge and updates the
     /// claimed sum with the same quadratic extrapolation as the plain path.
     pub(crate) fn fold_round_with_coefficients(&mut self, c0: EF, c_inf: EF, gamma: EF) {
+        // This entry point hardcodes the evaluation-basis reduction; its only
+        // caller is the zk residual path, which does not consult the basis.
+        // Guard the assumption so a projective configuration cannot silently
+        // run evaluation arithmetic here.
+        debug_assert_eq!(
+            self.poly.basis(),
+            Basis::Evaluation,
+            "the zk residual path does not support the projective basis"
+        );
         self.sum = extrapolate_01inf(c0, self.sum - c0, c_inf, gamma);
         self.poly.fold_round(gamma);
         debug_assert_eq!(self.sum, self.poly.dot_product());

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -392,6 +392,46 @@ pub enum VariableOrder {
     Suffix,
 }
 
+/// How the sumcheck tables are interpreted, and with it the round arithmetic.
+///
+/// The table bytes are identical in both bases; the tag selects which
+/// polynomial those bytes describe, and one round arithmetic follows from
+/// each choice (eprint 2026/762, Section 3):
+///
+/// | per round                    | [`Basis::Evaluation`]                        | [`Basis::Projective`]                          |
+/// |------------------------------|----------------------------------------------|------------------------------------------------|
+/// | a table entry is             | a value on the hypercube `{0,1}^n`           | a monomial coefficient (a value on `{0,inf}^n`) |
+/// | binding `X = r`              | `a0 + (a1 - a0) * r`                         | `a0 + a1 * r`                                  |
+/// | message sent                 | `[s(0), s(inf)]`                             | `[s(1), s(inf)]`                               |
+/// | value the verifier derives   | `s(1) := C - s(0)`                           | `s(0) := C - s(inf)`                           |
+/// | fold of committed data       | multilinear interpolation at `r`             | monomial (Horner) evaluation at `r`            |
+/// | weight tensor `(u_i, v_i)`   | `prod((1 - r_i) * u_i + r_i * v_i)`          | `prod(u_i + v_i * r_i)`                        |
+///
+/// The rows are one package per column: a consumer that folds committed data
+/// (such as WHIR, where the sumcheck challenge is also the codeword folding
+/// challenge) must take an entire column, never a mix.
+///
+/// The claim invariant `C = dot(evals, weights)` is the same in both bases:
+/// the `{0,1}`-sum of products in the evaluation basis and the `{0,inf}`-sum
+/// in the projective basis are both the dot product of the two tables, so
+/// the running-sum bookkeeping does not change. Like [`VariableOrder`], the
+/// tag is consulted once per round in the outer frame, never inside the
+/// O(2^n) inner loops.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Basis {
+    /// The tables hold values over the boolean hypercube `{0,1}^n`; rounds
+    /// sum over `{0,1}` and bind by linear interpolation. The default.
+    #[default]
+    Evaluation,
+    /// The tables hold monomial coefficients, equivalently values over
+    /// `{0,inf}^n`; rounds sum over `{0,inf}` and bind subtraction-free
+    /// (eprint 2026/762).
+    ///
+    /// Prefix order only: the projective kernels are implemented for
+    /// prefix-bound variables (WHIR's path).
+    Projective,
+}
+
 impl VariableOrder {
     /// Computes the [`RoundMessage`] for one quadratic sumcheck round.
     pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> RoundMessage<A>

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -388,17 +388,21 @@ where
 /// polynomial those bytes describe, and one round arithmetic follows from
 /// each choice (eprint 2026/762, Section 3):
 ///
-/// | per round                  | [`Basis::Evaluation`]              | [`Basis::Projective`]                           |
-/// |----------------------------|------------------------------------|-------------------------------------------------|
-/// | a table entry is           | a value on the hypercube `{0,1}^n` | a monomial coefficient (a value on `{0,inf}^n`) |
-/// | binding `X = r`            | `a0 + (a1 - a0) * r`               | `a0 + a1 * r`                                   |
-/// | message sent               | `[h(0), h(inf)]`                   | `[s(1), s(inf)]`                                |
-/// | value the verifier derives | `h(1) := C - h(0)`                 | `s(0) := C - s(inf)`                            |
+/// | per round                  | [`Basis::Evaluation`]               | [`Basis::Projective`]                           |
+/// |----------------------------|-------------------------------------|-------------------------------------------------|
+/// | a table entry is           | a value on the hypercube `{0,1}^n`  | a monomial coefficient (a value on `{0,inf}^n`) |
+/// | binding `X = r`            | `a0 + (a1 - a0) * r`                | `a0 + a1 * r`                                   |
+/// | message sent               | `[h(0), h(inf)]`                    | `[s(1), s(inf)]`                                |
+/// | value the verifier derives | `h(1) := C - h(0)`                  | `s(0) := C - s(inf)`                            |
+/// | fold of committed data     | multilinear interpolation at `r`    | monomial (Horner) evaluation at `r`             |
+/// | weight tensor `(u_i, v_i)` | `prod((1 - r_i) * u_i + r_i * v_i)` | `prod(u_i + v_i * r_i)`                         |
 ///
-/// The rows are one package per column: a consumer must take an entire
-/// column, never a mix. That is what the tag buys. A [`RoundMessage`] alone
-/// cannot say which column produced it, so the two values only ever leave or
-/// re-enter the transcript through the basis that defines them.
+/// The rows are one package per column: a consumer that folds committed data
+/// (such as WHIR, where the sumcheck challenge is also the codeword folding
+/// challenge) must take an entire column, never a mix. That is what the tag
+/// buys. A [`RoundMessage`] alone cannot say which column produced it, so the
+/// two values only ever leave or re-enter the transcript through the basis
+/// that defines them.
 ///
 /// The claim invariant `C = dot(evals, weights)` is the same in both bases:
 /// the `{0,1}`-sum of products in the evaluation basis and the `{0,inf}`-sum

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -475,6 +475,33 @@ impl Basis {
             Self::Projective => extrapolate_01inf(claimed_sum - c_inf, c_a, c_inf, r),
         }
     }
+
+    /// Binds the active round variable of `poly` to challenge `r`.
+    ///
+    /// - [`Basis::Evaluation`]: `a0 + (a1 - a0) * r`, dispatching on `order`.
+    /// - [`Basis::Projective`]: the subtraction-free `a0 + a1 * r` (prefix
+    ///   only).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the projective basis is paired with suffix binding.
+    pub fn fix_var<A, Ch>(self, order: VariableOrder, poly: &mut Poly<A>, r: Ch)
+    where
+        A: Algebra<Ch> + Copy + Send + Sync,
+        Ch: Copy + Send + Sync,
+    {
+        match self {
+            Self::Evaluation => order.fix_var(poly, r),
+            Self::Projective => {
+                assert_eq!(
+                    order,
+                    VariableOrder::Prefix,
+                    "the projective basis is prefix-only"
+                );
+                poly.fix_prefix_var_mut_monomial(r);
+            }
+        }
+    }
 }
 
 /// Which side of the variable order is bound first by the sumcheck rounds.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -130,6 +130,27 @@ where
     (acc1 + (w0 + w1) * (e0 + e1), acc_inf + w1 * e1)
 }
 
+/// The two prover-sent values of a quadratic sumcheck round.
+///
+/// The round polynomial has three unknowns; the verifier recovers the third
+/// from the running claim `C`, so only two values cross the transcript. Which
+/// finite point is sent differs by basis:
+///
+/// | basis      | `c_a`  | `c_inf`  | derived             |
+/// |------------|--------|----------|---------------------|
+/// | evaluation | `h(0)` | `h(inf)` | `h(1) = C - h(0)`   |
+/// | projective | `s(1)` | `s(inf)` | `s(0) = C - s(inf)` |
+///
+/// Named fields keep the two bases' different finite points from being
+/// swapped silently at dispatch sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoundMessage<A> {
+    /// The finite-point value: `h(0)` (evaluation basis) or `s(1)` (projective).
+    pub c_a: A,
+    /// The leading coefficient of the round polynomial: `h(inf)` / `s(inf)`.
+    pub c_inf: A,
+}
+
 /// Shared prefix round-coefficient scaffold, parameterised over the basis steps.
 ///
 /// The tiling, `PAR_THRESHOLD` par-vs-serial split, and `K`-tail fold are
@@ -216,7 +237,7 @@ where
     round_reduce(main, tail)
 }
 
-/// Computes `(h(0), h(inf))` for a prefix-binding sumcheck round.
+/// Computes the round message for a prefix-binding sumcheck round.
 ///
 /// # Inputs
 ///
@@ -225,20 +246,26 @@ where
 ///
 /// # Returns
 ///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
-/// - `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
+/// - `c_a` = `h(0)`     = sum_{b in {0,1}^{n-1}} f(0, b) * w(0, b)
+/// - `c_inf` = `h(inf)` = sum_{b} (f(1, b) - f(0, b)) * (w(1, b) - w(0, b))
 ///
 /// # Complexity
 ///
 /// O(2^n). Parallelised above a 2^14 threshold. The main loop is tiled by
 /// `K` over a delayed-reduction dot product; the `half mod K` tail uses a
 /// streaming fold.
-pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_prefix<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    sumcheck_coefficients_prefix_with(evals, weights, chunk_round_step::<B, A>, round_step::<B, A>)
+    let (c_a, c_inf) = sumcheck_coefficients_prefix_with(
+        evals,
+        weights,
+        chunk_round_step::<B, A>,
+        round_step::<B, A>,
+    );
+    RoundMessage { c_a, c_inf }
 }
 
 /// Projective (monomial-basis) variant of [`sumcheck_coefficients_prefix`]
@@ -248,25 +275,26 @@ where
 /// `[s(1), s(inf)]`; the verifier derives `s(0) := C - s(inf)` from the
 /// projective round identity `s(0) + s(inf) = C`. Returned as:
 ///
-/// - `s(1)`   = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
-/// - `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
+/// - `c_a` = `s(1)`     = sum_{b} (w(0,b) + w(inf,b)) * (f(0,b) + f(inf,b))
+/// - `c_inf` = `s(inf)` = sum_{b} w(inf, b) * f(inf, b)   (leading coefficient)
 ///
 /// The evaluation-basis kernel's per-pair subtractions (`hi - lo`) become
 /// additions (`lo + hi`); same `K`-tiled, delayed-reduction structure.
-pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_prefix_projective<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
 {
-    sumcheck_coefficients_prefix_with(
+    let (c_a, c_inf) = sumcheck_coefficients_prefix_with(
         evals,
         weights,
         chunk_round_step_projective::<B, A>,
         round_step_projective::<B, A>,
-    )
+    );
+    RoundMessage { c_a, c_inf }
 }
 
-/// Computes `(h(0), h(inf))` for a suffix-binding sumcheck round.
+/// Computes the round message for a suffix-binding sumcheck round.
 ///
 /// # Inputs
 ///
@@ -275,8 +303,8 @@ where
 ///
 /// # Returns
 ///
-/// - `h(0)`   = sum_{b in {0,1}^{n-1}} f(b, 0) * w(b, 0)
-/// - `h(inf)` = sum_{b} (f(b, 1) - f(b, 0)) * (w(b, 1) - w(b, 0))
+/// - `c_a` = `h(0)`     = sum_{b in {0,1}^{n-1}} f(b, 0) * w(b, 0)
+/// - `c_inf` = `h(inf)` = sum_{b} (f(b, 1) - f(b, 0)) * (w(b, 1) - w(b, 0))
 ///
 /// # Complexity
 ///
@@ -284,7 +312,7 @@ where
 /// buffer in `2K`-wide chunks: each chunk gathers `K` adjacent
 /// `(b_n=0, b_n=1)` pairs and dispatches to a delayed-reduction dot
 /// product.
-pub fn sumcheck_coefficients_suffix<B, A>(evals: &[B], weights: &[A]) -> (A, A)
+pub fn sumcheck_coefficients_suffix<B, A>(evals: &[B], weights: &[A]) -> RoundMessage<A>
 where
     B: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<B> + Copy + Send + Sync,
@@ -342,7 +370,8 @@ where
             round_step(acc, e[0], e[1], w[0], w[1])
         });
 
-    round_reduce(main, tail)
+    let (c_a, c_inf) = round_reduce(main, tail);
+    RoundMessage { c_a, c_inf }
 }
 
 /// Which side of the variable order is bound first by the sumcheck rounds.
@@ -364,8 +393,8 @@ pub enum VariableOrder {
 }
 
 impl VariableOrder {
-    /// Computes `(h(0), h(inf))` for one quadratic sumcheck round.
-    pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> (A, A)
+    /// Computes the [`RoundMessage`] for one quadratic sumcheck round.
+    pub fn sumcheck_coefficients<B, A>(self, evals: &[B], weights: &[A]) -> RoundMessage<A>
     where
         B: PrimeCharacteristicRing + Copy + Send + Sync,
         A: Algebra<B> + Copy + Send + Sync,
@@ -624,7 +653,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::VariableOrder;
+    use super::{RoundMessage, VariableOrder};
     use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
     use crate::constraints::{Constraint, Statements};
 
@@ -780,7 +809,8 @@ mod tests {
             let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
             let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
 
-            let (h1, h_inf) = super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+            let RoundMessage { c_a: h1, c_inf: h_inf } =
+                super::sumcheck_coefficients_prefix_projective(&evals, &weights);
 
             let half = n / 2;
             // s(1): the X = 1 evaluation of each coefficient pair is lo + hi.

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -465,6 +465,26 @@ impl Basis {
         }
     }
 
+    /// Reduces the running claim to `h(r)` from the two sent message elements.
+    ///
+    /// One source of truth for the round identity, shared by the prover and
+    /// the verifier:
+    ///
+    /// - [`Basis::Evaluation`]: message `[h(0), h(inf)]`; the identity
+    ///   `h(0) + h(1) = C` supplies `h(1) = C - h(0)`.
+    /// - [`Basis::Projective`]: message `[s(1), s(inf)]`; the identity
+    ///   `s(0) + s(inf) = C` supplies `s(0) = C - s(inf)`
+    ///   (eprint 2026/762, Fig. 3).
+    ///
+    /// Both reconstruct the quadratic through `{0, 1, inf}` and evaluate it
+    /// at `r`.
+    pub fn reduce_claim<EF: Field>(self, c_a: EF, c_inf: EF, r: EF, claimed_sum: EF) -> EF {
+        match self {
+            Self::Evaluation => extrapolate_01inf(c_a, claimed_sum - c_a, c_inf, r),
+            Self::Projective => extrapolate_01inf(claimed_sum - c_inf, c_a, c_inf, r),
+        }
+    }
+
     /// Binds the active round variable of `poly` to challenge `r`.
     ///
     /// - [`Basis::Evaluation`]: `a0 + (a1 - a0) * r`, dispatching on `order`.
@@ -664,6 +684,15 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     /// Folds the residual product polynomial by one challenge and updates the
     /// claimed sum with the same quadratic extrapolation as the plain path.
     pub(crate) fn fold_round_with_coefficients(&mut self, c0: EF, c_inf: EF, gamma: EF) {
+        // This entry point hardcodes the evaluation-basis reduction; its only
+        // caller is the zk residual path, which does not consult the basis.
+        // Guard the assumption so a projective configuration cannot silently
+        // run evaluation arithmetic here.
+        debug_assert_eq!(
+            self.poly.basis(),
+            Basis::Evaluation,
+            "the zk residual path does not support the projective basis"
+        );
         self.sum = extrapolate_01inf(c0, self.sum - c0, c_inf, gamma);
         self.poly.fold_round(gamma);
         debug_assert_eq!(self.sum, self.poly.dot_product());

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -645,8 +645,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
-    use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::{PrimeCharacteristicRing, dot_product};
     use p3_multilinear_util::point::Point;
     use p3_multilinear_util::poly::Poly;
     use proptest::prelude::*;
@@ -822,6 +822,47 @@ mod tests {
 
             prop_assert_eq!(h1, h1_ref);
             prop_assert_eq!(h_inf, h_inf_ref);
+        }
+
+        // The projective round identity, both protocol sides together: derive
+        // s(0) := C - s(inf) as the verifier does, evaluate the quadratic at
+        // the challenge, and compare against the dot product of the tables
+        // bound in the monomial basis. Unlike the reference check above, this
+        // fails if the sent message did not determine the round polynomial
+        // (e.g. the insufficient [s(0), s(inf)] message passes the reference
+        // check but not this one).
+        #[test]
+        fn prop_projective_round_message_satisfies_round_identity(
+            k in 1usize..=12,
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = 1usize << k;
+            let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let r: EF = rng.random();
+
+            let claim: EF = dot_product(evals.iter().copied(), weights.iter().copied());
+            let RoundMessage { c_a: s1, c_inf: s_inf } =
+                super::sumcheck_coefficients_prefix_projective(&evals, &weights);
+
+            // Verifier side: s(0) is derived, never sent. The quadratic is
+            // s(X) = s(0) + (s(1) - s(0) - s(inf)) * X + s(inf) * X^2.
+            let s0 = claim - s_inf;
+            let s_at_r = s0 + (s1 - s0 - s_inf) * r + s_inf * r.square();
+
+            // Prover side: bind the round variable at r in the monomial basis.
+            let (mut bound_evals, mut bound_weights) = (Poly::new(evals), Poly::new(weights));
+            bound_evals.fix_prefix_var_mut_monomial(r);
+            bound_weights.fix_prefix_var_mut_monomial(r);
+
+            prop_assert_eq!(
+                s_at_r,
+                dot_product(
+                    bound_evals.as_slice().iter().copied(),
+                    bound_weights.as_slice().iter().copied(),
+                )
+            );
         }
     }
 }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -559,6 +559,7 @@ impl VariableOrder {
         self,
         constraints: &[Constraint<F, EF>],
         challenge: &Point<EF>,
+        basis: Basis,
     ) -> EF
     where
         F: Field,
@@ -594,26 +595,44 @@ impl VariableOrder {
                 // Each statement group exposes its weights evaluated at the
                 // local challenge; the kinds differ only in how weights are formed.
                 for statement in constraint.statements() {
-                    match statement {
+                    match (statement, basis) {
                         // Equality weights: one term per recorded equality point.
-                        Statements::Eq(eq_statement) => {
+                        (Statements::Eq(eq_statement), Basis::Evaluation) => {
                             // Pair this group's weights with powers starting at the shift.
                             acc += dot_product::<EF, _, _>(
                                 eq_statement.weights_at(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
+                        // Projective: the same weight tensors read as monomial
+                        // coefficients, so the closed form changes.
+                        (Statements::Eq(eq_statement), Basis::Projective) => {
+                            acc += dot_product::<EF, _, _>(
+                                eq_statement.weights_at_projective(&local_challenge),
+                                constraint.challenge_powers(shift),
+                            );
+                        }
                         // Successor-view weights: equality through the repeat-last view.
-                        Statements::Next(next_statement) => {
+                        // Multi-stark only; the projective basis has no consumer for it.
+                        (Statements::Next(next_statement), Basis::Evaluation) => {
                             acc += dot_product::<EF, _, _>(
                                 next_statement.weights_at(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
+                        (Statements::Next(_), Basis::Projective) => {
+                            unimplemented!("Next statements are not supported projectively")
+                        }
                         // Selector weights: one term per single-variable selector.
-                        Statements::Select(sel_statement) => {
+                        (Statements::Select(sel_statement), Basis::Evaluation) => {
                             acc += dot_product::<EF, _, _>(
                                 sel_statement.weights_at(&local_challenge),
+                                constraint.challenge_powers(shift),
+                            );
+                        }
+                        (Statements::Select(sel_statement), Basis::Projective) => {
+                            acc += dot_product::<EF, _, _>(
+                                sel_statement.weights_at_projective(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
@@ -889,7 +908,11 @@ mod tests {
         let challenge = Point::rand(&mut rng, 20);
 
         // Fast path vs reference implementation must agree.
-        let got = VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge);
+        let got = VariableOrder::Prefix.eval_constraints_poly(
+            &constraints,
+            &challenge,
+            Basis::Evaluation,
+        );
         let expected =
             eval_constraints_poly_reference(VariableOrder::Prefix, &constraints, &challenge);
         assert_eq!(got, expected);
@@ -903,7 +926,11 @@ mod tests {
         let challenge = Point::rand(&mut rng, 20);
 
         // Fast path vs reference implementation must agree.
-        let got = VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge);
+        let got = VariableOrder::Suffix.eval_constraints_poly(
+            &constraints,
+            &challenge,
+            Basis::Evaluation,
+        );
         let expected =
             eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge);
         assert_eq!(got, expected);
@@ -924,11 +951,11 @@ mod tests {
             let challenge = Point::rand(&mut rng, total_num_variables);
 
             prop_assert_eq!(
-                VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge),
+                VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge, Basis::Evaluation),
                 eval_constraints_poly_reference(VariableOrder::Prefix, &constraints, &challenge),
             );
             prop_assert_eq!(
-                VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge),
+                VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge, Basis::Evaluation),
                 eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge),
             );
         }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -550,6 +550,7 @@ impl VariableOrder {
         self,
         constraints: &[Constraint<F, EF>],
         challenge: &Point<EF>,
+        basis: Basis,
     ) -> EF
     where
         F: Field,
@@ -585,26 +586,44 @@ impl VariableOrder {
                 // Each statement group exposes its weights evaluated at the
                 // local challenge; the kinds differ only in how weights are formed.
                 for statement in constraint.statements() {
-                    match statement {
+                    match (statement, basis) {
                         // Equality weights: one term per recorded equality point.
-                        Statements::Eq(eq_statement) => {
+                        (Statements::Eq(eq_statement), Basis::Evaluation) => {
                             // Pair this group's weights with powers starting at the shift.
                             acc += dot_product::<EF, _, _>(
                                 eq_statement.weights_at(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
+                        // Projective: the same weight tensors read as monomial
+                        // coefficients, so the closed form changes.
+                        (Statements::Eq(eq_statement), Basis::Projective) => {
+                            acc += dot_product::<EF, _, _>(
+                                eq_statement.weights_at_projective(&local_challenge),
+                                constraint.challenge_powers(shift),
+                            );
+                        }
                         // Successor-view weights: equality through the repeat-last view.
-                        Statements::Next(next_statement) => {
+                        // Multi-stark only; the projective basis has no consumer for it.
+                        (Statements::Next(next_statement), Basis::Evaluation) => {
                             acc += dot_product::<EF, _, _>(
                                 next_statement.weights_at(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
+                        (Statements::Next(_), Basis::Projective) => {
+                            unimplemented!("Next statements are not supported projectively")
+                        }
                         // Selector weights: one term per single-variable selector.
-                        Statements::Select(sel_statement) => {
+                        (Statements::Select(sel_statement), Basis::Evaluation) => {
                             acc += dot_product::<EF, _, _>(
                                 sel_statement.weights_at(&local_challenge),
+                                constraint.challenge_powers(shift),
+                            );
+                        }
+                        (Statements::Select(sel_statement), Basis::Projective) => {
+                            acc += dot_product::<EF, _, _>(
+                                sel_statement.weights_at_projective(&local_challenge),
                                 constraint.challenge_powers(shift),
                             );
                         }
@@ -783,7 +802,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::{RoundMessage, VariableOrder};
+    use super::{Basis, RoundMessage, VariableOrder};
     use crate::constraints::statement::{EqStatement, NextStatement, SelectStatement};
     use crate::constraints::{Constraint, Statements};
 
@@ -880,7 +899,11 @@ mod tests {
         let challenge = Point::rand(&mut rng, 20);
 
         // Fast path vs reference implementation must agree.
-        let got = VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge);
+        let got = VariableOrder::Prefix.eval_constraints_poly(
+            &constraints,
+            &challenge,
+            Basis::Evaluation,
+        );
         let expected =
             eval_constraints_poly_reference(VariableOrder::Prefix, &constraints, &challenge);
         assert_eq!(got, expected);
@@ -894,7 +917,11 @@ mod tests {
         let challenge = Point::rand(&mut rng, 20);
 
         // Fast path vs reference implementation must agree.
-        let got = VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge);
+        let got = VariableOrder::Suffix.eval_constraints_poly(
+            &constraints,
+            &challenge,
+            Basis::Evaluation,
+        );
         let expected =
             eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge);
         assert_eq!(got, expected);
@@ -915,11 +942,11 @@ mod tests {
             let challenge = Point::rand(&mut rng, total_num_variables);
 
             prop_assert_eq!(
-                VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge),
+                VariableOrder::Prefix.eval_constraints_poly(&constraints, &challenge, Basis::Evaluation),
                 eval_constraints_poly_reference(VariableOrder::Prefix, &constraints, &challenge),
             );
             prop_assert_eq!(
-                VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge),
+                VariableOrder::Suffix.eval_constraints_poly(&constraints, &challenge, Basis::Evaluation),
                 eval_constraints_poly_reference(VariableOrder::Suffix, &constraints, &challenge),
             );
         }

--- a/sumcheck/src/svo/accumulator.rs
+++ b/sumcheck/src/svo/accumulator.rs
@@ -427,11 +427,11 @@ mod test {
                 let cinf =
                     dot_product::<EF, _, _>(acc_inf.iter().copied(), weights.iter().copied());
 
-                let (c0_ref, cinf_ref) =
+                let msg =
                     VariableOrder::Suffix.sumcheck_coefficients(poly.as_slice(), eq.as_slice());
 
-                assert_eq!(c0, c0_ref);
-                assert_eq!(cinf, cinf_ref);
+                assert_eq!(c0, msg.c_a);
+                assert_eq!(cinf, msg.c_inf);
 
                 let r: EF = rng.random();
                 poly.fix_suffix_var_mut(r);
@@ -489,11 +489,11 @@ mod test {
                 let cinf =
                     dot_product::<EF, _, _>(acc_inf.iter().copied(), weights.iter().copied());
 
-                let (c0_ref, cinf_ref) =
+                let msg =
                     VariableOrder::Prefix.sumcheck_coefficients(poly.as_slice(), eq.as_slice());
 
-                assert_eq!(c0, c0_ref);
-                assert_eq!(cinf, cinf_ref);
+                assert_eq!(c0, msg.c_a);
+                assert_eq!(cinf, msg.c_inf);
 
                 let r: EF = rng.random();
                 poly.fix_prefix_var_mut(r);

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -9,13 +9,14 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_util::log2_strict_usize;
 use proptest::prelude::*;
-use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 use crate::constraints::statement::{EqStatement, SelectStatement};
 use crate::constraints::{Constraint, Statements};
 use crate::layout::{Layout, PrefixProver, SuffixProver, TableShape, Verifier};
-use crate::strategy::VariableOrder;
+use crate::product_polynomial::ProductPolynomial;
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::test_util::{stacked_num_variables, table_point_schedule, table_specs_to_tables};
 use crate::{
     OpeningBatch, OpeningEvals, OpeningProtocol, SumcheckData, SumcheckError, TableSpec,
@@ -348,7 +349,13 @@ where
 
         verifier_randomness.extend(
             &proof[0]
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -367,7 +374,13 @@ where
 
         verifier_randomness.extend(
             &proof[round]
-                .verify_rounds(&mut verifier_challenger, &mut sum, FOLDING, 0)
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut sum,
+                    FOLDING,
+                    0,
+                    Basis::Evaluation,
+                )
                 .unwrap(),
         );
         num_variables_inter -= FOLDING;
@@ -377,7 +390,13 @@ where
         &proof
             .last()
             .unwrap()
-            .verify_rounds(&mut verifier_challenger, &mut sum, num_variables_inter, 0)
+            .verify_rounds(
+                &mut verifier_challenger,
+                &mut sum,
+                num_variables_inter,
+                0,
+                Basis::Evaluation,
+            )
             .unwrap(),
     );
 
@@ -437,8 +456,15 @@ fn test_zero_rounds_returns_empty_point() {
     // Case 1: no data.
     let mut chal = challenger();
     let mut sum = EF::ZERO;
-    let point = verify_final_sumcheck_rounds::<F, EF, _>(None, &mut chal, &mut sum, 0, 0)
-        .expect("0 rounds + None must succeed");
+    let point = verify_final_sumcheck_rounds::<F, EF, _>(
+        None,
+        &mut chal,
+        &mut sum,
+        0,
+        0,
+        Basis::Evaluation,
+    )
+    .expect("0 rounds + None must succeed");
     assert!(point.as_slice().is_empty());
 
     // Case 2: data supplied but ignored.
@@ -448,8 +474,9 @@ fn test_zero_rounds_returns_empty_point() {
     };
     let mut chal = challenger();
     let mut sum = EF::ZERO;
-    let point = verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, 0, 0)
-        .expect("0 rounds + Some must succeed");
+    let point =
+        verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, 0, 0, Basis::Evaluation)
+            .expect("0 rounds + Some must succeed");
     assert!(point.as_slice().is_empty());
 }
 
@@ -460,8 +487,15 @@ fn test_missing_sumcheck_data() {
     let mut sum = EF::ZERO;
     let rounds = 3;
 
-    let err = verify_final_sumcheck_rounds::<F, EF, _>(None, &mut chal, &mut sum, rounds, 0)
-        .expect_err("None + rounds > 0 must error");
+    let err = verify_final_sumcheck_rounds::<F, EF, _>(
+        None,
+        &mut chal,
+        &mut sum,
+        rounds,
+        0,
+        Basis::Evaluation,
+    )
+    .expect_err("None + rounds > 0 must error");
 
     match err {
         // Inner field must echo the requested round count.
@@ -487,8 +521,15 @@ fn test_round_count_mismatch() {
         pow_witnesses: vec![],
     };
 
-    let err = verify_final_sumcheck_rounds(Some(&data), &mut chal, &mut sum, expected_rounds, 0)
-        .expect_err("length mismatch must error");
+    let err = verify_final_sumcheck_rounds(
+        Some(&data),
+        &mut chal,
+        &mut sum,
+        expected_rounds,
+        0,
+        Basis::Evaluation,
+    )
+    .expect_err("length mismatch must error");
 
     match err {
         SumcheckError::RoundCountMismatch { expected, actual } => {
@@ -515,7 +556,7 @@ fn test_verify_rounds_rejects_wrong_round_count() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, expected_rounds, 0)
+        .verify_rounds(&mut chal, &mut sum, expected_rounds, 0, Basis::Evaluation)
         .expect_err("wrong round count must error");
 
     match err {
@@ -540,7 +581,7 @@ fn test_pow_witness_count_mismatch() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, expected, 20)
+        .verify_rounds(&mut chal, &mut sum, expected, 20, Basis::Evaluation)
         .expect_err("witness-count mismatch must error before indexing");
 
     match err {
@@ -569,8 +610,124 @@ fn test_invalid_pow_witness() {
     };
 
     let err = data
-        .verify_rounds(&mut chal, &mut sum, data.num_rounds(), pow_bits)
+        .verify_rounds(
+            &mut chal,
+            &mut sum,
+            data.num_rounds(),
+            pow_bits,
+            Basis::Evaluation,
+        )
         .expect_err("zeroed witness must fail");
 
     assert!(matches!(err, SumcheckError::InvalidPowWitness));
+}
+
+/// Full projective sum-check round trip: prove with the projective
+/// `ProductPolynomial`, verify the transcript with the projective round
+/// identity, and check the reduced claim against monomial evaluations of the
+/// original tables (the final oracle check).
+///
+/// This drives the production kernels through a real prover AND a real
+/// verifier, the end-to-end evidence the Stage-1 equivalence test lacked.
+#[test]
+fn test_projective_sumcheck_round_trip() {
+    let mut rng = SmallRng::seed_from_u64(7);
+    let k = 6;
+    let n = 1usize << k;
+    let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let evals_poly = Poly::new(evals.clone());
+    let weights_poly = Poly::new(weights.clone());
+
+    // The claim is the same dot product in both bases.
+    let claim: EF = evals.iter().zip(&weights).map(|(&e, &w)| e * w).sum();
+
+    // Prover: k full projective rounds.
+    let poly = ProductPolynomial::<F, EF>::new_unpacked(
+        VariableOrder::Prefix,
+        evals_poly.clone(),
+        weights_poly.clone(),
+    )
+    .with_basis(Basis::Projective);
+    let mut prover = SumcheckProver::new(poly, claim);
+    let mut data = SumcheckData::default();
+    let mut prover_challenger = challenger();
+    let prover_randomness =
+        prover.compute_sumcheck_polynomials(&mut data, &mut prover_challenger, k, 0, None);
+
+    // Verifier: same transcript, projective derivation s(0) := C - s(inf).
+    let mut verifier_challenger = challenger();
+    let mut claimed = claim;
+    let verifier_randomness = data
+        .verify_rounds(
+            &mut verifier_challenger,
+            &mut claimed,
+            k,
+            0,
+            Basis::Projective,
+        )
+        .expect("honest projective transcript must verify");
+    assert_eq!(prover_randomness, verifier_randomness);
+
+    // Final oracle check: the reduced claim equals f(r) * w(r), both tables
+    // read as monomial polynomials.
+    let f_r = evals_poly.eval_monomial(&verifier_randomness);
+    let w_r = weights_poly.eval_monomial(&verifier_randomness);
+    assert_eq!(claimed, f_r * w_r);
+
+    // The prover's fully bound table agrees with the monomial evaluation.
+    assert_eq!(prover.evals().as_constant().unwrap(), f_r);
+    assert_eq!(prover.claimed_sum(), claimed);
+}
+
+/// Any perturbed projective round message breaks the final oracle check.
+#[test]
+fn test_projective_sumcheck_rejects_tampering() {
+    let mut rng = SmallRng::seed_from_u64(8);
+    let k = 5;
+    let n = 1usize << k;
+    let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let evals_poly = Poly::new(evals.clone());
+    let weights_poly = Poly::new(weights.clone());
+    let claim: EF = evals.iter().zip(&weights).map(|(&e, &w)| e * w).sum();
+
+    // One honest transcript, reused for every tampering position.
+    let poly = ProductPolynomial::<F, EF>::new_unpacked(
+        VariableOrder::Prefix,
+        evals_poly.clone(),
+        weights_poly.clone(),
+    )
+    .with_basis(Basis::Projective);
+    let mut prover = SumcheckProver::new(poly, claim);
+    let mut honest = SumcheckData::default();
+    let _ = prover.compute_sumcheck_polynomials(&mut honest, &mut challenger(), k, 0, None);
+
+    for round in 0..k {
+        for slot in 0..2 {
+            let mut tampered = honest.clone();
+            tampered.polynomial_evaluations[round][slot] += EF::ONE;
+
+            let mut verifier_challenger = challenger();
+            let mut claimed = claim;
+            let randomness = tampered
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut claimed,
+                    k,
+                    0,
+                    Basis::Projective,
+                )
+                .expect("structure is intact; rejection happens at the oracle check");
+
+            // The final oracle check must fail for every tampering position.
+            let f_r = evals_poly.eval_monomial(&randomness);
+            let w_r = weights_poly.eval_monomial(&randomness);
+            assert_ne!(
+                claimed,
+                f_r * w_r,
+                "tampering round {round} slot {slot} must be rejected"
+            );
+        }
+    }
 }

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -282,8 +282,12 @@ where
         .map(|(table_idx, batch)| layout.eval(table_idx, batch, &mut prover_challenger))
         .collect();
 
-    let (mut sumcheck, mut prover_randomness) =
-        layout.into_sumcheck(proof.first_mut().unwrap(), 0, &mut prover_challenger);
+    let (mut sumcheck, mut prover_randomness) = layout.into_sumcheck(
+        proof.first_mut().unwrap(),
+        0,
+        &mut prover_challenger,
+        Basis::Evaluation,
+    );
     let mut num_variables_inter = num_variables - FOLDING;
 
     for sumcheck_data in proof.iter_mut().take(num_rounds + 1).skip(1) {
@@ -401,9 +405,11 @@ where
     );
 
     assert_eq!(prover_randomness, verifier_randomness);
-    let weights = strategy
-        .variable_order
-        .eval_constraints_poly(&constraints, &verifier_randomness);
+    let weights = strategy.variable_order.eval_constraints_poly(
+        &constraints,
+        &verifier_randomness,
+        Basis::Evaluation,
+    );
     assert_eq!(sum, final_folded_value * weights);
 }
 

--- a/sumcheck/src/tests.rs
+++ b/sumcheck/src/tests.rs
@@ -9,13 +9,14 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_util::log2_strict_usize;
 use proptest::prelude::*;
-use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 use crate::constraints::statement::{EqStatement, SelectStatement};
 use crate::constraints::{Constraint, Statements};
 use crate::layout::{Layout, PrefixProver, SuffixProver, TableShape, Verifier};
-use crate::strategy::{Basis, VariableOrder};
+use crate::product_polynomial::ProductPolynomial;
+use crate::strategy::{Basis, SumcheckProver, VariableOrder};
 use crate::test_util::{stacked_num_variables, table_point_schedule, table_specs_to_tables};
 use crate::{
     OpeningBatch, OpeningEvals, OpeningProtocol, SumcheckData, SumcheckError, TableSpec,
@@ -619,4 +620,114 @@ fn test_invalid_pow_witness() {
         .expect_err("zeroed witness must fail");
 
     assert!(matches!(err, SumcheckError::InvalidPowWitness));
+}
+
+/// Full projective sum-check round trip: prove with the projective
+/// `ProductPolynomial`, verify the transcript with the projective round
+/// identity, and check the reduced claim against monomial evaluations of the
+/// original tables (the final oracle check).
+///
+/// This drives the production kernels through a real prover AND a real
+/// verifier, the end-to-end evidence the Stage-1 equivalence test lacked.
+#[test]
+fn test_projective_sumcheck_round_trip() {
+    let mut rng = SmallRng::seed_from_u64(7);
+    let k = 6;
+    let n = 1usize << k;
+    let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let evals_poly = Poly::new(evals.clone());
+    let weights_poly = Poly::new(weights.clone());
+
+    // The claim is the same dot product in both bases.
+    let claim: EF = evals.iter().zip(&weights).map(|(&e, &w)| e * w).sum();
+
+    // Prover: k full projective rounds.
+    let poly = ProductPolynomial::<F, EF>::new_unpacked(
+        VariableOrder::Prefix,
+        evals_poly.clone(),
+        weights_poly.clone(),
+    )
+    .with_basis(Basis::Projective);
+    let mut prover = SumcheckProver::new(poly, claim);
+    let mut data = SumcheckData::default();
+    let mut prover_challenger = challenger();
+    let prover_randomness =
+        prover.compute_sumcheck_polynomials(&mut data, &mut prover_challenger, k, 0, None);
+
+    // Verifier: same transcript, projective derivation s(0) := C - s(inf).
+    let mut verifier_challenger = challenger();
+    let mut claimed = claim;
+    let verifier_randomness = data
+        .verify_rounds(
+            &mut verifier_challenger,
+            &mut claimed,
+            k,
+            0,
+            Basis::Projective,
+        )
+        .expect("honest projective transcript must verify");
+    assert_eq!(prover_randomness, verifier_randomness);
+
+    // Final oracle check: the reduced claim equals f(r) * w(r), both tables
+    // read as monomial polynomials.
+    let f_r = evals_poly.eval_monomial(&verifier_randomness);
+    let w_r = weights_poly.eval_monomial(&verifier_randomness);
+    assert_eq!(claimed, f_r * w_r);
+
+    // The prover's fully bound table agrees with the monomial evaluation.
+    assert_eq!(prover.evals().as_constant().unwrap(), f_r);
+    assert_eq!(prover.claimed_sum(), claimed);
+}
+
+/// Any perturbed projective round message breaks the final oracle check.
+#[test]
+fn test_projective_sumcheck_rejects_tampering() {
+    let mut rng = SmallRng::seed_from_u64(8);
+    let k = 5;
+    let n = 1usize << k;
+    let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+    let evals_poly = Poly::new(evals.clone());
+    let weights_poly = Poly::new(weights.clone());
+    let claim: EF = evals.iter().zip(&weights).map(|(&e, &w)| e * w).sum();
+
+    // One honest transcript, reused for every tampering position.
+    let poly = ProductPolynomial::<F, EF>::new_unpacked(
+        VariableOrder::Prefix,
+        evals_poly.clone(),
+        weights_poly.clone(),
+    )
+    .with_basis(Basis::Projective);
+    let mut prover = SumcheckProver::new(poly, claim);
+    let mut honest = SumcheckData::default();
+    let _ = prover.compute_sumcheck_polynomials(&mut honest, &mut challenger(), k, 0, None);
+
+    for round in 0..k {
+        for slot in 0..2 {
+            let mut tampered = honest.clone();
+            tampered.polynomial_evaluations[round][slot] += EF::ONE;
+
+            let mut verifier_challenger = challenger();
+            let mut claimed = claim;
+            let randomness = tampered
+                .verify_rounds(
+                    &mut verifier_challenger,
+                    &mut claimed,
+                    k,
+                    0,
+                    Basis::Projective,
+                )
+                .expect("structure is intact; rejection happens at the oracle check");
+
+            // The final oracle check must fail for every tampering position.
+            let f_r = evals_poly.eval_monomial(&randomness);
+            let w_r = weights_poly.eval_monomial(&randomness);
+            assert_ne!(
+                claimed,
+                f_r * w_r,
+                "tampering round {round} slot {slot} must be rejected"
+            );
+        }
+    }
 }

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -10,7 +10,7 @@ use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCh
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
-use p3_sumcheck::strategy::sumcheck_coefficients_prefix;
+use p3_sumcheck::strategy::{Basis, sumcheck_coefficients_prefix};
 use p3_sumcheck::zk::{ZkLayout, ZkProver, ZkSumcheckData};
 use p3_sumcheck::{OpeningBatch, SumcheckData};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -142,7 +142,7 @@ where
 
 fn run_sumcheck<L: Layout<F, EF>>(prover: L, challenger: &mut Challenger, folding: usize) {
     let mut data = SumcheckData::default();
-    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger);
+    let (residual, randomness) = prover.into_sumcheck(&mut data, 0, challenger, Basis::Evaluation);
     assert_eq!(data.num_rounds(), folding);
     assert_eq!(randomness.num_variables(), folding);
     assert!(residual.num_variables() > 0);

--- a/whir/benches/sumcheck.rs
+++ b/whir/benches/sumcheck.rs
@@ -244,9 +244,10 @@ fn bench_round_coefficients(c: &mut Criterion) {
         &n,
         |b, _| {
             b.iter(|| {
-                let (c0, c_inf) =
-                    sumcheck_coefficients_prefix(black_box(&evals), black_box(&weights));
-                black_box((c0, c_inf))
+                black_box(sumcheck_coefficients_prefix(
+                    black_box(&evals),
+                    black_box(&weights),
+                ))
             });
         },
     );

--- a/whir/benches/whir_pcs.rs
+++ b/whir/benches/whir_pcs.rs
@@ -17,7 +17,9 @@ use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, PointSchedule, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
-use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
+use p3_whir::parameters::{
+    Basis, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig,
+};
 use p3_whir::pcs::proof::{PcsProof, QueryOpenings};
 use p3_whir::pcs::prover::WhirProver;
 use rand::SeedableRng;
@@ -57,6 +59,12 @@ const NUM_EVALUATIONS: usize = 1;
 /// One benchmark configuration.
 #[derive(Clone, Copy)]
 struct Options {
+    /// Polynomial basis the protocol runs in.
+    basis: Basis,
+    /// Target security level in bits.
+    security_level: usize,
+    /// Proof-of-work grinding budget in bits.
+    pow_bits: usize,
     /// Log-2 of the polynomial coefficient count.
     num_variables: usize,
     /// Variables eliminated per WHIR round.
@@ -71,6 +79,9 @@ impl Options {
     /// Default configuration sized to a polynomial of the given variable count.
     const fn sized(num_variables: usize) -> Self {
         Self {
+            basis: Basis::Evaluation,
+            security_level: SECURITY_LEVEL,
+            pow_bits: 20,
             num_variables,
             folding: FOLDING,
             log_inv_rate: LOG_INV_RATE,
@@ -79,6 +90,21 @@ impl Options {
     }
 
     /// Override the soundness assumption.
+    const fn with_basis(mut self, basis: Basis) -> Self {
+        self.basis = basis;
+        self
+    }
+
+    /// Grind-free low-security configuration: identical query structure in
+    /// both bases and zero proof-of-work noise. Grinding work is fixed per
+    /// transcript, and the two bases produce different transcripts, so a
+    /// grinding-enabled comparison carries an irreducible luck bias.
+    const fn grind_free(mut self) -> Self {
+        self.security_level = 32;
+        self.pow_bits = 0;
+        self
+    }
+
     const fn with_soundness(mut self, soundness: SecurityAssumption) -> Self {
         self.soundness = soundness;
         self
@@ -155,8 +181,8 @@ impl<L: Layout<F, EF>> Bench<L> {
         // Translate user options into the protocol's parameter struct.
         let folding_factor = FoldingFactor::Constant(opts.folding);
         let params = ProtocolParameters {
-            security_level: SECURITY_LEVEL,
-            pow_bits: 20,
+            security_level: opts.security_level,
+            pow_bits: opts.pow_bits,
             round_log_inv_rates: default_round_log_inv_rates(opts.num_variables, &folding_factor),
             folding_factor,
             soundness_type: opts.soundness,
@@ -164,7 +190,9 @@ impl<L: Layout<F, EF>> Bench<L> {
         };
 
         // Derive the per-round configuration and pre-allocate FFT twiddles.
-        let config = WhirConfig::<EF, F, Challenger>::new(opts.num_variables, params).unwrap();
+        let config = WhirConfig::<EF, F, Challenger>::new(opts.num_variables, params)
+            .unwrap()
+            .with_basis(opts.basis);
         let dft = Dft::new(1 << config.max_fft_size());
         let pcs = Pcs::<L>::new(config, dft, mmcs);
 
@@ -389,6 +417,52 @@ fn bench_scaling(c: &mut Criterion) {
     }
 }
 
+/// The basis comparison: evaluation vs projective (eprint 2026/762), prove
+/// phase, prefix layout (the projective basis is prefix-only).
+///
+/// This is the deciding benchmark of the projective-WHIR experiment: the
+/// pre-registered close condition compares these pairs per size.
+fn bench_basis(c: &mut Criterion) {
+    type L = PrefixProver<F, EF>;
+    // Primary: grind-free, so the comparison measures arithmetic and hashing
+    // rather than per-transcript grinding luck.
+    {
+        let mut group = c.benchmark_group("whir_pcs/basis/prove");
+        group.sample_size(10);
+        group.warm_up_time(Duration::from_secs(5));
+        group.measurement_time(Duration::from_secs(10));
+        for k in [14_usize, 18, 20, 22] {
+            for (tag, basis) in [
+                ("eval", Basis::Evaluation),
+                ("projective", Basis::Projective),
+            ] {
+                Bench::<L>::new(Options::sized(k).grind_free().with_basis(basis))
+                    .bench_prove(&mut group, &format!("k{k}_{tag}"));
+            }
+        }
+        group.finish();
+    }
+
+    // Secondary: the production-like grinding configuration, reported with
+    // the grinding-luck caveat.
+    {
+        let mut group = c.benchmark_group("whir_pcs/basis_pow20/prove");
+        group.sample_size(10);
+        group.warm_up_time(Duration::from_secs(5));
+        group.measurement_time(Duration::from_secs(10));
+        for k in [20_usize, 22] {
+            for (tag, basis) in [
+                ("eval", Basis::Evaluation),
+                ("projective", Basis::Projective),
+            ] {
+                Bench::<L>::new(Options::sized(k).with_basis(basis))
+                    .bench_prove(&mut group, &format!("k{k}_{tag}"));
+            }
+        }
+        group.finish();
+    }
+}
+
 /// Options sweep at the medium size, prove phase only.
 fn bench_options(c: &mut Criterion) {
     let base = Options::sized(MEDIUM);
@@ -455,6 +529,6 @@ fn report_proof_size(_c: &mut Criterion) {
     eprintln!();
 }
 
-criterion_group!(benches, bench_scaling, bench_options);
+criterion_group!(benches, bench_scaling, bench_options, bench_basis);
 criterion_group!(reports, report_proof_size);
 criterion_main!(benches, reports);

--- a/whir/examples/whir.rs
+++ b/whir/examples/whir.rs
@@ -15,12 +15,12 @@ use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_sumcheck::layout::{Layout as _, SuffixProver, Table};
+use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, PointSchedule, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
 use p3_whir::parameters::{
-    DEFAULT_MAX_POW, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig,
+    Basis, DEFAULT_MAX_POW, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig,
 };
 use p3_whir::pcs::prover::WhirProver;
 use rand::SeedableRng;
@@ -49,8 +49,7 @@ type MyChallenger = DuplexChallenger<F, Poseidon16, 16, 8>;
 type PackedF = <F as Field>::Packing;
 type MyMmcs = MerkleTreeMmcs<PackedF, PackedF, MerkleHash, MerkleCompress, 2, 8>;
 type MyDft = Radix2DFTSmallBatch<F>;
-type Layout = SuffixProver<F, EF>;
-type MyPcs = WhirProver<EF, F, MyDft, MyMmcs, MyChallenger, Layout>;
+type MyPcs<L> = WhirProver<EF, F, MyDft, MyMmcs, MyChallenger, L>;
 
 /// Command-line arguments for the WHIR benchmark.
 #[derive(Parser, Debug)]
@@ -88,12 +87,31 @@ struct Args {
     #[arg(long = "sec", default_value = "CapacityBound")]
     soundness_type: SecurityAssumption,
 
+    /// Run the protocol in the projective (monomial) basis of eprint 2026/762.
+    /// Requires the prefix variable order.
+    #[arg(long = "projective", default_value = "false")]
+    projective: bool,
+
+    /// Variable-binding order: "suffix" (default) or "prefix".
+    #[arg(long = "order", default_value = "suffix")]
+    order: String,
+
     /// Explicit comma-separated log-inverse rates for intermediate codewords.
     #[arg(long = "round-log-inv-rates", value_delimiter = ',')]
     round_log_inv_rates: Vec<usize>,
 }
 
 fn main() {
+    let args = Args::parse();
+    match (args.order.as_str(), args.projective) {
+        ("suffix", false) => run::<SuffixProver<F, EF>>(args),
+        ("prefix", _) => run::<PrefixProver<F, EF>>(args),
+        ("suffix", true) => panic!("the projective basis is prefix-only; pass --order prefix"),
+        (other, _) => panic!("unknown order {other:?}; use \"prefix\" or \"suffix\""),
+    }
+}
+
+fn run<L: Layout<F, EF>>(mut args: Args) {
     // Initialize structured logging with tracing-forest.
     // Respects RUST_LOG env var; defaults to INFO level.
     let env_filter = EnvFilter::builder()
@@ -104,9 +122,6 @@ fn main() {
         .with(env_filter)
         .with(ForestLayer::default())
         .init();
-
-    // Parse command-line arguments.
-    let mut args = Args::parse();
 
     // Default PoW to the protocol's recommended maximum if not specified.
     if args.pow_bits.is_none() {
@@ -172,7 +187,7 @@ fn main() {
     // Generate one random single-column table.
     let mut rng = SmallRng::seed_from_u64(0);
     let table = Table::rand(&mut rng, 1, num_variables);
-    let witness = Layout::new_witness(vec![table], folding_factor.at_round(0));
+    let witness = L::new_witness(vec![table], folding_factor.at_round(0));
 
     let point_schedule: PointSchedule = (0..num_evaluations)
         .map(|_| OpeningBatch::new(vec![0], Vec::new()))
@@ -185,8 +200,14 @@ fn main() {
     assert_eq!(witness.table_shapes(), protocol.table_shapes());
 
     // Derive the full round-by-round configuration from the committed witness.
-    let config =
-        WhirConfig::<EF, F, MyChallenger>::new(witness.num_variables(), whir_params).unwrap();
+    let basis = if args.projective {
+        Basis::Projective
+    } else {
+        Basis::Evaluation
+    };
+    let config = WhirConfig::<EF, F, MyChallenger>::new(witness.num_variables(), whir_params)
+        .unwrap()
+        .with_basis(basis);
     if !config.check_pow_bits() {
         warn!("more PoW bits required than what was specified");
     }
@@ -196,7 +217,7 @@ fn main() {
 
     // Pre-allocate DFT twiddle factors up to the maximum FFT size.
     let dft = Radix2DFTSmallBatch::<F>::new(1 << config.max_fft_size());
-    let pcs = MyPcs::new(config, dft, mmcs);
+    let pcs = MyPcs::<L>::new(config, dft, mmcs);
 
     // Phase 1: Commitment (DFT encoding + Merkle tree + OOD sampling).
     let mut prover_challenger = challenger.clone();
@@ -204,13 +225,16 @@ fn main() {
     pcs.add_domain_separator::<8>(&mut domainsep);
     domainsep.observe_domain_separator(&mut prover_challenger);
     let time = Instant::now();
-    let (commitment, prover_data) =
-        <MyPcs as MultilinearPcs<EF, MyChallenger>>::commit(&pcs, witness, &mut prover_challenger);
+    let (commitment, prover_data) = <MyPcs<L> as MultilinearPcs<EF, MyChallenger>>::commit(
+        &pcs,
+        witness,
+        &mut prover_challenger,
+    );
     let commit_time = time.elapsed();
 
     // Phase 2: Opening proof (multi-round sumcheck + STIR queries + PoW).
     let time = Instant::now();
-    let proof = <MyPcs as MultilinearPcs<EF, MyChallenger>>::open(
+    let proof = <MyPcs<L> as MultilinearPcs<EF, MyChallenger>>::open(
         &pcs,
         prover_data,
         protocol.clone(),
@@ -234,7 +258,7 @@ fn main() {
 
     // Phase 3: Verification (sumcheck checks + Merkle proof verification).
     let verif_time = Instant::now();
-    <MyPcs as MultilinearPcs<EF, MyChallenger>>::verify(
+    <MyPcs<L> as MultilinearPcs<EF, MyChallenger>>::verify(
         &pcs,
         &commitment,
         &proof,

--- a/whir/examples/whir_blake3.rs
+++ b/whir/examples/whir_blake3.rs
@@ -1,0 +1,222 @@
+//! WHIR PCS profiling example with a Blake3 Merkle backend.
+//!
+//! Identical protocol flow to the `whir` example, but with byte-oriented
+//! Blake3 hashing for the Merkle tree AND the Fiat-Shamir challenger, so both
+//! commitment hashing and proof-of-work grinding run on the cheap hash. This
+//! is the most sum-check-favorable configuration: it maximizes the fraction of
+//! prover time spent in basis-affected arithmetic.
+//!
+//! Run with: `cargo run --release --example whir_blake3 -- --num-variables 22 -p 20`
+
+use std::time::Instant;
+
+use clap::Parser;
+use p3_blake3::Blake3;
+use p3_challenger::{HashChallenger, SerializingChallenger32};
+use p3_commit::MultilinearPcs;
+use p3_dft::Radix2DFTSmallBatch;
+use p3_field::extension::BinomialExtensionField;
+use p3_koala_bear::KoalaBear;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_sumcheck::layout::{Layout as _, PrefixProver, Table};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, PointSchedule, TableShape, TableSpec};
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
+use p3_whir::parameters::{
+    DEFAULT_MAX_POW, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig,
+};
+use p3_whir::pcs::prover::WhirProver;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use tracing::{info, warn};
+use tracing_forest::ForestLayer;
+use tracing_forest::util::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+// Base field: 31-bit prime with large 2-adic subgroup.
+type F = KoalaBear;
+// Degree-4 extension for constraint batching and OOD sampling.
+type EF = BinomialExtensionField<F, 4>;
+
+// Blake3-backed Merkle: serialize field rows to bytes, hash into 32-byte digests.
+type ByteHash = Blake3;
+type FieldHash = SerializingHasher<Blake3>;
+type MerkleCompress = CompressionFunctionFromHasher<Blake3, 2, 32>;
+type MyMmcs = MerkleTreeMmcs<F, u8, FieldHash, MerkleCompress, 2, 32>;
+// Byte-stream challenger: Blake3 sponge feeding the Fiat-Shamir transcript.
+type MyChallenger = SerializingChallenger32<F, HashChallenger<u8, Blake3, 32>>;
+type MyDft = Radix2DFTSmallBatch<F>;
+type Layout = PrefixProver<F, EF>;
+type MyPcs = WhirProver<EF, F, MyDft, MyMmcs, MyChallenger, Layout>;
+
+/// Command-line arguments for the Blake3 WHIR profile.
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "WHIR multilinear PCS profile (Blake3 Merkle)"
+)]
+struct Args {
+    /// Target security level in bits (e.g. 90 or 128).
+    #[arg(short = 'l', long, default_value = "90")]
+    security_level: usize,
+
+    /// Proof-of-work grinding difficulty. Defaults to the protocol maximum.
+    #[arg(short = 'p', long)]
+    pow_bits: Option<usize>,
+
+    /// Number of variables m in the multilinear polynomial (degree = 2^m).
+    #[arg(short = 'd', long, default_value = "22")]
+    num_variables: usize,
+
+    /// Number of opening points for the single committed polynomial.
+    #[arg(short = 'e', long = "evaluations", default_value = "1")]
+    num_evaluations: usize,
+
+    /// Starting log-inverse rate: log_2(1/rho) where rho = 2^m / |L|.
+    #[arg(short = 'r', long, default_value = "1")]
+    rate: usize,
+
+    /// Folding parameter k: variables eliminated per WHIR round.
+    #[arg(short = 'k', long = "fold", default_value = "5")]
+    folding_factor: usize,
+
+    /// Soundness assumption: UniqueDecoding, JohnsonBound, or CapacityBound.
+    #[arg(long = "sec", default_value = "CapacityBound")]
+    soundness_type: SecurityAssumption,
+}
+
+fn main() {
+    // Structured logging with tracing-forest; respects RUST_LOG, defaults to INFO.
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    Registry::default()
+        .with(env_filter)
+        .with(ForestLayer::default())
+        .init();
+
+    let mut args = Args::parse();
+    if args.pow_bits.is_none() {
+        args.pow_bits = Some(DEFAULT_MAX_POW);
+    }
+
+    let security_level = args.security_level;
+    let pow_bits = args.pow_bits.unwrap();
+    let num_variables = args.num_variables;
+    let starting_rate = args.rate;
+    let folding_factor = FoldingFactor::Constant(args.folding_factor);
+    let soundness_type = args.soundness_type;
+    let num_evaluations = args.num_evaluations;
+
+    // Blake3 is stateless: no RNG or round constants needed.
+    let field_hash = FieldHash::new(ByteHash {});
+    let merkle_compress = MerkleCompress::new(ByteHash {});
+    let mmcs = MyMmcs::new(field_hash, merkle_compress, 0);
+
+    let round_log_inv_rates = {
+        let (num_rounds, _) = folding_factor
+            .compute_number_of_rounds(num_variables)
+            .expect("valid folding schedule");
+        let mut rates = Vec::with_capacity(num_rounds);
+        let mut rate = starting_rate;
+        for round in 0..num_rounds {
+            rate += folding_factor.at_round(round) - 1;
+            rates.push(rate);
+        }
+        rates
+    };
+
+    let whir_params = ProtocolParameters {
+        security_level,
+        pow_bits,
+        folding_factor: folding_factor.clone(),
+        soundness_type,
+        starting_log_inv_rate: starting_rate,
+        round_log_inv_rates,
+    };
+
+    info!(
+        num_variables,
+        num_evaluations,
+        %soundness_type,
+        pow_bits,
+        starting_rate,
+        "WHIR PCS (Blake3 Merkle + challenger)"
+    );
+
+    // One random multilinear as a single-column table.
+    let mut rng = SmallRng::seed_from_u64(0);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    let witness = Layout::new_witness(vec![table], folding_factor.at_round(0));
+
+    let point_schedule: PointSchedule = (0..num_evaluations)
+        .map(|_| OpeningBatch::new(vec![0], Vec::new()))
+        .collect();
+    let protocol = OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        point_schedule,
+    )])
+    .pad_to_min_num_variables(folding_factor.at_round(0));
+    assert_eq!(witness.table_shapes(), protocol.table_shapes());
+
+    let config =
+        WhirConfig::<EF, F, MyChallenger>::new(witness.num_variables(), whir_params).unwrap();
+    if !config.check_pow_bits() {
+        warn!("more PoW bits required than what was specified");
+    }
+
+    let challenger = MyChallenger::new(HashChallenger::new(vec![], ByteHash {}));
+
+    let dft = MyDft::new(1 << config.max_fft_size());
+    let pcs = MyPcs::new(config, dft, mmcs);
+
+    // Phase 1: Commitment (DFT encoding + Merkle tree + OOD sampling).
+    let mut prover_challenger = challenger.clone();
+    let mut domainsep = DomainSeparator::new(vec![]);
+    pcs.add_domain_separator::<32>(&mut domainsep);
+    domainsep.observe_domain_separator(&mut prover_challenger);
+    let time = Instant::now();
+    let (commitment, prover_data) =
+        <MyPcs as MultilinearPcs<EF, MyChallenger>>::commit(&pcs, witness, &mut prover_challenger);
+    let commit_time = time.elapsed();
+
+    // Phase 2: Opening proof (multi-round sumcheck + STIR queries + PoW).
+    let time = Instant::now();
+    let proof = <MyPcs as MultilinearPcs<EF, MyChallenger>>::open(
+        &pcs,
+        prover_data,
+        protocol.clone(),
+        &mut prover_challenger,
+    );
+    let opening_time = time.elapsed();
+
+    // Verifier: independent transcript from the same domain separator.
+    let mut verifier_challenger = challenger;
+    let mut domainsep = DomainSeparator::new(vec![]);
+    pcs.add_domain_separator::<32>(&mut domainsep);
+    domainsep.observe_domain_separator(&mut verifier_challenger);
+
+    let verif_time = Instant::now();
+    <MyPcs as MultilinearPcs<EF, MyChallenger>>::verify(
+        &pcs,
+        &commitment,
+        &proof,
+        &mut verifier_challenger,
+        protocol,
+    )
+    .expect("verification failed");
+    let verify_time = verif_time.elapsed();
+
+    let total_proving_ms = commit_time.as_millis() + opening_time.as_millis();
+    info!(
+        total_proving_ms,
+        commit_ms = commit_time.as_millis(),
+        opening_ms = opening_time.as_millis(),
+        verification_us = verify_time.as_micros(),
+        "done"
+    );
+}

--- a/whir/src/fiat_shamir/domain_separator.rs
+++ b/whir/src/fiat_shamir/domain_separator.rs
@@ -236,6 +236,12 @@ where
     /// Binds the protocol configuration into the pattern.
     fn bind_config_params<Challenger>(&mut self, config: &WhirConfig<EF, F, Challenger>) {
         // Bind the transcript to the protocol configuration.
+        //
+        // The basis changes the meaning of every sumcheck round message, so
+        // the two bases are domain-separated structurally: an
+        // evaluation-basis proof cannot share a transcript prefix with a
+        // projective verifier (or vice versa).
+        self.protocol_param(config.basis as usize);
         self.protocol_param(config.num_variables);
         self.protocol_param(config.security_level);
         self.protocol_param(config.starting_log_inv_rate);

--- a/whir/src/parameters/mod.rs
+++ b/whir/src/parameters/mod.rs
@@ -8,6 +8,7 @@ pub mod whir;
 
 pub use folding::{FoldingFactor, FoldingFactorError};
 pub use p3_security::whir::SecurityAssumption;
+pub use p3_sumcheck::strategy::Basis;
 pub use whir::{RoundConfig, WhirConfig, WhirConfigError};
 
 /// Fallback proof-of-work difficulty when the user does not specify one.

--- a/whir/src/parameters/whir.rs
+++ b/whir/src/parameters/whir.rs
@@ -8,7 +8,7 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use thiserror::Error;
 
-use super::{FoldingFactor, FoldingFactorError, ProtocolParameters};
+use super::{Basis, FoldingFactor, FoldingFactorError, ProtocolParameters};
 
 /// Reasons a set of user-facing parameters cannot form a valid WHIR configuration.
 #[derive(Debug, Error)]
@@ -167,6 +167,12 @@ where
     pub final_sumcheck_rounds: usize,
     /// PoW bits for the final folding sumcheck.
     pub final_folding_pow_bits: usize,
+    /// Polynomial basis the prover and verifier operate in.
+    ///
+    /// Defaults to [`Basis::Evaluation`]; set via [`WhirConfig::with_basis`] to
+    /// opt into the projective (monomial-basis) protocol of eprint 2026/762.
+    /// The two bases are proof-incompatible and domain-separated.
+    pub basis: Basis,
     /// Phantom marker for the extension field type.
     pub _extension_field: PhantomData<EF>,
     /// Phantom marker for the challenger type.
@@ -497,6 +503,7 @@ where
             final_pow_bits: ceil_pow_bits(final_pow_bits),
             final_sumcheck_rounds,
             final_folding_pow_bits: ceil_pow_bits(final_folding_pow_bits),
+            basis: Basis::Evaluation,
             _extension_field: PhantomData,
             _challenger: PhantomData,
         };
@@ -524,6 +531,22 @@ where
         }
 
         Ok(config)
+    }
+
+    /// Opts this configuration into a polynomial [`Basis`].
+    ///
+    /// Defaults to [`Basis::Evaluation`]. Setting [`Basis::Projective`] runs
+    /// the monomial-basis protocol of eprint 2026/762 end to end; the prover
+    /// and verifier must agree on the basis, and the transcripts of the two
+    /// bases are domain-separated.
+    ///
+    /// The projective basis is supported for prefix layouts on the plain
+    /// (non-hiding) pipeline only; the suffix layout and the zk path reject
+    /// or do not consult it.
+    #[must_use]
+    pub const fn with_basis(mut self, basis: Basis) -> Self {
+        self.basis = basis;
+        self
     }
 
     /// Returns the size of the initial evaluation domain.

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -16,7 +16,7 @@ use p3_sumcheck::constraints::statement::{EqStatement, SelectStatement};
 use p3_sumcheck::constraints::{Constraint, Statements};
 use p3_sumcheck::layout::Layout;
 use p3_sumcheck::strategy::{SumcheckProver, VariableOrder};
-use tracing::instrument;
+use tracing::{info_span, instrument};
 
 use crate::fiat_shamir::domain_separator::DomainSeparator;
 use crate::parameters::{Basis, WhirConfig};
@@ -165,12 +165,14 @@ where
         let variable_order = L::variable_order();
 
         let mut initial_sumcheck = SumcheckData::default();
-        let (sumcheck_prover, folding_randomness) = layout.into_sumcheck(
-            &mut initial_sumcheck,
-            self.starting_folding_pow_bits,
-            challenger,
-            self.basis,
-        );
+        let (sumcheck_prover, folding_randomness) = info_span!("initial sumcheck").in_scope(|| {
+            layout.into_sumcheck(
+                &mut initial_sumcheck,
+                self.starting_folding_pow_bits,
+                challenger,
+                self.basis,
+            )
+        });
 
         let mut round_state = RoundState {
             sumcheck_prover,
@@ -219,14 +221,16 @@ where
         let inv_rate = self.inv_rate(round_index);
 
         // Commit straight from the live sumcheck buffer; no scalar copy is materialized.
-        let (root, prover_data) = commit_extension(
-            variable_order,
-            &self.dft,
-            &self.extension_mmcs,
-            round_state.sumcheck_prover.evals_view(),
-            folding_factor_next,
-            inv_rate,
-        );
+        let (root, prover_data) = info_span!("commit").in_scope(|| {
+            commit_extension(
+                variable_order,
+                &self.dft,
+                &self.extension_mmcs,
+                round_state.sumcheck_prover.evals_view(),
+                folding_factor_next,
+                inv_rate,
+            )
+        });
 
         // Observe the round commitment.
         challenger.observe(root.clone());
@@ -235,14 +239,18 @@ where
         // OOD sampling.
         let mut ood_statement = EqStatement::initialize(num_variables);
         let mut ood_answers = Vec::with_capacity(round_params.ood_samples);
-        (0..round_params.ood_samples).for_each(|_| {
-            let point =
-                Point::expand_from_univariate(challenger.sample_algebra_element(), num_variables);
-            let eval = round_state.sumcheck_prover.eval(&point);
-            challenger.observe_algebra_element(eval);
+        info_span!("ood sampling").in_scope(|| {
+            (0..round_params.ood_samples).for_each(|_| {
+                let point = Point::expand_from_univariate(
+                    challenger.sample_algebra_element(),
+                    num_variables,
+                );
+                let eval = round_state.sumcheck_prover.eval(&point);
+                challenger.observe_algebra_element(eval);
 
-            ood_answers.push(eval);
-            ood_statement.add_evaluated_constraint(point, eval);
+                ood_answers.push(eval);
+                ood_statement.add_evaluated_constraint(point, eval);
+            });
         });
 
         // PoW grinding: prevents query manipulation by forcing work after committing.
@@ -270,6 +278,7 @@ where
 
         // Open all queried positions in one multiproof.
         // Each row folds in place; the same allocation then travels into the proof.
+        let stir_span = info_span!("stir openings").entered();
         let openings = match &round_state.round_data {
             RoundData::Base(data) => {
                 let mut opening =
@@ -304,6 +313,7 @@ where
                 QueryOpenings::Extension(opening)
             }
         };
+        drop(stir_span);
 
         // Batch the two statement groups into one constraint over the same cube.
         // The out-of-domain claims form the equality group.
@@ -322,13 +332,15 @@ where
 
         // Run sumcheck and fold the polynomial.
         let mut sumcheck_data: SumcheckData<F, EF> = SumcheckData::default();
-        let folding_randomness = round_state.sumcheck_prover.compute_sumcheck_polynomials(
-            &mut sumcheck_data,
-            challenger,
-            folding_factor_next,
-            round_params.folding_pow_bits,
-            Some(constraint),
-        );
+        let folding_randomness = info_span!("sumcheck").in_scope(|| {
+            round_state.sumcheck_prover.compute_sumcheck_polynomials(
+                &mut sumcheck_data,
+                challenger,
+                folding_factor_next,
+                round_params.folding_pow_bits,
+                Some(constraint),
+            )
+        });
 
         // Update round state for next iteration.
         round_state.folding_randomness = folding_randomness;
@@ -400,13 +412,15 @@ where
         // Optional final sumcheck.
         let final_sumcheck = (self.final_sumcheck_rounds > 0).then(|| {
             let mut sumcheck_data: SumcheckData<F, EF> = SumcheckData::default();
-            round_state.sumcheck_prover.compute_sumcheck_polynomials(
-                &mut sumcheck_data,
-                challenger,
-                self.final_sumcheck_rounds,
-                self.final_folding_pow_bits,
-                None,
-            );
+            info_span!("sumcheck").in_scope(|| {
+                round_state.sumcheck_prover.compute_sumcheck_polynomials(
+                    &mut sumcheck_data,
+                    challenger,
+                    self.final_sumcheck_rounds,
+                    self.final_folding_pow_bits,
+                    None,
+                )
+            });
             sumcheck_data
         });
 

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -19,7 +19,7 @@ use p3_sumcheck::strategy::{SumcheckProver, VariableOrder};
 use tracing::instrument;
 
 use crate::fiat_shamir::domain_separator::DomainSeparator;
-use crate::parameters::WhirConfig;
+use crate::parameters::{Basis, WhirConfig};
 use crate::pcs::committer::writer::commit_extension;
 use crate::pcs::proof::{
     QueryOpenings, SharedProofOpening, SumcheckData, WhirProof, WhirRoundProof,
@@ -113,6 +113,13 @@ where
     /// The extension-field MMCS is constructed by wrapping the base-field one,
     /// so callers never have to thread it through manually.
     pub fn new(config: WhirConfig<EF, F, Challenger>, dft: Dft, mmcs: MT) -> Self {
+        // The projective basis is prefix-only; reject the pairing before any
+        // protocol work.
+        assert!(
+            config.basis == Basis::Evaluation
+                || matches!(L::variable_order(), VariableOrder::Prefix),
+            "the projective basis is prefix-only"
+        );
         let extension_mmcs = ExtensionMmcs::new(mmcs.clone());
         Self {
             config,
@@ -269,7 +276,12 @@ where
                     SharedProofOpening::open(&self.mmcs, &stir_challenges_indexes, data);
                 for (row, &challenge) in opening.rows.iter_mut().zip(&stir_challenges_indexes) {
                     let poly = Poly::new(mem::take(row));
-                    let eval = poly.eval_base(&query_randomness);
+                    // Fold the opened row in the configured basis, matching
+                    // the sumcheck bind and the verifier's leaf fold.
+                    let eval = match self.basis {
+                        Basis::Evaluation => poly.eval_base(&query_randomness),
+                        Basis::Projective => poly.eval_monomial_base(&query_randomness),
+                    };
                     let var = round_params.folded_domain_gen.exp_u64(challenge as u64);
                     stir_statement.add_constraint(var, eval);
                     *row = poly.into_evals();
@@ -281,7 +293,10 @@ where
                     SharedProofOpening::open(&self.extension_mmcs, &stir_challenges_indexes, data);
                 for (row, &challenge) in opening.rows.iter_mut().zip(&stir_challenges_indexes) {
                     let poly = Poly::new(mem::take(row));
-                    let eval = poly.eval_ext::<F>(&query_randomness);
+                    let eval = match self.basis {
+                        Basis::Evaluation => poly.eval_ext::<F>(&query_randomness),
+                        Basis::Projective => poly.eval_monomial(&query_randomness),
+                    };
                     let var = round_params.folded_domain_gen.exp_u64(challenge as u64);
                     stir_statement.add_constraint(var, eval);
                     *row = poly.into_evals();

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -162,6 +162,7 @@ where
             &mut initial_sumcheck,
             self.starting_folding_pow_bits,
             challenger,
+            self.basis,
         );
 
         let mut round_state = RoundState {

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -19,7 +19,7 @@ use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
 use crate::fiat_shamir::domain_separator::DomainSeparator;
-use crate::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
+use crate::parameters::{Basis, FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
 use crate::pcs::prover::WhirProver;
 use crate::pcs::verifier::errors::VerifierError;
 
@@ -64,6 +64,22 @@ fn run_whir_pcs<L: Layout<F, EF>>(
     soundness_type: SecurityAssumption,
     pow_bits: usize,
 ) {
+    run_whir_pcs_in_basis::<L>(
+        specs,
+        folding_factor,
+        soundness_type,
+        pow_bits,
+        Basis::Evaluation,
+    );
+}
+
+fn run_whir_pcs_in_basis<L: Layout<F, EF>>(
+    specs: &[TableSpec],
+    folding_factor: FoldingFactor,
+    soundness_type: SecurityAssumption,
+    pow_bits: usize,
+    basis: Basis,
+) {
     let folding = folding_factor.at_round(0);
     let tables = table_specs_to_tables(specs);
     let witness = L::new_witness(tables, folding);
@@ -76,6 +92,7 @@ fn run_whir_pcs<L: Layout<F, EF>>(
         folding_factor,
         soundness_type,
         pow_bits,
+        basis,
     );
 }
 
@@ -86,6 +103,7 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
     folding_factor: FoldingFactor,
     soundness_type: SecurityAssumption,
     pow_bits: usize,
+    basis: Basis,
 ) {
     // Build Poseidon2-based hash and compression for the Merkle tree.
     let num_variables = witness.num_variables();
@@ -108,7 +126,9 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
 
     // Instantiate the PCS through the trait.
     let dft = MyDft::default();
-    let config = WhirConfig::new(num_variables, params).unwrap();
+    let config = WhirConfig::new(num_variables, params)
+        .unwrap()
+        .with_basis(basis);
     let pcs = TestWhirPcs::<L>::new(config, dft, mmcs);
 
     // Prover
@@ -149,6 +169,127 @@ fn run_whir_pcs_lifecycle_with_witness<L: Layout<F, EF>>(
         )
         .expect("verification failed");
     }
+}
+
+/// Projective (monomial-basis) WHIR round trips: the full protocol under
+/// `Basis::Projective`, across schedules with and without intermediate STIR
+/// rounds (eprint 2026/762).
+#[test]
+fn test_whir_projective_partial_final_fold() {
+    // Multi-round schedule: initial folds + one intermediate round + final
+    // phase (Constant(8) on 15 variables derives [8, 7]).
+    let specs = vec![TableSpec::new(
+        TableShape::new(15, 2),
+        vec![
+            OpeningBatch::new(vec![0], Vec::new()),
+            OpeningBatch::new(vec![1], Vec::new()),
+        ],
+    )];
+    run_whir_pcs_in_basis::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(8),
+        SecurityAssumption::UniqueDecoding,
+        0,
+        Basis::Projective,
+    );
+}
+
+/// Smaller schedule with more rounds, grinding enabled, and two tables, so
+/// the flat projective claim constraint must align with the verifier's
+/// placement-grouped alpha-power walk across placements.
+#[test]
+fn test_whir_projective_multi_round() {
+    let specs = vec![
+        TableSpec::new(
+            TableShape::new(12, 3),
+            vec![
+                OpeningBatch::new(vec![0, 1, 2], Default::default()),
+                OpeningBatch::new(vec![1], Default::default()),
+            ],
+        ),
+        TableSpec::new(
+            TableShape::new(10, 2),
+            vec![OpeningBatch::new(vec![0, 1], Default::default())],
+        ),
+    ];
+    run_whir_pcs_in_basis::<PrefixProver<F, EF>>(
+        &specs,
+        FoldingFactor::Constant(4),
+        SecurityAssumption::UniqueDecoding,
+        8,
+        Basis::Projective,
+    );
+}
+
+/// A proof produced in one basis must not verify in the other: the basis is
+/// bound into the domain separator, so the transcripts diverge structurally.
+#[test]
+fn test_whir_cross_basis_rejects() {
+    let specs = vec![TableSpec::new(
+        TableShape::new(12, 2),
+        vec![OpeningBatch::new(vec![0, 1], Vec::new())],
+    )];
+    let folding_factor = FoldingFactor::Constant(4);
+    let folding = folding_factor.at_round(0);
+    let tables = table_specs_to_tables(&specs);
+    let witness = <PrefixProver<F, EF> as Layout<F, EF>>::new_witness(tables, folding);
+    let protocol = OpeningProtocol::new(specs).pad_to_min_num_variables(folding);
+    let num_variables = witness.num_variables();
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let mmcs = MyMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
+
+    let params = ProtocolParameters {
+        security_level: 32,
+        pow_bits: 0,
+        round_log_inv_rates: default_round_log_inv_rates(num_variables, &folding_factor),
+        folding_factor,
+        soundness_type: SecurityAssumption::UniqueDecoding,
+        starting_log_inv_rate: 1,
+    };
+
+    // Prover runs projectively.
+    let prover_config = WhirConfig::new(num_variables, params.clone())
+        .unwrap()
+        .with_basis(Basis::Projective);
+    let prover_pcs =
+        TestWhirPcs::<PrefixProver<F, EF>>::new(prover_config, MyDft::default(), mmcs.clone());
+    let (commitment, proof) = {
+        let mut challenger = challenger();
+        let mut ds = DomainSeparator::new(vec![]);
+        prover_pcs.add_domain_separator::<8>(&mut ds);
+        ds.observe_domain_separator(&mut challenger);
+        let (commitment, prover_data) = <TestWhirPcs<PrefixProver<F, EF>> as MultilinearPcs<
+            EF,
+            MyChallenger,
+        >>::commit(&prover_pcs, witness, &mut challenger);
+        let proof = <TestWhirPcs<PrefixProver<F, EF>> as MultilinearPcs<EF, MyChallenger>>::open(
+            &prover_pcs,
+            prover_data,
+            protocol.clone(),
+            &mut challenger,
+        );
+        (commitment, proof)
+    };
+
+    // Verifier runs in the evaluation basis: its domain separator differs, so
+    // the transcript diverges and verification must fail.
+    let verifier_config = WhirConfig::new(num_variables, params).unwrap();
+    let verifier_pcs =
+        TestWhirPcs::<PrefixProver<F, EF>>::new(verifier_config, MyDft::default(), mmcs);
+    let mut challenger = challenger();
+    let mut ds = DomainSeparator::new(vec![]);
+    verifier_pcs.add_domain_separator::<8>(&mut ds);
+    ds.observe_domain_separator(&mut challenger);
+    let result = <TestWhirPcs<PrefixProver<F, EF>> as MultilinearPcs<EF, MyChallenger>>::verify(
+        &verifier_pcs,
+        &commitment,
+        &proof,
+        &mut challenger,
+        protocol,
+    );
+    assert!(result.is_err(), "cross-basis proof must be rejected");
 }
 
 /// How a prescribed-point run deviates from the honest transcript.

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -123,6 +123,7 @@ where
             &mut claimed_eval,
             self.round_folding_factor(0),
             self.starting_folding_pow_bits,
+            self.basis,
         )?;
         round_folding_randomness.push(folding_randomness);
 
@@ -176,6 +177,7 @@ where
                 &mut claimed_eval,
                 self.round_folding_factor(round_index + 1),
                 round_params.folding_pow_bits,
+                self.basis,
             )?;
             round_folding_randomness.push(folding_randomness);
 
@@ -227,6 +229,7 @@ where
             &mut claimed_eval,
             self.final_sumcheck_rounds,
             self.final_folding_pow_bits,
+            self.basis,
         )?;
         round_folding_randomness.push(final_sumcheck_randomness.clone());
 

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -123,7 +123,7 @@ where
             &mut claimed_eval,
             self.round_folding_factor(0),
             self.starting_folding_pow_bits,
-            Basis::Evaluation,
+            self.basis,
         )?;
         round_folding_randomness.push(folding_randomness);
 
@@ -177,7 +177,7 @@ where
                 &mut claimed_eval,
                 self.round_folding_factor(round_index + 1),
                 round_params.folding_pow_bits,
-                Basis::Evaluation,
+                self.basis,
             )?;
             round_folding_randomness.push(folding_randomness);
 
@@ -229,7 +229,7 @@ where
             &mut claimed_eval,
             self.final_sumcheck_rounds,
             self.final_folding_pow_bits,
-            Basis::Evaluation,
+            self.basis,
         )?;
         round_folding_randomness.push(final_sumcheck_randomness.clone());
 

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -12,14 +12,14 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::constraints::statement::SelectStatement;
 use p3_sumcheck::constraints::{Constraint, Statements};
-use p3_sumcheck::strategy::{Basis, VariableOrder};
+use p3_sumcheck::strategy::VariableOrder;
 use p3_sumcheck::verify_final_sumcheck_rounds;
 use tracing::instrument;
 
 use super::committer::reader::ParsedCommitment;
 use super::utils::get_challenge_stir_queries;
 use crate::alloc::string::ToString;
-use crate::parameters::{RoundConfig, WhirConfig};
+use crate::parameters::{Basis, RoundConfig, WhirConfig};
 use crate::pcs::proof::{QueryOpenings, WhirProof};
 
 pub mod errors;
@@ -76,6 +76,14 @@ where
         mmcs: &'a MT,
         variable_order: VariableOrder,
     ) -> Self {
+        // The projective basis is prefix-only. Rejecting the pairing at
+        // construction keeps the per-arm guards deeper in the verifier
+        // genuinely unreachable.
+        assert!(
+            matches!(config.basis, Basis::Evaluation)
+                || matches!(variable_order, VariableOrder::Prefix),
+            "the projective basis is prefix-only"
+        );
         Self {
             config,
             mmcs,
@@ -242,15 +250,29 @@ where
         );
 
         // Evaluate the constraint polynomial at the folding point.
-        let evaluation_of_weights = self
-            .variable_order
-            .eval_constraints_poly(&constraints, &folding_randomness, self.basis);
+        let evaluation_of_weights = self.variable_order.eval_constraints_poly(
+            &constraints,
+            &folding_randomness,
+            self.basis,
+        );
 
         // Final consistency check: claimed_eval == weight * f(r).
-        let final_value = match self.variable_order {
-            VariableOrder::Prefix => final_evaluations.eval_ext::<F>(&final_sumcheck_randomness),
-            VariableOrder::Suffix => {
+        //
+        // The final polynomial is the fully folded table; its value at the
+        // final randomness is read in the configured basis (the projective
+        // basis is prefix-only).
+        let final_value = match (self.variable_order, self.basis) {
+            (VariableOrder::Prefix, Basis::Evaluation) => {
+                final_evaluations.eval_ext::<F>(&final_sumcheck_randomness)
+            }
+            (VariableOrder::Prefix, Basis::Projective) => {
+                final_evaluations.eval_monomial(&final_sumcheck_randomness)
+            }
+            (VariableOrder::Suffix, Basis::Evaluation) => {
                 final_evaluations.eval_ext::<F>(&final_sumcheck_randomness.reversed())
+            }
+            (VariableOrder::Suffix, Basis::Projective) => {
+                unreachable!("the projective basis is prefix-only")
             }
         };
         if claimed_eval != evaluation_of_weights * final_value {
@@ -318,10 +340,14 @@ where
             VariableOrder::Suffix => folding_randomness.reversed(),
         };
 
-        // Evaluate folded polynomial at each queried position.
+        // Evaluate folded polynomial at each queried position, in the
+        // configured basis: the leaf fold must match the prover's bind rule.
         let folds: Vec<_> = answers
             .into_iter()
-            .map(|answer| Poly::new(answer).eval_ext::<F>(&query_randomness))
+            .map(|answer| match self.basis {
+                Basis::Evaluation => Poly::new(answer).eval_ext::<F>(&query_randomness),
+                Basis::Projective => Poly::new(answer).eval_monomial(&query_randomness),
+            })
             .collect();
 
         let stir_constraints = stir_challenges_indexes

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -19,7 +19,7 @@ use tracing::instrument;
 use super::committer::reader::ParsedCommitment;
 use super::utils::get_challenge_stir_queries;
 use crate::alloc::string::ToString;
-use crate::parameters::{RoundConfig, WhirConfig};
+use crate::parameters::{Basis, RoundConfig, WhirConfig};
 use crate::pcs::proof::{QueryOpenings, WhirProof};
 
 pub mod errors;
@@ -76,6 +76,14 @@ where
         mmcs: &'a MT,
         variable_order: VariableOrder,
     ) -> Self {
+        // The projective basis is prefix-only. Rejecting the pairing at
+        // construction keeps the per-arm guards deeper in the verifier
+        // genuinely unreachable.
+        assert!(
+            matches!(config.basis, Basis::Evaluation)
+                || matches!(variable_order, VariableOrder::Prefix),
+            "the projective basis is prefix-only"
+        );
         Self {
             config,
             mmcs,
@@ -242,15 +250,29 @@ where
         );
 
         // Evaluate the constraint polynomial at the folding point.
-        let evaluation_of_weights = self
-            .variable_order
-            .eval_constraints_poly(&constraints, &folding_randomness, self.basis);
+        let evaluation_of_weights = self.variable_order.eval_constraints_poly(
+            &constraints,
+            &folding_randomness,
+            self.basis,
+        );
 
         // Final consistency check: claimed_eval == weight * f(r).
-        let final_value = match self.variable_order {
-            VariableOrder::Prefix => final_evaluations.eval_ext::<F>(&final_sumcheck_randomness),
-            VariableOrder::Suffix => {
+        //
+        // The final polynomial is the fully folded table; its value at the
+        // final randomness is read in the configured basis (the projective
+        // basis is prefix-only).
+        let final_value = match (self.variable_order, self.basis) {
+            (VariableOrder::Prefix, Basis::Evaluation) => {
+                final_evaluations.eval_ext::<F>(&final_sumcheck_randomness)
+            }
+            (VariableOrder::Prefix, Basis::Projective) => {
+                final_evaluations.eval_monomial(&final_sumcheck_randomness)
+            }
+            (VariableOrder::Suffix, Basis::Evaluation) => {
                 final_evaluations.eval_ext::<F>(&final_sumcheck_randomness.reversed())
+            }
+            (VariableOrder::Suffix, Basis::Projective) => {
+                unreachable!("the projective basis is prefix-only")
             }
         };
         if claimed_eval != evaluation_of_weights * final_value {
@@ -318,10 +340,14 @@ where
             VariableOrder::Suffix => folding_randomness.reversed(),
         };
 
-        // Evaluate folded polynomial at each queried position.
+        // Evaluate folded polynomial at each queried position, in the
+        // configured basis: the leaf fold must match the prover's bind rule.
         let folds: Vec<_> = answers
             .into_iter()
-            .map(|answer| Poly::new(answer).eval_ext::<F>(&query_randomness))
+            .map(|answer| match self.basis {
+                Basis::Evaluation => Poly::new(answer).eval_ext::<F>(&query_randomness),
+                Basis::Projective => Poly::new(answer).eval_monomial(&query_randomness),
+            })
             .collect();
 
         let stir_constraints = stir_challenges_indexes

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -244,7 +244,7 @@ where
         // Evaluate the constraint polynomial at the folding point.
         let evaluation_of_weights = self
             .variable_order
-            .eval_constraints_poly(&constraints, &folding_randomness);
+            .eval_constraints_poly(&constraints, &folding_randomness, self.basis);
 
         // Final consistency check: claimed_eval == weight * f(r).
         let final_value = match self.variable_order {


### PR DESCRIPTION
Follow-up to #1900, now merged, so all 11 commits here are this PR's own. Closes the experiment of #1890.

**TL;DR.** Runs the full WHIR protocol in the projective (monomial) basis of eprint 2026/762 behind an opt-in flag, and measures it. The pre-registered close condition fires: end-to-end it is parity at best, so this is a documented negative result. The per-round win is real (subtraction-free binding, **1.13x** standalone) but acts on ~1% of a hash-dominated prover. The technique wants a sum-check-dominated prover (the paper's Jolt/Spartan setting), not a PCS on 31-bit fields.

## What

`WhirConfig::with_basis(Basis::Projective)` switches how the tables are interpreted. The committed bytes never change, and the default path is behaviourally unchanged. Because WHIR's sum-check challenge is also its codeword-folding challenge, four things switch together and only together:

- **Binding**: `a0 + (a1 - a0) * r` becomes the subtraction-free `a0 + a1 * r`.
- **Round message**: `[h(0), h(inf)]` becomes `[s(1), s(inf)]`, deriving `s(0) := C - s(inf)` (paper Fig. 3).
- **Folds of committed data**: monomial (Horner) evaluation.
- **Weight closed forms**: the same tensors read as coefficients, e.g. eq becomes `prod((1-z_i) + z_i*r_i)`.

#1900 landed the message half (`Basis`, `sumcheck_coefficients`, `reduce_claim`, the basis parameter on the verifier). This PR adds everything that needs a caller to be coherent: `Basis::fix_var`, the basis tag on `ProductPolynomial`, the projective weight closed forms and initial-round path, monomial evaluation in `p3-multilinear-util`, and the WHIR wiring including the domain-separator binding.

The out-of-domain anchor stays the MLE of the table, identical in both bases, so the constraint machinery needs no second tensor family. The basis is bound into the domain separator, making the two bases transcript-incompatible (tested); this also means evaluation-basis transcripts differ from main's.

## Numbers

M3 Pro, single-threaded, `-Ctarget-cpu=native`, KoalaBear + Poseidon2, prefix layout. The primary configuration is grind-free: grinding work is fixed per transcript and the two bases produce different transcripts, so a pow-enabled comparison carries per-case luck bias of tens of percent.

whir_pcs prove, speedup = eval / projective (> 1 means projective wins):

| Size | Evaluation | Projective | Speedup |
|---|---|---|---|
| k14 | 1.804 ms | 2.183 ms | 0.83x |
| k18 | 40.68 ms | 46.64 ms | 0.87x |
| k20 | 193.4 ms | 210.9 ms | 0.92x |
| k22 | 768.4 ms | 854.6 ms | 0.90x |

- **Round-coefficient kernel**: 0.98-0.99x, parity, as the cost accounting predicts. The complete message swaps a subtraction pass for an addition pass rather than removing one. (This corrects the ~11% figure from #1900's early review, which was measured against an incomplete `[s(0), s(inf)]` message.)
- **Binding kernel**: 1.10-1.14x across k16-k22 and both fields. The real per-round win.
- **Initial rounds**: the projective path runs them generically, ~10.8% of the grind-free k22 prove (92.2 ms vs 3.7 ms for the eval side's SVO fast path).

**The close condition fires** (pre-registered: under ~1% end-to-end means document the negative result rather than merge). The 9-21% deficit is almost entirely the initial-round asymmetry; crediting back the measured spans leaves 1.003x. Even a perfect projective SVO port reaches parity, not a win, because of where the time actually goes at k=22:

| Phase | Share | Basis-affected? |
|---|---|---|
| Merkle hashing | ~56% | no |
| PoW grinding | ~32% | no |
| DFT | ~9% | no |
| Sum-check arithmetic | ~1.2% | yes |

## Reproduce

Benchmarks taken on Rust 1.93, `parallel` feature off. Bench IDs come in eval/projective pairs; speedups are ratios of paired medians.

```bash
# Deciding benchmark. Needs this branch.
RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p p3-whir --bench whir_pcs -- "whir_pcs/basis"

# Both kernels. These are on main (#1900).
RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p p3-sumcheck --bench sumcheck -- \
  "round_coefficients/ext_ext_packed_prefix" --warm-up-time 5 --measurement-time 10
RUSTFLAGS="-Ctarget-cpu=native" cargo bench -p p3-sumcheck --bench sumcheck -- \
  "fix_var" --warm-up-time 5 --measurement-time 10

# Per-phase profile (drop --projective for the evaluation run).
RUSTFLAGS="-Ctarget-cpu=native" cargo run --release -p p3-whir --example whir -- \
  --num-variables 22 -p 20 --order prefix --projective
```

## Caveats

- **Initial-round asymmetry.** The eval side's SVO fast path is evaluation-specific; the projective side folds generically. A projective SVO variant is derivable (`s(0)=h(0)`, `s(inf)=h(1)`, `s(1)=2h(0)+2h(1)-h(inf)`) but needs the accumulators' X=1 slot materialised. Left as a follow-up, since even a perfect port only reaches parity.
- **Single-threaded, 31-bit fields**, matching the paper's methodology. The paper's larger wins are on 128-bit fields where subtractions cost proportionally more.
- **Scope**: Sections 3, 4.1, 4.3. The 4.2 weight simplifications are deliberately not taken, forgoing a ~1.06x table-build effect to keep the existing statement machinery unchanged.
- One bug en route: `ProductPolynomial::transition()` dropped the basis at the packed-to-scalar seam, silently reverting later rounds to evaluation arithmetic. The dot-product invariant cannot catch that class, since post-reset rounds are internally coherent; the regression test compares the fully bound table against a monomial evaluation of the original, which can.

## Test plan

- [x] Projective WHIR round trips on two multi-round schedules (incl. the `[8, 7]` partial final fold and a two-table spec), in debug with the internal dot-product assertions live.
- [x] Cross-basis rejection via the domain separator.
- [x] Standalone projective sum-check round trip, per-position tampering rejection, and kernel/binding proptests against independent references.
- [x] Evaluation-basis suites untouched. `clippy --all-targets -- -D warnings`, fmt, and docs clean on 1.98; `cargo test --workspace` green (112 suites).
