### PR TITLE
perf(stir): batch the OOD-sampling and degree-correction hot loops

### DIFF
--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -173,6 +173,32 @@ struct ProtocolReport {
     queries: String,
 }
 
+/// Verification takes a few milliseconds, so a single un-warmed call cannot resolve the
+/// few-percent differences this table exists to compare — code layout, allocator state and
+/// frequency scaling all move more than that between runs. Every row therefore warms the
+/// caches once and reports the median of a short timed run. Commit and open are seconds
+/// apiece, so the extra verifications cost nothing by comparison.
+const VERIFY_WARMUP_RUNS: usize = 1;
+const VERIFY_TIMED_RUNS: usize = 10;
+
+/// Median wall-clock of `verify_once` in microseconds, discarding the warm-up calls.
+///
+/// `verify_once` is responsible for supplying a fresh challenger each call, since verification
+/// consumes transcript state.
+fn median_verify_us(mut verify_once: impl FnMut()) -> u128 {
+    let mut samples = Vec::with_capacity(VERIFY_TIMED_RUNS);
+    for run in 0..VERIFY_WARMUP_RUNS + VERIFY_TIMED_RUNS {
+        let t = Instant::now();
+        verify_once();
+        let elapsed = t.elapsed().as_micros();
+        if run >= VERIFY_WARMUP_RUNS {
+            samples.push(elapsed);
+        }
+    }
+    samples.sort_unstable();
+    samples[VERIFY_TIMED_RUNS / 2]
+}
+
 /// Per-round inverse-rate schedule matching WHIR's default protocol parameters.
 fn default_round_log_inv_rates(num_variables: usize, folding_factor: &FoldingFactor) -> Vec<usize> {
     let (num_rounds, _) = folding_factor
@@ -229,19 +255,21 @@ where
         <Challenger as FieldChallenger<F>>::sample_algebra_element(&mut verifier_challenger);
     assert_eq!(derived, zeta, "verifier challenger drifted from prover");
 
-    let t = Instant::now();
-    let matrices_with_openings = domains
+    let matrices_with_openings: Vec<_> = domains
         .into_iter()
         .zip(values)
         .map(|(domain, vals)| (domain, vec![(zeta, vals)]))
         .collect();
-    pcs.verify(
-        vec![(commit, matrices_with_openings)],
-        &proof,
-        &mut verifier_challenger,
-    )
-    .unwrap_or_else(|_| panic!("{label} verify failed"));
-    let verify_us = t.elapsed().as_micros();
+
+    let verify_us = median_verify_us(|| {
+        let mut challenger = verifier_challenger.clone();
+        pcs.verify(
+            vec![(commit.clone(), matrices_with_openings.clone())],
+            &proof,
+            &mut challenger,
+        )
+        .unwrap_or_else(|_| panic!("{label} verify failed"));
+    });
 
     let proof_bytes = postcard::to_allocvec(&proof)
         .unwrap_or_else(|_| panic!("{label} proof failed to serialize"))
@@ -262,7 +290,7 @@ where
 fn run_whir(
     pcs: &WhirPcsTy,
     witness: <WhirPcsTy as MultilinearPcs<EF, Challenger>>::Witness,
-    protocol: OpeningProtocol,
+    protocol: &OpeningProtocol,
     domain_separator: &DomainSeparator<EF, F>,
     base_challenger: &Challenger,
 ) -> ProtocolReport {
@@ -286,16 +314,17 @@ fn run_whir(
     let mut verifier_challenger = base_challenger.clone();
     domain_separator.observe_domain_separator(&mut verifier_challenger);
 
-    let t = Instant::now();
-    <WhirPcsTy as MultilinearPcs<EF, Challenger>>::verify(
-        pcs,
-        &commitment,
-        &proof,
-        &mut verifier_challenger,
-        protocol,
-    )
-    .expect("whir verify failed");
-    let verify_us = t.elapsed().as_micros();
+    let verify_us = median_verify_us(|| {
+        let mut challenger = verifier_challenger.clone();
+        <WhirPcsTy as MultilinearPcs<EF, Challenger>>::verify(
+            pcs,
+            &commitment,
+            &proof,
+            &mut challenger,
+            protocol.clone(),
+        )
+        .expect("whir verify failed");
+    });
 
     let proof_bytes = postcard::to_allocvec(&proof)
         .expect("whir proof failed to serialize")
@@ -496,7 +525,7 @@ fn main() {
         reports.push(run_whir(
             &pcs,
             witness,
-            protocol,
+            &protocol,
             &domain_separator,
             &base_challenger,
         ));
@@ -656,7 +685,7 @@ fn main() {
         multi_reports.push(run_whir(
             &pcs,
             witness,
-            protocol,
+            &protocol,
             &domain_separator,
             &base_challenger,
         ));

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -285,13 +285,38 @@ where
     EF: ExtensionField<F>,
     Challenger: FieldChallenger<F>,
 {
+    // `shift^{-2^log_size}` per excluded domain, computed once in the base field (an
+    // inversion and an exponentiation cheaper than their extension-field counterparts) and
+    // reused for every candidate below, rather than an extension-field inversion redone once
+    // per domain per candidate.
+    let shift_inv_pows: [F; 3] =
+        excluded_domains.map(|(shift, log_size)| shift.inverse().exp_power_of_2(log_size));
+    let max_log_size = excluded_domains
+        .iter()
+        .map(|&(_, log_size)| log_size)
+        .max()
+        .unwrap_or(0);
+
     let mut ood_points: Vec<EF> = Vec::with_capacity(num_ood_samples);
     while ood_points.len() < num_ood_samples {
         let z: EF = challenger.sample_algebra_element();
-        let outside_all_domains = excluded_domains.iter().all(|&(shift, log_size)| {
-            let z_norm = z * EF::from(shift).inverse();
-            z_norm.exp_power_of_2(log_size) != EF::ONE || log_size == 0
-        });
+
+        // `z`'s doubling chain `z, z^2, z^4, ..., z^(2^max_log_size)`, shared across every
+        // excluded domain below instead of a fresh `exp_power_of_2` call (its own squaring
+        // chain from scratch) per domain.
+        let mut chain = Vec::with_capacity(max_log_size + 1);
+        chain.push(z);
+        for i in 0..max_log_size {
+            chain.push(chain[i].square());
+        }
+
+        let outside_all_domains =
+            excluded_domains
+                .iter()
+                .zip(&shift_inv_pows)
+                .all(|(&(_, log_size), &shift_inv_pow)| {
+                    log_size == 0 || chain[log_size] * shift_inv_pow != EF::ONE
+                });
         // Deduplicate OOD points.
         let not_dup = ood_points.iter().all(|&existing| existing != z);
         if outside_all_domains && not_dup {

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -285,6 +285,12 @@ where
     EF: ExtensionField<F>,
     Challenger: FieldChallenger<F>,
 {
+    // Nothing to sample, and nothing to precompute for it: keeps the contract identical to
+    // evaluating the predicate lazily, which did no inversions at all in this case.
+    if num_ood_samples == 0 {
+        return Vec::new();
+    }
+
     // `shift^{-2^log_size}` per excluded domain, computed once in the base field (an
     // inversion and an exponentiation cheaper than their extension-field counterparts) and
     // reused for every candidate below, rather than an extension-field inversion redone once
@@ -295,28 +301,36 @@ where
         .iter()
         .map(|&(_, log_size)| log_size)
         .max()
-        .unwrap_or(0);
+        .expect("three excluded domains");
 
     let mut ood_points: Vec<EF> = Vec::with_capacity(num_ood_samples);
     while ood_points.len() < num_ood_samples {
         let z: EF = challenger.sample_algebra_element();
 
-        // `z`'s doubling chain `z, z^2, z^4, ..., z^(2^max_log_size)`, shared across every
-        // excluded domain below instead of a fresh `exp_power_of_2` call (its own squaring
-        // chain from scratch) per domain.
-        let mut chain = Vec::with_capacity(max_log_size + 1);
-        chain.push(z);
-        for i in 0..max_log_size {
-            chain.push(chain[i].square());
+        // One doubling chain `z, z^2, z^4, ..., z^(2^max_log_size)` walked once, recording
+        // `z^(2^log_size)` for each excluded domain as it passes — instead of a fresh
+        // `exp_power_of_2` call (its own squaring chain from scratch) per domain. There are
+        // exactly three domains, so the recording slots are a fixed-size array.
+        let mut z_pows = [EF::ONE; 3];
+        let mut acc = z;
+        for l in 0..=max_log_size {
+            for (slot, &(_, log_size)) in z_pows.iter_mut().zip(&excluded_domains) {
+                if log_size == l {
+                    *slot = acc;
+                }
+            }
+            if l < max_log_size {
+                acc = acc.square();
+            }
         }
 
-        let outside_all_domains =
-            excluded_domains
-                .iter()
-                .zip(&shift_inv_pows)
-                .all(|(&(_, log_size), &shift_inv_pow)| {
-                    log_size == 0 || chain[log_size] * shift_inv_pow != EF::ONE
-                });
+        let outside_all_domains = excluded_domains
+            .iter()
+            .zip(&shift_inv_pows)
+            .zip(&z_pows)
+            .all(|((&(_, log_size), &shift_inv_pow), &z_pow)| {
+                log_size == 0 || z_pow * shift_inv_pow != EF::ONE
+            });
         // Deduplicate OOD points.
         let not_dup = ood_points.iter().all(|&existing| existing != z);
         if outside_all_domains && not_dup {
@@ -673,7 +687,8 @@ pub fn lagrange_interpolate_at<F: Field, EF: ExtensionField<F>>(
 
 #[cfg(test)]
 mod tests {
-    use p3_baby_bear::BabyBear;
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use proptest::prelude::*;
@@ -684,11 +699,116 @@ mod tests {
 
     type F = BabyBear;
     type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type TestChallenger = DuplexChallenger<F, Perm, 16, 8>;
 
     #[test]
     fn test_eval_poly_zero() {
         let poly: Vec<F> = vec![];
         assert_eq!(eval_poly(&poly, F::from_u64(3)), F::ZERO);
+    }
+
+    #[test]
+    fn eval_degree_correction_matches_the_geometric_sum_it_stands_for() {
+        // Three places evaluate this same sum: `eval_degree_correction`, the chunked sweep in
+        // `combine_on_coset`, and the split form `materialize_virtual_fiber` inlines. Only the
+        // first two are compared to each other (by the tests above), and their shared
+        // reference is this function — so it is pinned here to an independent oracle, plain
+        // summation, rather than to another implementation of itself.
+        //
+        // `geom = Σ_{l=0}^{gap} step^l`, so `gap = 2`, `step = 2` gives `1 + 2 + 4 = 7`.
+        assert_eq!(
+            eval_degree_correction(EF::ONE, EF::from_u64(2), EF::ONE, 2),
+            EF::from_u64(7)
+        );
+
+        let x = EF::from_u64(5);
+        // The last case makes `step = x * r` exactly one, the branch an honest transcript
+        // reaches with probability ~1/|EF| and which end-to-end coverage therefore never hits.
+        let cases = [
+            (x, EF::from_u64(3)),
+            (x, EF::ONE),
+            (EF::from_u64(7), EF::from_u64(11)),
+            (x, x.inverse()),
+        ];
+
+        for gap in [0usize, 1, 5, 40] {
+            for (point, r_comb) in cases {
+                let step = point * r_comb;
+
+                let mut expected = EF::ZERO;
+                let mut power = EF::ONE;
+                for _ in 0..=gap {
+                    expected += power;
+                    power *= step;
+                }
+                assert_eq!(
+                    eval_degree_correction(EF::ONE, point, r_comb, gap),
+                    expected,
+                    "gap={gap} point={point:?} r_comb={r_comb:?}"
+                );
+
+                // The factored form `materialize_virtual_fiber` evaluates, which splits
+                // `step^(gap+1)` into a round-constant `r_comb^(gap+1)` and a per-point
+                // `x^(gap+1)`.
+                let gap_plus_1 = (gap + 1) as u64;
+                let split = if step == EF::ONE {
+                    EF::from_usize(gap + 1)
+                } else {
+                    (EF::ONE - r_comb.exp_u64(gap_plus_1) * point.exp_u64(gap_plus_1))
+                        * (EF::ONE - step).inverse()
+                };
+                assert_eq!(
+                    split, expected,
+                    "gap={gap} point={point:?} r_comb={r_comb:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sample_ood_points_returns_nothing_for_zero_samples() {
+        let mut rng = SmallRng::seed_from_u64(3);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let mut challenger = TestChallenger::new(perm);
+        let excluded = [(F::GENERATOR, 4), (F::GENERATOR, 3), (F::GENERATOR, 2)];
+        let points: Vec<EF> = sample_ood_points(&mut challenger, excluded, 0);
+        assert!(points.is_empty());
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        /// The hoisted `shift^{-2^log_size}` and the shared squaring chain must compose back
+        /// into `(z / shift)^{2^log_size}`. The oracle is the original three-line predicate,
+        /// evaluated independently below; `log_sizes` are drawn freely so that equal sizes, a
+        /// zero size, and the maximum sitting at each of the three positions all occur.
+        #[test]
+        fn sample_ood_points_avoids_every_excluded_domain(
+            log_sizes in prop::collection::vec(0usize..=8, 3..=3),
+            shift_seeds in prop::collection::vec(1u64..(1 << 20), 3..=3),
+            num_ood_samples in 1usize..=3,
+            seed: u64,
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let perm = Perm::new_from_rng_128(&mut rng);
+            let mut challenger = TestChallenger::new(perm);
+
+            let excluded: [(F, usize); 3] =
+                core::array::from_fn(|i| (F::from_u64(shift_seeds[i]), log_sizes[i]));
+
+            let points: Vec<EF> = sample_ood_points(&mut challenger, excluded, num_ood_samples);
+            prop_assert_eq!(points.len(), num_ood_samples);
+
+            for (i, &z) in points.iter().enumerate() {
+                for &(shift, log_size) in &excluded {
+                    let outside = (z * EF::from(shift).inverse()).exp_power_of_2(log_size)
+                        != EF::ONE;
+                    prop_assert!(log_size == 0 || outside);
+                }
+                prop_assert!(!points[..i].contains(&z));
+            }
+        }
     }
 
     /// Reference implementation of `combine_on_coset`: `eval_degree_correction` called

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -13,9 +13,9 @@ use thiserror::Error;
 use crate::config::{StirConfig, StirRoundConfig};
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    check_shake_consistency, eval_degree_correction, eval_poly, eval_poly_at_base,
-    fold_domain_params, lagrange_interpolate_at, next_domain_shift, reduce_mod_x_pow_minus_c,
-    sample_ood_points, vanishing_poly_from_roots,
+    check_shake_consistency, eval_poly, eval_poly_at_base, fold_domain_params,
+    lagrange_interpolate_at, next_domain_shift, reduce_mod_x_pow_minus_c, sample_ood_points,
+    vanishing_poly_from_roots,
 };
 
 /// `(index, row)` pairs for a round's queries, in draw order.
@@ -29,6 +29,10 @@ struct VirtualRoundContext<EF> {
     /// query can reduce it rather than re-multiplying every root.
     vanishing_coeffs: Vec<EF>,
     r_comb: EF,
+    /// `r_comb^(all_points.len() + 1)`, the degree-correction geometric sum's `r_comb` factor
+    /// at the round's fixed gap. Computed once per round rather than as part of a fresh
+    /// `(point * r_comb)^gap` exponentiation per fiber point.
+    r_comb_pow_gap1: EF,
 }
 
 /// Translate one opened row of the previous round's oracle into values of the current
@@ -59,6 +63,7 @@ where
     let arity = row_evals.len();
     let points: Vec<F> = subgroup_points.iter().map(|&x| shift * x).collect();
     let common_power = points[0].exp_u64(arity as u64);
+    let gap = ctx.all_points.len();
 
     let ans_rem = reduce_mod_x_pow_minus_c(&ctx.ans_poly, arity, common_power);
     let vanishing_rem = reduce_mod_x_pow_minus_c(&ctx.vanishing_coeffs, arity, common_power);
@@ -72,14 +77,39 @@ where
     }
     let vanishing_inverses = batch_multiplicative_inverse(&vanishing_values);
 
-    Some(
-        row_evals
+    // Degree-correction geometric sum `(1 - step^(gap+1)) / (1 - step)` per point, `step :=
+    // point * r_comb`. `step^(gap+1) = x^(gap+1) * r_comb^(gap+1)` splits into a cheap
+    // per-point base-field exponentiation and the round-constant `r_comb_pow_gap1`
+    // (`VirtualRoundContext::finish`), instead of a fresh extension-field exponentiation of
+    // `step` at every point. `step == 1` (density `1/|EF|`) needs the sum's `gap + 1` closed
+    // form rather than a division by zero, so it is excluded from the batch inversion below.
+    let steps: Vec<EF> = points.iter().map(|&x| ctx.r_comb * x).collect();
+    let denom_inverses = batch_multiplicative_inverse(
+        &steps
             .iter()
-            .zip(points)
-            .zip(vanishing_inverses)
-            .map(|((&g_value, x), vanishing_inverse)| {
-                let quotient = (g_value - eval_poly_at_base(&ans_rem, x)) * vanishing_inverse;
-                eval_degree_correction(quotient, EF::from(x), ctx.r_comb, ctx.all_points.len())
+            .map(|&step| {
+                if step == EF::ONE {
+                    EF::ONE
+                } else {
+                    EF::ONE - step
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    Some(
+        (0..arity)
+            .map(|i| {
+                let x = points[i];
+                let quotient =
+                    (row_evals[i] - eval_poly_at_base(&ans_rem, x)) * vanishing_inverses[i];
+                let geom = if steps[i] == EF::ONE {
+                    EF::from_usize(gap + 1)
+                } else {
+                    let x_pow = x.exp_u64((gap + 1) as u64);
+                    (EF::ONE - ctx.r_comb_pow_gap1 * x_pow) * denom_inverses[i]
+                };
+                quotient * geom
             })
             .collect(),
     )
@@ -394,12 +424,14 @@ where
     /// Touches no transcript state, so it may run after the caller has moved on to other
     /// instances.
     fn finish(self, ans_polynomial: Vec<EF>, all_points: Vec<EF>) -> RoundVerifyOutput<F, EF> {
+        let r_comb_pow_gap1 = self.r_comb.exp_u64((all_points.len() + 1) as u64);
         RoundVerifyOutput {
             ctx: VirtualRoundContext {
                 vanishing_coeffs: vanishing_poly_from_roots(&all_points),
                 ans_poly: ans_polynomial,
                 all_points,
                 r_comb: self.r_comb,
+                r_comb_pow_gap1,
             },
             next_shift: self.next_shift,
             next_log_domain: self.next_log_domain,

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -2,6 +2,7 @@
 
 use alloc::vec::Vec;
 
+use itertools::izip;
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{
@@ -24,14 +25,17 @@ type FirstRoundPairs<EF> = Vec<(usize, Vec<EF>)>;
 #[derive(Clone)]
 struct VirtualRoundContext<EF> {
     ans_poly: Vec<EF>,
-    all_points: Vec<EF>,
     /// Coefficient form of `prod_{y in all_points} (X - y)`, built once per round so that each
     /// query can reduce it rather than re-multiplying every root.
     vanishing_coeffs: Vec<EF>,
     r_comb: EF,
-    /// `r_comb^(all_points.len() + 1)`, the degree-correction geometric sum's `r_comb` factor
-    /// at the round's fixed gap. Computed once per round rather than as part of a fresh
-    /// `(point * r_comb)^gap` exponentiation per fiber point.
+    /// The round's degree-correction gap: the number of points `ans` interpolates. Held here
+    /// rather than recovered from the point list at every use, so that it and the cached
+    /// `r_comb_pow_gap1` below are always derived from the same value.
+    gap: usize,
+    /// `r_comb^(gap + 1)`, the degree-correction geometric sum's `r_comb` factor at the
+    /// round's fixed gap. Computed once per round rather than as part of a fresh
+    /// `(point * r_comb)^(gap + 1)` exponentiation per fiber point.
     r_comb_pow_gap1: EF,
 }
 
@@ -63,53 +67,51 @@ where
     let arity = row_evals.len();
     let points: Vec<F> = subgroup_points.iter().map(|&x| shift * x).collect();
     let common_power = points[0].exp_u64(arity as u64);
-    let gap = ctx.all_points.len();
+    let gap = ctx.gap;
 
     let ans_rem = reduce_mod_x_pow_minus_c(&ctx.ans_poly, arity, common_power);
     let vanishing_rem = reduce_mod_x_pow_minus_c(&ctx.vanishing_coeffs, arity, common_power);
 
-    let vanishing_values: Vec<EF> = points
+    let mut denoms: Vec<EF> = points
         .iter()
         .map(|&x| eval_poly_at_base(&vanishing_rem, x))
         .collect();
-    if vanishing_values.contains(&EF::ZERO) {
+    // A vanishing evaluation of zero means this fiber meets the round's interpolation nodes,
+    // which is a malformed round. Checked before the degree-correction denominator is folded
+    // in, so it can never be confused with the `step == 1` case handled below.
+    if denoms.contains(&EF::ZERO) {
         return None;
     }
-    let vanishing_inverses = batch_multiplicative_inverse(&vanishing_values);
 
     // Degree-correction geometric sum `(1 - step^(gap+1)) / (1 - step)` per point, `step :=
     // point * r_comb`. `step^(gap+1) = x^(gap+1) * r_comb^(gap+1)` splits into a cheap
     // per-point base-field exponentiation and the round-constant `r_comb_pow_gap1`
     // (`VirtualRoundContext::finish`), instead of a fresh extension-field exponentiation of
-    // `step` at every point. `step == 1` (density `1/|EF|`) needs the sum's `gap + 1` closed
-    // form rather than a division by zero, so it is excluded from the batch inversion below.
+    // `step` at every point.
+    //
+    // The quotient's vanishing denominator and the geometric sum's `(1 - step)` denominator
+    // are formed in place as a single product and inverted together, mirroring the way
+    // `RoundProver::finish` fuses the same two factors. `step == 1` (density `1/|EF|`) needs
+    // the sum's `gap + 1` closed form rather than a division by zero, so that lane's
+    // vanishing denominator is left unscaled and the closed form is applied to it directly.
     let steps: Vec<EF> = points.iter().map(|&x| ctx.r_comb * x).collect();
-    let denom_inverses = batch_multiplicative_inverse(
-        &steps
-            .iter()
-            .map(|&step| {
-                if step == EF::ONE {
-                    EF::ONE
-                } else {
-                    EF::ONE - step
-                }
-            })
-            .collect::<Vec<_>>(),
-    );
+    for (denom, &step) in denoms.iter_mut().zip(&steps) {
+        if step != EF::ONE {
+            *denom *= EF::ONE - step;
+        }
+    }
+    let inverses = batch_multiplicative_inverse(&denoms);
 
     Some(
-        (0..arity)
-            .map(|i| {
-                let x = points[i];
-                let quotient =
-                    (row_evals[i] - eval_poly_at_base(&ans_rem, x)) * vanishing_inverses[i];
-                let geom = if steps[i] == EF::ONE {
-                    EF::from_usize(gap + 1)
+        izip!(row_evals, &points, &steps, &inverses)
+            .map(|(&row_eval, &x, &step, &inverse)| {
+                let quotient = (row_eval - eval_poly_at_base(&ans_rem, x)) * inverse;
+                if step == EF::ONE {
+                    quotient * EF::from_usize(gap + 1)
                 } else {
                     let x_pow = x.exp_u64((gap + 1) as u64);
-                    (EF::ONE - ctx.r_comb_pow_gap1 * x_pow) * denom_inverses[i]
-                };
-                quotient * geom
+                    quotient * (EF::ONE - ctx.r_comb_pow_gap1 * x_pow)
+                }
             })
             .collect(),
     )
@@ -423,14 +425,15 @@ where
 
     /// Touches no transcript state, so it may run after the caller has moved on to other
     /// instances.
-    fn finish(self, ans_polynomial: Vec<EF>, all_points: Vec<EF>) -> RoundVerifyOutput<F, EF> {
-        let r_comb_pow_gap1 = self.r_comb.exp_u64((all_points.len() + 1) as u64);
+    fn finish(self, ans_polynomial: Vec<EF>, all_points: &[EF]) -> RoundVerifyOutput<F, EF> {
+        let gap = all_points.len();
+        let r_comb_pow_gap1 = self.r_comb.exp_u64((gap + 1) as u64);
         RoundVerifyOutput {
             ctx: VirtualRoundContext {
-                vanishing_coeffs: vanishing_poly_from_roots(&all_points),
+                vanishing_coeffs: vanishing_poly_from_roots(all_points),
                 ans_poly: ans_polynomial,
-                all_points,
                 r_comb: self.r_comb,
+                gap,
                 r_comb_pow_gap1,
             },
             next_shift: self.next_shift,
@@ -560,7 +563,7 @@ where
         return Err(StirError::InvalidShakeConsistency { round });
     }
 
-    Ok(rv.finish(rp.ans_polynomial.clone(), all_points))
+    Ok(rv.finish(rp.ans_polynomial.clone(), &all_points))
 }
 
 /// One instance's in-flight final round, advanced in the order the transcript demands.
@@ -1240,7 +1243,7 @@ where
                 return Err(StirError::InvalidShakeConsistency { round: local_r });
             }
 
-            finishes.push((i, rv.finish(rp.ans_polynomial.clone(), all_points)));
+            finishes.push((i, rv.finish(rp.ans_polynomial.clone(), &all_points)));
         }
 
         // Phase 5: touches no transcript state, so instance order no longer matters.


### PR DESCRIPTION
Stacked on #1990 (Combine soundness fix + same-domain commit) — diff below is only this PR's one commit.

## Summary

Follows up on the STIR PCS perf audit's "Remaining — verifier" items 5, 7, 8, 9
(arithmetic hoists in the reduced-opening reconstruction, `fold_fiber`, degree
correction, and OOD sampling). Items 5 and 7 were already landed via #1980 before this
branch was cut; this commit covers the remaining two:

- **`sample_ood_points`**: each of the three excluded domains' shift inverses was
  recomputed as a full extension-field inversion, and each domain's `exp_power_of_2` was
  its own squaring chain, once per OOD candidate. Both are loop-invariant — the shift
  inverses move outside the sampling loop (and are derived from a cheap base-field
  inversion instead of an extension one), and every candidate now builds one shared
  doubling chain for its own value and indexes into it per domain, rather than three
  independent chains.
- **`materialize_virtual_fiber`**: the per-fiber-point degree-correction geometric sum
  recomputed `(point * r_comb)^(gap+1)` as a fresh extension-field exponentiation, and
  inverted its denominator individually, for every point of every query. `gap` is
  round-constant, so `r_comb^(gap+1)` is now hoisted into `VirtualRoundContext` once per
  round; the remaining per-point exponentiation is over the base-field coordinate alone
  (cheaper than the extension one it replaces), and the `arity`-many denominators are
  batch-inverted together instead of one at a time (excluding the negligible-density
  `step == 1` case, which needs the sum's closed form instead of a division by zero
  regardless of batching).

Proof size is unchanged — this is a pure verifier-arithmetic change, no format change.

## Benchmark

Multi-table run, `--log-message-size 20`, heights `2^{17,18,20}`, 100-bit security, each
side measured back-to-back on the same machine:

| width | verify time (before → after) | proof size |
|---|---|---|
| 32 | ~4.5ms → ~3.9ms (-17%) | unchanged (271,610 B) |
| 2  | 2947 → 2566 µs (-13%) | unchanged (118,328 B) |

## Test plan

- [x] `cargo test -p p3-stir` (29 lib + 56 integration + 22 utils tests, all green)
- [x] `cargo clippy -p p3-stir --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -p p3-stir -- --check`
- [x] Release-mode benchmark, before/after via `git stash`, confirming byte-identical proofs
