### PR TITLE
feat(field): characteristic-agnostic groundwork for binary fields

### DIFF
--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -751,6 +751,18 @@ pub fn test_binary_ops<R: PrimeCharacteristicRing + Eq + Copy>(
     );
 }
 
+/// Checks the fixed enumeration used for interpolation nodes.
+pub fn test_interpolation_nodes<F: Field>() {
+    assert_eq!(F::interpolation_node(0), F::ZERO);
+    assert_eq!(F::interpolation_node(1), F::ONE);
+    let nodes: Vec<F> = (0..64).map(F::interpolation_node).collect();
+    for (i, a) in nodes.iter().enumerate() {
+        for b in &nodes[..i] {
+            assert_ne!(a, b, "interpolation nodes must be pairwise distinct");
+        }
+    }
+}
+
 /// Tests the optimized implementation of `powers.take(n).collect()`
 pub fn test_powers_collect<F: Field>() {
     // Small using serial implementation
@@ -1117,6 +1129,10 @@ macro_rules! test_field {
             #[test]
             fn test_powers_collect() {
                 $crate::test_powers_collect::<$field>();
+            }
+            #[test]
+            fn test_interpolation_nodes() {
+                $crate::test_interpolation_nodes::<$field>();
             }
             #[test]
             fn test_ring_axioms_proptest() {

--- a/field/src/field.rs
+++ b/field/src/field.rs
@@ -1058,6 +1058,19 @@ pub trait Field:
         crate::sqrt::tonelli_shanks(*self)
     }
 
+    /// The `i`-th element of a fixed injective enumeration of `Self`, used as an
+    /// interpolation node. Must satisfy `interpolation_node(0) == ZERO` and
+    /// `interpolation_node(1) == ONE`, and be injective on every index a protocol
+    /// can use (round-polynomial degrees are tiny; `0..64` is the tested range).
+    ///
+    /// The default maps `i` through the prime subfield and is injective only while
+    /// `i` is below the characteristic. Fields of characteristic below `2^32` must
+    /// override it.
+    #[must_use]
+    fn interpolation_node(i: usize) -> Self {
+        Self::from_usize(i)
+    }
+
     /// Add two slices of field elements together, returning the result in the first slice.
     ///
     /// Makes use of packing to speed up the addition.

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -376,10 +376,10 @@ pub fn check_multiplicity_height_bound<F: PrimeField>(
         });
 
     // Compare against the exact characteristic `p`, valid for any prime size.
-    if weighted_height_sum >= F::order() {
+    if weighted_height_sum >= F::PrimeSubfield::order() {
         return Err(LookupError::MultiplicityHeightBoundExceeded {
             weighted_height_sum,
-            field_bits: F::bits(),
+            field_bits: F::PrimeSubfield::bits(),
         });
     }
     Ok(())
@@ -649,7 +649,7 @@ mod tests {
                 field_bits,
             } => {
                 assert_eq!(weighted_height_sum, BigUint::from(1u128 << 31));
-                assert_eq!(field_bits, F::bits());
+                assert_eq!(field_bits, F::PrimeSubfield::bits());
             }
             other => panic!("wrong error variant: {other:?}"),
         }

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -649,7 +649,7 @@ mod tests {
                 field_bits,
             } => {
                 assert_eq!(weighted_height_sum, BigUint::from(1u128 << 31));
-                assert_eq!(field_bits, F::PrimeSubfield::bits());
+                assert_eq!(field_bits, <F as PrimeCharacteristicRing>::PrimeSubfield::bits());
             }
             other => panic!("wrong error variant: {other:?}"),
         }

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -649,7 +649,10 @@ mod tests {
                 field_bits,
             } => {
                 assert_eq!(weighted_height_sum, BigUint::from(1u128 << 31));
-                assert_eq!(field_bits, <F as PrimeCharacteristicRing>::PrimeSubfield::bits());
+                assert_eq!(
+                    field_bits,
+                    <F as PrimeCharacteristicRing>::PrimeSubfield::bits()
+                );
             }
             other => panic!("wrong error variant: {other:?}"),
         }

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -590,7 +590,7 @@ impl<EF: Field> DegreeGroup<EF> {
                 self.last_evals[index]
             } else {
                 // Above this group's degree: extrapolate to the stage's top nodes.
-                self.eval(tau, EF::from_usize(node))
+                self.eval(tau, EF::interpolation_node(node))
             };
             *acc += value;
         }

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -939,7 +939,7 @@ where
     // The weighted message carries one extra degree from the equality factor.
     // Extrapolate the internal polynomial to that top node.
     let degree = evals.len() + 1;
-    let last = interpolator.eval(evals, unweighted_sum, EF::from_usize(degree));
+    let last = interpolator.eval(evals, unweighted_sum, EF::interpolation_node(degree));
 
     // Weight every transmitted node, skipping node one as the verifier rebuilds it.
     //
@@ -949,7 +949,7 @@ where
     let standard_evals = (0..=degree)
         .filter(|&node| node != 1)
         .zip(evals.iter().copied().chain(core::iter::once(last)))
-        .map(|(node, q)| eq_prefix * Point::eval_eq(&[tau], &[EF::from_usize(node)]) * q)
+        .map(|(node, q)| eq_prefix * Point::eval_eq(&[tau], &[EF::interpolation_node(node)]) * q)
         .collect();
 
     (standard_evals, unweighted_sum)

