### PR TITLE
fix: make bench run and add benches to CI

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,0 +1,32 @@
+name: Bench Smoke Test
+
+on:
+  schedule:
+    # Weekly. GitHub only runs scheduled workflows off the default branch (main).
+    - cron: "0 6 * * 1"
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  bench_smoke:
+    name: Bench smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rs-stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `--test` runs every benchmark body once instead of the full statistical
+      # sample, so this catches setup/panic regressions in `[[bench]]` targets
+      # without paying for a real `cargo bench` run. `p3-dft` is excluded: its
+      # field x algorithm x size sweep produces thousands of benchmark ids that
+      # make even a single pass too slow.
+      - name: Run each benchmark once
+        run: cargo bench --workspace --exclude p3-dft --features parallel -- --test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # sample, so this catches setup/panic regressions in `[[bench]]` targets
       # without paying for a real `cargo bench` run.
       - name: Run each benchmark once
-        run: cargo bench --workspace -- --test
+        run: cargo bench --workspace --features parallel -- --test
 
   check_embedded:
     name: Build embedded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # sample, so this catches setup/panic regressions in `[[bench]]` targets
       # without paying for a real `cargo bench` run.
       - name: Run each benchmark once
-        run: cargo bench --workspace --features parallel -- --test
+        run: cargo bench --workspace --exclude p3-dft --features parallel -- --test
 
   check_embedded:
     name: Build embedded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,25 @@ jobs:
           RUSTFLAGS: -C debuginfo=0 -C target-feature=-sha3
         run: cargo test -p p3-keccak
 
+  bench_smoke:
+    name: Bench smoke test
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rs-stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `--test` runs every benchmark body once instead of the full statistical
+      # sample, so this catches setup/panic regressions in `[[bench]]` targets
+      # without paying for a real `cargo bench` run.
+      - name: Run each benchmark once
+        run: cargo bench --workspace -- --test
+
   check_embedded:
     name: Build embedded
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,25 +62,6 @@ jobs:
           RUSTFLAGS: -C debuginfo=0 -C target-feature=-sha3
         run: cargo test -p p3-keccak
 
-  bench_smoke:
-    name: Bench smoke test
-    runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@stable
-        id: rs-stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      # `--test` runs every benchmark body once instead of the full statistical
-      # sample, so this catches setup/panic regressions in `[[bench]]` targets
-      # without paying for a real `cargo bench` run.
-      - name: Run each benchmark once
-        run: cargo bench --workspace --exclude p3-dft --features parallel -- --test
-
   check_embedded:
     name: Build embedded
     runs-on: ubuntu-latest

--- a/whir/benches/fri_vs_whir.rs
+++ b/whir/benches/fri_vs_whir.rs
@@ -126,8 +126,8 @@ const SECURITY_LEVEL: usize = 100;
 ///
 /// # Why this value
 ///
-/// - The WHIR side needs every per-round grinding requirement to fit under this budget. `20` is the smallest budget that clears that floor.
-const POW_BITS: usize = 20;
+/// - The WHIR side needs every per-round grinding requirement to fit under this budget. `21` is the smallest budget that clears that ceiling.
+const POW_BITS: usize = 21;
 
 /// log_2 of the inverse code rate.
 ///


### PR DESCRIPTION
I noticed the `fri_vs_whir` bench was broken, and this never was caught on CI because we never run benches there.
Fixes both issues.