### PR TITLE
feat(p3-security): const-fn fixed-point round budget for recursive verifiers

### DIFF
--- a/security/src/budget/mod.rs
+++ b/security/src/budget/mod.rs
@@ -1,0 +1,345 @@
+//! Conjectured round budget for a lifted (multi-AIR) STARK protocol, in fixed point.
+//!
+//! Fiat-Shamir security of the compiled argument is the minimum, over the protocol's rounds, of
+//! that round's soundness error plus the grinding sited immediately before its challenge. This
+//! module bounds each round and composes them, using [`crate::fixed`] throughout so the result is
+//! reproducible bit-for-bit by a recursive verifier.
+//!
+//! "Conjectured" here is the standard proximity-gaps conjecture regime: list sizes are taken as
+//! one up to capacity, so the algebraic rounds pay a plain Schwartz-Zippel error with no list-size
+//! multiplier, and the FRI query phase pays the random-words rate of
+//! [2025/2010](https://eprint.iacr.org/2025/2010) section 1.5 (see [`crate::fixed::bits_per_query`]).
+//! Proven bounds for this parameter class are far lower and are not modeled here; anything
+//! published from this module must be labeled conjectured.
+//!
+//! Every bound is stated as `error ≤ coefficient · size / |E|`, which in bits is
+//! `log2|E| − log2(coefficient) − log2(size)`. Coefficients round up and the field size rounds
+//! down, so each round is understated rather than overstated.
+//!
+//! # Folding accounting
+//!
+//! The folding round below sums a doubled per-round coefficient rather than searching for the
+//! single worst round: `error ≤ (arity − 1) · (n + 1) / |E|` per round, worst at the first round
+//! where the LDE domain `n` is largest, and doubling the coefficient absorbs the `+ 1`. This is
+//! more conservative than reporting only the worst round's tight bound — by less than one bit,
+//! since `2n ≥ n + 1` for `n ≥ 1` — in exchange for a coefficient that does not depend on how many
+//! folding rounds actually occur.
+//!
+//! # DEEP-quotient batching
+//!
+//! [`shape::AirShape::num_deep_terms`] is `Option`: a protocol that batches its DEEP quotient
+//! across every committed column via further α/β powers supplies it and gets an eighth accounted
+//! round; a protocol that performs no such column-batching reduction passes `None` and the round
+//! contributes no constraint on security (reported at the cap, the same convention
+//! [`shape::AirShape::lookup`] uses for "no such argument"). The out-of-domain round above is
+//! charged unconditionally either way — it is not what `None` waives.
+
+pub mod report;
+pub mod shape;
+
+use report::{
+    COLLISION_LABEL, COMPOSITION_LABEL, DEEP_COMPOSITION_LABEL, FOLDING_LABEL, LOOKUP_LABEL,
+    OUT_OF_DOMAIN_LABEL, QUERY_LABEL,
+};
+pub use report::{SecurityReport, SecurityTerm};
+pub use shape::{AirShape, InstanceShape, LookupShape, ProtocolParams};
+
+use crate::fixed;
+
+/// Grades a proof configuration, returning the per-round breakdown.
+///
+/// The attained level is [`SecurityReport::security_level`]; the round that binds is
+/// [`SecurityReport::binding_term`].
+pub const fn security_report(
+    params: &ProtocolParams,
+    instance: &InstanceShape,
+    air: &AirShape,
+) -> SecurityReport {
+    let cap = instance.cap();
+
+    // The lookup challenges are sampled once, right after the main-trace commitment, and shared
+    // by every bus. Each bus denominator is affine in the first challenge with total degree at
+    // most `max_message_width` in the two challenges jointly. If the bus multiset is unbalanced,
+    // the balance function `Φ = Σ mₖ/Dₖ` is a nonzero rational function of the challenges, and the
+    // cheat succeeds on either of two events.
+    //
+    // Each denominator `Dₖ = α + (bus + 1)·β^W + Σ_{j<W} β^j·payloadⱼ` has individual degree 1 in
+    // `α` and `W` in `β`, so the cleared numerator `Σₖ mₖ·Π_{l≠k} D_l` over `M` denominators has
+    // individual degrees `M − 1` and `W(M − 1)`. Sampling the two challenges independently and
+    // uniformly, the per-variable Schwartz-Zippel union bounds a numerator root by
+    // `(W + 1)(M − 1)/|E|`.
+    //
+    // Separately, a vanishing denominator degenerates the batched transition constraint: with
+    // `Dⱼ = 0` the identity collapses to `mⱼ·Π_{s≠j} D_s = 0`, forcing `mⱼ = 0` and letting the
+    // adversary drop message `j` from the bus for free. Each `Dₖ` is *monic* in `α`, so for any
+    // `β` exactly one `α` annihilates it: that event costs only `M/|E|`, not `M·W/|E|`.
+    //
+    // Together `ε ≤ (W + 1)(M − 1)/|E| + M/|E| ≤ (W + 2)·M/|E|`.
+    //
+    // `M` is taken as `fractions_per_row · 2^log_max_height`, charging every AIR the maximum
+    // height.
+    let lookup = round(
+        LOOKUP_LABEL,
+        instance,
+        (air.lookup.max_message_width as u64 + 2) * air.lookup.fractions_per_row as u64,
+        instance.log_max_height,
+        params.lookup_pow_bits,
+        cap,
+    );
+
+    // Constraints are batched by powers of one challenge and the AIRs by a second, so a violated
+    // constraint survives only on a root of the resulting univariate of degree below the total
+    // number of batched slots. Independent of trace length.
+    let composition = round(
+        COMPOSITION_LABEL,
+        instance,
+        air.num_composed_constraints as u64,
+        0,
+        0,
+        cap,
+    );
+
+    // The out-of-domain point is rejection-sampled outside the trace and LDE domains but is not
+    // ground. A violated constraint leaves the DEEP-ALI identity a nonzero polynomial in that
+    // point of degree at most `(max_constraint_degree + 1) · height`. Lifting evaluates the
+    // shorter AIRs at powers of the same point, so all of them pay the maximum height.
+    let out_of_domain = round(
+        OUT_OF_DOMAIN_LABEL,
+        instance,
+        air.max_constraint_degree as u64 + 1,
+        instance.log_max_height,
+        0,
+        cap,
+    );
+
+    // The DEEP quotient batches every committed column and out-of-domain point by powers of two
+    // further challenges, giving a univariate whose degree is the number of batched terms.
+    let deep_composition = round(
+        DEEP_COMPOSITION_LABEL,
+        instance,
+        match air.num_deep_terms {
+            Some(n) => n as u64,
+            None => 0,
+        },
+        0,
+        params.deep_pow_bits,
+        cap,
+    );
+
+    // Per folding round the error is at most `(arity − 1) · (n + 1) / |E|`, worst at the first
+    // round where the domain is largest. Doubling the coefficient absorbs the `+ 1`.
+    let folding = round(
+        FOLDING_LABEL,
+        instance,
+        2 * ((1u64 << params.log_folding_arity) - 1),
+        instance.log_max_height + params.log_blowup,
+        params.folding_pow_bits,
+        cap,
+    );
+
+    // Query sampling is the only round whose error is not a Schwartz-Zippel bound: it is the
+    // random-words rate compounded over independent queries.
+    let query_bits = params.num_queries as u64
+        * fixed::bits_per_query(params.log_blowup, instance.field_bits)
+        + fixed::from_bits(params.query_pow_bits);
+    let query = SecurityTerm::new(QUERY_LABEL, min(query_bits, cap));
+
+    SecurityReport::new([
+        lookup,
+        composition,
+        out_of_domain,
+        deep_composition,
+        folding,
+        query,
+        SecurityTerm::new(COLLISION_LABEL, cap),
+    ])
+}
+
+/// Bounds one round whose error is `coefficient · 2^log_size / |E|`, crediting the grinding sited
+/// before its challenge and capping at the transcript's own ceiling.
+///
+/// A zero coefficient means the protocol has no such round, which contributes no constraint on
+/// security and is reported at the cap.
+const fn round(
+    label: &'static str,
+    instance: &InstanceShape,
+    coefficient: u64,
+    log_size: u32,
+    pow_bits: u32,
+    cap: u64,
+) -> SecurityTerm {
+    if coefficient == 0 {
+        return SecurityTerm::new(label, cap);
+    }
+
+    let error = fixed::ceil_log2(coefficient) + fixed::from_bits(log_size);
+    let bits = if error >= instance.field_bits {
+        fixed::from_bits(pow_bits)
+    } else {
+        instance.field_bits - error + fixed::from_bits(pow_bits)
+    };
+
+    SecurityTerm::new(label, min(bits, cap))
+}
+
+const fn min(a: u64, b: u64) -> u64 {
+    if a < b { a } else { b }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::shape::LookupShape;
+
+    const FIELD_BITS: u64 = 8_388_607;
+
+    fn params() -> ProtocolParams {
+        ProtocolParams {
+            log_blowup: 3,
+            log_folding_arity: 2,
+            num_queries: 27,
+            query_pow_bits: 17,
+            deep_pow_bits: 12,
+            folding_pow_bits: 4,
+            lookup_pow_bits: 0,
+        }
+    }
+
+    fn instance(log_max_height: u32) -> InstanceShape {
+        InstanceShape {
+            log_max_height,
+            field_bits: FIELD_BITS,
+            collision_resistance: 128,
+        }
+    }
+
+    fn air() -> AirShape {
+        AirShape {
+            num_composed_constraints: 531,
+            max_constraint_degree: 9,
+            num_deep_terms: Some(130),
+            lookup: LookupShape {
+                fractions_per_row: 27,
+                max_message_width: 16,
+            },
+        }
+    }
+
+    /// At moderate trace heights the query phase is what limits the configuration.
+    #[test]
+    fn query_phase_binds_at_moderate_heights() {
+        let report = security_report(&params(), &instance(20), &air());
+        assert_eq!(report.binding_term().label, QUERY_LABEL);
+        assert_eq!(report.security_level(), 96);
+    }
+
+    /// The lookup round's error grows linearly in trace length while every other round is flat or
+    /// grows only logarithmically, so past some height it becomes the bottleneck.
+    #[test]
+    fn lookup_round_binds_at_large_heights() {
+        let report = security_report(&params(), &instance(29), &air());
+        assert_eq!(report.binding_term().label, LOOKUP_LABEL);
+        assert!(
+            report.security_level() < 96,
+            "lookup round should fall below the query-phase level at maximum trace height, got {}",
+            report.security_level()
+        );
+    }
+
+    /// Grinding before the lookup challenges is the direct remedy for the round above, and must
+    /// be credited to it bit for bit.
+    #[test]
+    fn lookup_grinding_lifts_the_lookup_round() {
+        let ungrounded = security_report(&params(), &instance(29), &air());
+        let grinding = ProtocolParams {
+            lookup_pow_bits: 8,
+            ..params()
+        };
+        let ground = security_report(&grinding, &instance(29), &air());
+
+        let before = ungrounded.terms()[0];
+        let after = ground.terms()[0];
+        assert_eq!(before.label, LOOKUP_LABEL);
+        assert_eq!(after.bits, before.bits + fixed::from_bits(8));
+    }
+
+    /// No round may be reported above the transcript's own ceiling.
+    #[test]
+    fn every_round_is_capped_by_collision_resistance() {
+        let instance = InstanceShape {
+            collision_resistance: 96,
+            ..instance(20)
+        };
+        let report = security_report(&params(), &instance, &air());
+        for term in report.terms() {
+            assert!(
+                term.bits <= fixed::from_bits(96),
+                "{} exceeds the cap",
+                term.label
+            );
+        }
+        assert_eq!(report.security_level(), 96);
+    }
+
+    /// Taller traces can never be more secure than shorter ones under the same parameters.
+    #[test]
+    fn security_is_monotone_in_trace_height() {
+        let mut previous = u32::MAX;
+        for log_height in 6..=30u32 {
+            let level = security_report(&params(), &instance(log_height), &air()).security_level();
+            assert!(level <= previous, "level rose at log height {log_height}");
+            previous = level;
+        }
+    }
+
+    /// A bigger or higher-degree AIR can never be more secure under the same parameters.
+    #[test]
+    fn security_is_monotone_in_air_size() {
+        let small = security_report(&params(), &instance(24), &air());
+        let large = AirShape {
+            num_composed_constraints: 4096,
+            max_constraint_degree: 9,
+            num_deep_terms: Some(1024),
+            lookup: LookupShape {
+                fractions_per_row: 64,
+                max_message_width: 16,
+            },
+        };
+        let large = security_report(&params(), &instance(24), &large);
+        assert!(large.security_level() <= small.security_level());
+    }
+
+    /// An AIR with no lookups pays no lookup round rather than being rejected or silently graded
+    /// against a zero-message bus.
+    #[test]
+    fn absent_lookup_argument_contributes_no_round() {
+        let air = AirShape {
+            lookup: LookupShape {
+                fractions_per_row: 0,
+                max_message_width: 0,
+            },
+            ..air()
+        };
+        let report = security_report(&params(), &instance(29), &air);
+        assert_eq!(report.terms()[0].bits, instance(29).cap());
+        assert_ne!(report.binding_term().label, LOOKUP_LABEL);
+    }
+
+    /// A protocol that does not batch its DEEP quotient this way pays no such round, and the
+    /// grind that would have sited it is simply unread.
+    #[test]
+    fn absent_deep_composition_contributes_no_round() {
+        let air = AirShape {
+            num_deep_terms: None,
+            ..air()
+        };
+        let report = security_report(&params(), &instance(20), &air);
+        let deep_term = report
+            .terms()
+            .iter()
+            .find(|t| t.label == DEEP_COMPOSITION_LABEL)
+            .expect("term present");
+        assert_eq!(deep_term.bits, instance(20).cap());
+        assert_ne!(report.binding_term().label, DEEP_COMPOSITION_LABEL);
+    }
+}

