### PR TITLE
perf(p3-goldilocks): faster Goldilocks wasm simd128 backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
         run: cargo run --release --target ${{ env.run_target }} --bin wasm_smoke -p p3-goldilocks
       - name: Run wasm_bench under wasmtime
         run: cargo run --release --target ${{ env.run_target }} --bin wasm_bench -p p3-goldilocks
+      - name: Run wasm_merkle_bench under wasmtime
+        run: cargo run --release --target ${{ env.run_target }} --example wasm_merkle_bench -p p3-goldilocks
 
   lint:
     name: Formatting and Clippy

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -29,7 +29,10 @@ serde = { workspace = true, features = ["derive"] }
 spin.workspace = true
 
 [dev-dependencies]
+p3-commit = { path = "../commit" }
 p3-field-testing = { path = "../field-testing" }
+p3-matrix = { path = "../matrix" }
+p3-merkle-tree = { path = "../merkle-tree" }
 
 proptest.workspace = true
 rand.workspace = true

--- a/goldilocks/examples/wasm_merkle_bench.rs
+++ b/goldilocks/examples/wasm_merkle_bench.rs
@@ -1,0 +1,76 @@
+//! End-to-end-ish benchmark for wasm32+simd128: builds a Merkle tree over a matrix of
+//! Goldilocks field elements using the specialized `PackedGoldilocksWasmSimd128` Poseidon2
+//! permutation for both leaf hashing and internal-node compression — the dominant real cost
+//! in Merkle-tree-heavy STARK proving. Serves as a realistic baseline for judging whether
+//! further Poseidon2-level optimizations (e.g. software-pipelined dual-permutation hashing)
+//! are worth pursuing, closer to a real workload than the isolated single-permutation
+//! microbenchmark in `wasm_bench.rs`.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="-C target-feature=+simd128" \
+//!   cargo run --release --target wasm32-wasip1 \
+//!     --example wasm_merkle_bench -p p3-goldilocks
+//! ```
+//! On non-wasm32 targets this binary is a no-op.
+
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+fn main() {
+    eprintln!(
+        "wasm_merkle_bench is a no-op on this target. Re-run with \
+         `cargo run --release --target wasm32-wasip1 --example wasm_merkle_bench -p p3-goldilocks` \
+         and RUSTFLAGS=\"-C target-feature=+simd128\"."
+    );
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn main() {
+    use std::time::Instant;
+
+    use p3_commit::Mmcs;
+    use p3_field::Field;
+    use p3_goldilocks::{Goldilocks, default_goldilocks_poseidon2_8};
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    type Perm = p3_goldilocks::Poseidon2Goldilocks<8>;
+    type Hasher = PaddingFreeSponge<Perm, 8, 4, 4>;
+    type Compressor = TruncatedPermutation<Perm, 2, 4, 8>;
+    type Packing = <Goldilocks as Field>::Packing;
+    type Mmcs8 = MerkleTreeMmcs<Packing, Packing, Hasher, Compressor, 2, 4>;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>28}: {per_op:>10.1} ns/leaf   ({n} leaves in {elapsed_ns} ns total)");
+    }
+
+    let perm = default_goldilocks_poseidon2_8();
+    let hasher = Hasher::new(perm.clone());
+    let compressor = Compressor::new(perm);
+    let mmcs = Mmcs8::new(hasher, compressor, 0);
+
+    let mut rng = SmallRng::seed_from_u64(0xBA5E);
+
+    // Sweep leaf counts spanning small (few tree levels) to large (many levels, more
+    // compression work relative to leaf hashing) so the pipelining question — does
+    // batching independent permutations help — has enough range to show a trend.
+    for &log_leaves in &[8usize, 12, 16] {
+        let rows = 1usize << log_leaves;
+        const COLS: usize = 8;
+        let values: Vec<Goldilocks> = (0..rows * COLS).map(|_| rng.random()).collect();
+        let matrix = RowMajorMatrix::new(values, COLS);
+
+        let t0 = Instant::now();
+        let (_commitment, _prover_data) = mmcs.commit(vec![matrix]);
+        let elapsed_ns = t0.elapsed().as_nanos();
+
+        report(
+            &format!("merkle_2^{log_leaves}_leaves"),
+            rows as u64,
+            elapsed_ns,
+        );
+    }
+}

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -141,7 +141,7 @@ fn main() {
 }
 
 /// Times the packed Goldilocks quadratic-extension multiplication and squaring
-/// (`quadratic_mul`/`binomial_square` in `p3_field::extension`, applied to
+/// (`binomial_mul`/`binomial_square` in `p3_field::extension`, applied to
 /// `[PackedGoldilocksWasmSimd128; 2]`), which route through the vectorized `dot_product`.
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 fn bench_quadratic_extension_mul() {

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -220,6 +220,73 @@ fn bench_dot_product() {
     bench_n!(8);
     bench_n!(16);
     bench_n!(32);
+
+    bench_batched_linear_combination();
+}
+
+/// Sweeps `chunked_linear_combination::<CHUNK, ...>` over every `CHUNK` size
+/// `Algebra::BATCHED_LC_CHUNK` is allowed to take (1, 2, 4, 8, 16, 32, 64), for a
+/// realistic runtime-length slice, to pick the best chunk size for the now-vectorized
+/// `mixed_dot_product` (previously tuned to chunk=2 for the old per-lane fallback).
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn bench_batched_linear_combination() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_field::{PrimeCharacteristicRing, chunked_linear_combination};
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    const M: u64 = 20_000;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>28}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    macro_rules! bench_len {
+        ($len:literal) => {{
+            let values: [PackedGoldilocksWasmSimd128; $len] = core::array::from_fn(|i| {
+                PackedGoldilocksWasmSimd128([
+                    Goldilocks::new((i as u64).wrapping_mul(0x9E3779B97F4A7C15) ^ 0x1234),
+                    Goldilocks::new((i as u64).wrapping_mul(0xBF58476D1CE4E5B9) ^ 0x5678),
+                ])
+            });
+            let coeffs: [Goldilocks; $len] = core::array::from_fn(|i| {
+                Goldilocks::new((i as u64).wrapping_mul(0x94D049BB133111EB) ^ 0x9abc)
+            });
+
+            macro_rules! bench_chunk {
+                ($chunk:literal) => {{
+                    let mut acc = PackedGoldilocksWasmSimd128::ZERO;
+                    let t0 = Instant::now();
+                    for _ in 0..M {
+                        acc += chunked_linear_combination::<
+                            $chunk,
+                            PackedGoldilocksWasmSimd128,
+                            Goldilocks,
+                        >(black_box(&values), black_box(&coeffs));
+                    }
+                    let dt = t0.elapsed().as_nanos();
+                    let _ = black_box(acc);
+                    report(concat!("batched_lc_len", $len, "_chunk", $chunk), M, dt);
+                }};
+            }
+
+            bench_chunk!(1);
+            bench_chunk!(2);
+            bench_chunk!(4);
+            bench_chunk!(8);
+            bench_chunk!(16);
+            bench_chunk!(32);
+            bench_chunk!(64);
+        }};
+    }
+
+    bench_len!(8);
+    bench_len!(16);
+    bench_len!(33);
+    bench_len!(64);
+    bench_len!(256);
 }
 
 /// Compares the specialized `Poseidon2ExternalLayerGoldilocksWasmSimd128`/

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -136,6 +136,72 @@ fn main() {
 
     bench_poseidon2();
     bench_dot_product();
+    bench_sum_array();
+}
+
+/// Compares the vectorized delayed-reduction `sum_array` (one `reduce128` for the whole
+/// sum) against a naive `+`-chain (what the generic tree-sum default reduces to for a
+/// packed type — every `+` is a full modular add, ~9 ops including a canonicalize step),
+/// for the `N` values that matter most: Poseidon2's internal-round `sum_tail` at widths
+/// 8/12/16 sums 7/11/15 terms.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn bench_sum_array() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_field::PrimeCharacteristicRing;
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    const M: u64 = 200_000;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>28}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    macro_rules! bench_n {
+        ($n:literal) => {{
+            let terms: [PackedGoldilocksWasmSimd128; $n] = core::array::from_fn(|i| {
+                PackedGoldilocksWasmSimd128([
+                    Goldilocks::new((i as u64).wrapping_mul(0x9E3779B97F4A7C15) ^ 0x1234),
+                    Goldilocks::new((i as u64).wrapping_mul(0xBF58476D1CE4E5B9) ^ 0x5678),
+                ])
+            });
+
+            {
+                let mut acc = PackedGoldilocksWasmSimd128::ZERO;
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    acc += PackedGoldilocksWasmSimd128::sum_array::<$n>(black_box(&terms));
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(acc);
+                report(concat!("sum_array_", $n, "_vectorized"), M, dt);
+            }
+
+            {
+                let mut acc = PackedGoldilocksWasmSimd128::ZERO;
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    let sum = black_box(&terms)
+                        .iter()
+                        .copied()
+                        .reduce(|x, y| x + y)
+                        .unwrap();
+                    acc += sum;
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(acc);
+                report(concat!("sum_array_", $n, "_chain"), M, dt);
+            }
+        }};
+    }
+
+    bench_n!(3);
+    bench_n!(7);
+    bench_n!(11);
+    bench_n!(15);
+    bench_n!(32);
 }
 
 /// Compares the vectorized delayed-reduction `dot_product` (one `reduce128` for the whole

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -135,6 +135,91 @@ fn main() {
     }
 
     bench_poseidon2();
