### PR TITLE
perf(stir): allow round 0's folding arity to differ from later rounds

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,6 +45,7 @@ p3-matrix = { path = "../matrix" }
 p3-poseidon1 = { path = "../poseidon1" }
 p3-stir = { path = "../stir" }
 p3-sumcheck = { path = "../sumcheck" }
+p3-util = { path = "../util" }
 p3-whir = { path = "../whir" }
 
 tracing.workspace = true

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -491,14 +491,6 @@ fn main() {
         ));
     }
 
-    print_report(
-        &format!(
-            "FRI vs STIR vs WHIR ({}-bit security, rho = 2^-{}, m = {}, width = 2^{})",
-            args.security_level, args.rate, args.log_message_size, args.log_width
-        ),
-        &reports,
-    );
-
     // Multi-table run: three tables batched into one commitment, with log heights
     // n, n + 1, and n + 3 (n + 3 is `--log-message-size`) and a shared column width.
     // This is closer to how a real prover commits several trace tables of different
@@ -649,6 +641,14 @@ fn main() {
             &base_challenger,
         ));
     }
+
+    print_report(
+        &format!(
+            "FRI vs STIR vs WHIR single-table ({}-bit security, rho = 2^-{}, m = {}, width = 2^{})",
+            args.security_level, args.rate, args.log_message_size, args.log_width
+        ),
+        &reports,
+    );
 
     print_report(
         &format!(

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -29,6 +29,18 @@
 //! description of the violated bound. Lower `stir-log-fold` or raise `rate` if that
 //! happens.
 //!
+//! # Multi-table run
+//!
+//! After the single-table comparison, the same three protocols run a second
+//! commit -> open -> verify cycle over three tables committed together in one batch,
+//! with log heights `n`, `n + 1`, and `n + 3` (`n + 3` is `--log-message-size`, so `n`
+//! is three less) and a shared column width set by `--multi-table-width`. This mirrors
+//! how a real prover batches multiple trace tables of different heights into a single
+//! commitment, rather than committing one uniform matrix. FRI and STIR batch the three
+//! matrices directly; WHIR stacks the three tables into one committed multilinear
+//! polynomial, so its round schedule is derived from the stacked size rather than from
+//! `log-message-size` directly.
+//!
 //! # Run
 //!
 //! Each protocol's internal tracing spans log at INFO by default; set `RUST_LOG=warn`
@@ -55,6 +67,7 @@ use p3_stir::{StirConfig, StirParameters, TwoAdicStirPcs};
 use p3_sumcheck::layout::{Layout, SuffixProver, Table};
 use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_util::log2_ceil_usize;
 use p3_whir::fiat_shamir::domain_separator::DomainSeparator;
 use p3_whir::parameters::{FoldingFactor, ProtocolParameters, SecurityAssumption, WhirConfig};
 use p3_whir::pcs::prover::WhirProver;
@@ -114,6 +127,12 @@ struct Args {
     #[arg(short = 'w', long, default_value = "0")]
     log_width: usize,
 
+    /// Column width shared by the three tables in the multi-table run, chosen to be
+    /// representative of a real trace table rather than the single-column default used
+    /// by the primary single-table comparison above.
+    #[arg(long, default_value = "32")]
+    multi_table_width: usize,
+
     /// Log_2 of the inverse rate of the starting Reed-Solomon code.
     #[arg(short = 'r', long, default_value = "1")]
     rate: usize,
@@ -157,13 +176,13 @@ fn default_round_log_inv_rates(num_variables: usize, folding_factor: &FoldingFac
     rates
 }
 
-/// Run one full commit -> open -> verify cycle for a univariate PCS (FRI or STIR) and
-/// report its timing, proof size, and query count.
+/// Run one full commit -> open -> verify cycle for a univariate PCS (FRI or STIR) over
+/// one or more matrices batched into a single commitment and opened at a shared
+/// out-of-domain point, then report timing, proof size, and query count.
 fn run_univariate_pcs<P>(
     label: &'static str,
     pcs: &P,
-    domain: TwoAdicMultiplicativeCoset<F>,
-    message: RowMajorMatrix<F>,
+    tables: Vec<(TwoAdicMultiplicativeCoset<F>, RowMajorMatrix<F>)>,
     base_challenger: &Challenger,
     queries: String,
     observe: impl Fn(&mut Challenger, &P::Commitment),
@@ -171,10 +190,11 @@ fn run_univariate_pcs<P>(
 where
     P: Pcs<EF, Challenger, Domain = TwoAdicMultiplicativeCoset<F>>,
 {
+    let domains: Vec<_> = tables.iter().map(|(domain, _)| *domain).collect();
     let mut prover_challenger = base_challenger.clone();
 
     let t = Instant::now();
-    let (commit, prover_data) = pcs.commit([(domain, message)]);
+    let (commit, prover_data) = pcs.commit(tables);
     let commit_ms = t.elapsed().as_millis();
 
     observe(&mut prover_challenger, &commit);
@@ -184,12 +204,13 @@ where
         <Challenger as FieldChallenger<F>>::sample_algebra_element(&mut prover_challenger);
 
     let t = Instant::now();
-    let (openings, proof) = pcs.open(
-        vec![(&prover_data, vec![vec![zeta]])],
-        &mut prover_challenger,
-    );
+    let opening_points = domains.iter().map(|_| vec![zeta]).collect();
+    let (openings, proof) = pcs.open(vec![(&prover_data, opening_points)], &mut prover_challenger);
     let open_ms = t.elapsed().as_millis();
-    let values = openings[0][0][0].clone();
+    let values: Vec<_> = openings[0]
+        .iter()
+        .map(|matrix_openings| matrix_openings[0].clone())
+        .collect();
 
     let mut verifier_challenger = base_challenger.clone();
     observe(&mut verifier_challenger, &commit);
@@ -198,8 +219,13 @@ where
     assert_eq!(derived, zeta, "verifier challenger drifted from prover");
 
     let t = Instant::now();
+    let matrices_with_openings = domains
+        .into_iter()
+        .zip(values)
+        .map(|(domain, vals)| (domain, vec![(zeta, vals)]))
+        .collect();
     pcs.verify(
-        vec![(commit, vec![(domain, vec![(zeta, values)])])],
+        vec![(commit, matrices_with_openings)],
         &proof,
         &mut verifier_challenger,
     )
@@ -282,12 +308,9 @@ fn run_whir(
     }
 }
 
-fn print_report(args: &Args, reports: &[ProtocolReport]) {
+fn print_report(title: &str, reports: &[ProtocolReport]) {
     println!();
-    println!(
-        "=== FRI vs STIR vs WHIR ({}-bit security, rho = 2^-{}, m = {}, width = 2^{}) ===",
-        args.security_level, args.rate, args.log_message_size, args.log_width
-    );
+    println!("=== {title} ===");
     println!(
         "  protocol | commit ms | open ms | total ms | verify us | proof bytes | proof KiB | queries"
     );
@@ -327,6 +350,10 @@ fn main() {
     assert!(
         args.log_width <= args.log_message_size,
         "log-width cannot exceed log-message-size"
+    );
+    assert!(
+        args.log_message_size >= 3,
+        "log-message-size must be at least 3 for the multi-table run (heights n, n + 1, n + 3)"
     );
 
     let log_height = args.log_message_size - args.log_width;
@@ -377,8 +404,7 @@ fn main() {
         reports.push(run_univariate_pcs(
             "fri",
             &pcs,
-            domain,
-            message,
+            vec![(domain, message)],
             &base_challenger,
             num_queries.to_string(),
             |ch, commit| ch.observe(commit.clone()),
@@ -393,7 +419,7 @@ fn main() {
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: args.security_level,
             max_pow_bits: args.pow_bits,
-            mmcs: challenge_mmcs,
+            mmcs: challenge_mmcs.clone(),
         };
         let config =
             StirConfig::<F, EF, ChallengeMmcs, Challenger>::new(log_height, stir_params.clone());
@@ -414,8 +440,7 @@ fn main() {
         reports.push(run_univariate_pcs(
             "stir",
             &pcs,
-            domain,
-            message,
+            vec![(domain, message)],
             &base_challenger,
             queries,
             // STIR commits one Merkle tree per distinct LDE height.
@@ -452,7 +477,7 @@ fn main() {
         .pad_to_min_num_variables(args.whir_fold);
 
         let dft = Dft::new(1 << config.max_fft_size());
-        let pcs = WhirPcsTy::new(config, dft, val_mmcs);
+        let pcs = WhirPcsTy::new(config, dft, val_mmcs.clone());
 
         let mut domain_separator = DomainSeparator::new(vec![]);
         pcs.add_domain_separator::<DIGEST_ELEMS>(&mut domain_separator);
@@ -466,5 +491,170 @@ fn main() {
         ));
     }
 
-    print_report(&args, &reports);
+    print_report(
+        &format!(
+            "FRI vs STIR vs WHIR ({}-bit security, rho = 2^-{}, m = {}, width = 2^{})",
+            args.security_level, args.rate, args.log_message_size, args.log_width
+        ),
+        &reports,
+    );
+
+    // Multi-table run: three tables batched into one commitment, with log heights
+    // n, n + 1, and n + 3 (n + 3 is `--log-message-size`) and a shared column width.
+    // This is closer to how a real prover commits several trace tables of different
+    // heights together, rather than one uniform matrix.
+    let n = args.log_message_size - 3;
+    let heights = [n, n + 1, args.log_message_size];
+    let multi_width = args.multi_table_width;
+
+    let mut multi_reports = Vec::with_capacity(3);
+
+    // FRI: the closed-form query count doesn't depend on the committed heights, so it's
+    // unchanged from the single-table run above; only the batch of committed matrices
+    // and the DFT size (sized for the tallest table) differ.
+    {
+        let num_queries = (args.security_level - args.pow_bits)
+            .div_ceil(args.rate)
+            .max(1);
+        let fri_params = FriParameters {
+            log_blowup: args.rate,
+            log_final_poly_len: 0,
+            max_log_arity: args.fri_log_arity,
+            num_queries,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: args.pow_bits,
+            mmcs: challenge_mmcs.clone(),
+        };
+        let dft = Dft::new(1 << (args.log_message_size + args.rate));
+        let pcs = FriPcsTy::new(dft, val_mmcs.clone(), fri_params);
+        let mut rng = SmallRng::seed_from_u64(0xF12F);
+        let tables = heights
+            .iter()
+            .map(|&h| {
+                let domain =
+                    <FriPcsTy as Pcs<EF, Challenger>>::natural_domain_for_degree(&pcs, 1 << h);
+                let message = RowMajorMatrix::<F>::rand(&mut rng, 1 << h, multi_width);
+                (domain, message)
+            })
+            .collect();
+        multi_reports.push(run_univariate_pcs(
+            "fri",
+            &pcs,
+            tables,
+            &base_challenger,
+            num_queries.to_string(),
+            |ch, commit| ch.observe(commit.clone()),
+        ));
+    }
+
+    // STIR: the round/PoW schedule is derived once from the tallest table, and the
+    // shorter tables are folded in once the running codeword reaches their height.
+    {
+        let stir_params = StirParameters {
+            log_blowup: args.rate,
+            log_folding_factor: args.stir_log_fold,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: args.security_level,
+            max_pow_bits: args.pow_bits,
+            mmcs: challenge_mmcs,
+        };
+        let config = StirConfig::<F, EF, ChallengeMmcs, Challenger>::new(
+            args.log_message_size,
+            stir_params.clone(),
+        );
+        let queries = config
+            .round_configs
+            .iter()
+            .map(|rc| rc.num_queries.to_string())
+            .chain(std::iter::once(config.final_queries.to_string()))
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let dft = Dft::new(1 << (args.log_message_size + args.rate));
+        let pcs = StirPcsTy::new(dft, val_mmcs.clone(), stir_params);
+        let mut rng = SmallRng::seed_from_u64(0x571131);
+        let tables = heights
+            .iter()
+            .map(|&h| {
+                let domain =
+                    <StirPcsTy as Pcs<EF, Challenger>>::natural_domain_for_degree(&pcs, 1 << h);
+                let message = RowMajorMatrix::<F>::rand(&mut rng, 1 << h, multi_width);
+                (domain, message)
+            })
+            .collect();
+        multi_reports.push(run_univariate_pcs(
+            "stir",
+            &pcs,
+            tables,
+            &base_challenger,
+            queries,
+            // STIR commits one Merkle tree per distinct LDE height.
+            |ch, commit| commit.iter().for_each(|c| ch.observe(c.clone())),
+        ));
+    }
+
+    // WHIR: the three tables are stacked into one committed multilinear polynomial, so
+    // the round schedule is derived from the stacked size rather than from
+    // `log-message-size` directly.
+    {
+        let stacked_num_variables =
+            log2_ceil_usize(heights.iter().map(|&h| multi_width << h).sum::<usize>());
+        let folding_factor = FoldingFactor::Constant(args.whir_fold);
+        let params = ProtocolParameters {
+            security_level: args.security_level,
+            pow_bits: args.pow_bits,
+            round_log_inv_rates: default_round_log_inv_rates(
+                stacked_num_variables,
+                &folding_factor,
+            ),
+            folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            starting_log_inv_rate: args.rate,
+        };
+        let config = WhirConfig::<EF, F, Challenger>::new(stacked_num_variables, params).unwrap();
+        if !config.check_pow_bits() {
+            warn!("WHIR requires more PoW bits than the configured budget for the multi-table run");
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x411123);
+        let tables = heights
+            .iter()
+            .map(|&h| Table::rand(&mut rng, multi_width, h))
+            .collect();
+        let witness = WhirLayout::new_witness(tables, args.whir_fold);
+        let protocol = OpeningProtocol::new(
+            heights
+                .iter()
+                .map(|&h| {
+                    TableSpec::new(
+                        TableShape::new(h, multi_width),
+                        vec![OpeningBatch::new((0..multi_width).collect(), Vec::new())],
+                    )
+                })
+                .collect(),
+        )
+        .pad_to_min_num_variables(args.whir_fold);
+
+        let dft = Dft::new(1 << config.max_fft_size());
+        let pcs = WhirPcsTy::new(config, dft, val_mmcs);
+
+        let mut domain_separator = DomainSeparator::new(vec![]);
+        pcs.add_domain_separator::<DIGEST_ELEMS>(&mut domain_separator);
+
+        multi_reports.push(run_whir(
+            &pcs,
+            witness,
+            protocol,
+            &domain_separator,
+            &base_challenger,
+        ));
+    }
+
+    print_report(
+        &format!(
+            "FRI vs STIR vs WHIR multi-table ({}-bit security, rho = 2^-{}, heights = 2^{{{}, {}, {}}}, width = {})",
+            args.security_level, args.rate, heights[0], heights[1], heights[2], multi_width
+        ),
+        &multi_reports,
+    );
 }

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -147,6 +147,17 @@ struct Args {
     #[arg(long, default_value = "4")]
     stir_log_fold: usize,
 
+    /// STIR log_2 folding arity used only in round 0 (the fold of the initial oracle).
+    ///
+    /// Defaults to the paper-backed minimum (arity 4), which shrinks every first-round
+    /// query's fiber (`2^k0` LDE rows, times the committed width) without touching the
+    /// improved-rate schedule the later rounds are priced on — the win grows with
+    /// column width, since a first-round query reads `k0` whole rows of every
+    /// committed matrix. Set equal to `stir-log-fold` to recover a constant-arity
+    /// schedule.
+    #[arg(long, default_value = "2")]
+    stir_log_starting_fold: usize,
+
     /// FRI log_2 folding arity per round.
     #[arg(long, default_value = "1")]
     fri_log_arity: usize,
@@ -355,7 +366,6 @@ fn main() {
         args.log_message_size >= 3,
         "log-message-size must be at least 3 for the multi-table run (heights n, n + 1, n + 3)"
     );
-
     let log_height = args.log_message_size - args.log_width;
     let width = 1usize << args.log_width;
 
@@ -416,6 +426,7 @@ fn main() {
         let stir_params = StirParameters {
             log_blowup: args.rate,
             log_folding_factor: args.stir_log_fold,
+            log_starting_folding_factor: args.stir_log_starting_fold,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: args.security_level,
             max_pow_bits: args.pow_bits,
@@ -545,6 +556,7 @@ fn main() {
         let stir_params = StirParameters {
             log_blowup: args.rate,
             log_folding_factor: args.stir_log_fold,
+            log_starting_folding_factor: args.stir_log_starting_fold,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: args.security_level,
             max_pow_bits: args.pow_bits,

--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -59,6 +59,7 @@ fn make_stir_env(log_folding_factor: usize) -> (StirParameters<MyMmcs>, Dft, Cha
     let params = StirParameters {
         log_blowup: 1,
         log_folding_factor,
+        log_starting_folding_factor: log_folding_factor,
         soundness_type: SecurityAssumption::CapacityBound,
         security_level: 100,
         max_pow_bits: 0,

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -54,6 +54,7 @@ fn make_pcs() -> (MyPcs, Challenger) {
     let stir_params = StirParameters {
         log_blowup: 1,
         log_folding_factor: 2,
+        log_starting_folding_factor: 2,
         soundness_type: SecurityAssumption::CapacityBound,
         security_level: 100,
         max_pow_bits: 20,

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -345,12 +345,13 @@ where
         };
 
         // Disjoint-coset side condition for round `i`. The schedule sets
-        // `shift_{i+1} = shift_i^{k_i} * GEN` (`k_i` round `i`'s own folding factor), so
-        // `shift_{i+1}/shift_i = GEN^{k_i^{i+1}}`. Disjoint cosets `L_i ∩ L_{i+1} = ∅`
-        // requires that ratio ∉ H_i, i.e. `(GEN^{k_i^{i+1}})^{|H_i|} = GEN^{2^{N_i}} ≠ 1`
-        // where `N_i = (Σ_{j≤i} log_folding_factor_j) + log_domain_i`, the cumulative
-        // folding-log through and including round `i`. Holds for any field whose
-        // multiplicative order has nontrivial odd part (BabyBear, KoalaBear,
+        // `shift_{i+1} = shift_i^{k_i} * GEN` each round (`k_i` = that round's own folding
+        // factor), so `shift_i = GEN^{c_i}` for the nested recursion `c_{i+1} = c_i * k_i + 1`
+        // — not a plain power of the summed `k_j`'s. Disjoint cosets `L_i ∩ L_{i+1} = ∅`
+        // require `GEN` to avoid the size-`2^{log_domain_i}` subgroup reached at round `i`;
+        // we check the simpler `GEN^{2^{N_i}} ≠ 1` where `N_i = (Σ_{j≤i} log_folding_factor_j)
+        // + log_domain_i` is the cumulative folding-log through round `i`. Holds for any
+        // field whose multiplicative order has nontrivial odd part (BabyBear, KoalaBear,
         // Goldilocks, …); the assertion catches pathological fields.
         let assert_disjoint_cosets =
             |round_index: usize, log_domain_i: usize, cumulative_log_folding: usize| {
@@ -898,28 +899,33 @@ mod tests {
         let val_mmcs = ValMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
         let field_size_bits = EF::bits();
 
-        // (log_starting_degree, log_blowup, log_folding_factor, security_level, max_pow_bits, soundness_type).
+        // (log_starting_degree, log_blowup, log_folding_factor, log_starting_folding_factor,
+        // security_level, max_pow_bits, soundness_type).
         let cb = SecurityAssumption::CapacityBound;
         let jb = SecurityAssumption::JohnsonBound;
         let cases = [
-            (8, 1, 2, 80, 20, cb),
-            (8, 2, 2, 80, 20, cb),
-            (8, 2, 2, 80, 20, jb),
-            (16, 1, 2, 80, 20, cb),
-            (4, 1, 2, 80, 20, cb),
-            (8, 1, 2, 16, 0, cb),
-            (12, 1, 3, 16, 0, cb),
-            (4, 1, 2, 16, 0, cb),
+            (8, 1, 2, 2, 80, 20, cb),
+            (8, 2, 2, 2, 80, 20, cb),
+            (8, 2, 2, 2, 80, 20, jb),
+            (16, 1, 2, 2, 80, 20, cb),
+            (4, 1, 2, 2, 80, 20, cb),
+            (8, 1, 2, 2, 16, 0, cb),
+            (12, 1, 3, 2, 16, 0, cb),
+            (4, 1, 2, 2, 16, 0, cb),
+            // k0 != k: round 0 folds by a different factor than every later round.
+            (16, 1, 3, 2, 80, 20, cb),
         ];
 
         {
-            for &(log_deg, log_blowup, log_fold, sec, max_pow, soundness_type) in &cases {
+            for &(log_deg, log_blowup, log_fold, log_starting_fold, sec, max_pow, soundness_type) in
+                &cases
+            {
                 let config = StirConfig::<F, EF, MyMmcs, MyChallenger>::new(
                     log_deg,
                     StirParameters {
                         log_blowup,
                         log_folding_factor: log_fold,
-                        log_starting_folding_factor: log_fold,
+                        log_starting_folding_factor: log_starting_fold,
                         soundness_type,
                         security_level: sec,
                         max_pow_bits: max_pow,
@@ -928,7 +934,7 @@ mod tests {
                 );
 
                 // Mirror `StirConfig::new`'s buffered target.
-                let total_folds = log_deg / log_fold;
+                let total_folds = 1 + (log_deg - log_starting_fold) / log_fold;
                 let buffer = libm::ceil(libm::log2((6 * (total_folds - 1) + 3) as f64)) as usize;
                 let buffered = (sec + buffer) as f64;
                 // Recomputed algebraic bits use the same `libm` math as the config, so

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -24,16 +24,27 @@ pub struct StirParameters<M> {
     /// `log_folding_factor - 1` per round.
     pub log_blowup: usize,
 
-    /// Log₂ of the folding factor applied in every round.
+    /// Log₂ of the folding factor applied from round 1 onward, and by the final
+    /// direct-send stage when the schedule has at least one intermediate round.
     ///
-    /// Each round folds `2^log_folding_factor` evaluation points into one,
+    /// Each such round folds `2^log_folding_factor` evaluation points into one,
     /// reducing the degree by that same factor, while the committed domain is halved
     /// (LDE step). This decoupling causes the code rate to improve each round.
-    /// Must satisfy `log_folding_factor <= log_starting_degree`.
     ///
     /// The paper-backed STIR schedule implemented here requires `k ≥ 4`
     /// (`log_folding_factor ≥ 2`).
     pub log_folding_factor: usize,
+
+    /// Log₂ of the folding factor applied in round 0 (the fold of the initial oracle).
+    ///
+    /// Construction 5.2 allows every round's folding parameter to differ; this crate
+    /// exposes that generality only for round 0, since a smaller `k₀` shrinks each
+    /// first-round query's fiber (`2^log_starting_folding_factor` rows of the input,
+    /// times the input width) without touching the improved-rate schedule the later
+    /// rounds are priced on. Must satisfy `log_starting_folding_factor <= log_starting_degree`
+    /// and, like `log_folding_factor`, `log_starting_folding_factor ≥ 2` (`k₀ ≥ 4`).
+    /// Set equal to `log_folding_factor` to recover a constant-arity schedule.
+    pub log_starting_folding_factor: usize,
 
     /// Which Reed-Solomon proximity bound to assume for soundness analysis.
     pub soundness_type: SecurityAssumption,
@@ -142,8 +153,11 @@ pub struct StirConfig<F, EF, M, Challenger> {
     /// The effective inverse rate increases by `log_folding_factor - 1` each round.
     pub log_blowup: usize,
 
-    /// Log₂ of the folding arity. Constant across all rounds.
+    /// Log₂ of the folding arity used from round 1 onward.
     pub log_folding_factor: usize,
+
+    /// Log₂ of the folding arity used in round 0 (the fold of the initial oracle).
+    pub log_starting_folding_factor: usize,
 
     /// Per-round derived configurations for each intermediate STIR round.
     pub round_configs: Vec<StirRoundConfig<F>>,
@@ -187,16 +201,22 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if `log_folding_factor < 2` or if `log_folding_factor > log_starting_degree`.
+    /// Panics if `log_folding_factor < 2`, if `log_starting_folding_factor < 2`, or if
+    /// `log_starting_folding_factor > log_starting_degree`.
     pub fn new(log_starting_degree: usize, params: StirParameters<M>) -> Self {
         assert!(
             params.log_folding_factor >= 2,
             "the paper-backed STIR parameter schedule requires log_folding_factor >= 2 (k >= 4)"
         );
         assert!(
-            params.log_folding_factor <= log_starting_degree,
-            "Folding factor ({}) must be <= starting degree ({}).",
-            params.log_folding_factor,
+            params.log_starting_folding_factor >= 2,
+            "the paper-backed STIR parameter schedule requires log_starting_folding_factor >= 2 \
+             (k0 >= 4)"
+        );
+        assert!(
+            params.log_starting_folding_factor <= log_starting_degree,
+            "Starting folding factor ({}) must be <= starting degree ({}).",
+            params.log_starting_folding_factor,
             log_starting_degree
         );
 
@@ -229,23 +249,27 @@ where
         let field_size_bits = EF::bits();
         let log_blowup = params.log_blowup;
         let log_folding_factor = params.log_folding_factor;
+        let log_starting_folding_factor = params.log_starting_folding_factor;
         let security_level = params.security_level;
         let max_pow_bits = params.max_pow_bits;
         let algebraic_security_level = security_level - max_pow_bits;
         let num_ood_samples = params.soundness_type.stir_num_ood_samples();
 
-        // Determine number of intermediate rounds. We fold all the way down to a polynomial
-        // of size `2^log_final_degree` (where log_final_degree < log_folding_factor) and
-        // send it directly. Each round reduces log_degree by log_folding_factor.
-        let total_folds = log_starting_degree / log_folding_factor;
-        assert!(
-            total_folds > 0,
-            "STIR requires at least one fold before the final direct-send stage"
-        );
+        // Determine number of intermediate rounds. Round 0 folds by k0
+        // (`log_starting_folding_factor`); every fold after that, including the final
+        // direct-send stage, folds by k (`log_folding_factor`). We fold all the way down
+        // to a polynomial of size `2^log_final_degree` (where log_final_degree <
+        // log_folding_factor, whenever more than the k0 fold happens) and send it
+        // directly. When `log_starting_degree - log_starting_folding_factor` is itself
+        // already `< log_folding_factor`, the k0 fold IS the final fold and no further
+        // k-fold occurs.
+        let after_starting_fold = log_starting_degree - log_starting_folding_factor;
+        let extra_folds = after_starting_fold / log_folding_factor;
+        let total_folds = 1 + extra_folds;
 
         // Last fold produces the final polynomial; intermediate rounds = total_folds - 1.
         let num_rounds = total_folds.saturating_sub(1);
-        let log_final_degree = log_starting_degree - total_folds * log_folding_factor;
+        let log_final_degree = after_starting_fold - extra_folds * log_folding_factor;
 
         // Per-round target adds a union-bound buffer of `ceil(log2(num_terms))` so that
         // summing every algebraic failure mode across the protocol is bounded by
@@ -321,30 +345,34 @@ where
         };
 
         // Disjoint-coset side condition for round `i`. The schedule sets
-        // `shift_{i+1} = shift_i^k * GEN`, so `shift_{i+1}/shift_i = GEN^{k^{i+1}}`.
-        // Disjoint cosets `L_i ∩ L_{i+1} = ∅` requires that ratio ∉ H_i, i.e.
-        // `(GEN^{k^{i+1}})^{|H_i|} = GEN^{2^{N_i}} ≠ 1` where
-        //   `N_i = (i+1) * log_folding_factor + log_domain_i`.
-        // Holds for any field whose multiplicative order has nontrivial odd part
-        // (BabyBear, KoalaBear, Goldilocks, …); the assertion catches pathological fields.
-        let assert_disjoint_cosets = |round_index: usize, log_domain_i: usize| {
-            let n_i = (round_index + 1) * log_folding_factor + log_domain_i;
-            assert!(
-                F::GENERATOR.exp_power_of_2(n_i) != F::ONE,
-                "STIR round {round_index}: disjoint-coset schedule requires \
-                 Field::GENERATOR^(2^{n_i}) ≠ 1 (i.e. GEN^(k^{}) ∉ subgroup of size 2^{log_domain_i}).",
-                round_index + 1,
-            );
-        };
+        // `shift_{i+1} = shift_i^{k_i} * GEN` (`k_i` round `i`'s own folding factor), so
+        // `shift_{i+1}/shift_i = GEN^{k_i^{i+1}}`. Disjoint cosets `L_i ∩ L_{i+1} = ∅`
+        // requires that ratio ∉ H_i, i.e. `(GEN^{k_i^{i+1}})^{|H_i|} = GEN^{2^{N_i}} ≠ 1`
+        // where `N_i = (Σ_{j≤i} log_folding_factor_j) + log_domain_i`, the cumulative
+        // folding-log through and including round `i`. Holds for any field whose
+        // multiplicative order has nontrivial odd part (BabyBear, KoalaBear,
+        // Goldilocks, …); the assertion catches pathological fields.
+        let assert_disjoint_cosets =
+            |round_index: usize, log_domain_i: usize, cumulative_log_folding: usize| {
+                let n_i = cumulative_log_folding + log_domain_i;
+                assert!(
+                    F::GENERATOR.exp_power_of_2(n_i) != F::ONE,
+                    "STIR round {round_index}: disjoint-coset schedule requires \
+                     Field::GENERATOR^(2^{n_i}) ≠ 1 (i.e. GEN ∉ subgroup of size \
+                     2^{log_domain_i} after the cumulative fold).",
+                );
+            };
 
         // Size eta against both classes of error: PoW-eligible folding/query terms target
         // `pow_target_bits`, while OOD and shake terms must reach the full buffered target.
+        // Round 0 folds by `log_starting_folding_factor` (k0), not the steady-state
+        // `log_folding_factor` used from round 1 on.
         let mut final_eta = params.soundness_type.stir_initial_eta(
             pow_target_bits,
             buffered_security_level,
             log_degree,
             log_inv_rate,
-            log_folding_factor,
+            log_starting_folding_factor,
             field_size_bits,
         );
         validate_eta(0, log_inv_rate, final_eta);
@@ -352,7 +380,13 @@ where
         // Round 0 reuses the `stir_initial_eta` already computed above; every subsequent
         // round derives eta from the previous round's query count via `stir_recursive_eta`.
         let mut prev_queries = 0;
+        let mut cumulative_log_folding = 0usize;
         for round in 0..num_rounds {
+            let round_log_folding_factor = if round == 0 {
+                log_starting_folding_factor
+            } else {
+                log_folding_factor
+            };
             if round != 0 {
                 final_eta = params.soundness_type.stir_recursive_eta(
                     pow_target_bits,
@@ -368,7 +402,8 @@ where
             }
 
             let num_queries = query_count(log_inv_rate, final_eta);
-            assert_disjoint_cosets(round, log_domain_size);
+            cumulative_log_folding += round_log_folding_factor;
+            assert_disjoint_cosets(round, log_domain_size, cumulative_log_folding);
 
             let fold_alg = params.soundness_type.fold_algebraic_bits_at_log_eta(
                 field_size_bits,
@@ -406,9 +441,9 @@ where
             round_configs.push(StirRoundConfig {
                 log_degree,
                 log_domain_size,
-                log_fold_domain_size: log_domain_size - log_folding_factor,
+                log_fold_domain_size: log_domain_size - round_log_folding_factor,
                 domain_shift,
-                log_folding_factor,
+                log_folding_factor: round_log_folding_factor,
                 eta: final_eta,
                 num_queries,
                 num_ood_samples,
@@ -417,10 +452,10 @@ where
             });
 
             prev_queries = num_queries;
-            log_degree -= log_folding_factor;
+            log_degree -= round_log_folding_factor;
             log_domain_size -= 1;
-            log_inv_rate += log_folding_factor - 1;
-            domain_shift = domain_shift.exp_power_of_2(log_folding_factor) * F::GENERATOR;
+            log_inv_rate += round_log_folding_factor - 1;
+            domain_shift = domain_shift.exp_power_of_2(round_log_folding_factor) * F::GENERATOR;
         }
 
         if total_folds != 1 {
@@ -462,6 +497,7 @@ where
             max_pow_bits: params.max_pow_bits,
             log_blowup,
             log_folding_factor: params.log_folding_factor,
+            log_starting_folding_factor,
             round_configs,
             log_final_degree,
             final_queries,
@@ -481,6 +517,19 @@ where
     /// Number of intermediate STIR rounds (excluding the final send).
     pub const fn num_rounds(&self) -> usize {
         self.round_configs.len()
+    }
+
+    /// Log₂ of the folding arity used by the final direct-send stage.
+    ///
+    /// This is `log_folding_factor` (the steady-state arity) unless the schedule has no
+    /// intermediate rounds, in which case round 0's fold IS the final fold and this
+    /// returns `log_starting_folding_factor` instead.
+    pub const fn final_log_folding_factor(&self) -> usize {
+        if self.num_rounds() == 0 {
+            self.log_starting_folding_factor
+        } else {
+            self.log_folding_factor
+        }
     }
 
     /// Number of codeword commitments produced (one per round + one for the input).
@@ -531,6 +580,7 @@ mod tests {
         StirParameters {
             log_blowup,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: 80,
             max_pow_bits: 20,
@@ -567,6 +617,7 @@ mod tests {
         let params = StirParameters {
             log_blowup: 1,
             log_folding_factor: 2,
+            log_starting_folding_factor: 2,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: 80,
             max_pow_bits: 20,
@@ -661,6 +712,7 @@ mod tests {
             StirParameters {
                 log_blowup: 2,
                 log_folding_factor: 2,
+                log_starting_folding_factor: 2,
                 soundness_type: SecurityAssumption::JohnsonBound,
                 security_level: 80,
                 max_pow_bits: 20,
@@ -674,6 +726,7 @@ mod tests {
             StirParameters {
                 log_blowup: 2,
                 log_folding_factor: 2,
+                log_starting_folding_factor: 2,
                 soundness_type: SecurityAssumption::CapacityBound,
                 security_level: 80,
                 max_pow_bits: 20,
@@ -698,6 +751,7 @@ mod tests {
             StirParameters {
                 log_blowup: 2,
                 log_folding_factor: 2,
+                log_starting_folding_factor: 2,
                 soundness_type: SecurityAssumption::JohnsonBound,
                 security_level: 100,
                 max_pow_bits: 0,
@@ -732,6 +786,7 @@ mod tests {
             StirParameters {
                 log_blowup: 2,
                 log_folding_factor: 2,
+                log_starting_folding_factor: 2,
                 soundness_type: SecurityAssumption::JohnsonBound,
                 security_level: 128,
                 max_pow_bits: 0,
@@ -783,6 +838,7 @@ mod tests {
                 StirParameters {
                     log_blowup: 1,
                     log_folding_factor: 2,
+                    log_starting_folding_factor: 2,
                     soundness_type: SecurityAssumption::CapacityBound,
                     security_level: 80,
                     max_pow_bits: 20,
@@ -863,6 +919,7 @@ mod tests {
                     StirParameters {
                         log_blowup,
                         log_folding_factor: log_fold,
+                        log_starting_folding_factor: log_fold,
                         soundness_type,
                         security_level: sec,
                         max_pow_bits: max_pow,

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -64,8 +64,8 @@ use crate::verifier::{StirError, verify_stir_multi_with_external_initial};
 pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     /// `opened_values[k][m]` is the opened fiber-grouped row of matrix `m` at the `k`-th
     /// queried position, in the same query order the prover and verifier both derive from
-    /// public data. Each such row concatenates the `2^log_folding_factor` LDE rows of one
-    /// fiber, ordered by the bit-reversal of the fiber column index.
+    /// public data. Each such row concatenates the `2^log_starting_folding_factor` LDE rows
+    /// of one fiber, ordered by the bit-reversal of the fiber column index.
     pub opened_values: Vec<Vec<Vec<Val>>>,
     /// Compact multi-opening proof authenticating every row at once.
     pub opening_proof: InputMmcs::MultiProof,
@@ -82,12 +82,12 @@ struct HeightClass<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
 /// Prover data for [`TwoAdicStirPcs`].
 ///
 /// Matrices are committed in fiber-grouped form — each Merkle leaf holds
-/// `2^log_folding_factor` consecutive bit-reversed LDE rows, exactly the rows one first-round
-/// STIR query reads — and grouped into one tree per distinct LDE height, in descending height
-/// order. STIR runs an independent sub-proof per height bucket, so a single shared tree would
-/// force every bucket's openings to carry the rows of every *other* height as well, purely to
-/// recompute the authentication path. `placement` maps each matrix, in the order the caller
-/// committed them, to its `(class, index within class)`.
+/// `2^log_starting_folding_factor` consecutive bit-reversed LDE rows, exactly the rows one
+/// first-round STIR query reads — and grouped into one tree per distinct LDE height, in
+/// descending height order. STIR runs an independent sub-proof per height bucket, so a single
+/// shared tree would force every bucket's openings to carry the rows of every *other* height
+/// as well, purely to recompute the authentication path. `placement` maps each matrix, in the
+/// order the caller committed them, to its `(class, index within class)`.
 pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     classes: Vec<HeightClass<Val, InputMmcs>>,
     placement: Vec<(usize, usize)>,
@@ -251,7 +251,7 @@ where
         &self,
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
     ) -> (Self::Commitment, Self::ProverData) {
-        let min_height = 1usize << self.stir.log_folding_factor;
+        let min_height = 1usize << self.stir.log_starting_folding_factor;
         let mut widths = Vec::new();
         let mut heights = Vec::new();
         let ldes: Vec<_> = evaluations
@@ -261,12 +261,12 @@ where
                 assert!(
                     evals.height() >= min_height,
                     "STIR PCS: matrix height {} is below the minimum of 2^{} (= {}) required \
-                     by log_folding_factor = {}. Pad the matrix to at least this height before \
-                     committing, or lower log_folding_factor.",
+                     by log_starting_folding_factor = {}. Pad the matrix to at least this \
+                     height before committing, or lower log_starting_folding_factor.",
                     evals.height(),
-                    self.stir.log_folding_factor,
+                    self.stir.log_starting_folding_factor,
                     min_height,
-                    self.stir.log_folding_factor,
+                    self.stir.log_starting_folding_factor,
                 );
                 let shift = Val::GENERATOR / domain.shift();
                 let lde = self
@@ -276,7 +276,7 @@ where
                     .to_row_major_matrix();
                 widths.push(lde.width());
                 heights.push(lde.height());
-                group_fiber_rows(lde, self.stir.log_folding_factor)
+                group_fiber_rows(lde, self.stir.log_starting_folding_factor)
             })
             .collect();
         commit_by_height_class(&self.input_mmcs, ldes, heights, widths)
@@ -318,17 +318,17 @@ where
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
         _num_chunks: usize,
     ) -> Vec<RowMajorMatrix<Val>> {
-        let min_height = 1usize << self.stir.log_folding_factor;
+        let min_height = 1usize << self.stir.log_starting_folding_factor;
         evaluations
             .into_iter()
             .map(|(domain, evals)| {
                 assert!(
                     evals.height() >= min_height,
                     "STIR PCS quotient: matrix height {} is below 2^{} required by \
-                     log_folding_factor = {}.",
+                     log_starting_folding_factor = {}.",
                     evals.height(),
-                    self.stir.log_folding_factor,
-                    self.stir.log_folding_factor,
+                    self.stir.log_starting_folding_factor,
+                    self.stir.log_starting_folding_factor,
                 );
                 let shift = Val::GENERATOR / domain.shift();
                 self.dft
@@ -340,7 +340,8 @@ where
     }
 
     fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
-        let min_lde_height = 1usize << (self.stir.log_folding_factor + self.stir.log_blowup);
+        let min_lde_height =
+            1usize << (self.stir.log_starting_folding_factor + self.stir.log_blowup);
         let mut widths = Vec::with_capacity(ldes.len());
         let mut heights = Vec::with_capacity(ldes.len());
         let grouped: Vec<_> = ldes
@@ -349,16 +350,16 @@ where
                 assert!(
                     lde.height() >= min_lde_height,
                     "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
-                     log_folding_factor + log_blowup = {} + {}.",
+                     log_starting_folding_factor + log_blowup = {} + {}.",
                     lde.height(),
-                    self.stir.log_folding_factor + self.stir.log_blowup,
+                    self.stir.log_starting_folding_factor + self.stir.log_blowup,
                     min_lde_height,
-                    self.stir.log_folding_factor,
+                    self.stir.log_starting_folding_factor,
                     self.stir.log_blowup,
                 );
                 widths.push(lde.width());
                 heights.push(lde.height());
-                group_fiber_rows(lde, self.stir.log_folding_factor)
+                group_fiber_rows(lde, self.stir.log_starting_folding_factor)
             })
             .collect();
         commit_by_height_class(&self.input_mmcs, grouped, heights, widths)
@@ -528,8 +529,7 @@ where
             .map(
                 |((&log_h, stir_config), (stir_proof, first_round_query_indices))| {
                     let bucket_height = 1usize << log_h;
-                    // Folding factor is constant across rounds.
-                    let log_arity0 = stir_config.log_folding_factor;
+                    let log_arity0 = stir_config.log_starting_folding_factor;
 
                     let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
                         commitment_data_with_opening_points
@@ -702,9 +702,7 @@ where
             .zip(proof.iter().map(|(_, input_openings)| input_openings))
             .map(|((&log_h, stir_config), input_openings)| {
                 let bucket_height = 1usize << log_h;
-                // The folding factor is constant across rounds, so the same arity applies
-                // whether STIR ran with intermediate rounds or only a final round.
-                let log_arity0 = stir_config.log_folding_factor;
+                let log_arity0 = stir_config.log_starting_folding_factor;
                 let arity0 = 1usize << log_arity0;
 
                 // A queried input row sits at LDE position `p = j + l * fold_height0`, whose

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -610,7 +610,7 @@ where
         current_shift: F,
         current_log_domain: usize,
     ) -> Self {
-        let final_log_arity = config.log_folding_factor;
+        let final_log_arity = config.final_log_folding_factor();
         let (final_new_log_domain, final_new_shift) =
             fold_domain_params(current_shift, current_log_domain, final_log_arity);
         Self {
@@ -630,7 +630,7 @@ where
     /// Fold at `final_gamma` and derive the final polynomial. The returned coefficients are
     /// the round's only prover message and must be absorbed by the caller.
     fn fold_and_derive(&mut self, current_oracle_codeword: &[EF], final_gamma: EF) -> &[EF] {
-        let final_log_arity = self.config.log_folding_factor;
+        let final_log_arity = self.config.final_log_folding_factor();
         // See the round-fold note in `RoundProver::fold_and_commit`: `gamma / current_shift`
         // over subgroup coordinates is the paper's coset fold at challenge `gamma`.
         let final_fold_beta = final_gamma * EF::from(self.current_shift.inverse());
@@ -704,7 +704,7 @@ where
         + GrindingChallenger<Witness = F>
         + CanSampleUniformBits<F>,
 {
-    let final_arity = 1usize << config.log_folding_factor;
+    let final_arity = 1usize << config.final_log_folding_factor();
     let mut state = FinalRoundProver::new(config, dft, current_shift, current_log_domain);
 
     let final_folding_pow_witness = challenger.grind(config.final_folding_pow_bits);
@@ -776,8 +776,11 @@ where
 
     // Commit before moving the codeword into the round state, avoiding a full clone.
     let (initial_commit, initial_data) = if commit_initial {
-        let (commit, data) =
-            commit_as_fiber_matrix(&config.mmcs, &initial_codeword, config.log_folding_factor);
+        let (commit, data) = commit_as_fiber_matrix(
+            &config.mmcs,
+            &initial_codeword,
+            config.log_starting_folding_factor,
+        );
         challenger.observe(commit.clone());
         (Some(commit), Some(data))
     } else {
@@ -910,8 +913,11 @@ where
             "initial STIR codeword length must match the configured starting domain"
         );
         let (initial_commitment, commit_data) = if commit_initial {
-            let (commit, data) =
-                commit_as_fiber_matrix(&configs[i].mmcs, &codeword, configs[i].log_folding_factor);
+            let (commit, data) = commit_as_fiber_matrix(
+                &configs[i].mmcs,
+                &codeword,
+                configs[i].log_starting_folding_factor,
+            );
             challenger.observe(commit.clone());
             (Some(commit), Some(data))
         } else {
@@ -1122,7 +1128,7 @@ where
 
     let mut results = Vec::with_capacity(b);
     for (i, mut frp) in final_provers.into_iter().enumerate() {
-        let final_arity = 1usize << configs[i].log_folding_factor;
+        let final_arity = 1usize << configs[i].final_log_folding_factor();
         let query_indices: Vec<usize> = (0..configs[i].final_queries)
             .map(|_| {
                 challenger

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -674,7 +674,7 @@ where
     Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
 {
     let mut fv = FinalRoundVerifier::<F, EF>::new(
-        config.log_folding_factor,
+        config.final_log_folding_factor(),
         current_shift,
         current_log_domain,
     );
@@ -1238,7 +1238,7 @@ where
     let mut fvs: Vec<FinalRoundVerifier<F, EF>> = (0..b)
         .map(|i| {
             FinalRoundVerifier::<F, EF>::new(
-                configs[i].log_folding_factor,
+                configs[i].final_log_folding_factor(),
                 shifts[i],
                 log_domains[i],
             )

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -123,6 +123,7 @@ mod babybear_stir {
         let params = StirParameters {
             log_blowup,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type,
             security_level,
             max_pow_bits,
@@ -191,6 +192,74 @@ mod babybear_stir {
         let mut v_ch = challenger;
         verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_ch)
             .expect("verification of num_rounds == 0 protocol failed");
+    }
+
+    /// `(params, dft, challenger)` with an explicit, possibly different, round-0 folding
+    /// factor — the other `make_*` helpers above always set `log_starting_folding_factor`
+    /// equal to `log_folding_factor`.
+    fn make_two_tier_params(
+        log_blowup: usize,
+        log_starting_folding_factor: usize,
+        log_folding_factor: usize,
+    ) -> (StirParameters<MyMmcs>, Dft, Challenger) {
+        let perm = Perm::new_from_rng_128(&mut seeded_rng());
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+        let val_mmcs = ValMmcs::new(hash, compress, 0);
+        let mmcs = MyMmcs::new(val_mmcs);
+
+        let params = StirParameters {
+            log_blowup,
+            log_folding_factor,
+            log_starting_folding_factor,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 16,
+            max_pow_bits: 0,
+            mmcs,
+        };
+        (params, Dft::default(), Challenger::new(perm))
+    }
+
+    #[test]
+    fn test_prove_verify_two_tier_folding_schedule() {
+        // Round 0 folds by k0=4 (log=2); every later round, and the final direct-send
+        // stage, folds by k=8 (log=3). log_starting_degree=10 gives after_starting_fold=8,
+        // extra_folds=2 (floor(8/3)), total_folds=3, num_rounds=2 (round0=k0, round1=k),
+        // log_final_degree=2 — exercises both arities across an intermediate round and the
+        // final stage.
+        let (params, dft, challenger) = make_two_tier_params(1, 2, 3);
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(10, params.clone());
+        assert_eq!(config.num_rounds(), 2);
+        assert_eq!(config.round_configs[0].log_folding_factor, 2);
+        assert_eq!(config.round_configs[1].log_folding_factor, 3);
+        assert_eq!(config.final_log_folding_factor(), 3);
+        assert_eq!(config.log_final_degree, 2);
+
+        do_test_stir_prove_verify::<F, EF, Dft, MyMmcs, Challenger>(&params, &dft, &challenger, 10);
+    }
+
+    #[test]
+    fn test_prove_verify_two_tier_zero_intermediate_rounds() {
+        // after_starting_fold = 5 - 2 = 3 < 4 = k, so round 0's k0-fold IS the final fold:
+        // exercises `final_log_folding_factor()` returning k0 (not the steady-state k) when
+        // num_rounds == 0.
+        let (params, dft, challenger) = make_two_tier_params(1, 2, 4);
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(5, params);
+        assert_eq!(config.num_rounds(), 0);
+        assert_eq!(config.final_log_folding_factor(), 2);
+        assert_eq!(config.log_final_degree, 3);
+
+        let mut rng = seeded_rng();
+        let degree = 1usize << 5;
+        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
+
+        let mut p_ch = challenger.clone();
+        let (proof, _idx) = prove_stir(&config, poly_coeffs, &dft, &mut p_ch);
+        assert!(proof.round_proofs.is_empty());
+
+        let mut v_ch = challenger;
+        verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_ch)
+            .expect("verification of two-tier num_rounds == 0 protocol failed");
     }
 
     // ---------------------------------------------------------------------------
@@ -741,6 +810,7 @@ mod koalabear_stir {
         let params = StirParameters {
             log_blowup,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: 16,
             max_pow_bits: 0,
@@ -801,6 +871,7 @@ mod goldilocks_stir {
         let params = StirParameters {
             log_blowup,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: 16,
             max_pow_bits: 0,
@@ -861,6 +932,7 @@ mod babybear_pcs {
         let stir_params = StirParameters {
             log_blowup: 1,
             log_folding_factor: 2,
+            log_starting_folding_factor: 2,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: 16,
             max_pow_bits: 0,
@@ -961,6 +1033,76 @@ mod babybear_pcs {
         do_test_pcs(&[4, 6, 8]);
     }
 
+    #[test]
+    fn test_pcs_two_tier_multiple_different_degrees() {
+        // Round 0 folds by k0=4 (log=2); every later round folds by k=8 (log=3) —
+        // exercises the PCS-layer input fiber grouping and reconstruction
+        // (`log_starting_folding_factor`) across multiple height buckets under a schedule
+        // that changes arity after round 0.
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let perm = Perm::new_from_rng_128(&mut seeded_rng());
+        let (val_mmcs, challenge_mmcs) = make_mmcs(&perm);
+        let stir_params = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 3,
+            log_starting_folding_factor: 2,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 16,
+            max_pow_bits: 0,
+            mmcs: challenge_mmcs,
+        };
+        let pcs = MyPcs::new(Dft::default(), val_mmcs, stir_params);
+        let challenger_template = Challenger::new(perm);
+
+        let log_degrees = [4, 6, 8];
+        let mut rng = seeded_rng();
+        let mut p_challenger = challenger_template.clone();
+
+        let domains_and_polys: Vec<_> = log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                let width = 3;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, width),
+                )
+            })
+            .collect();
+
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
+        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
+
+        let zeta: Challenge = p_challenger.sample_algebra_element();
+
+        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+        let data_and_points = vec![(&data, points)];
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_challenger);
+
+        let mut v_challenger = challenger_template;
+        commit.iter().for_each(|c| v_challenger.observe(c.clone()));
+        let v_zeta: Challenge = v_challenger.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect();
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_challenger,
+        )
+        .unwrap_or_else(|e| panic!("two-tier PCS verification failed: {e:?}"));
+    }
+
     fn compare_stir_proof_size_with_binary_fri(
         log_degree: usize,
         log_folding_factor: usize,
@@ -988,6 +1130,7 @@ mod babybear_pcs {
         let stir_params = StirParameters {
             log_blowup: 1,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level: SECURITY_BITS,
             max_pow_bits: 0,
@@ -1498,6 +1641,7 @@ mod babybear_stir_multi {
         let params = StirParameters {
             log_blowup,
             log_folding_factor,
+            log_starting_folding_factor: log_folding_factor,
             soundness_type: SecurityAssumption::CapacityBound,
             security_level,
             max_pow_bits,


### PR DESCRIPTION
## Summary

- Add a multi-table FRI vs STIR vs WHIR comparison benchmark (`examples/examples/pcs_comparison.rs`) that commits a mixed-height, shared-width trace batch (`2^{n, n+1, n+3}` rows, one column width) — the shape a real multi-table STARK actually commits — alongside the existing single-table comparison.
- Let STIR's round-0 folding arity (`log_starting_folding_factor`, k0) differ from the steady-state arity used from round 1 onward (`log_folding_factor`, k). Construction 5.2 already allows every round's folding parameter to vary independently; this exposes that generality for round 0 only, since a smaller k0 shrinks every first-round query's fiber (`2^k0` input rows × committed width) without touching the improved-rate schedule the later rounds are priced on.
- `pcs_comparison`'s `--stir-log-starting-fold` defaults to `2` (arity 4) rather than mirroring `--stir-log-fold`, so the win shows up with no extra flags.

## Benchmark

Multi-table run, heights `2^{17,18,20}`, width 32, 100-bit security, rho = 1/2, k0=4/k=16 vs the prior constant-arity k=16 schedule:

| | proof size | verify time | queries per round |
|---|---|---|---|
| before (k0 = k = 16) | 823.36 KiB | baseline | `[86,22,13,9,7]` |
| after (k0 = 4, k = 16) | **441.58 KiB (-46.4%)** | **-27%** | `[86,43,18,11,8]` |

(Prover open time +11%: one extra round's PoW grind, as expected from the extra round the smaller k0 introduces.)

## Test plan

- [x] `cargo test -p p3-stir` (lib + integration suites green)
- [x] `cargo clippy -p p3-stir --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p p3-stir -- --check`
- [x] Release-mode benchmark run (`cargo run --release --example pcs_comparison`), before/after with the flag defaulted
