### PR TITLE
perf(p3-field): vectorize packed field

### DIFF
--- a/baby-bear/src/baby_bear.rs
+++ b/baby-bear/src/baby_bear.rs
@@ -26,6 +26,9 @@ impl BarrettParameters for BabyBearParameters {}
 
 impl FieldParameters for BabyBearParameters {
     const MONTY_GEN: BabyBear = BabyBear::new(31);
+
+    // Measured -3.5% on quotient evaluation (twoadic PCS, Poseidon2 AIR, aarch64+neon).
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = true;
 }
 
 impl RelativelyPrimePower<7> for BabyBearParameters {

--- a/examples/src/airs.rs
+++ b/examples/src/airs.rs
@@ -9,7 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_poseidon1_air::VectorizedPoseidon1Air;
 use p3_poseidon2::GenericPoseidon2LinearLayers;
 use p3_poseidon2_air::{Poseidon2Air, VectorizedPoseidon2Air};
-use p3_uni_stark::{ProverConstraintFolder, StarkGenericConfig, VerifierConstraintFolder};
+use p3_uni_stark::{QuotientAir, StarkGenericConfig, VerifierConstraintFolder};
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
 
@@ -61,7 +61,7 @@ pub trait ExampleHashAir<F: Field, SC: StarkGenericConfig>:
     BaseAir<F>
     + for<'a> Air<DebugConstraintBuilder<'a, F>>
     + Air<SymbolicAirBuilder<F>>
-    + for<'a> Air<ProverConstraintFolder<'a, SC>>
+    + QuotientAir<SC>
     + for<'a> Air<VerifierConstraintFolder<'a, SC>>
 {
     fn generate_trace_rows(

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1005,12 +1005,14 @@ pub trait Field:
     /// independent dependency chains and hide packed-multiplication latency) is expected
     /// to help throughput for this field.
     ///
-    /// Defaults to `true`. Fields should override this to `false` when their packed
-    /// multiplication is not the bottleneck a lockstep evaluation strategy would address —
-    /// for instance because AIRs over this field already interleave enough independent
-    /// per-row work on their own, or because the field's packed multiply is already
-    /// short-latency relative to other pipeline costs.
-    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = true;
+    /// Only [`p3_uni_stark::quotient_values`](https://docs.rs/p3-uni-stark)'s `aarch64`
+    /// (`neon`)-gated path reads this constant; on every other target it has no effect,
+    /// so leaving it at the default is always safe there.
+    ///
+    /// Defaults to `false`, so fields fail safe into the plain (non-lockstep) path unless
+    /// explicitly measured to benefit. Override to `true` only once benchmarks confirm the
+    /// field's packed multiplication is latency-bound enough for lockstep evaluation to help.
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = false;
 
     /// Check if the given field element is equal to the unique additive identity (ZERO).
     #[must_use]

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1001,6 +1001,17 @@ pub trait Field:
     /// A generator of this field's multiplicative group.
     const GENERATOR: Self;
 
+    /// Whether evaluating multiple packed vectors of this field in lockstep (to overlap
+    /// independent dependency chains and hide packed-multiplication latency) is expected
+    /// to help throughput for this field.
+    ///
+    /// Defaults to `true`. Fields should override this to `false` when their packed
+    /// multiplication is not the bottleneck a lockstep evaluation strategy would address —
+    /// for instance because AIRs over this field already interleave enough independent
+    /// per-row work on their own, or because the field's packed multiply is already
+    /// short-latency relative to other pipeline costs.
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = true;
+
     /// Check if the given field element is equal to the unique additive identity (ZERO).
     #[must_use]
     #[inline]

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -15,6 +15,7 @@ pub mod integers;
 pub mod op_assign_macros;
 mod packed;
 mod sqrt;
+mod vectorized;
 
 pub use array::*;
 pub use batch_inverse::*;
@@ -23,3 +24,4 @@ pub use field::*;
 pub use helpers::*;
 pub use packed::*;
 pub use sqrt::{tonelli_shanks, tonelli_shanks_two_adic};
+pub use vectorized::*;

--- a/field/src/vectorized.rs
+++ b/field/src/vectorized.rs
@@ -1,0 +1,490 @@
+//! Lockstep evaluation over multiple packed vectors, trading register pressure
+//! for instruction-level parallelism in latency-bound field arithmetic.
+//!
+//! Inspired by stwo's `Vectorized` type:
+//! <https://github.com/starkware-libs/stwo/blob/cca98119f/crates/stwo/src/prover/backend/simd/very_packed_m31.rs>
+
+use core::array;
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::{
+    Algebra, BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PackedValue,
+    PrimeCharacteristicRing,
+};
+
+/// `N` packed base-field vectors operated on in lockstep.
+///
+/// A single packed vector often cannot saturate the CPU's multiplier pipes: a
+/// dependency chain of packed multiplications leaves most issue slots idle
+/// (e.g. NEON's modular multiply has ~10 cycles of latency at ~1.25 cycles of
+/// throughput per vector). Widening the *data type* rather than the loop turns
+/// every ring operation into `N` independent instructions back to back, giving
+/// the out-of-order core `N` interleaved dependency chains without changing the
+/// shape of the expression being evaluated.
+///
+/// Lane `i` of the logical vector lives in `self.0[i / W].as_slice()[i % W]`
+/// where `W = F::Packing::WIDTH`, i.e. components hold consecutive blocks of
+/// lanes.
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+#[must_use]
+pub struct Vectorized<F: Field, const N: usize>(pub [F::Packing; N]);
+
+/// `N` packed extension-field vectors operated on in lockstep.
+///
+/// The extension-field counterpart of [`Vectorized`]: lane `i` corresponds to
+/// lane `i` of a `Vectorized<F, N>` operand, so the two types can be mixed in
+/// the same expression (`VectorizedExt * Vectorized`, etc.).
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+#[must_use]
+pub struct VectorizedExt<F: Field, EF: ExtensionField<F>, const N: usize>(
+    pub [EF::ExtensionPacking; N],
+);
+
+impl<F: Field, const N: usize> Vectorized<F, N> {
+    /// Map a function over the `N` packed components.
+    #[inline]
+    fn map(self, f: impl FnMut(F::Packing) -> F::Packing) -> Self {
+        Self(self.0.map(f))
+    }
+
+    /// Combine two values component-wise.
+    #[inline]
+    fn zip_with<T: Copy>(
+        self,
+        rhs: &[T; N],
+        mut f: impl FnMut(F::Packing, T) -> F::Packing,
+    ) -> Self {
+        Self(array::from_fn(|i| f(self.0[i], rhs[i])))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> VectorizedExt<F, EF, N> {
+    /// Map a function over the `N` packed components.
+    #[inline]
+    fn map(self, f: impl FnMut(EF::ExtensionPacking) -> EF::ExtensionPacking) -> Self {
+        Self(self.0.map(f))
+    }
+
+    /// Combine two values component-wise.
+    #[inline]
+    fn zip_with<T: Copy>(
+        self,
+        rhs: &[T; N],
+        mut f: impl FnMut(EF::ExtensionPacking, T) -> EF::ExtensionPacking,
+    ) -> Self {
+        Self(array::from_fn(|i| f(self.0[i], rhs[i])))
+    }
+
+    /// Build from basis coefficients, where coefficient `d` is the vectorized
+    /// base-field value `coefficients[d]`.
+    ///
+    /// This is the vectorized analogue of
+    /// [`BasedVectorSpace::from_basis_coefficients_fn`]; it takes a slice
+    /// rather than a closure so each coefficient is computed once and shared
+    /// by all `N` components.
+    #[inline]
+    pub fn from_vectorized_basis_coefficients(coefficients: &[Vectorized<F, N>]) -> Self {
+        debug_assert_eq!(coefficients.len(), EF::DIMENSION);
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::from_basis_coefficients_fn(|d| coefficients[d].0[i])
+        }))
+    }
+
+    /// Extract the extension-field element at logical lane `i`.
+    ///
+    /// Lanes `0..F::Packing::WIDTH` come from component `0`, the next
+    /// `F::Packing::WIDTH` from component `1`, and so on.
+    #[inline]
+    pub fn extract(&self, i: usize) -> EF {
+        let width = F::Packing::WIDTH;
+        self.0[i / width].extract(i % width)
+    }
+}
+
+impl<F: Field, const N: usize> Default for Vectorized<F, N> {
+    #[inline]
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Default for VectorizedExt<F, EF, N> {
+    #[inline]
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<F: Field, const N: usize> From<F> for Vectorized<F, N> {
+    #[inline]
+    fn from(value: F) -> Self {
+        Self([F::Packing::from(value); N])
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> From<EF> for VectorizedExt<F, EF, N> {
+    #[inline]
+    fn from(value: EF) -> Self {
+        Self([EF::ExtensionPacking::from(value); N])
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> From<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn from(value: Vectorized<F, N>) -> Self {
+        Self(value.0.map(EF::ExtensionPacking::from))
+    }
+}
+
+macro_rules! impl_binary_ops {
+    ($ty:ty, $($bound:tt)*) => {
+        impl<$($bound)*> Add for $ty {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x + y)
+            }
+        }
+
+        impl<$($bound)*> Sub for $ty {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x - y)
+            }
+        }
+
+        impl<$($bound)*> Mul for $ty {
+            type Output = Self;
+            #[inline]
+            fn mul(self, rhs: Self) -> Self {
+                self.zip_with(&rhs.0, |x, y| x * y)
+            }
+        }
+
+        impl<$($bound)*> Neg for $ty {
+            type Output = Self;
+            #[inline]
+            fn neg(self) -> Self {
+                self.map(|x| -x)
+            }
+        }
+
+        impl<$($bound)*> AddAssign for $ty {
+            #[inline]
+            fn add_assign(&mut self, rhs: Self) {
+                *self = *self + rhs;
+            }
+        }
+
+        impl<$($bound)*> SubAssign for $ty {
+            #[inline]
+            fn sub_assign(&mut self, rhs: Self) {
+                *self = *self - rhs;
+            }
+        }
+
+        impl<$($bound)*> MulAssign for $ty {
+            #[inline]
+            fn mul_assign(&mut self, rhs: Self) {
+                *self = *self * rhs;
+            }
+        }
+
+        impl<$($bound)*> Sum for $ty {
+            #[inline]
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::ZERO, |acc, x| acc + x)
+            }
+        }
+
+        impl<$($bound)*> Product for $ty {
+            #[inline]
+            fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::ONE, |acc, x| acc * x)
+            }
+        }
+    };
+}
+
+macro_rules! impl_scalar_ops {
+    ($ty:ty, $scalar:ty, $($bound:tt)*) => {
+        impl<$($bound)*> Add<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn add(self, rhs: $scalar) -> Self {
+                self.map(|x| x + rhs)
+            }
+        }
+
+        impl<$($bound)*> Sub<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn sub(self, rhs: $scalar) -> Self {
+                self.map(|x| x - rhs)
+            }
+        }
+
+        impl<$($bound)*> Mul<$scalar> for $ty {
+            type Output = Self;
+            #[inline]
+            fn mul(self, rhs: $scalar) -> Self {
+                self.map(|x| x * rhs)
+            }
+        }
+
+        impl<$($bound)*> AddAssign<$scalar> for $ty {
+            #[inline]
+            fn add_assign(&mut self, rhs: $scalar) {
+                *self = *self + rhs;
+            }
+        }
+
+        impl<$($bound)*> SubAssign<$scalar> for $ty {
+            #[inline]
+            fn sub_assign(&mut self, rhs: $scalar) {
+                *self = *self - rhs;
+            }
+        }
+
+        impl<$($bound)*> MulAssign<$scalar> for $ty {
+            #[inline]
+            fn mul_assign(&mut self, rhs: $scalar) {
+                *self = *self * rhs;
+            }
+        }
+    };
+}
+
+impl_binary_ops!(Vectorized<F, N>, F: Field, const N: usize);
+impl_scalar_ops!(Vectorized<F, N>, F, F: Field, const N: usize);
+impl_binary_ops!(VectorizedExt<F, EF, N>, F: Field, EF: ExtensionField<F>, const N: usize);
+impl_scalar_ops!(VectorizedExt<F, EF, N>, EF, F: Field, EF: ExtensionField<F>, const N: usize);
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Add<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x + y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Sub<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x - y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Mul<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Vectorized<F, N>) -> Self {
+        self.zip_with(&rhs.0, |x, y| x * y)
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> AddAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> SubAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> MulAssign<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+    #[inline]
+    fn mul_assign(&mut self, rhs: Vectorized<F, N>) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: Field, const N: usize> PrimeCharacteristicRing for Vectorized<F, N> {
+    type PrimeSubfield = F::PrimeSubfield;
+
+    const ZERO: Self = Self([F::Packing::ZERO; N]);
+    const ONE: Self = Self([F::Packing::ONE; N]);
+    const TWO: Self = Self([F::Packing::TWO; N]);
+    const NEG_ONE: Self = Self([F::Packing::NEG_ONE; N]);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        F::from_prime_subfield(f).into()
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        self.map(|x| x.double())
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        self.map(|x| x.halve())
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        self.map(|x| x.square())
+    }
+
+    #[inline]
+    fn cube(&self) -> Self {
+        self.map(|x| x.cube())
+    }
+
+    #[inline]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        self.map(|x| x.exp_const_u64::<POWER>())
+    }
+
+    #[inline]
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        self.map(|x| x.mul_2exp_u64(exp))
+    }
+
+    #[inline]
+    fn dot_product<const M: usize>(u: &[Self; M], v: &[Self; M]) -> Self {
+        Self(array::from_fn(|i| {
+            F::Packing::dot_product::<M>(
+                &array::from_fn::<_, M, _>(|j| u[j].0[i]),
+                &array::from_fn::<_, M, _>(|j| v[j].0[i]),
+            )
+        }))
+    }
+
+    #[inline]
+    fn sum_array<const M: usize>(input: &[Self]) -> Self {
+        assert_eq!(input.len(), M);
+        Self(array::from_fn(|i| {
+            F::Packing::sum_array::<M>(&array::from_fn::<_, M, _>(|j| input[j].0[i]))
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> PrimeCharacteristicRing
+    for VectorizedExt<F, EF, N>
+{
+    type PrimeSubfield = <EF::ExtensionPacking as PrimeCharacteristicRing>::PrimeSubfield;
+
+    const ZERO: Self = Self([EF::ExtensionPacking::ZERO; N]);
+    const ONE: Self = Self([EF::ExtensionPacking::ONE; N]);
+    const TWO: Self = Self([EF::ExtensionPacking::TWO; N]);
+    const NEG_ONE: Self = Self([EF::ExtensionPacking::NEG_ONE; N]);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        Self([EF::ExtensionPacking::from_prime_subfield(f); N])
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        self.map(|x| x.double())
+    }
+
+    #[inline]
+    fn halve(&self) -> Self {
+        self.map(|x| x.halve())
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        self.map(|x| x.square())
+    }
+}
+
+impl<F: Field, const N: usize> Algebra<F> for Vectorized<F, N> {
+    const BATCHED_LC_CHUNK: usize = <F::Packing as Algebra<F>>::BATCHED_LC_CHUNK;
+
+    #[inline]
+    fn mixed_dot_product<const M: usize>(a: &[Self; M], f: &[F; M]) -> Self {
+        Self(array::from_fn(|i| {
+            F::Packing::mixed_dot_product(&array::from_fn(|j| a[j].0[i]), f)
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Algebra<EF> for VectorizedExt<F, EF, N> {
+    const BATCHED_LC_CHUNK: usize = <EF::ExtensionPacking as Algebra<EF>>::BATCHED_LC_CHUNK;
+
+    #[inline]
+    fn mixed_dot_product<const M: usize>(a: &[Self; M], f: &[EF; M]) -> Self {
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::mixed_dot_product(&array::from_fn(|j| a[j].0[i]), f)
+        }))
+    }
+}
+
+impl<F: Field, EF: ExtensionField<F>, const N: usize> Algebra<Vectorized<F, N>>
+    for VectorizedExt<F, EF, N>
+{
+}
+
+// SAFETY: `Vectorized<F, N>` is `repr(transparent)` over `[F::Packing; N]` and
+// `F::Packing: PackedField` guarantees that `F::Packing` can be cast to/from
+// `[F; F::Packing::WIDTH]` without UB. Hence `Vectorized<F, N>` can be cast
+// to/from `[F; F::Packing::WIDTH * N]`.
+unsafe impl<F: Field, const N: usize> PackedValue for Vectorized<F, N> {
+    type Value = F;
+
+    const WIDTH: usize = F::Packing::WIDTH * N;
+
+    #[inline]
+    fn from_fn<Fn>(mut f: Fn) -> Self
+    where
+        Fn: FnMut(usize) -> Self::Value,
+    {
+        Self(array::from_fn(|i| {
+            F::Packing::from_fn(|j| f(i * F::Packing::WIDTH + j))
+        }))
+    }
+
+    #[inline]
+    fn from_slice(slice: &[Self::Value]) -> &Self {
+        assert_eq!(slice.len(), Self::WIDTH);
+        let (_, values, _) = unsafe { slice.align_to::<Self>() };
+        assert_eq!(values.len(), 1, "slice is not aligned to Self");
+        &values[0]
+    }
+
+    #[inline]
+    fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
+        assert_eq!(slice.len(), Self::WIDTH);
+        let (_, values, _) = unsafe { slice.align_to_mut::<Self>() };
+        assert_eq!(values.len(), 1, "slice is not aligned to Self");
+        &mut values[0]
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[Self::Value] {
+        unsafe { core::slice::from_raw_parts(core::ptr::from_ref(self).cast(), Self::WIDTH) }
+    }
+
+    #[inline]
+    fn as_slice_mut(&mut self) -> &mut [Self::Value] {
+        unsafe { core::slice::from_raw_parts_mut(core::ptr::from_mut(self).cast(), Self::WIDTH) }
+    }
+}

--- a/field/src/vectorized.rs
+++ b/field/src/vectorized.rs
@@ -414,6 +414,39 @@ impl<F: Field, EF: ExtensionField<F>, const N: usize> PrimeCharacteristicRing
     fn square(&self) -> Self {
         self.map(|x| x.square())
     }
+
+    #[inline]
+    fn cube(&self) -> Self {
+        self.map(|x| x.cube())
+    }
+
+    #[inline]
+    fn exp_const_u64<const POWER: u64>(&self) -> Self {
+        self.map(|x| x.exp_const_u64::<POWER>())
+    }
+
+    #[inline]
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        self.map(|x| x.mul_2exp_u64(exp))
+    }
+
+    #[inline]
+    fn dot_product<const M: usize>(u: &[Self; M], v: &[Self; M]) -> Self {
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::dot_product::<M>(
+                &array::from_fn::<_, M, _>(|j| u[j].0[i]),
+                &array::from_fn::<_, M, _>(|j| v[j].0[i]),
+            )
+        }))
+    }
+
+    #[inline]
+    fn sum_array<const M: usize>(input: &[Self]) -> Self {
+        assert_eq!(input.len(), M);
+        Self(array::from_fn(|i| {
+            EF::ExtensionPacking::sum_array::<M>(&array::from_fn::<_, M, _>(|j| input[j].0[i]))
+        }))
+    }
 }
 
 impl<F: Field, const N: usize> Algebra<F> for Vectorized<F, N> {
@@ -446,7 +479,10 @@ impl<F: Field, EF: ExtensionField<F>, const N: usize> Algebra<Vectorized<F, N>>
 // SAFETY: `Vectorized<F, N>` is `repr(transparent)` over `[F::Packing; N]` and
 // `F::Packing: PackedField` guarantees that `F::Packing` can be cast to/from
 // `[F; F::Packing::WIDTH]` without UB. Hence `Vectorized<F, N>` can be cast
-// to/from `[F; F::Packing::WIDTH * N]`.
+// to/from `[F; F::Packing::WIDTH * N]`. `from_slice`/`from_slice_mut` additionally
+// rely on `align_of::<F::Packing>() <= align_of::<F>()`, the same invariant
+// `PackedValue::pack_slice` asserts, to cast a `&[F]` pointer to `&Self` without
+// under-aligning the read.
 unsafe impl<F: Field, const N: usize> PackedValue for Vectorized<F, N> {
     type Value = F;
 
@@ -465,17 +501,13 @@ unsafe impl<F: Field, const N: usize> PackedValue for Vectorized<F, N> {
     #[inline]
     fn from_slice(slice: &[Self::Value]) -> &Self {
         assert_eq!(slice.len(), Self::WIDTH);
-        let (_, values, _) = unsafe { slice.align_to::<Self>() };
-        assert_eq!(values.len(), 1, "slice is not aligned to Self");
-        &values[0]
+        unsafe { &*slice.as_ptr().cast() }
     }
 
     #[inline]
     fn from_slice_mut(slice: &mut [Self::Value]) -> &mut Self {
         assert_eq!(slice.len(), Self::WIDTH);
-        let (_, values, _) = unsafe { slice.align_to_mut::<Self>() };
-        assert_eq!(values.len(), 1, "slice is not aligned to Self");
-        &mut values[0]
+        unsafe { &mut *slice.as_mut_ptr().cast() }
     }
 
     #[inline]

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -420,6 +420,9 @@ impl Field for Goldilocks {
     // Sage: GF(2^64 - 2^32 + 1).multiplicative_generator()
     const GENERATOR: Self = Self::new(7);
 
+    // Measured -11% on quotient evaluation (twoadic PCS, Keccak AIR, aarch64+neon).
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = true;
+
     fn is_zero(&self) -> bool {
         self.value == 0 || self.value == Self::ORDER_U64
     }

--- a/koala-bear/src/koala_bear.rs
+++ b/koala-bear/src/koala_bear.rs
@@ -51,6 +51,9 @@ impl BarrettParameters for KoalaBearParameters {}
 
 impl FieldParameters for KoalaBearParameters {
     const MONTY_GEN: KoalaBear = KoalaBear::new(3);
+
+    // Measured -15% on quotient evaluation (twoadic PCS, Poseidon2 AIR, aarch64+neon).
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = true;
 }
 
 impl RelativelyPrimePower<3> for KoalaBearParameters {

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -365,6 +365,12 @@ impl Field for Mersenne31 {
     // Sage: GF(2^31 - 1).multiplicative_generator()
     const GENERATOR: Self = Self::new(7);
 
+    // Circle-STARK AIRs over this field (e.g. the vectorized Poseidon2 AIR) already
+    // interleave several independent permutations per row, which already supplies enough
+    // independent per-row dependency chains; evaluating additional packed vectors in
+    // lockstep on top of that does not improve throughput here.
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = false;
+
     #[inline]
     fn is_zero(&self) -> bool {
         self.value == 0 || self.value == Self::ORDER_U32

--- a/mersenne-31/src/mersenne_31.rs
+++ b/mersenne-31/src/mersenne_31.rs
@@ -365,10 +365,10 @@ impl Field for Mersenne31 {
     // Sage: GF(2^31 - 1).multiplicative_generator()
     const GENERATOR: Self = Self::new(7);
 
-    // Circle-STARK AIRs over this field (e.g. the vectorized Poseidon2 AIR) already
-    // interleave several independent permutations per row, which already supplies enough
-    // independent per-row dependency chains; evaluating additional packed vectors in
-    // lockstep on top of that does not improve throughput here.
+    // PackedMersenne31Neon's `dot_product` uses deferred-reduction accumulation (see #1894),
+    // which already closes the extension-field-multiply latency gap a lockstep evaluation
+    // strategy would otherwise address; evaluating additional packed vectors in lockstep on
+    // top of that does not improve throughput for this field (measured +10% regression).
     const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = false;
 
     #[inline]

--- a/monty-31/src/data_traits.rs
+++ b/monty-31/src/data_traits.rs
@@ -68,6 +68,13 @@ pub trait FieldParameters: PackedMontyParameters + Sized {
     const MONTY_GEN: MontyField31<Self>;
 
     const HALF_P_PLUS_1: u32 = (Self::PRIME + 1) >> 1;
+
+    /// See [`p3_field::Field::BENEFITS_FROM_LOCKSTEP_EVALUATION`].
+    ///
+    /// Defaults to `false`: this trait backs every `MontyField31<Self>` field, including
+    /// ones not yet benchmarked, so opting in is left to parameter sets that have measured
+    /// a win (e.g. `BabyBearParameters`, `KoalaBearParameters`).
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = false;
 }
 
 /// An integer `D` such that `gcd(D, p - 1) = 1`.

--- a/monty-31/src/monty_31.rs
+++ b/monty-31/src/monty_31.rs
@@ -441,6 +441,8 @@ impl<FP: FieldParameters> Field for MontyField31<FP> {
 
     const GENERATOR: Self = FP::MONTY_GEN;
 
+    const BENEFITS_FROM_LOCKSTEP_EVALUATION: bool = FP::BENEFITS_FROM_LOCKSTEP_EVALUATION;
+
     fn try_inverse(&self) -> Option<Self> {
         if self.is_zero() {
             return None;

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -1,11 +1,19 @@
 use alloc::vec::Vec;
 
 use p3_air::{AirBuilder, ExtensionBuilder, RowWindow};
-use p3_field::{Algebra, BasedVectorSpace};
+use p3_field::{Algebra, BasedVectorSpace, Vectorized, VectorizedExt};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
 
 use crate::{PackedChallenge, PackedVal, StarkGenericConfig, Val};
+
+/// Vectorized base-field expression type used by [`VectorizedConstraintFolder`]:
+/// `N` packed vectors evaluated in lockstep.
+pub type VectorizedVal<SC, const N: usize> = Vectorized<Val<SC>, N>;
+
+/// Vectorized extension-field expression type used by [`VectorizedConstraintFolder`].
+pub type VectorizedChallenge<SC, const N: usize> =
+    VectorizedExt<Val<SC>, <SC as StarkGenericConfig>::Challenge, N>;
 
 /// Packed constraint folder for SIMD-optimized prover evaluation.
 ///
@@ -49,6 +57,151 @@ pub struct ProverConstraintFolder<'a, SC: StarkGenericConfig> {
     pub constraint_index: usize,
     /// Total number of constraints in the AIR (debug-only bookkeeping)
     pub constraint_count: usize,
+}
+
+/// Packed constraint folder evaluating `N` packed vectors per constraint in lockstep.
+///
+/// Identical in role to [`ProverConstraintFolder`], but its expression types are
+/// [`Vectorized`]/[`VectorizedExt`] over `N` packed vectors instead of a single one.
+/// One packed vector of constraint evaluations forms a single dependency chain per
+/// expression; `N` lockstep chains let the CPU overlap the long-latency modular
+/// multiplies of independent rows, which a single chain cannot saturate.
+#[derive(Debug)]
+pub struct VectorizedConstraintFolder<'a, SC: StarkGenericConfig, const N: usize> {
+    /// The [`RowMajorMatrixView`] containing rows on which the constraint polynomial is evaluated.
+    pub main: RowMajorMatrixView<'a, VectorizedVal<SC, N>>,
+    /// The preprocessed columns as a [`RowMajorMatrixView`].
+    /// Zero-width when the AIR has no preprocessed trace.
+    pub preprocessed: RowMajorMatrixView<'a, VectorizedVal<SC, N>>,
+    /// Pre-built window over the preprocessed columns.
+    pub preprocessed_window: RowWindow<'a, VectorizedVal<SC, N>>,
+    /// Periodic column values at the current row(s), one vectorized value per column.
+    pub periodic_values: &'a [VectorizedVal<SC, N>],
+    /// Public inputs to the [AIR](`p3_air::Air`) implementation.
+    pub public_values: &'a [Val<SC>],
+    /// Evaluations of the first-row selector polynomial.
+    /// Non-zero only on the first trace row.
+    pub is_first_row: VectorizedVal<SC, N>,
+    /// Evaluations of the last-row selector polynomial.
+    /// Non-zero only on the last trace row.
+    pub is_last_row: VectorizedVal<SC, N>,
+    /// Evaluations of the transition selector polynomial.
+    /// Zero only on the last trace row.
+    pub is_transition: VectorizedVal<SC, N>,
+    /// Base-field alpha powers, reordered to match base constraint emission order.
+    /// `base_alpha_powers[d][j]` = d-th basis coefficient of alpha power for j-th base constraint.
+    pub base_alpha_powers: &'a [Vec<Val<SC>>],
+    /// Extension-field alpha powers, reordered to match ext constraint emission order.
+    pub ext_alpha_powers: &'a [SC::Challenge],
+    /// Collected base-field constraints for this row group.
+    pub base_constraints: Vec<VectorizedVal<SC, N>>,
+    /// Collected extension-field constraints for this row group.
+    pub ext_constraints: Vec<VectorizedChallenge<SC, N>>,
+    /// Current constraint index being processed (debug-only bookkeeping)
+    pub constraint_index: usize,
+    /// Total number of constraints in the AIR (debug-only bookkeeping)
+    pub constraint_count: usize,
+}
+
+impl<SC: StarkGenericConfig, const N: usize> VectorizedConstraintFolder<'_, SC, N> {
+    /// Combine all collected constraints with their pre-computed alpha powers.
+    ///
+    /// The same scheme as [`ProverConstraintFolder::finalize_constraints`], applied
+    /// per vectorized component: the [`Algebra::mixed_dot_product`] overrides on
+    /// [`Vectorized`]/[`VectorizedExt`] delegate each component to the underlying
+    /// packed type, so the specialized SIMD dot products are still used.
+    #[inline]
+    pub fn finalize_constraints(&self) -> VectorizedChallenge<SC, N> {
+        debug_assert_eq!(self.constraint_index, self.constraint_count);
+
+        let base = &self.base_constraints;
+        let base_coefficients: Vec<VectorizedVal<SC, N>> = self
+            .base_alpha_powers
+            .iter()
+            .map(|powers| VectorizedVal::<SC, N>::batched_linear_combination(base, powers))
+            .collect();
+        let acc =
+            VectorizedChallenge::<SC, N>::from_vectorized_basis_coefficients(&base_coefficients);
+        acc + VectorizedChallenge::<SC, N>::batched_linear_combination(
+            &self.ext_constraints,
+            self.ext_alpha_powers,
+        )
+    }
+}
+
+impl<'a, SC: StarkGenericConfig, const N: usize> AirBuilder
+    for VectorizedConstraintFolder<'a, SC, N>
+{
+    type F = Val<SC>;
+    type Expr = VectorizedVal<SC, N>;
+    type Var = VectorizedVal<SC, N>;
+    type PreprocessedWindow = RowWindow<'a, VectorizedVal<SC, N>>;
+    type MainWindow = RowWindow<'a, VectorizedVal<SC, N>>;
+    type PublicVar = Val<SC>;
+    type PeriodicVar = VectorizedVal<SC, N>;
+
+    #[inline]
+    fn main(&self) -> Self::MainWindow {
+        RowWindow::from_view(&self.main)
+    }
+
+    fn preprocessed(&self) -> &Self::PreprocessedWindow {
+        &self.preprocessed_window
+    }
+
+    #[inline]
+    fn is_first_row(&self) -> Self::Expr {
+        self.is_first_row
+    }
+
+    #[inline]
+    fn is_last_row(&self) -> Self::Expr {
+        self.is_last_row
+    }
+
+    #[inline]
+    fn is_transition(&self) -> Self::Expr {
+        self.is_transition
+    }
+
+    #[inline]
+    fn assert_zero<I: Into<Self::Expr>>(&mut self, x: I) {
+        self.base_constraints.push(x.into());
+        self.constraint_index += 1;
+    }
+
+    #[inline]
+    fn assert_zeros<const M: usize, I: Into<Self::Expr>>(&mut self, array: [I; M]) {
+        let expr_array = array.map(Into::into);
+        self.base_constraints.extend(expr_array);
+        self.constraint_index += M;
+    }
+
+    #[inline]
+    fn public_values(&self) -> &[Self::PublicVar] {
+        self.public_values
+    }
+
+    #[inline]
+    fn periodic_values(&self) -> &[Self::PeriodicVar] {
+        self.periodic_values
+    }
+}
+
+impl<SC: StarkGenericConfig, const N: usize> ExtensionBuilder
+    for VectorizedConstraintFolder<'_, SC, N>
+{
+    type EF = SC::Challenge;
+    type ExprEF = VectorizedChallenge<SC, N>;
+    type VarEF = VectorizedChallenge<SC, N>;
+
+    fn assert_zero_ext<I>(&mut self, x: I)
+    where
+        I: Into<Self::ExprEF>,
+    {
+        self.ext_constraints.push(x.into());
+        self.constraint_index += 1;
+    }
 }
 
 /// Handles constraint verification for the verifier in a STARK system.

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -110,18 +110,26 @@ impl<SC: StarkGenericConfig, const N: usize> VectorizedConstraintFolder<'_, SC, 
     /// per vectorized component: the [`Algebra::mixed_dot_product`] overrides on
     /// [`Vectorized`]/[`VectorizedExt`] delegate each component to the underlying
     /// packed type, so the specialized SIMD dot products are still used.
+    ///
+    /// `base_coefficients` is caller-owned scratch space for the per-basis-dimension
+    /// coefficients computed along the way; callers reuse it across row groups instead
+    /// of allocating fresh each call.
     #[inline]
-    pub fn finalize_constraints(&self) -> VectorizedChallenge<SC, N> {
+    pub fn finalize_constraints(
+        &self,
+        base_coefficients: &mut Vec<VectorizedVal<SC, N>>,
+    ) -> VectorizedChallenge<SC, N> {
         debug_assert_eq!(self.constraint_index, self.constraint_count);
 
         let base = &self.base_constraints;
-        let base_coefficients: Vec<VectorizedVal<SC, N>> = self
-            .base_alpha_powers
-            .iter()
-            .map(|powers| VectorizedVal::<SC, N>::batched_linear_combination(base, powers))
-            .collect();
+        base_coefficients.clear();
+        base_coefficients.extend(
+            self.base_alpha_powers
+                .iter()
+                .map(|powers| VectorizedVal::<SC, N>::batched_linear_combination(base, powers)),
+        );
         let acc =
-            VectorizedChallenge::<SC, N>::from_vectorized_basis_coefficients(&base_coefficients);
+            VectorizedChallenge::<SC, N>::from_vectorized_basis_coefficients(base_coefficients);
         acc + VectorizedChallenge::<SC, N>::batched_linear_combination(
             &self.ext_constraints,
             self.ext_alpha_powers,

--- a/uni-stark/src/preprocessed.rs
+++ b/uni-stark/src/preprocessed.rs
@@ -1,14 +1,12 @@
-use p3_air::Air;
-use p3_air::symbolic::SymbolicAirBuilder;
 use p3_commit::Pcs;
 use p3_matrix::Matrix;
 use tracing::debug_span;
 
-use crate::{ProverConstraintFolder, StarkGenericConfig, Val};
+use crate::{QuotientAir, StarkGenericConfig};
 
 /// Prover-side reusable data for preprocessed columns.
 ///
-/// This allows committing to the preprocessed trace once per [`Air`]/degree and reusing
+/// This allows committing to the preprocessed trace once per `Air`/degree and reusing
 /// the commitment and [`Pcs`] prover data across many proofs.
 pub struct PreprocessedProverData<SC: StarkGenericConfig> {
     /// The width (number of columns) of the preprocessed trace.
@@ -26,7 +24,7 @@ pub struct PreprocessedProverData<SC: StarkGenericConfig> {
 
 /// Verifier-side reusable data for preprocessed columns.
 ///
-/// This allows committing to the preprocessed trace once per [`Air`]/degree and reusing
+/// This allows committing to the preprocessed trace once per `Air`/degree and reusing
 /// the commitment across many verifications.
 #[derive(Clone)]
 pub struct PreprocessedVerifierKey<SC: StarkGenericConfig> {
@@ -40,10 +38,10 @@ pub struct PreprocessedVerifierKey<SC: StarkGenericConfig> {
     pub commitment: <SC::Pcs as Pcs<SC::Challenge, SC::Challenger>>::Commitment,
 }
 
-/// Set up and commit the preprocessed trace for a given [`Air`] and degree.
+/// Set up and commit the preprocessed trace for a given `Air` and degree.
 ///
-/// This can be called once per [`Air`]/degree configuration to obtain reusable
-/// prover data for preprocessed columns. Returns `None` if the [`Air`] does not
+/// This can be called once per `Air`/degree configuration to obtain reusable
+/// prover data for preprocessed columns. Returns `None` if the `Air` does not
 /// define any preprocessed columns.
 pub fn setup_preprocessed<SC, A>(
     config: &SC,
@@ -52,7 +50,7 @@ pub fn setup_preprocessed<SC, A>(
 ) -> Option<(PreprocessedProverData<SC>, PreprocessedVerifierKey<SC>)>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: QuotientAir<SC>,
 {
     let pcs = config.pcs();
     let is_zk = config.is_zk();

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -30,8 +30,12 @@ use crate::{VectorizedChallenge, VectorizedConstraintFolder, VectorizedVal};
 /// multiplication (e.g. ~10 cycles at ~1.25 cycles/vector throughput on NEON). Two
 /// lockstep chains let the out-of-order core overlap independent rows; values above 2
 /// increase register pressure with diminishing returns.
+///
+/// Public so that a concrete (non-generic) `impl Air<ProverConstraintFolder<'a, SC>>` can
+/// name it in the matching `impl Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>`
+/// required by [`QuotientAir`] on `aarch64`+`neon` — see that trait's docs.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-const QUOTIENT_ILP: usize = 2;
+pub const QUOTIENT_ILP: usize = 2;
 
 /// AIRs usable with [`quotient_values`] and the functions built on it.
 ///
@@ -40,6 +44,11 @@ const QUOTIENT_ILP: usize = 2;
 /// per field at runtime (see [`Field::BENEFITS_FROM_LOCKSTEP_EVALUATION`]); AIRs written
 /// generically over the builder (the usual pattern) satisfy both automatically. Elsewhere
 /// this is exactly the [`ProverConstraintFolder`] bound, unchanged.
+///
+/// A concrete AIR with its own `impl Air<ProverConstraintFolder<'a, SC>>` (rather than a
+/// generic `impl<B: AirBuilder> Air<B>`) compiles on `x86_64` but fails to compile on
+/// `aarch64`+`neon` unless it also adds `impl<'a, SC> Air<VectorizedConstraintFolder<'a,
+/// SC, QUOTIENT_ILP>> for MyAir`.
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 pub trait QuotientAir<SC: StarkGenericConfig>:
     Air<SymbolicAirBuilder<Val<SC>>>
@@ -468,7 +477,7 @@ where
 {
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     if Val::<SC>::BENEFITS_FROM_LOCKSTEP_EVALUATION {
-        return quotient_values_vectorized::<SC, A, Mat>(
+        return quotient_values_inner::<SC, A, Mat, VectorizedEval<QUOTIENT_ILP>>(
             pcs,
             air,
             public_values,
@@ -480,7 +489,7 @@ where
             alpha,
         );
     }
-    quotient_values_plain::<SC, A, Mat>(
+    quotient_values_inner::<SC, A, Mat, PlainEval>(
         pcs,
         air,
         public_values,
@@ -493,8 +502,167 @@ where
     )
 }
 
+/// Row-group constraint-folding strategy used by [`quotient_values_inner`].
+///
+/// Abstracts over the plain (single packed vector) and lockstep-vectorized folders so the
+/// row-group loop is written once. `quotient_values_inner` is monomorphized per `Self`, so
+/// instantiating it at two concrete strategies produces the same machine code as two
+/// hand-written copies of the loop — no shared runtime dispatch is introduced between them.
+trait QuotientEvalStrategy<SC: StarkGenericConfig, A> {
+    /// The packed base-field type this strategy evaluates constraints over.
+    type Pack: PackedValue<Value = Val<SC>> + Copy + Send + Sync;
+    /// The packed extension-field type constraints are folded into.
+    type Challenge: Copy + Send + Sync;
+
+    /// Evaluate one row group's constraints, fold them (dividing by the vanishing
+    /// polynomial via `inv_vanishing`), and return the resulting challenge together with
+    /// the `base_constraints`/`ext_constraints` buffers so the caller can reclaim and
+    /// reuse their allocations for the next row group.
+    #[allow(clippy::too_many_arguments)]
+    fn eval_row_group<'a>(
+        air: &A,
+        main: RowMajorMatrixView<'a, Self::Pack>,
+        preprocessed: RowMajorMatrixView<'a, Self::Pack>,
+        periodic_values: &'a [Self::Pack],
+        public_values: &'a [Val<SC>],
+        is_first_row: Self::Pack,
+        is_last_row: Self::Pack,
+        is_transition: Self::Pack,
+        inv_vanishing: Self::Pack,
+        base_alpha_powers: &'a [Vec<Val<SC>>],
+        ext_alpha_powers: &'a [SC::Challenge],
+        base_constraints: Vec<Self::Pack>,
+        ext_constraints: Vec<Self::Challenge>,
+        base_coefficients_buf: &mut Vec<Self::Pack>,
+        constraint_count: usize,
+    ) -> (Self::Challenge, Vec<Self::Pack>, Vec<Self::Challenge>);
+
+    /// Extract the scalar challenge at packed lane `idx`.
+    fn extract(challenge: &Self::Challenge, idx: usize) -> SC::Challenge;
+}
+
+/// [`QuotientEvalStrategy`] evaluating a single packed vector per constraint expression,
+/// via [`ProverConstraintFolder`].
+struct PlainEval;
+
+impl<SC, A> QuotientEvalStrategy<SC, A> for PlainEval
+where
+    SC: StarkGenericConfig,
+    A: for<'a> Air<ProverConstraintFolder<'a, SC>>,
+{
+    type Pack = PackedVal<SC>;
+    type Challenge = PackedChallenge<SC>;
+
+    #[inline]
+    fn eval_row_group<'a>(
+        air: &A,
+        main: RowMajorMatrixView<'a, Self::Pack>,
+        preprocessed: RowMajorMatrixView<'a, Self::Pack>,
+        periodic_values: &'a [Self::Pack],
+        public_values: &'a [Val<SC>],
+        is_first_row: Self::Pack,
+        is_last_row: Self::Pack,
+        is_transition: Self::Pack,
+        inv_vanishing: Self::Pack,
+        base_alpha_powers: &'a [Vec<Val<SC>>],
+        ext_alpha_powers: &'a [SC::Challenge],
+        base_constraints: Vec<Self::Pack>,
+        ext_constraints: Vec<Self::Challenge>,
+        _base_coefficients_buf: &mut Vec<Self::Pack>,
+        constraint_count: usize,
+    ) -> (Self::Challenge, Vec<Self::Pack>, Vec<Self::Challenge>) {
+        let mut folder = ProverConstraintFolder {
+            main,
+            preprocessed,
+            preprocessed_window: RowWindow::from_view(&preprocessed),
+            periodic_values,
+            public_values,
+            is_first_row,
+            is_last_row,
+            is_transition,
+            base_alpha_powers,
+            ext_alpha_powers,
+            base_constraints,
+            ext_constraints,
+            constraint_index: 0,
+            constraint_count,
+        };
+        air.eval(&mut folder);
+
+        // quotient(x) = constraints(x) / Z_H(x)
+        let quotient = folder.finalize_constraints() * inv_vanishing;
+        (quotient, folder.base_constraints, folder.ext_constraints)
+    }
+
+    #[inline]
+    fn extract(challenge: &Self::Challenge, idx: usize) -> SC::Challenge {
+        challenge.extract(idx)
+    }
+}
+
+/// [`QuotientEvalStrategy`] evaluating `N` packed vectors in lockstep per constraint
+/// expression, via [`VectorizedConstraintFolder`].
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+struct VectorizedEval<const N: usize>;
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+impl<SC, A, const N: usize> QuotientEvalStrategy<SC, A> for VectorizedEval<N>
+where
+    SC: StarkGenericConfig,
+    A: for<'a> Air<VectorizedConstraintFolder<'a, SC, N>>,
+{
+    type Pack = VectorizedVal<SC, N>;
+    type Challenge = VectorizedChallenge<SC, N>;
+
+    #[inline]
+    fn eval_row_group<'a>(
+        air: &A,
+        main: RowMajorMatrixView<'a, Self::Pack>,
+        preprocessed: RowMajorMatrixView<'a, Self::Pack>,
+        periodic_values: &'a [Self::Pack],
+        public_values: &'a [Val<SC>],
+        is_first_row: Self::Pack,
+        is_last_row: Self::Pack,
+        is_transition: Self::Pack,
+        inv_vanishing: Self::Pack,
+        base_alpha_powers: &'a [Vec<Val<SC>>],
+        ext_alpha_powers: &'a [SC::Challenge],
+        base_constraints: Vec<Self::Pack>,
+        ext_constraints: Vec<Self::Challenge>,
+        base_coefficients_buf: &mut Vec<Self::Pack>,
+        constraint_count: usize,
+    ) -> (Self::Challenge, Vec<Self::Pack>, Vec<Self::Challenge>) {
+        let mut folder = VectorizedConstraintFolder {
+            main,
+            preprocessed,
+            preprocessed_window: RowWindow::from_view(&preprocessed),
+            periodic_values,
+            public_values,
+            is_first_row,
+            is_last_row,
+            is_transition,
+            base_alpha_powers,
+            ext_alpha_powers,
+            base_constraints,
+            ext_constraints,
+            constraint_index: 0,
+            constraint_count,
+        };
+        air.eval(&mut folder);
+
+        // quotient(x) = constraints(x) / Z_H(x)
+        let quotient = folder.finalize_constraints(base_coefficients_buf) * inv_vanishing;
+        (quotient, folder.base_constraints, folder.ext_constraints)
+    }
+
+    #[inline]
+    fn extract(challenge: &Self::Challenge, idx: usize) -> SC::Challenge {
+        challenge.extract(idx)
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
-fn quotient_values_plain<SC, A, Mat>(
+fn quotient_values_inner<SC, A, Mat, Strat>(
     pcs: &SC::Pcs,
     air: &A,
     public_values: &[Val<SC>],
@@ -507,9 +675,13 @@ fn quotient_values_plain<SC, A, Mat>(
 ) -> Vec<SC::Challenge>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: Air<SymbolicAirBuilder<Val<SC>>>,
     Mat: Matrix<Val<SC>> + Sync,
+    Strat: QuotientEvalStrategy<SC, A>,
 {
+    type Pack<SC, A, Strat> = <Strat as QuotientEvalStrategy<SC, A>>::Pack;
+    type Challenge<SC, A, Strat> = <Strat as QuotientEvalStrategy<SC, A>>::Challenge;
+
     let quotient_size = quotient_domain.size();
     let width = trace_on_quotient_domain.width();
     let mut sels = debug_span!("Compute Selectors")
@@ -518,9 +690,9 @@ where
     let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
     let next_step = 1 << qdb;
 
-    // We take PackedVal::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
-    // pad with default values in the case where quotient_size is smaller than PackedVal::<SC>::WIDTH.
-    for _ in quotient_size..PackedVal::<SC>::WIDTH {
+    // We take Pack::WIDTH worth of values at a time from a quotient_size slice, so we need to
+    // pad with default values in the case where quotient_size is smaller than Pack::WIDTH.
+    for _ in quotient_size..Pack::<SC, A, Strat>::WIDTH {
         sels.is_first_row.push(Val::<SC>::default());
         sels.is_last_row.push(Val::<SC>::default());
         sels.is_transition.push(Val::<SC>::default());
@@ -533,8 +705,8 @@ where
     let periodic_table =
         pcs.build_periodic_lde_table(&periodic_cols, trace_domain, quotient_domain);
 
-    let pack_width = PackedVal::<SC>::WIDTH;
-    let periodic_packed: Vec<Vec<PackedVal<SC>>> = if periodic_table.is_empty() {
+    let pack_width = Pack::<SC, A, Strat>::WIDTH;
+    let periodic_packed: Vec<Vec<Pack<SC, A, Strat>>> = if periodic_table.is_empty() {
         Vec::new()
     } else {
         let ncols = periodic_table.width();
@@ -543,7 +715,7 @@ where
             .map(|i_start| {
                 (0..ncols)
                     .map(|col_idx| {
-                        PackedVal::<SC>::from_fn(|offset| {
+                        Pack::<SC, A, Strat>::from_fn(|offset| {
                             *periodic_table.get(i_start + offset, col_idx)
                         })
                     })
@@ -555,255 +727,99 @@ where
     // Buffers reused across row-groups on each worker thread: allocating the
     // packed row pairs and constraint accumulators fresh per group costs
     // ~20% of this function's runtime on wide traces.
-    struct GroupBuffers<SC: StarkGenericConfig> {
-        main: Vec<PackedVal<SC>>,
-        preprocessed: Vec<PackedVal<SC>>,
-        base_constraints: Vec<PackedVal<SC>>,
-        ext_constraints: Vec<PackedChallenge<SC>>,
+    struct GroupBuffers<P, C> {
+        main: Vec<P>,
+        preprocessed: Vec<P>,
+        base_constraints: Vec<P>,
+        ext_constraints: Vec<C>,
+        base_coefficients: Vec<P>,
     }
 
     let mut quotient_values = SC::Challenge::zero_vec(quotient_size);
     quotient_values
-        .par_chunks_mut(PackedVal::<SC>::WIDTH)
+        .par_chunks_mut(Pack::<SC, A, Strat>::WIDTH)
         .enumerate()
         .for_each_init(
-            || GroupBuffers::<SC> {
+            || GroupBuffers::<Pack<SC, A, Strat>, Challenge<SC, A, Strat>> {
                 main: Vec::with_capacity(2 * width),
                 preprocessed: Vec::with_capacity(
                     2 * preprocessed_on_quotient_domain.map_or(0, |p| p.width()),
                 ),
                 base_constraints: Vec::with_capacity(constraint_layout.base_indices.len()),
                 ext_constraints: Vec::with_capacity(constraint_layout.ext_indices.len()),
+                base_coefficients: Vec::with_capacity(base_alpha_powers.len()),
             },
             |bufs, (group, quotient_chunk)| {
-                let i_start = group * PackedVal::<SC>::WIDTH;
-                let i_range = i_start..i_start + PackedVal::<SC>::WIDTH;
+                let i_start = group * Pack::<SC, A, Strat>::WIDTH;
+                let i_range = i_start..i_start + Pack::<SC, A, Strat>::WIDTH;
 
                 let is_first_row =
-                    *PackedVal::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
-                let is_last_row = *PackedVal::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+                    *Pack::<SC, A, Strat>::from_slice(&sels.is_first_row[i_range.clone()]);
+                let is_last_row =
+                    *Pack::<SC, A, Strat>::from_slice(&sels.is_last_row[i_range.clone()]);
                 let is_transition =
-                    *PackedVal::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
-                let inv_vanishing = *PackedVal::<SC>::from_slice(&sels.inv_vanishing[i_range]);
+                    *Pack::<SC, A, Strat>::from_slice(&sels.is_transition[i_range.clone()]);
+                let inv_vanishing = *Pack::<SC, A, Strat>::from_slice(&sels.inv_vanishing[i_range]);
 
                 bufs.main.clear();
                 bufs.main.extend(
-                    trace_on_quotient_domain.vertically_packed_row::<PackedVal<SC>>(i_start),
+                    trace_on_quotient_domain.vertically_packed_row::<Pack<SC, A, Strat>>(i_start),
                 );
                 bufs.main.extend(
                     trace_on_quotient_domain
-                        .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                        .vertically_packed_row::<Pack<SC, A, Strat>>(i_start + next_step),
                 );
                 let main = RowMajorMatrixView::new(&bufs.main, width);
 
                 let preprocessed_view = match preprocessed_on_quotient_domain {
                     Some(preprocessed) => {
                         bufs.preprocessed.clear();
-                        bufs.preprocessed
-                            .extend(preprocessed.vertically_packed_row::<PackedVal<SC>>(i_start));
+                        bufs.preprocessed.extend(
+                            preprocessed.vertically_packed_row::<Pack<SC, A, Strat>>(i_start),
+                        );
                         bufs.preprocessed.extend(
                             preprocessed
-                                .vertically_packed_row::<PackedVal<SC>>(i_start + next_step),
+                                .vertically_packed_row::<Pack<SC, A, Strat>>(i_start + next_step),
                         );
                         RowMajorMatrixView::new(&bufs.preprocessed, preprocessed.width())
                     }
                     None => RowMajorMatrixView::new(&[], 0),
                 };
-                let periodic_values: &[PackedVal<SC>] = if periodic_packed.is_empty() {
+                let periodic_values: &[Pack<SC, A, Strat>] = if periodic_packed.is_empty() {
                     &[]
                 } else {
                     &periodic_packed[i_start / pack_width]
                 };
-                let mut folder = ProverConstraintFolder {
+
+                let (quotient, base_constraints, ext_constraints) = Strat::eval_row_group(
+                    air,
                     main,
-                    preprocessed: preprocessed_view,
-                    preprocessed_window: RowWindow::from_view(&preprocessed_view),
+                    preprocessed_view,
                     periodic_values,
                     public_values,
                     is_first_row,
                     is_last_row,
                     is_transition,
-                    base_alpha_powers: &base_alpha_powers,
-                    ext_alpha_powers: &ext_alpha_powers,
-                    base_constraints: core::mem::take(&mut bufs.base_constraints),
-                    ext_constraints: core::mem::take(&mut bufs.ext_constraints),
-                    constraint_index: 0,
-                    constraint_count: constraint_layout.total_constraints(),
-                };
-                air.eval(&mut folder);
-
-                // quotient(x) = constraints(x) / Z_H(x)
-                let quotient = folder.finalize_constraints() * inv_vanishing;
-
-                // The contents were folded into `quotient` above; reclaim the Vecs and
-                // `clear` them (`len = 0`, capacity kept) so the next row group reuses
-                // the allocations.
-                bufs.base_constraints = folder.base_constraints;
-                bufs.base_constraints.clear();
-                bufs.ext_constraints = folder.ext_constraints;
-                bufs.ext_constraints.clear();
-
-                // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
-                for (idx_in_packing, q) in quotient_chunk.iter_mut().enumerate() {
-                    *q = quotient.extract(idx_in_packing);
-                }
-            },
-        );
-    quotient_values
-}
-
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-#[allow(clippy::too_many_arguments)]
-fn quotient_values_vectorized<SC, A, Mat>(
-    pcs: &SC::Pcs,
-    air: &A,
-    public_values: &[Val<SC>],
-    layout: AirLayout,
-    trace_domain: Domain<SC>,
-    quotient_domain: Domain<SC>,
-    trace_on_quotient_domain: &Mat,
-    preprocessed_on_quotient_domain: Option<&Mat>,
-    alpha: SC::Challenge,
-) -> Vec<SC::Challenge>
-where
-    SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>>
-        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
-    Mat: Matrix<Val<SC>> + Sync,
-{
-    type Pack<SC> = VectorizedVal<SC, QUOTIENT_ILP>;
-    type Challenge<SC> = VectorizedChallenge<SC, QUOTIENT_ILP>;
-    type Folder<'a, SC> = VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>;
-
-    let quotient_size = quotient_domain.size();
-    let width = trace_on_quotient_domain.width();
-    let mut sels = debug_span!("Compute Selectors")
-        .in_scope(|| trace_domain.selectors_on_coset(quotient_domain));
-
-    let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
-    let next_step = 1 << qdb;
-
-    // We take Pack::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
-    // pad with default values in the case where quotient_size is smaller than Pack::<SC>::WIDTH.
-    for _ in quotient_size..Pack::<SC>::WIDTH {
-        sels.is_first_row.push(Val::<SC>::default());
-        sels.is_last_row.push(Val::<SC>::default());
-        sels.is_transition.push(Val::<SC>::default());
-        sels.inv_vanishing.push(Val::<SC>::default());
-    }
-
-    let constraint_layout = get_constraint_layout(air, layout);
-    let (base_alpha_powers, ext_alpha_powers) = constraint_layout.decompose_alpha(alpha);
-    let periodic_cols = air.periodic_columns();
-    let periodic_table =
-        pcs.build_periodic_lde_table(&periodic_cols, trace_domain, quotient_domain);
-
-    let pack_width = Pack::<SC>::WIDTH;
-    let periodic_packed: Vec<Vec<Pack<SC>>> = if periodic_table.is_empty() {
-        Vec::new()
-    } else {
-        let ncols = periodic_table.width();
-        (0..quotient_size)
-            .step_by(pack_width)
-            .map(|i_start| {
-                (0..ncols)
-                    .map(|col_idx| {
-                        Pack::<SC>::from_fn(|offset| *periodic_table.get(i_start + offset, col_idx))
-                    })
-                    .collect()
-            })
-            .collect()
-    };
-
-    // Buffers reused across row-groups on each worker thread: allocating the
-    // packed row pairs and constraint accumulators fresh per group costs
-    // ~20% of this function's runtime on wide traces.
-    struct GroupBuffers<SC: StarkGenericConfig> {
-        main: Vec<Pack<SC>>,
-        preprocessed: Vec<Pack<SC>>,
-        base_constraints: Vec<Pack<SC>>,
-        ext_constraints: Vec<Challenge<SC>>,
-    }
-
-    let mut quotient_values = SC::Challenge::zero_vec(quotient_size);
-    quotient_values
-        .par_chunks_mut(Pack::<SC>::WIDTH)
-        .enumerate()
-        .for_each_init(
-            || GroupBuffers::<SC> {
-                main: Vec::with_capacity(2 * width),
-                preprocessed: Vec::with_capacity(
-                    2 * preprocessed_on_quotient_domain.map_or(0, |p| p.width()),
-                ),
-                base_constraints: Vec::with_capacity(constraint_layout.base_indices.len()),
-                ext_constraints: Vec::with_capacity(constraint_layout.ext_indices.len()),
-            },
-            |bufs, (group, quotient_chunk)| {
-                let i_start = group * Pack::<SC>::WIDTH;
-                let i_range = i_start..i_start + Pack::<SC>::WIDTH;
-
-                let is_first_row = *Pack::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
-                let is_last_row = *Pack::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
-                let is_transition = *Pack::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
-                let inv_vanishing = *Pack::<SC>::from_slice(&sels.inv_vanishing[i_range]);
-
-                bufs.main.clear();
-                bufs.main
-                    .extend(trace_on_quotient_domain.vertically_packed_row::<Pack<SC>>(i_start));
-                bufs.main.extend(
-                    trace_on_quotient_domain.vertically_packed_row::<Pack<SC>>(i_start + next_step),
+                    inv_vanishing,
+                    &base_alpha_powers,
+                    &ext_alpha_powers,
+                    core::mem::take(&mut bufs.base_constraints),
+                    core::mem::take(&mut bufs.ext_constraints),
+                    &mut bufs.base_coefficients,
+                    constraint_layout.total_constraints(),
                 );
-                let main = RowMajorMatrixView::new(&bufs.main, width);
-
-                let preprocessed_view = match preprocessed_on_quotient_domain {
-                    Some(preprocessed) => {
-                        bufs.preprocessed.clear();
-                        bufs.preprocessed
-                            .extend(preprocessed.vertically_packed_row::<Pack<SC>>(i_start));
-                        bufs.preprocessed.extend(
-                            preprocessed.vertically_packed_row::<Pack<SC>>(i_start + next_step),
-                        );
-                        RowMajorMatrixView::new(&bufs.preprocessed, preprocessed.width())
-                    }
-                    None => RowMajorMatrixView::new(&[], 0),
-                };
-                let periodic_values: &[Pack<SC>] = if periodic_packed.is_empty() {
-                    &[]
-                } else {
-                    &periodic_packed[i_start / pack_width]
-                };
-                let mut folder = Folder::<SC> {
-                    main,
-                    preprocessed: preprocessed_view,
-                    preprocessed_window: RowWindow::from_view(&preprocessed_view),
-                    periodic_values,
-                    public_values,
-                    is_first_row,
-                    is_last_row,
-                    is_transition,
-                    base_alpha_powers: &base_alpha_powers,
-                    ext_alpha_powers: &ext_alpha_powers,
-                    base_constraints: core::mem::take(&mut bufs.base_constraints),
-                    ext_constraints: core::mem::take(&mut bufs.ext_constraints),
-                    constraint_index: 0,
-                    constraint_count: constraint_layout.total_constraints(),
-                };
-                air.eval(&mut folder);
-
-                // quotient(x) = constraints(x) / Z_H(x)
-                let quotient = folder.finalize_constraints() * inv_vanishing;
 
                 // The contents were folded into `quotient` above; reclaim the Vecs and
                 // `clear` them (`len = 0`, capacity kept) so the next row group reuses
                 // the allocations.
-                bufs.base_constraints = folder.base_constraints;
+                bufs.base_constraints = base_constraints;
                 bufs.base_constraints.clear();
-                bufs.ext_constraints = folder.ext_constraints;
+                bufs.ext_constraints = ext_constraints;
                 bufs.ext_constraints.clear();
 
                 // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
                 for (idx_in_packing, q) in quotient_chunk.iter_mut().enumerate() {
-                    *q = quotient.extract(idx_in_packing);
+                    *q = Strat::extract(&quotient, idx_in_packing);
                 }
             },
         );

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -6,6 +6,8 @@ use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::{Pcs, PolynomialSpace};
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use p3_field::Field;
 use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
@@ -18,6 +20,58 @@ use crate::{
     ProverConstraintFolder, StarkGenericConfig, Val, get_constraint_layout,
     get_log_num_quotient_chunks,
 };
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+use crate::{VectorizedChallenge, VectorizedConstraintFolder, VectorizedVal};
+
+/// Number of packed vectors evaluated in lockstep per constraint expression during
+/// quotient evaluation on NEON, for fields where
+/// [`Field::BENEFITS_FROM_LOCKSTEP_EVALUATION`] holds. A single packed vector forms one
+/// dependency chain per constraint expression, which cannot hide the latency of modular
+/// multiplication (e.g. ~10 cycles at ~1.25 cycles/vector throughput on NEON). Two
+/// lockstep chains let the out-of-order core overlap independent rows; values above 2
+/// increase register pressure with diminishing returns.
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const QUOTIENT_ILP: usize = 2;
+
+/// AIRs usable with [`quotient_values`] and the functions built on it.
+///
+/// On `aarch64` with NEON this requires implementing both [`ProverConstraintFolder`] and
+/// the wider [`VectorizedConstraintFolder`], so [`quotient_values`] can pick between them
+/// per field at runtime (see [`Field::BENEFITS_FROM_LOCKSTEP_EVALUATION`]); AIRs written
+/// generically over the builder (the usual pattern) satisfy both automatically. Elsewhere
+/// this is exactly the [`ProverConstraintFolder`] bound, unchanged.
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+pub trait QuotientAir<SC: StarkGenericConfig>:
+    Air<SymbolicAirBuilder<Val<SC>>>
+    + for<'a> Air<ProverConstraintFolder<'a, SC>>
+    + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>
+{
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+impl<SC, A> QuotientAir<SC> for A
+where
+    SC: StarkGenericConfig,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<ProverConstraintFolder<'a, SC>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
+{
+}
+
+/// AIRs usable with [`quotient_values`] and the functions built on it.
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+pub trait QuotientAir<SC: StarkGenericConfig>:
+    Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>
+{
+}
+
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+impl<SC, A> QuotientAir<SC> for A
+where
+    SC: StarkGenericConfig,
+    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+{
+}
 
 #[instrument(skip_all)]
 #[allow(clippy::multiple_bound_locations, clippy::type_repetition_in_bounds)] // cfg not supported in where clauses?
@@ -34,7 +88,7 @@ pub fn prove_with_preprocessed<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: QuotientAir<SC>,
 {
     #[cfg(debug_assertions)]
     p3_air::check_constraints(air, &trace, public_values);
@@ -388,7 +442,7 @@ pub fn prove<
 ) -> Proof<SC>
 where
     SC: StarkGenericConfig,
-    A: Air<SymbolicAirBuilder<Val<SC>>> + for<'a> Air<ProverConstraintFolder<'a, SC>>,
+    A: QuotientAir<SC>,
 {
     prove_with_preprocessed::<SC, A>(config, air, trace, public_values, None)
 }
@@ -397,6 +451,50 @@ where
 // TODO: Group some arguments to remove the `allow`?
 #[allow(clippy::too_many_arguments)]
 pub fn quotient_values<SC, A, Mat>(
+    pcs: &SC::Pcs,
+    air: &A,
+    public_values: &[Val<SC>],
+    layout: AirLayout,
+    trace_domain: Domain<SC>,
+    quotient_domain: Domain<SC>,
+    trace_on_quotient_domain: &Mat,
+    preprocessed_on_quotient_domain: Option<&Mat>,
+    alpha: SC::Challenge,
+) -> Vec<SC::Challenge>
+where
+    SC: StarkGenericConfig,
+    A: QuotientAir<SC>,
+    Mat: Matrix<Val<SC>> + Sync,
+{
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    if Val::<SC>::BENEFITS_FROM_LOCKSTEP_EVALUATION {
+        return quotient_values_vectorized::<SC, A, Mat>(
+            pcs,
+            air,
+            public_values,
+            layout,
+            trace_domain,
+            quotient_domain,
+            trace_on_quotient_domain,
+            preprocessed_on_quotient_domain,
+            alpha,
+        );
+    }
+    quotient_values_plain::<SC, A, Mat>(
+        pcs,
+        air,
+        public_values,
+        layout,
+        trace_domain,
+        quotient_domain,
+        trace_on_quotient_domain,
+        preprocessed_on_quotient_domain,
+        alpha,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn quotient_values_plain<SC, A, Mat>(
     pcs: &SC::Pcs,
     air: &A,
     public_values: &[Val<SC>],
@@ -517,6 +615,164 @@ where
                     &periodic_packed[i_start / pack_width]
                 };
                 let mut folder = ProverConstraintFolder {
+                    main,
+                    preprocessed: preprocessed_view,
+                    preprocessed_window: RowWindow::from_view(&preprocessed_view),
+                    periodic_values,
+                    public_values,
+                    is_first_row,
+                    is_last_row,
+                    is_transition,
+                    base_alpha_powers: &base_alpha_powers,
+                    ext_alpha_powers: &ext_alpha_powers,
+                    base_constraints: core::mem::take(&mut bufs.base_constraints),
+                    ext_constraints: core::mem::take(&mut bufs.ext_constraints),
+                    constraint_index: 0,
+                    constraint_count: constraint_layout.total_constraints(),
+                };
+                air.eval(&mut folder);
+
+                // quotient(x) = constraints(x) / Z_H(x)
+                let quotient = folder.finalize_constraints() * inv_vanishing;
+
+                // The contents were folded into `quotient` above; reclaim the Vecs and
+                // `clear` them (`len = 0`, capacity kept) so the next row group reuses
+                // the allocations.
+                bufs.base_constraints = folder.base_constraints;
+                bufs.base_constraints.clear();
+                bufs.ext_constraints = folder.ext_constraints;
+                bufs.ext_constraints.clear();
+
+                // "Transpose" D packed base coefficients into WIDTH scalar extension coefficients.
+                for (idx_in_packing, q) in quotient_chunk.iter_mut().enumerate() {
+                    *q = quotient.extract(idx_in_packing);
+                }
+            },
+        );
+    quotient_values
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[allow(clippy::too_many_arguments)]
+fn quotient_values_vectorized<SC, A, Mat>(
+    pcs: &SC::Pcs,
+    air: &A,
+    public_values: &[Val<SC>],
+    layout: AirLayout,
+    trace_domain: Domain<SC>,
+    quotient_domain: Domain<SC>,
+    trace_on_quotient_domain: &Mat,
+    preprocessed_on_quotient_domain: Option<&Mat>,
+    alpha: SC::Challenge,
+) -> Vec<SC::Challenge>
+where
+    SC: StarkGenericConfig,
+    A: Air<SymbolicAirBuilder<Val<SC>>>
+        + for<'a> Air<VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>>,
+    Mat: Matrix<Val<SC>> + Sync,
+{
+    type Pack<SC> = VectorizedVal<SC, QUOTIENT_ILP>;
+    type Challenge<SC> = VectorizedChallenge<SC, QUOTIENT_ILP>;
+    type Folder<'a, SC> = VectorizedConstraintFolder<'a, SC, QUOTIENT_ILP>;
+
+    let quotient_size = quotient_domain.size();
+    let width = trace_on_quotient_domain.width();
+    let mut sels = debug_span!("Compute Selectors")
+        .in_scope(|| trace_domain.selectors_on_coset(quotient_domain));
+
+    let qdb = log2_strict_usize(quotient_domain.size()) - log2_strict_usize(trace_domain.size());
+    let next_step = 1 << qdb;
+
+    // We take Pack::<SC>::WIDTH worth of values at a time from a quotient_size slice, so we need to
+    // pad with default values in the case where quotient_size is smaller than Pack::<SC>::WIDTH.
+    for _ in quotient_size..Pack::<SC>::WIDTH {
+        sels.is_first_row.push(Val::<SC>::default());
+        sels.is_last_row.push(Val::<SC>::default());
+        sels.is_transition.push(Val::<SC>::default());
+        sels.inv_vanishing.push(Val::<SC>::default());
+    }
+
+    let constraint_layout = get_constraint_layout(air, layout);
+    let (base_alpha_powers, ext_alpha_powers) = constraint_layout.decompose_alpha(alpha);
+    let periodic_cols = air.periodic_columns();
+    let periodic_table =
+        pcs.build_periodic_lde_table(&periodic_cols, trace_domain, quotient_domain);
+
+    let pack_width = Pack::<SC>::WIDTH;
+    let periodic_packed: Vec<Vec<Pack<SC>>> = if periodic_table.is_empty() {
+        Vec::new()
+    } else {
+        let ncols = periodic_table.width();
+        (0..quotient_size)
+            .step_by(pack_width)
+            .map(|i_start| {
+                (0..ncols)
+                    .map(|col_idx| {
+                        Pack::<SC>::from_fn(|offset| *periodic_table.get(i_start + offset, col_idx))
+                    })
+                    .collect()
+            })
+            .collect()
+    };
+
+    // Buffers reused across row-groups on each worker thread: allocating the
+    // packed row pairs and constraint accumulators fresh per group costs
+    // ~20% of this function's runtime on wide traces.
+    struct GroupBuffers<SC: StarkGenericConfig> {
+        main: Vec<Pack<SC>>,
+        preprocessed: Vec<Pack<SC>>,
+        base_constraints: Vec<Pack<SC>>,
+        ext_constraints: Vec<Challenge<SC>>,
+    }
+
+    let mut quotient_values = SC::Challenge::zero_vec(quotient_size);
+    quotient_values
+        .par_chunks_mut(Pack::<SC>::WIDTH)
+        .enumerate()
+        .for_each_init(
+            || GroupBuffers::<SC> {
+                main: Vec::with_capacity(2 * width),
+                preprocessed: Vec::with_capacity(
+                    2 * preprocessed_on_quotient_domain.map_or(0, |p| p.width()),
+                ),
+                base_constraints: Vec::with_capacity(constraint_layout.base_indices.len()),
+                ext_constraints: Vec::with_capacity(constraint_layout.ext_indices.len()),
+            },
+            |bufs, (group, quotient_chunk)| {
+                let i_start = group * Pack::<SC>::WIDTH;
+                let i_range = i_start..i_start + Pack::<SC>::WIDTH;
+
+                let is_first_row = *Pack::<SC>::from_slice(&sels.is_first_row[i_range.clone()]);
+                let is_last_row = *Pack::<SC>::from_slice(&sels.is_last_row[i_range.clone()]);
+                let is_transition = *Pack::<SC>::from_slice(&sels.is_transition[i_range.clone()]);
+                let inv_vanishing = *Pack::<SC>::from_slice(&sels.inv_vanishing[i_range]);
+
+                bufs.main.clear();
+                bufs.main
+                    .extend(trace_on_quotient_domain.vertically_packed_row::<Pack<SC>>(i_start));
+                bufs.main.extend(
+                    trace_on_quotient_domain.vertically_packed_row::<Pack<SC>>(i_start + next_step),
+                );
+                let main = RowMajorMatrixView::new(&bufs.main, width);
+
+                let preprocessed_view = match preprocessed_on_quotient_domain {
+                    Some(preprocessed) => {
+                        bufs.preprocessed.clear();
+                        bufs.preprocessed
+                            .extend(preprocessed.vertically_packed_row::<Pack<SC>>(i_start));
+                        bufs.preprocessed.extend(
+                            preprocessed.vertically_packed_row::<Pack<SC>>(i_start + next_step),
+                        );
+                        RowMajorMatrixView::new(&bufs.preprocessed, preprocessed.width())
+                    }
+                    None => RowMajorMatrixView::new(&[], 0),
+                };
+                let periodic_values: &[Pack<SC>] = if periodic_packed.is_empty() {
+                    &[]
+                } else {
+                    &periodic_packed[i_start / pack_width]
+                };
+                let mut folder = Folder::<SC> {
                     main,
                     preprocessed: preprocessed_view,
                     preprocessed_window: RowWindow::from_view(&preprocessed_view),


### PR DESCRIPTION
## Motivation

  Reconsiders #1802 (closed unmerged): quotient evaluation folds constraints over a single packed vector per row group, which can't hide NEON's packed-multiply latency (~10 cycles at ~1.25 cycles/vector throughput → needs ~8
  independent chains to saturate). #1802 fixed this by evaluating `N=2` packed vectors in lockstep, but was closed because forcing `N=1` on x86 to make it a no-op still regressed — every target paid the wrapper's
  abstraction cost even when it should have been inert.

  ## Changes

  - `p3-field`: adds `Vectorized<F,N>`/`VectorizedExt<F,EF,N>`, unchanged from #1802 — `N` packed vectors bundled behind the same `PackedValue`/`Algebra` interfaces as an ordinary packed value.
  - `p3-uni-stark`: `quotient_values` is split into `quotient_values_plain` (byte-identical to pre-#1802 code) and `quotient_values_vectorized` (`N=2`, `aarch64`+`neon` only). Non-NEON targets compile only the plain path —
  literally the same monomorphization as before this PR, not `Vectorized<F,1>` — so the x86 regression that sank #1802 is structurally impossible here, not just unlikely.
  - `p3-field`: adds `Field::BENEFITS_FROM_LOCKSTEP_EVALUATION` (default `true`), a compile-time-foldable per-field opt-out. `quotient_values` picks plain vs. vectorized via `if Val::<SC>::BENEFITS_FROM_LOCKSTEP_EVALUATION`,
  resolved per monomorphization.
  - `p3-mersenne-31`: overrides the const to `false`. Mersenne31 regresses under the vectorized path on current main, unlike when #1802 was authored — #1894 (merged after #1802 closed) gave `PackedMersenne31Neon` a
  deferred-reduction `dot_product`, closing the extension-field-multiply latency gap the lockstep trick was hiding for that field specifically.
  - All AIRs implemented generically over `AirBuilder` (the standard pattern) satisfy both folder bounds automatically — no downstream AIR changes needed.

  ## Benchmarks

  M4 pro, `prove_prime_field_31`/`prove_goldilocks_poseidon2` examples, isolated `quotient_values` span, `log_trace_length=18` (Goldilocks: fixed-size Keccak example), round-robin/interleaved trials:

  | Field | PCS / AIR | Δ quotient |
  |---|---|---|
  | BabyBear | twoadic, Poseidon2 | −3.5% |
  | KoalaBear | twoadic, Poseidon2 | −15% |
  | Goldilocks | twoadic, Keccak | −11% |
  | Mersenne31 | circle, Poseidon2 | excluded via `BENEFITS_FROM_LOCKSTEP_EVALUATION = false` (measured +10% regression if forced on) |

No impact on x86 (tested on AWS `c8a.8xlarge`).
  ## Test plan

  - [x] `cargo check`/`clippy --all-targets -D warnings` clean on `aarch64`+`neon` (native) and `x86_64` (cross-compiled)
  - [x] Full `p3-uni-stark`/`p3-examples`/`p3-mersenne-31` test suite green (two-adic, circle, ZK, preprocessed, periodic columns)
  - [x] Confirmed at runtime (temporary trace instrumentation, removed) that Mersenne31 dispatches to the plain path