### PR TITLE
perf(circle): drop verifier row clone

### DIFF
--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -357,18 +357,19 @@ where
         // Move from the leaf index to its parent in the folding tree.
         index >>= log_arity;
 
-        // Record the group index and reconstructed row for the round's shared
-        // verification. `evals` is tiny, so the clone is cheap.
-        group_indices_by_round[round].push(index);
-        rows_by_round[round].push(vec![evals.clone()]);
-
         // Fold the full sibling group down to a single evaluation using the random
-        // challenge beta. Circle PCS only ever folds by arity 2 (`CircleFriFolding::fold_row`
+        // challenge beta. Borrowing the row leaves it owned for the collector below.
+        // Circle PCS only ever folds by arity 2 (`CircleFriFolding::fold_row`
         // asserts this too); the twiddle for this round was already precomputed for the
         // whole query chain, so this is now pure arithmetic with no domain construction,
         // scalar multiplication, or inversion left to do.
         assert_eq!(log_arity, 1, "Circle PCS currently only supports arity 2");
-        folded_eval = fold_row_with_inv_twiddle(x_twiddle_inv[round], beta, evals.into_iter());
+        folded_eval = fold_row_with_inv_twiddle(x_twiddle_inv[round], beta, evals.iter().copied());
+
+        // Hand this query's group index and reconstructed row to the round's shared
+        // verification; the round's single proof authenticates every query at once.
+        group_indices_by_round[round].push(index);
+        rows_by_round[round].push(vec![evals]);
 
         // Advance to the next (smaller) domain.
         log_current_height = log_folded_height;


### PR DESCRIPTION
## What

Follow-up to #1943 that mirrors the two-adic FRI verifier change in #1940.

The pruned-multiproof circle verifier reconstructs each query's row, folds it into the parent FRI node, and also collects it for the round's shared `verify_multi_batch`. It collected the row by cloning it and then consumed the original in the fold, so every query paid one `Vec` allocation per round on the hot verification path.

Root cause: `circle/src/verifier.rs` pushed `vec![evals.clone()]` into the per-round collector and then folded `evals.into_iter()`, cloning a row that was about to be consumed anyway.

Fix: fold the row from a borrow (`evals.iter().copied()`), then move the owned `evals` into the collector. This is the same change #1940 made for the two-adic FRI verifier.

```text
before:  collect vec![evals.clone()]   then   fold evals.into_iter()     (1 clone / query / round)
after:   fold evals.iter().copied()    then   collect vec![evals]        (0 clones)
```

## Numbers

The clone was `num_queries * num_rounds` `Vec<Challenge>` allocations per verification. Each row is arity 2 so tiny, but the allocation and copy sat on the per-query hot loop; this removes all of them. The folded value and the collected row are bit-identical to before, and there is no proof-format change, so proof sizes and fixtures are untouched.

## Correctness

- The fold reads `evals` before the move and does not mutate it, so the row handed to `verify_multi_batch` and the folded evaluation are unchanged.
- All 40 `p3-circle` tests pass, including the malformed-proof suite and the three Merkle-tampering tests. `clippy --all-targets -D warnings` and `fmt` are clean.

## Scope

- Circle verifier only. No change to proof generation or format, so golden fixtures are unaffected.
- The query-collision collapse (introduced by the multiproof in #1943) is authenticated once inside the shared `verify_multi_batch` and is already covered end to end by #1940's FRI collision test through that same code path, so this PR does not duplicate that test.
