### PR TITLE
perf(stir): prune Merkle multi-openings for STIR

### DIFF
--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Structure
 //!
 //! - [`config`]: Protocol parameters ([`StirParameters`], [`StirConfig`], [`StirRoundConfig`]).
-//! - [`proof`]: Proof types ([`StirProof`], [`StirRoundProof`], [`StirQueryProof`]).
+//! - [`proof`]: Proof types ([`StirProof`], [`StirRoundProof`], [`StirQueryOpenings`]).
 //! - [`utils`]: Polynomial arithmetic primitives (shake, ans, Horner eval, synthetic division).
 //! - [`prover`]: The STIR prover ([`prover::prove_stir`]).
 //! - [`verifier`]: The STIR verifier ([`verifier::verify_stir`], [`verifier::StirError`]).
@@ -58,5 +58,5 @@ pub mod verifier;
 pub use config::{StirConfig, StirParameters, StirRoundConfig};
 pub use p3_security::whir::SecurityAssumption;
 pub use pcs::TwoAdicStirPcs;
-pub use proof::{StirFinalQueryProof, StirProof, StirQueryProof, StirRoundProof};
+pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};
 pub use verifier::{StirError, StirVerifyOutputs};

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -95,7 +95,7 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> Pcs<Challenge, Challe
 where
     Val: TwoAdicField,
     Dft: TwoAdicSubgroupDft<Val>,
-    InputMmcs: Mmcs<Val, MultiProof: Sync, Error: Sync + Debug>,
+    InputMmcs: Mmcs<Val, Error: Sync + Debug>,
     StirMmcs: Mmcs<Challenge>,
     Challenge: ExtensionField<Val> + TwoAdicField + BasedVectorSpace<Val>,
     Challenger: FieldChallenger<Val>

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -27,7 +27,7 @@ use core::marker::PhantomData;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{BatchOpening, BatchOpeningRef, Mmcs, OpenedValues, Pcs};
+use p3_commit::{Mmcs, OpenedValues, Pcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
@@ -41,12 +41,34 @@ use p3_matrix::interpolation::{Interpolate, compute_adjusted_weights};
 use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::config::{StirConfig, StirParameters};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_from_codeword;
 use crate::verifier::{StirError, verify_stir};
+
+/// Batched openings of one input commitment's LDE matrices at the STIR-derived query
+/// positions for one LDE-height bucket.
+///
+/// One multi-opening proof authenticates every opened row together, so sibling digests
+/// shared between the bucket's `(query, fiber column)` positions travel once.
+///
+/// `None` when the commitment has no matrix at this bucket's height.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(bound(
+    serialize = "Val: Serialize, InputMmcs::MultiProof: Serialize",
+    deserialize = "Val: Deserialize<'de>, InputMmcs::MultiProof: Deserialize<'de>"
+))]
+pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
+    /// `opened_values[k][m]` is the opened row of matrix `m` at the `k`-th queried position,
+    /// in the same `(query, fiber column)` order the prover and verifier both derive from
+    /// public data.
+    pub opened_values: Vec<Vec<Vec<Val>>>,
+    /// Compact multi-opening proof authenticating every row at once.
+    pub opening_proof: InputMmcs::MultiProof,
+}
 
 /// A polynomial commitment scheme using STIR to generate opening proofs.
 #[derive(Clone, Debug)]
@@ -73,7 +95,7 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> Pcs<Challenge, Challe
 where
     Val: TwoAdicField,
     Dft: TwoAdicSubgroupDft<Val>,
-    InputMmcs: Mmcs<Val, Proof: Sync, Error: Sync + Debug>,
+    InputMmcs: Mmcs<Val, MultiProof: Sync, Error: Sync + Debug>,
     StirMmcs: Mmcs<Challenge>,
     Challenge: ExtensionField<Val> + TwoAdicField + BasedVectorSpace<Val>,
     Challenger: FieldChallenger<Val>
@@ -93,13 +115,13 @@ where
     /// - `stir_proof`: the STIR IOP proof for that bucket (initial commitment plus per-round
     ///   IOP messages). The first-round query indices are NOT serialized — the verifier
     ///   re-derives them from `verify_stir`'s side outputs.
-    /// - `input_openings[commit_idx]`: per-commitment batch openings at the bucket's
-    ///   first-round STIR fiber positions, in the same sorted-by-index order the verifier
-    ///   reconstructs from `verify_stir`. Empty if the commitment has no matrices at this
-    ///   bucket's LDE height.
+    /// - `input_openings[commit_idx]`: one shared multi-opening proof for that commitment's
+    ///   rows at the bucket's first-round STIR fiber positions, in the same sorted-by-index
+    ///   order the verifier reconstructs from `verify_stir`. `None` if the commitment has no
+    ///   matrices at this bucket's LDE height.
     type Proof = Vec<(
         StirProof<Challenge, StirMmcs, Val>,
-        Vec<Vec<BatchOpening<Val, InputMmcs>>>,
+        Vec<Option<InputOpenings<Val, InputMmcs>>>,
     )>;
     type Error = StirError<StirMmcs::Error, InputMmcs::Error>;
 
