### PR TITLE
fix(hiding): require a CSPRNG and fork it on clone in the FRI path

### DIFF
--- a/batch-stark/Cargo.toml
+++ b/batch-stark/Cargo.toml
@@ -43,7 +43,7 @@ p3-symmetric = { path = "../symmetric" }
 
 criterion.workspace = true
 postcard = { workspace = true, features = ["alloc"] }
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 
 [[bench]]
 name = "prove_batch"

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -30,7 +30,7 @@ use p3_symmetric::{
 use p3_uni_stark::{InvalidProofShapeError, PeriodicColumnError, StarkConfig};
 use p3_util::{assert_clone, assert_send, assert_sync, log2_strict_usize};
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 
 const TWO_ADIC_FIXTURE: &str = "tests/fixtures/batch_stark_two_adic_v1.postcard";
 const CIRCLE_FIXTURE: &str = "tests/fixtures/batch_stark_circle_v1.postcard";
@@ -507,7 +507,7 @@ type HidingValMmcs = MerkleTreeHidingMmcs<
     <Val as Field>::Packing,
     MyHash,
     MyCompress,
-    SmallRng,
+    StdRng,
     2,
     8,
     4,
@@ -519,7 +519,7 @@ type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel<Val>;
 type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 type MyPcsWide = TwoAdicFriPcs<Val, Dft, ValMmcsWide, ChallengeMmcsWide>;
-type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, SmallRng>;
+type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, StdRng>;
 type MyConfig = StarkConfig<MyPcs, Challenge, Challenger>;
 type MyConfigWide = StarkConfig<MyPcsWide, Challenge, Challenger>;
 type MyHidingConfig = StarkConfig<HidingPcs, Challenge, Challenger>;
@@ -610,11 +610,11 @@ fn make_config_zk(seed: u64) -> MyHidingConfig {
     let perm = Perm::new_from_rng_128(&mut rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
-    let val_mmcs = HidingValMmcs::new(hash, compress, 2, rng.clone());
+    let val_mmcs = HidingValMmcs::new(hash, compress, 2, StdRng::seed_from_u64(1));
     let challenge_mmcs = HidingChallengeMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
     let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, rng);
+    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
     let challenger = Challenger::new(perm);
     StarkConfig::new(pcs, challenger)
 }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -20,7 +20,7 @@ p3-security.workspace = true
 p3-util.workspace = true
 
 itertools.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 spin.workspace = true
 thiserror.workspace = true

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -12,7 +12,7 @@ use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixCow};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 use p3_matrix::row_index_mapped::RowIndexMappedView;
 use rand::distr::{Distribution, StandardUniform};
-use rand::{Rng, RngExt, SeedableRng};
+use rand::{CryptoRng, RngExt, SeedableRng};
 use spin::Mutex;
 use tracing::info_span;
 
@@ -21,6 +21,11 @@ use crate::{BatchMultiOpening, FriParameters, FriProof, TwoAdicFriPcs};
 
 /// A hiding FRI PCS. Both MMCSs must also be hiding; this is not enforced at compile time so it's
 /// the user's responsibility to configure.
+///
+/// The random codewords that blind the committed trace come from the caller-supplied `R`, so it is
+/// bounded by [`CryptoRng`]. That rules out generators known to be unsuitable for cryptographic
+/// use, but it does not replace proper seeding: a caller who seeds from a predictable source lets
+/// an observer reproduce the stream and strip the masks.
 #[derive(Debug)]
 pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
     inner: TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>,
@@ -36,7 +41,7 @@ where
     Dft: Clone,
     InputMmcs: Clone,
     FriMmcs: Clone,