+    bench_dot_product();
+}
+
+/// Compares the vectorized delayed-reduction `dot_product` (one `reduce128` for the whole
+/// sum, computed 2 lanes at once) against the previous per-lane fallback (calling the
+/// scalar `Goldilocks::dot_product` — itself already delayed-reduction, just not
+/// vectorized — once per lane), for a range of `N`.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn bench_dot_product() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_field::PrimeCharacteristicRing;
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    const M: u64 = 200_000;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>28}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    /// Mirrors the removed per-lane fallback: unpack to 2 scalar arrays, call the
+    /// (already delayed-reduction) scalar `Goldilocks::dot_product` once per lane, repack.
+    fn dot_product_per_lane_fallback<const N: usize>(
+        lhs: &[PackedGoldilocksWasmSimd128; N],
+        rhs: &[PackedGoldilocksWasmSimd128; N],
+    ) -> PackedGoldilocksWasmSimd128 {
+        let lhs0: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].0[0]);
+        let rhs0: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].0[0]);
+        let lhs1: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].0[1]);
+        let rhs1: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].0[1]);
+        PackedGoldilocksWasmSimd128([
+            Goldilocks::dot_product(&lhs0, &rhs0),
+            Goldilocks::dot_product(&lhs1, &rhs1),
+        ])
+    }
+
+    macro_rules! bench_n {
+        ($n:literal) => {{
+            let lhs: [PackedGoldilocksWasmSimd128; $n] = core::array::from_fn(|i| {
+                PackedGoldilocksWasmSimd128([
+                    Goldilocks::new((i as u64).wrapping_mul(0x9E3779B97F4A7C15) ^ 0x1234),
+                    Goldilocks::new((i as u64).wrapping_mul(0xBF58476D1CE4E5B9) ^ 0x5678),
+                ])
+            });
+            let rhs: [PackedGoldilocksWasmSimd128; $n] = core::array::from_fn(|i| {
+                PackedGoldilocksWasmSimd128([
+                    Goldilocks::new((i as u64).wrapping_mul(0x94D049BB133111EB) ^ 0x9abc),
+                    Goldilocks::new((i as u64).wrapping_mul(0x2545F4914F6CDD1D) ^ 0xdef0),
+                ])
+            });
+
+            {
+                let mut acc = PackedGoldilocksWasmSimd128::ZERO;
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    acc +=
+                        PackedGoldilocksWasmSimd128::dot_product(black_box(&lhs), black_box(&rhs));
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(acc);
+                report(concat!("dot_product_", $n, "_vectorized"), M, dt);
+            }
+
+            {
+                let mut acc = PackedGoldilocksWasmSimd128::ZERO;
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    acc += dot_product_per_lane_fallback(black_box(&lhs), black_box(&rhs));
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(acc);
+                report(concat!("dot_product_", $n, "_per_lane"), M, dt);
+            }
+        }};
+    }
+
+    bench_n!(2);
+    bench_n!(3);
+    bench_n!(4);
+    bench_n!(5);
+    bench_n!(8);
+    bench_n!(16);
+    bench_n!(32);
 }
 
 /// Compares the specialized `Poseidon2ExternalLayerGoldilocksWasmSimd128`/

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -133,4 +133,103 @@ fn main() {
         let _ = black_box(acc);
         report("halve", N, dt);
     }
+
+    bench_poseidon2();
+}
+
+/// Compares the specialized `Poseidon2ExternalLayerGoldilocksWasmSimd128`/
+/// `Poseidon2InternalLayerGoldilocksWasmSimd128` layers (pre-broadcast round constants,
+/// batched S-box, split lane-sum) against the generic `Algebra<Goldilocks>` fallback path
+/// (crate-root `Poseidon2ExternalLayerGoldilocks`/`Poseidon2InternalLayerGoldilocks`, which
+/// re-broadcasts every round constant from scalar on every call), for the same round
+/// constants, applied to a packed wasm32 state.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn bench_poseidon2() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_goldilocks::{
+        Goldilocks, PackedGoldilocksWasmSimd128, Poseidon2ExternalLayerGoldilocks,
+        Poseidon2InternalLayerGoldilocks, default_goldilocks_poseidon2_8,
+        default_goldilocks_poseidon2_12, default_goldilocks_poseidon2_16,
+    };
+    use p3_poseidon2::Poseidon2;
+    use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    const M: u64 = 100_000;
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>24}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    fn make_state<const WIDTH: usize>(rng: &mut SmallRng) -> [PackedGoldilocksWasmSimd128; WIDTH] {
+        core::array::from_fn(|_| PackedGoldilocksWasmSimd128([rng.random(), rng.random()]))
+    }
+
+    macro_rules! bench_width {
+        ($width:literal, $specialized:expr, $generic:expr) => {{
+            let mut rng = SmallRng::seed_from_u64(3);
+            let specialized = $specialized;
+            let generic = $generic;
+
+            {
+                let mut state = make_state::<$width>(&mut rng);
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    specialized.permute_mut(black_box(&mut state));
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(&state);
+                report(concat!("poseidon2_", $width, "_specialized"), M, dt);
+            }
+
+            {
+                let mut state = make_state::<$width>(&mut rng);
+                let t0 = Instant::now();
+                for _ in 0..M {
+                    generic.permute_mut(black_box(&mut state));
+                }
+                let dt = t0.elapsed().as_nanos();
+                let _ = black_box(&state);
+                report(concat!("poseidon2_", $width, "_generic"), M, dt);
+            }
+        }};
+    }
+
+    bench_width!(
+        8,
+        default_goldilocks_poseidon2_8(),
+        Poseidon2::<
+            Goldilocks,
+            Poseidon2ExternalLayerGoldilocks<8>,
+            Poseidon2InternalLayerGoldilocks,
+            8,
+            7,
+        >::new_from_rng(8, 22, &mut SmallRng::seed_from_u64(99))
+    );
+    bench_width!(
+        12,
+        default_goldilocks_poseidon2_12(),
+        Poseidon2::<
+            Goldilocks,
+            Poseidon2ExternalLayerGoldilocks<12>,
+            Poseidon2InternalLayerGoldilocks,
+            12,
+            7,
+        >::new_from_rng(8, 22, &mut SmallRng::seed_from_u64(99))
+    );
+    bench_width!(
+        16,
+        default_goldilocks_poseidon2_16(),
+        Poseidon2::<
+            Goldilocks,
+            Poseidon2ExternalLayerGoldilocks<16>,
+            Poseidon2InternalLayerGoldilocks,
+            16,
+            7,
+        >::new_from_rng(8, 22, &mut SmallRng::seed_from_u64(99))
+    );
 }

--- a/goldilocks/src/bin/wasm_bench.rs
+++ b/goldilocks/src/bin/wasm_bench.rs
@@ -137,6 +137,65 @@ fn main() {
     bench_poseidon2();
     bench_dot_product();
     bench_sum_array();
+    bench_quadratic_extension_mul();
+}
+
+/// Times the packed Goldilocks quadratic-extension multiplication and squaring
+/// (`quadratic_mul`/`binomial_square` in `p3_field::extension`, applied to
+/// `[PackedGoldilocksWasmSimd128; 2]`), which route through the vectorized `dot_product`.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+fn bench_quadratic_extension_mul() {
+    use core::hint::black_box;
+    use std::time::Instant;
+
+    use p3_field::extension::{binomial_mul, binomial_square};
+    use p3_field::{PrimeCharacteristicRing, PrimeField64};
+    use p3_goldilocks::{Goldilocks, PackedGoldilocksWasmSimd128};
+
+    const N: u64 = 200_000;
+    const W: Goldilocks = Goldilocks::new(7);
+
+    fn report(name: &str, n: u64, elapsed_ns: u128) {
+        let per_op = elapsed_ns as f64 / n as f64;
+        println!("{name:>28}: {per_op:>8.2} ns/op   ({n} ops in {elapsed_ns} ns)");
+    }
+
+    let a: [PackedGoldilocksWasmSimd128; 2] = core::array::from_fn(|i| {
+        PackedGoldilocksWasmSimd128([
+            Goldilocks::new((i as u64 + 1).wrapping_mul(0x9E3779B97F4A7C15) ^ 0x1234),
+            Goldilocks::new((i as u64 + 1).wrapping_mul(0xBF58476D1CE4E5B9) ^ 0x5678),
+        ])
+    });
+    let b: [PackedGoldilocksWasmSimd128; 2] = core::array::from_fn(|i| {
+        PackedGoldilocksWasmSimd128([
+            Goldilocks::new((i as u64 + 1).wrapping_mul(0x94D049BB133111EB) ^ 0x9abc),
+            Goldilocks::new((i as u64 + 1).wrapping_mul(0x2545F4914F6CDD1D) ^ 0xdef0),
+        ])
+    });
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            let mut res = [PackedGoldilocksWasmSimd128::ZERO; 2];
+            binomial_mul(black_box(&acc), black_box(&b), &mut res, W);
+            acc = res;
+        }
+        let _ = black_box(acc[0].0[0].as_canonical_u64());
+        report("ext2_mul", N, t0.elapsed().as_nanos());
+    }
+
+    {
+        let mut acc = a;
+        let t0 = Instant::now();
+        for _ in 0..N {
+            let mut res = [PackedGoldilocksWasmSimd128::ZERO; 2];
+            binomial_square(black_box(&acc), &mut res, W);
+            acc = res;
+        }
+        let _ = black_box(acc[0].0[0].as_canonical_u64());
+        report("ext2_square", N, t0.elapsed().as_nanos());
+    }
 }
 
 /// Compares the vectorized delayed-reduction `sum_array` (one `reduce128` for the whole