@@ -365,28 +387,37 @@ where
             let fold_height0 = (1usize << stir_config.log_starting_domain_size()) >> log_arity0;
             let arity0 = 1usize << log_arity0;
 
-            let input_openings: Vec<Vec<BatchOpening<Val, InputMmcs>>> =
+            let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
                 commitment_data_with_opening_points
                     .iter()
                     .map(|(data, _)| {
                         let mats = self.input_mmcs.get_matrices(data);
                         if !mats.iter().any(|m| m.height() == bucket_height) {
-                            return Vec::new();
+                            return None;
                         }
                         let commit_max_height = mats.iter().map(|m| m.height()).max().unwrap();
                         let log_commit_max = log2_strict_usize(commit_max_height);
 
-                        first_round_query_indices
+                        // Flatten every `(query, fiber column)` position into one index list so
+                        // a single multi-opening proof covers the whole bucket for this
+                        // commitment, sharing sibling digests across positions.
+                        let q_globals: Vec<usize> = first_round_query_indices
                             .iter()
                             .flat_map(|&j| {
                                 (0..arity0).map(move |l| {
                                     let p = j + l * fold_height0;
                                     let q_local = reverse_bits_len(p, log_h);
-                                    let q_global = q_local << (log_commit_max - log_h);
-                                    self.input_mmcs.open_batch(q_global, data)
+                                    q_local << (log_commit_max - log_h)
                                 })
                             })
-                            .collect()
+                            .collect();
+
+                        let (opened_values, opening_proof) =
+                            self.input_mmcs.open_multi_batch(&q_globals, data);
+                        Some(InputOpenings {
+                            opened_values,
+                            opening_proof,
+                        })
                     })
                     .collect();
 
@@ -547,7 +578,7 @@ where
             // happen to exercise, mask the multi-commit case entirely).
             let mut expected_ro = vec![vec![Challenge::ZERO; arity0]; n_q];
 
-            for (commit_idx, ((commitment, domain_claims), per_commit_openings)) in
+            for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                 commitments_with_opening_points
                     .iter()
                     .zip(input_openings.iter())
@@ -560,16 +591,17 @@ where
 
                 let has_at_bucket = mat_lde_heights.contains(&bucket_height);
 
-                // SHAPE CHECK: per-commit opening count is determined entirely by public
-                // input. Validating up-front turns any mismatch into a clean
-                // `InvalidProofShape` instead of an out-of-bounds panic on adversarial input.
-                let expected_openings_len = if has_at_bucket { n_q * arity0 } else { 0 };
-                if per_commit_openings.len() != expected_openings_len {
-                    return Err(StirError::InvalidProofShape);
-                }
-
-                if !has_at_bucket {
+                // SHAPE CHECK: whether an opening is present at all is determined entirely by
+                // public input. Validating up-front turns a mismatch into a clean
+                // `InvalidProofShape` instead of silently skipping a binding check.
+                let Some(opening) = per_commit_opening else {
+                    if has_at_bucket {
+                        return Err(StirError::InvalidProofShape);
+                    }
                     continue;
+                };
+                if !has_at_bucket {
+                    return Err(StirError::InvalidProofShape);
                 }
 
                 let commit_max_height = mat_lde_heights.iter().copied().max().unwrap();
@@ -591,6 +623,34 @@ where
                     })
                     .collect();
 
+                // Flatten the `(query, fiber column)` positions in the same order the prover
+                // used to build `opening.opened_values`.
+                let q_globals: Vec<usize> = first_round_unique_js
+                    .iter()
+                    .flat_map(|&j| {
+                        (0..arity0).map(move |l| {
+                            let p = j + l * fold_height0;
+                            let q_local = reverse_bits_len(p, log_h);
+                            q_local << (log_commit_max - log_h)
+                        })
+                    })
+                    .collect();
+
+                // SHAPE CHECK: opened-row count is determined entirely by public input.
+                if opening.opened_values.len() != q_globals.len() {
+                    return Err(StirError::InvalidProofShape);
+                }
+
+                self.input_mmcs
+                    .verify_multi_batch(
+                        commitment,
+                        &dimensions,
+                        &q_globals,
+                        &opening.opened_values,
+                        &opening.opening_proof,
+                    )
+                    .map_err(StirError::InputError)?;
+
                 let mut opening_idx = 0usize;
 
                 for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