-    R: Rng + SeedableRng,
+    R: CryptoRng + SeedableRng,
 {
     fn clone(&self) -> Self {
         Self {
@@ -75,7 +80,7 @@ where
     Challenge: TwoAdicField + ExtensionField<Val>,
     Challenger:
         FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
-    R: Rng + Send + Sync,
+    R: CryptoRng + Send + Sync,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
@@ -506,7 +511,7 @@ mod tests {
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use rand::SeedableRng;
-    use rand::rngs::SmallRng;
+    use rand::rngs::{SmallRng, StdRng};
 
     use super::*;
 
@@ -520,7 +525,7 @@ mod tests {
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     type Dft = Radix2Dit<Val>;
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
-    type MyPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
+    type MyPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
 
     type Commitment = <ValMmcs as Mmcs<Val>>::Commitment;
     type Domain = TwoAdicMultiplicativeCoset<Val>;
@@ -579,7 +584,7 @@ mod tests {
             val_mmcs,
             fri_params,
             NUM_RANDOM_CODEWORDS,
-            SmallRng::seed_from_u64(2),
+            StdRng::seed_from_u64(2),
         );
 
         // The wrapper interleaves the trace with random rows, doubling its

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -18,7 +18,7 @@ p3-symmetric.workspace = true
 p3-util.workspace = true
 
 itertools.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 serde = { workspace = true, features = ["alloc"] }
 spin.workspace = true
 thiserror.workspace = true

--- a/merkle-tree/src/hiding_mmcs.rs
+++ b/merkle-tree/src/hiding_mmcs.rs
@@ -8,8 +8,8 @@ use p3_matrix::stack::HorizontalPair;
 use p3_matrix::{Dimensions, Matrix};
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use p3_util::zip_eq::zip_eq;
-use rand::Rng;
 use rand::distr::{Distribution, StandardUniform};
+use rand::{CryptoRng, SeedableRng};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use spin::Mutex;
@@ -27,9 +27,10 @@ use crate::{MerkleCap, MerkleTree, MerkleTreeError, MerkleTreeMmcs};
 /// `SALT_ELEMS` should be set such that the product of `SALT_ELEMS` with the size of the value
 /// (`P::Value`) is at least the target security parameter.
 ///
-/// `R` should be an appropriately seeded cryptographically secure pseudorandom number generator
-/// (CSPRNG). Something like `ThreadRng` may work, although it relies on the operating system to
-/// provide sufficient entropy.
+/// `R` is bounded by [`CryptoRng`], which rules out generators known to be unsuitable for
+/// cryptographic use. The bound does not replace proper seeding: the salts only hide the leaves
+/// if the generator is also seeded from unpredictable entropy, so production callers should seed
+/// from the operating system.
 ///
 /// Generics:
 /// - `P`: a leaf value
@@ -77,16 +78,19 @@ impl<P, PW, H, C, R, const N: usize, const DIGEST_ELEMS: usize, const SALT_ELEMS
     }
 }
 
+/// Cloning forks the RNG stream by drawing a fresh seed from the source RNG, so the clone and the
+/// original never salt two commitments with the same sequence. This mirrors `HidingFriPcs`, and it
+/// is also what lets `R` be a generator that deliberately withholds `Clone`.
 impl<P, PW, H, C, R, const N: usize, const DIGEST_ELEMS: usize, const SALT_ELEMS: usize> Clone
     for MerkleTreeHidingMmcs<P, PW, H, C, R, N, DIGEST_ELEMS, SALT_ELEMS>
 where
     MerkleTreeMmcs<P, PW, H, C, N, DIGEST_ELEMS>: Clone,
-    R: Clone,
+    R: CryptoRng + SeedableRng,
 {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            rng: Mutex::new(self.rng.lock().clone()),
+            rng: Mutex::new(R::from_rng(&mut *self.rng.lock())),
         }
     }
 }
@@ -103,7 +107,7 @@ where
     C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
         + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
         + Sync,
-    R: Rng + Clone + Send,
+    R: CryptoRng + SeedableRng + Send,
     PW::Value: Eq + Clone,
     [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     StandardUniform: Distribution<P::Value>,
@@ -284,7 +288,7 @@ mod tests {
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use p3_util::assert_sync;
     use rand::SeedableRng;
-    use rand::rngs::SmallRng;
+    use rand::rngs::{SmallRng, StdRng};
 
     use super::MerkleTreeHidingMmcs;
     use crate::MerkleTreeError;
@@ -300,7 +304,7 @@ mod tests {
         <F as Field>::Packing,
         MyHash,
         MyCompress,
-        SmallRng,
+        StdRng,
         2,
         8,
         SALT_ELEMS,
@@ -313,12 +317,38 @@ mod tests {
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
 
         // attempt to commit to a mat with 8 rows and a mat with 7 rows. this should panic.
         let large_mat = RowMajorMatrix::new([1, 2, 3, 4, 5, 6, 7, 8].map(F::from_u8).to_vec(), 1);
         let small_mat = RowMajorMatrix::new([1, 2, 3, 4, 5, 6, 7].map(F::from_u8).to_vec(), 1);
         let _ = mmcs.commit(vec![large_mat, small_mat]);
+    }
+
+    /// Invariant: cloning forks the salt stream.
+    ///
+    /// The usual wiring hands a clone of the value MMCS to the extension MMCS, so a clone that
+    /// copied the generator would salt two commitments with the same sequence and undo the
+    /// hiding. Committing the same matrix through the original and through its clone must
+    /// therefore land on different commitments.
+    #[test]
+    fn clone_forks_the_salt_stream() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let mat = RowMajorMatrix::<F>::rand(&mut rng, 16, 3);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
+        let forked = mmcs.clone();
+
+        let (commit, _) = mmcs.commit(vec![mat.clone()]);
+        let (forked_commit, _) = forked.commit(vec![mat]);
+
+        assert_ne!(
+            commit, forked_commit,
+            "a clone must not reuse the original's salt stream",
+        );
     }
 
     #[test]
@@ -331,7 +361,7 @@ mod tests {
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
 
         let dims = mats.iter().map(|m| m.dimensions()).collect_vec();
 
@@ -350,7 +380,7 @@ mod tests {
         // Commit to one matrix of width 4 through the hiding wrapper.
         let mat = RowMajorMatrix::<F>::rand(&mut rng, 8, 4);
         let dims = vec![mat.dimensions()];
-        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
         let (commit, prover_data) = mmcs.commit(vec![mat]);
 
         // Mutation: append one extra element to the opened row.
@@ -392,7 +422,7 @@ mod tests {
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
         let (commit, prover_data) = mmcs.commit(mats);
 
         // Open four leaves at once.
@@ -425,7 +455,7 @@ mod tests {
         let perm = Perm::new_from_rng_128(&mut rng);
         let hash = MyHash::new(perm.clone());
         let compress = MyCompress::new(perm);
-        let mmcs = MyMmcs::new(hash, compress, 0, rng);
+        let mmcs = MyMmcs::new(hash, compress, 0, StdRng::seed_from_u64(0));
         let (commit, prover_data) = mmcs.commit(vec![mat]);
 
         let indices = vec![2usize, 5];

--- a/poseidon2-air/Cargo.toml
+++ b/poseidon2-air/Cargo.toml
@@ -19,7 +19,7 @@ p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-poseidon2.workspace = true
 
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs
@@ -14,7 +14,7 @@ use p3_poseidon2_air::{RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher};
 use p3_uni_stark::{StarkConfig, prove, verify};
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 #[cfg(target_family = "unix")]
 use tikv_jemallocator::Jemalloc;
 use tracing_forest::ForestLayer;
@@ -64,20 +64,19 @@ fn main() -> Result<(), impl Debug> {
     type MyCompress = CompressionFunctionFromHasher<U64Hash, 2, 4>;
     let compress = MyCompress::new(u64_hash);
 
-    // WARNING: DO NOT USE SmallRng in proper applications! Use a real PRNG instead!
     type ValMmcs = MerkleTreeHidingMmcs<
         [Val; p3_keccak::VECTOR_LEN],
         [u64; p3_keccak::VECTOR_LEN],
         FieldHash,
         MyCompress,
-        SmallRng,
+        StdRng,
         2,
         4,
         4,
     >;
     let mut rng = SmallRng::seed_from_u64(1);
     let constants = RoundConstants::from_rng(&mut rng);
-    let val_mmcs = ValMmcs::new(field_hash, compress, 0, rng);
+    let val_mmcs = ValMmcs::new(field_hash, compress, 0, StdRng::seed_from_u64(1));
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
@@ -102,8 +101,8 @@ fn main() -> Result<(), impl Debug> {
 
     let dft = Dft::default();
 
-    type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
-    let pcs = Pcs::new(dft, val_mmcs, fri_params, 4, SmallRng::seed_from_u64(1));
+    type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
+    let pcs = Pcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
 
     type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
     let config = MyConfig::new(pcs, challenger);

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -42,7 +42,7 @@ p3-mersenne-31 = { path = "../mersenne-31" }
 p3-symmetric = { path = "../symmetric" }
 
 postcard = { workspace = true, features = ["alloc"] }
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 
 [lints]
 workspace = true

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -19,7 +19,7 @@ use p3_symmetric::{
 use p3_uni_stark::{InvalidProofShapeError, StarkConfig, prove, verify};
 use p3_util::assert_sync;
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 
 /// For testing the public values feature
 pub struct FibonacciAir {}
@@ -162,14 +162,14 @@ type ZkValHidingMmcs = MerkleTreeHidingMmcs<
     [u64; p3_keccak::VECTOR_LEN],
     ZkFieldHash,
     ZkCompress,
-    SmallRng,
+    StdRng,
     2,
     4,
     4,
 >;
 type ZkChallenger = SerializingChallenger32<Val, HashChallenger<u8, ZkByteHash, 32>>;
 type ZkChallengeHidingMmcs = ExtensionMmcs<Val, Challenge, ZkValHidingMmcs>;
-type ZkHidingPcs = HidingFriPcs<Val, Dft, ZkValHidingMmcs, ZkChallengeHidingMmcs, SmallRng>;
+type ZkHidingPcs = HidingFriPcs<Val, Dft, ZkValHidingMmcs, ZkChallengeHidingMmcs, StdRng>;
 type ZkConfig = StarkConfig<ZkHidingPcs, Challenge, ZkChallenger>;
 
 fn make_zk_config() -> ZkConfig {
@@ -181,11 +181,11 @@ fn make_zk_config() -> ZkConfig {
     let u64_hash = ZkU64Hash::new(KeccakF {});
     let field_hash = ZkFieldHash::new(u64_hash);
     let compress = ZkCompress::new(u64_hash);
-    let val_mmcs = ZkValHidingMmcs::new(field_hash, compress, 0, SmallRng::seed_from_u64(1));
+    let val_mmcs = ZkValHidingMmcs::new(field_hash, compress, 0, StdRng::seed_from_u64(1));
     let challenge_mmcs = ZkChallengeHidingMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
     let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = ZkHidingPcs::new(dft, val_mmcs, fri_params, 4, SmallRng::seed_from_u64(1));
+    let pcs = ZkHidingPcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
     let challenger = ZkChallenger::from_hasher(vec![], byte_hash);
     ZkConfig::new(pcs, challenger)
 }

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -21,7 +21,7 @@ use p3_symmetric::{
 };
 use p3_uni_stark::{StarkConfig, StarkGenericConfig, Val, prove, verify};
 use rand::distr::{Distribution, StandardUniform};
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 use rand::{RngExt, SeedableRng};
 
 /// How many `a * b = c` operations to do per row in the AIR.
@@ -257,13 +257,13 @@ fn prove_bb_twoadic_deg2_zk() -> Result<(), impl Debug> {
         <Val as Field>::Packing,
         MyHash,
         MyCompress,
-        SmallRng,
+        StdRng,
         2,
         8,
         4,
     >;
 
-    let val_mmcs = ValMmcs::new(hash, compress, 0, rng);
+    let val_mmcs = ValMmcs::new(hash, compress, 0, StdRng::seed_from_u64(1));
 
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
@@ -274,8 +274,8 @@ fn prove_bb_twoadic_deg2_zk() -> Result<(), impl Debug> {
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 
     let fri_params = FriParameters::new_testing_zk(challenge_mmcs);
-    type HidingPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
-    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, SmallRng::seed_from_u64(1));
+    type HidingPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
+    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
     type MyConfig = StarkConfig<HidingPcs, Challenge, Challenger>;
     let challenger = Challenger::new(perm);
     let config = MyConfig::new(pcs, challenger);

--- a/uni-stark/tests/mul_fib_pair.rs
+++ b/uni-stark/tests/mul_fib_pair.rs
@@ -15,7 +15,7 @@ use p3_uni_stark::{
     StarkConfig, prove_with_preprocessed, setup_preprocessed, verify_with_preprocessed,
 };
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 
 pub struct MulFibPAir {
     num_rows: usize,
@@ -179,7 +179,7 @@ type HidingValMmcs = MerkleTreeHidingMmcs<
     <Val as Field>::Packing,
     MyHash,
     MyCompress,
-    SmallRng,
+    StdRng,
     2,
     8,
     4,
@@ -190,7 +190,7 @@ type HidingChallengeMmcs = ExtensionMmcs<Val, Challenge, HidingValMmcs>;
 type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
 type Dft = Radix2DitParallel<Val>;
 type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, SmallRng>;
+type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, StdRng>;
 type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 type MyHidingConfig = StarkConfig<HidingPcs, Challenge, Challenger>;
 
@@ -212,10 +212,16 @@ fn setup_zk_test_config() -> MyHidingConfig {
     let perm = Perm::new_from_rng_128(&mut rng);
     let hash = MyHash::new(perm.clone());
     let compress = MyCompress::new(perm.clone());
-    let val_mmcs = HidingValMmcs::new(hash, compress, 0, rng.clone());
+    let val_mmcs = HidingValMmcs::new(hash, compress, 0, StdRng::seed_from_u64(1));
     let challenge_mmcs = HidingChallengeMmcs::new(val_mmcs.clone());
     let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = HidingPcs::new(Dft::default(), val_mmcs, fri_params, 4, rng);
+    let pcs = HidingPcs::new(
+        Dft::default(),
+        val_mmcs,
+        fri_params,
+        4,
+        StdRng::seed_from_u64(2),
+    );
     let challenger = Challenger::new(perm);
     MyHidingConfig::new(pcs, challenger)
 }

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -20,7 +20,7 @@ use p3_symmetric::{
 use p3_uni_stark::{StarkConfig, prove, verify};
 use p3_util::assert_sync;
 use rand::SeedableRng;
-use rand::rngs::SmallRng;
+use rand::rngs::{SmallRng, StdRng};
 
 #[derive(Clone)]
 struct PeriodicAir<F> {
@@ -133,14 +133,14 @@ fn periodic_air_two_adic_zk_prove_verify() -> Result<(), impl Debug> {
         <Val as Field>::Packing,
         Hash,
         Compress,
-        SmallRng,
+        StdRng,
         2,
         8,
         4,
     >;
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     type Dft = Radix2DitParallel<Val>;
-    type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, SmallRng>;
+    type Pcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
     type Config = StarkConfig<Pcs, Challenge, Challenger>;
 
@@ -152,11 +152,11 @@ fn periodic_air_two_adic_zk_prove_verify() -> Result<(), impl Debug> {
     let perm = Perm::new_from_rng_128(&mut rng);
     let hash = Hash::new(perm.clone());
     let compress = Compress::new(perm.clone());
-    let val_mmcs = ValMmcs::new(hash, compress, 0, rng);
+    let val_mmcs = ValMmcs::new(hash, compress, 0, StdRng::seed_from_u64(1));
     let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
     let dft = Dft::default();
     let fri_params = FriParameters::new_testing_zk(challenge_mmcs);
-    let pcs = Pcs::new(dft, val_mmcs, fri_params, 4, SmallRng::seed_from_u64(2));
+    let pcs = Pcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
     let challenger = Challenger::new(perm);
     let config = Config::new(pcs, challenger);
 


### PR DESCRIPTION
## What

The FRI hiding path draws its masking randomness from a caller-supplied generator, and two guarantees the rest of the tree already has were missing on it.

Root cause, two halves of the same gap:

- `HidingFriPcs` and `MerkleTreeHidingMmcs` bounded their RNG by `Rng`, not `CryptoRng`. A caller could instantiate either with a reproducible non-cryptographic stream, and an observer who reconstructs that stream removes the masks. This is the exposure #1960 closed for `HidingWhirPcs`; its body scopes itself to WHIR, so the FRI path was left behind.
- `MerkleTreeHidingMmcs::clone` copied the generator rather than reseeding one. The usual wiring is `ChallengeMmcs::new(val_mmcs.clone())`, so the extension-field commitments salted their leaves from the same sequence as the trace commitment. This matters because salts travel in the proof: `Mmcs::Proof` is `(salts, siblings)` and `open_batch` hands the verifier the salt of every opened row, so a salt learned from one commitment is a salt already spent on the other. #1921 gave `HidingFriPcs::clone` exactly this protection, with the comment "so the clone and the original never produce the same sequence of masks"; the MMCS it wraps was not covered. `HidingWhirPcs` sidesteps the question by having no `Clone` impl at all and deriving a fresh `StdRng` per `commit` and `open`.

Fix: bound both on `CryptoRng`, and fork the stream in the MMCS clone with `R::from_rng`, mirroring `HidingFriPcs`.

## Why the two halves cannot be separated

The old bound did not merely fail to enforce the documented requirement. It made that requirement unsatisfiable. `Mmcs` requires `Self: Clone`, the old impl reached that through `R: Clone`, and the cryptographic generators in `rand` do not implement `Clone`:

| generator | `Rng` | `CryptoRng` | `Clone` | `Send` | usable under `R: Rng + Clone + Send` |
|---|---|---|---|---|---|
| `StdRng` | yes | yes | **no** | yes | no |
| `ChaCha20Rng` | yes | yes | **no** | yes | no |
| `SmallRng` | yes | **no** | yes | yes | yes |
| `SysRng` | **no** | no | yes | yes | no |
| `ThreadRng` | yes | yes | yes | **no** | no |

So the only `rand` generator the old signature accepted was `SmallRng`, which is not cryptographic. The doc suggested `ThreadRng`, which the `Send` bound had already ruled out. Tightening to `CryptoRng` is therefore only possible together with replacing the `R: Clone` route to `Clone`:

```text
    before   R: Rng + Clone               clone -> same salt stream
    after    R: CryptoRng + SeedableRng   clone -> R::from_rng(parent)
```

`SysRng` and `ThreadRng` were unusable before this change and remain so; nothing that compiled against a cryptographic generator stops compiling.

## Correctness

The requirement was written down twice in prose and enforced neither time:

- `MerkleTreeHidingMmcs` docs asked for "an appropriately seeded cryptographically secure pseudorandom number generator (CSPRNG)".
- `poseidon2-air/examples/prove_poseidon2_baby_bear_keccak_zk.rs` carried `// WARNING: DO NOT USE SmallRng in proper applications! Use a real PRNG instead!`.

The type system now carries both. The example comment is redundant and is removed.

New regression test `clone_forks_the_salt_stream` commits one matrix through an MMCS and through its clone and requires the commitments to differ. It is not vacuous: two generators built from the same seed still produce equal commitments, so the old copying clone fails it.

2852 workspace tests pass, `clippy --all-targets -- -D warnings` is clean, and nightly `fmt --check` is clean.

## Cost

Moving the in-repo ZK example off a non-cryptographic generator is not free, so here is the number rather than a claim that it is negligible.

| `prove_poseidon2_baby_bear_keccak_zk` | median | min | max |
|---|---|---|---|
| before (`SmallRng`) | 12.44s | 12.37s | 14.45s |
| after (`StdRng`) | 12.74s | 12.69s | 14.61s |

`+2.41%` end to end. Medians of 11 interleaved runs, `-Ctarget-cpu=native`, M3, alternating the two binaries to cancel thermal drift.

Salts are drawn per leaf, so a stronger generator costs something. Since the old signature admitted no cryptographic generator at all, this is the cost of the configuration becoming available rather than a regression against one that was already reachable.

```text
repro: cargo run --release --example prove_poseidon2_baby_bear_keccak_zk -p p3-poseidon2-air
```

## Scope

Bounds and the MMCS clone only; no proof format, no wire format, and no prover or verifier logic changes. Callers move their hiding randomness to `StdRng` while unrelated fixture generation stays on `SmallRng`, the same split #1960 used. `StdRng` needs the `std_rng` feature, which `whir` already enabled and which is added here for `merkle-tree`, `fri`, `uni-stark`, `batch-stark`, and `poseidon2-air`.

This tightens a public bound, so downstream code passing `SmallRng` to `HidingFriPcs` or `MerkleTreeHidingMmcs` stops compiling. That is the intent, and it matches the break #1960 already took for `HidingWhirPcs`.
