### PR TITLE
ci: parallelize test legs and speed up tool installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,23 +27,50 @@ jobs:
     strategy:
       matrix:
         include:
+          # Default and `parallel`-feature runs are split into separate legs
+          # so they execute as concurrent jobs instead of sequential steps.
           - os: ubuntu-latest
+            parallel: false
+          - os: ubuntu-latest
+            parallel: true
           - os: ubuntu-latest
             features: "+avx2"
+            parallel: false
+          - os: ubuntu-latest
+            features: "+avx2"
+            parallel: true
           - os: ubuntu-latest
             features: "+avx512f"
             # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
             # so this leg only verifies the AVX-512 paths compile.
             compile_only: true
             target: x86_64-unknown-linux-gnu
+            parallel: false
+          - os: ubuntu-latest
+            features: "+avx512f"
+            compile_only: true
+            target: x86_64-unknown-linux-gnu
+            parallel: true
           - os: ubuntu-24.04-arm
             features: "+sve2"
             # GitHub's arm64 runners aren't guaranteed to have SVE2 hardware,
             # so this leg only verifies the SVE2 paths compile.
             compile_only: true
             target: aarch64-unknown-linux-gnu
+            parallel: false
+          - os: ubuntu-24.04-arm
+            features: "+sve2"
+            compile_only: true
+            target: aarch64-unknown-linux-gnu
+            parallel: true
           - os: macos-latest
+            parallel: false
+          - os: macos-latest
+            parallel: true
           - os: windows-latest
+            parallel: false
+          - os: windows-latest
+            parallel: true
     runs-on: ${{ matrix.os }}
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
@@ -62,28 +89,45 @@ jobs:
       # Smarter cache for Rust builds; avoids overfilling the runner disk.
       - uses: Swatinem/rust-cache@v2
 
-      - name: Test
+      # nextest schedules every test from every binary in one pool instead of
+      # running binaries one at a time, so idle cores get filled by other
+      # crates' tests while a single long-running test is still executing.
+      - uses: taiki-e/install-action@v2
         if: ${{ !matrix.compile_only }}
-        run: cargo test
+        with:
+          tool: cargo-nextest
+
+      - name: Test
+        if: ${{ !matrix.compile_only && !matrix.parallel }}
+        run: cargo nextest run
+
+      - name: Test doctests
+        if: ${{ !matrix.compile_only && !matrix.parallel }}
+        # nextest doesn't run doctests, so cover them with plain `cargo test`.
+        run: cargo test --doc
 
       - name: Test with parallel
-        if: ${{ !matrix.compile_only }}
-        run: cargo test --features parallel
+        if: ${{ !matrix.compile_only && matrix.parallel }}
+        run: cargo nextest run --features parallel
+
+      - name: Test with parallel doctests
+        if: ${{ !matrix.compile_only && matrix.parallel }}
+        run: cargo test --doc --features parallel
 
       - name: Build
-        if: ${{ matrix.compile_only }}
+        if: ${{ matrix.compile_only && !matrix.parallel }}
         # Keep target-feature RUSTFLAGS off host build scripts and proc macros.
         run: cargo build --target ${{ matrix.target }} --all-targets
 
       - name: Build with parallel
-        if: ${{ matrix.compile_only }}
+        if: ${{ matrix.compile_only && matrix.parallel }}
         run: cargo build --target ${{ matrix.target }} --all-targets --features parallel
 
       - name: Test keccak (aarch64, no SHA3)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' && !matrix.parallel }}
         env:
           RUSTFLAGS: -C debuginfo=0 -C target-feature=-sha3
-        run: cargo test -p p3-keccak
+        run: cargo nextest run -p p3-keccak
 
   check_embedded:
     name: Build embedded
@@ -207,14 +251,11 @@ jobs:
         with:
           components: rustfmt
 
-      - name: Install cargo-sort and taplo
-        run: |
-          cargo install cargo-sort
-          # `--locked` uses taplo-cli's shipped Cargo.lock, pinning its `time`
-          # dependency to a version whose impls do not collide with taplo's
-          # blanket `From` impls (an unlocked resolve picks a newer `time` that
-          # fails to compile with E0119).
-          cargo install taplo-cli --locked
+      # Prebuilt binaries instead of `cargo install`, which compiles both
+      # tools (and taplo's `time` dependency chain) from source every run.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort,taplo
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Description

CI main run currently takes 20~23 min to execute.

Split each `Build and Test` leg's sequential default/`parallel`-feature steps into separate matrix jobs so they run concurrently instead of back-to-back, and switch to `cargo-nextest` so tests from all binaries share one scheduling pool instead of running one binary at a time — several single, long-running tests (`sumcheck`, `multi-stark`, `whir`, `stir`) were otherwise leaving cores idle while blocking the rest of the suite. Also install `cargo-sort/taplo` via prebuilt binaries instead of compiling them from source on every run.