### PR TITLE
ci: isolate AVX-512 flags from host build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,12 @@ jobs:
 
       - name: Build
         if: ${{ matrix.compile_only }}
-        run: cargo build --all-targets
+        # Keep AVX-512 RUSTFLAGS off host build scripts and proc macros.
+        run: cargo build --target x86_64-unknown-linux-gnu --all-targets
 
       - name: Build with parallel
         if: ${{ matrix.compile_only }}
-        run: cargo build --all-targets --features parallel
+        run: cargo build --target x86_64-unknown-linux-gnu --all-targets --features parallel
 
       - name: Test keccak (aarch64, no SHA3)
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
## What changed

- build the compile-only AVX-512 matrix leg with an explicit `x86_64-unknown-linux-gnu` target
- leave the normal Ubuntu, AVX2, macOS, and Windows legs unchanged

## Why

The AVX-512 leg currently sets `RUSTFLAGS=-C target-feature=+avx512f` and invokes Cargo without `--target`. Cargo therefore applies AVX-512 to host build scripts and proc macros as well as target artifacts. GitHub-hosted runners are not guaranteed to expose AVX-512, so executing those host tools fails with `SIGILL` before the workspace is compiled.

The current `main` run fails while executing the `proc-macro2` and `num-traits` build scripts: https://github.com/Plonky3/Plonky3/actions/runs/29822526890/job/88608230140

Passing the host triple explicitly makes Cargo compile host tools separately without target `RUSTFLAGS`, while the workspace target artifacts still receive `+avx512f`. This is the behavior recommended by the Cargo reference: https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags

## Impact

This restores the intended compile-only AVX-512 coverage and prevents that leg from cancelling the rest of the build-and-test matrix through fail-fast.

## Validation

- `actionlint .github/workflows/ci.yml`
- YAML parse check
- `git diff --check`
- verified against Cargo's documented host/target `RUSTFLAGS` behavior

The PR workflow itself exercises both explicit-target AVX-512 build commands on the affected Ubuntu runner.
