### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,50 +99,50 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 ] }
 
 # Local dependencies
-p3-air = { path = "air", version = "0.6.1" }
-p3-baby-bear = { path = "baby-bear", version = "0.6.1" }
-p3-blake3 = { path = "blake3", version = "0.6.1" }
-p3-blake3-air = { path = "blake3-air", version = "0.6.1" }
-p3-bn254 = { path = "bn254", version = "0.6.1" }
-p3-challenger = { path = "challenger", version = "0.6.1" }
-p3-circle = { path = "circle", version = "0.6.1" }
-p3-commit = { path = "commit", version = "0.6.1" }
-p3-dft = { path = "dft", version = "0.6.1" }
+p3-air = { path = "air", version = "0.6.2" }
+p3-baby-bear = { path = "baby-bear", version = "0.6.2" }
+p3-blake3 = { path = "blake3", version = "0.6.2" }
+p3-blake3-air = { path = "blake3-air", version = "0.6.2" }
+p3-bn254 = { path = "bn254", version = "0.6.2" }
+p3-challenger = { path = "challenger", version = "0.6.2" }
+p3-circle = { path = "circle", version = "0.6.2" }
+p3-commit = { path = "commit", version = "0.6.2" }
+p3-dft = { path = "dft", version = "0.6.2" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.6.1" }
-p3-field-testing = { path = "field-testing", version = "0.6.1" }
-p3-fri = { path = "fri", version = "0.6.1" }
-p3-goldilocks = { path = "goldilocks", version = "0.6.1" }
-p3-keccak = { path = "keccak", version = "0.6.1" }
-p3-keccak-air = { path = "keccak-air", version = "0.6.1" }
-p3-koala-bear = { path = "koala-bear", version = "0.6.1" }
-p3-lookup = { path = "lookup", version = "0.6.1" }
-p3-matrix = { path = "matrix", version = "0.6.1" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.1" }
-p3-mds = { path = "mds", version = "0.6.1" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.6.1" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.6.1" }
-p3-monolith = { path = "monolith", version = "0.6.1" }
-p3-monolith-air = { path = "monolith-air", version = "0.6.1" }
-p3-monty-31 = { path = "monty-31", version = "0.6.1" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.6.1" }
-p3-poseidon1 = { path = "poseidon1", version = "0.6.1" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.1" }
-p3-poseidon2 = { path = "poseidon2", version = "0.6.1" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.1" }
-p3-rescue = { path = "rescue", version = "0.6.1" }
-p3-sha256 = { path = "sha256", version = "0.6.1" }
-p3-sumcheck = { path = "sumcheck", version = "0.6.1" }
-p3-symmetric = { path = "symmetric", version = "0.6.1" }
-p3-uni-stark = { path = "uni-stark", version = "0.6.1" }
-p3-util = { path = "util", version = "0.6.1" }
-p3-whir = { path = "whir", version = "0.6.1" }
-p3-zk-codes = { path = "zk-codes", version = "0.6.1" }
+p3-field = { path = "field", version = "0.6.2" }
+p3-field-testing = { path = "field-testing", version = "0.6.2" }
+p3-fri = { path = "fri", version = "0.6.2" }
+p3-goldilocks = { path = "goldilocks", version = "0.6.2" }
+p3-keccak = { path = "keccak", version = "0.6.2" }
+p3-keccak-air = { path = "keccak-air", version = "0.6.2" }
+p3-koala-bear = { path = "koala-bear", version = "0.6.2" }
+p3-lookup = { path = "lookup", version = "0.6.2" }
+p3-matrix = { path = "matrix", version = "0.6.2" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.2" }
+p3-mds = { path = "mds", version = "0.6.2" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.6.2" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.6.2" }
+p3-monolith = { path = "monolith", version = "0.6.2" }
+p3-monolith-air = { path = "monolith-air", version = "0.6.2" }
+p3-monty-31 = { path = "monty-31", version = "0.6.2" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.6.2" }
+p3-poseidon1 = { path = "poseidon1", version = "0.6.2" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.2" }
+p3-poseidon2 = { path = "poseidon2", version = "0.6.2" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.2" }
+p3-rescue = { path = "rescue", version = "0.6.2" }
+p3-sha256 = { path = "sha256", version = "0.6.2" }
+p3-sumcheck = { path = "sumcheck", version = "0.6.2" }
+p3-symmetric = { path = "symmetric", version = "0.6.2" }
+p3-uni-stark = { path = "uni-stark", version = "0.6.2" }
+p3-util = { path = "util", version = "0.6.2" }
+p3-whir = { path = "whir", version = "0.6.2" }
+p3-zk-codes = { path = "zk-codes", version = "0.6.2" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(blake3-air): remove redundant constraints and skip symbolic degree verification (#1933)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix(circle): allow quotient domain smaller than committed LDE (#1834)
+- Chore: move some tracing spans to debug level (#1845)
+- Fix(circle): reject opening point equal to a query point instead of panicking (#1849)
+- Fix(circle): reject input matrices opened at zero points (#1853)
+- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
+- Perf(circle): precompute per-query FRI twiddle chain, hoist verifier-side redundant work (#1922)
+- Revert "fix(circle): reject input matrices opened at zero points (#1853)"
+- Revert "fix(circle): reject opening point equal to a query point instead of panicking (#1849)"
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(circle): parallelize the FRI fold kernels (#1809)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(dft): skip zero-padding work in Radix2Dit coset LDE (#1832)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(circle): flatten the fused CFFT pass driver (#1819)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
+- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
+- Perf: make BoundedPowers::collect scalar for small requests (#1908)
+- Perf(field): make cubic squaring 33% faster (#1909)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(fri): batch (z - x) inversions in the verifier (#1843)
+- Chore: move some tracing spans to debug level (#1845)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
+- Fix: correct MAX_SINGLE_SAMPLE_BITS for Goldilocks (#1914)
+- Fix: doc and light tweaks (#1920)
+- Perf: speed-up NEON Poseidon2 lanes and remove MdsMatrixGoldilocks redundant DFT (#1927)
+- Perf(Goldilocks): add support for AVX vectorization for Poseidon2 (#1953)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(keccak-air): cut redundant packed muls in eval() and dedupe padding trace gen (#1923)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(lookup): flag-zero skip for sparse rows + dot_product tuple combine (#1812)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(matrix): gather packed rows without per-call allocation in the non-wrapping case (#1830)
+- Perf(matrix): no-alloc `vertically_packed_row` for `RowIndexMappedView` (#1904)
+- Perf(matrix): pack rows through composition wrappers (#1911)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(m31): widening NEON MACs for the mixed base×extension dot-product kernels (#1822)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Fix: doc and light tweaks (#1920)
+- Perf: speed-up NEON Poseidon2 lanes and remove MdsMatrixGoldilocks redundant DFT (#1927)
+- Perf(poseidon-air): speed-up Poseidon1Air and Poseidon2Air (#1936)
+- Revert "perf(poseidon-air): speed-up Poseidon1Air and Poseidon2Air (#1936)"
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(merkle-tree): hoist default_packed out of the per-chunk compression loop (#1839)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(merkle-tree): hash single-matrix leaf rows without flat_map (#1813)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
+- Perf(mersenne-31): add deferred-reduction `dot_product` for AVX2/AVX-512 (#1855)
+- Perf(mersenne-31): specialize PackedMersenne31Neon dot_product with deferred reduction (#1894)
+- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
+- Perf(circle): cache exponentiation for two_adic_generator (#1934)
+
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(m31): use the degree-4 extension field for `Mersenne31` Circle proofs (#1817)

--- a/monolith-air/CHANGELOG.md
+++ b/monolith-air/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(monty-31): add NEON xor/andn Montgomery overrides (#1846)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(monty-31): use dedicated quintic_square kernel for QuinticTrinomial ext_square (#1829)
+- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
+- Perf(monty-31): add NEON xor/andn Montgomery overrides (#1846)
+- Perf(monty-31): pack the coset-shift scale in the RecursiveDft LDE (#1893)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/multi-stark/CHANGELOG.md
+++ b/multi-stark/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Reuse LDE from `LdtBasedPcs` to compute quotient (#120)
+- Split Keccak example into a few variants (#154)
+- Remove some unnecessary PhantomData (#164)
+- Remove separate `Domain` field types (#176)
+- Remove unused dependencies (#180)
+- Add a `SymbolicAirBuilder` in uni-stark (#185)
+- Rename StarkConfig (#237)
+- Tentative pcs rework (#253)
+- Add multi-STARK prover and verifier (#1088)
+- Clippy: small step (#1102)
+- Clippy: add nursery (#1103)
+- Clippy: add `needless_pass_by_value` (#1112)
+- Rename multi-stark crate to batch-stark (#1122)
+- Feat(multi-stark): add crate skeleton with boundary selectors and AIR folder (#1700)
+- Feat(multi-stark): add config trait and trace commitment (#1872)
+- Feat(multi-stark): add constraint metadata module (#1871)
+- Feat(multi-stark): AIR zerocheck via generic-degree sumcheck (#1879)
+- Perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)
+- Revert "perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)"
+- Revert "feat(multi-stark): AIR zerocheck via generic-degree sumcheck (#1879)"
+

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(multilinear-util): fold suffix variable in place, drop the extra memcpy (#1841)
+- Perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)
+- Revert "perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)"
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf: add NEON vectorization for RPO on 31bit fields (#1899)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/sumcheck/CHANGELOG.md
+++ b/sumcheck/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Bench(sumcheck): add generic Criterion benchmark suite (#1835)
+- Docs(sumcheck): document Fiat-Shamir binding contract on Constraint::new (#1838)
+- Perf(sumcheck): reuse Poly::unpack for packed-to-scalar conversion (#1844)
+- Docs(sumcheck): fix inverted batch_pows ordering and complete SelectStatement panics doc (#1859)
+- Perf(sumcheck): hoist invariant alpha exponentiation out of the SVO round loop (#1861)
+- Fix(sumcheck): assert accumulator length in scalar combine paths (#1860)
+- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
+- Fix: doc and light tweaks (#1920)
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -27,14 +27,14 @@ use p3_field::{
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
-use p3_sumcheck::constraints::statement::{EqStatement, SelectStatement};
+use p3_sumcheck::SumcheckData;
 use p3_sumcheck::constraints::Constraint;
+use p3_sumcheck::constraints::statement::{EqStatement, SelectStatement};
 use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
 use p3_sumcheck::product_polynomial::ProductPolynomial;
 use p3_sumcheck::strategy::{
     SumcheckProver, VariableOrder, sumcheck_coefficients_prefix, sumcheck_coefficients_suffix,
 };
-use p3_sumcheck::SumcheckData;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ### Merged PRs
 - Perf(uni-stark): reuse per-thread buffers in quotient_values (#1815)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Refactor(util): replace `transpose` crate with portable engine (#1874)
+- Refactor: use p3-maybe-rayon instead of rayon for p3-util (#1880)
+- Perf(util): stripe parallel transpose along the longer dimension (#1888)
+- Perf(util): stripe the 8-byte parallel transpose along the longer dimension (#1889)
+- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
+- Fix: doc and light tweaks (#1920)
+- Revert "refactor: use p3-maybe-rayon instead of rayon for p3-util (#1880)"
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/whir/CHANGELOG.md
+++ b/whir/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
+### Merged PRs
+- Perf(whir): drop redundant to_row_major_matrix after dft_algebra_batch (#1840)
+- Fix(whir): round proof-of-work bits up instead of down (#1851)
+- Fix(whir): reject non-redundant code rates in WhirConfig::new (#1850)
+- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
+- Fix: make bench run and add benches to CI (#1952)
+- Revert "fix(whir): reject non-redundant code rates in WhirConfig::new (#1850)"
+
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs

--- a/zk-codes/CHANGELOG.md
+++ b/zk-codes/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11
 ### Merged PRs


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-util`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-field`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-matrix`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-air`: 0.6.1 -> 0.6.2
* `p3-dft`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-symmetric`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-mds`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-poseidon1`: 0.6.1 -> 0.6.2
* `p3-poseidon2`: 0.6.1 -> 0.6.2
* `p3-monty-31`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-challenger`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-baby-bear`: 0.6.1 -> 0.6.2
* `p3-goldilocks`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-koala-bear`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-mersenne-31`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-bn254`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-field-testing`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-multilinear-util`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-commit`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-fri`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-uni-stark`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-lookup`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-batch-stark`: 0.6.1 -> 0.6.2
* `p3-circle`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-keccak`: 0.6.1 -> 0.6.2
* `p3-merkle-tree`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-blake3`: 0.6.1 -> 0.6.2
* `p3-rescue`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-blake3-air`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-keccak-air`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-poseidon2-air`: 0.6.1 -> 0.6.2
* `p3-sha256`: 0.6.1 -> 0.6.2
* `p3-monolith`: 0.6.1 -> 0.6.2
* `p3-monolith-air`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-multi-stark`: 0.6.1 -> 0.6.2
* `p3-poseidon1-air`: 0.6.1 -> 0.6.2
* `p3-zk-codes`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-sumcheck`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `p3-whir`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `p3-maybe-rayon`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix: doc and light tweaks (#1920)
</blockquote>

## `p3-util`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Refactor(util): replace `transpose` crate with portable engine (#1874)
- Refactor: use p3-maybe-rayon instead of rayon for p3-util (#1880)
- Perf(util): stripe parallel transpose along the longer dimension (#1888)
- Perf(util): stripe the 8-byte parallel transpose along the longer dimension (#1889)
- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
- Fix: doc and light tweaks (#1920)
- Revert "refactor: use p3-maybe-rayon instead of rayon for p3-util (#1880)"
</blockquote>

## `p3-field`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
- Perf: make BoundedPowers::collect scalar for small requests (#1908)
- Perf(field): make cubic squaring 33% faster (#1909)
</blockquote>

## `p3-matrix`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(matrix): gather packed rows without per-call allocation in the non-wrapping case (#1830)
- Perf(matrix): no-alloc `vertically_packed_row` for `RowIndexMappedView` (#1904)
- Perf(matrix): pack rows through composition wrappers (#1911)
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-dft`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(dft): skip zero-padding work in Radix2Dit coset LDE (#1832)
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-mds`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix: doc and light tweaks (#1920)
- Perf: speed-up NEON Poseidon2 lanes and remove MdsMatrixGoldilocks redundant DFT (#1927)
- Perf(poseidon-air): speed-up Poseidon1Air and Poseidon2Air (#1936)
- Revert "perf(poseidon-air): speed-up Poseidon1Air and Poseidon2Air (#1936)"
</blockquote>



## `p3-monty-31`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(monty-31): use dedicated quintic_square kernel for QuinticTrinomial ext_square (#1829)
- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
- Perf(monty-31): add NEON xor/andn Montgomery overrides (#1846)
- Perf(monty-31): pack the coset-shift scale in the RecursiveDft LDE (#1893)
- Fix: doc and light tweaks (#1920)
</blockquote>

## `p3-challenger`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-goldilocks`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
- Fix: correct MAX_SINGLE_SAMPLE_BITS for Goldilocks (#1914)
- Fix: doc and light tweaks (#1920)
- Perf: speed-up NEON Poseidon2 lanes and remove MdsMatrixGoldilocks redundant DFT (#1927)
- Perf(Goldilocks): add support for AVX vectorization for Poseidon2 (#1953)
</blockquote>

## `p3-koala-bear`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix: doc and light tweaks (#1920)
</blockquote>

## `p3-mersenne-31`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)
- Perf(mersenne-31): add deferred-reduction `dot_product` for AVX2/AVX-512 (#1855)
- Perf(mersenne-31): specialize PackedMersenne31Neon dot_product with deferred reduction (#1894)
- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
- Perf(circle): cache exponentiation for two_adic_generator (#1934)
</blockquote>


## `p3-field-testing`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
</blockquote>

## `p3-multilinear-util`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(multilinear-util): fold suffix variable in place, drop the extra memcpy (#1841)
- Perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)
- Revert "perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)"
</blockquote>


## `p3-fri`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(fri): batch (z - x) inversions in the verifier (#1843)
- Chore: move some tracing spans to debug level (#1845)
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-lookup`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-circle`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Fix(circle): allow quotient domain smaller than committed LDE (#1834)
- Chore: move some tracing spans to debug level (#1845)
- Fix(circle): reject opening point equal to a query point instead of panicking (#1849)
- Fix(circle): reject input matrices opened at zero points (#1853)
- Perf(mersenne-31,circle): defer M31 mixed_dot_product reduction; truncate circle LDE interpolation (#1903)
- Perf(circle): precompute per-query FRI twiddle chain, hoist verifier-side redundant work (#1922)
- Revert "fix(circle): reject input matrices opened at zero points (#1853)"
- Revert "fix(circle): reject opening point equal to a query point instead of panicking (#1849)"
</blockquote>


## `p3-merkle-tree`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(merkle-tree): hoist default_packed out of the per-chunk compression loop (#1839)
- Fix: doc and light tweaks (#1920)
</blockquote>


## `p3-rescue`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf: add NEON vectorization for RPO on 31bit fields (#1899)
</blockquote>

## `p3-blake3-air`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(blake3-air): remove redundant constraints and skip symbolic degree verification (#1933)
</blockquote>

## `p3-keccak-air`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(keccak-air): cut redundant packed muls in eval() and dedupe padding trace gen (#1923)
</blockquote>




## `p3-monolith-air`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(monty-31): add NEON xor/andn Montgomery overrides (#1846)
</blockquote>

## `p3-multi-stark`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Reuse LDE from `LdtBasedPcs` to compute quotient (#120)
- Split Keccak example into a few variants (#154)
- Remove some unnecessary PhantomData (#164)
- Remove separate `Domain` field types (#176)
- Remove unused dependencies (#180)
- Add a `SymbolicAirBuilder` in uni-stark (#185)
- Rename StarkConfig (#237)
- Tentative pcs rework (#253)
- Add multi-STARK prover and verifier (#1088)
- Clippy: small step (#1102)
- Clippy: add nursery (#1103)
- Clippy: add `needless_pass_by_value` (#1112)
- Rename multi-stark crate to batch-stark (#1122)
- Feat(multi-stark): add crate skeleton with boundary selectors and AIR folder (#1700)
- Feat(multi-stark): add config trait and trace commitment (#1872)
- Feat(multi-stark): add constraint metadata module (#1871)
- Feat(multi-stark): AIR zerocheck via generic-degree sumcheck (#1879)
- Perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)
- Revert "perf(multi-stark): tighten AIR zerocheck round-poly and degree (#1885)"
- Revert "feat(multi-stark): AIR zerocheck via generic-degree sumcheck (#1879)"
</blockquote>



## `p3-sumcheck`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Bench(sumcheck): add generic Criterion benchmark suite (#1835)
- Docs(sumcheck): document Fiat-Shamir binding contract on Constraint::new (#1838)
- Perf(sumcheck): reuse Poly::unpack for packed-to-scalar conversion (#1844)
- Docs(sumcheck): fix inverted batch_pows ordering and complete SelectStatement panics doc (#1859)
- Perf(sumcheck): hoist invariant alpha exponentiation out of the SVO round loop (#1861)
- Fix(sumcheck): assert accumulator length in scalar combine paths (#1860)
- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
- Fix: doc and light tweaks (#1920)
</blockquote>

## `p3-whir`

<blockquote>

## [0.6.2] - 2026-07-20

### Merged PRs
- Perf(whir): drop redundant to_row_major_matrix after dft_algebra_batch (#1840)
- Fix(whir): round proof-of-work bits up instead of down (#1851)
- Fix(whir): reject non-redundant code rates in WhirConfig::new (#1850)
- Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)
- Fix: make bench run and add benches to CI (#1952)
- Revert "fix(whir): reject non-redundant code rates in WhirConfig::new (#1850)"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).