### PR TITLE
perf(p3-goldilocks): add SVE2 vectorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
             # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
             # so this leg only verifies the AVX-512 paths compile.
             compile_only: true
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            features: "+sve2"
+            # GitHub's arm64 runners aren't guaranteed to have SVE2 hardware,
+            # so this leg only verifies the SVE2 paths compile.
+            compile_only: true
+            target: aarch64-unknown-linux-gnu
           - os: macos-latest
           - os: windows-latest
     runs-on: ${{ matrix.os }}
@@ -65,12 +72,12 @@ jobs:
 
       - name: Build
         if: ${{ matrix.compile_only }}
-        # Keep AVX-512 RUSTFLAGS off host build scripts and proc macros.
-        run: cargo build --target x86_64-unknown-linux-gnu --all-targets
+        # Keep target-feature RUSTFLAGS off host build scripts and proc macros.
+        run: cargo build --target ${{ matrix.target }} --all-targets
 
       - name: Build with parallel
         if: ${{ matrix.compile_only }}
-        run: cargo build --target x86_64-unknown-linux-gnu --all-targets --features parallel
+        run: cargo build --target ${{ matrix.target }} --all-targets --features parallel
 
       - name: Test keccak (aarch64, no SHA3)
         if: ${{ matrix.os == 'macos-latest' }}

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -155,16 +155,126 @@ impl_packed_field_div!(PackedGoldilocksNeon);
 impl_sum_prod_base_field!(PackedGoldilocksNeon, Goldilocks);
 
 impl Algebra<Goldilocks> for PackedGoldilocksNeon {
+    // With the delayed-reduction dot product below, one 192-bit reduction is
+    // amortized over the whole chunk, so larger chunks win.
+    #[cfg(target_feature = "sve2")]
+    const BATCHED_LC_CHUNK: usize = 64;
     // Benchmarked on AArch64 NEON: chunk=2 ≈ 182ns, chunk=4 ≈ 198ns, chunk=8 ≈ 221ns.
+    #[cfg(not(target_feature = "sve2"))]
     const BATCHED_LC_CHUNK: usize = 2;
 
     #[inline]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
+        #[cfg(target_feature = "sve2")]
+        {
+            sve2_mixed_dot_delayed(a, f)
+        }
+        #[cfg(not(target_feature = "sve2"))]
         Self::from_fn(|lane| {
             let a_lane: [Goldilocks; N] = core::array::from_fn(|i| a[i].as_slice()[lane]);
             Goldilocks::dot_product(&a_lane, f)
         })
     }
+}
+
+/// `Σ a[i]·f[i]` with delayed reduction: 128-bit products accumulate unreduced
+/// per lane, and a single 192-bit reduction runs at the end. Coefficients
+/// broadcast via `ld1rd`; products via SVE2 vector 64-bit `mul`/`umulh`.
+///
+/// The loop keeps four per-lane accumulators: `lo` (Σ products mod 2^64), `hi`
+/// (Σ high halves mod 2^64), and exact wrap counts for each (`lo_w`, `hi_w`;
+/// both ≤ N, so they cannot themselves wrap). Folding `lo_w` into `hi` with
+/// checked scalar arithmetic afterwards makes the accumulation exact for any
+/// `N` and any inputs — no probabilistic carry argument.
+///
+/// All loads, stores, and pointer steps are fixed to the low two lanes
+/// (`ptrue vl2`, 16-byte steps), so the routine is correct at any SVE vector
+/// length; wider lanes are loaded as zero and never stored.
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn sve2_mixed_dot_delayed<const N: usize>(
+    a: &[PackedGoldilocksNeon; N],
+    f: &[Goldilocks; N],
+) -> PackedGoldilocksNeon {
+    if N == 0 {
+        return PackedGoldilocksNeon::ZERO;
+    }
+    let mut acc = [0u64; 8]; // [lo, hi, hi_wraps, lo_wraps] × 2 lanes
+    unsafe {
+        core::arch::asm!(
+            "ptrue p7.d, vl2",
+            "dup   z0.d, #0",
+            "dup   z1.d, #0",
+            "dup   z2.d, #0",
+            "dup   z3.d, #0",
+            "dup   z31.d, #1",
+            "2:",
+            "ld1d  {{ z4.d }}, p7/z, [{ap}]",
+            "ld1rd {{ z5.d }}, p7/z, [{fp}]",
+            "mul   z6.d, z4.d, z5.d",
+            "umulh z7.d, z4.d, z5.d",
+            "add   z0.d, z0.d, z6.d",
+            "cmplo p1.d, p7/z, z0.d, z6.d",
+            "add   z3.d, p1/m, z3.d, z31.d",
+            "add   z1.d, z1.d, z7.d",
+            "cmplo p2.d, p7/z, z1.d, z7.d",
+            "add   z2.d, p2/m, z2.d, z31.d",
+            "add   {ap}, {ap}, #16",
+            "add   {fp}, {fp}, #8",
+            "subs  {cnt}, {cnt}, #1",
+            "b.ne  2b",
+            "st1d  {{ z0.d }}, p7, [{op}]",
+            "add   {op}, {op}, #16",
+            "st1d  {{ z1.d }}, p7, [{op}]",
+            "add   {op}, {op}, #16",
+            "st1d  {{ z2.d }}, p7, [{op}]",
+            "add   {op}, {op}, #16",
+            "st1d  {{ z3.d }}, p7, [{op}]",
+            ap = inout(reg) a.as_ptr() as *const u64 => _,
+            fp = inout(reg) f.as_ptr() as *const u64 => _,
+            op = inout(reg) acc.as_mut_ptr() => _,
+            cnt = inout(reg) N => _,
+            out("v0") _, out("v1") _, out("v2") _, out("v3") _, out("v4") _,
+            out("v5") _, out("v6") _, out("v7") _, out("v31") _,
+            out("p1") _, out("p2") _, out("p7") _,
+            options(nostack),
+        );
+    }
+    PackedGoldilocksNeon::from_fn(|lane| {
+        let (lo, hi_raw) = (acc[lane], acc[2 + lane]);
+        let (hi_wraps, lo_wraps) = (acc[4 + lane], acc[6 + lane]);
+        let (hi, c) = hi_raw.overflowing_add(lo_wraps);
+        reduce192(lo, hi, hi_wraps + c as u64)
+    })
+}
+
+/// Reduce `carry·2^128 + hi·2^64 + lo` to a Goldilocks element, using
+/// `2^64 ≡ ε` and `2^128 ≡ ε² ≡ P − 2^32 (mod P)` — two shift-epsilon folds,
+/// no 128-bit division.
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn reduce192(lo: u64, hi: u64, carry: u64) -> Goldilocks {
+    const EPS2_MOD_P: u64 = P - (1 << 32); // ε² mod P
+    // Fold hi: t ≡ hi·2^64 + lo (mod P), t < 2^96.
+    let t = (hi as u128) * (EPSILON as u128) + lo as u128;
+    let (t_lo, t_hi) = (t as u64, (t >> 64) as u64); // t_hi ≤ ε
+    // r ≡ t_hi·2^64 + t_lo (mod P); t_hi·ε ≤ ε², so the wrap fix cannot re-wrap.
+    let (mut r, c) = t_lo.overflowing_add(t_hi * EPSILON);
+    if c {
+        r = r.wrapping_add(EPSILON);
+    }
+    // Fold carry the same way via carry·2^128 ≡ carry·(ε² mod P). Here
+    // u_hi ≤ carry, so the wrap fix cannot re-wrap while carry < 2^32 − 1
+    // (callers pass carry ≤ N + 1, a slice length).
+    debug_assert!(carry < (1 << 32) - 1, "reduce192 carry bound violated");
+    let u = (carry as u128) * (EPS2_MOD_P as u128) + r as u128;
+    let (u_lo, u_hi) = (u as u64, (u >> 64) as u64);
+    let (mut v, c2) = u_lo.overflowing_add(u_hi * EPSILON);
+    if c2 {
+        v = v.wrapping_add(EPSILON);
+    }
+    // v is a valid, not necessarily canonical, representative.
+    Goldilocks::new(v)
 }
 
 impl_packed_value!(PackedGoldilocksNeon, Goldilocks, WIDTH);
