### PR TITLE
fix(fri): call bit_reverse_rows after coset_dft_batch in get_evaluations_on_domain

### DIFF
--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -396,6 +396,7 @@ where
         let result = self
             .dft
             .coset_dft_batch(coeffs, domain.shift())
+            .bit_reverse_rows()
             .to_row_major_matrix();
         let result_width = result.width();
 


### PR DESCRIPTION
## Bug

This appears to be a simple implementation bug. When the FRI blowup factor is less than the degree of the constraints, the verifier returns a `Verification(OodEvaluationMismatch { index: Some(0) })` error.

## Cause

In `fri/src/two_adic_pcs.rs`, the result of `coset_dft_batch` is in bit-reversed row order. Without applying `bit_reverse_rows()`, the subsequent `to_row_major_matrix()` produces evaluations in the wrong order, causing an out-of-domain evaluation mismatch during verification.

## Fix

Added a `.bit_reverse_rows()` call after `coset_dft_batch()` and before `to_row_major_matrix()` to restore the correct row ordering. 

(The verifier succeeds after this fix :))