### PR TITLE
perf(stir): add a couple improvements to the STIR PCS

### DIFF
--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -483,17 +483,6 @@ where
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
-        let global_max_height = commitments_with_opening_points
-            .iter()
-            .flat_map(|(_, domain_claims)| {
-                domain_claims
-                    .iter()
-                    .map(|(domain, _)| domain.size() << self.stir.log_blowup)
-            })
-            .max()
-            .unwrap_or(1);
-        let log_global_max_height = log2_strict_usize(global_max_height);
-
         // Observe all opened values to keep the transcript in sync.
         for (_, domain_claims) in &commitments_with_opening_points {
             for (_, point_claims) in domain_claims {
@@ -563,14 +552,6 @@ where
             Challenge::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied())
                 .collect_vec();
 
-        let coset: Vec<Val> = {
-            let coset =
-                TwoAdicMultiplicativeCoset::new(Val::GENERATOR, log_global_max_height).unwrap();
-            let mut pts = coset.iter().collect();
-            reverse_slice_index_bits(&mut pts);
-            pts
-        };
-
         // Verify each height bucket's STIR sub-proof and input binding.
         for (bucket_idx, &log_h) in bucket_log_heights.iter().enumerate() {
             let bucket_height = 1usize << log_h;
@@ -595,6 +576,13 @@ where
             // STIR ran with intermediate rounds or only a final round.
             let log_arity0 = stir_config.log_folding_factor;
             let arity0 = 1usize << log_arity0;
+
+            // A queried input row sits at LDE position `p = j + l * fold_height0`, whose coset
+            // point is `GENERATOR * g^p` for `g = two_adic_generator(log_h)`. Walking a fiber's
+            // `arity0` lanes is therefore one exponentiation per query followed by repeated
+            // multiplication by the fixed step `g^fold_height0`, an `arity0`-th root of unity.
+            let domain_gen = Val::two_adic_generator(log_h);
+            let fiber_step = domain_gen.exp_power_of_2(log_h - log_arity0);
 
             // STIR's initial oracle is the reduced opening, which is a deterministic function
             // of the input commitments, the claimed values, and `alpha` — all already in the
@@ -682,14 +670,13 @@ where
 
                         for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
                             let row_vals_by_mat = &opening.opened_values[q_idx];
-                            let group = reverse_bits_len(j, log_h - log_arity0);
+                            let mut fiber_point = Val::GENERATOR * domain_gen.exp_u64(j as u64);
 
                             #[allow(clippy::needless_range_loop)]
                             for l in 0..arity0 {
-                                // Fiber column `l` sits at slot `reverse_bits_len(l, log_arity0)` of the
-                                // grouped row, and at LDE row `group * arity0 + slot`.
+                                // Fiber column `l` sits at slot `reverse_bits_len(l, log_arity0)`
+                                // of the grouped row.
                                 let slot = reverse_bits_len(l, log_arity0);
-                                let q_local = (group << log_arity0) | slot;
 
                                 for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate()
                                 {
@@ -721,12 +708,14 @@ where
                                             .sum();
 
                                         let inv_denom =
-                                            (*point - Challenge::from(coset[q_local])).inverse();
+                                            (*point - Challenge::from(fiber_point)).inverse();
 
                                         expected_ro[q_idx][l] +=
                                             alpha_pow_offset * (p_x - y_combined) * inv_denom;
                                     }
                                 }
+
+                                fiber_point *= fiber_step;
                             }
                         }
                     }

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -595,7 +595,7 @@ where
             let reconstruct_initial_fibers =
                 |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
                     let n_q = first_round_unique_js.len();
-                    let mut expected_ro = vec![vec![Challenge::ZERO; arity0]; n_q];
+                    let mut expected_ro = vec![Challenge::zero_vec(arity0); n_q];
 
                     for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                         commitments_with_opening_points

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -62,12 +62,53 @@ use crate::verifier::{StirError, verify_stir};
     deserialize = "Val: Deserialize<'de>, InputMmcs::MultiProof: Deserialize<'de>"
 ))]
 pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
-    /// `opened_values[k][m]` is the opened row of matrix `m` at the `k`-th queried position,
-    /// in the same `(query, fiber column)` order the prover and verifier both derive from
-    /// public data.
+    /// `opened_values[k][m]` is the opened fiber-grouped row of matrix `m` at the `k`-th
+    /// queried position, in the same query order the prover and verifier both derive from
+    /// public data. Each such row concatenates the `2^log_folding_factor` LDE rows of one
+    /// fiber, ordered by the bit-reversal of the fiber column index.
     pub opened_values: Vec<Vec<Vec<Val>>>,
     /// Compact multi-opening proof authenticating every row at once.
     pub opening_proof: InputMmcs::MultiProof,
+}
+
+/// Prover data for [`TwoAdicStirPcs`].
+///
+/// The LDE matrices are committed in fiber-grouped form: each Merkle leaf holds
+/// `2^log_folding_factor` consecutive bit-reversed LDE rows, i.e. exactly the rows one
+/// first-round STIR query reads. `widths` records each matrix's column count before grouping
+/// so the original shape can be recovered for opening and quotient computation.
+pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
+    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    widths: Vec<usize>,
+}
+
+/// Reinterpret a bit-reversed LDE as a matrix whose rows are whole STIR fibers.
+///
+/// A first-round query at fold-domain index `j` reads the LDE rows
+/// `reverse_bits_len(j + l * 2^(log_h - log_arity), log_h)` for `l < 2^log_arity`. Writing
+/// `j` into the low `log_h - log_arity` bits and `l` into the high `log_arity` bits, the
+/// reversal maps that set onto the contiguous block
+/// `[rev(j) * 2^log_arity, (rev(j) + 1) * 2^log_arity)`, so grouping is a pure reshape of the
+/// same buffer: no row ever straddles two leaves.
+fn group_fiber_rows<Val: Clone + Send + Sync>(
+    lde: RowMajorMatrix<Val>,
+    log_arity: usize,
+) -> RowMajorMatrix<Val> {
+    let width = lde.width() << log_arity;
+    RowMajorMatrix::new(lde.values, width)
+}
+
+/// Recover views of the committed matrices in their pre-grouping shape.
+fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
+    input_mmcs: &InputMmcs,
+    prover_data: &'a StirProverData<Val, InputMmcs>,
+) -> Vec<RowMajorMatrixView<'a, Val>> {
+    input_mmcs
+        .get_matrices(&prover_data.data)
+        .into_iter()
+        .zip(prover_data.widths.iter())
+        .map(|(mat, &width)| RowMajorMatrixView::new(mat.values.as_slice(), width))
+        .collect()
 }
 
 /// A polynomial commitment scheme using STIR to generate opening proofs.
@@ -107,7 +148,7 @@ where
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
-    type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
+    type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
     /// Proof structure: one entry per distinct LDE-height bucket (descending).
     ///
@@ -140,6 +181,7 @@ where
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
     ) -> (Self::Commitment, Self::ProverData) {
         let min_height = 1usize << self.stir.log_folding_factor;
+        let mut widths = Vec::new();
         let ldes: Vec<_> = evaluations
             .into_iter()
             .map(|(domain, evals)| {
@@ -155,13 +197,17 @@ where
                     self.stir.log_folding_factor,
                 );
                 let shift = Val::GENERATOR / domain.shift();
-                self.dft
+                let lde = self
+                    .dft
                     .coset_lde_batch(evals, self.stir.log_blowup, shift)
                     .bit_reverse_rows()
-                    .to_row_major_matrix()
+                    .to_row_major_matrix();
+                widths.push(lde.width());
+                group_fiber_rows(lde, self.stir.log_folding_factor)
             })
             .collect();
-        self.input_mmcs.commit(ldes)
+        let (commitment, data) = self.input_mmcs.commit(ldes);
+        (commitment, StirProverData { data, widths })
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -170,12 +216,16 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let lde = self.input_mmcs.get_matrices(prover_data)[idx];
+        let lde = lde_views(&self.input_mmcs, prover_data).swap_remove(idx);
         if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
-            return lde.split_rows(domain.size()).0.as_cow().bit_reverse_rows();
+            let width = lde.width();
+            let values: &'a [Val] = lde.values;
+            return RowMajorMatrixView::new(&values[..domain.size() * width], width)
+                .as_cow()
+                .bit_reverse_rows();
         }
         let poly_height = lde.height() >> self.stir.log_blowup;
-        let lde_mat = lde.as_view().bit_reverse_rows().to_row_major_matrix();
+        let lde_mat = lde.bit_reverse_rows().to_row_major_matrix();
         let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
         let width = coeffs.width();
         coeffs.values.truncate(poly_height * width);
@@ -216,19 +266,26 @@ where
 
     fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
         let min_lde_height = 1usize << (self.stir.log_folding_factor + self.stir.log_blowup);
-        for lde in &ldes {
-            assert!(
-                lde.height() >= min_lde_height,
-                "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
-                 log_folding_factor + log_blowup = {} + {}.",
-                lde.height(),
-                self.stir.log_folding_factor + self.stir.log_blowup,
-                min_lde_height,
-                self.stir.log_folding_factor,
-                self.stir.log_blowup,
-            );
-        }
-        self.input_mmcs.commit(ldes)
+        let mut widths = Vec::with_capacity(ldes.len());
+        let grouped: Vec<_> = ldes
+            .into_iter()
+            .map(|lde| {
+                assert!(
+                    lde.height() >= min_lde_height,
+                    "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
+                     log_folding_factor + log_blowup = {} + {}.",
+                    lde.height(),
+                    self.stir.log_folding_factor + self.stir.log_blowup,
+                    min_lde_height,
+                    self.stir.log_folding_factor,
+                    self.stir.log_blowup,
+                );
+                widths.push(lde.width());
+                group_fiber_rows(lde, self.stir.log_folding_factor)
+            })
+            .collect();
+        let (commitment, data) = self.input_mmcs.commit(grouped);
+        (commitment, StirProverData { data, widths })
     }
 
     #[instrument(name = "STIR PCS open", skip_all)]
@@ -240,15 +297,7 @@ where
         // Step 1: Compute evaluations at opening points using Lagrange interpolation.
         let mats_and_points: Vec<_> = commitment_data_with_opening_points
             .iter()
-            .map(|(data, points)| {
-                let mats = self
-                    .input_mmcs
-                    .get_matrices(data)
-                    .into_iter()
-                    .map(|m| m.as_view())
-                    .collect_vec();
-                (mats, points)
-            })
+            .map(|(data, points)| (lde_views(&self.input_mmcs, data), points))
             .collect();
 
         let (global_max_height, global_max_width) = mats_and_points
@@ -384,36 +433,34 @@ where
 
             // Input binding for this bucket. Folding factor is constant across rounds.
             let log_arity0 = stir_config.log_folding_factor;
