### PR TITLE
perf(stir): commit height classes on a shared domain, merge via Combine (§7)

### DIFF
--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -455,7 +455,7 @@ fn main() {
             &base_challenger,
             queries,
             // STIR commits one Merkle tree per distinct LDE height.
-            |ch, commit| commit.iter().for_each(|c| ch.observe(c.clone())),
+            |ch, commit| ch.observe(commit.clone()),
         ));
     }
 
@@ -593,7 +593,7 @@ fn main() {
             &base_challenger,
             queries,
             // STIR commits one Merkle tree per distinct LDE height.
-            |ch, commit| commit.iter().for_each(|c| ch.observe(c.clone())),
+            |ch, commit| ch.observe(commit.clone()),
         ));
     }
 

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -550,8 +550,12 @@ fn main() {
         ));
     }
 
-    // STIR: the round/PoW schedule is derived once from the tallest table, and the
-    // shorter tables are folded in once the running codeword reaches their height.
+    // STIR: every table here shares one `commit()` call, so the real prover extends
+    // all three onto one shared LDE domain (sized to the tallest) and merges their
+    // native-height classes via `Combine` (§7, Construction 7.2) before STIR runs.
+    // Reconstruct that same bucket (`ell` per Lemma 4.13, matching what `p3_stir`'s
+    // PCS impl computes internally) so the printed schedule reflects what actually
+    // proves, not a plain single-height instance.
     {
         let stir_params = StirParameters {
             log_blowup: args.rate,
@@ -562,9 +566,13 @@ fn main() {
             max_pow_bits: args.pow_bits,
             mmcs: challenge_mmcs,
         };
-        let config = StirConfig::<F, EF, ChallengeMmcs, Challenger>::new(
+        let ell: u64 = heights.len() as u64 * ((1u64 << args.log_message_size) + 1)
+            - heights.iter().map(|&h| 1u64 << h).sum::<u64>();
+        let config = StirConfig::<F, EF, ChallengeMmcs, Challenger>::new_with_combine(
             args.log_message_size,
             stir_params.clone(),
+            heights.len(),
+            ell,
         );
         let queries = config
             .round_configs
@@ -592,7 +600,7 @@ fn main() {
             tables,
             &base_challenger,
             queries,
-            // STIR commits one Merkle tree per distinct LDE height.
+            // STIR commits one shared Merkle tree for every table in this call.
             |ch, commit| ch.observe(commit.clone()),
         ));
     }

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -40,6 +40,7 @@ p3-symmetric = { path = "../symmetric" }
 
 criterion.workspace = true
 postcard = { workspace = true, features = ["alloc"] }
+proptest.workspace = true
 rand = { workspace = true, features = ["std"] }
 
 [[bench]]

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -112,7 +112,7 @@ fn bench_open(c: &mut Criterion) {
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
         let mut base = challenger.clone();
-        commit.iter().for_each(|c| base.observe(c.clone()));
+        base.observe(commit.clone());
         let zeta: Challenge = base.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
 
@@ -148,7 +148,7 @@ fn bench_verify(c: &mut Criterion) {
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
         let mut p_challenger = challenger.clone();
-        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
+        p_challenger.observe(commit.clone());
         let zeta: Challenge = p_challenger.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
         let (opened, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
@@ -167,7 +167,7 @@ fn bench_verify(c: &mut Criterion) {
 
         // Same transcript state `open` reached: commitment observed, opening point drawn.
         let mut v_base = challenger.clone();
-        commit.iter().for_each(|c| v_base.observe(c.clone()));
+        v_base.observe(commit.clone());
         let _: Challenge = v_base.sample_algebra_element();
 
         group.bench_with_input(BenchmarkId::from_parameter(name), &claims, |b, claims| {

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -14,8 +14,8 @@ use crate::soundness::{StirSoundness, combine_min_log_eta};
 /// Extra requirement round 0's `eta` must additionally satisfy so that the
 /// batch-degree-correction `Combine` step (§4.5) reaches the target security when merging
 /// `num_classes` height classes sharing this config's initial domain before the round-0
-/// fold. `ell` is Lemma 4.13's inflated error argument, consulted only under
-/// `SecurityAssumption::JohnsonBound`.
+/// fold. `ell` is Lemma 4.13's inflated error argument, consulted by both
+/// `SecurityAssumption` regimes' error terms.
 #[derive(Clone, Copy, Debug)]
 struct CombineRequirement {
     num_classes: usize,
@@ -228,8 +228,8 @@ where
     /// correlated agreement" guarantee actually apply to STIR's own decoding.
     ///
     /// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ each
-    /// class's own, non-quotiented degree bound); only consulted under
-    /// `SecurityAssumption::JohnsonBound` — pass `0` under `CapacityBound`.
+    /// class's own, non-quotiented degree bound), consulted by both
+    /// `SecurityAssumption` regimes' error terms.
     ///
     /// # Panics
     ///
@@ -439,7 +439,6 @@ where
                 field_size_bits,
                 log_inv_rate,
                 log_degree,
-                c.num_classes,
                 c.ell,
                 buffered_security_level,
             );

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -9,7 +9,7 @@ use p3_commit::Mmcs;
 use p3_field::{ExtensionField, TwoAdicField};
 
 use crate::SecurityAssumption;
-use crate::soundness::{StirSoundness, combine_min_log_eta};
+use crate::soundness::StirSoundness;
 
 /// Extra requirement round 0's `eta` must additionally satisfy so that the
 /// batch-degree-correction `Combine` step (§4.5) reaches the target security when merging
@@ -25,6 +25,31 @@ struct CombineRequirement {
 /// User-facing STIR protocol parameters.
 ///
 /// These are the inputs from which the full [`StirConfig`] is derived.
+///
+/// # Combine feasibility envelope
+///
+/// [`StirConfig::new`] is feasible over a wide range of these parameters, but
+/// [`StirConfig::new_with_combine`] — the §7 Construction 7.2 path the PCS takes when one
+/// commitment holds matrices of more than one native height — is not. Merging classes of total
+/// multiplicity `ell` into a degree-`d* = 2^log_d_star` codeword costs roughly `2·log_d_star`
+/// bits of challenge field, because the `dᵢ` are distinct powers of two and so every degree gap
+/// is within a factor of two of `d*` however tight the height spread is.
+///
+/// Solving the `CapacityBound` requirement against the `eta <= rho/2` side condition gives a
+/// closed form for when Combine fits:
+///
+/// ```text
+/// EF::bits() >= security_level + union_bound_buffer + 3*log_blowup + 1
+///               + log2(ell - 1) + log_d_star
+/// ```
+///
+/// At `d* = 2^20`, `log_blowup = 1` and 100-bit security that is ~151 bits, so a 155-bit
+/// quintic extension fits with a few bits to spare and narrower challenge fields do not.
+/// `JohnsonBound` does not fit at production scale at all: the largest permitted
+/// `eta = sqrt(rho)/20` pins BCSS25's multiplicity at `m = 10`, which retains only ~95 bits at
+/// the same shape.
+/// Outside the envelope, derivation reports the shortfall rather than silently weakening the
+/// parameters; callers that need wider height spreads should commit the outliers separately.
 #[derive(Clone, Debug)]
 pub struct StirParameters<M> {
     /// Log₂ of the inverse rate of the initial Reed-Solomon code.
@@ -215,7 +240,7 @@ where
     /// Panics if `log_folding_factor < 2`, if `log_starting_folding_factor < 2`, or if
     /// `log_starting_folding_factor > log_starting_degree`.
     pub fn new(log_starting_degree: usize, params: StirParameters<M>) -> Self {
-        Self::new_impl(log_starting_degree, params, None)
+        Self::new_with_optional_combine(log_starting_degree, params, None)
     }
 
     /// Like [`Self::new`], but additionally inflates round 0's `eta` (and, transitively,
@@ -233,21 +258,34 @@ where
     ///
     /// # Panics
     ///
-    /// Same conditions as [`Self::new`].
+    /// Every condition of [`Self::new`], plus: if `num_classes < 2` (a single class needs no
+    /// `Combine`, so [`Self::new`] is the correct entry point), if `ell < num_classes as u64`
+    /// (every class contributes at least one to the multiplicity), or if the parameters fall
+    /// outside the feasibility envelope documented on [`StirParameters`].
     pub fn new_with_combine(
         log_starting_degree: usize,
         params: StirParameters<M>,
         num_classes: usize,
         ell: u64,
     ) -> Self {
-        Self::new_impl(
+        assert!(
+            num_classes >= 2,
+            "new_with_combine requires at least 2 height classes (got {num_classes}); a single \
+             class needs no Combine, so use StirConfig::new"
+        );
+        assert!(
+            ell >= num_classes as u64,
+            "Combine multiplicity ell = {ell} is below the class count {num_classes}; every \
+             class contributes at least one to ell = Σᵢ (gapᵢ + 1)"
+        );
+        Self::new_with_optional_combine(
             log_starting_degree,
             params,
             Some(CombineRequirement { num_classes, ell }),
         )
     }
 
-    fn new_impl(
+    fn new_with_optional_combine(
         log_starting_degree: usize,
         params: StirParameters<M>,
         combine: Option<CombineRequirement>,
@@ -434,15 +472,38 @@ where
         // 0's own starting degree and rate, matching what Combine merges at (immediately
         // before the round-0 fold).
         if let Some(c) = combine.filter(|c| c.num_classes >= 2) {
-            let log_combine_eta = combine_min_log_eta(
-                params.soundness_type,
+            let combine_eta = params.soundness_type.stir_combine_eta(
                 field_size_bits,
                 log_inv_rate,
                 log_degree,
                 c.ell,
                 buffered_security_level,
             );
-            final_eta = final_eta.max(libm::pow(2., log_combine_eta));
+            // Reported here rather than left to `validate_eta` below: the schedule's own
+            // `stir_initial_eta` is always within the ceiling, so a round-0 violation is
+            // always Combine's, and the caller needs the envelope to act on it.
+            assert!(
+                params
+                    .soundness_type
+                    .stir_eta_is_valid(log_inv_rate, combine_eta),
+                "Combine over {} height classes (multiplicity ell = {}) at degree 2^{log_degree} \
+                 needs eta = {combine_eta}, above the {:?} side-condition ceiling {}. \
+                 CapacityBound admits Combine only when EF::bits() >= security_level + \
+                 union_bound_buffer + 3*log_blowup + 1 + log2(ell - 1) + log_d_star \
+                 (= {} + {union_bound_buffer} + {} + 1 + {:.2} + {log_degree} = {:.2}; \
+                 EF::bits() = {field_size_bits}). Widen the challenge field, lower \
+                 security_level, raise log_blowup, or narrow the committed height spread.",
+                c.num_classes,
+                c.ell,
+                params.soundness_type,
+                params.soundness_type.stir_eta_upper_bound(log_inv_rate),
+                security_level,
+                3 * log_inv_rate,
+                libm::log2(c.ell.saturating_sub(1).max(1) as f64),
+                (security_level + union_bound_buffer + 3 * log_inv_rate + 1 + log_degree) as f64
+                    + libm::log2(c.ell.saturating_sub(1).max(1) as f64),
+            );
+            final_eta = final_eta.max(combine_eta);
         }
         validate_eta(0, log_inv_rate, final_eta);
 

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -9,7 +9,18 @@ use p3_commit::Mmcs;
 use p3_field::{ExtensionField, TwoAdicField};
 
 use crate::SecurityAssumption;
-use crate::soundness::StirSoundness;
+use crate::soundness::{StirSoundness, combine_min_log_eta};
+
+/// Extra requirement round 0's `eta` must additionally satisfy so that the
+/// batch-degree-correction `Combine` step (§4.5) reaches the target security when merging
+/// `num_classes` height classes sharing this config's initial domain before the round-0
+/// fold. `ell` is Lemma 4.13's inflated error argument, consulted only under
+/// `SecurityAssumption::JohnsonBound`.
+#[derive(Clone, Copy, Debug)]
+struct CombineRequirement {
+    num_classes: usize,
+    ell: u64,
+}
 
 /// User-facing STIR protocol parameters.
 ///
@@ -204,6 +215,43 @@ where
     /// Panics if `log_folding_factor < 2`, if `log_starting_folding_factor < 2`, or if
     /// `log_starting_folding_factor > log_starting_degree`.
     pub fn new(log_starting_degree: usize, params: StirParameters<M>) -> Self {
+        Self::new_impl(log_starting_degree, params, None)
+    }
+
+    /// Like [`Self::new`], but additionally inflates round 0's `eta` (and, transitively,
+    /// the whole schedule that follows from it) so the batch-degree-correction `Combine`
+    /// step (§4.5) also reaches `params.security_level` when merging `num_classes` height
+    /// classes that share this config's initial domain, immediately before the round-0
+    /// fold. Sharing `eta` between STIR's own round-0 acceptance radius and `Combine`'s
+    /// error term (rather than checking `Combine` against a separately assumed radius)
+    /// is what makes `Combine`'s "if the merged codeword passes, each class has
+    /// correlated agreement" guarantee actually apply to STIR's own decoding.
+    ///
+    /// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ each
+    /// class's own, non-quotiented degree bound); only consulted under
+    /// `SecurityAssumption::JohnsonBound` — pass `0` under `CapacityBound`.
+    ///
+    /// # Panics
+    ///
+    /// Same conditions as [`Self::new`].
+    pub fn new_with_combine(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        num_classes: usize,
+        ell: u64,
+    ) -> Self {
+        Self::new_impl(
+            log_starting_degree,
+            params,
+            Some(CombineRequirement { num_classes, ell }),
+        )
+    }
+
+    fn new_impl(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        combine: Option<CombineRequirement>,
+    ) -> Self {
         assert!(
             params.log_folding_factor >= 2,
             "the paper-backed STIR parameter schedule requires log_folding_factor >= 2 (k >= 4)"
@@ -276,12 +324,16 @@ where
         // `2^{-security_level}`. Exact term count: each of the `total_folds - 1`
         // intermediate rounds has six independent terms (query tier: query
         // failure, OOD, random-combination, shake-check; folding tier: proximity-gaps,
-        // sumcheck); the final stage has three (folding tier + final query failure).
-        // The buffer applies to every per-event term. OOD and shake-check must reach the
-        // buffered target algebraically because the query-phase grind does not protect them.
+        // sumcheck); the final stage has three (folding tier + final query failure); a
+        // `Combine` bucket adds one more (Theorem 7.1's `ε_com` term, §4.5).
+        // The buffer applies to every per-event term. OOD, shake-check, and Combine must
+        // reach the buffered target algebraically because the query-phase grind does not
+        // protect them.
         const TERMS_PER_INTERMEDIATE_ROUND: usize = 6;
         const FINAL_STAGE_TERMS: usize = 3;
-        let num_alg_terms = TERMS_PER_INTERMEDIATE_ROUND * (total_folds - 1) + FINAL_STAGE_TERMS;
+        let combine_term = usize::from(combine.is_some_and(|c| c.num_classes >= 2));
+        let num_alg_terms =
+            TERMS_PER_INTERMEDIATE_ROUND * (total_folds - 1) + FINAL_STAGE_TERMS + combine_term;
         let union_bound_buffer = libm::ceil(libm::log2(num_alg_terms as f64)) as usize;
         let buffered_security_level = security_level + union_bound_buffer;
 
@@ -376,6 +428,23 @@ where
             log_starting_folding_factor,
             field_size_bits,
         );
+        // Combine (§4.5) is not PoW-eligible (it runs once, before the query phase's
+        // grind), so — like OOD and shake-check — it must reach the full buffered target
+        // on its own. Evaluated at `log_degree`/`log_inv_rate` as they stand here: round
+        // 0's own starting degree and rate, matching what Combine merges at (immediately
+        // before the round-0 fold).
+        if let Some(c) = combine.filter(|c| c.num_classes >= 2) {
+            let log_combine_eta = combine_min_log_eta(
+                params.soundness_type,
+                field_size_bits,
+                log_inv_rate,
+                log_degree,
+                c.num_classes,
+                c.ell,
+                buffered_security_level,
+            );
+            final_eta = final_eta.max(libm::pow(2., log_combine_eta));
+        }
         validate_eta(0, log_inv_rate, final_eta);
 
         // Round 0 reuses the `stir_initial_eta` already computed above; every subsequent

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -1,25 +1,34 @@
 //! `TwoAdicStirPcs`: implementing the [`Pcs`] trait using STIR.
 //!
-//! **Commit**: given trace matrices evaluated on two-adic cosets, compute their LDEs and commit
-//! to those LDEs using an `InputMmcs`.
+//! **Commit**: every matrix passed to one `commit()` call is extended onto one shared LDE
+//! domain, sized to the *tallest* matrix (§7, Construction 7.2's same-domain requirement) —
+//! shorter matrices are extended further, at an effectively higher per-matrix blowup. All
+//! matrices land in one Merkle tree per commitment, rather than one tree per distinct height.
 //!
-//! **Open**: alpha-batch quotient polynomials `(f_i(z) - f_i(x)) / (z - x)` into per-height
-//! reduced-opening polynomials, then run STIR on each distinct LDE-height bucket.
+//! **Open**: alpha-batch quotient polynomials `(f_i(z) - f_i(x)) / (z - x)` into one
+//! reduced-opening polynomial per *native* (pre-shared-domain) matrix height — the same
+//! per-height batching as before, just with every reduced-opening now living on the shared
+//! domain rather than its own native-sized one. Commitments sharing the same shared-domain
+//! size are then run through one STIR instance together (as many domain sizes as distinct
+//! shared domains, "buckets" below); within a bucket, if more than one native-height class is
+//! present, they are merged into a single codeword via batch degree correction
+//! ([`combine_on_coset`](crate::utils::combine_on_coset), §4.5's `Combine`) before STIR runs,
+//! at the tallest class's degree and full proximity radius (no per-class query-count floor).
 //! The prover returns the deduplicated first-round STIR query indices alongside the IOP
 //! proof; at those positions the prover also opens the input LDE matrices (via `InputMmcs`)
-//! so the verifier can confirm the reduced-opening polynomial is correctly derived from the
+//! so the verifier can confirm the reduced-opening polynomials are correctly derived from the
 //! committed inputs.
 //!
-//! **Verify**: replay the same alpha-batching from the opening values, then for each height
-//! bucket call [`verify_stir_with_external_initial`](crate::verifier::verify_stir_with_external_initial).
-//! STIR's initial oracle *is* the reduced opening, which the transcript already pins through
-//! the input commitments, the claimed values, and `alpha`, so it is never committed a second
-//! time: whenever STIR needs its queried fibers, the verifier rebuilds them from the input
-//! MMCS openings at exactly the positions STIR sampled. No hand-mirrored transcript replay is
-//! needed.
+//! **Verify**: replay the same alpha-batching and `Combine` from the opening values, then for
+//! each bucket call [`verify_stir_with_external_initial`](crate::verifier::verify_stir_with_external_initial).
+//! STIR's initial oracle *is* the (possibly combined) reduced opening, which the transcript
+//! already pins through the input commitments, the claimed values, `alpha`, and (when a
+//! bucket combines more than one class) the combination challenge, so it is never committed a
+//! second time: whenever STIR needs its queried fibers, the verifier rebuilds them from the
+//! input MMCS openings at exactly the positions STIR sampled. No hand-mirrored transcript
+//! replay is needed.
 
 use alloc::borrow::Cow;
-use alloc::collections::BTreeSet;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -31,7 +40,7 @@ use p3_commit::{Mmcs, OpenedValues, Pcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
-    BasedVectorSpace, ExtensionField, PackedFieldExtension, TwoAdicField,
+    BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, TwoAdicField,
     batch_multiplicative_inverse,
 };
 use p3_matrix::Matrix;
@@ -47,6 +56,7 @@ use tracing::instrument;
 use crate::config::{StirConfig, StirParameters};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_external_codewords;
+use crate::utils::{combine_on_coset, eval_degree_correction};
 use crate::verifier::{StirError, verify_stir_multi_with_external_initial};
 
 /// Batched openings of one input commitment's LDE matrices at the STIR-derived query
@@ -71,74 +81,48 @@ pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     pub opening_proof: InputMmcs::MultiProof,
 }
 
-/// One LDE-height class of a commitment: its own Merkle tree over the matrices at that height.
-struct HeightClass<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
-    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
-    /// Column count of each matrix in this class before fiber grouping.
-    widths: Vec<usize>,
-    lde_height: usize,
-}
-
 /// Prover data for [`TwoAdicStirPcs`].
 ///
-/// Matrices are committed in fiber-grouped form — each Merkle leaf holds
-/// `2^log_starting_folding_factor` consecutive bit-reversed LDE rows, exactly the rows one
-/// first-round STIR query reads — and grouped into one tree per distinct LDE height, in
-/// descending height order. STIR runs an independent sub-proof per height bucket, so a single
-/// shared tree would force every bucket's openings to carry the rows of every *other* height
-/// as well, purely to recompute the authentication path. `placement` maps each matrix, in the
-/// order the caller committed them, to its `(class, index within class)`.
+/// Every matrix passed to one `commit()` call is extended onto one shared LDE domain (sized
+/// to the tallest matrix) and committed in fiber-grouped form in a single Merkle tree — each
+/// leaf holds `2^log_starting_folding_factor` consecutive bit-reversed LDE rows, exactly the
+/// rows one first-round STIR query reads. `log_native_heights[i]` is matrix `i`'s own
+/// (pre-shared-domain) log2 height, in the order the caller committed them; this is what
+/// distinguishes matrices for alpha-batching and `Combine` grouping once they all sit on the
+/// same physical domain.
 pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
-    classes: Vec<HeightClass<Val, InputMmcs>>,
-    placement: Vec<(usize, usize)>,
+    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    /// Column count of each matrix, in the order the caller committed them.
+    widths: Vec<usize>,
+    /// Native (pre-shared-domain) log2 height of each matrix, in the order committed.
+    log_native_heights: Vec<usize>,
+    /// Log2 of the shared LDE domain every matrix in this commitment was extended onto.
+    log_shared_lde_height: usize,
 }
 
-/// Split fiber-grouped LDEs into one height class per distinct LDE height, descending.
-///
-/// `heights` and `widths` are the pre-grouping LDE heights and column counts, in caller order.
-fn commit_by_height_class<Val, InputMmcs>(
+/// Commit fiber-grouped LDEs (all sharing one height) in a single tree, recording each
+/// matrix's own native height and column count for later alpha-batching/`Combine` grouping.
+fn commit_shared_domain<Val, InputMmcs>(
     input_mmcs: &InputMmcs,
     grouped: Vec<RowMajorMatrix<Val>>,
-    heights: Vec<usize>,
+    log_native_heights: Vec<usize>,
     widths: Vec<usize>,
-) -> (Vec<InputMmcs::Commitment>, StirProverData<Val, InputMmcs>)
+    log_shared_lde_height: usize,
+) -> (InputMmcs::Commitment, StirProverData<Val, InputMmcs>)
 where
     Val: Send + Sync + Clone,
     InputMmcs: Mmcs<Val>,
 {
-    let mut class_heights = heights.clone();
-    class_heights.sort_unstable();
-    class_heights.dedup();
-    class_heights.reverse();
-
-    let mut class_mats = vec![Vec::new(); class_heights.len()];
-    let mut class_widths = vec![Vec::new(); class_heights.len()];
-    let mut placement = Vec::with_capacity(grouped.len());
-    for ((mat, height), width) in grouped.into_iter().zip(heights).zip(widths) {
-        let class = class_heights
-            .iter()
-            .position(|&h| h == height)
-            .expect("every height is one of the distinct heights");
-        placement.push((class, class_mats[class].len()));
-        class_mats[class].push(mat);
-        class_widths[class].push(width);
-    }
-
-    let (commitments, classes) = izip!(class_mats, class_widths, class_heights)
-        .map(|(mats, widths, lde_height)| {
-            let (commitment, data) = input_mmcs.commit(mats);
-            (
-                commitment,
-                HeightClass {
-                    data,
-                    widths,
-                    lde_height,
-                },
-            )
-        })
-        .unzip();
-
-    (commitments, StirProverData { classes, placement })
+    let (commitment, data) = input_mmcs.commit(grouped);
+    (
+        commitment,
+        StirProverData {
+            data,
+            widths,
+            log_native_heights,
+            log_shared_lde_height,
+        },
+    )
 }
 
 /// Reinterpret a bit-reversed LDE as a matrix whose rows are whole STIR fibers.
@@ -162,20 +146,11 @@ fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
     input_mmcs: &InputMmcs,
     prover_data: &'a StirProverData<Val, InputMmcs>,
 ) -> Vec<RowMajorMatrixView<'a, Val>> {
-    let per_class: Vec<_> = prover_data
-        .classes
-        .iter()
-        .map(|class| input_mmcs.get_matrices(&class.data))
-        .collect();
-    prover_data
-        .placement
-        .iter()
-        .map(|&(class, index)| {
-            RowMajorMatrixView::new(
-                per_class[class][index].values.as_slice(),
-                prover_data.classes[class].widths[index],
-            )
-        })
+    let matrices = input_mmcs.get_matrices(&prover_data.data);
+    matrices
+        .into_iter()
+        .zip(&prover_data.widths)
+        .map(|(grouped, &width)| RowMajorMatrixView::new(grouped.values.as_slice(), width))
         .collect()
 }
 
@@ -199,6 +174,14 @@ impl<Val, Dft, InputMmcs, StirMmcs> TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs
     }
 }
 
+/// One bucket's `Combine` state for the verifier: the sampled combination challenge and each
+/// present native height's `(r_i, gap_i)` coefficients (`None` when the bucket has only one
+/// class, so no `Combine` step ran).
+type BucketCombine<Challenge> = Option<(
+    Challenge,
+    alloc::collections::BTreeMap<usize, (Challenge, usize)>,
+)>;
+
 impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> Pcs<Challenge, Challenger>
     for TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs>
 where
@@ -215,8 +198,9 @@ where
         + Clone,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
-    /// One Merkle root per distinct LDE height, in descending height order.
-    type Commitment = Vec<InputMmcs::Commitment>;
+    /// One Merkle root per commitment: every matrix passed to one `commit()` call shares a
+    /// single tree on the shared LDE domain (§7's same-domain requirement).
+    type Commitment = InputMmcs::Commitment;
     type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
     /// Proof structure: one entry per distinct LDE-height bucket (descending).
@@ -252,34 +236,56 @@ where
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
     ) -> (Self::Commitment, Self::ProverData) {
         let min_height = 1usize << self.stir.log_starting_folding_factor;
-        let mut widths = Vec::new();
-        let mut heights = Vec::new();
-        let ldes: Vec<_> = evaluations
+        let inputs: Vec<(Self::Domain, RowMajorMatrix<Val>)> = evaluations.into_iter().collect();
+        assert!(
+            !inputs.is_empty(),
+            "STIR PCS: commit requires at least one matrix"
+        );
+        for (domain, evals) in &inputs {
+            assert_eq!(domain.size(), evals.height());
+            assert!(
+                evals.height() >= min_height,
+                "STIR PCS: matrix height {} is below the minimum of 2^{} (= {}) required by \
+                 log_starting_folding_factor = {}. Pad the matrix to at least this height \
+                 before committing, or lower log_starting_folding_factor.",
+                evals.height(),
+                self.stir.log_starting_folding_factor,
+                min_height,
+                self.stir.log_starting_folding_factor,
+            );
+        }
+        let log_max_native_height = inputs
+            .iter()
+            .map(|(domain, _)| log2_strict_usize(domain.size()))
+            .max()
+            .expect("checked non-empty above");
+        let log_shared_lde_height = log_max_native_height + self.stir.log_blowup;
+
+        let mut widths = Vec::with_capacity(inputs.len());
+        let mut log_native_heights = Vec::with_capacity(inputs.len());
+        let grouped: Vec<_> = inputs
             .into_iter()
             .map(|(domain, evals)| {
-                assert_eq!(domain.size(), evals.height());
-                assert!(
-                    evals.height() >= min_height,
-                    "STIR PCS: matrix height {} is below the minimum of 2^{} (= {}) required \
-                     by log_starting_folding_factor = {}. Pad the matrix to at least this \
-                     height before committing, or lower log_starting_folding_factor.",
-                    evals.height(),
-                    self.stir.log_starting_folding_factor,
-                    min_height,
-                    self.stir.log_starting_folding_factor,
-                );
+                let log_native_height = log2_strict_usize(domain.size());
+                let extra_bits = log_shared_lde_height - log_native_height;
                 let shift = Val::GENERATOR / domain.shift();
                 let lde = self
                     .dft
-                    .coset_lde_batch(evals, self.stir.log_blowup, shift)
+                    .coset_lde_batch(evals, extra_bits, shift)
                     .bit_reverse_rows()
                     .to_row_major_matrix();
                 widths.push(lde.width());
-                heights.push(lde.height());
+                log_native_heights.push(log_native_height);
                 group_fiber_rows(lde, self.stir.log_starting_folding_factor)
             })
             .collect();
-        commit_by_height_class(&self.input_mmcs, ldes, heights, widths)
+        commit_shared_domain(
+            &self.input_mmcs,
+            grouped,
+            log_native_heights,
+            widths,
+            log_shared_lde_height,
+        )
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -288,10 +294,8 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let (class, index) = prover_data.placement[idx];
-        let class_data = &prover_data.classes[class];
-        let grouped = self.input_mmcs.get_matrices(&class_data.data)[index];
-        let lde = RowMajorMatrixView::new(grouped.values.as_slice(), class_data.widths[index]);
+        let grouped = self.input_mmcs.get_matrices(&prover_data.data)[idx];
+        let lde = RowMajorMatrixView::new(grouped.values.as_slice(), prover_data.widths[idx]);
         if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
             let width = lde.width();
             let values: &'a [Val] = lde.values;
@@ -299,7 +303,7 @@ where
                 .as_cow()
                 .bit_reverse_rows();
         }
-        let poly_height = lde.height() >> self.stir.log_blowup;
+        let poly_height = 1usize << prover_data.log_native_heights[idx];
         let lde_mat = lde.bit_reverse_rows().to_row_major_matrix();
         let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
         let width = coeffs.width();
@@ -342,27 +346,71 @@ where
     fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
         let min_lde_height =
             1usize << (self.stir.log_starting_folding_factor + self.stir.log_blowup);
+        assert!(
+            !ldes.is_empty(),
+            "STIR PCS: commit_ldes requires at least one matrix"
+        );
+        for lde in &ldes {
+            assert!(
+                lde.height() >= min_lde_height,
+                "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
+                 log_starting_folding_factor + log_blowup = {} + {}.",
+                lde.height(),
+                self.stir.log_starting_folding_factor + self.stir.log_blowup,
+                min_lde_height,
+                self.stir.log_starting_folding_factor,
+                self.stir.log_blowup,
+            );
+        }
+
+        // `ldes[i]` is already bit-reversed at `2^(native_i + log_blowup)`, GENERATOR-shifted
+        // (matching `get_quotient_ldes`'s output convention). Shorter ones are re-extended
+        // onto the shared domain sized to the tallest.
+        let log_native_heights: Vec<usize> = ldes
+            .iter()
+            .map(|lde| log2_strict_usize(lde.height()) - self.stir.log_blowup)
+            .collect();
+        let log_max_native_height = log_native_heights
+            .iter()
+            .copied()
+            .max()
+            .expect("checked non-empty above");
+        let log_shared_lde_height = log_max_native_height + self.stir.log_blowup;
+
         let mut widths = Vec::with_capacity(ldes.len());
-        let mut heights = Vec::with_capacity(ldes.len());
         let grouped: Vec<_> = ldes
             .into_iter()
-            .map(|lde| {
-                assert!(
-                    lde.height() >= min_lde_height,
-                    "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
-                     log_starting_folding_factor + log_blowup = {} + {}.",
-                    lde.height(),
-                    self.stir.log_starting_folding_factor + self.stir.log_blowup,
-                    min_lde_height,
-                    self.stir.log_starting_folding_factor,
-                    self.stir.log_blowup,
-                );
+            .zip(&log_native_heights)
+            .map(|(lde, &log_native_height)| {
                 widths.push(lde.width());
-                heights.push(lde.height());
-                group_fiber_rows(lde, self.stir.log_starting_folding_factor)
+                let extended = if lde.height() == 1usize << log_shared_lde_height {
+                    lde
+                } else {
+                    let natural_lde = lde.bit_reverse_rows().to_row_major_matrix();
+                    let mut coeffs = self.dft.coset_idft_batch(natural_lde, Val::GENERATOR);
+                    let width = coeffs.width();
+                    coeffs
+                        .values
+                        .truncate((1usize << log_native_height) * width);
+                    self.dft
+                        .coset_lde_batch(
+                            coeffs,
+                            log_shared_lde_height - log_native_height,
+                            Val::GENERATOR,
+                        )
+                        .bit_reverse_rows()
+                        .to_row_major_matrix()
+                };
+                group_fiber_rows(extended, self.stir.log_starting_folding_factor)
             })
             .collect();
-        commit_by_height_class(&self.input_mmcs, grouped, heights, widths)
+        commit_shared_domain(
+            &self.input_mmcs,
+            grouped,
+            log_native_heights,
+            widths,
+            log_shared_lde_height,
+        )
     }
 
     #[instrument(name = "STIR PCS open", skip_all)]
@@ -404,10 +452,11 @@ where
 
         let all_opened_values: OpenedValues<Challenge> = mats_and_points
             .iter()
-            .map(|(mats, points)| {
-                izip!(mats.iter(), points.iter())
-                    .map(|(mat, points_for_mat)| {
-                        let h = mat.height() >> self.stir.log_blowup;
+            .zip(&commitment_data_with_opening_points)
+            .map(|((mats, points), (data, _))| {
+                izip!(mats.iter(), points.iter(), data.log_native_heights.iter())
+                    .map(|(mat, points_for_mat, &log_native_h)| {
+                        let h = 1usize << log_native_h;
                         let (low_coset, _) = mat.split_rows(h);
 
                         points_for_mat
@@ -430,7 +479,10 @@ where
             })
             .collect_vec();
 
-        // Step 2: Alpha-batch into a single reduced-opening vector.
+        // Step 2: Alpha-batch into one reduced-opening vector per (shared LDE domain, native
+        // height) class. Every matrix in a class lives on the same physical domain (its
+        // commitment's shared domain) and shares the same claimed degree, both required to
+        // alpha-batch them together and, later, for `Combine` to merge classes soundly.
         let alpha: Challenge = challenger.sample_algebra_element();
         let packed_alpha_powers =
             Challenge::ExtensionPacking::packed_ext_powers_capped(alpha, global_max_width)
@@ -439,21 +491,26 @@ where
             Challenge::ExtensionPacking::to_ext_iter(packed_alpha_powers.iter().copied())
                 .collect_vec();
 
-        // `reduced[log_h]`: alpha-batched reduced-opening at log-height `log_h`. Keyed by
-        // arbitrary `log_h` so the structure scales with the field's two-adicity rather than
-        // a hardcoded array bound.
-        let mut reduced_openings: alloc::collections::BTreeMap<usize, Vec<Challenge>> =
+        // Keyed by `(log_shared_lde_height, log_native_height)`. The outer key selects which
+        // STIR instance a class feeds; the inner key is `Combine`'s per-class degree.
+        let mut reduced_openings: alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>> =
             alloc::collections::BTreeMap::new();
-        let mut num_reduced: alloc::collections::BTreeMap<usize, usize> =
+        let mut num_reduced: alloc::collections::BTreeMap<(usize, usize), usize> =
             alloc::collections::BTreeMap::new();
 
-        for ((mats, points), opened_vals) in mats_and_points.iter().zip(&all_opened_values) {
-            for ((mat, points_for_mat), opened_for_mat) in
-                izip!(mats.iter(), points.iter()).zip(opened_vals.iter())
+        for (((mats, points), opened_vals), (data, _)) in mats_and_points
+            .iter()
+            .zip(&all_opened_values)
+            .zip(&commitment_data_with_opening_points)
+        {
+            for (((mat, points_for_mat), opened_for_mat), &log_native_h) in
+                izip!(mats.iter(), points.iter())
+                    .zip(opened_vals.iter())
+                    .zip(data.log_native_heights.iter())
             {
-                let log_h = log2_strict_usize(mat.height());
+                let key = (data.log_shared_lde_height, log_native_h);
                 let ro = reduced_openings
-                    .entry(log_h)
+                    .entry(key)
                     .or_insert_with(|| vec![Challenge::ZERO; mat.height()]);
 
                 // Precompute alpha-batched row values for this matrix (reused per point).
@@ -462,7 +519,7 @@ where
                     .collect();
 
                 for (point, ys) in points_for_mat.iter().zip(opened_for_mat.iter()) {
-                    let height_count = num_reduced.entry(log_h).or_insert(0);
+                    let height_count = num_reduced.entry(key).or_insert(0);
                     let alpha_pow_offset = alpha.exp_u64(*height_count as u64);
                     *height_count += ys.len();
 
@@ -484,21 +541,59 @@ where
             }
         }
 
-        // Step 3: run STIR on every non-empty height bucket's reduced opening in lockstep,
-        // sharing every grind across buckets, then bind the input MMCS at each bucket's
-        // query positions. Each distinct LDE height gets its own STIR sub-proof. BTreeMap
-        // iterates in ascending key order, so reverse for descending.
-        let bucket_log_heights: Vec<usize> = reduced_openings.keys().rev().copied().collect();
+        // Step 3: within each distinct shared-LDE-height bucket (one physical domain, hence
+        // one STIR instance), merge its native-height classes via `Combine` (§4.5) when more
+        // than one is present, then run STIR on every bucket in lockstep, sharing every
+        // grind across buckets, then bind the input MMCS at each bucket's query positions.
+        let bucket_log_heights: Vec<usize> = {
+            let mut heights: Vec<usize> = reduced_openings.keys().map(|&(h, _)| h).collect();
+            heights.sort_unstable();
+            heights.dedup();
+            heights.reverse();
+            heights
+        };
+
+        // Native-height classes present in each bucket, descending, computed once and
+        // shared by the `StirConfig` construction below (which needs the class count and
+        // `ell` to size round 0's `eta` for `Combine`) and `combined_bucket_codeword`
+        // (which needs the same classes to actually run `Combine`).
+        let bucket_native_heights: Vec<Vec<usize>> = bucket_log_heights
+            .iter()
+            .map(|&log_h| {
+                let mut heights: Vec<usize> = reduced_openings
+                    .keys()
+                    .filter(|&&(h, _)| h == log_h)
+                    .map(|&(_, log_d)| log_d)
+                    .collect();
+                heights.sort_unstable();
+                heights.dedup();
+                heights.reverse();
+                heights
+            })
+            .collect();
 
         let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
             bucket_log_heights
                 .iter()
-                .map(|&log_h| {
+                .zip(&bucket_native_heights)
+                .map(|(&log_h, native_heights)| {
                     let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-                    StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                        log_stir_degree,
-                        self.stir.clone(),
-                    )
+                    if native_heights.len() >= 2 {
+                        let log_d_star = native_heights[0];
+                        let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
+                            - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
+                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
+                            log_stir_degree,
+                            self.stir.clone(),
+                            native_heights.len(),
+                            ell,
+                        )
+                    } else {
+                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
+                            log_stir_degree,
+                            self.stir.clone(),
+                        )
+                    }
                 })
                 .collect();
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
@@ -506,12 +601,12 @@ where
 
         let initial_codewords: Vec<Vec<Challenge>> = bucket_log_heights
             .iter()
-            .map(|&log_h| {
-                let mut ro_natural = reduced_openings
-                    .remove(&log_h)
-                    .expect("present by construction");
-                reverse_slice_index_bits(&mut ro_natural);
-                ro_natural
+            .map(|&log_shared_h| {
+                combined_bucket_codeword::<Val, Challenge, Challenger>(
+                    &reduced_openings,
+                    log_shared_h,
+                    challenger,
+                )
             })
             .collect();
 
@@ -528,30 +623,26 @@ where
             .zip(bucket_results)
             .map(
                 |((&log_h, stir_config), (stir_proof, first_round_query_indices))| {
-                    let bucket_height = 1usize << log_h;
                     let log_arity0 = stir_config.log_starting_folding_factor;
 
                     let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> =
                         commitment_data_with_opening_points
                             .iter()
                             .map(|(data, _)| {
-                                // Only this bucket's height class is opened; the other classes live
-                                // in their own trees and never appear in this bucket's proof.
-                                let class = data
-                                    .classes
-                                    .iter()
-                                    .find(|class| class.lde_height == bucket_height)?;
+                                // A commitment's whole shared domain either feeds this
+                                // bucket or none of it does -- there is no partial case
+                                // now that every matrix in a commitment shares one domain.
+                                if data.log_shared_lde_height != log_h {
+                                    return None;
+                                }
 
-                                // Every matrix in the class shares the bucket's height, so the
-                                // grouped row index is the query index itself: one index per query,
-                                // and the whole fiber lives in that single row.
                                 let q_globals: Vec<usize> = first_round_query_indices
                                     .iter()
                                     .map(|&j| reverse_bits_len(j, log_h - log_arity0))
                                     .collect();
 
                                 let (opened_values, opening_proof) =
-                                    self.input_mmcs.open_multi_batch(&q_globals, &class.data);
+                                    self.input_mmcs.open_multi_batch(&q_globals, &data.data);
                                 Some(InputOpenings {
                                     opened_values,
                                     opening_proof,
@@ -588,16 +679,29 @@ where
 
         let alpha: Challenge = challenger.sample_algebra_element();
 
-        // Determine the set of distinct LDE-height buckets (descending) from the public domains.
-        // Must match the prover's bucket iteration order.
+        // Every matrix in one commitment shares its shared LDE domain: the tallest matrix's
+        // native height plus log_blowup. This is public (derived from the claimed domains),
+        // matching how the prover derived it at commit time.
+        let commitment_shared_heights: Vec<usize> = commitments_with_opening_points
+            .iter()
+            .map(|(_, domain_claims)| {
+                let log_max_native = domain_claims
+                    .iter()
+                    .map(|(domain, _)| log2_strict_usize(domain.size()))
+                    .max()
+                    .unwrap_or(0);
+                log_max_native + self.stir.log_blowup
+            })
+            .collect();
+
+        // Distinct outer buckets (shared LDE heights), descending. Must match the prover's
+        // bucket iteration order.
         let bucket_log_heights: Vec<usize> = {
-            let mut seen = BTreeSet::new();
-            for (_, domain_claims) in &commitments_with_opening_points {
-                for (domain, _) in domain_claims {
-                    seen.insert(log2_strict_usize(domain.size() << self.stir.log_blowup));
-                }
-            }
-            seen.into_iter().rev().collect()
+            let mut heights: Vec<usize> = commitment_shared_heights.clone();
+            heights.sort_unstable();
+            heights.dedup();
+            heights.reverse();
+            heights
         };
 
         if proof.len() != bucket_log_heights.len() {
@@ -626,23 +730,25 @@ where
         // functions of public input — independent of which bucket is being verified — so
         // computing them once here (rather than inside the per-bucket, per-query,
         // per-fiber-lane loop below) turns an `O(n_q * arity0)` recomputation per point into
-        // `O(1)`. `alpha_pow_offset` is tracked per log_h via a BTreeMap so the structure
-        // scales with the field's two-adicity rather than a hardcoded array length.
-        let mut height_num_reduced: alloc::collections::BTreeMap<usize, usize> =
+        // `O(1)`. Keyed like the prover's `reduced_openings`, by `(log_shared_lde_height,
+        // log_native_height)`, so the structure scales with the field's two-adicity rather
+        // than a hardcoded array length.
+        let mut class_num_reduced: alloc::collections::BTreeMap<(usize, usize), usize> =
             alloc::collections::BTreeMap::new();
         let point_data: Vec<Vec<Vec<(Challenge, Challenge)>>> = commitments_with_opening_points
             .iter()
-            .map(|(_, domain_claims)| {
+            .zip(&commitment_shared_heights)
+            .map(|((_, domain_claims), &log_shared_h)| {
                 domain_claims
                     .iter()
                     .map(|(domain, point_claims)| {
-                        let log_h = log2_strict_usize(domain.size() << self.stir.log_blowup);
+                        let key = (log_shared_h, log2_strict_usize(domain.size()));
                         point_claims
                             .iter()
                             .map(|(_, vals)| {
-                                let height_count = height_num_reduced.entry(log_h).or_insert(0);
-                                let offset = alpha.exp_u64(*height_count as u64);
-                                *height_count += vals.len();
+                                let count = class_num_reduced.entry(key).or_insert(0);
+                                let offset = alpha.exp_u64(*count as u64);
+                                *count += vals.len();
 
                                 let y_combined: Challenge = vals
                                     .iter()
@@ -670,15 +776,52 @@ where
             }
         }
 
+        // Native-height classes present in each bucket, descending, computed once and
+        // shared by the `StirConfig` construction below (which needs the class count and
+        // `ell` to size round 0's `eta` for `Combine`) and the `Combine`-challenge sampling
+        // that follows (which needs the same classes to derive its coefficients).
+        let bucket_native_heights: Vec<Vec<usize>> = bucket_log_heights
+            .iter()
+            .map(|&log_shared_h| {
+                let mut native_heights: Vec<usize> = commitments_with_opening_points
+                    .iter()
+                    .zip(&commitment_shared_heights)
+                    .filter(|&(_, h)| *h == log_shared_h)
+                    .flat_map(|((_, domain_claims), _)| {
+                        domain_claims
+                            .iter()
+                            .map(|(domain, _)| log2_strict_usize(domain.size()))
+                    })
+                    .collect();
+                native_heights.sort_unstable();
+                native_heights.dedup();
+                native_heights.reverse();
+                native_heights
+            })
+            .collect();
+
         let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
             bucket_log_heights
                 .iter()
-                .map(|&log_h| {
+                .zip(&bucket_native_heights)
+                .map(|(&log_h, native_heights)| {
                     let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-                    StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                        log_stir_degree,
-                        self.stir.clone(),
-                    )
+                    if native_heights.len() >= 2 {
+                        let log_d_star = native_heights[0];
+                        let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
+                            - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
+                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
+                            log_stir_degree,
+                            self.stir.clone(),
+                            native_heights.len(),
+                            ell,
+                        )
+                    } else {
+                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
+                            log_stir_degree,
+                            self.stir.clone(),
+                        )
+                    }
                 })
                 .collect();
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
@@ -686,21 +829,46 @@ where
         let stir_proofs: Vec<&StirProof<Challenge, StirMmcs, Val>> =
             proof.iter().map(|(p, _)| p).collect();
 
+        // For every bucket with more than one native-height class present, sample the
+        // `Combine` challenge and derive its per-class coefficients up front, at the same
+        // transcript position the prover's `combined_bucket_codeword` used (before any
+        // STIR-internal transcript operations) — mirroring how `alpha` itself is sampled
+        // once, up front, rather than lazily inside a bucket's closure.
+        let bucket_combine: Vec<BucketCombine<Challenge>> = bucket_log_heights
+            .iter()
+            .zip(&bucket_native_heights)
+            .map(|(_, native_heights)| {
+                if native_heights.len() <= 1 {
+                    return None;
+                }
+
+                let log_d_star = native_heights[0];
+                let r_comb: Challenge = challenger.sample_algebra_element();
+                let (_, coeffs) =
+                    combine_coefficients(r_comb, log_d_star, native_heights.iter().copied());
+                Some((r_comb, native_heights.iter().copied().zip(coeffs).collect()))
+            })
+            .collect();
+
         // Captured by every bucket's closure below; taking references up front lets `move`
         // give each closure its own copy of the reference rather than the whole value.
         let commitments_with_opening_points = &commitments_with_opening_points;
+        let commitment_shared_heights = &commitment_shared_heights;
         let point_data = &point_data;
         let alpha_powers = &alpha_powers;
+        let bucket_combine = &bucket_combine;
 
-        // STIR's initial oracle is the reduced opening, which is a deterministic function of
-        // the input commitments, the claimed values, and `alpha` — all already in the
-        // transcript. Rather than have the prover commit and open it a second time, rebuild
-        // its queried fibers from the input MMCS openings on demand.
+        // STIR's initial oracle is the (possibly `Combine`d) reduced opening, which is a
+        // deterministic function of the input commitments, the claimed values, `alpha`, and
+        // (when a bucket merges more than one class) the combination challenge — all already
+        // in the transcript. Rather than have the prover commit and open it a second time,
+        // rebuild its queried fibers from the input MMCS openings on demand.
         let initial_fibers: Vec<_> = bucket_log_heights
             .iter()
             .zip(&stir_configs)
             .zip(proof.iter().map(|(_, input_openings)| input_openings))
-            .map(|((&log_h, stir_config), input_openings)| {
+            .zip(bucket_combine)
+            .map(|(((&log_h, stir_config), input_openings), combine_info)| {
                 let bucket_height = 1usize << log_h;
                 let log_arity0 = stir_config.log_starting_folding_factor;
                 let arity0 = 1usize << log_arity0;
@@ -715,17 +883,22 @@ where
 
                 move |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
                     let n_q = first_round_unique_js.len();
-                    let mut expected_ro = vec![Challenge::zero_vec(arity0); n_q];
 
-                    // Distinct opening points among matrices active at this bucket height.
-                    // Matrices typically share opening points (e.g. one STARK's `zeta`), so
-                    // this list is usually far shorter than the matrix count.
+                    // One accumulator per native-height class present in this bucket; merged
+                    // into the final expected codeword fibers after the accumulation loop.
+                    let mut expected_ro_by_class: alloc::collections::BTreeMap<
+                        usize,
+                        Vec<Vec<Challenge>>,
+                    > = alloc::collections::BTreeMap::new();
+
+                    // Distinct opening points among matrices active at this bucket. Matrices
+                    // typically share opening points (e.g. one STARK's `zeta`), so this list
+                    // is usually far shorter than the matrix count.
                     let bucket_points: Vec<Challenge> = commitments_with_opening_points
                         .iter()
-                        .flat_map(|(_, domain_claims)| domain_claims.iter())
-                        .filter(|(domain, _)| {
-                            (domain.size() << self.stir.log_blowup) == bucket_height
-                        })
+                        .zip(commitment_shared_heights.iter())
+                        .filter(|&(_, h)| *h == log_h)
+                        .flat_map(|((_, domain_claims), _)| domain_claims.iter())
                         .flat_map(|(_, point_claims)| point_claims.iter().map(|(point, _)| *point))
                         .fold(Vec::new(), |mut points, point| {
                             if !points.contains(&point) {
@@ -750,25 +923,17 @@ where
                     }
                     let inv_denoms = batch_multiplicative_inverse(&denom_diffs);
 
-                    // The accumulation runs across ALL commitments: when several contribute
-                    // matrices to the same height bucket, `ro[p]` is their sum, so a
-                    // per-commitment reconstruction would be wrong.
+                    // A commitment's whole shared domain either feeds this bucket (all its
+                    // matrices) or none of it does — there is no partial case now that every
+                    // matrix in a commitment shares one domain.
                     for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                         commitments_with_opening_points
                             .iter()
                             .zip(input_openings.iter())
                             .enumerate()
                     {
-                        let mat_lde_heights: Vec<usize> = domain_claims
-                            .iter()
-                            .map(|(domain, _)| domain.size() << self.stir.log_blowup)
-                            .collect();
+                        let has_at_bucket = commitment_shared_heights[commit_idx] == log_h;
 
-                        let has_at_bucket = mat_lde_heights.contains(&bucket_height);
-
-                        // SHAPE CHECK: whether an opening is present at all is determined entirely by
-                        // public input. Validating up-front turns a mismatch into a clean
-                        // `InvalidProofShape` instead of silently skipping a binding check.
                         let Some(opening) = per_commit_opening else {
                             if has_at_bucket {
                                 return Err(StirError::InvalidProofShape);
@@ -786,41 +951,17 @@ where
                             })
                             .collect();
 
-                        // The commitment is one root per distinct LDE height, descending; this
-                        // bucket reads only its own class, so only that class's matrices appear
-                        // in the opening.
-                        let mut class_heights = mat_lde_heights.clone();
-                        class_heights.sort_unstable();
-                        class_heights.dedup();
-                        class_heights.reverse();
-
-                        // SHAPE CHECK: the class count is determined entirely by public input.
-                        if commitment.len() != class_heights.len() {
-                            return Err(StirError::InvalidProofShape);
-                        }
-                        let class_idx = class_heights
+                        // Every matrix in the commitment shares this bucket's domain, so all
+                        // of them are opened. Matrices are committed fiber-grouped:
+                        // `2^log_arity0` LDE rows per committed row.
+                        let dimensions: Vec<p3_matrix::Dimensions> = mat_widths
                             .iter()
-                            .position(|&h| h == bucket_height)
-                            .expect("`has_at_bucket` established this class exists");
-                        let class_members: Vec<usize> = mat_lde_heights
-                            .iter()
-                            .enumerate()
-                            .filter(|&(_, &h)| h == bucket_height)
-                            .map(|(mat_idx, _)| mat_idx)
-                            .collect();
-
-                        // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per
-                        // committed row.
-                        let dimensions: Vec<p3_matrix::Dimensions> = class_members
-                            .iter()
-                            .map(|&mat_idx| p3_matrix::Dimensions {
+                            .map(|&width| p3_matrix::Dimensions {
                                 height: bucket_height >> log_arity0,
-                                width: mat_widths[mat_idx] << log_arity0,
+                                width: width << log_arity0,
                             })
                             .collect();
 
-                        // Every matrix in the class shares the bucket's height, so the grouped
-                        // row index is the query index itself.
                         let q_globals: Vec<usize> = first_round_unique_js
                             .iter()
                             .map(|&j| reverse_bits_len(j, log_h - log_arity0))
@@ -833,7 +974,7 @@ where
 
                         self.input_mmcs
                             .verify_multi_batch(
-                                &commitment[class_idx],
+                                commitment,
                                 &dimensions,
                                 &q_globals,
                                 &opening.opened_values,
@@ -850,19 +991,22 @@ where
                                 // of the grouped row.
                                 let slot = reverse_bits_len(l, log_arity0);
 
-                                for (local_idx, &mat_idx) in class_members.iter().enumerate() {
-                                    let (_, point_claims) = &domain_claims[mat_idx];
-
-                                    // `verify_multi_batch` already pinned each grouped row to
-                                    // `dimensions[local_idx].width`, so this slice is in bounds.
+                                for (mat_idx, (domain, point_claims)) in
+                                    domain_claims.iter().enumerate()
+                                {
+                                    let log_native_h = log2_strict_usize(domain.size());
                                     let width = mat_widths[mat_idx];
                                     let row_vals =
-                                        &row_vals_by_mat[local_idx][slot * width..][..width];
+                                        &row_vals_by_mat[mat_idx][slot * width..][..width];
                                     let p_x: Challenge = row_vals
                                         .iter()
                                         .zip(alpha_powers.iter())
                                         .map(|(&v, &ap)| ap * v)
                                         .sum();
+
+                                    let ro_class = expected_ro_by_class
+                                        .entry(log_native_h)
+                                        .or_insert_with(|| vec![Challenge::zero_vec(arity0); n_q]);
 
                                     for (point_idx, (point, _)) in point_claims.iter().enumerate() {
                                         let (alpha_pow_offset, y_combined) =
@@ -875,7 +1019,7 @@ where
                                         let inv_denom =
                                             inv_denoms[(q_idx * arity0 + l) * n_bp + bp_idx];
 
-                                        expected_ro[q_idx][l] +=
+                                        ro_class[q_idx][l] +=
                                             alpha_pow_offset * (p_x - y_combined) * inv_denom;
                                     }
                                 }
@@ -883,7 +1027,45 @@ where
                         }
                     }
 
-                    Ok(expected_ro)
+                    // Merge the per-class accumulators into the bucket's expected codeword
+                    // fibers, mirroring the prover's `combine_on_coset`/`eval_degree_correction`
+                    // pointwise, only at the queried fiber lanes.
+                    match combine_info {
+                        None => {
+                            // SHAPE CHECK: exactly one class expected when no Combine ran.
+                            if expected_ro_by_class.len() != 1 {
+                                return Err(StirError::InvalidProofShape);
+                            }
+                            Ok(expected_ro_by_class.into_values().next().unwrap())
+                        }
+                        Some((r_comb, coeffs_by_height)) => {
+                            // SHAPE CHECK: every expected class must be present.
+                            if expected_ro_by_class.len() != coeffs_by_height.len() {
+                                return Err(StirError::InvalidProofShape);
+                            }
+                            let mut combined = vec![Challenge::zero_vec(arity0); n_q];
+                            for (log_native_h, ro_class) in &expected_ro_by_class {
+                                let &(r_i, gap) = coeffs_by_height
+                                    .get(log_native_h)
+                                    .ok_or(StirError::InvalidProofShape)?;
+                                for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
+                                    let mut fiber_point =
+                                        Val::GENERATOR * domain_gen.exp_u64(j as u64);
+                                    for l in 0..arity0 {
+                                        let x = Challenge::from(fiber_point);
+                                        combined[q_idx][l] += eval_degree_correction(
+                                            r_i * ro_class[q_idx][l],
+                                            x,
+                                            *r_comb,
+                                            gap,
+                                        );
+                                        fiber_point *= fiber_step;
+                                    }
+                                }
+                            }
+                            Ok(combined)
+                        }
+                    }
                 }
             })
             .collect();
@@ -899,6 +1081,85 @@ where
 
         Ok(())
     }
+}
+
+/// Definition 4.11's per-class `Combine` coefficients, for classes already sorted in
+/// descending native-degree order (tallest first, so the target degree `d* := 2^log_d_star`
+/// is the first class's own degree, giving it `gap = 0` and, per `r_1 := 1`, a trivial
+/// coefficient).
+///
+/// Returns `(d*, [(r_i, gap_i)])` where `gap_i = d* - dᵢ` (a degree count, not log) is what
+/// `eval_degree_correction`/`combine_on_coset` expect directly.
+fn combine_coefficients<EF: Field>(
+    r_comb: EF,
+    log_d_star: usize,
+    sorted_log_ds: impl Iterator<Item = usize>,
+) -> (u64, Vec<(EF, usize)>) {
+    let d_star = 1u64 << log_d_star;
+    let mut running_exp = 0u64;
+    let coeffs = sorted_log_ds
+        .map(|log_d| {
+            let r_i = r_comb.exp_u64(running_exp);
+            let gap = (d_star - (1u64 << log_d)) as usize;
+            running_exp += 1 + gap as u64;
+            (r_i, gap)
+        })
+        .collect();
+    (d_star, coeffs)
+}
+
+/// Merge one shared-LDE-height bucket's native-height classes into a single codeword on
+/// their shared domain, via `Combine` (§4.5) when more than one class is present.
+///
+/// `reduced_openings` is keyed by `(log_shared_lde_height, log_native_height)`; this pulls
+/// out every class at `log_shared_h`, descending by native height, and returns the natural
+/// (not yet bit-reversed) combined codeword STIR should run on.
+fn combined_bucket_codeword<Val, Challenge, Challenger>(
+    reduced_openings: &alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>>,
+    log_shared_h: usize,
+    challenger: &mut Challenger,
+) -> Vec<Challenge>
+where
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val> + TwoAdicField,
+    Challenger: FieldChallenger<Val>,
+{
+    let mut classes: Vec<(usize, &Vec<Challenge>)> = reduced_openings
+        .iter()
+        .filter(|((h, _), _)| *h == log_shared_h)
+        .map(|(&(_, log_d), ro)| (log_d, ro))
+        .collect();
+    classes.sort_unstable_by(|(a, _), (b, _)| b.cmp(a));
+
+    if classes.len() == 1 {
+        let mut natural = classes[0].1.clone();
+        reverse_slice_index_bits(&mut natural);
+        return natural;
+    }
+
+    let log_d_star = classes[0].0;
+    let r_comb: Challenge = challenger.sample_algebra_element();
+    let (_, coeffs) =
+        combine_coefficients(r_comb, log_d_star, classes.iter().map(|&(log_d, _)| log_d));
+
+    // `combine_on_coset` indexes its inputs (and produces its output) in natural order, but
+    // `reduced_openings` is bit-reversed (built from the bit-reversed LDE matrices), so each
+    // class's codeword is un-reversed before combining; the combined result is then already
+    // in the natural order STIR expects, with no further reversal needed.
+    let natural_ros: Vec<Vec<Challenge>> = classes
+        .iter()
+        .map(|&(_, ro)| {
+            let mut natural = ro.clone();
+            reverse_slice_index_bits(&mut natural);
+            natural
+        })
+        .collect();
+    let groups: Vec<(Challenge, usize, &[Challenge])> = coeffs
+        .into_iter()
+        .zip(&natural_ros)
+        .map(|((r_i, gap), ro)| (r_i, gap, ro.as_slice()))
+        .collect();
+    combine_on_coset(&groups, r_comb, Val::GENERATOR, log_shared_h)
 }
 
 type MatricesAndPoints<'a, F, EF> = (Vec<RowMajorMatrixView<'a, F>>, &'a Vec<Vec<EF>>);

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -12,7 +12,7 @@
 //! size are then run through one STIR instance together (as many domain sizes as distinct
 //! shared domains, "buckets" below); within a bucket, if more than one native-height class is
 //! present, they are merged into a single codeword via batch degree correction
-//! ([`combine_on_coset`](crate::utils::combine_on_coset), §4.5's `Combine`) before STIR runs,
+//! ([`crate::utils::combine_on_coset`], §4.5's `Combine`) before STIR runs,
 //! at the tallest class's degree and full proximity radius (no per-class query-count floor).
 //! The prover returns the deduplicated first-round STIR query indices alongside the IOP
 //! proof; at those positions the prover also opens the input LDE matrices (via `InputMmcs`)
@@ -27,6 +27,17 @@
 //! second time: whenever STIR needs its queried fibers, the verifier rebuilds them from the
 //! input MMCS openings at exactly the positions STIR sampled. No hand-mirrored transcript
 //! replay is needed.
+//!
+//! **Cost profile**: opening and verification get cheaper — one STIR instance per commitment
+//! instead of one per height class — but committing gets more expensive, and the trade moves
+//! with the height spread. A matrix at native height `2^h` alongside a tallest matrix at
+//! `2^H` pays a `2^(H - h + log_blowup)` blowup instead of `2^log_blowup`, in both its DFT and
+//! its share of the Merkle tree (the tree is `2^(H + log_blowup)` rows deep and carries every
+//! matrix's full width in each leaf, so hashing goes from `Σᵢ 2^(hᵢ + b)·widthᵢ` to
+//! `2^(H + b)·Σᵢ widthᵢ`). Callers committing matrices whose heights differ by many octaves —
+//! or more classes than the `Combine` feasibility envelope on [`StirParameters`] admits —
+//! should split them across separate `commit()` calls, which keeps each shared domain close to
+//! its own matrices' heights.
 
 use alloc::borrow::Cow;
 use alloc::vec;
@@ -56,7 +67,7 @@ use tracing::instrument;
 use crate::config::{StirConfig, StirParameters};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_external_codewords;
-use crate::utils::{combine_on_coset, eval_degree_correction};
+use crate::utils::combine_on_coset;
 use crate::verifier::{StirError, verify_stir_multi_with_external_initial};
 
 /// Batched openings of one input commitment's LDE matrices at the STIR-derived query
@@ -98,31 +109,6 @@ pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     log_native_heights: Vec<usize>,
     /// Log2 of the shared LDE domain every matrix in this commitment was extended onto.
     log_shared_lde_height: usize,
-}
-
-/// Commit fiber-grouped LDEs (all sharing one height) in a single tree, recording each
-/// matrix's own native height and column count for later alpha-batching/`Combine` grouping.
-fn commit_shared_domain<Val, InputMmcs>(
-    input_mmcs: &InputMmcs,
-    grouped: Vec<RowMajorMatrix<Val>>,
-    log_native_heights: Vec<usize>,
-    widths: Vec<usize>,
-    log_shared_lde_height: usize,
-) -> (InputMmcs::Commitment, StirProverData<Val, InputMmcs>)
-where
-    Val: Send + Sync + Clone,
-    InputMmcs: Mmcs<Val>,
-{
-    let (commitment, data) = input_mmcs.commit(grouped);
-    (
-        commitment,
-        StirProverData {
-            data,
-            widths,
-            log_native_heights,
-            log_shared_lde_height,
-        },
-    )
 }
 
 /// Reinterpret a bit-reversed LDE as a matrix whose rows are whole STIR fibers.
@@ -172,6 +158,31 @@ impl<Val, Dft, InputMmcs, StirMmcs> TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs
             _phantom: PhantomData,
         }
     }
+
+    /// Commit fiber-grouped LDEs (all sharing one height) in a single tree, recording each
+    /// matrix's own native height and column count for later alpha-batching/`Combine` grouping.
+    fn commit_shared_domain(
+        &self,
+        grouped: Vec<RowMajorMatrix<Val>>,
+        log_native_heights: Vec<usize>,
+        widths: Vec<usize>,
+        log_shared_lde_height: usize,
+    ) -> (InputMmcs::Commitment, StirProverData<Val, InputMmcs>)
+    where
+        Val: Send + Sync + Clone,
+        InputMmcs: Mmcs<Val>,
+    {
+        let (commitment, data) = self.input_mmcs.commit(grouped);
+        (
+            commitment,
+            StirProverData {
+                data,
+                widths,
+                log_native_heights,
+                log_shared_lde_height,
+            },
+        )
+    }
 }
 
 /// One bucket's `Combine` state for the verifier: the sampled combination challenge and each
@@ -203,7 +214,9 @@ where
     type Commitment = InputMmcs::Commitment;
     type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
-    /// Proof structure: one entry per distinct LDE-height bucket (descending).
+    /// Proof structure: one entry per distinct shared LDE height across the commitments
+    /// (descending). Every matrix in a single `commit()` shares one LDE domain, so a
+    /// commitment contributes to exactly one entry.
     ///
     /// Each bucket contains:
     /// - `stir_proof`: the STIR IOP proof for that bucket (per-round IOP messages; the initial
@@ -267,6 +280,8 @@ where
             .into_iter()
             .map(|(domain, evals)| {
                 let log_native_height = log2_strict_usize(domain.size());
+                // Effective per-matrix blowup: `log_blowup` for the tallest matrix, and one
+                // extra bit per octave of height below it. See the module-level cost note.
                 let extra_bits = log_shared_lde_height - log_native_height;
                 let shift = Val::GENERATOR / domain.shift();
                 let lde = self
@@ -279,13 +294,7 @@ where
                 group_fiber_rows(lde, self.stir.log_starting_folding_factor)
             })
             .collect();
-        commit_shared_domain(
-            &self.input_mmcs,
-            grouped,
-            log_native_heights,
-            widths,
-            log_shared_lde_height,
-        )
+        self.commit_shared_domain(grouped, log_native_heights, widths, log_shared_lde_height)
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -404,13 +413,7 @@ where
                 group_fiber_rows(extended, self.stir.log_starting_folding_factor)
             })
             .collect();
-        commit_shared_domain(
-            &self.input_mmcs,
-            grouped,
-            log_native_heights,
-            widths,
-            log_shared_lde_height,
-        )
+        self.commit_shared_domain(grouped, log_native_heights, widths, log_shared_lde_height)
     }
 
     #[instrument(name = "STIR PCS open", skip_all)]
@@ -603,7 +606,7 @@ where
             .iter()
             .map(|&log_shared_h| {
                 combined_bucket_codeword::<Val, Challenge, Challenger>(
-                    &reduced_openings,
+                    &mut reduced_openings,
                     log_shared_h,
                     challenger,
                 )
@@ -844,7 +847,7 @@ where
 
                 let log_d_star = native_heights[0];
                 let r_comb: Challenge = challenger.sample_algebra_element();
-                let (_, coeffs) =
+                let coeffs =
                     combine_coefficients(r_comb, log_d_star, native_heights.iter().copied());
                 Some((r_comb, native_heights.iter().copied().zip(coeffs).collect()))
             })
@@ -868,7 +871,9 @@ where
             .zip(&stir_configs)
             .zip(proof.iter().map(|(_, input_openings)| input_openings))
             .zip(bucket_combine)
-            .map(|(((&log_h, stir_config), input_openings), combine_info)| {
+            .zip(&bucket_native_heights)
+            .map(
+                |((((&log_h, stir_config), input_openings), combine_info), native_heights)| {
                 let bucket_height = 1usize << log_h;
                 let log_arity0 = stir_config.log_starting_folding_factor;
                 let arity0 = 1usize << log_arity0;
@@ -884,12 +889,11 @@ where
                 move |first_round_unique_js: &[usize]| -> Result<Vec<Vec<Challenge>>, Self::Error> {
                     let n_q = first_round_unique_js.len();
 
-                    // One accumulator per native-height class present in this bucket; merged
-                    // into the final expected codeword fibers after the accumulation loop.
-                    let mut expected_ro_by_class: alloc::collections::BTreeMap<
-                        usize,
-                        Vec<Vec<Challenge>>,
-                    > = alloc::collections::BTreeMap::new();
+                    // One accumulator per native-height class present in this bucket, indexed
+                    // as `native_heights` is (descending); merged into the final expected
+                    // codeword fibers after the accumulation loop.
+                    let mut expected_ro_by_class: Vec<Vec<Vec<Challenge>>> =
+                        vec![vec![Challenge::zero_vec(arity0); n_q]; native_heights.len()];
 
                     // Distinct opening points among matrices active at this bucket. Matrices
                     // typically share opening points (e.g. one STARK's `zeta`), so this list
@@ -951,6 +955,36 @@ where
                             })
                             .collect();
 
+                        // A matrix's native-height class, and each of its opening points'
+                        // slot in `bucket_points`, are fixed for the whole commitment. Both
+                        // are resolved once here rather than once per
+                        // `(query, lane, matrix, point)`, which is where the innermost loop
+                        // below would otherwise re-scan `bucket_points` linearly.
+                        let mat_class_indices: Vec<usize> = domain_claims
+                            .iter()
+                            .map(|(domain, _)| {
+                                let log_native_h = log2_strict_usize(domain.size());
+                                native_heights
+                                    .iter()
+                                    .position(|&h| h == log_native_h)
+                                    .expect("bucket_native_heights is built from these claims")
+                            })
+                            .collect();
+                        let mat_point_slots: Vec<Vec<usize>> = domain_claims
+                            .iter()
+                            .map(|(_, point_claims)| {
+                                point_claims
+                                    .iter()
+                                    .map(|(point, _)| {
+                                        bucket_points
+                                            .iter()
+                                            .position(|p| p == point)
+                                            .expect("point is in bucket_points by construction")
+                                    })
+                                    .collect()
+                            })
+                            .collect();
+
                         // Every matrix in the commitment shares this bucket's domain, so all
                         // of them are opened. Matrices are committed fiber-grouped:
                         // `2^log_arity0` LDE rows per committed row.
@@ -991,10 +1025,9 @@ where
                                 // of the grouped row.
                                 let slot = reverse_bits_len(l, log_arity0);
 
-                                for (mat_idx, (domain, point_claims)) in
-                                    domain_claims.iter().enumerate()
+                                for (mat_idx, point_slots) in
+                                    mat_point_slots.iter().enumerate()
                                 {
-                                    let log_native_h = log2_strict_usize(domain.size());
                                     let width = mat_widths[mat_idx];
                                     let row_vals =
                                         &row_vals_by_mat[mat_idx][slot * width..][..width];
@@ -1004,18 +1037,12 @@ where
                                         .map(|(&v, &ap)| ap * v)
                                         .sum();
 
-                                    let ro_class = expected_ro_by_class
-                                        .entry(log_native_h)
-                                        .or_insert_with(|| vec![Challenge::zero_vec(arity0); n_q]);
+                                    let ro_class =
+                                        &mut expected_ro_by_class[mat_class_indices[mat_idx]];
 
-                                    for (point_idx, (point, _)) in point_claims.iter().enumerate() {
+                                    for (point_idx, &bp_idx) in point_slots.iter().enumerate() {
                                         let (alpha_pow_offset, y_combined) =
                                             point_data[commit_idx][mat_idx][point_idx];
-
-                                        let bp_idx = bucket_points
-                                            .iter()
-                                            .position(|p| p == point)
-                                            .expect("point is in bucket_points by construction");
                                         let inv_denom =
                                             inv_denoms[(q_idx * arity0 + l) * n_bp + bp_idx];
 
@@ -1036,38 +1063,82 @@ where
                             if expected_ro_by_class.len() != 1 {
                                 return Err(StirError::InvalidProofShape);
                             }
-                            Ok(expected_ro_by_class.into_values().next().unwrap())
+                            Ok(expected_ro_by_class.into_iter().next().unwrap())
                         }
                         Some((r_comb, coeffs_by_height)) => {
                             // SHAPE CHECK: every expected class must be present.
                             if expected_ro_by_class.len() != coeffs_by_height.len() {
                                 return Err(StirError::InvalidProofShape);
                             }
+
+                            // Pointwise mirror of the prover's `combine_on_coset`, evaluated
+                            // only at the queried lanes. The `1 − r_comb·x` denominators do
+                            // not depend on the class, so they are swept once for the whole
+                            // fiber set and inverted in a single batch rather than once per
+                            // `(class, query, lane)`.
+                            let mut fiber_steps = Vec::with_capacity(n_q * arity0);
+                            let mut denoms = Vec::with_capacity(n_q * arity0);
+                            for &j in first_round_unique_js {
+                                let mut fiber_point =
+                                    Val::GENERATOR * domain_gen.exp_u64(j as u64);
+                                for _ in 0..arity0 {
+                                    let step = *r_comb * fiber_point;
+                                    fiber_steps.push(step);
+                                    denoms.push(Challenge::ONE - step);
+                                    fiber_point *= fiber_step;
+                                }
+                            }
+
+                            // The queried lanes are distinct coset points, so at most one can
+                            // reach `step = 1`, where the geometric sum degenerates to
+                            // `gap + 1`. Substituting a unit keeps the batch inversion defined
+                            // and makes that lane's numerator vanish, so the sweep below
+                            // contributes nothing there and the closed form is added back —
+                            // the same handling `combine_on_coset` applies on the prover side.
+                            let degenerate = denoms.iter().position(|d| d.is_zero());
+                            if let Some(lane) = degenerate {
+                                denoms[lane] = Challenge::ONE;
+                            }
+                            let inv_denoms = batch_multiplicative_inverse(&denoms);
+
                             let mut combined = vec![Challenge::zero_vec(arity0); n_q];
-                            for (log_native_h, ro_class) in &expected_ro_by_class {
+                            for (&log_native_h, ro_class) in
+                                native_heights.iter().zip(&expected_ro_by_class)
+                            {
                                 let &(r_i, gap) = coeffs_by_height
-                                    .get(log_native_h)
+                                    .get(&log_native_h)
                                     .ok_or(StirError::InvalidProofShape)?;
-                                for (q_idx, &j) in first_round_unique_js.iter().enumerate() {
-                                    let mut fiber_point =
-                                        Val::GENERATOR * domain_gen.exp_u64(j as u64);
+
+                                // Within a query the lanes advance by the fixed base-field
+                                // ratio `fiber_step^(gap+1)`, so the numerator sweep costs one
+                                // extension exponentiation per query instead of one per lane.
+                                let gap_plus_1 = (gap + 1) as u64;
+                                let lane_ratio = fiber_step.exp_u64(gap_plus_1);
+                                for q_idx in 0..n_q {
+                                    let base = q_idx * arity0;
+                                    let mut step_hi = fiber_steps[base].exp_u64(gap_plus_1);
                                     for l in 0..arity0 {
-                                        let x = Challenge::from(fiber_point);
-                                        combined[q_idx][l] += eval_degree_correction(
-                                            r_i * ro_class[q_idx][l],
-                                            x,
-                                            *r_comb,
-                                            gap,
-                                        );
-                                        fiber_point *= fiber_step;
+                                        combined[q_idx][l] += r_i
+                                            * ro_class[q_idx][l]
+                                            * (Challenge::ONE - step_hi)
+                                            * inv_denoms[base + l];
+                                        step_hi *= lane_ratio;
                                     }
+                                }
+
+                                if let Some(lane) = degenerate {
+                                    let (q_idx, l) = (lane / arity0, lane % arity0);
+                                    combined[q_idx][l] += r_i
+                                        * ro_class[q_idx][l]
+                                        * Challenge::from_usize(gap + 1);
                                 }
                             }
                             Ok(combined)
                         }
                     }
-                }
-            })
+                    }
+                },
+            )
             .collect();
 
         // Any transcript-touching step stays inside `verify_stir_multi_with_external_initial`;
@@ -1088,34 +1159,47 @@ where
 /// is the first class's own degree, giving it `gap = 0` and, per `r_1 := 1`, a trivial
 /// coefficient).
 ///
-/// Returns `(d*, [(r_i, gap_i)])` where `gap_i = d* - dᵢ` (a degree count, not log) is what
+/// Returns `[(r_i, gap_i)]` where `gap_i = d* - dᵢ` (a degree count, not log) is what
 /// `eval_degree_correction`/`combine_on_coset` expect directly.
+///
+/// # Panics
+///
+/// If any `log_d` exceeds `log_d_star`. Both call sites read `log_d_star` off the head of the
+/// same descending list they pass in, so this holds by construction — but the invariant lives
+/// outside the function, and an unchecked `d* - dᵢ` would wrap in release and yield a wrong
+/// codeword rather than a failure.
 fn combine_coefficients<EF: Field>(
     r_comb: EF,
     log_d_star: usize,
     sorted_log_ds: impl Iterator<Item = usize>,
-) -> (u64, Vec<(EF, usize)>) {
+) -> Vec<(EF, usize)> {
     let d_star = 1u64 << log_d_star;
     let mut running_exp = 0u64;
-    let coeffs = sorted_log_ds
+    sorted_log_ds
         .map(|log_d| {
             let r_i = r_comb.exp_u64(running_exp);
-            let gap = (d_star - (1u64 << log_d)) as usize;
+            let gap = d_star
+                .checked_sub(1u64 << log_d)
+                .expect("classes must be sorted descending, so every dᵢ <= d*")
+                as usize;
             running_exp += 1 + gap as u64;
             (r_i, gap)
         })
-        .collect();
-    (d_star, coeffs)
+        .collect()
 }
 
 /// Merge one shared-LDE-height bucket's native-height classes into a single codeword on
 /// their shared domain, via `Combine` (§4.5) when more than one class is present.
 ///
-/// `reduced_openings` is keyed by `(log_shared_lde_height, log_native_height)`; this pulls
-/// out every class at `log_shared_h`, descending by native height, and returns the natural
+/// `reduced_openings` is keyed by `(log_shared_lde_height, log_native_height)`; this removes
+/// every class at `log_shared_h`, descending by native height, and returns the natural
 /// (not yet bit-reversed) combined codeword STIR should run on.
+///
+/// Each class's codeword is taken out of the map rather than borrowed so it can be
+/// un-bit-reversed in place: at PCS scale a class spans the whole shared domain, so cloning
+/// them all would double peak memory for the duration of `Combine`.
 fn combined_bucket_codeword<Val, Challenge, Challenger>(
-    reduced_openings: &alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>>,
+    reduced_openings: &mut alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>>,
     log_shared_h: usize,
     challenger: &mut Challenger,
 ) -> Vec<Challenge>
@@ -1124,36 +1208,36 @@ where
     Challenge: ExtensionField<Val> + TwoAdicField,
     Challenger: FieldChallenger<Val>,
 {
-    let mut classes: Vec<(usize, &Vec<Challenge>)> = reduced_openings
-        .iter()
-        .filter(|((h, _), _)| *h == log_shared_h)
-        .map(|(&(_, log_d), ro)| (log_d, ro))
+    let mut log_ds: Vec<usize> = reduced_openings
+        .keys()
+        .filter(|(h, _)| *h == log_shared_h)
+        .map(|&(_, log_d)| log_d)
         .collect();
-    classes.sort_unstable_by(|(a, _), (b, _)| b.cmp(a));
-
-    if classes.len() == 1 {
-        let mut natural = classes[0].1.clone();
-        reverse_slice_index_bits(&mut natural);
-        return natural;
-    }
-
-    let log_d_star = classes[0].0;
-    let r_comb: Challenge = challenger.sample_algebra_element();
-    let (_, coeffs) =
-        combine_coefficients(r_comb, log_d_star, classes.iter().map(|&(log_d, _)| log_d));
+    log_ds.sort_unstable_by(|a, b| b.cmp(a));
 
     // `combine_on_coset` indexes its inputs (and produces its output) in natural order, but
     // `reduced_openings` is bit-reversed (built from the bit-reversed LDE matrices), so each
     // class's codeword is un-reversed before combining; the combined result is then already
     // in the natural order STIR expects, with no further reversal needed.
-    let natural_ros: Vec<Vec<Challenge>> = classes
+    let mut natural_ros: Vec<Vec<Challenge>> = log_ds
         .iter()
-        .map(|&(_, ro)| {
-            let mut natural = ro.clone();
+        .map(|&log_d| {
+            let mut natural = reduced_openings
+                .remove(&(log_shared_h, log_d))
+                .expect("key came from this map");
             reverse_slice_index_bits(&mut natural);
             natural
         })
         .collect();
+
+    if natural_ros.len() == 1 {
+        return natural_ros.pop().expect("checked non-empty above");
+    }
+
+    let log_d_star = log_ds[0];
+    let r_comb: Challenge = challenger.sample_algebra_element();
+    let coeffs = combine_coefficients(r_comb, log_d_star, log_ds.iter().copied());
+
     let groups: Vec<(Challenge, usize, &[Challenge])> = coeffs
         .into_iter()
         .zip(&natural_ros)
@@ -1194,4 +1278,49 @@ fn compute_inverse_denominators<'a, F: TwoAdicField, EF: ExtensionField<F>>(
             (z, inv_diffs)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+
+    use super::*;
+
+    type EF = BinomialExtensionField<BabyBear, 4>;
+
+    #[test]
+    fn combine_coefficients_matches_definition_4_11() {
+        // Definition 4.11 fixes `r_1 = 1` and `r_i = r^{(i-1) + Σ_{j<i}(d* - d_j)}`. Pinning
+        // the exponents to that closed form rather than to the running-sum recurrence itself
+        // is what keeps the two from drifting together: a wrong `r_i` still produces a
+        // low-degree combined codeword, so prover and verifier would agree on a
+        // miscomputation and STIR would accept it.
+        //
+        // The exponents are what make class `i` occupy the consecutive power block
+        // `[e_i, e_i + gap_i]`, with the blocks tiling `[0, ell - 1]` without overlap. For
+        // `d_i = [8, 4, 2]` and `d* = 8` the gaps are `[0, 4, 6]`, so the blocks are
+        // `[0,0] | [1,5] | [6,12]` — exponents `[0, 1, 6]` and `ell = 13`.
+        let r_comb = EF::from_u64(3);
+        let coeffs = combine_coefficients(r_comb, 3, [3usize, 2, 1].into_iter());
+
+        assert_eq!(
+            coeffs,
+            vec![(EF::ONE, 0), (r_comb.exp_u64(1), 4), (r_comb.exp_u64(6), 6),]
+        );
+
+        // The blocks tile exactly `Σᵢ (gapᵢ + 1)`, which is the `ell` the config's Combine
+        // soundness accounting is charged at.
+        let ell: usize = coeffs.iter().map(|&(_, gap)| gap + 1).sum();
+        assert_eq!(ell, 13);
+    }
+
+    #[test]
+    #[should_panic(expected = "classes must be sorted descending")]
+    fn combine_coefficients_rejects_a_class_above_d_star() {
+        // `d_i > d*` would wrap the `d* - d_i` subtraction in release and yield a wrong
+        // codeword rather than a failure, so the precondition is checked rather than assumed.
+        let _ = combine_coefficients(EF::from_u64(3), 3, [3usize, 4].into_iter());
+    }
 }

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -494,36 +494,47 @@ impl StirSoundness for SecurityAssumption {
 /// sound if it covers at least as far as STIR's own round-0 acceptance radius, and sharing
 /// the variable makes that automatic rather than a separate value to keep in sync.
 ///
-/// - `CapacityBound`: Conjecture 5.6's `err*(d*, rho, delta, m) = (m-1)*d* / (eta*rho^2*|F|)`
-///   (`c1=c2=1`), taken directly at the *raw* class count `m := num_classes` — Conjecture 5.6
-///   is stated for `Combine` itself, not derived via Theorem 4.1's random-linear-combination
-///   reduction, so it does not inflate `m` into `ell` the way the provable route does.
+/// Both arms charge Lemma 7.3's round-by-round soundness of Construction 7.2 at the
+/// degree-gap-inflated multiplicity `ell`, not the raw class count: `err*` is the §4.1
+/// abstraction the lemma invokes regardless of which regime bounds it, so the conjectured
+/// route (Conjecture 5.6, `CapacityBound`) inflates by `ell` exactly like the provable one
+/// (Theorem 4.1, `JohnsonBound`).
+/// - `CapacityBound`: `err*(d*, rho, delta, ell) = (ell-1)*d* / (eta*rho^2*|F|)` (`c1=c2=1`).
+///   Lemma 7.3 also requires `delta < 1 - rho - 1/|L_0|`, which under `delta = 1 - rho - eta`
+///   needs `eta >= 2/|L_0|` — the same margin `stir_recursive_eta`'s `CapacityBound` arm
+///   keeps for later rounds.
 /// - `JohnsonBound`: Theorem 4.1's "far"-case `err*(d*, rho, delta, ell) = (ell-1)*d*^2 /
 ///   (|F|*(2*eta)^7)` (Lemma 4.13's own route, valid only up to `delta < 1 - sqrt(rho)`, so
-///   `eta` must additionally stay `<= sqrt(rho)/20` — `stir_eta_upper_bound` already enforces
-///   this once the returned value is `.max()`-folded into `stir_initial_eta`).
+///   `eta` must additionally stay `<= sqrt(rho)/20` — `stir_eta_upper_bound` enforces this
+///   once the returned value is `.max()`-folded into `stir_initial_eta`, checked by
+///   `validate_eta` in `StirConfig::new`). This regime satisfies the `1/|L_0|` side
+///   condition automatically.
 ///
 /// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ the untouched,
-/// i.e. not further quotiented, degree bound of each class's reduced-opening); only used by
-/// the `JohnsonBound` branch.
+/// i.e. not further quotiented, degree bound of each class's reduced-opening).
 pub(crate) fn combine_min_log_eta(
     assumption: SecurityAssumption,
     field_size_bits: usize,
     log_inv_rate: usize,
     log_d_star: usize,
-    num_classes: usize,
     ell: u64,
     target_bits: usize,
 ) -> f64 {
     match assumption {
         SecurityAssumption::CapacityBound => {
-            // bits = field_bits + log2(eta) + 2*log2(rho) - log2(m-1) - log_d_star
-            //      = field_bits + log2(eta) - 2*log_inv_rate - log2(m-1) - log_d_star
-            target_bits as f64
-                + 2. * log_inv_rate as f64
-                + libm::log2((num_classes - 1) as f64)
-                + log_d_star as f64
-                - field_size_bits as f64
+            // bits = field_bits + log2(eta) + 2*log2(rho) - log2(ell-1) - log_d_star
+            //      = field_bits + log2(eta) - 2*log_inv_rate - log2(ell-1) - log_d_star
+            let log_ell_minus_1 = libm::log2((ell.saturating_sub(1)).max(1) as f64);
+            let log_eta_conjecture =
+                target_bits as f64 + 2. * log_inv_rate as f64 + log_ell_minus_1 + log_d_star as f64
+                    - field_size_bits as f64;
+
+            // Lemma 7.3's delta < 1 - rho - 1/|L_0| side condition, restated as a floor on
+            // eta (|L_0| = 2^(log_d_star + log_inv_rate), round 0's domain size).
+            let log_domain_size = (log_d_star + log_inv_rate) as f64;
+            let log_eta_side_condition = 1. - log_domain_size;
+
+            log_eta_conjecture.max(log_eta_side_condition)
         }
         SecurityAssumption::JohnsonBound => {
             // bits = field_bits + 7*(1 + log2(eta)) - log2(ell-1) - 2*log_d_star
@@ -561,26 +572,26 @@ mod tests {
 
     #[test]
     fn combine_min_log_eta_capacity_bound_matches_closed_form() {
-        // bits(eta) = field_bits + log2(eta) - 2*log_inv_rate - log2(m-1) - log_d_star, so
-        // the minimum log2(eta) for a target is exactly solving that for log2(eta).
+        // bits(eta) = field_bits + log2(eta) - 2*log_inv_rate - log2(ell-1) - log_d_star, so
+        // the minimum log2(eta) for a target is exactly solving that for log2(eta). Chosen so
+        // the Lemma 7.3 side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)) does not bind.
         let field_bits = 155;
         let log_inv_rate = 1;
         let log_d_star = 20;
-        let num_classes = 3;
+        let ell = 1 << 20;
         let target_bits = 100;
         let log_eta = combine_min_log_eta(
             SecurityAssumption::CapacityBound,
             field_bits,
             log_inv_rate,
             log_d_star,
-            num_classes,
-            0,
+            ell,
             target_bits,
         );
         let bits = target_bits as f64
             - (field_bits as f64 + log_eta
                 - 2. * log_inv_rate as f64
-                - libm::log2((num_classes - 1) as f64)
+                - libm::log2((ell - 1) as f64)
                 - log_d_star as f64);
         assert!(
             libm::fabs(bits) < 1e-9,
@@ -589,41 +600,28 @@ mod tests {
     }
 
     #[test]
-    fn combine_min_log_eta_capacity_bound_relaxes_with_fewer_classes() {
-        // Fewer classes (smaller m) need a smaller (more negative) minimum log2(eta).
-        let three = combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 3, 0, 100);
-        let two = combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 2, 0, 100);
-        assert!(two < three);
+    fn combine_min_log_eta_capacity_bound_relaxes_with_smaller_ell() {
+        // A smaller ell needs a smaller (more negative) minimum log2(eta). Both values stay
+        // clear of the Lemma 7.3 side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)).
+        let larger =
+            combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 1 << 20, 100);
+        let smaller =
+            combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 1 << 19, 100);
+        assert!(smaller < larger);
     }
 
     #[test]
-    fn combine_min_log_eta_johnson_bound_decreases_with_more_groups() {
+    fn combine_min_log_eta_johnson_bound_increases_with_more_groups() {
         // A larger ell (more/taller classes) demands a larger minimum eta.
-        let fewer = combine_min_log_eta(
-            SecurityAssumption::JohnsonBound,
-            192,
-            1,
-            20,
-            0,
-            1 << 21,
-            100,
-        );
-        let more = combine_min_log_eta(
-            SecurityAssumption::JohnsonBound,
-            192,
-            1,
-            20,
-            0,
-            1 << 22,
-            100,
-        );
+        let fewer = combine_min_log_eta(SecurityAssumption::JohnsonBound, 192, 1, 20, 1 << 21, 100);
+        let more = combine_min_log_eta(SecurityAssumption::JohnsonBound, 192, 1, 20, 1 << 22, 100);
         assert!(more > fewer);
     }
 
     #[test]
     #[should_panic(expected = "does not support UniqueDecoding")]
     fn combine_min_log_eta_rejects_unique_decoding() {
-        combine_min_log_eta(SecurityAssumption::UniqueDecoding, 192, 1, 20, 3, 4, 100);
+        combine_min_log_eta(SecurityAssumption::UniqueDecoding, 192, 1, 20, 4, 100);
     }
 
     #[test]

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -34,6 +34,15 @@ pub(crate) trait StirSoundness {
         prev_queries: usize,
     ) -> f64;
 
+    fn stir_combine_eta(
+        &self,
+        field_size_bits: usize,
+        log_inv_rate: usize,
+        log_d_star: usize,
+        ell: u64,
+        target_bits: usize,
+    ) -> f64;
+
     fn stir_queries_for_base(&self, security_bits: usize, failure_base: f64) -> usize;
 
     fn fold_algebraic_bits_at_log_eta(
@@ -136,6 +145,35 @@ fn list_size_bits_at_log_eta(
     }
 }
 
+/// Log2 of the exceptional set a proximity-gaps argument charges over a degree-`2^log_degree`
+/// code at rate `2^-log_inv_rate`, evaluated at distance `delta = 1 - B*(rho) - eta`.
+///
+/// Every proximity-gaps-shaped error in this file is this quantity plus `log2(multiplicity - 1)`
+/// subtracted from the field size. Both batching arguments STIR runs — the random linear
+/// combination of `num_functions` oracles, and §7's `ell`-fold batch degree correction — differ
+/// only in that multiplicity, so they share one bound per regime instead of each deriving its
+/// own.
+fn prox_gaps_exceptional_set_bits_at_log_eta(
+    assumption: SecurityAssumption,
+    log_degree: usize,
+    log_inv_rate: usize,
+    log_eta: f64,
+) -> f64 {
+    match assumption {
+        SecurityAssumption::UniqueDecoding => (log_degree + log_inv_rate) as f64,
+        SecurityAssumption::JohnsonBound => {
+            // BCSS25 Theorem 1.5, dominant term, at the protocol's actual eta:
+            // m = max(ceil(sqrt(rho) / (2 eta)), 3).
+            let log_sqrt_rho_over_2eta = -(log_inv_rate as f64) / 2. - 1. - log_eta;
+            let m = libm::ceil(libm::pow(2., log_sqrt_rho_over_2eta)).max(3.);
+            let log_n = (log_degree + log_inv_rate) as f64;
+            let constant = libm::log2(2. * libm::pow(m + 0.5, 5.) / 3.);
+            log_n + constant + 1.5 * log_inv_rate as f64
+        }
+        SecurityAssumption::CapacityBound => (log_degree + 2 * log_inv_rate) as f64 - log_eta,
+    }
+}
+
 fn prox_gaps_error_at_log_eta(
     assumption: SecurityAssumption,
     log_degree: usize,
@@ -149,21 +187,34 @@ fn prox_gaps_error_at_log_eta(
         "num_functions must be >= 2 to compute proximity gaps error"
     );
 
-    let exceptional_set_bits = match assumption {
-        SecurityAssumption::UniqueDecoding => (log_degree + log_inv_rate) as f64,
-        SecurityAssumption::JohnsonBound => {
-            // BCSS25 Theorem 1.5, dominant term, at the protocol's actual eta:
-            // m = max(ceil(sqrt(rho) / (2 eta)), 3).
-            let log_sqrt_rho_over_2eta = -(log_inv_rate as f64) / 2. - 1. - log_eta;
-            let m = libm::ceil(libm::pow(2., log_sqrt_rho_over_2eta)).max(3.);
-            let log_n = (log_degree + log_inv_rate) as f64;
-            let constant = libm::log2(2. * libm::pow(m + 0.5, 5.) / 3.);
-            log_n + constant + 1.5 * log_inv_rate as f64
-        }
-        SecurityAssumption::CapacityBound => (log_degree + 2 * log_inv_rate) as f64 - log_eta,
-    };
+    let exceptional_set_bits =
+        prox_gaps_exceptional_set_bits_at_log_eta(assumption, log_degree, log_inv_rate, log_eta);
 
     field_size_bits as f64 - (exceptional_set_bits + libm::log2(num_functions as f64 - 1.))
+}
+
+/// Algebraic bits §7 Construction 7.2's batch degree correction retains merging classes of total
+/// multiplicity `ell` into a single codeword of degree `2^log_d_star`, at `delta = 1 - B*(rho) -
+/// eta`.
+///
+/// This is [`prox_gaps_error_at_log_eta`] with the linear combination's `num_functions - 1`
+/// replaced by Lemma 4.13's degree-gap-inflated `ell - 1`: `err*` is the §4.1 abstraction both
+/// lemmas invoke, so the conjectured route (Conjecture 5.6, `CapacityBound`) and the provable one
+/// (BCSS25 Theorem 1.5, `JohnsonBound`) each inflate by `ell` exactly as they do by the oracle
+/// count.
+fn combine_error_at_log_eta(
+    assumption: SecurityAssumption,
+    log_d_star: usize,
+    log_inv_rate: usize,
+    field_size_bits: usize,
+    ell: u64,
+    log_eta: f64,
+) -> f64 {
+    let exceptional_set_bits =
+        prox_gaps_exceptional_set_bits_at_log_eta(assumption, log_d_star, log_inv_rate, log_eta);
+
+    field_size_bits as f64
+        - (exceptional_set_bits + libm::log2(ell.saturating_sub(1).max(1) as f64))
 }
 
 fn ood_error_at_log_eta(
@@ -398,6 +449,73 @@ impl StirSoundness for SecurityAssumption {
         schedule_eta.max(fold_eta).max(ood_eta)
     }
 
+    /// Smallest `eta` at which §7 Construction 7.2's batch degree correction ("Combine")
+    /// retains `target_bits` merging classes of total multiplicity `ell` into a single
+    /// codeword of degree `2^log_d_star`.
+    ///
+    /// Returning `eta` rather than a bound on it lets `StirConfig` fold this into the
+    /// schedule's round-0 `eta` with a plain `.max()`. Sharing that one variable is what pins
+    /// `delta_combine` to exactly the schedule's own `delta_0`: Combine's guarantee ("if the
+    /// merged codeword passes, each class has correlated agreement") is sound only if it
+    /// reaches at least as far as STIR's round-0 acceptance radius, and one variable makes
+    /// that automatic rather than a second value to keep in sync.
+    ///
+    /// Combine runs once, before the query phase's grind, so it is not PoW-eligible and
+    /// `target_bits` must be the full buffered target, as for OOD and the shake check.
+    ///
+    /// `CapacityBound` additionally carries Lemma 7.3's `delta < 1 - rho - 1/|L_0|` side
+    /// condition, which under `delta = 1 - rho - eta` is the floor `eta >= 2/|L_0|` — the same
+    /// margin `stir_recursive_eta`'s `CapacityBound` arm keeps for later rounds.
+    ///
+    /// # Feasibility
+    ///
+    /// `ell = Σᵢ (gapᵢ + 1)` with distinct power-of-two `dᵢ`, so every `gapᵢ` is within a
+    /// factor of two of `d*` and `log2(ell)` is close to `log_d_star` however tight the height
+    /// spread is. Combine therefore costs roughly `2·log_d_star` bits of field regardless of
+    /// how the classes are chosen, and is feasible only on wide challenge fields — see
+    /// [`crate::StirParameters`] for the closed form. Under `JohnsonBound` it does not fit at
+    /// production scale at all: the largest permitted `eta = sqrt(rho)/20` pins BCSS25's
+    /// multiplicity at `m = 10`, which at `log_d_star = 20`, `log_inv_rate = 1` and a 155-bit
+    /// challenge field retains only ~95 bits.
+    ///
+    /// # Panics
+    ///
+    /// If no permitted `eta` reaches `target_bits`.
+    fn stir_combine_eta(
+        &self,
+        field_size_bits: usize,
+        log_inv_rate: usize,
+        log_d_star: usize,
+        ell: u64,
+        target_bits: usize,
+    ) -> f64 {
+        let eta = minimum_eta_for_target(
+            self.stir_eta_upper_bound(log_inv_rate),
+            target_bits,
+            |eta| {
+                combine_error_at_log_eta(
+                    *self,
+                    log_d_star,
+                    log_inv_rate,
+                    field_size_bits,
+                    ell,
+                    libm::log2(eta),
+                )
+            },
+            "Combine batch-degree-correction bound",
+        );
+
+        match self {
+            // `2/|L_0|` with `|L_0| = 2^(log_d_star + log_inv_rate)`, round 0's domain size.
+            Self::CapacityBound => eta.max(libm::pow(2., 1. - (log_d_star + log_inv_rate) as f64)),
+            // The Johnson regime satisfies the `1/|L_0|` side condition automatically.
+            Self::JohnsonBound => eta,
+            Self::UniqueDecoding => {
+                panic!("STIR's paper-backed parameter schedule does not support UniqueDecoding")
+            }
+        }
+    }
+
     fn stir_queries_for_base(&self, security_bits: usize, failure_base: f64) -> usize {
         let _ = self;
         query_count_from_failure_base(security_bits, failure_base)
@@ -483,72 +601,6 @@ impl StirSoundness for SecurityAssumption {
     }
 }
 
-/// Minimum `log2(eta)` the batch-degree-correction "Combine" step (§4.5) needs merging
-/// `num_classes` height classes into a single codeword of degree `2^log_d_star` to reach
-/// `target_bits` of algebraic security, at distance `delta := 1 - B*(rho) - eta` (`B*` per
-/// the assumption: `sqrt(rho)` for `JohnsonBound`, `rho` for `CapacityBound`).
-///
-/// Using `eta` here — the *same* variable `stir_initial_eta` folds this into via `.max()` —
-/// is what pins `delta_combine` to exactly the schedule's own round-0 `delta_0`: Combine's
-/// guarantee ("if the merged codeword passes, each class has correlated agreement") is only
-/// sound if it covers at least as far as STIR's own round-0 acceptance radius, and sharing
-/// the variable makes that automatic rather than a separate value to keep in sync.
-///
-/// Both arms charge Lemma 7.3's round-by-round soundness of Construction 7.2 at the
-/// degree-gap-inflated multiplicity `ell`, not the raw class count: `err*` is the §4.1
-/// abstraction the lemma invokes regardless of which regime bounds it, so the conjectured
-/// route (Conjecture 5.6, `CapacityBound`) inflates by `ell` exactly like the provable one
-/// (Theorem 4.1, `JohnsonBound`).
-/// - `CapacityBound`: `err*(d*, rho, delta, ell) = (ell-1)*d* / (eta*rho^2*|F|)` (`c1=c2=1`).
-///   Lemma 7.3 also requires `delta < 1 - rho - 1/|L_0|`, which under `delta = 1 - rho - eta`
-///   needs `eta >= 2/|L_0|` — the same margin `stir_recursive_eta`'s `CapacityBound` arm
-///   keeps for later rounds.
-/// - `JohnsonBound`: Theorem 4.1's "far"-case `err*(d*, rho, delta, ell) = (ell-1)*d*^2 /
-///   (|F|*(2*eta)^7)` (Lemma 4.13's own route, valid only up to `delta < 1 - sqrt(rho)`, so
-///   `eta` must additionally stay `<= sqrt(rho)/20` — `stir_eta_upper_bound` enforces this
-///   once the returned value is `.max()`-folded into `stir_initial_eta`, checked by
-///   `validate_eta` in `StirConfig::new`). This regime satisfies the `1/|L_0|` side
-///   condition automatically.
-///
-/// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ the untouched,
-/// i.e. not further quotiented, degree bound of each class's reduced-opening).
-pub(crate) fn combine_min_log_eta(
-    assumption: SecurityAssumption,
-    field_size_bits: usize,
-    log_inv_rate: usize,
-    log_d_star: usize,
-    ell: u64,
-    target_bits: usize,
-) -> f64 {
-    match assumption {
-        SecurityAssumption::CapacityBound => {
-            // bits = field_bits + log2(eta) + 2*log2(rho) - log2(ell-1) - log_d_star
-            //      = field_bits + log2(eta) - 2*log_inv_rate - log2(ell-1) - log_d_star
-            let log_ell_minus_1 = libm::log2((ell.saturating_sub(1)).max(1) as f64);
-            let log_eta_conjecture =
-                target_bits as f64 + 2. * log_inv_rate as f64 + log_ell_minus_1 + log_d_star as f64
-                    - field_size_bits as f64;
-
-            // Lemma 7.3's delta < 1 - rho - 1/|L_0| side condition, restated as a floor on
-            // eta (|L_0| = 2^(log_d_star + log_inv_rate), round 0's domain size).
-            let log_domain_size = (log_d_star + log_inv_rate) as f64;
-            let log_eta_side_condition = 1. - log_domain_size;
-
-            log_eta_conjecture.max(log_eta_side_condition)
-        }
-        SecurityAssumption::JohnsonBound => {
-            // bits = field_bits + 7*(1 + log2(eta)) - log2(ell-1) - 2*log_d_star
-            let log_ell_minus_1 = libm::log2((ell.saturating_sub(1)).max(1) as f64);
-            (target_bits as f64 - field_size_bits as f64 + log_ell_minus_1 + 2. * log_d_star as f64)
-                / 7.
-                - 1.
-        }
-        SecurityAssumption::UniqueDecoding => {
-            panic!("STIR's paper-backed parameter schedule does not support UniqueDecoding")
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -571,23 +623,63 @@ mod tests {
     }
 
     #[test]
-    fn combine_min_log_eta_capacity_bound_matches_closed_form() {
+    fn combine_error_matches_prox_gaps_error_at_matching_multiplicity() {
+        // Combine charges the same exceptional set as the linear-combination proximity-gaps
+        // argument, with `num_functions - 1` replaced by `ell - 1`. At `ell = num_functions`
+        // the two must therefore agree exactly, in both regimes — this is what keeps the file
+        // from deriving eta off two different Johnson-regime bounds.
+        for assumption in [
+            SecurityAssumption::JohnsonBound,
+            SecurityAssumption::CapacityBound,
+        ] {
+            for log_inv_rate in [1, 2, 4] {
+                for log_d_star in [10, 20, 24] {
+                    for num_functions in [2usize, 3, 17, 1024] {
+                        for log_eta in [-4.822, -8., -13.5] {
+                            assert_eq!(
+                                combine_error_at_log_eta(
+                                    assumption,
+                                    log_d_star,
+                                    log_inv_rate,
+                                    155,
+                                    num_functions as u64,
+                                    log_eta,
+                                ),
+                                prox_gaps_error_at_log_eta(
+                                    assumption,
+                                    log_d_star,
+                                    log_inv_rate,
+                                    155,
+                                    num_functions,
+                                    log_eta,
+                                ),
+                                "{assumption:?} lir={log_inv_rate} d*={log_d_star} \
+                                 nf={num_functions} log_eta={log_eta}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn combine_eta_capacity_bound_matches_closed_form() {
         // bits(eta) = field_bits + log2(eta) - 2*log_inv_rate - log2(ell-1) - log_d_star, so
-        // the minimum log2(eta) for a target is exactly solving that for log2(eta). Chosen so
-        // the Lemma 7.3 side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)) does not bind.
+        // the minimum eta for a target is exactly solving that for log2(eta). Chosen so the
+        // Lemma 7.3 side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)) does not bind.
         let field_bits = 155;
         let log_inv_rate = 1;
         let log_d_star = 20;
         let ell = 1 << 20;
         let target_bits = 100;
-        let log_eta = combine_min_log_eta(
-            SecurityAssumption::CapacityBound,
+        let log_eta = libm::log2(SecurityAssumption::CapacityBound.stir_combine_eta(
             field_bits,
             log_inv_rate,
             log_d_star,
             ell,
             target_bits,
-        );
+        ));
         let bits = target_bits as f64
             - (field_bits as f64 + log_eta
                 - 2. * log_inv_rate as f64
@@ -600,28 +692,54 @@ mod tests {
     }
 
     #[test]
-    fn combine_min_log_eta_capacity_bound_relaxes_with_smaller_ell() {
-        // A smaller ell needs a smaller (more negative) minimum log2(eta). Both values stay
-        // clear of the Lemma 7.3 side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)).
-        let larger =
-            combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 1 << 20, 100);
-        let smaller =
-            combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 1 << 19, 100);
+    fn combine_eta_capacity_bound_relaxes_with_smaller_ell() {
+        // A smaller ell needs a smaller minimum eta. Both values stay clear of the Lemma 7.3
+        // side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)).
+        let cb = SecurityAssumption::CapacityBound;
+        let larger = cb.stir_combine_eta(155, 1, 20, 1 << 20, 100);
+        let smaller = cb.stir_combine_eta(155, 1, 20, 1 << 19, 100);
         assert!(smaller < larger);
     }
 
     #[test]
-    fn combine_min_log_eta_johnson_bound_increases_with_more_groups() {
+    fn combine_eta_capacity_bound_respects_side_condition_floor() {
+        // At a tiny ell the conjectured term is far below the target's reach, so what binds is
+        // Lemma 7.3's `delta < 1 - rho - 1/|L_0|` floor, `eta >= 2^(1 - (log_d_star + lir))`.
+        let cb = SecurityAssumption::CapacityBound;
+        let (log_d_star, log_inv_rate) = (20, 1);
+        let eta = cb.stir_combine_eta(155, log_inv_rate, log_d_star, 2, 100);
+        assert_eq!(eta, libm::pow(2., 1. - (log_d_star + log_inv_rate) as f64));
+    }
+
+    #[test]
+    fn combine_eta_johnson_bound_increases_with_more_groups() {
         // A larger ell (more/taller classes) demands a larger minimum eta.
-        let fewer = combine_min_log_eta(SecurityAssumption::JohnsonBound, 192, 1, 20, 1 << 21, 100);
-        let more = combine_min_log_eta(SecurityAssumption::JohnsonBound, 192, 1, 20, 1 << 22, 100);
+        let jb = SecurityAssumption::JohnsonBound;
+        let fewer = jb.stir_combine_eta(192, 1, 20, 1 << 21, 100);
+        let more = jb.stir_combine_eta(192, 1, 20, 1 << 22, 100);
         assert!(more > fewer);
     }
 
     #[test]
+    fn combine_eta_johnson_bound_is_infeasible_at_production_scale() {
+        // Documented consequence of deriving Combine from the same BCSS25 bound the rest of
+        // the file validates against: at `d* = 2^20` on a 155-bit challenge field, the largest
+        // permitted eta pins `m = 10` and retains well under the buffered 100-bit target.
+        let jb = SecurityAssumption::JohnsonBound;
+        let (log_inv_rate, log_d_star, ell) = (1, 20, (1u64 << 20) + (1 << 19) + 3);
+        let upper = jb.stir_eta_upper_bound(log_inv_rate);
+        let bits =
+            combine_error_at_log_eta(jb, log_d_star, log_inv_rate, 155, ell, libm::log2(upper));
+        assert!(
+            bits < 100.,
+            "expected JB + Combine to fall short, got {bits}"
+        );
+    }
+
+    #[test]
     #[should_panic(expected = "does not support UniqueDecoding")]
-    fn combine_min_log_eta_rejects_unique_decoding() {
-        combine_min_log_eta(SecurityAssumption::UniqueDecoding, 192, 1, 20, 4, 100);
+    fn combine_eta_rejects_unique_decoding() {
+        SecurityAssumption::UniqueDecoding.stir_combine_eta(192, 1, 20, 4, 100);
     }
 
     #[test]

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -483,6 +483,61 @@ impl StirSoundness for SecurityAssumption {
     }
 }
 
+/// Minimum `log2(eta)` the batch-degree-correction "Combine" step (§4.5) needs merging
+/// `num_classes` height classes into a single codeword of degree `2^log_d_star` to reach
+/// `target_bits` of algebraic security, at distance `delta := 1 - B*(rho) - eta` (`B*` per
+/// the assumption: `sqrt(rho)` for `JohnsonBound`, `rho` for `CapacityBound`).
+///
+/// Using `eta` here — the *same* variable `stir_initial_eta` folds this into via `.max()` —
+/// is what pins `delta_combine` to exactly the schedule's own round-0 `delta_0`: Combine's
+/// guarantee ("if the merged codeword passes, each class has correlated agreement") is only
+/// sound if it covers at least as far as STIR's own round-0 acceptance radius, and sharing
+/// the variable makes that automatic rather than a separate value to keep in sync.
+///
+/// - `CapacityBound`: Conjecture 5.6's `err*(d*, rho, delta, m) = (m-1)*d* / (eta*rho^2*|F|)`
+///   (`c1=c2=1`), taken directly at the *raw* class count `m := num_classes` — Conjecture 5.6
+///   is stated for `Combine` itself, not derived via Theorem 4.1's random-linear-combination
+///   reduction, so it does not inflate `m` into `ell` the way the provable route does.
+/// - `JohnsonBound`: Theorem 4.1's "far"-case `err*(d*, rho, delta, ell) = (ell-1)*d*^2 /
+///   (|F|*(2*eta)^7)` (Lemma 4.13's own route, valid only up to `delta < 1 - sqrt(rho)`, so
+///   `eta` must additionally stay `<= sqrt(rho)/20` — `stir_eta_upper_bound` already enforces
+///   this once the returned value is `.max()`-folded into `stir_initial_eta`).
+///
+/// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ the untouched,
+/// i.e. not further quotiented, degree bound of each class's reduced-opening); only used by
+/// the `JohnsonBound` branch.
+pub(crate) fn combine_min_log_eta(
+    assumption: SecurityAssumption,
+    field_size_bits: usize,
+    log_inv_rate: usize,
+    log_d_star: usize,
+    num_classes: usize,
+    ell: u64,
+    target_bits: usize,
+) -> f64 {
+    match assumption {
+        SecurityAssumption::CapacityBound => {
+            // bits = field_bits + log2(eta) + 2*log2(rho) - log2(m-1) - log_d_star
+            //      = field_bits + log2(eta) - 2*log_inv_rate - log2(m-1) - log_d_star
+            target_bits as f64
+                + 2. * log_inv_rate as f64
+                + libm::log2((num_classes - 1) as f64)
+                + log_d_star as f64
+                - field_size_bits as f64
+        }
+        SecurityAssumption::JohnsonBound => {
+            // bits = field_bits + 7*(1 + log2(eta)) - log2(ell-1) - 2*log_d_star
+            let log_ell_minus_1 = libm::log2((ell.saturating_sub(1)).max(1) as f64);
+            (target_bits as f64 - field_size_bits as f64 + log_ell_minus_1 + 2. * log_d_star as f64)
+                / 7.
+                - 1.
+        }
+        SecurityAssumption::UniqueDecoding => {
+            panic!("STIR's paper-backed parameter schedule does not support UniqueDecoding")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -502,6 +557,73 @@ mod tests {
                 ood_error_at_log_eta(jb, 20, 2, field_bits, 1, libm::log2(eta)) >= target as f64
             );
         }
+    }
+
+    #[test]
+    fn combine_min_log_eta_capacity_bound_matches_closed_form() {
+        // bits(eta) = field_bits + log2(eta) - 2*log_inv_rate - log2(m-1) - log_d_star, so
+        // the minimum log2(eta) for a target is exactly solving that for log2(eta).
+        let field_bits = 155;
+        let log_inv_rate = 1;
+        let log_d_star = 20;
+        let num_classes = 3;
+        let target_bits = 100;
+        let log_eta = combine_min_log_eta(
+            SecurityAssumption::CapacityBound,
+            field_bits,
+            log_inv_rate,
+            log_d_star,
+            num_classes,
+            0,
+            target_bits,
+        );
+        let bits = target_bits as f64
+            - (field_bits as f64 + log_eta
+                - 2. * log_inv_rate as f64
+                - libm::log2((num_classes - 1) as f64)
+                - log_d_star as f64);
+        assert!(
+            libm::fabs(bits) < 1e-9,
+            "closed form does not round-trip: {bits}"
+        );
+    }
+
+    #[test]
+    fn combine_min_log_eta_capacity_bound_relaxes_with_fewer_classes() {
+        // Fewer classes (smaller m) need a smaller (more negative) minimum log2(eta).
+        let three = combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 3, 0, 100);
+        let two = combine_min_log_eta(SecurityAssumption::CapacityBound, 155, 1, 20, 2, 0, 100);
+        assert!(two < three);
+    }
+
+    #[test]
+    fn combine_min_log_eta_johnson_bound_decreases_with_more_groups() {
+        // A larger ell (more/taller classes) demands a larger minimum eta.
+        let fewer = combine_min_log_eta(
+            SecurityAssumption::JohnsonBound,
+            192,
+            1,
+            20,
+            0,
+            1 << 21,
+            100,
+        );
+        let more = combine_min_log_eta(
+            SecurityAssumption::JohnsonBound,
+            192,
+            1,
+            20,
+            0,
+            1 << 22,
+            100,
+        );
+        assert!(more > fewer);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support UniqueDecoding")]
+    fn combine_min_log_eta_rejects_unique_decoding() {
+        combine_min_log_eta(SecurityAssumption::UniqueDecoding, 192, 1, 20, 3, 4, 100);
     }
 
     #[test]

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -109,6 +109,74 @@ pub fn eval_degree_correction<F: Field>(value: F, point: F, r_comb: F, gap: usiz
     value * geom
 }
 
+/// Evaluate the batch-degree-correction `Combine` (§4.5, Definition 4.11) at every point of
+/// the coset `shift · ⟨g⟩` of size `2^log_domain`:
+/// `Combine(x) = Σᵢ rᵢ · fᵢ(x) · GeomSum(r_comb·x, gapᵢ)`.
+///
+/// `groups[i] = (r_i, gap_i, values_i)`: `r_i` is Definition 4.11's own per-group shifting
+/// coefficient (distinct from `r_comb`, the random point the geometric sum runs in), `gap_i =
+/// d* − dᵢ` is a degree count (not log), and `values_i[p]` is group `i`'s reduced-opening
+/// evaluated at `shift · g^p`, `p` in the same natural order as the returned codeword.
+///
+/// The geometric sum's numerator and denominator both advance by a fixed ratio (a power of
+/// `g`) across the coset, so each is seeded once per `POWER_CHUNK`-sized chunk (one
+/// exponentiation) instead of once per point — mirroring the degree-correction sweep in
+/// `RoundProver::finish`. The shared `(1 − r_comb·x)` denominators are inverted in one batch.
+pub fn combine_on_coset<F, EF>(
+    groups: &[(EF, usize, &[EF])],
+    r_comb: EF,
+    shift: F,
+    log_domain: usize,
+) -> Vec<EF>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+{
+    let n = 1usize << log_domain;
+    let g = F::two_adic_generator(log_domain);
+    let step_start = r_comb * EF::from(shift);
+
+    const POWER_CHUNK: usize = 1 << 12;
+    let mut result = EF::zero_vec(n);
+
+    for &(r_i, gap, values) in groups {
+        assert_eq!(values.len(), n, "group values must span the full coset");
+
+        let mut denoms = EF::zero_vec(n);
+        denoms
+            .par_chunks_mut(POWER_CHUNK)
+            .enumerate()
+            .for_each(|(chunk_idx, chunk)| {
+                let mut step = step_start * EF::from(g.exp_u64((chunk_idx * POWER_CHUNK) as u64));
+                for d in chunk.iter_mut() {
+                    *d = EF::ONE - step;
+                    step *= EF::from(g);
+                }
+            });
+        let inv_denoms = batch_multiplicative_inverse(&denoms);
+        drop(denoms);
+
+        let g_hi = g.exp_u64((gap + 1) as u64);
+        let step_start_hi = step_start.exp_u64((gap + 1) as u64);
+        result
+            .par_chunks_mut(POWER_CHUNK)
+            .zip(values.par_chunks(POWER_CHUNK))
+            .zip(inv_denoms.par_chunks(POWER_CHUNK))
+            .enumerate()
+            .for_each(|(chunk_idx, ((res_chunk, val_chunk), inv_chunk))| {
+                let mut step_hi =
+                    step_start_hi * EF::from(g_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64));
+                for ((res, &val), &inv_denom) in res_chunk.iter_mut().zip(val_chunk).zip(inv_chunk)
+                {
+                    let numer = EF::ONE - step_hi;
+                    *res += r_i * val * numer * inv_denom;
+                    step_hi *= EF::from(g_hi);
+                }
+            });
+    }
+    result
+}
+
 /// Horner evaluation of an extension-coefficient polynomial at a **base-field** point.
 ///
 /// Identical to [`eval_poly`] on a lifted point, but each step is an extension-by-base
@@ -578,6 +646,59 @@ mod tests {
     fn test_eval_poly_zero() {
         let poly: Vec<F> = vec![];
         assert_eq!(eval_poly(&poly, F::from_u64(3)), F::ZERO);
+    }
+
+    /// Reference implementation of `combine_on_coset`: `eval_degree_correction` called
+    /// pointwise, with no chunked-power-sweep optimization.
+    fn naive_combine_on_coset(
+        groups: &[(EF, usize, &[EF])],
+        r_comb: EF,
+        shift: F,
+        log_domain: usize,
+    ) -> Vec<EF> {
+        let n = 1usize << log_domain;
+        let g = F::two_adic_generator(log_domain);
+        let mut x = shift;
+        let mut result = vec![EF::ZERO; n];
+        for (p, slot) in result.iter_mut().enumerate() {
+            let point = EF::from(x);
+            for &(r_i, gap, values) in groups {
+                *slot += eval_degree_correction(r_i * values[p], point, r_comb, gap);
+            }
+            x *= g;
+        }
+        result
+    }
+
+    #[test]
+    fn test_combine_on_coset_matches_naive_reference() {
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        let mut rng = SmallRng::seed_from_u64(7);
+        let shift = F::GENERATOR;
+
+        // log_domain=13 (2 chunks at POWER_CHUNK=4096) with 3 groups of varying gaps,
+        // including gap=0 (d*=d_i, the identity-DegCor case) and a large gap.
+        let log_domain = 13usize;
+        let n = 1usize << log_domain;
+        let values_a: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+        let values_b: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+        let values_c: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+        let r_a: EF = rng.random();
+        let r_b: EF = rng.random();
+        let r_c: EF = rng.random();
+        let r_comb: EF = rng.random();
+
+        let groups: Vec<(EF, usize, &[EF])> = vec![
+            (r_a, 0, values_a.as_slice()),
+            (r_b, 917_504, values_b.as_slice()),
+            (r_c, 12, values_c.as_slice()),
+        ];
+
+        let fast = combine_on_coset(&groups, r_comb, shift, log_domain);
+        let naive = naive_combine_on_coset(&groups, r_comb, shift, log_domain);
+        assert_eq!(fast, naive);
     }
 
     #[test]

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -121,7 +121,8 @@ pub fn eval_degree_correction<F: Field>(value: F, point: F, r_comb: F, gap: usiz
 /// The geometric sum's numerator and denominator both advance by a fixed ratio (a power of
 /// `g`) across the coset, so each is seeded once per `POWER_CHUNK`-sized chunk (one
 /// exponentiation) instead of once per point — mirroring the degree-correction sweep in
-/// `RoundProver::finish`. The shared `(1 − r_comb·x)` denominators are inverted in one batch.
+/// `RoundProver::finish`. The `(1 − r_comb·x)` denominators do not depend on the group, so
+/// they are swept and inverted once for all of `groups` rather than once per group.
 pub fn combine_on_coset<F, EF>(
     groups: &[(EF, usize, &[EF])],
     r_comb: EF,
@@ -139,22 +140,32 @@ where
     const POWER_CHUNK: usize = 1 << 12;
     let mut result = EF::zero_vec(n);
 
+    let mut denoms = EF::zero_vec(n);
+    denoms
+        .par_chunks_mut(POWER_CHUNK)
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let mut step = step_start * EF::from(g.exp_u64((chunk_idx * POWER_CHUNK) as u64));
+            for d in chunk.iter_mut() {
+                *d = EF::ONE - step;
+                step *= EF::from(g);
+            }
+        });
+
+    // `p ↦ r_comb·shift·g^p` is injective over the coset, so at most one lane can reach
+    // `step = 1`, where the geometric sum degenerates to `gap + 1` and the denominator
+    // vanishes. Substituting a unit keeps the batch inversion defined and makes that lane's
+    // numerator `1 − step^(gap+1) = 0`, so the sweep below contributes nothing there and the
+    // closed form is added back afterwards — matching `eval_degree_correction` pointwise.
+    let degenerate = denoms.iter().position(|d| d.is_zero());
+    if let Some(p) = degenerate {
+        denoms[p] = EF::ONE;
+    }
+    let inv_denoms = batch_multiplicative_inverse(&denoms);
+    drop(denoms);
+
     for &(r_i, gap, values) in groups {
         assert_eq!(values.len(), n, "group values must span the full coset");
-
-        let mut denoms = EF::zero_vec(n);
-        denoms
-            .par_chunks_mut(POWER_CHUNK)
-            .enumerate()
-            .for_each(|(chunk_idx, chunk)| {
-                let mut step = step_start * EF::from(g.exp_u64((chunk_idx * POWER_CHUNK) as u64));
-                for d in chunk.iter_mut() {
-                    *d = EF::ONE - step;
-                    step *= EF::from(g);
-                }
-            });
-        let inv_denoms = batch_multiplicative_inverse(&denoms);
-        drop(denoms);
 
         let g_hi = g.exp_u64((gap + 1) as u64);
         let step_start_hi = step_start.exp_u64((gap + 1) as u64);
@@ -173,6 +184,10 @@ where
                     step_hi *= EF::from(g_hi);
                 }
             });
+
+        if let Some(p) = degenerate {
+            result[p] += r_i * values[p] * EF::from_usize(gap + 1);
+        }
     }
     result
 }
@@ -636,6 +651,9 @@ mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
 
@@ -672,9 +690,6 @@ mod tests {
 
     #[test]
     fn test_combine_on_coset_matches_naive_reference() {
-        use rand::rngs::SmallRng;
-        use rand::{RngExt, SeedableRng};
-
         let mut rng = SmallRng::seed_from_u64(7);
         let shift = F::GENERATOR;
 
@@ -699,6 +714,79 @@ mod tests {
         let fast = combine_on_coset(&groups, r_comb, shift, log_domain);
         let naive = naive_combine_on_coset(&groups, r_comb, shift, log_domain);
         assert_eq!(fast, naive);
+    }
+
+    #[test]
+    fn test_combine_on_coset_matches_reference_at_degenerate_step() {
+        // `combine_on_coset` and `eval_degree_correction` must agree pointwise, including on
+        // the one lane where `step = r_comb·shift·g^p` can equal 1 and the geometric sum
+        // collapses to `gap + 1`. Reaching it needs `r_comb = (shift·g^p)^{-1}`, which an
+        // honest transcript hits with probability ~n/|F|, so only a constructed input gets
+        // here — and the naive reference alone would never reveal a divergence.
+        let log_domain = 4usize;
+        let n = 1usize << log_domain;
+        let g = F::two_adic_generator(log_domain);
+        let shift = F::GENERATOR;
+
+        let degenerate_p = 3usize;
+        let r_comb = EF::from(shift * g.exp_u64(degenerate_p as u64)).inverse();
+
+        let mut values: Vec<EF> = (0..n).map(|i| EF::from_u64(i as u64)).collect();
+        values[degenerate_p] = EF::from_u64(4);
+        let groups: Vec<(EF, usize, &[EF])> = vec![(EF::ONE, 5, values.as_slice())];
+
+        let fast = combine_on_coset(&groups, r_comb, shift, log_domain);
+        let naive = naive_combine_on_coset(&groups, r_comb, shift, log_domain);
+        assert_eq!(fast, naive);
+        // `value * (gap + 1)` = 4 * 6 at the degenerate lane.
+        assert_eq!(fast[degenerate_p], EF::from_u64(24));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(48))]
+
+        /// `combine_on_coset`'s chunked power sweep must stay in step with the true
+        /// `p`-indexed powers for every coset size and gap, not just the one seed
+        /// `test_combine_on_coset_matches_naive_reference` fixes. A failure here means a
+        /// `POWER_CHUNK` boundary desync or a wrong `g_hi` seed: `log_domain` spans cosets
+        /// below, exactly at, and straddling the chunk size, and `snap_to_period` forces
+        /// `gap + 1 ≡ 0 (mod n)`, where `g_hi` collapses to 1.
+        #[test]
+        fn combine_on_coset_matches_naive_reference_over_shapes(
+            log_domain in 2usize..=14,
+            gap_specs in prop::collection::vec((0usize..(1 << 20), any::<bool>()), 1..=4),
+            seed: u64,
+        ) {
+            let n = 1usize << log_domain;
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let shift = F::GENERATOR;
+            let r_comb: EF = rng.random();
+
+            let values: Vec<Vec<EF>> = gap_specs
+                .iter()
+                .map(|_| (0..n).map(|_| rng.random()).collect())
+                .collect();
+            let coeffs: Vec<EF> = gap_specs.iter().map(|_| rng.random()).collect();
+
+            let groups: Vec<(EF, usize, &[EF])> = gap_specs
+                .iter()
+                .zip(&coeffs)
+                .zip(&values)
+                .map(|((&(raw_gap, snap_to_period), &r_i), vals)| {
+                    let gap = if snap_to_period {
+                        (raw_gap % 32 + 1) * n - 1
+                    } else {
+                        raw_gap
+                    };
+                    (r_i, gap, vals.as_slice())
+                })
+                .collect();
+
+            prop_assert_eq!(
+                combine_on_coset(&groups, r_comb, shift, log_domain),
+                naive_combine_on_coset(&groups, r_comb, shift, log_domain)
+            );
+        }
     }
 
     #[test]

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -976,7 +976,7 @@ mod babybear_pcs {
 
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
+        p_challenger.observe(commit.clone());
 
         let zeta: Challenge = p_challenger.sample_algebra_element();
 
@@ -987,7 +987,7 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_challenger = challenger_template;
-        commit.iter().for_each(|c| v_challenger.observe(c.clone()));
+        v_challenger.observe(commit.clone());
         let v_zeta: Challenge = v_challenger.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1074,7 +1074,7 @@ mod babybear_pcs {
 
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        commit.iter().for_each(|c| p_challenger.observe(c.clone()));
+        p_challenger.observe(commit.clone());
 
         let zeta: Challenge = p_challenger.sample_algebra_element();
 
@@ -1084,7 +1084,7 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_challenger);
 
         let mut v_challenger = challenger_template;
-        commit.iter().for_each(|c| v_challenger.observe(c.clone()));
+        v_challenger.observe(commit.clone());
         let v_zeta: Challenge = v_challenger.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1178,9 +1178,7 @@ mod babybear_pcs {
         let mut stir_p_ch = Challenger::new(perm.clone());
         let (stir_commit, stir_data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&stir_pcs, [(stir_domain, mat)]);
-        stir_commit
-            .iter()
-            .for_each(|c| stir_p_ch.observe(c.clone()));
+        stir_p_ch.observe(stir_commit.clone());
         // STIR's input commitment hashes fiber-grouped leaves, so its root — and hence the
         // point derived from it — differs from FRI's over the same matrix. Proof size does
         // not depend on which point is opened, so the comparison stays like-for-like.
@@ -1192,9 +1190,7 @@ mod babybear_pcs {
         );
 
         let mut stir_v_ch = Challenger::new(perm);
-        stir_commit
-            .iter()
-            .for_each(|c| stir_v_ch.observe(c.clone()));
+        stir_v_ch.observe(stir_commit.clone());
         let stir_v_zeta: Challenge = stir_v_ch.sample_algebra_element();
         assert_eq!(stir_v_zeta, stir_zeta);
         let stir_claims = vec![(
@@ -1284,10 +1280,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_a, mat_a)]);
-        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_a.clone());
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_b, mat_b)]);
-        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_b.clone());
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1298,8 +1294,8 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_ch = challenger_template;
-        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
-        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit_a.clone());
+        v_ch.observe(commit_b.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1339,10 +1335,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_a.clone());
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_b.clone());
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1351,8 +1347,8 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
 
         let mut v_ch = challenger_template;
-        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
-        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit_a.clone());
+        v_ch.observe(commit_b.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1384,10 +1380,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_a.clone());
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_b.clone());
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1403,8 +1399,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
-        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit_a.clone());
+        v_ch.observe(commit_b.clone());
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1439,10 +1435,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        commit_a.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_a.clone());
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        commit_b.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit_b.clone());
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1458,8 +1454,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        commit_a.iter().for_each(|c| v_ch.observe(c.clone()));
-        commit_b.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit_a.clone());
+        v_ch.observe(commit_b.clone());
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1492,7 +1488,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        commit.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit.clone());
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1509,7 +1505,7 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        commit.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1538,7 +1534,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        commit.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit.clone());
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1547,7 +1543,7 @@ mod babybear_pcs {
         );
 
         let mut v_ch = challenger_template;
-        commit.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1578,7 +1574,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        commit.iter().for_each(|c| p_ch.observe(c.clone()));
+        p_ch.observe(commit.clone());
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1592,7 +1588,7 @@ mod babybear_pcs {
         proof[0].0.initial_commitment = Some(proof[0].0.round_proofs[0].commitment.clone());
 
         let mut v_ch = challenger_template;
-        commit.iter().for_each(|c| v_ch.observe(c.clone()));
+        v_ch.observe(commit.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         let claims = vec![(
             commit,

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -1520,6 +1520,232 @@ mod babybear_pcs {
 
     /// Tampering with the alpha-batched opening value (the claimed `f_i(z)`) should be
     /// rejected by the input-MMCS binding check inside `pcs::verify`.
+    /// Commit and open honestly at `prove_log_degrees`, then verify against
+    /// `claim_log_degrees`. Every native height in the claims must give the same shared LDE
+    /// height as the honest commitment, so the two sides agree on the bucket and disagree
+    /// only on how many `Combine` classes it holds.
+    fn verify_with_claimed_degrees(
+        prove_log_degrees: &[usize],
+        claim_log_degrees: &[usize],
+    ) -> Result<(), <MyPcs as Pcs<Challenge, Challenger>>::Error> {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let domains_and_polys: Vec<_> = prove_log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+
+        let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims: Vec<_> = claim_log_degrees
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .map(|(&log_d, mat_openings)| {
+                let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+                    &pcs,
+                    1 << log_d,
+                );
+                (domain, vec![(zeta, mat_openings[0].clone())])
+            })
+            .collect();
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_ch,
+        )
+    }
+
+    #[test]
+    fn test_pcs_verify_rejects_understated_native_height() {
+        // Prover sees one class (no `Combine`, no `r_comb` drawn); the verifier is told matrix
+        // 1 sits at 2^6, so it sees two classes, draws `r_comb`, and applies degree
+        // correction. The degree-correction gap is the only thing binding a short class's
+        // degree bound, so this is what stops a prover passing a degree-2^8 polynomial off as
+        // a degree-2^6 one.
+        let err = verify_with_claimed_degrees(&[8, 8], &[8, 6])
+            .expect_err("an understated native height must be rejected");
+        assert!(
+            matches!(err, p3_stir::StirError::InvalidProofShape),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_pcs_verify_rejects_overstated_native_height() {
+        // The mirror image: the prover ran `Combine` over two classes, the verifier is told
+        // there is only one and skips it entirely.
+        let err = verify_with_claimed_degrees(&[8, 6], &[8, 8])
+            .expect_err("an overstated native height must be rejected");
+        assert!(
+            matches!(err, p3_stir::StirError::InvalidProofShape),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_pcs_honest_claims_verify_across_native_height_classes() {
+        // Control for the two rejections above: the same shape passes when claimed honestly.
+        verify_with_claimed_degrees(&[8, 6], &[8, 6])
+            .unwrap_or_else(|e| panic!("honest multi-class proof must verify: {e:?}"));
+    }
+
+    #[test]
+    fn test_pcs_tampered_opening_in_short_combine_class_fails() {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        // `test_pcs_tampered_opening_value_fails` runs at a single height, so it never
+        // exercises a `Combine`d bucket. Perturbing the *short* class specifically is what
+        // catches a wrong per-class coefficient or degree-correction gap: a mistake there
+        // still yields a low-degree combined codeword, so only a value that must not fit can
+        // separate the two.
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+        let log_degrees = [8usize, 6];
+
+        let domains_and_polys: Vec<_> = log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let mut tampered_short = opening_values[0][1][0].clone();
+        tampered_short[0] += Challenge::from(Val::ONE);
+
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .enumerate()
+            .map(|(mat_idx, (domain, _))| {
+                let vals = if mat_idx == 1 {
+                    tampered_short.clone()
+                } else {
+                    opening_values[0][mat_idx][0].clone()
+                };
+                (*domain, vec![(zeta, vals)])
+            })
+            .collect();
+
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_ch,
+        );
+        assert!(
+            res.is_err(),
+            "PCS verify must reject a tampered opening in the short Combine class"
+        );
+    }
+
+    #[test]
+    fn test_pcs_johnson_bound_multiple_native_height_classes() {
+        // Every other PCS test here runs under `CapacityBound`. The Johnson regime derives
+        // `Combine`'s eta from BCSS25's multiplicity `m`, which grows fast enough in `d*` that
+        // this shape is right at the edge of feasibility — so it is the configuration that
+        // actually exercises the round-0 eta ceiling rather than passing it comfortably.
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let perm = Perm::new_from_rng_128(&mut seeded_rng());
+        let (val_mmcs, challenge_mmcs) = make_mmcs(&perm);
+        let stir_params = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 2,
+            log_starting_folding_factor: 2,
+            soundness_type: SecurityAssumption::JohnsonBound,
+            security_level: 64,
+            max_pow_bits: 0,
+            mmcs: challenge_mmcs,
+        };
+        let pcs = MyPcs::new(Dft::default(), val_mmcs, stir_params);
+        let challenger_template = Challenger::new(perm);
+
+        let log_degrees = [14usize, 12];
+        let mut rng = seeded_rng();
+        let domains_and_polys: Vec<_> = log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 1),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect();
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_ch,
+        )
+        .unwrap_or_else(|e| panic!("JohnsonBound PCS verification failed: {e:?}"));
+    }
+
     #[test]
     fn test_pcs_tampered_opening_value_fails() {
         let (pcs, challenger_template) = get_pcs();


### PR DESCRIPTION
Stacked on #1989 (round-0 folding arity) — diff below is only this PR's two commits.

## Summary

1. **`fix(stir)`: correctly account Combine's soundness against the schedule's own eta.**
   The batch-degree-correction step (§4.5 `Combine`) now derives its minimum-`eta`
   requirement per security assumption — Conjecture 5.6's `m`-based formula under
   `CapacityBound`, Theorem 4.1's `ℓ`-based formula under `JohnsonBound` — and folds it
   into round 0's own `eta` via `StirConfig::new_with_combine` (`.max()`'d against the
   schedule's actual value), so `delta_combine` can never diverge from whatever radius
   round 0 actually settled on. Counted as an extra term in the union-bound buffer.

2. **`perf(stir)`: commit height classes on a shared domain, merge via Combine (§7,
   Construction 7.2).** Every matrix passed to one `commit()` call is now extended onto a
   single shared LDE domain (sized to the tallest matrix) and committed together in one
   Merkle tree, instead of one independent STIR instance per native matrix height. Within
   a shared-domain bucket, per-height-class reduced-openings are merged into a single
   codeword via batch degree correction (Combine, Definition 4.11/4.12) at the tallest
   class's degree and full proximity radius before STIR runs — so shorter classes stop
   paying for their own STIR instance and query-count floor.

## Why the soundness fix landed first

The initial `Combine` implementation checked its error term against a fixed, assumed
distance (a Johnson-bound ceiling) independent of round 0's real `eta`, and always used
the provable (not conjectured) bound regardless of the configured security assumption.
That under-priced the step and panicked at the benchmark's actual target scale
("the Combine step ... delivers only 67.55 bits of security for a 100-bit target").
Reusing the exact `eta` STIR's own round 0 lands on closes that gap for a negligible
query-count cost — both quantities sit far below the Johnson/capacity ceiling at these
parameters.

## Benchmark

Multi-table run, `--log-message-size 20`, heights `2^{17,18,20}`, 100-bit security, vs.
the round-0-folding-arity baseline in #1989:

| width | proof size | verify time |
|---|---|---|
| 32 | 441.58 → **265.24 KiB (-39.9%)** | 8003 → **4304 µs (-46%)** |
| 2  | 292.67 → **115.55 KiB (-60.5%)** | 6572 → **2940 µs (-55%)** |

Both widths are clean wins at the benchmark's actual target scale. (A mid-investigation
measurement at a smaller scale, taken while the soundness bug above was still blocking
the real-scale run, showed a regression at width 32 — that turned out to be a small-scale
artifact, not representative.)

## Test plan

- [x] `cargo test -p p3-stir` (29 lib + 56 integration tests, all green)
- [x] `cargo clippy -p p3-stir --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p p3-stir -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] Release-mode benchmark at target scale (`--log-message-size 20 --multi-table-width {32,2}`), before/after via `git stash`