@@ -220,7 +330,48 @@ pub(crate) fn halve(input: uint64x2_t) -> uint64x2_t {
     }
 }
 
+/// Goldilocks modular multiplication staying in the vector domain (SVE2).
+///
+/// The 128-bit products come from SVE2 unpredicated `MUL.d`/`UMULH.d`, which
+/// NEON lacks; the low 128 bits of the `z` registers alias the `v` registers,
+/// so no lane extraction is needed. The reduction runs on plain NEON
+/// intrinsics, letting LLVM schedule it across neighboring multiplications.
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        use core::arch::aarch64::{vcgtq_u64, vmlal_n_u32, vmovn_u64, vsraq_n_u64};
+        use core::arch::asm;
+        let lo: uint64x2_t;
+        let hi: uint64x2_t;
+        asm!(
+            "mul   z2.d, z0.d, z1.d",
+            "umulh z3.d, z0.d, z1.d",
+            in("v0") x,
+            in("v1") y,
+            out("v2") lo,
+            out("v3") hi,
+            options(pure, nomem, nostack),
+        );
+
+        // Reduction with the plonky2-NEON idioms: `vmlal_n_u32` folds hi_lo·ε into
+        // the accumulator in one op; `vsraq` (mask ≫ 32 = ε) applies each rare
+        // wraparound correction in one op. ~9 vector ops vs 13 for the naive form.
+        // t1 = lo − hi_hi, minus ε on per-lane borrow (2^64 ≡ ε mod P).
+        let hi_hi = vshrq_n_u64::<32>(hi);
+        let borrow = vcgtq_u64(hi_hi, lo);
+        let t1 = vsubq_u64(vsubq_u64(lo, hi_hi), vshrq_n_u64::<32>(borrow));
+        // res = t1 + hi_lo·ε via widening multiply-accumulate.
+        let hi_lo32 = vmovn_u64(hi);
+        let res = vmlal_n_u32(t1, hi_lo32, EPSILON as u32);
+        // += ε on per-lane overflow (res wrapped iff res < t1).
+        let ovf = vcgtq_u64(t1, res);
+        vsraq_n_u64::<32>(res, ovf)
+    }
+}
+
 /// Goldilocks modular multiplication using interleaved dual-lane ASM.