--- a/goldilocks/src/bin/wasm_smoke.rs
+++ b/goldilocks/src/bin/wasm_smoke.rs
@@ -197,5 +197,45 @@ fn main() {
     assert_eq!(packed.0, lanes, "from_fn round-trip mismatch");
     println!("from_fn: OK");
 
+    // ---- dot_product ---------------------------------------------------------
+    // N=5 exercises the vectorized delayed-reduction path (N > 1); includes the
+    // all-maximal-value case, the densest adversarial input for its bit-96 split.
+    {
+        let a0 = [P - 1, 1, 0xffff_ffff, 0, P - 2];
+        let a1 = [u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX];
+        let b0 = [2u64, P - 1, 0xdead_beef, 1, u64::MAX];
+        let b1 = [u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX];
+        let lhs: [PackedGoldilocksWasmSimd128; 5] = core::array::from_fn(|i| pack(a0[i], a1[i]));
+        let rhs: [PackedGoldilocksWasmSimd128; 5] = core::array::from_fn(|i| pack(b0[i], b1[i]));
+        let got = PackedGoldilocksWasmSimd128::dot_product(&lhs, &rhs);
+        let want0 = Goldilocks::dot_product(&a0.map(Goldilocks::new), &b0.map(Goldilocks::new));
+        let want1 = Goldilocks::dot_product(&a1.map(Goldilocks::new), &b1.map(Goldilocks::new));
+        assert_eq!(
+            got.0,
+            [want0, want1],
+            "dot_product mismatch: {a0:#x?}.{b0:#x?} / {a1:#x?}.{b1:#x?}"
+        );
+    }
+    println!("dot_product: OK");
+
+    // ---- mixed_dot_product ----------------------------------------------------
+    {
+        use p3_field::Algebra;
+
+        let a0 = [P - 1, 1, 0xffff_ffff, 0, P - 2];
+        let a1 = [u64::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX];
+        let f = [2u64, P - 1, 0xdead_beef, 1, u64::MAX].map(Goldilocks::new);
+        let a: [PackedGoldilocksWasmSimd128; 5] = core::array::from_fn(|i| pack(a0[i], a1[i]));
+        let got = PackedGoldilocksWasmSimd128::mixed_dot_product(&a, &f);
+        let want0 = Goldilocks::dot_product(&a0.map(Goldilocks::new), &f);
+        let want1 = Goldilocks::dot_product(&a1.map(Goldilocks::new), &f);
+        assert_eq!(
+            got.0,
+            [want0, want1],
+            "mixed_dot_product mismatch: {a0:#x?} / {a1:#x?}, f={f:?}"
+        );
+    }
+    println!("mixed_dot_product: OK");
+
     println!("all packed wasm32+simd128 ops match scalar Goldilocks");
 }

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -96,11 +96,26 @@ pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
 
 /// An implementation of the Poseidon2 hash function for the Goldilocks field.
 ///
+/// It acts on arrays of the form `[Goldilocks; WIDTH]` and `[PackedGoldilocksWasmSimd128; WIDTH]`,
+/// with round constants pre-broadcast into packed vectors at construction time. See
+/// [`crate::wasm32_simd128::Poseidon2ExternalLayerGoldilocksWasmSimd128`] for details.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
+    Goldilocks,
+    crate::wasm32_simd128::Poseidon2ExternalLayerGoldilocksWasmSimd128<WIDTH>,
+    crate::wasm32_simd128::Poseidon2InternalLayerGoldilocksWasmSimd128,
+    WIDTH,
+    GOLDILOCKS_S_BOX_DEGREE,
+>;
+
+/// An implementation of the Poseidon2 hash function for the Goldilocks field.
+///
 /// It acts on arrays of the form `[Goldilocks; WIDTH]`.
 #[cfg(not(any(
     all(target_arch = "aarch64", target_feature = "neon"),
     all(target_arch = "x86_64", target_feature = "avx2"),
     all(target_arch = "x86_64", target_feature = "avx512f"),
+    all(target_arch = "wasm32", target_feature = "simd128"),
 )))]
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
     Goldilocks,

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -99,6 +99,13 @@ pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
 /// It acts on arrays of the form `[Goldilocks; WIDTH]` and `[PackedGoldilocksWasmSimd128; WIDTH]`,
 /// with round constants pre-broadcast into packed vectors at construction time. See
 /// [`crate::wasm32_simd128::Poseidon2ExternalLayerGoldilocksWasmSimd128`] for details.
+///
+/// This is a concrete, non-generic type: it only implements `Permutation` for
+/// `[Goldilocks; WIDTH]` and `[PackedGoldilocksWasmSimd128; WIDTH]` (not the generic
+/// `Algebra<Goldilocks>` state that the fallback `p3_poseidon2::Poseidon2` type below
+/// supports). Code that needs to build against all platforms should go through
+/// [`default_goldilocks_poseidon2_8`], [`default_goldilocks_poseidon2_12`],
+/// [`default_goldilocks_poseidon2_16`], or `new_from_rng`/`new_from_rng_128`.
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 pub type Poseidon2Goldilocks<const WIDTH: usize> = Poseidon2<
     Goldilocks,

--- a/goldilocks/src/wasm32_simd128/mod.rs
+++ b/goldilocks/src/wasm32_simd128/mod.rs
@@ -1,2 +1,4 @@
 mod packing;
+mod poseidon2;
 pub use packing::*;
+pub use poseidon2::*;

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -166,11 +166,17 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
-        Self::from_fn(|lane| {
-            let lhs_lane: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].as_slice()[lane]);
-            let rhs_lane: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].as_slice()[lane]);
-            Goldilocks::dot_product(&lhs_lane, &rhs_lane)
-        })
+        const {
+            assert!((N as u32) <= (1 << 31));
+        }
+        match N {
+            0 => Self::ZERO,
+            1 => lhs[0] * rhs[0],
+            _ => Self::from_vector(dot_product_delayed_reduce::<N>(
+                &core::array::from_fn(|i| lhs[i].to_vector()),
+                &core::array::from_fn(|i| rhs[i].to_vector()),
+            )),
+        }
     }
 }
 
@@ -421,6 +427,59 @@ fn reduce128(hi: v128, lo: v128) -> v128 {
     shift(lo2_s)
 }
 
+/// `1` in each lane where `a < b` (unsigned), else `0`. Used to detect unsigned-add
+/// overflow when accumulating 128-bit-per-lane values across `v128` pairs, via the same
+/// sign-bit-shift trick as [`canonicalize_s`] and friends.
+#[inline(always)]
+fn unsigned_lt_as_carry(a: v128, b: v128) -> v128 {
+    let mask = i64x2_gt(shift(b), shift(a));
+    u64x2_shr(mask, 63)
+}
+
+/// Delayed-reduction dot product: `sum(lhs[i] * rhs[i])` with a single final [`reduce128`]
+/// instead of one reduction per term. Mirrors the scalar `Goldilocks::dot_product`'s
+/// `N > 2` algorithm (see `goldilocks.rs`), vectorized to 2 lanes.
+///
+/// Each 128-bit product `val` is split at bit 96 (not bit 64) into `lo96 + hi32 * 2^96`:
+/// `hi32 = val >> 96` is bounded by `2^32 - 1` per term, so up to `N <= 2^31` terms can be
+/// summed into a single 64-bit-per-lane accumulator (`acc_hi96`) without overflow. The full
+/// 128-bit `val` is separately accumulated with wrapping 128-bit-per-lane addition
+/// (`acc_lo`); at the end, `acc_lo - (acc_hi96 << 96)` recovers `sum(lo96_i)` exactly modulo
+/// `2^128`, because that sum is itself `< 2^127` (`N <= 2^31` terms, each `lo96_i < 2^96`).
+/// Finally `2^96 ≡ -1 (mod P)` folds `acc_hi96` back in before the single [`reduce128`] call.
+#[inline]
+fn dot_product_delayed_reduce<const N: usize>(lhs: &[v128; N], rhs: &[v128; N]) -> v128 {
+    let mut acc_lo_hi = u64x2_splat(0);
+    let mut acc_lo_lo = u64x2_splat(0);
+    let mut acc_hi96 = u64x2_splat(0);
+
+    for i in 0..N {
+        let (term_hi, term_lo) = mul64_64(lhs[i], rhs[i]);
+        let term_hi96 = u64x2_shr(term_hi, 32);
+
+        let new_lo_lo = i64x2_add(acc_lo_lo, term_lo);
+        let carry = unsigned_lt_as_carry(new_lo_lo, acc_lo_lo);
+        acc_lo_hi = i64x2_add(i64x2_add(acc_lo_hi, term_hi), carry);
+        acc_lo_lo = new_lo_lo;
+
+        acc_hi96 = i64x2_add(acc_hi96, term_hi96);
+    }
+
+    // `lo = acc_lo - (acc_hi96 << 96)`. The subtrahend's low 64 bits are always 0, so
+    // subtracting it never borrows into the low word.
+    let hi96_shifted = i64x2_shl(acc_hi96, 32);
+    let lo_hi = i64x2_sub(acc_lo_hi, hi96_shifted);
+    let lo_lo = acc_lo_lo;
+
+    // `sum = lo + (P - acc_hi96)`, a 128-bit + 64-bit add with carry into the high word.
+    let p_minus_hi = i64x2_sub(u64x2_splat(P), acc_hi96);
+    let sum_lo = i64x2_add(lo_lo, p_minus_hi);
+    let carry2 = unsigned_lt_as_carry(sum_lo, lo_lo);
+    let sum_hi = i64x2_add(lo_hi, carry2);
+
+    reduce128(sum_hi, sum_lo)
+}
+
 /// Goldilocks modular multiplication. Computes `x * y mod FIELD_ORDER`.
 ///
 /// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
