### PR TITLE
bench(whir): make ZK overhead comparisons grind-free

### DIFF
--- a/whir/benches/zk_overhead.rs
+++ b/whir/benches/zk_overhead.rs
@@ -10,22 +10,24 @@ use criterion::measurement::WallTime;
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
-use p3_challenger::DuplexChallenger;
-use p3_commit::MultilinearPcs;
+use p3_challenger::{CanObserve, DuplexChallenger};
+use p3_commit::{Mmcs as MmcsTrait, MultilinearPcs};
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, Table};
-use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
 use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
+use p3_whir::pcs::proof::{PcsProof, QueryOpenings, SharedProofOpening};
 use p3_whir::pcs::prover::WhirProver;
-use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig};
+use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig, ZkWhirProof};
 use rand::SeedableRng;
 use rand::rngs::{SmallRng, StdRng};
 
@@ -44,7 +46,12 @@ type Dft = Radix2DFTSmallBatch<F>;
 
 type PlainPcs = WhirProver<EF, F, Dft, Mmcs, Challenger, PrefixProver<F, EF>>;
 type ZkPcs = HidingWhirPcs<EF, F, Dft, Mmcs, Challenger, StdRng>;
+type OcticPlainPcs = WhirProver<OcticEF, F, Dft, Mmcs, Challenger, PrefixProver<F, OcticEF>>;
 type OcticZkPcs = HidingWhirPcs<OcticEF, F, Dft, Mmcs, Challenger, StdRng>;
+type Commitment = <Mmcs as MmcsTrait<F>>::Commitment;
+type MerkleMultiProof = <Mmcs as MmcsTrait<F>>::MultiProof;
+type OcticPlainProof = PcsProof<F, OcticEF, Mmcs>;
+type OcticZkProof = ZkWhirProof<F, OcticEF, Mmcs>;
 
 // Polynomial sizes (log_2 of coefficient count) and shared knobs.
 const SIZES: [usize; 2] = [16, 18];
@@ -75,7 +82,11 @@ fn octic_no_pow_protocol_params() -> ProtocolParameters {
     }
 }
 
