### PR TITLE
perf(stir): share grinds across STIR PCS height buckets

### DIFF
--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -166,10 +166,10 @@ fn run_univariate_pcs<P>(
     message: RowMajorMatrix<F>,
     base_challenger: &Challenger,
     queries: String,
+    observe: impl Fn(&mut Challenger, &P::Commitment),
 ) -> ProtocolReport
 where
     P: Pcs<EF, Challenger, Domain = TwoAdicMultiplicativeCoset<F>>,
-    Challenger: CanObserve<P::Commitment>,
 {
     let mut prover_challenger = base_challenger.clone();
 
@@ -177,7 +177,7 @@ where
     let (commit, prover_data) = pcs.commit([(domain, message)]);
     let commit_ms = t.elapsed().as_millis();
 
-    prover_challenger.observe(commit.clone());
+    observe(&mut prover_challenger, &commit);
     // UFCS spelling pins the challenger's field generic so trait selection is unambiguous
     // in the presence of the generic `P::Commitment` bound above.
     let zeta: EF =
@@ -192,7 +192,7 @@ where
     let values = openings[0][0][0].clone();
 
     let mut verifier_challenger = base_challenger.clone();
-    verifier_challenger.observe(commit.clone());
+    observe(&mut verifier_challenger, &commit);
     let derived: EF =
         <Challenger as FieldChallenger<F>>::sample_algebra_element(&mut verifier_challenger);
     assert_eq!(derived, zeta, "verifier challenger drifted from prover");
@@ -381,6 +381,7 @@ fn main() {
             message,
             &base_challenger,
             num_queries.to_string(),
+            |ch, commit| ch.observe(commit.clone()),
         ));
     }
 
@@ -417,6 +418,8 @@ fn main() {
             message,
             &base_challenger,
             queries,
+            // STIR commits one Merkle tree per distinct LDE height.
+            |ch, commit| commit.iter().for_each(|c| ch.observe(c.clone())),
         ));
     }
 

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -46,5 +46,9 @@ rand = { workspace = true, features = ["std"] }
 name = "stir"
 harness = false
 
+[[bench]]
+name = "stir_pcs"
+harness = false
+
 [lints]
 workspace = true

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -1,0 +1,192 @@
+//! Benchmarks for [`TwoAdicStirPcs`] across LDE-height buckets.
+//!
+//! Matrices sharing an LDE height form one bucket. `max_pow_bits` is set high so grind-sharing
+//! dominates `open()`.
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_challenger::{CanObserve, DuplexChallenger, FieldChallenger};
+use p3_commit::{ExtensionMmcs, Pcs};
+use p3_dft::Radix2DitParallel;
+use p3_field::Field;
+use p3_field::extension::QuinticTrinomialExtensionField;
+use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_stir::{SecurityAssumption, StirParameters, TwoAdicStirPcs};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+type Val = KoalaBear;
+type Challenge = QuinticTrinomialExtensionField<Val>;
+type Perm = Poseidon2KoalaBear<16>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type ValMmcs =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type Dft = Radix2DitParallel<Val>;
+type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+
+/// Columns per committed matrix.
+const WIDTH: usize = 4;
+
+/// Bucket layouts under test: log-degrees of the matrices in one commitment.
+const LAYOUTS: &[(&str, &[usize])] = &[
+    ("1bucket", &[18]),
+    ("2buckets_ratio2", &[18, 17]),
+    ("2buckets_ratio4", &[18, 16]),
+    ("3buckets_ratio4", &[18, 17, 16]),
+];
+
+fn seeded_rng() -> SmallRng {
+    SmallRng::seed_from_u64(0xdeadbeef)
+}
+
+fn make_pcs() -> (MyPcs, Challenger) {
+    let perm = Perm::new_from_rng_128(&mut seeded_rng());
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+
+    let stir_params = StirParameters {
+        log_blowup: 1,
+        log_folding_factor: 2,
+        soundness_type: SecurityAssumption::CapacityBound,
+        security_level: 100,
+        max_pow_bits: 20,
+        mmcs: challenge_mmcs,
+    };
+
+    (
+        MyPcs::new(Dft::default(), val_mmcs, stir_params),
+        Challenger::new(perm),
+    )
+}
+
+type DomainsAndPolys = Vec<(
+    <MyPcs as Pcs<Challenge, Challenger>>::Domain,
+    RowMajorMatrix<Val>,
+)>;
+
+fn make_inputs(pcs: &MyPcs, log_degrees: &[usize]) -> DomainsAndPolys {
+    let mut rng = seeded_rng();
+    log_degrees
+        .iter()
+        .map(|&log_d| {
+            let d = 1 << log_d;
+            (
+                <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(pcs, d),
+                RowMajorMatrix::<Val>::rand(&mut rng, d, WIDTH),
+            )
+        })
+        .collect()
+}
+
+fn bench_commit(c: &mut Criterion) {
+    let (pcs, _) = make_pcs();
+    let mut group = c.benchmark_group("stir_pcs/commit");
+    group.sample_size(10);
+    for &(name, log_degrees) in LAYOUTS {
+        let inputs = make_inputs(&pcs, log_degrees);
+        group.bench_with_input(BenchmarkId::from_parameter(name), &inputs, |b, inputs| {
+            b.iter_batched(
+                || inputs.clone(),
+                |inputs| <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_open(c: &mut Criterion) {
+    let (pcs, challenger) = make_pcs();
+    let mut group = c.benchmark_group("stir_pcs/open");
+    group.sample_size(10);
+    for &(name, log_degrees) in LAYOUTS {
+        let inputs = make_inputs(&pcs, log_degrees);
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
+        let mut base = challenger.clone();
+        commit.iter().for_each(|c| base.observe(c.clone()));
+        let zeta: Challenge = base.sample_algebra_element();
+        let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
+
+        let mut nonce_rng = seeded_rng();
+        group.bench_with_input(BenchmarkId::from_parameter(name), &points, |b, points| {
+            b.iter_batched(
+                || {
+                    let mut challenger = base.clone();
+                    let nonce: Val = nonce_rng.random();
+                    challenger.observe(nonce);
+                    (challenger, points.clone())
+                },
+                |(mut challenger, points)| {
+                    <MyPcs as Pcs<Challenge, Challenger>>::open(
+                        &pcs,
+                        vec![(&data, points)],
+                        &mut challenger,
+                    )
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let (pcs, challenger) = make_pcs();
+    let mut group = c.benchmark_group("stir_pcs/verify");
+    group.sample_size(10);
+    for &(name, log_degrees) in LAYOUTS {
+        let inputs = make_inputs(&pcs, log_degrees);
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
+        let mut p_challenger = challenger.clone();
+        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
+        let zeta: Challenge = p_challenger.sample_algebra_element();
+        let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
+        let (opened, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![(&data, points)],
+            &mut p_challenger,
+        );
+
+        let claims: Vec<_> = inputs
+            .iter()
+            .zip(opened.first().unwrap().iter())
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect();
+        let proof_bytes = postcard::to_allocvec(&proof).unwrap().len();
+        eprintln!("stir_pcs/proof_size/{name}: {proof_bytes} bytes");
+
+        // Same transcript state `open` reached: commitment observed, opening point drawn.
+        let mut v_base = challenger.clone();
+        commit.iter().for_each(|c| v_base.observe(c.clone()));
+        let _: Challenge = v_base.sample_algebra_element();
+
+        group.bench_with_input(BenchmarkId::from_parameter(name), &claims, |b, claims| {
+            b.iter_batched(
+                || v_base.clone(),
+                |mut challenger| {
+                    <MyPcs as Pcs<Challenge, Challenger>>::verify(
+                        &pcs,
+                        vec![(commit.clone(), claims.clone())],
+                        &proof,
+                        &mut challenger,
+                    )
+                    .expect("verification failed in benchmark");
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_commit, bench_open, bench_verify);
+criterion_main!(benches);

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -45,8 +45,8 @@ use tracing::instrument;
 
 use crate::config::{StirConfig, StirParameters};
 use crate::proof::StirProof;
-use crate::prover::prove_stir_from_external_codeword;
-use crate::verifier::{StirError, verify_stir_with_external_initial};
+use crate::prover::prove_stir_multi_from_external_codewords;
+use crate::verifier::{StirError, verify_stir_multi_with_external_initial};
 
 /// Batched openings of one input commitment's LDE matrices at the STIR-derived query
 /// positions for one LDE-height bucket.
@@ -482,63 +482,86 @@ where
             }
         }
 
-        // Step 3: For each non-empty height bucket (descending), run STIR on the bucket's
-        // reduced opening and bind the input MMCS. Each distinct LDE height gets its own
-        // STIR sub-proof. BTreeMap iterates in ascending key order, so reverse for descending.
-        let mut bucket_proofs = Vec::new();
-
+        // Step 3: run STIR on every non-empty height bucket's reduced opening in lockstep,
+        // sharing every grind across buckets, then bind the input MMCS at each bucket's
+        // query positions. Each distinct LDE height gets its own STIR sub-proof. BTreeMap
+        // iterates in ascending key order, so reverse for descending.
         let bucket_log_heights: Vec<usize> = reduced_openings.keys().rev().copied().collect();
-        for log_h in bucket_log_heights {
-            let ro = reduced_openings
-                .remove(&log_h)
-                .expect("present by construction");
-            let bucket_height = 1usize << log_h;
 
-            let mut ro_natural = ro;
-            reverse_slice_index_bits(&mut ro_natural);
+        let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+            bucket_log_heights
+                .iter()
+                .map(|&log_h| {
+                    let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
+                    StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
+                        log_stir_degree,
+                        self.stir.clone(),
+                    )
+                })
+                .collect();
+        let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+            stir_configs.iter().collect();
 
-            let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-            let stir_config = StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                log_stir_degree,
-                self.stir.clone(),
-            );
+        let initial_codewords: Vec<Vec<Challenge>> = bucket_log_heights
+            .iter()
+            .map(|&log_h| {
+                let mut ro_natural = reduced_openings
+                    .remove(&log_h)
+                    .expect("present by construction");
+                reverse_slice_index_bits(&mut ro_natural);
+                ro_natural
+            })
+            .collect();
 
-            let (stir_proof, first_round_query_indices) =
-                prove_stir_from_external_codeword(&stir_config, ro_natural, &self.dft, challenger);
+        let bucket_results = prove_stir_multi_from_external_codewords(
+            &stir_config_refs,
+            initial_codewords,
+            &self.dft,
+            challenger,
+        );
 
-            // Input binding for this bucket. Folding factor is constant across rounds.
-            let log_arity0 = stir_config.log_folding_factor;
+        let bucket_proofs = bucket_log_heights
+            .iter()
+            .zip(&stir_configs)
+            .zip(bucket_results)
+            .map(
+                |((&log_h, stir_config), (stir_proof, first_round_query_indices))| {
+                    let bucket_height = 1usize << log_h;
+                    // Folding factor is constant across rounds.
+                    let log_arity0 = stir_config.log_folding_factor;
 
-            let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
-                commitment_data_with_opening_points
-                    .iter()
-                    .map(|(data, _)| {
-                        // Only this bucket's height class is opened; the other classes live in
-                        // their own trees and never appear in this bucket's proof.
-                        let class = data
-                            .classes
+                    let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
+                        commitment_data_with_opening_points
                             .iter()
-                            .find(|class| class.lde_height == bucket_height)?;
+                            .map(|(data, _)| {
+                                // Only this bucket's height class is opened; the other classes live
+                                // in their own trees and never appear in this bucket's proof.
+                                let class = data
+                                    .classes
+                                    .iter()
+                                    .find(|class| class.lde_height == bucket_height)?;
 
-                        // Every matrix in the class shares the bucket's height, so the grouped
-                        // row index is the query index itself: one index per query, and the
-                        // whole fiber lives in that single row.
-                        let q_globals: Vec<usize> = first_round_query_indices
-                            .iter()
-                            .map(|&j| reverse_bits_len(j, log_h - log_arity0))
+                                // Every matrix in the class shares the bucket's height, so the
+                                // grouped row index is the query index itself: one index per query,
+                                // and the whole fiber lives in that single row.
+                                let q_globals: Vec<usize> = first_round_query_indices
+                                    .iter()
+                                    .map(|&j| reverse_bits_len(j, log_h - log_arity0))
+                                    .collect();
+
+                                let (opened_values, opening_proof) =
+                                    self.input_mmcs.open_multi_batch(&q_globals, &class.data);
+                                Some(InputOpenings {
+                                    opened_values,
+                                    opening_proof,
+                                })
+                            })
                             .collect();
 
-                        let (opened_values, opening_proof) =
-                            self.input_mmcs.open_multi_batch(&q_globals, &class.data);
-                        Some(InputOpenings {
-                            opened_values,
-                            opening_proof,
-                        })
-                    })
-                    .collect();
-
-            bucket_proofs.push((stir_proof, input_openings));
-        }
+                    (stir_proof, input_openings)
+                },
+            )
+            .collect();
 
         (all_opened_values, bucket_proofs)
     }
@@ -634,48 +657,64 @@ where
             })
             .collect();
 
-        // Verify each height bucket's STIR sub-proof and input binding.
-        for (bucket_idx, &log_h) in bucket_log_heights.iter().enumerate() {
-            let bucket_height = 1usize << log_h;
-            let (stir_proof, input_openings) = &proof[bucket_idx];
-
-            // SHAPE CHECK: input_openings has one slot per public commitment. Without this,
-            // a malicious proof could omit trailing commitments — a `zip` would silently
-            // drop them, their claimed values would still be observed into the transcript
-            // (above), but they'd never be MMCS-opened or included in the reduced-opening
-            // accumulation, so the proof would verify against a subset of the public input.
+        // SHAPE CHECK: every bucket's input_openings has one slot per public commitment.
+        // Without this, a malicious proof could omit trailing commitments — a `zip` would
+        // silently drop them, their claimed values would still be observed into the
+        // transcript (above), but they'd never be MMCS-opened or included in the
+        // reduced-opening accumulation, so the proof would verify against a subset of the
+        // public input.
+        for (_, input_openings) in proof {
             if input_openings.len() != commitments_with_opening_points.len() {
                 return Err(StirError::InvalidProofShape);
             }
+        }
 
-            let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-            let stir_config = StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                log_stir_degree,
-                self.stir.clone(),
-            );
+        let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+            bucket_log_heights
+                .iter()
+                .map(|&log_h| {
+                    let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
+                    StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
+                        log_stir_degree,
+                        self.stir.clone(),
+                    )
+                })
+                .collect();
+        let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+            stir_configs.iter().collect();
+        let stir_proofs: Vec<&StirProof<Challenge, StirMmcs, Val>> =
+            proof.iter().map(|(p, _)| p).collect();
 
-            // The folding factor is constant across rounds, so the same arity applies whether
-            // STIR ran with intermediate rounds or only a final round.
-            let log_arity0 = stir_config.log_folding_factor;
-            let arity0 = 1usize << log_arity0;
+        // Captured by every bucket's closure below; taking references up front lets `move`
+        // give each closure its own copy of the reference rather than the whole value.
+        let commitments_with_opening_points = &commitments_with_opening_points;
+        let point_data = &point_data;
+        let alpha_powers = &alpha_powers;
 
-            // A queried input row sits at LDE position `p = j + l * fold_height0`, whose coset
-            // point is `GENERATOR * g^p` for `g = two_adic_generator(log_h)`. Walking a fiber's
-            // `arity0` lanes is therefore one exponentiation per query followed by repeated
-            // multiplication by the fixed step `g^fold_height0`, an `arity0`-th root of unity.
-            let domain_gen = Val::two_adic_generator(log_h);
-            let fiber_step = domain_gen.exp_power_of_2(log_h - log_arity0);
+        // STIR's initial oracle is the reduced opening, which is a deterministic function of
+        // the input commitments, the claimed values, and `alpha` — all already in the
+        // transcript. Rather than have the prover commit and open it a second time, rebuild
+        // its queried fibers from the input MMCS openings on demand.
+        let initial_fibers: Vec<_> = bucket_log_heights
+            .iter()
+            .zip(&stir_configs)
+            .zip(proof.iter().map(|(_, input_openings)| input_openings))
+            .map(|((&log_h, stir_config), input_openings)| {
+                let bucket_height = 1usize << log_h;
+                // The folding factor is constant across rounds, so the same arity applies
+                // whether STIR ran with intermediate rounds or only a final round.
+                let log_arity0 = stir_config.log_folding_factor;
+                let arity0 = 1usize << log_arity0;
 
-            // STIR's initial oracle is the reduced opening, which is a deterministic function
-            // of the input commitments, the claimed values, and `alpha` — all already in the
-            // transcript. Rather than have the prover commit and open it a second time, rebuild
-            // its queried fibers from the input MMCS openings on demand.
-            //
-            // The accumulation runs across ALL commitments: when several contribute matrices to
-            // the same height bucket, `ro[p]` is their sum, so a per-commitment reconstruction
-            // would be wrong.
-            let reconstruct_initial_fibers =
-                |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
+                // A queried input row sits at LDE position `p = j + l * fold_height0`, whose
+                // coset point is `GENERATOR * g^p` for `g = two_adic_generator(log_h)`.
+                // Walking a fiber's `arity0` lanes is therefore one exponentiation per query
+                // followed by repeated multiplication by the fixed step `g^fold_height0`, an
+                // `arity0`-th root of unity.
+                let domain_gen = Val::two_adic_generator(log_h);
+                let fiber_step = domain_gen.exp_power_of_2(log_h - log_arity0);
+
+                move |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
                     let n_q = first_round_unique_js.len();
                     let mut expected_ro = vec![Challenge::zero_vec(arity0); n_q];
 
@@ -712,6 +751,9 @@ where
                     }
                     let inv_denoms = batch_multiplicative_inverse(&denom_diffs);
 
+                    // The accumulation runs across ALL commitments: when several contribute
+                    // matrices to the same height bucket, `ro[p]` is their sum, so a
+                    // per-commitment reconstruction would be wrong.
                     for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                         commitments_with_opening_points
                             .iter()
@@ -843,17 +885,18 @@ where
                     }
 
                     Ok(expected_ro)
-                };
+                }
+            })
+            .collect();
 
-            // Any transcript-touching step stays inside `verify_stir_with_external_initial`;
-            // the closure above only reads public data and the input openings.
-            verify_stir_with_external_initial(
-                &stir_config,
-                stir_proof,
-                challenger,
-                reconstruct_initial_fibers,
-            )?;
-        }
+        // Any transcript-touching step stays inside `verify_stir_multi_with_external_initial`;
+        // every closure above only reads public data and its own bucket's input openings.
+        verify_stir_multi_with_external_initial(
+            &stir_config_refs,
+            &stir_proofs,
+            challenger,
+            initial_fibers,
+        )?;
 
         Ok(())
     }

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -70,15 +70,74 @@ pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     pub opening_proof: InputMmcs::MultiProof,
 }
 
