### PR TITLE
fix(stir): fallible config derivation & dedup eta-parameterized security formulas

### DIFF
--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -100,7 +100,7 @@ type ChallengeMmcs = ExtensionMmcs<F, EF, ValMmcs>;
 type Challenger = DuplexChallenger<F, Poseidon16, 16, 8>;
 
 type FriPcsTy = TwoAdicFriPcs<F, Dft, ValMmcs, ChallengeMmcs>;
-type StirPcsTy = TwoAdicStirPcs<F, Dft, ValMmcs, ChallengeMmcs>;
+type StirPcsTy = TwoAdicStirPcs<F, Dft, ValMmcs, ChallengeMmcs, EF, Challenger>;
 type WhirLayout = SuffixProver<F, EF>;
 type WhirPcsTy = WhirProver<EF, F, Dft, ValMmcs, Challenger, WhirLayout>;
 

--- a/security/src/assumption.rs
+++ b/security/src/assumption.rs
@@ -74,23 +74,48 @@ impl SecurityAssumption {
         }
     }
 
-    /// `log₂(L⁺)` for the regime's list size at distance δ.
+    /// `log₂(η)`, or `0.` for [`Self::UniqueDecoding`], where no eta term applies and every
+    /// `_at_log_eta` formula ignores the value in its UD branch.
+    pub(crate) const fn log_eta_or_zero(&self, log_inv_rate: usize) -> f64 {
+        match self {
+            Self::UniqueDecoding => 0.,
+            _ => self.log_eta(log_inv_rate),
+        }
+    }
+
+    /// `log₂(L⁺)` for the regime's list size at an explicit `log_eta`, rather than the
+    /// regime's own default safety margin ([`Self::log_eta`]).
+    ///
+    /// A caller deriving its own schedule of `eta` values across a protocol (STIR's per-round
+    /// bisection, for instance) needs the list size at each of those working points, not just
+    /// at the regime's fixed default; [`Self::list_size_bits`] is the
+    /// `log_eta = self.log_eta(log_inv_rate)` specialization of this.
     #[must_use]
