### PR TITLE
fix(release): bump internal dep version pins when cutting an rc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,14 @@ name: CI
 
 on:
   # Release-plz verifies CI on the post-merge commit of the base branch, so
-  # push CI must run on every branch that can host a release: main and the
-  # vX.Y.Z version branches (including -rcN pre-releases).
+  # push CI must run on every branch that can host a release: main, the
+  # vX.Y.Z stable branches, and the X.Y.Z-rc.N release-candidate branches
+  # created by create_release.sh (named after the rc version, no "v" prefix).
   push:
     branches:
       - "main"
       - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,14 +1,15 @@
 name: Release-plz
 
 on:
-  # Fires on releases cut from main or a vX.Y.Z version branch (including -rcN
-  # pre-releases).
+  # Fires on releases cut from main, a vX.Y.Z stable branch, or an
+  # X.Y.Z-rc.N release-candidate branch (named after the rc version, no "v"
+  # prefix, see create_release.sh).
   pull_request:
     types: [closed]
     branches:
       - "main"
       - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   # Allow manual re-runs if publish fails (e.g., crates.io outage)
   workflow_dispatch:
 

--- a/create_release.sh
+++ b/create_release.sh
@@ -71,8 +71,24 @@ if [ -n "$rc_version" ]; then
 
   # Every crate inherits `version.workspace = true`, so bumping the single
   # [workspace.package] version sets the whole workspace in lock-step.
+  old_version=$(grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "(.*)"$/\1/')
+  old_version_re=$(printf '%s' "$old_version" | sed -E 's/[.[\*^$]/\\&/g')
+
   sed -i.bak -E "s/^version = \".*\"/version = \"$rc_version\"/" Cargo.toml
+
+  # [workspace.dependencies] pins each internal crate's own version requirement
+  # separately, e.g. `p3-field = { path = "field", version = "0.6.0" }`. Bump
+  # those too, or crates still requiring the old version fail to resolve
+  # against the now-bumped local path packages.
+  sed -i.bak -E "s/(path = \"[^\"]+\", version = )\"$old_version_re\"/\1\"$rc_version\"/" Cargo.toml
   rm -f Cargo.toml.bak
+
+  check_binary_installed "cargo"
+  echo "Verifying dependency resolution..."
+  if ! cargo metadata --format-version 1 --quiet > /dev/null; then
+    echo "Error: cargo metadata failed after version bump. Aborting before commit."
+    exit 1
+  fi
 
   git switch -c "$pr_branch"
   git commit -m "chore: release $rc_version" Cargo.toml


### PR DESCRIPTION
The rc path only bumped [workspace.package].version, leaving each internal crate's own requirement in [workspace.dependencies] (e.g. p3-field = { path = "field", version = "0.6.0" }) pointing at the old version. 
Once the local path package moved past that version, cargo could no longer resolve it, breaking every downstream build.

Also verify resolution with `cargo metadata` before committing, so a mismatch is caught locally instead of in CI.

See #1985 initial commit for a visual explainer of the failure pre-fix from this PR.