+/// One LDE-height class of a commitment: its own Merkle tree over the matrices at that height.
+struct HeightClass<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
+    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    /// Column count of each matrix in this class before fiber grouping.
+    widths: Vec<usize>,
+    lde_height: usize,
+}
+
 /// Prover data for [`TwoAdicStirPcs`].
 ///
-/// The LDE matrices are committed in fiber-grouped form: each Merkle leaf holds
-/// `2^log_folding_factor` consecutive bit-reversed LDE rows, i.e. exactly the rows one
-/// first-round STIR query reads. `widths` records each matrix's column count before grouping
-/// so the original shape can be recovered for opening and quotient computation.
+/// Matrices are committed in fiber-grouped form — each Merkle leaf holds
+/// `2^log_folding_factor` consecutive bit-reversed LDE rows, exactly the rows one first-round
+/// STIR query reads — and grouped into one tree per distinct LDE height, in descending height
+/// order. STIR runs an independent sub-proof per height bucket, so a single shared tree would
+/// force every bucket's openings to carry the rows of every *other* height as well, purely to
+/// recompute the authentication path. `placement` maps each matrix, in the order the caller
+/// committed them, to its `(class, index within class)`.
 pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
-    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    classes: Vec<HeightClass<Val, InputMmcs>>,
+    placement: Vec<(usize, usize)>,
+}
+
+/// Split fiber-grouped LDEs into one height class per distinct LDE height, descending.
+///
+/// `heights` and `widths` are the pre-grouping LDE heights and column counts, in caller order.
+fn commit_by_height_class<Val, InputMmcs>(
+    input_mmcs: &InputMmcs,
+    grouped: Vec<RowMajorMatrix<Val>>,
+    heights: Vec<usize>,
     widths: Vec<usize>,
+) -> (Vec<InputMmcs::Commitment>, StirProverData<Val, InputMmcs>)
+where
+    Val: Send + Sync + Clone,
+    InputMmcs: Mmcs<Val>,
+{
+    let mut class_heights = heights.clone();
+    class_heights.sort_unstable();
+    class_heights.dedup();
+    class_heights.reverse();
+
+    let mut class_mats = vec![Vec::new(); class_heights.len()];
+    let mut class_widths = vec![Vec::new(); class_heights.len()];
+    let mut placement = Vec::with_capacity(grouped.len());
+    for ((mat, height), width) in grouped.into_iter().zip(heights).zip(widths) {
+        let class = class_heights
+            .iter()
+            .position(|&h| h == height)
+            .expect("every height is one of the distinct heights");
+        placement.push((class, class_mats[class].len()));
+        class_mats[class].push(mat);
+        class_widths[class].push(width);
+    }
+
+    let (commitments, classes) = izip!(class_mats, class_widths, class_heights)
+        .map(|(mats, widths, lde_height)| {
+            let (commitment, data) = input_mmcs.commit(mats);
+            (
+                commitment,
+                HeightClass {
+                    data,
+                    widths,
+                    lde_height,
+                },
+            )
+        })
+        .unzip();
+
+    (commitments, StirProverData { classes, placement })
 }
 
 /// Reinterpret a bit-reversed LDE as a matrix whose rows are whole STIR fibers.
@@ -97,16 +156,25 @@ fn group_fiber_rows<Val: Clone + Send + Sync>(
     RowMajorMatrix::new(lde.values, width)
 }
 
-/// Recover views of the committed matrices in their pre-grouping shape.
+/// Recover views of the committed matrices in their pre-grouping shape and caller order.
 fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
     input_mmcs: &InputMmcs,
     prover_data: &'a StirProverData<Val, InputMmcs>,
 ) -> Vec<RowMajorMatrixView<'a, Val>> {
-    input_mmcs
-        .get_matrices(&prover_data.data)
-        .into_iter()
-        .zip(prover_data.widths.iter())
-        .map(|(mat, &width)| RowMajorMatrixView::new(mat.values.as_slice(), width))
+    let per_class: Vec<_> = prover_data
+        .classes
+        .iter()
+        .map(|class| input_mmcs.get_matrices(&class.data))
+        .collect();
+    prover_data
+        .placement
+        .iter()
+        .map(|&(class, index)| {
+            RowMajorMatrixView::new(
+                per_class[class][index].values.as_slice(),
+                prover_data.classes[class].widths[index],
+            )
+        })
         .collect()
 }
 
@@ -146,7 +214,8 @@ where
         + Clone,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
-    type Commitment = InputMmcs::Commitment;
+    /// One Merkle root per distinct LDE height, in descending height order.
+    type Commitment = Vec<InputMmcs::Commitment>;
     type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
     /// Proof structure: one entry per distinct LDE-height bucket (descending).
@@ -183,6 +252,7 @@ where
     ) -> (Self::Commitment, Self::ProverData) {
         let min_height = 1usize << self.stir.log_folding_factor;
         let mut widths = Vec::new();
+        let mut heights = Vec::new();
         let ldes: Vec<_> = evaluations
             .into_iter()
             .map(|(domain, evals)| {
@@ -204,11 +274,11 @@ where
                     .bit_reverse_rows()
                     .to_row_major_matrix();
                 widths.push(lde.width());
+                heights.push(lde.height());
                 group_fiber_rows(lde, self.stir.log_folding_factor)
             })
             .collect();
-        let (commitment, data) = self.input_mmcs.commit(ldes);
-        (commitment, StirProverData { data, widths })
+        commit_by_height_class(&self.input_mmcs, ldes, heights, widths)
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -217,7 +287,10 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let lde = lde_views(&self.input_mmcs, prover_data).swap_remove(idx);
+        let (class, index) = prover_data.placement[idx];
+        let class_data = &prover_data.classes[class];
+        let grouped = self.input_mmcs.get_matrices(&class_data.data)[index];
+        let lde = RowMajorMatrixView::new(grouped.values.as_slice(), class_data.widths[index]);
         if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
             let width = lde.width();
             let values: &'a [Val] = lde.values;
@@ -268,6 +341,7 @@ where
     fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
         let min_lde_height = 1usize << (self.stir.log_folding_factor + self.stir.log_blowup);
         let mut widths = Vec::with_capacity(ldes.len());
+        let mut heights = Vec::with_capacity(ldes.len());
         let grouped: Vec<_> = ldes
             .into_iter()
             .map(|lde| {
@@ -282,11 +356,11 @@ where
                     self.stir.log_blowup,
                 );
                 widths.push(lde.width());
+                heights.push(lde.height());
                 group_fiber_rows(lde, self.stir.log_folding_factor)
             })
             .collect();
-        let (commitment, data) = self.input_mmcs.commit(grouped);
-        (commitment, StirProverData { data, widths })
+        commit_by_height_class(&self.input_mmcs, grouped, heights, widths)
     }
 
     #[instrument(name = "STIR PCS open", skip_all)]
