### PR TITLE
perf(whir): drop hiding-prover row clone in open_and_fold

### DIFF
--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -9,6 +9,7 @@ mod masks;
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
+use core::mem;
 
 pub use data::HidingWhirProverData;
 use data::ZkRoundData;
@@ -529,20 +530,33 @@ where
     ) -> (QueryOpenings<F, EF, MT::MultiProof>, Vec<EF>) {
         match round_data {
             ZkRoundData::Base(data) => {
-                let opening = SharedProofOpening::open(self.mmcs, indices, data);
+                let mut opening = SharedProofOpening::open(self.mmcs, indices, data);
                 let folded = opening
                     .rows
-                    .iter()
-                    .map(|row| Poly::new(row.clone()).eval_base(randomness))
+                    .iter_mut()
+                    .map(|row| {
+                        // Fold from the owned row, then move it back. The row itself is what
+                        // travels into the proof, so cloning it just to satisfy `Poly::new`
+                        // is pure allocation. Mirrors the non-ZK prover's fold.
+                        let poly = Poly::new(mem::take(row));
+                        let eval = poly.eval_base(randomness);
+                        *row = poly.into_evals();
+                        eval
+                    })
                     .collect();
                 (QueryOpenings::Base(opening), folded)
             }
             ZkRoundData::Ext(data) => {
-                let opening = SharedProofOpening::open(&self.extension_mmcs, indices, data);
+                let mut opening = SharedProofOpening::open(&self.extension_mmcs, indices, data);
                 let folded = opening
                     .rows
-                    .iter()
-                    .map(|row| Poly::new(row.clone()).eval_ext::<F>(randomness))
+                    .iter_mut()
+                    .map(|row| {
+                        let poly = Poly::new(mem::take(row));
+                        let eval = poly.eval_ext::<F>(randomness);
+                        *row = poly.into_evals();
+                        eval
+                    })
                     .collect();
                 (QueryOpenings::Extension(opening), folded)
             }


### PR DESCRIPTION
## What

The hiding (ZK) WHIR prover folds each query's opened row to the next round and also keeps that row for the proof. It kept the row by cloning it and then consumed the clone in the fold, so every query paid one `Vec` allocation per round on the prover query path.

Root cause: `open_and_fold` in `whir/src/pcs/zk/prover/mod.rs` iterated `opening.rows` by reference and folded `Poly::new(row.clone())`. `Poly` only reads the row (`eval_base` and `eval_ext` take `&self`), and `opening` already carries the row into the proof, so the clone was pure allocation.

Fix: fold from the owned row and move it back. `mem::take` the row into the `Poly`, evaluate, then restore it with `into_evals()`. This is the idiom the non-ZK prover (`whir/src/pcs/prover/mod.rs`) already uses, and it mirrors the verifier-side clone drops in #1940 (fri) and #1950 (circle).

## Numbers

Deterministic effect: `num_queries * rounds` fewer `Vec` allocations on the hiding-prover query path, one per opened row per round.

Wall-clock: within measurement noise. On the `zk_overhead` hiding-prover bench (`-Ctarget-cpu=native`, `--features parallel`, paired before/after, ten samples per point) the per-size medians disagree in direction (one nominally faster, one nominally slower) and the sample intervals overlap, so there is no measurable prover-time change. This is an allocation and consistency cleanup that brings the hiding prover in line with the non-ZK prover, not a wall-clock optimization.

```
repro: cargo bench -p p3-whir --features parallel --bench zk_overhead -- zk
```

## Correctness

- `into_evals(Poly::new(v))` returns `v`, and `eval_base` / `eval_ext` take `&self`, so the restored row and the folded values are identical to before. The proof is byte-identical by construction.
- All 117 `p3-whir` tests pass, including the ZK suite. `clippy --all-targets -D warnings` and `fmt` are clean.

## Scope

- The hiding prover's `open_and_fold` only. The non-ZK prover already used this idiom; the verifier-side analogs landed in #1940 and #1950.