-fn octic_no_pow_config(num_variables: usize) -> ZkWhirConfig<OcticEF, F, Challenger> {
+fn octic_no_pow_plain_config(num_variables: usize) -> WhirConfig<OcticEF, F, Challenger> {
+    WhirConfig::new(num_variables, octic_no_pow_protocol_params()).unwrap()
+}
+
+fn octic_no_pow_zk_config(num_variables: usize) -> ZkWhirConfig<OcticEF, F, Challenger> {
     ZkWhirConfig::new(
         num_variables,
         octic_no_pow_protocol_params(),
@@ -97,6 +108,112 @@ fn mmcs() -> Mmcs {
 fn challenger() -> Challenger {
     let mut rng = SmallRng::seed_from_u64(2);
     Challenger::new(Poseidon16::new_from_rng_128(&mut rng))
+}
+
+/// Plain and hiding fixtures for the matched, grind-free comparison.
+///
+/// Both sides use the same field, security parameters, folding schedule,
+/// polynomial size, and one-point opening workload. Their adapter-specific
+/// witness/protocol types are kept separate so the benchmark exercises the
+/// public PCS interfaces exactly as downstream users do.
+struct OcticPlainFixture {
+    pcs: OcticPlainPcs,
+    witness: <OcticPlainPcs as MultilinearPcs<OcticEF, Challenger>>::Witness,
+    protocol: <OcticPlainPcs as MultilinearPcs<OcticEF, Challenger>>::OpeningProtocol,
+    points: Vec<Point<OcticEF>>,
+    domain_separator: DomainSeparator<OcticEF, F>,
+}
+
+impl OcticPlainFixture {
+    fn new(num_variables: usize) -> Self {
+        let config = octic_no_pow_plain_config(num_variables);
+        let pcs = OcticPlainPcs::new(config, Dft::default(), mmcs());
+
+        let mut rng = SmallRng::seed_from_u64(3);
+        let poly = Poly::<F>::rand(&mut rng, num_variables);
+        let table = Table::new(RowMajorMatrix::new(
+            poly.as_slice().to_vec(),
+            1 << num_variables,
+        ));
+        let witness = PrefixProver::<F, OcticEF>::new_witness(vec![table], 8);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![OpeningBatch::new(vec![0], Vec::new())],
+        )]);
+        let mut point_rng = SmallRng::seed_from_u64(5);
+        let points = vec![Point::<OcticEF>::rand(&mut point_rng, num_variables)];
+
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        Self {
+            pcs,
+            witness,
+            protocol,
+            points,
+            domain_separator,
+        }
+    }
+
+    fn challenger(&self) -> Challenger {
+        let mut challenger = challenger();
+        self.domain_separator
+            .observe_domain_separator(&mut challenger);
+        challenger
+    }
+
+    fn build_proof(&self) -> (Commitment, OcticPlainProof) {
+        let mut challenger = self.challenger();
+        let (commitment, data) = self.pcs.commit(self.witness.clone(), &mut challenger);
+        let proof = self
+            .pcs
+            .open_at(data, &self.protocol, &self.points, &mut challenger);
+        (commitment, proof)
+    }
+}
+
+struct OcticZkFixture {
+    pcs: OcticZkPcs,
+    witness: Poly<F>,
+    points: Vec<Point<OcticEF>>,
+    domain_separator: DomainSeparator<OcticEF, F>,
+}
+
+impl OcticZkFixture {
+    fn new(num_variables: usize) -> Self {
+        let pcs = OcticZkPcs::new(
+            octic_no_pow_zk_config(num_variables),
+            Dft::default(),
+            mmcs(),
+            StdRng::seed_from_u64(4),
+        );
+        let mut rng = SmallRng::seed_from_u64(3);
+        let witness = Poly::<F>::rand(&mut rng, num_variables);
+        let mut point_rng = SmallRng::seed_from_u64(5);
+        let points = vec![Point::<OcticEF>::rand(&mut point_rng, num_variables)];
+
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        Self {
+            pcs,
+            witness,
+            points,
+            domain_separator,
+        }
+    }
+
+    fn challenger(&self) -> Challenger {
+        let mut challenger = challenger();
+        self.domain_separator
+            .observe_domain_separator(&mut challenger);
+        challenger
+    }
+
+    fn build_proof(&self) -> (Commitment, OcticZkProof) {
+        let mut challenger = self.challenger();
+        let (commitment, data) = self.pcs.commit(self.witness.clone(), &mut challenger);
+        let proof = self.pcs.open(data, self.points.clone(), &mut challenger);
+        (commitment, proof)
+    }
 }
 
 /// Benchmarks the plain (non-hiding) prover for one size.
@@ -231,45 +348,296 @@ fn bench_zk_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-/// Measures the opening path affected by batched mask encoding.
+/// Matched grind-free comparison, split into commit, open, and verify phases.
 ///
-/// Commitment setup is deliberately outside the timed routine and PoW is
-/// disabled so unrelated work does not hide the encoding cost. Run this group
-/// with the crate's `parallel` feature to model the threaded prover path.
-fn bench_octic_zk_open_no_pow(c: &mut Criterion) {
-    let mut group = c.benchmark_group("whir_zk_open_no_pow");
-    group
-        .sample_size(30)
-        .measurement_time(Duration::from_secs(20));
+/// The legacy group above keeps the production-like PoW configuration for
+/// continuity. It must not be used for close plain-vs-ZK timing comparisons:
+/// the two transcripts reach grinding in different states, so they search
+/// different nonce sequences even when their challengers start from one seed.
+fn bench_octic_no_pow(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/commit");
+        group
+            .sample_size(10)
+            .measurement_time(Duration::from_secs(20));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
 
-    for num_variables in OCTIC_OPEN_SIZES {
-        let pcs = OcticZkPcs::new(
-            octic_no_pow_config(num_variables),
-            Dft::default(),
-            mmcs(),
-            StdRng::seed_from_u64(4),
-        );
-        let mut rng = SmallRng::seed_from_u64(3);
-        let witness = Poly::<F>::rand(&mut rng, num_variables);
-        let points = vec![Point::<OcticEF>::rand(&mut rng, num_variables)];
-
-        group.bench_function(format!("octic_n{num_variables}_ff8_6_ell3_rate3"), |b| {
-            b.iter_batched(
-                || {
-                    let mut ch = challenger();
-                    let mut ds = DomainSeparator::new(vec![]);
-                    pcs.add_domain_separator::<8>(&mut ds);
-                    ds.observe_domain_separator(&mut ch);
-                    let (_, data) = pcs.commit(witness.clone(), &mut ch);
-                    (ch, data)
-                },
-                |(mut ch, data)| pcs.open(data, points.clone(), &mut ch),
-                BatchSize::PerIteration,
-            );
-        });
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || (plain.witness.clone(), plain.challenger()),
+                    |(witness, mut challenger)| plain.pcs.commit(witness, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || (zk.witness.clone(), zk.challenger()),
+                    |(witness, mut challenger)| zk.pcs.commit(witness, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
     }
-    group.finish();
+
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/open");
+        group
+            .sample_size(20)
+            .measurement_time(Duration::from_secs(20));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
+
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || {
+                        let mut challenger = plain.challenger();
+                        let (_, data) = plain.pcs.commit(plain.witness.clone(), &mut challenger);
+                        (
+                            challenger,
+                            data,
+                            plain.protocol.clone(),
+                            plain.points.clone(),
+                        )
+                    },
+                    |(mut challenger, data, protocol, points)| {
+                        plain.pcs.open_at(data, &protocol, &points, &mut challenger)
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || {
+                        let mut challenger = zk.challenger();
+                        let (_, data) = zk.pcs.commit(zk.witness.clone(), &mut challenger);
+                        (challenger, data, zk.points.clone())
+                    },
+                    |(mut challenger, data, points)| zk.pcs.open(data, points, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/verify");
+        group
+            .sample_size(30)
+            .measurement_time(Duration::from_secs(10));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let (plain_commitment, plain_proof) = plain.build_proof();
+            let (zk_commitment, zk_proof) = zk.build_proof();
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
+
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || {
+                        (
+                            plain.challenger(),
+                            plain.protocol.clone(),
+                            plain.points.clone(),
+                        )
+                    },
+                    |(mut challenger, protocol, points)| {
+                        challenger.observe(plain_commitment.clone());
+                        plain
+                            .pcs
+                            .verify_at(
+                                &plain_commitment,
+                                &plain_proof,
+                                &protocol,
+                                &points,
+                                &mut challenger,
+                            )
+                            .unwrap();
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || (zk.challenger(), zk.points.clone()),
+                    |(mut challenger, points)| {
+                        zk.pcs
+                            .verify(&zk_commitment, &zk_proof, &mut challenger, points)
+                            .unwrap();
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
 }
 
-criterion_group!(benches, bench_zk_overhead, bench_octic_zk_open_no_pow);
-criterion_main!(benches);
+/// Logical Merkle payload counts, independent of postcard's integer encoding.
+#[derive(Clone, Copy, Default)]
+struct OpeningShape {
+    multiproofs: usize,
+    authenticated_rows: usize,
+    base_values: usize,
+    extension_values: usize,
+    sibling_digests: usize,
+}
+
+impl OpeningShape {
+    const fn merge(&mut self, rhs: Self) {
+        self.multiproofs += rhs.multiproofs;
+        self.authenticated_rows += rhs.authenticated_rows;
+        self.base_values += rhs.base_values;
+        self.extension_values += rhs.extension_values;
+        self.sibling_digests += rhs.sibling_digests;
+    }
+}
+
+fn query_opening_shape<Ext>(opening: &QueryOpenings<F, Ext, MerkleMultiProof>) -> OpeningShape {
+    match opening {
+        QueryOpenings::Base(opening) => OpeningShape {
+            multiproofs: 1,
+            authenticated_rows: opening.rows.len(),
+            base_values: opening.rows.iter().map(Vec::len).sum(),
+            extension_values: 0,
+            sibling_digests: opening.proof.sibling_hashes.len(),
+        },
+        QueryOpenings::Extension(opening) => OpeningShape {
+            multiproofs: 1,
+            authenticated_rows: opening.rows.len(),
+            base_values: 0,
+            extension_values: opening.rows.iter().map(Vec::len).sum(),
+            sibling_digests: opening.proof.sibling_hashes.len(),
+        },
+    }
+}
+
+fn extension_opening_shape<Ext>(
+    opening: &SharedProofOpening<Ext, MerkleMultiProof>,
+) -> OpeningShape {
+    OpeningShape {
+        multiproofs: 1,
+        authenticated_rows: opening.rows.len(),
+        base_values: 0,
+        extension_values: opening.rows.iter().map(Vec::len).sum(),
+        sibling_digests: opening.proof.sibling_hashes.len(),
+    }
+}
+
+fn postcard_len<T: serde::Serialize>(value: &T) -> usize {
+    postcard::to_allocvec(value)
+        .expect("proof component serializes")
+        .len()
+}
+
+/// Print a reproducible proof-shape report for the matched no-PoW case.
+///
+/// Bytes and sibling counts are the fixed-seed realized cost: varint widths
+/// and multiproof overlap can change with another transcript. Roots, rows,
+/// and leaf-value counts expose the protocol shape independently.
+fn report_octic_proof_shape(_c: &mut Criterion) {
+    eprintln!();
+    eprintln!("WHIR ZK overhead report (128-bit, no PoW, octic extension, ff=8/6)");
+    eprintln!(
+        "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+        "vars",
+        "kind",
+        "proof_bytes",
+        "roots",
+        "proofs",
+        "auth_rows",
+        "base_values",
+        "ext_values",
+        "merkle_digests",
+    );
+
+    for num_variables in OCTIC_OPEN_SIZES {
+        let plain = OcticPlainFixture::new(num_variables);
+        let zk = OcticZkFixture::new(num_variables);
+        let (_, plain_proof) = plain.build_proof();
+        let (_, zk_proof) = zk.build_proof();
+        assert_eq!(plain_proof.evals[0].current()[0], zk_proof.evals[0]);
+
+        let mut plain_shape = OpeningShape::default();
+        for round in &plain_proof.whir.rounds {
+            plain_shape.merge(query_opening_shape(&round.openings));
+        }
+        plain_shape.merge(query_opening_shape(&plain_proof.whir.final_openings));
+        let plain_roots = 1 + plain_proof
+            .whir
+            .rounds
+            .iter()
+            .filter(|round| round.commitment.is_some())
+            .count();
+
+        let mut zk_shape = OpeningShape::default();
+        for round in &zk_proof.rounds {
+            zk_shape.merge(query_opening_shape(&round.openings));
+        }
+        zk_shape.merge(query_opening_shape(&zk_proof.base_case.source_openings));
+        zk_shape.merge(extension_opening_shape(
+            &zk_proof.base_case.fresh_main_openings,
+        ));
+        for pair in &zk_proof.base_case.mask_openings {
+            zk_shape.merge(extension_opening_shape(&pair.carried));
+            zk_shape.merge(extension_opening_shape(&pair.fresh));
+        }
+        let zk_roots = 1
+            + zk_proof.sumcheck_mask_commitments.len()
+            + 2 * zk_proof.rounds.len()
+            + 1
+            + zk_proof.base_case.fresh_mask_commitments.len();
+
+        eprintln!(
+            "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+            num_variables,
+            "plain",
+            postcard_len(&plain_proof),
+            plain_roots,
+            plain_shape.multiproofs,
+            plain_shape.authenticated_rows,
+            plain_shape.base_values,
+            plain_shape.extension_values,
+            plain_shape.sibling_digests,
+        );
+        eprintln!(
+            "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+            num_variables,
+            "zk",
+            postcard_len(&zk_proof),
+            zk_roots,
+            zk_shape.multiproofs,
+            zk_shape.authenticated_rows,
+            zk_shape.base_values,
+            zk_shape.extension_values,
+            zk_shape.sibling_digests,
+        );
+        let blinded_mask_elements: usize = zk_proof
+            .base_case
+            .blinded_masks
+            .iter()
+            .map(|mask| mask.message.len() + mask.randomness.len())
+            .sum();
+        eprintln!(
+            "      zk components: rounds={} sumchecks={} base_case={} mask_openings={} blinded_masks={} mask_groups={} blinded_mask_elements={}",
+            postcard_len(&zk_proof.rounds),
+            postcard_len(&zk_proof.sumchecks),
+            postcard_len(&zk_proof.base_case),
+            postcard_len(&zk_proof.base_case.mask_openings),
+            postcard_len(&zk_proof.base_case.blinded_masks),
+            zk_proof.base_case.mask_openings.len(),
+            blinded_mask_elements,
+        );
+    }
+    eprintln!();
+}
+
+criterion_group!(benches, bench_zk_overhead, bench_octic_no_pow);
+criterion_group!(reports, report_octic_proof_shape);
+criterion_main!(benches, reports);


### PR DESCRIPTION
## What changed

- retain the existing PoW-enabled ZK-WHIR benchmark for production-like continuity
- add a matched 128-bit, PoW-free plain-vs-ZK comparison split into commit, open, and verify phases
- use the same polynomial and prescribed opening point on both sides
- exclude witness/protocol/point cloning and commitment setup from the relevant timed regions
- add an opt-in, fixed-seed proof report covering roots, multiproofs, authenticated rows, leaf values, Merkle siblings, and the dominant ZK proof components
- port the benchmark to the typed Fiat-Shamir and fallible PCS APIs on current `main`

## Why

The existing benchmark initializes both challengers identically, but plain and ZK transcripts differ before grinding. Their 16-bit PoW searches therefore have unrelated stopping times, so a plain-vs-ZK ratio can be materially biased by nonce-search luck.

The new grind-free groups isolate protocol work while keeping the existing group available as a realistic end-to-end configuration. This is deliberately a query-heavy operating point: 128-bit Johnson soundness, start rate `2^-1`, intermediate rate `2^-6`, folding `8/6`, and no PoW. The intermediate rate leaves enough terminal slack for the occupancy-aware hiding budget introduced in #1995 at every benchmark size.

This compares the complete plain and hiding pipelines, not a pure wrapper cost: hiding WHIR omits the plain commitment-OOD and final-fold phases.

Proof reporting is opt-in so `--list`, `--test`, and filtered benchmark runs do not perform full proofs:

```console
P3_WHIR_PROOF_REPORT=1 cargo bench -p p3-whir --bench zk_overhead --features parallel -- --test
```

Current fixed-seed proof-shape output:

| vars | kind | proof bytes | roots | proofs | auth rows | base values | extension values | Merkle digests |
|---:|:---|---:|---:|---:|---:|---:|---:|---:|
| 18 | plain | 423,458 | 2 | 2 | 342 | 76,288 | 2,816 | 804 |
| 18 | ZK | 735,379 | 9 | 9 | 1,024 | 76,288 | 8,580 | 2,967 |
| 19 | plain | 434,050 | 2 | 2 | 342 | 76,288 | 2,816 | 1,117 |
| 19 | ZK | 694,917 | 9 | 9 | 978 | 76,288 | 7,085 | 3,206 |
| 20 | plain | 444,258 | 2 | 2 | 342 | 76,288 | 2,816 | 1,402 |
| 20 | ZK | 677,833 | 9 | 9 | 950 | 76,288 | 6,175 | 3,565 |

## Validation

- `cargo +nightly fmt --all --check`
- `cargo clippy -p p3-whir --bench zk_overhead --features parallel -- -D warnings`
- `cargo bench -p p3-whir --bench zk_overhead --features parallel -- --test`
- `cargo bench -p p3-whir --bench zk_overhead --features parallel -- --list`
- `P3_WHIR_PROOF_REPORT=1 cargo bench -p p3-whir --bench zk_overhead --features parallel -- --test`
- `cargo test -p p3-whir --features parallel` (196 passed, 3 ignored)

This is the first PR in a two-part ZK-WHIR overhead investigation. A follow-up draft will use this accounting to evaluate batching the base-case fresh mask commitments.