@@ -487,4 +546,109 @@ mod tests {
         &[super::ONES],
         crate::PackedGoldilocksWasmSimd128(super::SPECIAL_VALS)
     );
+
+    /// Adversarial + random coverage for `dot_product`'s delayed-reduction path (`N > 1`),
+    /// across every lane independently, for `N` both below and (via repeated calls) well
+    /// above the width the scalar `match` arms special-case.
+    #[test]
+    fn dot_product_delayed_reduction_matches_scalar() {
+        use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField64};
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        const EDGE_VALUES: [u64; 5] = [
+            0,
+            1,
+            Goldilocks::ORDER_U64 - 1,
+            0xFFFF_FFFF_0000_0000, // = 2^64 - 2^32, one below the field order
+            u64::MAX,              // maximal non-canonical representative
+        ];
+
+        /// Checks lane 0 against `(lhs0, rhs0)` and lane 1 against `(lhs1, rhs1)`
+        /// independently, so a bug that crosses lanes is caught, not just one that's
+        /// uniform across both.
+        fn check<const N: usize>(
+            lhs0: [Goldilocks; N],
+            rhs0: [Goldilocks; N],
+            lhs1: [Goldilocks; N],
+            rhs1: [Goldilocks; N],
+        ) {
+            let packed_lhs: [PackedGoldilocksWasmSimd128; N] =
+                core::array::from_fn(|i| PackedGoldilocksWasmSimd128([lhs0[i], lhs1[i]]));
+            let packed_rhs: [PackedGoldilocksWasmSimd128; N] =
+                core::array::from_fn(|i| PackedGoldilocksWasmSimd128([rhs0[i], rhs1[i]]));
+
+            let expected0 = Goldilocks::dot_product(&lhs0, &rhs0);
+            let expected1 = Goldilocks::dot_product(&lhs1, &rhs1);
+            let actual = PackedGoldilocksWasmSimd128::dot_product(&packed_lhs, &packed_rhs);
+
+            assert_eq!(
+                actual.as_slice()[0].as_canonical_u64(),
+                expected0.as_canonical_u64(),
+                "N={N} mismatch at lane 0: lhs={lhs0:?} rhs={rhs0:?}"
+            );
+            assert_eq!(
+                actual.as_slice()[1].as_canonical_u64(),
+                expected1.as_canonical_u64(),
+                "N={N} mismatch at lane 1: lhs={lhs1:?} rhs={rhs1:?}"
+            );
+        }
+
+        // All-maximal-value products in lane 0, all-zero in lane 1, every N from 2 to 32:
+        // the densest possible adversarial case for the bit-96 split (every term's top-32-bit
+        // contribution is maximal), paired against the opposite extreme in the other lane.
+        macro_rules! check_edge_n {
+            ($n:literal) => {
+                check::<$n>(
+                    [Goldilocks::new(u64::MAX); $n],
+                    [Goldilocks::new(u64::MAX); $n],
+                    [Goldilocks::ZERO; $n],
+                    [Goldilocks::new(u64::MAX); $n],
+                );
+            };
+        }
+        check_edge_n!(2);
+        check_edge_n!(3);
+        check_edge_n!(4);
+        check_edge_n!(5);
+        check_edge_n!(8);
+        check_edge_n!(12);
+        check_edge_n!(16);
+        check_edge_n!(32);
+
+        // Edge-value permutations for small N, same pattern reversed between lanes.
+        for &a in &EDGE_VALUES {
+            for &b in &EDGE_VALUES {
+                for &c in &EDGE_VALUES {
+                    check::<3>(
+                        [Goldilocks::new(a), Goldilocks::new(b), Goldilocks::new(c)],
+                        [Goldilocks::new(c), Goldilocks::new(b), Goldilocks::new(a)],
+                        [Goldilocks::new(c), Goldilocks::new(b), Goldilocks::new(a)],
+                        [Goldilocks::new(a), Goldilocks::new(b), Goldilocks::new(c)],
+                    );
+                }
+            }
+        }
+
+        // Random stress across a range of N, including N well above what a single loop
+        // iteration bound might be expected to special-case.
+        let mut rng = SmallRng::seed_from_u64(0xD07_9A0D_7CE);
+        macro_rules! check_random_n {
+            ($n:literal, $count:literal) => {
+                for _ in 0..$count {
+                    let lhs0: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let rhs0: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let lhs1: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let rhs1: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    check::<$n>(lhs0, rhs0, lhs1, rhs1);
+                }
+            };
+        }
+        check_random_n!(2, 32);
+        check_random_n!(3, 32);
+        check_random_n!(4, 32);
+        check_random_n!(7, 32);
+        check_random_n!(16, 16);
+        check_random_n!(64, 8);
+    }
 }

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -199,15 +199,28 @@ impl_packed_field_div!(PackedGoldilocksWasmSimd128);
 impl_sum_prod_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
 
 impl Algebra<Goldilocks> for PackedGoldilocksWasmSimd128 {
-    // Matches the aarch64 NEON chunk for the same WIDTH=2 lane layout.
-    const BATCHED_LC_CHUNK: usize = 2;
+    // Benchmarked on wasm32+simd128 under wasmtime across slice lengths 8, 16, 33, 64, 256:
+    // chunk=4 is consistently the fastest or near-fastest choice at every length (8-15%
+    // faster than chunk=2 throughout), while chunk=8/16 are consistently *worse* than
+    // chunk=2 for most lengths, and chunk=32/64 only win when the length happens to be a
+    // multiple of them (e.g. 256) — otherwise the leftover falls into the unvectorized
+    // per-element remainder path in `chunked_linear_combination`, which dominates for
+    // realistic (non-power-of-two) constraint counts.
+    const BATCHED_LC_CHUNK: usize = 4;
 
     #[inline]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        Self::from_fn(|lane| {
-            let a_lane: [Goldilocks; N] = core::array::from_fn(|i| a[i].as_slice()[lane]);
-            Goldilocks::dot_product(&a_lane, f)
-        })
+        const {
+            assert!((N as u32) <= (1 << 31));
+        }
+        match N {
+            0 => Self::ZERO,
+            1 => a[0] * f[0],
+            _ => Self::from_vector(dot_product_delayed_reduce::<N>(
+                &core::array::from_fn(|i| a[i].to_vector()),
+                &core::array::from_fn(|i| Self::from(f[i]).to_vector()),
+            )),
+        }
     }
 }
 
@@ -650,5 +663,66 @@ mod tests {
         check_random_n!(7, 32);
         check_random_n!(16, 16);
         check_random_n!(64, 8);
+    }
+
+    /// Adversarial coverage for `mixed_dot_product`, which reuses the same
+    /// `dot_product_delayed_reduce` machinery with the coefficients broadcast per term
+    /// instead of genuinely packed — the new risk is specifically in that broadcast wiring.
+    #[test]
+    fn mixed_dot_product_delayed_reduction_matches_scalar() {
+        use p3_field::{Algebra, PackedValue, PrimeCharacteristicRing, PrimeField64};
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        fn check<const N: usize>(a0: [Goldilocks; N], a1: [Goldilocks; N], f: [Goldilocks; N]) {
+            let packed_a: [PackedGoldilocksWasmSimd128; N] =
+                core::array::from_fn(|i| PackedGoldilocksWasmSimd128([a0[i], a1[i]]));
+
+            let expected0 = Goldilocks::dot_product(&a0, &f);
+            let expected1 = Goldilocks::dot_product(&a1, &f);
+            let actual = PackedGoldilocksWasmSimd128::mixed_dot_product(&packed_a, &f);
+
+            assert_eq!(
+                actual.as_slice()[0].as_canonical_u64(),
+                expected0.as_canonical_u64(),
+                "N={N} mismatch at lane 0"
+            );
+            assert_eq!(
+                actual.as_slice()[1].as_canonical_u64(),
+                expected1.as_canonical_u64(),
+                "N={N} mismatch at lane 1"
+            );
+        }
+
+        macro_rules! check_edge_n {
+            ($n:literal) => {
+                check::<$n>(
+                    [Goldilocks::new(u64::MAX); $n],
+                    [Goldilocks::ZERO; $n],
+                    [Goldilocks::new(u64::MAX); $n],
+                );
+            };
+        }
+        check_edge_n!(2);
+        check_edge_n!(5);
+        check_edge_n!(8);
+        check_edge_n!(16);
+        check_edge_n!(32);
+
+        let mut rng = SmallRng::seed_from_u64(0x11ED_D07_9A0D);
+        macro_rules! check_random_n {
+            ($n:literal, $count:literal) => {
+                for _ in 0..$count {
+                    let a0: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let a1: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let f: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    check::<$n>(a0, a1, f);
+                }
+            };
+        }
+        check_random_n!(2, 16);
+        check_random_n!(3, 16);
+        check_random_n!(8, 16);
+        check_random_n!(16, 8);
     }
 }

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -165,6 +165,23 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
     }
 
     #[inline]
+    fn sum_array<const N: usize>(input: &[Self]) -> Self {
+        assert_eq!(N, input.len());
+        const {
+            assert!((N as u32) <= (1 << 31));
+        }
+        match N {
+            0 => Self::ZERO,
+            1 => input[0],
+            2 => input[0] + input[1],
+            _ => {
+                let vectors: [v128; N] = core::array::from_fn(|i| input[i].to_vector());
+                Self::from_vector(sum_delayed_reduce::<N>(&vectors))
+            }
+        }
+    }
+
+    #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
         const {
             assert!((N as u32) <= (1 << 31));
@@ -495,6 +512,30 @@ fn dot_product_delayed_reduce<const N: usize>(lhs: &[v128; N], rhs: &[v128; N]) 
     reduce128(sum_hi, sum_lo)
 }
 