-    pub const fn list_size_bits(&self, log_degree: usize, log_inv_rate: usize) -> f64 {
+    pub const fn list_size_bits_at_log_eta(
+        &self,
+        log_degree: usize,
+        log_inv_rate: usize,
+        log_eta: f64,
+    ) -> f64 {
         match self {
             // In UD the list size is 1
             Self::UniqueDecoding => 0.,
 
             // By the JB, RS codes are (1 - sqrt(rho) - eta, (2*eta*sqrt(rho))^-1)-list decodable.
             Self::JohnsonBound => {
-                let log_eta = self.log_eta(log_inv_rate);
                 let log_inv_sqrt_rate: f64 = log_inv_rate as f64 / 2.;
                 log_inv_sqrt_rate - (1. + log_eta)
             }
 
             // In CB we assume that RS codes are (1 - rho - eta, d/rho*eta)-list decodable (see Conjecture 5.6 in STIR).
-            Self::CapacityBound => (log_degree + log_inv_rate) as f64 - self.log_eta(log_inv_rate),
+            Self::CapacityBound => (log_degree + log_inv_rate) as f64 - log_eta,
         }
+    }
+
+    /// `log₂(L⁺)` for the regime's list size at distance δ.
+    #[must_use]
+    pub const fn list_size_bits(&self, log_degree: usize, log_inv_rate: usize) -> f64 {
+        self.list_size_bits_at_log_eta(log_degree, log_inv_rate, self.log_eta_or_zero(log_inv_rate))
     }
 
     /// Proximity-gap error in bits for combining `num_functions` functions
@@ -113,36 +138,72 @@ impl SecurityAssumption {
         field_size_bits: usize,
         num_functions: usize,
     ) -> f64 {
+        self.prox_gaps_error_at_log_eta(
+            log_degree,
+            log_inv_rate,
+            field_size_bits,
+            num_functions,
+            self.log_eta_or_zero(log_inv_rate),
+        )
+    }
+
+    /// [`Self::prox_gaps_error`] at an explicit `log_eta`, rather than the regime's own
+    /// default safety margin ([`Self::log_eta`]).
+    ///
+    /// A caller deriving its own schedule of `eta` values across a protocol (STIR's per-round
+    /// bisection, for instance) needs the proximity-gap error at each of those working
+    /// points, not just at the regime's fixed default. On [`SecurityAssumption::JohnsonBound`]
+    /// this derives the \[BCSS25\] proximity parameter `m = max(ceil(√ρ / (2η)), 3)` from
+    /// `log_eta` and defers to [`Self::prox_gaps_error_jb_at_m`] — at
+    /// `log_eta = self.log_eta(log_inv_rate)` that derivation reduces to exactly `m = 10`,
+    /// [`Self::prox_gaps_error`]'s fixed safety choice.
+    #[must_use]
+    pub fn prox_gaps_error_at_log_eta(
+        &self,
+        log_degree: usize,
+        log_inv_rate: usize,
+        field_size_bits: usize,
+        num_functions: usize,
+        log_eta: f64,
+    ) -> f64 {
         assert!(
             num_functions >= 2,
             "num_functions must be >= 2 to compute proximity gaps error",
         );
 
-        // Note that this does not include the field_size
-        let error = match self {
+        match self {
             // In UD the error is |L|/|F| = d/(rho*|F|)
-            Self::UniqueDecoding => (log_degree + log_inv_rate) as f64,
+            Self::UniqueDecoding => {
+                let error = (log_degree + log_inv_rate) as f64;
+                let num_functions_1_log = libm::log2(num_functions as f64 - 1.);
+                field_size_bits as f64 - (error + num_functions_1_log)
+            }
 
             // From Theorem 1.5 in [BCSS25] "On Proximity Gaps for Reed-Solomon Codes":
             //
             // For gamma < J(delta) - eta, the number of exceptional z's is bounded by:
             //   a > (2(m + 1/2)^5 + 3(m + 1/2)*gamma*rho) / (3*rho^(3/2)) * n + (m + 1/2) / sqrt(rho)
             //
-            // With eta = sqrt(rho)/20 (safe gap), m = max(ceil(sqrt(rho)/(2*eta)), 3) = max(10, 3) = 10.
-            //
-            // This improves over [BCI+20] which had:
-            //   log_2(a) = 2*log_degree + 3.5*log_inv_rate + 23.24
-            Self::JohnsonBound => jb_prox_gaps_dominant_term_bits(log_degree, log_inv_rate, 10),
+            // m = max(ceil(sqrt(rho)/(2*eta)), 3).
+            Self::JohnsonBound => {
+                let log_sqrt_rho_over_2eta = -(log_inv_rate as f64) / 2. - 1. - log_eta;
+                let m = libm::ceil(libm::pow(2., log_sqrt_rho_over_2eta)).max(3.) as usize;
+                Self::prox_gaps_error_jb_at_m(
+                    log_degree,
+                    log_inv_rate,
+                    field_size_bits,
+                    num_functions,
+                    m,
+                )
+            }
 
             // In CB we assume the error is degree/(eta*rho^2)
             Self::CapacityBound => {
-                (log_degree + 2 * log_inv_rate) as f64 - self.log_eta(log_inv_rate)
+                let error = (log_degree + 2 * log_inv_rate) as f64 - log_eta;
+                let num_functions_1_log = libm::log2(num_functions as f64 - 1.);
+                field_size_bits as f64 - (error + num_functions_1_log)
             }
-        };
-
-        // Error is (num_functions - 1) * error/|F|;
-        let num_functions_1_log = libm::log2(num_functions as f64 - 1.);
-        field_size_bits as f64 - (error + num_functions_1_log)
+        }
     }
 
     /// Johnson-bound proximity-gap error (\[BCSS25\] Theorem 1.5, dominant

--- a/security/src/assumption.rs
+++ b/security/src/assumption.rs
@@ -76,7 +76,12 @@ impl SecurityAssumption {
 
     /// `log₂(η)`, or `0.` for [`Self::UniqueDecoding`], where no eta term applies and every
     /// `_at_log_eta` formula ignores the value in its UD branch.
-    pub(crate) const fn log_eta_or_zero(&self, log_inv_rate: usize) -> f64 {
+    ///
+    /// Public alongside the `_at_log_eta` family: a caller feeding those its own schedule of
+    /// eta values still needs this convention to reproduce the fixed-eta entry points, and
+    /// has no other way to spell "the regime's default" for `UniqueDecoding`.
+    #[must_use]
+    pub const fn log_eta_or_zero(&self, log_inv_rate: usize) -> f64 {
         match self {
             Self::UniqueDecoding => 0.,
             _ => self.log_eta(log_inv_rate),
@@ -559,6 +564,522 @@ mod tests {
                  expected log_2({}) = {expected_loss:.1} bits, got {loss:.6}",
                 num_functions - 1
             );
+        }
+    }
+
+    /// Field size used by the known-answer table below: a degree-5 extension of KoalaBear.
+    const TABLE_FIELD_BITS: usize = 155;
+
+    #[test]
+    fn fixed_eta_formulas_match_their_recorded_values() {
+        // These five entry points feed WHIR's, FRI's and STIR's derived parameters, so any
+        // drift in them silently changes every protocol's security. Freezing the values is
+        // the point: a property test would need the pre-refactor implementation as its
+        // oracle, and that no longer exists.
+        //
+        // Columns: list_size_bits, prox_gaps_error(num_functions = 17),
+        // ood_error(ood_samples = 2), fold_sumcheck_error,
+        // queries_combination_error(ood_samples = 2, num_queries = 40).
+        #[allow(clippy::type_complexity)]
+        let table: [(SecurityAssumption, usize, usize, [f64; 5]); 45] = [
+            (
+                SecurityAssumption::JohnsonBound,
+                1,
+                10,
+                [
+                    4.321928094887362,
+                    122.12337538682735,
+                    282.35614381022526,
+                    149.67807190511263,
+                    144.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                1,
+                20,
+                [
+                    4.321928094887362,
+                    112.12337538682735,
+                    262.35614381022526,
+                    149.67807190511263,
+                    144.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                1,
+                24,
+                [
+                    4.321928094887362,
+                    108.12337538682735,
+                    254.35614381022526,
+                    149.67807190511263,
+                    144.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                2,
+                10,
+                [
+                    5.321928094887362,
+                    119.62337538682735,
+                    280.35614381022526,
+                    148.67807190511263,
+                    143.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                2,
+                20,
+                [
+                    5.321928094887362,
+                    109.62337538682735,
+                    260.35614381022526,
+                    148.67807190511263,
+                    143.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                2,
+                24,
+                [
+                    5.321928094887362,
+                    105.62337538682735,
+                    252.35614381022526,
+                    148.67807190511263,
+                    143.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                3,
+                10,
+                [
+                    6.321928094887362,
+                    117.12337538682735,
+                    278.35614381022526,
+                    147.67807190511263,
+                    142.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                3,
+                20,
+                [
+                    6.321928094887362,
+                    107.12337538682735,
+                    258.35614381022526,
+                    147.67807190511263,
+                    142.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                3,
+                24,
+                [
+                    6.321928094887362,
+                    103.12337538682735,
+                    250.35614381022526,
+                    147.67807190511263,
+                    142.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                4,
+                10,
+                [
+                    7.321928094887362,
+                    114.62337538682735,
+                    276.35614381022526,
+                    146.67807190511263,
+                    141.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                4,
+                20,
+                [
+                    7.321928094887362,
+                    104.62337538682735,
+                    256.35614381022526,
+                    146.67807190511263,
+                    141.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                4,
+                24,
+                [
+                    7.321928094887362,
+                    100.62337538682735,
+                    248.35614381022526,
+                    146.67807190511263,
+                    141.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                8,
+                10,
+                [
+                    11.321928094887362,
+                    104.62337538682735,
+                    268.35614381022526,
+                    142.67807190511263,
+                    137.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                8,
+                20,
+                [
+                    11.321928094887362,
+                    94.62337538682735,
+                    248.35614381022526,
+                    142.67807190511263,
+                    137.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::JohnsonBound,
+                8,
+                24,
+                [
+                    11.321928094887362,
+                    90.62337538682735,
+                    240.35614381022526,
+                    142.67807190511263,
+                    137.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                1,
+                10,
+                [
+                    16.32192809488736,
+                    133.67807190511263,
+                    258.35614381022526,
+                    137.67807190511263,
+                    132.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                1,
+                20,
+                [
+                    26.32192809488736,
+                    123.67807190511263,
+                    218.35614381022526,
+                    127.67807190511263,
+                    122.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                1,
+                24,
+                [
+                    30.32192809488736,
+                    119.67807190511263,
+                    202.35614381022526,
+                    123.67807190511263,
+                    118.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                2,
+                10,
+                [
+                    18.32192809488736,
+                    130.67807190511263,
+                    254.35614381022526,
+                    135.67807190511263,
+                    130.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                2,
+                20,
+                [
+                    28.32192809488736,
+                    120.67807190511263,
+                    214.35614381022526,
+                    125.67807190511263,
+                    120.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                2,
+                24,
+                [
+                    32.32192809488736,
+                    116.67807190511263,
+                    198.35614381022526,
+                    121.67807190511263,
+                    116.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                3,
+                10,
+                [
+                    20.32192809488736,
+                    127.67807190511263,
+                    250.35614381022526,
+                    133.67807190511263,
+                    128.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                3,
+                20,
+                [
+                    30.32192809488736,
+                    117.67807190511263,
+                    210.35614381022526,
+                    123.67807190511263,
+                    118.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                3,
+                24,
+                [
+                    34.32192809488736,
+                    113.67807190511263,
+                    194.35614381022526,
+                    119.67807190511263,
+                    114.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                4,
+                10,
+                [
+                    22.32192809488736,
+                    124.67807190511263,
+                    246.35614381022526,
+                    131.67807190511263,
+                    126.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                4,
+                20,
+                [
+                    32.32192809488736,
+                    114.67807190511263,
+                    206.35614381022526,
+                    121.67807190511263,
+                    116.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                4,
+                24,
+                [
+                    36.32192809488736,
+                    110.67807190511263,
+                    190.35614381022526,
+                    117.67807190511263,
+                    112.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                8,
+                10,
+                [
+                    30.32192809488736,
+                    112.67807190511263,
+                    230.35614381022526,
+                    123.67807190511263,
+                    118.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                8,
+                20,
+                [
+                    40.32192809488736,
+                    102.67807190511263,
+                    190.35614381022526,
+                    113.67807190511263,
+                    108.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::CapacityBound,
+                8,
+                24,
+                [
+                    44.32192809488736,
+                    98.67807190511263,
+                    174.35614381022526,
+                    109.67807190511263,
+                    104.28575448233389,
+                ],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                1,
+                10,
+                [0.0, 140.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                1,
+                20,
+                [0.0, 130.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                1,
+                24,
+                [0.0, 126.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                2,
+                10,
+                [0.0, 139.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                2,
+                20,
+                [0.0, 129.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                2,
+                24,
+                [0.0, 125.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                3,
+                10,
+                [0.0, 138.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                3,
+                20,
+                [0.0, 128.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                3,
+                24,
+                [0.0, 124.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                4,
+                10,
+                [0.0, 137.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                4,
+                20,
+                [0.0, 127.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                4,
+                24,
+                [0.0, 123.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                8,
+                10,
+                [0.0, 133.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                8,
+                20,
+                [0.0, 123.0, 0.0, 154.0, 148.60768257722123],
+            ),
+            (
+                SecurityAssumption::UniqueDecoding,
+                8,
+                24,
+                [0.0, 119.0, 0.0, 154.0, 148.60768257722123],
+            ),
+        ];
+
+        for (assumption, log_inv_rate, log_degree, expected) in table {
+            let actual = [
+                assumption.list_size_bits(log_degree, log_inv_rate),
+                assumption.prox_gaps_error(log_degree, log_inv_rate, TABLE_FIELD_BITS, 17),
+                assumption.ood_error(log_degree, log_inv_rate, TABLE_FIELD_BITS, 2),
+                assumption.fold_sumcheck_error(TABLE_FIELD_BITS, log_degree, log_inv_rate),
+                assumption.queries_combination_error(
+                    TABLE_FIELD_BITS,
+                    log_degree,
+                    log_inv_rate,
+                    2,
+                    40,
+                ),
+            ];
+            assert_eq!(
+                actual, expected,
+                "{assumption:?} log_inv_rate={log_inv_rate} log_degree={log_degree}"
+            );
+        }
+    }
+
+    #[test]
+    fn jb_prox_gaps_default_eta_is_m_10() {
+        // `prox_gaps_error`'s Johnson branch delegates to `prox_gaps_error_jb_at_m` through a
+        // `f64 -> usize` round-trip whose input lands one ULP *below* 10 — on the correct side
+        // of the `ceil`, but only just. Reassociating the `log_eta` expression could push the
+        // residue the other way, making `m = 11` and moving every JB proximity-gap error by
+        // about 0.65 bits, with nothing else in the suite noticing.
+        let jb = SecurityAssumption::JohnsonBound;
+        for log_inv_rate in 0..=32 {
+            for log_degree in [10, 20, 24] {
+                for num_functions in [2, 3, 17] {
+                    assert_eq!(
+                        jb.prox_gaps_error(log_degree, log_inv_rate, 128, num_functions),
+                        SecurityAssumption::prox_gaps_error_jb_at_m(
+                            log_degree,
+                            log_inv_rate,
+                            128,
+                            num_functions,
+                            10,
+                        ),
+                        "log_inv_rate={log_inv_rate} log_degree={log_degree} \
+                         num_functions={num_functions}"
+                    );
+                }
+            }
         }
     }
 }

--- a/security/src/whir/mod.rs
+++ b/security/src/whir/mod.rs
@@ -11,6 +11,31 @@ pub mod hiding;
 pub use crate::assumption::SecurityAssumption;
 
 impl SecurityAssumption {
+    /// [`Self::ood_error`] at an explicit `log_eta`, rather than the regime's own default
+    /// safety margin ([`Self::log_eta`]).
+    ///
+    /// A caller deriving its own schedule of `eta` values across a protocol (STIR's per-round
+    /// bisection, for instance) needs the OOD error at each of those working points, not just
+    /// at the regime's fixed default.
+    #[must_use]
+    pub const fn ood_error_at_log_eta(
+        &self,
+        log_degree: usize,
+        log_inv_rate: usize,
+        field_size_bits: usize,
+        ood_samples: usize,
+        log_eta: f64,
+    ) -> f64 {
+        if matches!(self, Self::UniqueDecoding) {
+            return 0.;
+        }
+
+        let list_size_bits = self.list_size_bits_at_log_eta(log_degree, log_inv_rate, log_eta);
+
+        let error = 2. * list_size_bits + (log_degree * ood_samples) as f64;
+        (ood_samples * field_size_bits) as f64 + 1. - error
+    }
+
     /// OOD sampling error (in bits). See Lemma 4.5 in STIR:
     /// `error = L⁺² · (degree / |F|)^reps`.
     /// The domain size is discounted as negligible relative to `|F|`.
@@ -22,14 +47,13 @@ impl SecurityAssumption {
         field_size_bits: usize,
         ood_samples: usize,
     ) -> f64 {
-        if matches!(self, Self::UniqueDecoding) {
-            return 0.;
-        }
-
-        let list_size_bits = self.list_size_bits(log_degree, log_inv_rate);
-
-        let error = 2. * list_size_bits + (log_degree * ood_samples) as f64;
-        (ood_samples * field_size_bits) as f64 + 1. - error
+        self.ood_error_at_log_eta(
+            log_degree,
+            log_inv_rate,
+            field_size_bits,
+            ood_samples,
+            self.log_eta_or_zero(log_inv_rate),
+        )
     }
 
     /// Smallest number of OOD samples (from the extension field) needed
@@ -77,8 +101,30 @@ impl SecurityAssumption {
         num_variables: usize,
         log_inv_rate: usize,
     ) -> f64 {
+        self.fold_sumcheck_error_at_log_eta(
+            field_size_bits,
+            num_variables,
+            log_inv_rate,
+            self.log_eta_or_zero(log_inv_rate),
+        )
+    }
+
+    /// [`Self::fold_sumcheck_error`] at an explicit `log_eta`, rather than the regime's own
+    /// default safety margin ([`Self::log_eta`]).
+    ///
+    /// A caller deriving its own schedule of `eta` values across a protocol (STIR's per-round
+    /// bisection, for instance) needs the fold-sumcheck error at each of those working
+    /// points, not just at the regime's fixed default.
+    #[must_use]
+    pub const fn fold_sumcheck_error_at_log_eta(
+        &self,
+        field_size_bits: usize,
+        num_variables: usize,
+        log_inv_rate: usize,
+        log_eta: f64,
+    ) -> f64 {
         // List size at the current proximity parameter and code rate.
-        let list_size = self.list_size_bits(num_variables, log_inv_rate);
+        let list_size = self.list_size_bits_at_log_eta(num_variables, log_inv_rate, log_eta);
 
         // Security = field size minus the adversary's advantage from list decoding.
         field_size_bits as f64 - (list_size + 1.)
@@ -100,8 +146,34 @@ impl SecurityAssumption {
         ood_samples: usize,
         num_queries: usize,
     ) -> f64 {
+        self.queries_combination_error_at_log_eta(
+            field_size_bits,
+            num_variables,
+            log_inv_rate,
+            ood_samples,
+            num_queries,
+            self.log_eta_or_zero(log_inv_rate),
+        )
+    }
+
+    /// [`Self::queries_combination_error`] at an explicit `log_eta`, rather than the regime's
+    /// own default safety margin ([`Self::log_eta`]).
+    ///
+    /// A caller deriving its own schedule of `eta` values across a protocol (STIR's per-round
+    /// bisection, for instance) needs the query-combination error at each of those working
+    /// points, not just at the regime's fixed default.
+    #[must_use]
+    pub fn queries_combination_error_at_log_eta(
+        &self,
+        field_size_bits: usize,
+        num_variables: usize,
+        log_inv_rate: usize,
+        ood_samples: usize,
+        num_queries: usize,
+        log_eta: f64,
+    ) -> f64 {
         // List size at the current proximity parameter.
-        let list_size = self.list_size_bits(num_variables, log_inv_rate);
+        let list_size = self.list_size_bits_at_log_eta(num_variables, log_inv_rate, log_eta);
 
         // Total number of evaluation points available for the combination.
         let log_combination = libm::log2((ood_samples + num_queries) as f64);

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -25,6 +25,7 @@ p3-util.workspace = true
 itertools.workspace = true
 libm.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
+spin.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -27,7 +27,7 @@ type ValMmcs =
 type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
 type Dft = Radix2DitParallel<Val>;
 type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
-type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs, Challenge, Challenger>;
 
 /// Columns per committed matrix.
 const WIDTH: usize = 4;

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -1,7 +1,5 @@
 //! STIR protocol configuration: user-facing parameters and derived per-round configs.
 
-use alloc::format;
-use alloc::string::String;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
@@ -168,6 +166,12 @@ pub struct StirRoundConfig<F> {
     pub folding_pow_bits: usize,
 }
 
+/// Marker for type parameters a [`StirConfig`] mentions but owns no value of.
+///
+/// The function-pointer form is unconditionally `Send + Sync` and covariant, so these
+/// parameters contribute no auto-trait or variance constraints to anything holding a config.
+type NonOwning<F, EF, Challenger> = PhantomData<fn() -> (F, EF, Challenger)>;
+
 /// Fully derived STIR protocol configuration.
 ///
 /// Built from [`StirParameters`] plus the starting polynomial degree.
@@ -223,7 +227,32 @@ pub struct StirConfig<F, EF, M, Challenger> {
     /// Merkle tree commitment scheme.
     pub mmcs: M,
 
-    _phantom: PhantomData<(F, EF, Challenger)>,
+    /// `fn() -> _` rather than a bare tuple: this config *mentions* these types but owns no
+    /// value of any of them, and the function-pointer form is unconditionally `Send + Sync`
+    /// and covariant. A bare `PhantomData<(F, EF, Challenger)>` would instead propagate each
+    /// parameter's auto traits and variance to every holder — including [`TwoAdicStirPcs`],
+    /// which reaches these parameters only through its memoized configs.
+    ///
+    /// [`TwoAdicStirPcs`]: crate::TwoAdicStirPcs
+    _phantom: NonOwning<F, EF, Challenger>,
+}
+
+/// Which stage of the derived schedule a [`StirConfigError`] came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Stage {
+    /// An intermediate STIR round, by index.
+    Round(usize),
+    /// The final, directly-sent stage.
+    Final,
+}
+
+impl core::fmt::Display for Stage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Round(round) => write!(f, "round {round}"),
+            Self::Final => write!(f, "final"),
+        }
+    }
 }
 
 /// Reasons [`StirConfig::try_new`] can fail to derive a round schedule reaching
@@ -233,7 +262,7 @@ pub struct StirConfig<F, EF, M, Challenger> {
 /// variant here, so a caller deriving a config for a proof-controlled degree (e.g. per
 /// LDE-height bucket) can reject cleanly via [`StirConfig::try_new`] instead of aborting the
 /// process.
-#[derive(Clone, Debug, PartialEq, Error)]
+#[derive(Clone, Copy, Debug, PartialEq, Error)]
 pub enum StirConfigError {
     /// `log_folding_factor` was below the paper-backed schedule's minimum of 2 (k >= 4).
     #[error(
@@ -306,13 +335,13 @@ pub enum StirConfigError {
     /// A stage's algebraic security fell short of the buffered target by more than the
     /// configured `max_pow_bits` can bridge.
     #[error(
-        "{round} {label} requires {needed} PoW bits to reach buffered security target = \
+        "{stage} {label} requires {needed} PoW bits to reach buffered security target = \
          {buffered_security_level} (security_level = {security_level} + union-bound buffer = \
          {union_bound_buffer}, algebraic bits = {algebraic_bits:.4}), but max_pow_bits = \
          {max_pow_bits}. Increase max_pow_bits, log_blowup, or use a larger field."
     )]
     PowBudgetExceeded {
-        round: String,
+        stage: Stage,
         label: &'static str,
         needed: usize,
         buffered_security_level: usize,
@@ -325,14 +354,85 @@ pub enum StirConfigError {
     /// A stage's OOD/shake checks fell below the buffered target; these terms receive no
     /// PoW credit.
     #[error(
-        "{round} OOD/shake checks reach only {unprotected_alg:.4} bits, below the buffered \
+        "{stage} OOD/shake checks reach only {unprotected_alg:.4} bits, below the buffered \
          target {buffered_security_level}; these challenges are not protected by the \
          query-phase PoW"
     )]
     UnprotectedChecksBelowTarget {
-        round: String,
+        stage: Stage,
         unprotected_alg: f64,
         buffered_security_level: usize,
+    },
+
+    /// `log_blowup` was 0, so the initial code has rate 1: there is no redundancy for a
+    /// proximity test to measure distance against, and the query-count formula has no
+    /// per-query failure probability below 1 to invert.
+    #[error("log_blowup must be >= 1; rate 1 leaves no redundancy for a proximity test")]
+    RateNotBelowOne,
+
+    /// The challenge field has no room for points outside a round's evaluation domain.
+    #[error(
+        "challenge field ({field_size_bits} bits) must contain points outside the \
+         2^{log_domain_size} evaluation domain"
+    )]
+    FieldTooSmallForDomain {
+        field_size_bits: usize,
+        log_domain_size: usize,
+    },
+
+    /// A per-query failure probability fell outside `(0, 1)`, which the query-count formula
+    /// inverts a logarithm of.
+    #[error("STIR query-count formula requires a failure base in (0, 1), got {failure_base}")]
+    InvalidFailureBase { failure_base: f64 },
+
+    /// No permitted `eta` reaches a stage's target, so no schedule exists at these parameters
+    /// — typically a challenge field too narrow for the requested security level and degree.
+    #[error(
+        "{label} reaches only {upper_bits:.4} bits at the largest permitted eta \
+         ({upper_bound}); target is {target_bits} bits"
+    )]
+    EtaInfeasibleForTarget {
+        label: &'static str,
+        upper_bits: f64,
+        upper_bound: f64,
+        target_bits: usize,
+    },
+
+    /// `Combine` was requested for fewer than two height classes.
+    #[error(
+        "Combine requires at least 2 height classes, got {num_classes}; a single class needs \
+         no Combine, so use the plain constructor"
+    )]
+    CombineNeedsMultipleClasses { num_classes: usize },
+
+    /// The `Combine` multiplicity was below the class count, which `ell = Σᵢ (gapᵢ + 1)`
+    /// cannot be.
+    #[error(
+        "Combine multiplicity ell = {ell} is below the class count {num_classes}; every class \
+         contributes at least one to ell = Σᵢ (gapᵢ + 1)"
+    )]
+    CombineMultiplicityTooSmall { num_classes: usize, ell: u64 },
+
+    /// `Combine`'s `eta` requirement exceeded the paper's side-condition ceiling, so the
+    /// height classes cannot be merged at these parameters. See [`StirParameters`] for the
+    /// feasibility envelope.
+    #[error(
+        "Combine over {num_classes} height classes (multiplicity ell = {ell}) at degree \
+         2^{log_d_star} needs eta = {eta}, above the side-condition ceiling {upper_bound}. \
+         CapacityBound admits Combine only when EF::bits() >= security_level + \
+         union_bound_buffer + 3*log_blowup + 1 + log2(ell - 1) + log_d_star \
+         (>= {required_field_bits:.2} here; EF::bits() = {field_size_bits}). Widen the \
+         challenge field, lower security_level, raise log_blowup, or narrow the committed \
+         height spread."
+    )]
+    CombineEtaExceedsCeiling {
+        num_classes: usize,
+        ell: u64,
+        log_d_star: usize,
+        eta: f64,
+        upper_bound: f64,
+        required_field_bits: f64,
+        field_size_bits: usize,
     },
 
     /// The disjoint-coset side condition failed for a pathological base field.
@@ -384,12 +484,29 @@ where
     /// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ each
     /// class's own, non-quotiented degree bound), consulted by both
     /// `SecurityAssumption` regimes' error terms.
+    ///
+    /// # Errors
+    ///
+    /// Every failure mode of [`Self::try_new`], plus
+    /// [`StirConfigError::CombineNeedsMultipleClasses`] (a single class needs no `Combine`,
+    /// so [`Self::try_new`] is the correct entry point),
+    /// [`StirConfigError::CombineMultiplicityTooSmall`], and
+    /// [`StirConfigError::CombineEtaExceedsCeiling`] when the parameters fall outside the
+    /// feasibility envelope documented on [`StirParameters`].
     pub fn try_new_with_combine(
         log_starting_degree: usize,
         params: StirParameters<M>,
         num_classes: usize,
         ell: u64,
     ) -> Result<Self, StirConfigError> {
+        // `ell` carries the real information, so without these a `num_classes` of 1 would
+        // silently skip all Combine accounting despite the name.
+        if num_classes < 2 {
+            return Err(StirConfigError::CombineNeedsMultipleClasses { num_classes });
+        }
+        if ell < num_classes as u64 {
+            return Err(StirConfigError::CombineMultiplicityTooSmall { num_classes, ell });
+        }
         Self::try_new_with_optional_combine(
             log_starting_degree,
             params,
@@ -421,6 +538,13 @@ where
         params: StirParameters<M>,
         combine: Option<CombineRequirement>,
     ) -> Result<Self, StirConfigError> {
+        // Rate 1 leaves no redundancy to test proximity against: `delta = 1 - rho - eta` is
+        // non-positive, so the query-count formula has no per-query failure probability
+        // below 1 to invert. Rejected here rather than downstream, where it would surface as
+        // an arithmetic edge in a formula rather than as the static parameter mistake it is.
+        if params.log_blowup == 0 {
+            return Err(StirConfigError::RateNotBelowOne);
+        }
         if params.log_folding_factor < 2 {
             return Err(StirConfigError::FoldingFactorTooSmall {
                 log_folding_factor: params.log_folding_factor,
@@ -515,14 +639,14 @@ where
         // do not deliver `security_level` bits over `total_folds` rounds even after
         // exhausting the PoW budget.
         let derive_pow_bits = |label: &'static str,
-                               round: &str,
+                               stage: Stage,
                                algebraic_bits: f64|
          -> Result<usize, StirConfigError> {
             let gap = (buffered_security_level as f64 - algebraic_bits).max(0.0);
             let needed = libm::ceil(gap) as usize;
             if needed > max_pow_bits {
                 return Err(StirConfigError::PowBudgetExceeded {
-                    round: round.into(),
+                    stage,
                     label,
                     needed,
                     buffered_security_level,
@@ -553,7 +677,7 @@ where
         // Query count uses the PoW-assisted target so that summing the per-round query
         // failure over all folds is bounded by `2^{-algebraic_security_level}`.
         let pow_target_bits = algebraic_security_level + union_bound_buffer;
-        let query_count = |stage_log_inv_rate: usize, eta: f64| {
+        let query_count = |stage_log_inv_rate: usize, eta: f64| -> Result<usize, StirConfigError> {
             let failure_base = params
                 .soundness_type
                 .stir_query_failure_base(stage_log_inv_rate, eta);
@@ -609,7 +733,7 @@ where
             log_inv_rate,
             log_starting_folding_factor,
             field_size_bits,
-        );
+        )?;
         // Combine (§4.5) is not PoW-eligible (it runs once, before the query phase's
         // grind), so — like OOD and shake-check — it must reach the full buffered target
         // on its own. Evaluated at `log_degree`/`log_inv_rate` as they stand here: round
@@ -622,31 +746,29 @@ where
                 log_degree,
                 c.ell,
                 buffered_security_level,
-            );
+            )?;
             // Reported here rather than left to `validate_eta` below: the schedule's own
             // `stir_initial_eta` is always within the ceiling, so a round-0 violation is
             // always Combine's, and the caller needs the envelope to act on it.
-            assert!(
-                params
-                    .soundness_type
-                    .stir_eta_is_valid(log_inv_rate, combine_eta),
-                "Combine over {} height classes (multiplicity ell = {}) at degree 2^{log_degree} \
-                 needs eta = {combine_eta}, above the {:?} side-condition ceiling {}. \
-                 CapacityBound admits Combine only when EF::bits() >= security_level + \
-                 union_bound_buffer + 3*log_blowup + 1 + log2(ell - 1) + log_d_star \
-                 (= {} + {union_bound_buffer} + {} + 1 + {:.2} + {log_degree} = {:.2}; \
-                 EF::bits() = {field_size_bits}). Widen the challenge field, lower \
-                 security_level, raise log_blowup, or narrow the committed height spread.",
-                c.num_classes,
-                c.ell,
-                params.soundness_type,
-                params.soundness_type.stir_eta_upper_bound(log_inv_rate),
-                security_level,
-                3 * log_inv_rate,
-                libm::log2(c.ell.saturating_sub(1).max(1) as f64),
-                (security_level + union_bound_buffer + 3 * log_inv_rate + 1 + log_degree) as f64
-                    + libm::log2(c.ell.saturating_sub(1).max(1) as f64),
-            );
+            if !params
+                .soundness_type
+                .stir_eta_is_valid(log_inv_rate, combine_eta)
+            {
+                return Err(StirConfigError::CombineEtaExceedsCeiling {
+                    num_classes: c.num_classes,
+                    ell: c.ell,
+                    log_d_star: log_degree,
+                    eta: combine_eta,
+                    upper_bound: params.soundness_type.stir_eta_upper_bound(log_inv_rate),
+                    required_field_bits: (security_level
+                        + union_bound_buffer
+                        + 3 * log_inv_rate
+                        + 1
+                        + log_degree) as f64
+                        + libm::log2(c.ell.saturating_sub(1).max(1) as f64),
+                    field_size_bits,
+                });
+            }
             final_eta = final_eta.max(combine_eta);
         }
         validate_eta(0, log_inv_rate, final_eta)?;
@@ -671,11 +793,11 @@ where
                     log_folding_factor,
                     field_size_bits,
                     prev_queries,
-                );
+                )?;
                 validate_eta(round, log_inv_rate, final_eta)?;
             }
 
-            let num_queries = query_count(log_inv_rate, final_eta);
+            let num_queries = query_count(log_inv_rate, final_eta)?;
             cumulative_log_folding += round_log_folding_factor;
             assert_disjoint_cosets(round, log_domain_size, cumulative_log_folding)?;
 
@@ -701,16 +823,16 @@ where
                 num_queries,
                 num_ood_samples,
             );
-            let round_label = format!("round {round}");
+            let stage = Stage::Round(round);
             if unprotected_alg < buffered_security_level as f64 {
                 return Err(StirConfigError::UnprotectedChecksBelowTarget {
-                    round: round_label,
+                    stage,
                     unprotected_alg,
                     buffered_security_level,
                 });
             }
-            let folding_pow_bits = derive_pow_bits("folding", &round_label, fold_alg)?;
-            let pow_bits = derive_pow_bits("query", &round_label, query_alg)?;
+            let folding_pow_bits = derive_pow_bits("folding", stage, fold_alg)?;
+            let pow_bits = derive_pow_bits("query", stage, query_alg)?;
 
             round_configs.push(StirRoundConfig {
                 log_degree,
@@ -742,10 +864,10 @@ where
                 log_folding_factor,
                 field_size_bits,
                 prev_queries,
-            );
+            )?;
             validate_eta(num_rounds, log_inv_rate, final_eta)?;
         }
-        let final_queries = query_count(log_inv_rate, final_eta);
+        let final_queries = query_count(log_inv_rate, final_eta)?;
 
         // Final-round PoW: the final fold uses (log_degree, log_inv_rate) at the protocol
         // tail (after all intermediate increments). The final query phase has no OOD or
@@ -761,8 +883,8 @@ where
             final_eta,
             final_queries,
         );
-        let final_folding_pow_bits = derive_pow_bits("folding", "final", final_fold_alg)?;
-        let final_pow_bits = derive_pow_bits("query", "final", final_query_alg)?;
+        let final_folding_pow_bits = derive_pow_bits("folding", Stage::Final, final_fold_alg)?;
+        let final_pow_bits = derive_pow_bits("query", Stage::Final, final_query_alg)?;
 
         Ok(Self {
             log_starting_degree,
@@ -824,6 +946,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
     use p3_commit::ExtensionMmcs;
@@ -832,6 +956,7 @@ mod tests {
     use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use proptest::prelude::*;
     use rand::SeedableRng;
 
     use super::*;
@@ -860,6 +985,175 @@ mod tests {
             max_pow_bits: 20,
             mmcs: TestMmcs::new(val_mmcs),
         }
+    }
+
+    /// [`test_params`] with every knob the fallibility tests need to vary exposed.
+    fn params_with(
+        soundness_type: SecurityAssumption,
+        security_level: usize,
+        max_pow_bits: usize,
+        log_blowup: usize,
+        log_folding_factor: usize,
+        log_starting_folding_factor: usize,
+    ) -> StirParameters<TestMmcs> {
+        StirParameters {
+            soundness_type,
+            security_level,
+            max_pow_bits,
+            log_blowup,
+            log_folding_factor,
+            log_starting_folding_factor,
+            ..test_params(log_blowup, log_folding_factor)
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// `try_new` is the total form `Pcs::verify` derives its per-bucket configs through,
+        /// so an infeasible claim shape must come back as a `StirConfigError` rather than
+        /// aborting the process. The corners that matter — `log_blowup = 0`,
+        /// `security_level` just above `max_pow_bits`, a degree at the field's two-adicity
+        /// edge, a challenge field too narrow for the target — are exactly what a generator
+        /// reaches and a hand-written fixture list misses.
+        #[test]
+        fn try_new_reports_every_infeasibility_as_an_error(
+            soundness_type in prop_oneof![
+                Just(SecurityAssumption::JohnsonBound),
+                Just(SecurityAssumption::CapacityBound),
+                Just(SecurityAssumption::UniqueDecoding),
+            ],
+            security_level in 1usize..=160,
+            max_pow_bits in 0usize..=32,
+            log_blowup in 0usize..=4,
+            log_folding_factor in 1usize..=4,
+            log_starting_folding_factor in 1usize..=4,
+            log_starting_degree in 0usize..=28,
+        ) {
+            extern crate std;
+
+            let params = params_with(
+                soundness_type,
+                security_level,
+                max_pow_bits,
+                log_blowup,
+                log_folding_factor,
+                log_starting_folding_factor,
+            );
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::try_new(
+                    log_starting_degree,
+                    params,
+                )
+                .is_ok()
+            }));
+            prop_assert!(
+                outcome.is_ok(),
+                "try_new panicked at soundness={soundness_type:?} sec={security_level} \
+                 pow={max_pow_bits} lb={log_blowup} k={log_folding_factor} \
+                 k0={log_starting_folding_factor} deg={log_starting_degree}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_new_maps_each_static_misconfiguration_to_its_variant() {
+        let cb = SecurityAssumption::CapacityBound;
+        let jb = SecurityAssumption::JohnsonBound;
+        let ud = SecurityAssumption::UniqueDecoding;
+
+        // (label, log_starting_degree, params, predicate on the returned variant). Ordered as
+        // the checks run, so each case reaches the variant it names rather than an earlier one.
+        type Check = fn(&StirConfigError) -> bool;
+        let cases: [(&str, usize, StirParameters<TestMmcs>, Check); 8] = [
+            ("rate 1", 20, params_with(cb, 100, 0, 0, 4, 4), |e| {
+                matches!(e, StirConfigError::RateNotBelowOne)
+            }),
+            (
+                "k below the schedule's minimum",
+                20,
+                params_with(cb, 100, 0, 1, 1, 4),
+                |e| matches!(e, StirConfigError::FoldingFactorTooSmall { .. }),
+            ),
+            (
+                "k0 below the schedule's minimum",
+                20,
+                params_with(cb, 100, 0, 1, 4, 1),
+                |e| matches!(e, StirConfigError::StartingFoldingFactorTooSmall { .. }),
+            ),
+            (
+                "k0 above the starting degree",
+                2,
+                params_with(cb, 100, 0, 1, 4, 4),
+                |e| {
+                    matches!(
+                        e,
+                        StirConfigError::StartingFoldingFactorExceedsDegree { .. }
+                    )
+                },
+            ),
+            (
+                "initial domain past the base field's two-adicity",
+                27,
+                params_with(cb, 100, 0, 1, 4, 4),
+                |e| matches!(e, StirConfigError::InitialDomainExceedsTwoAdicity { .. }),
+            ),
+            (
+                "unique decoding",
+                20,
+                params_with(ud, 100, 0, 1, 4, 4),
+                |e| matches!(e, StirConfigError::UnsupportedSoundnessType),
+            ),
+            (
+                "security level not above the PoW budget",
+                20,
+                params_with(cb, 20, 20, 1, 4, 4),
+                |e| matches!(e, StirConfigError::SecurityLevelNotGreaterThanPow { .. }),
+            ),
+            (
+                "challenge field too narrow for the target",
+                20,
+                params_with(jb, 100, 20, 1, 4, 4),
+                |e| matches!(e, StirConfigError::EtaInfeasibleForTarget { .. }),
+            ),
+        ];
+
+        for (label, log_starting_degree, params, is_expected) in cases {
+            let err = StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::try_new(
+                log_starting_degree,
+                params,
+            )
+            .expect_err(label);
+            assert!(is_expected(&err), "{label}: got {err:?}");
+        }
+    }
+
+    #[test]
+    fn try_new_with_combine_validates_its_multiplicity_arguments() {
+        let params = params_with(SecurityAssumption::CapacityBound, 100, 0, 1, 4, 4);
+        let build = |num_classes, ell| {
+            StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::try_new_with_combine(
+                20,
+                params.clone(),
+                num_classes,
+                ell,
+            )
+        };
+
+        // A single class does no Combine accounting at all, so accepting it would silently
+        // return a config that is not the one the name promises.
+        assert!(matches!(
+            build(1, 4).unwrap_err(),
+            StirConfigError::CombineNeedsMultipleClasses { num_classes: 1 }
+        ));
+        // `ell = Σᵢ (gapᵢ + 1)` is at least the class count.
+        assert!(matches!(
+            build(3, 2).unwrap_err(),
+            StirConfigError::CombineMultiplicityTooSmall {
+                num_classes: 3,
+                ell: 2
+            }
+        ));
     }
 
     #[test]

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -1,12 +1,14 @@
 //! STIR protocol configuration: user-facing parameters and derived per-round configs.
 
 use alloc::format;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, TwoAdicField};
+use thiserror::Error;
 
 use crate::SecurityAssumption;
 use crate::soundness::StirSoundness;
@@ -224,6 +226,123 @@ pub struct StirConfig<F, EF, M, Challenger> {
     _phantom: PhantomData<(F, EF, Challenger)>,
 }
 
+/// Reasons [`StirConfig::try_new`] can fail to derive a round schedule reaching
+/// `security_level` for the requested parameters and starting degree.
+///
+/// Every condition that would otherwise panic in [`StirConfig::new`] has a corresponding
+/// variant here, so a caller deriving a config for a proof-controlled degree (e.g. per
+/// LDE-height bucket) can reject cleanly via [`StirConfig::try_new`] instead of aborting the
+/// process.
+#[derive(Clone, Debug, PartialEq, Error)]
+pub enum StirConfigError {
+    /// `log_folding_factor` was below the paper-backed schedule's minimum of 2 (k >= 4).
+    #[error(
+        "the paper-backed STIR parameter schedule requires log_folding_factor >= 2 (k >= 4), \
+         got {log_folding_factor}"
+    )]
+    FoldingFactorTooSmall { log_folding_factor: usize },
+
+    /// `log_starting_folding_factor` was below the paper-backed schedule's minimum of 2 (k0 >= 4).
+    #[error(
+        "the paper-backed STIR parameter schedule requires log_starting_folding_factor >= 2 \
+         (k0 >= 4), got {log_starting_folding_factor}"
+    )]
+    StartingFoldingFactorTooSmall { log_starting_folding_factor: usize },
+
+    /// `log_starting_folding_factor` exceeded `log_starting_degree`, so round 0's fold cannot run.
+    #[error(
+        "starting folding factor ({log_starting_folding_factor}) must be <= starting degree \
+         ({log_starting_degree})"
+    )]
+    StartingFoldingFactorExceedsDegree {
+        log_starting_folding_factor: usize,
+        log_starting_degree: usize,
+    },
+
+    /// `log_starting_degree + log_blowup` overflowed `usize`.
+    #[error("Initial domain exponent log_starting_degree + log_blowup overflows usize")]
+    InitialDomainExponentOverflow,
+
+    /// The initial domain exponent did not fit in `usize::BITS` bits.
+    #[error("Initial domain exponent {log_starting_domain} must be less than usize::BITS ({bits})")]
+    InitialDomainTooLarge {
+        log_starting_domain: usize,
+        bits: usize,
+    },
+
+    /// The initial domain exceeds the base field's two-adicity.
+    #[error(
+        "Initial domain size 2^{log_starting_domain} exceeds the two-adicity of the base \
+         field ({two_adicity})"
+    )]
+    InitialDomainExceedsTwoAdicity {
+        log_starting_domain: usize,
+        two_adicity: usize,
+    },
+
+    /// `SecurityAssumption::UniqueDecoding` was requested; the paper-backed schedule needs
+    /// a list-decoding regime.
+    #[error("the paper-backed STIR parameter schedule does not support UniqueDecoding")]
+    UnsupportedSoundnessType,
+
+    /// `max_pow_bits` left no positive algebraic security budget.
+    #[error("security_level ({security_level}) must be greater than max_pow_bits ({max_pow_bits})")]
+    SecurityLevelNotGreaterThanPow {
+        security_level: usize,
+        max_pow_bits: usize,
+    },
+
+    /// A derived `eta` violated the paper's side-condition bound for its stage.
+    #[error(
+        "round {round} produced eta = {eta}, which violates the paper's side-condition bound \
+         {upper_bound}"
+    )]
+    InvalidEta {
+        round: usize,
+        eta: f64,
+        upper_bound: f64,
+    },
+
+    /// A stage's algebraic security fell short of the buffered target by more than the
+    /// configured `max_pow_bits` can bridge.
+    #[error(
+        "{round} {label} requires {needed} PoW bits to reach buffered security target = \
+         {buffered_security_level} (security_level = {security_level} + union-bound buffer = \
+         {union_bound_buffer}, algebraic bits = {algebraic_bits:.4}), but max_pow_bits = \
+         {max_pow_bits}. Increase max_pow_bits, log_blowup, or use a larger field."
+    )]
+    PowBudgetExceeded {
+        round: String,
+        label: &'static str,
+        needed: usize,
+        buffered_security_level: usize,
+        security_level: usize,
+        union_bound_buffer: usize,
+        algebraic_bits: f64,
+        max_pow_bits: usize,
+    },
+
+    /// A stage's OOD/shake checks fell below the buffered target; these terms receive no
+    /// PoW credit.
+    #[error(
+        "{round} OOD/shake checks reach only {unprotected_alg:.4} bits, below the buffered \
+         target {buffered_security_level}; these challenges are not protected by the \
+         query-phase PoW"
+    )]
+    UnprotectedChecksBelowTarget {
+        round: String,
+        unprotected_alg: f64,
+        buffered_security_level: usize,
+    },
+
+    /// The disjoint-coset side condition failed for a pathological base field.
+    #[error(
+        "STIR round {round_index}: disjoint-coset schedule requires \
+         Field::GENERATOR^(2^{n_i}) != 1"
+    )]
+    NonDisjointCosets { round_index: usize, n_i: usize },
+}
+
 impl<F, EF, M, Challenger> StirConfig<F, EF, M, Challenger>
 where
     F: TwoAdicField,
@@ -234,16 +353,26 @@ where
     /// Derive a full STIR configuration from user-facing parameters.
     ///
     /// `log_starting_degree` is log₂ of the degree of the polynomial to commit to.
+    pub fn try_new(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+    ) -> Result<Self, StirConfigError> {
+        Self::try_new_with_optional_combine(log_starting_degree, params, None)
+    }
+
+    /// Derive a full STIR configuration from user-facing parameters.
+    ///
+    /// `log_starting_degree` is log₂ of the degree of the polynomial to commit to.
     ///
     /// # Panics
     ///
-    /// Panics if `log_folding_factor < 2`, if `log_starting_folding_factor < 2`, or if
-    /// `log_starting_folding_factor > log_starting_degree`.
+    /// Panics if the requested parameters cannot reach `security_level` at this degree; see
+    /// [`Self::try_new`] for the fallible form and [`StirConfigError`] for the failure modes.
     pub fn new(log_starting_degree: usize, params: StirParameters<M>) -> Self {
-        Self::new_with_optional_combine(log_starting_degree, params, None)
+        Self::try_new(log_starting_degree, params).unwrap_or_else(|e| panic!("{e}"))
     }
 
-    /// Like [`Self::new`], but additionally inflates round 0's `eta` (and, transitively,
+    /// Like [`Self::try_new`], but additionally inflates round 0's `eta` (and, transitively,
     /// the whole schedule that follows from it) so the batch-degree-correction `Combine`
     /// step (§4.5) also reaches `params.security_level` when merging `num_classes` height
     /// classes that share this config's initial domain, immediately before the round-0
@@ -255,6 +384,21 @@ where
     /// `ell` is Lemma 4.13's error argument `num_classes·(d* + 1) − Σᵢ dᵢ` (dᵢ each
     /// class's own, non-quotiented degree bound), consulted by both
     /// `SecurityAssumption` regimes' error terms.
+    pub fn try_new_with_combine(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        num_classes: usize,
+        ell: u64,
+    ) -> Result<Self, StirConfigError> {
+        Self::try_new_with_optional_combine(
+            log_starting_degree,
+            params,
+            Some(CombineRequirement { num_classes, ell }),
+        )
+    }
+
+    /// Like [`Self::new`], but additionally inflates round 0's `eta` per
+    /// [`Self::try_new_with_combine`].
     ///
     /// # Panics
     ///
@@ -268,69 +412,59 @@ where
         num_classes: usize,
         ell: u64,
     ) -> Self {
-        assert!(
-            num_classes >= 2,
-            "new_with_combine requires at least 2 height classes (got {num_classes}); a single \
-             class needs no Combine, so use StirConfig::new"
-        );
-        assert!(
-            ell >= num_classes as u64,
-            "Combine multiplicity ell = {ell} is below the class count {num_classes}; every \
-             class contributes at least one to ell = Σᵢ (gapᵢ + 1)"
-        );
-        Self::new_with_optional_combine(
-            log_starting_degree,
-            params,
-            Some(CombineRequirement { num_classes, ell }),
-        )
+        Self::try_new_with_combine(log_starting_degree, params, num_classes, ell)
+            .unwrap_or_else(|e| panic!("{e}"))
     }
 
-    fn new_with_optional_combine(
+    fn try_new_with_optional_combine(
         log_starting_degree: usize,
         params: StirParameters<M>,
         combine: Option<CombineRequirement>,
-    ) -> Self {
-        assert!(
-            params.log_folding_factor >= 2,
-            "the paper-backed STIR parameter schedule requires log_folding_factor >= 2 (k >= 4)"
-        );
-        assert!(
-            params.log_starting_folding_factor >= 2,
-            "the paper-backed STIR parameter schedule requires log_starting_folding_factor >= 2 \
-             (k0 >= 4)"
-        );
-        assert!(
-            params.log_starting_folding_factor <= log_starting_degree,
-            "Starting folding factor ({}) must be <= starting degree ({}).",
-            params.log_starting_folding_factor,
-            log_starting_degree
-        );
+    ) -> Result<Self, StirConfigError> {
+        if params.log_folding_factor < 2 {
+            return Err(StirConfigError::FoldingFactorTooSmall {
+                log_folding_factor: params.log_folding_factor,
+            });
+        }
+        if params.log_starting_folding_factor < 2 {
+            return Err(StirConfigError::StartingFoldingFactorTooSmall {
+                log_starting_folding_factor: params.log_starting_folding_factor,
+            });
+        }
+        if params.log_starting_folding_factor > log_starting_degree {
+            return Err(StirConfigError::StartingFoldingFactorExceedsDegree {
+                log_starting_folding_factor: params.log_starting_folding_factor,
+                log_starting_degree,
+            });
+        }
 
         let log_starting_domain = log_starting_degree
             .checked_add(params.log_blowup)
-            .expect("Initial domain exponent log_starting_degree + log_blowup overflows usize");
+            .ok_or(StirConfigError::InitialDomainExponentOverflow)?;
 
-        assert!(
-            log_starting_domain < usize::BITS as usize,
-            "Initial domain exponent {log_starting_domain} must be less than usize::BITS ({})",
-            usize::BITS
-        );
+        if log_starting_domain >= usize::BITS as usize {
+            return Err(StirConfigError::InitialDomainTooLarge {
+                log_starting_domain,
+                bits: usize::BITS as usize,
+            });
+        }
 
-        assert!(
-            log_starting_domain <= F::TWO_ADICITY,
-            "Initial domain size 2^{} exceeds the two-adicity of the base field ({}).",
-            log_starting_domain,
-            F::TWO_ADICITY,
-        );
+        if log_starting_domain > F::TWO_ADICITY {
+            return Err(StirConfigError::InitialDomainExceedsTwoAdicity {
+                log_starting_domain,
+                two_adicity: F::TWO_ADICITY,
+            });
+        }
 
-        assert!(
-            !matches!(params.soundness_type, SecurityAssumption::UniqueDecoding),
-            "the paper-backed STIR parameter schedule does not support UniqueDecoding"
-        );
-        assert!(
-            params.security_level > params.max_pow_bits,
-            "security_level must be greater than max_pow_bits"
-        );
+        if matches!(params.soundness_type, SecurityAssumption::UniqueDecoding) {
+            return Err(StirConfigError::UnsupportedSoundnessType);
+        }
+        if params.security_level <= params.max_pow_bits {
+            return Err(StirConfigError::SecurityLevelNotGreaterThanPow {
+                security_level: params.security_level,
+                max_pow_bits: params.max_pow_bits,
+            });
+        }
 
         let field_size_bits = EF::bits();
         let log_blowup = params.log_blowup;
@@ -380,19 +514,25 @@ where
         // A derived value > max_pow_bits is a hard misconfiguration: the user's parameters
         // do not deliver `security_level` bits over `total_folds` rounds even after
         // exhausting the PoW budget.
-        let derive_pow_bits = |label: &str, round: &str, algebraic_bits: f64| -> usize {
+        let derive_pow_bits = |label: &'static str,
+                               round: &str,
+                               algebraic_bits: f64|
+         -> Result<usize, StirConfigError> {
             let gap = (buffered_security_level as f64 - algebraic_bits).max(0.0);
             let needed = libm::ceil(gap) as usize;
-            assert!(
-                needed <= max_pow_bits,
-                "{round} {label} requires {needed} PoW bits to reach \
-                 buffered security target = {buffered_security_level} \
-                 (security_level = {security_level} + union-bound buffer = {union_bound_buffer}, \
-                 algebraic bits = {algebraic_bits}), \
-                 but max_pow_bits = {max_pow_bits}. Increase max_pow_bits, log_blowup, \
-                 or use a larger field.",
-            );
-            needed
+            if needed > max_pow_bits {
+                return Err(StirConfigError::PowBudgetExceeded {
+                    round: round.into(),
+                    label,
+                    needed,
+                    buffered_security_level,
+                    security_level,
+                    union_bound_buffer,
+                    algebraic_bits,
+                    max_pow_bits,
+                });
+            }
+            Ok(needed)
         };
 
         // Initial domain shift: use the multiplicative generator so the
@@ -421,18 +561,22 @@ where
                 .soundness_type
                 .stir_queries_for_base(pow_target_bits, failure_base)
         };
-        let validate_eta = |stage: usize, stage_log_inv_rate: usize, eta: f64| {
-            assert!(
-                params
+        let validate_eta =
+            |round: usize, stage_log_inv_rate: usize, eta: f64| -> Result<(), StirConfigError> {
+                if !params
                     .soundness_type
-                    .stir_eta_is_valid(stage_log_inv_rate, eta),
-                "round {stage} produced eta = {eta}, which violates the paper's side-condition \
-                 bound {}",
-                params
-                    .soundness_type
-                    .stir_eta_upper_bound(stage_log_inv_rate)
-            );
-        };
+                    .stir_eta_is_valid(stage_log_inv_rate, eta)
+                {
+                    return Err(StirConfigError::InvalidEta {
+                        round,
+                        eta,
+                        upper_bound: params
+                            .soundness_type
+                            .stir_eta_upper_bound(stage_log_inv_rate),
+                    });
+                }
+                Ok(())
+            };
 
         // Disjoint-coset side condition for round `i`. The schedule sets
         // `shift_{i+1} = shift_i^{k_i} * GEN` each round (`k_i` = that round's own folding
@@ -442,17 +586,17 @@ where
         // we check the simpler `GEN^{2^{N_i}} ≠ 1` where `N_i = (Σ_{j≤i} log_folding_factor_j)
         // + log_domain_i` is the cumulative folding-log through round `i`. Holds for any
         // field whose multiplicative order has nontrivial odd part (BabyBear, KoalaBear,
-        // Goldilocks, …); the assertion catches pathological fields.
-        let assert_disjoint_cosets =
-            |round_index: usize, log_domain_i: usize, cumulative_log_folding: usize| {
-                let n_i = cumulative_log_folding + log_domain_i;
-                assert!(
-                    F::GENERATOR.exp_power_of_2(n_i) != F::ONE,
-                    "STIR round {round_index}: disjoint-coset schedule requires \
-                     Field::GENERATOR^(2^{n_i}) ≠ 1 (i.e. GEN ∉ subgroup of size \
-                     2^{log_domain_i} after the cumulative fold).",
-                );
-            };
+        // Goldilocks, …); the check catches pathological fields.
+        let assert_disjoint_cosets = |round_index: usize,
+                                      log_domain_i: usize,
+                                      cumulative_log_folding: usize|
+         -> Result<(), StirConfigError> {
+            let n_i = cumulative_log_folding + log_domain_i;
+            if F::GENERATOR.exp_power_of_2(n_i) == F::ONE {
+                return Err(StirConfigError::NonDisjointCosets { round_index, n_i });
+            }
+            Ok(())
+        };
 
         // Size eta against both classes of error: PoW-eligible folding/query terms target
         // `pow_target_bits`, while OOD and shake terms must reach the full buffered target.
@@ -505,7 +649,7 @@ where
             );
             final_eta = final_eta.max(combine_eta);
         }
-        validate_eta(0, log_inv_rate, final_eta);
+        validate_eta(0, log_inv_rate, final_eta)?;
 
         // Round 0 reuses the `stir_initial_eta` already computed above; every subsequent
         // round derives eta from the previous round's query count via `stir_recursive_eta`.
@@ -528,12 +672,12 @@ where
                     field_size_bits,
                     prev_queries,
                 );
-                validate_eta(round, log_inv_rate, final_eta);
+                validate_eta(round, log_inv_rate, final_eta)?;
             }
 
             let num_queries = query_count(log_inv_rate, final_eta);
             cumulative_log_folding += round_log_folding_factor;
-            assert_disjoint_cosets(round, log_domain_size, cumulative_log_folding);
+            assert_disjoint_cosets(round, log_domain_size, cumulative_log_folding)?;
 
             let fold_alg = params.soundness_type.fold_algebraic_bits_at_log_eta(
                 field_size_bits,
@@ -558,15 +702,15 @@ where
                 num_ood_samples,
             );
             let round_label = format!("round {round}");
-            assert!(
-                unprotected_alg >= buffered_security_level as f64,
-                "{round_label} OOD/shake checks reach only {unprotected_alg:.4} bits, below \
-                 the buffered target {buffered_security_level}; these challenges are not \
-                 protected by the query-phase PoW. Use a larger challenge field or lower \
-                 security target."
-            );
-            let folding_pow_bits = derive_pow_bits("folding", &round_label, fold_alg);
-            let pow_bits = derive_pow_bits("query", &round_label, query_alg);
+            if unprotected_alg < buffered_security_level as f64 {
+                return Err(StirConfigError::UnprotectedChecksBelowTarget {
+                    round: round_label,
+                    unprotected_alg,
+                    buffered_security_level,
+                });
+            }
+            let folding_pow_bits = derive_pow_bits("folding", &round_label, fold_alg)?;
+            let pow_bits = derive_pow_bits("query", &round_label, query_alg)?;
 
             round_configs.push(StirRoundConfig {
                 log_degree,
@@ -599,7 +743,7 @@ where
                 field_size_bits,
                 prev_queries,
             );
-            validate_eta(num_rounds, log_inv_rate, final_eta);
+            validate_eta(num_rounds, log_inv_rate, final_eta)?;
         }
         let final_queries = query_count(log_inv_rate, final_eta);
 
@@ -617,10 +761,10 @@ where
             final_eta,
             final_queries,
         );
-        let final_folding_pow_bits = derive_pow_bits("folding", "final", final_fold_alg);
-        let final_pow_bits = derive_pow_bits("query", "final", final_query_alg);
+        let final_folding_pow_bits = derive_pow_bits("folding", "final", final_fold_alg)?;
+        let final_pow_bits = derive_pow_bits("query", "final", final_query_alg)?;
 
-        Self {
+        Ok(Self {
             log_starting_degree,
             soundness_type: params.soundness_type,
             security_level: params.security_level,
@@ -636,7 +780,7 @@ where
             final_folding_pow_bits,
             mmcs: params.mmcs,
             _phantom: PhantomData,
-        }
+        })
     }
 
     /// Log₂ of the initial evaluation domain size.
@@ -1163,5 +1307,105 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A parameter set that is feasible at one starting degree can become infeasible at a
+    /// larger one (the schedule's algebraic security shrinks as more rounds are needed).
+    /// `try_new` must report this as an `Err`, not a panic — the fixed `StirParameters` are
+    /// reused across every LDE-height bucket a PCS commits to, so this is reachable from
+    /// proof-controlled data (the trace height) rather than only from a bad static config.
+    #[test]
+    fn try_new_rejects_infeasible_degree_without_panicking() {
+        use p3_challenger::DuplexChallenger;
+        use p3_commit::ExtensionMmcs;
+        use p3_field::Field;
+        use p3_field::extension::BinomialExtensionField;
+        use p3_merkle_tree::MerkleTreeMmcs;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+
+        type F = BabyBear;
+        type EF = BinomialExtensionField<F, 5>;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+        type PackedF = <F as Field>::Packing;
+        type ValMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
+        type MyMmcs = ExtensionMmcs<F, EF, ValMmcs>;
+        type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
+
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(7);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let val_mmcs = ValMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
+
+        let params = |log_blowup| StirParameters {
+            log_blowup,
+            log_folding_factor: 4,
+            log_starting_folding_factor: 4,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 100,
+            max_pow_bits: 0,
+            mmcs: MyMmcs::new(val_mmcs.clone()),
+        };
+
+        // Feasible at a moderate degree.
+        assert!(StirConfig::<F, EF, MyMmcs, MyChallenger>::try_new(20, params(1)).is_ok());
+
+        // Infeasible two rounds deeper, with the exact same parameters: the derived eta at a
+        // later round violates the paper's side-condition bound rather than reaching the
+        // configured security level.
+        let err = StirConfig::<F, EF, MyMmcs, MyChallenger>::try_new(22, params(1)).unwrap_err();
+        assert!(matches!(err, StirConfigError::InvalidEta { .. }), "{err}");
+    }
+
+    #[test]
+    fn new_panics_with_the_same_message_as_try_new_errors_with() {
+        extern crate std;
+
+        use alloc::string::ToString;
+
+        use p3_challenger::DuplexChallenger;
+        use p3_commit::ExtensionMmcs;
+        use p3_field::Field;
+        use p3_field::extension::BinomialExtensionField;
+        use p3_merkle_tree::MerkleTreeMmcs;
+        use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+        use rand::SeedableRng;
+
+        type F = BabyBear;
+        type EF = BinomialExtensionField<F, 5>;
+        type Perm = Poseidon2BabyBear<16>;
+        type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+        type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+        type PackedF = <F as Field>::Packing;
+        type ValMmcs = MerkleTreeMmcs<PackedF, PackedF, MyHash, MyCompress, 2, 8>;
+        type MyMmcs = ExtensionMmcs<F, EF, ValMmcs>;
+        type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
+
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(7);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let val_mmcs = ValMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
+
+        let params = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 4,
+            log_starting_folding_factor: 4,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 100,
+            max_pow_bits: 0,
+            mmcs: MyMmcs::new(val_mmcs),
+        };
+
+        let err = StirConfig::<F, EF, MyMmcs, MyChallenger>::try_new(22, params.clone())
+            .unwrap_err()
+            .to_string();
+        let panic_payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            StirConfig::<F, EF, MyMmcs, MyChallenger>::new(22, params)
+        }))
+        .unwrap_err();
+        let panic_message = panic_payload
+            .downcast_ref::<alloc::string::String>()
+            .unwrap();
+        assert_eq!(*panic_message, err);
     }
 }

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -55,7 +55,7 @@ mod soundness;
 pub mod utils;
 pub mod verifier;
 
-pub use config::{StirConfig, StirConfigError, StirParameters, StirRoundConfig};
+pub use config::{Stage, StirConfig, StirConfigError, StirParameters, StirRoundConfig};
 pub use p3_security::whir::SecurityAssumption;
 pub use pcs::TwoAdicStirPcs;
 pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -55,7 +55,7 @@ mod soundness;
 pub mod utils;
 pub mod verifier;
 
-pub use config::{StirConfig, StirParameters, StirRoundConfig};
+pub use config::{StirConfig, StirConfigError, StirParameters, StirRoundConfig};
 pub use p3_security::whir::SecurityAssumption;
 pub use pcs::TwoAdicStirPcs;
 pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -40,10 +40,10 @@
 //! its own matrices' heights.
 
 use alloc::borrow::Cow;
+use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
-use core::marker::PhantomData;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
@@ -62,9 +62,10 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
 use serde::{Deserialize, Serialize};
+use spin::RwLock;
 use tracing::instrument;
 
-use crate::config::{StirConfig, StirParameters};
+use crate::config::{StirConfig, StirConfigError, StirParameters};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_external_codewords;
 use crate::utils::combine_on_coset;
@@ -140,22 +141,38 @@ fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
         .collect()
 }
 
+/// STIR configs derived on demand, memoized by `log_stir_degree`.
+type StirConfigCache<Val, Challenge, StirMmcs, Challenger> = Arc<
+    RwLock<
+        alloc::collections::BTreeMap<usize, Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>>,
+    >,
+>;
+
 /// A polynomial commitment scheme using STIR to generate opening proofs.
 #[derive(Clone, Debug)]
-pub struct TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs> {
+pub struct TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> {
     dft: Dft,
     input_mmcs: InputMmcs,
     stir: StirParameters<StirMmcs>,
-    _phantom: PhantomData<Val>,
+    /// `StirConfig::new` runs an 80-iteration floating-point bisection to derive sound round
+    /// parameters. `open`/`verify` re-derive it per LDE-height bucket, and the same degree
+    /// recurs across calls and across proofs, so caching it here (bounded by the base
+    /// field's two-adicity) avoids repeating that derivation every time. Only the base
+    /// (non-`Combine`) construction is memoized: `Combine` configs are additionally keyed by
+    /// per-bucket runtime state (`num_classes`, `ell`) that does not collapse into this
+    /// single-`usize` cache key.
+    config_cache: StirConfigCache<Val, Challenge, StirMmcs, Challenger>,
 }
 
-impl<Val, Dft, InputMmcs, StirMmcs> TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs> {
-    pub const fn new(dft: Dft, input_mmcs: InputMmcs, stir: StirParameters<StirMmcs>) -> Self {
+impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
+    TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
+{
+    pub fn new(dft: Dft, input_mmcs: InputMmcs, stir: StirParameters<StirMmcs>) -> Self {
         Self {
             dft,
             input_mmcs,
             stir,
-            _phantom: PhantomData,
+            config_cache: Arc::new(RwLock::new(alloc::collections::BTreeMap::new())),
         }
     }
 
@@ -185,6 +202,43 @@ impl<Val, Dft, InputMmcs, StirMmcs> TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs
     }
 }
 
+impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
+    TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
+where
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
+    StirMmcs: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger<Witness = Val>,
+{
+    /// Returns the derived STIR config for `log_stir_degree`, computing and caching it on
+    /// first use.
+    fn get_or_try_compute_stir_config(
+        &self,
+        log_stir_degree: usize,
+    ) -> Result<Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>, StirConfigError> {
+        if let Some(config) = self.config_cache.read().get(&log_stir_degree) {
+            return Ok(config.clone());
+        }
+        let mut w_lock = self.config_cache.write();
+        if let Some(config) = w_lock.get(&log_stir_degree) {
+            return Ok(config.clone());
+        }
+        let config = Arc::new(StirConfig::try_new(log_stir_degree, self.stir.clone())?);
+        w_lock.insert(log_stir_degree, config.clone());
+        Ok(config)
+    }
+
+    /// Like [`Self::get_or_try_compute_stir_config`], but panics on an infeasible config —
+    /// for use on the prover side, where `open` cannot return a `Result`.
+    fn get_or_compute_stir_config(
+        &self,
+        log_stir_degree: usize,
+    ) -> Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>> {
+        self.get_or_try_compute_stir_config(log_stir_degree)
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+}
+
 /// One bucket's `Combine` state for the verifier: the sampled combination challenge and each
 /// present native height's `(r_i, gap_i)` coefficients (`None` when the bucket has only one
 /// class, so no `Combine` step ran).
@@ -194,7 +248,7 @@ type BucketCombine<Challenge> = Option<(
 )>;
 
 impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> Pcs<Challenge, Challenger>
-    for TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs>
+    for TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
 where
     Val: TwoAdicField,
     Dft: TwoAdicSubgroupDft<Val>,
@@ -511,6 +565,13 @@ where
                     .zip(opened_vals.iter())
                     .zip(data.log_native_heights.iter())
             {
+                // A matrix opened at no points contributes nothing to the reduced opening;
+                // skip the O(height * width) alpha-batched dot product below rather than
+                // computing it only to leave it unused.
+                if points_for_mat.is_empty() {
+                    continue;
+                }
+
                 let key = (data.log_shared_lde_height, log_native_h);
                 let ro = reduced_openings
                     .entry(key)
@@ -575,7 +636,7 @@ where
             })
             .collect();
 
-        let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+        let stir_configs: Vec<Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>> =
             bucket_log_heights
                 .iter()
                 .zip(&bucket_native_heights)
@@ -585,22 +646,21 @@ where
                         let log_d_star = native_heights[0];
                         let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
                             - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
-                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
-                            log_stir_degree,
-                            self.stir.clone(),
-                            native_heights.len(),
-                            ell,
+                        Arc::new(
+                            StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
+                                log_stir_degree,
+                                self.stir.clone(),
+                                native_heights.len(),
+                                ell,
+                            ),
                         )
                     } else {
-                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                            log_stir_degree,
-                            self.stir.clone(),
-                        )
+                        self.get_or_compute_stir_config(log_stir_degree)
                     }
                 })
                 .collect();
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
-            stir_configs.iter().collect();
+            stir_configs.iter().map(AsRef::as_ref).collect();
 
         let initial_codewords: Vec<Vec<Challenge>> = bucket_log_heights
             .iter()
@@ -803,7 +863,7 @@ where
             })
             .collect();
 
-        let stir_configs: Vec<StirConfig<Val, Challenge, StirMmcs, Challenger>> =
+        let stir_configs: Vec<Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>> =
             bucket_log_heights
                 .iter()
                 .zip(&bucket_native_heights)
@@ -813,22 +873,21 @@ where
                         let log_d_star = native_heights[0];
                         let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
                             - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
-                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
+                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::try_new_with_combine(
                             log_stir_degree,
                             self.stir.clone(),
                             native_heights.len(),
                             ell,
                         )
+                        .map(Arc::new)
                     } else {
-                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::new(
-                            log_stir_degree,
-                            self.stir.clone(),
-                        )
+                        self.get_or_try_compute_stir_config(log_stir_degree)
                     }
                 })