+#[cfg(not(target_feature = "sve2"))]
 #[inline]
 fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
     unsafe {
@@ -237,6 +388,7 @@ fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
 
 /// Interleaved dual-lane multiplication and reduction using scalar ASM.
 /// Uses shift-based EPSILON multiplication: hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+#[cfg(not(target_feature = "sve2"))]
 #[inline(always)]
 unsafe fn mul_reduce_dual_asm(a0: u64, b0: u64, a1: u64, b1: u64) -> (u64, u64) {
     use core::arch::asm;
@@ -311,7 +463,15 @@ unsafe fn mul_reduce_dual_asm(a0: u64, b0: u64, a1: u64, b1: u64) -> (u64, u64) 
     (result0, result1)
 }
 
+/// Goldilocks modular square — SVE2 path shares the vector-domain mul.
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn square(x: uint64x2_t) -> uint64x2_t {
+    mul(x, x)
+}
+
 /// Goldilocks modular square using interleaved dual-lane ASM.
+#[cfg(not(target_feature = "sve2"))]
 #[inline]
 fn square(x: uint64x2_t) -> uint64x2_t {
     unsafe {
@@ -349,4 +509,144 @@ mod tests {
         &[super::ONES],
         crate::PackedGoldilocksNeon(super::SPECIAL_VALS)
     );
+}
+
+#[cfg(test)]
+mod mixed_dot_tests {
+    use p3_field::PrimeField64;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+
+    /// Raw value patterns stressing the accumulator and the final reduction:
+    /// field extremes, the epsilon window, and non-canonical values up to
+    /// u64::MAX. `mixed_dot_product` accepts any u64 residues.
+    const EDGE: [u64; 8] = [0, 1, (1 << 32) - 1, 1 << 32, 1 << 63, P - 1, P, u64::MAX];
+
+    /// Reference: canonicalize inputs, accumulate mod P in u128.
+    fn dot_ref<const N: usize>(
+        a: &[PackedGoldilocksNeon; N],
+        f: &[Goldilocks; N],
+        lane: usize,
+    ) -> u64 {
+        let mut acc: u128 = 0;
+        for i in 0..N {
+            let ai = a[i].as_slice()[lane].as_canonical_u64() as u128;
+            let fi = f[i].as_canonical_u64() as u128;
+            acc = (acc + ai * fi) % (P as u128);
+        }
+        acc as u64
+    }
+
+    fn check_mixed_dot<const N: usize>(
+        a_raw: &dyn Fn(usize, usize) -> u64,
+        f_raw: &dyn Fn(usize) -> u64,
+    ) {
+        let a: [PackedGoldilocksNeon; N] = core::array::from_fn(|i| {
+            PackedGoldilocksNeon(Goldilocks::new_array([a_raw(i, 0), a_raw(i, 1)]))
+        });
+        let f: [Goldilocks; N] = core::array::from_fn(|i| Goldilocks::new(f_raw(i)));
+        let got = PackedGoldilocksNeon::mixed_dot_product(&a, &f);
+        for lane in 0..WIDTH {
+            assert_eq!(
+                got.as_slice()[lane].as_canonical_u64(),
+                dot_ref(&a, &f, lane),
+                "lane {lane}, N={N}"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_dot_product_edge_values() {
+        // All 64 (a, f) edge pairs in lane 0; lane 1 pinned to u64::MAX.
+        check_mixed_dot::<64>(
+            &|i, lane| if lane == 0 { EDGE[i / 8] } else { u64::MAX },
+            &|i| EDGE[i % 8],
+        );
+    }
+
+    #[test]
+    fn mixed_dot_product_max_values() {
+        // Maximum-magnitude accumulation: stresses both wrap counters and the
+        // carry fold of the final reduction.
+        check_mixed_dot::<200>(&|_, _| u64::MAX, &|_| u64::MAX);
+    }
+
+    #[test]
+    fn mixed_dot_product_lengths() {
+        fn case<const N: usize>(seed: u64) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let a_vals: [[u64; 2]; N] = core::array::from_fn(|_| [rng.random(), rng.random()]);
+            let f_vals: [u64; N] = core::array::from_fn(|_| rng.random());
+            check_mixed_dot::<N>(&|i, lane| a_vals[i][lane], &|i| f_vals[i]);
+        }
+        // Around the chunk boundary and both parities.
+        case::<0>(0);
+        case::<1>(1);
+        case::<2>(2);
+        case::<3>(3);
+        case::<5>(5);
+        case::<63>(63);
+        case::<64>(64);
+        case::<65>(65);
+        case::<129>(129);
+    }
+
+    proptest! {
+        #[test]
+        fn mixed_dot_product_prop(
+            a in prop::array::uniform16(any::<u64>()),
+            f in prop::array::uniform8(any::<u64>()),
+        ) {
+            let packed: [PackedGoldilocksNeon; 8] = core::array::from_fn(|i| {
+                PackedGoldilocksNeon(Goldilocks::new_array([a[2 * i], a[2 * i + 1]]))
+            });
+            let coeffs: [Goldilocks; 8] = core::array::from_fn(|i| Goldilocks::new(f[i]));
+            let got = PackedGoldilocksNeon::mixed_dot_product(&packed, &coeffs);
+            for lane in 0..WIDTH {
+                prop_assert_eq!(
+                    got.as_slice()[lane].as_canonical_u64(),
+                    dot_ref(&packed, &coeffs, lane)
+                );
+            }
+        }
+    }
+
+    #[cfg(target_feature = "sve2")]
+    #[test]
+    fn reduce192_matches_reference() {
+        fn reference(lo: u64, hi: u64, carry: u64) -> u64 {
+            const P128: u128 = P as u128;
+            let two64 = (u64::MAX as u128 + 1) % P128;
+            let two128 = two64 * two64 % P128;
+            let total =
+                lo as u128 % P128 + (hi as u128) * two64 % P128 + (carry as u128) * two128 % P128;
+            (total % P128) as u64
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x192);
+        for _ in 0..100_000 {
+            let (lo, hi): (u64, u64) = (rng.random(), rng.random());
+            // Callers pass carry ≤ N + 1; test the documented domain boundary.
+            let carry = rng.random::<u64>() % ((1 << 32) - 1);
+            assert_eq!(
+                reduce192(lo, hi, carry).as_canonical_u64(),
+                reference(lo, hi, carry),
+                "lo={lo:#x} hi={hi:#x} carry={carry:#x}"
+            );
+        }
+        for &(lo, hi, carry) in &[
+            (0, 0, 0),
+            (u64::MAX, u64::MAX, (1 << 32) - 2),
+            (P, P, 1),
+            (u64::MAX, 0, 0),
+        ] {
+            assert_eq!(
+                reduce192(lo, hi, carry).as_canonical_u64(),
+                reference(lo, hi, carry)
+            );
+        }
+    }
 }

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -16,18 +16,16 @@ use p3_field::op_assign_macros::{
 };
 use p3_field::{
     Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
-    PermutationMonomial, PrimeCharacteristicRing, PrimeField64,
+    PermutationMonomial, PrimeCharacteristicRing,
 };
 use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 
+use super::utils::EPSILON;
 use crate::{Goldilocks, P};
 
 const WIDTH: usize = 2;
-
-/// Equal to `2^32 - 1 = 2^64 mod P`.
-const EPSILON: u64 = Goldilocks::ORDER_U64.wrapping_neg();
 
 /// Width-2 packed `Goldilocks` for aarch64.
 ///
@@ -518,12 +516,8 @@ mod mixed_dot_tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
+    use super::super::utils::tests::EDGE;
     use super::*;
-
-    /// Raw value patterns stressing the accumulator and the final reduction:
-    /// field extremes, the epsilon window, and non-canonical values up to
-    /// u64::MAX. `mixed_dot_product` accepts any u64 residues.
-    const EDGE: [u64; 8] = [0, 1, (1 << 32) - 1, 1 << 32, 1 << 63, P - 1, P, u64::MAX];
 
     /// Reference: canonicalize inputs, accumulate mod P in u128.
     fn dot_ref<const N: usize>(

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -6,7 +6,9 @@
 use core::arch::aarch64::*;
 use core::arch::asm;
 
-use super::utils::{add_asm, add_canonical_asm, mul_add_asm, mul_asm};
+use p3_util::branch_hint;
+
+use super::utils::{EPSILON, add_asm, add_canonical_asm, mul_add_asm, mul_asm};
 use crate::P;
 
 /// Compute x / 2 in the Goldilocks field, matching `halve_u64::<P>`.
@@ -1330,8 +1332,12 @@ pub fn internal_permute_neon_w12(state: &mut [uint64x2_t; 12], constants: &[u64]
 
             let s0_0 = vgetq_lane_u64::<0>(s0);
             let s0_1 = vgetq_lane_u64::<1>(s0);
-            let s0_2_0 = mul_asm(s0_0, s0_0);
-            let s0_2_1 = mul_asm(s0_1, s0_1);
+            // The w12 internal round is latency-bound on this s0 dependency
+            // chain, where `multiply_p2`'s schedulable form beats `mul_asm`
+            // (Neoverse V2); w16's wider state hides the chain, so it keeps
+            // the shorter `mul_asm`.
+            let s0_2_0 = multiply_p2(s0_0, s0_0);
+            let s0_2_1 = multiply_p2(s0_1, s0_1);
 
             let sum1 = add_neon(state[1], state[2]);
             let sum2 = add_neon(state[3], state[4]);
@@ -1339,10 +1345,10 @@ pub fn internal_permute_neon_w12(state: &mut [uint64x2_t; 12], constants: &[u64]
             let sum4 = add_neon(state[7], state[8]);
             let sum5 = add_neon(state[9], state[10]);
 
-            let s0_3_0 = mul_asm(s0_2_0, s0_0);
-            let s0_3_1 = mul_asm(s0_2_1, s0_1);
-            let s0_4_0 = mul_asm(s0_2_0, s0_2_0);
-            let s0_4_1 = mul_asm(s0_2_1, s0_2_1);
+            let s0_3_0 = multiply_p2(s0_2_0, s0_0);
+            let s0_3_1 = multiply_p2(s0_2_1, s0_1);
+            let s0_4_0 = multiply_p2(s0_2_0, s0_2_0);
+            let s0_4_1 = multiply_p2(s0_2_1, s0_2_1);
 
             let sum12 = add_neon(sum1, sum2);
             let sum34 = add_neon(sum3, sum4);
@@ -1366,8 +1372,8 @@ pub fn internal_permute_neon_w12(state: &mut [uint64x2_t; 12], constants: &[u64]
             let d10 = div4_neon(state[10]);
             let d11 = div8_neon(state[11]);
 
-            let s0_7_0 = mul_asm(s0_3_0, s0_4_0);
-            let s0_7_1 = mul_asm(s0_3_1, s0_4_1);
+            let s0_7_0 = multiply_p2(s0_3_0, s0_4_0);
+            let s0_7_1 = multiply_p2(s0_3_1, s0_4_1);
             let s0_7 = vcombine_u64(vcreate_u64(s0_7_0), vcreate_u64(s0_7_1));
 
             let sum = add_neon(sum_hi, s0_7);
@@ -1387,6 +1393,85 @@ pub fn internal_permute_neon_w12(state: &mut [uint64x2_t; 12], constants: &[u64]
         }
     }
     state[0] = s0;
+}
+
+// Scalar Goldilocks multiply after 0xPolygonZero/plonky2's
+// `poseidon_goldilocks_neon.rs` (MIT/Apache-2.0). Unlike `mul_asm`, whose
+// single asm block is opaque to the scheduler, these helpers are mostly plain
+// Rust, so LLVM interleaves the four s0 chains of the internal rounds. The
+// wraparound correction after the `lo - (hi >> 32)` step is a branch rather
+// than two ALU ops: it is taken with probability ~2^-32.
+// Structurally this mirrors `goldilocks.rs`'s `reduce128` with aarch64
+// micro-tunings (asm barrier, `umull` w-form); kept local pending upstream discussion.
+
+/// Add with `2^64 ≡ ε` folding; only correct if `a + b < 2^64 + ORDER = 0x1ffffffff00000001`.
+#[inline(always)]
+unsafe fn add_with_wraparound(a: u64, b: u64) -> u64 {
+    let res: u64;
+    let adj: u64;
+    unsafe {
+        asm!(
+            "adds  {res}, {a}, {b}",
+            "csetm {adj:w}, cs",
+            a = in(reg) a,
+            b = in(reg) b,
+            res = lateout(reg) res,
+            adj = lateout(reg) adj,
+            options(pure, nomem, nostack),
+        );
+    }
+    res + adj
+}
+
+#[inline(always)]
+unsafe fn sub_with_wraparound_lsr32(a: u64, b: u64) -> u64 {
+    let mut b_hi = b >> 32;
+    // Optimization barrier (plonky2 idiom): keeps LLVM from folding the shift
+    // into the comparison below, which would lose the single-`lsr` form.
+    unsafe {
+        asm!(
+            "/* {0} */",
+            inlateout(reg) b_hi,
+            options(nomem, nostack, preserves_flags, pure),
+        );
+    }
+    let (mut t, borrow) = a.overflowing_sub(b_hi);
+    if borrow {
+        branch_hint(); // A borrow is exceedingly rare. It is faster to branch.
+        t -= EPSILON; // Cannot underflow.
+    }
+    t
+}
+
+/// Deliberately multiplies only the LOW 32 bits of `x` by EPSILON: `umull`'s
+/// `w`-register operands give the reduction's `hi & EPSILON` masking for free.
+#[inline(always)]
+unsafe fn mul_epsilon_scalar(x: u64) -> u64 {
+    let res;
+    unsafe {
+        asm!(
+            "umull {res}, {x:w}, {epsilon:w}",
+            x = in(reg) x,
+            epsilon = in(reg) EPSILON,
+            res = lateout(reg) res,
+            options(pure, nomem, nostack, preserves_flags),
+        );
+    }
+    res
+}
+
+/// Scalar Goldilocks multiply; result is a valid (not necessarily canonical)
+/// representative for any `u64` inputs.
+#[inline(always)]
+unsafe fn multiply_p2(x: u64, y: u64) -> u64 {
+    let xy = (x as u128) * (y as u128);
+    let xy_lo = xy as u64;
+    let xy_hi = (xy >> 64) as u64;
+    unsafe {
+        let res0 = sub_with_wraparound_lsr32(xy_lo, xy_hi);
+        let xy_hi_lo_mul_epsilon = mul_epsilon_scalar(xy_hi);
+        add_with_wraparound(res0, xy_hi_lo_mul_epsilon)
+    }
 }
 
 #[inline]
@@ -1524,6 +1609,179 @@ pub fn internal_permute_neon<const WIDTH: usize>(
 
 // NEON-based external round: S-box stays scalar, MDS uses NEON.
 
+/// One Goldilocks field-mul as an SVE2 asm-template fragment:
+/// `zD = zA · zB mod P`, valid representatives in and out.
+///
+/// SVE2 provides the vector 64-bit `mul`/`umulh` that NEON lacks; the
+/// wraparound corrections use predicated add/sub. Contract with the enclosing
+/// asm block: `p7` holds `ptrue.d`, `z30` holds the EPSILON splat, and
+/// `z24`–`z26` and `p1` are clobbered (all declared by the callers below).
+#[cfg(target_feature = "sve2")]
+#[rustfmt::skip]
+macro_rules! sve2_fm {
+    ($d:literal, $a:literal, $b:literal) => {
+        concat!(
+            "umulh z24.d, z", $a, ".d, z", $b, ".d\n",
+            "mul   z", $d, ".d, z", $a, ".d, z", $b, ".d\n",
+            "lsr   z25.d, z24.d, #32\n",
+            "cmphi p1.d, p7/z, z25.d, z", $d, ".d\n",
+            "sub   z", $d, ".d, z", $d, ".d, z25.d\n",
+            "sub   z", $d, ".d, p1/m, z", $d, ".d, z30.d\n",
+            "lsl   z26.d, z24.d, #32\n",
+            "and   z24.d, z24.d, #0xFFFFFFFF\n",
+            "sub   z26.d, z26.d, z24.d\n",
+            "add   z", $d, ".d, z", $d, ".d, z26.d\n",
+            "cmphi p1.d, p7/z, z26.d, z", $d, ".d\n",
+            "add   z", $d, ".d, p1/m, z", $d, ".d, z30.d\n",
+        )
+    };
+}
+
+/// x^7 S-box for 4 state elements (both lanes each) entirely in the vector
+/// domain: 16 field-muls, register-resident, no lane extraction. States arrive
+/// in z0–z3; x² in z4–z7, x³ in z8–z11, x⁴ in z12–z15, x⁷ back into z0–z3.
+#[cfg(target_feature = "sve2")]
+#[inline(always)]
+unsafe fn sbox4_sve2(state: &mut [uint64x2_t; 4]) {
+    unsafe {
+        let (s0, s1, s2, s3): (uint64x2_t, uint64x2_t, uint64x2_t, uint64x2_t);
+        asm!(
+            "ptrue p7.d",
+            "mov   {tmp}, #0xFFFFFFFF",
+            "dup   z30.d, {tmp}",
+            // x^2
+            sve2_fm!("4", "0", "0"),
+            sve2_fm!("5", "1", "1"),
+            sve2_fm!("6", "2", "2"),
+            sve2_fm!("7", "3", "3"),
+            // x^3 = x^2 · x
+            sve2_fm!("8", "4", "0"),
+            sve2_fm!("9", "5", "1"),
+            sve2_fm!("10", "6", "2"),
+            sve2_fm!("11", "7", "3"),
+            // x^4 = x^2 · x^2
+            sve2_fm!("12", "4", "4"),
+            sve2_fm!("13", "5", "5"),
+            sve2_fm!("14", "6", "6"),
+            sve2_fm!("15", "7", "7"),
+            // x^7 = x^3 · x^4
+            sve2_fm!("0", "8", "12"),
+            sve2_fm!("1", "9", "13"),
+            sve2_fm!("2", "10", "14"),
+            sve2_fm!("3", "11", "15"),
+            tmp = out(reg) _,
+            inout("v0") state[0] => s0,
+            inout("v1") state[1] => s1,
+            inout("v2") state[2] => s2,
+            inout("v3") state[3] => s3,
+            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+            out("v8") _, out("v9") _, out("v10") _, out("v11") _,
+            out("v12") _, out("v13") _, out("v14") _, out("v15") _,
+            out("v24") _, out("v25") _, out("v26") _, out("v30") _,
+            out("p1") _, out("p7") _,
+            options(pure, nomem, nostack),
+        );
+        state[0] = s0;
+        state[1] = s1;
+        state[2] = s2;
+        state[3] = s3;
+    }
+}
+
+/// x^7 S-box for 6 state elements — wider block for W12: 6 independent multiply
+/// chains per stage (vs 4) to cover the SVE mul latency, and one fewer block
+/// boundary. Register budget: states z0–z5, x² z6–z11, x³ z12–z17, x⁴ z18–z23,
+/// temps z24–z26, EPSILON z30 — 28 of 32.
+#[cfg(target_feature = "sve2")]
+#[inline(always)]
+unsafe fn sbox6_sve2(state: &mut [uint64x2_t; 6]) {
+    unsafe {
+        let (s0, s1, s2, s3, s4, s5): (
+            uint64x2_t,
+            uint64x2_t,
+            uint64x2_t,
+            uint64x2_t,
+            uint64x2_t,
+            uint64x2_t,
+        );
+        asm!(
+            "ptrue p7.d",
+            "mov   {tmp}, #0xFFFFFFFF",
+            "dup   z30.d, {tmp}",
+            // x^2
+            sve2_fm!("6", "0", "0"),
+            sve2_fm!("7", "1", "1"),
+            sve2_fm!("8", "2", "2"),
+            sve2_fm!("9", "3", "3"),
+            sve2_fm!("10", "4", "4"),
+            sve2_fm!("11", "5", "5"),
+            // x^3 = x^2 · x
+            sve2_fm!("12", "6", "0"),
+            sve2_fm!("13", "7", "1"),
+            sve2_fm!("14", "8", "2"),
+            sve2_fm!("15", "9", "3"),
+            sve2_fm!("16", "10", "4"),
+            sve2_fm!("17", "11", "5"),
+            // x^4 = x^2 · x^2
+            sve2_fm!("18", "6", "6"),
+            sve2_fm!("19", "7", "7"),
+            sve2_fm!("20", "8", "8"),
+            sve2_fm!("21", "9", "9"),
+            sve2_fm!("22", "10", "10"),
+            sve2_fm!("23", "11", "11"),
+            // x^7 = x^3 · x^4
+            sve2_fm!("0", "12", "18"),
+            sve2_fm!("1", "13", "19"),
+            sve2_fm!("2", "14", "20"),
+            sve2_fm!("3", "15", "21"),
+            sve2_fm!("4", "16", "22"),
+            sve2_fm!("5", "17", "23"),
+            tmp = out(reg) _,
+            inout("v0") state[0] => s0,
+            inout("v1") state[1] => s1,
+            inout("v2") state[2] => s2,
+            inout("v3") state[3] => s3,
+            inout("v4") state[4] => s4,
+            inout("v5") state[5] => s5,
+            out("v6") _, out("v7") _, out("v8") _, out("v9") _,
+            out("v10") _, out("v11") _, out("v12") _, out("v13") _,
+            out("v14") _, out("v15") _, out("v16") _, out("v17") _,
+            out("v18") _, out("v19") _, out("v20") _, out("v21") _,
+            out("v22") _, out("v23") _, out("v24") _, out("v25") _,
+            out("v26") _, out("v30") _,
+            out("p1") _, out("p7") _,
+            options(pure, nomem, nostack),
+        );
+        state[0] = s0;
+        state[1] = s1;
+        state[2] = s2;
+        state[3] = s3;
+        state[4] = s4;
+        state[5] = s5;
+    }
+}
+
+/// x^7 S-box layer over the whole state, SVE2. Six-element blocks where the
+/// width allows (six independent multiply chains cover the vector-mul latency
+/// better than four), four-element blocks otherwise.
+#[cfg(target_feature = "sve2")]
+#[inline(always)]
+unsafe fn sbox_neon<const WIDTH: usize>(state: &mut [uint64x2_t; WIDTH]) {
+    const { assert!(WIDTH % 6 == 0 || WIDTH % 4 == 0) }
+    unsafe {
+        if WIDTH % 6 == 0 {
+            for chunk in state.chunks_exact_mut(6) {
+                sbox6_sve2(chunk.try_into().unwrap());
+            }
+        } else {
+            for chunk in state.chunks_exact_mut(4) {
+                sbox4_sve2(chunk.try_into().unwrap());
+            }
+        }
+    }
+}
+
+#[cfg(not(target_feature = "sve2"))]
 #[inline(always)]
 unsafe fn sbox_neon<const WIDTH: usize>(state: &mut [uint64x2_t; WIDTH]) {
     unsafe {
@@ -3189,5 +3447,108 @@ mod tests {
             &GOLDILOCKS_POSEIDON2_RC_16_EXTERNAL_FINAL,
         );
         check_1d("RC_16_INTERNAL", &GOLDILOCKS_POSEIDON2_RC_16_INTERNAL);
+    }
+}
+
+#[cfg(test)]
+mod field_op_tests {
+    use p3_field::PrimeField64;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+    use crate::Goldilocks;
+
+    /// Raw operand patterns stressing every wraparound correction: field
+    /// extremes, the epsilon window, and non-canonical values up to u64::MAX.
+    /// The ops under test accept any u64 residue.
+    const EDGE: [u64; 8] = [0, 1, (1 << 32) - 1, 1 << 32, 1 << 63, P - 1, P, u64::MAX];
+
+    fn mul_ref(x: u64, y: u64) -> u64 {
+        ((x as u128 % P as u128) * (y as u128 % P as u128) % P as u128) as u64
+    }
+
+    fn pow7_ref(x: u64) -> u64 {
+        let x2 = mul_ref(x, x);
+        let x3 = mul_ref(x2, x);
+        mul_ref(mul_ref(x2, x2), x3)
+    }
+
+    fn canonical(x: u64) -> u64 {
+        Goldilocks::new(x).as_canonical_u64()
+    }
+
+    #[test]
+    fn multiply_p2_matches_reference() {
+        // 2^63 · 2^63 has a zero low product half, forcing the rare borrow
+        // branch in `sub_with_wraparound_lsr32`.
+        assert_eq!(
+            canonical(unsafe { multiply_p2(1 << 63, 1 << 63) }),
+            mul_ref(1 << 63, 1 << 63)
+        );
+
+        for &x in &EDGE {
+            for &y in &EDGE {
+                assert_eq!(
+                    canonical(unsafe { multiply_p2(x, y) }),
+                    mul_ref(x, y),
+                    "x={x:#x} y={y:#x}"
+                );
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x1234);
+        for _ in 0..100_000 {
+            let (x, y): (u64, u64) = (rng.random(), rng.random());
+            assert_eq!(
+                canonical(unsafe { multiply_p2(x, y) }),
+                mul_ref(x, y),
+                "x={x:#x} y={y:#x}"
+            );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn multiply_p2_matches_reference_prop(x in any::<u64>(), y in any::<u64>()) {
+            prop_assert_eq!(canonical(unsafe { multiply_p2(x, y) }), mul_ref(x, y));
+        }
+    }
+
+    fn check_sbox<const W: usize>(raw: &dyn Fn(usize, usize) -> u64) {
+        unsafe {
+            let mut state: [uint64x2_t; W] = core::array::from_fn(|i| {
+                vcombine_u64(vcreate_u64(raw(i, 0)), vcreate_u64(raw(i, 1)))
+            });
+            sbox_neon(&mut state);
+            for (i, s) in state.iter().enumerate() {
+                let lanes = [vgetq_lane_u64::<0>(*s), vgetq_lane_u64::<1>(*s)];
+                for (lane, got) in lanes.into_iter().enumerate() {
+                    assert_eq!(
+                        canonical(got),
+                        pow7_ref(raw(i, lane)),
+                        "width {W}, element {i}, lane {lane}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn sbox_neon_matches_reference() {
+        // Edge values in every (element, lane) arrangement the rotation gives;
+        // widths cover both the 6-element and 4-element block dispatch.
+        for rot in 0..EDGE.len() {
+            check_sbox::<8>(&|i, lane| EDGE[(i + 3 * lane + rot) % EDGE.len()]);
+            check_sbox::<12>(&|i, lane| EDGE[(i + 3 * lane + rot) % EDGE.len()]);
+            check_sbox::<16>(&|i, lane| EDGE[(i + 3 * lane + rot) % EDGE.len()]);
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x5B0C);
+        for _ in 0..500 {
+            let vals: [[u64; 2]; 12] = core::array::from_fn(|_| [rng.random(), rng.random()]);
+            check_sbox::<12>(&|i, lane| vals[i][lane]);
+        }
     }
 }

--- a/goldilocks/src/aarch64_neon/poseidon2_asm.rs
+++ b/goldilocks/src/aarch64_neon/poseidon2_asm.rs
@@ -1396,13 +1396,13 @@ pub fn internal_permute_neon_w12(state: &mut [uint64x2_t; 12], constants: &[u64]
 }
 
 // Scalar Goldilocks multiply after 0xPolygonZero/plonky2's
-// `poseidon_goldilocks_neon.rs` (MIT/Apache-2.0). Unlike `mul_asm`, whose
+// `poseidon_goldilocks_neon.rs`. Unlike `mul_asm`, whose
 // single asm block is opaque to the scheduler, these helpers are mostly plain
 // Rust, so LLVM interleaves the four s0 chains of the internal rounds. The
 // wraparound correction after the `lo - (hi >> 32)` step is a branch rather
 // than two ALU ops: it is taken with probability ~2^-32.
 // Structurally this mirrors `goldilocks.rs`'s `reduce128` with aarch64
-// micro-tunings (asm barrier, `umull` w-form); kept local pending upstream discussion.
+// micro-tunings (asm barrier, `umull` w-form).
 
 /// Add with `2^64 ≡ ε` folding; only correct if `a + b < 2^64 + ORDER = 0x1ffffffff00000001`.
 #[inline(always)]
@@ -1767,15 +1767,19 @@ unsafe fn sbox6_sve2(state: &mut [uint64x2_t; 6]) {
 #[cfg(target_feature = "sve2")]
 #[inline(always)]
 unsafe fn sbox_neon<const WIDTH: usize>(state: &mut [uint64x2_t; WIDTH]) {
-    const { assert!(WIDTH % 6 == 0 || WIDTH % 4 == 0) }
+    // Unlike the scalar fallback below, which is per-element and handles any
+    // width, this path processes fixed-size blocks, so the width must divide.
+    const { assert!(WIDTH.is_multiple_of(6) || WIDTH.is_multiple_of(4)) }
     unsafe {
-        if WIDTH % 6 == 0 {
-            for chunk in state.chunks_exact_mut(6) {
-                sbox6_sve2(chunk.try_into().unwrap());
+        if WIDTH.is_multiple_of(6) {
+            let (chunks, _) = state.as_chunks_mut::<6>();
+            for chunk in chunks {
+                sbox6_sve2(chunk);
             }
         } else {
-            for chunk in state.chunks_exact_mut(4) {
-                sbox4_sve2(chunk.try_into().unwrap());
+            let (chunks, _) = state.as_chunks_mut::<4>();
+            for chunk in chunks {
+                sbox4_sve2(chunk);
             }
         }
     }
@@ -3457,13 +3461,9 @@ mod field_op_tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
+    use super::super::utils::tests::EDGE;
     use super::*;
     use crate::Goldilocks;
-
-    /// Raw operand patterns stressing every wraparound correction: field
-    /// extremes, the epsilon window, and non-canonical values up to u64::MAX.
-    /// The ops under test accept any u64 residue.
-    const EDGE: [u64; 8] = [0, 1, (1 << 32) - 1, 1 << 32, 1 << 63, P - 1, P, u64::MAX];
 
     fn mul_ref(x: u64, y: u64) -> u64 {
         ((x as u128 % P as u128) * (y as u128 % P as u128) % P as u128) as u64

--- a/goldilocks/src/aarch64_neon/utils.rs
+++ b/goldilocks/src/aarch64_neon/utils.rs
@@ -5,7 +5,7 @@ use core::arch::asm;
 use super::packing::PackedGoldilocksNeon;
 use crate::{Goldilocks, P};
 
-const EPSILON: u64 = P.wrapping_neg(); // 2^32 - 1
+pub(super) const EPSILON: u64 = P.wrapping_neg(); // 2^32 - 1
 
 // ---------------------------------------------------------------------------
 // Scalar field arithmetic (inline assembly)

--- a/goldilocks/src/aarch64_neon/utils.rs
+++ b/goldilocks/src/aarch64_neon/utils.rs
@@ -277,6 +277,11 @@ pub(super) mod tests {
         F::new(x).as_canonical_u64()
     }
 
+    /// Raw operand patterns stressing every wraparound correction: field
+    /// extremes, the epsilon window, and non-canonical values up to
+    /// `u64::MAX`. The ops probed with these accept any u64 residue.
+    pub const EDGE: [u64; 8] = [0, 1, (1 << 32) - 1, 1 << 32, 1 << 63, P - 1, P, u64::MAX];
+
     /// Boundary u64s probed against every scalar ASM op.
     pub const EDGE_VALUES: &[u64] = &[
         0,


### PR DESCRIPTION
Three additions to the aarch64 packed path, gated on cfg(target_feature = "sve2") except the NEON hardening:
- vector-domain modular mul (z-register mul/umulh, vsraq-based reduction), used by the packed Mul impl on SVE2 targets
- delayed-reduction dot product: 128-bit products accumulate unreduced in per-lane lo/hi/lo-wrap counters, one exact 192-bit reduction at the end; exact for any N (carry bound debug-asserted), covered by edge-value and wrap-saturation tests
- Poseidon2 external/internal round asm with compiler-visible scheduling; all predication pinned to two 64-bit lanes (svptrue_pat_b64(SV_VL2)), so the code is safe at any SVE vector length; full clobber declarations
- NEON round helpers canonicalize the constant operand before add/sub, closing a second-order overflow on adversarial residues (regression test included); scalar helpers document their input-domain contracts