+/// Delayed-reduction sum: `sum(terms)` with a single final [`reduce128`] instead of one
+/// reduction per term (the generic `sum_array`/`+`-chain default pays a full `add`, ~9 ops
+/// including a canonicalize step, for every term).
+///
+/// Each term is a single (arbitrary, possibly non-canonical) 64-bit value, i.e. a 128-bit
+/// value with a zero high half, so — unlike [`dot_product_delayed_reduce`] — no bit-96 split
+/// is needed: accumulating with plain wrapping 128-bit-per-lane addition (carry from the low
+/// word into the high word on overflow) gives the *exact* sum as long as `N < 2^64`, which
+/// always holds. `reduce128` finishes it.
+#[inline]
+fn sum_delayed_reduce<const N: usize>(terms: &[v128; N]) -> v128 {
+    let mut acc_hi = u64x2_splat(0);
+    let mut acc_lo = u64x2_splat(0);
+
+    for &term in terms {
+        let new_lo = i64x2_add(acc_lo, term);
+        let carry = unsigned_lt_as_carry(new_lo, acc_lo);
+        acc_hi = i64x2_add(acc_hi, carry);
+        acc_lo = new_lo;
+    }
+
+    reduce128(acc_hi, acc_lo)
+}
+
 /// Goldilocks modular multiplication. Computes `x * y mod FIELD_ORDER`.
 ///
 /// Inputs can be arbitrary, output is not guaranteed to be less than `FIELD_ORDER`.
@@ -561,6 +602,70 @@ mod tests {
         &[super::ONES],
         crate::PackedGoldilocksWasmSimd128(super::SPECIAL_VALS)
     );
+
+    /// Adversarial + random coverage for `sum_array`'s delayed-reduction path (`N > 2`),
+    /// across every lane independently.
+    #[test]
+    fn sum_array_delayed_reduction_matches_scalar() {
+        use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField64};
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        fn check<const N: usize>(terms0: [Goldilocks; N], terms1: [Goldilocks; N]) {
+            let packed: [PackedGoldilocksWasmSimd128; N] =
+                core::array::from_fn(|i| PackedGoldilocksWasmSimd128([terms0[i], terms1[i]]));
+
+            let expected0 = Goldilocks::sum_array::<N>(&terms0);
+            let expected1 = Goldilocks::sum_array::<N>(&terms1);
+            let actual = PackedGoldilocksWasmSimd128::sum_array::<N>(&packed);
+
+            assert_eq!(
+                actual.as_slice()[0].as_canonical_u64(),
+                expected0.as_canonical_u64(),
+                "N={N} mismatch at lane 0: terms={terms0:?}"
+            );
+            assert_eq!(
+                actual.as_slice()[1].as_canonical_u64(),
+                expected1.as_canonical_u64(),
+                "N={N} mismatch at lane 1: terms={terms1:?}"
+            );
+        }
+
+        // Every term at the maximal non-canonical representative, in lane 0, paired against
+        // zero in lane 1: the densest possible carry chain for the wrapping 128-bit
+        // accumulator, at every N from 3 (first delayed-reduction arm) to 32.
+        macro_rules! check_edge_n {
+            ($n:literal) => {
+                check::<$n>([Goldilocks::new(u64::MAX); $n], [Goldilocks::ZERO; $n]);
+            };
+        }
+        check_edge_n!(3);
+        check_edge_n!(4);
+        check_edge_n!(5);
+        check_edge_n!(7);
+        check_edge_n!(8);
+        check_edge_n!(11);
+        check_edge_n!(12);
+        check_edge_n!(15);
+        check_edge_n!(16);
+        check_edge_n!(32);
+
+        let mut rng = SmallRng::seed_from_u64(0x5A_A0_D1CA_7E);
+        macro_rules! check_random_n {
+            ($n:literal, $count:literal) => {
+                for _ in 0..$count {
+                    let terms0: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    let terms1: [Goldilocks; $n] = core::array::from_fn(|_| rng.random());
+                    check::<$n>(terms0, terms1);
+                }
+            };
+        }
+        check_random_n!(3, 32);
+        check_random_n!(7, 32);
+        check_random_n!(11, 16);
+        check_random_n!(15, 16);
+        check_random_n!(64, 8);
+    }
 
     /// Adversarial + random coverage for `dot_product`'s delayed-reduction path (`N > 1`),
     /// across every lane independently, for `N` both below and (via repeated calls) well

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -167,9 +167,6 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
     #[inline]
     fn sum_array<const N: usize>(input: &[Self]) -> Self {
         assert_eq!(N, input.len());
-        const {
-            assert!((N as u32) <= (1 << 31));
-        }
         match N {
             0 => Self::ZERO,
             1 => input[0],
@@ -183,16 +180,10 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
-        const {
-            assert!((N as u32) <= (1 << 31));
-        }
         match N {
             0 => Self::ZERO,
             1 => lhs[0] * rhs[0],
-            _ => Self::from_vector(dot_product_delayed_reduce::<N>(
-                &core::array::from_fn(|i| lhs[i].to_vector()),
-                &core::array::from_fn(|i| rhs[i].to_vector()),
-            )),
+            _ => Self::from_vector(dot_pairs::<N>(|i| (lhs[i].to_vector(), rhs[i].to_vector()))),
         }
     }
 }
@@ -217,28 +208,17 @@ impl_sum_prod_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
 
 impl Algebra<Goldilocks> for PackedGoldilocksWasmSimd128 {
     // Benchmarked across slice lengths 8, 16, 33, 64, 256 under both wasmtime/Cranelift and
-    // Node/V8, since the two engines disagree sharply on the best chunk: Cranelift likes
-    // chunk=32/64 for aligned lengths (falling back to the unvectorized per-element
-    // remainder path in `chunked_linear_combination` otherwise), while V8 prefers chunk=16
-    // and regresses badly (2.2-2.3x slower than optimal) at chunk=32/64 regardless of
-    // alignment. chunk=4 is the min-max choice: worst-case 1.38x slower than the
-    // best-for-that-engine-and-length chunk across all 10 (engine, length) combinations
-    // tested, versus 1.57-1.59x for chunk=8/16 and 2.2x+ for chunk=32/64 — always
-    // reasonable, never catastrophic, on either engine.
+    // Node/V8, feeding `dot_pairs` directly rather than through a materialized `[v128; N]`.
     const BATCHED_LC_CHUNK: usize = 4;
 
     #[inline]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        const {
-            assert!((N as u32) <= (1 << 31));
-        }
         match N {
             0 => Self::ZERO,
             1 => a[0] * f[0],
-            _ => Self::from_vector(dot_product_delayed_reduce::<N>(
-                &core::array::from_fn(|i| a[i].to_vector()),
-                &core::array::from_fn(|i| Self::from(f[i]).to_vector()),
-            )),
+            _ => Self::from_vector(dot_pairs::<N>(|i| {
+                (a[i].to_vector(), Self::from(f[i]).to_vector())
+            })),
         }
     }
 }
@@ -468,9 +448,14 @@ fn unsigned_lt_as_carry(a: v128, b: v128) -> v128 {
     u64x2_shr(mask, 63)
 }
 
-/// Delayed-reduction dot product: `sum(lhs[i] * rhs[i])` with a single final [`reduce128`]
-/// instead of one reduction per term. Mirrors the scalar `Goldilocks::dot_product`'s
-/// `N > 2` algorithm (see `goldilocks.rs`), vectorized to 2 lanes.
+/// Delayed-reduction dot product: `sum(get(i).0 * get(i).1)` with a single final
+/// [`reduce128`] instead of one reduction per term. Mirrors the scalar
+/// `Goldilocks::dot_product`'s `N > 2` algorithm (see `goldilocks.rs`), vectorized to 2 lanes.
+///
+/// Terms are produced one pair at a time by `get` rather than passed as `&[v128; N]`
+/// slices: materializing the `N` vectors first via `core::array::from_fn(|i| ...to_vector())`
+/// doesn't get elided by the wasm backend, and it costs real time and stack for `N` above a
+/// handful.
 ///
 /// Each 128-bit product `val` is split at bit 96 (not bit 64) into `lo96 + hi32 * 2^96`:
 /// `hi32 = val >> 96` is bounded by `2^32 - 1` per term, so up to `N <= 2^31` terms can be
