### PR TITLE
fix(p3-security): grade conjectured security per round and at the instance shape

### DIFF
--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -844,6 +844,7 @@ fn test_two_instances() -> Result<(), impl Debug> {
 /// uses representative deployment-scale parameters.
 #[test]
 fn security_estimate_with_and_without_lookups() {
+    use p3_security::grinding::GrindingSites;
     use p3_security::logup::{self, LOGUP_LABEL, LogUpAir};
     use p3_security::shape::{InstanceShape, StarkAirParams};
     use p3_security::stark::proven_security_report;
@@ -912,9 +913,13 @@ fn security_estimate_with_and_without_lookups() {
         max_message_width: 16,
     };
 
-    let without = proven_security_report(&regime, &air, &shape, &[]);
-    let lookup_term = logup::security_term(&lookups, &shape).expect("batch uses a LogUp bus");
-    let with = proven_security_report(&regime, &air, &shape, &[lookup_term]);
+    // The batch grinds only inside FRI, which `regime` already carries.
+    let grinding = GrindingSites::NONE;
+
+    let without = proven_security_report(&regime, &air, &shape, &[], &grinding);
+    let lookup_term =
+        logup::security_term(&lookups, &shape, &grinding).expect("batch uses a LogUp bus");
+    let with = proven_security_report(&regime, &air, &shape, &[lookup_term], &grinding);
     let lookup_bits = logup::fingerprint_error(&lookups, &shape).bits();
 
     let (wo_regime, wo_bind) = without.binding();

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -311,7 +311,7 @@ where
 {
     println!(
         "Conjectured security: {} bits",
-        Proof::<SC>::conjectured_security(security_params).security_bits
+        proof.conjectured_security(security_params).security_bits
     );
     let proven = proof.proven_security(security_params);
     println!(

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -18,7 +18,6 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use libm::{log2, pow};
-use p3_util::log2_floor_usize;
 
 use crate::error::ErrorBits;
 use crate::ldt::LowDegreeTest;
@@ -123,13 +122,20 @@ pub fn conjectured_commit_phase_error(
 ///
 /// ε ≤ (folding − 1)·(n + 1) / |F|, applied when at least one fold occurs.
 /// Slightly conservative versus `soundcalc`'s tighter `(γn + 1)` factor.
+///
+/// Returns `None` when `regime.max_log_arity` is `0` (folding factor `1`,
+/// i.e. no fold at all) — such a regime has no commit-phase round, rather
+/// than being indistinguishable from arity 2.
 pub fn commit_phase_error_udr(regime: &FriRegime, shape: &InstanceShape) -> Option<ErrorBits> {
+    let folding_minus_one = regime.folding_factor() - 1.0;
+    if folding_minus_one <= 0.0 {
+        return None;
+    }
     let lde_log = shape.log_trace_length + regime.log_blowup;
-    let num_layers = log2_floor_usize(1usize << lde_log).saturating_sub(regime.log_final_poly_len);
+    let num_layers = lde_log.saturating_sub(regime.log_final_poly_len) / regime.max_log_arity;
     if num_layers == 0 {
         return None;
     }
-    let folding_minus_one = (regime.folding_factor() - 1.0).max(1.0);
     let n = (1u64 << lde_log) as f64;
     let bits = shape.modulus_bits as f64 - log2(folding_minus_one * (n + 1.0))
         + regime.commit_pow_bits as f64;
@@ -145,17 +151,28 @@ pub fn commit_phase_error_udr(regime: &FriRegime, shape: &InstanceShape) -> Opti
 /// We also evaluate the n/q-style bound from [2024/1553] and report the
 /// tighter of the two. Round-by-round soundness is dominated by round 0
 /// (largest `n`), so we use `n = lde_domain_size` for every round.
-pub fn commit_phase_error_ldr_m(regime: &FriRegime, shape: &InstanceShape, m: usize) -> ErrorBits {
+///
+/// Returns `None` when `regime.max_log_arity` is `0` (folding factor `1`,
+/// i.e. no fold at all) — such a regime has no commit-phase round, rather
+/// than being indistinguishable from arity 2.
+pub fn commit_phase_error_ldr_m(
+    regime: &FriRegime,
+    shape: &InstanceShape,
+    m: usize,
+) -> Option<ErrorBits> {
     let rho = pow(2.0, -(regime.log_blowup as f64));
     let sqrt_rho = libm::sqrt(rho);
     let m_shifted = m as f64 + 0.5;
     let pp = gamma_ldr_m(regime.log_blowup, m);
     if pp <= 0.0 {
-        return ErrorBits::from_log2(0.0);
+        return Some(ErrorBits::from_log2(0.0));
+    }
+    let folding_minus_one = regime.folding_factor() - 1.0;
+    if folding_minus_one <= 0.0 {
+        return None;
     }
     let lde_log = shape.log_trace_length + regime.log_blowup;
     let n = (1u64 << lde_log) as f64;
-    let folding_minus_one = (regime.folding_factor() - 1.0).max(1.0);
 
     let num = (2.0 * pow(m_shifted, 5.0) + 3.0 * m_shifted * pp * rho) * n;
     let den = 3.0 * rho * sqrt_rho;
@@ -171,7 +188,9 @@ pub fn commit_phase_error_ldr_m(regime: &FriRegime, shape: &InstanceShape, m: us
         + 0.5 * log2(rho)
         + regime.commit_pow_bits as f64;
 
-    ErrorBits::from_log2(bits_linear.min(bits_n_over_q).max(0.0))
+    Some(ErrorBits::from_log2(
+        bits_linear.min(bits_n_over_q).max(0.0),
+    ))
 }
 
 /// FRI query-phase error: ε ≤ αᵏ, contributing `query_pow − k·log2(α)` bits.
@@ -227,9 +246,9 @@ pub fn proven_error_ldr_m(
     if k + air.max_combo as f64 >= (1.0 - pp) * lde {
         return ErrorBits::from_log2(0.0);
     }
-    let commit = commit_phase_error_ldr_m(regime, shape, m);
     let query = query_phase_error(alpha, regime.num_queries, regime.query_pow_bits);
-    ErrorBits::min(&[commit, query])
+    commit_phase_error_ldr_m(regime, shape, m)
+        .map_or(query, |commit| ErrorBits::min(&[commit, query]))
 }
 
 /// Search `m ∈ [3, min(compute_upper_m, LDR_M_CAP)]` for the value
@@ -402,6 +421,36 @@ mod tests {
             LowDegreeTest::conjectured_terms(&no_folds, &shape).len(),
             1,
             "a fold-free regime reports the query phase only"
+        );
+    }
+
+    /// `max_log_arity: 0` (folding factor 1) is a genuinely fold-free regime,
+    /// not a stand-in for arity 2: both the UDR and LDR commit-phase bounds
+    /// must report no round rather than silently clamping to arity 2's
+    /// `folding_minus_one = 1`.
+    #[test]
+    fn arity_one_reports_no_commit_round_rather_than_impersonating_arity_two() {
+        let base = benchmark_regime();
+        let shape = benchmark_shape();
+        let air = benchmark_air();
+        let no_arity = FriRegime {
+            max_log_arity: 0,
+            ..base
+        };
+
+        assert!(commit_phase_error_udr(&no_arity, &shape).is_none());
+        assert!(commit_phase_error_ldr_m(&no_arity, &shape, 10).is_none());
+        assert!(conjectured_commit_phase_error(&no_arity, &shape).is_none());
+
+        // The UDR/LDR composites fall back to the query-phase error alone.
+        assert_eq!(
+            proven_error_udr(&no_arity, &air, &shape).bits(),
+            query_phase_error(
+                alpha_udr(shape.log_trace_length, no_arity.log_blowup, air.max_combo),
+                no_arity.num_queries,
+                no_arity.query_pow_bits,
+            )
+            .bits()
         );
     }
 

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -14,12 +14,16 @@
 //! - `CapacityBound` is not currently supported by FRI's commit-phase
 //!   analysis.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use libm::{log2, pow};
 use p3_util::log2_floor_usize;
 
 use crate::error::ErrorBits;
 use crate::ldt::LowDegreeTest;
 use crate::proximity::{LDR_M_CAP, alpha_ldr_m, alpha_udr, compute_upper_m, gamma_ldr_m};
+use crate::report::{LDT_COMMIT_LABEL, LDT_QUERY_LABEL, SecurityTerm};
 use crate::shape::{InstanceShape, StarkAirParams};
 
 /// Security-relevant mirror of `p3_fri::FriParameters`.
@@ -60,6 +64,18 @@ impl LowDegreeTest for FriRegime {
     fn conjectured_error(&self, shape: &InstanceShape) -> ErrorBits {
         conjectured_error(self, shape)
     }
+
+    fn conjectured_terms(&self, shape: &InstanceShape) -> Vec<SecurityTerm> {
+        let mut terms = vec![SecurityTerm::new(
+            LDT_QUERY_LABEL,
+            conjectured_error(self, shape),
+        )];
+        terms.extend(
+            conjectured_commit_phase_error(self, shape)
+                .map(|bits| SecurityTerm::new(LDT_COMMIT_LABEL, bits)),
+        );
+        terms
+    }
 }
 
 /// Conjectured low-degree-test soundness (random-words, [2025/2010] §1.5).
@@ -81,6 +97,26 @@ pub fn conjectured_error(regime: &FriRegime, shape: &InstanceShape) -> ErrorBits
     let bits_per_query = -log2(effective);
     let bits = regime.num_queries as f64 * bits_per_query + regime.query_pow_bits as f64;
     ErrorBits::from_log2(bits)
+}
+
+/// FRI commit-phase per-round error in the conjectured regime.
+///
+/// Identical to [`commit_phase_error_udr`], and deliberately so: the bound
+/// counts the folding challenges that are *exceptional* for a given committed
+/// word, and that count does not depend on the decoding regime. What the
+/// random-words conjecture buys is the removal of the list-size multiplier
+/// `L⁺` that the Johnson-bound analysis pays (see
+/// [`crate::stark::conjectured_security_report`]) — it does not assert that a
+/// bad folding challenge cannot exist. Dropping the round entirely, as an
+/// LDT-only conjectured number does, therefore overstates security for a large
+/// LDE domain over a small field.
+///
+/// Returns `None` when no fold occurs, in which case there is no such round.
+pub fn conjectured_commit_phase_error(
+    regime: &FriRegime,
+    shape: &InstanceShape,
+) -> Option<ErrorBits> {
+    commit_phase_error_udr(regime, shape)
 }
 
 /// FRI commit-phase per-round error in UDR.
@@ -299,6 +335,74 @@ mod tests {
         .bits()
         .floor() as usize;
         assert_eq!(combined, 65);
+    }
+
+    /// The conjectured commit-phase round is a real constraint, not a
+    /// formality: over a 128-bit field with a 2^26 LDE domain it lands near 100
+    /// bits, below a 128-bit target, so an LDT-only conjectured number that
+    /// omits it overstates security. It also matches the UDR bound exactly —
+    /// the conjecture removes the list-size multiplier, not the count of
+    /// exceptional folding challenges.
+    #[test]
+    fn conjectured_commit_phase_binds_below_a_128_bit_target() {
+        let regime = FriRegime {
+            log_blowup: 3,
+            num_queries: 27,
+            log_final_poly_len: 0,
+            max_log_arity: 2,
+            commit_pow_bits: 0,
+            query_pow_bits: 16,
+        };
+        let shape = InstanceShape {
+            log_trace_length: 23,
+            modulus_bits: 128,
+            collision_resistance: 128,
+            num_batched_functions: 1,
+        };
+
+        let commit = conjectured_commit_phase_error(&regime, &shape).expect("folds occur");
+        // |F| - log2(3 * (2^26 + 1)) = 128 - 27.585
+        assert!(
+            (commit.bits() - (128.0 - libm::log2(3.0 * (65_536.0 * 1024.0 + 1.0)))).abs() < 1e-9
+        );
+        assert!(commit.bits() < 128.0, "got {}", commit.bits());
+        assert_eq!(
+            commit.bits(),
+            commit_phase_error_udr(&regime, &shape).unwrap().bits()
+        );
+    }
+
+    /// Commit-phase grinding is credited to the commit-phase term and to
+    /// nothing else, and a fold-free configuration has no such round at all.
+    #[test]
+    fn conjectured_commit_phase_credits_only_its_own_grinding() {
+        let base = benchmark_regime();
+        let shape = benchmark_shape();
+
+        let ground = FriRegime {
+            commit_pow_bits: 12,
+            ..base
+        };
+        let b0 = conjectured_commit_phase_error(&base, &shape).expect("folds occur");
+        let b12 = conjectured_commit_phase_error(&ground, &shape).expect("folds occur");
+        assert!((b12.bits() - b0.bits() - 12.0).abs() < 1e-12);
+        // The query phase is untouched by it.
+        assert_eq!(
+            conjectured_error(&ground, &shape).bits(),
+            conjectured_error(&base, &shape).bits()
+        );
+
+        // Folding down to the full domain leaves no commit round.
+        let no_folds = FriRegime {
+            log_final_poly_len: shape.log_trace_length + base.log_blowup,
+            ..base
+        };
+        assert!(conjectured_commit_phase_error(&no_folds, &shape).is_none());
+        assert_eq!(
+            LowDegreeTest::conjectured_terms(&no_folds, &shape).len(),
+            1,
+            "a fold-free regime reports the query phase only"
+        );
     }
 
     #[test]

--- a/security/src/grinding.rs
+++ b/security/src/grinding.rs
@@ -1,8 +1,91 @@
 //! Grinding (proof-of-work) bits — additive contribution to security.
+//!
+//! A grind sited immediately before a Fiat–Shamir challenge forces a
+//! malicious prover to redo `2^pow_bits` work per resampling attempt, so it
+//! adds `pow_bits` to the round-by-round error of the round that challenge
+//! opens (ethSTARK [2021/582](https://eprint.iacr.org/2021/582) §5, and
+//! [2024/1553](https://eprint.iacr.org/2024/1553) §2 for the round-by-round
+//! accounting the composite uses).
+//!
+//! Which round a grind boosts therefore depends on **where** the protocol
+//! grinds. [`GrindingSites`] enumerates those sites so a protocol states them
+//! as data instead of the crate hardcoding one placement per protocol.
+
+use serde::Serialize;
+
+use crate::error::ErrorBits;
 
 /// Bits added to the soundness budget by a `pow_bits`-bit grinding round.
 /// Equal to `pow_bits` when grinding is honest; provided as a function
 /// so future tweaks (multi-round PoW, variable difficulty) stay local.
 pub const fn grinding_bits(pow_bits: usize) -> f64 {
     pow_bits as f64
+}
+
+/// `error` boosted by a `pow_bits`-bit grind placed before the challenge that
+/// round samples. A zero-bit grind is the identity.
+pub const fn boost(error: ErrorBits, pow_bits: usize) -> ErrorBits {
+    ErrorBits::from_log2(error.bits() + grinding_bits(pow_bits))
+}
+
+/// Where a STARK grinds, in bits per site.
+///
+/// Every field defaults to `0` — a protocol declares only the sites it
+/// actually uses, and a default-constructed value is neutral.
+///
+/// Each site is consumed by the term whose round it opens:
+///
+/// - [`Self::query_phase`] and [`Self::ldt_commit_phase`] are consumed by the
+///   [`crate::ldt::LowDegreeTest`] implementation, which already carries them
+///   (`FriRegime::query_pow_bits` / `FriRegime::commit_pow_bits`). The
+///   composite does not re-apply them, so they are never double-counted.
+/// - [`Self::out_of_domain`] is applied to the DEEP-ALI term by
+///   [`crate::stark::proven_security_report`] and
+///   [`crate::stark::conjectured_security_report`].
+/// - [`Self::lookup_challenge`] is applied to the LogUp fingerprint term by
+///   [`crate::logup::security_term`].
+///
+/// A protocol grinding at a site this crate does not model builds its own
+/// [`crate::report::SecurityTerm`], applies [`boost`] to it, and passes it
+/// through `extras` — no change to this struct is needed.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct GrindingSites {
+    /// Bits ground once before the low-degree test samples query positions.
+    pub query_phase: usize,
+    /// Bits ground at every low-degree-test commit-phase round, before its
+    /// folding challenge.
+    pub ldt_commit_phase: usize,
+    /// Bits ground before the DEEP out-of-domain point is sampled.
+    pub out_of_domain: usize,
+    /// Bits ground before the lookup / permutation argument's challenges are
+    /// sampled.
+    pub lookup_challenge: usize,
+}
+
+impl GrindingSites {
+    /// No grinding at any site — the neutral element, usable in `const`
+    /// contexts where [`Default::default`] is not available.
+    pub const NONE: Self = Self {
+        query_phase: 0,
+        ldt_commit_phase: 0,
+        out_of_domain: 0,
+        lookup_challenge: 0,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boost_adds_pow_bits_and_zero_is_neutral() {
+        let error = ErrorBits::from_log2(80.0);
+        assert!((boost(error, 0).bits() - 80.0).abs() < 1e-12);
+        assert!((boost(error, 16).bits() - 96.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn default_sites_are_neutral() {
+        assert_eq!(GrindingSites::default(), GrindingSites::NONE);
+    }
 }

--- a/security/src/grinding.rs
+++ b/security/src/grinding.rs
@@ -35,30 +35,25 @@ pub const fn boost(error: ErrorBits, pow_bits: usize) -> ErrorBits {
 ///
 /// Each site is consumed by the term whose round it opens:
 ///
-/// - [`Self::query_phase`] and [`Self::ldt_commit_phase`] are consumed by the
-///   [`crate::ldt::LowDegreeTest`] implementation, which already carries them
-///   (`FriRegime::query_pow_bits` / `FriRegime::commit_pow_bits`). The
-///   composite does not re-apply them, so they are never double-counted. Each
-///   boosts only the phase it precedes, in both the proven and conjectured
-///   paths — see [`crate::ldt::LowDegreeTest::conjectured_terms`], which keeps
-///   the two phases as separate terms so a grind credited to one cannot raise
-///   a bound set by the other.
 /// - [`Self::out_of_domain`] is applied to the DEEP-ALI term by
 ///   [`crate::stark::proven_security_report`] and
 ///   [`crate::stark::conjectured_security_report`].
 /// - [`Self::lookup_challenge`] is applied to the LogUp fingerprint term by
 ///   [`crate::logup::security_term`].
 ///
+/// The low-degree test's own grinding sites (e.g. FRI's query- and
+/// commit-phase proof-of-work) are **not** modeled here: a
+/// [`crate::ldt::LowDegreeTest`] implementation carries those itself
+/// (`FriRegime::query_pow_bits` / `FriRegime::commit_pow_bits`) and folds
+/// them into the terms it returns, so the composite never re-applies them —
+/// a site in this struct for them would be read back out unchanged, never
+/// consulted.
+///
 /// A protocol grinding at a site this crate does not model builds its own
 /// [`crate::report::SecurityTerm`], applies [`boost`] to it, and passes it
 /// through `extras` — no change to this struct is needed.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct GrindingSites {
-    /// Bits ground once before the low-degree test samples query positions.
-    pub query_phase: usize,
-    /// Bits ground at every low-degree-test commit-phase round, before its
-    /// folding challenge.
-    pub ldt_commit_phase: usize,
     /// Bits ground before the DEEP out-of-domain point is sampled.
     pub out_of_domain: usize,
     /// Bits ground before the lookup / permutation argument's challenges are
@@ -70,8 +65,6 @@ impl GrindingSites {
     /// No grinding at any site — the neutral element, usable in `const`
     /// contexts where [`Default::default`] is not available.
     pub const NONE: Self = Self {
-        query_phase: 0,
-        ldt_commit_phase: 0,
         out_of_domain: 0,
         lookup_challenge: 0,
     };

--- a/security/src/grinding.rs
+++ b/security/src/grinding.rs
@@ -38,7 +38,11 @@ pub const fn boost(error: ErrorBits, pow_bits: usize) -> ErrorBits {
 /// - [`Self::query_phase`] and [`Self::ldt_commit_phase`] are consumed by the
 ///   [`crate::ldt::LowDegreeTest`] implementation, which already carries them
 ///   (`FriRegime::query_pow_bits` / `FriRegime::commit_pow_bits`). The
-///   composite does not re-apply them, so they are never double-counted.
+///   composite does not re-apply them, so they are never double-counted. Each
+///   boosts only the phase it precedes, in both the proven and conjectured
+///   paths — see [`crate::ldt::LowDegreeTest::conjectured_terms`], which keeps
+///   the two phases as separate terms so a grind credited to one cannot raise
+///   a bound set by the other.
 /// - [`Self::out_of_domain`] is applied to the DEEP-ALI term by
 ///   [`crate::stark::proven_security_report`] and
 ///   [`crate::stark::conjectured_security_report`].

--- a/security/src/ldt.rs
+++ b/security/src/ldt.rs
@@ -63,3 +63,53 @@ pub trait LowDegreeTest {
         vec![SecurityTerm::new(LDT_LABEL, self.conjectured_error(shape))]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A low-degree test that leaves every default in place, including
+    /// [`LowDegreeTest::conjectured_terms`], so the default body has a
+    /// dedicated test rather than relying on the first downstream `impl` —
+    /// currently [`crate::fri::FriRegime`], which overrides it — to exercise
+    /// it incidentally.
+    struct StubLdt;
+
+    impl LowDegreeTest for StubLdt {
+        fn log_blowup(&self) -> usize {
+            1
+        }
+
+        fn proven_error_udr(&self, _air: &StarkAirParams, _shape: &InstanceShape) -> ErrorBits {
+            ErrorBits::from_log2(0.0)
+        }
+
+        fn best_ldr(
+            &self,
+            _air: &StarkAirParams,
+            _shape: &InstanceShape,
+        ) -> Option<(usize, ErrorBits)> {
+            None
+        }
+
+        fn conjectured_error(&self, _shape: &InstanceShape) -> ErrorBits {
+            ErrorBits::from_log2(42.0)
+        }
+    }
+
+    #[test]
+    fn default_conjectured_terms_wraps_conjectured_error_under_ldt_label() {
+        let shape = InstanceShape {
+            log_trace_length: 0,
+            modulus_bits: 1,
+            collision_resistance: 1,
+            num_batched_functions: 1,
+        };
+
+        let terms = StubLdt.conjectured_terms(&shape);
+
+        assert_eq!(terms.len(), 1);
+        assert_eq!(terms[0].label, LDT_LABEL);
+        assert!((terms[0].bits.bits() - 42.0).abs() < 1e-12);
+    }
+}

--- a/security/src/ldt.rs
+++ b/security/src/ldt.rs
@@ -7,7 +7,11 @@
 //! [`crate::fri`]; [`crate::whir`] currently exposes only the underlying WHIR
 //! error terms, not yet a [`LowDegreeTest`] impl.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::error::ErrorBits;
+use crate::report::{LDT_LABEL, SecurityTerm};
 use crate::shape::{InstanceShape, StarkAirParams};
 
 /// A low-degree test whose per-regime error terms compose with the AIR +
@@ -34,4 +38,28 @@ pub trait LowDegreeTest {
 
     /// Conjectured LDT error (random-words / heuristic regime).
     fn conjectured_error(&self, shape: &InstanceShape) -> ErrorBits;
+
+    /// The conjectured regime's LDT terms, labeled per phase.
+    ///
+    /// [`crate::stark::conjectured_security_report`] takes the minimum over
+    /// these alongside the ALI, DEEP, and collision terms, so an implementation
+    /// that reports its phases separately keeps each one inspectable rather
+    /// than collapsing them into a single number — the same reason the proven
+    /// path is a [`crate::report::RegimeReport`] and not a scalar.
+    ///
+    /// The default returns [`Self::conjectured_error`] under
+    /// [`LDT_LABEL`], which is correct for any LDT whose conjectured error is
+    /// already a single composed bound. Override it when the protocol has
+    /// distinct rounds worth surfacing — [`crate::fri::FriRegime`] splits the
+    /// query phase from the commit-phase folding rounds.
+    ///
+    /// Each returned term must bound a **distinct round** of the protocol.
+    /// The composite takes the minimum rather than summing because an
+    /// adversary who breaks any single round breaks the LDT, so the attained
+    /// security is that of the weakest round — the round-by-round accounting
+    /// of [2024/1553](https://eprint.iacr.org/2024/1553) §2. Returning two
+    /// bounds on the *same* round would silently discard the tighter one.
+    fn conjectured_terms(&self, shape: &InstanceShape) -> Vec<SecurityTerm> {
+        vec![SecurityTerm::new(LDT_LABEL, self.conjectured_error(shape))]
+    }
 }

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -55,6 +55,7 @@ pub mod stark;
 
 pub use assumption::SecurityAssumption;
 pub use error::ErrorBits;
+pub use grinding::GrindingSites;
 pub use ldt::LowDegreeTest;
 pub use report::{Regime, RegimeReport, SecurityReport, SecurityTerm};
 pub use shape::{InstanceShape, StarkAirParams};

--- a/security/src/logup.rs
+++ b/security/src/logup.rs
@@ -40,6 +40,7 @@
 use libm::log2;
 
 use crate::error::ErrorBits;
+use crate::grinding::{GrindingSites, boost};
 use crate::report::SecurityTerm;
 use crate::shape::InstanceShape;
 
@@ -75,13 +76,20 @@ pub fn fingerprint_error(air: &LogUpAir, shape: &InstanceShape) -> ErrorBits {
 
 /// The LogUp fingerprint term for use in `extras`, or `None` when the AIR has
 /// no interactions (no lookup argument, hence no term).
-pub fn security_term(air: &LogUpAir, shape: &InstanceShape) -> Option<SecurityTerm> {
+///
+/// `grinding.lookup_challenge` is the grind sited immediately before
+/// `(alpha, beta)` are sampled; it boosts this term and nothing else.
+pub fn security_term(
+    air: &LogUpAir,
+    shape: &InstanceShape,
+    grinding: &GrindingSites,
+) -> Option<SecurityTerm> {
     if air.num_interactions == 0 {
         return None;
     }
     Some(SecurityTerm::new(
         LOGUP_LABEL,
-        fingerprint_error(air, shape),
+        boost(fingerprint_error(air, shape), grinding.lookup_challenge),
     ))
 }
 
@@ -138,15 +146,36 @@ mod tests {
             num_interactions: 0,
             max_message_width: 4,
         };
-        assert!(security_term(&none, &shape(128)).is_none());
+        assert!(security_term(&none, &shape(128), &GrindingSites::NONE).is_none());
 
         let some = LogUpAir {
             num_interactions: 4,
             max_message_width: 4,
         };
-        let term = security_term(&some, &shape(128)).expect("has interactions");
+        let term =
+            security_term(&some, &shape(128), &GrindingSites::NONE).expect("has interactions");
         assert_eq!(term.label, LOGUP_LABEL);
         assert_eq!(term.bits, fingerprint_error(&some, &shape(128)));
+    }
+
+    /// A grind sited before the lookup challenges adds its bits to this term
+    /// and leaves the underlying fingerprint bound untouched.
+    #[test]
+    fn lookup_challenge_grinding_boosts_the_term() {
+        let air = LogUpAir {
+            num_interactions: 4,
+            max_message_width: 4,
+        };
+        let s = shape(128);
+        let grinding = GrindingSites {
+            lookup_challenge: 20,
+            ..GrindingSites::NONE
+        };
+
+        let base = security_term(&air, &s, &GrindingSites::NONE).expect("has interactions");
+        let ground = security_term(&air, &s, &grinding).expect("has interactions");
+
+        assert!((ground.bits.bits() - base.bits.bits() - 20.0).abs() < 1e-12);
     }
 
     /// The term flows through `proven_security_report`'s `extras` and appears
@@ -177,9 +206,9 @@ mod tests {
             max_message_width: 8,
         };
 
-        let baseline = proven_security_report(&regime, &air, &s, &[]);
-        let term = security_term(&logup, &s).expect("has interactions");
-        let with_logup = proven_security_report(&regime, &air, &s, &[term]);
+        let baseline = proven_security_report(&regime, &air, &s, &[], &GrindingSites::NONE);
+        let term = security_term(&logup, &s, &GrindingSites::NONE).expect("has interactions");
+        let with_logup = proven_security_report(&regime, &air, &s, &[term], &GrindingSites::NONE);
 
         // Extras only tighten.
         assert!(with_logup.security_bits() <= baseline.security_bits());

--- a/security/src/logup.rs
+++ b/security/src/logup.rs
@@ -22,10 +22,13 @@
 //!
 //! A root of the numerator is not the only way through. A *vanishing
 //! denominator* degenerates the batched transition identity: with `denom_j = 0`
-//! the constraint collapses to `multiplicity_j · Π_{s≠j} denom_s = 0`, forcing
-//! `multiplicity_j = 0` and letting a prover drop message `j` from the bus for
-//! free. Each denominator is monic in `alpha`, so for any `beta` exactly one
-//! `alpha` annihilates it — that event costs `N / |EF|`, not `N·W / |EF|`.
+//! the common denominator itself is `0`, so the constraint
+//! `common_denominator · frac_local − numerator = 0` no longer pins the
+//! fraction column — `frac_local` is multiplied away and left completely
+//! unconstrained on that row, letting a prover write any value into it and
+//! have the accumulator absorb it. Each denominator is monic in `alpha`, so
+//! for any `beta` exactly one `alpha` annihilates it — that event costs
+//! `N / |EF|`, not `N·W / |EF|`.
 //!
 //! Together
 //!

--- a/security/src/logup.rs
+++ b/security/src/logup.rs
@@ -29,9 +29,12 @@
 //! `Challenges`), so it contributes no separate error term. The multiplicity
 //! height bound (`Σ wᵢ·hᵢ < p`) is enforced in-circuit and is not modeled here.
 //!
-//! The resulting term is passed to [`crate::stark::proven_security_report`] as
-//! an `extras` [`SecurityTerm`] by the protocol call site; it is not wired into
-//! the composite automatically, since not every STARK uses lookups.
+//! The resulting term is passed to [`crate::stark::proven_security_report`] or
+//! [`crate::stark::conjectured_security_report`] as an `extras`
+//! [`SecurityTerm`] by the protocol call site; it is not wired into the
+//! composite automatically, since not every STARK uses lookups. In the
+//! conjectured composite it is often the binding term at large trace lengths:
+//! `N` grows linearly in the trace while the query-phase error does not.
 //!
 //! # References
 //! - Haböck, *Multivariate lookups based on logarithmic derivatives*

--- a/security/src/logup.rs
+++ b/security/src/logup.rs
@@ -17,11 +17,20 @@
 //! ≤ `N·W` in `beta`, where `N = num_interactions · trace_length` is the
 //! number of denominator factors (interactions summed over all buses) and
 //! `W = max_message_width` is the widest payload. Sampling both challenges
-//! independently and uniformly from the challenge field `EF`, the union bound
-//! gives
+//! independently and uniformly from the challenge field `EF`, the per-variable
+//! union bound puts a numerator root at `N·(W + 1) / |EF|`.
+//!
+//! A root of the numerator is not the only way through. A *vanishing
+//! denominator* degenerates the batched transition identity: with `denom_j = 0`
+//! the constraint collapses to `multiplicity_j · Π_{s≠j} denom_s = 0`, forcing
+//! `multiplicity_j = 0` and letting a prover drop message `j` from the bus for
+//! free. Each denominator is monic in `alpha`, so for any `beta` exactly one
+//! `alpha` annihilates it — that event costs `N / |EF|`, not `N·W / |EF|`.
+//!
+//! Together
 //!
 //! ```text
-//!     ε_logup ≤ N·(W + 1) / |EF|.
+//!     ε_logup ≤ N·(W + 1) / |EF| + N / |EF| = N·(W + 2) / |EF|.
 //! ```
 //!
 //! Bus batching is subsumed: `N` already sums interactions over every bus, and
@@ -61,8 +70,11 @@ pub struct LogUpAir {
     pub max_message_width: usize,
 }
 
-/// `-log2(ε_logup)` in bits, following `ε_logup ≤ N·(W + 1) / |EF|` with
+/// `-log2(ε_logup)` in bits, following `ε_logup ≤ N·(W + 2) / |EF|` with
 /// `N = num_interactions · 2^log_trace_length` and `W = max_message_width`.
+///
+/// The `W + 2` covers both ways a sampled `(alpha, beta)` breaks the argument: a root of the
+/// cleared numerator, and a vanishing denominator that lets a message be dropped.
 ///
 /// Returns 0 bits for degenerate inputs (no interactions, or unknown field
 /// size). Prefer [`security_term`], which omits the term entirely when there
@@ -73,7 +85,7 @@ pub fn fingerprint_error(air: &LogUpAir, shape: &InstanceShape) -> ErrorBits {
     }
     let log_n = shape.log_trace_length as f64 + log2(air.num_interactions as f64);
     let width = air.max_message_width.max(1) as f64;
-    let bits = shape.modulus_bits as f64 - log_n - log2(width + 1.0);
+    let bits = shape.modulus_bits as f64 - log_n - log2(width + 2.0);
     ErrorBits::from_log2(bits.max(0.0))
 }
 
@@ -109,8 +121,8 @@ mod tests {
         }
     }
 
-    /// `ε ≤ N·(W+1)/|EF|` → bits = |EF| − log2(N) − log2(W+1). For
-    /// N = 2^20 · 16 = 2^24 and W = 3: 128 − 24 − log2(4) = 102.
+    /// `ε ≤ N·(W+2)/|EF|` → bits = |EF| − log2(N) − log2(W+2). For
+    /// N = 2^20 · 16 = 2^24 and W = 3: 128 − 24 − log2(5).
     #[test]
     fn fingerprint_error_regression() {
         let air = LogUpAir {
@@ -118,7 +130,8 @@ mod tests {
             max_message_width: 3,
         };
         let bits = fingerprint_error(&air, &shape(128)).bits();
-        assert!((bits - 102.0).abs() < 1e-9, "got {bits}");
+        let expected = 128.0 - 24.0 - 5f64.log2();
+        assert!((bits - expected).abs() < 1e-9, "got {bits}");
     }
 
     /// More interactions and wider messages both tighten (lower) the bound.

--- a/security/src/proximity.rs
+++ b/security/src/proximity.rs
@@ -49,6 +49,19 @@ pub const fn list_size_udr() -> f64 {
     1.0
 }
 
+/// Conjectured-regime list size: L⁺ = 1.
+///
+/// The random-words heuristic of [2025/2010] §1.5 treats a malicious prover's
+/// committed word as distributed like a uniformly random word, whose distance
+/// to the code concentrates at capacity `1 − ρ`. Conjecturing correlated
+/// agreement up to that radius, the relevant decoding list is a single
+/// codeword — numerically the same L⁺ = 1 as [`list_size_udr`], but justified
+/// by the conjecture rather than by the unique-decoding radius. The ALI and
+/// DEEP-ALI bounds therefore carry no list-size multiplier in this regime.
+pub const fn list_size_conjectured() -> f64 {
+    1.0
+}
+
 /// LDR list size: L⁺ = (m + 1/2)/√ρ. Matches `soundcalc`
 /// `johnson_bound::get_max_list_size` (explicit-m branch).
 pub fn list_size_ldr_m(log_blowup: usize, m: usize) -> f64 {

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -43,6 +43,10 @@ pub enum Regime {
     UniqueDecoding,
     /// List-decoding regime at proximity parameter `m`.
     ListDecoding { m: usize },
+    /// Conjectured (random-words) regime: correlated agreement up to
+    /// list-decoding capacity, at list size 1. See
+    /// [`crate::proximity::list_size_conjectured`].
+    Conjectured,
 }
 
 /// Full soundness breakdown within a single proximity regime.
@@ -51,6 +55,10 @@ pub enum Regime {
 /// and the commitment-collision cap. The attained security is the minimum
 /// over all terms: a collision, or any single binding error, forges the
 /// proof.
+///
+/// This is also the top-level output of
+/// [`crate::stark::conjectured_security_report`], which has a single regime
+/// and therefore no [`SecurityReport`] envelope to maximize over.
 #[derive(Clone, Debug, Serialize)]
 pub struct RegimeReport {
     pub regime: Regime,

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -16,8 +16,28 @@ use crate::error::ErrorBits;
 pub const ALI_LABEL: &str = "air-composition";
 /// Label for the DEEP-ALI out-of-domain term.
 pub const DEEP_LABEL: &str = "deep-ali";
-/// Label for the low-degree-test term.
+/// Label for the low-degree-test term, when an implementation reports its
+/// phases as one already-composed bound.
+///
+/// # Asymmetry with the conjectured path
+///
+/// The proven path reports this single label while the conjectured path
+/// reports [`LDT_QUERY_LABEL`] and [`LDT_COMMIT_LABEL`] separately, so a
+/// consumer diffing the two sees different label sets for the same protocol
+/// phases. That is deliberate, not an oversight: the proven path's LDT error
+/// is *already* a minimum by the time the composite sees it, because
+/// [`crate::fri::best_ldr_m`] searches for the proximity parameter `m`
+/// maximising `min(commit, query)` and returns only the winning value.
+/// Splitting the label there would require the regime search to carry both
+/// phases through, which changes what `best_ldr` optimises. The conjectured
+/// path has no such search, so nothing forces the phases together.
 pub const LDT_LABEL: &str = "low-degree-test";
+/// Label for the low-degree test's query-phase term, when an implementation
+/// reports its phases separately (see [`crate::ldt::LowDegreeTest::conjectured_terms`]).
+pub const LDT_QUERY_LABEL: &str = "ldt-query-phase";
+/// Label for the low-degree test's commit-phase (folding) term, when an
+/// implementation reports its phases separately.
+pub const LDT_COMMIT_LABEL: &str = "ldt-commit-phase";
 /// Label for the batched-openings random-linear-combination term.
 pub const BATCH_LABEL: &str = "batch-combination";
 /// Label for the commitment-collision cap term.

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -58,6 +58,7 @@ impl SecurityTerm {
 
 /// The proximity regime a [`RegimeReport`] was evaluated in.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub enum Regime {
     /// Unique-decoding regime (list size 1).
     UniqueDecoding,

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -12,6 +12,7 @@ use alloc::vec::Vec;
 
 use crate::assumption::SecurityAssumption;
 use crate::error::ErrorBits;
+use crate::grinding::{GrindingSites, boost};
 use crate::ldt::LowDegreeTest;
 use crate::proximity::{list_size_ldr_m, list_size_udr};
 use crate::report::{
@@ -145,6 +146,9 @@ fn batching_term(
 /// Attained security is the min over these (see
 /// [`RegimeReport::security_bits`]), matching [`proven_security_regime`] plus
 /// the batching term.
+///
+/// `grinding.out_of_domain` boosts the DEEP term; the low-degree test's own
+/// sites are already folded into `ldt_error` by the [`LowDegreeTest`] impl.
 fn regime_report(
     regime: Regime,
     air: &StarkAirParams,
@@ -153,9 +157,13 @@ fn regime_report(
     ldt_error: ErrorBits,
     batch: Option<SecurityTerm>,
     extras: &[SecurityTerm],
+    grinding: &GrindingSites,
 ) -> RegimeReport {
     let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
-    let deep = deep::deep_ali_error(air, shape, list_size);
+    let deep = boost(
+        deep::deep_ali_error(air, shape, list_size),
+        grinding.out_of_domain,
+    );
     let mut terms = Vec::with_capacity(5 + extras.len());
     terms.push(SecurityTerm::new(ALI_LABEL, ali));
     terms.push(SecurityTerm::new(DEEP_LABEL, deep));
@@ -179,11 +187,15 @@ fn regime_report(
 ///
 /// [`SecurityReport::security_bits`] reproduces [`proven_security`]; the report
 /// additionally exposes which term binds in each regime.
+///
+/// `grinding` sites the protocol's proof-of-work per error source; pass
+/// [`GrindingSites::NONE`] when the low-degree test carries all of it.
 pub fn proven_security_report<L: LowDegreeTest>(
     ldt: &L,
     air: &StarkAirParams,
     shape: &InstanceShape,
     extras: &[SecurityTerm],
+    grinding: &GrindingSites,
 ) -> SecurityReport {
     let log_blowup = ldt.log_blowup();
 
@@ -196,6 +208,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
         udr_ldt,
         batching_term(SecurityAssumption::UniqueDecoding, shape, log_blowup, None),
         extras,
+        grinding,
     );
 
     let ldr = ldt.best_ldr(air, shape).map(|(m, ldr_ldt)| {
@@ -208,6 +221,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
             ldr_ldt,
             batching_term(SecurityAssumption::JohnsonBound, shape, log_blowup, Some(m)),
             extras,
+            grinding,
         )
     });
 
@@ -276,6 +290,7 @@ mod tests {
             ldt,
             None,
             &[SecurityTerm::new("extra", extra)],
+            &GrindingSites::NONE,
         );
 
         assert!((report.security_bits() - expected.bits()).abs() < 1e-12);
@@ -300,7 +315,7 @@ mod tests {
         let air = air();
         let shape = shape();
 
-        let report = proven_security_report(&regime, &air, &shape, &[]);
+        let report = proven_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
 
         // Same per-regime and combined numbers as ProvenSecurity / proven_security.
         assert_eq!(report.udr.security_bits().floor() as usize, 57);
@@ -377,7 +392,13 @@ mod tests {
     /// term is emitted in either regime.
     #[test]
     fn no_batch_term_for_single_function() {
-        let report = proven_security_report(&benchmark_regime(), &air(), &shape(), &[]);
+        let report = proven_security_report(
+            &benchmark_regime(),
+            &air(),
+            &shape(),
+            &[],
+            &GrindingSites::NONE,
+        );
         assert!(report.udr.terms().iter().all(|t| t.label != BATCH_LABEL));
         if let Some(ldr) = &report.ldr {
             assert!(ldr.terms().iter().all(|t| t.label != BATCH_LABEL));
@@ -401,8 +422,8 @@ mod tests {
             ..base
         };
 
-        let no_batch = proven_security_report(&regime, &air, &base, &[]);
-        let with_batch = proven_security_report(&regime, &air, &batched, &[]);
+        let no_batch = proven_security_report(&regime, &air, &base, &[], &GrindingSites::NONE);
+        let with_batch = proven_security_report(&regime, &air, &batched, &[], &GrindingSites::NONE);
 
         // Batching is an extra independent error source: it can only tighten.
         assert!(with_batch.security_bits() <= no_batch.security_bits());
@@ -424,7 +445,7 @@ mod tests {
             ..shape()
         };
 
-        let report = proven_security_report(&regime, &air, &shape, &[]);
+        let report = proven_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
         let ldr = report
             .ldr
             .as_ref()
@@ -461,5 +482,25 @@ mod tests {
             )
             .max(0.0);
         assert!(batch_term.bits.bits() < fixed_m_bits);
+    }
+
+    /// The same monotonicity holds on the proven path, in both regimes.
+    #[test]
+    fn proven_more_grinding_is_not_less_security() {
+        let regime = benchmark_regime();
+        let air = air();
+        let shape = InstanceShape {
+            modulus_bits: 100,
+            ..shape()
+        };
+        let ground = GrindingSites {
+            out_of_domain: 24,
+            ..GrindingSites::NONE
+        };
+
+        let b0 = proven_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let b24 = proven_security_report(&regime, &air, &shape, &[], &ground);
+        assert!(b24.udr.security_bits() >= b0.udr.security_bits());
+        assert!(b24.security_bits() >= b0.security_bits());
     }
 }

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -3,6 +3,9 @@
 //! via plain function arguments — `fri.rs`, `whir.rs`, and downstream
 //! drop-in LDTs all compose with the same orchestrator.
 //!
+//! The conjectured counterpart ([`conjectured_security_report`]) composes the
+//! same sources in the single random-words regime, where the list size is 1.
+//!
 //! Extra protocol-specific error terms (lookup arguments, custom DEEP
 //! variants, batched openings, …) are passed through `extras: &[ErrorBits]`
 //! at every entry point and folded into the same round-by-round min.
@@ -14,7 +17,7 @@ use crate::assumption::SecurityAssumption;
 use crate::error::ErrorBits;
 use crate::grinding::{GrindingSites, boost};
 use crate::ldt::LowDegreeTest;
-use crate::proximity::{list_size_ldr_m, list_size_udr};
+use crate::proximity::{list_size_conjectured, list_size_ldr_m, list_size_udr};
 use crate::report::{
     ALI_LABEL, BATCH_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, Regime, RegimeReport,
     SecurityReport, SecurityTerm,
@@ -226,6 +229,99 @@ pub fn proven_security_report<L: LowDegreeTest>(
     });
 
     SecurityReport { udr, ldr }
+}
+
+/// Composite conjectured bits: the min over the AIR-composition, DEEP-ALI,
+/// low-degree-test, and `extras` terms, capped at the commitment-collision
+/// resistance. Scalar mirror of [`conjectured_security_report`], standing to
+/// it exactly as [`proven_security_regime`] stands to the report path.
+///
+/// `ldt_error` is the low-degree test's conjectured error (e.g.
+/// [`crate::fri::conjectured_error`]). The ALI and DEEP terms are evaluated at
+/// [`list_size_conjectured`] — see [`conjectured_security_report`] for why the
+/// proven path's L⁺ multiplier is absent here.
+///
+/// Like the scalar proven path, this models no grinding sites: a caller that
+/// grinds boosts the affected term itself via [`crate::grinding::boost`], or
+/// uses [`conjectured_security_report`], which consults
+/// [`crate::grinding::GrindingSites`] directly.
+pub fn conjectured_security(
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    ldt_error: ErrorBits,
+    extras: &[ErrorBits],
+) -> ErrorBits {
+    let list_size = list_size_conjectured();
+    let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
+    let deep = deep::deep_ali_error(air, shape, list_size);
+    let mut all: Vec<ErrorBits> = Vec::with_capacity(3 + extras.len());
+    all.push(ali);
+    all.push(deep);
+    all.push(ldt_error);
+    all.extend_from_slice(extras);
+    let algebraic = ErrorBits::min(&all);
+    ErrorBits::from_log2(algebraic.bits().min(shape.collision_resistance as f64))
+}
+
+/// Composite conjectured-security report, generic over the low-degree test.
+///
+/// Composes the LDT's conjectured error ([`LowDegreeTest::conjectured_error`])
+/// with the ALI, DEEP-ALI, `extras`, and commitment-collision terms and
+/// returns the labeled breakdown. Attained security is the min over the terms,
+/// exactly as in [`proven_security_report`], so the binding term stays
+/// inspectable — which is the point: for an AIR with lookups the LogUp
+/// fingerprint error grows linearly in the trace length and can bind well
+/// below the query-phase term, an overstatement an LDT-only conjectured number
+/// cannot express.
+///
+/// # Why one regime, and why no L⁺
+///
+/// The conjectured regime is a single proximity regime, so the result is one
+/// [`RegimeReport`] rather than a [`SecurityReport`]: the latter's job is to
+/// maximize over the two independent proven regimes (UDR and best-`m` LDR),
+/// and there is nothing to maximize over here.
+///
+/// Within it, the random-words heuristic of
+/// [2025/2010](https://eprint.iacr.org/2025/2010) §1.5 conjectures correlated
+/// agreement up to list-decoding capacity at list size 1
+/// ([`list_size_conjectured`]). ALI is then `ε ≤ num_constraints / |F|` and
+/// DEEP-ALI is `ε ≤ (max_deg·(k + max_combo − 1) + (k − 1)) / |F|`, neither
+/// carrying the `L⁺` factor the proven path's Johnson-bound list size forces
+/// ([2024/1553](https://eprint.iacr.org/2024/1553) Theorem 2). Both drop out
+/// of [`air::composition_error`] and [`deep::deep_ali_error`] at `list_size =
+/// 1`, since `log2(1) = 0`.
+///
+/// # Not modeled
+///
+/// The batched-openings random-linear-combination term
+/// ([`proven_security_report`]'s `batch-combination`) has no accepted
+/// conjectured analogue — the random-words heuristic bounds the distance
+/// distribution, not the proximity gap of the batching RLC — so it is omitted
+/// rather than guessed. A caller with a bound for it passes it via `extras`.
+pub fn conjectured_security_report<L: LowDegreeTest>(
+    ldt: &L,
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    extras: &[SecurityTerm],
+    grinding: &GrindingSites,
+) -> RegimeReport {
+    let list_size = list_size_conjectured();
+    let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
+    let deep = boost(
+        deep::deep_ali_error(air, shape, list_size),
+        grinding.out_of_domain,
+    );
+
+    let mut terms = Vec::with_capacity(4 + extras.len());
+    terms.push(SecurityTerm::new(ALI_LABEL, ali));
+    terms.push(SecurityTerm::new(DEEP_LABEL, deep));
+    terms.push(SecurityTerm::new(LDT_LABEL, ldt.conjectured_error(shape)));
+    terms.extend_from_slice(extras);
+    terms.push(SecurityTerm::new(
+        COLLISION_LABEL,
+        ErrorBits::from_log2(shape.collision_resistance as f64),
+    ));
+    RegimeReport::new(Regime::Conjectured, terms)
 }
 
 #[cfg(test)]
@@ -482,6 +578,150 @@ mod tests {
             )
             .max(0.0);
         assert!(batch_term.bits.bits() < fixed_m_bits);
+    }
+
+    /// The conjectured report's attained bits equal the scalar
+    /// `conjectured_security` for the same LDT error and extras, and it is
+    /// tagged as the conjectured regime.
+    #[test]
+    fn conjectured_report_matches_scalar_composite() {
+        use crate::fri::conjectured_error;
+
+        let regime = benchmark_regime();
+        let air = air();
+        let shape = shape();
+        let extra = ErrorBits::from_log2(40.0);
+
+        let report = conjectured_security_report(
+            &regime,
+            &air,
+            &shape,
+            &[SecurityTerm::new("extra", extra)],
+            &GrindingSites::NONE,
+        );
+        let scalar =
+            conjectured_security(&air, &shape, conjectured_error(&regime, &shape), &[extra]);
+
+        assert_eq!(report.regime, Regime::Conjectured);
+        assert!((report.security_bits() - scalar.bits()).abs() < 1e-12);
+        assert_eq!(report.binding().label, "extra");
+    }
+
+    /// Conjectured mode decodes at list size 1, so ALI and DEEP carry no
+    /// `L⁺` multiplier: both match the proven UDR terms (also `L⁺ = 1`) and
+    /// are strictly looser than the proven LDR terms, whose Johnson-bound
+    /// list size costs `log2(L⁺)` bits.
+    #[test]
+    fn conjectured_ali_and_deep_carry_no_list_size() {
+        let regime = benchmark_regime();
+        let air = air();
+        let shape = shape();
+
+        let conjectured =
+            conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let proven = proven_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let ldr = proven
+            .ldr
+            .as_ref()
+            .expect("benchmark has a valid LDR regime");
+
+        for label in [ALI_LABEL, DEEP_LABEL] {
+            let find = |r: &RegimeReport| {
+                r.terms()
+                    .iter()
+                    .find(|t| t.label == label)
+                    .expect("every regime carries the ALI and DEEP terms")
+                    .bits
+                    .bits()
+            };
+            assert!((find(&conjectured) - find(&proven.udr)).abs() < 1e-12);
+            assert!(find(&conjectured) > find(ldr));
+        }
+    }
+
+    /// The gap this composite closes: at a large trace the LogUp fingerprint
+    /// error binds well below the LDT's conjectured query-phase term, so an
+    /// LDT-only conjectured number overstates security.
+    #[test]
+    fn conjectured_logup_extra_binds_below_the_ldt_term() {
+        use crate::logup::{LOGUP_LABEL, LogUpAir, security_term};
+
+        // Queries chosen so the LDT term sits between the DEEP term above it
+        // and the lookup term below it, isolating what binds.
+        let regime = crate::fri::FriRegime {
+            num_queries: 80,
+            ..benchmark_regime()
+        };
+        let air = air();
+        let shape = InstanceShape {
+            log_trace_length: 28,
+            modulus_bits: 128,
+            collision_resistance: 128,
+            num_batched_functions: 1,
+        };
+        let logup = LogUpAir {
+            num_interactions: 64,
+            max_message_width: 8,
+        };
+
+        let term = security_term(&logup, &shape, &GrindingSites::NONE).expect("has interactions");
+        let ldt_only =
+            conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let with_logup =
+            conjectured_security_report(&regime, &air, &shape, &[term], &GrindingSites::NONE);
+
+        // Without the lookup term the low-degree test is what binds.
+        assert_eq!(ldt_only.binding().label, LDT_LABEL);
+        // With it, the lookup term binds strictly lower — the overstatement.
+        assert_eq!(with_logup.binding().label, LOGUP_LABEL);
+        assert!(with_logup.security_bits() < ldt_only.security_bits());
+    }
+
+    /// More constraints can only tighten (never loosen) the conjectured
+    /// bound, via the AIR-composition term.
+    #[test]
+    fn conjectured_more_constraints_is_not_more_security() {
+        let regime = benchmark_regime();
+        let shape = shape();
+        let few = StarkAirParams {
+            num_constraints: 1,
+            ..air()
+        };
+        let many = StarkAirParams {
+            num_constraints: 1 << 20,
+            ..air()
+        };
+
+        let b_few = conjectured_security_report(&regime, &few, &shape, &[], &GrindingSites::NONE);
+        let b_many = conjectured_security_report(&regime, &many, &shape, &[], &GrindingSites::NONE);
+        assert!(b_many.security_bits() <= b_few.security_bits());
+    }
+
+    /// Grinding before the out-of-domain challenge can only loosen (never
+    /// tighten) the DEEP term, so security is non-decreasing in it — and the
+    /// neutral default reproduces the ungrounded report exactly.
+    #[test]
+    fn conjectured_more_grinding_is_not_less_security() {
+        let regime = benchmark_regime();
+        let air = air();
+        // A small field puts DEEP in range of the other terms, so the grind
+        // is observable rather than masked by the collision cap.
+        let shape = InstanceShape {
+            modulus_bits: 100,
+            ..shape()
+        };
+        let ground = GrindingSites {
+            out_of_domain: 24,
+            ..GrindingSites::NONE
+        };
+
+        let b0 = conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let b24 = conjectured_security_report(&regime, &air, &shape, &[], &ground);
+        assert!(b24.security_bits() >= b0.security_bits());
+
+        let default_sites =
+            conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::default());
+        assert!((default_sites.security_bits() - b0.security_bits()).abs() < 1e-12);
     }
 
     /// The same monotonicity holds on the proven path, in both regimes.

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -236,32 +236,38 @@ pub fn proven_security_report<L: LowDegreeTest>(
 /// resistance. Scalar mirror of [`conjectured_security_report`], standing to
 /// it exactly as [`proven_security_regime`] stands to the report path.
 ///
-/// `ldt_error` is the low-degree test's conjectured error. For FRI that is the
-/// minimum of [`crate::fri::conjectured_error`] (query phase) and
-/// [`crate::fri::conjectured_commit_phase_error`] (folding rounds); passing
-/// only the former overstates security for a large LDE domain over a small
-/// field. [`conjectured_security_report`] composes both automatically via
-/// [`LowDegreeTest::conjectured_terms`]. The ALI and DEEP terms are evaluated at
-/// [`list_size_conjectured`] — see [`conjectured_security_report`] for why the
-/// proven path's L⁺ multiplier is absent here.
+/// The low-degree test's terms are taken from [`LowDegreeTest::conjectured_terms`]
+/// rather than passed in. Unlike the proven scalar path — where the caller has
+/// already resolved a per-regime error via [`crate::fri::proven_error_udr`] or
+/// [`crate::fri::best_ldr_m`] — the conjectured regime has no such search, so an
+/// `ErrorBits` parameter here would silently accept
+/// [`crate::fri::conjectured_error`] alone and drop the commit-phase round,
+/// overstating security for a large LDE domain over a small field. Taking the
+/// test itself makes that unrepresentable.
 ///
-/// Like the scalar proven path, this models no grinding sites: a caller that
-/// grinds boosts the affected term itself via [`crate::grinding::boost`], or
-/// uses [`conjectured_security_report`], which consults
+/// The ALI and DEEP terms are evaluated at [`list_size_conjectured`] — see
+/// [`conjectured_security_report`] for why the proven path's L⁺ multiplier is
+/// absent here.
+///
+/// Like the scalar proven path, this models no grinding sites beyond those the
+/// low-degree test already carries: a caller that grinds elsewhere boosts the
+/// affected term itself via [`crate::grinding::boost`], or uses
+/// [`conjectured_security_report`], which consults
 /// [`crate::grinding::GrindingSites`] directly.
-pub fn conjectured_security(
+pub fn conjectured_security<L: LowDegreeTest>(
+    ldt: &L,
     air: &StarkAirParams,
     shape: &InstanceShape,
-    ldt_error: ErrorBits,
     extras: &[ErrorBits],
 ) -> ErrorBits {
     let list_size = list_size_conjectured();
     let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
     let deep = deep::deep_ali_error(air, shape, list_size);
-    let mut all: Vec<ErrorBits> = Vec::with_capacity(3 + extras.len());
+    let ldt_terms = ldt.conjectured_terms(shape);
+    let mut all: Vec<ErrorBits> = Vec::with_capacity(2 + ldt_terms.len() + extras.len());
     all.push(ali);
     all.push(deep);
-    all.push(ldt_error);
+    all.extend(ldt_terms.iter().map(|t| t.bits));
     all.extend_from_slice(extras);
     let algebraic = ErrorBits::min(&all);
     ErrorBits::from_log2(algebraic.bits().min(shape.collision_resistance as f64))
@@ -588,16 +594,25 @@ mod tests {
     }
 
     /// The conjectured report's attained bits equal the scalar
-    /// `conjectured_security` for the same LDT error and extras, and it is
+    /// `conjectured_security` for the same LDT, shape, and extras, and it is
     /// tagged as the conjectured regime.
+    ///
+    /// Checked with and without `extras`: a binding extra would mask a
+    /// divergence between the two paths' LDT term sets, which is exactly what
+    /// went unnoticed while the scalar path took a caller-supplied
+    /// `ErrorBits` and the report path composed `conjectured_terms`.
     #[test]
     fn conjectured_report_matches_scalar_composite() {
-        use crate::fri::conjectured_error;
-
         let regime = benchmark_regime();
         let air = air();
         let shape = shape();
         let extra = ErrorBits::from_log2(40.0);
+
+        // Without extras, the LDT terms are what the two paths must agree on.
+        let bare_report =
+            conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
+        let bare_scalar = conjectured_security(&regime, &air, &shape, &[]);
+        assert!((bare_report.security_bits() - bare_scalar.bits()).abs() < 1e-12);
 
         let report = conjectured_security_report(
             &regime,
@@ -606,8 +621,7 @@ mod tests {
             &[SecurityTerm::new("extra", extra)],
             &GrindingSites::NONE,
         );
-        let scalar =
-            conjectured_security(&air, &shape, conjectured_error(&regime, &shape), &[extra]);
+        let scalar = conjectured_security(&regime, &air, &shape, &[extra]);
 
         assert_eq!(report.regime, Regime::Conjectured);
         assert!((report.security_bits() - scalar.bits()).abs() < 1e-12);

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -236,8 +236,12 @@ pub fn proven_security_report<L: LowDegreeTest>(
 /// resistance. Scalar mirror of [`conjectured_security_report`], standing to
 /// it exactly as [`proven_security_regime`] stands to the report path.
 ///
-/// `ldt_error` is the low-degree test's conjectured error (e.g.
-/// [`crate::fri::conjectured_error`]). The ALI and DEEP terms are evaluated at
+/// `ldt_error` is the low-degree test's conjectured error. For FRI that is the
+/// minimum of [`crate::fri::conjectured_error`] (query phase) and
+/// [`crate::fri::conjectured_commit_phase_error`] (folding rounds); passing
+/// only the former overstates security for a large LDE domain over a small
+/// field. [`conjectured_security_report`] composes both automatically via
+/// [`LowDegreeTest::conjectured_terms`]. The ALI and DEEP terms are evaluated at
 /// [`list_size_conjectured`] — see [`conjectured_security_report`] for why the
 /// proven path's L⁺ multiplier is absent here.
 ///
@@ -265,7 +269,8 @@ pub fn conjectured_security(
 
 /// Composite conjectured-security report, generic over the low-degree test.
 ///
-/// Composes the LDT's conjectured error ([`LowDegreeTest::conjectured_error`])
+/// Composes the LDT's conjectured terms ([`LowDegreeTest::conjectured_terms`],
+/// which for FRI splits the query phase from the commit-phase folding rounds)
 /// with the ALI, DEEP-ALI, `extras`, and commitment-collision terms and
 /// returns the labeled breakdown. Attained security is the min over the terms,
 /// exactly as in [`proven_security_report`], so the binding term stays
@@ -312,10 +317,11 @@ pub fn conjectured_security_report<L: LowDegreeTest>(
         grinding.out_of_domain,
     );
 
-    let mut terms = Vec::with_capacity(4 + extras.len());
+    let ldt_terms = ldt.conjectured_terms(shape);
+    let mut terms = Vec::with_capacity(3 + ldt_terms.len() + extras.len());
     terms.push(SecurityTerm::new(ALI_LABEL, ali));
     terms.push(SecurityTerm::new(DEEP_LABEL, deep));
-    terms.push(SecurityTerm::new(LDT_LABEL, ldt.conjectured_error(shape)));
+    terms.extend(ldt_terms);
     terms.extend_from_slice(extras);
     terms.push(SecurityTerm::new(
         COLLISION_LABEL,
@@ -327,6 +333,7 @@ pub fn conjectured_security_report<L: LowDegreeTest>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::report::LDT_QUERY_LABEL;
 
     fn shape() -> InstanceShape {
         InstanceShape {
@@ -670,8 +677,8 @@ mod tests {
         let with_logup =
             conjectured_security_report(&regime, &air, &shape, &[term], &GrindingSites::NONE);
 
-        // Without the lookup term the low-degree test is what binds.
-        assert_eq!(ldt_only.binding().label, LDT_LABEL);
+        // Without the lookup term the low-degree test's query phase is what binds.
+        assert_eq!(ldt_only.binding().label, LDT_QUERY_LABEL);
         // With it, the lookup term binds strictly lower — the overstatement.
         assert_eq!(with_logup.binding().label, LOGUP_LABEL);
         assert!(with_logup.security_bits() < ldt_only.security_bits());

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -249,20 +249,23 @@ pub fn proven_security_report<L: LowDegreeTest>(
 /// [`conjectured_security_report`] for why the proven path's L⁺ multiplier is
 /// absent here.
 ///
-/// Like the scalar proven path, this models no grinding sites beyond those the
-/// low-degree test already carries: a caller that grinds elsewhere boosts the
-/// affected term itself via [`crate::grinding::boost`], or uses
-/// [`conjectured_security_report`], which consults
-/// [`crate::grinding::GrindingSites`] directly.
+/// `grinding.out_of_domain` boosts the DEEP term, exactly as in
+/// [`conjectured_security_report`]; the low-degree test's own sites are
+/// already folded into `ldt.conjectured_terms`'s output by the
+/// [`LowDegreeTest`] impl.
 pub fn conjectured_security<L: LowDegreeTest>(
     ldt: &L,
     air: &StarkAirParams,
     shape: &InstanceShape,
     extras: &[ErrorBits],
+    grinding: &GrindingSites,
 ) -> ErrorBits {
     let list_size = list_size_conjectured();
     let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
-    let deep = deep::deep_ali_error(air, shape, list_size);
+    let deep = boost(
+        deep::deep_ali_error(air, shape, list_size),
+        grinding.out_of_domain,
+    );
     let ldt_terms = ldt.conjectured_terms(shape);
     let mut all: Vec<ErrorBits> = Vec::with_capacity(2 + ldt_terms.len() + extras.len());
     all.push(ali);
@@ -611,7 +614,7 @@ mod tests {
         // Without extras, the LDT terms are what the two paths must agree on.
         let bare_report =
             conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
-        let bare_scalar = conjectured_security(&regime, &air, &shape, &[]);
+        let bare_scalar = conjectured_security(&regime, &air, &shape, &[], &GrindingSites::NONE);
         assert!((bare_report.security_bits() - bare_scalar.bits()).abs() < 1e-12);
 
         let report = conjectured_security_report(
@@ -621,11 +624,23 @@ mod tests {
             &[SecurityTerm::new("extra", extra)],
             &GrindingSites::NONE,
         );
-        let scalar = conjectured_security(&regime, &air, &shape, &[extra]);
+        let scalar = conjectured_security(&regime, &air, &shape, &[extra], &GrindingSites::NONE);
 
         assert_eq!(report.regime, Regime::Conjectured);
         assert!((report.security_bits() - scalar.bits()).abs() < 1e-12);
         assert_eq!(report.binding().label, "extra");
+
+        // And at a nonzero grinding site — the axis the two paths could only
+        // diverge on before `conjectured_security` modeled `GrindingSites`
+        // itself, since it had no way to express the DEEP-term boost that
+        // `conjectured_security_report` applies.
+        let ground = GrindingSites {
+            out_of_domain: 24,
+            ..GrindingSites::NONE
+        };
+        let ground_report = conjectured_security_report(&regime, &air, &shape, &[], &ground);
+        let ground_scalar = conjectured_security(&regime, &air, &shape, &[], &ground);
+        assert!((ground_report.security_bits() - ground_scalar.bits()).abs() < 1e-12);
     }
 
     /// Conjectured mode decodes at list size 1, so ALI and DEEP carry no

--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -27,12 +27,9 @@ pub struct Proof<SC: StarkGenericConfig> {
 impl<SC: StarkGenericConfig> Proof<SC> {
     /// Conjectured security level (in bits).
     ///
-    /// This is a parameter-space property and does not depend on `self`; the method
-    /// is exposed on [`Proof`] for parity with [`Self::proven_security`].
-    ///
     /// See [`ConjecturedSecurity`].
-    pub fn conjectured_security(params: &StarkSecurityParams) -> ConjecturedSecurity {
-        ConjecturedSecurity::compute_from_params(params)
+    pub fn conjectured_security(&self, params: &StarkSecurityParams) -> ConjecturedSecurity {
+        ConjecturedSecurity::compute_from_params(params, self.degree_bits)
     }
 
     /// Proven security level (in bits).

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -247,10 +247,11 @@ impl ConjecturedSecurity {
     ///   [`conjectured_security_report`] omits it rather than guessing. An
     ///   instance that random-linear-combines several committed codewords is
     ///   graded optimistically here relative to [`ProvenSecurity`].
-    /// - `fri_commit_proof_of_work_bits` is ignored. The conjectured
-    ///   low-degree-test error models the query phase only, so there is no
-    ///   commit-phase round for it to be credited to. This understates
-    ///   security for a configuration that grinds there.
+    /// - `fri_commit_proof_of_work_bits` is credited, but only to the
+    ///   commit-phase term ([`p3_security::fri::conjectured_commit_phase_error`]),
+    ///   which is one of several the composite takes a minimum over. Grinding
+    ///   there raises the reported level only while that term is the binding
+    ///   one.
     pub fn compute_from_params(params: &StarkSecurityParams, degree_bits: usize) -> Self {
         debug_assert!(
             params.air_max_constraint_degree <= (1usize << params.fri_log_blowup) + 1,
@@ -357,9 +358,13 @@ mod tests {
     const TEST_AIR_MAX_DEG: usize = 2;
     const TEST_MAX_COMBO: usize = 2;
 
+    /// A 256-bit field puts every algebraic term — including the commit-phase
+    /// folding round, which over a 128-bit field would bind here at 119 — well
+    /// above the hash's 128-bit collision resistance, leaving the cap as the
+    /// only thing that binds.
     #[test]
     fn conjectured_security_bounded_by_collision_resistance() {
-        let s = ConjecturedSecurity::compute_ldt_only(8, 32, 0, 128, 128);
+        let s = ConjecturedSecurity::compute_ldt_only(8, 32, 0, 128, 256);
         assert_eq!(s.security_bits, 128);
     }
 
@@ -493,16 +498,23 @@ mod tests {
     /// num_modulus_bits, expected_bits)`.
     ///
     /// A uni-STARK has no lookups and batches nothing in the conjectured
-    /// path, so the composite must reduce exactly to
-    /// `min(fri_conjectured, collision_resistance, num_modulus_bits)`.
+    /// path, so the composite reduces to `min` over the query phase, the
+    /// commit-phase folding round, `collision_resistance`, and
+    /// `num_modulus_bits`.
+    ///
+    /// This entry point pins `max_log_arity = 0` and a single-row trace, so
+    /// the folding round is evaluated at `n = 2^log_blowup` — it binds only in
+    /// the two rows where the query phase would otherwise clear the collision
+    /// cap (`log_blowup` 2 and 8), which is exactly the overstatement that
+    /// omitting the round produced.
     #[test]
     fn conjectured_security_ldt_only_regression_vector() {
         const VECTOR: [(usize, usize, usize, usize, usize, usize); 8] = [
             (1, 100, 16, 128, 252, 114),
             (1, 100, 0, 128, 128, 97),
-            (2, 64, 20, 128, 128, 128),
+            (2, 64, 20, 128, 128, 125),
             (4, 20, 8, 256, 128, 86),
-            (8, 32, 0, 128, 128, 128),
+            (8, 32, 0, 128, 128, 119),
             (0, 100, 16, 128, 256, 16),
             (1, 84, 16, 100, 128, 97),
             (3, 27, 21, 128, 128, 100),
@@ -539,16 +551,19 @@ mod tests {
     /// DEEP-ALI term is in range of the query-phase term rather than masked by
     /// the collision cap.
     ///
-    /// DEEP-ALI binds throughout and its error is
-    /// `(max_deg·(k + max_combo − 1) + (k − 1)) / |F|`, which at `max_deg = 2`,
-    /// `max_combo = 2` is `(3·k + 1) / |F|` — so the level falls exactly one
-    /// bit per degree bit, from `96 − log2(3) − 1` downward. That slope is the
-    /// whole point of this entry point: [`ConjecturedSecurity::compute_ldt_only`]
-    /// reports a single constant across all five heights.
+    /// The FRI commit phase binds throughout, at
+    /// `|F| − log2((folding − 1)·(n + 1))` with `n = 2^(degree_bits + blowup)`
+    /// and `folding − 1 = 7` — so the level is `92.19 − degree_bits`, falling
+    /// exactly one bit per degree bit. DEEP-ALI tracks about 2.2 bits above it
+    /// (`|F| − log2(3·k + 1)`) and would bind at a lower folding arity.
+    ///
+    /// That slope is the whole point of this entry point:
+    /// [`ConjecturedSecurity::compute_ldt_only`] reports a single constant
+    /// across all five heights, because neither term is visible to it.
     #[test]
     fn conjectured_security_from_params_regression_vector() {
         const DEGREE_BITS: [usize; 5] = [10, 16, 20, 24, 28];
-        const EXPECTED: [usize; 5] = [84, 78, 74, 70, 66];
+        const EXPECTED: [usize; 5] = [82, 76, 72, 68, 64];
 
         let params = benchmark_high_arity_params(96);
         let actual = DEGREE_BITS

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -178,8 +178,9 @@ pub struct ConjecturedSecurity {
 }
 
 impl ConjecturedSecurity {
-    /// Conjectured security from FRI parameters using the random-words formula
-    /// ([2025/2010] §1.5). Requires `num_modulus_bits` (log2 of field size) for the η cutoff.
+    /// Conjectured security from FRI parameters alone, using the random-words
+    /// formula ([2025/2010] §1.5). Requires `num_modulus_bits` (log2 of field
+    /// size) for the η cutoff.
     ///
     /// This entry point takes no AIR shape and no trace length, so the
     /// AIR-composition and DEEP-ALI terms are evaluated on the smallest
@@ -187,7 +188,14 @@ impl ConjecturedSecurity {
     /// single-row trace — where both reduce to the field-size cap. A uni-STARK
     /// has no lookups, so no `extras` apply either, leaving the low-degree
     /// test and the commitment-collision cap as the only binding terms.
-    pub fn compute(
+    ///
+    /// The result is therefore a property of the parameter space, not of any
+    /// particular instance: it answers "what can these FRI parameters attain
+    /// at best", and an instance with a real AIR over a real trace attains at
+    /// most this. Use [`Self::compute_from_params`] once the trace length is
+    /// known — the DEEP-ALI term grows with it, so this bound is optimistic
+    /// for every instance larger than a single row.
+    pub fn compute_ldt_only(
         log_blowup: usize,
         num_queries: usize,
         query_proof_of_work_bits: usize,
@@ -219,15 +227,48 @@ impl ConjecturedSecurity {
         }
     }
 
-    /// Compute conjectured security from a parameter bundle.
-    pub fn compute_from_params(params: &StarkSecurityParams) -> Self {
-        Self::compute(
-            params.fri_log_blowup,
-            params.fri_num_queries,
-            params.fri_query_proof_of_work_bits,
-            params.collision_resistance,
-            params.num_modulus_bits,
-        )
+    /// Compute conjectured security from a parameter bundle and the proof's
+    /// degree bits, composing the AIR-composition and DEEP-ALI terms at the
+    /// instance's real shape rather than the degenerate one
+    /// [`Self::compute_ldt_only`] uses.
+    ///
+    /// `degree_bits` already reflects the committed-polynomial size (post-zk
+    /// padding, when applicable), so the trace domain is `2^degree_bits` —
+    /// the same convention as [`ProvenSecurity::compute_from_proof`].
+    ///
+    /// # Two fields this does not consume
+    ///
+    /// `params` is threaded whole, but the conjectured composite reads less of
+    /// it than the proven one does:
+    ///
+    /// - `num_batched_functions` is ignored. The batched-openings term has no
+    ///   accepted conjectured analogue — the random-words heuristic bounds the
+    ///   distance distribution, not the proximity gap of the batching RLC — so
+    ///   [`conjectured_security_report`] omits it rather than guessing. An
+    ///   instance that random-linear-combines several committed codewords is
+    ///   graded optimistically here relative to [`ProvenSecurity`].
+    /// - `fri_commit_proof_of_work_bits` is ignored. The conjectured
+    ///   low-degree-test error models the query phase only, so there is no
+    ///   commit-phase round for it to be credited to. This understates
+    ///   security for a configuration that grinds there.
+    pub fn compute_from_params(params: &StarkSecurityParams, degree_bits: usize) -> Self {
+        debug_assert!(
+            params.air_max_constraint_degree <= (1usize << params.fri_log_blowup) + 1,
+            "AIR max constraint degree {} exceeds blowup+1 ({}); the prover cannot commit a quotient",
+            params.air_max_constraint_degree,
+            (1usize << params.fri_log_blowup) + 1
+        );
+
+        let report = conjectured_security_report(
+            &params.fri_regime(),
+            &params.air_shape(),
+            &params.instance_shape(degree_bits),
+            &[],
+            &params.grinding(),
+        );
+        Self {
+            security_bits: report.security_bits() as usize,
+        }
     }
 }
 
@@ -318,19 +359,19 @@ mod tests {
 
     #[test]
     fn conjectured_security_bounded_by_collision_resistance() {
-        let s = ConjecturedSecurity::compute(8, 32, 0, 128, 128);
+        let s = ConjecturedSecurity::compute_ldt_only(8, 32, 0, 128, 128);
         assert_eq!(s.security_bits, 128);
     }
 
     #[test]
     fn conjectured_security_random_words_formula() {
-        let s = ConjecturedSecurity::compute(4, 20, 8, 256, 128);
+        let s = ConjecturedSecurity::compute_ldt_only(4, 20, 8, 256, 128);
         assert!(s.security_bits > 0 && s.security_bits <= 256);
     }
 
     #[test]
     fn conjectured_security_log_blowup_zero_returns_zero_fri_bits() {
-        let s = ConjecturedSecurity::compute(0, 100, 16, 128, 256);
+        let s = ConjecturedSecurity::compute_ldt_only(0, 100, 16, 128, 256);
         assert_eq!(s.security_bits, 16);
     }
 
@@ -354,7 +395,7 @@ mod tests {
 
     #[test]
     fn proven_security_lower_than_conjectured_for_same_params() {
-        let c = ConjecturedSecurity::compute(8, 32, 8, 256, 252);
+        let c = ConjecturedSecurity::compute_ldt_only(8, 32, 8, 256, 252);
         let mut params = benchmark_high_arity_params(252);
         params.fri_log_blowup = 8;
         params.fri_num_queries = 32;
@@ -446,8 +487,8 @@ mod tests {
         assert_eq!(p.list_decoding_bits, 65);
     }
 
-    /// Regression vector pinning `ConjecturedSecurity` across the parameter
-    /// space it is routed through. Entries are
+    /// Regression vector pinning [`ConjecturedSecurity::compute_ldt_only`]
+    /// across the parameter space it is routed through. Entries are
     /// `(log_blowup, num_queries, query_pow, collision_resistance,
     /// num_modulus_bits, expected_bits)`.
     ///
@@ -455,7 +496,7 @@ mod tests {
     /// path, so the composite must reduce exactly to
     /// `min(fri_conjectured, collision_resistance, num_modulus_bits)`.
     #[test]
-    fn conjectured_security_regression_vector() {
+    fn conjectured_security_ldt_only_regression_vector() {
         const VECTOR: [(usize, usize, usize, usize, usize, usize); 8] = [
             (1, 100, 16, 128, 252, 114),
             (1, 100, 0, 128, 128, 97),
@@ -468,7 +509,7 @@ mod tests {
         ];
 
         for (log_blowup, num_queries, query_pow, collision, modulus, expected) in VECTOR {
-            let s = ConjecturedSecurity::compute(
+            let s = ConjecturedSecurity::compute_ldt_only(
                 log_blowup,
                 num_queries,
                 query_pow,
@@ -488,8 +529,84 @@ mod tests {
     /// collision-resistance cap.
     #[test]
     fn conjectured_more_query_grinding_is_not_less_security() {
-        let s0 = ConjecturedSecurity::compute(1, 64, 0, 256, 256);
-        let s16 = ConjecturedSecurity::compute(1, 64, 16, 256, 256);
+        let s0 = ConjecturedSecurity::compute_ldt_only(1, 64, 0, 256, 256);
+        let s16 = ConjecturedSecurity::compute_ldt_only(1, 64, 16, 256, 256);
         assert!(s16.security_bits >= s0.security_bits);
+    }
+
+    /// Regression vector pinning [`ConjecturedSecurity::compute_from_params`]
+    /// across trace heights, over a field small enough that the shape-bearing
+    /// DEEP-ALI term is in range of the query-phase term rather than masked by
+    /// the collision cap.
+    ///
+    /// DEEP-ALI binds throughout and its error is
+    /// `(max_deg·(k + max_combo − 1) + (k − 1)) / |F|`, which at `max_deg = 2`,
+    /// `max_combo = 2` is `(3·k + 1) / |F|` — so the level falls exactly one
+    /// bit per degree bit, from `96 − log2(3) − 1` downward. That slope is the
+    /// whole point of this entry point: [`ConjecturedSecurity::compute_ldt_only`]
+    /// reports a single constant across all five heights.
+    #[test]
+    fn conjectured_security_from_params_regression_vector() {
+        const DEGREE_BITS: [usize; 5] = [10, 16, 20, 24, 28];
+        const EXPECTED: [usize; 5] = [84, 78, 74, 70, 66];
+
+        let params = benchmark_high_arity_params(96);
+        let actual = DEGREE_BITS
+            .map(|degree_bits| ConjecturedSecurity::compute_from_params(&params, degree_bits))
+            .map(|s| s.security_bits);
+        assert_eq!(actual, EXPECTED, "conjectured security drifted");
+    }
+
+    /// The shape-aware path can only report at or below the shape-free one:
+    /// [`ConjecturedSecurity::compute_ldt_only`] evaluates the AIR-composition
+    /// and DEEP-ALI terms on a single-row, one-constraint instance, which is
+    /// the best case every real instance is measured against.
+    #[test]
+    fn conjectured_from_params_never_exceeds_ldt_only() {
+        let params = benchmark_high_arity_params(96);
+        let ldt_only = ConjecturedSecurity::compute_ldt_only(
+            params.fri_log_blowup,
+            params.fri_num_queries,
+            params.fri_query_proof_of_work_bits,
+            params.collision_resistance,
+            params.num_modulus_bits,
+        );
+
+        for degree_bits in 1..=28 {
+            let shaped = ConjecturedSecurity::compute_from_params(&params, degree_bits);
+            assert!(
+                shaped.security_bits <= ldt_only.security_bits,
+                "shape-aware bound exceeded the shape-free one at degree_bits={degree_bits}"
+            );
+        }
+    }
+
+    /// The DEEP-ALI term grows with the trace domain, so a taller instance can
+    /// never grade above a shorter one under the same parameters. This is the
+    /// dependence the shape-free entry point cannot express.
+    #[test]
+    fn conjectured_from_params_is_monotone_in_trace_height() {
+        let params = benchmark_high_arity_params(96);
+        let mut previous = usize::MAX;
+        for degree_bits in 1..=28 {
+            let bits = ConjecturedSecurity::compute_from_params(&params, degree_bits).security_bits;
+            assert!(bits <= previous, "level rose at degree_bits={degree_bits}");
+            previous = bits;
+        }
+    }
+
+    /// Proven security is never above conjectured at the same shape — the
+    /// conjectured regime drops the list-size multiplier the proven one pays.
+    #[test]
+    fn proven_never_exceeds_conjectured_at_the_same_shape() {
+        let params = benchmark_high_arity_params(252);
+        for degree_bits in [8, 16, 20, 24] {
+            let c = ConjecturedSecurity::compute_from_params(&params, degree_bits);
+            let p = ProvenSecurity::compute_from_proof(degree_bits, &params);
+            assert!(
+                p.security_bits() <= c.security_bits,
+                "proven exceeded conjectured at degree_bits={degree_bits}"
+            );
+        }
     }
 }

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -10,6 +10,7 @@ use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
 use p3_field::{ExtensionField, Field};
 use p3_security::fri::{FriRegime, conjectured_error};
+use p3_security::grinding::GrindingSites;
 use p3_security::shape::{InstanceShape, StarkAirParams as P3AirShape};
 use p3_security::stark::proven_security_report;
 use p3_util::log2_floor_usize;
@@ -117,14 +118,29 @@ impl StarkSecurityParams {
         )
     }
 
+    /// Where this configuration grinds, by error source. A uni-STARK grinds
+    /// only inside FRI, so the DEEP and lookup-challenge sites stay at the
+    /// neutral `0`.
+    const fn grinding(&self) -> GrindingSites {
+        GrindingSites {
+            query_phase: self.fri_query_proof_of_work_bits,
+            ldt_commit_phase: self.fri_commit_proof_of_work_bits,
+            out_of_domain: 0,
+            lookup_challenge: 0,
+        }
+    }
+
+    /// The low-degree test owns the query- and commit-phase grinding sites,
+    /// so they are carried here and never re-applied by the composite.
     const fn fri_regime(&self) -> FriRegime {
+        let grinding = self.grinding();
         FriRegime {
             log_blowup: self.fri_log_blowup,
             num_queries: self.fri_num_queries,
             log_final_poly_len: self.fri_log_final_poly_len,
             max_log_arity: self.fri_max_log_arity,
-            commit_pow_bits: self.fri_commit_proof_of_work_bits,
-            query_pow_bits: self.fri_query_proof_of_work_bits,
+            commit_pow_bits: grinding.ldt_commit_phase,
+            query_pow_bits: grinding.query_phase,
         }
     }
 
@@ -269,7 +285,7 @@ impl ProvenSecurity {
         let air = params.air_shape();
         let shape = params.instance_shape(degree_bits);
 
-        let report = proven_security_report(&regime, &air, &shape, &[]);
+        let report = proven_security_report(&regime, &air, &shape, &[], &params.grinding());
 
         Self {
             unique_decoding_bits: report.udr.security_bits() as usize,

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -62,6 +62,14 @@ impl StarkSecurityParams {
     ///
     /// Use [`from_air`](Self::from_air) when an AIR is available — it derives
     /// `num_constraints` and `air_max_constraint_degree` from symbolic evaluation.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// If `air_max_constraint_degree` exceeds `blowup + 1`, the prover cannot
+    /// fit the quotient in the LDE and the resulting parameters describe an
+    /// unbuildable configuration. This does not account for zk: under zk the
+    /// prover's real bound is one tighter (`blowup`, not `blowup + 1`), but
+    /// `StarkSecurityParams` carries no `is_zk` flag to check that here.
     pub const fn new(
         fri: FriRegime,
         num_modulus_bits: usize,
@@ -70,6 +78,10 @@ impl StarkSecurityParams {
         air_max_constraint_degree: usize,
         max_combo: usize,
     ) -> Self {
+        debug_assert!(
+            air_max_constraint_degree <= (1usize << fri.log_blowup) + 1,
+            "AIR max constraint degree exceeds blowup+1; the prover cannot commit a quotient"
+        );
         Self {
             fri_log_blowup: fri.log_blowup,
             fri_log_final_poly_len: fri.log_final_poly_len,
@@ -118,29 +130,26 @@ impl StarkSecurityParams {
         )
     }
 
-    /// Where this configuration grinds, by error source. A uni-STARK grinds
-    /// only inside FRI, so the DEEP and lookup-challenge sites stay at the
-    /// neutral `0`.
+    /// Where this configuration grinds, by error source, excluding the FRI
+    /// query- and commit-phase sites — [`Self::fri_regime`] carries those
+    /// directly, since [`GrindingSites`] does not model the low-degree
+    /// test's own sites. A uni-STARK grinds only inside FRI, so the DEEP and
+    /// lookup-challenge sites stay at the neutral `0`.
     const fn grinding(&self) -> GrindingSites {
-        GrindingSites {
-            query_phase: self.fri_query_proof_of_work_bits,
-            ldt_commit_phase: self.fri_commit_proof_of_work_bits,
-            out_of_domain: 0,
-            lookup_challenge: 0,
-        }
+        GrindingSites::NONE
     }
 
     /// The low-degree test owns the query- and commit-phase grinding sites,
-    /// so they are carried here and never re-applied by the composite.
+    /// so they are read straight from `self` and never re-applied by the
+    /// composite.
     const fn fri_regime(&self) -> FriRegime {
-        let grinding = self.grinding();
         FriRegime {
             log_blowup: self.fri_log_blowup,
             num_queries: self.fri_num_queries,
             log_final_poly_len: self.fri_log_final_poly_len,
             max_log_arity: self.fri_max_log_arity,
-            commit_pow_bits: grinding.ldt_commit_phase,
-            query_pow_bits: grinding.query_phase,
+            commit_pow_bits: self.fri_commit_proof_of_work_bits,
+            query_pow_bits: self.fri_query_proof_of_work_bits,
         }
     }
 
@@ -202,11 +211,16 @@ impl ConjecturedSecurity {
         collision_resistance: usize,
         num_modulus_bits: usize,
     ) -> Self {
+        // `max_log_arity: 1` is the minimum arity `p3-fri` accepts (folding
+        // factor 2). The commit-phase error is non-increasing in arity (see
+        // `commit_phase_error_udr`), so evaluating it at the smallest legal
+        // arity keeps this a true upper bound over every real FRI config,
+        // whatever arity it actually folds at.
         let regime = FriRegime {
             log_blowup,
             num_queries,
             log_final_poly_len: 0,
-            max_log_arity: 0,
+            max_log_arity: 1,
             commit_pow_bits: 0,
             query_pow_bits: query_proof_of_work_bits,
         };
@@ -253,13 +267,6 @@ impl ConjecturedSecurity {
     ///   there raises the reported level only while that term is the binding
     ///   one.
     pub fn compute_from_params(params: &StarkSecurityParams, degree_bits: usize) -> Self {
-        debug_assert!(
-            params.air_max_constraint_degree <= (1usize << params.fri_log_blowup) + 1,
-            "AIR max constraint degree {} exceeds blowup+1 ({}); the prover cannot commit a quotient",
-            params.air_max_constraint_degree,
-            (1usize << params.fri_log_blowup) + 1
-        );
-
         let report = conjectured_security_report(
             &params.fri_regime(),
             &params.air_shape(),
@@ -327,13 +334,6 @@ impl ProvenSecurity {
                 list_decoding_bits: 0,
             };
         }
-        debug_assert!(
-            params.air_max_constraint_degree <= (1usize << params.fri_log_blowup) + 1,
-            "AIR max constraint degree {} exceeds blowup+1 ({}); the prover cannot commit a quotient",
-            params.air_max_constraint_degree,
-            (1usize << params.fri_log_blowup) + 1
-        );
-
         let regime = params.fri_regime();
         let air = params.air_shape();
         let shape = params.instance_shape(degree_bits);
@@ -502,11 +502,11 @@ mod tests {
     /// commit-phase folding round, `collision_resistance`, and
     /// `num_modulus_bits`.
     ///
-    /// This entry point pins `max_log_arity = 0` and a single-row trace, so
-    /// the folding round is evaluated at `n = 2^log_blowup` — it binds only in
-    /// the two rows where the query phase would otherwise clear the collision
-    /// cap (`log_blowup` 2 and 8), which is exactly the overstatement that
-    /// omitting the round produced.
+    /// This entry point pins `max_log_arity = 1` (the minimum arity `p3-fri`
+    /// accepts) and a single-row trace, so the folding round is evaluated at
+    /// `n = 2^log_blowup` — it binds only in the two rows where the query
+    /// phase would otherwise clear the collision cap (`log_blowup` 2 and 8),
+    /// which is exactly the overstatement that omitting the round produced.
     #[test]
     fn conjectured_security_ldt_only_regression_vector() {
         const VECTOR: [(usize, usize, usize, usize, usize, usize); 8] = [

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -4,15 +4,15 @@
 //! and crypto parameters into [`StarkSecurityParams`], builds the
 //! corresponding regime / instance shape, and delegates the math.
 
-use core::cmp::{max, min};
+use core::cmp::max;
 
 use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder};
 use p3_field::{ExtensionField, Field};
-use p3_security::fri::{FriRegime, conjectured_error};
+use p3_security::fri::FriRegime;
 use p3_security::grinding::GrindingSites;
 use p3_security::shape::{InstanceShape, StarkAirParams as P3AirShape};
-use p3_security::stark::proven_security_report;
+use p3_security::stark::{conjectured_security_report, proven_security_report};
 use p3_util::log2_floor_usize;
 
 /// Parameters required to compute STARK proof security level.
@@ -180,6 +180,13 @@ pub struct ConjecturedSecurity {
 impl ConjecturedSecurity {
     /// Conjectured security from FRI parameters using the random-words formula
     /// ([2025/2010] §1.5). Requires `num_modulus_bits` (log2 of field size) for the η cutoff.
+    ///
+    /// This entry point takes no AIR shape and no trace length, so the
+    /// AIR-composition and DEEP-ALI terms are evaluated on the smallest
+    /// instance that carries them — one degree-1 constraint over a
+    /// single-row trace — where both reduce to the field-size cap. A uni-STARK
+    /// has no lookups, so no `extras` apply either, leaving the low-degree
+    /// test and the commitment-collision cap as the only binding terms.
     pub fn compute(
         log_blowup: usize,
         num_queries: usize,
@@ -195,16 +202,20 @@ impl ConjecturedSecurity {
             commit_pow_bits: 0,
             query_pow_bits: query_proof_of_work_bits,
         };
+        let air = P3AirShape {
+            num_constraints: 1,
+            max_constraint_degree: 1,
+            max_combo: 1,
+        };
         let shape = InstanceShape {
             log_trace_length: 0,
             modulus_bits: num_modulus_bits,
             collision_resistance,
             num_batched_functions: 1,
         };
-        let fri_bits = conjectured_error(&regime, &shape).bits() as usize;
-        let bits = min(min(fri_bits, collision_resistance), num_modulus_bits);
+        let report = conjectured_security_report(&regime, &air, &shape, &[], &GrindingSites::NONE);
         Self {
-            security_bits: bits,
+            security_bits: report.security_bits() as usize,
         }
     }
 
@@ -433,5 +444,52 @@ mod tests {
         let p = ProvenSecurity::compute(&params, 1 << 20);
         assert_eq!(p.unique_decoding_bits, 57);
         assert_eq!(p.list_decoding_bits, 65);
+    }
+
+    /// Regression vector pinning `ConjecturedSecurity` across the parameter
+    /// space it is routed through. Entries are
+    /// `(log_blowup, num_queries, query_pow, collision_resistance,
+    /// num_modulus_bits, expected_bits)`.
+    ///
+    /// A uni-STARK has no lookups and batches nothing in the conjectured
+    /// path, so the composite must reduce exactly to
+    /// `min(fri_conjectured, collision_resistance, num_modulus_bits)`.
+    #[test]
+    fn conjectured_security_regression_vector() {
+        const VECTOR: [(usize, usize, usize, usize, usize, usize); 8] = [
+            (1, 100, 16, 128, 252, 114),
+            (1, 100, 0, 128, 128, 97),
+            (2, 64, 20, 128, 128, 128),
+            (4, 20, 8, 256, 128, 86),
+            (8, 32, 0, 128, 128, 128),
+            (0, 100, 16, 128, 256, 16),
+            (1, 84, 16, 100, 128, 97),
+            (3, 27, 21, 128, 128, 100),
+        ];
+
+        for (log_blowup, num_queries, query_pow, collision, modulus, expected) in VECTOR {
+            let s = ConjecturedSecurity::compute(
+                log_blowup,
+                num_queries,
+                query_pow,
+                collision,
+                modulus,
+            );
+            assert_eq!(
+                s.security_bits, expected,
+                "conjectured security drifted at \
+                 (log_blowup={log_blowup}, num_queries={num_queries}, query_pow={query_pow}, \
+                 collision={collision}, modulus={modulus})"
+            );
+        }
+    }
+
+    /// More query grinding can only raise the conjectured bound, up to the
+    /// collision-resistance cap.
+    #[test]
+    fn conjectured_more_query_grinding_is_not_less_security() {
+        let s0 = ConjecturedSecurity::compute(1, 64, 0, 256, 256);
+        let s16 = ConjecturedSecurity::compute(1, 64, 16, 256, 256);
+        assert!(s16.security_bits >= s0.security_bits);
     }
 }


### PR DESCRIPTION
Conjectured security was computed from the FRI query phase alone. Two other things also limit it, and neither was counted:

  - **The FRI folding rounds.** Only the query phase was charged. The commit phase existed but was reachable from the proven path only.
  - **The instance itself.** `compute_from_params` ignored the trace length and the AIR, so it graded every proof as if it were a single row with one constraint. The proven path already read both.

  Both omissions push the reported number up, so the fix pushes it down.

  ### Numbers that change

  | case | was | now |
  |---|---|---|
  | `compute_ldt_only`, blowup 2 | 128 | 125 |
  | `compute_ldt_only`, blowup 8 | 128 | 119 |
  | `compute_from_params`, 96-bit field, degree bits 10→28 | 84…66 | 82…64 |

  The two `compute_ldt_only` rows were sitting at the 128-bit collision cap; the folding round now binds below it. In the shape-aware vector the binding term moves from DEEP-ALI to folding.