@@ -439,29 +513,23 @@ where
                 commitment_data_with_opening_points
                     .iter()
                     .map(|(data, _)| {
-                        // Committed matrices are fiber-grouped, so their heights are the LDE
-                        // heights divided by the fold arity.
-                        let mats = self.input_mmcs.get_matrices(&data.data);
-                        if !mats
+                        // Only this bucket's height class is opened; the other classes live in
+                        // their own trees and never appear in this bucket's proof.
+                        let class = data
+                            .classes
                             .iter()
-                            .any(|m| m.height() << log_arity0 == bucket_height)
-                        {
-                            return None;
-                        }
-                        let commit_max_height =
-                            mats.iter().map(|m| m.height()).max().unwrap() << log_arity0;
-                        let log_commit_max = log2_strict_usize(commit_max_height);
+                            .find(|class| class.lde_height == bucket_height)?;
 
-                        // One index per query: the whole fiber lives in a single grouped row.
+                        // Every matrix in the class shares the bucket's height, so the grouped
+                        // row index is the query index itself: one index per query, and the
+                        // whole fiber lives in that single row.
                         let q_globals: Vec<usize> = first_round_query_indices
                             .iter()
-                            .map(|&j| {
-                                reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h)
-                            })
+                            .map(|&j| reverse_bits_len(j, log_h - log_arity0))
                             .collect();
 
                         let (opened_values, opening_proof) =
-                            self.input_mmcs.open_multi_batch(&q_globals, &data.data);
+                            self.input_mmcs.open_multi_batch(&q_globals, &class.data);
                         Some(InputOpenings {
                             opened_values,
                             opening_proof,
@@ -670,9 +738,6 @@ where
                             return Err(StirError::InvalidProofShape);
                         }
 
-                        let commit_max_height = mat_lde_heights.iter().copied().max().unwrap();
-                        let log_commit_max = log2_strict_usize(commit_max_height);
-
                         let mat_widths: Vec<usize> = domain_claims
                             .iter()
                             .map(|(_, point_claims)| {
@@ -680,24 +745,44 @@ where
                             })
                             .collect();
 
-                        // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per committed
-                        // row.
-                        let dimensions: Vec<p3_matrix::Dimensions> = mat_lde_heights
+                        // The commitment is one root per distinct LDE height, descending; this
+                        // bucket reads only its own class, so only that class's matrices appear
+                        // in the opening.
+                        let mut class_heights = mat_lde_heights.clone();
+                        class_heights.sort_unstable();
+                        class_heights.dedup();
+                        class_heights.reverse();
+
+                        // SHAPE CHECK: the class count is determined entirely by public input.
+                        if commitment.len() != class_heights.len() {
+                            return Err(StirError::InvalidProofShape);
+                        }
+                        let class_idx = class_heights
                             .iter()
-                            .zip(mat_widths.iter())
-                            .map(|(&h, &w)| p3_matrix::Dimensions {
-                                height: h >> log_arity0,
-                                width: w << log_arity0,
+                            .position(|&h| h == bucket_height)
+                            .expect("`has_at_bucket` established this class exists");
+                        let class_members: Vec<usize> = mat_lde_heights
+                            .iter()
+                            .enumerate()
+                            .filter(|&(_, &h)| h == bucket_height)
+                            .map(|(mat_idx, _)| mat_idx)
+                            .collect();
+
+                        // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per
+                        // committed row.
+                        let dimensions: Vec<p3_matrix::Dimensions> = class_members
+                            .iter()
+                            .map(|&mat_idx| p3_matrix::Dimensions {
+                                height: bucket_height >> log_arity0,
+                                width: mat_widths[mat_idx] << log_arity0,
                             })
                             .collect();
 
-                        // One grouped row per query, in the same order the prover used to build
-                        // `opening.opened_values`.
+                        // Every matrix in the class shares the bucket's height, so the grouped
+                        // row index is the query index itself.
                         let q_globals: Vec<usize> = first_round_unique_js
                             .iter()
-                            .map(|&j| {
-                                reverse_bits_len(j, log_h - log_arity0) << (log_commit_max - log_h)
-                            })
+                            .map(|&j| reverse_bits_len(j, log_h - log_arity0))
                             .collect();
 
                         // SHAPE CHECK: opened-row count is determined entirely by public input.
@@ -707,7 +792,7 @@ where
 
                         self.input_mmcs
                             .verify_multi_batch(
-                                commitment,
+                                &commitment[class_idx],
                                 &dimensions,
                                 &q_globals,
                                 &opening.opened_values,
@@ -724,17 +809,14 @@ where
                                 // of the grouped row.
                                 let slot = reverse_bits_len(l, log_arity0);
 
-                                for (mat_idx, (_, point_claims)) in domain_claims.iter().enumerate()
-                                {
-                                    if mat_lde_heights[mat_idx] != bucket_height {
-                                        continue;
-                                    }
+                                for (local_idx, &mat_idx) in class_members.iter().enumerate() {
+                                    let (_, point_claims) = &domain_claims[mat_idx];
 
                                     // `verify_multi_batch` already pinned each grouped row to
-                                    // `dimensions[mat_idx].width`, so this slice is in bounds.
+                                    // `dimensions[local_idx].width`, so this slice is in bounds.
                                     let width = mat_widths[mat_idx];
                                     let row_vals =
-                                        &row_vals_by_mat[mat_idx][slot * width..][..width];
+                                        &row_vals_by_mat[local_idx][slot * width..][..width];
                                     let p_x: Challenge = row_vals
                                         .iter()
                                         .zip(alpha_powers.iter())

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -11,11 +11,12 @@
 //! committed inputs.
 //!
 //! **Verify**: replay the same alpha-batching from the opening values, then for each height
-//! bucket call [`verify_stir_with_external_initial`]. STIR's initial oracle *is* the reduced
-//! opening, which the transcript already pins through the input commitments, the claimed
-//! values, and `alpha`, so it is never committed a second time: whenever STIR needs its
-//! queried fibers, the verifier rebuilds them from the input MMCS openings at exactly the
-//! positions STIR sampled. No hand-mirrored transcript replay is needed.
+//! bucket call [`verify_stir_with_external_initial`](crate::verifier::verify_stir_with_external_initial).
+//! STIR's initial oracle *is* the reduced opening, which the transcript already pins through
+//! the input commitments, the claimed values, and `alpha`, so it is never committed a second
+//! time: whenever STIR needs its queried fibers, the verifier rebuilds them from the input
+//! MMCS openings at exactly the positions STIR sampled. No hand-mirrored transcript replay is
+//! needed.
 
 use alloc::borrow::Cow;
 use alloc::collections::BTreeSet;

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -575,6 +575,113 @@ struct FinalRoundOutput<EF: Field, M: Mmcs<EF>, Witness> {
     seen_query_indices: Vec<usize>,
 }
 
+/// One instance's in-flight final round, advanced in the order the transcript demands.
+///
+/// The phases, in order: \[grind\] `fold_and_derive` -> absorb final polynomial -> \[grind\] ->
+/// squeeze query indices -> `record_queries` -> `finish`.
+struct FinalRoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+    config: &'a StirConfig<F, EF, M, Challenger>,
+    dft: &'a Dft,
+
+    current_shift: F,
+    current_log_domain: usize,
+    final_new_log_domain: usize,
+    final_new_shift: F,
+
+    final_codeword: Vec<EF>,
+    final_poly: Vec<EF>,
+
+    query_indices: Vec<usize>,
+    seen_query_indices: Vec<usize>,
+}
+
+impl<'a, F, EF, Dft, M, Challenger> FinalRoundProver<'a, F, EF, Dft, M, Challenger>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+{
+    /// Fix the final round's domain geometry. Touches no transcript state.
+    fn new(
+        config: &'a StirConfig<F, EF, M, Challenger>,
+        dft: &'a Dft,
+        current_shift: F,
+        current_log_domain: usize,
+    ) -> Self {
+        let final_log_arity = config.log_folding_factor;
+        let (final_new_log_domain, final_new_shift) =
+            fold_domain_params(current_shift, current_log_domain, final_log_arity);
+        Self {
+            config,
+            dft,
+            current_shift,
+            current_log_domain,
+            final_new_log_domain,
+            final_new_shift,
+            final_codeword: Vec::new(),
+            final_poly: Vec::new(),
+            query_indices: Vec::new(),
+            seen_query_indices: Vec::new(),
+        }
+    }
+
+    /// Fold at `final_gamma` and derive the final polynomial. The returned coefficients are
+    /// the round's only prover message and must be absorbed by the caller.
+    fn fold_and_derive(&mut self, current_oracle_codeword: &[EF], final_gamma: EF) -> &[EF] {
+        let final_log_arity = self.config.log_folding_factor;
+        // See the round-fold note in `RoundProver::fold_and_commit`: `gamma / current_shift`
+        // over subgroup coordinates is the paper's coset fold at challenge `gamma`.
+        let final_fold_beta = final_gamma * EF::from(self.current_shift.inverse());
+        self.final_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
+            fold_codeword::<F, EF>(
+                current_oracle_codeword,
+                final_fold_beta,
+                final_log_arity,
+                self.current_log_domain,
+            )
+        });
+        // The final polynomial has only `final_len` coefficients, far fewer than
+        // `final_codeword`'s full domain size. Rather than run a full-size iDFT and discard
+        // the (necessarily zero) high coefficients, gather a `final_len`-sized coset — every
+        // `stride`-th natural-order point, which is exactly the subgroup coset of that size —
+        // and run the small iDFT directly on it.
+        let final_len = self.config.final_poly_len();
+        let stride = self.final_codeword.len() / final_len;
+        let final_poly_evals: Vec<EF> = (0..final_len)
+            .map(|i| self.final_codeword[i * stride])
+            .collect();
+        self.final_poly = coeffs_from_codeword(self.dft, &final_poly_evals, self.final_new_shift);
+        &self.final_poly
+    }
+
+    /// Record the sampled query indices.
+    fn record_queries(&mut self, query_indices: Vec<usize>) {
+        let mut seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
+        for &j in &query_indices {
+            seen.insert(j);
+        }
+        self.query_indices = query_indices;
+        self.seen_query_indices = seen.into_iter().collect();
+    }
+
+    /// Touches no transcript state, so it may run after the caller has moved on to other
+    /// instances.
+    fn finish(self) -> FinalRoundFinish<EF> {
+        FinalRoundFinish {
+            final_poly: self.final_poly,
+            seen_query_indices: self.seen_query_indices,
+        }
+    }
+}
+
+/// Everything a finished final round hands back once its transcript phases are done.
+struct FinalRoundFinish<EF: Field> {
+    final_poly: Vec<EF>,
+    seen_query_indices: Vec<usize>,
+}
+
 /// Prove the final STIR round: fold the last committed codeword and send the resulting
 /// low-degree polynomial directly, rather than committing and querying it again.
 #[instrument(skip_all)]
@@ -597,63 +704,43 @@ where
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>,
 {
-    let final_log_arity = config.log_folding_factor;
-    let final_arity = 1usize << final_log_arity;
-    let (final_new_log_domain, final_new_shift) =
-        fold_domain_params(current_shift, current_log_domain, final_log_arity);
+    let final_arity = 1usize << config.log_folding_factor;
+    let mut state = FinalRoundProver::new(config, dft, current_shift, current_log_domain);
 
     let final_folding_pow_witness = challenger.grind(config.final_folding_pow_bits);
     let final_gamma: EF = challenger.sample_algebra_element();
 
-    // See the round-fold note: `gamma / current_shift` over subgroup coordinates is
-    // the paper's coset fold at challenge `gamma`.
-    let final_fold_beta = final_gamma * EF::from(current_shift.inverse());
-    let final_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
-        fold_codeword::<F, EF>(
-            current_oracle_codeword,
-            final_fold_beta,
-            final_log_arity,
-            current_log_domain,
-        )
-    });
-    // The final polynomial has only `final_len` coefficients, far fewer than
-    // `final_codeword`'s full domain size. Rather than run a full-size iDFT and discard
-    // the (necessarily zero) high coefficients, gather a `final_len`-sized coset — every
-    // `stride`-th natural-order point, which is exactly the subgroup coset of that size —
-    // and run the small iDFT directly on it.
-    let final_len = config.final_poly_len();
-    let stride = final_codeword.len() / final_len;
-    let final_poly_evals: Vec<EF> = (0..final_len).map(|i| final_codeword[i * stride]).collect();
-    let final_poly = coeffs_from_codeword(dft, &final_poly_evals, final_new_shift);
+    let final_poly = state.fold_and_derive(current_oracle_codeword, final_gamma);
+    challenger.observe_algebra_slice(final_poly);
 
-    challenger.observe_algebra_slice(&final_poly);
     let final_pow_witness = challenger.grind(config.final_pow_bits);
 
     let mut final_query_indices = Vec::with_capacity(config.final_queries);
-    let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
     for _ in 0..config.final_queries {
         let j = challenger
-            .sample_uniform_bits::<true>(final_new_log_domain)
+            .sample_uniform_bits::<true>(state.final_new_log_domain)
             .expect("RESAMPLE = true: rejection loops internally, never errors");
-        final_seen.insert(j);
         final_query_indices.push(j);
     }
+    state.record_queries(final_query_indices);
 
     let final_query_openings = current_commit_data
         .as_ref()
-        .map(|data| open_fiber_rows(&config.mmcs, &final_query_indices, data));
+        .map(|data| open_fiber_rows(&config.mmcs, &state.query_indices, data));
     debug_assert!(
         final_query_openings
             .iter()
             .all(|o| o.row_evals.iter().all(|row| row.len() == final_arity))
     );
 
+    let finish = state.finish();
+
     FinalRoundOutput {
-        final_polynomial: final_poly,
+        final_polynomial: finish.final_poly,
         final_folding_pow_witness,
         final_pow_witness,
         final_query_openings,
-        seen_query_indices: final_seen.into_iter().collect(),
+        seen_query_indices: finish.seen_query_indices,
     }
 }
 

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -847,6 +847,418 @@ where
     (proof, first_round_query_indices)
 }
 
+/// One `(proof, first_round_query_indices)` pair per instance, in `configs` order.
+type StirMultiOutput<EF, M, Witness> = Vec<(StirProof<EF, M, Witness>, Vec<usize>)>;
+
+/// Per-instance mutable state threaded through [`prove_stir_multi_inner`]'s round loop.
+struct MultiInstanceState<F, EF: Field, M: Mmcs<EF>> {
+    codeword: Vec<EF>,
+    shift: F,
+    log_domain: usize,
+    commit_data: Option<M::ProverData<RowMajorMatrix<EF>>>,
+    initial_commitment: Option<M::Commitment>,
+    round_proofs: Vec<StirRoundProof<EF, M, F>>,
+    first_round_query_indices: Vec<usize>,
+}
+
+/// Prove low degree for `B` polynomials of possibly different degrees in lockstep, sharing
+/// every grind across the instances active at that site.
+///
+/// Instances are right-aligned: instance `i`, with `Mi = configs[i].num_rounds()`
+/// intermediate rounds, runs its local rounds at global rounds `max_m - Mi .. max_m`
+/// (`max_m = maxᵢ Mi`), so every instance reaches its final round on the same global step. At
+/// each global round the shared grind bits are the max, over the instances active at that
+/// round, of THAT instance's local round's bits: the round error is `maxᵢ εᵢ`, not `Σᵢ εᵢ`,
+/// because the statement is false in specific instances, fixed before the grind, and the
+/// adversary wins only if every doomed instance's fresh challenge lands lucky. Widening the
+/// active set adds hurdles, not chances, so no union-bound penalty applies.
+///
+/// The shared witness is replicated verbatim into every active instance's own proof slot;
+/// `verifier::verify_stir_multi_inner` checks the copies agree before checking the grind once.
+///
+/// Returns one `(proof, first_round_query_indices)` pair per instance, in `configs` order.
+fn prove_stir_multi_inner<F, EF, Dft, M, Challenger>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    initial_codewords: Vec<Vec<EF>>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+    commit_initial: bool,
+) -> StirMultiOutput<EF, M, Challenger::Witness>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    let b = configs.len();
+    assert_eq!(
+        initial_codewords.len(),
+        b,
+        "one initial codeword per instance"
+    );
+
+    let mut states: Vec<MultiInstanceState<F, EF, M>> = Vec::with_capacity(b);
+    for (i, codeword) in initial_codewords.into_iter().enumerate() {
+        let log_initial_domain = configs[i].log_starting_domain_size();
+        assert_eq!(
+            codeword.len(),
+            1 << log_initial_domain,
+            "initial STIR codeword length must match the configured starting domain"
+        );
+        let (initial_commitment, commit_data) = if commit_initial {
+            let (commit, data) =
+                commit_as_fiber_matrix(&configs[i].mmcs, &codeword, configs[i].log_folding_factor);
+            challenger.observe(commit.clone());
+            (Some(commit), Some(data))
+        } else {
+            (None, None)
+        };
+        states.push(MultiInstanceState {
+            codeword,
+            shift: F::GENERATOR,
+            log_domain: log_initial_domain,
+            commit_data,
+            initial_commitment,
+            round_proofs: Vec::with_capacity(configs[i].num_rounds()),
+            first_round_query_indices: Vec::new(),
+        });
+    }
+
+    let max_m = configs.iter().map(|c| c.num_rounds()).max().unwrap_or(0);
+    let offset = |i: usize| max_m - configs[i].num_rounds();
+
+    for r in 0..max_m {
+        let active: Vec<usize> = (0..b).filter(|&i| offset(i) <= r).collect();
+
+        // [grind folding_pow_bits], shared across every active instance's local round.
+        let shared_folding_bits = active
+            .iter()
+            .map(|&i| configs[i].round_configs[r - offset(i)].folding_pow_bits)
+            .max()
+            .expect("`active` is non-empty for r < max_m");
+        let folding_pow_witness = challenger.grind(shared_folding_bits);
+
+        // Phase 1: per-instance folding challenge, fold, commit, and absorb the commitment.
+        struct Phase1<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+            rp: RoundProver<'a, F, EF, Dft, M, Challenger>,
+            commit: M::Commitment,
+        }
+        let phase1: Vec<Phase1<'_, F, EF, Dft, M, Challenger>> = active
+            .iter()
+            .map(|&i| {
+                let local_r = r - offset(i);
+                let mut rp = RoundProver::new(
+                    configs[i],
+                    local_r,
+                    dft,
+                    states[i].shift,
+                    states[i].log_domain,
+                );
+                let gamma: EF = challenger.sample_algebra_element();
+                let commit = rp.fold_and_commit(
+                    &states[i].codeword,
+                    states[i].shift,
+                    states[i].log_domain,
+                    gamma,
+                );
+                challenger.observe(commit.clone());
+                Phase1 { rp, commit }
+            })
+            .collect();
+
+        // Phase 2: per-instance OOD sampling and answer absorb.
+        struct Phase2<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+            rp: RoundProver<'a, F, EF, Dft, M, Challenger>,
+            commit: M::Commitment,
+            ood_answers: Vec<EF>,
+        }
+        let phase2: Vec<Phase2<'_, F, EF, Dft, M, Challenger>> = active
+            .iter()
+            .zip(phase1)
+            .map(|(&i, p)| {
+                let rc = &configs[i].round_configs[r - offset(i)];
+                let mut rp = p.rp;
+                let ood_points = sample_ood_points(
+                    challenger,
+                    rp.ood_excluded_domains(states[i].shift, states[i].log_domain),
+                    rc.num_ood_samples,
+                );
+                let ood_answers = rp.ood_answers(ood_points).to_vec();
+                challenger.observe_algebra_slice(&ood_answers);
+                Phase2 {
+                    rp,
+                    commit: p.commit,
+                    ood_answers,
+                }
+            })
+            .collect();
+
+        // [grind pow_bits], shared across every active instance's local round.
+        let shared_pow_bits = active
+            .iter()
+            .map(|&i| configs[i].round_configs[r - offset(i)].pow_bits)
+            .max()
+            .expect("`active` is non-empty for r < max_m");
+        let pow_witness = challenger.grind(shared_pow_bits);
+
+        // Phase 3: per-instance combination challenge, query sampling, and query openings.
+        struct Phase3<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+            rp: RoundProver<'a, F, EF, Dft, M, Challenger>,
+            commit: M::Commitment,
+            ood_answers: Vec<EF>,
+            query_openings: Option<StirQueryOpenings<EF, M>>,
+            r_comb: EF,
+        }
+        let phase3: Vec<Phase3<'_, F, EF, Dft, M, Challenger>> = active
+            .iter()
+            .zip(phase2)
+            .map(|(&i, p)| {
+                let rc = &configs[i].round_configs[r - offset(i)];
+                let mut rp = p.rp;
+                let r_comb: EF = challenger.sample_algebra_element();
+                let query_indices: Vec<usize> = (0..rc.num_queries)
+                    .map(|_| {
+                        challenger
+                            .sample_uniform_bits::<true>(rp.fold_log_domain)
+                            .expect("RESAMPLE = true: rejection loops internally, never errors")
+                    })
+                    .collect();
+                rp.record_queries(query_indices);
+
+                let query_openings = states[i]
+                    .commit_data
+                    .as_ref()
+                    .map(|data| open_fiber_rows(&configs[i].mmcs, &rp.query_indices, data));
+                debug_assert!(query_openings.iter().all(|o| {
+                    o.row_evals
+                        .iter()
+                        .all(|row| row.len() == 1usize << rp.log_arity)
+                }));
+
+                Phase3 {
+                    rp,
+                    commit: p.commit,
+                    ood_answers: p.ood_answers,
+                    query_openings,
+                    r_comb,
+                }
+            })
+            .collect();
+
+        // Phase 4: per-instance answer/shake polynomial absorb and shake-check challenge.
+        struct Phase4<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+            rp: RoundProver<'a, F, EF, Dft, M, Challenger>,
+            commit: M::Commitment,
+            ood_answers: Vec<EF>,
+            query_openings: Option<StirQueryOpenings<EF, M>>,
+            r_comb: EF,
+        }
+        let phase4: Vec<Phase4<'_, F, EF, Dft, M, Challenger>> = phase3
+            .into_iter()
+            .map(|p| {
+                let mut rp = p.rp;
+                let (ans, shake) = rp.ans_shake();
+                let ans = ans.to_vec();
+                let shake = shake.to_vec();
+                challenger.observe_algebra_slice(&ans);
+                challenger.observe_algebra_slice(&shake);
+                let _rho: EF = challenger.sample_algebra_element();
+                Phase4 {
+                    rp,
+                    commit: p.commit,
+                    ood_answers: p.ood_answers,
+                    query_openings: p.query_openings,
+                    r_comb: p.r_comb,
+                }
+            })
+            .collect();
+
+        // Phase 5 (finish): touches no transcript state, so instance order no longer matters.
+        for (&i, p) in active.iter().zip(phase4) {
+            let finish = p.rp.finish(p.r_comb);
+            states[i].round_proofs.push(StirRoundProof {
+                commitment: p.commit,
+                folding_pow_witness,
+                ood_answers: p.ood_answers,
+                pow_witness,
+                ans_polynomial: finish.ans_poly,
+                shake_polynomial: finish.shake_poly,
+                query_openings: p.query_openings,
+            });
+            if r == offset(i) {
+                states[i].first_round_query_indices = finish.seen_query_indices;
+            }
+            states[i].codeword = finish.next_codeword;
+            states[i].commit_data = Some(finish.next_commit_data);
+            states[i].shift = finish.next_shift;
+            states[i].log_domain = finish.next_log_domain;
+        }
+    }
+
+    // Final round: every instance reaches it on this same global step (right-alignment).
+    let shared_final_folding_bits = configs
+        .iter()
+        .map(|c| c.final_folding_pow_bits)
+        .max()
+        .unwrap_or(0);
+    let final_folding_pow_witness = challenger.grind(shared_final_folding_bits);
+
+    let mut final_provers: Vec<FinalRoundProver<'_, F, EF, Dft, M, Challenger>> =
+        Vec::with_capacity(b);
+    for i in 0..b {
+        let mut frp = FinalRoundProver::new(configs[i], dft, states[i].shift, states[i].log_domain);
+        let final_gamma: EF = challenger.sample_algebra_element();
+        let final_poly = frp.fold_and_derive(&states[i].codeword, final_gamma);
+        challenger.observe_algebra_slice(final_poly);
+        final_provers.push(frp);
+    }
+
+    let shared_final_pow_bits = configs.iter().map(|c| c.final_pow_bits).max().unwrap_or(0);
+    let final_pow_witness = challenger.grind(shared_final_pow_bits);
+
+    let mut results = Vec::with_capacity(b);
+    for (i, mut frp) in final_provers.into_iter().enumerate() {
+        let final_arity = 1usize << configs[i].log_folding_factor;
+        let query_indices: Vec<usize> = (0..configs[i].final_queries)
+            .map(|_| {
+                challenger
+                    .sample_uniform_bits::<true>(frp.final_new_log_domain)
+                    .expect("RESAMPLE = true: rejection loops internally, never errors")
+            })
+            .collect();
+        frp.record_queries(query_indices);
+
+        let final_query_openings = states[i]
+            .commit_data
+            .as_ref()
+            .map(|data| open_fiber_rows(&configs[i].mmcs, &frp.query_indices, data));
+        debug_assert!(
+            final_query_openings
+                .iter()
+                .all(|o| o.row_evals.iter().all(|row| row.len() == final_arity))
+        );
+
+        let finish = frp.finish();
+        if configs[i].num_rounds() == 0 {
+            states[i].first_round_query_indices = finish.seen_query_indices;
+        }
+
+        let proof = StirProof {
+            initial_commitment: states[i].initial_commitment.clone(),
+            round_proofs: core::mem::take(&mut states[i].round_proofs),
+            final_polynomial: finish.final_poly,
+            final_folding_pow_witness,
+            final_pow_witness,
+            final_query_openings,
+        };
+        results.push((
+            proof,
+            core::mem::take(&mut states[i].first_round_query_indices),
+        ));
+    }
+
+    results
+}
+
+/// Prove low degree for `B` polynomials of possibly different degrees (given in coefficient
+/// form over `EF`), sharing every grind across the STIR instances active at that grind's site.
+///
+/// See `prove_stir_multi_inner` for the shared-grind soundness argument.
+#[instrument(skip_all)]
+pub fn prove_stir_multi<F, EF, Dft, M, Challenger>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    poly_coeffs: Vec<Vec<EF>>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+) -> StirMultiOutput<EF, M, Challenger::Witness>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    assert_eq!(
+        configs.len(),
+        poly_coeffs.len(),
+        "one polynomial per instance"
+    );
+    let initial_codewords = configs
+        .iter()
+        .zip(poly_coeffs)
+        .map(|(config, coeffs)| {
+            let log_initial_domain = config.log_starting_domain_size();
+            let mut coeffs = coeffs;
+            coeffs.resize(1 << log_initial_domain, EF::ZERO);
+            codeword_from_coeffs(dft, coeffs, F::GENERATOR, log_initial_domain)
+        })
+        .collect();
+    prove_stir_multi_inner(configs, initial_codewords, dft, challenger, true)
+}
+
+/// Prove low degree for `B` initial natural-order codewords on each instance's starting
+/// domain, sharing every grind across the STIR instances active at that grind's site.
+///
+/// See [`prove_stir_from_codeword`] for the codeword layout requirement, applied per instance,
+/// and `prove_stir_multi_inner` for the shared-grind soundness argument.
+#[instrument(skip_all)]
+pub fn prove_stir_multi_from_codewords<F, EF, Dft, M, Challenger>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    initial_codewords: Vec<Vec<EF>>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+) -> StirMultiOutput<EF, M, Challenger::Witness>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    prove_stir_multi_inner(configs, initial_codewords, dft, challenger, true)
+}
+
+/// Prove low degree for `B` initial codewords the caller has already bound (see
+/// [`prove_stir_from_external_codeword`]), sharing every grind across the STIR instances
+/// active at that grind's site.
+///
+/// # Soundness requirement
+///
+/// See [`prove_stir_from_external_codeword`]: each caller-supplied codeword must already be
+/// pinned by data absorbed into `challenger` before this call, and independently for each
+/// instance.
+///
+/// See `prove_stir_multi_inner` for the shared-grind soundness argument.
+#[instrument(skip_all)]
+pub fn prove_stir_multi_from_external_codewords<F, EF, Dft, M, Challenger>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    initial_codewords: Vec<Vec<EF>>,
+    dft: &Dft,
+    challenger: &mut Challenger,
+) -> StirMultiOutput<EF, M, Challenger::Witness>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    prove_stir_multi_inner(configs, initial_codewords, dft, challenger, false)
+}
+
 /// Evaluate two polynomials of at most `2^log_len` coefficients on the coset `shift * <g>` of
 /// size `2^log_size`, returning both codewords in **natural order**.
 ///

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -138,6 +138,205 @@ struct RoundOutput<F, EF: Field, M: Mmcs<EF>, Witness> {
     seen_query_indices: Vec<usize>,
 }
 