--- a/sumcheck/src/data.rs
+++ b/sumcheck/src/data.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, Field};
 use p3_multilinear_util::point::Point;
 use serde::{Deserialize, Serialize};
 
@@ -124,8 +124,8 @@ impl<F, EF> SumcheckData<F, EF> {
         basis: Basis,
     ) -> Result<Point<EF>, SumcheckError>
     where
-        F: TwoAdicField,
-        EF: ExtensionField<F> + TwoAdicField,
+        F: Field,
+        EF: ExtensionField<F>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Bind the round count to the protocol-fixed value before folding anything.
@@ -189,8 +189,8 @@ pub fn verify_final_sumcheck_rounds<F, EF, Challenger>(
     basis: Basis,
 ) -> Result<Point<EF>, SumcheckError>
 where
-    F: TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField,
+    F: Field,
+    EF: ExtensionField<F>,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {
     if rounds == 0 {

--- a/sumcheck/src/generic_degree/util.rs
+++ b/sumcheck/src/generic_degree/util.rs
@@ -27,11 +27,12 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
     ///
     /// - `degree`: the per-variable degree, so the domain has `degree + 1` nodes.
     pub fn new(degree: usize) -> Self {
-        // Domain: the integer nodes 0, 1, …, degree lifted into the field.
-        let x_coords: Vec<EF> = (0..=degree).map(EF::from_usize).collect();
+        // Domain: the first `degree + 1` interpolation nodes of the field.
+        let x_coords: Vec<EF> = (0..=degree).map(EF::interpolation_node).collect();
 
-        // Integer nodes are pairwise distinct, so the weights always exist.
-        let weights = barycentric_weights(&x_coords).expect("integer nodes are pairwise distinct");
+        // Interpolation nodes are pairwise distinct, so the weights always exist.
+        let weights =
+            barycentric_weights(&x_coords).expect("interpolation nodes are pairwise distinct");
 
         Self { x_coords, weights }
     }
@@ -92,7 +93,7 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
         // Each appended entry `i` carries node `i + 1`, extrapolated from the input.
         extended.extend(
             (evals.len()..target_len)
-                .map(|i| self.eval(evals, sum_constraint, EF::from_usize(i + 1))),
+                .map(|i| self.eval(evals, sum_constraint, EF::interpolation_node(i + 1))),
         );
         extended
     }


### PR DESCRIPTION
## Summary

  Three small, behavior-neutral hygiene fixes that prepare the field layer for characteristic-2 (binary tower) field support, landed ahead of that work as independently reviewable groundwork. None of these change behavior
  for any field currently in the codebase (BabyBear, KoalaBear, Goldilocks, Mersenne31, BN254, or their extensions).

  This is Phase 0 of a staged plan to add binary field support to Plonky3. It has no dependency on later phases and is safe to land on its own.

  ## Changes

  **Bound the lookup multiplicity-height check by the characteristic, not the field order** (`lookup/src/types.rs`)

  `check_multiplicity_height_bound` compared the weighted height sum against `F::order()`. The comment above the check already said "compare against the exact characteristic `p`" — this makes the code match the comment. For
  every prime base field in the codebase today, `F::PrimeSubfield::order()` and `F::order()` are identical, so this is a pure correctness/clarity fix with no behavior change. It matters once a field's order and
  characteristic diverge (as they do for any non-prime base field).

  **Drop unused `TwoAdicField` bounds on sumcheck verification** (`sumcheck/src/data.rs`)

  `SumcheckData::verify` and a related free function required `F: TwoAdicField` and `EF: ExtensionField<F> + TwoAdicField`, but neither bound is used anywhere in either function body. Relaxed to `F: Field, EF:
  ExtensionField<F>` — strictly more general, and every existing caller compiles unchanged.

  **Add `Field::interpolation_node` and route sumcheck/multi-stark's round-polynomial node construction through it** (`field/src/field.rs`, `field-testing/src/lib.rs`, `sumcheck/src/generic_degree/util.rs`, 
  `multi-stark/src/rounds.rs`, `multi-stark/src/zerocheck.rs`)

  Round-polynomial code in `p3-sumcheck` and `p3-multi-stark` currently builds its interpolation node set via `F::from_usize(i)` for small indices. That only works because every field in the codebase today has characteristic
  far above any round-polynomial degree a protocol ever uses. This adds a new defaulted trait method, `Field::interpolation_node(i: usize) -> Self` (default: `Self::from_usize(i)`), and routes every node-construction call 
  site through it instead. The default is identical to what every call site already computed, so this is behavior-neutral for every field today — it exists purely as the indirection point a future field can override.

  ## Testing

  - `cargo test -p p3-lookup -p p3-multi-stark -p p3-batch-stark -p p3-uni-stark`
  - `cargo test -p p3-sumcheck`
  - `cargo test -p p3-baby-bear -p p3-koala-bear -p p3-goldilocks -p p3-mersenne-31 -p p3-bn254 interpolation_nodes`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - The existing multi-stark proof-serialization compat fixture passes unchanged, confirming the node values are byte-identical to before this change for every current field.

  ## Notes for reviewers
  
  - Diffs are intentionally minimal and surgical — one concern per commit, no drive-by refactors.
  - The `interpolation_node` doc comment spells out the contract a future override must satisfy (`interpolation_node(0) == ZERO`, `interpolation_node(1) == ONE`, injective on every index a protocol can use).