@@ -480,13 +465,18 @@ fn unsigned_lt_as_carry(a: v128, b: v128) -> v128 {
 /// `2^128`, because that sum is itself `< 2^127` (`N <= 2^31` terms, each `lo96_i < 2^96`).
 /// Finally `2^96 ≡ -1 (mod P)` folds `acc_hi96` back in before the single [`reduce128`] call.
 #[inline]
-fn dot_product_delayed_reduce<const N: usize>(lhs: &[v128; N], rhs: &[v128; N]) -> v128 {
+fn dot_pairs<const N: usize>(get: impl Fn(usize) -> (v128, v128)) -> v128 {
+    const {
+        assert!((N as u32) <= (1 << 31));
+    }
+
     let mut acc_lo_hi = u64x2_splat(0);
     let mut acc_lo_lo = u64x2_splat(0);
     let mut acc_hi96 = u64x2_splat(0);
 
     for i in 0..N {
-        let (term_hi, term_lo) = mul64_64(lhs[i], rhs[i]);
+        let (lhs, rhs) = get(i);
+        let (term_hi, term_lo) = mul64_64(lhs, rhs);
         let term_hi96 = u64x2_shr(term_hi, 32);
 
         let new_lo_lo = i64x2_add(acc_lo_lo, term_lo);
@@ -639,6 +629,7 @@ mod tests {
                 check::<$n>([Goldilocks::new(u64::MAX); $n], [Goldilocks::ZERO; $n]);
             };
         }
+        check::<2>([Goldilocks::new(u64::MAX); 2], [Goldilocks::ZERO; 2]);
         check_edge_n!(3);
         check_edge_n!(4);
         check_edge_n!(5);
@@ -650,7 +641,7 @@ mod tests {
         check_edge_n!(16);
         check_edge_n!(32);
 
-        let mut rng = SmallRng::seed_from_u64(0x5A_A0_D1CA_7E);
+        let mut rng = SmallRng::seed_from_u64(0x005A_A0D1_CA7E);
         macro_rules! check_random_n {
             ($n:literal, $count:literal) => {
                 for _ in 0..$count {
@@ -752,7 +743,7 @@ mod tests {
 
         // Random stress across a range of N, including N well above what a single loop
         // iteration bound might be expected to special-case.
-        let mut rng = SmallRng::seed_from_u64(0xD07_9A0D_7CE);
+        let mut rng = SmallRng::seed_from_u64(0x00D0_79A0_D7CE);
         macro_rules! check_random_n {
             ($n:literal, $count:literal) => {
                 for _ in 0..$count {
@@ -816,7 +807,7 @@ mod tests {
         check_edge_n!(16);
         check_edge_n!(32);
 
-        let mut rng = SmallRng::seed_from_u64(0x11ED_D07_9A0D);
+        let mut rng = SmallRng::seed_from_u64(0x011E_DD07_9A0D);
         macro_rules! check_random_n {
             ($n:literal, $count:literal) => {
                 for _ in 0..$count {

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -199,13 +199,15 @@ impl_packed_field_div!(PackedGoldilocksWasmSimd128);
 impl_sum_prod_base_field!(PackedGoldilocksWasmSimd128, Goldilocks);
 
 impl Algebra<Goldilocks> for PackedGoldilocksWasmSimd128 {
-    // Benchmarked on wasm32+simd128 under wasmtime across slice lengths 8, 16, 33, 64, 256:
-    // chunk=4 is consistently the fastest or near-fastest choice at every length (8-15%
-    // faster than chunk=2 throughout), while chunk=8/16 are consistently *worse* than
-    // chunk=2 for most lengths, and chunk=32/64 only win when the length happens to be a
-    // multiple of them (e.g. 256) — otherwise the leftover falls into the unvectorized
-    // per-element remainder path in `chunked_linear_combination`, which dominates for
-    // realistic (non-power-of-two) constraint counts.
+    // Benchmarked across slice lengths 8, 16, 33, 64, 256 under both wasmtime/Cranelift and
+    // Node/V8, since the two engines disagree sharply on the best chunk: Cranelift likes
+    // chunk=32/64 for aligned lengths (falling back to the unvectorized per-element
+    // remainder path in `chunked_linear_combination` otherwise), while V8 prefers chunk=16
+    // and regresses badly (2.2-2.3x slower than optimal) at chunk=32/64 regardless of
+    // alignment. chunk=4 is the min-max choice: worst-case 1.38x slower than the
+    // best-for-that-engine-and-length chunk across all 10 (engine, length) combinations
+    // tested, versus 1.57-1.59x for chunk=8/16 and 2.2x+ for chunk=32/64 — always
+    // reasonable, never catastrophic, on either engine.
     const BATCHED_LC_CHUNK: usize = 4;
 
     #[inline]

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -507,7 +507,7 @@ fn dot_pairs<const N: usize>(get: impl Fn(usize) -> (v128, v128)) -> v128 {
 /// including a canonicalize step, for every term).
 ///
 /// Each term is a single (arbitrary, possibly non-canonical) 64-bit value, i.e. a 128-bit
-/// value with a zero high half, so — unlike [`dot_product_delayed_reduce`] — no bit-96 split
+/// value with a zero high half, so — unlike [`dot_pairs`] — no bit-96 split
 /// is needed: accumulating with plain wrapping 128-bit-per-lane addition (carry from the low
 /// word into the high word on overflow) gives the *exact* sum as long as `N < 2^64`, which
 /// always holds. `reduce128` finishes it.
@@ -764,7 +764,7 @@ mod tests {
     }
 
     /// Adversarial coverage for `mixed_dot_product`, which reuses the same
-    /// `dot_product_delayed_reduce` machinery with the coefficients broadcast per term
+    /// `dot_pairs` machinery with the coefficients broadcast per term
     /// instead of genuinely packed — the new risk is specifically in that broadcast wiring.
     #[test]
     fn mixed_dot_product_delayed_reduction_matches_scalar() {

--- a/goldilocks/src/wasm32_simd128/poseidon2.rs
+++ b/goldilocks/src/wasm32_simd128/poseidon2.rs
@@ -1,0 +1,502 @@
+//! Poseidon2 external/internal layers specialized for `PackedGoldilocksWasmSimd128`.
+//!
+//! `Poseidon2ExternalLayerGoldilocks`/`Poseidon2InternalLayerGoldilocks` (in the crate root
+//! `poseidon2` module) already act correctly on `PackedGoldilocksWasmSimd128` through their
+//! generic `Algebra<Goldilocks>` implementation, since `PackedGoldilocksWasmSimd128` implements
+//! both `Algebra<Goldilocks>` and `InjectiveMonomial<7>`. That generic path re-broadcasts every
+//! round constant from scalar `Goldilocks` into a packed vector on every single
+//! `permute_state`/`permute_state_initial`/`permute_state_terminal` call, which is wasted work
+//! once the permutation is used to hash many inputs.
+//!
+//! The types here instead:
+//! - broadcast each round constant into a `PackedGoldilocksWasmSimd128` once, at construction
+//!   time, and reuse the packed constants across every future permutation call,
+//! - in the internal rounds, compute the lane sum used by the diffusion matrix from
+//!   `state[1..WIDTH]` independently of the S-box applied to `state[0]`, so the two
+//!   (data-independent) computations can be scheduled without one waiting on the other,
+//!   instead of forcing the sum to wait on the S-box's multiply/reduce chain, and
+//! - in the external rounds, where every state element's S-box is independent of every other,
+//!   batch the S-box's multiply/reduce chain by stage across the whole state (see
+//!   [`sbox_array`]) instead of fully computing one element's `x^7` before starting the next.
+//!
+//! For scalar `Goldilocks` state, both layers simply delegate to the existing generic
+//! implementation, which is already effectively optimal for a single field element.
+
+use alloc::vec::Vec;
+
+use p3_field::{InjectiveMonomial, PrimeCharacteristicRing};
+use p3_poseidon2::{
+    ExternalLayer, ExternalLayerConstants, ExternalLayerConstructor, InternalLayer,
+    InternalLayerConstructor, MDSMat4, mds_light_permutation,
+};
+
+use crate::poseidon1::GOLDILOCKS_S_BOX_DEGREE;
+use crate::wasm32_simd128::packing::PackedGoldilocksWasmSimd128;
+use crate::{Goldilocks, Poseidon2ExternalLayerGoldilocks, Poseidon2InternalLayerGoldilocks};
+
+/// Add a round constant then apply the S-box (`x^7`) to a single packed element. Used by the
+/// internal rounds, where only `state[0]` is S-box'd each round; see [`sbox_array`] for the
+/// external rounds, where every state element is S-box'd and batching by stage matters.
+#[inline(always)]
+fn add_rc_and_sbox(val: &mut PackedGoldilocksWasmSimd128, rc: PackedGoldilocksWasmSimd128) {
+    *val = (*val + rc).injective_exp_n();
+}
+
+/// Apply the Poseidon2 S-box (`x^7`) to every element of a packed wasm32 state.
+///
+/// `p3_poseidon2`'s generic external-round driver applies the S-box one element at a time,
+/// fully completing one element's multiply/reduce chain (`x^2`, `x^3`, `x^4`, `x^7`) before
+/// starting the next. Since every state element's S-box is independent of every other, this
+/// instead batches the computation by stage across the whole state: all `WIDTH` squarings,
+/// then all `WIDTH` pairs of the next two (mutually independent) products, then all `WIDTH`
+/// final products. This gives the compiler `WIDTH`-many independent multiply/reduce chains to
+/// interleave at each stage instead of one at a time, mirroring `PrimeCharacteristicRing`'s own
+/// `exp_const_u64::<7>` addition chain (`x2 = x^2`, `x3 = x2*x`, `x4 = x2^2`, `x7 = x3*x4`),
+/// just computed array-wise rather than per-element.
+#[inline(always)]
+fn sbox_array<const WIDTH: usize>(state: &mut [PackedGoldilocksWasmSimd128; WIDTH]) {
+    let x2: [PackedGoldilocksWasmSimd128; WIDTH] = core::array::from_fn(|i| state[i].square());
+    // `x3`/`x4` start as copies of `x2` (a plain register/array copy, no computation) so that
+    // computing `x3[i] = x2[i] * state[i]` and `x4[i] = x2[i]^2` can share a single loop over
+    // `i`, instead of two separate full-width passes.
+    let mut x3 = x2;
+    let mut x4 = x2;
+    for i in 0..WIDTH {
+        x3[i] *= state[i];
+        x4[i] = x4[i].square();
+    }
+    for i in 0..WIDTH {
+        state[i] = x3[i] * x4[i];
+    }
+}
+
+/// Apply one external round (add round constants, S-box every element, apply the `4x4`-MDS
+/// light permutation) to a packed wasm32 state.
+#[inline(always)]
+fn external_round<const WIDTH: usize>(
+    state: &mut [PackedGoldilocksWasmSimd128; WIDTH],
+    rc: &[PackedGoldilocksWasmSimd128; WIDTH],
+) {
+    for i in 0..WIDTH {
+        state[i] += rc[i];
+    }
+    sbox_array(state);
+    mds_light_permutation(state, &MDSMat4);
+}
+
+/// Apply one internal round (add round constant, S-box `state[0]`, diffuse) of the
+/// width-8 Goldilocks Poseidon2 internal linear layer to a packed wasm32 state.
+///
+/// Mirrors `internal_layer_mat_mul_goldilocks_8` in the crate root `poseidon2` module, with
+/// the lane sum split into a part independent of the S-box (`sum_tail`, covering
+/// `state[1..8]`) and the S-box'd `state[0]`, combined only once both are ready.
+#[inline(always)]
+fn internal_round_goldilocks_8(
+    state: &mut [PackedGoldilocksWasmSimd128; 8],
+    rc: PackedGoldilocksWasmSimd128,
+) {
+    let s1 = state[1];
+    let s2 = state[2];
+    let s3 = state[3];
+    let s4 = state[4];
+    let s5 = state[5];
+    let s6 = state[6];
+    let s7 = state[7];
+    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7;
+
+    add_rc_and_sbox(&mut state[0], rc);
+    let s0 = state[0];
+    let sum = sum_tail + s0;
+
+    // V[0] = -2
+    state[0] = sum - (s0 + s0);
+    // V[1] = 1
+    state[1] = sum + s1;
+    // V[2] = 2
+    state[2] = sum + (s2 + s2);
+    // V[3] = 1/2
+    state[3] = sum + s3.halve();
+    // V[4] = 3
+    state[4] = sum + (s4 + s4 + s4);
+    // V[5] = -1/2
+    state[5] = sum - s5.halve();
+    // V[6] = -3
+    state[6] = sum - (s6 + s6 + s6);
+    // V[7] = -4
+    let two_s7 = s7 + s7;
+    state[7] = sum - (two_s7 + two_s7);
+}
+
+/// Apply one internal round of the width-12 Goldilocks Poseidon2 internal linear layer to a
+/// packed wasm32 state. See [`internal_round_goldilocks_8`] and
+/// `internal_layer_mat_mul_goldilocks_12` in the crate root `poseidon2` module.
+#[inline(always)]
+fn internal_round_goldilocks_12(
+    state: &mut [PackedGoldilocksWasmSimd128; 12],
+    rc: PackedGoldilocksWasmSimd128,
+) {
+    let s1 = state[1];
+    let s2 = state[2];
+    let s3 = state[3];
+    let s4 = state[4];
+    let s5 = state[5];
+    let s6 = state[6];
+    let s7 = state[7];
+    let s8 = state[8];
+    let s9 = state[9];
+    let s10 = state[10];
+    let s11 = state[11];
+    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10 + s11;
+
+    add_rc_and_sbox(&mut state[0], rc);
+    let s0 = state[0];
+    let sum = sum_tail + s0;
+
+    // V[0] = -2
+    state[0] = sum - (s0 + s0);
+    // V[1] = 1
+    state[1] = sum + s1;
+    // V[2] = 2
+    state[2] = sum + (s2 + s2);
+    // V[3] = 1/2
+    state[3] = sum + s3.halve();
+    // V[4] = 3
+    state[4] = sum + (s4 + s4 + s4);
+    // V[5] = 4
+    let two_s5 = s5 + s5;
+    state[5] = sum + (two_s5 + two_s5);
+    // V[6] = -1/2
+    state[6] = sum - s6.halve();
+    // V[7] = -3
+    state[7] = sum - (s7 + s7 + s7);
+    // V[8] = -4
+    let two_s8 = s8 + s8;
+    state[8] = sum - (two_s8 + two_s8);
+    // V[9] = 1/2^2
+    state[9] = sum + s9.halve().halve();
+    // V[10] = -1/2^2
+    state[10] = sum - s10.halve().halve();
+    // V[11] = 1/2^3
+    state[11] = sum + s11.halve().halve().halve();
+}
+
+/// Apply one internal round of the width-16 Goldilocks Poseidon2 internal linear layer to a
+/// packed wasm32 state. See [`internal_round_goldilocks_8`] and
+/// `internal_layer_mat_mul_goldilocks_16` in the crate root `poseidon2` module.
+#[inline(always)]
+fn internal_round_goldilocks_16(
+    state: &mut [PackedGoldilocksWasmSimd128; 16],
+    rc: PackedGoldilocksWasmSimd128,
+) {
+    let s1 = state[1];
+    let s2 = state[2];
+    let s3 = state[3];
+    let s4 = state[4];
+    let s5 = state[5];
+    let s6 = state[6];
+    let s7 = state[7];
+    let s8 = state[8];
+    let s9 = state[9];
+    let s10 = state[10];
+    let s11 = state[11];
+    let s12 = state[12];
+    let s13 = state[13];
+    let s14 = state[14];
+    let s15 = state[15];
+    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10 + s11 + s12 + s13 + s14 + s15;
+
+    add_rc_and_sbox(&mut state[0], rc);
+    let s0 = state[0];
+    let sum = sum_tail + s0;
+
+    // V[0] = -2
+    state[0] = sum - (s0 + s0);
+    // V[1] = 1
+    state[1] = sum + s1;
+    // V[2] = 2
+    state[2] = sum + (s2 + s2);
+    // V[3] = 1/2
+    state[3] = sum + s3.halve();
+    // V[4] = 3
+    state[4] = sum + (s4 + s4 + s4);
+    // V[5] = 4
+    let two_s5 = s5 + s5;
+    state[5] = sum + (two_s5 + two_s5);
+    // V[6] = -1/2
+    state[6] = sum - s6.halve();
+    // V[7] = -3
+    state[7] = sum - (s7 + s7 + s7);
+    // V[8] = -4
+    let two_s8 = s8 + s8;
+    state[8] = sum - (two_s8 + two_s8);
+    // V[9] = 1/2^3
+    state[9] = sum + s9.halve().halve().halve();
+    // V[10] = 1/2^4
+    state[10] = sum + s10.halve().halve().halve().halve();
+    // V[11] = 1/2^5
+    state[11] = sum + s11.halve().halve().halve().halve().halve();
+    // V[12] = -1/2^3
+    state[12] = sum - s12.halve().halve().halve();
+    // V[13] = -1/2^4
+    state[13] = sum - s13.halve().halve().halve().halve();
+    // V[14] = -1/2^5
+    state[14] = sum - s14.halve().halve().halve().halve().halve();
+    // V[15] = 1/2^32
+    let inv_2_32 = crate::MATRIX_DIAG_16_GOLDILOCKS[15];
+    state[15] = sum + s15 * inv_2_32;
+}
+
+/// The internal layers of the Poseidon2 permutation, specialized for `PackedGoldilocksWasmSimd128`.
+#[derive(Clone, Debug, Default)]
+pub struct Poseidon2InternalLayerGoldilocksWasmSimd128 {
+    /// Scalar fallback, used for `Permutation<[Goldilocks; WIDTH]>`.
+    inner: Poseidon2InternalLayerGoldilocks,
+    /// Each internal round constant, pre-broadcast into a packed vector.
+    packed_internal_constants: Vec<PackedGoldilocksWasmSimd128>,
+}
+
+impl InternalLayerConstructor<Goldilocks> for Poseidon2InternalLayerGoldilocksWasmSimd128 {
+    fn new_from_constants(internal_constants: Vec<Goldilocks>) -> Self {
+        let packed_internal_constants = internal_constants
+            .iter()
+            .copied()
+            .map(PackedGoldilocksWasmSimd128::from)
+            .collect();
+        let inner = Poseidon2InternalLayerGoldilocks::new_from_constants(internal_constants);
+        Self {
+            inner,
+            packed_internal_constants,
+        }
+    }
+}
+
+impl InternalLayer<Goldilocks, 8, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 8]) {
+        InternalLayer::<Goldilocks, 8, GOLDILOCKS_S_BOX_DEGREE>::permute_state(&self.inner, state);
+    }
+}
+
+impl InternalLayer<Goldilocks, 12, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 12]) {
+        InternalLayer::<Goldilocks, 12, GOLDILOCKS_S_BOX_DEGREE>::permute_state(&self.inner, state);
+    }
+}
+
+impl InternalLayer<Goldilocks, 16, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 16]) {
+        InternalLayer::<Goldilocks, 16, GOLDILOCKS_S_BOX_DEGREE>::permute_state(&self.inner, state);
+    }
+}
+
+// `MATRIX_DIAG_20_GOLDILOCKS` holds opaque full field elements rather than small
+// integers/powers of two (see its doc comment in the crate root `poseidon2` module), so it
+// doesn't admit the same cheap-add fast path as widths 8/12/16. Width 20 is otherwise
+// unused in this crate (no default constructor, no known-answer test), so both the scalar
+// and packed cases simply delegate to the existing generic implementation for correctness
+// parity with every other Goldilocks Poseidon2 backend, rather than leaving it unsupported.
+impl InternalLayer<Goldilocks, 20, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [Goldilocks; 20]) {
+        InternalLayer::<Goldilocks, 20, GOLDILOCKS_S_BOX_DEGREE>::permute_state(&self.inner, state);
+    }
+}
+
+impl InternalLayer<PackedGoldilocksWasmSimd128, 20, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksWasmSimd128; 20]) {
+        InternalLayer::<PackedGoldilocksWasmSimd128, 20, GOLDILOCKS_S_BOX_DEGREE>::permute_state(
+            &self.inner,
+            state,
+        );
+    }
+}
+
+impl InternalLayer<PackedGoldilocksWasmSimd128, 8, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksWasmSimd128; 8]) {
+        for &rc in &self.packed_internal_constants {
+            internal_round_goldilocks_8(state, rc);
+        }
+    }
+}
+
+impl InternalLayer<PackedGoldilocksWasmSimd128, 12, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksWasmSimd128; 12]) {
+        for &rc in &self.packed_internal_constants {
+            internal_round_goldilocks_12(state, rc);
+        }
+    }
+}
+
+impl InternalLayer<PackedGoldilocksWasmSimd128, 16, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2InternalLayerGoldilocksWasmSimd128
+{
+    fn permute_state(&self, state: &mut [PackedGoldilocksWasmSimd128; 16]) {
+        for &rc in &self.packed_internal_constants {
+            internal_round_goldilocks_16(state, rc);
+        }
+    }
+}
+
+/// The external layers of the Poseidon2 permutation, specialized for `PackedGoldilocksWasmSimd128`.
+#[derive(Clone)]
+pub struct Poseidon2ExternalLayerGoldilocksWasmSimd128<const WIDTH: usize> {
+    /// Scalar fallback, used for `Permutation<[Goldilocks; WIDTH]>`.
+    inner: Poseidon2ExternalLayerGoldilocks<WIDTH>,
+    /// Each initial-round constant vector, pre-broadcast lane-wise into packed vectors.
+    packed_initial_external_constants: Vec<[PackedGoldilocksWasmSimd128; WIDTH]>,
+    /// Each terminal-round constant vector, pre-broadcast lane-wise into packed vectors.
+    packed_terminal_external_constants: Vec<[PackedGoldilocksWasmSimd128; WIDTH]>,
+}
+
+impl<const WIDTH: usize> ExternalLayerConstructor<Goldilocks, WIDTH>
+    for Poseidon2ExternalLayerGoldilocksWasmSimd128<WIDTH>
+{
+    fn new_from_constants(external_constants: ExternalLayerConstants<Goldilocks, WIDTH>) -> Self {
+        let pack_round = |rc: &[Goldilocks; WIDTH]| rc.map(PackedGoldilocksWasmSimd128::from);
+        let packed_initial_external_constants = external_constants
+            .get_initial_constants()
+            .iter()
+            .map(pack_round)
+            .collect();
+        let packed_terminal_external_constants = external_constants
+            .get_terminal_constants()
+            .iter()
+            .map(pack_round)
+            .collect();
+        let inner = Poseidon2ExternalLayerGoldilocks::new_from_constants(external_constants);
+        Self {
+            inner,
+            packed_initial_external_constants,
+            packed_terminal_external_constants,
+        }
+    }
+}
+
+impl<const WIDTH: usize> ExternalLayer<Goldilocks, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2ExternalLayerGoldilocksWasmSimd128<WIDTH>
+{
+    fn permute_state_initial(&self, state: &mut [Goldilocks; WIDTH]) {
+        ExternalLayer::<Goldilocks, WIDTH, GOLDILOCKS_S_BOX_DEGREE>::permute_state_initial(
+            &self.inner,
+            state,
+        );
+    }
+
+    fn permute_state_terminal(&self, state: &mut [Goldilocks; WIDTH]) {
+        ExternalLayer::<Goldilocks, WIDTH, GOLDILOCKS_S_BOX_DEGREE>::permute_state_terminal(
+            &self.inner,
+            state,
+        );
+    }
+}
+
+impl<const WIDTH: usize> ExternalLayer<PackedGoldilocksWasmSimd128, WIDTH, GOLDILOCKS_S_BOX_DEGREE>
+    for Poseidon2ExternalLayerGoldilocksWasmSimd128<WIDTH>
+{
+    fn permute_state_initial(&self, state: &mut [PackedGoldilocksWasmSimd128; WIDTH]) {
+        mds_light_permutation(state, &MDSMat4);
+        for rc in &self.packed_initial_external_constants {
+            external_round(state, rc);
+        }
+    }
+
+    fn permute_state_terminal(&self, state: &mut [PackedGoldilocksWasmSimd128; WIDTH]) {
+        for rc in &self.packed_terminal_external_constants {
+            external_round(state, rc);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field::PackedValue;
+    use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+    use crate::{
+        default_goldilocks_poseidon2_8, default_goldilocks_poseidon2_12,
+        default_goldilocks_poseidon2_16,
+    };
+
+    const PACKING_WIDTH: usize = <PackedGoldilocksWasmSimd128 as PackedValue>::WIDTH;
+
+    /// Applying the packed wasm32 permutation lane-by-lane must agree with applying the scalar
+    /// permutation independently to each lane, for every lane of a random packed state.
+    fn assert_packed_matches_scalar<const WIDTH: usize>(
+        scalar_perm: &impl Permutation<[Goldilocks; WIDTH]>,
+        packed_perm: &impl Permutation<[PackedGoldilocksWasmSimd128; WIDTH]>,
+        rng: &mut SmallRng,
+    ) {
+        let lanes: [[Goldilocks; WIDTH]; PACKING_WIDTH] = core::array::from_fn(|_| rng.random());
+
+        let mut packed_state: [PackedGoldilocksWasmSimd128; WIDTH] =
+            core::array::from_fn(|i| PackedGoldilocksWasmSimd128::from_fn(|l| lanes[l][i]));
+        packed_perm.permute_mut(&mut packed_state);
+
+        for (l, lane) in lanes.into_iter().enumerate() {
+            let mut scalar_state = lane;
+            scalar_perm.permute_mut(&mut scalar_state);
+            for i in 0..WIDTH {
+                assert_eq!(
+                    scalar_state[i],
+                    packed_state[i].as_slice()[l],
+                    "width {WIDTH}, lane {l}, element {i}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn packed_matches_scalar_width_8() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let perm = default_goldilocks_poseidon2_8();
+        assert_packed_matches_scalar(&perm, &perm, &mut rng);
+    }
+
+    #[test]
+    fn packed_matches_scalar_width_12() {
+        let mut rng = SmallRng::seed_from_u64(2);
+        let perm = default_goldilocks_poseidon2_12();
+        assert_packed_matches_scalar(&perm, &perm, &mut rng);
+    }
+
+    #[test]
+    fn packed_matches_scalar_width_16() {
+        let mut rng = SmallRng::seed_from_u64(3);
+        let perm = default_goldilocks_poseidon2_16();
+        assert_packed_matches_scalar(&perm, &perm, &mut rng);
+    }
+
+    /// Width 20 has no default constructor or known-answer test anywhere in this crate (its
+    /// diagonal constants are undocumented), so there is no `default_goldilocks_poseidon2_20`
+    /// to call here. This only exercises that the scalar and packed `InternalLayer`/
+    /// `ExternalLayer` impls agree with each other for width 20 (i.e. that delegating to the
+    /// generic implementation was wired correctly), not that the round numbers used are
+    /// cryptographically appropriate.
+    #[test]
+    fn packed_matches_scalar_width_20() {
+        let mut rng = SmallRng::seed_from_u64(4);
+        let perm: p3_poseidon2::Poseidon2<
+            Goldilocks,
+            Poseidon2ExternalLayerGoldilocksWasmSimd128<20>,
+            Poseidon2InternalLayerGoldilocksWasmSimd128,
+            20,
+            GOLDILOCKS_S_BOX_DEGREE,
+        > = p3_poseidon2::Poseidon2::new_from_rng(8, 22, &mut rng);
+        assert_packed_matches_scalar(&perm, &perm, &mut rng);
+    }
+}

--- a/goldilocks/src/wasm32_simd128/poseidon2.rs
+++ b/goldilocks/src/wasm32_simd128/poseidon2.rs
@@ -102,7 +102,7 @@ fn internal_round_goldilocks_8(
     let s5 = state[5];
     let s6 = state[6];
     let s7 = state[7];
-    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7;
+    let sum_tail = PackedGoldilocksWasmSimd128::sum_array::<7>(&[s1, s2, s3, s4, s5, s6, s7]);
 
     add_rc_and_sbox(&mut state[0], rc);
     let s0 = state[0];
@@ -146,7 +146,9 @@ fn internal_round_goldilocks_12(
     let s9 = state[9];
     let s10 = state[10];
     let s11 = state[11];
-    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10 + s11;
+    let sum_tail = PackedGoldilocksWasmSimd128::sum_array::<11>(&[
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
+    ]);
 
     add_rc_and_sbox(&mut state[0], rc);
     let s0 = state[0];
@@ -203,7 +205,9 @@ fn internal_round_goldilocks_16(
     let s13 = state[13];
     let s14 = state[14];
     let s15 = state[15];
-    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10 + s11 + s12 + s13 + s14 + s15;
+    let sum_tail = PackedGoldilocksWasmSimd128::sum_array::<15>(&[
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15,
+    ]);
 
     add_rc_and_sbox(&mut state[0], rc);
     let s0 = state[0];


### PR DESCRIPTION
Yields from 23% to 31% reduction for Poseidon2 instances over Goldilocks, 1.8x to 2.6x faster dot product with WASM SIMD128 backend. `batched_linear_combination` is also 11% to 15% faster and `sum_array` is 28% to 43% faster depending on `N`.