--- a/security/src/budget/report.rs
+++ b/security/src/budget/report.rs
@@ -1,0 +1,84 @@
+//! Labeled soundness breakdown produced by [`super::security_report`].
+//!
+//! Fiat-Shamir security of the compiled argument is the minimum over its rounds: an adversary
+//! needs only one round to break. Keeping the rounds as named terms rather than collapsing them
+//! into a single number means the *binding* round stays visible, which is what tells a reader
+//! whether a parameter change helped the round that actually mattered.
+
+/// Label for the lookup / permutation-argument bus-challenge round.
+pub const LOOKUP_LABEL: &str = "lookup-challenge";
+/// Label for the constraint-batching round.
+pub const COMPOSITION_LABEL: &str = "constraint-composition";
+/// Label for the out-of-domain evaluation round.
+pub const OUT_OF_DOMAIN_LABEL: &str = "out-of-domain";
+/// Label for the DEEP-quotient batching round.
+pub const DEEP_COMPOSITION_LABEL: &str = "deep-composition";
+/// Label for the FRI commit-phase folding rounds.
+pub const FOLDING_LABEL: &str = "fri-folding";
+/// Label for the FRI query round.
+pub const QUERY_LABEL: &str = "fri-query";
+/// Label for the commitment-collision cap.
+pub const COLLISION_LABEL: &str = "commitment-collision";
+
+/// Number of rounds a [`SecurityReport`] carries.
+pub const NUM_TERMS: usize = 7;
+
+/// One round's contribution, as `-log2(error)` in fixed point.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SecurityTerm {
+    /// Which round this bounds.
+    pub label: &'static str,
+    /// Attained bits for the round, grinding included, in fixed point.
+    pub bits: u64,
+}
+
+impl SecurityTerm {
+    /// Builds a term from a label and its fixed-point bit count.
+    pub const fn new(label: &'static str, bits: u64) -> Self {
+        Self { label, bits }
+    }
+}
+
+/// The per-round soundness breakdown of one proof configuration.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SecurityReport {
+    terms: [SecurityTerm; NUM_TERMS],
+}
+
+impl SecurityReport {
+    /// Builds a report from its rounds.
+    pub const fn new(terms: [SecurityTerm; NUM_TERMS]) -> Self {
+        Self { terms }
+    }
+
+    /// Every round.
+    pub const fn terms(&self) -> &[SecurityTerm; NUM_TERMS] {
+        &self.terms
+    }
+
+    /// The round that binds — the one attaining the minimum.
+    ///
+    /// Ties resolve to the earliest such round, so the reported bottleneck is the one an
+    /// adversary reaches first.
+    pub const fn binding_term(&self) -> SecurityTerm {
+        let mut binding = self.terms[0];
+        let mut index = 1;
+        while index < NUM_TERMS {
+            if self.terms[index].bits < binding.bits {
+                binding = self.terms[index];
+            }
+            index += 1;
+        }
+        binding
+    }
+
+    /// Attained conjectured security, in fixed point.
+    pub const fn attained(&self) -> u64 {
+        self.binding_term().bits
+    }
+
+    /// Attained conjectured security in whole bits, rounded down.
+    pub const fn security_level(&self) -> u32 {
+        crate::fixed::to_bits(self.attained())
+    }
+}