@@ -598,25 +658,16 @@ where
                     for l in 0..arity0 {
                         let p = j + l * fold_height0;
                         let q_local = reverse_bits_len(p, log_h);
-                        let q_global = q_local << (log_commit_max - log_h);
 
-                        let batch_open = &per_commit_openings[opening_idx];
+                        let row_vals_by_mat = &opening.opened_values[opening_idx];
                         opening_idx += 1;
-
-                        let batch_ref = BatchOpeningRef::new(
-                            &batch_open.opened_values,
-                            &batch_open.opening_proof,
-                        );
-                        self.input_mmcs
-                            .verify_batch(commitment, &dimensions, q_global, batch_ref)
-                            .map_err(StirError::InputError)?;
 
                         for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate() {
                             if mat_lde_heights[mat_idx] != bucket_height {
                                 continue;
                             }
 
-                            let row_vals = &batch_open.opened_values[mat_idx];
+                            let row_vals = &row_vals_by_mat[mat_idx];
                             let p_x: Challenge = row_vals
                                 .iter()
                                 .zip(alpha_powers.iter())

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -28,8 +28,9 @@ pub struct StirProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// Proof-of-work witness for the final query phase.
     pub final_pow_witness: Witness,
 
-    /// Merkle openings for the final consistency queries against the last committed codeword.
-    pub final_query_proofs: Vec<StirFinalQueryProof<EF, M>>,
+    /// Merkle openings for the final consistency queries against the last committed codeword,
+    /// sharing one pruned multi-opening proof.
+    pub final_query_openings: StirQueryOpenings<EF, M>,
 }
 
 /// Proof for a single STIR round.
@@ -68,37 +69,31 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// malicious prover cannot fit `Ans` to a known `rho`.
     pub shake_polynomial: Vec<EF>,
 
-    /// Merkle openings for each STIR query.
-    pub query_proofs: Vec<StirQueryProof<EF, M>>,
+    /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.
+    pub query_openings: StirQueryOpenings<EF, M>,
 }
 
-/// Merkle opening and fiber evaluations for a single STIR query.
+/// Batched Merkle openings and fiber evaluations for the queries of one round.
 ///
-/// The opened row is taken from the CURRENT commitment:
+/// The opened rows are taken from the CURRENT commitment:
 /// - in round 0 this is the current oracle itself,
 /// - in later rounds this is the previous round's folded oracle `g_i`.
 ///
-/// The verifier translates the opened row into current-round oracle values before
+/// The verifier translates each opened row into current-round oracle values before
 /// applying the fold.
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "")]
-pub struct StirQueryProof<EF: Field, M: Mmcs<EF>> {
-    /// The opened row from the current commitment's fiber matrix.
-    pub row_evals: Vec<EF>,
-
-    /// Merkle opening proof authenticating `row_evals` against the current commitment.
-    pub opening_proof: M::Proof,
-}
-
-/// Merkle opening and fiber evaluations for a final-round query.
 ///