-            let fold_height0 = (1usize << stir_config.log_starting_domain_size()) >> log_arity0;
-            let arity0 = 1usize << log_arity0;
 
             let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
                 commitment_data_with_opening_points
                     .iter()
                     .map(|(data, _)| {
-                        let mats = self.input_mmcs.get_matrices(data);
-                        if !mats.iter().any(|m| m.height() == bucket_height) {
+                        // Committed matrices are fiber-grouped, so their heights are the LDE
+                        // heights divided by the fold arity.
+                        let mats = self.input_mmcs.get_matrices(&data.data);
+                        if !mats
+                            .iter()
+                            .any(|m| m.height() << log_arity0 == bucket_height)
+                        {
                             return None;
                         }
-                        let commit_max_height = mats.iter().map(|m| m.height()).max().unwrap();
+                        let commit_max_height =
+                            mats.iter().map(|m| m.height()).max().unwrap() << log_arity0;
                         let log_commit_max = log2_strict_usize(commit_max_height);
 
-                        // Flatten every `(query, fiber column)` position into one index list so
-                        // a single multi-opening proof covers the whole bucket for this
-                        // commitment, sharing sibling digests across positions.
+                        // One index per query: the whole fiber lives in a single grouped row.
                         let q_globals: Vec<usize> = first_round_query_indices
                             .iter()
-                            .flat_map(|&j| {
-                                (0..arity0).map(move |l| {
-                                    let p = j + l * fold_height0;
-                                    let q_local = reverse_bits_len(p, log_h);
-                                    q_local << (log_commit_max - log_h)
-                                })
+                            .map(|&j| {
+                                reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h)
                             })
                             .collect();
 
                         let (opened_values, opening_proof) =
-                            self.input_mmcs.open_multi_batch(&q_globals, data);
+                            self.input_mmcs.open_multi_batch(&q_globals, &data.data);
                         Some(InputOpenings {
                             opened_values,
                             opening_proof,
@@ -551,10 +598,9 @@ where
                 e.map_input_err(|_| unreachable!("verify_stir does not produce InputError"))
             })?;
 
-            // The folding factor is constant across rounds, so the same arity/fold_height
-            // applies whether STIR ran with intermediate rounds or only a final round.
+            // The folding factor is constant across rounds, so the same arity applies whether
+            // STIR ran with intermediate rounds or only a final round.
             let log_arity0 = stir_config.log_folding_factor;
-            let fold_height0 = (1usize << stir_config.log_starting_domain_size()) >> log_arity0;
             let arity0 = 1usize << log_arity0;
 
             let first_round_unique_js = stir_outputs.first_round_indices;
@@ -614,26 +660,22 @@ where
                     })
                     .collect();
 
+                // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per committed
+                // row.
                 let dimensions: Vec<p3_matrix::Dimensions> = mat_lde_heights
                     .iter()
                     .zip(mat_widths.iter())
                     .map(|(&h, &w)| p3_matrix::Dimensions {
-                        height: h,
-                        width: w,
+                        height: h >> log_arity0,
+                        width: w << log_arity0,
                     })
                     .collect();
 
-                // Flatten the `(query, fiber column)` positions in the same order the prover
-                // used to build `opening.opened_values`.
+                // One grouped row per query, in the same order the prover used to build
+                // `opening.opened_values`.
                 let q_globals: Vec<usize> = first_round_unique_js
                     .iter()
-                    .flat_map(|&j| {
-                        (0..arity0).map(move |l| {
-                            let p = j + l * fold_height0;
-                            let q_local = reverse_bits_len(p, log_h);
-                            q_local << (log_commit_max - log_h)
-                        })
-                    })
+                    .map(|&j| reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h))
                     .collect();
 
                 // SHAPE CHECK: opened-row count is determined entirely by public input.
@@ -651,23 +693,26 @@ where
                     )
                     .map_err(StirError::InputError)?;
 
-                let mut opening_idx = 0usize;
-
                 for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
+                    let row_vals_by_mat = &opening.opened_values[q_idx];
+                    let group = reverse_bits_len(j, log_h - log_arity0);
+
                     #[allow(clippy::needless_range_loop)]
                     for l in 0..arity0 {
-                        let p = j + l * fold_height0;
-                        let q_local = reverse_bits_len(p, log_h);
-
-                        let row_vals_by_mat = &opening.opened_values[opening_idx];
-                        opening_idx += 1;
+                        // Fiber column `l` sits at slot `reverse_bits_len(l, log_arity0)` of the
+                        // grouped row, and at LDE row `group * arity0 + slot`.
+                        let slot = reverse_bits_len(l, log_arity0);
+                        let q_local = (group << log_arity0) | slot;
 
                         for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate() {
                             if mat_lde_heights[mat_idx] != bucket_height {
                                 continue;
                             }
 
-                            let row_vals = &row_vals_by_mat[mat_idx];
+                            // `verify_multi_batch` already pinned each grouped row to
+                            // `dimensions[mat_idx].width`, so this slice is in bounds.
+                            let width = mat_widths[mat_idx];
+                            let row_vals = &row_vals_by_mat[mat_idx][slot * width..][..width];
                             let p_x: Challenge = row_vals
                                 .iter()
                                 .zip(alpha_powers.iter())

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -11,12 +11,11 @@
 //! committed inputs.
 //!
 //! **Verify**: replay the same alpha-batching from the opening values, then for each height
-//! bucket call [`verify_stir`] and consume its [`StirVerifyOutputs`] — the sorted unique
-//! first-round query indices and their fiber evaluations. With those in hand the verifier
-//! checks each input MMCS opening against the committed input and confirms it agrees with
-//! the STIR first-round fiber evaluations. No hand-mirrored transcript replay is needed.
-//!
-//! [`StirVerifyOutputs`]: crate::verifier::StirVerifyOutputs
+//! bucket call [`verify_stir_with_external_initial`]. STIR's initial oracle *is* the reduced
+//! opening, which the transcript already pins through the input commitments, the claimed
+//! values, and `alpha`, so it is never committed a second time: whenever STIR needs its
+//! queried fibers, the verifier rebuilds them from the input MMCS openings at exactly the
+//! positions STIR sampled. No hand-mirrored transcript replay is needed.
 
 use alloc::borrow::Cow;
 use alloc::collections::BTreeSet;
@@ -46,8 +45,8 @@ use tracing::instrument;
 
 use crate::config::{StirConfig, StirParameters};
 use crate::proof::StirProof;
-use crate::prover::prove_stir_from_codeword;
-use crate::verifier::{StirError, verify_stir};
+use crate::prover::prove_stir_from_external_codeword;
+use crate::verifier::{StirError, verify_stir_with_external_initial};
 
 /// Batched openings of one input commitment's LDE matrices at the STIR-derived query
 /// positions for one LDE-height bucket.
@@ -153,13 +152,14 @@ where
     /// Proof structure: one entry per distinct LDE-height bucket (descending).
     ///
     /// Each bucket contains:
-    /// - `stir_proof`: the STIR IOP proof for that bucket (initial commitment plus per-round
-    ///   IOP messages). The first-round query indices are NOT serialized — the verifier
-    ///   re-derives them from `verify_stir`'s side outputs.
+    /// - `stir_proof`: the STIR IOP proof for that bucket (per-round IOP messages; the initial
+    ///   oracle is external, so neither its commitment nor its openings appear). The
+    ///   first-round query indices are NOT serialized — the verifier re-derives them from the
+    ///   transcript.
     /// - `input_openings[commit_idx]`: one shared multi-opening proof for that commitment's
     ///   rows at the bucket's first-round STIR fiber positions, in the same sorted-by-index
-    ///   order the verifier reconstructs from `verify_stir`. `None` if the commitment has no
-    ///   matrices at this bucket's LDE height.
+    ///   order the verifier reconstructs. `None` if the commitment has no matrices at this
+    ///   bucket's LDE height.
     type Proof = Vec<(
         StirProof<Challenge, StirMmcs, Val>,
         Vec<Option<InputOpenings<Val, InputMmcs>>>,
@@ -429,7 +429,7 @@ where
             );
 
             let (stir_proof, first_round_query_indices) =
-                prove_stir_from_codeword(&stir_config, ro_natural, &self.dft, challenger);
+                prove_stir_from_external_codeword(&stir_config, ro_natural, &self.dft, challenger);
 
             // Input binding for this bucket. Folding factor is constant across rounds.
             let log_arity0 = stir_config.log_folding_factor;
@@ -591,168 +591,157 @@ where
                 self.stir.clone(),
             );
 
-            // Run STIR verification and consume its first-round query view directly. No
-            // hand-mirrored transcript replay: anything that touches the FS state is contained
-            // inside `verify_stir` itself.
-            let stir_outputs = verify_stir(&stir_config, stir_proof, challenger).map_err(|e| {
-                e.map_input_err(|_| unreachable!("verify_stir does not produce InputError"))
-            })?;
-
             // The folding factor is constant across rounds, so the same arity applies whether
             // STIR ran with intermediate rounds or only a final round.
             let log_arity0 = stir_config.log_folding_factor;
             let arity0 = 1usize << log_arity0;
 
-            let first_round_unique_js = stir_outputs.first_round_indices;
-            let fiber_evals_per_query = stir_outputs.first_round_fiber_evals;
-            let n_q = first_round_unique_js.len();
+            // STIR's initial oracle is the reduced opening, which is a deterministic function
+            // of the input commitments, the claimed values, and `alpha` — all already in the
+            // transcript. Rather than have the prover commit and open it a second time, rebuild
+            // its queried fibers from the input MMCS openings on demand.
+            //
+            // The accumulation runs across ALL commitments: when several contribute matrices to
+            // the same height bucket, `ro[p]` is their sum, so a per-commitment reconstruction
+            // would be wrong.
+            let reconstruct_initial_fibers =
+                |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
+                    let n_q = first_round_unique_js.len();
+                    let mut expected_ro = vec![vec![Challenge::ZERO; arity0]; n_q];
 
-            // Up-front fiber-shape check: each first-round fiber from STIR must have the
-            // expected width. Done once here so the inner accumulation loop can index without
-            // a bounds check on every iteration.
-            for row_evals in &fiber_evals_per_query {
-                if row_evals.len() != arity0 {
-                    return Err(StirError::InvalidProofShape);
-                }
-            }
+                    for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
+                        commitments_with_opening_points
+                            .iter()
+                            .zip(input_openings.iter())
+                            .enumerate()
+                    {
+                        let mat_lde_heights: Vec<usize> = domain_claims
+                            .iter()
+                            .map(|(domain, _)| domain.size() << self.stir.log_blowup)
+                            .collect();
 
-            // Accumulate the verifier-side expected reduced opening across ALL commitments.
-            // Comparing against `row_evals[l]` per commit was incorrect: when multiple
-            // commitments contribute matrices to the same height bucket, the prover's
-            // `ro[p]` is the sum across commitments, and the per-commit-equality check
-            // would fail (or, in the single-commit-per-bucket path that the existing tests
-            // happen to exercise, mask the multi-commit case entirely).
-            let mut expected_ro = vec![vec![Challenge::ZERO; arity0]; n_q];
+                        let has_at_bucket = mat_lde_heights.contains(&bucket_height);
 
-            for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
-                commitments_with_opening_points
-                    .iter()
-                    .zip(input_openings.iter())
-                    .enumerate()
-            {
-                let mat_lde_heights: Vec<usize> = domain_claims
-                    .iter()
-                    .map(|(domain, _)| domain.size() << self.stir.log_blowup)
-                    .collect();
-
-                let has_at_bucket = mat_lde_heights.contains(&bucket_height);
-
-                // SHAPE CHECK: whether an opening is present at all is determined entirely by
-                // public input. Validating up-front turns a mismatch into a clean
-                // `InvalidProofShape` instead of silently skipping a binding check.
-                let Some(opening) = per_commit_opening else {
-                    if has_at_bucket {
-                        return Err(StirError::InvalidProofShape);
-                    }
-                    continue;
-                };
-                if !has_at_bucket {
-                    return Err(StirError::InvalidProofShape);
-                }
-
-                let commit_max_height = mat_lde_heights.iter().copied().max().unwrap();
-                let log_commit_max = log2_strict_usize(commit_max_height);
-
-                let mat_widths: Vec<usize> = domain_claims
-                    .iter()
-                    .map(|(_, point_claims)| {
-                        point_claims.first().map(|(_, v)| v.len()).unwrap_or(0)
-                    })
-                    .collect();
-
-                // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per committed
-                // row.
-                let dimensions: Vec<p3_matrix::Dimensions> = mat_lde_heights
-                    .iter()
-                    .zip(mat_widths.iter())
-                    .map(|(&h, &w)| p3_matrix::Dimensions {
-                        height: h >> log_arity0,
-                        width: w << log_arity0,
-                    })
-                    .collect();
-
-                // One grouped row per query, in the same order the prover used to build
-                // `opening.opened_values`.
-                let q_globals: Vec<usize> = first_round_unique_js
-                    .iter()
-                    .map(|&j| reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h))
-                    .collect();
-
-                // SHAPE CHECK: opened-row count is determined entirely by public input.
-                if opening.opened_values.len() != q_globals.len() {
-                    return Err(StirError::InvalidProofShape);
-                }
-
-                self.input_mmcs
-                    .verify_multi_batch(
-                        commitment,
-                        &dimensions,
-                        &q_globals,
-                        &opening.opened_values,
-                        &opening.opening_proof,
-                    )
-                    .map_err(StirError::InputError)?;
-
-                for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
-                    let row_vals_by_mat = &opening.opened_values[q_idx];
-                    let group = reverse_bits_len(j, log_h - log_arity0);
-
-                    #[allow(clippy::needless_range_loop)]
-                    for l in 0..arity0 {
-                        // Fiber column `l` sits at slot `reverse_bits_len(l, log_arity0)` of the
-                        // grouped row, and at LDE row `group * arity0 + slot`.
-                        let slot = reverse_bits_len(l, log_arity0);
-                        let q_local = (group << log_arity0) | slot;
-
-                        for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate() {
-                            if mat_lde_heights[mat_idx] != bucket_height {
-                                continue;
+                        // SHAPE CHECK: whether an opening is present at all is determined entirely by
+                        // public input. Validating up-front turns a mismatch into a clean
+                        // `InvalidProofShape` instead of silently skipping a binding check.
+                        let Some(opening) = per_commit_opening else {
+                            if has_at_bucket {
+                                return Err(StirError::InvalidProofShape);
                             }
+                            continue;
+                        };
+                        if !has_at_bucket {
+                            return Err(StirError::InvalidProofShape);
+                        }
 
-                            // `verify_multi_batch` already pinned each grouped row to
-                            // `dimensions[mat_idx].width`, so this slice is in bounds.
-                            let width = mat_widths[mat_idx];
-                            let row_vals = &row_vals_by_mat[mat_idx][slot * width..][..width];
-                            let p_x: Challenge = row_vals
-                                .iter()
-                                .zip(alpha_powers.iter())
-                                .map(|(&v, &ap)| Challenge::from(v) * ap)
-                                .sum();
+                        let commit_max_height = mat_lde_heights.iter().copied().max().unwrap();
+                        let log_commit_max = log2_strict_usize(commit_max_height);
 
-                            for (point_idx, (point, vals)) in point_claims.iter().enumerate() {
-                                let alpha_pow_offset =
-                                    alpha_offsets[commit_idx][mat_idx][point_idx];
+                        let mat_widths: Vec<usize> = domain_claims
+                            .iter()
+                            .map(|(_, point_claims)| {
+                                point_claims.first().map(|(_, v)| v.len()).unwrap_or(0)
+                            })
+                            .collect();
 
-                                let y_combined: Challenge = vals
-                                    .iter()
-                                    .zip(alpha_powers.iter())
-                                    .map(|(&y, &ap)| y * ap)
-                                    .sum();
+                        // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per committed
+                        // row.
+                        let dimensions: Vec<p3_matrix::Dimensions> = mat_lde_heights
+                            .iter()
+                            .zip(mat_widths.iter())
+                            .map(|(&h, &w)| p3_matrix::Dimensions {
+                                height: h >> log_arity0,
+                                width: w << log_arity0,
+                            })
+                            .collect();
 
-                                let inv_denom =
-                                    (*point - Challenge::from(coset[q_local])).inverse();
+                        // One grouped row per query, in the same order the prover used to build
+                        // `opening.opened_values`.
+                        let q_globals: Vec<usize> = first_round_unique_js
+                            .iter()
+                            .map(|&j| {
+                                reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h)
+                            })
+                            .collect();
 
-                                expected_ro[q_idx][l] +=
-                                    alpha_pow_offset * (p_x - y_combined) * inv_denom;
+                        // SHAPE CHECK: opened-row count is determined entirely by public input.
+                        if opening.opened_values.len() != q_globals.len() {
+                            return Err(StirError::InvalidProofShape);
+                        }
+
+                        self.input_mmcs
+                            .verify_multi_batch(
+                                commitment,
+                                &dimensions,
+                                &q_globals,
+                                &opening.opened_values,
+                                &opening.opening_proof,
+                            )
+                            .map_err(StirError::InputError)?;
+
+                        for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
+                            let row_vals_by_mat = &opening.opened_values[q_idx];
+                            let group = reverse_bits_len(j, log_h - log_arity0);
+
+                            #[allow(clippy::needless_range_loop)]
+                            for l in 0..arity0 {
+                                // Fiber column `l` sits at slot `reverse_bits_len(l, log_arity0)` of the
+                                // grouped row, and at LDE row `group * arity0 + slot`.
+                                let slot = reverse_bits_len(l, log_arity0);
+                                let q_local = (group << log_arity0) | slot;
+
+                                for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate()
+                                {
+                                    if mat_lde_heights[mat_idx] != bucket_height {
+                                        continue;
+                                    }
+
+                                    // `verify_multi_batch` already pinned each grouped row to
+                                    // `dimensions[mat_idx].width`, so this slice is in bounds.
+                                    let width = mat_widths[mat_idx];
+                                    let row_vals =
+                                        &row_vals_by_mat[mat_idx][slot * width..][..width];
+                                    let p_x: Challenge = row_vals
+                                        .iter()
+                                        .zip(alpha_powers.iter())
+                                        .map(|(&v, &ap)| Challenge::from(v) * ap)
+                                        .sum();
+
+                                    for (point_idx, (point, vals)) in
+                                        point_claims.iter().enumerate()
+                                    {
+                                        let alpha_pow_offset =
+                                            alpha_offsets[commit_idx][mat_idx][point_idx];
+
+                                        let y_combined: Challenge = vals
+                                            .iter()
+                                            .zip(alpha_powers.iter())
+                                            .map(|(&y, &ap)| y * ap)
+                                            .sum();
+
+                                        let inv_denom =
+                                            (*point - Challenge::from(coset[q_local])).inverse();
+
+                                        expected_ro[q_idx][l] +=
+                                            alpha_pow_offset * (p_x - y_combined) * inv_denom;
+                                    }
+                                }
                             }
                         }
                     }
-                }
-            }
 
-            // Final binding check: the cross-commitment accumulated reduced opening must
-            // match the first-round fiber evaluations the STIR verifier extracted.
-            for (q_idx, _) in first_round_unique_js.iter().enumerate() {
-                let row_evals = &fiber_evals_per_query[q_idx];
-                for l in 0..arity0 {
-                    if expected_ro[q_idx][l] != row_evals[l] {
-                        return Err(StirError::PcsBindingMismatch {
-                            query: q_idx,
-                            column: l,
-                        });
-                    }
-                }
-            }
+                    Ok(expected_ro)
+                };
+
+            // Any transcript-touching step stays inside `verify_stir_with_external_initial`;
+            // the closure above only reads public data and the input openings.
+            verify_stir_with_external_initial(
+                &stir_config,
+                stir_proof,
+                challenger,
+                reconstruct_initial_fibers,
+            )?;
         }
 
         Ok(())

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -349,11 +349,11 @@ where
                         .map(|(&y, &ap)| y * ap)
                         .sum();
 