--- a/security/src/budget/shape.rs
+++ b/security/src/budget/shape.rs
@@ -1,0 +1,93 @@
+//! Inputs to the round budget: protocol parameters, instance shape, and AIR shape.
+//!
+//! These mirror the security-relevant subset of a protocol's runtime configuration rather than
+//! wrapping it. The runtime types live in the protocol's own crate, which this one must not depend
+//! on, so the caller — the only site with visibility into both sides — assembles these explicitly.
+
+/// Protocol parameters that enter the round budget.
+///
+/// Every field must be bound into the protocol's Fiat-Shamir transcript, so a proof cannot be
+/// graded under parameters it was not produced with.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolParams {
+    /// Log2 of the LDE blowup factor; the FRI rate is `2^-log_blowup`.
+    pub log_blowup: u32,
+    /// Log2 of the FRI folding arity.
+    pub log_folding_arity: u32,
+    /// Number of FRI query repetitions.
+    pub num_queries: u32,
+    /// Grinding bits before query index sampling.
+    pub query_pow_bits: u32,
+    /// Grinding bits before the DEEP-composition challenge is sampled. Read only when
+    /// [`AirShape::num_deep_terms`] is `Some`.
+    pub deep_pow_bits: u32,
+    /// Grinding bits before each FRI folding challenge.
+    pub folding_pow_bits: u32,
+    /// Grinding bits before the lookup / permutation argument's challenges are sampled.
+    ///
+    /// The lookup round's error grows linearly in trace length, so this is the only grinding site
+    /// whose absence degrades with instance size.
+    pub lookup_pow_bits: u32,
+}
+
+/// Shape of the proof instance being graded.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct InstanceShape {
+    /// Log2 of the largest AIR trace height in the proof.
+    ///
+    /// A lifted (multi-AIR) statement commits every matrix at the maximum height and tests a
+    /// single FRI instance against it, with shorter AIRs opened at powers of the same
+    /// out-of-domain point; every degree-dependent error therefore scales with this height, not
+    /// with each AIR's own. A single-AIR statement uses its own trace height directly.
+    pub log_max_height: u32,
+    /// Log2 of the challenge field size, in fixed point.
+    pub field_bits: u64,
+    /// Collision resistance of the commitment hash, in whole bits.
+    pub collision_resistance: u32,
+}
+
+impl InstanceShape {
+    /// The ceiling any reported level is capped at: no argument compiled with this transcript can
+    /// exceed the smaller of the challenge-field size and the commitment hash's collision
+    /// resistance.
+    pub const fn cap(&self) -> u64 {
+        let collision = crate::fixed::from_bits(self.collision_resistance);
+        if collision < self.field_bits {
+            collision
+        } else {
+            self.field_bits
+        }
+    }
+}
+
+/// Shape of a LogUp-style lookup argument, aggregated over every AIR in the proof.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LookupShape {
+    /// Total lookup fractions emitted per row, summed over all AIRs.
+    ///
+    /// Bounds the number of distinct bus messages an adversary can place in an unbalanced
+    /// multiset at `fractions_per_row · 2^log_max_height`.
+    pub fractions_per_row: u32,
+    /// Maximum message width, i.e. the highest power of the second lookup challenge a denominator
+    /// can reach.
+    pub max_message_width: u32,
+}
+
+/// Shape of the AIRs being proved, aggregated over every AIR in the proof.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AirShape {
+    /// Total constraints batched into the composition polynomial, plus one slot for each AIR
+    /// beyond the first when a second challenge batches multiple AIRs together (`0` slots for a
+    /// single-AIR statement, which needs no cross-AIR batching challenge).
+    pub num_composed_constraints: u32,
+    /// Maximum constraint degree over all AIRs.
+    pub max_constraint_degree: u32,
+    /// Total committed columns opened by a DEEP-quotient batching argument, plus one slot per
+    /// out-of-domain point, or `None` when the protocol performs no α/β column-batching reduction
+    /// over its committed openings. The budget's out-of-domain round is charged regardless of this
+    /// field; `None` only waives the separate DEEP-composition round.
+    pub num_deep_terms: Option<u32>,
+    /// Lookup argument shape. A zero `fractions_per_row` means the protocol has no lookup
+    /// argument, and the round contributes no constraint on security.
+    pub lookup: LookupShape,
+}

