### PR TITLE
fix(whir): require cryptographic RNG for hiding PCS

### DIFF
--- a/whir/benches/zk_overhead.rs
+++ b/whir/benches/zk_overhead.rs
@@ -27,7 +27,7 @@ use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption,
 use p3_whir::pcs::prover::WhirProver;
 use p3_whir::pcs::zk::{HidingWhirPcs, ZkParameters, ZkWhirConfig};
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 
 type F = KoalaBear;
 type EF = BinomialExtensionField<F, 4>;
@@ -43,8 +43,8 @@ type Mmcs = MerkleTreeMmcs<PackedF, PackedF, MerkleHash, MerkleCompress, 2, 8>;
 type Dft = Radix2DFTSmallBatch<F>;
 
 type PlainPcs = WhirProver<EF, F, Dft, Mmcs, Challenger, PrefixProver<F, EF>>;
-type ZkPcs = HidingWhirPcs<EF, F, Dft, Mmcs, Challenger, SmallRng>;
-type OcticZkPcs = HidingWhirPcs<OcticEF, F, Dft, Mmcs, Challenger, SmallRng>;
+type ZkPcs = HidingWhirPcs<EF, F, Dft, Mmcs, Challenger, StdRng>;
+type OcticZkPcs = HidingWhirPcs<OcticEF, F, Dft, Mmcs, Challenger, StdRng>;
 
 // Polynomial sizes (log_2 of coefficient count) and shared knobs.
 const SIZES: [usize; 2] = [16, 18];
@@ -143,7 +143,7 @@ fn bench_zk(group: &mut BenchmarkGroup<'_, WallTime>, num_variables: usize) {
         },
     )
     .unwrap();
-    let pcs = ZkPcs::new(config, Dft::default(), mmcs(), SmallRng::seed_from_u64(4));
+    let pcs = ZkPcs::new(config, Dft::default(), mmcs(), StdRng::seed_from_u64(4));
 
     let mut rng = SmallRng::seed_from_u64(3);
     let witness = Poly::<F>::rand(&mut rng, num_variables);
@@ -199,7 +199,7 @@ fn report_proof_sizes(num_variables: usize) {
         },
     )
     .unwrap();
-    let pcs = ZkPcs::new(config, Dft::default(), mmcs(), SmallRng::seed_from_u64(4));
+    let pcs = ZkPcs::new(config, Dft::default(), mmcs(), StdRng::seed_from_u64(4));
     let mut rng = SmallRng::seed_from_u64(3);
     let witness = Poly::<F>::rand(&mut rng, num_variables);
     let points = vec![Point::<EF>::rand(&mut rng, num_variables)];
@@ -247,7 +247,7 @@ fn bench_octic_zk_open_no_pow(c: &mut Criterion) {
             octic_no_pow_config(num_variables),
             Dft::default(),
             mmcs(),
-            SmallRng::seed_from_u64(4),
+            StdRng::seed_from_u64(4),
         );
         let mut rng = SmallRng::seed_from_u64(3);
         let witness = Poly::<F>::rand(&mut rng, num_variables);

--- a/whir/src/pcs/zk/adapter.rs
+++ b/whir/src/pcs/zk/adapter.rs
@@ -10,7 +10,7 @@ use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{CryptoRng, SeedableRng};
 use spin::Mutex;
 
 use super::config::ZkWhirConfig;
@@ -44,6 +44,7 @@ impl<EF, F, Dft, MT, Challenger, R> HidingWhirPcs<EF, F, Dft, MT, Challenger, R>
 where
     F: TwoAdicField,
     EF: ExtensionField<F>,
+    R: CryptoRng,
 {
     /// Bundles the PCS dependencies.
     ///
@@ -54,7 +55,10 @@ where
     /// Zero knowledge holds only if `rng` is a cryptographically secure
     /// generator; a predictable stream lets an observer strip every mask and
     /// recover the witness from the reveals.
-    /// Tests seed a deterministic generator on purpose.
+    /// The [`CryptoRng`] bound rules out known non-cryptographic generators,
+    /// but production callers must still seed their generator from
+    /// unpredictable entropy. Tests use a deterministic seed only for
+    /// reproducibility.
     ///
     /// `rng` itself is only ever used to seed a fresh `StdRng` (a CSPRNG) for
     /// each `commit`/`open` call, under a briefly-held lock; the forked generator
@@ -96,7 +100,7 @@ where
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>
         + CanObserve<MT::Commitment>,
-    R: Rng + Send + Sync,
+    R: CryptoRng + Send + Sync,
     StandardUniform: Distribution<EF> + Distribution<F>,
 {
     type Commitment = MT::Commitment;

--- a/whir/src/pcs/zk/tests.rs
+++ b/whir/src/pcs/zk/tests.rs
@@ -13,7 +13,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 use rand::{RngExt, SeedableRng};
 
 use super::adapter::HidingWhirPcs;
@@ -34,7 +34,7 @@ type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 type PackedF = <F as Field>::Packing;
 type MyMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
 type MyDft = Radix2DFTSmallBatch<F>;
-type TestZkPcs = HidingWhirPcs<EF, F, MyDft, MyMmcs, MyChallenger, SmallRng>;
+type TestZkPcs = HidingWhirPcs<EF, F, MyDft, MyMmcs, MyChallenger, StdRng>;
 
 /// Commitment type of the test PCS.
 type TestCommitment = <TestZkPcs as MultilinearPcs<EF, MyChallenger>>::Commitment;
@@ -130,7 +130,7 @@ impl Setup {
             config,
             MyDft::default(),
             mmcs,
-            SmallRng::seed_from_u64(self.seed),
+            StdRng::seed_from_u64(self.seed),
         )
     }
 


### PR DESCRIPTION
## Summary

Require `R: CryptoRng` at the `HidingWhirPcs` constructor and `MultilinearPcs` implementation boundaries.

The ZK tests and benchmarks now use `StdRng` for PCS hiding randomness. Their unrelated random fixture generation remains on `SmallRng`.

## Why

All WHIR hiding randomness—including encoding masks, sumcheck masks, OOD pads, and base-case one-time pads—ultimately comes from the caller-supplied RNG.

Previously, the API accepted any `Rng`. Although each `commit` or `open` operation seeds a fresh `StdRng`, seeding a CSPRNG from a predictable source does not create entropy. A caller could therefore instantiate the hiding PCS with a reproducible non-cryptographic stream, allowing an observer who reconstructs that stream to remove the masks.

`CryptoRng` rules out RNG algorithms known to be unsuitable for cryptographic use. It does not replace proper seeding: production callers must still initialize the RNG from unpredictable entropy. Deterministic seeds remain appropriate for tests and benchmarks.

## API impact

> [!IMPORTANT]
> This is a source-breaking API hardening.

Downstream `HidingWhirPcs` users whose RNG only implements `Rng`, such as callers using `SmallRng`, will need to supply a `CryptoRng` implementation instead.

This PR is intentionally limited to `HidingWhirPcs`. `HidingFriPcs` retains its existing broader RNG bound and is out of scope; API consistency there can be considered separately.

## Checks

- `cargo +nightly fmt --all -- --check`
- `cargo check -p p3-whir --benches`
- `cargo test -p p3-whir pcs::zk` — 49 passed
- `cargo test -p p3-whir --all-features` — 117 passed, 1 ignored
- `cargo check -p p3-whir --no-default-features`
- `cargo clippy -p p3-whir --all-targets -- -D warnings`
- `cargo doc -p p3-whir --no-deps`