-/// Used to verify consistency between the last virtual oracle and the final polynomial.
+/// One multi-opening proof authenticates every row together, so sibling digests shared
+/// between queries — including queries that land on the same index — travel once.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound = "")]
-pub struct StirFinalQueryProof<EF: Field, M: Mmcs<EF>> {
-    /// The opened row from the last commitment's fiber matrix.
-    pub row_evals: Vec<EF>,
+#[serde(bound(
+    serialize = "M::MultiProof: Serialize",
+    deserialize = "M::MultiProof: Deserialize<'de>"
+))]
+pub struct StirQueryOpenings<EF: Field, M: Mmcs<EF>> {
+    /// `row_evals[q]` is the opened row from the current commitment's fiber matrix at the
+    /// `q`-th queried position, in query order.
+    pub row_evals: Vec<Vec<EF>>,
 
-    /// Merkle opening proof authenticating `row_evals` against the last committed codeword.
-    pub opening_proof: M::Proof,
+    /// Compact multi-opening proof authenticating every row at once.
+    pub opening_proof: M::MultiProof,
 }

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -9,7 +9,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{BatchOpening, Mmcs};
+use p3_commit::Mmcs;
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{
     BasedVectorSpace, ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse,
@@ -19,7 +19,7 @@ use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::config::StirConfig;
-use crate::proof::{StirFinalQueryProof, StirProof, StirQueryProof, StirRoundProof};
+use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
     compute_shake_polynomial, degree_correction_poly, eval_poly, fold_codeword, interpolate_poly,
     next_domain_shift, vanishing_poly_from_roots,
@@ -189,7 +189,7 @@ where
         // Step 4: Query sampling.
         let fold_gen = F::two_adic_generator(fold_log_domain);
 
-        let mut query_proofs = Vec::with_capacity(rc.num_queries);
+        let mut query_indices = Vec::with_capacity(rc.num_queries);
         let mut query_points = Vec::with_capacity(rc.num_queries);
         let mut query_answers = Vec::with_capacity(rc.num_queries);
 
@@ -197,8 +197,6 @@ where
             alloc::collections::BTreeSet::new();
 
         let r_comb: EF = challenger.sample_algebra_element();
-
-        let current_opening_data = &current_commit_data;
 
         for _ in 0..rc.num_queries {
             // `RESAMPLE = true`: the challenger loops on field-side rejection internally,
@@ -210,20 +208,22 @@ where
                 .expect("RESAMPLE = true: rejection loops internally, never errors");
             let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
 
-            let opening = config.mmcs.open_batch(j, current_opening_data);
-            let (row_evals, opening_proof) = into_single_opened_row(opening);
-            debug_assert_eq!(row_evals.len(), arity);
-
-            query_proofs.push(StirQueryProof {
-                row_evals,
-                opening_proof,
-            });
+            query_indices.push(j);
 
             if seen_query_indices.insert(j) {
                 query_points.push(fold_point);
                 query_answers.push(folded_codeword[j]);
             }
         }
+
+        // One shared, pruned multi-opening proof for every query drawn this round.
+        let query_openings = open_fiber_rows(&config.mmcs, &query_indices, &current_commit_data);
+        debug_assert!(
+            query_openings
+                .row_evals
+                .iter()
+                .all(|row| row.len() == arity)
+        );
 
         // Collect first-round query indices for the PCS binding check.
         if round == 0 {
@@ -287,7 +287,7 @@ where
             pow_witness,
             ans_polynomial: ans_poly,
             shake_polynomial: shake_poly,
-            query_proofs,
+            query_openings,
         });
 
         current_oracle_codeword = next_oracle_codeword;
@@ -322,21 +322,24 @@ where
     challenger.observe_algebra_slice(&final_poly);
     let final_pow_witness = challenger.grind(config.final_pow_bits);
 
-    let mut final_query_proofs = Vec::with_capacity(config.final_queries);
+    let mut final_query_indices = Vec::with_capacity(config.final_queries);
     let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
     for _ in 0..config.final_queries {
         let j = challenger
             .sample_uniform_bits::<true>(final_new_log_domain)
             .expect("RESAMPLE = true: rejection loops internally, never errors");
         final_seen.insert(j);
-        let opening = config.mmcs.open_batch(j, &current_commit_data);
-        let (row_evals, opening_proof) = into_single_opened_row(opening);
-        debug_assert_eq!(row_evals.len(), final_arity);
-        final_query_proofs.push(StirFinalQueryProof {
-            row_evals,
-            opening_proof,
-        });
+        final_query_indices.push(j);
     }
+
+    let final_query_openings =
+        open_fiber_rows(&config.mmcs, &final_query_indices, &current_commit_data);
+    debug_assert!(
+        final_query_openings
+            .row_evals
+            .iter()
+            .all(|row| row.len() == final_arity)
+    );
 
     // When there are no intermediate rounds the final queries target the
     // initial codeword.  Expose them for PCS input binding.
@@ -350,7 +353,7 @@ where
         final_polynomial: final_poly,
         final_folding_pow_witness,
         final_pow_witness,
-        final_query_proofs,
+        final_query_openings,
     };
     (proof, first_round_query_indices)
 }
@@ -415,17 +418,27 @@ fn commit_as_fiber_matrix<EF: Field, M: Mmcs<EF>>(
     mmcs.commit_matrix(RowMajorMatrix::new(matrix, arity))
 }
 
-fn into_single_opened_row<EF: Field, M: Mmcs<EF>>(
-    opening: BatchOpening<EF, M>,
-) -> (Vec<EF>, M::Proof) {
-    let (mut opened_values, opening_proof) = opening.unpack();
-    assert_eq!(
-        opened_values.len(),
-        1,
-        "STIR commits exactly one codeword matrix"
-    );
-    let row_evals = opened_values
-        .pop()
-        .expect("STIR commits exactly one codeword matrix");
-    (row_evals, opening_proof)
+/// Opens `indices` against the current commitment's fiber matrix as one shared, pruned
+/// multi-opening proof.
+fn open_fiber_rows<EF: Field, M: Mmcs<EF>>(
+    mmcs: &M,
+    indices: &[usize],
+    prover_data: &M::ProverData<RowMajorMatrix<EF>>,
+) -> StirQueryOpenings<EF, M> {
+    let (values, opening_proof) = mmcs.open_multi_batch(indices, prover_data);
+    let row_evals = values
+        .into_iter()
+        .map(|mut per_matrix| {
+            assert_eq!(
+                per_matrix.len(),
+                1,
+                "STIR commits exactly one codeword matrix"
+            );
+            per_matrix.swap_remove(0)
+        })
+        .collect();
+    StirQueryOpenings {
+        row_evals,
+        opening_proof,
+    }
 }

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -67,6 +67,18 @@ where
     )
 }
 
