### PR TITLE
test(whir): clarify and extend ZK simulation coverage

### DIFF
--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -25,6 +25,13 @@ use super::verifier::ZkVerifier;
 /// - Sample each wire coordinate uniformly over `EF` (the honest joint distribution).
 /// - Reconstruct the dropped `c_1` from the affine identity, so every simulated wire verifies by construction.
 ///
+/// # Scope
+///
+/// This simulates one Construction 6.3 sumcheck batch, not the composed
+/// HVZK-WHIR protocol. It discards the mask oracle's prover data and does not
+/// return the mask messages or encoding randomness needed for later
+/// code-switch and base-case openings.
+///
 /// # Wire distribution
 ///
 /// The construction is instantiated over `EF`, so every wire coordinate is
@@ -207,7 +214,8 @@ mod tests {
         coeffs[1..].iter().any(|c| *c != F::ZERO)
     }
 
-    /// Lemma 6.4 view-match driver for Reed-Solomon mask encoding.
+    /// Lemma 6.4 acceptance and mask-prelude coupling driver for
+    /// Reed-Solomon mask encoding.
     ///
     /// # Invariants per `(binding, n_vars, folding, ell_zk, num_eqs)` case
     ///
@@ -217,7 +225,7 @@ mod tests {
     /// 4. The mask encoding's own simulator returns the correct shape (RS simulator error = 0).
     ///
     /// The binding parameter only affects the real run; the simulator output depends only on the wire schema, which both binding modes share.
-    fn run_view_match_rs(
+    fn run_acceptance_and_mask_prelude_coupling(
         binding: VariableOrder,
         n_vars: usize,
         folding_factor: usize,
@@ -365,17 +373,18 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(16))]
 
         #[test]
-        fn prop_simulator_view_matches_real_rs_prefix(
+        fn prop_simulator_accepts_and_couples_mask_prelude_rs_prefix(
             n_vars in 3usize..=8,
             ell_zk in 3usize..=5,
             num_eqs in 1usize..=3,
             seed in 0u64..1024,
         ) {
-            // Invariant: simulator view matches honest view across the
-            //            (n_vars, folding, ell_zk, num_eqs) cube for RS mask
-            //            encoding on the prefix path.
+            // Invariant: both transcripts accept and their mask preludes
+            // couple under matched RNG seeds across the parameter cube for
+            // RS mask encoding on the prefix path.
             //
-            // Per-case invariants pinned by run_view_match_rs (see docstring).
+            // Per-case invariants pinned by
+            // run_acceptance_and_mask_prelude_coupling (see docstring).
 
             // Compression step requires the folded polynomial to retain at
             // least one full packed lane. Packing width depends on the ISA.
@@ -384,12 +393,19 @@ mod tests {
             let folding_factor = 1 + (seed as usize % (n_vars - k_pack));
 
             prop_assert!(
-                run_view_match_rs(VariableOrder::Prefix, n_vars, folding_factor, ell_zk, num_eqs, seed).is_ok()
+                run_acceptance_and_mask_prelude_coupling(
+                    VariableOrder::Prefix,
+                    n_vars,
+                    folding_factor,
+                    ell_zk,
+                    num_eqs,
+                    seed,
+                ).is_ok()
             );
         }
 
         #[test]
-        fn prop_simulator_view_matches_real_rs_suffix(
+        fn prop_simulator_accepts_and_couples_mask_prelude_rs_suffix(
             n_vars in 3usize..=8,
             ell_zk in 3usize..=5,
             num_eqs in 1usize..=3,
@@ -401,7 +417,14 @@ mod tests {
             let folding_factor = 1 + (seed as usize % (n_vars - 1).max(1));
 
             prop_assert!(
-                run_view_match_rs(VariableOrder::Suffix, n_vars, folding_factor, ell_zk, num_eqs, seed).is_ok()
+                run_acceptance_and_mask_prelude_coupling(
+                    VariableOrder::Suffix,
+                    n_vars,
+                    folding_factor,
+                    ell_zk,
+                    num_eqs,
+                    seed,
+                ).is_ok()
             );
         }
     }
@@ -449,7 +472,7 @@ mod tests {
             //
             //     coverage source                 | what it pins
             //     --------------------------------+----------------------------------
-            //     view-match proptests (both)     | prefix + suffix coupling
+            //     acceptance/coupling tests       | prefix + suffix coverage
             //     this test (prefix only)         | shape + stratification invariants
             let mut verifier = ZkVerifier::<F, EF>::new_prefix(&[TableShape::new(n_vars, 1)]);
             for _ in 0..num_eqs {
@@ -540,5 +563,45 @@ mod tests {
                 replay.err(),
             );
         }
+    }
+
+    #[test]
+    fn simulator_with_pow_replays() {
+        // The simulator must emit one valid grinding witness per round when
+        // the sumcheck configuration enables PoW.
+        let seed = 0x5eed;
+        let n_vars = 4;
+        let folding_factor = 2;
+        let ell_zk = 4;
+        let pow_bits = 4;
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+
+        let mut simulator_challenger = MyChallenger::new(perm);
+        let mut verifier = ZkVerifier::<F, EF>::new_prefix(&[TableShape::new(n_vars, 1)]);
+        verifier.add_virtual_eval(EF::from_u64(7), &mut simulator_challenger);
+        let mut verifier_challenger = simulator_challenger.clone();
+        let mut rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+
+        let (zk_data, mask_commitment, _) = simulate_classic_unpacked::<F, EF, _, _, _, _>(
+            &mut simulator_challenger,
+            &verifier,
+            folding_factor,
+            pow_bits,
+            &encoding,
+            &mmcs,
+            &mut rng,
+        );
+
+        assert_eq!(zk_data.pow_witnesses.len(), folding_factor);
+        verifier
+            .into_sumcheck::<MyMmcs, _>(
+                &zk_data,
+                &mask_commitment,
+                ell_zk,
+                folding_factor,
+                pow_bits,
+                &mut verifier_challenger,
+            )
+            .expect("verifier must accept the simulator's PoW witnesses");
     }
 }

--- a/whir/src/pcs/zk/code_switch.rs
+++ b/whir/src/pcs/zk/code_switch.rs
@@ -296,6 +296,52 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(64))]
 
         #[test]
+        fn prop_two_ood_answers_are_jointly_programmable_with_two_pad_slots(
+            seed in any::<u64>(),
+        ) {
+            // Invariant: two fresh pad coordinates can program two private
+            // OOD answers jointly at distinct, nonzero points.
+            //
+            // After removing the committed prefix and dividing by rho_i^L,
+            // solve
+            //
+            //     s_0 + rho_1 * s_1 = b_1
+            //     s_0 + rho_2 * s_1 = b_2.
+            //
+            // The determinant is rho_2 - rho_1, so distinct points give a
+            // unique pad for every target pair.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let message_len = 1 + (seed % 7) as usize;
+            let randomness_len = ((seed / 7) % 4) as usize;
+            let message: Vec<EF> = (0..message_len).map(|_| rng.random()).collect();
+            let source_randomness: Vec<EF> =
+                (0..randomness_len).map(|_| rng.random()).collect();
+            let committed = [message.clone(), source_randomness.clone()].concat();
+            let targets: [EF; 2] = core::array::from_fn(|_| rng.random());
+            let mut points: [EF; 2] = core::array::from_fn(|_| rng.random());
+            while points[0] == EF::ZERO {
+                points[0] = rng.random();
+            }
+            while points[1] == EF::ZERO || points[1] == points[0] {
+                points[1] = rng.random();
+            }
+
+            let shift = committed.len() as u64;
+            let residuals: [EF; 2] = core::array::from_fn(|i| {
+                let point = points[i];
+                let committed_eval = eval_ze_star_n(point, &committed);
+                let pad_scale = point.exp_u64(shift);
+                (targets[i] - committed_eval) / pad_scale
+            });
+            let pad_1 = (residuals[1] - residuals[0]) / (points[1] - points[0]);
+            let pad_0 = residuals[0] - points[0] * pad_1;
+            let mask = [source_randomness, vec![pad_0, pad_1]].concat();
+
+            let answers = points.map(|point| padded_ood_t1(point, &message, &mask));
+            prop_assert_eq!(answers, targets);
+        }
+
+        #[test]
         fn prop_switch_mask_covector_matches_slotwise_reference(seed in any::<u64>()) {
             // Invariant: for every shape, slot s of the mask covector is
             //

--- a/whir/src/pcs/zk/tests.rs
+++ b/whir/src/pcs/zk/tests.rs
@@ -183,7 +183,7 @@ impl Setup {
 struct Proven {
     /// The hiding PCS the proof was produced with.
     pcs: TestZkPcs,
-    /// Commitment to the (possibly simulated) witness.
+    /// Commitment to the witness used by the honest prover.
     commitment: TestCommitment,
     /// The opening proof; tamper tests mutate it in place.
     proof: ZkWhirProof<F, EF, MyMmcs>,
@@ -559,7 +559,7 @@ fn zk_whir_rejects_wrong_commitment() {
 /// - The system is solved jointly via Gaussian elimination over the
 ///   extension field.
 /// - Base-field inputs keep the solution in the base field.
-fn condition_witness(
+fn sample_witness_conditioned_on_claims(
     rng: &mut SmallRng,
     num_variables: usize,
     claims: &[(Point<EF>, EF)],
@@ -619,15 +619,15 @@ fn condition_witness(
 }
 
 #[test]
-fn zk_whir_simulator_witness_free_transcript_accepts() {
-    // Completeness direction of the simulator.
+fn zk_whir_conditioned_witness_round_trip_accepts() {
+    // Same-claim-fiber completeness check.
     //
-    //     witness-free transcript  ->  verifies
-    //                              ->  exposes exactly the public claims
+    // This samples a complete alternate witness conditioned on the public
+    // claims, then runs the honest prover against a fresh commitment to that
+    // witness. It does not construct a witness-free transcript simulator or
+    // establish transcript indistinguishability (Theorem 4.5).
     //
-    // The message is random, conditioned only on those claims.
-    // This is not the composed-distribution argument (Theorem 4.5).
-    // The per-component distribution proofs live where the masks are drawn:
+    // The per-component simulation tests live where the masks are drawn:
     //
     //     masked sumcheck wires  ->  p3-sumcheck simulator tests
     //     private OOD answers    ->  code_switch programmability tests
@@ -651,29 +651,30 @@ fn zk_whir_simulator_witness_free_transcript_accepts() {
         .map(|point| (point.clone(), witness.eval_base(point)))
         .collect();
 
-    // Simulator side: garbage witness agreeing exactly on the claims.
-    let mut simulator_rng = SmallRng::seed_from_u64(22);
-    let simulated_witness = condition_witness(&mut simulator_rng, num_variables, &claims);
+    // Alternate witness agreeing exactly on the claims.
+    let mut alternate_rng = SmallRng::seed_from_u64(22);
+    let alternate_witness =
+        sample_witness_conditioned_on_claims(&mut alternate_rng, num_variables, &claims);
     for (point, value) in &claims {
-        assert_eq!(simulated_witness.eval_base(point), *value);
+        assert_eq!(alternate_witness.eval_base(point), *value);
     }
     assert_ne!(
-        simulated_witness.as_slice(),
+        alternate_witness.as_slice(),
         witness.as_slice(),
-        "the simulated witness must differ from the real one off the claims",
+        "the alternate witness must differ from the original off the claims",
     );
 
-    // The simulated transcript verifies against the simulated commitment
-    // with the real public claims.
-    let proven = Setup::new(23).prove_with(simulated_witness, points);
+    // The honest transcript verifies against the alternate witness's own
+    // commitment while carrying the original public claims.
+    let proven = Setup::new(23).prove_with(alternate_witness, points);
     assert_eq!(
         proven.proof.evals,
         claims.iter().map(|(_, value)| *value).collect::<Vec<_>>(),
-        "the simulated transcript must expose exactly the public claims",
+        "the proof evaluation payload must match the public claims",
     );
     proven
         .verify()
-        .expect("simulated HVZK transcript must verify");
+        .expect("the conditioned-witness proof must verify");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This is a test- and documentation-only change; it does not alter protocol behavior.

- Add a 64-case property test showing that two fresh pad coordinates can jointly program arbitrary answers at two distinct, nonzero OOD points by solving the corresponding 2 × 2 Vandermonde system.
- Add simulator replay coverage with nonzero proof of work (`pow_bits = 4`), including verifier acceptance.
- Rename the simulator “view matches” tests to state what they establish: verifier acceptance and matched-RNG mask-prelude coupling for prefix and suffix variable orders.
- Document that `simulate_classic_unpacked` covers one Construction 6.3 sumcheck batch and does not return the mask data and encoding randomness needed to compose a full HVZK-WHIR simulator.
- Rename the conditioned-witness round-trip helper and test to make clear that they run the honest prover with an alternate witness on the same claim fiber.

## Motivation

The previous test names and comments implied a stronger simulation result than their assertions established. This change records the exact hiding invariants currently covered while keeping the missing composed-simulator boundary explicit. In particular, the conditioned-witness round trip establishes completeness, not witness-free simulation or Theorem 4.5 transcript indistinguishability.

This follows up on the ZK-WHIR coverage introduced in #1767.

## Checks

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p p3-sumcheck -p p3-whir`
  - `p3-sumcheck`: 240 passed
  - `p3-whir`: 118 passed, 1 ignored
- `cargo clippy -p p3-sumcheck -p p3-whir --all-targets -- -D warnings`
