### PR TITLE
whir: batch base-case fresh masks in one MMCS commitment

### DIFF
--- a/whir/benches/zk_overhead.rs
+++ b/whir/benches/zk_overhead.rs
@@ -25,7 +25,7 @@ use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape,
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
 use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
-use p3_whir::pcs::proof::{PcsProof, QueryOpenings, SharedProofOpening};
+use p3_whir::pcs::proof::{PcsProof, QueryOpenings, SharedBatchOpening, SharedProofOpening};
 use p3_whir::pcs::prover::WhirProver;
 use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig, ZkWhirProof};
 use rand::SeedableRng;
@@ -530,6 +530,23 @@ fn extension_opening_shape<Ext>(
     }
 }
 
+fn extension_batch_opening_shape<Ext>(
+    opening: &SharedBatchOpening<Ext, MerkleMultiProof>,
+) -> OpeningShape {
+    OpeningShape {
+        multiproofs: 1,
+        authenticated_rows: opening.rows.iter().map(Vec::len).sum(),
+        base_values: 0,
+        extension_values: opening
+            .rows
+            .iter()
+            .flat_map(|rows| rows.iter())
+            .map(Vec::len)
+            .sum(),
+        sibling_digests: opening.proof.sibling_hashes.len(),
+    }
+}
+
 fn postcard_len<T: serde::Serialize>(value: &T) -> usize {
     postcard::to_allocvec(value)
         .expect("proof component serializes")
@@ -584,15 +601,17 @@ fn report_octic_proof_shape(_c: &mut Criterion) {
         zk_shape.merge(extension_opening_shape(
             &zk_proof.base_case.fresh_main_openings,
         ));
-        for pair in &zk_proof.base_case.mask_openings {
-            zk_shape.merge(extension_opening_shape(&pair.carried));
-            zk_shape.merge(extension_opening_shape(&pair.fresh));
+        for opening in &zk_proof.base_case.carried_mask_openings {
+            zk_shape.merge(extension_opening_shape(opening));
+        }
+        if let Some(opening) = &zk_proof.base_case.fresh_mask_opening {
+            zk_shape.merge(extension_batch_opening_shape(opening));
         }
         let zk_roots = 1
             + zk_proof.sumcheck_mask_commitments.len()
             + 2 * zk_proof.rounds.len()
             + 1
-            + zk_proof.base_case.fresh_mask_commitments.len();
+            + usize::from(zk_proof.base_case.fresh_mask_commitment.is_some());
 
         eprintln!(
             "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
@@ -625,13 +644,14 @@ fn report_octic_proof_shape(_c: &mut Criterion) {
             .map(|mask| mask.message.len() + mask.randomness.len())
             .sum();
         eprintln!(
-            "      zk components: rounds={} sumchecks={} base_case={} mask_openings={} blinded_masks={} mask_groups={} blinded_mask_elements={}",
+            "      zk components: rounds={} sumchecks={} base_case={} carried_mask_openings={} fresh_mask_opening={} blinded_masks={} mask_groups={} blinded_mask_elements={}",
             postcard_len(&zk_proof.rounds),
             postcard_len(&zk_proof.sumchecks),
             postcard_len(&zk_proof.base_case),
-            postcard_len(&zk_proof.base_case.mask_openings),
+            postcard_len(&zk_proof.base_case.carried_mask_openings),
+            postcard_len(&zk_proof.base_case.fresh_mask_opening),
             postcard_len(&zk_proof.base_case.blinded_masks),
-            zk_proof.base_case.mask_openings.len(),
+            zk_proof.base_case.carried_mask_openings.len(),
             blinded_mask_elements,
         );
     }

--- a/whir/benches/zk_overhead.rs
+++ b/whir/benches/zk_overhead.rs
@@ -10,22 +10,24 @@ use criterion::measurement::WallTime;
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
-use p3_challenger::DuplexChallenger;
-use p3_commit::MultilinearPcs;
+use p3_challenger::{CanObserve, DuplexChallenger};
+use p3_commit::{Mmcs as MmcsTrait, MultilinearPcs};
 use p3_dft::Radix2DFTSmallBatch;
 use p3_field::Field;
 use p3_field::extension::BinomialExtensionField;
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, PrefixProver, Table};
-use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
 use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
+use p3_whir::pcs::proof::{PcsProof, QueryOpenings, SharedProofOpening};
 use p3_whir::pcs::prover::WhirProver;
-use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig};
+use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig, ZkWhirProof};
 use rand::SeedableRng;
 use rand::rngs::{SmallRng, StdRng};
 
@@ -44,7 +46,12 @@ type Dft = Radix2DFTSmallBatch<F>;
 
 type PlainPcs = WhirProver<EF, F, Dft, Mmcs, Challenger, PrefixProver<F, EF>>;
 type ZkPcs = HidingWhirPcs<EF, F, Dft, Mmcs, Challenger, StdRng>;
+type OcticPlainPcs = WhirProver<OcticEF, F, Dft, Mmcs, Challenger, PrefixProver<F, OcticEF>>;
 type OcticZkPcs = HidingWhirPcs<OcticEF, F, Dft, Mmcs, Challenger, StdRng>;
+type Commitment = <Mmcs as MmcsTrait<F>>::Commitment;
+type MerkleMultiProof = <Mmcs as MmcsTrait<F>>::MultiProof;
+type OcticPlainProof = PcsProof<F, OcticEF, Mmcs>;
+type OcticZkProof = ZkWhirProof<F, OcticEF, Mmcs>;
 
 // Polynomial sizes (log_2 of coefficient count) and shared knobs.
 const SIZES: [usize; 2] = [16, 18];
@@ -75,7 +82,11 @@ fn octic_no_pow_protocol_params() -> ProtocolParameters {
     }
 }
 