-                    for (ro_val, (&inv_d, &p_x)) in
-                        ro.iter_mut().zip(inv_denom.iter().zip(p_x_vec.iter()))
-                    {
-                        *ro_val += alpha_pow_offset * (p_x - y_combined) * inv_d;
-                    }
+                    ro.par_iter_mut()
+                        .zip(inv_denom.par_iter().zip(p_x_vec.par_iter()))
+                        .for_each(|(ro_val, (&inv_d, &p_x))| {
+                            *ro_val += alpha_pow_offset * (p_x - y_combined) * inv_d;
+                        });
                 }
             }
         }

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -14,7 +14,11 @@ use serde::{Deserialize, Serialize};
 ))]
 pub struct StirProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// Commitment to the initial codeword on L_0.
-    pub initial_commitment: M::Commitment,
+    ///
+    /// `None` when the initial oracle is external: the caller binds that codeword through its
+    /// own commitment and supplies the queried fibers at verification time, so STIR neither
+    /// commits to it nor opens it.
+    pub initial_commitment: Option<M::Commitment>,
 
     /// One proof per intermediate STIR round (excluding the final send).
     pub round_proofs: Vec<StirRoundProof<EF, M, Witness>>,
@@ -30,7 +34,10 @@ pub struct StirProof<EF: Field, M: Mmcs<EF>, Witness> {
 
     /// Merkle openings for the final consistency queries against the last committed codeword,
     /// sharing one pruned multi-opening proof.
-    pub final_query_openings: StirQueryOpenings<EF, M>,
+    ///
+    /// `None` exactly when these queries read an external initial oracle, which happens only
+    /// if there are no intermediate rounds.
+    pub final_query_openings: Option<StirQueryOpenings<EF, M>>,
 }
 
 /// Proof for a single STIR round.
@@ -70,7 +77,10 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     pub shake_polynomial: Vec<EF>,
 
     /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.
-    pub query_openings: StirQueryOpenings<EF, M>,
+    ///
+    /// `None` exactly when this round's queries read an external initial oracle, which happens
+    /// only in round 0.
+    pub query_openings: Option<StirQueryOpenings<EF, M>>,
 }
 
 /// Batched Merkle openings and fiber evaluations for the queries of one round.

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -351,10 +351,15 @@ where
         final_log_arity,
         current_log_domain,
     );
-    let final_new_coeffs = coeffs_from_codeword(dft, &final_codeword, final_new_shift);
+    // The final polynomial has only `final_len` coefficients, far fewer than
+    // `final_codeword`'s full domain size. Rather than run a full-size iDFT and discard
+    // the (necessarily zero) high coefficients, gather a `final_len`-sized coset — every
+    // `stride`-th natural-order point, which is exactly the subgroup coset of that size —
+    // and run the small iDFT directly on it.
     let final_len = config.final_poly_len();
-    let mut final_poly = final_new_coeffs;
-    final_poly.resize(final_len, EF::ZERO);
+    let stride = final_codeword.len() / final_len;
+    let final_poly_evals: Vec<EF> = (0..final_len).map(|i| final_codeword[i * stride]).collect();
+    let final_poly = coeffs_from_codeword(dft, &final_poly_evals, final_new_shift);
 
     challenger.observe_algebra_slice(&final_poly);
     let final_pow_witness = challenger.grind(config.final_pow_bits);

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -16,6 +16,7 @@ use p3_field::{
 };
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
+use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
 use crate::config::StirConfig;
@@ -334,28 +335,24 @@ where
         // coset (base-field ratio, EF-valued start), so it is evaluated pointwise via two
         // `Powers` sweeps instead of a third DFT; its `(1 - r_comb*x)` denominator is folded
         // into the vanishing-polynomial batch inversion below (one inversion, not two). Ans
-        // and the vanishing polynomial still need a DFT each — their roots are this round's
-        // arbitrary interpolation points — so those two are batched into one call.
+        // and the vanishing polynomial still need evaluating — their roots are this round's
+        // arbitrary interpolation points — but both are tiny next to the domain, so they go
+        // through the low-degree coset evaluation rather than a full-size DFT each.
         let num_answers = all_points.len();
         let next_domain_size = 1usize << next_log_domain;
 
         let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
-        let mut combined_coeffs = EF::zero_vec(next_domain_size * 2);
-        for (i, &c) in ans_poly.iter().enumerate().take(next_domain_size) {
-            combined_coeffs[2 * i] = c;
-        }
-        for (i, &c) in vanishing_coeffs.iter().enumerate().take(next_domain_size) {
-            combined_coeffs[2 * i + 1] = c;
-        }
-        let combined_evals = dft
-            .coset_dft_algebra_batch(RowMajorMatrix::new(combined_coeffs, 2), next_shift)
-            .values;
-        let mut ans_evals = EF::zero_vec(next_domain_size);
-        let mut vanishing_evals = EF::zero_vec(next_domain_size);
-        for (i, pair) in combined_evals.chunks_exact(2).enumerate() {
-            ans_evals[i] = pair[0];
-            vanishing_evals[i] = pair[1];
-        }
+        // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
+        // `num_answers + 1` coefficients.
+        let log_answer_len = log2_ceil_usize(num_answers + 1).min(next_log_domain);
+        let (ans_evals, vanishing_evals) = eval_low_degree_pair_on_coset(
+            dft,
+            &ans_poly,
+            &vanishing_coeffs,
+            next_shift,
+            next_log_domain,
+            log_answer_len,
+        );
 
         // x_j = next_shift * g^j; step_j = r_comb * x_j = step_start * g^j.
         let g_next = F::two_adic_generator(next_log_domain);