+/// One instance's in-flight intermediate round, advanced in the order the transcript demands.
+///
+/// The round alternates between blocks of squeezed challenges and blocks of absorbed prover
+/// messages, and every grind sits immediately before a challenge block with no prover message
+/// in between — the property that lets a grind bind the challenge that follows it. Holding the
+/// round open across those boundaries lets a caller drive several instances through the same
+/// boundaries, so one grind can cover every instance's challenges at that site.
+///
+/// The phases, in order: \[grind\] `fold_and_commit` -> absorb commitment -> squeeze OOD points
+/// -> `ood_answers` -> absorb answers -> \[grind\] -> squeeze `r_comb` and query indices ->
+/// `record_queries` -> `ans_shake` -> absorb Ans/shake -> squeeze rho -> `finish`.
+struct RoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
+    config: &'a StirConfig<F, EF, M, Challenger>,
+    round: usize,
+    dft: &'a Dft,
+
+    log_arity: usize,
+    fold_log_domain: usize,
+    fold_shift: F,
+    next_log_domain: usize,
+    next_shift: F,
+
+    folded_codeword: Vec<EF>,
+    fold_coeffs: Vec<EF>,
+    next_commit_codeword: Vec<EF>,
+    new_data: Option<M::ProverData<RowMajorMatrix<EF>>>,
+
+    ood_points: Vec<EF>,
+    ood_answers: Vec<EF>,
+
+    query_indices: Vec<usize>,
+    query_points: Vec<EF>,
+    query_answers: Vec<EF>,
+    seen_query_indices: Vec<usize>,
+
+    ans_poly: Vec<EF>,
+    shake_poly: Vec<EF>,
+    all_points: Vec<EF>,
+}
+
+impl<'a, F, EF, Dft, M, Challenger> RoundProver<'a, F, EF, Dft, M, Challenger>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+    M: Mmcs<EF>,
+{
+    /// Fix the round's domain geometry. Touches no transcript state.
+    fn new(
+        config: &'a StirConfig<F, EF, M, Challenger>,
+        round: usize,
+        dft: &'a Dft,
+        current_shift: F,
+        current_log_domain: usize,
+    ) -> Self {
+        let log_arity = config.round_configs[round].log_folding_factor;
+        let (fold_log_domain, fold_shift) =
+            fold_domain_params(current_shift, current_log_domain, log_arity);
+        Self {
+            config,
+            round,
+            dft,
+            log_arity,
+            fold_log_domain,
+            fold_shift,
+            next_log_domain: current_log_domain - 1,
+            next_shift: next_domain_shift(current_shift, log_arity),
+            folded_codeword: Vec::new(),
+            fold_coeffs: Vec::new(),
+            next_commit_codeword: Vec::new(),
+            new_data: None,
+            ood_points: Vec::new(),
+            ood_answers: Vec::new(),
+            query_indices: Vec::new(),
+            query_points: Vec::new(),
+            query_answers: Vec::new(),
+            seen_query_indices: Vec::new(),
+            ans_poly: Vec::new(),
+            shake_poly: Vec::new(),
+            all_points: Vec::new(),
+        }
+    }
+
+    /// Fold at `gamma` and commit the folded oracle. The returned commitment is the round's
+    /// first prover message and must be absorbed by the caller.
+    fn fold_and_commit(
+        &mut self,
+        current_oracle_codeword: &[EF],
+        current_shift: F,
+        current_log_domain: usize,
+        gamma: EF,
+    ) -> M::Commitment {
+        // `fold_codeword` interpolates at subgroup coordinates `g^{·}`. The codeword
+        // lives on the coset `current_shift · <g>`, so passing `gamma / current_shift`
+        // yields exactly Construction 4.5's coset fold at challenge `gamma`.
+        let fold_beta = gamma * EF::from(current_shift.inverse());
+        self.folded_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
+            fold_codeword::<F, EF>(
+                current_oracle_codeword,
+                fold_beta,
+                self.log_arity,
+                current_log_domain,
+            )
+        });
+        self.fold_coeffs = coeffs_from_codeword(self.dft, &self.folded_codeword, self.fold_shift);
+
+        self.next_commit_codeword = codeword_from_coeffs(
+            self.dft,
+            self.fold_coeffs.clone(),
+            self.next_shift,
+            self.next_log_domain,
+        );
+        let (new_commit, new_data) =
+            tracing::debug_span!("commit_as_fiber_matrix").in_scope(|| {
+                commit_as_fiber_matrix(
+                    &self.config.mmcs,
+                    &self.next_commit_codeword,
+                    self.config.log_folding_factor,
+                )
+            });
+        self.new_data = Some(new_data);
+        new_commit
+    }
+
+    /// The domains an OOD point must avoid: the current and next witness domains, and the
+    /// fold-query domain. Excluding the fold domain prevents an honest-prover failure where an
+    /// OOD point coincides with a sampled query point and the later interpolation hits
+    /// duplicate roots.
+    const fn ood_excluded_domains(
+        &self,
+        current_shift: F,
+        current_log_domain: usize,
+    ) -> [(F, usize); 3] {
+        [
+            (current_shift, current_log_domain),
+            (self.next_shift, self.next_log_domain),
+            (self.fold_shift, self.fold_log_domain),
+        ]
+    }
+
+    /// Evaluate the folded polynomial at the sampled OOD points. The answers are the round's
+    /// second prover message and must be absorbed by the caller.
+    fn ood_answers(&mut self, ood_points: Vec<EF>) -> &[EF] {
+        // `fold_coeffs` is padded to the next round's full domain size, but the folded
+        // polynomial's true degree is bounded by the round's degree schedule (a fixed
+        // factor smaller); evaluating only the non-trivially-zero prefix cuts Horner's
+        // work by that same factor.
+        let rc = &self.config.round_configs[self.round];
+        let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
+        let truncated = &self.fold_coeffs[..folded_degree_bound.min(self.fold_coeffs.len())];
+
+        self.ood_points = ood_points;
+        self.ood_answers = self
+            .ood_points
+            .iter()
+            .map(|&z| eval_poly_parallel(truncated, z))
+            .collect();
+        &self.ood_answers
+    }
+
+    /// Record the sampled query indices and the folded values they read.
+    fn record_queries(&mut self, query_indices: Vec<usize>) {
+        let fold_gen = F::two_adic_generator(self.fold_log_domain);
+        let mut seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
+
+        for &j in &query_indices {
+            if seen.insert(j) {
+                self.query_points
+                    .push(EF::from(self.fold_shift) * EF::from(fold_gen.exp_u64(j as u64)));
+                self.query_answers.push(self.folded_codeword[j]);
+            }
+        }
+        self.query_indices = query_indices;
+        self.seen_query_indices = seen.into_iter().collect();
+    }
+
+    /// Interpolate the answer polynomial and derive the shake polynomial. Both are prover
+    /// messages and must be absorbed by the caller before rho is squeezed — otherwise a
+    /// malicious prover could fit Ans to satisfy the shake identity at a known rho.
+    fn ans_shake(&mut self) -> (&[EF], &[EF]) {
+        self.all_points = self
+            .ood_points
+            .iter()
+            .chain(self.query_points.iter())
+            .copied()
+            .collect();
+        let all_values: Vec<EF> = self
+            .ood_answers
+            .iter()
+            .chain(self.query_answers.iter())
+            .copied()
+            .collect();
+
+        self.ans_poly = interpolate_poly(&self.all_points, &all_values);
+        self.shake_poly = compute_shake_polynomial(&self.ans_poly, &self.all_points);
+        (&self.ans_poly, &self.shake_poly)
+    }
+}
+
 /// Prove one intermediate STIR round (Construction 5.2): fold the current oracle, sample OOD
 /// and query points, answer them, commit the folded oracle, and evaluate the next virtual
 /// witness directly on the next round's domain.
@@ -164,69 +363,29 @@ where
         + CanSampleUniformBits<F>,
 {
     let rc = &config.round_configs[round];
-    let log_arity = rc.log_folding_factor;
-    let arity = 1 << log_arity;
+    let arity = 1 << rc.log_folding_factor;
 
-    let (fold_log_domain, fold_shift) =
-        fold_domain_params(current_shift, current_log_domain, log_arity);
-    let next_log_domain = current_log_domain - 1;
-    let next_shift = next_domain_shift(current_shift, log_arity);
+    let mut state = RoundProver::new(config, round, dft, current_shift, current_log_domain);
 
     // Step 1: fold. Derive gamma after folding PoW.
     let folding_pow_witness = challenger.grind(rc.folding_pow_bits);
     let gamma: EF = challenger.sample_algebra_element();
 
-    // `fold_codeword` interpolates at subgroup coordinates `g^{·}`. The codeword
-    // lives on the coset `current_shift · <g>`, so passing `gamma / current_shift`
-    // yields exactly Construction 4.5's coset fold at challenge `gamma`.
-    let fold_beta = gamma * EF::from(current_shift.inverse());
-    let folded_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
-        fold_codeword::<F, EF>(
-            current_oracle_codeword,
-            fold_beta,
-            log_arity,
-            current_log_domain,
-        )
-    });
-    let fold_coeffs = coeffs_from_codeword(dft, &folded_codeword, fold_shift);
-
-    let next_commit_codeword: Vec<EF> =
-        codeword_from_coeffs(dft, fold_coeffs.clone(), next_shift, next_log_domain);
-    let (new_commit, new_data) = tracing::debug_span!("commit_as_fiber_matrix").in_scope(|| {
-        commit_as_fiber_matrix(
-            &config.mmcs,
-            &next_commit_codeword,
-            config.log_folding_factor,
-        )
-    });
+    let new_commit = state.fold_and_commit(
+        current_oracle_codeword,
+        current_shift,
+        current_log_domain,
+        gamma,
+    );
     challenger.observe(new_commit.clone());
 
     // Step 2: OOD sampling.