-fn octic_no_pow_config(num_variables: usize) -> ZkWhirConfig<OcticEF, F, Challenger> {
+fn octic_no_pow_plain_config(num_variables: usize) -> WhirConfig<OcticEF, F, Challenger> {
+    WhirConfig::new(num_variables, octic_no_pow_protocol_params()).unwrap()
+}
+
+fn octic_no_pow_zk_config(num_variables: usize) -> ZkWhirConfig<OcticEF, F, Challenger> {
     ZkWhirConfig::new(
         num_variables,
         octic_no_pow_protocol_params(),
@@ -97,6 +108,112 @@ fn mmcs() -> Mmcs {
 fn challenger() -> Challenger {
     let mut rng = SmallRng::seed_from_u64(2);
     Challenger::new(Poseidon16::new_from_rng_128(&mut rng))
+}
+
+/// Plain and hiding fixtures for the matched, grind-free comparison.
+///
+/// Both sides use the same field, security parameters, folding schedule,
+/// polynomial size, and one-point opening workload. Their adapter-specific
+/// witness/protocol types are kept separate so the benchmark exercises the
+/// public PCS interfaces exactly as downstream users do.
+struct OcticPlainFixture {
+    pcs: OcticPlainPcs,
+    witness: <OcticPlainPcs as MultilinearPcs<OcticEF, Challenger>>::Witness,
+    protocol: <OcticPlainPcs as MultilinearPcs<OcticEF, Challenger>>::OpeningProtocol,
+    points: Vec<Point<OcticEF>>,
+    domain_separator: DomainSeparator<OcticEF, F>,
+}
+
+impl OcticPlainFixture {
+    fn new(num_variables: usize) -> Self {
+        let config = octic_no_pow_plain_config(num_variables);
+        let pcs = OcticPlainPcs::new(config, Dft::default(), mmcs());
+
+        let mut rng = SmallRng::seed_from_u64(3);
+        let poly = Poly::<F>::rand(&mut rng, num_variables);
+        let table = Table::new(RowMajorMatrix::new(
+            poly.as_slice().to_vec(),
+            1 << num_variables,
+        ));
+        let witness = PrefixProver::<F, OcticEF>::new_witness(vec![table], 8);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![OpeningBatch::new(vec![0], Vec::new())],
+        )]);
+        let mut point_rng = SmallRng::seed_from_u64(5);
+        let points = vec![Point::<OcticEF>::rand(&mut point_rng, num_variables)];
+
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        Self {
+            pcs,
+            witness,
+            protocol,
+            points,
+            domain_separator,
+        }
+    }
+
+    fn challenger(&self) -> Challenger {
+        let mut challenger = challenger();
+        self.domain_separator
+            .observe_domain_separator(&mut challenger);
+        challenger
+    }
+
+    fn build_proof(&self) -> (Commitment, OcticPlainProof) {
+        let mut challenger = self.challenger();
+        let (commitment, data) = self.pcs.commit(self.witness.clone(), &mut challenger);
+        let proof = self
+            .pcs
+            .open_at(data, &self.protocol, &self.points, &mut challenger);
+        (commitment, proof)
+    }
+}
+
+struct OcticZkFixture {
+    pcs: OcticZkPcs,
+    witness: Poly<F>,
+    points: Vec<Point<OcticEF>>,
+    domain_separator: DomainSeparator<OcticEF, F>,
+}
+
+impl OcticZkFixture {
+    fn new(num_variables: usize) -> Self {
+        let pcs = OcticZkPcs::new(
+            octic_no_pow_zk_config(num_variables),
+            Dft::default(),
+            mmcs(),
+            StdRng::seed_from_u64(4),
+        );
+        let mut rng = SmallRng::seed_from_u64(3);
+        let witness = Poly::<F>::rand(&mut rng, num_variables);
+        let mut point_rng = SmallRng::seed_from_u64(5);
+        let points = vec![Point::<OcticEF>::rand(&mut point_rng, num_variables)];
+
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<8>(&mut domain_separator);
+        Self {
+            pcs,
+            witness,
+            points,
+            domain_separator,
+        }
+    }
+
+    fn challenger(&self) -> Challenger {
+        let mut challenger = challenger();
+        self.domain_separator
+            .observe_domain_separator(&mut challenger);
+        challenger
+    }
+
+    fn build_proof(&self) -> (Commitment, OcticZkProof) {
+        let mut challenger = self.challenger();
+        let (commitment, data) = self.pcs.commit(self.witness.clone(), &mut challenger);
+        let proof = self.pcs.open(data, self.points.clone(), &mut challenger);
+        (commitment, proof)
+    }
 }
 
 /// Benchmarks the plain (non-hiding) prover for one size.
@@ -231,45 +348,296 @@ fn bench_zk_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-/// Measures the opening path affected by batched mask encoding.
+/// Matched grind-free comparison, split into commit, open, and verify phases.
 ///
-/// Commitment setup is deliberately outside the timed routine and PoW is
-/// disabled so unrelated work does not hide the encoding cost. Run this group
-/// with the crate's `parallel` feature to model the threaded prover path.
-fn bench_octic_zk_open_no_pow(c: &mut Criterion) {
-    let mut group = c.benchmark_group("whir_zk_open_no_pow");
-    group
-        .sample_size(30)
-        .measurement_time(Duration::from_secs(20));
+/// The legacy group above keeps the production-like PoW configuration for
+/// continuity. It must not be used for close plain-vs-ZK timing comparisons:
+/// the two transcripts reach grinding in different states, so they search
+/// different nonce sequences even when their challengers start from one seed.
+fn bench_octic_no_pow(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/commit");
+        group
+            .sample_size(10)
+            .measurement_time(Duration::from_secs(20));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
 
-    for num_variables in OCTIC_OPEN_SIZES {
-        let pcs = OcticZkPcs::new(
-            octic_no_pow_config(num_variables),
-            Dft::default(),
-            mmcs(),
-            StdRng::seed_from_u64(4),
-        );
-        let mut rng = SmallRng::seed_from_u64(3);
-        let witness = Poly::<F>::rand(&mut rng, num_variables);
-        let points = vec![Point::<OcticEF>::rand(&mut rng, num_variables)];
-
-        group.bench_function(format!("octic_n{num_variables}_ff8_6_ell3_rate3"), |b| {
-            b.iter_batched(
-                || {
-                    let mut ch = challenger();
-                    let mut ds = DomainSeparator::new(vec![]);
-                    pcs.add_domain_separator::<8>(&mut ds);
-                    ds.observe_domain_separator(&mut ch);
-                    let (_, data) = pcs.commit(witness.clone(), &mut ch);
-                    (ch, data)
-                },
-                |(mut ch, data)| pcs.open(data, points.clone(), &mut ch),
-                BatchSize::PerIteration,
-            );
-        });
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || (plain.witness.clone(), plain.challenger()),
+                    |(witness, mut challenger)| plain.pcs.commit(witness, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || (zk.witness.clone(), zk.challenger()),
+                    |(witness, mut challenger)| zk.pcs.commit(witness, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
     }
-    group.finish();
+
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/open");
+        group
+            .sample_size(20)
+            .measurement_time(Duration::from_secs(20));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
+
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || {
+                        let mut challenger = plain.challenger();
+                        let (_, data) = plain.pcs.commit(plain.witness.clone(), &mut challenger);
+                        (
+                            challenger,
+                            data,
+                            plain.protocol.clone(),
+                            plain.points.clone(),
+                        )
+                    },
+                    |(mut challenger, data, protocol, points)| {
+                        plain.pcs.open_at(data, &protocol, &points, &mut challenger)
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || {
+                        let mut challenger = zk.challenger();
+                        let (_, data) = zk.pcs.commit(zk.witness.clone(), &mut challenger);
+                        (challenger, data, zk.points.clone())
+                    },
+                    |(mut challenger, data, points)| zk.pcs.open(data, points, &mut challenger),
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("whir_zk_overhead_no_pow/verify");
+        group
+            .sample_size(30)
+            .measurement_time(Duration::from_secs(10));
+        for num_variables in OCTIC_OPEN_SIZES {
+            let plain = OcticPlainFixture::new(num_variables);
+            let zk = OcticZkFixture::new(num_variables);
+            let (plain_commitment, plain_proof) = plain.build_proof();
+            let (zk_commitment, zk_proof) = zk.build_proof();
+            let label = format!("n{num_variables}_ff8_6_ell3_rate3");
+
+            group.bench_function(BenchmarkId::new("plain", &label), |b| {
+                b.iter_batched(
+                    || {
+                        (
+                            plain.challenger(),
+                            plain.protocol.clone(),
+                            plain.points.clone(),
+                        )
+                    },
+                    |(mut challenger, protocol, points)| {
+                        challenger.observe(plain_commitment.clone());
+                        plain
+                            .pcs
+                            .verify_at(
+                                &plain_commitment,
+                                &plain_proof,
+                                &protocol,
+                                &points,
+                                &mut challenger,
+                            )
+                            .unwrap();
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("zk", &label), |b| {
+                b.iter_batched(
+                    || (zk.challenger(), zk.points.clone()),
+                    |(mut challenger, points)| {
+                        zk.pcs
+                            .verify(&zk_commitment, &zk_proof, &mut challenger, points)
+                            .unwrap();
+                    },
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
 }
 
-criterion_group!(benches, bench_zk_overhead, bench_octic_zk_open_no_pow);
-criterion_main!(benches);
+/// Logical Merkle payload counts, independent of postcard's integer encoding.
+#[derive(Clone, Copy, Default)]
+struct OpeningShape {
+    multiproofs: usize,
+    authenticated_rows: usize,
+    base_values: usize,
+    extension_values: usize,
+    sibling_digests: usize,
+}
+
+impl OpeningShape {
+    const fn merge(&mut self, rhs: Self) {
+        self.multiproofs += rhs.multiproofs;
+        self.authenticated_rows += rhs.authenticated_rows;
+        self.base_values += rhs.base_values;
+        self.extension_values += rhs.extension_values;
+        self.sibling_digests += rhs.sibling_digests;
+    }
+}
+
+fn query_opening_shape<Ext>(opening: &QueryOpenings<F, Ext, MerkleMultiProof>) -> OpeningShape {
+    match opening {
+        QueryOpenings::Base(opening) => OpeningShape {
+            multiproofs: 1,
+            authenticated_rows: opening.rows.len(),
+            base_values: opening.rows.iter().map(Vec::len).sum(),
+            extension_values: 0,
+            sibling_digests: opening.proof.sibling_hashes.len(),
+        },
+        QueryOpenings::Extension(opening) => OpeningShape {
+            multiproofs: 1,
+            authenticated_rows: opening.rows.len(),
+            base_values: 0,
+            extension_values: opening.rows.iter().map(Vec::len).sum(),
+            sibling_digests: opening.proof.sibling_hashes.len(),
+        },
+    }
+}
+
+fn extension_opening_shape<Ext>(
+    opening: &SharedProofOpening<Ext, MerkleMultiProof>,
+) -> OpeningShape {
+    OpeningShape {
+        multiproofs: 1,
+        authenticated_rows: opening.rows.len(),
+        base_values: 0,
+        extension_values: opening.rows.iter().map(Vec::len).sum(),
+        sibling_digests: opening.proof.sibling_hashes.len(),
+    }
+}
+
+fn postcard_len<T: serde::Serialize>(value: &T) -> usize {
+    postcard::to_allocvec(value)
+        .expect("proof component serializes")
+        .len()
+}
+
+/// Print a reproducible proof-shape report for the matched no-PoW case.
+///
+/// Bytes and sibling counts are the fixed-seed realized cost: varint widths
+/// and multiproof overlap can change with another transcript. Roots, rows,
+/// and leaf-value counts expose the protocol shape independently.
+fn report_octic_proof_shape(_c: &mut Criterion) {
+    eprintln!();
+    eprintln!("WHIR ZK overhead report (128-bit, no PoW, octic extension, ff=8/6)");
+    eprintln!(
+        "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+        "vars",
+        "kind",
+        "proof_bytes",
+        "roots",
+        "proofs",
+        "auth_rows",
+        "base_values",
+        "ext_values",
+        "merkle_digests",
+    );
+
+    for num_variables in OCTIC_OPEN_SIZES {
+        let plain = OcticPlainFixture::new(num_variables);
+        let zk = OcticZkFixture::new(num_variables);
+        let (_, plain_proof) = plain.build_proof();
+        let (_, zk_proof) = zk.build_proof();
+        assert_eq!(plain_proof.evals[0].current()[0], zk_proof.evals[0]);
+
+        let mut plain_shape = OpeningShape::default();
+        for round in &plain_proof.whir.rounds {
+            plain_shape.merge(query_opening_shape(&round.openings));
+        }
+        plain_shape.merge(query_opening_shape(&plain_proof.whir.final_openings));
+        let plain_roots = 1 + plain_proof
+            .whir
+            .rounds
+            .iter()
+            .filter(|round| round.commitment.is_some())
+            .count();
+
+        let mut zk_shape = OpeningShape::default();
+        for round in &zk_proof.rounds {
+            zk_shape.merge(query_opening_shape(&round.openings));
+        }
+        zk_shape.merge(query_opening_shape(&zk_proof.base_case.source_openings));
+        zk_shape.merge(extension_opening_shape(
+            &zk_proof.base_case.fresh_main_openings,
+        ));
+        for pair in &zk_proof.base_case.mask_openings {
+            zk_shape.merge(extension_opening_shape(&pair.carried));
+            zk_shape.merge(extension_opening_shape(&pair.fresh));
+        }
+        let zk_roots = 1
+            + zk_proof.sumcheck_mask_commitments.len()
+            + 2 * zk_proof.rounds.len()
+            + 1
+            + zk_proof.base_case.fresh_mask_commitments.len();
+
+        eprintln!(
+            "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+            num_variables,
+            "plain",
+            postcard_len(&plain_proof),
+            plain_roots,
+            plain_shape.multiproofs,
+            plain_shape.authenticated_rows,
+            plain_shape.base_values,
+            plain_shape.extension_values,
+            plain_shape.sibling_digests,
+        );
+        eprintln!(
+            "{:>5} {:>6} {:>12} {:>7} {:>7} {:>10} {:>11} {:>12} {:>15}",
+            num_variables,
+            "zk",
+            postcard_len(&zk_proof),
+            zk_roots,
+            zk_shape.multiproofs,
+            zk_shape.authenticated_rows,
+            zk_shape.base_values,
+            zk_shape.extension_values,
+            zk_shape.sibling_digests,
+        );
+        let blinded_mask_elements: usize = zk_proof
+            .base_case
+            .blinded_masks
+            .iter()
+            .map(|mask| mask.message.len() + mask.randomness.len())
+            .sum();
+        eprintln!(
+            "      zk components: rounds={} sumchecks={} base_case={} mask_openings={} blinded_masks={} mask_groups={} blinded_mask_elements={}",
+            postcard_len(&zk_proof.rounds),
+            postcard_len(&zk_proof.sumchecks),
+            postcard_len(&zk_proof.base_case),
+            postcard_len(&zk_proof.base_case.mask_openings),
+            postcard_len(&zk_proof.base_case.blinded_masks),
+            zk_proof.base_case.mask_openings.len(),
+            blinded_mask_elements,
+        );
+    }
+    eprintln!();
+}
+
+criterion_group!(benches, bench_zk_overhead, bench_octic_no_pow);
+criterion_group!(reports, report_octic_proof_shape);
+criterion_main!(benches, reports);

--- a/whir/src/fiat_shamir/domain_separator.rs
+++ b/whir/src/fiat_shamir/domain_separator.rs
@@ -496,10 +496,12 @@ where
         let folded_domain_size = final_config.domain_size >> final_config.folding_factor;
         let domain_size_bytes = ((folded_domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
         let randomness_len = config.oracle_randomness[config.n_rounds()];
+        let mask_groups = config.mask_groups();
 
-        // Fresh main mask plus one fresh blind group per carried mask group.
+        // Fresh main mask plus one mixed-dimension commitment containing all
+        // fresh mask groups.
         self.observe(DIGEST_ELEMS, Observe::MerkleDigest);
-        for _ in 0..config.mask_groups().len() {
+        if !mask_groups.is_empty() {
             self.observe(DIGEST_ELEMS, Observe::MerkleDigest);
         }
         self.observe(1, Observe::ZkBaseCaseClaim);
@@ -509,7 +511,7 @@ where
             (1 << final_config.num_variables) + randomness_len,
             Observe::ZkBaseCaseReveal,
         );
-        for group in config.mask_groups() {
+        for group in &mask_groups {
             for _ in 0..group.width {
                 self.observe(
                     group.shape.message_len + group.shape.randomness_len,
@@ -518,7 +520,7 @@ where
             }
         }
 
-        // Spot checks: source positions, then per-mask positions.
+        // Spot checks: source positions, then one global mask-query vector.
         self.pow(config.final_pow_bits);
         self.sample(
             config.final_queries * domain_size_bytes,
@@ -526,9 +528,18 @@ where
         );
         self.hint(Hint::StirAnswers);
         self.hint(Hint::MerkleProof);
-        for group in config.mask_groups() {
-            let mask_bytes = ((group.shape.domain_size * 2 - 1).ilog2() as usize).div_ceil(8);
+        if let Some(max_mask_domain) = mask_groups
+            .iter()
+            .map(|group| group.shape.domain_size)
+            .max()
+        {
+            let mask_bytes = ((max_mask_domain * 2 - 1).ilog2() as usize).div_ceil(8);
             self.sample(config.mask_queries * mask_bytes, Sample::StirQueries);
+            // One carried multiproof per group, then one mixed fresh proof.
+            for _ in &mask_groups {
+                self.hint(Hint::StirAnswers);
+                self.hint(Hint::MerkleProof);
+            }
             self.hint(Hint::StirAnswers);
             self.hint(Hint::MerkleProof);
         }

--- a/whir/src/lib.rs
+++ b/whir/src/lib.rs
@@ -14,12 +14,14 @@ pub use parameters::{
     SecurityAssumption, WhirConfig, WhirConfigError,
 };
 pub use pcs::WhirProverData;
-pub use pcs::proof::{PcsProof, QueryOpenings, SharedProofOpening, WhirProof, WhirRoundProof};
+pub use pcs::proof::{
+    PcsProof, QueryOpenings, SharedBatchOpening, SharedProofOpening, WhirProof, WhirRoundProof,
+};
 pub use pcs::prover::WhirProver;
 pub use pcs::verifier::WhirVerifier;
 pub use pcs::verifier::errors::VerifierError;
 pub use pcs::zk::{
     BaseCaseZkError, BaseCaseZkProof, BlindedMask, CodeSwitchError, HidingWhirPcs,
-    HidingWhirProverData, MaskCodeShape, MaskGroupShape, MaskOpeningPair, ZkConfigError,
-    ZkParameters, ZkRoundProof, ZkVerifierError, ZkWhirConfig, ZkWhirProof,
+    HidingWhirProverData, MaskCodeShape, MaskGroupShape, ZkConfigError, ZkParameters, ZkRoundProof,
+    ZkVerifierError, ZkWhirConfig, ZkWhirProof,
 };

--- a/whir/src/pcs/proof.rs
+++ b/whir/src/pcs/proof.rs
@@ -100,6 +100,24 @@ pub struct SharedProofOpening<T, P> {
     pub proof: P,
 }
 
+/// Rows opened from a mixed batch of matrices, plus one proof shared across
+/// every matrix and queried position.
+///
+/// `rows[q][m]` is the row of matrix `m` selected by global query `q`.
+/// The MMCS projects a global index onto shorter matrices according to its
+/// mixed-height index semantics.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(bound(
+    serialize = "T: Serialize, P: Serialize",
+    deserialize = "T: Deserialize<'de>, P: Deserialize<'de>"
+))]
+pub struct SharedBatchOpening<T, P> {
+    /// Opened rows in `[query][matrix][column]` order.
+    pub rows: Vec<Vec<Vec<T>>>,
+    /// Compact multiproof authenticating every row at once.
+    pub proof: P,
+}
+
 impl<T: Send + Sync + Clone, P> SharedProofOpening<T, P> {
     /// Opens `indices` on a commitment holding exactly one matrix.
     pub(crate) fn open<MT, M>(mmcs: &MT, indices: &[usize], prover_data: &MT::ProverData<M>) -> Self
@@ -145,6 +163,38 @@ impl<T: Send + Sync + Clone, P> SharedProofOpening<T, P> {
         // - The slice borrows the row, copying no field data.
         let opened_values: Vec<Vec<&[T]>> =
             self.rows.iter().map(|row| vec![row.as_slice()]).collect();
+        mmcs.verify_multi_batch(commit, dimensions, indices, &opened_values, &self.proof)
+    }
+}
+
+impl<T: Send + Sync + Clone, P> SharedBatchOpening<T, P> {
+    /// Opens `indices` against every matrix in one mixed MMCS commitment.
+    pub(crate) fn open<MT, M>(mmcs: &MT, indices: &[usize], prover_data: &MT::ProverData<M>) -> Self
+    where
+        MT: Mmcs<T, MultiProof = P>,
+        M: Matrix<T>,
+    {
+        let (rows, proof) = mmcs.open_multi_batch(indices, prover_data);
+        Self { rows, proof }
+    }
+
+    /// Verifies all mixed-matrix rows at the verifier-derived indices.
+    pub(crate) fn verify<MT>(
+        &self,
+        mmcs: &MT,
+        commit: &MT::Commitment,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+    ) -> Result<(), MT::Error>
+    where
+        MT: Mmcs<T, MultiProof = P>,
+        T: PartialEq,
+    {
+        let opened_values: Vec<Vec<&[T]>> = self
+            .rows
+            .iter()
+            .map(|rows| rows.iter().map(Vec::as_slice).collect())
+            .collect();
         mmcs.verify_multi_batch(commit, dimensions, indices, &opened_values, &self.proof)
     }
 }

--- a/whir/src/pcs/utils.rs
+++ b/whir/src/pcs/utils.rs
@@ -118,6 +118,33 @@ where
     queries
 }
 
+/// Sample independent, exactly uniform query indices with replacement.
+///
+/// Unlike [`get_challenge_stir_queries`], this preserves duplicate draws and
+/// never caps the requested count. It is used when one global query is
+/// projected onto several mixed-height MMCS matrices: independence on the
+/// largest domain implies independence and uniformity after every power-of-two
+/// projection, while each matrix still reveals at most `num_queries` distinct
+/// positions.
+pub(crate) fn get_challenge_iid_queries<Challenger, F>(
+    domain_size: usize,
+    num_queries: usize,
+    challenger: &mut Challenger,
+) -> Vec<usize>
+where
+    Challenger: FieldChallenger<F> + CanSampleUniformBits<F>,
+    F: Field,
+{
+    let domain_size_bits = log2_strict_usize(domain_size);
+    (0..num_queries)
+        .map(|_| {
+            challenger
+                .sample_uniform_bits::<true>(domain_size_bits)
+                .expect("RESAMPLE = true: rejection loops internally, never errors")
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::collections::BTreeSet;
@@ -308,5 +335,20 @@ mod tests {
                 "bucket {bucket}: count {count} deviates from {expected} by {deviation} > {TOLERANCE}; counts = {counts:?}"
             );
         }
+    }
+
+    #[test]
+    fn iid_queries_keep_duplicates_and_replay() {
+        // Two bins and many draws force duplicates. They must remain in the
+        // transcript order rather than being deduplicated or capped.
+        let mut challenger_a = challenger_with_seed(0x51A2ED);
+        let queries_a = get_challenge_iid_queries::<MyChallenger, F>(2, 8, &mut challenger_a);
+        assert_eq!(queries_a.len(), 8);
+        assert!(queries_a.iter().all(|&query| query < 2));
+        assert!(queries_a.iter().copied().collect::<BTreeSet<_>>().len() < queries_a.len());
+
+        let mut challenger_b = challenger_with_seed(0x51A2ED);
+        let queries_b = get_challenge_iid_queries::<MyChallenger, F>(2, 8, &mut challenger_b);
+        assert_eq!(queries_a, queries_b);
     }
 }

--- a/whir/src/pcs/zk/base_case/mod.rs
+++ b/whir/src/pcs/zk/base_case/mod.rs
@@ -55,9 +55,29 @@
 //! # Mask groups
 //!
 //! - Masks committed together form one interleaved oracle.
-//! - A group shares its evaluation domain, spot-check positions, and Merkle
-//!   paths.
-//! - The fresh blinds mirror that grouping.
+//! - The carried commitments retain their original group-specific domains.
+//! - Every fresh blind group is committed in one mixed-dimension MMCS tree.
+//! - One global query vector is projected onto each shorter mask domain.
+//! - Each projection remains independent and uniform for its group. Group-to-
+//!   group correlation does not affect the soundness union bound.
+//!
+//! # Shared-query security argument
+//!
+//! Let `M` be the largest mask domain and `m_i` one group's domain. Both are
+//! powers of two. MMCS maps a global query `q` to that group by
+//! `q >> log2(M / m_i)`. Every group index has exactly `M / m_i` preimages,
+//! so an independent uniform `q` projects to an independent uniform group
+//! query. Consequently:
+//!
+//! - every mask exposes at most `t_zk` distinct positions, preserving its
+//!   Reed-Solomon ZK query budget;
+//! - a bad set in any group lifts to a global bad set of the same density, so
+//!   its miss probability remains `(1 - delta_i)^t_zk`;
+//! - correlations between different groups do not invalidate the union bound.
+//!
+//! This is a concrete extension of Construction 7.2 from one common `C_zk`
+//! to heterogeneous power-of-two mask domains and requires protocol-level
+//! review before the optimization is treated as production-ready.
 //!
 //! # Source oracle abstraction
 //!
@@ -70,6 +90,34 @@ mod config;
 mod error;
 mod prover;
 mod verifier;
+
+use alloc::vec::Vec;
+
+use crate::pcs::zk::mask::MaskGroupShape;
+
+/// Largest mask-code domain represented by a mixed fresh-mask commitment.
+fn max_mask_domain_size(groups: &[MaskGroupShape]) -> Option<usize> {
+    groups.iter().map(|group| group.shape.domain_size).max()
+}
+
+/// Project global mixed-MMCS indices onto one mask group's domain.
+///
+/// All mask domains are powers of two. This is the same high-bit projection
+/// specified by [`p3_commit::Mmcs`] for matrices shorter than the tallest one.
+fn project_mask_positions(
+    global_positions: &[usize],
+    max_domain_size: usize,
+    group_domain_size: usize,
+) -> Vec<usize> {
+    assert!(max_domain_size.is_power_of_two());
+    assert!(group_domain_size.is_power_of_two());
+    assert!(group_domain_size <= max_domain_size);
+    let shift = max_domain_size.ilog2() - group_domain_size.ilog2();
+    global_positions
+        .iter()
+        .map(|&position| position >> shift)
+        .collect()
+}
 
 pub use config::{BaseCaseZkConfig, MaskGroupWitness, MaskProverData};
 pub use error::BaseCaseZkError;

--- a/whir/src/pcs/zk/base_case/mod.rs
+++ b/whir/src/pcs/zk/base_case/mod.rs
@@ -58,8 +58,8 @@
 //! - The carried commitments retain their original group-specific domains.
 //! - Every fresh blind group is committed in one mixed-dimension MMCS tree.
 //! - One global query vector is projected onto each shorter mask domain.
-//! - Each projection remains independent and uniform for its group. Group-to-
-//!   group correlation does not affect the soundness union bound.
+//! - Each fixed group receives independent uniform draws. Different groups
+//!   are correlated, but that does not worsen the query-round maximum bound.
 //!
 //! # Shared-query security argument
 //!
@@ -73,11 +73,38 @@
 //!   Reed-Solomon ZK query budget;
 //! - a bad set in any group lifts to a global bad set of the same density, so
 //!   its miss probability remains `(1 - delta_i)^t_zk`;
-//! - correlations between different groups do not invalidate the union bound.
+//! - after the pre-query transcript fixes a bad group, accepting every group
+//!   implies missing that selected group's bad set. Thus the query-round error
+//!   is the maximum group miss probability, not a union bound.
 //!
-//! This is a concrete extension of Construction 7.2 from one common `C_zk`
-//! to heterogeneous power-of-two mask domains and requires protocol-level
-//! review before the optimization is treated as production-ready.
+//! Groups with the same code, radius, domain, query count, and exact projected
+//! query vector may additionally be analyzed as one wider interleaved
+//! component. Its disagreement set is the union of the constituent row
+//! disagreement sets; no alignment assumption is made. Without exact row
+//! synchronization, their candidate-list factors must remain separate.
+//!
+//! # Heterogeneous Construction 7.2 contract
+//!
+//! At the ideal-oracle layer, let `M_0` be the source-code MCA error and `M_i`
+//! the MCA error of mask group `i`. Let `L_0` and `L_i` bound the corresponding
+//! old/fresh interleaved lists. The inherited two-round bounds have the shape
+//!
+//! ```text
+//! epsilon_gamma <= M_0 + sum_i M_i + L_0 * product_i L_i / |EF|
+//! epsilon_query <= max(source_miss, max_i group_miss_i)
+//! ```
+//!
+//! MCA errors add because every group uses the same `gamma`; candidate lists
+//! multiply because complete candidates form a Cartesian product. The query
+//! maximum follows because a bad component can be selected from the fixed
+//! pre-query transcript. This contract requires linear injective randomized
+//! encodings, fresh independent encoding randomness, and radii strictly below
+//! the corresponding code distances.
+//!
+//! The concrete Merkle and Fiat-Shamir compilation additionally relies on the
+//! mixed MMCS binding the verifier-shaped, height-stratified row streams. The
+//! configuration retains its conservative query surcharge until the complete
+//! MCA/list/field accounting is reviewed.
 //!
 //! # Source oracle abstraction
 //!

--- a/whir/src/pcs/zk/base_case/prover.rs
+++ b/whir/src/pcs/zk/base_case/prover.rs
@@ -11,9 +11,10 @@ use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 
 use super::config::{BaseCaseZkConfig, MaskGroupWitness};
-use crate::pcs::proof::{QueryOpenings, SharedProofOpening};
-use crate::pcs::utils::get_challenge_stir_queries;
-use crate::pcs::zk::proof::{BaseCaseZkProof, BlindedMask, MaskOpeningPair};
+use super::{max_mask_domain_size, project_mask_positions};
+use crate::pcs::proof::{QueryOpenings, SharedBatchOpening, SharedProofOpening};
+use crate::pcs::utils::{get_challenge_iid_queries, get_challenge_stir_queries};
+use crate::pcs::zk::proof::{BaseCaseZkProof, BlindedMask};
 
 /// HVZK base-case prover (Construction 7.2).
 pub struct BaseCaseZkProver<'a, F, EF, MT>
@@ -96,12 +97,13 @@ where
 
         // Move 1b: one fresh blind s'_i = Enc(s~'_i, r'_i) per carried mask.
         //
-        // Blinds are committed group-wise, mirroring how the carried masks
-        // were committed:
+        // Each group keeps its own encoding and dimensions, mirroring the
+        // carried masks. The mixed MMCS commits every encoded matrix under
+        // one root:
         //
         //     group of width w  ->  w codewords stacked into one matrix
-        //                       ->  one root, one Merkle path per position
-        let mut fresh_mask_commitments = Vec::with_capacity(masks.len());
+        //     all group matrices -> one mixed-height commitment
+        let mut fresh_matrices = Vec::with_capacity(masks.len());
         let mut fresh_groups = Vec::with_capacity(masks.len());
         for (group, witness) in self.config.mask_groups.iter().zip(masks) {
             // Every member of a group shares the group's code.
@@ -117,13 +119,17 @@ where
                 blind_randomness.push(randomness);
             }
             // Row z of the stacked matrix holds position z of every blind.
-            let (commitment, data) = self.extension_mmcs.commit_matrix(
-                encoding.encode_batch_with_randomness(&blind_messages, &blind_randomness),
-            );
-            challenger.observe(commitment.clone());
-            fresh_mask_commitments.push(commitment);
-            fresh_groups.push((blind_messages, blind_randomness, data, witness));
+            fresh_matrices
+                .push(encoding.encode_batch_with_randomness(&blind_messages, &blind_randomness));
+            fresh_groups.push((blind_messages, blind_randomness, witness));
         }
+        let (fresh_mask_commitment, fresh_mask_data) = if fresh_matrices.is_empty() {
+            (None, None)
+        } else {
+            let (commitment, data) = self.extension_mmcs.commit(fresh_matrices);
+            challenger.observe(commitment.clone());
+            (Some(commitment), Some(data))
+        };
 
         // Move 2: the fresh-side claim.
         //
@@ -135,7 +141,7 @@ where
             fresh_message.iter().copied(),
             source_covector.iter().copied(),
         );
-        for (blind_messages, _, _, witness) in &fresh_groups {
+        for (blind_messages, _, witness) in &fresh_groups {
             for (message, covector) in blind_messages.iter().zip(witness.covectors) {
                 masked_claim +=
                     dot_product::<EF, _, _>(message.iter().copied(), covector.iter().copied());
@@ -167,7 +173,7 @@ where
         // - xi*_i = s~'_i + gamma * xi_i,
         // - the analogous r*_i for each mask's encoding randomness.
         let mut blinded_masks = Vec::new();
-        for (blind_messages, blind_randomness, _, witness) in &fresh_groups {
+        for (blind_messages, blind_randomness, witness) in &fresh_groups {
             for ((message, randomness), (hidden_message, hidden_randomness)) in blind_messages
                 .iter()
                 .zip(blind_randomness)
@@ -212,35 +218,51 @@ where
         let fresh_main_openings =
             SharedProofOpening::open(self.extension_mmcs, &positions, &fresh_main_data);
 
-        // Move 5b: mask spot checks, t_zk positions per group.
+        // Move 5b: mask spot checks from one global t_zk-query vector.
         //
         // The verifier will recheck, per position y and group member i:
         //
         //     Enc(xi*_i, r*_i)(y) = s'_i(y) + gamma * xi_i(y)
         //
-        // Positions are shared across the group, so one opened row of each
-        // oracle serves every member.
-        let mut mask_openings = Vec::with_capacity(fresh_groups.len());
-        for (group, (_, _, fresh_data, witness)) in
-            self.config.mask_groups.iter().zip(&fresh_groups)
-        {
-            let positions = get_challenge_stir_queries::<Challenger, F>(
-                group.shape.domain_size,
-                0,
+        // A uniform index on the largest domain projects uniformly onto every
+        // shorter power-of-two domain. Sampling with replacement preserves
+        // independence after projection and reveals at most t_zk distinct
+        // positions from any mask.
+        let max_mask_domain = max_mask_domain_size(&self.config.mask_groups);
+        let global_mask_positions = max_mask_domain.map(|domain_size| {
+            get_challenge_iid_queries::<Challenger, F>(
+                domain_size,
                 self.config.mask_queries,
                 challenger,
-            );
-            // xi_i(y) and s'_i(y): the carried group oracle and its fresh
-            // blind, opened at the same shared positions.
-            mask_openings.push(MaskOpeningPair {
-                carried: SharedProofOpening::open(self.extension_mmcs, &positions, witness.data),
-                fresh: SharedProofOpening::open(self.extension_mmcs, &positions, fresh_data),
-            });
+            )
+        });
+        let mut carried_mask_openings = Vec::with_capacity(fresh_groups.len());
+        if let (Some(max_domain), Some(global_positions)) =
+            (max_mask_domain, global_mask_positions.as_deref())
+        {
+            for (group, (_, _, witness)) in self.config.mask_groups.iter().zip(&fresh_groups) {
+                let positions =
+                    project_mask_positions(global_positions, max_domain, group.shape.domain_size);
+                carried_mask_openings.push(SharedProofOpening::open(
+                    self.extension_mmcs,
+                    &positions,
+                    witness.data,
+                ));
+            }
         }
+        let fresh_mask_opening = global_mask_positions.as_deref().map(|positions| {
+            SharedBatchOpening::open(
+                self.extension_mmcs,
+                positions,
+                fresh_mask_data
+                    .as_ref()
+                    .expect("fresh data exists whenever mask positions do"),
+            )
+        });
 
         BaseCaseZkProof {
             fresh_main_commitment,
-            fresh_mask_commitments,
+            fresh_mask_commitment,
             masked_claim,
             blinded_message,
             blinded_randomness,
@@ -248,7 +270,8 @@ where
             pow_witness,
             source_openings,
             fresh_main_openings,
-            mask_openings,
+            carried_mask_openings,
+            fresh_mask_opening,
         }
     }
 }

--- a/whir/src/pcs/zk/base_case/tests.rs
+++ b/whir/src/pcs/zk/base_case/tests.rs
@@ -5,7 +5,6 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::slice::from_ref;
 
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
@@ -106,34 +105,41 @@ fn honest_run(
     let source_codeword = code.encode_column(&dft, &committed_source, &source_randomness);
     let (source_commitment, source_data) = extension_mmcs.commit_matrix(source_codeword);
 
-    // Carried masks as width-one groups with their own RS-ZK codes.
+    // Carried masks use mixed widths and domain heights. This exercises the
+    // same heterogeneous geometry as the integrated ZK-WHIR pipeline.
     let mask_groups: Vec<MaskGroupShape> = (0..num_masks)
         .map(|i| MaskGroupShape {
-            shape: MaskCodeShape::new(4 + i, 2, 1),
-            width: 1,
+            shape: MaskCodeShape::new(4 + 8 * i, 2, 1),
+            width: if i == 0 { 2 } else { 1 },
         })
         .collect();
     let mut mask_messages = Vec::new();
     let mut mask_randomness = Vec::new();
-    let mut mask_covectors = Vec::new();
+    let mut grouped_mask_covectors = Vec::new();
     let mut mask_commitments = Vec::new();
     let mut mask_data = Vec::new();
     for (i, group) in mask_groups.iter().enumerate() {
         let encoding = group.shape.encoding::<EF>();
-        let message = encoding.sample_message(&mut rng);
-        let randomness = encoding.sample_randomness(&mut rng);
+        let messages: Vec<Vec<EF>> = (0..group.width)
+            .map(|_| encoding.sample_message(&mut rng))
+            .collect();
+        let randomness: Vec<Vec<EF>> = (0..group.width)
+            .map(|_| encoding.sample_randomness(&mut rng))
+            .collect();
         // Under MaskMessage the first committed mask encodes a shifted
         // message, while the reveals and target keep the original.
-        let mut committed = message.clone();
+        let mut committed = messages.clone();
         if tamper == Tamper::MaskMessage && i == 0 {
-            committed[0] += EF::ONE;
+            committed[0][0] += EF::ONE;
         }
-        let codeword = encoding.encode_with_randomness(&committed, &randomness);
+        let codeword = encoding.encode_batch_with_randomness(&committed, &randomness);
         let (commitment, data) = extension_mmcs.commit_matrix(codeword);
-        let covector: Vec<EF> = (0..group.shape.message_len).map(|_| rng.random()).collect();
-        mask_messages.push(vec![message]);
-        mask_randomness.push(vec![randomness]);
-        mask_covectors.push(covector);
+        let covectors: Vec<Vec<EF>> = (0..group.width)
+            .map(|_| (0..group.shape.message_len).map(|_| rng.random()).collect())
+            .collect();
+        mask_messages.push(messages);
+        mask_randomness.push(randomness);
+        grouped_mask_covectors.push(covectors);
         mask_commitments.push(commitment);
         mask_data.push(data);
     }
@@ -144,9 +150,12 @@ fn honest_run(
         source_message.iter().copied(),
         source_covector.iter().copied(),
     );
-    for (messages, covector) in mask_messages.iter().zip(&mask_covectors) {
-        target += dot_product::<EF, _, _>(messages[0].iter().copied(), covector.iter().copied());
+    for (messages, covectors) in mask_messages.iter().zip(&grouped_mask_covectors) {
+        for (message, covector) in messages.iter().zip(covectors) {
+            target += dot_product::<EF, _, _>(message.iter().copied(), covector.iter().copied());
+        }
     }
+    let mask_covectors: Vec<Vec<EF>> = grouped_mask_covectors.iter().flatten().cloned().collect();
 
     let config = BaseCaseZkConfig {
         code,
@@ -163,13 +172,13 @@ fn honest_run(
     let witnesses: Vec<MaskGroupWitness<'_, F, EF, MyMmcs>> = mask_messages
         .iter()
         .zip(&mask_randomness)
-        .zip(&mask_covectors)
+        .zip(&grouped_mask_covectors)
         .zip(&mask_data)
         .map(
-            |(((messages, randomness), covector), data)| MaskGroupWitness {
+            |(((messages, randomness), covectors), data)| MaskGroupWitness {
                 messages,
                 randomness,
-                covectors: from_ref(covector),
+                covectors,
                 data,
             },
         )
@@ -264,6 +273,131 @@ proptest! {
 }
 
 #[test]
+fn base_case_batches_mixed_fresh_mask_groups() {
+    let (config, mmcs, proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBA7C, 3, 0, Tamper::None, None);
+
+    assert_eq!(
+        config
+            .mask_groups
+            .iter()
+            .map(|group| (group.shape.domain_size, group.width))
+            .collect::<Vec<_>>(),
+        vec![(16, 2), (32, 1), (64, 1)],
+    );
+    assert!(proof.fresh_mask_commitment.is_some());
+    assert_eq!(proof.carried_mask_openings.len(), 3);
+    let fresh = proof.fresh_mask_opening.as_ref().unwrap();
+    assert_eq!(fresh.rows.len(), config.mask_queries);
+    for rows in &fresh.rows {
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.iter().map(Vec::len).collect::<Vec<_>>(), vec![2, 1, 1]);
+    }
+    assert!(
+        verify_run(
+            &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn base_case_rejects_tampered_shared_fresh_row() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBAD5EED, 2, 0, Tamper::None, None);
+    proof.fresh_mask_opening.as_mut().unwrap().rows[0][0][0] += EF::ONE;
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::MerkleVerificationFailed {
+            kind: "fresh masks"
+        }
+    );
+}
+
+#[test]
+fn base_case_rejects_truncated_shared_fresh_matrix_axis() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBADDA7A, 2, 0, Tamper::None, None);
+    proof.fresh_mask_opening.as_mut().unwrap().rows[0].pop();
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::MerkleVerificationFailed {
+            kind: "fresh masks"
+        }
+    );
+}
+
+#[test]
+fn base_case_rejects_missing_shared_fresh_commitment() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBAD_C011, 2, 0, Tamper::None, None);
+    proof.fresh_mask_commitment = None;
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::MaskCountMismatch {
+            expected: 1,
+            actual: 0,
+        }
+    );
+}
+
+#[test]
+fn base_case_rejects_missing_shared_fresh_opening() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBAD_0E11, 2, 0, Tamper::None, None);
+    proof.fresh_mask_opening = None;
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::MaskCountMismatch {
+            expected: 1,
+            actual: 0,
+        }
+    );
+}
+
+#[test]
+fn base_case_rejects_truncated_shared_fresh_query_axis() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xBAD_A115, 2, 0, Tamper::None, None);
+    proof.fresh_mask_opening.as_mut().unwrap().rows.pop();
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::OpeningCountMismatch {
+            kind: "fresh masks",
+            expected: config.mask_queries,
+            actual: config.mask_queries - 1,
+        }
+    );
+}
+
+#[test]
+fn mixed_mask_positions_follow_mmcs_projection() {
+    let global = [0, 1, 3, 4, 31];
+    assert_eq!(project_mask_positions(&global, 32, 32), global);
+    assert_eq!(project_mask_positions(&global, 32, 8), vec![0, 0, 0, 1, 7]);
+}
+
+#[test]
 fn base_case_rejects_wrong_target() {
     // The joint linear identity pins the carried target.
     let (config, mmcs, proof, w, u, commits, target, source, challenger) =
@@ -347,9 +481,9 @@ fn base_case_rejects_unbound_source_reveal() {
         &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
     )
     .unwrap_err();
-    // The committed source genuinely differs from the reveal, so the source
-    // spot check fails. The failing position is fixed by the test seed.
-    assert_eq!(err, BaseCaseZkError::SourceSpotCheckFailed { position: 1 });
+    // The committed source genuinely differs from the reveal, so a source
+    // spot check fails at one of the transcript-derived positions.
+    assert!(matches!(err, BaseCaseZkError::SourceSpotCheckFailed { .. }));
 }
 
 #[test]
@@ -368,15 +502,12 @@ fn base_case_rejects_unbound_mask_reveal() {
         &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
     )
     .unwrap_err();
-    // The committed mask genuinely differs from the reveal, so the mask
-    // spot check fails in group 0. The failing position is fixed by the seed.
-    assert_eq!(
+    // The committed mask genuinely differs from the reveal, so a mask spot
+    // check fails in group 0 at a transcript-derived position.
+    assert!(matches!(
         err,
-        BaseCaseZkError::MaskSpotCheckFailed {
-            group: 0,
-            position: 3
-        }
-    );
+        BaseCaseZkError::MaskSpotCheckFailed { group: 0, .. }
+    ));
 }
 
 #[test]

--- a/whir/src/pcs/zk/base_case/tests.rs
+++ b/whir/src/pcs/zk/base_case/tests.rs
@@ -106,10 +106,12 @@ fn honest_run(
     let (source_commitment, source_data) = extension_mmcs.commit_matrix(source_codeword);
 
     // Carried masks use mixed widths and domain heights. This exercises the
-    // same heterogeneous geometry as the integrated ZK-WHIR pipeline.
+    // same heterogeneous geometry as the integrated ZK-WHIR pipeline. The
+    // final two groups deliberately have equal height and width but different
+    // code dimensions, pinning their order inside one MMCS height bucket.
     let mask_groups: Vec<MaskGroupShape> = (0..num_masks)
         .map(|i| MaskGroupShape {
-            shape: MaskCodeShape::new(4 + 8 * i, 2, 1),
+            shape: MaskCodeShape::new(4 + 4 * i, 2, 1),
             width: if i == 0 { 2 } else { 1 },
         })
         .collect();
@@ -283,7 +285,7 @@ fn base_case_batches_mixed_fresh_mask_groups() {
             .iter()
             .map(|group| (group.shape.domain_size, group.width))
             .collect::<Vec<_>>(),
-        vec![(16, 2), (32, 1), (64, 1)],
+        vec![(16, 2), (32, 1), (32, 1)],
     );
     assert!(proof.fresh_mask_commitment.is_some());
     assert_eq!(proof.carried_mask_openings.len(), 3);
@@ -395,6 +397,60 @@ fn mixed_mask_positions_follow_mmcs_projection() {
     let global = [0, 1, 3, 4, 31];
     assert_eq!(project_mask_positions(&global, 32, 32), global);
     assert_eq!(project_mask_positions(&global, 32, 8), vec![0, 0, 0, 1, 7]);
+}
+
+#[test]
+fn mixed_mask_projection_has_balanced_power_of_two_fibers() {
+    for max_log in 0..=10 {
+        let max_domain = 1 << max_log;
+        let global_positions: Vec<_> = (0..max_domain).collect();
+        for group_log in 0..=max_log {
+            let group_domain = 1 << group_log;
+            let stride = max_domain / group_domain;
+            let projected = project_mask_positions(&global_positions, max_domain, group_domain);
+            let mut fiber_sizes = vec![0; group_domain];
+
+            for (&global, &local) in global_positions.iter().zip(&projected) {
+                assert!(local < group_domain);
+                assert_eq!(local, global / stride);
+                fiber_sizes[local] += 1;
+            }
+            assert!(fiber_sizes.iter().all(|&size| size == stride));
+        }
+    }
+}
+
+#[test]
+fn base_case_rejects_swapped_equal_height_fresh_groups() {
+    let (config, mmcs, mut proof, w, u, commits, target, source, challenger) =
+        honest_run(0xE0A1, 3, 0, Tamper::None, None);
+    assert_eq!(
+        config
+            .mask_groups
+            .iter()
+            .map(|group| (group.shape.domain_size, group.width))
+            .collect::<Vec<_>>(),
+        vec![(16, 2), (32, 1), (32, 1)],
+    );
+
+    // Equal-height rows are flattened in stable configuration order. Swapping
+    // the two equal-width groups preserves every public axis, so rejection
+    // specifically exercises binding of that group order rather than a width
+    // or matrix-count check.
+    for rows in &mut proof.fresh_mask_opening.as_mut().unwrap().rows {
+        rows.swap(1, 2);
+    }
+
+    let err = verify_run(
+        &config, &mmcs, &proof, &w, &u, &commits, target, &source, challenger,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        BaseCaseZkError::MerkleVerificationFailed {
+            kind: "fresh masks"
+        }
+    );
 }
 
 #[test]

--- a/whir/src/pcs/zk/base_case/verifier.rs
+++ b/whir/src/pcs/zk/base_case/verifier.rs
@@ -12,8 +12,9 @@ use p3_util::log2_strict_usize;
 
 use super::config::BaseCaseZkConfig;
 use super::error::BaseCaseZkError;
-use crate::pcs::proof::{QueryOpenings, SharedProofOpening};
-use crate::pcs::utils::get_challenge_stir_queries;
+use super::{max_mask_domain_size, project_mask_positions};
+use crate::pcs::proof::{QueryOpenings, SharedBatchOpening, SharedProofOpening};
+use crate::pcs::utils::{get_challenge_iid_queries, get_challenge_stir_queries};
 use crate::pcs::zk::proof::BaseCaseZkProof;
 use crate::utils::padded_ood_t1;
 
@@ -101,7 +102,15 @@ where
         count(mask_commitments.len(), num_groups)?;
         count(source_covector.len(), code.message_len)?;
         count(proof.blinded_masks.len(), num_masks)?;
-        count(proof.fresh_mask_commitments.len(), num_groups)?;
+        count(
+            usize::from(proof.fresh_mask_commitment.is_some()),
+            usize::from(num_groups > 0),
+        )?;
+        count(
+            usize::from(proof.fresh_mask_opening.is_some()),
+            usize::from(num_groups > 0),
+        )?;
+        count(proof.carried_mask_openings.len(), num_groups)?;
         // Per-mask reveal and covector lengths against the group's code.
         let blinded = |kind, actual: usize, expected: usize| {
             if actual == expected {
@@ -148,7 +157,7 @@ where
         //     move 4  ->  reveals f*, r*, xi*_i, r*_i
         let fresh_main_commitment = &proof.fresh_main_commitment;
         challenger.observe(fresh_main_commitment.clone());
-        for commitment in &proof.fresh_mask_commitments {
+        if let Some(commitment) = &proof.fresh_mask_commitment {
             challenger.observe(commitment.clone());
         }
         challenger.observe_algebra_element(proof.masked_claim);
@@ -237,72 +246,89 @@ where
             }
         }
 
-        // Check 5: mask spot checks at t_zk positions per group.
+        // Check 5: mask spot checks from one global t_zk-query vector.
         //
         // Same equation as check 4, per group member i and position y:
         //
         //     Enc(xi*_i, r*_i)(y) = s'_i(y) + gamma * xi_i(y)
         //
-        // Positions are shared across a group: one opened row of each
-        // oracle serves every member.
-        openings("mask", proof.mask_openings.len(), num_groups)?;
-        let mut mask_offset = 0;
-        for (group_index, (group, pair)) in self
-            .config
-            .mask_groups
-            .iter()
-            .zip(&proof.mask_openings)
-            .enumerate()
-        {
-            let positions = get_challenge_stir_queries::<Challenger, F>(
-                group.shape.domain_size,
-                0,
+        // The shared fresh commitment follows mixed-MMCS index semantics:
+        // every global position is right-shifted for a shorter matrix. We use
+        // exactly those projected positions for the corresponding carried
+        // commitment, so both sides evaluate the same group-code point.
+        if let Some(max_domain) = max_mask_domain_size(&self.config.mask_groups) {
+            let global_positions = get_challenge_iid_queries::<Challenger, F>(
+                max_domain,
                 self.config.mask_queries,
                 challenger,
             );
-            let dims = vec![Dimensions {
-                height: group.shape.domain_size,
-                width: group.width,
-            }];
-            // xi_i(y) for every member i: rows of the carried oracle.
-            let carried_rows = self.verify_rows(
-                &mask_commitments[group_index],
-                &dims,
-                &positions,
-                &pair.carried,
-                group.width,
-                "carried mask",
+            let fresh_dims: Vec<Dimensions> = self
+                .config
+                .mask_groups
+                .iter()
+                .map(|group| Dimensions {
+                    height: group.shape.domain_size,
+                    width: group.width,
+                })
+                .collect();
+            let fresh_rows = self.verify_batch_rows(
+                proof
+                    .fresh_mask_commitment
+                    .as_ref()
+                    .expect("mask count check pins the shared commitment"),
+                &fresh_dims,
+                &global_positions,
+                proof
+                    .fresh_mask_opening
+                    .as_ref()
+                    .expect("mask count check pins the shared opening"),
+                "fresh masks",
             )?;
-            // s'_i(y) for every member i: rows of the fresh blind.
-            let fresh_rows = self.verify_rows(
-                &proof.fresh_mask_commitments[group_index],
-                &dims,
-                &positions,
-                &pair.fresh,
-                group.width,
-                "fresh mask",
-            )?;
-            // Evaluation domain of the mask code over the extension field.
-            let mask_gen = EF::two_adic_generator(log2_strict_usize(group.shape.domain_size));
-            let blinded = &proof.blinded_masks[mask_offset..mask_offset + group.width];
-            for ((&position, carried_row), fresh_row) in
-                positions.iter().zip(carried_rows).zip(fresh_rows)
+
+            let mut mask_offset = 0;
+            for (group_index, (group, carried_opening)) in self
+                .config
+                .mask_groups
+                .iter()
+                .zip(&proof.carried_mask_openings)
+                .enumerate()
             {
-                // The field point behind position y.
-                let point = mask_gen.exp_u64(position as u64);
-                for ((blinded, &carried), &fresh) in blinded.iter().zip(carried_row).zip(fresh_row)
+                let positions =
+                    project_mask_positions(&global_positions, max_domain, group.shape.domain_size);
+                let dims = vec![Dimensions {
+                    height: group.shape.domain_size,
+                    width: group.width,
+                }];
+                let carried_rows = self.verify_rows(
+                    &mask_commitments[group_index],
+                    &dims,
+                    &positions,
+                    carried_opening,
+                    group.width,
+                    "carried mask",
+                )?;
+                let mask_gen = EF::two_adic_generator(log2_strict_usize(group.shape.domain_size));
+                let blinded = &proof.blinded_masks[mask_offset..mask_offset + group.width];
+                for (query, (&position, carried_row)) in
+                    positions.iter().zip(carried_rows).enumerate()
                 {
-                    // Enc(xi*_i, r*_i)(y): re-encode member i's reveal.
-                    let blinded_value = padded_ood_t1(point, &blinded.message, &blinded.randomness);
-                    if blinded_value != fresh + gamma * carried {
-                        return Err(BaseCaseZkError::MaskSpotCheckFailed {
-                            group: group_index,
-                            position,
-                        });
+                    let fresh_row = &fresh_rows[query][group_index];
+                    let point = mask_gen.exp_u64(position as u64);
+                    for ((blinded, &carried), &fresh) in
+                        blinded.iter().zip(carried_row).zip(fresh_row)
+                    {
+                        let blinded_value =
+                            padded_ood_t1(point, &blinded.message, &blinded.randomness);
+                        if blinded_value != fresh + gamma * carried {
+                            return Err(BaseCaseZkError::MaskSpotCheckFailed {
+                                group: group_index,
+                                position,
+                            });
+                        }
                     }
                 }
+                mask_offset += group.width;
             }
-            mask_offset += group.width;
         }
 
         Ok(())
@@ -330,6 +356,38 @@ where
         }
         // Pin every row width locally before any caller indexes into it.
         if opening.rows.iter().any(|row| row.len() != width) {
+            return Err(BaseCaseZkError::MerkleVerificationFailed { kind });
+        }
+        opening
+            .verify(self.extension_mmcs, commitment, dims, positions)
+            .map_err(|_| BaseCaseZkError::MerkleVerificationFailed { kind })?;
+        Ok(&opening.rows)
+    }
+
+    /// Verifies one mixed-matrix extension opening and pins every axis before
+    /// callers index into the nested row structure.
+    fn verify_batch_rows<'p>(
+        &self,
+        commitment: &MT::Commitment,
+        dims: &[Dimensions],
+        positions: &[usize],
+        opening: &'p SharedBatchOpening<EF, MT::MultiProof>,
+        kind: &'static str,
+    ) -> Result<&'p [Vec<Vec<EF>>], BaseCaseZkError> {
+        if opening.rows.len() != positions.len() {
+            return Err(BaseCaseZkError::OpeningCountMismatch {
+                kind,
+                expected: positions.len(),
+                actual: opening.rows.len(),
+            });
+        }
+        if opening.rows.iter().any(|rows| {
+            rows.len() != dims.len()
+                || rows
+                    .iter()
+                    .zip(dims)
+                    .any(|(row, dimensions)| row.len() != dimensions.width)
+        }) {
             return Err(BaseCaseZkError::MerkleVerificationFailed { kind });
         }
         opening

--- a/whir/src/pcs/zk/mod.rs
+++ b/whir/src/pcs/zk/mod.rs
@@ -38,8 +38,8 @@
 //! - Masks committed together share an evaluation domain.
 //! - They stack into one interleaved oracle: one commitment per sumcheck
 //!   batch, one per code-switching round.
-//! - Base-case spot checks authenticate a whole group with a single Merkle
-//!   path per position.
+//! - Base-case spot checks keep one carried proof per group while every fresh
+//!   blind group shares one mixed-dimension commitment and multiproof.
 //! - The proof-size overhead stays an additive constant in the witness size.
 //!
 //! # Differences from the non-ZK pipeline
@@ -71,7 +71,7 @@ pub use base_case::BaseCaseZkError;
 pub use code_switch::CodeSwitchError;
 pub use config::{ZkConfigError, ZkParameters, ZkWhirConfig};
 pub use mask::{MaskCodeShape, MaskGroupShape};
-pub use proof::{BaseCaseZkProof, BlindedMask, MaskOpeningPair, ZkRoundProof, ZkWhirProof};
+pub use proof::{BaseCaseZkProof, BlindedMask, ZkRoundProof, ZkWhirProof};
 pub use prover::HidingWhirProverData;
 pub use verifier::ZkVerifierError;
 

--- a/whir/src/pcs/zk/proof.rs
+++ b/whir/src/pcs/zk/proof.rs
@@ -6,7 +6,7 @@ use p3_commit::Mmcs;
 use p3_sumcheck::zk::ZkSumcheckData;
 use serde::{Deserialize, Serialize};
 
-use crate::pcs::proof::{QueryOpenings, SharedProofOpening};
+use crate::pcs::proof::{QueryOpenings, SharedBatchOpening, SharedProofOpening};
 
 /// Complete HVZK-WHIR opening proof.
 #[derive(Serialize, Deserialize, Clone)]
@@ -59,8 +59,10 @@ pub struct ZkRoundProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
 pub struct BaseCaseZkProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     /// Commitment to the fresh main mask `g`, in the folded source code.
     pub fresh_main_commitment: MT::Commitment,
-    /// Commitments to the fresh blinds, one per carried mask group, in chronological group order.
-    pub fresh_mask_commitments: Vec<MT::Commitment>,
+    /// One mixed-dimension commitment to every fresh mask blind.
+    ///
+    /// `None` is used only by a standalone base case with no carried masks.
+    pub fresh_mask_commitment: Option<MT::Commitment>,
     /// Fresh-side claim `mu_g = <g~, W> + sum_i <s~'_i, u_i>`.
     pub masked_claim: EF,
     /// Blinded source message `f* = g~ + gamma . f`.
@@ -75,9 +77,12 @@ pub struct BaseCaseZkProof<F: Send + Sync + Clone, EF, MT: Mmcs<F>> {
     pub source_openings: QueryOpenings<F, EF, MT::MultiProof>,
     /// Spot-check openings of the fresh main mask `g` at the same positions.
     pub fresh_main_openings: SharedProofOpening<EF, MT::MultiProof>,
-    /// Per group: paired openings of the carried oracle and its fresh blind.
-    /// Each opened row spans the whole group.
-    pub mask_openings: Vec<MaskOpeningPair<EF, MT::MultiProof>>,
+    /// One opening per carried mask-group commitment.
+    pub carried_mask_openings: Vec<SharedProofOpening<EF, MT::MultiProof>>,
+    /// One mixed-matrix opening shared by every fresh mask group.
+    ///
+    /// `None` iff there are no carried masks.
+    pub fresh_mask_opening: Option<SharedBatchOpening<EF, MT::MultiProof>>,
 }
 
 /// One mask oracle's blinded reveal.
@@ -87,20 +92,4 @@ pub struct BlindedMask<EF> {
     pub message: Vec<EF>,
     /// `r*_i = r'_i + gamma . r_i`.
     pub randomness: Vec<EF>,
-}
-
-/// Paired openings of one carried mask group and its fresh blind.
-///
-/// Both oracles open at the same shared spot-check positions,
-/// each under its own multiproof.
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(bound(
-    serialize = "EF: Serialize, P: Serialize",
-    deserialize = "EF: Deserialize<'de>, P: Deserialize<'de>"
-))]
-pub struct MaskOpeningPair<EF, P> {
-    /// Openings of the carried mask oracle `xi_i`.
-    pub carried: SharedProofOpening<EF, P>,
-    /// Openings of the fresh blind `s'_i`.
-    pub fresh: SharedProofOpening<EF, P>,
 }


### PR DESCRIPTION
## Summary

Batch the freshly sampled base-case ZK mask matrices into one mixed-dimension extension-MMCS commitment and one shared multi-opening.

- Retain every carried mask commitment from the existing transcript.
- Sample one IID-with-replacement query vector over the largest fresh-mask domain.
- Project those indices to each smaller power-of-two domain using the same high-bit rule as mixed-height MMCS openings.
- Update the Fiat-Shamir shape, proof type, benchmark accounting, and malformed-proof tests.

This reduces `G` fresh roots to one and `2G` mask multiproofs to `G + 1`. It does not reduce opened leaf values, mask encodings, or DFT work.

This PR is stacked on #1955. After rebasing on current `main`, the benchmark commit is `2393a2d9`, the protocol commit is `b04e2b07`, and the theorem-contract/test commit is `239a3227`.

## Measured impact

Matched no-PoW octic 128-bit benchmark at `n = 2^18`:

| Metric | #1955 baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Serialized proof | 825,146 B | 806,258 B | -18,888 B (-2.29%) |
| Merkle roots | 9 | 7 | -2 |
| Multiproofs | 9 | 7 | -2 |
| Merkle digests | 2,676 | 2,191 | -485 (-18.1%) |
| Open median | 16.919 ms | 16.471 ms | -2.65% |
| Verify median | 15.721 ms | 15.456 ms | -1.69% |

Representative stock-parameter runs were roughly 15-17% smaller at `n = 2^16` and `n = 2^18`; exact byte counts vary with sampled paths and variable-length serialization. The structural counts survive the rebase; timing medians are the original matched run and should be refreshed after protocol signoff.

## Security review required

**Draft/RFC: do not merge without protocol review.** Construction 7.2 is stated for one common mask code and domain. This implementation generalizes it to heterogeneous power-of-two mask domains with correlated projected queries.

For a group domain `M` and maximum domain `m`, both powers of two, a uniform global index `J` maps to `floor(J / (m / M))`. Every group index has exactly `m / M` preimages, so each fixed group receives IID uniform draws. A bad set lifts with the same density, and each group exposes at most `t_zk` positions.

The derived heterogeneous ideal-oracle contract is:

```text
epsilon_gamma <= M_0 + sum_i M_i + L_0 * product_i L_i / |EF|
epsilon_query <= max(source_miss, max_i group_miss_i)
```

`M_i` is the MCA error of the relevant row-interleaved code and `L_i` bounds its old/fresh candidate list. MCA errors add under the shared `gamma`; candidate lists multiply. The query error is a maximum because the pre-query transcript fixes a bad component and full acceptance implies that selected component accepted.

Groups may be coarsened into one wider interleaving only when they have the same code, radius, domain, query count, and exact projected query vector. The joint row-disagreement set is then their union; no alignment assumption is made. Otherwise their list factors remain separate.

The code documents the required linearity, fresh-randomness, strict-radius, and height-stratified MMCS assumptions. The existing conservative `t_zk` surcharge is intentionally unchanged until a separate diagnostic report accounts for the MCA/list/field terms.

## Regression coverage added

- Exhaustive balanced-fiber checks for every power-of-two domain pair through `2^10`.
- Equal-height, equal-width group-axis swap rejection, isolating stable order within one MMCS height bucket.
- Existing malformed proof, one-time-pad, and end-to-end checks retained.

## Compatibility

This intentionally changes the public proof layout and wire format: `MaskOpeningPair` is removed and `BaseCaseZkProof` now separates carried openings from one optional shared fresh commitment/opening.

## Validation

- `cargo fmt --all`
- `cargo clippy -p p3-whir --all-targets --all-features -- -D warnings`
- `cargo test -p p3-whir base_case --lib` (18 passed)
- `cargo test -p p3-whir --all-features` (128 passed, 1 ignored)
- `cargo check -p p3-whir --bench zk_overhead --features parallel` on the rebased #1955 base
- `git diff --check`