@@ -465,6 +462,86 @@ where
         final_query_openings,
     };
     (proof, first_round_query_indices)
+}
+
+/// Evaluate two polynomials of at most `2^log_len` coefficients on the coset `shift * <g>` of
+/// size `2^log_size`, returning both codewords in **natural order**.
+///
+/// A full-size DFT would spend all `log_size` butterfly layers on an input that is zero past
+/// its first `2^log_len` coefficients. Instead, split the coset into
+/// `m = 2^(log_size - log_len)` cosets of the size-`2^log_len` subgroup: writing the natural
+/// index as `i = a + m*b` with `a < m` and `b < 2^log_len`,
+///
+/// ```text
+/// x_i = shift * g^(a + m*b) = (shift * g^a) * (g^m)^b
+/// ```
+///
+/// and `g^m` generates that subgroup. So evaluating on the whole coset is `m` independent
+/// size-`2^log_len` DFTs, one per `a`, of the coefficients pre-scaled by `(shift * g^a)^c` —
+/// `O(N * log_len)` instead of `O(N * log_size)`. The `m` transforms are the columns of one
+/// batched call, and each output row lands on a contiguous natural-order block.
+///
+/// Coefficients past index `2^log_size` are ignored, matching evaluation of the truncation.
+fn eval_low_degree_pair_on_coset<F, EF, Dft>(
+    dft: &Dft,
+    first: &[EF],
+    second: &[EF],
+    shift: F,
+    log_size: usize,
+    log_len: usize,
+) -> (Vec<EF>, Vec<EF>)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    debug_assert!(log_len <= log_size);
+    let size = 1usize << log_size;
+    let num_cosets = size >> log_len;
+    let generator = F::two_adic_generator(log_size);
+
+    // Row `c` holds the pair of degree-`c` coefficients scaled by `(shift * g^a)^c`, which as
+    // `a` varies is the geometric sequence starting at `shift^c` with ratio `g^c`.
+    let mut scaled = EF::zero_vec((1usize << log_len) * 2 * num_cosets);
+    scaled
+        .par_chunks_mut(2 * num_cosets)
+        .enumerate()
+        .for_each(|(c, row)| {
+            let first_c = first.get(c).copied().unwrap_or(EF::ZERO);
+            let second_c = second.get(c).copied().unwrap_or(EF::ZERO);
+            let ratio = generator.exp_u64(c as u64);
+            let mut scale = shift.exp_u64(c as u64);
+            for pair in row.chunks_exact_mut(2) {
+                pair[0] = first_c * scale;
+                pair[1] = second_c * scale;
+                scale *= ratio;
+            }
+        });
+
+    let transformed = dft
+        .dft_algebra_batch(RowMajorMatrix::new(scaled, 2 * num_cosets))
+        .values;
+
+    // Transform row `b` holds the evaluations at `i = a + num_cosets * b` for every `a`, i.e.
+    // the natural-order block `[num_cosets * b, num_cosets * (b + 1))`.
+    let mut first_evals = EF::zero_vec(size);
+    let mut second_evals = EF::zero_vec(size);
+    first_evals
+        .par_chunks_mut(num_cosets)
+        .zip(second_evals.par_chunks_mut(num_cosets))
+        .zip(transformed.par_chunks_exact(2 * num_cosets))
+        .for_each(|((first_block, second_block), row)| {
+            for ((first_slot, second_slot), pair) in first_block
+                .iter_mut()
+                .zip(second_block.iter_mut())
+                .zip(row.chunks_exact(2))
+            {
+                *first_slot = pair[0];
+                *second_slot = pair[1];
+            }
+        });
+
+    (first_evals, second_evals)
 }
 
 /// Evaluate a polynomial (coefficients in `EF`) on a coset `shift * <g>` of size

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -63,6 +63,43 @@ where
     prove_stir_from_codeword(config, initial_codeword, dft, challenger)
 }
 
+/// Prove low degree from an initial codeword that the caller has already bound.
+///
+/// Identical to [`prove_stir_from_codeword`] except that the initial oracle is never committed:
+/// no Merkle tree is built over it, its commitment is absent from the proof, and the queries
+/// that read it ship no rows. The verifier side is [`verify_stir_with_external_initial`], whose
+/// caller supplies the queried fibers.
+///
+/// # Soundness requirement
+///
+/// The caller MUST guarantee that the initial codeword is uniquely determined by data already
+/// absorbed into `challenger` before this call — for the PCS layer, the input commitments, the
+/// claimed opening values, and the batching challenge derived from them. STIR draws the round-0
+/// folding challenge after this point, so a prover still free to choose the initial codeword
+/// afterwards would break the proximity argument. A commitment adds nothing once the codeword
+/// is already pinned, which is exactly why it can be dropped.
+///
+/// [`verify_stir_with_external_initial`]: crate::verifier::verify_stir_with_external_initial
+#[instrument(skip_all)]
+pub fn prove_stir_from_external_codeword<F, EF, Dft, M, Challenger>(
+    config: &StirConfig<F, EF, M, Challenger>,
+    initial_codeword: Vec<EF>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+) -> (StirProof<EF, M, Challenger::Witness>, Vec<usize>)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    prove_stir_inner(config, initial_codeword, dft, challenger, false)
+}
+
 /// Prove low degree from an initial natural-order codeword on STIR's starting domain.
 ///
 /// This avoids an inverse DFT followed by a forward DFT when a caller already has the
@@ -85,6 +122,29 @@ where
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>,
 {
+    prove_stir_inner(config, initial_codeword, dft, challenger, true)
+}
+
+/// Shared body of [`prove_stir_from_codeword`] and [`prove_stir_from_external_codeword`].
+///
+/// `commit_initial` selects whether the initial oracle is committed and opened by STIR.
+fn prove_stir_inner<F, EF, Dft, M, Challenger>(
+    config: &StirConfig<F, EF, M, Challenger>,
+    initial_codeword: Vec<EF>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+    commit_initial: bool,
+) -> (StirProof<EF, M, Challenger::Witness>, Vec<usize>)
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
     let num_rounds = config.num_rounds();
     let initial_shift = F::GENERATOR;
     let log_initial_domain = config.log_starting_domain_size();
@@ -96,9 +156,14 @@ where
     );
 
     // Commit before moving the codeword into the round state, avoiding a full clone.
-    let (initial_commit, initial_data) =
-        commit_as_fiber_matrix(&config.mmcs, &initial_codeword, config.log_folding_factor);
-    challenger.observe(initial_commit.clone());
+    let (initial_commit, initial_data) = if commit_initial {
+        let (commit, data) =
+            commit_as_fiber_matrix(&config.mmcs, &initial_codeword, config.log_folding_factor);
+        challenger.observe(commit.clone());
+        (Some(commit), Some(data))
+    } else {
+        (None, None)
+    };
 
     let mut current_oracle_codeword = initial_codeword;
     let mut current_shift = initial_shift;
@@ -223,13 +288,15 @@ where
             }
         }
 
-        // One shared, pruned multi-opening proof for every query drawn this round.
-        let query_openings = open_fiber_rows(&config.mmcs, &query_indices, &current_commit_data);
+        // One shared, pruned multi-opening proof for every query drawn this round. Absent when
+        // this round reads an external initial oracle, whose fibers the verifier rebuilds.
+        let query_openings = current_commit_data
+            .as_ref()
+            .map(|data| open_fiber_rows(&config.mmcs, &query_indices, data));
         debug_assert!(
             query_openings
-                .row_evals
                 .iter()
-                .all(|row| row.len() == arity)
+                .all(|o| o.row_evals.iter().all(|row| row.len() == arity))
         );
 
         // Collect first-round query indices for the PCS binding check.
@@ -328,7 +395,7 @@ where
         });
 
         current_oracle_codeword = next_oracle_codeword;
-        current_commit_data = new_data;
+        current_commit_data = Some(new_data);
         current_shift = next_shift;
         current_log_domain = next_log_domain;
     }
@@ -374,13 +441,13 @@ where
         final_query_indices.push(j);
     }
 
-    let final_query_openings =
-        open_fiber_rows(&config.mmcs, &final_query_indices, &current_commit_data);
+    let final_query_openings = current_commit_data
+        .as_ref()
+        .map(|data| open_fiber_rows(&config.mmcs, &final_query_indices, data));
     debug_assert!(
         final_query_openings
-            .row_evals
             .iter()
-            .all(|row| row.len() == final_arity)
+            .all(|o| o.row_evals.iter().all(|row| row.len() == final_arity))
     );
 
     // When there are no intermediate rounds the final queries target the

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -21,8 +21,8 @@ use tracing::instrument;
 use crate::config::StirConfig;
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    compute_shake_polynomial, eval_poly, fold_codeword, interpolate_poly, next_domain_shift,
-    vanishing_poly_from_roots,
+    compute_shake_polynomial, eval_poly_parallel, fold_codeword, interpolate_poly,
+    next_domain_shift, vanishing_poly_from_roots,
 };
 
 /// Prove that a polynomial (given in coefficient form over `EF`) has low degree,
@@ -175,9 +175,16 @@ where
             }
         }
 
+        // `fold_coeffs` is padded to the next round's full domain size, but the folded
+        // polynomial's true degree is bounded by the round's degree schedule (a fixed
+        // factor smaller); evaluating only the non-trivially-zero prefix cuts Horner's
+        // work by that same factor.
+        let folded_degree_bound = 1usize << (rc.log_degree - log_arity);
+        let truncated_fold_coeffs = &fold_coeffs[..folded_degree_bound.min(fold_coeffs.len())];
+
         let ood_answers: Vec<EF> = ood_points
             .iter()
-            .map(|&z| eval_poly(&fold_coeffs, z))
+            .map(|&z| eval_poly_parallel(truncated_fold_coeffs, z))
             .collect();
         challenger.observe_algebra_slice(&ood_answers);
 

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -21,8 +21,8 @@ use tracing::instrument;
 use crate::config::StirConfig;
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    compute_shake_polynomial, degree_correction_poly, eval_poly, fold_codeword, interpolate_poly,
-    next_domain_shift, vanishing_poly_from_roots,
+    compute_shake_polynomial, eval_poly, fold_codeword, interpolate_poly, next_domain_shift,
+    vanishing_poly_from_roots,
 };
 
 /// Prove that a polynomial (given in coefficient form over `EF`) has low degree,
@@ -254,30 +254,60 @@ where
         let _rho: EF = challenger.sample_algebra_element();
 
         // Step 5: Construction 5.2 — evaluate the next virtual witness directly on L_{i+1}:
-        // f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}). This avoids serial synthetic division
-        // and coefficient-domain degree correction; the three independent DFTs are parallel.
+        // f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}).
+        //
+        // DegCor(x) = (1 - (r_comb*x)^{gap+1}) / (1 - r_comb*x) is geometric in x over the
+        // coset (base-field ratio, EF-valued start), so it is evaluated pointwise via two
+        // `Powers` sweeps instead of a third DFT; its `(1 - r_comb*x)` denominator is folded
+        // into the vanishing-polynomial batch inversion below (one inversion, not two). Ans
+        // and the vanishing polynomial still need a DFT each — their roots are this round's
+        // arbitrary interpolation points — so those two are batched into one call.
         let num_answers = all_points.len();
-        let ans_evals = codeword_from_coeffs(dft, ans_poly.clone(), next_shift, next_log_domain);
-        let vanishing_evals = codeword_from_coeffs(
-            dft,
-            vanishing_poly_from_roots(&all_points),
-            next_shift,
-            next_log_domain,
-        );
-        let degree_correction_evals = codeword_from_coeffs(
-            dft,
-            degree_correction_poly(r_comb, num_answers),
-            next_shift,
-            next_log_domain,
-        );
-        let vanishing_inverses = batch_multiplicative_inverse(&vanishing_evals);
+        let next_domain_size = 1usize << next_log_domain;
 
