### PR TITLE
feat(multi-stark): fractional gkr

### DIFF
--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -22,6 +22,7 @@ p3-air.workspace = true
 p3-challenger.workspace = true
 p3-commit.workspace = true
 p3-field.workspace = true
+p3-lookup.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-multilinear-util.workspace = true

--- a/multi-stark/src/fractional_gkr/materialize.rs
+++ b/multi-stark/src/fractional_gkr/materialize.rs
@@ -280,7 +280,7 @@ pub(super) mod tests {
     use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{Field, PrimeCharacteristicRing};
+    use p3_field::{Field, PrimeCharacteristicRing, PrimeField};
     use p3_lookup::{Count, InteractionBuilder, InteractionSymbolicBuilder};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_util::log2_strict_usize;
@@ -305,7 +305,7 @@ pub(super) mod tests {
         beta: EF,
     ) -> Option<Fraction<Poly<F>, PolyMaybePacked<F, EF>>>
     where
-        F: Field,
+        F: PrimeField,
         EF: ExtensionField<F>,
         A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
     {
@@ -313,7 +313,8 @@ pub(super) mod tests {
             .iter()
             .map(|table| table.num_variables())
             .collect::<Vec<_>>();
-        let plan = LookupPlan::build::<EF, A>(airs, &num_variables)?;
+        let plan = LookupPlan::build::<EF, A>(airs, &num_variables)
+            .expect("lookup multiplicity height bound should hold")?;
         Some(plan.materialize_fraction(main, preprocessed, public_values, alpha, beta))
     }
 
@@ -327,6 +328,7 @@ pub(super) mod tests {
         WideGlobal,
         SymbolicSources,
         EmptyLocal,
+        ExcessiveMultiplicity,
         None,
     }
 
@@ -407,6 +409,11 @@ pub(super) mod tests {
                         Count<AB::Expr>,
                     )>());
                 }
+                Declaration::ExcessiveMultiplicity => builder.push_interaction(
+                    "range",
+                    [local[0]],
+                    Count::bounded(AB::Expr::ONE, u32::MAX),
+                ),
                 Declaration::None => {}
             }
         }