-                .collect();
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(StirError::Config)?;
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
-            stir_configs.iter().collect();
+            stir_configs.iter().map(AsRef::as_ref).collect();
         let stir_proofs: Vec<&StirProof<Challenge, StirMmcs, Val>> =
             proof.iter().map(|(p, _)| p).collect();
 
@@ -948,12 +1007,22 @@ where
                             return Err(StirError::InvalidProofShape);
                         }
 
+                        // Pin each matrix's width to its claimed evaluation count, never to
+                        // the proof: a matrix opened at no points carries no claim to pin its
+                        // width, so reject rather than silently deriving width 0 (mirrors
+                        // `fri::verifier::FriError::MatrixWithoutOpeningPoints`).
                         let mat_widths: Vec<usize> = domain_claims
                             .iter()
-                            .map(|(_, point_claims)| {
-                                point_claims.first().map(|(_, v)| v.len()).unwrap_or(0)
+                            .enumerate()
+                            .map(|(mat_idx, (_, point_claims))| {
+                                point_claims.first().map(|(_, v)| v.len()).ok_or(
+                                    StirError::MatrixWithoutOpeningPoints {
+                                        commitment: commit_idx,
+                                        matrix: mat_idx,
+                                    },
+                                )
                             })
-                            .collect();
+                            .collect::<Result<Vec<usize>, _>>()?;
 
                         // A matrix's native-height class, and each of its opening points'
                         // slot in `bucket_points`, are fixed for the whole commitment. Both

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -141,12 +141,30 @@ fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
         .collect()
 }
 
-/// STIR configs derived on demand, memoized by `log_stir_degree`.
+/// Key identifying a derived STIR config: the bucket's degree plus, when §7's `Combine` runs,
+/// the class count and multiplicity that size round 0's `eta`.
+///
+/// `(log_stir_degree, 1, 0)` is the canonical no-`Combine` key; it cannot collide with a
+/// `Combine` key, since [`StirConfig::try_new_with_combine`] rejects `num_classes < 2`.
+type StirConfigKey = (usize, usize, u64);
+
+/// STIR configs derived on demand, memoized by [`StirConfigKey`].
 type StirConfigCache<Val, Challenge, StirMmcs, Challenger> = Arc<
     RwLock<
-        alloc::collections::BTreeMap<usize, Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>>,
+        alloc::collections::BTreeMap<
+            StirConfigKey,
+            Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>,
+        >,
     >,
 >;
+
+/// Cap on memoized configs.
+///
+/// The key space is bounded by the base field's two-adicity and the height shapes a caller
+/// actually commits, but `verify` derives its keys from claim shapes, so a hard cap keeps a
+/// pathological caller from growing the map without bound. Past the cap, derivation still
+/// returns a correct config — just an unmemoized one.
+const CONFIG_CACHE_CAPACITY: usize = 256;
 
 /// A polynomial commitment scheme using STIR to generate opening proofs.
 #[derive(Clone, Debug)]
@@ -154,13 +172,13 @@ pub struct TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> 
     dft: Dft,
     input_mmcs: InputMmcs,
     stir: StirParameters<StirMmcs>,
-    /// `StirConfig::new` runs an 80-iteration floating-point bisection to derive sound round
-    /// parameters. `open`/`verify` re-derive it per LDE-height bucket, and the same degree
-    /// recurs across calls and across proofs, so caching it here (bounded by the base
-    /// field's two-adicity) avoids repeating that derivation every time. Only the base
-    /// (non-`Combine`) construction is memoized: `Combine` configs are additionally keyed by
-    /// per-bucket runtime state (`num_classes`, `ell`) that does not collapse into this
-    /// single-`usize` cache key.
+    /// `StirConfig::try_new` runs an 80-iteration floating-point bisection per stage to
+    /// derive sound round parameters. `open`/`verify` re-derive it per LDE-height bucket, and
+    /// bucket shapes recur across calls and across proofs of the same statement, so caching
+    /// them here avoids repeating that derivation every time. `Combine` configs are keyed by
+    /// their `(num_classes, ell)` alongside the degree: with matrices sharing one domain, a
+    /// commitment holding several native heights always takes the `Combine` branch, so a
+    /// degree-only key would miss on exactly the shape this PCS exists for.
     config_cache: StirConfigCache<Val, Challenge, StirMmcs, Challenger>,
 }
 
