### PR TITLE
chore: release v0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,50 +99,50 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 ] }
 
 # Local dependencies
-p3-air = { path = "air", version = "0.6.2" }
-p3-baby-bear = { path = "baby-bear", version = "0.6.2" }
-p3-blake3 = { path = "blake3", version = "0.6.2" }
-p3-blake3-air = { path = "blake3-air", version = "0.6.2" }
-p3-bn254 = { path = "bn254", version = "0.6.2" }
-p3-challenger = { path = "challenger", version = "0.6.2" }
-p3-circle = { path = "circle", version = "0.6.2" }
-p3-commit = { path = "commit", version = "0.6.2" }
-p3-dft = { path = "dft", version = "0.6.2" }
+p3-air = { path = "air", version = "0.6.3" }
+p3-baby-bear = { path = "baby-bear", version = "0.6.3" }
+p3-blake3 = { path = "blake3", version = "0.6.3" }
+p3-blake3-air = { path = "blake3-air", version = "0.6.3" }
+p3-bn254 = { path = "bn254", version = "0.6.3" }
+p3-challenger = { path = "challenger", version = "0.6.3" }
+p3-circle = { path = "circle", version = "0.6.3" }
+p3-commit = { path = "commit", version = "0.6.3" }
+p3-dft = { path = "dft", version = "0.6.3" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.6.2" }
-p3-field-testing = { path = "field-testing", version = "0.6.2" }
-p3-fri = { path = "fri", version = "0.6.2" }
-p3-goldilocks = { path = "goldilocks", version = "0.6.2" }
-p3-keccak = { path = "keccak", version = "0.6.2" }
-p3-keccak-air = { path = "keccak-air", version = "0.6.2" }
-p3-koala-bear = { path = "koala-bear", version = "0.6.2" }
-p3-lookup = { path = "lookup", version = "0.6.2" }
-p3-matrix = { path = "matrix", version = "0.6.2" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.2" }
-p3-mds = { path = "mds", version = "0.6.2" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.6.2" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.6.2" }
-p3-monolith = { path = "monolith", version = "0.6.2" }
-p3-monolith-air = { path = "monolith-air", version = "0.6.2" }
-p3-monty-31 = { path = "monty-31", version = "0.6.2" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.6.2" }
-p3-poseidon1 = { path = "poseidon1", version = "0.6.2" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.2" }
-p3-poseidon2 = { path = "poseidon2", version = "0.6.2" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.2" }
-p3-rescue = { path = "rescue", version = "0.6.2" }
-p3-sha256 = { path = "sha256", version = "0.6.2" }
-p3-sumcheck = { path = "sumcheck", version = "0.6.2" }
-p3-symmetric = { path = "symmetric", version = "0.6.2" }
-p3-uni-stark = { path = "uni-stark", version = "0.6.2" }
-p3-util = { path = "util", version = "0.6.2" }
-p3-whir = { path = "whir", version = "0.6.2" }
-p3-zk-codes = { path = "zk-codes", version = "0.6.2" }
+p3-field = { path = "field", version = "0.6.3" }
+p3-field-testing = { path = "field-testing", version = "0.6.3" }
+p3-fri = { path = "fri", version = "0.6.3" }
+p3-goldilocks = { path = "goldilocks", version = "0.6.3" }
+p3-keccak = { path = "keccak", version = "0.6.3" }
+p3-keccak-air = { path = "keccak-air", version = "0.6.3" }
+p3-koala-bear = { path = "koala-bear", version = "0.6.3" }
+p3-lookup = { path = "lookup", version = "0.6.3" }
+p3-matrix = { path = "matrix", version = "0.6.3" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.3" }
+p3-mds = { path = "mds", version = "0.6.3" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.6.3" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.6.3" }
+p3-monolith = { path = "monolith", version = "0.6.3" }
+p3-monolith-air = { path = "monolith-air", version = "0.6.3" }
+p3-monty-31 = { path = "monty-31", version = "0.6.3" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.6.3" }
+p3-poseidon1 = { path = "poseidon1", version = "0.6.3" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.3" }
+p3-poseidon2 = { path = "poseidon2", version = "0.6.3" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.3" }
+p3-rescue = { path = "rescue", version = "0.6.3" }
+p3-sha256 = { path = "sha256", version = "0.6.3" }
+p3-sumcheck = { path = "sumcheck", version = "0.6.3" }
+p3-symmetric = { path = "symmetric", version = "0.6.3" }
+p3-uni-stark = { path = "uni-stark", version = "0.6.3" }
+p3-util = { path = "util", version = "0.6.3" }
+p3-whir = { path = "whir", version = "0.6.3" }
+p3-zk-codes = { path = "zk-codes", version = "0.6.3" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Fix(lookup): enforce uniform tuple width per bus and bound local lookup multiplicities (#1912)
+
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ### Merged PRs

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(blake3-air): remove redundant constraints and skip symbolic degree verification (#1933)

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Chore(deps): update num-bigint requirement from 0.4.6 to 0.5.1 in the cargo group (#1930)
+
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix: doc and light tweaks (#1920)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix(circle): allow quotient domain smaller than committed LDE (#1834)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(dft): skip zero-padding work in Radix2Dit coset LDE (#1832)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(whir): commit folded rounds straight from the live sumcheck buffer (#1804)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(fri): batch (z - x) inversions in the verifier (#1843)

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Perf(p3-goldilocks): add SVE2 vectorization (#1956)
+- Perf(p3-goldilocks): faster Goldilocks wasm simd128 backend (#1964)
+- Fix(goldilocks): canonicalize NEON add/sub operand to close second-order overflow (#1921)
+
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(keccak-air): cut redundant packed muls in eval() and dedupe padding trace gen (#1923)

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix: doc and light tweaks (#1920)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Fix(lookup): enforce uniform tuple width per bus and bound local lookup multiplicities (#1912)
+
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix: doc and light tweaks (#1920)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(matrix): gather packed rows without per-call allocation in the non-wrapping case (#1830)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix: doc and light tweaks (#1920)

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Fix: doc and light tweaks (#1920)

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(merkle-tree): hoist default_packed out of the per-chunk compression loop (#1839)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Test: add poseidon1-permutations objective in example (#1842)
+
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(mersenne-31): complex-squaring scalar QM31 square (#1831)

--- a/monolith-air/CHANGELOG.md
+++ b/monolith-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(monty-31): add NEON xor/andn Montgomery overrides (#1846)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(monty-31): use dedicated quintic_square kernel for QuinticTrinomial ext_square (#1829)

--- a/multi-stark/CHANGELOG.md
+++ b/multi-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Reuse LDE from `LdtBasedPcs` to compute quotient (#120)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(multilinear-util): fold suffix variable in place, drop the extra memcpy (#1841)

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf: add NEON vectorization for RPO on 31bit fields (#1899)

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/sumcheck/CHANGELOG.md
+++ b/sumcheck/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Test(whir): clarify and extend ZK simulation coverage (#1959)
+
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Bench(sumcheck): add generic Criterion benchmark suite (#1835)

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ### Merged PRs

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Refactor(util): replace `transpose` crate with portable engine (#1874)

--- a/whir/CHANGELOG.md
+++ b/whir/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
+### Merged PRs
+- Docs(whir): clarify randomized oracle geometry (#1961)
+- Test(whir): clarify and extend ZK simulation coverage (#1959)
+
 ## [0.6.2] - 2026-07-20
 ### Merged PRs
 - Perf(whir): drop redundant to_row_major_matrix after dft_algebra_batch (#1840)

--- a/zk-codes/CHANGELOG.md
+++ b/zk-codes/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.6.3] - 2026-07-30
 ## [0.6.2] - 2026-07-20
 ## [0.6.1] - 2026-06-13
 ## [0.6.0] - 2026-06-11


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.6.2 -> 0.6.3
* `p3-util`: 0.6.2 -> 0.6.3
* `p3-field`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-matrix`: 0.6.2 -> 0.6.3
* `p3-air`: 0.6.2 -> 0.6.3
* `p3-dft`: 0.6.2 -> 0.6.3
* `p3-symmetric`: 0.6.2 -> 0.6.3
* `p3-mds`: 0.6.2 -> 0.6.3
* `p3-poseidon1`: 0.6.2 -> 0.6.3
* `p3-poseidon2`: 0.6.2 -> 0.6.3
* `p3-monty-31`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-challenger`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-baby-bear`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-goldilocks`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-koala-bear`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-mersenne-31`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-bn254`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-field-testing`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-multilinear-util`: 0.6.2 -> 0.6.3
* `p3-commit`: 0.6.2 -> 0.6.3
* `p3-merkle-tree`: 0.6.2 -> 0.6.3
* `p3-blake3`: 0.6.2 -> 0.6.3
* `p3-keccak`: 0.6.2 -> 0.6.3
* `p3-rescue`: 0.6.2 -> 0.6.3
* `p3-fri`: 0.6.2 -> 0.6.3
* `p3-uni-stark`: 0.6.2 -> 0.6.3
* `p3-lookup`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-batch-stark`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-circle`: 0.6.2 -> 0.6.3
* `p3-blake3-air`: 0.6.2 -> 0.6.3
* `p3-keccak-air`: 0.6.2 -> 0.6.3
* `p3-poseidon1-air`: 0.6.2 -> 0.6.3
* `p3-poseidon2-air`: 0.6.2 -> 0.6.3
* `p3-sha256`: 0.6.2 -> 0.6.3
* `p3-monolith`: 0.6.2 -> 0.6.3
* `p3-monolith-air`: 0.6.2 -> 0.6.3
* `p3-multi-stark`: 0.6.2 -> 0.6.3
* `p3-zk-codes`: 0.6.2 -> 0.6.3
* `p3-sumcheck`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `p3-whir`: 0.6.2 -> 0.6.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>














## `p3-goldilocks`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Perf(p3-goldilocks): add SVE2 vectorization (#1956)
- Perf(p3-goldilocks): faster Goldilocks wasm simd128 backend (#1964)
- Fix(goldilocks): canonicalize NEON add/sub operand to close second-order overflow (#1921)
</blockquote>


## `p3-mersenne-31`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Test: add poseidon1-permutations objective in example (#1842)
</blockquote>

## `p3-bn254`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Chore(deps): update num-bigint requirement from 0.4.6 to 0.5.1 in the cargo group (#1930)
</blockquote>










## `p3-lookup`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Fix(lookup): enforce uniform tuple width per bus and bound local lookup multiplicities (#1912)
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Fix(lookup): enforce uniform tuple width per bus and bound local lookup multiplicities (#1912)
</blockquote>











## `p3-sumcheck`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Test(whir): clarify and extend ZK simulation coverage (#1959)
</blockquote>

## `p3-whir`

<blockquote>

## [0.6.3] - 2026-07-30

### Merged PRs
- Docs(whir): clarify randomized oracle geometry (#1961)
- Test(whir): clarify and extend ZK simulation coverage (#1959)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).