-    // OOD points must be outside the current and next witness domains AND outside the
-    // fold-query domain. Excluding the fold domain prevents an honest-prover failure
-    // where an OOD point coincides with a sampled query point and the interpolation in
-    // step 4 hits duplicate roots.
     let ood_points = sample_ood_points(
         challenger,
-        [
-            (current_shift, current_log_domain),
-            (next_shift, next_log_domain),
-            (fold_shift, fold_log_domain),
-        ],
+        state.ood_excluded_domains(current_shift, current_log_domain),
         rc.num_ood_samples,
     );
-
-    // `fold_coeffs` is padded to the next round's full domain size, but the folded
-    // polynomial's true degree is bounded by the round's degree schedule (a fixed
-    // factor smaller); evaluating only the non-trivially-zero prefix cuts Horner's
-    // work by that same factor.
-    let folded_degree_bound = 1usize << (rc.log_degree - log_arity);
-    let truncated_fold_coeffs = &fold_coeffs[..folded_degree_bound.min(fold_coeffs.len())];
-
-    let ood_answers: Vec<EF> = ood_points
-        .iter()
-        .map(|&z| eval_poly_parallel(truncated_fold_coeffs, z))
-        .collect();
+    let ood_answers = state.ood_answers(ood_points).to_vec();
     challenger.observe_algebra_slice(&ood_answers);
 
     // Step 3: query-phase PoW. It protects the immediately following combination challenge
@@ -235,40 +394,26 @@ where
     let pow_witness = challenger.grind(rc.pow_bits);
 
     // Step 4: Query sampling.
-    let fold_gen = F::two_adic_generator(fold_log_domain);
-
-    let mut query_indices = Vec::with_capacity(rc.num_queries);
-    let mut query_points = Vec::with_capacity(rc.num_queries);
-    let mut query_answers = Vec::with_capacity(rc.num_queries);
-
-    let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
-        alloc::collections::BTreeSet::new();
-
     let r_comb: EF = challenger.sample_algebra_element();
 
-    for _ in 0..rc.num_queries {
-        // `RESAMPLE = true`: the challenger loops on field-side rejection internally,
-        // so this `expect` is unreachable for every challenger in this workspace.
-        // Unbiased sampling is required because `sample_bits` carries a per-draw modular
-        // bias of `2^fold_log_domain / |F|`, which is non-negligible over 31-bit fields.
-        let j = challenger
-            .sample_uniform_bits::<true>(fold_log_domain)
-            .expect("RESAMPLE = true: rejection loops internally, never errors");
-        let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
-
-        query_indices.push(j);
-
-        if seen_query_indices.insert(j) {
-            query_points.push(fold_point);
-            query_answers.push(folded_codeword[j]);
-        }
-    }
+    let query_indices: Vec<usize> = (0..rc.num_queries)
+        .map(|_| {
+            // `RESAMPLE = true`: the challenger loops on field-side rejection internally,
+            // so this `expect` is unreachable for every challenger in this workspace.
+            // Unbiased sampling is required because `sample_bits` carries a per-draw modular
+            // bias of `2^fold_log_domain / |F|`, which is non-negligible over 31-bit fields.
+            challenger
+                .sample_uniform_bits::<true>(state.fold_log_domain)
+                .expect("RESAMPLE = true: rejection loops internally, never errors")
+        })
+        .collect();
+    state.record_queries(query_indices);
 
     // One shared, pruned multi-opening proof for every query drawn this round. Absent when
     // this round reads an external initial oracle, whose fibers the verifier rebuilds.
     let query_openings = current_commit_data
         .as_ref()
-        .map(|data| open_fiber_rows(&config.mmcs, &query_indices, data));
+        .map(|data| open_fiber_rows(&config.mmcs, &state.query_indices, data));
     debug_assert!(
         query_openings
             .iter()
@@ -276,19 +421,8 @@ where
     );
 
     // Step 4: Answer polynomial, shake polynomial, and shake-check challenge.
-    let all_points: Vec<EF> = ood_points
-        .iter()
-        .chain(query_points.iter())
-        .copied()
-        .collect();
-    let all_values: Vec<EF> = ood_answers
-        .iter()
-        .chain(query_answers.iter())
-        .copied()
-        .collect();
-
-    let ans_poly = interpolate_poly(&all_points, &all_values);
-    let shake_poly = compute_shake_polynomial(&ans_poly, &all_points);
+    let (ans_poly, shake_poly) = state.ans_shake();
+    let (ans_poly, shake_poly) = (ans_poly.to_vec(), shake_poly.to_vec());
     // Bind ans_poly into the transcript BEFORE rho is sampled — otherwise a malicious prover
     // could fit Ans to satisfy the shake identity at a known rho.
     challenger.observe_algebra_slice(&ans_poly);
@@ -308,6 +442,13 @@ where
     // and the vanishing polynomial still need evaluating — their roots are this round's
     // arbitrary interpolation points — but both are tiny next to the domain, so they go
     // through the low-degree coset evaluation rather than a full-size DFT each.
+    let all_points = core::mem::take(&mut state.all_points);
+    let next_shift = state.next_shift;
+    let next_log_domain = state.next_log_domain;
+    let next_commit_codeword = core::mem::take(&mut state.next_commit_codeword);
+    let new_data = state.new_data.take().expect("set by `fold_and_commit`");
+    let seen_query_indices = core::mem::take(&mut state.seen_query_indices);
+
     let num_answers = all_points.len();
 
     let vanishing_coeffs = vanishing_poly_from_roots(&all_points);

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -335,6 +335,109 @@ where
         self.shake_poly = compute_shake_polynomial(&self.ans_poly, &self.all_points);
         (&self.ans_poly, &self.shake_poly)
     }
+
+    /// Evaluate the next virtual witness on the next round's domain. Touches no transcript
+    /// state, so it may run after the caller has moved on to other instances.
+    fn finish(mut self, r_comb: EF) -> RoundFinish<F, EF, M> {
+        // Construction 5.2: f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}).
+        //
+        // DegCor(x) = (1 - (r_comb*x)^{gap+1}) / (1 - r_comb*x) is geometric in x over the
+        // coset (base-field ratio, EF-valued start), so it is evaluated pointwise via two
+        // `Powers` sweeps instead of a third DFT; its `(1 - r_comb*x)` denominator is folded
+        // into the vanishing-polynomial batch inversion below (one inversion, not two). Ans
+        // and the vanishing polynomial still need evaluating — their roots are this round's
+        // arbitrary interpolation points — but both are tiny next to the domain, so they go
+        // through the low-degree coset evaluation rather than a full-size DFT each.
+        let all_points = core::mem::take(&mut self.all_points);
+        let next_shift = self.next_shift;
+        let next_log_domain = self.next_log_domain;
+        let num_answers = all_points.len();
+
+        let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
+        // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
+        // `num_answers + 1` coefficients.
+        let log_answer_len = log2_ceil_usize(num_answers + 1).min(next_log_domain);
+        let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
+            .in_scope(|| {
+                eval_low_degree_pair_on_coset(
+                    self.dft,
+                    &self.ans_poly,
+                    &vanishing_coeffs,
+                    next_shift,
+                    next_log_domain,
+                    log_answer_len,
+                )
+            });
+
+        // x_j = next_shift * g^j, so step_j = r_comb * x_j = step_start * g^j, and the degree
+        // correction's numerator sweeps the same coset at stride `num_answers + 1`. Both are
+        // geometric with a base-field ratio, so each chunk seeds one exponentiation and then
+        // advances by a base-field multiply: no power tables, and no ext-by-ext products.
+        const POWER_CHUNK: usize = 1 << 12;
+        let g_next = F::two_adic_generator(next_log_domain);
+        let g_next_hi = g_next.exp_u64((num_answers + 1) as u64);
+        let step_start = r_comb * next_shift;
+        let step_start_hi = step_start.exp_u64((num_answers + 1) as u64);
+
+        // The quotient denominators are the vanishing evaluations scaled by the degree
+        // correction's `(1 - step)` denominator, so they are formed in place.
+        let next_oracle_codeword = tracing::debug_span!("quotient_sweep").in_scope(|| {
+            let mut combined_denoms = vanishing_evals;
+            combined_denoms
+                .par_chunks_mut(POWER_CHUNK)
+                .enumerate()
+                .for_each(|(chunk_idx, chunk)| {
+                    let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                    for denom in chunk.iter_mut() {
+                        *denom *= EF::ONE - step;
+                        step *= g_next;
+                    }
+                });
+            let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
+            drop(combined_denoms);
+
+            // `commit_as_fiber_matrix` has already copied the committed codeword into the
+            // Merkle tree, so the next oracle is formed in place over it.
+            let mut next_oracle_codeword = core::mem::take(&mut self.next_commit_codeword);
+            next_oracle_codeword
+                .par_chunks_mut(POWER_CHUNK)
+                .zip(ans_evals.par_chunks(POWER_CHUNK))
+                .zip(combined_inverses.par_chunks(POWER_CHUNK))
+                .enumerate()
+                .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
+                    let mut numerator_step =
+                        step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                    for ((value, &ans), &inverse) in
+                        chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk)
+                    {
+                        *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
+                        numerator_step *= g_next_hi;
+                    }
+                });
+            next_oracle_codeword
+        });
+
+        RoundFinish {
+            next_codeword: next_oracle_codeword,
+            next_commit_data: self.new_data.take().expect("set by `fold_and_commit`"),
+            next_shift,
+            next_log_domain,
+            seen_query_indices: core::mem::take(&mut self.seen_query_indices),
+            ans_poly: core::mem::take(&mut self.ans_poly),
+            shake_poly: core::mem::take(&mut self.shake_poly),
+        }
+    }
+}
+
+/// Everything a finished round hands back once its transcript phases are done.
+struct RoundFinish<F, EF: Field, M: Mmcs<EF>> {
+    next_codeword: Vec<EF>,
+    next_commit_data: M::ProverData<RowMajorMatrix<EF>>,
+    next_shift: F,
+    next_log_domain: usize,
+    seen_query_indices: Vec<usize>,
+    ans_poly: Vec<EF>,
+    shake_poly: Vec<EF>,
 }
 
 /// Prove one intermediate STIR round (Construction 5.2): fold the current oracle, sample OOD
@@ -422,11 +525,10 @@ where
 
     // Step 4: Answer polynomial, shake polynomial, and shake-check challenge.
     let (ans_poly, shake_poly) = state.ans_shake();
-    let (ans_poly, shake_poly) = (ans_poly.to_vec(), shake_poly.to_vec());
     // Bind ans_poly into the transcript BEFORE rho is sampled — otherwise a malicious prover
     // could fit Ans to satisfy the shake identity at a known rho.
-    challenger.observe_algebra_slice(&ans_poly);
-    challenger.observe_algebra_slice(&shake_poly);
+    challenger.observe_algebra_slice(ans_poly);
+    challenger.observe_algebra_slice(shake_poly);
 
     // Sample and discard the shake-check challenge so the transcript state
     // stays consistent with the verifier.
@@ -442,77 +544,7 @@ where
     // and the vanishing polynomial still need evaluating — their roots are this round's
     // arbitrary interpolation points — but both are tiny next to the domain, so they go
     // through the low-degree coset evaluation rather than a full-size DFT each.
