### PR TITLE
feat: adapt log levels of some inner functions

### DIFF
--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -730,7 +730,7 @@ where
 ///
 /// The output is written directly into a pre-allocated buffer through
 /// disjoint mutable pointer access, avoiding an intermediate `collect`.
-#[instrument(name = "compute quotient polynomial", skip_all)]
+#[instrument(name = "compute quotient polynomial", skip_all, level = "debug")]
 #[allow(clippy::too_many_arguments)]
 pub fn quotient_values<SC, A, Mat, LG>(
     pcs: &SC::Pcs,

--- a/challenger/src/grinding_challenger.rs
+++ b/challenger/src/grinding_challenger.rs
@@ -105,7 +105,7 @@ where
 {
     type Witness = F;
 
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    #[instrument(name = "grind for proof-of-work witness", skip_all, level = "debug")]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         // Ensure `bits` is small enough to be used in a shift.
         assert!(bits < 64, "bit count must be valid");
@@ -240,14 +240,22 @@ where
     P: CryptographicPermutation<[F; WIDTH]>
         + CryptographicPermutation<[<F as Field>::Packing; WIDTH]>,
 {
-    #[instrument(name = "grind uniform for proof-of-work witness", skip_all)]
+    #[instrument(
+        name = "grind uniform for proof-of-work witness",
+        skip_all,
+        level = "debug"
+    )]
     fn grind_uniform(&mut self, bits: usize) -> Self::Witness {
         // Call the generic grinder with the "resample" checking logic.
         self.grind_generic(bits, |challenger, witness| {
             challenger.check_witness_uniform(bits, witness)
         })
     }
-    #[instrument(name = "grind uniform may error for proof-of-work witness", skip_all)]
+    #[instrument(
+        name = "grind uniform may error for proof-of-work witness",
+        skip_all,
+        level = "debug"
+    )]
     fn grind_uniform_may_error(&mut self, bits: usize) -> Self::Witness {
         // Call the generic grinder with the "error" checking logic.
         self.grind_generic(bits, |challenger, witness| {
@@ -296,7 +304,7 @@ where
 {
     type Witness = F;
 
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    #[instrument(name = "grind for proof-of-work witness", skip_all, level = "debug")]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize), "bit count must be valid");
         // Evaluate the bound in `u64` to keep the shift within its type width.

--- a/challenger/src/serializing_challenger.rs
+++ b/challenger/src/serializing_challenger.rs
@@ -206,7 +206,7 @@ where
 {
     type Witness = F;
 
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    #[instrument(name = "grind for proof-of-work witness", skip_all, level = "debug")]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < (usize::BITS as usize));
         // Evaluate the bound in `u64` to keep the shift within its type width.
@@ -401,7 +401,7 @@ where
 {
     type Witness = F;
 
-    #[instrument(name = "grind for proof-of-work witness", skip_all)]
+    #[instrument(name = "grind for proof-of-work witness", skip_all, level = "debug")]
     fn grind(&mut self, bits: usize) -> Self::Witness {
         assert!(bits < 64);
         assert!((1u64 << bits) < F::ORDER_U64);

--- a/circle/src/cfft.rs
+++ b/circle/src/cfft.rs
@@ -43,7 +43,7 @@ impl<F: Copy + Send + Sync, M: Matrix<F>> CircleEvaluations<F, M> {
 }
 
 impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
-    #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
+    #[instrument(skip_all, level = "debug", fields(dims = %self.values.dimensions()))]
     pub fn interpolate(self) -> RowMajorMatrix<F> {
         let len = self.domain.size() * self.values.width();
         self.interpolate_with_capacity(len)
@@ -105,7 +105,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
         RowMajorMatrix::new(buf, w)
     }
 
-    #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
+    #[instrument(skip_all, level = "debug", fields(dims = %self.values.dimensions()))]
     pub fn extrapolate(
         self,
         target_domain: CircleDomain<F>,
@@ -191,7 +191,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
 }
 
 impl<F: ComplexExtendable> CircleEvaluations<F, RowMajorMatrix<F>> {
-    #[instrument(skip_all, fields(dims = %coeffs.dimensions()))]
+    #[instrument(skip_all, level = "debug", fields(dims = %coeffs.dimensions()))]
     pub fn evaluate(domain: CircleDomain<F>, mut coeffs: RowMajorMatrix<F>) -> Self {
         let log_n = log2_strict_usize(coeffs.height());
         assert!(log_n <= domain.log_n);

--- a/circle/src/deep_quotient.rs
+++ b/circle/src/deep_quotient.rs
@@ -125,7 +125,7 @@ pub(crate) struct VanishingParts<EF> {
 /// Compute the [`VanishingParts`] of the DEEP quotient at `zeta` for the given domain points.
 ///
 /// `points` must be the domain points in CFFT order.
-#[instrument(skip_all, fields(n = points.len()))]
+#[instrument(skip_all, level = "debug", fields(n = points.len()))]
 pub(crate) fn compute_vanishing_parts<F: ComplexExtendable, EF: ExtensionField<F>>(
     points: &[Point<F>],
     zeta: Point<EF>,
@@ -192,7 +192,7 @@ impl<F: ComplexExtendable, M: Matrix<F>> CircleEvaluations<F, M> {
     /// so its values on the prefix determine it. Reducing the prefix and extrapolating a
     /// single extension-field column costs `1 / blowup` of the full-matrix traversal plus
     /// a narrow CFFT, instead of a full traversal.
-    #[instrument(skip_all, fields(dims = %self.values.dimensions()))]
+    #[instrument(skip_all, level = "debug", fields(dims = %self.values.dimensions()))]
     pub(crate) fn rowwise_alpha_reduce_lifted<EF: ExtensionField<F>>(
         &self,
         alpha: EF,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -259,7 +259,7 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
     chunks=2: 0 1 1 0 0 1 1 0 0 1 1 0 0 1 1 0
     chunks=4: 0 1 2 3 3 2 1 0 0 1 2 3 3 2 1 0
     */
-    #[instrument(skip_all, fields(log_n = %coset.log_n))]
+    #[instrument(skip_all, level = "debug", fields(log_n = %coset.log_n))]
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>> {
         let pts = coset.points().collect_vec();
         let n = pts.len();

--- a/dft/src/util.rs
+++ b/dft/src/util.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 /// # Panics
 ///
 /// Panics if the height of the matrix is not a power of two.
-#[instrument(skip_all, fields(dims = %mat.dimensions()))]
+#[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions()))]
 pub fn divide_by_height<F: Field, S: DenseStorage<F> + BorrowMut<[F]>>(
     mat: &mut DenseMatrix<F, S>,
 ) {

--- a/monty-31/src/dft/mod.rs
+++ b/monty-31/src/dft/mod.rs
@@ -118,7 +118,7 @@ impl<MP: FieldParameters + TwoAdicData> RecursiveDft<MontyField31<MP>> {
     }
 
     /// Compute twiddle factors, or take memoized ones if already available.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "debug")]
     fn update_twiddles(&self, fft_len: usize) {
         // As we don't save the twiddles for the final layer where
         // the only twiddle is 1, roots_of_unity_table(fft_len)
@@ -206,7 +206,7 @@ impl<MP: MontyParameters + FieldParameters + TwoAdicData> TwoAdicSubgroupDft<Mon
 {
     type Evaluations = BitReversedMatrixView<RowMajorMatrix<MontyField31<MP>>>;
 
-    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits))]
+    #[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions(), added_bits))]
     fn dft_batch(&self, mut mat: RowMajorMatrix<MontyField31<MP>>) -> Self::Evaluations
     where
         MP: MontyParameters + FieldParameters + TwoAdicData,
@@ -240,7 +240,7 @@ impl<MP: MontyParameters + FieldParameters + TwoAdicData> TwoAdicSubgroupDft<Mon
         mat.bit_reverse_rows()
     }
 
-    #[instrument(skip_all, fields(dims = %mat.dimensions(), added_bits))]
+    #[instrument(skip_all, level = "debug", fields(dims = %mat.dimensions(), added_bits))]
     fn idft_batch(&self, mat: RowMajorMatrix<MontyField31<MP>>) -> RowMajorMatrix<MontyField31<MP>>
     where
         MP: MontyParameters + FieldParameters + TwoAdicData,

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -633,7 +633,7 @@ where
     ///
     /// `degrees[i]` is the degree of AIR `i` after stripping the active eq factor.
     /// Every entry must be positive. The round degree is the maximum AIR degree.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn new(
         stage: &Stage<'air, 'data, A, F>,
         alpha: EF,
@@ -789,7 +789,7 @@ where
             .unwrap()
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn round_poly(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
@@ -803,7 +803,7 @@ where
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     fn round_poly_packed(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>
@@ -955,7 +955,7 @@ where
         out
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn round_poly_unpacked(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
@@ -1065,7 +1065,7 @@ where
         out
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn fold(mut self, r: EF) -> RoundStateExt<'air, 'data, A, F, EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, F, EF>>,
@@ -1208,7 +1208,7 @@ where
     /// Computes the round polynomial evaluations, dispatching to the
     /// SIMD-packed kernel once there are enough residual rows to fill a
     /// packed lane, mirroring [`RoundStateBase::round_poly`].
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn round_poly(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>
@@ -1229,7 +1229,7 @@ where
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     fn round_poly_unpacked(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,
@@ -1378,7 +1378,7 @@ where
     /// columns. The AIR is driven through [`PackedExt`], which wraps the
     /// packed extension value so it supports arithmetic against the base
     /// field `F` directly (see that type's docs for why this is needed).
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     fn round_poly_packed(&mut self, eq_suffix: &Poly<EF>) -> Vec<EF>
     where
         A: for<'b> Air<
@@ -1561,7 +1561,7 @@ where
         out
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn fold(&mut self, r: EF)
     where
         A: for<'b> Air<MultilinearFolder<'b, F, EF, EF>>,

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -444,7 +444,7 @@ struct RoundFinish<F, EF: Field, M: Mmcs<EF>> {
 /// and query points, answer them, commit the folded oracle, and evaluate the next virtual
 /// witness directly on the next round's domain.
 #[allow(clippy::too_many_arguments)]
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "debug")]
 fn prove_round<F, EF, Dft, M, Challenger>(
     config: &StirConfig<F, EF, M, Challenger>,
     round: usize,

--- a/sumcheck/src/constraints/statement/eq.rs
+++ b/sumcheck/src/constraints/statement/eq.rs
@@ -273,7 +273,7 @@ impl<F: Field> EqStatement<F> {
     /// The shift starts this group's powers where the previous group's powers ended.
     ///
     /// The const generic flag controls whether the weight accumulator is added to when true or overwritten when false.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables(), shift))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables(), shift))]
     pub fn combine_hypercube<Base, const INITIALIZED: bool>(
         &self,
         acc_weights: &mut Poly<F>,
@@ -334,7 +334,7 @@ impl<F: Field> EqStatement<F> {
     ///
     /// - When the packing width spans at least half the variables, build each constraint's equality polynomial and pack it directly.
     /// - Otherwise split the variables at the midpoint, expand each half, and recombine them with a parallel dot product over the lanes.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables(), shift))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables(), shift))]
     pub fn combine_hypercube_packed<Base, const INITIALIZED: bool>(
         &self,
         weights: &mut Poly<F::ExtensionPacking>,

--- a/sumcheck/src/constraints/statement/next.rs
+++ b/sumcheck/src/constraints/statement/next.rs
@@ -151,7 +151,7 @@ impl<F: Field> NextStatement<F> {
     /// - `acc_sum`: scalar accumulator for the expected sum.
     /// - `challenge`: the batching challenge whose powers weight each constraint.
     /// - `shift`: offset of the first challenge power, so this group follows earlier groups.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables()))]
     pub fn combine(&self, acc_weights: &mut Poly<F>, acc_sum: &mut F, challenge: F, shift: usize) {
         // Nothing to fold when this group holds no constraints.
         if self.constraints.is_empty() {
@@ -185,7 +185,7 @@ impl<F: Field> NextStatement<F> {
     ///
     /// Panics if the variable count is below the packing width.
     /// Panics if the packed buffer arity plus the packing width differs from the group's arity.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables()))]
     pub fn combine_packed<Base>(
         &self,
         weights: &mut Poly<F::ExtensionPacking>,

--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -372,7 +372,7 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
     ///
     /// 3. **Challenge combination**: Dot each row of the select matrix
     ///    with the challenge power vector to produce the weight polynomial.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables()))]
     pub fn combine(
         &self,
         acc_weights: &mut Poly<EF>,
@@ -489,7 +489,7 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
     ///    power table.
     /// 4. For each pair of rows (left packed, right scalar), compute the
     ///    weighted dot product with the challenge powers.
-    #[instrument(skip_all, fields(num_constraints = self.len(), num_variables = self.num_variables()))]
+    #[instrument(skip_all, level = "debug", fields(num_constraints = self.len(), num_variables = self.num_variables()))]
     pub fn combine_packed(
         &self,
         weights: &mut Poly<EF::ExtensionPacking>,

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -324,7 +324,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     /// # Returns
     ///
     /// The verifier's challenge `r \in EF` for this round.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, level = "debug")]
     pub fn round<Challenger>(
         &mut self,
         sumcheck_data: &mut SumcheckData<F, EF>,

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -713,7 +713,7 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     /// # Panics
     ///
     /// - Folding factor must not exceed the current number of remaining variables.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, level = "debug")]
     pub fn compute_sumcheck_polynomials<Challenger>(
         &mut self,
         sumcheck_data: &mut SumcheckData<F, EF>,

--- a/whir/src/pcs/prover/mod.rs
+++ b/whir/src/pcs/prover/mod.rs
@@ -191,7 +191,7 @@ where
         }
     }
 
-    #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.total_folded_through(round_index)))]
+    #[instrument(skip_all, level = "debug", fields(round_number = round_index, log_size = self.num_variables - self.total_folded_through(round_index)))]
     #[allow(clippy::too_many_lines)]
     fn round(
         &self,


### PR DESCRIPTION
## Description

Lower the log level of a couple inner functions.
This got reported by some downstream users that have to deal with fairly noisy telemetry coming from Plonky3 internals, that probably shouldn't be at the `INFO` level anyway for a start.