@@ -210,22 +228,43 @@ where
     StirMmcs: Mmcs<Challenge>,
     Challenger: FieldChallenger<Val> + GrindingChallenger<Witness = Val>,
 {
-    /// Returns the derived STIR config for `log_stir_degree`, computing and caching it on
-    /// first use.
+    /// Returns the derived STIR config for one bucket, computing and caching it on first use.
+    ///
+    /// `combine` carries the bucket's `(num_classes, ell)` when more than one native-height
+    /// class shares its domain and §7's `Combine` therefore runs, and is `None` otherwise.
     fn get_or_try_compute_stir_config(
         &self,
         log_stir_degree: usize,
+        combine: Option<(usize, u64)>,
     ) -> Result<Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>, StirConfigError> {
-        if let Some(config) = self.config_cache.read().get(&log_stir_degree) {
+        let key: StirConfigKey = combine.map_or((log_stir_degree, 1, 0), |(classes, ell)| {
+            (log_stir_degree, classes, ell)
+        });
+
+        if let Some(config) = self.config_cache.read().get(&key) {
             return Ok(config.clone());
         }
-        let mut w_lock = self.config_cache.write();
-        if let Some(config) = w_lock.get(&log_stir_degree) {
-            return Ok(config.clone());
+
+        // Derived before the write guard is taken: `spin::RwLock` does not park, so holding it
+        // across the bisection would make a thread missing on *any* key busy-spin for the
+        // whole derivation — under rayon, possibly while the holder is descheduled. The
+        // derivation is idempotent, so a racing duplicate is harmless: the loser's `Arc` is
+        // simply dropped in favour of whichever landed first.
+        let config = Arc::new(match combine {
+            Some((num_classes, ell)) => StirConfig::try_new_with_combine(
+                log_stir_degree,
+                self.stir.clone(),
+                num_classes,
+                ell,
+            )?,
+            None => StirConfig::try_new(log_stir_degree, self.stir.clone())?,
+        });
+
+        let mut cache = self.config_cache.write();
+        if cache.len() >= CONFIG_CACHE_CAPACITY && !cache.contains_key(&key) {
+            return Ok(config);
         }
-        let config = Arc::new(StirConfig::try_new(log_stir_degree, self.stir.clone())?);
-        w_lock.insert(log_stir_degree, config.clone());
-        Ok(config)
+        Ok(cache.entry(key).or_insert(config).clone())
     }
 
     /// Like [`Self::get_or_try_compute_stir_config`], but panics on an infeasible config —
@@ -233,9 +272,23 @@ where
     fn get_or_compute_stir_config(
         &self,
         log_stir_degree: usize,
+        combine: Option<(usize, u64)>,
     ) -> Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>> {
-        self.get_or_try_compute_stir_config(log_stir_degree)
+        self.get_or_try_compute_stir_config(log_stir_degree, combine)
             .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// A bucket's `Combine` key: `None` when only one native-height class shares the domain.
+    ///
+    /// `ell` is Lemma 4.13's multiplicity `num_classes·(d* + 1) − Σᵢ dᵢ`, with `d*` the
+    /// tallest class's degree (`native_heights` is descending).
+    fn combine_key(native_heights: &[usize]) -> Option<(usize, u64)> {
+        (native_heights.len() >= 2).then(|| {
+            let d_star = 1u64 << native_heights[0];
+            let ell = native_heights.len() as u64 * (d_star + 1)
+                - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
+            (native_heights.len(), ell)
+        })
     }
 }
 
@@ -565,12 +618,16 @@ where
                     .zip(opened_vals.iter())
                     .zip(data.log_native_heights.iter())
             {
-                // A matrix opened at no points contributes nothing to the reduced opening;
-                // skip the O(height * width) alpha-batched dot product below rather than
-                // computing it only to leave it unused.
-                if points_for_mat.is_empty() {
-                    continue;
-                }
+                // A matrix opened at no points would contribute nothing to the reduced
+                // opening, but the verifier still counts it as a native-height class (it reads
+                // class membership off the claimed domains), so skipping it here would emit a
+                // proof that cannot verify. `verify` rejects the same shape up front; this is
+                // the prover-side mirror.
+                assert!(
+                    !points_for_mat.is_empty(),
+                    "STIR PCS: matrix at native height 2^{log_native_h} was opened at no \
+                     points; every committed matrix must be opened at least once"
+                );
 
                 let key = (data.log_shared_lde_height, log_native_h);
                 let ro = reduced_openings
@@ -642,21 +699,10 @@ where
                 .zip(&bucket_native_heights)
                 .map(|(&log_h, native_heights)| {
                     let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-                    if native_heights.len() >= 2 {
-                        let log_d_star = native_heights[0];
-                        let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
-                            - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
-                        Arc::new(
-                            StirConfig::<Val, Challenge, StirMmcs, Challenger>::new_with_combine(
-                                log_stir_degree,
-                                self.stir.clone(),
-                                native_heights.len(),
-                                ell,
-                            ),
-                        )
-                    } else {
-                        self.get_or_compute_stir_config(log_stir_degree)
-                    }
+                    self.get_or_compute_stir_config(
+                        log_stir_degree,
+                        Self::combine_key(native_heights),
+                    )
                 })
                 .collect();
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
@@ -731,6 +777,25 @@ where
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
+        // SHAPE CHECK, before anything reaches the transcript: a matrix opened at no points
+        // carries no claim to pin its width, and the prover skips it entirely — so it would
+        // not create a native-height class where the verifier, reading class membership off
+        // the claimed domains, still counts one. That disagreement decides whether `Combine`
+        // runs and therefore whether `r_comb` is drawn, so it has to be settled before the
+        // transcript can fork on it. Depends only on the public claims (mirrors
+        // `fri::verifier::FriError::MatrixWithoutOpeningPoints`).
+        for (commitment, domain_claims) in commitments_with_opening_points
+            .iter()
+            .enumerate()
+            .map(|(commit_idx, (_, domain_claims))| (commit_idx, domain_claims))
+        {
+            for (matrix, (_, point_claims)) in domain_claims.iter().enumerate() {
+                if point_claims.is_empty() {
+                    return Err(StirError::MatrixWithoutOpeningPoints { commitment, matrix });
+                }
+            }
+        }
+
         // Observe all opened values to keep the transcript in sync.
         for (_, domain_claims) in &commitments_with_opening_points {
             for (_, point_claims) in domain_claims {
@@ -869,20 +934,10 @@ where
                 .zip(&bucket_native_heights)
                 .map(|(&log_h, native_heights)| {
                     let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
-                    if native_heights.len() >= 2 {
-                        let log_d_star = native_heights[0];
-                        let ell: u64 = native_heights.len() as u64 * ((1u64 << log_d_star) + 1)
-                            - native_heights.iter().map(|&d| 1u64 << d).sum::<u64>();
-                        StirConfig::<Val, Challenge, StirMmcs, Challenger>::try_new_with_combine(
-                            log_stir_degree,
-                            self.stir.clone(),
-                            native_heights.len(),
-                            ell,
-                        )
-                        .map(Arc::new)
-                    } else {
-                        self.get_or_try_compute_stir_config(log_stir_degree)
-                    }
+                    self.get_or_try_compute_stir_config(
+                        log_stir_degree,
+                        Self::combine_key(native_heights),
+                    )
                 })
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(StirError::Config)?;
@@ -1008,21 +1063,17 @@ where
                         }
 
                         // Pin each matrix's width to its claimed evaluation count, never to
-                        // the proof: a matrix opened at no points carries no claim to pin its
-                        // width, so reject rather than silently deriving width 0 (mirrors
-                        // `fri::verifier::FriError::MatrixWithoutOpeningPoints`).
+                        // the proof. Every matrix has at least one claim — the up-front check
+                        // in `verify` rejects otherwise before the transcript is touched.
                         let mat_widths: Vec<usize> = domain_claims
                             .iter()
-                            .enumerate()
-                            .map(|(mat_idx, (_, point_claims))| {
-                                point_claims.first().map(|(_, v)| v.len()).ok_or(
-                                    StirError::MatrixWithoutOpeningPoints {
-                                        commitment: commit_idx,
-                                        matrix: mat_idx,
-                                    },
-                                )
+                            .map(|(_, point_claims)| {
+                                point_claims
+                                    .first()
+                                    .map(|(_, v)| v.len())
+                                    .expect("rejected up front in verify")
                             })
-                            .collect::<Result<Vec<usize>, _>>()?;
+                            .collect();
 
                         // A matrix's native-height class, and each of its opening points'
                         // slot in `bucket_points`, are fixed for the whole commitment. Both
@@ -1351,9 +1402,18 @@ fn compute_inverse_denominators<'a, F: TwoAdicField, EF: ExtensionField<F>>(
 
 #[cfg(test)]
 mod tests {
-    use p3_baby_bear::BabyBear;
+    use alloc::format;
+
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
+    use p3_commit::ExtensionMmcs;
+    use p3_dft::Radix2DitParallel;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_security::whir::SecurityAssumption;
+    use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use rand::SeedableRng;
 
     use super::*;
 
@@ -1391,5 +1451,120 @@ mod tests {
         // `d_i > d*` would wrap the `d* - d_i` subtraction in release and yield a wrong
         // codeword rather than a failure, so the precondition is checked rather than assumed.
         let _ = combine_coefficients(EF::from_u64(3), 3, [3usize, 4].into_iter());
+    }
+
+    type TestVal = BabyBear;
+    type TestPerm = Poseidon2BabyBear<16>;
+    type TestHash = PaddingFreeSponge<TestPerm, 16, 8, 8>;
+    type TestCompress = TruncatedPermutation<TestPerm, 2, 8, 16>;
+    type TestPacked = <TestVal as Field>::Packing;
+    type TestValMmcs = MerkleTreeMmcs<TestPacked, TestPacked, TestHash, TestCompress, 2, 8>;
+    type TestStirMmcs = ExtensionMmcs<TestVal, EF, TestValMmcs>;
+    type TestChallenger = DuplexChallenger<TestVal, TestPerm, 16, 8>;
+    type TestPcs = TwoAdicStirPcs<
+        TestVal,
+        Radix2DitParallel<TestVal>,
+        TestValMmcs,
+        TestStirMmcs,
+        EF,
+        TestChallenger,
+    >;
+    type TestConfig = StirConfig<TestVal, EF, TestStirMmcs, TestChallenger>;
+
+    /// Every value the schedule derives, in one comparable string. `StirConfig` has no
+    /// `PartialEq`, and only the derived schedule matters here — the `mmcs` field is cloned
+    /// straight from the shared parameters.
+    fn schedule_fingerprint(config: &TestConfig) -> alloc::string::String {
+        format!(
+            "{:?}|{}|{}|{}|{}|{}|{}|{}|{}|{:?}|{}|{}|{:?}",
+            config.soundness_type,
+            config.log_starting_degree,
+            config.security_level,
+            config.max_pow_bits,
+            config.log_blowup,
+            config.log_folding_factor,
+            config.log_starting_folding_factor,
+            config.log_final_degree,
+            config.final_queries,
+            config.final_eta,
+            config.final_pow_bits,
+            config.final_folding_pow_bits,
+            config.round_configs,
+        )
+    }
+
+    fn test_pcs_and_params() -> (TestPcs, StirParameters<TestStirMmcs>) {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(11);
+        let perm = TestPerm::new_from_rng_128(&mut rng);
+        let val_mmcs = TestValMmcs::new(TestHash::new(perm.clone()), TestCompress::new(perm), 0);
+        let stir = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 2,
+            log_starting_folding_factor: 2,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 32,
+            max_pow_bits: 0,
+            mmcs: TestStirMmcs::new(val_mmcs.clone()),
+        };
+        (
+            TwoAdicStirPcs::new(Radix2DitParallel::default(), val_mmcs, stir.clone()),
+            stir,
+        )
+    }
+
+    #[test]
+    fn cached_configs_match_a_fresh_derivation() {
+        // An under-specified cache key is silent in the worst way: a proof produced under one
+        // config and checked under another. Deriving the same shapes twice through the cache
+        // and comparing against an uncached derivation is what catches it — in particular that
+        // two buckets sharing a degree but differing in class count do not collide.
+        let (pcs, stir) = test_pcs_and_params();
+
+        let shapes: [(usize, Option<(usize, u64)>); 4] = [
+            (8, None),
+            // Same degree, but merging two classes: a degree-only key would alias these.
+            (8, Some((2, 194))),
+            (8, Some((3, 300))),
+            (6, None),
+        ];
+
+        for (log_stir_degree, combine) in shapes {
+            let expected = match combine {
+                Some((num_classes, ell)) => TestConfig::try_new_with_combine(
+                    log_stir_degree,
+                    stir.clone(),
+                    num_classes,
+                    ell,
+                ),
+                None => TestConfig::try_new(log_stir_degree, stir.clone()),
+            }
+            .expect("feasible shape");
+
+            // Twice: the first call populates the entry, the second must return the same one.
+            for round in 0..2 {
+                let cached = pcs
+                    .get_or_try_compute_stir_config(log_stir_degree, combine)
+                    .expect("feasible shape");
+                assert_eq!(
+                    schedule_fingerprint(&cached),
+                    schedule_fingerprint(&expected),
+                    "deg={log_stir_degree} combine={combine:?} round={round}"
+                );
+            }
+        }
+
+        // One entry per distinct shape, so nothing aliased and nothing was inserted twice.
+        assert_eq!(pcs.config_cache.read().len(), shapes.len());
+    }
+
+    #[test]
+    fn cache_errors_are_not_memoized() {
+        // A garbage claim shape must not be able to occupy a cache slot permanently.
+        let (pcs, _) = test_pcs_and_params();
+        assert!(
+            pcs.get_or_try_compute_stir_config(8, Some((2, 1))).is_err(),
+            "ell below the class count must be rejected"
+        );
+        assert!(pcs.config_cache.read().is_empty());
     }
 }

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -132,76 +132,17 @@ fn minimum_eta_for_target(
     high
 }
 
-fn list_size_bits_at_log_eta(
-    assumption: SecurityAssumption,
-    log_degree: usize,
-    log_inv_rate: usize,
-    log_eta: f64,
-) -> f64 {
-    match assumption {
-        SecurityAssumption::UniqueDecoding => 0.,
-        SecurityAssumption::JohnsonBound => log_inv_rate as f64 / 2. - (1. + log_eta),
-        SecurityAssumption::CapacityBound => (log_degree + log_inv_rate) as f64 - log_eta,
-    }
-}
-
-/// Log2 of the exceptional set a proximity-gaps argument charges over a degree-`2^log_degree`
-/// code at rate `2^-log_inv_rate`, evaluated at distance `delta = 1 - B*(rho) - eta`.
+/// Algebraic bits §7 Construction 7.2's batch degree correction ("Combine") retains merging
+/// classes of total multiplicity `ell` into a single codeword of degree `2^log_d_star`, at
+/// `delta = 1 - B*(rho) - eta`.
 ///
-/// Every proximity-gaps-shaped error in this file is this quantity plus `log2(multiplicity - 1)`
-/// subtracted from the field size. Both batching arguments STIR runs — the random linear
-/// combination of `num_functions` oracles, and §7's `ell`-fold batch degree correction — differ
-/// only in that multiplicity, so they share one bound per regime instead of each deriving its
-/// own.
-fn prox_gaps_exceptional_set_bits_at_log_eta(
-    assumption: SecurityAssumption,
-    log_degree: usize,
-    log_inv_rate: usize,
-    log_eta: f64,
-) -> f64 {
-    match assumption {
-        SecurityAssumption::UniqueDecoding => (log_degree + log_inv_rate) as f64,
-        SecurityAssumption::JohnsonBound => {
-            // BCSS25 Theorem 1.5, dominant term, at the protocol's actual eta:
-            // m = max(ceil(sqrt(rho) / (2 eta)), 3).
-            let log_sqrt_rho_over_2eta = -(log_inv_rate as f64) / 2. - 1. - log_eta;
-            let m = libm::ceil(libm::pow(2., log_sqrt_rho_over_2eta)).max(3.);
-            let log_n = (log_degree + log_inv_rate) as f64;
-            let constant = libm::log2(2. * libm::pow(m + 0.5, 5.) / 3.);
-            log_n + constant + 1.5 * log_inv_rate as f64
-        }
-        SecurityAssumption::CapacityBound => (log_degree + 2 * log_inv_rate) as f64 - log_eta,
-    }
-}
-
-fn prox_gaps_error_at_log_eta(
-    assumption: SecurityAssumption,
-    log_degree: usize,
-    log_inv_rate: usize,
-    field_size_bits: usize,
-    num_functions: usize,
-    log_eta: f64,
-) -> f64 {
-    assert!(
-        num_functions >= 2,
-        "num_functions must be >= 2 to compute proximity gaps error"
-    );
-
-    let exceptional_set_bits =
-        prox_gaps_exceptional_set_bits_at_log_eta(assumption, log_degree, log_inv_rate, log_eta);
-
-    field_size_bits as f64 - (exceptional_set_bits + libm::log2(num_functions as f64 - 1.))
-}
-
-/// Algebraic bits §7 Construction 7.2's batch degree correction retains merging classes of total
-/// multiplicity `ell` into a single codeword of degree `2^log_d_star`, at `delta = 1 - B*(rho) -
-/// eta`.
-///
-/// This is [`prox_gaps_error_at_log_eta`] with the linear combination's `num_functions - 1`
-/// replaced by Lemma 4.13's degree-gap-inflated `ell - 1`: `err*` is the §4.1 abstraction both
-/// lemmas invoke, so the conjectured route (Conjecture 5.6, `CapacityBound`) and the provable one
-/// (BCSS25 Theorem 1.5, `JohnsonBound`) each inflate by `ell` exactly as they do by the oracle
-/// count.
+/// This is [`SecurityAssumption::prox_gaps_error_at_log_eta`] with the linear combination's
+/// oracle count replaced by Lemma 4.13's degree-gap-inflated `ell`: `err*` is the §4.1
+/// abstraction both lemmas invoke, so the conjectured route (Conjecture 5.6, `CapacityBound`)
+/// and the provable one (BCSS25 Theorem 1.5, `JohnsonBound`) each inflate by `ell` exactly as
+/// they do by the oracle count. Sharing the function, rather than restating either regime's
+/// bound, is what keeps `eta` from being derived off two different Johnson-regime bounds
+/// depending on which term is asked about.
 fn combine_error_at_log_eta(
     assumption: SecurityAssumption,
     log_d_star: usize,
@@ -210,53 +151,18 @@ fn combine_error_at_log_eta(
     ell: u64,
     log_eta: f64,
 ) -> f64 {
-    let exceptional_set_bits =
-        prox_gaps_exceptional_set_bits_at_log_eta(assumption, log_d_star, log_inv_rate, log_eta);
+    // `ell >= 2` holds for any genuine Combine (two classes already give `ell >= 3`); the
+    // clamp keeps the shared assert unreachable from here, and the saturating conversion keeps
+    // the bound conservative rather than wrapping on a 32-bit target.
+    let multiplicity = usize::try_from(ell.max(2)).unwrap_or(usize::MAX);
 
-    field_size_bits as f64
-        - (exceptional_set_bits + libm::log2(ell.saturating_sub(1).max(1) as f64))
-}
-
-fn ood_error_at_log_eta(
-    assumption: SecurityAssumption,
-    log_degree: usize,
-    log_inv_rate: usize,
-    field_size_bits: usize,
-    ood_samples: usize,
-    log_eta: f64,
-) -> f64 {
-    if matches!(assumption, SecurityAssumption::UniqueDecoding) {
-        return 0.;
-    }
-
-    let list_size = list_size_bits_at_log_eta(assumption, log_degree, log_inv_rate, log_eta);
-    let error = 2. * list_size + (log_degree * ood_samples) as f64;
-    (ood_samples * field_size_bits) as f64 + 1. - error
-}
-
-fn fold_sumcheck_error_at_log_eta(
-    assumption: SecurityAssumption,
-    field_size_bits: usize,
-    log_degree: usize,
-    log_inv_rate: usize,
-    log_eta: f64,
-) -> f64 {
-    let list_size = list_size_bits_at_log_eta(assumption, log_degree, log_inv_rate, log_eta);
-    field_size_bits as f64 - (list_size + 1.)
-}
-
-fn queries_combination_error_at_log_eta(
-    assumption: SecurityAssumption,
-    field_size_bits: usize,
-    log_degree: usize,
-    log_inv_rate: usize,
-    ood_samples: usize,
-    num_queries: usize,
-    log_eta: f64,
-) -> f64 {
-    let list_size = list_size_bits_at_log_eta(assumption, log_degree, log_inv_rate, log_eta);
-    let log_combination = libm::log2((ood_samples + num_queries) as f64);
-    field_size_bits as f64 - (log_combination + list_size + 1.)
+    assumption.prox_gaps_error_at_log_eta(
+        log_d_star,
+        log_inv_rate,
+        field_size_bits,
+        multiplicity,
+        log_eta,
+    )
 }
 
 fn shake_check_error(field_size_bits: usize, num_queries: usize, num_ood_samples: usize) -> f64 {
@@ -328,8 +234,7 @@ impl StirSoundness for SecurityAssumption {
             upper,
             unprotected_target_bits,
             |eta| {
-                ood_error_at_log_eta(
-                    *self,
+                self.ood_error_at_log_eta(
                     log_degree,
                     log_inv_rate,
                     field_size_bits,
@@ -434,8 +339,7 @@ impl StirSoundness for SecurityAssumption {
             upper,
             unprotected_target_bits,
             |eta| {
-                ood_error_at_log_eta(
-                    *self,
+                self.ood_error_at_log_eta(
                     log_degree,
                     log_inv_rate,
                     field_size_bits,
@@ -528,21 +432,10 @@ impl StirSoundness for SecurityAssumption {
         log_inv_rate: usize,
         log_eta: f64,
     ) -> f64 {
-        let prox_gaps = prox_gaps_error_at_log_eta(
-            *self,
-            log_degree,
-            log_inv_rate,
-            field_size_bits,
-            2,
-            log_eta,
-        );
-        let sumcheck = fold_sumcheck_error_at_log_eta(
-            *self,
-            field_size_bits,
-            log_degree,
-            log_inv_rate,
-            log_eta,
-        );
+        let prox_gaps =
+            self.prox_gaps_error_at_log_eta(log_degree, log_inv_rate, field_size_bits, 2, log_eta);
+        let sumcheck =
+            self.fold_sumcheck_error_at_log_eta(field_size_bits, log_degree, log_inv_rate, log_eta);
         prox_gaps.min(sumcheck)
     }
 
@@ -557,8 +450,7 @@ impl StirSoundness for SecurityAssumption {
     ) -> f64 {
         let failure_base = self.stir_query_failure_base(log_inv_rate, eta);
         let query_failure = -(num_queries as f64) * libm::log2(failure_base);
-        let combination = queries_combination_error_at_log_eta(
-            *self,
+        let combination = self.queries_combination_error_at_log_eta(
             field_size_bits,
             log_degree,
             log_inv_rate,
@@ -578,8 +470,7 @@ impl StirSoundness for SecurityAssumption {
         num_queries: usize,
         num_ood_samples: usize,
     ) -> f64 {
-        let ood = ood_error_at_log_eta(
-            *self,
+        let ood = self.ood_error_at_log_eta(
             log_degree,
             log_inv_rate,
             field_size_bits,
@@ -617,17 +508,17 @@ mod tests {
                     >= target as f64
             );
             assert!(
-                ood_error_at_log_eta(jb, 20, 2, field_bits, 1, libm::log2(eta)) >= target as f64
+                jb.ood_error_at_log_eta(20, 2, field_bits, 1, libm::log2(eta)) >= target as f64
             );
         }
     }
 
     #[test]
     fn combine_error_matches_prox_gaps_error_at_matching_multiplicity() {
-        // Combine charges the same exceptional set as the linear-combination proximity-gaps
-        // argument, with `num_functions - 1` replaced by `ell - 1`. At `ell = num_functions`
-        // the two must therefore agree exactly, in both regimes — this is what keeps the file
-        // from deriving eta off two different Johnson-regime bounds.
+        // Combine charges the same bound as the linear-combination proximity-gaps argument,
+        // with the oracle count replaced by `ell`. At `ell = num_functions` the two must
+        // therefore agree exactly, in both regimes — which pins the delegation's mapping of
+        // `(log_d_star, ell)` onto `(log_degree, num_functions)`.
         for assumption in [
             SecurityAssumption::JohnsonBound,
             SecurityAssumption::CapacityBound,
@@ -645,8 +536,7 @@ mod tests {
                                     num_functions as u64,
                                     log_eta,
                                 ),
-                                prox_gaps_error_at_log_eta(
-                                    assumption,
+                                assumption.prox_gaps_error_at_log_eta(
                                     log_d_star,
                                     log_inv_rate,
                                     155,
@@ -752,7 +642,7 @@ mod tests {
         assert!(unprotected.is_finite());
         assert_eq!(
             unprotected,
-            ood_error_at_log_eta(cb, 20, 2, 124, 2, libm::log2(0.01))
+            cb.ood_error_at_log_eta(20, 2, 124, 2, libm::log2(0.01))
                 .min(shake_check_error(124, 40, 2))
         );
     }
@@ -764,12 +654,12 @@ mod tests {
         let smaller = safe - 20.;
 
         assert!(
-            prox_gaps_error_at_log_eta(cb, 20, 1, 155, 2, smaller)
-                < prox_gaps_error_at_log_eta(cb, 20, 1, 155, 2, safe)
+            cb.prox_gaps_error_at_log_eta(20, 1, 155, 2, smaller)
+                < cb.prox_gaps_error_at_log_eta(20, 1, 155, 2, safe)
         );
         assert!(
-            ood_error_at_log_eta(cb, 20, 1, 155, 2, smaller)
-                < ood_error_at_log_eta(cb, 20, 1, 155, 2, safe)
+            cb.ood_error_at_log_eta(20, 1, 155, 2, smaller)
+                < cb.ood_error_at_log_eta(20, 1, 155, 2, safe)
         );
     }
 }

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -2,6 +2,8 @@
 
 use p3_security::whir::SecurityAssumption;
 
+use crate::config::StirConfigError;
+
 pub(crate) trait StirSoundness {
     fn stir_num_ood_samples(&self) -> usize;
 
@@ -19,7 +21,7 @@ pub(crate) trait StirSoundness {
         log_inv_rate: usize,
         log_folding_factor: usize,
         field_size_bits: usize,
-    ) -> f64;
+    ) -> Result<f64, StirConfigError>;
 
     #[allow(clippy::too_many_arguments)]
     fn stir_recursive_eta(
@@ -32,7 +34,7 @@ pub(crate) trait StirSoundness {
         log_folding_factor: usize,
         field_size_bits: usize,
         prev_queries: usize,
-    ) -> f64;
+    ) -> Result<f64, StirConfigError>;
 
     fn stir_combine_eta(
         &self,
@@ -41,9 +43,13 @@ pub(crate) trait StirSoundness {
         log_d_star: usize,
         ell: u64,
         target_bits: usize,
-    ) -> f64;
+    ) -> Result<f64, StirConfigError>;
 
-    fn stir_queries_for_base(&self, security_bits: usize, failure_base: f64) -> usize;
+    fn stir_queries_for_base(
+        &self,
+        security_bits: usize,
+        failure_base: f64,
+    ) -> Result<usize, StirConfigError>;
 
     fn fold_algebraic_bits_at_log_eta(
         &self,
@@ -85,35 +91,45 @@ fn rate_from_log_inv_rate(log_inv_rate: usize) -> f64 {
     libm::pow(2., -(log_inv_rate as f64))
 }
 
-fn log2_field_minus_domain(field_size_bits: usize, log_domain_size: usize) -> f64 {
-    assert!(
-        field_size_bits > log_domain_size,
-        "challenge field must contain points outside the evaluation domain"
-    );
+fn log2_field_minus_domain(
+    field_size_bits: usize,
+    log_domain_size: usize,
+) -> Result<f64, StirConfigError> {
+    if field_size_bits <= log_domain_size {
+        return Err(StirConfigError::FieldTooSmallForDomain {
+            field_size_bits,
+            log_domain_size,
+        });
+    }
     let ratio = libm::pow(2., log_domain_size as f64 - field_size_bits as f64);
-    field_size_bits as f64 + libm::log2(1. - ratio)
+    Ok(field_size_bits as f64 + libm::log2(1. - ratio))
 }
 
-fn query_count_from_failure_base(security_bits: usize, failure_base: f64) -> usize {
-    assert!(
-        failure_base > 0. && failure_base < 1.,
-        "STIR query-count formula requires a failure base in (0, 1), got {failure_base}"
-    );
-    libm::ceil(security_bits as f64 / -libm::log2(failure_base)) as usize
+fn query_count_from_failure_base(
+    security_bits: usize,
+    failure_base: f64,
+) -> Result<usize, StirConfigError> {
+    if !(failure_base > 0. && failure_base < 1.) {
+        return Err(StirConfigError::InvalidFailureBase { failure_base });
+    }
+    Ok(libm::ceil(security_bits as f64 / -libm::log2(failure_base)) as usize)
 }
 
 fn minimum_eta_for_target(
     upper_bound: f64,
     target_bits: usize,
     mut bits_at_eta: impl FnMut(f64) -> f64,
-    label: &str,
-) -> f64 {
+    label: &'static str,
+) -> Result<f64, StirConfigError> {
     let upper_bits = bits_at_eta(upper_bound);
-    assert!(
-        upper_bits >= target_bits as f64,
-        "{label} reaches only {upper_bits:.4} bits at the largest permitted eta \
-         ({upper_bound}); target is {target_bits} bits"
-    );
+    if upper_bits < target_bits as f64 {
+        return Err(StirConfigError::EtaInfeasibleForTarget {
+            label,
+            upper_bits,
+            upper_bound,
+            target_bits,
+        });
+    }
 
     // Every bound used here is monotone in eta: a larger safety gap means a
     // smaller list and a smaller BCSS25 exceptional set. Keep `high` feasible
@@ -129,7 +145,7 @@ fn minimum_eta_for_target(
             low = mid;
         }
     }
-    high
+    Ok(high)
 }
 
 /// Algebraic bits §7 Construction 7.2's batch degree correction ("Combine") retains merging
@@ -213,7 +229,7 @@ impl StirSoundness for SecurityAssumption {
         log_inv_rate: usize,
         log_folding_factor: usize,
         field_size_bits: usize,
-    ) -> f64 {
+    ) -> Result<f64, StirConfigError> {
         let upper = self.stir_eta_upper_bound(log_inv_rate);
         let ood_samples = self.stir_num_ood_samples();
 
@@ -229,7 +245,7 @@ impl StirSoundness for SecurityAssumption {
                 )
             },
             "initial STIR folding bound",
-        );
+        )?;
         let ood_eta = minimum_eta_for_target(
             upper,
             unprotected_target_bits,
@@ -243,7 +259,7 @@ impl StirSoundness for SecurityAssumption {
                 )
             },
             "initial STIR OOD bound",
-        );
+        )?;
 
         let schedule_eta = match self {
             // The old BCIKS-form 1/7-power expression is intentionally not
@@ -276,7 +292,7 @@ impl StirSoundness for SecurityAssumption {
             }
         };
 
-        schedule_eta.max(fold_eta).max(ood_eta)
+        Ok(schedule_eta.max(fold_eta).max(ood_eta))
     }
 
     fn stir_recursive_eta(
@@ -289,10 +305,10 @@ impl StirSoundness for SecurityAssumption {
         log_folding_factor: usize,
         field_size_bits: usize,
         prev_queries: usize,
-    ) -> f64 {
+    ) -> Result<f64, StirConfigError> {
         let k = 1usize << log_folding_factor;
         let log_domain = log_domain_size as f64;
-        let log_field_minus_domain = log2_field_minus_domain(field_size_bits, log_domain_size);
+        let log_field_minus_domain = log2_field_minus_domain(field_size_bits, log_domain_size)?;
 
         let schedule_eta = match self {
             Self::JohnsonBound => {
@@ -334,7 +350,7 @@ impl StirSoundness for SecurityAssumption {
                 )
             },
             "recursive STIR folding bound",
-        );
+        )?;
         let ood_eta = minimum_eta_for_target(
             upper,
             unprotected_target_bits,
@@ -348,9 +364,9 @@ impl StirSoundness for SecurityAssumption {
                 )
             },
             "recursive STIR OOD bound",
-        );
+        )?;
 
-        schedule_eta.max(fold_eta).max(ood_eta)
+        Ok(schedule_eta.max(fold_eta).max(ood_eta))
     }
 
     /// Smallest `eta` at which §7 Construction 7.2's batch degree correction ("Combine")
@@ -382,9 +398,11 @@ impl StirSoundness for SecurityAssumption {
     /// multiplicity at `m = 10`, which at `log_d_star = 20`, `log_inv_rate = 1` and a 155-bit
     /// challenge field retains only ~95 bits.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// If no permitted `eta` reaches `target_bits`.
+    /// [`StirConfigError::EtaInfeasibleForTarget`] if no permitted `eta` reaches
+    /// `target_bits`, and [`StirConfigError::UnsupportedSoundnessType`] under
+    /// `UniqueDecoding`.
     fn stir_combine_eta(
         &self,
         field_size_bits: usize,
@@ -392,7 +410,12 @@ impl StirSoundness for SecurityAssumption {
         log_d_star: usize,
         ell: u64,
         target_bits: usize,
-    ) -> f64 {
+    ) -> Result<f64, StirConfigError> {
+        // Checked before any derivation, since `stir_eta_upper_bound` has no answer here.
+        if matches!(self, Self::UniqueDecoding) {
+            return Err(StirConfigError::UnsupportedSoundnessType);
+        }
+
         let eta = minimum_eta_for_target(
             self.stir_eta_upper_bound(log_inv_rate),
             target_bits,
@@ -407,20 +430,24 @@ impl StirSoundness for SecurityAssumption {
                 )
             },
             "Combine batch-degree-correction bound",
-        );
+        )?;
 
         match self {
             // `2/|L_0|` with `|L_0| = 2^(log_d_star + log_inv_rate)`, round 0's domain size.
-            Self::CapacityBound => eta.max(libm::pow(2., 1. - (log_d_star + log_inv_rate) as f64)),
-            // The Johnson regime satisfies the `1/|L_0|` side condition automatically.
-            Self::JohnsonBound => eta,
-            Self::UniqueDecoding => {
-                panic!("STIR's paper-backed parameter schedule does not support UniqueDecoding")
+            Self::CapacityBound => {
+                Ok(eta.max(libm::pow(2., 1. - (log_d_star + log_inv_rate) as f64)))
             }
+            // The Johnson regime satisfies the `1/|L_0|` side condition automatically.
+            Self::JohnsonBound => Ok(eta),
+            Self::UniqueDecoding => Err(StirConfigError::UnsupportedSoundnessType),
         }
     }
 
-    fn stir_queries_for_base(&self, security_bits: usize, failure_base: f64) -> usize {
+    fn stir_queries_for_base(
+        &self,
+        security_bits: usize,
+        failure_base: f64,
+    ) -> Result<usize, StirConfigError> {
         let _ = self;
         query_count_from_failure_base(security_bits, failure_base)
     }
@@ -501,7 +528,9 @@ mod tests {
         let jb = SecurityAssumption::JohnsonBound;
 
         for (target, field_bits) in [(100, 155), (128, 192)] {
-            let eta = jb.stir_initial_eta(target, target, 20, 2, 2, field_bits);
+            let eta = jb
+                .stir_initial_eta(target, target, 20, 2, 2, field_bits)
+                .unwrap();
             assert!(jb.stir_eta_is_valid(2, eta));
             assert!(
                 jb.fold_algebraic_bits_at_log_eta(field_bits, 20, 2, libm::log2(eta))
@@ -563,13 +592,10 @@ mod tests {
         let log_d_star = 20;
         let ell = 1 << 20;
         let target_bits = 100;
-        let log_eta = libm::log2(SecurityAssumption::CapacityBound.stir_combine_eta(
-            field_bits,
-            log_inv_rate,
-            log_d_star,
-            ell,
-            target_bits,
-        ));
+        let eta = SecurityAssumption::CapacityBound
+            .stir_combine_eta(field_bits, log_inv_rate, log_d_star, ell, target_bits)
+            .expect("feasible at these parameters");
+        let log_eta = libm::log2(eta);
         let bits = target_bits as f64
             - (field_bits as f64 + log_eta
                 - 2. * log_inv_rate as f64
@@ -586,8 +612,8 @@ mod tests {
         // A smaller ell needs a smaller minimum eta. Both values stay clear of the Lemma 7.3
         // side-condition floor (eta >= 2/|L_0| = 2^(1 - 21)).
         let cb = SecurityAssumption::CapacityBound;
-        let larger = cb.stir_combine_eta(155, 1, 20, 1 << 20, 100);
-        let smaller = cb.stir_combine_eta(155, 1, 20, 1 << 19, 100);
+        let larger = cb.stir_combine_eta(155, 1, 20, 1 << 20, 100).unwrap();
+        let smaller = cb.stir_combine_eta(155, 1, 20, 1 << 19, 100).unwrap();
         assert!(smaller < larger);
     }
 
@@ -597,7 +623,9 @@ mod tests {
         // Lemma 7.3's `delta < 1 - rho - 1/|L_0|` floor, `eta >= 2^(1 - (log_d_star + lir))`.
         let cb = SecurityAssumption::CapacityBound;
         let (log_d_star, log_inv_rate) = (20, 1);
-        let eta = cb.stir_combine_eta(155, log_inv_rate, log_d_star, 2, 100);
+        let eta = cb
+            .stir_combine_eta(155, log_inv_rate, log_d_star, 2, 100)
+            .unwrap();
         assert_eq!(eta, libm::pow(2., 1. - (log_d_star + log_inv_rate) as f64));
     }
 
@@ -605,8 +633,8 @@ mod tests {
     fn combine_eta_johnson_bound_increases_with_more_groups() {
         // A larger ell (more/taller classes) demands a larger minimum eta.
         let jb = SecurityAssumption::JohnsonBound;
-        let fewer = jb.stir_combine_eta(192, 1, 20, 1 << 21, 100);
-        let more = jb.stir_combine_eta(192, 1, 20, 1 << 22, 100);
+        let fewer = jb.stir_combine_eta(192, 1, 20, 1 << 21, 100).unwrap();
+        let more = jb.stir_combine_eta(192, 1, 20, 1 << 22, 100).unwrap();
         assert!(more > fewer);
     }
 
@@ -627,9 +655,24 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "does not support UniqueDecoding")]
     fn combine_eta_rejects_unique_decoding() {
-        SecurityAssumption::UniqueDecoding.stir_combine_eta(192, 1, 20, 4, 100);
+        assert_eq!(
+            SecurityAssumption::UniqueDecoding.stir_combine_eta(192, 1, 20, 4, 100),
+            Err(StirConfigError::UnsupportedSoundnessType)
+        );
+    }
+
+    #[test]
+    fn combine_eta_reports_infeasibility_instead_of_panicking() {
+        // The Johnson regime cannot fit Combine at production scale; the caller gets the
+        // shortfall rather than an abort, which is what `StirConfig::try_new` relies on.
+        let err = SecurityAssumption::JohnsonBound
+            .stir_combine_eta(155, 1, 20, (1u64 << 20) + (1 << 19) + 3, 106)
+            .expect_err("JB + Combine must not fit at this scale");
+        assert!(
+            matches!(err, StirConfigError::EtaInfeasibleForTarget { .. }),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -760,7 +760,7 @@ where
 }
 
 /// Errors returned by [`verify_stir`].
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum StirError<MmcsError, InputError = ()> {
     /// A proof-of-work witness failed verification.
     #[error("Invalid proof-of-work witness in round {round}")]
@@ -790,6 +790,15 @@ pub enum StirError<MmcsError, InputError = ()> {
     #[error("Invalid proof shape")]
     InvalidProofShape,
 
+    /// A matrix in `commitment`'s batch was opened at zero points, so its width cannot be
+    /// pinned from the claimed evaluations. Every input matrix must be opened at >= 1 point.
+    #[error("Matrix {matrix} in commitment {commitment} was opened at zero points")]
+    MatrixWithoutOpeningPoints { commitment: usize, matrix: usize },
+
+    /// The requested STIR parameters cannot reach `security_level` at some LDE-height bucket.
+    #[error("STIR config error: {0}")]
+    Config(#[source] crate::config::StirConfigError),
+
     /// An error propagated from the input polynomial commitment scheme.
     #[error("Input error")]
     InputError(InputError),
@@ -809,6 +818,10 @@ impl<E1, IE1> StirError<E1, IE1> {
             }
             Self::FinalPolyMismatch => StirError::FinalPolyMismatch,
             Self::InvalidProofShape => StirError::InvalidProofShape,
+            Self::MatrixWithoutOpeningPoints { commitment, matrix } => {
+                StirError::MatrixWithoutOpeningPoints { commitment, matrix }
+            }
+            Self::Config(e) => StirError::Config(e),
             Self::InputError(e) => StirError::InputError(f(e)),
         }
     }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -1362,48 +1362,129 @@ mod babybear_pcs {
             .unwrap_or_else(|e| panic!("two-commitment same-bucket verification failed: {e:?}"));
     }
 
-    /// A matrix opened at zero points carries no claim that could pin its width, so `verify`
-    /// must reject it with a named error rather than silently deriving width 0 and failing
-    /// with a `WrongWidth` error naming the Merkle layer instead of the actual cause.
+    /// Committing a matrix and then opening it at no points would emit a proof that cannot
+    /// verify: the verifier reads native-height class membership off the claimed domains, so
+    /// it still counts the matrix as a class even though the prover contributed nothing for
+    /// it. Rejecting in `open` turns that into a named prover error rather than a mystery
+    /// proof.
     #[test]
-    fn test_pcs_matrix_without_opening_points_rejected() {
+    #[should_panic(expected = "was opened at no points")]
+    fn test_pcs_open_rejects_matrix_without_opening_points() {
         let (pcs, challenger_template) = get_pcs();
         let mut rng = seeded_rng();
 
         let log_d = 6;
-        let width = 3;
         let domain =
             <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
-        let mat_a = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
-        let mat_b = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+        let mat_a = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3);
+        let mat_b = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3);
 
-        let mut p_ch = challenger_template.clone();
+        let mut p_ch = challenger_template;
         let (commit, data) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
             &pcs,
             vec![(domain, mat_a), (domain, mat_b)],
         );
-        p_ch.observe(commit.clone());
-
+        p_ch.observe(commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         // `mat_a` is opened at `zeta`; `mat_b` is opened at no points at all.
         let data_and_points = vec![(&data, vec![vec![zeta], vec![]])];
+        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+    }
+
+    /// The degenerate extreme of the above: nothing is opened at all, so the prover would
+    /// otherwise emit a proof with no STIR instances in it.
+    #[test]
+    #[should_panic(expected = "was opened at no points")]
+    fn test_pcs_open_rejects_a_commitment_opened_at_no_points() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let log_d = 6;
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3);
+
+        let mut p_ch = challenger_template;
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
+        p_ch.observe(commit);
+
+        let data_and_points = vec![(&data, vec![vec![]])];
+        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+    }
+
+    /// Prove honestly at `prove_log_degrees`, then verify with matrix `emptied`'s claims
+    /// stripped to no points. Returns the verifier's result together with a challenger that
+    /// was never handed to `verify`, so the caller can check how far the transcript got.
+    fn verify_with_matrix_claims_emptied(
+        prove_log_degrees: &[usize],
+        emptied: usize,
+    ) -> (
+        Result<(), <MyPcs as Pcs<Challenge, Challenger>>::Error>,
+        Challenger,
+        Challenger,
+    ) {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let domains_and_polys: Vec<_> = prove_log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+
+        let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
         let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
 
         let mut v_ch = challenger_template;
         v_ch.observe(commit.clone());
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
+        let untouched = v_ch.clone();
 
-        let opening_a = opening_values[0][0][0].clone();
-        let claims = vec![(
-            commit,
-            vec![(domain, vec![(zeta, opening_a)]), (domain, vec![])],
-        )];
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .enumerate()
+            .map(|(mat_idx, ((domain, _), mat_openings))| {
+                let point_claims = if mat_idx == emptied {
+                    vec![]
+                } else {
+                    vec![(zeta, mat_openings[0].clone())]
+                };
+                (*domain, point_claims)
+            })
+            .collect();
 
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .unwrap_err();
+        let result = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_ch,
+        );
+        (result, v_ch, untouched)
+    }
+
+    #[test]
+    fn test_pcs_matrix_without_opening_points_rejected() {
+        let (result, _, _) = verify_with_matrix_claims_emptied(&[6, 6], 1);
+        let err = result.expect_err("a matrix claimed at no points must be rejected");
         assert!(
             matches!(
                 err,
@@ -1413,6 +1494,35 @@ mod babybear_pcs {
                 }
             ),
             "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_pcs_matrix_without_opening_points_rejected_before_the_transcript_forks() {
+        // With distinct native heights the emptied matrix is the *only* member of its class,
+        // so whether it counts decides whether `Combine` runs and therefore whether `r_comb`
+        // is drawn. Rejecting before anything reaches the transcript is what keeps the cause
+        // legible: were the check left inside the per-bucket work, the config divergence
+        // would surface first, as an unrelated-looking failure.
+        let (result, mut used, mut untouched) = verify_with_matrix_claims_emptied(&[8, 6], 1);
+        let err = result.expect_err("a matrix claimed at no points must be rejected");
+        assert!(
+            matches!(
+                err,
+                p3_stir::StirError::MatrixWithoutOpeningPoints {
+                    commitment: 0,
+                    matrix: 1,
+                }
+            ),
+            "{err:?}"
+        );
+
+        // Nothing was observed or sampled, so the two challengers still agree.
+        let after: Challenge = used.sample_algebra_element();
+        let expected: Challenge = untouched.sample_algebra_element();
+        assert_eq!(
+            after, expected,
+            "verify touched the transcript before rejecting"
         );
     }
 

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -914,7 +914,7 @@ mod babybear_pcs {
     type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
     type Dft = Radix2DitParallel<Val>;
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
-    type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+    type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs, Challenge, Challenger>;
     type FriPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 
     fn make_mmcs(perm: &Perm) -> (ValMmcs, ChallengeMmcs) {
@@ -1360,6 +1360,60 @@ mod babybear_pcs {
         ];
         <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
             .unwrap_or_else(|e| panic!("two-commitment same-bucket verification failed: {e:?}"));
+    }
+
+    /// A matrix opened at zero points carries no claim that could pin its width, so `verify`
+    /// must reject it with a named error rather than silently deriving width 0 and failing
+    /// with a `WrongWidth` error naming the Merkle layer instead of the actual cause.
+    #[test]
+    fn test_pcs_matrix_without_opening_points_rejected() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let log_d = 6;
+        let width = 3;
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat_a = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+        let mat_b = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, width);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
+            &pcs,
+            vec![(domain, mat_a), (domain, mat_b)],
+        );
+        p_ch.observe(commit.clone());
+
+        let zeta: Challenge = p_ch.sample_algebra_element();
+
+        // `mat_a` is opened at `zeta`; `mat_b` is opened at no points at all.
+        let data_and_points = vec![(&data, vec![vec![zeta], vec![]])];
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let opening_a = opening_values[0][0][0].clone();
+        let claims = vec![(
+            commit,
+            vec![(domain, vec![(zeta, opening_a)]), (domain, vec![])],
+        )];
+
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                p3_stir::StirError::MatrixWithoutOpeningPoints {
+                    commitment: 0,
+                    matrix: 1,
+                }
+            ),
+            "{err:?}"
+        );
     }
 
     /// A proof with the per-commitment input-openings vector dropped (truncated) must be


### PR DESCRIPTION
## Summary

  Two independent fixes from the outstanding-items audit, blockers for wiring STIR under a STARK:

  - StirConfig is fallible. StirConfig::new asserted on every infeasibility condition (folding-factor bounds, PoW budget, eta side-conditions, disjoint-coset side-condition, OOD/shake floor, ...). Since
    TwoAdicStirPcs::open/verify derive a fresh config per LDE-height bucket, a parameter set that's feasible at one trace height could abort the whole process at another — a verifier panic instead of a rejected proof. Added
    StirConfig::try_new/try_new_with_combine returning Result<_, StirConfigError> (one variant per former assert!); new/new_with_combine are now thin unwrap_or_else(|e| panic!("{e}")) wrappers, so existing panic-message
    tests are unaffected. verify() propagates StirConfigError via a new StirError::Config variant instead of panicking; open() keeps the panicking form since Pcs::open can't return a Result.
  - Configs are memoized. StirConfig::new runs an 80-iteration floating-point bisection per call; open/verify re-derive it once per height bucket, and the same log_stir_degree recurs across calls and across proofs.
    TwoAdicStirPcs now caches the base (non-Combine) config keyed by log_stir_degree, following the Radix2Dit twiddle-cache pattern (Arc<RwLock<BTreeMap<...>>>). Required adding Challenge, Challenger as first-class generics
    on TwoAdicStirPcs so the cache's value type can name StirConfig<Val, Challenge, StirMmcs, Challenger> — a small ripple into 3 downstream type aliases (tests, bench, example). Combine configs stay uncached: their cache
    key would need (log_stir_degree, num_classes, ell), not just a usize.
  - Zero-opening-point matrices are rejected, not silently mis-verified. verify() derived a matrix's width from point_claims.first().map(...).unwrap_or(0), so a matrix opened at zero points got width 0 fed into the MMCS
    dimensions — an honest proof would fail with a confusing WrongWidth error naming the Merkle layer rather than the actual cause. Added StirError::MatrixWithoutOpeningPoints, mirroring FRI's own guard
    (fri::verifier::FriError::MatrixWithoutOpeningPoints). open() also skips the now-dead per-matrix alpha-batched dot product (O(height × width)) for such a matrix, since it never contributes to the reduced opening.
  - Dedup the eta-parameterized proximity formulas. p3-security's list_size_bits/prox_gaps_error/ood_error/fold_sumcheck_error/queries_combination_error all grade a fixed, regime-default eta. stir/src/soundness.rs had
    re-implemented all five at an explicit, per-round eta it derives via its own bisection — a second copy that had already drifted from the originals. Promoted each to a _at_log_eta sibling in p3-security; the fixed-eta
    original now delegates to it at self.log_eta(log_inv_rate) (the JohnsonBound proximity-gap branch derives its BCSS25 m from log_eta and calls the existing prox_gaps_error_jb_at_m rather than re-deriving the dominant-term
    formula). Deleted STIR's five private copies; shake_check_error has no p3-security analog and is unchanged.

 ## Test plan

  - [x] cargo test -p p3-stir -p p3-security — all passing, including two new regression tests: try_new_rejects_infeasible_degree_without_panicking (reproduces the audit's exact "feasible at one degree, infeasible at a
    larger one" scenario) and test_pcs_matrix_without_opening_points_rejected.
  - [x] cargo test -p p3-whir -p p3-uni-stark -p p3-fri — unaffected, all passing (sanity-checks the shared p3-security formula changes are behavior-preserving).
  - [x] cargo build --workspace --all-targets — clean.
  - [x] cargo clippy -p p3-stir -p p3-security --all-targets — no warnings.
  - [x] cargo fmt --check — clean.
  - [x] Confirmed the m = 10 JB proximity-gap round-trip through pow/log2 is numerically exact (no ULP drift past the audit's 1e-9-tolerance regression tests).