-    let all_points = core::mem::take(&mut state.all_points);
-    let next_shift = state.next_shift;
-    let next_log_domain = state.next_log_domain;
-    let next_commit_codeword = core::mem::take(&mut state.next_commit_codeword);
-    let new_data = state.new_data.take().expect("set by `fold_and_commit`");
-    let seen_query_indices = core::mem::take(&mut state.seen_query_indices);
-
-    let num_answers = all_points.len();
-
-    let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
-    // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
-    // `num_answers + 1` coefficients.
-    let log_answer_len = log2_ceil_usize(num_answers + 1).min(next_log_domain);
-    let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
-        .in_scope(|| {
-            eval_low_degree_pair_on_coset(
-                dft,
-                &ans_poly,
-                &vanishing_coeffs,
-                next_shift,
-                next_log_domain,
-                log_answer_len,
-            )
-        });
-
-    // x_j = next_shift * g^j, so step_j = r_comb * x_j = step_start * g^j, and the degree
-    // correction's numerator sweeps the same coset at stride `num_answers + 1`. Both are
-    // geometric with a base-field ratio, so each chunk seeds one exponentiation and then
-    // advances by a base-field multiply: no power tables, and no ext-by-ext products.
-    const POWER_CHUNK: usize = 1 << 12;
-    let g_next = F::two_adic_generator(next_log_domain);
-    let g_next_hi = g_next.exp_u64((num_answers + 1) as u64);
-    let step_start = r_comb * next_shift;
-    let step_start_hi = step_start.exp_u64((num_answers + 1) as u64);
-
-    // The quotient denominators are the vanishing evaluations scaled by the degree
-    // correction's `(1 - step)` denominator, so they are formed in place.
-    let next_oracle_codeword = tracing::debug_span!("quotient_sweep").in_scope(|| {
-        let mut combined_denoms = vanishing_evals;
-        combined_denoms
-            .par_chunks_mut(POWER_CHUNK)
-            .enumerate()
-            .for_each(|(chunk_idx, chunk)| {
-                let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
-                for denom in chunk.iter_mut() {
-                    *denom *= EF::ONE - step;
-                    step *= g_next;
-                }
-            });
-        let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
-        drop(combined_denoms);
-
-        // `commit_as_fiber_matrix` has already copied the committed codeword into the
-        // Merkle tree, so the next oracle is formed in place over it.
-        let mut next_oracle_codeword = next_commit_codeword;
-        next_oracle_codeword
-            .par_chunks_mut(POWER_CHUNK)
-            .zip(ans_evals.par_chunks(POWER_CHUNK))
-            .zip(combined_inverses.par_chunks(POWER_CHUNK))
-            .enumerate()
-            .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
-                let mut numerator_step =
-                    step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
-                for ((value, &ans), &inverse) in chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk)
-                {
-                    *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
-                    numerator_step *= g_next_hi;
-                }
-            });
-        next_oracle_codeword
-    });
+    let finish = state.finish(r_comb);
 
     RoundOutput {
         proof: StirRoundProof {
@@ -520,15 +552,15 @@ where
             folding_pow_witness,
             ood_answers,
             pow_witness,
-            ans_polynomial: ans_poly,
-            shake_polynomial: shake_poly,
+            ans_polynomial: finish.ans_poly,
+            shake_polynomial: finish.shake_poly,
             query_openings,
         },
-        next_codeword: next_oracle_codeword,
-        next_commit_data: new_data,
-        next_shift,
-        next_log_domain,
-        seen_query_indices: seen_query_indices.into_iter().collect(),
+        next_codeword: finish.next_codeword,
+        next_commit_data: finish.next_commit_data,
+        next_shift: finish.next_shift,
+        next_log_domain: finish.next_log_domain,
+        seen_query_indices: finish.seen_query_indices,
     }
 }
 

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -10,7 +10,7 @@ use p3_field::{
 use p3_matrix::Dimensions;
 use thiserror::Error;
 
-use crate::config::StirConfig;
+use crate::config::{StirConfig, StirRoundConfig};
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
     check_shake_consistency, eval_degree_correction, eval_poly, eval_poly_at_base,
@@ -233,6 +233,181 @@ struct RoundVerifyOutput<F, EF> {
     first_round_pairs: FirstRoundPairs<EF>,
 }
 
+/// One instance's in-flight intermediate round, advanced in the order the transcript demands.
+///
+/// Mirrors `prover::RoundProver`: every grind sits immediately before a challenge
+/// block with no prover message in between, so holding the round's virtual-oracle state open
+/// across those boundaries lets a caller drive several instances through the same boundaries,
+/// sharing one grind per site.
+struct RoundVerifier<F, EF: Field> {
+    arity: usize,
+    fold_log_domain: usize,
+    fold_shift: F,
+    next_log_domain: usize,
+    next_shift: F,
+
+    fold_beta: EF,
+    ood_points: Vec<EF>,
+    query_points: Vec<EF>,
+    query_answers: Vec<EF>,
+    first_round_pairs: FirstRoundPairs<EF>,
+    r_comb: EF,
+}
+
+impl<F, EF> RoundVerifier<F, EF>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+{
+    /// Fix the round's domain geometry. Touches no transcript state.
+    fn new(rc: &StirRoundConfig<F>, current_shift: F, current_log_domain: usize) -> Self {
+        let log_arity = rc.log_folding_factor;
+        let (fold_log_domain, fold_shift) =
+            fold_domain_params(current_shift, current_log_domain, log_arity);
+        Self {
+            arity: 1usize << log_arity,
+            fold_log_domain,
+            fold_shift,
+            next_log_domain: current_log_domain - 1,
+            next_shift: next_domain_shift(current_shift, log_arity),
+            fold_beta: EF::ZERO,
+            ood_points: Vec::new(),
+            query_points: Vec::new(),
+            query_answers: Vec::new(),
+            first_round_pairs: Vec::new(),
+            r_comb: EF::ZERO,
+        }
+    }
+
+    /// The domains an OOD point must avoid, matching `prover::RoundProver::ood_excluded_domains`.
+    const fn excluded_domains(
+        &self,
+        current_shift: F,
+        current_log_domain: usize,
+    ) -> [(F, usize); 3] {
+        [
+            (current_shift, current_log_domain),
+            (self.next_shift, self.next_log_domain),
+            (self.fold_shift, self.fold_log_domain),
+        ]
+    }
+
+    /// Consume the folding challenge, deriving the coset fold point.
+    fn set_gamma(&mut self, gamma: EF, current_shift: F) {
+        self.fold_beta = gamma * EF::from(current_shift.inverse());
+    }
+
+    /// Fetch this round's oracle rows, translate each into the current virtual oracle, and
+    /// fold. Records the round-0 `(index, row)` pairs the PCS layer needs for input binding.
+    #[allow(clippy::too_many_arguments)]
+    fn fetch_and_fold<M, Challenger, IE, Src>(
+        &mut self,
+        config: &StirConfig<F, EF, M, Challenger>,
+        round: usize,
+        rp: &StirRoundProof<EF, M, F>,
+        current_shift: F,
+        current_log_domain: usize,
+        prev_ctx: Option<&VirtualRoundContext<EF>>,
+        is_external: bool,
+        external_fibers: &mut Option<Src>,
+        commitment: Option<&M::Commitment>,
+        query_indices: &[usize],
+    ) -> Result<(), StirError<M::Error, IE>>
+    where
+        M: Mmcs<EF>,
+        Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+    {
+        let fold_height = 1usize << self.fold_log_domain;
+        let cur_dimensions = alloc::vec![Dimensions {
+            height: fold_height,
+            width: self.arity
+        }];
+
+        let round_rows = fetch_round_rows(
+            &config.mmcs,
+            is_external,
+            external_fibers,
+            &RoundRowsRequest {
+                query_openings: rp.query_openings.as_ref(),
+                query_indices,
+                arity: self.arity,
+                expected_num_queries: query_indices.len(),
+                commitment,
+                dimensions: &cur_dimensions,
+                error_round: round,
+            },
+        )?;
+
+        let fold_gen = F::two_adic_generator(self.fold_log_domain);
+        // The fiber of query `j` sits at subgroup coordinates `g^j * (g^fold_height)^l`, a
+        // coset of the arity-th roots of unity. Deriving it once per query serves both the
+        // virtual-oracle materialization and the fold.
+        let domain_gen = F::two_adic_generator(current_log_domain);
+        let fiber_step = domain_gen.exp_power_of_2(self.fold_log_domain);
+
+        let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
+            alloc::collections::BTreeSet::new();
+
+        for (q, (&j, row_evals)) in query_indices.iter().zip(&round_rows).enumerate() {
+            let fold_point = EF::from(self.fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
+
+            let fold_val = query_fold_value(
+                row_evals,
+                j,
+                domain_gen,
+                fiber_step,
+                self.arity,
+                current_shift,
+                self.fold_beta,
+                prev_ctx,
+                round,
+                q,
+            )?;
+
+            if seen_query_indices.insert(j) {
+                self.query_points.push(fold_point);
+                self.query_answers.push(fold_val);
+                if round == 0 {
+                    self.first_round_pairs.push((j, row_evals.clone()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The OOD + query points and their claimed values, in the order `Ans` interpolates them.
+    fn all_points_and_values(&self, ood_answers: &[EF]) -> (Vec<EF>, Vec<EF>) {
+        let all_points: Vec<EF> = self
+            .ood_points
+            .iter()
+            .chain(self.query_points.iter())
+            .copied()
+            .collect();
+        let all_values: Vec<EF> = ood_answers
+            .iter()
+            .chain(self.query_answers.iter())
+            .copied()
+            .collect();
+        (all_points, all_values)
+    }
+
+    /// Touches no transcript state, so it may run after the caller has moved on to other
+    /// instances.
+    fn finish(self, ans_polynomial: Vec<EF>, all_points: Vec<EF>) -> RoundVerifyOutput<F, EF> {
+        RoundVerifyOutput {
+            ctx: VirtualRoundContext {
+                vanishing_coeffs: vanishing_poly_from_roots(&all_points),
+                ans_poly: ans_polynomial,
+                all_points,
+                r_comb: self.r_comb,
+            },
+            next_shift: self.next_shift,
+            next_log_domain: self.next_log_domain,
+            first_round_pairs: self.first_round_pairs,
+        }
+    }
+}
+
 /// Verify one intermediate STIR round (Construction 5.2) against the current virtual oracle,
 /// producing the virtual-oracle context and domain state the next round (or the final round)
 /// builds on.
@@ -260,14 +435,7 @@ where
     Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
 {
     let rc = &config.round_configs[round];
-    let log_arity = rc.log_folding_factor;
-    let arity = 1 << log_arity;
-
-    let (fold_log_domain, fold_shift) =
-        fold_domain_params(current_shift, current_log_domain, log_arity);
-    let fold_height = 1usize << fold_log_domain;
-    let next_log_domain = current_log_domain - 1;
-    let next_shift = next_domain_shift(current_shift, log_arity);
+    let mut rv = RoundVerifier::<F, EF>::new(rc, current_shift, current_log_domain);
 
     // Step 1: folding PoW, folding challenge gamma, and folded-oracle commitment.
     if !challenger.check_witness(rc.folding_pow_bits, rp.folding_pow_witness) {
@@ -276,23 +444,18 @@ where
 
     let gamma: EF = challenger.sample_algebra_element();
     challenger.observe(rp.commitment.clone());
-
     // Mirror the prover: fold at coset coordinates via `gamma / current_shift`
     // (`fold_fiber` interpolates at subgroup coordinates).
-    let fold_beta = gamma * EF::from(current_shift.inverse());
+    rv.set_gamma(gamma, current_shift);
 
     // Step 2: OOD sampling and answer observation.
     if rp.ood_answers.len() != rc.num_ood_samples {
         return Err(StirError::InvalidProofShape);
     }
 
-    let ood_points: Vec<EF> = sample_ood_points(
+    rv.ood_points = sample_ood_points(
         challenger,
-        [
-            (current_shift, current_log_domain),
-            (next_shift, next_log_domain),
-            (fold_shift, fold_log_domain),
-        ],
+        rv.excluded_domains(current_shift, current_log_domain),
         rc.num_ood_samples,
     );
 
@@ -306,15 +469,8 @@ where
     }
 
     // Step 4: combination challenge, query sampling, and fiber verification.
-
-    let fold_gen = F::two_adic_generator(fold_log_domain);
-
-    let cur_dimensions = alloc::vec![Dimensions {
-        height: fold_height,
-        width: arity
-    }];
-
     let r_comb: EF = challenger.sample_algebra_element();
+    rv.r_comb = r_comb;
 
     // Step 4a: sample every query index first, in draw order, mirroring the prover's
     // unbiased-sampling policy so the Fiat-Shamir transcript stays in sync. Merkle
@@ -322,80 +478,28 @@ where
     let mut query_indices: Vec<usize> = Vec::with_capacity(rc.num_queries);
     for _ in 0..rc.num_queries {
         let j = challenger
-            .sample_uniform_bits::<true>(fold_log_domain)
+            .sample_uniform_bits::<true>(rv.fold_log_domain)
             .expect("RESAMPLE = true: rejection loops internally, never errors");
         query_indices.push(j);
     }
 
-    // Step 4b: obtain this round's oracle rows. An external initial oracle is answered by
-    // the caller against its own binding; every committed oracle has one shared, pruned
-    // Merkle multi-opening proof authenticating all of its query rows at once.
-    let round_rows = fetch_round_rows(
-        &config.mmcs,
+    // Step 4b/4c: obtain this round's oracle rows and fold each query against the current
+    // virtual oracle.
+    rv.fetch_and_fold(
+        config,
+        round,
+        rp,
+        current_shift,
+        current_log_domain,
+        prev_ctx,
         is_external,
         external_fibers,
-        &RoundRowsRequest {
-            query_openings: rp.query_openings.as_ref(),
-            query_indices: &query_indices,
-            arity,
-            expected_num_queries: rc.num_queries,
-            commitment,
-            dimensions: &cur_dimensions,
-            error_round: round,
-        },
+        commitment,
+        &query_indices,
     )?;
 
-    // Step 4c: per-query virtual-oracle materialization and folding.
-    let mut query_points: Vec<EF> = Vec::with_capacity(rc.num_queries);
-    let mut query_answers: Vec<EF> = Vec::with_capacity(rc.num_queries);
-    let mut first_round_pairs: FirstRoundPairs<EF> = Vec::new();
-
-    let mut seen_query_indices: alloc::collections::BTreeSet<usize> =
-        alloc::collections::BTreeSet::new();
-
-    // The fiber of query `j` sits at subgroup coordinates `g^j * (g^fold_height)^l`, a
-    // coset of the arity-th roots of unity. Deriving it once per query serves both the
-    // virtual-oracle materialization and the fold.
-    let domain_gen = F::two_adic_generator(current_log_domain);
-    let fiber_step = domain_gen.exp_power_of_2(fold_log_domain);
-
-    for (q, (&j, row_evals)) in query_indices.iter().zip(&round_rows).enumerate() {
-        let fold_point = EF::from(fold_shift) * EF::from(fold_gen.exp_u64(j as u64));
-
-        let fold_val = query_fold_value(
-            row_evals,
-            j,
-            domain_gen,
-            fiber_step,
-            arity,
-            current_shift,
-            fold_beta,
-            prev_ctx,
-            round,
-            q,
-        )?;
-
-        if seen_query_indices.insert(j) {
-            query_points.push(fold_point);
-            query_answers.push(fold_val);
-            if round == 0 {
-                first_round_pairs.push((j, row_evals.clone()));
-            }
-        }
-    }
-
     // Step 4: ans + shake polynomial observation and consistency check.
-    let all_points: Vec<EF> = ood_points
-        .iter()
-        .chain(query_points.iter())
-        .copied()
-        .collect();
-    let all_values: Vec<EF> = rp
-        .ood_answers
-        .iter()
-        .chain(query_answers.iter())
-        .copied()
-        .collect();
+    let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
     // Ans interpolates |all_points| values, so its degree is `< all_points.len()`. The
     // prover may have stripped trailing zeros, so accept any length up to that bound; reject
@@ -424,17 +528,124 @@ where
         return Err(StirError::InvalidShakeConsistency { round });
     }
 
-    Ok(RoundVerifyOutput {
-        ctx: VirtualRoundContext {
-            ans_poly: rp.ans_polynomial.clone(),
-            vanishing_coeffs: vanishing_poly_from_roots(&all_points),
-            all_points,
-            r_comb,
-        },
-        next_shift,
-        next_log_domain,
-        first_round_pairs,
-    })
+    Ok(rv.finish(rp.ans_polynomial.clone(), all_points))
+}
+
+/// One instance's in-flight final round, advanced in the order the transcript demands.
+///
+/// Mirrors `prover::FinalRoundProver`.
+struct FinalRoundVerifier<F, EF: Field> {
+    final_arity: usize,
+    final_new_log_domain: usize,
+    final_new_shift: F,
+    fold_beta: EF,
+}
+
+impl<F, EF> FinalRoundVerifier<F, EF>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+{
+    /// Fix the final round's domain geometry. Touches no transcript state.
+    fn new(log_folding_factor: usize, current_shift: F, current_log_domain: usize) -> Self {
+        let (final_new_log_domain, final_new_shift) =
+            fold_domain_params(current_shift, current_log_domain, log_folding_factor);
+        Self {
+            final_arity: 1usize << log_folding_factor,
+            final_new_log_domain,
+            final_new_shift,
+            fold_beta: EF::ZERO,
+        }
+    }
+
+    /// Consume the final folding challenge, deriving the coset fold point.
+    fn set_gamma(&mut self, final_gamma: EF, current_shift: F) {
+        self.fold_beta = final_gamma * EF::from(current_shift.inverse());
+    }
+
+    /// Fetch the final-round oracle rows, fold each query against the current virtual oracle,
+    /// and check the fold against the sent final polynomial. Returns the round-0 `(index, row)`
+    /// pairs the PCS layer needs for input binding, when this is also the first round.
+    #[allow(clippy::too_many_arguments)]
+    fn fetch_and_check<M, Challenger, IE, Src>(
+        &self,
+        config: &StirConfig<F, EF, M, Challenger>,
+        proof: &StirProof<EF, M, F>,
+        num_rounds: usize,
+        current_shift: F,
+        current_log_domain: usize,
+        prev_ctx: Option<&VirtualRoundContext<EF>>,
+        is_external: bool,
+        external_fibers: &mut Option<Src>,
+        commitment: Option<&M::Commitment>,
+        final_indices: &[usize],
+    ) -> Result<FirstRoundPairs<EF>, StirError<M::Error, IE>>
+    where
+        M: Mmcs<EF>,
+        Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+    {
+        let final_new_height = 1usize << self.final_new_log_domain;
+        let final_dimensions = alloc::vec![Dimensions {
+            height: final_new_height,
+            width: self.final_arity,
+        }];
+        let final_gen = F::two_adic_generator(self.final_new_log_domain);
+
+        // With no intermediate rounds these queries read the initial oracle, so they follow
+        // the same external-or-committed split as an intermediate round.
+        let final_rows = fetch_round_rows(
+            &config.mmcs,
+            is_external,
+            external_fibers,
+            &RoundRowsRequest {
+                query_openings: proof.final_query_openings.as_ref(),
+                query_indices: final_indices,
+                arity: self.final_arity,
+                expected_num_queries: final_indices.len(),
+                commitment,
+                dimensions: &final_dimensions,
+                error_round: num_rounds,
+            },
+        )?;
+
+        // When num_rounds == 0 the final queries also serve as the PCS first-round binding.
+        // Track them with the same dedup-on-first-occurrence rule as the intermediate-round
+        // path.
+        let mut final_seen: alloc::collections::BTreeSet<usize> =
+            alloc::collections::BTreeSet::new();
+        let mut first_round_pairs: FirstRoundPairs<EF> = Vec::new();
+
+        let final_domain_gen = F::two_adic_generator(current_log_domain);
+        let final_fiber_step = final_domain_gen.exp_power_of_2(self.final_new_log_domain);
+
+        for (q, (&j, row_evals)) in final_indices.iter().zip(&final_rows).enumerate() {
+            let fold_val = query_fold_value(
+                row_evals,
+                j,
+                final_domain_gen,
+                final_fiber_step,
+                self.final_arity,
+                current_shift,
+                self.fold_beta,
+                prev_ctx,
+                num_rounds,
+                q,
+            )?;
+
+            let x_j = EF::from(self.final_new_shift) * EF::from(final_gen.exp_u64(j as u64));
+
+            let expected = eval_poly(&proof.final_polynomial, x_j);
+            if fold_val != expected {
+                return Err(StirError::FinalPolyMismatch);
+            }
+
+            if num_rounds == 0 && final_seen.insert(j) {
+                first_round_pairs.push((j, row_evals.clone()));
+            }
+        }
+
+        Ok(first_round_pairs)
+    }
 }
 
 /// Verify the final STIR round: the last fold is checked directly against the sent final
@@ -462,11 +673,11 @@ where
         + CanSampleUniformBits<F>,
     Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
 {
-    let final_log_arity = config.log_folding_factor;
-    let final_arity = 1usize << final_log_arity;
-    let (final_new_log_domain, final_new_shift) =
-        fold_domain_params(current_shift, current_log_domain, final_log_arity);
-    let final_new_height = 1usize << final_new_log_domain;
+    let mut fv = FinalRoundVerifier::<F, EF>::new(
+        config.log_folding_factor,
+        current_shift,
+        current_log_domain,
+    );
 
     if !challenger.check_witness(
         config.final_folding_pow_bits,
@@ -476,8 +687,7 @@ where
     }
 
     let final_gamma: EF = challenger.sample_algebra_element();
-    // See the round-fold note: coset fold at `final_gamma` via `final_gamma / current_shift`.
-    let final_fold_beta = final_gamma * EF::from(current_shift.inverse());
+    fv.set_gamma(final_gamma, current_shift);
 
     let expected_final_len = config.final_poly_len();
     if proof.final_polynomial.len() != expected_final_len {
@@ -490,74 +700,28 @@ where
         return Err(StirError::InvalidPowWitness { round: num_rounds });
     }
 
-    let final_dimensions = alloc::vec![Dimensions {
-        height: final_new_height,
-        width: final_arity,
-    }];
-    let final_gen = F::two_adic_generator(final_new_log_domain);
-
     // Sample every final-round query index first, deferring Merkle verification to a single
     // shared multi-opening check below.
     let mut final_indices: Vec<usize> = Vec::with_capacity(config.final_queries);
     for _ in 0..config.final_queries {
         let j = challenger
-            .sample_uniform_bits::<true>(final_new_log_domain)
+            .sample_uniform_bits::<true>(fv.final_new_log_domain)
             .expect("RESAMPLE = true: rejection loops internally, never errors");
         final_indices.push(j);
     }
 
-    // With no intermediate rounds these queries read the initial oracle, so they follow the
-    // same external-or-committed split as an intermediate round.
-    let final_rows = fetch_round_rows(
-        &config.mmcs,
+    fv.fetch_and_check(
+        config,
+        proof,
+        num_rounds,
+        current_shift,
+        current_log_domain,
+        prev_ctx,
         is_external,
         external_fibers,
-        &RoundRowsRequest {
-            query_openings: proof.final_query_openings.as_ref(),
-            query_indices: &final_indices,
-            arity: final_arity,
-            expected_num_queries: config.final_queries,
-            commitment,
-            dimensions: &final_dimensions,
-            error_round: num_rounds,
-        },
-    )?;
-
-    // When num_rounds == 0 the final queries also serve as the PCS first-round binding.
-    // Track them with the same dedup-on-first-occurrence rule as the intermediate-round path.
-    let mut final_seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
-    let mut first_round_pairs: FirstRoundPairs<EF> = Vec::new();
-
-    let final_domain_gen = F::two_adic_generator(current_log_domain);
-    let final_fiber_step = final_domain_gen.exp_power_of_2(final_new_log_domain);
-
-    for (q, (&j, row_evals)) in final_indices.iter().zip(&final_rows).enumerate() {
-        let fold_val = query_fold_value(
-            row_evals,
-            j,
-            final_domain_gen,
-            final_fiber_step,
-            final_arity,
-            current_shift,
-            final_fold_beta,
-            prev_ctx,
-            num_rounds,
-            q,
-        )?;
-
-        let x_j = EF::from(final_new_shift) * EF::from(final_gen.exp_u64(j as u64));
-
-        let expected = eval_poly(&proof.final_polynomial, x_j);
-        if fold_val != expected {
-            return Err(StirError::FinalPolyMismatch);
-        }
-
-        if num_rounds == 0 && final_seen.insert(j) {
-            first_round_pairs.push((j, row_evals.clone()));
-        }
-    }
-
-    Ok(first_round_pairs)
+        commitment,
+        &final_indices,
+    )
 }
 
 /// Errors returned by [`verify_stir`].

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -958,3 +958,360 @@ where
         first_round_fiber_evals,
     })
 }
+
+/// Source of the queried fibers of `B` external initial oracles, when there are none.
+type NoExternalFibersMulti<EF, MmcsError> =
+    fn(&[usize]) -> Result<Vec<Vec<EF>>, StirError<MmcsError>>;
+
+/// Verify `B` STIR proofs of possibly different degrees in lockstep, mirroring
+/// [`crate::prover::prove_stir_multi`].
+pub fn verify_stir_multi<F, EF, M, Challenger>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    proofs: &[&StirProof<EF, M, Challenger::Witness>],
+    challenger: &mut Challenger,
+) -> Result<Vec<StirVerifyOutputs<EF>>, StirError<M::Error>>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+{
+    verify_stir_multi_inner(
+        configs,
+        proofs,
+        challenger,
+        None::<Vec<NoExternalFibersMulti<EF, M::Error>>>,
+    )
+}
+
+/// Verify `B` STIR proofs whose initial oracles are external, mirroring
+/// [`crate::prover::prove_stir_multi_from_external_codewords`].
+///
+/// `initial_fibers[i]` is called once with instance `i`'s sorted unique fold-domain indices,
+/// exactly as [`verify_stir_with_external_initial`]'s single-instance callback.
+pub fn verify_stir_multi_with_external_initial<F, EF, M, Challenger, IE, Src>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    proofs: &[&StirProof<EF, M, Challenger::Witness>],
+    challenger: &mut Challenger,
+    initial_fibers: Vec<Src>,
+) -> Result<Vec<StirVerifyOutputs<EF>>, StirError<M::Error, IE>>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+    Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+{
+    verify_stir_multi_inner(configs, proofs, challenger, Some(initial_fibers))
+}
+
+/// Shared body of [`verify_stir_multi`] and [`verify_stir_multi_with_external_initial`].
+///
+/// Mirrors `prover::prove_stir_multi_inner`'s right-aligned lockstep schedule: at
+/// each global round, every active instance's grind witness must agree (checked via
+/// `PartialEq`, else [`StirError::InvalidProofShape`]), then the shared grind is checked once
+/// at the max of the active instances' bits.
+fn verify_stir_multi_inner<F, EF, M, Challenger, IE, Src>(
+    configs: &[&StirConfig<F, EF, M, Challenger>],
+    proofs: &[&StirProof<EF, M, Challenger::Witness>],
+    challenger: &mut Challenger,
+    external_fibers: Option<Vec<Src>>,
+) -> Result<Vec<StirVerifyOutputs<EF>>, StirError<M::Error, IE>>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField + BasedVectorSpace<F>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F>
+        + CanObserve<M::Commitment>
+        + GrindingChallenger<Witness = F>
+        + CanSampleUniformBits<F>,
+    Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
+{
+    let b = configs.len();
+    assert_eq!(proofs.len(), b, "one proof per instance");
+
+    for i in 0..b {
+        if proofs[i].round_proofs.len() != configs[i].num_rounds() {
+            return Err(StirError::InvalidProofShape);
+        }
+    }
+
+    let initial_is_external = external_fibers.is_some();
+    let mut external_fibers: Vec<Option<Src>> = external_fibers.map_or_else(
+        || (0..b).map(|_| None).collect(),
+        |v| {
+            assert_eq!(v.len(), b, "one external-fiber source per instance");
+            v.into_iter().map(Some).collect()
+        },
+    );
+
+    // The initial oracle is either committed by STIR — in which case its commitment enters the
+    // transcript here — or external, in which case the caller has already bound it and every
+    // proof must carry no commitment at all.
+    let mut shifts = Vec::with_capacity(b);
+    let mut log_domains = Vec::with_capacity(b);
+    for i in 0..b {
+        match (&proofs[i].initial_commitment, initial_is_external) {
+            (Some(commitment), false) => challenger.observe(commitment.clone()),
+            (None, true) => {}
+            _ => return Err(StirError::InvalidProofShape),
+        }
+        shifts.push(F::GENERATOR);
+        log_domains.push(configs[i].log_starting_domain_size());
+    }
+
+    let max_m = configs.iter().map(|c| c.num_rounds()).max().unwrap_or(0);
+    let offset = |i: usize| max_m - configs[i].num_rounds();
+
+    let mut prev_ctx: Vec<Option<VirtualRoundContext<EF>>> = (0..b).map(|_| None).collect();
+    let mut first_round_pairs: Vec<FirstRoundPairs<EF>> = (0..b).map(|_| Vec::new()).collect();
+
+    for r in 0..max_m {
+        let active: Vec<usize> = (0..b).filter(|&i| offset(i) <= r).collect();
+
+        let mut rvs: Vec<RoundVerifier<F, EF>> = active
+            .iter()
+            .map(|&i| {
+                RoundVerifier::<F, EF>::new(
+                    &configs[i].round_configs[r - offset(i)],
+                    shifts[i],
+                    log_domains[i],
+                )
+            })
+            .collect();
+
+        // [grind folding_pow_bits]: every active instance's replicated witness must agree.
+        let folding_witnesses: Vec<F> = active
+            .iter()
+            .map(|&i| proofs[i].round_proofs[r - offset(i)].folding_pow_witness)
+            .collect();
+        if folding_witnesses.windows(2).any(|w| w[0] != w[1]) {
+            return Err(StirError::InvalidProofShape);
+        }
+        let shared_folding_bits = active
+            .iter()
+            .map(|&i| configs[i].round_configs[r - offset(i)].folding_pow_bits)
+            .max()
+            .expect("`active` is non-empty for r < max_m");
+        if !challenger.check_witness(shared_folding_bits, folding_witnesses[0]) {
+            return Err(StirError::InvalidPowWitness { round: r });
+        }
+
+        // Phase 1: per-instance folding challenge and commitment absorb.
+        for (&i, rv) in active.iter().zip(rvs.iter_mut()) {
+            let gamma: EF = challenger.sample_algebra_element();
+            challenger.observe(proofs[i].round_proofs[r - offset(i)].commitment.clone());
+            rv.set_gamma(gamma, shifts[i]);
+        }
+
+        // Phase 2: per-instance OOD sampling and answer absorb.
+        for (&i, rv) in active.iter().zip(rvs.iter_mut()) {
+            let local_r = r - offset(i);
+            let rc = &configs[i].round_configs[local_r];
+            let rp = &proofs[i].round_proofs[local_r];
+            if rp.ood_answers.len() != rc.num_ood_samples {
+                return Err(StirError::InvalidProofShape);
+            }
+            rv.ood_points = sample_ood_points(
+                challenger,
+                rv.excluded_domains(shifts[i], log_domains[i]),
+                rc.num_ood_samples,
+            );
+            challenger.observe_algebra_slice(&rp.ood_answers);
+        }
+
+        // [grind pow_bits]: every active instance's replicated witness must agree.
+        let query_witnesses: Vec<F> = active
+            .iter()
+            .map(|&i| proofs[i].round_proofs[r - offset(i)].pow_witness)
+            .collect();
+        if query_witnesses.windows(2).any(|w| w[0] != w[1]) {
+            return Err(StirError::InvalidProofShape);
+        }
+        let shared_pow_bits = active
+            .iter()
+            .map(|&i| configs[i].round_configs[r - offset(i)].pow_bits)
+            .max()
+            .expect("`active` is non-empty for r < max_m");
+        if !challenger.check_witness(shared_pow_bits, query_witnesses[0]) {
+            return Err(StirError::InvalidPowWitness { round: r });
+        }
+
+        // Phase 3: per-instance combination challenge, query sampling, and fiber
+        // materialization/folding.
+        for (&i, rv) in active.iter().zip(rvs.iter_mut()) {
+            let local_r = r - offset(i);
+            let rc = &configs[i].round_configs[local_r];
+            let r_comb: EF = challenger.sample_algebra_element();
+            rv.r_comb = r_comb;
+
+            let mut query_indices: Vec<usize> = Vec::with_capacity(rc.num_queries);
+            for _ in 0..rc.num_queries {
+                let j = challenger
+                    .sample_uniform_bits::<true>(rv.fold_log_domain)
+                    .expect("RESAMPLE = true: rejection loops internally, never errors");
+                query_indices.push(j);
+            }
+
+            let commitment = if local_r == 0 {
+                proofs[i].initial_commitment.as_ref()
+            } else {
+                Some(&proofs[i].round_proofs[local_r - 1].commitment)
+            };
+            let is_external = local_r == 0 && initial_is_external;
+
+            rv.fetch_and_fold(
+                configs[i],
+                local_r,
+                &proofs[i].round_proofs[local_r],
+                shifts[i],
+                log_domains[i],
+                prev_ctx[i].as_ref(),
+                is_external,
+                &mut external_fibers[i],
+                commitment,
+                &query_indices,
+            )?;
+        }
+
+        // Phase 4: per-instance ans/shake absorb, shake-check challenge, and consistency.
+        let mut finishes: Vec<(usize, RoundVerifyOutput<F, EF>)> = Vec::with_capacity(active.len());
+        for (&i, rv) in active.iter().zip(rvs) {
+            let local_r = r - offset(i);
+            let rp = &proofs[i].round_proofs[local_r];
+            let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
+
+            let max_ans_len = all_points.len();
+            if rp.ans_polynomial.len() > max_ans_len
+                || rp.shake_polynomial.len() > max_ans_len.saturating_sub(1)
+            {
+                return Err(StirError::InvalidProofShape);
+            }
+
+            challenger.observe_algebra_slice(&rp.ans_polynomial);
+            challenger.observe_algebra_slice(&rp.shake_polynomial);
+            let rho: EF = challenger.sample_algebra_element();
+
+            if !check_shake_consistency(
+                &rp.ans_polynomial,
+                &rp.shake_polynomial,
+                &all_points,
+                &all_values,
+                rho,
+            ) {
+                return Err(StirError::InvalidShakeConsistency { round: local_r });
+            }
+
+            finishes.push((i, rv.finish(rp.ans_polynomial.clone(), all_points)));
+        }
+
+        // Phase 5: touches no transcript state, so instance order no longer matters.
+        for (i, output) in finishes {
+            first_round_pairs[i].extend(output.first_round_pairs);
+            prev_ctx[i] = Some(output.ctx);
+            shifts[i] = output.next_shift;
+            log_domains[i] = output.next_log_domain;
+        }
+    }
+
+    // Final round: every instance reaches it on this same global step (right-alignment).
+    let final_folding_witnesses: Vec<F> =
+        proofs.iter().map(|p| p.final_folding_pow_witness).collect();
+    if final_folding_witnesses.windows(2).any(|w| w[0] != w[1]) {
+        return Err(StirError::InvalidProofShape);
+    }
+    let shared_final_folding_bits = configs
+        .iter()
+        .map(|c| c.final_folding_pow_bits)
+        .max()
+        .unwrap_or(0);
+    if !challenger.check_witness(shared_final_folding_bits, final_folding_witnesses[0]) {
+        return Err(StirError::InvalidPowWitness { round: max_m });
+    }
+
+    let mut fvs: Vec<FinalRoundVerifier<F, EF>> = (0..b)
+        .map(|i| {
+            FinalRoundVerifier::<F, EF>::new(
+                configs[i].log_folding_factor,
+                shifts[i],
+                log_domains[i],
+            )
+        })
+        .collect();
+
+    for i in 0..b {
+        let final_gamma: EF = challenger.sample_algebra_element();
+        fvs[i].set_gamma(final_gamma, shifts[i]);
+
+        let expected_final_len = configs[i].final_poly_len();
+        if proofs[i].final_polynomial.len() != expected_final_len {
+            return Err(StirError::InvalidProofShape);
+        }
+        challenger.observe_algebra_slice(&proofs[i].final_polynomial);
+    }
+
+    let final_query_witnesses: Vec<F> = proofs.iter().map(|p| p.final_pow_witness).collect();
+    if final_query_witnesses.windows(2).any(|w| w[0] != w[1]) {
+        return Err(StirError::InvalidProofShape);
+    }
+    let shared_final_pow_bits = configs.iter().map(|c| c.final_pow_bits).max().unwrap_or(0);
+    if !challenger.check_witness(shared_final_pow_bits, final_query_witnesses[0]) {
+        return Err(StirError::InvalidPowWitness { round: max_m });
+    }
+
+    for i in 0..b {
+        let mut final_indices: Vec<usize> = Vec::with_capacity(configs[i].final_queries);
+        for _ in 0..configs[i].final_queries {
+            let j = challenger
+                .sample_uniform_bits::<true>(fvs[i].final_new_log_domain)
+                .expect("RESAMPLE = true: rejection loops internally, never errors");
+            final_indices.push(j);
+        }
+
+        let commitment = if configs[i].num_rounds() == 0 {
+            proofs[i].initial_commitment.as_ref()
+        } else {
+            Some(
+                &proofs[i]
+                    .round_proofs
+                    .last()
+                    .expect("num_rounds() > 0")
+                    .commitment,
+            )
+        };
+        let is_external = configs[i].num_rounds() == 0 && initial_is_external;
+
+        let final_pairs = fvs[i].fetch_and_check(
+            configs[i],
+            proofs[i],
+            configs[i].num_rounds(),
+            shifts[i],
+            log_domains[i],
+            prev_ctx[i].as_ref(),
+            is_external,
+            &mut external_fibers[i],
+            commitment,
+            &final_indices,
+        )?;
+        first_round_pairs[i].extend(final_pairs);
+    }
+
+    Ok(first_round_pairs
+        .into_iter()
+        .map(|mut pairs| {
+            pairs.sort_by_key(|(j, _)| *j);
+            let (first_round_indices, first_round_fiber_evals): (Vec<_>, Vec<_>) =
+                pairs.into_iter().unzip();
+            StirVerifyOutputs {
+                first_round_indices,
+                first_round_fiber_evals,
+            }
+        })
+        .collect())
+}

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -904,7 +904,7 @@ mod babybear_pcs {
 
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_challenger.observe(commit.clone());
+        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
 
         let zeta: Challenge = p_challenger.sample_algebra_element();
 
@@ -915,7 +915,7 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_challenger = challenger_template;
-        v_challenger.observe(commit.clone());
+        commit.iter().for_each(|c| v_challenger.observe(c.clone()));
         let v_zeta: Challenge = v_challenger.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1035,7 +1035,9 @@ mod babybear_pcs {
         let mut stir_p_ch = Challenger::new(perm.clone());
         let (stir_commit, stir_data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&stir_pcs, [(stir_domain, mat)]);
-        stir_p_ch.observe(stir_commit.clone());
+        stir_commit
+            .iter()
+            .for_each(|c| stir_p_ch.observe(c.clone()));
         // STIR's input commitment hashes fiber-grouped leaves, so its root — and hence the
         // point derived from it — differs from FRI's over the same matrix. Proof size does
         // not depend on which point is opened, so the comparison stays like-for-like.
@@ -1047,7 +1049,9 @@ mod babybear_pcs {
         );
 
         let mut stir_v_ch = Challenger::new(perm);
-        stir_v_ch.observe(stir_commit.clone());
+        stir_commit
+            .iter()
+            .for_each(|c| stir_v_ch.observe(c.clone()));
         let stir_v_zeta: Challenge = stir_v_ch.sample_algebra_element();
         assert_eq!(stir_v_zeta, stir_zeta);
         let stir_claims = vec![(
@@ -1137,10 +1141,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_a, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_b, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1151,8 +1155,8 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
+        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1192,10 +1196,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1204,8 +1208,8 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
+        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1237,10 +1241,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1256,8 +1260,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
+        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1292,10 +1296,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1311,8 +1315,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
+        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1345,7 +1349,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        commit.iter().for_each(|c| p_ch.observe(c.clone()));
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1362,7 +1366,7 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        commit.iter().for_each(|c| v_ch.observe(c.clone()));
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1391,7 +1395,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        commit.iter().for_each(|c| p_ch.observe(c.clone()));
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1400,7 +1404,7 @@ mod babybear_pcs {
         );
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        commit.iter().for_each(|c| v_ch.observe(c.clone()));
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1431,7 +1435,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        commit.iter().for_each(|c| p_ch.observe(c.clone()));
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1445,7 +1449,7 @@ mod babybear_pcs {
         proof[0].0.initial_commitment = Some(proof[0].0.round_proofs[0].commitment.clone());
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        commit.iter().for_each(|c| v_ch.observe(c.clone()));
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         let claims = vec![(
             commit,

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -1460,3 +1460,213 @@ mod babybear_pcs {
         assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Multi-instance lockstep driver: grind sharing across STIR height buckets.
+// ---------------------------------------------------------------------------
+
+mod babybear_stir_multi {
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_stir::prover::{prove_stir, prove_stir_multi};
+    use p3_stir::verifier::verify_stir_multi;
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type ValMmcs =
+        MerkleTreeMmcs<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress, 2, 8>;
+    type MyMmcs = ExtensionMmcs<F, EF, ValMmcs>;
+    type Dft = Radix2DitParallel<F>;
+    type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+    fn make_params(
+        log_blowup: usize,
+        log_folding_factor: usize,
+        security_level: usize,
+        max_pow_bits: usize,
+    ) -> (StirParameters<MyMmcs>, Dft, Challenger) {
+        let perm = Perm::new_from_rng_128(&mut seeded_rng());
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+        let val_mmcs = ValMmcs::new(hash, compress, 0);
+        let mmcs = MyMmcs::new(val_mmcs);
+
+        let params = StirParameters {
+            log_blowup,
+            log_folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level,
+            max_pow_bits,
+            mmcs,
+        };
+        (params, Dft::default(), Challenger::new(perm))
+    }
+
+    type Instances = (Vec<StirConfig<F, EF, MyMmcs, Challenger>>, Vec<Vec<EF>>);
+
+    /// Build one config per `log_degrees` entry (all sharing `params`) plus a random
+    /// polynomial for each.
+    fn make_instances(params: &StirParameters<MyMmcs>, log_degrees: &[usize]) -> Instances {
+        let mut rng = seeded_rng();
+        let configs = log_degrees
+            .iter()
+            .map(|&log_degree| {
+                StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params.clone())
+            })
+            .collect();
+        let polys = log_degrees
+            .iter()
+            .map(|&log_degree| (0..1usize << log_degree).map(|_| rng.random()).collect())
+            .collect();
+        (configs, polys)
+    }
+
+    /// Run `prove_stir_multi` then `verify_stir_multi` over one bucket per `log_degrees` entry
+    /// and assert the proof verifies.
+    fn do_test_multi_prove_verify(
+        params: &StirParameters<MyMmcs>,
+        dft: &Dft,
+        challenger_template: &Challenger,
+        log_degrees: &[usize],
+    ) {
+        let (configs, polys) = make_instances(params, log_degrees);
+        let config_refs: Vec<&StirConfig<F, EF, MyMmcs, Challenger>> = configs.iter().collect();
+
+        let mut p_ch = challenger_template.clone();
+        let results = prove_stir_multi(&config_refs, polys, dft, &mut p_ch);
+        assert_eq!(results.len(), log_degrees.len());
+
+        let proofs: Vec<_> = results.iter().map(|(proof, _)| proof).collect();
+        let mut v_ch = challenger_template.clone();
+        verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
+            .unwrap_or_else(|e| {
+                panic!("multi-bucket verification failed for log_degrees={log_degrees:?}: {e}")
+            });
+    }
+
+    #[test]
+    fn test_multi_one_bucket() {
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        do_test_multi_prove_verify(&params, &dft, &challenger, &[8]);
+    }
+
+    #[test]
+    fn test_multi_two_buckets_ratio2() {
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        do_test_multi_prove_verify(&params, &dft, &challenger, &[9, 8]);
+    }
+
+    #[test]
+    fn test_multi_two_buckets_ratio8() {
+        // log_degree 11 vs 8: LDE-height ratio 2^3 = 8. Grind sharing is ratio-independent,
+        // so this must configure and verify exactly like the ratio-2 case.
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        do_test_multi_prove_verify(&params, &dft, &challenger, &[11, 8]);
+    }
+
+    #[test]
+    fn test_multi_three_buckets_ratio2_steps() {
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        do_test_multi_prove_verify(&params, &dft, &challenger, &[10, 9, 8]);
+    }
+
+    #[test]
+    fn test_multi_three_buckets_ratio8_spread() {
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        do_test_multi_prove_verify(&params, &dft, &challenger, &[12, 9, 8]);
+    }
+
+    #[test]
+    fn test_multi_one_bucket_matches_single_instance_bytes() {
+        // At B=1 the shared-grind schedule degenerates to the single-instance schedule, so
+        // the multi-driver must reproduce the exact same transcript and proof bytes.
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        let log_degree = 8;
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+
+        let mut rng = seeded_rng();
+        let poly: Vec<EF> = (0..1usize << log_degree).map(|_| rng.random()).collect();
+
+        let mut p_ch_single = challenger.clone();
+        let (single_proof, single_idx) = prove_stir(&config, poly.clone(), &dft, &mut p_ch_single);
+
+        let config_refs = [&config];
+        let mut p_ch_multi = challenger;
+        let results = prove_stir_multi(&config_refs, vec![poly], &dft, &mut p_ch_multi);
+        assert_eq!(results.len(), 1);
+        let (multi_proof, multi_idx) = &results[0];
+
+        assert_eq!(single_idx, *multi_idx);
+        let single_bytes = postcard::to_allocvec(&single_proof).expect("serialize");
+        let multi_bytes = postcard::to_allocvec(multi_proof).expect("serialize");
+        assert_eq!(
+            single_bytes, multi_bytes,
+            "B=1 multi-driver must be byte-identical to the single-instance path"
+        );
+    }
+
+    #[test]
+    fn test_multi_witness_replayed_across_grind_sites_rejected() {
+        let (params, dft, challenger) = make_params(1, 2, 32, 12);
+        let log_degree = 8;
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let round_with_pow = config
+            .round_configs
+            .iter()
+            .position(|rc| rc.pow_bits > 0)
+            .expect("expected a round with pow_bits > 0");
+
+        let mut rng = seeded_rng();
+        let poly: Vec<EF> = (0..1usize << log_degree).map(|_| rng.random()).collect();
+
+        let config_refs = [&config];
+        let mut p_ch = challenger.clone();
+        let results = prove_stir_multi(&config_refs, vec![poly], &dft, &mut p_ch);
+        let (mut proof, _idx) = results.into_iter().next().expect("one instance");
+
+        // Replay the folding-grind witness at the query-grind site of the same round: the two
+        // grinds bind different transcript states, so this must be rejected.
+        proof.round_proofs[round_with_pow].pow_witness =
+            proof.round_proofs[round_with_pow].folding_pow_witness;
+
+        let mut v_ch = challenger;
+        let proofs = [&proof];
+        let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
+            .expect_err("a witness replayed from another grind site must be rejected");
+        assert!(matches!(err, p3_stir::StirError::InvalidPowWitness { .. }));
+    }
+
+    #[test]
+    fn test_multi_disagreeing_replicated_witness_rejected() {
+        let (params, dft, challenger) = make_params(1, 2, 32, 12);
+        let log_degree = 8;
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        // Two identical-height instances so their round indices line up 1:1 and share every
+        // grind site exactly.
+        let config_refs = [&config, &config];
+
+        let mut rng = seeded_rng();
+        let polys = vec![
+            (0..1usize << log_degree).map(|_| rng.random()).collect(),
+            (0..1usize << log_degree).map(|_| rng.random()).collect(),
+        ];
+
+        let mut p_ch = challenger.clone();
+        let mut results = prove_stir_multi(&config_refs, polys, &dft, &mut p_ch).into_iter();
+        let proof_a = results.next().expect("bucket a").0;
+        let mut proof_b = results.next().expect("bucket b").0;
+
+        // Disagree bucket B's round-0 folding-grind witness from bucket A's replicated copy.
+        proof_b.round_proofs[0].folding_pow_witness += F::ONE;
+
+        let mut v_ch = challenger;
+        let proofs = [&proof_a, &proof_b];
+        let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
+            .expect_err("disagreeing replicated witnesses across buckets must be rejected");
+        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+    }
+}


### PR DESCRIPTION
## Summary

  `TwoAdicStirPcs` runs one independent STIR instance per distinct LDE height in a batched commitment. Each instance grinds at `2Mᵢ + 2` sites (2 per intermediate round + 2 in the final round), so `open()` for `B` buckets
  paid `Σᵢ(2Mᵢ + 2)` independent grinds — at deployment `pow_bits≈20` this is the dominant cost of multi-height `open()`.

  This PR adds a lockstep multi-instance driver (`prove_stir_multi*` / `verify_stir_multi*`) that runs all `B` buckets on one shared transcript, so every grind site is paid once across all buckets instead of once per bucket,
  and wires `TwoAdicStirPcs::open()`/`verify()` to it. Proof size and verify time are unchanged (still per-bucket) — this only touches the prover's grinding cost.

  ## How it works

  Instances are right-aligned by round count: instance `i` (with `Mᵢ` intermediate rounds) runs its local rounds at global rounds `maxM − Mᵢ .. maxM` (`maxM = maxᵢ Mᵢ`), so every instance reaches its final round on the same
  global step and their two final-round grinds merge too. At each shared grind site, bits = `max` over the instances active at that round of that instance's own local-round bits. The single resulting witness is replicated
  verbatim into every active instance's own `StirRoundProof` slot — no changes to `StirProof`, `StirRoundProof`, or the existing single-instance `prove_stir`/`verify_stir` API. The verifier checks all replicated copies agree
  (`StirError::InvalidProofShape` if not) before checking the grind once, against the max bits — never against any individual instance's own (possibly lower) bits.

  ## Soundness

  The round error is `maxᵢ εᵢ`, not `Σᵢ εᵢ`. Sharing one grind at `p = maxᵢ pᵢ` still caps the prover's resampling power at `2^p` attempts before it must lock in a message and let each instance's *own, independently-drawn*
  fresh challenge come out of the (now-fixed) transcript — so every instance gets at least the resampling cap its own schedule specifies. The batch fails only if the verifier accepts while some instance is genuinely false
  *and* that instance's own proximity test is fooled — a single-instance event bounded by that instance's own `εᵢ`, not a union over `B`. There is no `Σᵢ εᵢ` term to buy back with `pow_bits += log₂B`; that would pay `B·2^p`
  to defend against a bound that was never `B` times worse.

  ## Testing

  - `test_multi_one_bucket_matches_single_instance_bytes`: at `B=1` the multi-driver reproduces byte-identical proofs to the pre-existing single-instance path (postcard-serialized and compared directly).
  - Round-trip tests at 1/2/3 buckets, height ratios 2 and 8.
  - Negative tests: a witness replayed from one grind site at another is rejected; replicated witnesses that disagree across buckets are rejected (`InvalidProofShape`).
  - 53+22 existing/new `p3-stir` tests pass; `cargo clippy -p p3-stir --all-targets` clean (default and `--features parallel`).

  ## Benchmarks

  Analytical grind-cost comparison (`Σ 2^bits` over grind sites, derived from `StirConfig::round_configs`) at KoalaBear log_degree≈18, `max_pow_bits=20`:

  | layout | before (Σ solo) | after (Σ shared) | reduction |
  |---|---|---|---|
  | 2 buckets, height ratio 2 | 8,101,888 | 6,053,888 | −25.3% |
  | 2 buckets, height ratio 4 | 8,478,720 | 6,299,648 | −25.7% |
  
  In wall-clock terms: 
  
  | layout | before (median) | after (median) | change |
  |---|---|---|---|
  | 1 bucket | 754ms | 752ms | ~0% (expected — B=1 path unchanged) |
  | 2 buckets, ratio 2 | 1253ms | 1062ms | −15% |
  | 2 buckets, ratio 4 | 1307ms | 1043ms | −20% |
  | 3 buckets, ratio 4 | 1931ms | 999ms | −48% |