--- a/security/src/fixed.rs
+++ b/security/src/fixed.rs
@@ -1,0 +1,227 @@
+//! Deterministic integer analog of this crate's floating-point error-bit arithmetic.
+//!
+//! Every quantity elsewhere in this crate is `-log2(error)` as an `f64` via [`crate::error::ErrorBits`].
+//! A protocol that grades proof soundness *inside a recursive verifier* — a circuit or a VM with no
+//! floating-point unit — cannot reproduce that arithmetic bit-for-bit, and needs every rounding
+//! step biased toward understating security rather than overstating it. This module provides that:
+//! `-log2(error)` as a 16-fractional-bit fixed-point integer, computed with `const fn` integer
+//! operations only, rounding down on added logarithms and up on subtracted ones so the result is
+//! always a conservative lower bound on the true value.
+//!
+//! Not wired into the rest of the crate's `f64` composition machinery — a consumer needing
+//! bit-exact recursive verification uses this module's primitives directly rather than
+//! [`crate::error::ErrorBits`].
+
+/// Number of fractional bits in the fixed-point representation.
+pub const FRACTIONAL_BITS: u32 = 16;
+
+/// The value `1.0` in fixed point.
+pub const ONE: u64 = 1 << FRACTIONAL_BITS;
+
+/// `log2(e)` in fixed point, rounded down.
+///
+/// Appears in the random-words cutoff of [2025/2010](https://eprint.iacr.org/2025/2010) section 1.5.
+pub const LOG2_E: u64 = 94_548;
+
+/// Converts a whole number of bits into fixed point.
+pub const fn from_bits(bits: u32) -> u64 {
+    (bits as u64) << FRACTIONAL_BITS
+}
+
+/// Truncates a fixed-point quantity to whole bits, rounding down.
+pub const fn to_bits(value: u64) -> u32 {
+    (value >> FRACTIONAL_BITS) as u32
+}
+
+/// Returns `log2(x)` in fixed point, rounded down.
+///
+/// # Panics
+/// Panics if `x` is zero, which has no logarithm.
+pub const fn floor_log2(x: u64) -> u64 {
+    assert!(x != 0, "log2 is undefined at zero");
+
+    let integer_part = 63 - x.leading_zeros() as u64;
+    let mut result = integer_part << FRACTIONAL_BITS;
+
+    // Normalize the mantissa to Q32, so it lies in `[1, 2)` and its square stays inside a `u128`.
+    let mut mantissa: u128 = if integer_part >= 32 {
+        (x as u128) >> (integer_part - 32)
+    } else {
+        (x as u128) << (32 - integer_part)
+    };
+
+    // Standard bit-by-bit binary logarithm: squaring the mantissa shifts the next fractional bit
+    // of the result into the integer position.
+    let mut bit = 0;
+    while bit < FRACTIONAL_BITS {
+        mantissa = (mantissa * mantissa) >> 32;
+        if mantissa >= 1 << 33 {
+            mantissa >>= 1;
+            result |= 1 << (FRACTIONAL_BITS - 1 - bit);
+        }
+        bit += 1;
+    }
+
+    result
+}
+
+/// Returns `log2(x)` in fixed point, rounded up.
+///
+/// Exact for powers of two; otherwise one unit in the last place above [`floor_log2`], which is at
+/// most `2^-16` of a bit coarser than the true value.
+///
+/// # Panics
+/// Panics if `x` is zero, which has no logarithm.
+pub const fn ceil_log2(x: u64) -> u64 {
+    if x.is_power_of_two() {
+        from_bits(x.trailing_zeros())
+    } else {
+        floor_log2(x) + 1
+    }
+}
+
+/// Returns the conjectured security contributed by a single FRI query, in fixed point.
+///
+/// This is the "random words" rate of [2025/2010](https://eprint.iacr.org/2025/2010) section 1.5:
+///
+/// ```text
+/// bits_per_query = -log2(ρ + η),   ρ = 2^-log_blowup,   η = log2(e/ρ) · ρ / log2(q)
+/// ```
+///
+/// Rewriting to keep every step in fixed point and avoid materializing `ρ`:
+///
+/// ```text
+/// -log2(ρ + η) = log_blowup - log2(1 + (log2(e) + log_blowup) / log2(q))
+/// ```
+///
+/// so the correction is a ratio of two fixed-point integers whose logarithm [`ceil_log2`] can take
+/// directly. The correction is rounded up and then subtracted, keeping the rate conservative.
+///
+/// `field_bits` is `log2(q)` for the field FRI operates over — the challenge field, in fixed point.
+///
+/// Returns zero when the correction would exceed `log_blowup`, i.e. when the rate is not positive
+/// and queries contribute nothing.
+pub const fn bits_per_query(log_blowup: u32, field_bits: u64) -> u64 {
+    if log_blowup == 0 || field_bits == 0 {
+        return 0;
+    }
+
+    let uncorrected = from_bits(log_blowup);
+    let numerator = field_bits + LOG2_E + uncorrected;
+    let correction = ceil_log2(numerator) - floor_log2(field_bits);
+
+    uncorrected.saturating_sub(correction)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fri::{FriRegime, conjectured_error};
+    use crate::shape::InstanceShape;
+
+    /// The true value of `log2` must never be understated by [`ceil_log2`] nor overstated by
+    /// [`floor_log2`], and both must track it to within one unit in the last place. These are the
+    /// directions a round budget built on this module relies on to stay conservative.
+    #[test]
+    fn log2_brackets_the_true_logarithm() {
+        let mut x = 1u64;
+        while x < u64::MAX / 3 {
+            for candidate in [x, x + 1, x * 3 / 2] {
+                let truth = (candidate as f64).log2() * ONE as f64;
+                let floor = floor_log2(candidate) as f64;
+                let ceil = ceil_log2(candidate) as f64;
+
+                assert!(
+                    floor <= truth + 1.0,
+                    "floor_log2({candidate}) overstates log2"
+                );
+                assert!(
+                    truth - floor < 2.0,
+                    "floor_log2({candidate}) is more than 1 ulp low"
+                );
+                assert!(
+                    ceil + 1.0 >= truth,
+                    "ceil_log2({candidate}) understates log2"
+                );
+                assert!(
+                    ceil - truth < 2.0,
+                    "ceil_log2({candidate}) is more than 1 ulp high"
+                );
+            }
+            x *= 2;
+        }
+    }
+
+    #[test]
+    fn log2_is_exact_on_powers_of_two() {
+        for exponent in 0..64u32 {
+            assert_eq!(floor_log2(1 << exponent), from_bits(exponent));
+            assert_eq!(ceil_log2(1 << exponent), from_bits(exponent));
+        }
+    }
+
+    /// The fixed-point per-query rate must never exceed the real-valued random-words formula, and
+    /// must track it within one ulp, across every blowup the PCS parameters admit.
+    #[test]
+    fn bits_per_query_never_overstates_the_random_words_rate() {
+        for log_blowup in 1..=8u32 {
+            for field_bits in [from_bits(64), from_bits(96), from_bits(128), from_bits(192)] {
+                let rho = 2f64.powi(-(log_blowup as i32));
+                let eta = (core::f64::consts::LOG2_E + f64::from(log_blowup)) * rho
+                    / (field_bits as f64 / ONE as f64);
+                let truth = -(rho + eta).log2() * ONE as f64;
+
+                let actual = bits_per_query(log_blowup, field_bits) as f64;
+                assert!(
+                    actual <= truth,
+                    "bits_per_query({log_blowup}, {field_bits}) overstates the rate"
+                );
+                assert!(
+                    truth - actual < 2.0,
+                    "bits_per_query({log_blowup}, {field_bits}) is more than 1 ulp low"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bits_per_query_is_zero_without_a_blowup() {
+        assert_eq!(bits_per_query(0, from_bits(128)), 0);
+    }
+
+    /// [`bits_per_query`] and this crate's own [`crate::fri::conjectured_error`] compute the same
+    /// per-query rate through two independent code paths (fixed-point vs. `f64` + `libm`); at a
+    /// single query with no grinding they must agree to within the fixed-point representation's own
+    /// resolution.
+    #[test]
+    fn bits_per_query_matches_fri_conjectured_error_per_query_rate() {
+        for log_blowup in 1..=8usize {
+            let regime = FriRegime {
+                log_blowup,
+                num_queries: 1,
+                log_final_poly_len: 0,
+                max_log_arity: 0,
+                commit_pow_bits: 0,
+                query_pow_bits: 0,
+            };
+            let shape = InstanceShape {
+                log_trace_length: 20,
+                modulus_bits: 128,
+                collision_resistance: 128,
+                num_batched_functions: 1,
+            };
+
+            let f64_bits = conjectured_error(&regime, &shape).bits();
+            let fixed_bits = bits_per_query(log_blowup as u32, from_bits(128)) as f64 / ONE as f64;
+
+            assert!(
+                fixed_bits <= f64_bits + 1e-9,
+                "log_blowup={log_blowup}: fixed overstates f64"
+            );
+            assert!(
+                f64_bits - fixed_bits < 2.0 / ONE as f64 + 1e-9,
+                "log_blowup={log_blowup}: fixed is more than 1 ulp below f64"
+            );
+        }
+    }
+}

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -38,6 +38,7 @@ extern crate alloc;
 
 pub mod assumption;
 pub mod error;
+pub mod fixed;
 pub mod proximity;
 pub mod report;
 pub mod shape;

--- a/security/src/lib.rs
+++ b/security/src/lib.rs
@@ -37,6 +37,7 @@
 extern crate alloc;
 
 pub mod assumption;
+pub mod budget;
 pub mod error;
 pub mod fixed;
 pub mod proximity;

--- a/security/tests/budget_parity.rs
+++ b/security/tests/budget_parity.rs
@@ -1,0 +1,312 @@
+//! Cross-checks [`p3_security::budget`]'s fixed-point rounds against this crate's own `f64`
+//! composite (`fri`, `logup`, `deep`, `air`) on a synthetic grid, so the two representations of
+//! the same conjectured-security math can never drift apart silently.
+//!
+//! See `budget`'s module doc for the folding-accounting and DEEP-quotient-batching design notes
+//! this test exercises. The out-of-domain round is the one place the two formulas genuinely
+//! differ (not just fixed-point vs. `f64`): `budget`'s out-of-domain round assumes a single
+//! out-of-domain point per column (`factor = (d + 1)·height`), while `deep::deep_ali_error`
+//! accounts for `max_combo` points (`factor = d·(height + combo − 1) + (height − 1)`). At
+//! `combo = 2` these differ by exactly `d − 1`, so [`ood_tolerance`] bounds that gap analytically
+//! rather than folding it into a flat epsilon.
+
+use p3_security::budget::report::{
+    COLLISION_LABEL, COMPOSITION_LABEL, DEEP_COMPOSITION_LABEL, FOLDING_LABEL, LOOKUP_LABEL,
+    OUT_OF_DOMAIN_LABEL, QUERY_LABEL,
+};
+use p3_security::budget::{
+    AirShape, InstanceShape, LookupShape, ProtocolParams, SecurityReport, security_report,
+};
+use p3_security::fri::{FriRegime, commit_phase_error_udr, conjectured_error};
+use p3_security::grinding::{GrindingSites, boost};
+use p3_security::logup::{LogUpAir, security_term as logup_security_term};
+use p3_security::shape::{InstanceShape as F64InstanceShape, StarkAirParams};
+use p3_security::{air, deep, fixed};
+
+const TIGHT_TOL: f64 = 1e-4;
+const LOG_BLOWUP: u32 = 3;
+const LOG_FOLDING_ARITY: u32 = 2;
+const CAP_BITS: usize = 128;
+const FIELD_BITS: u64 = fixed::from_bits(128) - 2; // shy of 128.0, as a real field's log2 would be
+
+struct AirVector {
+    num_composed_constraints: u32,
+    max_constraint_degree: u32,
+    num_deep_terms: u32,
+    fractions_per_row: u32,
+    max_message_width: u32,
+}
+
+const SMALL: AirVector = AirVector {
+    num_composed_constraints: 40,
+    max_constraint_degree: 3,
+    num_deep_terms: 20,
+    fractions_per_row: 4,
+    max_message_width: 4,
+};
+
+const LARGE: AirVector = AirVector {
+    num_composed_constraints: 587,
+    max_constraint_degree: 9,
+    num_deep_terms: 770,
+    fractions_per_row: 244,
+    max_message_width: 18,
+};
+
+const PARAM_ROWS: &[(u32, u32, u32, u32)] = &[(27, 17, 12, 4), (100, 0, 0, 0), (150, 31, 31, 31)];
+
+fn to_f64(fixed_bits: u64) -> f64 {
+    fixed_bits as f64 / fixed::ONE as f64
+}
+
+const fn f64_instance(log_max_height: u32) -> F64InstanceShape {
+    F64InstanceShape {
+        log_trace_length: log_max_height as usize,
+        modulus_bits: CAP_BITS,
+        collision_resistance: CAP_BITS,
+        num_batched_functions: 1,
+    }
+}
+
+fn term_bits(report: &SecurityReport, label: &str) -> f64 {
+    to_f64(
+        report
+            .terms()
+            .iter()
+            .find(|t| t.label == label)
+            .expect("label present")
+            .bits,
+    )
+}
+
+/// Caps an uncapped `f64` reference value the same way [`security_report`] caps its fixed-point
+/// terms, so the two sides are compared on equal footing near the ceiling.
+const fn cap(bits: f64) -> f64 {
+    if bits < CAP_BITS as f64 {
+        bits
+    } else {
+        CAP_BITS as f64
+    }
+}
+
+fn ood_tolerance(max_constraint_degree: u32, log_max_height: u32) -> f64 {
+    let d = max_constraint_degree as f64;
+    let height = 2f64.powi(log_max_height as i32);
+    (1.0 + (d - 1.0) / ((d + 1.0) * height)).log2() + TIGHT_TOL
+}
+
+#[test]
+fn every_round_direction_and_tightness() {
+    for air_vector in [&SMALL, &LARGE] {
+        for &(num_queries, query_pow_bits, deep_pow_bits, folding_pow_bits) in PARAM_ROWS {
+            let params = ProtocolParams {
+                log_blowup: LOG_BLOWUP,
+                log_folding_arity: LOG_FOLDING_ARITY,
+                num_queries,
+                query_pow_bits,
+                deep_pow_bits,
+                folding_pow_bits,
+                lookup_pow_bits: 0,
+            };
+            let air_shape = AirShape {
+                num_composed_constraints: air_vector.num_composed_constraints,
+                max_constraint_degree: air_vector.max_constraint_degree,
+                num_deep_terms: Some(air_vector.num_deep_terms),
+                lookup: LookupShape {
+                    fractions_per_row: air_vector.fractions_per_row,
+                    max_message_width: air_vector.max_message_width,
+                },
+            };
+
+            for log_max_height in 6..=29u32 {
+                let instance = InstanceShape {
+                    log_max_height,
+                    field_bits: FIELD_BITS,
+                    collision_resistance: CAP_BITS as u32,
+                };
+                let report = security_report(&params, &instance, &air_shape);
+
+                check_query(&report, num_queries, query_pow_bits);
+                check_lookup(&report, air_vector, log_max_height);
+                check_composition(&report, air_vector);
+                check_ood(&report, air_vector, log_max_height);
+                check_folding(&report, log_max_height, folding_pow_bits);
+                check_deep_composition(&report, air_vector, deep_pow_bits);
+            }
+        }
+    }
+}
+
+fn check_query(report: &SecurityReport, num_queries: u32, query_pow_bits: u32) {
+    let fixed_bits = term_bits(report, QUERY_LABEL);
+    let regime = FriRegime {
+        log_blowup: LOG_BLOWUP as usize,
+        num_queries: num_queries as usize,
+        log_final_poly_len: 0,
+        max_log_arity: LOG_FOLDING_ARITY as usize,
+        commit_pow_bits: 0,
+        query_pow_bits: query_pow_bits as usize,
+    };
+    let p3_bits = cap(conjectured_error(&regime, &f64_instance(20)).bits());
+
+    // `bits_per_query` rounds its per-query rate down by less than 2 ulps (see its doc test's own
+    // margin), and the fixed-point total multiplies that single per-query rounding by
+    // `num_queries` before capping — the same tolerance bounds both directions.
+    let tolerance = (num_queries as f64).mul_add(2.0 / fixed::ONE as f64, TIGHT_TOL);
+    assert!(
+        fixed_bits <= p3_bits + tolerance,
+        "query: {fixed_bits} > {p3_bits} + {tolerance}"
+    );
+    assert!(
+        p3_bits - fixed_bits < tolerance,
+        "query: gap {} >= tolerance {tolerance}, fixed drifted conservative",
+        p3_bits - fixed_bits
+    );
+}
+
+fn check_lookup(report: &SecurityReport, air_vector: &AirVector, log_max_height: u32) {
+    let fixed_bits = term_bits(report, LOOKUP_LABEL);
+    let logup_air = LogUpAir {
+        num_interactions: air_vector.fractions_per_row as usize,
+        max_message_width: air_vector.max_message_width as usize,
+    };
+    let p3_bits = cap(logup_security_term(
+        &logup_air,
+        &f64_instance(log_max_height),
+        &GrindingSites::NONE,
+    )
+    .expect("has interactions")
+    .bits
+    .bits());
+
+    assert!(
+        fixed_bits <= p3_bits + TIGHT_TOL,
+        "lookup: {fixed_bits} > {p3_bits}"
+    );
+    assert!(
+        p3_bits - fixed_bits < TIGHT_TOL,
+        "lookup: gap {} >= tolerance, fixed drifted conservative",
+        p3_bits - fixed_bits
+    );
+}
+
+fn check_composition(report: &SecurityReport, air_vector: &AirVector) {
+    let fixed_bits = term_bits(report, COMPOSITION_LABEL);
+    let p3_bits =
+        cap(
+            air::composition_error(air_vector.num_composed_constraints as usize, 1.0, CAP_BITS)
+                .bits(),
+        );
+
+    assert!(
+        fixed_bits <= p3_bits + TIGHT_TOL,
+        "composition: {fixed_bits} > {p3_bits}"
+    );
+    assert!(
+        p3_bits - fixed_bits < TIGHT_TOL,
+        "composition: gap {} >= tolerance, fixed drifted conservative",
+        p3_bits - fixed_bits
+    );
+}
+
+fn check_ood(report: &SecurityReport, air_vector: &AirVector, log_max_height: u32) {
+    let fixed_bits = term_bits(report, OUT_OF_DOMAIN_LABEL);
+    let stark_air = StarkAirParams {
+        num_constraints: air_vector.num_composed_constraints as usize,
+        max_constraint_degree: air_vector.max_constraint_degree as usize,
+        max_combo: 2,
+    };
+    let p3_bits = cap(deep::deep_ali_error(&stark_air, &f64_instance(log_max_height), 1.0).bits());
+
+    // `tolerance` is the analytic gap between the two formulas (see this file's module doc) plus
+    // `TIGHT_TOL` of rounding slop; the direction check below bounds one side of that gap, and the
+    // tightness check bounds the other against the analytic gap alone.
+    let tolerance = ood_tolerance(air_vector.max_constraint_degree, log_max_height);
+    let exact_gap = tolerance - TIGHT_TOL;
+    assert!(
+        fixed_bits <= p3_bits + tolerance,
+        "ood: {fixed_bits} > {p3_bits} + {tolerance} at h={log_max_height}"
+    );
+    assert!(
+        p3_bits + exact_gap - fixed_bits < TIGHT_TOL,
+        "ood: gap {} >= tolerance at h={log_max_height}, fixed drifted conservative",
+        p3_bits + exact_gap - fixed_bits
+    );
+}
+
+fn check_folding(report: &SecurityReport, log_max_height: u32, folding_pow_bits: u32) {
+    let fixed_bits = term_bits(report, FOLDING_LABEL);
+    let regime = FriRegime {
+        log_blowup: LOG_BLOWUP as usize,
+        num_queries: 1,
+        log_final_poly_len: 0,
+        max_log_arity: LOG_FOLDING_ARITY as usize,
+        commit_pow_bits: folding_pow_bits as usize,
+        query_pow_bits: 0,
+    };
+    let p3_bits = cap(
+        commit_phase_error_udr(&regime, &f64_instance(log_max_height))
+            .expect("folds at every swept height")
+            .bits(),
+    );
+
+    assert!(
+        fixed_bits <= p3_bits + TIGHT_TOL,
+        "folding: {fixed_bits} > {p3_bits}"
+    );
+    assert!(
+        p3_bits - fixed_bits < 1.0 + TIGHT_TOL,
+        "folding: gap {} >= 1 bit",
+        p3_bits - fixed_bits
+    );
+}
+
+fn check_deep_composition(report: &SecurityReport, air_vector: &AirVector, deep_pow_bits: u32) {
+    let fixed_bits = term_bits(report, DEEP_COMPOSITION_LABEL);
+    let p3_bits = cap(boost(
+        air::composition_error(air_vector.num_deep_terms as usize, 1.0, CAP_BITS),
+        deep_pow_bits as usize,
+    )
+    .bits());
+
+    assert!(
+        fixed_bits <= p3_bits + TIGHT_TOL,
+        "deep-composition: {fixed_bits} > {p3_bits}"
+    );
+    assert!(
+        p3_bits - fixed_bits < TIGHT_TOL,
+        "deep-composition: gap {} >= tolerance, fixed drifted conservative",
+        p3_bits - fixed_bits
+    );
+}
+
+/// The collision-resistance term is reported at the cap verbatim on both sides — a degenerate but
+/// worthwhile check, since it is what every other round's capping is measured against above.
+#[test]
+fn collision_term_is_the_cap() {
+    let params = ProtocolParams {
+        log_blowup: LOG_BLOWUP,
+        log_folding_arity: LOG_FOLDING_ARITY,
+        num_queries: 27,
+        query_pow_bits: 17,
+        deep_pow_bits: 12,
+        folding_pow_bits: 4,
+        lookup_pow_bits: 0,
+    };
+    let instance = InstanceShape {
+        log_max_height: 20,
+        field_bits: FIELD_BITS,
+        collision_resistance: 96,
+    };
+    let air_shape = AirShape {
+        num_composed_constraints: LARGE.num_composed_constraints,
+        max_constraint_degree: LARGE.max_constraint_degree,
+        num_deep_terms: Some(LARGE.num_deep_terms),
+        lookup: LookupShape {
+            fractions_per_row: LARGE.fractions_per_row,
+            max_message_width: LARGE.max_message_width,
+        },
+    };
+    let report = security_report(&params, &instance, &air_shape);
+    assert_eq!(term_bits(&report, COLLISION_LABEL), 96.0);
+}


### PR DESCRIPTION
Adds a deterministic, bit-exact integer counterpart to this crate's `f64` error-bit arithmetic, for protocols that grade proof soundness inside a recursive verifier (a circuit/VM with no floating-point unit, needing the grade reproducible bit-for-bit with every rounding biased toward understatement):

  - security::fixed — 16-fractional-bit fixed-point `log2`/`bits_per_query` as const fns, cross-checked within 1 ulp against this crate's own `fri::conjectured_error`.
  - security::budget — the fixed-point counterpart to `stark::conjectured_security_report`: the same conjectured-regime rounds (lookup, constraint-composition, out-of-domain, DEEP-quotient batching, FRI folding, FRI query, commitment-collision), composed as const fns.

  Two design choices in budget are proposals, open for discussion:
  
 1. Folding sums a doubled per-round coefficient rather than searching for the worst round (see module doc) — conservative by < 1 bit vs. `fri::commit_phase_error_udr`'s worst-round bound.
 2. DEEP-quotient batching (`AirShape::num_deep_terms: Option<u32>`) is a first-class optional round on the fixed side with no `f64`-side equivalent; could instead go through `stark`'s extras mechanism if that's preferred.