+/// Wraps each opened row as a single-matrix batch for [`Mmcs::verify_multi_batch`].
+///
+/// `verify_multi_batch` takes `opened_values[query][matrix]` to support batches spanning
+/// several committed matrices at once; STIR only ever commits one matrix per round, so every
+/// inner `Vec` here always holds exactly one row slice.
+fn single_matrix_opened_values<EF>(row_evals: &[Vec<EF>]) -> Vec<Vec<&[EF]>> {
+    row_evals
+        .iter()
+        .map(|row| alloc::vec![row.as_slice()])
+        .collect()
+}
+
 /// Errors returned by [`verify_stir`].
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum StirError<MmcsError, InputError = ()> {
@@ -287,12 +299,7 @@ where
 
         // Step 4b: one shared, pruned Merkle multi-opening proof authenticates every query
         // row against the current commitment at once.
-        let opened_values: Vec<Vec<&[EF]>> = rp
-            .query_openings
-            .row_evals
-            .iter()
-            .map(|row| alloc::vec![row.as_slice()])
-            .collect();
+        let opened_values = single_matrix_opened_values(&rp.query_openings.row_evals);
         config
             .mmcs
             .verify_multi_batch(
@@ -454,12 +461,7 @@ where
         return Err(StirError::InvalidProofShape);
     }
 
-    let opened_values: Vec<Vec<&[EF]>> = proof
-        .final_query_openings
-        .row_evals
-        .iter()
-        .map(|row| alloc::vec![row.as_slice()])
-        .collect();
+    let opened_values = single_matrix_opened_values(&proof.final_query_openings.row_evals);
     config
         .mmcs
         .verify_multi_batch(

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -3,7 +3,7 @@
 use alloc::vec::Vec;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_commit::{BatchOpeningRef, Mmcs};
+use p3_commit::Mmcs;
 use p3_field::{BasedVectorSpace, ExtensionField, TwoAdicField, batch_multiplicative_inverse};
 use p3_matrix::Dimensions;
 use thiserror::Error;
@@ -74,11 +74,10 @@ pub enum StirError<MmcsError, InputError = ()> {
     #[error("Invalid proof-of-work witness in round {round}")]
     InvalidPowWitness { round: usize },
 
-    /// A Merkle opening proof failed.
-    #[error("Invalid MMCS opening proof in round {round}, query {query}")]
+    /// A Merkle multi-opening proof failed for a round's queries.
+    #[error("Invalid MMCS opening proof in round {round}")]
     InvalidMmcsProof {
         round: usize,
-        query: usize,
         #[source]
         source: MmcsError,
     },
@@ -115,15 +114,9 @@ impl<E1, IE1> StirError<E1, IE1> {
     pub fn map_input_err<IE2>(self, f: impl FnOnce(IE1) -> IE2) -> StirError<E1, IE2> {
         match self {
             Self::InvalidPowWitness { round } => StirError::InvalidPowWitness { round },
-            Self::InvalidMmcsProof {
-                round,
-                query,
-                source,
-            } => StirError::InvalidMmcsProof {
-                round,
-                query,
-                source,
-            },
+            Self::InvalidMmcsProof { round, source } => {
+                StirError::InvalidMmcsProof { round, source }
+            }
             Self::InvalidShakeConsistency { round } => StirError::InvalidShakeConsistency { round },
             Self::InvalidRoundConsistency { round, query } => {
                 StirError::InvalidRoundConsistency { round, query }
@@ -258,7 +251,7 @@ where
 
         // Step 4: combination challenge, query sampling, and fiber verification.
 
-        if rp.query_proofs.len() != rc.num_queries {
+        if rp.query_openings.row_evals.len() != rc.num_queries {
             return Err(StirError::InvalidProofShape);
         }
 
@@ -270,41 +263,63 @@ where
             width: arity
         }];
 
+        let r_comb: EF = challenger.sample_algebra_element();
+
+        // Step 4a: sample every query index first, in draw order, mirroring the prover's
+        // unbiased-sampling policy so the Fiat-Shamir transcript stays in sync. Merkle
+        // verification is deferred to a single shared multi-opening check below.
+        let mut query_indices: Vec<usize> = Vec::with_capacity(rc.num_queries);
+        for _ in 0..rc.num_queries {
+            let j = challenger
+                .sample_uniform_bits::<true>(fold_log_domain)
+                .expect("RESAMPLE = true: rejection loops internally, never errors");
+            query_indices.push(j);
+        }
+
+        if rp
+            .query_openings
+            .row_evals
+            .iter()
+            .any(|row| row.len() != arity)
+        {
+            return Err(StirError::InvalidProofShape);
+        }
+
+        // Step 4b: one shared, pruned Merkle multi-opening proof authenticates every query
+        // row against the current commitment at once.
+        let opened_values: Vec<Vec<&[EF]>> = rp
+            .query_openings
+            .row_evals
+            .iter()
+            .map(|row| alloc::vec![row.as_slice()])
+            .collect();
+        config
+            .mmcs
+            .verify_multi_batch(
+                cur_commit,
+                &cur_dimensions,
+                &query_indices,
+                &opened_values,
+                &rp.query_openings.opening_proof,
+            )
+            .map_err(|source| StirError::InvalidMmcsProof { round, source })?;
+
+        // Step 4c: per-query virtual-oracle materialization and folding.
         let mut query_points: Vec<EF> = Vec::with_capacity(rc.num_queries);
         let mut query_answers: Vec<EF> = Vec::with_capacity(rc.num_queries);
 
         let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
             alloc::collections::BTreeSet::new();
 
-        let r_comb: EF = challenger.sample_algebra_element();
-
-        for (q, qp) in rp.query_proofs.iter().enumerate() {
-            // See `prover.rs` for the unbiased-sampling rationale; the verifier must mirror
-            // the prover's draw policy exactly to keep the Fiat-Shamir transcript in sync.
-            let j = challenger
-                .sample_uniform_bits::<true>(fold_log_domain)
-                .expect("RESAMPLE = true: rejection loops internally, never errors");
-            if qp.row_evals.len() != arity {
-                return Err(StirError::InvalidProofShape);
-            }
-
+        for (q, (&j, row_evals)) in query_indices
+            .iter()
+            .zip(&rp.query_openings.row_evals)
+            .enumerate()
+        {
             let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
 
-            // Verify the Merkle opening of the current commitment at row j.
-            let opened_values: alloc::vec::Vec<alloc::vec::Vec<EF>> =
-                alloc::vec![qp.row_evals.clone()];
-            let batch_opening = BatchOpeningRef::new(&opened_values, &qp.opening_proof);
-            config
-                .mmcs
-                .verify_batch(cur_commit, &cur_dimensions, j, batch_opening)
-                .map_err(|source| StirError::InvalidMmcsProof {
-                    round,
-                    query: q,
-                    source,
-                })?;
-
             let current_fiber = materialize_virtual_fiber::<F, EF>(
-                &qp.row_evals,
+                row_evals,
                 j,
                 fold_height,
                 current_log_domain,
@@ -320,7 +335,7 @@ where
                 query_points.push(fold_point);
                 query_answers.push(fold_val);
                 if round == 0 {
-                    first_round_pairs.push((j, qp.row_evals.clone()));
+                    first_round_pairs.push((j, row_evals.clone()));
                 }
             }
         }
@@ -404,7 +419,7 @@ where
         return Err(StirError::InvalidPowWitness { round: num_rounds });
     }
 
-    if proof.final_query_proofs.len() != config.final_queries {
+    if proof.final_query_openings.row_evals.len() != config.final_queries {
         return Err(StirError::InvalidProofShape);
     }
 
@@ -420,33 +435,56 @@ where
     }];
     let final_gen = F::two_adic_generator(final_new_log_domain);
 
+    // Sample every final-round query index first, deferring Merkle verification to a single
+    // shared multi-opening check below.
+    let mut final_indices: Vec<usize> = Vec::with_capacity(config.final_queries);
+    for _ in 0..config.final_queries {
+        let j = challenger
+            .sample_uniform_bits::<true>(final_new_log_domain)
+            .expect("RESAMPLE = true: rejection loops internally, never errors");
+        final_indices.push(j);
+    }
+
+    if proof
+        .final_query_openings
+        .row_evals
+        .iter()
+        .any(|row| row.len() != final_arity)
+    {
+        return Err(StirError::InvalidProofShape);
+    }
+
+    let opened_values: Vec<Vec<&[EF]>> = proof
+        .final_query_openings
+        .row_evals
+        .iter()
+        .map(|row| alloc::vec![row.as_slice()])
+        .collect();
+    config
+        .mmcs
+        .verify_multi_batch(
+            last_commit,
+            &final_dimensions,
+            &final_indices,
+            &opened_values,
+            &proof.final_query_openings.opening_proof,
+        )
+        .map_err(|source| StirError::InvalidMmcsProof {
+            round: num_rounds,
+            source,
+        })?;
+
     // When num_rounds == 0 the final queries also serve as the PCS first-round binding.
     // Track them with the same dedup-on-first-occurrence rule as the intermediate-round path.
     let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
 
-    for (q, fqp) in proof.final_query_proofs.iter().enumerate() {
-        let j = challenger
-            .sample_uniform_bits::<true>(final_new_log_domain)
-            .expect("RESAMPLE = true: rejection loops internally, never errors");
-
-        if fqp.row_evals.len() != final_arity {
-            return Err(StirError::InvalidProofShape);
-        }
-
-        let opened_values: alloc::vec::Vec<alloc::vec::Vec<EF>> =
-            alloc::vec![fqp.row_evals.clone()];
-        let batch_opening = BatchOpeningRef::new(&opened_values, &fqp.opening_proof);
-        config
-            .mmcs
-            .verify_batch(last_commit, &final_dimensions, j, batch_opening)
-            .map_err(|source| StirError::InvalidMmcsProof {
-                round: num_rounds,
-                query: q,
-                source,
-            })?;
-
+    for (q, (&j, row_evals)) in final_indices
+        .iter()
+        .zip(&proof.final_query_openings.row_evals)
+        .enumerate()
+    {
         let current_fiber = materialize_virtual_fiber::<F, EF>(
-            &fqp.row_evals,
+            row_evals,
             j,
             final_new_height,
             current_log_domain,
@@ -474,7 +512,7 @@ where
         }
 
         if num_rounds == 0 && final_seen.insert(j) {
-            first_round_pairs.push((j, fqp.row_evals.clone()));
+            first_round_pairs.push((j, row_evals.clone()));
         }
     }
 

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -436,6 +436,92 @@ mod babybear_stir {
         );
     }
 
+    /// Swapping two `row_evals` entries keeps every length check happy (same count, same
+    /// per-row width), so only the positional binding between `row_evals` and the
+    /// transcript-derived `query_indices` inside Merkle verification can catch it.
+    #[test]
+    fn test_permuted_row_evals_rejected() {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let degree = 1usize << log_degree;
+        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let mut p_challenger = challenger.clone();
+        let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+
+        let row_evals = &mut proof.round_proofs[0].query_openings.row_evals;
+        assert!(row_evals.len() >= 2, "need at least two queries to permute");
+        assert_ne!(
+            row_evals[0], row_evals[1],
+            "rows must differ for the permutation to change anything"
+        );
+        row_evals.swap(0, 1);
+
+        let mut v_challenger = challenger;
+        assert!(
+            verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err(),
+            "permuted row_evals must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_tampered_pruned_sibling_rejected() {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let degree = 1usize << log_degree;
+        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let mut p_challenger = challenger.clone();
+        let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+
+        let sibs = &mut proof.round_proofs[0]
+            .query_openings
+            .opening_proof
+            .sibling_hashes;
+        assert!(!sibs.is_empty());
+        sibs[0][0] += F::ONE;
+
+        let mut v_challenger = challenger;
+        let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+            .expect_err("tampered sibling hash must be rejected");
+        assert!(matches!(
+            err,
+            p3_stir::StirError::InvalidMmcsProof { round: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn test_dropped_pruned_sibling_rejected() {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let degree = 1usize << log_degree;
+        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let mut p_challenger = challenger.clone();
+        let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+
+        let sibs = &mut proof.round_proofs[0]
+            .query_openings
+            .opening_proof
+            .sibling_hashes;
+        assert!(!sibs.is_empty());
+        sibs.pop();
+
+        let mut v_challenger = challenger;
+        let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+            .expect_err("dropped sibling hash must be rejected");
+        assert!(matches!(
+            err,
+            p3_stir::StirError::InvalidMmcsProof { round: 0, .. }
+        ));
+    }
+
     #[test]
     fn test_tampered_ood_answer_fails() {
         let (params, dft, challenger) = make_params(1, 2);
@@ -1137,6 +1223,108 @@ mod babybear_pcs {
         assert!(
             matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
             "truncated input_openings must be rejected as InvalidProofShape, got {res:?}"
+        );
+    }
+
+    /// A present-but-should-be-`Some` per-commitment input opening turned into `None` must
+    /// be rejected. This is distinct from truncation: the slot still exists at the right
+    /// index, only its content is dropped, so only the `has_at_bucket` shape check (not a
+    /// length mismatch) can catch it.
+    #[test]
+    fn test_pcs_input_opening_present_to_none_rejected() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let log_d = 6;
+        let width = 3;
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat_a = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+        let mat_b = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit_a, data_a) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
+        p_ch.observe(commit_a.clone());
+        let (commit_b, data_b) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
+        p_ch.observe(commit_b.clone());
+
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
+        let (opening_values, mut proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+
+        // Both commitments land in the same bucket, so both slots start as `Some`. Blank
+        // out the first one in place, keeping the vector's length untouched.
+        for (_stir_proof, input_openings) in proof.iter_mut() {
+            assert_eq!(input_openings.len(), 2);
+            assert!(input_openings[0].is_some());
+            input_openings[0] = None;
+        }
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit_a.clone());
+        v_ch.observe(commit_b.clone());
+        let _v_zeta: Challenge = v_ch.sample_algebra_element();
+
+        let opening_a = opening_values[0][0][0].clone();
+        let opening_b = opening_values[1][0][0].clone();
+        let claims = vec![
+            (commit_a, vec![(domain, vec![(zeta, opening_a)])]),
+            (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
+        ];
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        assert!(
+            matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
+            "Some -> None input opening must be rejected as InvalidProofShape, got {res:?}"
+        );
+    }
+
+    /// A per-commitment `opened_values` vector truncated to fewer rows than the queried
+    /// positions must be rejected before the MMCS multi-batch verification (which expects
+    /// matching lengths) is even called.
+    #[test]
+    fn test_pcs_opened_values_truncated_rejected() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+        let log_d = 6;
+        let width = 3;
+
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![(&data, vec![vec![zeta]])],
+            &mut p_ch,
+        );
+
+        for (_stir_proof, input_openings) in proof.iter_mut() {
+            let opening = input_openings[0]
+                .as_mut()
+                .expect("single commitment must have a present opening");
+            assert!(!opening.opened_values.is_empty());
+            opening.opened_values.pop();
+        }
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let opening = opening_values[0][0][0].clone();
+        let claims = vec![(commit, vec![(domain, vec![(zeta, opening)])])];
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        assert!(
+            matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
+            "truncated opened_values must be rejected as InvalidProofShape, got {res:?}"
         );
     }
 

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -408,7 +408,10 @@ mod babybear_stir {
             assert_eq!(rp_a.ood_answers, rp_b.ood_answers);
             assert_eq!(rp_a.ans_polynomial, rp_b.ans_polynomial);
             assert_eq!(rp_a.shake_polynomial, rp_b.shake_polynomial);
-            assert_eq!(rp_a.query_proofs.len(), rp_b.query_proofs.len());
+            assert_eq!(
+                rp_a.query_openings.row_evals.len(),
+                rp_b.query_openings.row_evals.len()
+            );
         }
     }
 
@@ -424,8 +427,8 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        assert!(!proof.round_proofs[0].query_proofs.is_empty());
-        proof.round_proofs[0].query_proofs[0].row_evals[0] += EF::from(F::ONE);
+        assert!(!proof.round_proofs[0].query_openings.row_evals.is_empty());
+        proof.round_proofs[0].query_openings.row_evals[0][0] += EF::from(F::ONE);
 
         let mut v_challenger = challenger;
         assert!(
@@ -536,14 +539,14 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _idx) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        assert!(!proof.final_query_proofs.is_empty());
-        assert!(!proof.final_query_proofs[0].row_evals.is_empty());
-        proof.final_query_proofs[0].row_evals[0] += EF::from(F::ONE);
+        assert!(!proof.final_query_openings.row_evals.is_empty());
+        assert!(!proof.final_query_openings.row_evals[0].is_empty());
+        proof.final_query_openings.row_evals[0][0] += EF::from(F::ONE);
 
         let mut v_challenger = challenger;
         assert!(
             verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err(),
-            "tampered final_query_proofs.row_evals must be rejected"
+            "tampered final_query_openings.row_evals must be rejected"
         );
     }
 
@@ -936,8 +939,8 @@ mod babybear_pcs {
         );
 
         // This intentionally measures serialized PCS proof objects only. Opened values are
-        // excluded because both proofs open the same point and width. The always-running test
-        // reports the current sizes; the ignored regression below records the intended ordering.
+        // excluded because both proofs open the same point and width. This test reports the
+        // current sizes; the regression below asserts the intended ordering.
         (stir_bytes.len(), fri_bytes.len())
     }
 
@@ -951,7 +954,6 @@ mod babybear_pcs {
     }
 
     #[test]
-    #[ignore = "TODO(#1917, #1919): port pruned MMCS openings to STIR"]
     fn assert_stir_proof_smaller_than_binary_fri() {
         const WIDTH: usize = 3;
 


### PR DESCRIPTION
STIR proofs are now 1.41x–1.57x smaller than binary FRI at the tested sizes