-        let next_oracle_codeword: Vec<EF> = next_commit_codeword
-            .par_iter()
-            .zip(ans_evals.par_iter())
-            .zip(vanishing_inverses.par_iter())
-            .zip(degree_correction_evals.par_iter())
-            .map(|(((&g, &ans), &z_inv), &correction)| (g - ans) * z_inv * correction)
+        let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
+        let mut combined_coeffs = EF::zero_vec(next_domain_size * 2);
+        for (i, &c) in ans_poly.iter().enumerate().take(next_domain_size) {
+            combined_coeffs[2 * i] = c;
+        }
+        for (i, &c) in vanishing_coeffs.iter().enumerate().take(next_domain_size) {
+            combined_coeffs[2 * i + 1] = c;
+        }
+        let combined_evals = dft
+            .coset_dft_algebra_batch(RowMajorMatrix::new(combined_coeffs, 2), next_shift)
+            .values;
+        let mut ans_evals = EF::zero_vec(next_domain_size);
+        let mut vanishing_evals = EF::zero_vec(next_domain_size);
+        for (i, pair) in combined_evals.chunks_exact(2).enumerate() {
+            ans_evals[i] = pair[0];
+            vanishing_evals[i] = pair[1];
+        }
+
+        // x_j = next_shift * g^j; step_j = r_comb * x_j = step_start * g^j.
+        let g_next = F::two_adic_generator(next_log_domain);
+        let g_powers: Vec<F> = g_next.powers().collect_n(next_domain_size);
+        let g_powers_hi: Vec<F> = g_next
+            .exp_u64((num_answers + 1) as u64)
+            .powers()
+            .collect_n(next_domain_size);
+        let step_start = r_comb * EF::from(next_shift);
+        let step_start_hi = step_start.exp_u64((num_answers + 1) as u64);
+
+        let combined_denoms: Vec<EF> = (0..next_domain_size)
+            .into_par_iter()
+            .map(|j| vanishing_evals[j] * (EF::ONE - step_start * EF::from(g_powers[j])))
+            .collect();
+        let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
+
+        let next_oracle_codeword: Vec<EF> = (0..next_domain_size)
+            .into_par_iter()
+            .map(|j| {
+                let degree_correction_numerator =
+                    EF::ONE - step_start_hi * EF::from(g_powers_hi[j]);
+                (next_commit_codeword[j] - ans_evals[j])
+                    * combined_inverses[j]
+                    * degree_correction_numerator
+            })
             .collect();
 
         round_proofs.push(StirRoundProof {

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -205,7 +205,7 @@ where
         );
         let fold_coeffs = coeffs_from_codeword(dft, &folded_codeword, fold_shift);
 
-        let next_commit_codeword =
+        let next_commit_codeword: Vec<EF> =
             codeword_from_coeffs(dft, fold_coeffs.clone(), next_shift, next_log_domain);
         let (new_commit, new_data) = commit_as_fiber_matrix(
             &config.mmcs,
@@ -339,7 +339,6 @@ where
         // arbitrary interpolation points — but both are tiny next to the domain, so they go
         // through the low-degree coset evaluation rather than a full-size DFT each.
         let num_answers = all_points.len();
-        let next_domain_size = 1usize << next_log_domain;
 
         let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
         // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
@@ -354,32 +353,49 @@ where
             log_answer_len,
         );
 
-        // x_j = next_shift * g^j; step_j = r_comb * x_j = step_start * g^j.
+        // x_j = next_shift * g^j, so step_j = r_comb * x_j = step_start * g^j, and the degree
+        // correction's numerator sweeps the same coset at stride `num_answers + 1`. Both are
+        // geometric with a base-field ratio, so each chunk seeds one exponentiation and then
+        // advances by a base-field multiply: no power tables, and no ext-by-ext products.
+        const POWER_CHUNK: usize = 1 << 12;
         let g_next = F::two_adic_generator(next_log_domain);
-        let g_powers: Vec<F> = g_next.powers().collect_n(next_domain_size);
-        let g_powers_hi: Vec<F> = g_next
-            .exp_u64((num_answers + 1) as u64)
-            .powers()
-            .collect_n(next_domain_size);
-        let step_start = r_comb * EF::from(next_shift);
+        let g_next_hi = g_next.exp_u64((num_answers + 1) as u64);
+        let step_start = r_comb * next_shift;
         let step_start_hi = step_start.exp_u64((num_answers + 1) as u64);
 
-        let combined_denoms: Vec<EF> = (0..next_domain_size)
-            .into_par_iter()
-            .map(|j| vanishing_evals[j] * (EF::ONE - step_start * EF::from(g_powers[j])))
-            .collect();
+        // The quotient denominators are the vanishing evaluations scaled by the degree
+        // correction's `(1 - step)` denominator, so they are formed in place.
+        let mut combined_denoms = vanishing_evals;
+        combined_denoms
+            .par_chunks_mut(POWER_CHUNK)
+            .enumerate()
+            .for_each(|(chunk_idx, chunk)| {
+                let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                for denom in chunk.iter_mut() {
+                    *denom *= EF::ONE - step;
+                    step *= g_next;
+                }
+            });
         let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
+        drop(combined_denoms);
 
-        let next_oracle_codeword: Vec<EF> = (0..next_domain_size)
-            .into_par_iter()
-            .map(|j| {
-                let degree_correction_numerator =
-                    EF::ONE - step_start_hi * EF::from(g_powers_hi[j]);
-                (next_commit_codeword[j] - ans_evals[j])
-                    * combined_inverses[j]
-                    * degree_correction_numerator
-            })
-            .collect();
+        // `commit_as_fiber_matrix` has already copied the committed codeword into the Merkle
+        // tree, so the next oracle is formed in place over it.
+        let mut next_oracle_codeword = next_commit_codeword;
+        next_oracle_codeword
+            .par_chunks_mut(POWER_CHUNK)
+            .zip(ans_evals.par_chunks(POWER_CHUNK))
+            .zip(combined_inverses.par_chunks(POWER_CHUNK))
+            .enumerate()
+            .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
+                let mut numerator_step =
+                    step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                for ((value, &ans), &inverse) in chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk)
+                {
+                    *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
+                    numerator_step *= g_next_hi;
+                }
+            });
 
         round_proofs.push(StirRoundProof {
             commitment: new_commit,

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -24,6 +24,33 @@ pub fn eval_poly<F: Field>(poly: &[F], point: F) -> F {
         .fold(F::ZERO, |acc, &coeff| acc * point + coeff)
 }
 
+/// Evaluate a polynomial at a point using a chunk-parallel Horner scheme.
+///
+/// Splits `poly` into contiguous chunks, evaluates each chunk's local Horner sum in
+/// parallel, then combines the per-chunk results with one more Horner pass over powers
+/// of `point^chunk_len`:
+/// `value = chunk_0 + point^L * (chunk_1 + point^L * (chunk_2 + ...))`.
+///
+/// Falls back to plain [`eval_poly`] for inputs too small to amortize the parallel
+/// dispatch.
+pub fn eval_poly_parallel<F: Field>(poly: &[F], point: F) -> F {
+    const MIN_PARALLEL_LEN: usize = 4096;
+    if poly.len() < MIN_PARALLEL_LEN {
+        return eval_poly(poly, point);
+    }
+
+    let num_chunks = current_num_threads().max(1);
+    let chunk_size = poly.len().div_ceil(num_chunks);
+    let point_pow_chunk = point.exp_u64(chunk_size as u64);
+
+    poly.par_chunks(chunk_size)
+        .map(|chunk| eval_poly(chunk, point))
+        .collect::<Vec<F>>()
+        .into_iter()
+        .rev()
+        .fold(F::ZERO, |acc, chunk_val| acc * point_pow_chunk + chunk_val)
+}
+
 /// Divide a coefficient-form polynomial by the linear factor `(X - point)`.
 ///
 /// Returns `(quotient, remainder)` via synthetic (Horner) division.
@@ -538,6 +565,20 @@ mod tests {
     fn test_eval_poly_zero() {
         let poly: Vec<F> = vec![];
         assert_eq!(eval_poly(&poly, F::from_u64(3)), F::ZERO);
+    }
+
+    #[test]
+    fn test_eval_poly_parallel_matches_eval_poly() {
+        // Exercise chunk boundaries around and past the parallel-dispatch threshold.
+        for len in [0, 1, 4095, 4096, 4097, 10_000] {
+            let poly: Vec<F> = (0..len).map(|i| F::from_u64(i as u64 + 1)).collect();
+            let point = F::from_u64(12345);
+            assert_eq!(
+                eval_poly_parallel(&poly, point),
+                eval_poly(&poly, point),
+                "mismatch at len={len}"
+            );
+        }
     }
 
     #[test]

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -225,6 +225,39 @@ pub fn eval_vanishing_at_roots<F: Field>(roots: &[F], point: F) -> F {
     roots.iter().fold(F::ONE, |acc, &root| acc * (point - root))
 }
 
+/// Horner evaluation of an extension-coefficient polynomial at a **base-field** point.
+///
+/// Identical to [`eval_poly`] on a lifted point, but each step is an extension-by-base
+/// product rather than a full extension multiplication.
+pub fn eval_poly_at_base<F: Field, EF: ExtensionField<F>>(poly: &[EF], point: F) -> EF {
+    poly.iter()
+        .rev()
+        .fold(EF::ZERO, |acc, &coeff| acc * point + coeff)
+}
+
+/// Reduce `poly` modulo `X^n - c`, returning the `n` remainder coefficients.
+///
+/// Writing `i = q*n + r` gives `X^i = (X^n)^q * X^r ≡ c^q * X^r`, so every coefficient folds
+/// onto its index mod `n` scaled by a power of `c`: one pass over `poly`, independent of `n`.
+///
+/// Evaluating the reduced polynomial agrees with the original at any point `x` with
+/// `x^n = c`, which for a coset of the `n`-th roots of unity is every point at once.
+pub fn reduce_mod_x_pow_minus_c<F: Field, EF: ExtensionField<F>>(
+    poly: &[EF],
+    n: usize,
+    c: F,
+) -> Vec<EF> {
+    let mut remainder = EF::zero_vec(n);
+    let mut c_pow = F::ONE;
+    for block in poly.chunks(n) {
+        for (slot, &coeff) in remainder.iter_mut().zip(block) {
+            *slot += coeff * c_pow;
+        }
+        c_pow *= c;
+    }
+    remainder
+}
+
 /// Coefficients of the vanishing polynomial `prod_{y in roots} (X - y)`.
 ///
 /// The result is in ascending coefficient order, has length `roots.len() + 1`,

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -389,13 +389,21 @@ pub fn check_shake_consistency<F: Field>(
 ///
 /// Construction 4.5 defines `Fold(f, β)(y)` over **coset** preimages
 /// `α·g^{j + l·new_height}` (`α` = domain shift). Interpolating at subgroup
-/// coordinates instead (no `α`) lets the barycentric weights be precomputed once
-/// and reused across all `j` (the `α^{j·(k-1)}` factor cancels in the ratio).
+/// coordinates instead (no `α`) lets the fold be decomposed into `log_arity`
+/// sequential arity-2 folds (below), which only works cleanly without a coset shift.
 ///
 /// Because the y-values are identical and the x-nodes scale by `α`,
 /// `P_coset(X) = P_subgroup(X/α)` exactly for any arity. Callers therefore pass
 /// `β = γ/α` to obtain Construction 4.5's coset fold at challenge `γ`; this crate's
 /// prover and verifier both do so, so the realized fold matches the paper literally.
+///
+/// # Binary-pass decomposition
+///
+/// An arity-`2^k` fold at challenge `beta` equals `k` sequential arity-2 folds at
+/// challenges `beta, beta^2, beta^4, …, beta^{2^(k-1)}` (the standard FFT decimation
+/// identity underlying FRI-style low-degree tests). Each pass halves the natural-order
+/// codeword, pairing index `j` with `j + height/2`: since `g^{height/2} = -1` on the
+/// pass's current domain, this pairs conjugate points `x` and `-x`.
 pub fn fold_codeword<F: TwoAdicField, EF: ExtensionField<F>>(
     codeword: &[EF],
     beta: EF,
@@ -406,114 +414,40 @@ pub fn fold_codeword<F: TwoAdicField, EF: ExtensionField<F>>(
     let new_height = codeword.len() / arity;
     assert!(new_height > 0);
 
-    if log_arity == 1 {
-        // Arity-2: x_j = g^j, x_{j+new_height} = -g^j  (since g^{new_height} = -1).
+    let mut data = codeword.to_vec();
+    let mut current_beta = beta;
+    let mut cur_log_domain = log_domain_size;
+
+    for _ in 0..log_arity {
+        let height = data.len() / 2;
+
         // fold(j) = (lo + hi)/2 + beta * (lo - hi) / (2 * g^j)
         //         = (lo + hi)/2 + (beta/2) * g_inv^j * (lo - hi)
         //
-        // g_orig has order `domain_size`, so g_inv = g_orig.inverse() has the same order.
-        // halve_inv_powers[j] = (1/2) * g_orig^{-j}
-        let g_orig_inv = F::two_adic_generator(log_domain_size).inverse();
+        // g_orig has order `2^cur_log_domain`, so g_inv = g_orig.inverse() has the same
+        // order. halve_inv_powers[j] = (1/2) * g_orig^{-j}.
+        let g_orig_inv = F::two_adic_generator(cur_log_domain).inverse();
         let halve_inv_powers: Vec<F> = g_orig_inv
             .shifted_powers(F::ONE.halve())
-            .take(new_height)
+            .take(height)
             .collect();
 
-        (0..new_height)
+        data = (0..height)
             .into_par_iter()
             .map(|j| {
-                let lo = codeword[j];
-                let hi = codeword[j + new_height];
+                let lo = data[j];
+                let hi = data[j + height];
                 let hip = EF::from(halve_inv_powers[j]);
-                (lo + hi).halve() + (lo - hi) * beta * hip
+                (lo + hi).halve() + (lo - hi) * current_beta * hip
             })
-            .collect()
-    } else {
-        // General arity k = 2^log_arity: evaluate Lagrange interpolation at `beta`
-        // through all k fiber values for each new-domain index j.
-        //
-        // x-coordinates for new-domain index j:
-        //   x_l = g^{j + l * new_height}  for l = 0..k-1
-        // where g = two_adic_generator(log_domain_size).
-        //
-        // Key identity: x_l^{(j)} = g^j * x_l^{(0)} for all l. The barycentric weight
-        // for node (j, l) satisfies w_l^{(j)} = g^{-j*(k-1)} * w_l^{(0)}. Since this
-        // factor is common to numerator and denominator, it cancels in the ratio. Thus
-        // the weights from j=0 (xs_0 = [1, step, step^2, ...]) can be reused for all j,
-        // and only the x-coordinates need to be rescaled by g^j.
-        let g = F::two_adic_generator(log_domain_size);
-        let step = g.exp_u64(new_height as u64); // arity-th root of unity
+            .collect();
 
-        // Precompute base x-coordinates xs_0[l] = step^l (for j = 0).
-        let xs_0: Vec<F> = {
-            let mut acc = F::ONE;
-            (0..arity)
-                .map(|_| {
-                    let v = acc;
-                    acc *= step;
-                    v
-                })
-                .collect()
-        };
-
-        // Precompute barycentric weights for xs_0 (reused for all j after cancellation).
-        let barycentric_weights: Vec<F> = {
-            let mut w = vec![F::ONE; arity];
-            for i in 0..arity {
-                for j in 0..arity {
-                    if i != j {
-                        w[i] *= xs_0[i] - xs_0[j];
-                    }
-                }
-            }
-            batch_multiplicative_inverse(&w)
-        };
-
-        // Precompute g^j for j = 0..new_height.
-        let g_powers: Vec<F> = g.powers().collect_n(new_height);
-
-        (0..new_height)
-            .into_par_iter()
-            .map(|j| {
-                let gj = g_powers[j];
-                // xs_j[l] = gj * xs_0[l]
-                let ys_j: Vec<EF> = (0..arity).map(|l| codeword[j + l * new_height]).collect();
-
-                // Check if beta equals one of the xs_j nodes (exact match).
-                for l in 0..arity {
-                    if beta == EF::from(gj * xs_0[l]) {
-                        return ys_j[l];
-                    }
-                }
-
-                // Barycentric Lagrange eval: use precomputed weights (cancellation of g^{j*(k-1)})
-                // num = sum_l w_l * ys_j[l] / (beta - gj * xs_0[l])
-                // den = sum_l w_l / (beta - gj * xs_0[l])
-                //
-                // The `arity` denominators are batch-inverted via Montgomery's trick (one EF
-                // inversion plus O(arity) multiplications) instead of `arity` separate divisions.
-                let diffs: Vec<EF> = (0..arity).map(|l| beta - EF::from(gj * xs_0[l])).collect();
-                let mut prefix = Vec::with_capacity(arity);
-                let mut running = EF::ONE;
-                for &diff in &diffs {
-                    prefix.push(running);
-                    running *= diff;
-                }
-                let mut inv_running = running.inverse();
-
-                let mut num = EF::ZERO;
-                let mut den = EF::ZERO;
-                for l in (0..arity).rev() {
-                    let inv_diff = inv_running * prefix[l];
-                    inv_running *= diffs[l];
-                    let term = EF::from(barycentric_weights[l]) * inv_diff;
-                    num += term * ys_j[l];
-                    den += term;
-                }
-                num / den
-            })
-            .collect()
+        current_beta = current_beta.square();
+        cur_log_domain -= 1;
     }
+
+    debug_assert_eq!(data.len(), new_height);
+    data
 }
 
 /// Compute the expected folded value for a single fiber (used by the verifier).

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -11,23 +11,35 @@ use thiserror::Error;
 use crate::config::StirConfig;
 use crate::proof::StirProof;
 use crate::utils::{
-    check_shake_consistency, eval_degree_correction, eval_poly, eval_vanishing_at_roots,
-    fold_fiber, next_domain_shift,
+    check_shake_consistency, eval_degree_correction, eval_poly, eval_poly_at_base,
+    lagrange_eval_at, next_domain_shift, reduce_mod_x_pow_minus_c, vanishing_poly_from_roots,
 };
 
 #[derive(Clone)]
 struct VirtualRoundContext<EF> {
     ans_poly: Vec<EF>,
     all_points: Vec<EF>,
+    /// Coefficient form of `prod_{y in all_points} (X - y)`, built once per round so that each
+    /// query can reduce it rather than re-multiplying every root.
+    vanishing_coeffs: Vec<EF>,
     r_comb: EF,
 }
 
+/// Translate one opened row of the previous round's oracle into values of the current
+/// virtual oracle `DegCor((g - Ans) / Z)`.
+///
+/// `subgroup_points` are the fiber's coordinates on the domain's subgroup; the fiber itself
+/// lives at `shift * subgroup_points`. Those are **base-field** points, so every evaluation
+/// here is extension-by-base.
+///
+/// The fiber is a coset of the `arity`-th roots of unity, hence every point shares the same
+/// `x^arity`. Reducing `Ans` and the vanishing polynomial modulo `X^arity - x^arity` once per
+/// query leaves `arity` coefficients to evaluate at `arity` points, turning `O(arity * t)`
+/// work per query into `O(t + arity^2)`.
 fn materialize_virtual_fiber<F, EF>(
     row_evals: &[EF],
-    row_index: usize,
-    row_height: usize,
-    current_log_domain: usize,
-    current_shift: F,
+    subgroup_points: &[F],
+    shift: F,
     prev_ctx: Option<&VirtualRoundContext<EF>>,
 ) -> Option<Vec<EF>>
 where
@@ -38,16 +50,16 @@ where
         return Some(row_evals.to_vec());
     };
 
-    let domain_gen = F::two_adic_generator(current_log_domain);
-    let points: Vec<EF> = (0..row_evals.len())
-        .map(|col| {
-            let natural_index = row_index + col * row_height;
-            EF::from(current_shift) * EF::from(domain_gen.exp_u64(natural_index as u64))
-        })
-        .collect();
+    let arity = row_evals.len();
+    let points: Vec<F> = subgroup_points.iter().map(|&x| shift * x).collect();
+    let common_power = points[0].exp_u64(arity as u64);
+
+    let ans_rem = reduce_mod_x_pow_minus_c(&ctx.ans_poly, arity, common_power);
+    let vanishing_rem = reduce_mod_x_pow_minus_c(&ctx.vanishing_coeffs, arity, common_power);
+
     let vanishing_values: Vec<EF> = points
         .iter()
-        .map(|&x| eval_vanishing_at_roots(&ctx.all_points, x))
+        .map(|&x| eval_poly_at_base(&vanishing_rem, x))
         .collect();
     if vanishing_values.contains(&EF::ZERO) {
         return None;
@@ -60,8 +72,8 @@ where
             .zip(points)
             .zip(vanishing_inverses)
             .map(|((&g_value, x), vanishing_inverse)| {
-                let quotient = (g_value - eval_poly(&ctx.ans_poly, x)) * vanishing_inverse;
-                eval_degree_correction(quotient, x, ctx.r_comb, ctx.all_points.len())
+                let quotient = (g_value - eval_poly_at_base(&ans_rem, x)) * vanishing_inverse;
+                eval_degree_correction(quotient, EF::from(x), ctx.r_comb, ctx.all_points.len())
             })
             .collect(),
     )
@@ -420,21 +432,29 @@ where
         let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
             alloc::collections::BTreeSet::new();
 
+        // The fiber of query `j` sits at subgroup coordinates `g^j * (g^fold_height)^l`, a
+        // coset of the arity-th roots of unity. Deriving it once per query serves both the
+        // virtual-oracle materialization and the fold.
+        let domain_gen = F::two_adic_generator(current_log_domain);
+        let fiber_step = domain_gen.exp_power_of_2(fold_log_domain);
+
         for (q, (&j, row_evals)) in query_indices.iter().zip(round_rows).enumerate() {
             let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
 
+            let subgroup_points: Vec<F> = fiber_step
+                .shifted_powers(domain_gen.exp_u64(j as u64))
+                .take(arity)
+                .collect();
+
             let current_fiber = materialize_virtual_fiber::<F, EF>(
                 row_evals,
-                j,
-                fold_height,
-                current_log_domain,
+                &subgroup_points,
                 current_shift,
                 prev_ctx.as_ref(),
             )
             .ok_or(StirError::InvalidRoundConsistency { round, query: q })?;
 
-            let fold_val =
-                fold_fiber::<F, EF>(&current_fiber, j, fold_log_domain, log_arity, fold_beta);
+            let fold_val = lagrange_eval_at(&subgroup_points, &current_fiber, fold_beta);
 
             if seen_query_indices.insert(j) {
                 query_points.push(fold_point);
@@ -487,6 +507,7 @@ where
 
         prev_ctx = Some(VirtualRoundContext {
             ans_poly: rp.ans_polynomial.clone(),
+            vanishing_coeffs: vanishing_poly_from_roots(&all_points),
             all_points,
             r_comb,
         });
@@ -594,12 +615,18 @@ where
     // Track them with the same dedup-on-first-occurrence rule as the intermediate-round path.
     let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
 
+    let final_domain_gen = F::two_adic_generator(current_log_domain);
+    let final_fiber_step = final_domain_gen.exp_power_of_2(final_new_log_domain);
+
     for (q, (&j, row_evals)) in final_indices.iter().zip(final_rows).enumerate() {
+        let subgroup_points: Vec<F> = final_fiber_step
+            .shifted_powers(final_domain_gen.exp_u64(j as u64))
+            .take(final_arity)
+            .collect();
+
         let current_fiber = materialize_virtual_fiber::<F, EF>(
             row_evals,
-            j,
-            final_new_height,
-            current_log_domain,
+            &subgroup_points,
             current_shift,
             prev_ctx.as_ref(),
         )
@@ -608,13 +635,7 @@ where
             query: q,
         })?;
 
-        let fold_val = fold_fiber::<F, EF>(
-            &current_fiber,
-            j,
-            final_new_log_domain,
-            final_log_arity,
-            final_fold_beta,
-        );
+        let fold_val = lagrange_eval_at(&subgroup_points, &current_fiber, final_fold_beta);
 
         let x_j = EF::from(final_new_shift) * EF::from(final_gen.exp_u64(j as u64));
 

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -79,6 +79,35 @@ fn single_matrix_opened_values<EF>(row_evals: &[Vec<EF>]) -> Vec<Vec<&[EF]>> {
         .collect()
 }
 
+/// Fetch an external initial oracle's queried fibers and lay them out in draw order.
+///
+/// Queries are sampled with replacement, so `indices` may repeat; the source is asked once for
+/// the sorted unique indices and must answer in that same order.
+fn external_fibers_in_draw_order<EF: Clone, MmcsError, InputError>(
+    indices: &[usize],
+    arity: usize,
+    source: impl FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<MmcsError, InputError>>,
+) -> Result<Vec<Vec<EF>>, StirError<MmcsError, InputError>> {
+    let mut unique = indices.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+
+    let fibers = source(&unique)?;
+    if fibers.len() != unique.len() || fibers.iter().any(|fiber| fiber.len() != arity) {
+        return Err(StirError::InvalidProofShape);
+    }
+
+    Ok(indices
+        .iter()
+        .map(|j| {
+            let pos = unique
+                .binary_search(j)
+                .expect("every draw appears in the deduplicated index list");
+            fibers[pos].clone()
+        })
+        .collect())
+}
+
 /// Errors returned by [`verify_stir`].
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum StirError<MmcsError, InputError = ()> {
@@ -110,12 +139,6 @@ pub enum StirError<MmcsError, InputError = ()> {
     #[error("Invalid proof shape")]
     InvalidProofShape,
 
-    /// The PCS layer's cross-commitment accumulated reduced opening did not match the STIR
-    /// first-round fiber evaluations. Indicates the input commitments and the STIR oracle are
-    /// not consistent (e.g. a claimed evaluation was tampered with).
-    #[error("PCS reduced-opening binding mismatch at query {query}, column {column}")]
-    PcsBindingMismatch { query: usize, column: usize },
-
     /// An error propagated from the input polynomial commitment scheme.
     #[error("Input error")]
     InputError(InputError),
@@ -135,9 +158,6 @@ impl<E1, IE1> StirError<E1, IE1> {
             }
             Self::FinalPolyMismatch => StirError::FinalPolyMismatch,
             Self::InvalidProofShape => StirError::InvalidProofShape,
-            Self::PcsBindingMismatch { query, column } => {
-                StirError::PcsBindingMismatch { query, column }
-            }
             Self::InputError(e) => StirError::InputError(f(e)),
         }
     }
@@ -145,12 +165,12 @@ impl<E1, IE1> StirError<E1, IE1> {
 
 /// Side outputs of a successful STIR verification.
 ///
-/// The PCS layer needs to bind the input commitment to the STIR proof at the same fold-domain
-/// positions the verifier sampled in the first round (or the final round, when
-/// `num_rounds == 0`). Rather than have the PCS replay the Fiat-Shamir transcript by hand —
-/// fragile against any future change to `verify_stir`'s transcript order — `verify_stir`
-/// returns this view directly. `first_round_fiber_evals[i]` corresponds to
-/// `first_round_indices[i]`, and the indices are sorted in ascending order.
+/// A caller binding its own commitment to the STIR proof needs the fold-domain positions the
+/// verifier sampled in the first round (or the final round, when `num_rounds == 0`) and the
+/// oracle values there. Returning that view directly saves the caller from replaying the
+/// Fiat-Shamir transcript by hand, which would be fragile against any future change to the
+/// transcript order. `first_round_fiber_evals[i]` corresponds to `first_round_indices[i]`, and
+/// the indices are sorted in ascending order.
 #[derive(Debug, Clone)]
 pub struct StirVerifyOutputs<EF> {
     /// Sorted (ascending) unique fold-domain query indices from the first round (or the final
@@ -160,6 +180,9 @@ pub struct StirVerifyOutputs<EF> {
     /// Row evaluations for each unique query, aligned with `first_round_indices`.
     pub first_round_fiber_evals: Vec<Vec<EF>>,
 }
+
+/// Source of the queried fibers of an external initial oracle, when there is none.
+type NoExternalFibers<EF, MmcsError> = fn(&[usize]) -> Result<Vec<Vec<EF>>, StirError<MmcsError>>;
 
 /// Verify a STIR proof (Construction 5.2).
 pub fn verify_stir<F, EF, M, Challenger>(
@@ -176,13 +199,80 @@ where
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>,
 {
+    verify_stir_inner(
+        config,
+        proof,
+        challenger,
+        None::<NoExternalFibers<EF, M::Error>>,
+    )
+}
+
+/// Verify a STIR proof whose initial oracle is external.
+///
+/// The proof carries no commitment to the initial codeword and no openings against it. Instead
+/// `initial_fibers` is called once with the sorted unique fold-domain indices STIR sampled for
+/// the round that reads the initial oracle; it must return the matching fibers, each of length
+/// `2^log_folding_factor` and ordered by fiber column, as authenticated by whatever commitment
+/// the caller has already bound into the transcript.
+///
+/// # Soundness requirement
+///
+/// See [`prove_stir_from_external_codeword`]: the initial codeword must already be pinned by
+/// data absorbed into the challenger before proving, and the returned fibers must be derived
+/// from that same binding.
+///
+/// [`prove_stir_from_external_codeword`]: crate::prover::prove_stir_from_external_codeword
+pub fn verify_stir_with_external_initial<F, EF, M, Challenger, IE>(
+    config: &StirConfig<F, EF, M, Challenger>,
+    proof: &StirProof<EF, M, Challenger::Witness>,
+    challenger: &mut Challenger,
+    initial_fibers: impl FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+) -> Result<StirVerifyOutputs<EF>, StirError<M::Error, IE>>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    verify_stir_inner(config, proof, challenger, Some(initial_fibers))
+}
+
+/// Shared body of [`verify_stir`] and [`verify_stir_with_external_initial`].
+fn verify_stir_inner<F, EF, M, Challenger, IE, Src>(
+    config: &StirConfig<F, EF, M, Challenger>,
+    proof: &StirProof<EF, M, Challenger::Witness>,
+    challenger: &mut Challenger,
+    external_fibers: Option<Src>,
+) -> Result<StirVerifyOutputs<EF>, StirError<M::Error, IE>>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+    Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+{
     let num_rounds = config.num_rounds();
 
     if proof.round_proofs.len() != num_rounds {
         return Err(StirError::InvalidProofShape);
     }
 
-    challenger.observe(proof.initial_commitment.clone());
+    // The initial oracle is either committed by STIR — in which case its commitment enters the
+    // transcript here — or external, in which case the caller has already bound it and the
+    // proof must not carry a commitment at all.
+    let mut external_fibers = external_fibers;
+    let initial_is_external = external_fibers.is_some();
+    match (&proof.initial_commitment, initial_is_external) {
+        (Some(commitment), false) => challenger.observe(commitment.clone()),
+        (None, true) => {}
+        _ => return Err(StirError::InvalidProofShape),
+    }
 
     // Initial domain shift is always F::GENERATOR; round_configs[0].domain_shift mirrors it
     // when num_rounds > 0.
@@ -194,11 +284,13 @@ where
     // Pairs are inserted in challenger-sample (insertion) order; sorted by index at the end.
     let mut first_round_pairs: Vec<(usize, Vec<EF>)> = Vec::new();
 
-    let round_commitment = |r: usize| -> &M::Commitment {
+    // Commitment holding the oracle round `r` reads. Round 0 reads the initial oracle, which
+    // has no commitment when it is external — callers must not reach this for that case.
+    let round_commitment = |r: usize| -> Option<&M::Commitment> {
         if r == 0 {
-            &proof.initial_commitment
+            proof.initial_commitment.as_ref()
         } else {
-            &proof.round_proofs[r - 1].commitment
+            Some(&proof.round_proofs[r - 1].commitment)
         }
     };
 
@@ -263,12 +355,7 @@ where
 
         // Step 4: combination challenge, query sampling, and fiber verification.
 
-        if rp.query_openings.row_evals.len() != rc.num_queries {
-            return Err(StirError::InvalidProofShape);
-        }
-
         let fold_gen = F::two_adic_generator(fold_log_domain);
-        let cur_commit = round_commitment(round);
 
         let cur_dimensions = alloc::vec![Dimensions {
             height: fold_height,
@@ -288,28 +375,43 @@ where
             query_indices.push(j);
         }
 
-        if rp
-            .query_openings
-            .row_evals
-            .iter()
-            .any(|row| row.len() != arity)
-        {
-            return Err(StirError::InvalidProofShape);
-        }
-
-        // Step 4b: one shared, pruned Merkle multi-opening proof authenticates every query
-        // row against the current commitment at once.
-        let opened_values = single_matrix_opened_values(&rp.query_openings.row_evals);
-        config
-            .mmcs
-            .verify_multi_batch(
-                cur_commit,
-                &cur_dimensions,
-                &query_indices,
-                &opened_values,
-                &rp.query_openings.opening_proof,
-            )
-            .map_err(|source| StirError::InvalidMmcsProof { round, source })?;
+        // Step 4b: obtain this round's oracle rows. An external initial oracle is answered by
+        // the caller against its own binding; every committed oracle has one shared, pruned
+        // Merkle multi-opening proof authenticating all of its query rows at once.
+        let external_rows;
+        let round_rows: &[Vec<EF>] = if round == 0 && initial_is_external {
+            if rp.query_openings.is_some() {
+                return Err(StirError::InvalidProofShape);
+            }
+            let source = external_fibers
+                .take()
+                .expect("the external source is consumed exactly once");
+            external_rows = external_fibers_in_draw_order(&query_indices, arity, source)?;
+            &external_rows
+        } else {
+            let openings = rp
+                .query_openings
+                .as_ref()
+                .ok_or(StirError::InvalidProofShape)?;
+            if openings.row_evals.len() != rc.num_queries
+                || openings.row_evals.iter().any(|row| row.len() != arity)
+            {
+                return Err(StirError::InvalidProofShape);
+            }
+            let cur_commit = round_commitment(round).ok_or(StirError::InvalidProofShape)?;
+            let opened_values = single_matrix_opened_values(&openings.row_evals);
+            config
+                .mmcs
+                .verify_multi_batch(
+                    cur_commit,
+                    &cur_dimensions,
+                    &query_indices,
+                    &opened_values,
+                    &openings.opening_proof,
+                )
+                .map_err(|source| StirError::InvalidMmcsProof { round, source })?;
+            &openings.row_evals
+        };
 
         // Step 4c: per-query virtual-oracle materialization and folding.
         let mut query_points: Vec<EF> = Vec::with_capacity(rc.num_queries);
@@ -318,11 +420,7 @@ where
         let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
             alloc::collections::BTreeSet::new();
 
-        for (q, (&j, row_evals)) in query_indices
-            .iter()
-            .zip(&rp.query_openings.row_evals)
-            .enumerate()
-        {
+        for (q, (&j, row_evals)) in query_indices.iter().zip(round_rows).enumerate() {
             let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
 
             let current_fiber = materialize_virtual_fiber::<F, EF>(
@@ -426,16 +524,6 @@ where
         return Err(StirError::InvalidPowWitness { round: num_rounds });
     }
 
-    if proof.final_query_openings.row_evals.len() != config.final_queries {
-        return Err(StirError::InvalidProofShape);
-    }
-
-    let last_commit = if num_rounds > 0 {
-        &proof.round_proofs[num_rounds - 1].commitment
-    } else {
-        &proof.initial_commitment
-    };
-
     let final_dimensions = alloc::vec![Dimensions {
         height: final_new_height,
         width: final_arity,
@@ -452,39 +540,61 @@ where
         final_indices.push(j);
     }
 
-    if proof
-        .final_query_openings
-        .row_evals
-        .iter()
-        .any(|row| row.len() != final_arity)
-    {
-        return Err(StirError::InvalidProofShape);
-    }
-
-    let opened_values = single_matrix_opened_values(&proof.final_query_openings.row_evals);
-    config
-        .mmcs
-        .verify_multi_batch(
-            last_commit,
-            &final_dimensions,
-            &final_indices,
-            &opened_values,
-            &proof.final_query_openings.opening_proof,
-        )
-        .map_err(|source| StirError::InvalidMmcsProof {
-            round: num_rounds,
-            source,
-        })?;
+    // With no intermediate rounds these queries read the initial oracle, so they follow the
+    // same external-or-committed split as round 0 above.
+    let external_final_rows;
+    let final_rows: &[Vec<EF>] = if num_rounds == 0 && initial_is_external {
+        if proof.final_query_openings.is_some() {
+            return Err(StirError::InvalidProofShape);
+        }
+        let source = external_fibers
+            .take()
+            .expect("the external source is consumed exactly once");
+        external_final_rows = external_fibers_in_draw_order(&final_indices, final_arity, source)?;
+        &external_final_rows
+    } else {
+        let openings = proof
+            .final_query_openings
+            .as_ref()
+            .ok_or(StirError::InvalidProofShape)?;
+        if openings.row_evals.len() != config.final_queries
+            || openings
+                .row_evals
+                .iter()
+                .any(|row| row.len() != final_arity)
+        {
+            return Err(StirError::InvalidProofShape);
+        }
+        let last_commit = if num_rounds > 0 {
+            &proof.round_proofs[num_rounds - 1].commitment
+        } else {
+            proof
+                .initial_commitment
+                .as_ref()
+                .ok_or(StirError::InvalidProofShape)?
+        };
+        let opened_values = single_matrix_opened_values(&openings.row_evals);
+        config
+            .mmcs
+            .verify_multi_batch(
+                last_commit,
+                &final_dimensions,
+                &final_indices,
+                &opened_values,
+                &openings.opening_proof,
+            )
+            .map_err(|source| StirError::InvalidMmcsProof {
+                round: num_rounds,
+                source,
+            })?;
+        &openings.row_evals
+    };
 
     // When num_rounds == 0 the final queries also serve as the PCS first-round binding.
     // Track them with the same dedup-on-first-occurrence rule as the intermediate-round path.
     let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
 
-    for (q, (&j, row_evals)) in final_indices
-        .iter()
-        .zip(&proof.final_query_openings.row_evals)
-        .enumerate()
-    {
+    for (q, (&j, row_evals)) in final_indices.iter().zip(final_rows).enumerate() {
         let current_fiber = materialize_virtual_fiber::<F, EF>(
             row_evals,
             j,

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -988,11 +988,10 @@ mod babybear_pcs {
         let (stir_commit, stir_data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&stir_pcs, [(stir_domain, mat)]);
         stir_p_ch.observe(stir_commit.clone());
+        // STIR's input commitment hashes fiber-grouped leaves, so its root — and hence the
+        // point derived from it — differs from FRI's over the same matrix. Proof size does
+        // not depend on which point is opened, so the comparison stays like-for-like.
         let stir_zeta: Challenge = stir_p_ch.sample_algebra_element();
-        assert_eq!(
-            stir_zeta, zeta,
-            "same input commitment and challenger seed should give the same opening point"
-        );
         let (stir_openings, stir_proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &stir_pcs,
             vec![(&stir_data, vec![vec![stir_zeta]])],

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -409,8 +409,8 @@ mod babybear_stir {
             assert_eq!(rp_a.ans_polynomial, rp_b.ans_polynomial);
             assert_eq!(rp_a.shake_polynomial, rp_b.shake_polynomial);
             assert_eq!(
-                rp_a.query_openings.row_evals.len(),
-                rp_b.query_openings.row_evals.len()
+                rp_a.query_openings.as_ref().unwrap().row_evals.len(),
+                rp_b.query_openings.as_ref().unwrap().row_evals.len()
             );
         }
     }
@@ -427,8 +427,13 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        assert!(!proof.round_proofs[0].query_openings.row_evals.is_empty());
-        proof.round_proofs[0].query_openings.row_evals[0][0] += EF::from(F::ONE);
+        let row_evals = &mut proof.round_proofs[0]
+            .query_openings
+            .as_mut()
+            .unwrap()
+            .row_evals;
+        assert!(!row_evals.is_empty());
+        row_evals[0][0] += EF::from(F::ONE);
 
         let mut v_challenger = challenger;
         assert!(
@@ -451,7 +456,11 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        let row_evals = &mut proof.round_proofs[0].query_openings.row_evals;
+        let row_evals = &mut proof.round_proofs[0]
+            .query_openings
+            .as_mut()
+            .unwrap()
+            .row_evals;
         assert!(row_evals.len() >= 2, "need at least two queries to permute");
         assert_ne!(
             row_evals[0], row_evals[1],
@@ -480,6 +489,8 @@ mod babybear_stir {
 
         let sibs = &mut proof.round_proofs[0]
             .query_openings
+            .as_mut()
+            .unwrap()
             .opening_proof
             .sibling_hashes;
         assert!(!sibs.is_empty());
@@ -508,6 +519,8 @@ mod babybear_stir {
 
         let sibs = &mut proof.round_proofs[0]
             .query_openings
+            .as_mut()
+            .unwrap()
             .opening_proof
             .sibling_hashes;
         assert!(!sibs.is_empty());
@@ -614,6 +627,28 @@ mod babybear_stir {
     }
 
     #[test]
+    fn test_missing_initial_commitment_rejected() {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let degree = 1usize << log_degree;
+        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let mut p_challenger = challenger.clone();
+        let (mut proof, _idx) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+
+        // `verify_stir` verifies the initial oracle against its commitment, so a proof that
+        // omits the commitment cannot be checked and must be rejected rather than skipped.
+        proof.initial_commitment = None;
+
+        let mut v_challenger = challenger;
+        let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+            .expect_err("a missing initial commitment must be rejected");
+        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+    }
+
+    #[test]
     fn test_tampered_final_query_proof_fails() {
         let (params, dft, challenger) = make_params(1, 2);
         let mut rng = seeded_rng();
@@ -625,9 +660,10 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _idx) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        assert!(!proof.final_query_openings.row_evals.is_empty());
-        assert!(!proof.final_query_openings.row_evals[0].is_empty());
-        proof.final_query_openings.row_evals[0][0] += EF::from(F::ONE);
+        let row_evals = &mut proof.final_query_openings.as_mut().unwrap().row_evals;
+        assert!(!row_evals.is_empty());
+        assert!(!row_evals[0].is_empty());
+        row_evals[0][0] += EF::from(F::ONE);
 
         let mut v_challenger = challenger;
         assert!(
@@ -901,6 +937,13 @@ mod babybear_pcs {
     #[test]
     fn test_pcs_single_degree4() {
         do_test_pcs(&[4]);
+    }
+
+    #[test]
+    fn test_pcs_single_degree2_no_intermediate_rounds() {
+        // log_stir_degree == log_folding_factor, so STIR runs no intermediate rounds and the
+        // final-round queries read the external initial oracle directly.
+        do_test_pcs(&[2]);
     }
 
     #[test]
@@ -1356,9 +1399,9 @@ mod babybear_pcs {
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
-        // Tamper one coordinate of the claimed evaluation. The reduced opening recomputed
-        // by the verifier will diverge from what STIR queried, so the input-binding loop
-        // must reject.
+        // Tamper one coordinate of the claimed evaluation. The reduced opening the verifier
+        // reconstructs then diverges from the codeword STIR actually folded, so the round
+        // consistency checks must reject.
         let mut tampered = opening_values[0][0][0].clone();
         tampered[0] += Challenge::from(Val::ONE);
 
@@ -1368,5 +1411,43 @@ mod babybear_pcs {
             res.is_err(),
             "PCS verify must reject a tampered claimed opening"
         );
+    }
+
+    #[test]
+    fn test_pcs_rejects_stray_initial_commitment() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+        let log_d = 6;
+
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![(&data, vec![vec![zeta]])],
+            &mut p_ch,
+        );
+
+        // The PCS runs STIR with an external initial oracle, so a proof carrying a commitment
+        // to it is malformed: accepting one would let a prover feed the transcript an extra
+        // message the verifier never checks.
+        proof[0].0.initial_commitment = Some(proof[0].0.round_proofs[0].commitment.clone());
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        let claims = vec![(
+            commit,
+            vec![(domain, vec![(v_zeta, opening_values[0][0][0].clone())])],
+        )];
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
+            .expect_err("a stray initial commitment must be rejected");
+        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
     }
 }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -417,28 +417,33 @@ mod babybear_stir {
 
     #[test]
     fn test_tampered_round_query_opening_fails() {
-        let (params, dft, challenger) = make_params(1, 2);
-        let mut rng = seeded_rng();
-        let log_degree = 8;
-        let degree = 1usize << log_degree;
-        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+        // Covers arity 4, 8, and 16 (log_folding_factor 2, 3, 4).
+        for log_folding_factor in [2, 3, 4] {
+            let (params, dft, challenger) = make_params(1, log_folding_factor);
+            let mut rng = seeded_rng();
+            let log_degree = 8;
+            let degree = 1usize << log_degree;
+            let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
 
-        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
-        let mut p_challenger = challenger.clone();
-        let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+            let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+            let mut p_challenger = challenger.clone();
+            let (mut proof, _query_indices) =
+                prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        let row_evals = &mut proof.round_proofs[0]
-            .query_openings
-            .as_mut()
-            .unwrap()
-            .row_evals;
-        assert!(!row_evals.is_empty());
-        row_evals[0][0] += EF::from(F::ONE);
+            let row_evals = &mut proof.round_proofs[0]
+                .query_openings
+                .as_mut()
+                .unwrap()
+                .row_evals;
+            assert!(!row_evals.is_empty());
+            row_evals[0][0] += EF::ONE;
 
-        let mut v_challenger = challenger;
-        assert!(
-            verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err()
-        );
+            let mut v_challenger = challenger;
+            assert!(
+                verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+                    .is_err()
+            );
+        }
     }
 
     /// Swapping two `row_evals` entries keeps every length check happy (same count, same

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -359,3 +359,38 @@ fn test_fold_codeword_agrees_with_fold_fiber() {
         );
     }
 }
+
+#[test]
+fn test_fold_codeword_higher_arity_agrees_with_fold_fiber() {
+    use p3_dft::Radix2DitParallel;
+    use p3_stir::prover::codeword_from_coeffs;
+    use p3_stir::utils::{fold_codeword, fold_fiber};
+
+    let log_domain = 6;
+    let domain_size = 1 << log_domain;
+    let dft = Radix2DitParallel::<F>::default();
+    let shift = F::GENERATOR;
+
+    let coeffs: Vec<EF> = (1..=domain_size).map(|i| ef(i as u64)).collect();
+    let codeword = codeword_from_coeffs(&dft, coeffs, shift, log_domain);
+
+    // Binary-pass decomposition kicks in for log_arity >= 2; check arity 4 and arity 8.
+    for log_arity in [2usize, 3usize] {
+        let gamma = ef(1000 + log_arity as u64);
+        let folded = fold_codeword::<F, EF>(&codeword, gamma, log_arity, log_domain);
+
+        let new_height = codeword.len() >> log_arity;
+        let log_new_height = log_domain - log_arity;
+
+        for j in 0..new_height {
+            let fiber: Vec<EF> = (0..(1 << log_arity))
+                .map(|k| codeword[j + k * new_height])
+                .collect();
+            let expected = fold_fiber::<F, EF>(&fiber, j, log_new_height, log_arity, gamma);
+            assert_eq!(
+                folded[j], expected,
+                "fold_codeword and fold_fiber disagree at log_arity={log_arity}, j={j}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
For the whole STIR prover on my M4 pro across instances (at 0 bits of grinding)
- prover time: -64%
- proof size: -44%
- verifier time: -64%