### PR TITLE
perf(stir,sumcheck): batch verifier arithmetic, parallel SVO opens

### DIFF
--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -109,10 +109,11 @@ fn bench_prove<F, EF, M, D, C>(
             BenchmarkId::from_parameter(1usize << log_degree),
             &log_degree,
             |b, _| {
-                b.iter(|| {
-                    let mut ch = challenger_template.clone();
-                    prove_stir(&config, poly.clone(), dft, &mut ch)
-                });
+                b.iter_batched(
+                    || (challenger_template.clone(), poly.clone()),
+                    |(mut ch, poly)| prove_stir(&config, poly, dft, &mut ch),
+                    BatchSize::LargeInput,
+                );
             },
         );
     }

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -176,6 +176,7 @@ where
         Val::TWO_ADICITY.saturating_sub(self.stir.log_blowup)
     }
 
+    #[instrument(name = "STIR PCS commit", skip_all)]
     fn commit(
         &self,
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
@@ -474,6 +475,7 @@ where
         (all_opened_values, bucket_proofs)
     }
 
+    #[instrument(name = "STIR PCS verify", skip_all)]
     fn verify(
         &self,
         commitments_with_opening_points: Vec<(

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -510,32 +510,6 @@ where
             return Err(StirError::InvalidProofShape);
         }
 
-        // Precompute alpha_pow_offset for each (commit, mat, point) triple. Tracked per
-        // log_h via a BTreeMap so the structure scales with the field's two-adicity rather
-        // than a hardcoded array length.
-        let mut height_num_reduced: alloc::collections::BTreeMap<usize, usize> =
-            alloc::collections::BTreeMap::new();
-        let alpha_offsets: Vec<Vec<Vec<Challenge>>> = commitments_with_opening_points
-            .iter()
-            .map(|(_, domain_claims)| {
-                domain_claims
-                    .iter()
-                    .map(|(domain, point_claims)| {
-                        let log_h = log2_strict_usize(domain.size() << self.stir.log_blowup);
-                        point_claims
-                            .iter()
-                            .map(|(_, vals)| {
-                                let height_count = height_num_reduced.entry(log_h).or_insert(0);
-                                let offset = alpha.exp_u64(*height_count as u64);
-                                *height_count += vals.len();
-                                offset
-                            })
-                            .collect()
-                    })
-                    .collect()
-            })
-            .collect();
-
         let global_max_width = commitments_with_opening_points
             .iter()
             .flat_map(|(_, domain_claims)| {
@@ -551,6 +525,44 @@ where
         let alpha_powers: Vec<Challenge> =
             Challenge::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied())
                 .collect_vec();
+
+        // Precompute, for each (commit, mat, point) triple: `alpha_pow_offset`, the power of
+        // `alpha` this point's contribution to the reduced opening is weighted by, and
+        // `y_combined`, the alpha-batched claimed value at that point. Both are pure
+        // functions of public input — independent of which bucket is being verified — so
+        // computing them once here (rather than inside the per-bucket, per-query,
+        // per-fiber-lane loop below) turns an `O(n_q * arity0)` recomputation per point into
+        // `O(1)`. `alpha_pow_offset` is tracked per log_h via a BTreeMap so the structure
+        // scales with the field's two-adicity rather than a hardcoded array length.
+        let mut height_num_reduced: alloc::collections::BTreeMap<usize, usize> =
+            alloc::collections::BTreeMap::new();
+        let point_data: Vec<Vec<Vec<(Challenge, Challenge)>>> = commitments_with_opening_points
+            .iter()
+            .map(|(_, domain_claims)| {
+                domain_claims
+                    .iter()
+                    .map(|(domain, point_claims)| {
+                        let log_h = log2_strict_usize(domain.size() << self.stir.log_blowup);
+                        point_claims
+                            .iter()
+                            .map(|(_, vals)| {
+                                let height_count = height_num_reduced.entry(log_h).or_insert(0);
+                                let offset = alpha.exp_u64(*height_count as u64);
+                                *height_count += vals.len();
+
+                                let y_combined: Challenge = vals
+                                    .iter()
+                                    .zip(alpha_powers.iter())
+                                    .map(|(&y, &ap)| y * ap)
+                                    .sum();
+
+                                (offset, y_combined)
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
 
         // Verify each height bucket's STIR sub-proof and input binding.
         for (bucket_idx, &log_h) in bucket_log_heights.iter().enumerate() {
@@ -596,6 +608,39 @@ where
                 |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
                     let n_q = first_round_unique_js.len();
                     let mut expected_ro = vec![Challenge::zero_vec(arity0); n_q];
+
+                    // Distinct opening points among matrices active at this bucket height.
+                    // Matrices typically share opening points (e.g. one STARK's `zeta`), so
+                    // this list is usually far shorter than the matrix count.
+                    let bucket_points: Vec<Challenge> = commitments_with_opening_points
+                        .iter()
+                        .flat_map(|(_, domain_claims)| domain_claims.iter())
+                        .filter(|(domain, _)| {
+                            (domain.size() << self.stir.log_blowup) == bucket_height
+                        })
+                        .flat_map(|(_, point_claims)| point_claims.iter().map(|(point, _)| *point))
+                        .fold(Vec::new(), |mut points, point| {
+                            if !points.contains(&point) {
+                                points.push(point);
+                            }
+                            points
+                        });
+                    let n_bp = bucket_points.len();
+
+                    // Every `(query, fiber lane)` needs `1 / (point - fiber_point)` for each
+                    // distinct point in `bucket_points`. Collect every such difference for the
+                    // whole bucket and invert them all in one batch, rather than inverting each
+                    // one individually once per (query, lane, matrix, point) quadruple below.
+                    let mut denom_diffs = Vec::with_capacity(n_q * arity0 * n_bp);
+                    for &j in first_round_unique_js {
+                        let mut fiber_point = Val::GENERATOR * domain_gen.exp_u64(j as u64);
+                        for _ in 0..arity0 {
+                            let fp = Challenge::from(fiber_point);
+                            denom_diffs.extend(bucket_points.iter().map(|&point| point - fp));
+                            fiber_point *= fiber_step;
+                        }
+                    }
+                    let inv_denoms = batch_multiplicative_inverse(&denom_diffs);
 
                     for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                         commitments_with_opening_points
@@ -668,9 +713,8 @@ where
                             )
                             .map_err(StirError::InputError)?;
 
-                        for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
+                        for q_idx in 0..n_q {
                             let row_vals_by_mat = &opening.opened_values[q_idx];
-                            let mut fiber_point = Val::GENERATOR * domain_gen.exp_u64(j as u64);
 
                             #[allow(clippy::needless_range_loop)]
                             for l in 0..arity0 {
@@ -692,30 +736,24 @@ where
                                     let p_x: Challenge = row_vals
                                         .iter()
                                         .zip(alpha_powers.iter())
-                                        .map(|(&v, &ap)| Challenge::from(v) * ap)
+                                        .map(|(&v, &ap)| ap * v)
                                         .sum();
 
-                                    for (point_idx, (point, vals)) in
-                                        point_claims.iter().enumerate()
-                                    {
-                                        let alpha_pow_offset =
-                                            alpha_offsets[commit_idx][mat_idx][point_idx];
+                                    for (point_idx, (point, _)) in point_claims.iter().enumerate() {
+                                        let (alpha_pow_offset, y_combined) =
+                                            point_data[commit_idx][mat_idx][point_idx];
 
-                                        let y_combined: Challenge = vals
+                                        let bp_idx = bucket_points
                                             .iter()
-                                            .zip(alpha_powers.iter())
-                                            .map(|(&y, &ap)| y * ap)
-                                            .sum();
-
+                                            .position(|p| p == point)
+                                            .expect("point is in bucket_points by construction");
                                         let inv_denom =
-                                            (*point - Challenge::from(fiber_point)).inverse();
+                                            inv_denoms[(q_idx * arity0 + l) * n_bp + bp_idx];
 
                                         expected_ro[q_idx][l] +=
                                             alpha_pow_offset * (p_x - y_combined) * inv_denom;
                                     }
                                 }
-
-                                fiber_point *= fiber_step;
                             }
                         }
                     }

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -142,6 +142,7 @@ struct RoundOutput<F, EF: Field, M: Mmcs<EF>, Witness> {
 /// and query points, answer them, commit the folded oracle, and evaluate the next virtual
 /// witness directly on the next round's domain.
 #[allow(clippy::too_many_arguments)]
+#[instrument(skip_all)]
 fn prove_round<F, EF, Dft, M, Challenger>(
     config: &StirConfig<F, EF, M, Challenger>,
     round: usize,
@@ -179,21 +180,25 @@ where
     // lives on the coset `current_shift · <g>`, so passing `gamma / current_shift`
     // yields exactly Construction 4.5's coset fold at challenge `gamma`.
     let fold_beta = gamma * EF::from(current_shift.inverse());
-    let folded_codeword = fold_codeword::<F, EF>(
-        current_oracle_codeword,
-        fold_beta,
-        log_arity,
-        current_log_domain,
-    );
+    let folded_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
+        fold_codeword::<F, EF>(
+            current_oracle_codeword,
+            fold_beta,
+            log_arity,
+            current_log_domain,
+        )
+    });
     let fold_coeffs = coeffs_from_codeword(dft, &folded_codeword, fold_shift);
 
     let next_commit_codeword: Vec<EF> =
         codeword_from_coeffs(dft, fold_coeffs.clone(), next_shift, next_log_domain);
-    let (new_commit, new_data) = commit_as_fiber_matrix(
-        &config.mmcs,
-        &next_commit_codeword,
-        config.log_folding_factor,
-    );
+    let (new_commit, new_data) = tracing::debug_span!("commit_as_fiber_matrix").in_scope(|| {
+        commit_as_fiber_matrix(
+            &config.mmcs,
+            &next_commit_codeword,
+            config.log_folding_factor,
+        )
+    });
     challenger.observe(new_commit.clone());
 
     // Step 2: OOD sampling.
@@ -309,14 +314,17 @@ where
     // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
     // `num_answers + 1` coefficients.
     let log_answer_len = log2_ceil_usize(num_answers + 1).min(next_log_domain);
-    let (ans_evals, vanishing_evals) = eval_low_degree_pair_on_coset(
-        dft,
-        &ans_poly,
-        &vanishing_coeffs,
-        next_shift,
-        next_log_domain,
-        log_answer_len,
-    );
+    let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
+        .in_scope(|| {
+            eval_low_degree_pair_on_coset(
+                dft,
+                &ans_poly,
+                &vanishing_coeffs,
+                next_shift,
+                next_log_domain,
+                log_answer_len,
+            )
+        });
 
     // x_j = next_shift * g^j, so step_j = r_comb * x_j = step_start * g^j, and the degree
     // correction's numerator sweeps the same coset at stride `num_answers + 1`. Both are
@@ -330,36 +338,40 @@ where
 
     // The quotient denominators are the vanishing evaluations scaled by the degree
     // correction's `(1 - step)` denominator, so they are formed in place.
-    let mut combined_denoms = vanishing_evals;
-    combined_denoms
-        .par_chunks_mut(POWER_CHUNK)
-        .enumerate()
-        .for_each(|(chunk_idx, chunk)| {
-            let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
-            for denom in chunk.iter_mut() {
-                *denom *= EF::ONE - step;
-                step *= g_next;
-            }
-        });
-    let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
-    drop(combined_denoms);
+    let next_oracle_codeword = tracing::debug_span!("quotient_sweep").in_scope(|| {
+        let mut combined_denoms = vanishing_evals;
+        combined_denoms
+            .par_chunks_mut(POWER_CHUNK)
+            .enumerate()
+            .for_each(|(chunk_idx, chunk)| {
+                let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                for denom in chunk.iter_mut() {
+                    *denom *= EF::ONE - step;
+                    step *= g_next;
+                }
+            });
+        let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
+        drop(combined_denoms);
 
-    // `commit_as_fiber_matrix` has already copied the committed codeword into the Merkle
-    // tree, so the next oracle is formed in place over it.
-    let mut next_oracle_codeword = next_commit_codeword;
-    next_oracle_codeword
-        .par_chunks_mut(POWER_CHUNK)
-        .zip(ans_evals.par_chunks(POWER_CHUNK))
-        .zip(combined_inverses.par_chunks(POWER_CHUNK))
-        .enumerate()
-        .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
-            let mut numerator_step =
-                step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
-            for ((value, &ans), &inverse) in chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk) {
-                *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
-                numerator_step *= g_next_hi;
-            }
-        });
+        // `commit_as_fiber_matrix` has already copied the committed codeword into the
+        // Merkle tree, so the next oracle is formed in place over it.
+        let mut next_oracle_codeword = next_commit_codeword;
+        next_oracle_codeword
+            .par_chunks_mut(POWER_CHUNK)
+            .zip(ans_evals.par_chunks(POWER_CHUNK))
+            .zip(combined_inverses.par_chunks(POWER_CHUNK))
+            .enumerate()
+            .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
+                let mut numerator_step =
+                    step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                for ((value, &ans), &inverse) in chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk)
+                {
+                    *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
+                    numerator_step *= g_next_hi;
+                }
+            });
+        next_oracle_codeword
+    });
 
     RoundOutput {
         proof: StirRoundProof {
@@ -392,6 +404,7 @@ struct FinalRoundOutput<EF: Field, M: Mmcs<EF>, Witness> {
 
 /// Prove the final STIR round: fold the last committed codeword and send the resulting
 /// low-degree polynomial directly, rather than committing and querying it again.
+#[instrument(skip_all)]
 fn prove_final_round<F, EF, Dft, M, Challenger>(
     config: &StirConfig<F, EF, M, Challenger>,
     dft: &Dft,
@@ -422,12 +435,14 @@ where
     // See the round-fold note: `gamma / current_shift` over subgroup coordinates is
     // the paper's coset fold at challenge `gamma`.
     let final_fold_beta = final_gamma * EF::from(current_shift.inverse());
-    let final_codeword = fold_codeword::<F, EF>(
-        current_oracle_codeword,
-        final_fold_beta,
-        final_log_arity,
-        current_log_domain,
-    );
+    let final_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
+        fold_codeword::<F, EF>(
+            current_oracle_codeword,
+            final_fold_beta,
+            final_log_arity,
+            current_log_domain,
+        )
+    });
     // The final polynomial has only `final_len` coefficients, far fewer than
     // `final_codeword`'s full domain size. Rather than run a full-size iDFT and discard
     // the (necessarily zero) high coefficients, gather a `final_len`-sized coset — every

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -13,6 +13,7 @@ use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse,
 };
 use p3_maybe_rayon::prelude::*;
+use p3_util::log2_strict_usize;
 
 /// Evaluate a polynomial at a point using Horner's method.
 ///
@@ -472,7 +473,7 @@ pub fn fold_fiber<F: TwoAdicField, EF: ExtensionField<F>>(
     let step = g.exp_u64(new_height as u64); // = zeta = arity-th root of unity
     let xs: Vec<F> = step.shifted_powers(x0).take(arity).collect();
 
-    lagrange_eval_at(&xs, fiber, beta)
+    lagrange_interpolate_at(&xs, fiber, beta)
 }
 
 /// Evaluate the Lagrange interpolating polynomial through `(xs[i], ys[i])` at `point`.
@@ -512,6 +513,54 @@ pub fn lagrange_eval_at<F: Field, EF: ExtensionField<F>>(xs: &[F], ys: &[EF], po
         den += term;
     }
     num / den
+}
+
+/// Evaluate, at `point`, the degree-`< n` polynomial through `(xs[i], ys[i])`, where `xs` is
+/// a coset of the `n`-th roots of unity (`n` a power of two).
+///
+/// On a full root-of-unity coset the barycentric weights collapse to a closed form
+/// `w_i = x_i / (n * xs[0]^n)`, so the barycentric denominator `sum_i w_i / (point - x_i)`
+/// simplifies to `prod_i (point - x_i)` and needs no separate accumulation. One batch
+/// inversion covers every `(point - x_i)`, against [`lagrange_eval_at`]'s `O(n^2)` weight
+/// construction plus `n` separate divisions.
+///
+/// # Panics
+///
+/// Panics if `xs.len() != ys.len()`, or if `xs.len()` is not a power of two.
+pub fn lagrange_interpolate_at<F: Field, EF: ExtensionField<F>>(
+    xs: &[F],
+    ys: &[EF],
+    point: EF,
+) -> EF {
+    let n = xs.len();
+    assert_eq!(ys.len(), n);
+    if n == 0 {
+        return EF::ZERO;
+    }
+
+    // Short-circuit: if point coincides with one of the nodes, return the known value directly.
+    for i in 0..n {
+        if point == EF::from(xs[i]) {
+            return ys[i];
+        }
+    }
+
+    let log_n = log2_strict_usize(n);
+
+    // All xs lie in a coset of the 2^log_n roots of unity, so every x_i shares the same
+    // x_i^n = xs[0]^n.
+    let coset_power = xs[0].exp_power_of_2(log_n);
+    let weight_scale = (F::from_usize(n) * coset_power).inverse();
+
+    let diffs: Vec<EF> = xs.iter().map(|&x| point - EF::from(x)).collect();
+    let diff_invs = batch_multiplicative_inverse(&diffs);
+    let l_point = diffs.iter().copied().product::<EF>();
+
+    let mut result = EF::ZERO;
+    for ((&x, &y), &diff_inv) in xs.iter().zip(ys).zip(diff_invs.iter()) {
+        result += y * (x * weight_scale) * diff_inv;
+    }
+    result * l_point
 }
 
 #[cfg(test)]
@@ -646,6 +695,47 @@ mod tests {
         ];
         let result = lagrange_eval_at(&xs, &ys, EF::from(F::from_u64(4)));
         assert_eq!(result, EF::from(F::from_u64(16)));
+    }
+
+    #[test]
+    fn test_lagrange_interpolate_at_agrees_with_lagrange_eval_at_on_coset() {
+        // xs = a coset of the 8th roots of unity: shift * g^i for i in 0..8.
+        let log_n = 3;
+        let n = 1 << log_n;
+        let g = F::two_adic_generator(log_n);
+        let shift = F::GENERATOR;
+        let xs: Vec<F> = g.shifted_powers(shift).take(n).collect();
+        let ys: Vec<EF> = (0..n)
+            .map(|i| EF::from(F::from_u64(i as u64 * i as u64 + 1)))
+            .collect();
+
+        for z in [
+            EF::from(F::from_u64(1000)),
+            EF::ZERO,
+            -EF::from(F::from_u64(7)),
+        ] {
+            assert_eq!(
+                lagrange_interpolate_at(&xs, &ys, z),
+                lagrange_eval_at(&xs, &ys, z),
+                "closed-form and general barycentric forms must agree"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lagrange_interpolate_at_returns_node_value_on_exact_match() {
+        let log_n = 2;
+        let n = 1 << log_n;
+        let g = F::two_adic_generator(log_n);
+        let shift = F::GENERATOR;
+        let xs: Vec<F> = g.shifted_powers(shift).take(n).collect();
+        let ys: Vec<EF> = (0..n)
+            .map(|i| EF::from(F::from_u64(i as u64 + 10)))
+            .collect();
+
+        for (i, &x) in xs.iter().enumerate() {
+            assert_eq!(lagrange_interpolate_at(&xs, &ys, EF::from(x)), ys[i]);
+        }
     }
 
     #[test]

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -14,7 +14,7 @@ use crate::config::StirConfig;
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
     check_shake_consistency, eval_degree_correction, eval_poly, eval_poly_at_base,
-    fold_domain_params, lagrange_eval_at, next_domain_shift, reduce_mod_x_pow_minus_c,
+    fold_domain_params, lagrange_interpolate_at, next_domain_shift, reduce_mod_x_pow_minus_c,
     sample_ood_points, vanishing_poly_from_roots,
 };
 
@@ -217,7 +217,7 @@ where
         materialize_virtual_fiber::<F, EF>(row_evals, &subgroup_points, current_shift, prev_ctx)
             .ok_or(StirError::InvalidRoundConsistency { round, query })?;
 
-    Ok(lagrange_eval_at(
+    Ok(lagrange_interpolate_at(
         &subgroup_points,
         &current_fiber,
         fold_beta,

--- a/sumcheck/src/layout/prover/prefix.rs
+++ b/sumcheck/src/layout/prover/prefix.rs
@@ -6,6 +6,7 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{
     ExtensionField, Field, PackedFieldExtension, PackedValue, TwoAdicField, dot_product,
 };
+use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_multilinear_util::split_eq::SplitEq;
@@ -113,8 +114,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
 
         // Current group: evaluate each column at the point.
         // Each entry yields an opening (carrying preprocessing residuals) plus the bare eval.
+        // Each column is an independent O(2^n) pass, so columns evaluate in parallel.
         let (current_openings, current_evals): (Vec<_>, Vec<EF>) = current
-            .iter()
+            .into_par_iter()
             .copied()
             .map(|poly_idx| {
                 let (eval, partial_evals) = point.eval(table.poly(poly_idx));
@@ -125,7 +127,7 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for PrefixProver<F, E
         // Next group: evaluate the repeat-last successor view at the same point.
         // The prefix layout folds the leading variables, so the successor is taken accordingly.
         let (next_openings, next_evals): (Vec<_>, Vec<EF>) = next
-            .iter()
+            .into_par_iter()
             .copied()
             .map(|poly_idx| {
                 let (eval, partial_evals) = point.eval_next_prefix(table.poly(poly_idx));

--- a/sumcheck/src/layout/prover/suffix.rs
+++ b/sumcheck/src/layout/prover/suffix.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField, dot_product};
+use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_multilinear_util::split_eq::SplitEq;
@@ -112,8 +113,9 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
 
         // Current group: evaluate each column at the point.
         // Each entry yields an opening (carrying preprocessing residuals) plus the bare eval.
+        // Each column is an independent O(2^n) pass, so columns evaluate in parallel.
         let (current_openings, current_evals): (Vec<_>, Vec<EF>) = current
-            .iter()
+            .into_par_iter()
             .copied()
             .map(|poly_idx| {
                 let (eval, partial_evals) = point.eval(table.poly(poly_idx));
@@ -122,8 +124,10 @@ impl<F: TwoAdicField, EF: ExtensionField<F>> Layout<F, EF> for SuffixProver<F, E
             .unzip();
 
         // Next group: evaluate the repeat-last successor view at the same point.
+        // `current_openings` is fully built above and only read here, so this is safe to
+        // run in parallel alongside it.
         let (next_openings, next_evals): (Vec<_>, Vec<EF>) = next
-            .iter()
+            .into_par_iter()
             .copied()
             .map(|poly_idx| {
                 // Reuse: if this column was already opened in the current group,


### PR DESCRIPTION
## Summary

  Implements some perf items for `p3-stir` and `p3-sumcheck`:

  - **STIR-B2+B4** — batch the verifier's reduced-opening reconstruction arithmetic
  - **MLU-SVO** — parallelize the SVO per-column opening loop
  - **STIR-B6** — close the prover-side tracing/benchmark harness gaps

  No proof format or soundness changes — the verifier arithmetic is refactored to compute
  algebraically identical values with fewer redundant operations, and is exercised by all
  existing STIR/PCS tests without modification.

  ## Changes

  ### `perf(stir)`: batch verifier arithmetic in the reduced-opening reconstruction

  `TwoAdicStirPcs::verify`'s `reconstruct_initial_fibers` recomputed `y_combined` and each
  fiber's inverse denominator once per `(query, lane, matrix, point)`, even though they only
  depend on `(matrix, point)` and `(query, lane, point)` respectively — so with `M` matrices
  sharing a height bucket, the same values were recomputed `M` times.

  - `y_combined` is now precomputed once per `(commit, mat, point)` alongside the existing
    `alpha_pow_offset`.
  - Every `(point - fiber_point)` needed for a bucket is collected into one vector and inverted
    with a single `batch_multiplicative_inverse` call, instead of one inversion per quadruple.
  - The row-value alpha combination (`p_x`) is flipped from an extension embed-then-multiply
    (`Challenge::from(v) * ap`) to a direct base-by-extension multiply (`ap * v`).
  - `lagrange_eval_at`'s O(k²) general barycentric-weight construction is replaced, at its two
    hot call sites (`fold_fiber` and the verifier's per-round fold), with a closed-form
    interpolation valid on a coset of roots of unity — the same technique
    `fri/src/two_adic_pcs.rs` already uses. The general form is kept as `lagrange_eval_at` for
    arbitrary-point callers (and its existing test).

  ### `perf(sumcheck)`: parallelize the SVO per-column opening loops

  `PrefixProver::eval_at` and `SuffixProver::eval_at` evaluated each opened column serially via
  `.iter().map(...)`, even though each column is an independent O(2ⁿ) pass over the table and
  `point.eval`/`table.poly` are both `&self` reads. Both the current and next column loops now
  use `into_par_iter()`. No kernel or signature changes.

  ### `bench(stir)`: instrument prover phases and fix a stray clone in the prove bench

  `prove_round`, `prove_final_round`, and the PCS's `commit`/`verify` entry points carried no
  tracing span, so profiles attributed their cost to the nearest instrumented caller. Added:

  - `#[instrument(skip_all)]` on `prove_round`, `prove_final_round`, `Pcs::commit`, `Pcs::verify`
  - `debug_span!`s around `fold_codeword`, `commit_as_fiber_matrix`,
    `eval_low_degree_pair_on_coset`, and the in-place quotient sweep inside `prove_round`

  Also moved `stir/benches/stir.rs`'s `bench_prove` polynomial clone out of the timed `b.iter`
  closure into `iter_batched`'s setup, matching `bench_verify`'s existing pattern (it was
  inflating the measured prove time with an untimed-in-practice clone).

  ## Benchmarks

  Ad hoc A/B timing (temporary harnesses, not included in this PR), before vs. after each change:

  **Verifier arithmetic hoist** (`TwoAdicStirPcs::verify`, KoalaBear, 2^16-row matrices):

  | matrices | 1 shared point | 2 shared points |
  |---|---|---|
  | 1  | 3.35 → 2.65 ms (1.26×) | 3.62 → 2.67 ms (1.35×) |
  | 4  | 7.05 → 5.53 ms (1.28×) | 8.00 → 5.57 ms (1.43×) |
  | 16 | 20.79 → 17.10 ms (1.22×) | 24.62 → 17.70 ms (1.39×) |
  | 64 | 77.44 → 64.86 ms (1.19×) | 90.72 → 66.42 ms (1.37×) |

  **Closed-form Lagrange interpolation** (per-call, isolated):

  | arity | general | closed-form | speedup |
  |---|---|---|---|
  | 4  | 525 ns  | 278 ns | 1.89× |
  | 8  | 672 ns  | 391 ns | 1.72× |
  | 16 | 1436 ns | 582 ns | 2.47× |

  **SVO column-loop parallelization** (14-core machine, `--features parallel`, BabyBear):

  | k  | cols | prefix | suffix |
  |---|---|---|---|
  | 20 | 32 | 4.25 → 2.02 ms (2.1×) | 5.68 → 3.36 ms (1.7×) |
  | 20 | 64 | 8.14 → 3.34 ms (2.4×) | 11.30 → 9.04 ms (1.25×) |
  | 22 | 64 | 22.46 → 11.10 ms (2.0×) | 30.74 → 23.93 ms (1.28×) |