### PR TITLE
chore: release v0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,46 +89,46 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 transpose = "0.2.3"
 
 # Local dependencies
-p3-air = { path = "air", version = "0.5.3" }
-p3-baby-bear = { path = "baby-bear", version = "0.5.3" }
-p3-blake3 = { path = "blake3", version = "0.5.3" }
-p3-blake3-air = { path = "blake3-air", version = "0.5.3" }
-p3-bn254 = { path = "bn254", version = "0.5.3" }
-p3-challenger = { path = "challenger", version = "0.5.3" }
-p3-circle = { path = "circle", version = "0.5.3" }
-p3-commit = { path = "commit", version = "0.5.3" }
-p3-dft = { path = "dft", version = "0.5.3" }
+p3-air = { path = "air", version = "0.5.4" }
+p3-baby-bear = { path = "baby-bear", version = "0.5.4" }
+p3-blake3 = { path = "blake3", version = "0.5.4" }
+p3-blake3-air = { path = "blake3-air", version = "0.5.4" }
+p3-bn254 = { path = "bn254", version = "0.5.4" }
+p3-challenger = { path = "challenger", version = "0.5.4" }
+p3-circle = { path = "circle", version = "0.5.4" }
+p3-commit = { path = "commit", version = "0.5.4" }
+p3-dft = { path = "dft", version = "0.5.4" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.5.3" }
-p3-field-testing = { path = "field-testing", version = "0.5.3" }
-p3-fri = { path = "fri", version = "0.5.3" }
-p3-goldilocks = { path = "goldilocks", version = "0.5.3" }
-p3-interpolation = { path = "interpolation", version = "0.5.3" }
-p3-keccak = { path = "keccak", version = "0.5.3" }
-p3-keccak-air = { path = "keccak-air", version = "0.5.3" }
-p3-koala-bear = { path = "koala-bear", version = "0.5.3" }
-p3-lookup = { path = "lookup", version = "0.5.3" }
-p3-matrix = { path = "matrix", version = "0.5.3" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.5.3" }
-p3-mds = { path = "mds", version = "0.5.3" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.5.3" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.5.3" }
-p3-monty-31 = { path = "monty-31", version = "0.5.3" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.5.3" }
-p3-poseidon1 = { path = "poseidon1", version = "0.5.3" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.5.3" }
-p3-poseidon2 = { path = "poseidon2", version = "0.5.3" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.5.3" }
-p3-rescue = { path = "rescue", version = "0.5.3" }
-p3-sha256 = { path = "sha256", version = "0.5.3" }
-p3-symmetric = { path = "symmetric", version = "0.5.3" }
-p3-uni-stark = { path = "uni-stark", version = "0.5.3" }
-p3-util = { path = "util", version = "0.5.3" }
+p3-field = { path = "field", version = "0.5.4" }
+p3-field-testing = { path = "field-testing", version = "0.5.4" }
+p3-fri = { path = "fri", version = "0.5.4" }
+p3-goldilocks = { path = "goldilocks", version = "0.5.4" }
+p3-interpolation = { path = "interpolation", version = "0.5.4" }
+p3-keccak = { path = "keccak", version = "0.5.4" }
+p3-keccak-air = { path = "keccak-air", version = "0.5.4" }
+p3-koala-bear = { path = "koala-bear", version = "0.5.4" }
+p3-lookup = { path = "lookup", version = "0.5.4" }
+p3-matrix = { path = "matrix", version = "0.5.4" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.5.4" }
+p3-mds = { path = "mds", version = "0.5.4" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.5.4" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.5.4" }
+p3-monty-31 = { path = "monty-31", version = "0.5.4" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.5.4" }
+p3-poseidon1 = { path = "poseidon1", version = "0.5.4" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.5.4" }
+p3-poseidon2 = { path = "poseidon2", version = "0.5.4" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.5.4" }
+p3-rescue = { path = "rescue", version = "0.5.4" }
+p3-sha256 = { path = "sha256", version = "0.5.4" }
+p3-symmetric = { path = "symmetric", version = "0.5.4" }
+p3-uni-stark = { path = "uni-stark", version = "0.5.4" }
+p3-util = { path = "util", version = "0.5.4" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Air: document virtual pair column composition patterns (#1419)

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf(monty-31/neon): specialized exp_4 skipping intermediate reduction (#1558)

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Fix(batch-stark): correct misleading degree_bits documentation (#1437)

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf(circle): drop vp_denoms after batch inversion (#1502)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf(dft): butterfly micro-optimizations for Radix2DitParallel (~3% on coset_lde_batch) (#1492)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf: faster `GoldilocksPackedNeon` field operations (#1515)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Field: add missing extension degree for `packed_mod_add` and `packed_mod_sub` (#1421)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
+### Merged PRs
+- Fix(goldilocks): canonicalize NEON add/sub operand to close second-order overflow (#1921)
+
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf: faster `GoldilocksPackedNeon` field operations (#1515)

--- a/interpolation/CHANGELOG.md
+++ b/interpolation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Perf: use Neon Goldilocks only for hash operations (#1517)

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Add carry-critical NEON dot product regression tests (#1600)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ### Merged PRs

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ### Merged PRs

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Field: specialize packed mixed_dot_product by chunk strategy (#1573)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Monty-31: improve `monty_reduce_u128` speed (#1483)

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ### Merged PRs

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ### Merged PRs

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ### Merged PRs

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.4] - 2026-07-30
 ## [0.5.3] - 2026-05-15
 ## [0.5.2] - 2026-03-27
 ## [0.5.1] - 2026-03-16


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-util`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-field`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-matrix`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-air`: 0.5.3 -> 0.5.4
* `p3-dft`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-symmetric`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-mds`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-poseidon1`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-poseidon2`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-monty-31`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-challenger`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-baby-bear`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-goldilocks`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-koala-bear`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-mersenne-31`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-bn254`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-field-testing`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-commit`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-uni-stark`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-lookup`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-batch-stark`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-interpolation`: 0.5.3 -> 0.5.4
* `p3-fri`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-circle`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-keccak`: 0.5.3 -> 0.5.4
* `p3-merkle-tree`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-blake3`: 0.5.3 -> 0.5.4
* `p3-rescue`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-blake3-air`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-sha256`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-keccak-air`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-poseidon2-air`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-monolith`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-multilinear-util`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `p3-poseidon1-air`: 0.5.3 -> 0.5.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>














## `p3-goldilocks`

<blockquote>

## [0.5.4] - 2026-07-30

### Merged PRs
- Fix(goldilocks): canonicalize NEON add/sub operand to close second-order overflow (#1921)
</blockquote>
























</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).