@@ -570,7 +577,19 @@ pub(super) mod tests {
         let wide = TestAir(Declaration::GlobalNamedWide("shared"));
         let num_variables = test_lookup_num_variables();
 
-        LookupPlan::<F>::build::<EF, _>(&[&narrow, &wide], &[num_variables, num_variables]);
+        LookupPlan::<F>::build::<EF, _>(&[&narrow, &wide], &[num_variables, num_variables])
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_a_multiplicity_height_bound_reaching_the_characteristic() {
+        let air = TestAir(Declaration::ExcessiveMultiplicity);
+        let result = LookupPlan::<F>::build::<EF, _>(&[&air], &[test_lookup_num_variables()]);
+
+        assert!(matches!(
+            result,
+            Err(p3_lookup::LookupError::MultiplicityHeightBoundExceeded { .. })
+        ));
     }
 
     #[test]

--- a/multi-stark/src/fractional_gkr/materialize.rs
+++ b/multi-stark/src/fractional_gkr/materialize.rs
@@ -1,0 +1,837 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_air::symbolic::SymbolicExpression;
+use p3_air::{AirBuilder, RowWindow};
+use p3_field::{Algebra, ExtensionField, Field, PackedValue, PrimeCharacteristicRing, dot_product};
+use p3_lookup::Challenges;
+use p3_maybe_rayon::prelude::*;
+use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
+use p3_sumcheck::layout::Table;
+use p3_util::DisjointMutPtr;
+
+use super::Fraction;
+use crate::lookup::LookupPlan;
+use crate::selectors::BoundaryEvals;
+
+/// Base-field context used to resolve only the symbolic expressions retained
+/// by [`p3_lookup::Lookups::from_air`].
+struct LookupRowEvaluator<'row, F, Var> {
+    main_window: RowWindow<'row, Var>,
+    preprocessed_window: RowWindow<'row, Var>,
+    boundary: BoundaryEvals<Var>,
+    public_values: &'row [F],
+}
+
+impl<'row, F, Var> AirBuilder for LookupRowEvaluator<'row, F, Var>
+where
+    F: Field,
+    Var: Algebra<F> + Copy + Send + Sync,
+{
+    type F = F;
+    type Expr = Var;
+    type Var = Var;
+    type PreprocessedWindow = RowWindow<'row, Var>;
+    type MainWindow = RowWindow<'row, Var>;
+    type PublicVar = F;
+    type PeriodicVar = Var;
+
+    fn main(&self) -> Self::MainWindow {
+        self.main_window
+    }
+
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
+        &self.preprocessed_window
+    }
+
+    fn is_first_row(&self) -> Self::Expr {
+        self.boundary.first
+    }
+
+    fn is_last_row(&self) -> Self::Expr {
+        self.boundary.last
+    }
+
+    fn is_transition(&self) -> Self::Expr {
+        self.boundary.transition
+    }
+
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, _x: I) {
+        unreachable!("lookup row evaluator only resolves retained symbolic expressions")
+    }
+
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
+    }
+}
+
+struct Scratch<Var> {
+    local: Vec<Var>,
+    next: Vec<Var>,
+    preprocessed_local: Vec<Var>,
+    preprocessed_next: Vec<Var>,
+}
+
+impl<Var: PrimeCharacteristicRing> Scratch<Var> {
+    fn new(main_width: usize, preprocessed_width: usize) -> Self {
+        Self {
+            local: vec![Var::ZERO; main_width],
+            next: vec![Var::ZERO; main_width],
+            preprocessed_local: vec![Var::ZERO; preprocessed_width],
+            preprocessed_next: vec![Var::ZERO; preprocessed_width],
+        }
+    }
+}
+
+struct ContributionEval<'a, F, E> {
+    fields: &'a [SymbolicExpression<F>],
+    multiplicity: &'a SymbolicExpression<F>,
+    bus_prefix: E,
+    beta_powers: &'a [E],
+}
+
+impl<F: Field> LookupPlan<F> {
+    /// Materializes the numerator and denominator tables consumed by fractional GKR.
+    ///
+    /// `main`, `preprocessed`, and `public_values` use the original AIR order
+    /// supplied to [`LookupPlan::build`]. Each atomic lookup contribution owns
+    /// one exact-height block in the output. Any remaining tail is padded with
+    /// the neutral fraction `0 / 1`.
+    ///
+    /// `alpha` and `beta` are the lookup challenges used to separate buses and
+    /// compress each contribution's payload.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a planned AIR has no corresponding entry in one of the input
+    /// slices or a retained lookup expression refers to unavailable trace,
+    /// preprocessed, or public-value data.
+    pub fn materialize_fraction<EF>(
+        &self,
+        main: &[&Table<F>],
+        preprocessed: &[Option<&Table<F>>],
+        public_values: &[&[F]],
+        alpha: EF,
+        beta: EF,
+    ) -> Fraction<Poly<F>, PolyMaybePacked<F, EF>>
+    where
+        EF: ExtensionField<F>,
+    {
+        let packed_beta_powers = beta
+            .powers()
+            .take(self.max_width)
+            .map(EF::ExtensionPacking::from)
+            .collect::<Vec<_>>();
+        let challenges = Challenges::new(alpha, beta, self.max_width, self.num_buses);
+
+        let height = 1 << self.num_variables;
+        let mut numerators = F::zero_vec(height);
+        let mut denominators = vec![EF::ExtensionPacking::ONE; height / F::Packing::WIDTH];
+
+        for planned in &self.instances {
+            let main = main[planned.air_index];
+            let preprocessed = preprocessed[planned.air_index];
+            let public_values = public_values[planned.air_index];
+            debug_assert_eq!(main.num_variables(), planned.num_variables);
+            if let Some(preprocessed) = preprocessed {
+                debug_assert_eq!(preprocessed.num_variables(), planned.num_variables);
+            }
+            let num_evals = 1 << planned.num_variables;
+            let packed_len = num_evals / F::Packing::WIDTH;
+            let beta_powers = packed_beta_powers.as_slice();
+            let contributions = planned
+                .lookups
+                .iter()
+                .zip(&planned.bus_ids)
+                .flat_map(|(lookup, &bus_id)| {
+                    let bus_prefix = EF::ExtensionPacking::from(challenges.bus_prefix[bus_id]);
+                    lookup.elements.iter().zip(&lookup.multiplicities).map(
+                        move |(fields, multiplicity)| ContributionEval {
+                            fields,
+                            multiplicity,
+                            bus_prefix,
+                            beta_powers,
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            let numerator_len = contributions.len() * num_evals;
+            let denominator_len = contributions.len() * packed_len;
+            debug_assert_eq!(planned.base_offset % F::Packing::WIDTH, 0);
+            let packed_start = planned.base_offset / F::Packing::WIDTH;
+            materialize_contributions_packed::<F, EF>(
+                main,
+                preprocessed,
+                public_values,
+                &contributions,
+                &mut numerators[planned.base_offset..planned.base_offset + numerator_len],
+                &mut denominators[packed_start..packed_start + denominator_len],
+            );
+        }
+
+        Fraction {
+            n: Poly::new(numerators),
+            d: PolyMaybePacked::Packed(Poly::new(denominators)),
+        }
+    }
+}
+
+/// Materialize every atomic lookup contribution of one AIR in a single row scan.
+///
+/// Output remains block-major: contribution `i` owns one exact-height numerator
+/// block and one packed denominator block. Parallel row workers scatter into
+/// disjoint positions across those blocks after loading the trace row once.
+fn materialize_contributions_packed<F, EF>(
+    main: &Table<F>,
+    preprocessed: Option<&Table<F>>,
+    public_values: &[F],
+    contributions: &[ContributionEval<'_, F, EF::ExtensionPacking>],
+    numerators: &mut [F],
+    denominators: &mut [EF::ExtensionPacking],
+) where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    let packing_width = F::Packing::WIDTH;
+    let num_evals = 1 << main.num_variables();
+    let packed_len = num_evals / packing_width;
+    let main_width = main.num_polys();
+    let preprocessed_width = preprocessed.map_or(0, Table::num_polys);
+    assert_eq!(numerators.len(), contributions.len() * num_evals);
+    assert_eq!(denominators.len(), contributions.len() * packed_len);
+
+    let numerator_ptr = DisjointMutPtr::new(numerators);
+    let denominator_ptr = DisjointMutPtr::new(denominators);
+
+    (0..packed_len).into_par_iter().for_each_init(
+        || Scratch::new(main_width, preprocessed_width),
+        |scratch, packed_row| {
+            let row = packed_row * packing_width;
+            let fill_columns =
+                |local: &mut [F::Packing], next: &mut [F::Packing], table: &Table<F>| {
+                    local.iter_mut().zip(next).zip(table.iter_polys()).for_each(
+                        |((local, next), column)| {
+                            *local = *F::Packing::from_slice(&column[row..row + packing_width]);
+                            *next = if row + 1 + packing_width <= num_evals {
+                                *F::Packing::from_slice(&column[row + 1..row + 1 + packing_width])
+                            } else {
+                                F::Packing::from_fn(|lane| {
+                                    column[core::cmp::min(row + lane + 1, num_evals - 1)]
+                                })
+                            };
+                        },
+                    );
+                };
+
+            fill_columns(&mut scratch.local, &mut scratch.next, main);
+            if let Some(preprocessed) = preprocessed {
+                fill_columns(
+                    &mut scratch.preprocessed_local,
+                    &mut scratch.preprocessed_next,
+                    preprocessed,
+                );
+            }
+
+            let evaluator = LookupRowEvaluator {
+                main_window: RowWindow::from_two_rows(&scratch.local, &scratch.next),
+                preprocessed_window: RowWindow::from_two_rows(
+                    &scratch.preprocessed_local,
+                    &scratch.preprocessed_next,
+                ),
+                boundary: BoundaryEvals::from_packed_row(row, num_evals),
+                public_values,
+            };
+
+            for (contribution_index, contribution) in contributions.iter().enumerate() {
+                let numerator_offset = contribution_index * num_evals + row;
+                let denominator_offset = contribution_index * packed_len + packed_row;
+
+                // SAFETY: `packed_row` is unique to this parallel iteration.
+                // Different contributions own disjoint exact-height blocks, and
+                // different rows own disjoint packed entries within each block.
+                let numerator_chunk =
+                    unsafe { numerator_ptr.slice_mut(numerator_offset, packing_width) };
+                let denominator =
+                    unsafe { &mut denominator_ptr.slice_mut(denominator_offset, 1)[0] };
+
+                *F::Packing::from_slice_mut(numerator_chunk) =
+                    contribution.multiplicity.resolve(&evaluator);
+                let fingerprint: EF::ExtensionPacking = dot_product(
+                    contribution.beta_powers.iter().copied(),
+                    contribution
+                        .fields
+                        .iter()
+                        .map(|field| field.resolve(&evaluator)),
+                );
+                *denominator = contribution.bus_prefix - fingerprint;
+            }
+        },
+    );
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    extern crate std;
+
+    use alloc::vec;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+    use p3_baby_bear::BabyBear;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_field::{Field, PrimeCharacteristicRing};
+    use p3_lookup::{Count, InteractionBuilder, InteractionSymbolicBuilder};
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_util::log2_strict_usize;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+
+    fn test_lookup_num_variables() -> usize {
+        log2_strict_usize(<F as Field>::Packing::WIDTH).max(4)
+    }
+
+    pub(crate) fn materialize<'a, F, EF, A>(
+        airs: &[&'a A],
+        main: &[&'a Table<F>],
+        preprocessed: &[Option<&'a Table<F>>],
+        public_values: &[&'a [F]],
+        alpha: EF,
+        beta: EF,
+    ) -> Option<Fraction<Poly<F>, PolyMaybePacked<F, EF>>>
+    where
+        F: Field,
+        EF: ExtensionField<F>,
+        A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
+    {
+        let num_variables = main
+            .iter()
+            .map(|table| table.num_variables())
+            .collect::<Vec<_>>();
+        let plan = LookupPlan::build::<EF, A>(airs, &num_variables)?;
+        Some(plan.materialize_fraction(main, preprocessed, public_values, alpha, beta))
+    }
+
+    #[derive(Clone, Copy)]
+    enum Declaration {
+        Global,
+        GlobalNamed(&'static str),
+        GlobalNamedWide(&'static str),
+        LocalPair,
+        NextGlobal,
+        WideGlobal,
+        SymbolicSources,
+        EmptyLocal,
+        None,
+    }
+
+    struct TestAir(Declaration);
+
+    impl<F: Field> BaseAir<F> for TestAir {
+        fn width(&self) -> usize {
+            3
+        }
+
+        fn preprocessed_width(&self) -> usize {
+            usize::from(matches!(self.0, Declaration::SymbolicSources))
+        }
+
+        fn num_public_values(&self) -> usize {
+            usize::from(matches!(self.0, Declaration::SymbolicSources))
+        }
+    }
+
+    impl<AB> Air<AB> for TestAir
+    where
+        AB: AirBuilder<F: Field> + InteractionBuilder,
+    {
+        fn eval(&self, builder: &mut AB) {
+            let main = builder.main();
+            let local = main.current_slice();
+
+            match self.0 {
+                Declaration::Global => {
+                    builder.push_interaction("range", [local[0]], Count::bounded(AB::Expr::ONE, 1));
+                }
+                Declaration::GlobalNamed(name) => {
+                    builder.push_interaction(name, [local[0]], Count::bounded(AB::Expr::ONE, 1));
+                }
+                Declaration::GlobalNamedWide(name) => builder.push_interaction(
+                    name,
+                    [local[0], local[1]],
+                    Count::bounded(AB::Expr::ONE, 1),
+                ),
+                Declaration::LocalPair => builder.push_local_interaction([
+                    (vec![local[0].into()], Count::bounded(AB::Expr::ONE, 1)),
+                    (vec![local[1].into()], Count::provided(-AB::Expr::ONE)),
+                ]),
+                Declaration::NextGlobal => {
+                    let next = main.next_slice();
+                    let payload = local[0] * local[1] - next[0];
+                    builder.push_interaction(
+                        "range",
+                        [payload],
+                        Count::bounded(local[2].into(), 3),
+                    );
+                }
+                Declaration::WideGlobal => builder.push_interaction(
+                    "wide",
+                    [local[0], local[1]],
+                    Count::bounded(AB::Expr::ONE, 1),
+                ),
+                Declaration::SymbolicSources => {
+                    let preprocessed = builder.preprocessed();
+                    let preprocessed_local: AB::Expr = preprocessed.current_slice()[0].into();
+                    let preprocessed_next: AB::Expr = preprocessed.next_slice()[0].into();
+                    let public: AB::Expr = builder.public_values()[0].into();
+                    let payload = preprocessed_local
+                        + preprocessed_next.double()
+                        + public
+                        + builder.is_first_row() * AB::Expr::from_u64(3)
+                        + builder.is_last_row() * AB::Expr::from_u64(5)
+                        + builder.is_transition() * AB::Expr::from_u64(7);
+                    builder.push_interaction(
+                        "sources",
+                        [payload, local[0].into()],
+                        Count::bounded(local[1].into(), 3),
+                    );
+                }
+                Declaration::EmptyLocal => {
+                    builder.push_local_interaction(core::iter::empty::<(
+                        Vec<AB::Expr>,
+                        Count<AB::Expr>,
+                    )>());
+                }
+                Declaration::None => {}
+            }
+        }
+    }
+
+    struct CountedAir {
+        eval_calls: AtomicUsize,
+    }
+
+    impl<F: Field> BaseAir<F> for CountedAir {
+        fn width(&self) -> usize {
+            2
+        }
+    }
+
+    impl<AB> Air<AB> for CountedAir
+    where
+        AB: AirBuilder<F: Field> + InteractionBuilder,
+    {
+        fn eval(&self, builder: &mut AB) {
+            self.eval_calls.fetch_add(1, Ordering::Relaxed);
+            let main = builder.main();
+            let local = main.current_slice();
+            builder.assert_eq(local[0], local[1]);
+            builder.push_interaction("range", [local[0]], 1);
+        }
+    }
+
+    fn table(columns: &[&[u64]]) -> Table<F> {
+        let height = columns[0].len();
+        Table::new(RowMajorMatrix::new(
+            columns
+                .iter()
+                .flat_map(|column| column.iter().copied().map(F::from_u64))
+                .collect(),
+            height,
+        ))
+    }
+
+    fn unpack_denominators(
+        materialization: &Fraction<Poly<F>, PolyMaybePacked<F, EF>>,
+    ) -> Poly<EF> {
+        materialization.d.clone().unpack()
+    }
+
+    #[test]
+    fn materializes_local_and_global_buses_with_neutral_padding() {
+        let local = TestAir(Declaration::LocalPair);
+        let global = TestAir(Declaration::Global);
+        let height = 1 << test_lookup_num_variables();
+        let local_values = vec![3; height];
+        let local_provided = vec![8; height];
+        let global_values = vec![5; height];
+        let zeros = vec![0; height];
+        let local_main = table(&[&local_values, &local_provided, &zeros]);
+        let global_main = table(&[&global_values, &zeros, &zeros]);
+
+        let materialization = materialize(
+            &[&local, &global],
+            &[&local_main, &global_main],
+            &[None, None],
+            &[&[], &[]],
+            EF::from_u64(20),
+            EF::from_u64(5),
+        )
+        .unwrap();
+        let numerators = materialization.n.as_slice();
+        let denominators = unpack_denominators(&materialization);
+        assert!(numerators[..height].iter().all(|&value| value == F::ONE));
+        assert!(
+            numerators[height..2 * height]
+                .iter()
+                .all(|&value| value == -F::ONE)
+        );
+        assert!(
+            numerators[2 * height..3 * height]
+                .iter()
+                .all(|&value| value == F::ONE)
+        );
+        assert!(
+            numerators[3 * height..]
+                .iter()
+                .all(|&value| value == F::ZERO)
+        );
+        assert!(
+            denominators.as_slice()[..height]
+                .iter()
+                .all(|&value| value == EF::from_u64(22))
+        );
+        assert!(
+            denominators.as_slice()[height..2 * height]
+                .iter()
+                .all(|&value| value == EF::from_u64(17))
+        );
+        assert!(
+            denominators.as_slice()[2 * height..3 * height]
+                .iter()
+                .all(|&value| value == EF::from_u64(25))
+        );
+        assert!(
+            denominators.as_slice()[3 * height..]
+                .iter()
+                .all(|&value| value == EF::ONE)
+        );
+    }
+
+    #[test]
+    fn shares_named_global_buses_and_separates_different_names() {
+        let shared_a = TestAir(Declaration::GlobalNamed("shared"));
+        let shared_b = TestAir(Declaration::GlobalNamed("shared"));
+        let other = TestAir(Declaration::GlobalNamed("other"));
+        let height = 1 << test_lookup_num_variables();
+        let values = vec![5; height];
+        let zeros = vec![0; height];
+        let main = table(&[&values, &zeros, &zeros]);
+
+        let materialization = materialize(
+            &[&shared_a, &shared_b, &other],
+            &[&main, &main, &main],
+            &[None, None, None],
+            &[&[], &[], &[]],
+            EF::from_u64(100),
+            EF::from_u64(7),
+        )
+        .unwrap();
+        let active_height = 3 * height;
+        let denominators = unpack_denominators(&materialization);
+        assert!(
+            materialization.n.as_slice()[..active_height]
+                .iter()
+                .all(|&value| value == F::ONE)
+        );
+        assert!(
+            materialization.n.as_slice()[active_height..]
+                .iter()
+                .all(|&value| value == F::ZERO)
+        );
+        assert!(
+            denominators.as_slice()[..2 * height]
+                .iter()
+                .all(|&value| value == EF::from_u64(102))
+        );
+        assert!(
+            denominators.as_slice()[2 * height..active_height]
+                .iter()
+                .all(|&value| value == EF::from_u64(109))
+        );
+        assert!(
+            denominators.as_slice()[active_height..]
+                .iter()
+                .all(|&value| value == EF::ONE)
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "named global lookup bus `shared` uses payload width 2, but its established width is 1"
+    )]
+    fn rejects_different_payload_widths_on_one_named_global_bus() {
+        let narrow = TestAir(Declaration::GlobalNamed("shared"));
+        let wide = TestAir(Declaration::GlobalNamedWide("shared"));
+        let num_variables = test_lookup_num_variables();
+
+        LookupPlan::<F>::build::<EF, _>(&[&narrow, &wide], &[num_variables, num_variables]);
+    }
+
+    #[test]
+    fn places_mixed_height_instances_in_descending_stable_order() {
+        let air = TestAir(Declaration::Global);
+        let short_height = 1 << test_lookup_num_variables();
+        let middle_height = 2 * short_height;
+        let tall_height = 4 * short_height;
+        let short_values = (0..short_height)
+            .map(|row| 40 + row as u64)
+            .collect::<Vec<_>>();
+        let middle_values = (0..middle_height)
+            .map(|row| 100 + row as u64)
+            .collect::<Vec<_>>();
+        let tall_a_values = (0..tall_height)
+            .map(|row| 200 + row as u64)
+            .collect::<Vec<_>>();
+        let tall_b_values = (0..tall_height)
+            .map(|row| 300 + row as u64)
+            .collect::<Vec<_>>();
+        let short_zeros = vec![0; short_height];
+        let middle_zeros = vec![0; middle_height];
+        let tall_zeros = vec![0; tall_height];
+        let short = table(&[&short_values, &short_zeros, &short_zeros]);
+        let middle = table(&[&middle_values, &middle_zeros, &middle_zeros]);
+        let tall_a = table(&[&tall_a_values, &tall_zeros, &tall_zeros]);
+        let tall_b = table(&[&tall_b_values, &tall_zeros, &tall_zeros]);
+        let alpha = EF::from_u64(100);
+        let beta = EF::from_u64(7);
+
+        let materialization = materialize(
+            &[&air, &air, &air, &air],
+            &[&short, &tall_a, &middle, &tall_b],
+            &[None, None, None, None],
+            &[&[], &[], &[], &[]],
+            alpha,
+            beta,
+        )
+        .unwrap();
+
+        let active_values = tall_a_values
+            .iter()
+            .chain(&tall_b_values)
+            .chain(&middle_values)
+            .chain(&short_values)
+            .copied()
+            .collect::<Vec<_>>();
+        let bus_prefix = Challenges::new(alpha, beta, 1, 1).bus_prefix[0];
+        let denominators = unpack_denominators(&materialization);
+        assert_eq!(
+            materialization.n.num_evals(),
+            active_values.len().next_power_of_two()
+        );
+        assert!(
+            materialization.n.as_slice()[..active_values.len()]
+                .iter()
+                .all(|&numer| numer == F::ONE)
+        );
+        assert!(
+            materialization.n.as_slice()[active_values.len()..]
+                .iter()
+                .all(|&numer| numer == F::ZERO)
+        );
+        for (row, value) in active_values.into_iter().enumerate() {
+            assert_eq!(
+                denominators.as_slice()[row],
+                bus_prefix - EF::from_u64(value)
+            );
+        }
+        assert!(
+            denominators.as_slice()[tall_height * 2 + middle_height + short_height..]
+                .iter()
+                .all(|&denom| denom == EF::ONE)
+        );
+    }
+
+    #[test]
+    fn resolves_count_expression_and_repeat_last_next() {
+        let air = TestAir(Declaration::NextGlobal);
+        let height = 1 << test_lookup_num_variables();
+        let left = (0..height).map(|row| row as u64 + 2).collect::<Vec<_>>();
+        let right = (0..height).map(|row| row as u64 + 10).collect::<Vec<_>>();
+        let multiplicity = (0..height)
+            .map(|row| [1, 2, 0, 3][row % 4])
+            .collect::<Vec<_>>();
+        let main = table(&[&left, &right, &multiplicity]);
+
+        let materialization = materialize(
+            &[&air],
+            &[&main],
+            &[None],
+            &[&[]],
+            EF::from_u64(100),
+            EF::from_u64(7),
+        )
+        .unwrap();
+        let denominators = unpack_denominators(&materialization);
+        let bus_prefix = Challenges::new(EF::from_u64(100), EF::from_u64(7), 1, 1).bus_prefix[0];
+        for row in 0..height {
+            let next_row = core::cmp::min(row + 1, height - 1);
+            let payload =
+                F::from_u64(left[row]) * F::from_u64(right[row]) - F::from_u64(left[next_row]);
+            assert_eq!(
+                materialization.n.as_slice()[row],
+                F::from_u64(multiplicity[row])
+            );
+            assert_eq!(denominators.as_slice()[row], bus_prefix - EF::from(payload));
+        }
+    }
+
+    #[test]
+    fn combines_payload_in_extension_field_with_precomputed_powers() {
+        let air = TestAir(Declaration::WideGlobal);
+        let height = 1 << test_lookup_num_variables();
+        let first = (0..height).map(|row| row as u64 + 2).collect::<Vec<_>>();
+        let second = (0..height).map(|row| row as u64 + 7).collect::<Vec<_>>();
+        let zeros = vec![0; height];
+        let main = table(&[&first, &second, &zeros]);
+
+        let materialization = materialize(
+            &[&air],
+            &[&main],
+            &[None],
+            &[&[]],
+            EF::from_u64(100),
+            EF::from_u64(5),
+        )
+        .unwrap();
+        let denominators = unpack_denominators(&materialization);
+        let alpha = EF::from_u64(100);
+        let beta = EF::from_u64(5);
+        let bus_prefix = Challenges::new(alpha, beta, 2, 1).bus_prefix[0];
+        for row in 0..height {
+            let fingerprint = EF::from_u64(first[row]) + beta * EF::from_u64(second[row]);
+            assert_eq!(materialization.n.as_slice()[row], F::ONE);
+            assert_eq!(denominators.as_slice()[row], bus_prefix - fingerprint);
+        }
+    }
+
+    #[test]
+    fn packed_materialization_matches_the_row_formula() {
+        let air = TestAir(Declaration::NextGlobal);
+        let height = core::cmp::max(
+            1 << test_lookup_num_variables(),
+            2 * <<F as Field>::Packing as PackedValue>::WIDTH,
+        );
+        let left = (0..height).map(|i| i as u64 + 2).collect::<Vec<_>>();
+        let right = (0..height).map(|i| (i % 5) as u64 + 3).collect::<Vec<_>>();
+        let multiplicity = (0..height).map(|i| (i % 4) as u64).collect::<Vec<_>>();
+        let main = table(&[&left, &right, &multiplicity]);
+        let alpha = EF::from_u64(1_000);
+        let beta = EF::from_u64(7);
+
+        let materialization = materialize(&[&air], &[&main], &[None], &[&[]], alpha, beta).unwrap();
+        let bus_prefix = Challenges::new(alpha, beta, 1, 1).bus_prefix[0];
+        let denominators = unpack_denominators(&materialization);
+
+        for row in 0..height {
+            let next_row = core::cmp::min(row + 1, height - 1);
+            let payload =
+                F::from_u64(left[row]) * F::from_u64(right[row]) - F::from_u64(left[next_row]);
+            assert_eq!(
+                materialization.n.as_slice()[row],
+                F::from_u64(multiplicity[row])
+            );
+            assert_eq!(denominators.as_slice()[row], bus_prefix - EF::from(payload));
+        }
+    }
+
+    #[test]
+    fn resolves_all_symbolic_sources_with_extension_challenges() {
+        let air = TestAir(Declaration::SymbolicSources);
+        let mut rng = SmallRng::seed_from_u64(0xA11_50CE5);
+
+        for height in [
+            1 << test_lookup_num_variables(),
+            core::cmp::max(
+                2 << test_lookup_num_variables(),
+                2 * <<F as Field>::Packing as PackedValue>::WIDTH,
+            ),
+        ] {
+            let key_tail = (0..height).map(|i| i as u64 + 2).collect::<Vec<_>>();
+            let multiplicity = (0..height).map(|i| (i % 3) as u64 + 1).collect::<Vec<_>>();
+            let unused = vec![0; height];
+            let preprocessed_values = (0..height).map(|i| 10 + (i % 7) as u64).collect::<Vec<_>>();
+            let main = table(&[&key_tail, &multiplicity, &unused]);
+            let preprocessed = table(&[&preprocessed_values]);
+            let public_values = [F::from_u64(6)];
+            let alpha: EF = rng.random();
+            let beta: EF = rng.random();
+
+            let materialization = materialize(
+                &[&air],
+                &[&main],
+                &[Some(&preprocessed)],
+                &[&public_values],
+                alpha,
+                beta,
+            )
+            .unwrap();
+            let bus_prefix = Challenges::new(alpha, beta, 2, 1).bus_prefix[0];
+            let denominators = unpack_denominators(&materialization);
+
+            for row in 0..height {
+                let next_row = core::cmp::min(row + 1, height - 1);
+                let payload = F::from_u64(preprocessed_values[row])
+                    + F::from_u64(preprocessed_values[next_row]).double()
+                    + public_values[0]
+                    + F::from_u64(3) * F::from_bool(row == 0)
+                    + F::from_u64(5) * F::from_bool(row + 1 == height)
+                    + F::from_u64(7) * F::from_bool(row + 1 < height);
+                let fingerprint = EF::from(payload) + beta * F::from_u64(key_tail[row]);
+
+                assert_eq!(
+                    materialization.n.as_slice()[row],
+                    F::from_u64(multiplicity[row])
+                );
+                assert_eq!(denominators.as_slice()[row], bus_prefix - fingerprint);
+            }
+        }
+    }
+
+    #[test]
+    fn evaluates_air_symbolically_only_once() {
+        let air = CountedAir {
+            eval_calls: AtomicUsize::new(0),
+        };
+        let height = 1 << test_lookup_num_variables();
+        let values = (0..height).map(|row| row as u64 + 2).collect::<Vec<_>>();
+        let main = table(&[&values, &values]);
+
+        let materialization = materialize(
+            &[&air],
+            &[&main],
+            &[None],
+            &[&[]],
+            EF::from_u64(100),
+            EF::from_u64(7),
+        );
+
+        assert!(materialization.is_some());
+        assert_eq!(air.eval_calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn interaction_free_batch_materializes_no_rows() {
+        let no_declaration = TestAir(Declaration::None);
+        let empty_local = TestAir(Declaration::EmptyLocal);
+        let main = table(&[&[0, 0], &[0, 0], &[0, 0]]);
+
+        let no_declaration = materialize(
+            &[&no_declaration],
+            &[&main],
+            &[None],
+            &[&[]],
+            F::ZERO,
+            F::ZERO,
+        );
+        let empty_local = materialize(&[&empty_local], &[&main], &[None], &[&[]], F::ZERO, F::ZERO);
+
+        assert!(no_declaration.is_none());
+        assert!(empty_local.is_none());
+    }
+}

--- a/multi-stark/src/fractional_gkr/materialize.rs
+++ b/multi-stark/src/fractional_gkr/materialize.rs
@@ -75,10 +75,10 @@ struct Scratch<Var> {
 impl<Var: PrimeCharacteristicRing> Scratch<Var> {
     fn new(main_width: usize, preprocessed_width: usize) -> Self {
         Self {
-            local: vec![Var::ZERO; main_width],
-            next: vec![Var::ZERO; main_width],
-            preprocessed_local: vec![Var::ZERO; preprocessed_width],
-            preprocessed_next: vec![Var::ZERO; preprocessed_width],
+            local: Var::zero_vec(main_width),
+            next: Var::zero_vec(main_width),
+            preprocessed_local: Var::zero_vec(preprocessed_width),
+            preprocessed_next: Var::zero_vec(preprocessed_width),
         }
     }
 }

--- a/multi-stark/src/fractional_gkr/materialize.rs
+++ b/multi-stark/src/fractional_gkr/materialize.rs
@@ -216,6 +216,8 @@ fn materialize_contributions_packed<F, EF>(
                             *next = if row + 1 + packing_width <= num_evals {
                                 *F::Packing::from_slice(&column[row + 1..row + 1 + packing_width])
                             } else {
+                                // Match ordinary AIR evaluation: at the final row, `next`
+                                // repeats the local row rather than wrapping to row zero.
                                 F::Packing::from_fn(|lane| {
                                     column[core::cmp::min(row + lane + 1, num_evals - 1)]
                                 })

--- a/multi-stark/src/fractional_gkr/mod.rs
+++ b/multi-stark/src/fractional_gkr/mod.rs
@@ -1,0 +1,81 @@
+//! Fractional GKR for reducing a table of fractions to a single sum.
+//!
+//! The protocol folds pairs of fractions up a binary tree and proves each
+//! reduction with sumcheck. Its output is an opening of the original numerator
+//! and denominator tables at a transcript-derived point.
+
+use alloc::vec::Vec;
+
+use p3_field::PrimeCharacteristicRing;
+use p3_multilinear_util::point::Point;
+use serde::{Deserialize, Serialize};
+
+pub(crate) mod materialize;
+mod prover;
+mod verifier;
+
+#[cfg(test)]
+mod test;
+
+pub use prover::prove_fractional_gkr;
+/// Verification errors and the verifier for a fractional-GKR proof.
+pub use verifier::{FractionGkrError, verify_fractional_gkr};
+
+/// A numerator and denominator pair with independently chosen storage types.
+#[derive(Clone, Debug)]
+pub struct Fraction<N, D> {
+    /// The numerator or numerator evaluation table.
+    pub n: N,
+    /// The denominator or denominator evaluation table.
+    pub d: D,
+}
+
+/// The two child fractions opened at the end of a reduction layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SplitFraction<T> {
+    /// Numerator of the child at branch zero.
+    pub n0: T,
+    /// Denominator of the child at branch zero.
+    pub d0: T,
+    /// Numerator of the child at branch one.
+    pub n1: T,
+    /// Denominator of the child at branch one.
+    pub d1: T,
+}
+
+impl<A: PrimeCharacteristicRing + Copy> SplitFraction<A> {
+    pub(crate) fn gate(&self, lambda: A) -> A {
+        self.d1 * self.n0 + self.d0 * self.n1 + lambda * self.d0 * self.d1
+    }
+}
+
+/// The proof messages for one layer of the fractional reduction tree.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FractionGkrLayerProof<EF> {
+    /// Sumcheck polynomial evaluations at points zero, two, and three.
+    pub round_polys: Vec<[EF; 3]>,
+    /// The two child fractions to which the layer's sumcheck reduces.
+    pub claims: SplitFraction<EF>,
+}
+
+/// A proof that a table of fractions reduces to the claimed root fraction.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FractionGkrProof<EF> {
+    /// Numerator of the fully reduced root fraction.
+    pub root_numerator: EF,
+    /// Denominator of the fully reduced root fraction.
+    pub root_denominator: EF,
+    /// Layer proofs in root-to-input order.
+    pub layers: Vec<FractionGkrLayerProof<EF>>,
+}
+
+/// The opening claim for the original fraction tables produced by the protocol.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FractionGkrOutput<EF> {
+    /// The transcript-derived point at which both tables are opened.
+    pub point: Point<EF>,
+    /// The multilinear evaluation of the numerator table at `point`.
+    pub numerator: EF,
+    /// The multilinear evaluation of the denominator table at `point`.
+    pub denominator: EF,
+}

--- a/multi-stark/src/fractional_gkr/mod.rs
+++ b/multi-stark/src/fractional_gkr/mod.rs
@@ -58,11 +58,9 @@ pub struct FractionGkrLayerProof<EF> {
     pub claims: SplitFraction<EF>,
 }
 
-/// A proof that a table of fractions reduces to the claimed root fraction.
+/// A proof that a table of fractions reduces to a zero root numerator.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FractionGkrProof<EF> {
-    /// Numerator of the fully reduced root fraction.
-    pub root_numerator: EF,
     /// Denominator of the fully reduced root fraction.
     pub root_denominator: EF,
     /// Layer proofs in root-to-input order.

--- a/multi-stark/src/fractional_gkr/mod.rs
+++ b/multi-stark/src/fractional_gkr/mod.rs
@@ -67,13 +67,13 @@ pub struct FractionGkrProof<EF> {
     pub layers: Vec<FractionGkrLayerProof<EF>>,
 }
 
-/// The opening claim for the original fraction tables produced by the protocol.
+/// An unauthenticated opening claim for the original fraction tables.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FractionGkrOutput<EF> {
-    /// The transcript-derived point at which both tables are opened.
+    /// The transcript-derived point at which both tables are claimed to be opened.
     pub point: Point<EF>,
-    /// The multilinear evaluation of the numerator table at `point`.
+    /// The claimed multilinear evaluation of the numerator table at `point`.
     pub numerator: EF,
-    /// The multilinear evaluation of the denominator table at `point`.
+    /// The claimed multilinear evaluation of the denominator table at `point`.
     pub denominator: EF,
 }

--- a/multi-stark/src/fractional_gkr/prover.rs
+++ b/multi-stark/src/fractional_gkr/prover.rs
@@ -504,12 +504,11 @@ fn restore_equality_factor<EF: Field>(
     (round_poly, q_sum)
 }
 
-/// Proves a binary-tree reduction of a table of fractions.
+/// Proves that a table of fractions sums to zero via a binary-tree reduction.
 ///
-/// The proof reduces the sum of the input fractions to a single root fraction.
-/// It observes the root and layer messages in `challenger` and returns the
-/// numerator and denominator openings of the input tables at the resulting
-/// transcript-derived point.
+/// It observes the root denominator and layer messages in `challenger` and
+/// returns the numerator and denominator openings of the input tables at the
+/// resulting transcript-derived point.
 ///
 /// # Panics
 ///
@@ -542,21 +541,21 @@ where
             n1: EF::from(fraction.n.as_slice()[1]),
             d1: denom.as_slice()[1],
         };
-        let root_numerator = root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1;
         let root_denominator = root_claims.d0 * root_claims.d1;
+        debug_assert_eq!(
+            root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1,
+            EF::ZERO,
+            "fraction GKR input fractions must sum to zero"
+        );
         assert_ne!(
             root_denominator,
             EF::ZERO,
             "fraction GKR root denominator must be nonzero"
         );
         challenger.observe_algebra_element(root_denominator);
-        challenger.observe_algebra_element(root_numerator);
 
         let lambda: EF = challenger.sample_algebra_element();
-        debug_assert_eq!(
-            root_numerator + lambda * root_denominator,
-            root_claims.gate(lambda)
-        );
+        debug_assert_eq!(lambda * root_denominator, root_claims.gate(lambda));
         challenger.observe_algebra_slice(&[
             root_claims.n0,
             root_claims.d0,
@@ -569,7 +568,6 @@ where
 
         return (
             FractionGkrProof {
-                root_numerator,
                 root_denominator,
                 layers: vec![FractionGkrLayerProof {
                     round_polys: Vec::new(),
@@ -610,25 +608,26 @@ where
     }
 
     let root_claims = fractions.pop().unwrap().unpack().into_constants();
-    let root_numerator = root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1;
     let root_denominator = root_claims.d0 * root_claims.d1;
+    debug_assert_eq!(
+        root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1,
+        EF::ZERO,
+        "fraction GKR input fractions must sum to zero"
+    );
     assert_ne!(
         root_denominator,
         EF::ZERO,
         "fraction GKR root denominator must be nonzero"
     );
     challenger.observe_algebra_element(root_denominator);
-    challenger.observe_algebra_element(root_numerator);
     let interpolator = RoundPolyInterpolator::new(2);
     let mut layer_proofs = Vec::with_capacity(num_variables);
 
     // Prove the final reduction from the two one-variable children to the scalar root. This
-    // layer has no sumcheck variables, but its random linear combination binds both root fields.
+    // layer has no sumcheck variables, but its random linear combination binds the root
+    // denominator to the zero-numerator statement.
     let lambda: EF = challenger.sample_algebra_element();
-    debug_assert_eq!(
-        root_numerator + lambda * root_denominator,
-        root_claims.gate(lambda)
-    );
+    debug_assert_eq!(lambda * root_denominator, root_claims.gate(lambda));
     challenger.observe_algebra_slice(&[
         root_claims.n0,
         root_claims.d0,
@@ -743,7 +742,6 @@ where
 
     (
         FractionGkrProof {
-            root_numerator,
             root_denominator,
             layers: layer_proofs,
         },

--- a/multi-stark/src/fractional_gkr/prover.rs
+++ b/multi-stark/src/fractional_gkr/prover.rs
@@ -551,7 +551,7 @@ where
             d1: denom.as_slice()[1],
         };
         let root_denominator = root_claims.d0 * root_claims.d1;
-        debug_assert_eq!(
+        assert_eq!(
             root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1,
             EF::ZERO,
             "fraction GKR input fractions must sum to zero"
@@ -618,7 +618,7 @@ where
 
     let root_claims = fractions.pop().unwrap().unpack().into_constants();
     let root_denominator = root_claims.d0 * root_claims.d1;
-    debug_assert_eq!(
+    assert_eq!(
         root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1,
         EF::ZERO,
         "fraction GKR input fractions must sum to zero"

--- a/multi-stark/src/fractional_gkr/prover.rs
+++ b/multi-stark/src/fractional_gkr/prover.rs
@@ -1,0 +1,756 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_challenger::FieldChallenger;
+use p3_field::{
+    Algebra, ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
+};
+#[cfg(test)]
+use p3_field::{batch_multiplicative_inverse, dot_product};
+use p3_maybe_rayon::prelude::*;
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
+use p3_sumcheck::generic_degree::RoundPolyInterpolator;
+use p3_util::log2_strict_usize;
+
+use super::{Fraction, FractionGkrLayerProof, FractionGkrOutput, FractionGkrProof, SplitFraction};
+
+struct InputLayer<'a, F: Field, EF: ExtensionField<F>> {
+    fraction: &'a Fraction<Poly<F>, PolyMaybePacked<F, EF>>,
+    eq_suffix: PolyMaybePacked<F, EF>,
+}
+
+struct Layer<F: Field, EF: ExtensionField<F>> {
+    fraction: SplitFractionMaybePacked<F, EF>,
+    eq_suffix: PolyMaybePacked<F, EF>,
+    eq_prefix: EF,
+}
+
+enum SplitFractionMaybePacked<F: Field, EF: ExtensionField<F>> {
+    Packed(SplitFraction<Poly<EF::ExtensionPacking>>),
+    Scalar(SplitFraction<Poly<EF>>),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mixed_round_polys<N, A>(
+    eq_suffix: &[A],
+    n0_lo: &[N],
+    n0_hi: &[N],
+    n1_lo: &[N],
+    n1_hi: &[N],
+    d0_lo: &[A],
+    d0_hi: &[A],
+    d1_lo: &[A],
+    d1_hi: &[A],
+    lambda: A,
+) -> [A; 2]
+where
+    N: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<N> + Copy + Send + Sync,
+{
+    eq_suffix
+        .par_iter()
+        .zip(n0_lo.par_iter().zip(n0_hi.par_iter()))
+        .zip(n1_lo.par_iter().zip(n1_hi.par_iter()))
+        .zip(d0_lo.par_iter().zip(d0_hi.par_iter()))
+        .zip(d1_lo.par_iter().zip(d1_hi.par_iter()))
+        .par_fold_reduce(
+            || [A::ZERO; 2],
+            |mut acc, ((((&eq_suffix, n0), n1), d0), d1)| {
+                let (&n0_lo, &n0_hi) = n0;
+                let (&n1_lo, &n1_hi) = n1;
+                let (&d0_lo, &d0_hi) = d0;
+                let (&d1_lo, &d1_hi) = d1;
+                let n0_dif = n0_hi - n0_lo;
+                let n1_dif = n1_hi - n1_lo;
+                let d0_dif = d0_hi - d0_lo;
+                let d1_dif = d1_hi - d1_lo;
+                let evaluate = |n0: N, n1: N, d0: A, d1: A| d1 * n0 + d0 * n1 + lambda * d0 * d1;
+
+                acc[0] += eq_suffix * evaluate(n0_lo, n1_lo, d0_lo, d1_lo);
+
+                let n0 = n0_hi + n0_dif;
+                let n1 = n1_hi + n1_dif;
+                let d0 = d0_hi + d0_dif;
+                let d1 = d1_hi + d1_dif;
+
+                acc[1] += eq_suffix * evaluate(n0, n1, d0, d1);
+
+                acc
+            },
+            |mut lhs, rhs| {
+                lhs.iter_mut().zip(rhs).for_each(|(lhs, rhs)| *lhs += rhs);
+                lhs
+            },
+        )
+}
+
+fn reduce_fraction<N, A>(n0: &[N], n1: &[N], d0: &[A], d1: &[A]) -> SplitFraction<Poly<A>>
+where
+    N: PrimeCharacteristicRing + Copy + Send + Sync,
+    A: Algebra<N> + Copy + Send + Sync,
+{
+    debug_assert_eq!(n0.len(), n1.len());
+    debug_assert_eq!(n0.len(), d0.len());
+    debug_assert_eq!(n0.len(), d1.len());
+    let (n00, n01) = n0.split_at(n0.len() / 2);
+    let (n10, n11) = n1.split_at(n1.len() / 2);
+    let (d00, d01) = d0.split_at(d0.len() / 2);
+    let (d10, d11) = d1.split_at(d1.len() / 2);
+
+    let reduce = |n0: &[N], n1: &[N], d0: &[A], d1: &[A]| {
+        n0.par_iter()
+            .zip(n1.par_iter())
+            .zip(d0.par_iter())
+            .zip(d1.par_iter())
+            .map(|(((&n0, &n1), &d0), &d1)| (d1 * n0 + d0 * n1, d0 * d1))
+            .unzip::<_, _, Vec<_>, Vec<_>>()
+    };
+
+    let (n0, d0) = reduce(n00, n10, d00, d10);
+    let (n1, d1) = reduce(n01, n11, d01, d11);
+    SplitFraction {
+        n0: Poly::new(n0),
+        d0: Poly::new(d0),
+        n1: Poly::new(n1),
+        d1: Poly::new(d1),
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> Fraction<Poly<F>, PolyMaybePacked<F, EF>> {
+    fn reduce(&self) -> SplitFractionMaybePacked<F, EF> {
+        match &self.d {
+            PolyMaybePacked::Packed(denom) => {
+                let numer = F::Packing::pack_slice(self.n.as_slice());
+                let (n0, n1) = numer.split_at(numer.len() / 2);
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                SplitFractionMaybePacked::Packed(reduce_fraction(n0, n1, d0, d1))
+            }
+            PolyMaybePacked::Scalar(denom) => {
+                let (n0, n1) = self.n.as_slice().split_at(self.n.num_evals() / 2);
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                SplitFractionMaybePacked::Scalar(reduce_fraction(n0, n1, d0, d1))
+            }
+        }
+    }
+}
+
+impl<'a, F: Field, EF: ExtensionField<F>> InputLayer<'a, F, EF> {
+    fn new(fraction: &'a Fraction<Poly<F>, PolyMaybePacked<F, EF>>, point: &Point<EF>) -> Self {
+        assert_eq!(fraction.d.num_variables(), point.num_variables() + 1);
+        assert_eq!(fraction.n.num_variables(), point.num_variables() + 1);
+
+        let eq_suffix = match &fraction.d {
+            PolyMaybePacked::Packed(_) => PolyMaybePacked::Packed(Poly::new_packed_from_point(
+                &point.as_slice()[1..],
+                EF::ONE,
+            )),
+            PolyMaybePacked::Scalar(_) => {
+                PolyMaybePacked::Scalar(Poly::new_from_point(&point.as_slice()[1..], EF::ONE))
+            }
+        };
+
+        Self {
+            fraction,
+            eq_suffix,
+        }
+    }
+
+    fn round_polys(&self, lambda: EF) -> [EF; 2] {
+        let (n0, n1) = self
+            .fraction
+            .n
+            .as_slice()
+            .split_at(self.fraction.n.num_evals() / 2);
+
+        match (&self.fraction.d, &self.eq_suffix) {
+            (PolyMaybePacked::Packed(denom), PolyMaybePacked::Packed(eq_suffix)) => {
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                let (n0_lo, n0_hi) = n0.split_at(n0.len() / 2);
+                let (n1_lo, n1_hi) = n1.split_at(n1.len() / 2);
+                let (d0_lo, d0_hi) = d0.split_at(d0.len() / 2);
+                let (d1_lo, d1_hi) = d1.split_at(d1.len() / 2);
+
+                mixed_round_polys(
+                    eq_suffix.as_slice(),
+                    F::Packing::pack_slice(n0_lo),
+                    F::Packing::pack_slice(n0_hi),
+                    F::Packing::pack_slice(n1_lo),
+                    F::Packing::pack_slice(n1_hi),
+                    d0_lo,
+                    d0_hi,
+                    d1_lo,
+                    d1_hi,
+                    EF::ExtensionPacking::from(lambda),
+                )
+                .map(|value| EF::ExtensionPacking::to_ext_iter([value]).sum())
+            }
+            (PolyMaybePacked::Scalar(denom), PolyMaybePacked::Scalar(eq_suffix)) => {
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                let half = eq_suffix.num_evals();
+                let (n0_lo, n0_hi) = n0.split_at(half);
+                let (n1_lo, n1_hi) = n1.split_at(half);
+                let (d0_lo, d0_hi) = d0.split_at(half);
+                let (d1_lo, d1_hi) = d1.split_at(half);
+
+                mixed_round_polys(
+                    eq_suffix.as_slice(),
+                    n0_lo,
+                    n0_hi,
+                    n1_lo,
+                    n1_hi,
+                    d0_lo,
+                    d0_hi,
+                    d1_lo,
+                    d1_hi,
+                    lambda,
+                )
+            }
+            _ => unreachable!("input denominator and equality table use the same representation"),
+        }
+    }
+
+    fn fold(self, coordinate: EF, r: EF) -> Layer<F, EF> {
+        let Fraction { n, d } = self.fraction;
+        let (n0, n1) = n.as_slice().split_at(n.num_evals() / 2);
+
+        let (fraction, eq_suffix) = match (d, self.eq_suffix) {
+            (PolyMaybePacked::Packed(denom), PolyMaybePacked::Packed(mut eq_suffix)) => {
+                eq_suffix.sum_prefix_var_mut();
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                let r_packed = EF::ExtensionPacking::from(r);
+                (
+                    SplitFractionMaybePacked::Packed(SplitFraction {
+                        n0: Poly::new(n0).fix_prefix_var_to_packed(r),
+                        n1: Poly::new(n1).fix_prefix_var_to_packed(r),
+                        d0: Poly::new(d0).fix_prefix_var(r_packed),
+                        d1: Poly::new(d1).fix_prefix_var(r_packed),
+                    }),
+                    PolyMaybePacked::Packed(eq_suffix),
+                )
+            }
+            (PolyMaybePacked::Scalar(denom), PolyMaybePacked::Scalar(mut eq_suffix)) => {
+                eq_suffix.sum_prefix_var_mut();
+                let (d0, d1) = denom.as_slice().split_at(denom.num_evals() / 2);
+                (
+                    SplitFractionMaybePacked::Scalar(SplitFraction {
+                        n0: Poly::new(n0).fix_prefix_var(r),
+                        n1: Poly::new(n1).fix_prefix_var(r),
+                        d0: Poly::new(d0).fix_prefix_var(r),
+                        d1: Poly::new(d1).fix_prefix_var(r),
+                    }),
+                    PolyMaybePacked::Scalar(eq_suffix),
+                )
+            }
+            _ => unreachable!("input denominator and equality table use the same representation"),
+        };
+
+        let mut layer = Layer {
+            fraction,
+            eq_suffix,
+            eq_prefix: (EF::ONE - coordinate) + r * (coordinate.double() - EF::ONE),
+        };
+        layer.transition();
+        layer
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> Layer<F, EF> {
+    fn new(fraction: SplitFractionMaybePacked<F, EF>, point: &Point<EF>) -> Self {
+        let eq_suffix = match &fraction {
+            SplitFractionMaybePacked::Packed(_) => PolyMaybePacked::Packed(
+                Poly::new_packed_from_point(&point.as_slice()[1..], EF::ONE),
+            ),
+            SplitFractionMaybePacked::Scalar(_) => {
+                PolyMaybePacked::Scalar(Poly::new_from_point(&point.as_slice()[1..], EF::ONE))
+            }
+        };
+        let mut layer = Self {
+            fraction,
+            eq_suffix,
+            eq_prefix: EF::ONE,
+        };
+        layer.transition();
+        layer
+    }
+
+    fn num_variables(&self) -> usize {
+        self.fraction.num_variables() - 1
+    }
+
+    /// Evaluate the equality-stripped quadratic round polynomial at `0` and `2`.
+    fn round_polys(&self, lambda: EF) -> [EF; 2] {
+        match (&self.fraction, &self.eq_suffix) {
+            (SplitFractionMaybePacked::Packed(fraction), PolyMaybePacked::Packed(eq)) => fraction
+                .round_polys(eq, EF::ExtensionPacking::from(lambda))
+                .map(|value| EF::ExtensionPacking::to_ext_iter([value]).sum()),
+            (SplitFractionMaybePacked::Scalar(fraction), PolyMaybePacked::Scalar(eq)) => {
+                fraction.round_polys(eq, lambda)
+            }
+            _ => unreachable!("fraction and equality tables use the same representation"),
+        }
+    }
+
+    fn fold(&mut self, coordinate: EF, r: EF) {
+        match (&mut self.fraction, &mut self.eq_suffix) {
+            (SplitFractionMaybePacked::Packed(fraction), PolyMaybePacked::Packed(eq_suffix)) => {
+                let r = EF::ExtensionPacking::from(r);
+                fraction.n0.fix_prefix_var_mut(r);
+                fraction.n1.fix_prefix_var_mut(r);
+                fraction.d0.fix_prefix_var_mut(r);
+                fraction.d1.fix_prefix_var_mut(r);
+                eq_suffix.sum_prefix_var_mut();
+            }
+            (SplitFractionMaybePacked::Scalar(fraction), PolyMaybePacked::Scalar(eq_suffix)) => {
+                fraction.n0.fix_prefix_var_mut(r);
+                fraction.n1.fix_prefix_var_mut(r);
+                fraction.d0.fix_prefix_var_mut(r);
+                fraction.d1.fix_prefix_var_mut(r);
+                eq_suffix.sum_prefix_var_mut();
+            }
+            _ => unreachable!("fraction and equality tables use the same representation"),
+        }
+        self.eq_prefix *= (EF::ONE - coordinate) + r * (coordinate.double() - EF::ONE);
+        self.transition();
+    }
+
+    fn into_claims(self) -> SplitFraction<EF> {
+        assert_eq!(self.num_variables(), 0);
+
+        match &self.fraction {
+            SplitFractionMaybePacked::Scalar(fraction) => SplitFraction {
+                n0: fraction.n0.as_constant().unwrap(),
+                d0: fraction.d0.as_constant().unwrap(),
+                n1: fraction.n1.as_constant().unwrap(),
+                d1: fraction.d1.as_constant().unwrap(),
+            },
+            _ => unreachable!("fraction and equality tables use the same representation"),
+        }
+    }
+
+    fn transition(&mut self) {
+        if let (SplitFractionMaybePacked::Packed(fraction), PolyMaybePacked::Packed(eq_suffix)) =
+            (&mut self.fraction, &mut self.eq_suffix)
+            && eq_suffix.num_evals() == 1
+        {
+            self.fraction = SplitFractionMaybePacked::Scalar(SplitFraction {
+                n0: fraction.n0.unpack::<F, EF>(),
+                d0: fraction.d0.unpack::<F, EF>(),
+                n1: fraction.n1.unpack::<F, EF>(),
+                d1: fraction.d1.unpack::<F, EF>(),
+            });
+            self.eq_suffix = PolyMaybePacked::Scalar(eq_suffix.unpack::<F, EF>());
+        }
+    }
+}
+
+impl<A> SplitFraction<Poly<A>>
+where
+    A: PrimeCharacteristicRing + Copy + Send + Sync,
+{
+    fn num_variables(&self) -> usize {
+        self.n0.num_variables() + 1
+    }
+
+    fn reduce(&self) -> Self {
+        reduce_fraction(
+            self.n0.as_slice(),
+            self.n1.as_slice(),
+            self.d0.as_slice(),
+            self.d1.as_slice(),
+        )
+    }
+
+    fn round_polys(&self, eq_suffix: &Poly<A>, lambda: A) -> [A; 2] {
+        let half = eq_suffix.num_evals();
+        let (n0_lo, n0_hi) = self.n0.as_slice().split_at(half);
+        let (n1_lo, n1_hi) = self.n1.as_slice().split_at(half);
+        let (d0_lo, d0_hi) = self.d0.as_slice().split_at(half);
+        let (d1_lo, d1_hi) = self.d1.as_slice().split_at(half);
+
+        mixed_round_polys(
+            eq_suffix.as_slice(),
+            n0_lo,
+            n0_hi,
+            n1_lo,
+            n1_hi,
+            d0_lo,
+            d0_hi,
+            d1_lo,
+            d1_hi,
+            lambda,
+        )
+    }
+
+    fn into_constants(self) -> SplitFraction<A> {
+        SplitFraction {
+            n0: self
+                .n0
+                .as_constant()
+                .expect("root numerator must be constant"),
+            d0: self
+                .d0
+                .as_constant()
+                .expect("root denominator must be constant"),
+            n1: self
+                .n1
+                .as_constant()
+                .expect("root numerator must be constant"),
+            d1: self
+                .d1
+                .as_constant()
+                .expect("root denominator must be constant"),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<A: Field> SplitFraction<Poly<A>> {
+    pub(super) fn sum(&self) -> A {
+        let mut denom = Vec::with_capacity(self.d0.num_evals() + self.d1.num_evals());
+        denom.extend_from_slice(self.d0.as_slice());
+        denom.extend_from_slice(self.d1.as_slice());
+        let denom_inv = batch_multiplicative_inverse(&denom);
+
+        dot_product(
+            denom_inv.into_iter(),
+            self.n0.as_slice().iter().chain(self.n1.as_slice()).copied(),
+        )
+    }
+
+    pub(super) fn eval(&self, point: &Point<A>) -> (A, A) {
+        assert_eq!(point.num_variables(), self.num_variables());
+        let branch = point[0];
+        let suffix = point.get_subpoint_over_range(1..);
+        let n0 = self.n0.eval_ext::<A>(&suffix);
+        let n1 = self.n1.eval_ext::<A>(&suffix);
+        let d0 = self.d0.eval_ext::<A>(&suffix);
+        let d1 = self.d1.eval_ext::<A>(&suffix);
+
+        (n0 + branch * (n1 - n0), d0 + branch * (d1 - d0))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>> SplitFractionMaybePacked<F, EF> {
+    fn num_variables(&self) -> usize {
+        match self {
+            Self::Packed(fraction) => {
+                fraction.num_variables() + log2_strict_usize(F::Packing::WIDTH)
+            }
+            Self::Scalar(fraction) => fraction.num_variables(),
+        }
+    }
+
+    fn reduce(&self) -> Self {
+        let mut reduced = match self {
+            Self::Packed(fraction) => Self::Packed(fraction.reduce()),
+            Self::Scalar(fraction) => Self::Scalar(fraction.reduce()),
+        };
+        reduced.transition();
+        reduced
+    }
+
+    /// Leave packed mode after its final useful SIMD reduction.
+    fn transition(&mut self) {
+        match self {
+            Self::Packed(fraction) if fraction.n0.num_evals() == 1 => {
+                *self = Self::Scalar(SplitFraction {
+                    n0: fraction.n0.unpack::<F, EF>(),
+                    d0: fraction.d0.unpack::<F, EF>(),
+                    n1: fraction.n1.unpack::<F, EF>(),
+                    d1: fraction.d1.unpack::<F, EF>(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    fn unpack(self) -> SplitFraction<Poly<EF>> {
+        match self {
+            Self::Packed(fraction) => SplitFraction {
+                n0: fraction.n0.unpack::<F, EF>(),
+                n1: fraction.n1.unpack::<F, EF>(),
+                d0: fraction.d0.unpack::<F, EF>(),
+                d1: fraction.d1.unpack::<F, EF>(),
+            },
+            Self::Scalar(fraction) => fraction,
+        }
+    }
+}
+
+/// Restore the current equality factor to the internally quadratic round polynomial.
+///
+/// The returned message contains the cubic evaluations expected by the existing verifier.
+/// `q_sum` is the normalized quadratic sum `q(0) + q(1)` used only by the prover.
+fn restore_equality_factor<EF: Field>(
+    quadratic_evals: [EF; 2],
+    normalized_sum: EF,
+    coordinate: EF,
+    equality_prefix: EF,
+    interpolator: &RoundPolyInterpolator<EF>,
+) -> ([EF; 3], EF) {
+    let q1 = (normalized_sum - (EF::ONE - coordinate) * quadratic_evals[0]) * coordinate.inverse();
+    let q_sum = quadratic_evals[0] + q1;
+    let q3 = interpolator.eval(&quadratic_evals, q_sum, EF::from_u8(3));
+    let equality_0 = EF::ONE - coordinate;
+    let equality_step = coordinate.double() - EF::ONE;
+    let equality_2 = equality_0 + EF::TWO * equality_step;
+    let equality_3 = equality_2 + equality_step;
+    let round_poly = [
+        equality_prefix * equality_0 * quadratic_evals[0],
+        equality_prefix * equality_2 * quadratic_evals[1],
+        equality_prefix * equality_3 * q3,
+    ];
+    (round_poly, q_sum)
+}
+
+/// Proves a binary-tree reduction of a table of fractions.
+///
+/// The proof reduces the sum of the input fractions to a single root fraction.
+/// It observes the root and layer messages in `challenger` and returns the
+/// numerator and denominator openings of the input tables at the resulting
+/// transcript-derived point.
+///
+/// # Panics
+///
+/// Panics if the numerator and denominator have different variable counts, if
+/// they have no variables, or if the fully reduced root denominator is zero.
+pub fn prove_fractional_gkr<F, EF, Challenger>(
+    fraction: &Fraction<Poly<F>, PolyMaybePacked<F, EF>>,
+    challenger: &mut Challenger,
+) -> (FractionGkrProof<EF>, FractionGkrOutput<EF>)
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Challenger: FieldChallenger<F>,
+{
+    let num_variables = fraction.n.num_variables();
+    assert_eq!(num_variables, fraction.d.num_variables());
+    assert!(
+        num_variables >= 1,
+        "fraction GKR requires at least one input variable"
+    );
+
+    // With one input variable, the original two leaves are already the root's children. The
+    // root layer is therefore also the input layer: it has no sumcheck rounds and directly opens
+    // the input at the sampled branch coordinate.
+    if num_variables == 1 {
+        let denom = fraction.d.clone().unpack();
+        let root_claims = SplitFraction {
+            n0: EF::from(fraction.n.as_slice()[0]),
+            d0: denom.as_slice()[0],
+            n1: EF::from(fraction.n.as_slice()[1]),
+            d1: denom.as_slice()[1],
+        };
+        let root_numerator = root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1;
+        let root_denominator = root_claims.d0 * root_claims.d1;
+        assert_ne!(
+            root_denominator,
+            EF::ZERO,
+            "fraction GKR root denominator must be nonzero"
+        );
+        challenger.observe_algebra_element(root_denominator);
+        challenger.observe_algebra_element(root_numerator);
+
+        let lambda: EF = challenger.sample_algebra_element();
+        debug_assert_eq!(
+            root_numerator + lambda * root_denominator,
+            root_claims.gate(lambda)
+        );
+        challenger.observe_algebra_slice(&[
+            root_claims.n0,
+            root_claims.d0,
+            root_claims.n1,
+            root_claims.d1,
+        ]);
+        let branch: EF = challenger.sample_algebra_element();
+        let numerator = root_claims.n0 + branch * (root_claims.n1 - root_claims.n0);
+        let denominator = root_claims.d0 + branch * (root_claims.d1 - root_claims.d0);
+
+        return (
+            FractionGkrProof {
+                root_numerator,
+                root_denominator,
+                layers: vec![FractionGkrLayerProof {
+                    round_polys: Vec::new(),
+                    claims: root_claims,
+                }],
+            },
+            FractionGkrOutput {
+                point: Point::new(vec![branch]),
+                numerator,
+                denominator,
+            },
+        );
+    }
+
+    // The packed input path needs three backing variables: two for its initial
+    // branch splits and one for dropping the first equality-suffix variable
+    // before transitioning to scalar storage. With fewer, those logical
+    // variables live entirely inside SIMD lanes, where the backing-table folds
+    // cannot address them. At this tiny boundary, unpack once and reuse the
+    // scalar prover so its proof and transcript stay identical to scalar storage.
+    let scalar_fraction = if let PolyMaybePacked::Packed(denom) = &fraction.d
+        && denom.num_variables() < 3
+    {
+        Some(Fraction {
+            n: fraction.n.clone(),
+            d: PolyMaybePacked::Scalar(denom.unpack::<F, EF>()),
+        })
+    } else {
+        None
+    };
+    let fraction = scalar_fraction.as_ref().unwrap_or(fraction);
+
+    // Build every reduced tree layer while retaining the original input for the
+    // final mixed base/extension-field layer.
+    let mut fractions = vec![fraction.reduce()];
+    while fractions.last().unwrap().num_variables() > 1 {
+        fractions.push(fractions.last().unwrap().reduce());
+    }
+
+    let root_claims = fractions.pop().unwrap().unpack().into_constants();
+    let root_numerator = root_claims.d1 * root_claims.n0 + root_claims.d0 * root_claims.n1;
+    let root_denominator = root_claims.d0 * root_claims.d1;
+    assert_ne!(
+        root_denominator,
+        EF::ZERO,
+        "fraction GKR root denominator must be nonzero"
+    );
+    challenger.observe_algebra_element(root_denominator);
+    challenger.observe_algebra_element(root_numerator);
+    let interpolator = RoundPolyInterpolator::new(2);
+    let mut layer_proofs = Vec::with_capacity(num_variables);
+
+    // Prove the final reduction from the two one-variable children to the scalar root. This
+    // layer has no sumcheck variables, but its random linear combination binds both root fields.
+    let lambda: EF = challenger.sample_algebra_element();
+    debug_assert_eq!(
+        root_numerator + lambda * root_denominator,
+        root_claims.gate(lambda)
+    );
+    challenger.observe_algebra_slice(&[
+        root_claims.n0,
+        root_claims.d0,
+        root_claims.n1,
+        root_claims.d1,
+    ]);
+    let branch: EF = challenger.sample_algebra_element();
+    let mut numerator = root_claims.n0 + branch * (root_claims.n1 - root_claims.n0);
+    let mut denominator = root_claims.d0 + branch * (root_claims.d1 - root_claims.d0);
+    let mut point = Point::new(vec![branch]);
+    layer_proofs.push(FractionGkrLayerProof {
+        round_polys: Vec::new(),
+        claims: root_claims,
+    });
+
+    // Reduced extension-field layers are consumed from the top of the tree down.
+    for fraction in fractions.into_iter().rev() {
+        let lambda: EF = challenger.sample_algebra_element();
+        let mut normalized_sum = numerator + lambda * denominator;
+        let mut layer = Layer::new(fraction, &point);
+        let mut round_polys = Vec::with_capacity(point.num_variables());
+        let mut round_point = Vec::with_capacity(point.num_variables());
+
+        debug_assert_eq!(layer.num_variables(), point.num_variables());
+        for round in 0..point.num_variables() {
+            let coordinate = point[round];
+            let quadratic_evals = layer.round_polys(lambda);
+            let (round_poly, q_sum) = restore_equality_factor(
+                quadratic_evals,
+                normalized_sum,
+                coordinate,
+                layer.eq_prefix,
+                &interpolator,
+            );
+            challenger.observe_algebra_slice(&round_poly);
+            let challenge: EF = challenger.sample_algebra_element();
+            round_polys.push(round_poly);
+            round_point.push(challenge);
+            normalized_sum = interpolator.eval(&quadratic_evals, q_sum, challenge);
+            layer.fold(coordinate, challenge);
+        }
+
+        let claims = layer.into_claims();
+        debug_assert_eq!(normalized_sum, claims.gate(lambda));
+        challenger.observe_algebra_slice(&[claims.n0, claims.d0, claims.n1, claims.d1]);
+        let branch: EF = challenger.sample_algebra_element();
+        numerator = claims.n0 + branch * (claims.n1 - claims.n0);
+        denominator = claims.d0 + branch * (claims.d1 - claims.d0);
+        round_point.insert(0, branch);
+        point = Point::new(round_point);
+        layer_proofs.push(FractionGkrLayerProof {
+            round_polys,
+            claims,
+        });
+    }
+
+    // The original lookup arrays are the only mixed base/extension-field layer.
+    // Its first fold promotes the numerators; all later rounds use Layer.
+    let lambda: EF = challenger.sample_algebra_element();
+    let mut normalized_sum = numerator + lambda * denominator;
+    let input_layer = InputLayer::new(fraction, &point);
+    let mut round_polys = Vec::with_capacity(point.num_variables());
+    let mut round_point = Vec::with_capacity(point.num_variables());
+
+    let coordinate = point[0];
+    let quadratic_evals = input_layer.round_polys(lambda);
+    let (round_poly, q_sum) = restore_equality_factor(
+        quadratic_evals,
+        normalized_sum,
+        coordinate,
+        EF::ONE,
+        &interpolator,
+    );
+    challenger.observe_algebra_slice(&round_poly);
+    let challenge: EF = challenger.sample_algebra_element();
+    round_polys.push(round_poly);
+    round_point.push(challenge);
+    normalized_sum = interpolator.eval(&quadratic_evals, q_sum, challenge);
+    let mut layer = input_layer.fold(coordinate, challenge);
+
+    debug_assert_eq!(layer.num_variables(), point.num_variables() - 1);
+    for round in 1..point.num_variables() {
+        let coordinate = point[round];
+        let quadratic_evals = layer.round_polys(lambda);
+        let (round_poly, q_sum) = restore_equality_factor(
+            quadratic_evals,
+            normalized_sum,
+            coordinate,
+            layer.eq_prefix,
+            &interpolator,
+        );
+        challenger.observe_algebra_slice(&round_poly);
+        let challenge: EF = challenger.sample_algebra_element();
+        round_polys.push(round_poly);
+        round_point.push(challenge);
+        normalized_sum = interpolator.eval(&quadratic_evals, q_sum, challenge);
+        layer.fold(coordinate, challenge);
+    }
+
+    let claims = layer.into_claims();
+    debug_assert_eq!(normalized_sum, claims.gate(lambda));
+    challenger.observe_algebra_slice(&[claims.n0, claims.d0, claims.n1, claims.d1]);
+    let branch: EF = challenger.sample_algebra_element();
+    let numerator = claims.n0 + branch * (claims.n1 - claims.n0);
+    let denominator = claims.d0 + branch * (claims.d1 - claims.d0);
+    round_point.insert(0, branch);
+    let point = Point::new(round_point);
+    layer_proofs.push(FractionGkrLayerProof {
+        round_polys,
+        claims,
+    });
+
+    (
+        FractionGkrProof {
+            root_numerator,
+            root_denominator,
+            layers: layer_proofs,
+        },
+        FractionGkrOutput {
+            point,
+            numerator,
+            denominator,
+        },
+    )
+}

--- a/multi-stark/src/fractional_gkr/prover.rs
+++ b/multi-stark/src/fractional_gkr/prover.rs
@@ -48,6 +48,15 @@ where
     N: PrimeCharacteristicRing + Copy + Send + Sync,
     A: Algebra<N> + Copy + Send + Sync,
 {
+    debug_assert_eq!(eq_suffix.len(), n0_lo.len());
+    debug_assert_eq!(eq_suffix.len(), n0_hi.len());
+    debug_assert_eq!(eq_suffix.len(), n1_lo.len());
+    debug_assert_eq!(eq_suffix.len(), n1_hi.len());
+    debug_assert_eq!(eq_suffix.len(), d0_lo.len());
+    debug_assert_eq!(eq_suffix.len(), d0_hi.len());
+    debug_assert_eq!(eq_suffix.len(), d1_lo.len());
+    debug_assert_eq!(eq_suffix.len(), d1_hi.len());
+
     eq_suffix
         .par_iter()
         .zip(n0_lo.par_iter().zip(n0_hi.par_iter()))

--- a/multi-stark/src/fractional_gkr/test.rs
+++ b/multi-stark/src/fractional_gkr/test.rs
@@ -1,0 +1,139 @@
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{DuplexChallenger, FieldChallenger};
+use p3_field::extension::BinomialExtensionField;
+use p3_field::{Field, PackedValue};
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
+use p3_util::log2_strict_usize;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use super::{Fraction, SplitFraction, prove_fractional_gkr, verify_fractional_gkr};
+
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+fn fresh_challenger() -> Challenger {
+    let mut rng = SmallRng::seed_from_u64(0xFACC_7100);
+    Challenger::new(Perm::new_from_rng_128(&mut rng))
+}
+
+#[test]
+fn test_gkr_identities() {
+    let mut rng = SmallRng::seed_from_u64(1);
+
+    for num_variables in 1..=10 {
+        let numer = Poly::<F>::rand(&mut rng, num_variables);
+        let denom = Poly::<EF>::rand(&mut rng, num_variables);
+        let direct_sum = numer
+            .iter()
+            .zip(denom.iter())
+            .map(|(&numer, &denom)| denom.inverse() * numer)
+            .sum::<EF>();
+
+        let mut prover_challenger = fresh_challenger();
+        let (proof, prover_output) = prove_fractional_gkr(
+            &Fraction {
+                n: numer.clone(),
+                d: PolyMaybePacked::Scalar(denom.clone()),
+            },
+            &mut prover_challenger,
+        );
+
+        assert_eq!(proof.layers.len(), num_variables);
+        assert!(
+            proof
+                .layers
+                .iter()
+                .enumerate()
+                .all(|(layer, proof)| proof.round_polys.len() == layer)
+        );
+        let top_sum = proof.root_numerator * proof.root_denominator.inverse();
+        assert_eq!(top_sum, direct_sum);
+        assert_eq!(
+            prover_output.numerator,
+            numer.eval_base::<EF>(&prover_output.point),
+        );
+        assert_eq!(
+            prover_output.denominator,
+            denom.eval_ext::<F>(&prover_output.point),
+        );
+
+        let mut verifier_challenger = fresh_challenger();
+        let verifier_output =
+            verify_fractional_gkr::<F, EF, _>(&proof, num_variables, &mut verifier_challenger)
+                .unwrap();
+        assert_eq!(verifier_output, prover_output);
+
+        let prover_final_challenge: EF = prover_challenger.sample_algebra_element();
+        let verifier_final_challenge: EF = verifier_challenger.sample_algebra_element();
+        assert_eq!(prover_final_challenge, verifier_final_challenge);
+    }
+}
+
+#[test]
+fn packed_denominator_preserves_the_gkr_transcript() {
+    let mut rng = SmallRng::seed_from_u64(0xFACC_7103);
+    let packing_variables = log2_strict_usize(<F as Field>::Packing::WIDTH);
+
+    for num_variables in packing_variables.max(1)..=10 {
+        let numer = Poly::<F>::rand(&mut rng, num_variables);
+        let denom = Poly::<EF>::rand(&mut rng, num_variables);
+        let packed_denom = PolyMaybePacked::Packed(denom.pack::<F, EF>());
+        let mut scalar_challenger = fresh_challenger();
+        let (scalar_proof, scalar_output) = prove_fractional_gkr(
+            &Fraction {
+                n: numer.clone(),
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut scalar_challenger,
+        );
+        let mut packed_challenger = fresh_challenger();
+        let (packed_proof, packed_output) = prove_fractional_gkr(
+            &Fraction {
+                n: numer,
+                d: packed_denom,
+            },
+            &mut packed_challenger,
+        );
+
+        assert_eq!(packed_proof, scalar_proof);
+        assert_eq!(packed_output, scalar_output);
+        assert_eq!(
+            packed_challenger.sample_algebra_element::<EF>(),
+            scalar_challenger.sample_algebra_element::<EF>()
+        );
+    }
+}
+
+#[test]
+fn split_fraction_matches_unsplit_sum_and_evaluation() {
+    let mut rng = SmallRng::seed_from_u64(0xFACC_7102);
+
+    for num_variables in 2..=10 {
+        let numer = Poly::<EF>::rand(&mut rng, num_variables);
+        let denom = Poly::<EF>::rand(&mut rng, num_variables);
+        let point = Point::<EF>::rand(&mut rng, num_variables);
+        let half = numer.num_evals() / 2;
+        let fraction = SplitFraction {
+            n0: Poly::new(numer.as_slice()[..half].to_vec()),
+            d0: Poly::new(denom.as_slice()[..half].to_vec()),
+            n1: Poly::new(numer.as_slice()[half..].to_vec()),
+            d1: Poly::new(denom.as_slice()[half..].to_vec()),
+        };
+
+        let direct_sum = numer
+            .iter()
+            .zip(denom.iter())
+            .map(|(&numer, &denom)| numer * denom.inverse())
+            .sum::<EF>();
+
+        assert_eq!(fraction.sum(), direct_sum);
+        assert_eq!(
+            fraction.eval(&point),
+            (numer.eval_ext::<F>(&point), denom.eval_ext::<F>(&point)),
+        );
+    }
+}

--- a/multi-stark/src/fractional_gkr/test.rs
+++ b/multi-stark/src/fractional_gkr/test.rs
@@ -1,14 +1,16 @@
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, FieldChallenger};
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, PackedValue};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
 use p3_util::log2_strict_usize;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 
-use super::{Fraction, SplitFraction, prove_fractional_gkr, verify_fractional_gkr};
+use super::{
+    Fraction, FractionGkrError, SplitFraction, prove_fractional_gkr, verify_fractional_gkr,
+};
 
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
@@ -20,18 +22,140 @@ fn fresh_challenger() -> Challenger {
     Challenger::new(Perm::new_from_rng_128(&mut rng))
 }
 
+fn zero_sum_fraction(rng: &mut SmallRng, num_variables: usize) -> (Poly<F>, Poly<EF>) {
+    loop {
+        let mut numer = Poly::<F>::rand(rng, num_variables);
+        let mut denom = Poly::<EF>::rand(rng, num_variables);
+        let last = numer.num_evals() - 1;
+
+        if denom.as_slice()[..last].contains(&EF::ZERO) {
+            continue;
+        }
+
+        let partial_sum = numer.as_slice()[..last]
+            .iter()
+            .zip(&denom.as_slice()[..last])
+            .map(|(&numer, &denom)| denom.inverse() * numer)
+            .sum::<EF>();
+        if partial_sum == EF::ZERO {
+            continue;
+        }
+
+        numer.as_mut_slice()[last] = F::ONE;
+        denom.as_mut_slice()[last] = -partial_sum.inverse();
+        return (numer, denom);
+    }
+}
+
+#[test]
+fn accepts_honest_proofs() {
+    let (numer, denom) = zero_sum_fraction(&mut SmallRng::seed_from_u64(3), 6);
+    let mut prover_challenger = fresh_challenger();
+    let (proof, prover_output) = prove_fractional_gkr(
+        &Fraction {
+            n: numer.clone(),
+            d: PolyMaybePacked::Scalar(denom),
+        },
+        &mut prover_challenger,
+    );
+
+    let mut verifier_challenger = fresh_challenger();
+    let verifier_output =
+        verify_fractional_gkr::<F, EF, _>(&proof, numer.num_variables(), &mut verifier_challenger)
+            .unwrap();
+
+    assert_eq!(verifier_output, prover_output);
+}
+
+#[test]
+fn rejects_a_tampered_round_polynomial() {
+    let (numer, denom) = zero_sum_fraction(&mut SmallRng::seed_from_u64(4), 6);
+    let mut prover_challenger = fresh_challenger();
+    let (mut proof, _) = prove_fractional_gkr(
+        &Fraction {
+            n: numer,
+            d: PolyMaybePacked::Scalar(denom),
+        },
+        &mut prover_challenger,
+    );
+    proof.layers[1].round_polys[0][0] += EF::ONE;
+
+    let mut verifier_challenger = fresh_challenger();
+    assert!(matches!(
+        verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+        Err(FractionGkrError::LayerConsistency { .. })
+    ));
+}
+
+#[test]
+fn rejects_a_tampered_claim() {
+    let (numer, denom) = zero_sum_fraction(&mut SmallRng::seed_from_u64(5), 6);
+    let mut prover_challenger = fresh_challenger();
+    let (mut proof, _) = prove_fractional_gkr(
+        &Fraction {
+            n: numer,
+            d: PolyMaybePacked::Scalar(denom),
+        },
+        &mut prover_challenger,
+    );
+    proof.layers[0].claims.n0 += EF::ONE;
+
+    let mut verifier_challenger = fresh_challenger();
+    assert_eq!(
+        verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+        Err(FractionGkrError::LayerConsistency { layer: 0 })
+    );
+}
+
+#[test]
+fn rejects_a_tampered_root_denominator() {
+    let (numer, denom) = zero_sum_fraction(&mut SmallRng::seed_from_u64(7), 6);
+    let mut prover_challenger = fresh_challenger();
+    let (mut proof, _) = prove_fractional_gkr(
+        &Fraction {
+            n: numer,
+            d: PolyMaybePacked::Scalar(denom),
+        },
+        &mut prover_challenger,
+    );
+    proof.root_denominator *= EF::TWO;
+
+    let mut verifier_challenger = fresh_challenger();
+    assert_eq!(
+        verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+        Err(FractionGkrError::LayerConsistency { layer: 0 })
+    );
+}
+
+#[test]
+fn rejects_the_wrong_layer_shape() {
+    let (numer, denom) = zero_sum_fraction(&mut SmallRng::seed_from_u64(6), 6);
+    let mut prover_challenger = fresh_challenger();
+    let (mut proof, _) = prove_fractional_gkr(
+        &Fraction {
+            n: numer,
+            d: PolyMaybePacked::Scalar(denom),
+        },
+        &mut prover_challenger,
+    );
+    proof.layers.pop();
+
+    let mut verifier_challenger = fresh_challenger();
+    assert_eq!(
+        verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+        Err(FractionGkrError::InvalidLayerCount {
+            expected: 6,
+            actual: 5,
+        })
+    );
+}
+
 #[test]
 fn test_gkr_identities() {
     let mut rng = SmallRng::seed_from_u64(1);
 
     for num_variables in 1..=10 {
-        let numer = Poly::<F>::rand(&mut rng, num_variables);
-        let denom = Poly::<EF>::rand(&mut rng, num_variables);
-        let direct_sum = numer
-            .iter()
-            .zip(denom.iter())
-            .map(|(&numer, &denom)| denom.inverse() * numer)
-            .sum::<EF>();
+        let (numer, denom) = zero_sum_fraction(&mut rng, num_variables);
 
         let mut prover_challenger = fresh_challenger();
         let (proof, prover_output) = prove_fractional_gkr(
@@ -50,8 +174,6 @@ fn test_gkr_identities() {
                 .enumerate()
                 .all(|(layer, proof)| proof.round_polys.len() == layer)
         );
-        let top_sum = proof.root_numerator * proof.root_denominator.inverse();
-        assert_eq!(top_sum, direct_sum);
         assert_eq!(
             prover_output.numerator,
             numer.eval_base::<EF>(&prover_output.point),
@@ -79,8 +201,7 @@ fn packed_denominator_preserves_the_gkr_transcript() {
     let packing_variables = log2_strict_usize(<F as Field>::Packing::WIDTH);
 
     for num_variables in packing_variables.max(1)..=10 {
-        let numer = Poly::<F>::rand(&mut rng, num_variables);
-        let denom = Poly::<EF>::rand(&mut rng, num_variables);
+        let (numer, denom) = zero_sum_fraction(&mut rng, num_variables);
         let packed_denom = PolyMaybePacked::Packed(denom.pack::<F, EF>());
         let mut scalar_challenger = fresh_challenger();
         let (scalar_proof, scalar_output) = prove_fractional_gkr(

--- a/multi-stark/src/fractional_gkr/verifier.rs
+++ b/multi-stark/src/fractional_gkr/verifier.rs
@@ -1,0 +1,245 @@
+use alloc::vec::Vec;
+
+use p3_challenger::FieldChallenger;
+use p3_field::{ExtensionField, Field};
+use p3_multilinear_util::point::Point;
+use p3_sumcheck::generic_degree::RoundPolyInterpolator;
+use thiserror::Error;
+
+use super::{FractionGkrOutput, FractionGkrProof};
+
+/// Malformed fractional-GKR proofs rejected by the verifier.
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum FractionGkrError {
+    #[error("fraction GKR requires at least one input variable")]
+    InvalidVariableCount,
+    #[error("fraction GKR proof has {actual} layers, expected {expected}")]
+    InvalidLayerCount { expected: usize, actual: usize },
+    #[error("fraction GKR layer {layer} has {actual} sumcheck rounds, expected {expected}")]
+    InvalidRoundCount {
+        layer: usize,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("fraction GKR root denominator is zero")]
+    ZeroRootDenominator,
+    #[error("fraction GKR layer {layer} failed its gate consistency check")]
+    LayerConsistency { layer: usize },
+}
+
+/// Verify a fractional-GKR proof and recover its input-table opening claims.
+pub fn verify_fractional_gkr<F, EF, Challenger>(
+    proof: &FractionGkrProof<EF>,
+    num_variables: usize,
+    challenger: &mut Challenger,
+) -> Result<FractionGkrOutput<EF>, FractionGkrError>
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    Challenger: FieldChallenger<F>,
+{
+    if num_variables < 1 {
+        return Err(FractionGkrError::InvalidVariableCount);
+    }
+
+    let expected_layers = num_variables;
+    if proof.layers.len() != expected_layers {
+        return Err(FractionGkrError::InvalidLayerCount {
+            expected: expected_layers,
+            actual: proof.layers.len(),
+        });
+    }
+
+    if proof.root_denominator == EF::ZERO {
+        return Err(FractionGkrError::ZeroRootDenominator);
+    }
+
+    challenger.observe_algebra_element(proof.root_denominator);
+    challenger.observe_algebra_element(proof.root_numerator);
+    let mut point = Point::<EF>::new(Vec::new());
+    let mut numerator = proof.root_numerator;
+    let mut denominator = proof.root_denominator;
+    let interpolator = RoundPolyInterpolator::new(3);
+
+    for (layer_index, layer) in proof.layers.iter().enumerate() {
+        let expected_rounds = layer_index;
+        if layer.round_polys.len() != expected_rounds {
+            return Err(FractionGkrError::InvalidRoundCount {
+                layer: layer_index,
+                expected: expected_rounds,
+                actual: layer.round_polys.len(),
+            });
+        }
+
+        let lambda: EF = challenger.sample_algebra_element();
+        let mut running_sum = numerator + lambda * denominator;
+        let mut round_point = Vec::with_capacity(expected_rounds + 1);
+        for round_poly in &layer.round_polys {
+            challenger.observe_algebra_slice(round_poly);
+            let r: EF = challenger.sample_algebra_element();
+            running_sum = interpolator.eval(round_poly, running_sum, r);
+            round_point.push(r);
+        }
+
+        let expected = Point::eval_eq(point.as_slice(), &round_point) * layer.claims.gate(lambda);
+        if running_sum != expected {
+            return Err(FractionGkrError::LayerConsistency { layer: layer_index });
+        }
+
+        challenger.observe_algebra_slice(&[
+            layer.claims.n0,
+            layer.claims.d0,
+            layer.claims.n1,
+            layer.claims.d1,
+        ]);
+        let branch: EF = challenger.sample_algebra_element();
+        numerator = layer.claims.n0 + branch * (layer.claims.n1 - layer.claims.n0);
+        denominator = layer.claims.d0 + branch * (layer.claims.d1 - layer.claims.d0);
+        round_point.insert(0, branch);
+        point = Point::new(round_point);
+    }
+
+    Ok(FractionGkrOutput {
+        point,
+        numerator,
+        denominator,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+    use crate::fractional_gkr::Fraction;
+    use crate::fractional_gkr::prover::prove_fractional_gkr;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+    fn fresh_challenger() -> Challenger {
+        let mut rng = SmallRng::seed_from_u64(0xFACC_7100);
+        Challenger::new(Perm::new_from_rng_128(&mut rng))
+    }
+
+    fn fraction(seed: u64) -> (Poly<F>, Poly<EF>) {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let numer = Poly::new((0..1 << 6).map(|_| rng.random()).collect());
+        let denom = Poly::new((0..1 << 6).map(|i| EF::from_u64((i + 1) as u64)).collect());
+        (numer, denom)
+    }
+
+    #[test]
+    fn accepts_honest_proofs() {
+        let (numer, denom) = fraction(3);
+        let mut prover_challenger = fresh_challenger();
+        let (proof, prover_output) = prove_fractional_gkr(
+            &Fraction {
+                n: numer.clone(),
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut prover_challenger,
+        );
+
+        let mut verifier_challenger = fresh_challenger();
+        let verifier_output = verify_fractional_gkr::<F, EF, _>(
+            &proof,
+            numer.num_variables(),
+            &mut verifier_challenger,
+        )
+        .unwrap();
+
+        assert_eq!(verifier_output, prover_output);
+    }
+
+    #[test]
+    fn rejects_a_tampered_round_polynomial() {
+        let (numer, denom) = fraction(4);
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = prove_fractional_gkr(
+            &Fraction {
+                n: numer,
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut prover_challenger,
+        );
+        proof.layers[1].round_polys[0][0] += EF::ONE;
+
+        let mut verifier_challenger = fresh_challenger();
+        assert!(matches!(
+            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+            Err(FractionGkrError::LayerConsistency { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_a_tampered_claim() {
+        let (numer, denom) = fraction(5);
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = prove_fractional_gkr(
+            &Fraction {
+                n: numer,
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut prover_challenger,
+        );
+        proof.layers[0].claims.n0 += EF::ONE;
+
+        let mut verifier_challenger = fresh_challenger();
+        assert_eq!(
+            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+            Err(FractionGkrError::LayerConsistency { layer: 0 })
+        );
+    }
+
+    #[test]
+    fn rejects_a_tampered_root() {
+        let (numer, denom) = fraction(7);
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = prove_fractional_gkr(
+            &Fraction {
+                n: numer,
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut prover_challenger,
+        );
+        proof.root_numerator += EF::ONE;
+
+        let mut verifier_challenger = fresh_challenger();
+        assert_eq!(
+            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+            Err(FractionGkrError::LayerConsistency { layer: 0 })
+        );
+    }
+
+    #[test]
+    fn rejects_the_wrong_layer_shape() {
+        let (numer, denom) = fraction(6);
+        let mut prover_challenger = fresh_challenger();
+        let (mut proof, _) = prove_fractional_gkr(
+            &Fraction {
+                n: numer,
+                d: PolyMaybePacked::Scalar(denom),
+            },
+            &mut prover_challenger,
+        );
+        proof.layers.pop();
+
+        let mut verifier_challenger = fresh_challenger();
+        assert_eq!(
+            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
+            Err(FractionGkrError::InvalidLayerCount {
+                expected: 6,
+                actual: 5,
+            })
+        );
+    }
+}

--- a/multi-stark/src/fractional_gkr/verifier.rs
+++ b/multi-stark/src/fractional_gkr/verifier.rs
@@ -27,7 +27,8 @@ pub enum FractionGkrError {
     LayerConsistency { layer: usize },
 }
 
-/// Verify a fractional-GKR proof and recover its input-table opening claims.
+/// Verify that a fractional-GKR reduction has zero root numerator and recover
+/// its input-table opening claims.
 pub fn verify_fractional_gkr<F, EF, Challenger>(
     proof: &FractionGkrProof<EF>,
     num_variables: usize,
@@ -55,9 +56,8 @@ where
     }
 
     challenger.observe_algebra_element(proof.root_denominator);
-    challenger.observe_algebra_element(proof.root_numerator);
     let mut point = Point::<EF>::new(Vec::new());
-    let mut numerator = proof.root_numerator;
+    let mut numerator = EF::ZERO;
     let mut denominator = proof.root_denominator;
     let interpolator = RoundPolyInterpolator::new(3);
 
@@ -104,142 +104,4 @@ where
         numerator,
         denominator,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::DuplexChallenger;
-    use p3_field::PrimeCharacteristicRing;
-    use p3_field::extension::BinomialExtensionField;
-    use p3_multilinear_util::poly::{Poly, PolyMaybePacked};
-    use rand::rngs::SmallRng;
-    use rand::{RngExt, SeedableRng};
-
-    use super::*;
-    use crate::fractional_gkr::Fraction;
-    use crate::fractional_gkr::prover::prove_fractional_gkr;
-
-    type F = BabyBear;
-    type EF = BinomialExtensionField<F, 4>;
-    type Perm = Poseidon2BabyBear<16>;
-    type Challenger = DuplexChallenger<F, Perm, 16, 8>;
-
-    fn fresh_challenger() -> Challenger {
-        let mut rng = SmallRng::seed_from_u64(0xFACC_7100);
-        Challenger::new(Perm::new_from_rng_128(&mut rng))
-    }
-
-    fn fraction(seed: u64) -> (Poly<F>, Poly<EF>) {
-        let mut rng = SmallRng::seed_from_u64(seed);
-        let numer = Poly::new((0..1 << 6).map(|_| rng.random()).collect());
-        let denom = Poly::new((0..1 << 6).map(|i| EF::from_u64((i + 1) as u64)).collect());
-        (numer, denom)
-    }
-
-    #[test]
-    fn accepts_honest_proofs() {
-        let (numer, denom) = fraction(3);
-        let mut prover_challenger = fresh_challenger();
-        let (proof, prover_output) = prove_fractional_gkr(
-            &Fraction {
-                n: numer.clone(),
-                d: PolyMaybePacked::Scalar(denom),
-            },
-            &mut prover_challenger,
-        );
-
-        let mut verifier_challenger = fresh_challenger();
-        let verifier_output = verify_fractional_gkr::<F, EF, _>(
-            &proof,
-            numer.num_variables(),
-            &mut verifier_challenger,
-        )
-        .unwrap();
-
-        assert_eq!(verifier_output, prover_output);
-    }
-
-    #[test]
-    fn rejects_a_tampered_round_polynomial() {
-        let (numer, denom) = fraction(4);
-        let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) = prove_fractional_gkr(
-            &Fraction {
-                n: numer,
-                d: PolyMaybePacked::Scalar(denom),
-            },
-            &mut prover_challenger,
-        );
-        proof.layers[1].round_polys[0][0] += EF::ONE;
-
-        let mut verifier_challenger = fresh_challenger();
-        assert!(matches!(
-            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
-            Err(FractionGkrError::LayerConsistency { .. })
-        ));
-    }
-
-    #[test]
-    fn rejects_a_tampered_claim() {
-        let (numer, denom) = fraction(5);
-        let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) = prove_fractional_gkr(
-            &Fraction {
-                n: numer,
-                d: PolyMaybePacked::Scalar(denom),
-            },
-            &mut prover_challenger,
-        );
-        proof.layers[0].claims.n0 += EF::ONE;
-
-        let mut verifier_challenger = fresh_challenger();
-        assert_eq!(
-            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
-            Err(FractionGkrError::LayerConsistency { layer: 0 })
-        );
-    }
-
-    #[test]
-    fn rejects_a_tampered_root() {
-        let (numer, denom) = fraction(7);
-        let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) = prove_fractional_gkr(
-            &Fraction {
-                n: numer,
-                d: PolyMaybePacked::Scalar(denom),
-            },
-            &mut prover_challenger,
-        );
-        proof.root_numerator += EF::ONE;
-
-        let mut verifier_challenger = fresh_challenger();
-        assert_eq!(
-            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
-            Err(FractionGkrError::LayerConsistency { layer: 0 })
-        );
-    }
-
-    #[test]
-    fn rejects_the_wrong_layer_shape() {
-        let (numer, denom) = fraction(6);
-        let mut prover_challenger = fresh_challenger();
-        let (mut proof, _) = prove_fractional_gkr(
-            &Fraction {
-                n: numer,
-                d: PolyMaybePacked::Scalar(denom),
-            },
-            &mut prover_challenger,
-        );
-        proof.layers.pop();
-
-        let mut verifier_challenger = fresh_challenger();
-        assert_eq!(
-            verify_fractional_gkr::<F, EF, _>(&proof, 6, &mut verifier_challenger),
-            Err(FractionGkrError::InvalidLayerCount {
-                expected: 6,
-                actual: 5,
-            })
-        );
-    }
 }

--- a/multi-stark/src/fractional_gkr/verifier.rs
+++ b/multi-stark/src/fractional_gkr/verifier.rs
@@ -27,8 +27,13 @@ pub enum FractionGkrError {
     LayerConsistency { layer: usize },
 }
 
-/// Verify that a fractional-GKR reduction has zero root numerator and recover
-/// its input-table opening claims.
+/// Verify the internal consistency of a zero-sum fractional-GKR reduction and
+/// return its input-table opening claim.
+///
+/// This function does not authenticate the returned numerator and denominator
+/// against committed input polynomials. To complete verification of the
+/// zero-sum statement, the caller must verify that the returned values are the
+/// openings of the corresponding input tables at the returned point.
 pub fn verify_fractional_gkr<F, EF, Challenger>(
     proof: &FractionGkrProof<EF>,
     num_variables: usize,

--- a/multi-stark/src/lib.rs
+++ b/multi-stark/src/lib.rs
@@ -11,8 +11,10 @@ extern crate alloc;
 
 pub mod config;
 pub mod folder;
+pub mod fractional_gkr;
 pub mod instance;
 pub mod keys;
+pub mod lookup;
 pub mod metadata;
 pub mod opening;
 pub mod packed_ext;

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -12,8 +12,8 @@ use core::cmp::Reverse;
 
 use p3_air::symbolic::{BaseEntry, BaseLeaf, SymbolicExpr};
 use p3_air::{Air, BaseAir, SymbolicExpression};
-use p3_field::{ExtensionField, Field, PackedValue};
-use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookups};
+use p3_field::{ExtensionField, Field, PackedValue, PrimeField};
+use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookups, check_multiplicity_height_bound};
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 
 /// Whether a lookup expression reads one of the AIR's fixed periodic columns.
@@ -75,36 +75,56 @@ pub struct LookupPlan<F: Field> {
 
 impl<F: Field> LookupPlan<F> {
     /// Extract lookup declarations once, assign buses, and place exact-height blocks.
-    pub fn build<EF, A>(airs: &[&A], num_variables: &[usize]) -> Option<Self>
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lookup multiplicity height bound reaches the
+    /// characteristic of `F`.
+    pub fn build<EF, A>(
+        airs: &[&A],
+        num_variables: &[usize],
+    ) -> Result<Option<Self>, p3_lookup::LookupError>
     where
+        F: PrimeField,
         EF: ExtensionField<F>,
         A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
     {
         assert_eq!(airs.len(), num_variables.len());
 
-        // Symbolically evaluate each AIR once and retain only instances that emit
-        // at least one atomic lookup contribution. Empty local declarations are inert.
-        let mut active = airs
+        // Symbolically evaluate each AIR once. The resulting public weights and
+        // trace heights determine the multiplicity soundness bound on both sides.
+        let lookups = airs
             .iter()
-            .zip(num_variables)
+            .map(|&air| Lookups::from_air::<EF, _>(air))
+            .collect::<Vec<_>>();
+        for lookup in lookups.iter().flat_map(|lookups| lookups.iter()) {
+            assert!(
+                lookup.flags.is_none(),
+                "multi-STARK lookups do not support exclusive interactions"
+            );
+            assert!(
+                !lookup
+                    .elements
+                    .iter()
+                    .flatten()
+                    .chain(lookup.multiplicities.iter())
+                    .any(uses_periodic_column),
+                "multi-STARK lookup expressions do not support periodic columns"
+            );
+        }
+        let trace_heights = num_variables
+            .iter()
+            .map(|&num_variables| 1usize << num_variables)
+            .collect::<Vec<_>>();
+        check_multiplicity_height_bound(&lookups, &trace_heights)?;
+
+        // Retain only instances that emit at least one atomic lookup
+        // contribution. Empty local declarations are inert.
+        let mut active = lookups
+            .into_iter()
+            .zip(num_variables.iter().copied())
             .enumerate()
-            .filter_map(|(air_index, (&air, &num_variables))| {
-                let lookups = Lookups::from_air::<EF, _>(air);
-                for lookup in lookups.iter() {
-                    assert!(
-                        lookup.flags.is_none(),
-                        "multi-STARK lookups do not support exclusive interactions"
-                    );
-                    assert!(
-                        !lookup
-                            .elements
-                            .iter()
-                            .flatten()
-                            .chain(lookup.multiplicities.iter())
-                            .any(uses_periodic_column),
-                        "multi-STARK lookup expressions do not support periodic columns"
-                    );
-                }
+            .filter_map(|(air_index, (lookups, num_variables))| {
                 lookups
                     .iter()
                     .any(|lookup| !lookup.elements.is_empty())
@@ -124,7 +144,7 @@ impl<F: Field> LookupPlan<F> {
 
         // No active lookup means this batch has no lookup transcript or proof section.
         if active.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         // Packed denominator blocks require at least one complete SIMD word per trace.
@@ -205,11 +225,11 @@ impl<F: Field> LookupPlan<F> {
                 .collect();
         }
 
-        Some(Self {
+        Ok(Some(Self {
             instances: active,
             max_width,
             num_buses: bus_to_id.len(),
             num_variables: log2_ceil_usize(active_height),
-        })
+        }))
     }
 }

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -1,0 +1,215 @@
+//! Planning for the multilinear lookup argument.
+//!
+//! [`LookupPlan`] extracts symbolic lookup declarations from a collection of
+//! AIRs, assigns their buses, and lays out the fraction tables consumed by the
+//! fractional-GKR protocol.
+
+use alloc::collections::BTreeMap;
+use alloc::collections::btree_map::Entry;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Reverse;
+
+use p3_air::symbolic::{BaseEntry, BaseLeaf, SymbolicExpr};
+use p3_air::{Air, BaseAir, SymbolicExpression};
+use p3_field::{ExtensionField, Field, PackedValue};
+use p3_lookup::{InteractionSymbolicBuilder, Kind, Lookups};
+use p3_util::{log2_ceil_usize, log2_strict_usize};
+
+/// Whether a lookup expression reads one of the AIR's fixed periodic columns.
+fn uses_periodic_column<F>(expression: &SymbolicExpression<F>) -> bool {
+    match expression {
+        SymbolicExpr::Leaf(BaseLeaf::Variable(variable)) => variable.entry == BaseEntry::Periodic,
+        SymbolicExpr::Leaf(_) => false,
+        SymbolicExpr::Add { x, y, .. }
+        | SymbolicExpr::Sub { x, y, .. }
+        | SymbolicExpr::Mul { x, y, .. } => uses_periodic_column(x) || uses_periodic_column(y),
+        SymbolicExpr::Neg { x, .. } => uses_periodic_column(x),
+    }
+}
+
+/// One logical lookup bus.
+///
+/// Global buses are shared by name. Each local declaration owns a bus scoped
+/// to its AIR instance and declaration index.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum LookupBus {
+    Global {
+        name: String,
+    },
+    Local {
+        instance_index: usize,
+        interaction_index: usize,
+    },
+}
+
+/// One active AIR's position and symbolic lookup declarations.
+pub(crate) struct LookupInstancePlan<F: Field> {
+    /// Original position of this AIR in the multi-AIR input arrays.
+    pub(crate) air_index: usize,
+    /// Base-two logarithm of this AIR instance's trace height.
+    pub(crate) num_variables: usize,
+    /// First scalar leaf owned by this instance in the materialized lookup arrays.
+    pub(crate) base_offset: usize,
+    /// Symbolic lookup declarations extracted from this AIR, in protocol order.
+    pub(crate) lookups: Lookups<F>,
+    /// Bus identifier for each entry of `lookups`, in the same order.
+    pub(crate) bus_ids: Vec<usize>,
+}
+
+/// Deterministic metadata shared by lookup materialization and AIR coupling.
+///
+/// This stores no trace rows and allocates no numerator or denominator table.
+/// Physical contribution blocks are recovered from an instance's `base_offset`,
+/// `num_variables`, and declaration-order contribution index.
+pub struct LookupPlan<F: Field> {
+    /// Lookup-active AIR instances, sorted by descending trace height.
+    pub(crate) instances: Vec<LookupInstancePlan<F>>,
+    /// Largest payload tuple width among all planned lookup declarations.
+    pub(crate) max_width: usize,
+    /// Number of distinct local and named global buses in this plan.
+    pub(crate) num_buses: usize,
+    /// Variable count of the padded materialized lookup arrays consumed by GKR.
+    pub(crate) num_variables: usize,
+}
+
+impl<F: Field> LookupPlan<F> {
+    /// Extract lookup declarations once, assign buses, and place exact-height blocks.
+    pub fn build<EF, A>(airs: &[&A], num_variables: &[usize]) -> Option<Self>
+    where
+        EF: ExtensionField<F>,
+        A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
+    {
+        assert_eq!(airs.len(), num_variables.len());
+
+        // Symbolically evaluate each AIR once and retain only instances that emit
+        // at least one atomic lookup contribution. Empty local declarations are inert.
+        let mut active = airs
+            .iter()
+            .zip(num_variables)
+            .enumerate()
+            .filter_map(|(air_index, (&air, &num_variables))| {
+                let lookups = Lookups::from_air::<EF, _>(air);
+                for lookup in lookups.iter() {
+                    assert!(
+                        lookup.flags.is_none(),
+                        "multi-STARK lookups do not support exclusive interactions"
+                    );
+                    assert!(
+                        !lookup
+                            .elements
+                            .iter()
+                            .flatten()
+                            .chain(lookup.multiplicities.iter())
+                            .any(uses_periodic_column),
+                        "multi-STARK lookup expressions do not support periodic columns"
+                    );
+                }
+                lookups
+                    .iter()
+                    .any(|lookup| !lookup.elements.is_empty())
+                    .then_some(LookupInstancePlan {
+                        air_index,
+                        num_variables,
+                        lookups,
+                        base_offset: 0,
+                        bus_ids: Vec::new(),
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        // Tallest traces come first. Since every height is a power of two, all
+        // preceding blocks then leave `base_offset` aligned for every later instance.
+        active.sort_by_key(|instance| Reverse(instance.num_variables));
+
+        // No active lookup means this batch has no lookup transcript or proof section.
+        if active.is_empty() {
+            return None;
+        }
+
+        // Packed denominator blocks require at least one complete SIMD word per trace.
+        let packing_variables = log2_strict_usize(F::Packing::WIDTH);
+        assert!(
+            active
+                .iter()
+                .all(|instance| instance.num_variables >= packing_variables),
+            "lookup-active AIR trace height must be at least the field packing width"
+        );
+
+        // Bus IDs domain-separate unrelated lookup arguments. `max_width` determines
+        // how many beta powers are needed; `active_height` measures unpadded GKR leaves.
+        let mut bus_to_id = BTreeMap::new();
+        let mut max_width = 0;
+        let mut active_height = 0;
+
+        for instance in &mut active {
+            let trace_height = 1usize << instance.num_variables;
+
+            // Every atomic tuple owns one contiguous block of this instance's trace
+            // height. All blocks for an instance are adjacent in declaration order.
+            instance.base_offset = active_height;
+            let contribution_count = instance
+                .lookups
+                .iter()
+                .map(|lookup| lookup.elements.len())
+                .sum::<usize>();
+            let instance_height = contribution_count * trace_height;
+            active_height += instance_height;
+
+            // Record one bus ID per lookup declaration. Local buses are scoped to
+            // their declaring AIR, while equally named global buses share an ID.
+            instance.bus_ids = instance
+                .lookups
+                .iter()
+                .enumerate()
+                .map(|(lookup_index, lookup)| {
+                    let bus = match &lookup.kind {
+                        Kind::Local => LookupBus::Local {
+                            instance_index: instance.air_index,
+                            interaction_index: lookup_index,
+                        },
+                        Kind::Global(name) => LookupBus::Global { name: name.clone() },
+                    };
+
+                    // The widest payload fixes the first beta power reserved for
+                    // bus separation in `Challenges::new`.
+                    let width = lookup.elements.first().map_or(0, Vec::len);
+                    let next_id = bus_to_id.len();
+
+                    // The first declaration fixes both the ID and payload schema.
+                    // Reusing a named global bus with another width would otherwise
+                    // let a shorter tuple alias a longer tuple ending in zeroes.
+                    let bus_id = match bus_to_id.entry(bus) {
+                        Entry::Vacant(entry) => {
+                            entry.insert((next_id, width));
+                            next_id
+                        }
+                        Entry::Occupied(entry) => {
+                            let &(bus_id, established_width) = entry.get();
+                            match entry.key() {
+                                LookupBus::Global { name } => assert_eq!(
+                                    width, established_width,
+                                    "named global lookup bus `{name}` uses payload width {width}, \
+                                     but its established width is {established_width}"
+                                ),
+                                LookupBus::Local { .. } => {
+                                    debug_assert_eq!(width, established_width);
+                                }
+                            }
+                            bus_id
+                        }
+                    };
+                    max_width = max_width.max(width);
+                    bus_id
+                })
+                .collect();
+        }
+
+        Some(Self {
+            instances: active,
+            max_width,
+            num_buses: bus_to_id.len(),
+            num_variables: log2_ceil_usize(active_height),
+        })
+    }
+}

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -62,7 +62,7 @@ pub(crate) struct LookupInstancePlan<F: Field> {
 /// This stores no trace rows and allocates no numerator or denominator table.
 /// Physical contribution blocks are recovered from an instance's `base_offset`,
 /// `num_variables`, and declaration-order contribution index.
-pub struct LookupPlan<F: Field> {
+pub(crate) struct LookupPlan<F: Field> {
     /// Lookup-active AIR instances, sorted by descending trace height.
     pub(crate) instances: Vec<LookupInstancePlan<F>>,
     /// Largest payload tuple width among all planned lookup declarations.

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -62,7 +62,7 @@ pub(crate) struct LookupInstancePlan<F: Field> {
 /// This stores no trace rows and allocates no numerator or denominator table.
 /// Physical contribution blocks are recovered from an instance's `base_offset`,
 /// `num_variables`, and declaration-order contribution index.
-pub(crate) struct LookupPlan<F: Field> {
+pub struct LookupPlan<F: Field> {
     /// Lookup-active AIR instances, sorted by descending trace height.
     pub(crate) instances: Vec<LookupInstancePlan<F>>,
     /// Largest payload tuple width among all planned lookup declarations.

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -212,9 +212,7 @@ impl<F: Field> LookupPlan<F> {
                                     "named global lookup bus `{name}` uses payload width {width}, \
                                      but its established width is {established_width}"
                                 ),
-                                LookupBus::Local { .. } => {
-                                    debug_assert_eq!(width, established_width);
-                                }
+                                _ => unreachable!(),
                             }
                             bus_id
                         }


### PR DESCRIPTION
Adds the fractional logup GKR prover and verifier, together with lookup planning and packed fraction-table materialization. Lookup contributions are arranged in power-of-two tables and padded with the neutral fraction 0 / 1. Exclusive lookup interactions are not supported yet.