### PR TITLE
fix: migrate constant-size chunks_exact to as_chunks for Rust 1.98 clippy

### DIFF
--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -207,7 +207,7 @@ impl<F: Field + PrimeCharacteristicRing> PeriodicAir<F> {
 
     fn valid_trace(&self, rows: usize) -> RowMajorMatrix<F> {
         let mut values = F::zero_vec(rows * 2);
-        for (i, row) in values.chunks_exact_mut(2).enumerate() {
+        for (i, row) in values.as_chunks_mut::<2>().0.iter_mut().enumerate() {
             row[0] = self.periodic[0][i % self.periodic[0].len()];
             row[1] = self.periodic[1][i % self.periodic[1].len()];
         }

--- a/dft/src/butterflies.rs
+++ b/dft/src/butterflies.rs
@@ -134,9 +134,12 @@ impl<F: Field> Butterfly<F> for DifButterfly<F> {
         debug_assert_eq!(shorts_1.len(), shorts_2.len());
         debug_assert_eq!(suffix_1.len(), suffix_2.len());
         let twiddle_packed = F::Packing::from(self.0);
-        let mut c1 = shorts_1.chunks_exact_mut(4);
-        let mut c2 = shorts_2.chunks_exact_mut(4);
-        for (p1, p2) in (&mut c1).zip(&mut c2) {
+        // Split off the unroll-4 body and its tail up front; `as_chunks_mut`
+        // types each chunk as `&mut [_; 4]`, so the indexing below is checked
+        // once by the compiler instead of per access.
+        let (c1, rem_1) = shorts_1.as_chunks_mut::<4>();
+        let (c2, rem_2) = shorts_2.as_chunks_mut::<4>();
+        for (p1, p2) in c1.iter_mut().zip(c2.iter_mut()) {
             let a1 = p1[0];
             let b1 = p1[1];
             let c1_ = p1[2];
@@ -154,11 +157,7 @@ impl<F: Field> Butterfly<F> for DifButterfly<F> {
             p2[2] = (c1_ - c2_) * twiddle_packed;
             p2[3] = (d1 - d2) * twiddle_packed;
         }
-        for (x_1, x_2) in c1
-            .into_remainder()
-            .iter_mut()
-            .zip(c2.into_remainder().iter_mut())
-        {
+        for (x_1, x_2) in rem_1.iter_mut().zip(rem_2.iter_mut()) {
             let sum = *x_1 + *x_2;
             *x_2 = (*x_1 - *x_2) * twiddle_packed;
             *x_1 = sum;
@@ -241,9 +240,12 @@ impl<F: Field> Butterfly<F> for DitButterfly<F> {
         debug_assert_eq!(shorts_1.len(), shorts_2.len());
         debug_assert_eq!(suffix_1.len(), suffix_2.len());
         let twiddle_packed = F::Packing::from(self.0);
-        let mut c1 = shorts_1.chunks_exact_mut(4);
-        let mut c2 = shorts_2.chunks_exact_mut(4);
-        for (p1, p2) in (&mut c1).zip(&mut c2) {
+        // Split off the unroll-4 body and its tail up front; `as_chunks_mut`
+        // types each chunk as `&mut [_; 4]`, so the indexing below is checked
+        // once by the compiler instead of per access.
+        let (c1, rem_1) = shorts_1.as_chunks_mut::<4>();
+        let (c2, rem_2) = shorts_2.as_chunks_mut::<4>();
+        for (p1, p2) in c1.iter_mut().zip(c2.iter_mut()) {
             let a1 = p1[0];
             let b1 = p1[1];
             let c1_ = p1[2];
@@ -265,11 +267,7 @@ impl<F: Field> Butterfly<F> for DitButterfly<F> {
             p1[3] = d1 + d2t;
             p2[3] = d1 - d2t;
         }
-        for (x_1, x_2) in c1
-            .into_remainder()
-            .iter_mut()
-            .zip(c2.into_remainder().iter_mut())
-        {
+        for (x_1, x_2) in rem_1.iter_mut().zip(rem_2.iter_mut()) {
             let x_2_twiddle = *x_2 * twiddle_packed;
             let new_x1 = *x_1 + x_2_twiddle;
             *x_2 = *x_1 - x_2_twiddle;
@@ -405,9 +403,12 @@ impl<F: Field> Butterfly<F> for ScaledDitButterfly<F> {
         let twiddle_times_scale_packed = F::Packing::from(self.twiddle_times_scale);
         // ScaledDitButterfly has 2 muls per butterfly (scale + twiddle_scale), so unroll-4
         // exposes 8 independent mul chains — better ILP than unroll-2's 4 chains.
-        let mut c1 = shorts_1.chunks_exact_mut(4);
-        let mut c2 = shorts_2.chunks_exact_mut(4);
-        for (p1, p2) in (&mut c1).zip(&mut c2) {
+        // Split off the unroll-4 body and its tail up front; `as_chunks_mut`
+        // types each chunk as `&mut [_; 4]`, so the indexing below is checked
+        // once by the compiler instead of per access.
+        let (c1, rem_1) = shorts_1.as_chunks_mut::<4>();
+        let (c2, rem_2) = shorts_2.as_chunks_mut::<4>();
+        for (p1, p2) in c1.iter_mut().zip(c2.iter_mut()) {
             let a1 = p1[0];
             let b1 = p1[1];
             let c1_ = p1[2];
@@ -433,11 +434,7 @@ impl<F: Field> Butterfly<F> for ScaledDitButterfly<F> {
             p1[3] = d1s + d2t;
             p2[3] = d1s - d2t;
         }
-        for (x_1, x_2) in c1
-            .into_remainder()
-            .iter_mut()
-            .zip(c2.into_remainder().iter_mut())
-        {
+        for (x_1, x_2) in rem_1.iter_mut().zip(rem_2.iter_mut()) {
             let x_1_scale = *x_1 * scale_packed;
             let x_2_twiddle_scale = *x_2 * twiddle_times_scale_packed;
             *x_1 = x_1_scale + x_2_twiddle_scale;

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1138,7 +1138,9 @@ pub fn generic_batched_columnwise_dot_product<F, EF, R, I, const N: usize>(
 {
     for (row, scales) in items {
         let packed_scales = scales.map(EF::ExtensionPacking::from);
-        for (acc_c, r) in acc.chunks_exact_mut(N).zip(row) {
+        // `as_chunks_mut` carries the chunk length in the type, so `acc_c` is a
+        // `&mut [_; N]` rather than a slice that has to be re-checked.
+        for (acc_c, r) in acc.as_chunks_mut::<N>().0.iter_mut().zip(row) {
             for (a, &s) in acc_c.iter_mut().zip(&packed_scales) {
                 *a += s * r;
             }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -596,7 +596,9 @@ mod tests {
         let prev_layer: Vec<[u8; 32]> = (0..8).map(|_| rng.random()).collect();
         let compressor = DummyCompressionFunction;
         let expected: Vec<[u8; 32]> = prev_layer
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let mut result = [0u8; 32];
                 for (i, r) in result.iter_mut().enumerate() {

--- a/mersenne-31/src/aarch64_neon/packing.rs
+++ b/mersenne-31/src/aarch64_neon/packing.rs
@@ -537,6 +537,13 @@ fn mac_up_to_3(vs: &[uint32x4_t], svs: [uint32x4_t; 3]) -> (uint64x2_t, uint64x2
 /// into u64 lane accumulators. A safety fold of the accumulators every `2^28` row
 /// triples keeps them below `2^62` for any stream length, so the final two folds
 /// plus `reduce_sum` always produce canonical values.
+// The chunk strides below are `N * D * 2` and `D * 2`. Both depend on const
+// generic parameters, so they cannot be written as `as_chunks::<{ .. }>()`
+// without `generic_const_exprs`, which is unstable.
+#[allow(
+    clippy::chunks_exact_to_as_chunks,
+    reason = "chunk stride is a generic const expression; as_chunks needs generic_const_exprs"
+)]
 fn columnwise_kernel<EF, R, I, const N: usize, const D: usize>(
     out: &mut [EF::ExtensionPacking],
     mut items: I,
@@ -803,7 +810,7 @@ mod tests {
             let mut expected = EF::ExtensionPacking::zero_vec(packed_width * N);
             for (row, s) in items() {
                 let packed_scales = s.map(EF::ExtensionPacking::from);
-                for (acc_c, r) in expected.chunks_exact_mut(N).zip(row) {
+                for (acc_c, r) in expected.as_chunks_mut::<N>().0.iter_mut().zip(row) {
                     for (a, &ps) in acc_c.iter_mut().zip(&packed_scales) {
                         *a += ps * r;
                     }

--- a/monty-31/src/dft/backward.rs
+++ b/monty-31/src/dft/backward.rs
@@ -66,7 +66,7 @@ fn backward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
     // roots <-- [1, roots[1], ..., roots[HALF_RADIX-1], 1, roots[1], ...]
     let roots = T::from_fn(|i| roots[i % HALF_RADIX]);
 
-    input.chunks_exact_mut(2).for_each(|pair| {
+    input.as_chunks_mut::<2>().0.iter_mut().for_each(|pair| {
         let (x, y) = backward_butterfly_interleaved::<HALF_RADIX, _>(pair[0], pair[1], roots);
         pair[0] = x;
         pair[1] = y;
@@ -75,7 +75,7 @@ fn backward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
 
 #[inline]
 fn backward_iterative_packed_radix_2<T: PackedFieldPow2>(input: &mut [T]) {
-    input.chunks_exact_mut(2).for_each(|pair| {
+    input.as_chunks_mut::<2>().0.iter_mut().for_each(|pair| {
         let x = pair[0];
         let y = pair[1];
         let (mut x, y) = x.interleave(y, 1);

--- a/monty-31/src/dft/forward.rs
+++ b/monty-31/src/dft/forward.rs
@@ -117,7 +117,7 @@ fn forward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
     // roots <-- [1, roots[1], ..., roots[HALF_RADIX-1], 1, roots[1], ...]
     let roots = T::from_fn(|i| roots[i % HALF_RADIX]);
 
-    input.chunks_exact_mut(2).for_each(|pair| {
+    input.as_chunks_mut::<2>().0.iter_mut().for_each(|pair| {
         let (x, y) = forward_butterfly_interleaved::<HALF_RADIX, _>(pair[0], pair[1], roots);
         pair[0] = x;
         pair[1] = y;
@@ -126,7 +126,7 @@ fn forward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
 
 #[inline]
 fn forward_iterative_packed_radix_2<T: PackedFieldPow2>(input: &mut [T]) {
-    input.chunks_exact_mut(2).for_each(|pair| {
+    input.as_chunks_mut::<2>().0.iter_mut().for_each(|pair| {
         let x = pair[0];
         let y = pair[1];
         let (mut x, y) = x.interleave(y, 1);

--- a/poseidon2/src/external.rs
+++ b/poseidon2/src/external.rs
@@ -135,8 +135,8 @@ pub fn mds_light_permutation<
         4 | 8 | 12 | 16 | 20 | 24 | 32 => {
             // First, we apply M_4 to each consecutive four elements of the state.
             // In Appendix B's terminology, this replaces each x_i with x_i'.
-            for chunk in state.chunks_exact_mut(4) {
-                mdsmat.permute_mut(chunk.try_into().unwrap());
+            for chunk in state.as_chunks_mut::<4>().0.iter_mut() {
+                mdsmat.permute_mut(chunk);
             }
             // Now, we apply the outer circulant matrix (to compute the y_i values).
 

--- a/sha256/src/lib.rs
+++ b/sha256/src/lib.rs
@@ -49,7 +49,7 @@ impl PseudoCompressionFunction<[u8; 32], 2> for Sha256Compress {
         sha2::block_api::compress256(&mut state, core::slice::from_ref(block));
 
         let mut output = [0u8; 32];
-        for (chunk, word) in output.chunks_exact_mut(4).zip(state) {
+        for (chunk, word) in output.as_chunks_mut::<4>().0.iter_mut().zip(state) {
             chunk.copy_from_slice(&word.to_be_bytes());
         }
         output

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -1306,7 +1306,7 @@ where
             let second_c = second.get(c).copied().unwrap_or(EF::ZERO);
             let ratio = generator.exp_u64(c as u64);
             let mut scale = shift.exp_u64(c as u64);
-            for pair in row.chunks_exact_mut(2) {
+            for pair in row.as_chunks_mut::<2>().0.iter_mut() {
                 pair[0] = first_c * scale;
                 pair[1] = second_c * scale;
                 scale *= ratio;
@@ -1329,7 +1329,7 @@ where
             for ((first_slot, second_slot), pair) in first_block
                 .iter_mut()
                 .zip(second_block.iter_mut())
-                .zip(row.chunks_exact(2))
+                .zip(row.as_chunks::<2>().0.iter())
             {
                 *first_slot = pair[0];
                 *second_slot = pair[1];

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -132,6 +132,7 @@ where
             .par_fold_reduce(
                 || (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                    // rayon has no `as_chunks` equivalent, so these stay slices.
                     let chunk = chunk_round_step::<B, A>(
                         e_lo_c.try_into().unwrap(),
                         e_hi_c.try_into().unwrap(),
@@ -144,18 +145,21 @@ where
             )
     } else {
         e_lo_main
-            .chunks_exact(K)
-            .zip(e_hi_main.chunks_exact(K))
-            .zip(w_lo_main.chunks_exact(K).zip(w_hi_main.chunks_exact(K)))
+            .as_chunks::<K>()
+            .0
+            .iter()
+            .zip(e_hi_main.as_chunks::<K>().0.iter())
+            .zip(
+                w_lo_main
+                    .as_chunks::<K>()
+                    .0
+                    .iter()
+                    .zip(w_hi_main.as_chunks::<K>().0.iter()),
+            )
             .fold(
                 (A::ZERO, A::ZERO),
                 |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
-                    let chunk = chunk_round_step::<B, A>(
-                        e_lo_c.try_into().unwrap(),
-                        e_hi_c.try_into().unwrap(),
-                        w_lo_c.try_into().unwrap(),
-                        w_hi_c.try_into().unwrap(),
-                    );
+                    let chunk = chunk_round_step::<B, A>(e_lo_c, e_hi_c, w_lo_c, w_hi_c);
                     round_reduce(acc, chunk)
                 },
             )
@@ -231,8 +235,10 @@ where
             )
     } else {
         evals_main
-            .chunks_exact(2 * K)
-            .zip(weights_main.chunks_exact(2 * K))
+            .as_chunks::<{ 2 * K }>()
+            .0
+            .iter()
+            .zip(weights_main.as_chunks::<{ 2 * K }>().0.iter())
             .fold((A::ZERO, A::ZERO), |acc, (e_chunk, w_chunk)| {
                 let (e_lo, e_hi) = gather_pairs::<B>(e_chunk);
                 let (w_lo, w_hi) = gather_pairs::<A>(w_chunk);

--- a/uni-stark/tests/periodic_air.rs
+++ b/uni-stark/tests/periodic_air.rs
@@ -44,7 +44,7 @@ impl<F: Field + PrimeCharacteristicRing> PeriodicAir<F> {
 
     fn valid_trace(&self, rows: usize) -> RowMajorMatrix<F> {
         let mut values = F::zero_vec(rows * 2);
-        for (i, row) in values.chunks_exact_mut(2).enumerate() {
+        for (i, row) in values.as_chunks_mut::<2>().0.iter_mut().enumerate() {
             row[0] = self.periodic[0][i % self.periodic[0].len()];
             row[1] = self.periodic[1][i % self.periodic[1].len()];
         }


### PR DESCRIPTION
## Why

Rust 1.98 (released 2026-08-18) added [`clippy::chunks_exact_to_as_chunks`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks). CI's lint job runs `dtolnay/rust-toolchain@stable` with `-D warnings`, so it picks the new lint up automatically.

This is not branch-specific. A pristine checkout of `main` fails the lint job under 1.98. The last green run on `main` was 2026-08-20, but `rustc 1.97.1`.

## What

Mechanical migration of `chunks_exact(N)` / `chunks_exact_mut(N)` to `as_chunks::<N>()` / `as_chunks_mut::<N>()` where `N` is a constant. The chunk length moves into the type, so each chunk arrives as `&[T; N]` instead of `&[T]`.

Three places where it is more than a substitution:

- **`dft/src/butterflies.rs`** (3 loops): these used `ChunksExactMut::into_remainder()`, which `as_chunks_mut` has no equivalent for since it returns `(chunks, remainder)` up front. The loops are restructured to split first, which reads better than reaching for the remainder after the fact.
- **`sumcheck/src/strategy.rs`**: the serial path's chunks are now arrays, so four `.try_into().unwrap()` calls became redundant and are dropped. The rayon path keeps them: `par_chunks_exact` has no `as_chunks` equivalent and still yields slices.
- **`poseidon2/src/external.rs`**: `permute_mut(chunk.try_into().unwrap())` becomes `permute_mut(chunk)`.

## The one exception

`mersenne-31/src/aarch64_neon/packing.rs` has four sites whose chunk strides are `N * D * 2` and `D * 2`, where `N` and `D` are const generic parameters. Those cannot be written as `as_chunks::<{ N * D * 2 }>()` without `generic_const_exprs`, which is unstable:

```
error: generic parameters may not be used in const operations
```

They carry a single scoped `#[allow]` on the enclosing function with a `reason`, rather than a blanket allow. Arguably a clippy false positive worth reporting upstream, since the lint fires where its own suggestion does not compile. A fifth site in the same file uses a bare `N` and does migrate.

Note this file is `aarch64`-only, so it is not what breaks the CI lint job (ubuntu x86_64). It shows up when running clippy on Apple silicon.

## Checks

Run against 1.98.0 stable, matching the CI lint job step for step:

- `cargo +stable clippy --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo +stable sort --workspace --grouped --check`
- `cargo +stable doc --no-deps --workspace --document-private-items` with `-D rustdoc::broken_intra_doc_links`
- `cargo test --workspace`

No functional change intended: `as_chunks` and `chunks_exact` agree on both the chunks and the remainder.
