### PR TITLE
perf(stir): bucket committed heights into several bounded-spread shared domains

### DIFF
--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -483,8 +483,9 @@ fn main() {
             vec![(domain, message)],
             &base_challenger,
             queries,
-            // STIR commits one Merkle tree per distinct LDE height.
-            |ch, commit| ch.observe(commit.clone()),
+            // STIR commits one Merkle tree per shared-domain group; a single table is one
+            // group, hence one root.
+            |ch, commit| commit.iter().for_each(|root| ch.observe(root.clone())),
         ));
     }
 
@@ -579,12 +580,14 @@ fn main() {
         ));
     }
 
-    // STIR: every table here shares one `commit()` call, so the real prover extends
-    // all three onto one shared LDE domain (sized to the tallest) and merges their
-    // native-height classes via `Combine` (§7, Construction 7.2) before STIR runs.
-    // Reconstruct that same bucket (`ell` per Lemma 4.13, matching what `p3_stir`'s
-    // PCS impl computes internally) so the printed schedule reflects what actually
-    // proves, not a plain single-height instance.
+    // STIR: every table here shares one `commit()` call, and the three heights span exactly
+    // `DEFAULT_MAX_LOG_HEIGHT_SPREAD` octaves, so they land in one shared-domain group: the
+    // real prover extends all three onto one LDE domain (sized to the tallest) and merges
+    // their native-height classes via `Combine` (§7, Construction 7.2) before STIR runs.
+    // Reconstruct that same bucket (`ell` per Lemma 4.13, matching what `p3_stir`'s PCS impl
+    // computes internally) so the printed schedule reflects what actually proves, not a plain
+    // single-height instance. A wider height spread would be split across several groups, and
+    // this reconstruction would then describe only the tallest.
     {
         let stir_params = StirParameters {
             log_blowup: args.rate,
@@ -629,8 +632,9 @@ fn main() {
             tables,
             &base_challenger,
             queries,
-            // STIR commits one shared Merkle tree for every table in this call.
-            |ch, commit| ch.observe(commit.clone()),
+            // STIR commits one Merkle tree per shared-domain group: the tables here are
+            // partitioned by bounded height spread, so this is one root per group.
+            |ch, commit| commit.iter().for_each(|root| ch.observe(root.clone())),
         ));
     }
 

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -586,8 +586,9 @@ fn main() {
     // their native-height classes via `Combine` (§7, Construction 7.2) before STIR runs.
     // Reconstruct that same bucket (`ell` per Lemma 4.13, matching what `p3_stir`'s PCS impl
     // computes internally) so the printed schedule reflects what actually proves, not a plain
-    // single-height instance. A wider height spread would be split across several groups, and
-    // this reconstruction would then describe only the tallest.
+    // single-height instance. Where `Combine` does not fit the challenge field, the PCS splits
+    // the heights across several groups instead of failing, and so does the reconstruction:
+    // the schedule then printed is the tallest group's, without `Combine`.
     {
         let stir_params = StirParameters {
             log_blowup: args.rate,
@@ -600,12 +601,14 @@ fn main() {
         };
         let ell: u64 = heights.len() as u64 * ((1u64 << args.log_message_size) + 1)
             - heights.iter().map(|&h| 1u64 << h).sum::<u64>();
-        let config = StirConfig::<F, EF, ChallengeMmcs, Challenger>::new_with_combine(
+        let config = StirConfig::<F, EF, ChallengeMmcs, Challenger>::try_new_with_combine(
             args.log_message_size,
             stir_params.clone(),
             heights.len(),
             ell,
-        );
+        )
+        .or_else(|_| StirConfig::try_new(args.log_message_size, stir_params.clone()))
+        .expect("STIR parameters are infeasible even without Combine");
         let queries = config
             .round_configs
             .iter()

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -20,6 +20,7 @@ p3-field.workspace = true
 p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-security.workspace = true
+p3-symmetric.workspace = true
 p3-util.workspace = true
 
 itertools.workspace = true
@@ -30,6 +31,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+p3-air = { path = "../air" }
 p3-baby-bear = { path = "../baby-bear" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
@@ -37,7 +39,7 @@ p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }
 p3-koala-bear = { path = "../koala-bear" }
 p3-merkle-tree = { path = "../merkle-tree" }
-p3-symmetric = { path = "../symmetric" }
+p3-uni-stark = { path = "../uni-stark" }
 
 criterion.workspace = true
 postcard = { workspace = true, features = ["alloc"] }

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -112,7 +112,7 @@ fn bench_open(c: &mut Criterion) {
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
         let mut base = challenger.clone();
-        base.observe(commit.clone());
+        commit.iter().for_each(|root| base.observe(root.clone()));
         let zeta: Challenge = base.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
 
@@ -148,7 +148,9 @@ fn bench_verify(c: &mut Criterion) {
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, inputs.iter().cloned());
         let mut p_challenger = challenger.clone();
-        p_challenger.observe(commit.clone());
+        commit
+            .iter()
+            .for_each(|root| p_challenger.observe(root.clone()));
         let zeta: Challenge = p_challenger.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
         let (opened, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
@@ -167,7 +169,7 @@ fn bench_verify(c: &mut Criterion) {
 
         // Same transcript state `open` reached: commitment observed, opening point drawn.
         let mut v_base = challenger.clone();
-        v_base.observe(commit.clone());
+        commit.iter().for_each(|root| v_base.observe(root.clone()));
         let _: Challenge = v_base.sample_algebra_element();
 
         group.bench_with_input(BenchmarkId::from_parameter(name), &claims, |b, claims| {

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -57,6 +57,6 @@ pub mod verifier;
 
 pub use config::{Stage, StirConfig, StirConfigError, StirParameters, StirRoundConfig};
 pub use p3_security::whir::SecurityAssumption;
-pub use pcs::TwoAdicStirPcs;
+pub use pcs::{DEFAULT_MAX_LOG_HEIGHT_SPREAD, TwoAdicStirPcs};
 pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};
 pub use verifier::{StirError, StirVerifyOutputs};

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -57,6 +57,6 @@ pub mod verifier;
 
 pub use config::{Stage, StirConfig, StirConfigError, StirParameters, StirRoundConfig};
 pub use p3_security::whir::SecurityAssumption;
-pub use pcs::{DEFAULT_MAX_LOG_HEIGHT_SPREAD, TwoAdicStirPcs};
+pub use pcs::{DEFAULT_MAX_LOG_HEIGHT_SPREAD, StirCommitment, TwoAdicStirPcs};
 pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};
 pub use verifier::{StirError, StirVerifyOutputs};

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -1,26 +1,36 @@
 //! `TwoAdicStirPcs`: implementing the [`Pcs`] trait using STIR.
 //!
-//! **Commit**: every matrix passed to one `commit()` call is extended onto one shared LDE
-//! domain, sized to the *tallest* matrix (§7, Construction 7.2's same-domain requirement) —
-//! shorter matrices are extended further, at an effectively higher per-matrix blowup. All
-//! matrices land in one Merkle tree per commitment, rather than one tree per distinct height.
+//! **Commit**: the matrices passed to one `commit()` call are partitioned into *shared-domain
+//! groups* of bounded native-height spread. Each group is extended onto one shared LDE domain
+//! sized to that group's tallest matrix (§7, Construction 7.2's same-domain requirement) and
+//! committed in its own Merkle tree, so a commitment carries one root per group. A group
+//! holding a single native height needs no merging at all; a group holding several merges
+//! them below.
+//!
+//! The two ends of the spread cap ([`TwoAdicStirPcs::with_max_log_height_spread`],
+//! [`DEFAULT_MAX_LOG_HEIGHT_SPREAD`]) are the two layouts this generalizes: a cap of `0` puts
+//! every distinct native height on its own domain, so `Combine` never runs and each height
+//! gets its own STIR instance, while a cap at or above the committed spread puts everything on
+//! one domain and merges it all. Groups also shrink on their own when `Combine`'s soundness
+//! cost does not fit the challenge field, so an infeasible parameter set degrades into more
+//! STIR instances rather than failing.
 //!
 //! **Open**: alpha-batch quotient polynomials `(f_i(z) - f_i(x)) / (z - x)` into one
-//! reduced-opening polynomial per *native* (pre-shared-domain) matrix height — the same
-//! per-height batching as before, just with every reduced-opening now living on the shared
-//! domain rather than its own native-sized one. Commitments sharing the same shared-domain
-//! size are then run through one STIR instance together (as many domain sizes as distinct
-//! shared domains, "buckets" below); within a bucket, if more than one native-height class is
-//! present, they are merged into a single codeword via batch degree correction
-//! ([`crate::utils::combine_on_coset`], §4.5's `Combine`) before STIR runs,
-//! at the tallest class's degree and full proximity radius (no per-class query-count floor).
-//! The prover returns the deduplicated first-round STIR query indices alongside the IOP
-//! proof; at those positions the prover also opens the input LDE matrices (via `InputMmcs`)
-//! so the verifier can confirm the reduced-opening polynomials are correctly derived from the
-//! committed inputs.
+//! reduced-opening polynomial per *native* matrix height, each living on its group's shared
+//! domain. Groups sharing a domain size — across commitments as well as within one — are run
+//! through a single STIR instance ("buckets" below, one per distinct shared LDE height);
+//! within a bucket, if more than one native-height class is present, they are merged into a
+//! single codeword via batch degree correction ([`crate::utils::combine_on_coset`], §4.5's
+//! `Combine`) before STIR runs, at the tallest class's degree and full proximity radius (no
+//! per-class query-count floor). The prover returns the deduplicated first-round STIR query
+//! indices alongside the IOP proof; at those positions the prover also opens the input LDE
+//! matrices (via `InputMmcs`) so the verifier can confirm the reduced-opening polynomials are
+//! correctly derived from the committed inputs.
 //!
-//! **Verify**: replay the same alpha-batching and `Combine` from the opening values, then for
-//! each bucket call [`verify_stir_with_external_initial`](crate::verifier::verify_stir_with_external_initial).
+//! **Verify**: reproduce the grouping from the claimed domain sizes — it is a pure function of
+//! those and the PCS parameters, so no part of it travels in the proof — then replay the same
+//! alpha-batching and `Combine` from the opening values, and for each bucket call
+//! [`verify_stir_with_external_initial`](crate::verifier::verify_stir_with_external_initial).
 //! STIR's initial oracle *is* the (possibly combined) reduced opening, which the transcript
 //! already pins through the input commitments, the claimed values, `alpha`, and (when a
 //! bucket combines more than one class) the combination challenge, so it is never committed a
@@ -28,16 +38,15 @@
 //! input MMCS openings at exactly the positions STIR sampled. No hand-mirrored transcript
 //! replay is needed.
 //!
-//! **Cost profile**: opening and verification get cheaper — one STIR instance per commitment
-//! instead of one per height class — but committing gets more expensive, and the trade moves
-//! with the height spread. A matrix at native height `2^h` alongside a tallest matrix at
-//! `2^H` pays a `2^(H - h + log_blowup)` blowup instead of `2^log_blowup`, in both its DFT and
-//! its share of the Merkle tree (the tree is `2^(H + log_blowup)` rows deep and carries every
-//! matrix's full width in each leaf, so hashing goes from `Σᵢ 2^(hᵢ + b)·widthᵢ` to
-//! `2^(H + b)·Σᵢ widthᵢ`). Callers committing matrices whose heights differ by many octaves —
-//! or more classes than the `Combine` feasibility envelope on [`StirParameters`] admits —
-//! should split them across separate `commit()` calls, which keeps each shared domain close to
-//! its own matrices' heights.
+//! **Cost profile**: merging classes onto one domain makes opening and verification cheaper —
+//! one STIR instance instead of one per height class — and committing more expensive, and the
+//! spread cap is what bounds the second. A matrix at native height `2^h` in a group whose
+//! tallest is `2^H` pays a `2^(H - h + log_blowup)` blowup instead of `2^log_blowup`, in both
+//! its DFT and its share of that group's Merkle tree (the tree is `2^(H + log_blowup)` rows
+//! deep and carries every group member's full width in each leaf, so hashing goes from
+//! `Σᵢ 2^(hᵢ + b)·widthᵢ` to `2^(H + b)·Σᵢ widthᵢ`). Capping the spread caps `H - h`, so a
+//! short matrix committed alongside a much taller one lands in its own group and pays its own
+//! blowup rather than the tallest one's.
 
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
@@ -93,23 +102,68 @@ pub struct InputOpenings<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
     pub opening_proof: InputMmcs::MultiProof,
 }
 
+/// One shared-LDE-domain group of a commitment: its own Merkle tree over the matrices whose
+/// native heights the partition placed together.
+///
+/// Every matrix here is extended onto the same domain (sized to the group's tallest) and
+/// committed in fiber-grouped form — each leaf holds `2^log_starting_folding_factor`
+/// consecutive bit-reversed LDE rows, exactly the rows one first-round STIR query reads.
+struct DomainGroup<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
+    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    /// Column count of each matrix in this group, in the order the caller committed them.
+    widths: Vec<usize>,
+    /// Native (pre-extension) log2 height of each matrix in this group, same order. This is
+    /// what distinguishes matrices for alpha-batching and `Combine` grouping once they all
+    /// sit on the same physical domain.
+    log_native_heights: Vec<usize>,
+    /// Log2 of the shared LDE domain this group's matrices were extended onto.
+    log_lde_height: usize,
+}
+
 /// Prover data for [`TwoAdicStirPcs`].
 ///
-/// Every matrix passed to one `commit()` call is extended onto one shared LDE domain (sized
-/// to the tallest matrix) and committed in fiber-grouped form in a single Merkle tree — each
-/// leaf holds `2^log_starting_folding_factor` consecutive bit-reversed LDE rows, exactly the
-/// rows one first-round STIR query reads. `log_native_heights[i]` is matrix `i`'s own
-/// (pre-shared-domain) log2 height, in the order the caller committed them; this is what
-/// distinguishes matrices for alpha-batching and `Combine` grouping once they all sit on the
-/// same physical domain.
+/// The matrices passed to one `commit()` call are partitioned into shared-domain groups of
+/// bounded height spread ([`TwoAdicStirPcs::with_max_log_height_spread`]), each committed in its
+/// own tree. A group of one native height runs no `Combine` at all; a group spanning several
+/// merges them on its shared domain per §7's same-domain requirement.
 pub struct StirProverData<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> {
-    data: InputMmcs::ProverData<RowMajorMatrix<Val>>,
-    /// Column count of each matrix, in the order the caller committed them.
-    widths: Vec<usize>,
-    /// Native (pre-shared-domain) log2 height of each matrix, in the order committed.
-    log_native_heights: Vec<usize>,
-    /// Log2 of the shared LDE domain every matrix in this commitment was extended onto.
-    log_shared_lde_height: usize,
+    /// Groups in descending LDE height, matching the commitment's root order.
+    groups: Vec<DomainGroup<Val, InputMmcs>>,
+    /// `placement[i] = (group index, index within that group)` for the caller's matrix `i`.
+    placement: Vec<(usize, usize)>,
+}
+
+impl<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> StirProverData<Val, InputMmcs> {
+    /// `(native log2 height, log2 LDE height of the group holding it)` per matrix, in the
+    /// order the caller committed them.
+    fn matrix_layout(&self) -> Vec<(usize, usize)> {
+        self.placement
+            .iter()
+            .map(|&(group_idx, idx)| {
+                let group = &self.groups[group_idx];
+                (group.log_native_heights[idx], group.log_lde_height)
+            })
+            .collect()
+    }
+
+    /// The group committed on the domain of size `2^log_lde_height`, if this commitment has
+    /// one. Group LDE heights are distinct, so at most one can match.
+    fn group_at(&self, log_lde_height: usize) -> Option<&DomainGroup<Val, InputMmcs>> {
+        self.groups
+            .iter()
+            .find(|group| group.log_lde_height == log_lde_height)
+    }
+}
+
+/// How one commitment's matrices are partitioned across shared LDE domains.
+///
+/// Derived identically by the prover (from the committed heights) and the verifier (from the
+/// claimed domain sizes), so no part of it travels in the proof.
+struct GroupPlan {
+    /// Log2 LDE height of each group, descending.
+    log_lde_heights: Vec<usize>,
+    /// Group index of each matrix, in the order the caller supplied them.
+    group_of_matrix: Vec<usize>,
 }
 
 /// Reinterpret a bit-reversed LDE as a matrix whose rows are whole STIR fibers.
@@ -129,15 +183,27 @@ fn group_fiber_rows<Val: Clone + Send + Sync>(
 }
 
 /// Recover views of the committed matrices in their pre-grouping shape and caller order.
+///
+/// Matrices live in per-group trees, so the caller order is reassembled through
+/// [`StirProverData::placement`].
 fn lde_views<'a, Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>>(
     input_mmcs: &InputMmcs,
     prover_data: &'a StirProverData<Val, InputMmcs>,
 ) -> Vec<RowMajorMatrixView<'a, Val>> {
-    let matrices = input_mmcs.get_matrices(&prover_data.data);
-    matrices
-        .into_iter()
-        .zip(&prover_data.widths)
-        .map(|(grouped, &width)| RowMajorMatrixView::new(grouped.values.as_slice(), width))
+    let per_group: Vec<Vec<&'a RowMajorMatrix<Val>>> = prover_data
+        .groups
+        .iter()
+        .map(|group| input_mmcs.get_matrices(&group.data))
+        .collect();
+
+    prover_data
+        .placement
+        .iter()
+        .map(|&(group_idx, idx)| {
+            let grouped = per_group[group_idx][idx];
+            let width = prover_data.groups[group_idx].widths[idx];
+            RowMajorMatrixView::new(grouped.values.as_slice(), width)
+        })
         .collect()
 }
 
@@ -166,12 +232,27 @@ type StirConfigCache<Val, Challenge, StirMmcs, Challenger> = Arc<
 /// returns a correct config — just an unmemoized one.
 const CONFIG_CACHE_CAPACITY: usize = 256;
 
+/// Default cap on the height spread sharing one LDE domain.
+///
+/// Merging native-height classes onto one domain trades commit work for proof size: a matrix
+/// `s` octaves below its group's tallest pays a `2^s` larger blowup, while §7's `Combine`
+/// removes a whole STIR instance and its query-count floor. Three octaves is the spread of
+/// the shape that trade was measured on; past it the extra DFT and Merkle work grows without
+/// bound while `Combine`'s return does not, so wider spreads get their own domain.
+pub const DEFAULT_MAX_LOG_HEIGHT_SPREAD: usize = 3;
+
 /// A polynomial commitment scheme using STIR to generate opening proofs.
 #[derive(Clone, Debug)]
 pub struct TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> {
     dft: Dft,
     input_mmcs: InputMmcs,
     stir: StirParameters<StirMmcs>,
+    /// Maximum `h_max - h_min`, in octaves, among the native heights sharing one LDE domain.
+    ///
+    /// `0` puts every distinct native height on its own domain, so `Combine` never runs and
+    /// each height gets its own STIR instance. A value at or above the committed spread puts
+    /// everything on one domain. See [`DEFAULT_MAX_LOG_HEIGHT_SPREAD`].
+    max_log_height_spread: usize,
     /// `StirConfig::try_new` runs an 80-iteration floating-point bisection per stage to
     /// derive sound round parameters. `open`/`verify` re-derive it per LDE-height bucket, and
     /// bucket shapes recur across calls and across proofs of the same statement, so caching
@@ -190,33 +271,71 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
             dft,
             input_mmcs,
             stir,
+            max_log_height_spread: DEFAULT_MAX_LOG_HEIGHT_SPREAD,
             config_cache: Arc::new(RwLock::new(alloc::collections::BTreeMap::new())),
         }
     }
 
-    /// Commit fiber-grouped LDEs (all sharing one height) in a single tree, recording each
-    /// matrix's own native height and column count for later alpha-batching/`Combine` grouping.
-    fn commit_shared_domain(
+    /// Override how wide a native-height spread may share one LDE domain.
+    ///
+    /// Both sides of a proof must agree on this, since it decides the commit layout and how
+    /// many STIR instances a proof holds; it is not carried in the proof.
+    #[must_use]
+    pub const fn with_max_log_height_spread(mut self, max_log_height_spread: usize) -> Self {
+        self.max_log_height_spread = max_log_height_spread;
+        self
+    }
+
+    /// Commit one tree per shared-domain group.
+    ///
+    /// `plan` assigns matrices to groups; `grouped[i]` is matrix `i`'s fiber-grouped LDE,
+    /// already extended onto the domain of its own group.
+    fn commit_groups(
         &self,
+        plan: &GroupPlan,
         grouped: Vec<RowMajorMatrix<Val>>,
-        log_native_heights: Vec<usize>,
-        widths: Vec<usize>,
-        log_shared_lde_height: usize,
-    ) -> (InputMmcs::Commitment, StirProverData<Val, InputMmcs>)
+        log_native_heights: &[usize],
+        widths: &[usize],
+    ) -> (Vec<InputMmcs::Commitment>, StirProverData<Val, InputMmcs>)
     where
         Val: Send + Sync + Clone,
         InputMmcs: Mmcs<Val>,
     {
-        let (commitment, data) = self.input_mmcs.commit(grouped);
-        (
-            commitment,
-            StirProverData {
-                data,
-                widths,
-                log_native_heights,
-                log_shared_lde_height,
-            },
+        let num_groups = plan.log_lde_heights.len();
+        let mut per_group: Vec<Vec<RowMajorMatrix<Val>>> = vec![Vec::new(); num_groups];
+        let mut per_group_heights: Vec<Vec<usize>> = vec![Vec::new(); num_groups];
+        let mut per_group_widths: Vec<Vec<usize>> = vec![Vec::new(); num_groups];
+        let mut placement = Vec::with_capacity(grouped.len());
+
+        for (matrix_idx, matrix) in grouped.into_iter().enumerate() {
+            let group_idx = plan.group_of_matrix[matrix_idx];
+            placement.push((group_idx, per_group[group_idx].len()));
+            per_group[group_idx].push(matrix);
+            per_group_heights[group_idx].push(log_native_heights[matrix_idx]);
+            per_group_widths[group_idx].push(widths[matrix_idx]);
+        }
+
+        let (commitments, groups) = izip!(
+            per_group,
+            per_group_widths,
+            per_group_heights,
+            &plan.log_lde_heights
         )
+        .map(|(matrices, widths, log_native_heights, &log_lde_height)| {
+            let (commitment, data) = self.input_mmcs.commit(matrices);
+            (
+                commitment,
+                DomainGroup {
+                    data,
+                    widths,
+                    log_native_heights,
+                    log_lde_height,
+                },
+            )
+        })
+        .unzip();
+
+        (commitments, StirProverData { groups, placement })
     }
 }
 
@@ -278,6 +397,112 @@ where
             .unwrap_or_else(|e| panic!("{e}"))
     }
 
+    /// Log2 STIR degree of a bucket whose shared LDE domain has size `2^log_lde_height`.
+    fn log_stir_degree(&self, log_lde_height: usize) -> usize {
+        log_lde_height.saturating_sub(self.stir.log_blowup).max(1)
+    }
+
+    /// Widest band of native heights below `tallest`, in octaves, that may share `tallest`'s
+    /// LDE domain.
+    ///
+    /// Growth stops at the first of two limits: the configured spread cap, which bounds the
+    /// extra blowup a short matrix pays for sitting on a taller group's domain; and `Combine`
+    /// feasibility, which is what makes an infeasible parameter set degrade into more STIR
+    /// instances rather than failing.
+    ///
+    /// Feasibility is probed against the *whole* band `[tallest - w, tallest]` rather than the
+    /// heights a particular commitment happens to hold. That matters because a bucket pools
+    /// every group topped at `tallest`, across all commitments opened together, and merges
+    /// their classes into one `Combine`. Adding a class raises Lemma 4.13's `ell` by
+    /// `2^tallest + 1 - 2^h > 0`, so the full band maximizes `ell` over every subset that
+    /// could form, and a width feasible for it is feasible for whatever union actually shows
+    /// up. Since the width depends only on `tallest` and this PCS's parameters, every
+    /// commitment independently agrees on it.
+    ///
+    /// A width of `0` runs no `Combine` at all, so this always terminates: in the worst case
+    /// every distinct height gets its own domain and its own STIR instance.
+    ///
+    /// The configs derived while probing are served from the same cache the bucket
+    /// construction later reads, so a repeated shape pays for them once.
+    fn combine_band_width(&self, tallest: usize) -> usize {
+        let log_stir_degree = self.log_stir_degree(tallest + self.stir.log_blowup);
+        let max_width = self.max_log_height_spread.min(tallest);
+
+        let mut width = 0;
+        while width < max_width {
+            let band: Vec<usize> = (0..=width + 1).map(|i| tallest - i).collect();
+            if self
+                .get_or_try_compute_stir_config(log_stir_degree, Self::combine_key(&band))
+                .is_err()
+            {
+                break;
+            }
+            width += 1;
+        }
+        width
+    }
+
+    /// Partition distinct native heights, descending, into shared-domain groups.
+    ///
+    /// Returns each group's size, so group `g` covers the slice starting after the previous
+    /// groups. Each group takes every remaining height inside the band
+    /// [`Self::combine_band_width`] admits below its tallest.
+    fn partition_native_heights(&self, descending: &[usize]) -> Vec<usize> {
+        let mut sizes = Vec::new();
+        let mut start = 0;
+
+        while start < descending.len() {
+            let tallest = descending[start];
+            let floor = tallest - self.combine_band_width(tallest);
+            let size = descending[start..]
+                .iter()
+                .take_while(|&&h| h >= floor)
+                .count();
+            sizes.push(size);
+            start += size;
+        }
+
+        sizes
+    }
+
+    /// Assign a commitment's matrices to shared LDE domains.
+    ///
+    /// Depends only on the multiset of native heights and this PCS's parameters, so the
+    /// verifier reproduces it exactly from the claimed domain sizes — the layout is never
+    /// carried in the proof, and a prover that used a different one fails the input MMCS
+    /// check, whose dimensions it fixes.
+    fn plan_groups(&self, log_native_heights: &[usize]) -> GroupPlan {
+        let mut distinct: Vec<usize> = log_native_heights.to_vec();
+        distinct.sort_unstable();
+        distinct.dedup();
+        distinct.reverse();
+
+        let sizes = self.partition_native_heights(&distinct);
+
+        // Group index of each distinct native height, then of each matrix through it.
+        let mut group_of_height: alloc::collections::BTreeMap<usize, usize> =
+            alloc::collections::BTreeMap::new();
+        let mut log_lde_heights = Vec::with_capacity(sizes.len());
+        let mut offset = 0;
+        for (group_idx, size) in sizes.into_iter().enumerate() {
+            log_lde_heights.push(distinct[offset] + self.stir.log_blowup);
+            for &log_native_h in &distinct[offset..offset + size] {
+                group_of_height.insert(log_native_h, group_idx);
+            }
+            offset += size;
+        }
+
+        let group_of_matrix = log_native_heights
+            .iter()
+            .map(|log_native_h| group_of_height[log_native_h])
+            .collect();
+
+        GroupPlan {
+            log_lde_heights,
+            group_of_matrix,
+        }
+    }
+
     /// A bucket's `Combine` key: `None` when only one native-height class shares the domain.
     ///
     /// `ell` is Lemma 4.13's multiplicity `num_classes·(d* + 1) − Σᵢ dᵢ`, with `d*` the
@@ -316,14 +541,18 @@ where
         + Clone,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
-    /// One Merkle root per commitment: every matrix passed to one `commit()` call shares a
-    /// single tree on the shared LDE domain (§7's same-domain requirement).
-    type Commitment = InputMmcs::Commitment;
+    /// One Merkle root per shared-domain group, in descending LDE height.
+    ///
+    /// The matrices of one `commit()` call are partitioned into groups of bounded height
+    /// spread, each extended onto its own shared domain (§7's same-domain requirement applies
+    /// within a group, not across the whole commitment) and committed in its own tree. A
+    /// commitment whose heights all fit one group therefore has a single root, and callers
+    /// observe the roots in order.
+    type Commitment = Vec<InputMmcs::Commitment>;
     type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
-    /// Proof structure: one entry per distinct shared LDE height across the commitments
-    /// (descending). Every matrix in a single `commit()` shares one LDE domain, so a
-    /// commitment contributes to exactly one entry.
+    /// Proof structure: one entry per distinct shared LDE height across every commitment's
+    /// groups (descending). A commitment contributes to one entry per group it holds.
     ///
     /// Each bucket contains:
     /// - `stir_proof`: the STIR IOP proof for that bucket (per-round IOP messages; the initial
@@ -332,7 +561,7 @@ where
     ///   transcript.
     /// - `input_openings[commit_idx]`: one shared multi-opening proof for that commitment's
     ///   rows at the bucket's first-round STIR fiber positions, in the same sorted-by-index
-    ///   order the verifier reconstructs. `None` if the commitment has no matrices at this
+    ///   order the verifier reconstructs. `None` if the commitment has no group at this
     ///   bucket's LDE height.
     type Proof = Vec<(
         StirProof<Challenge, StirMmcs, Val>,
@@ -374,22 +603,22 @@ where
                 self.stir.log_starting_folding_factor,
             );
         }
-        let log_max_native_height = inputs
+        let log_native_heights: Vec<usize> = inputs
             .iter()
             .map(|(domain, _)| log2_strict_usize(domain.size()))
-            .max()
-            .expect("checked non-empty above");
-        let log_shared_lde_height = log_max_native_height + self.stir.log_blowup;
+            .collect();
+        let plan = self.plan_groups(&log_native_heights);
 
         let mut widths = Vec::with_capacity(inputs.len());
-        let mut log_native_heights = Vec::with_capacity(inputs.len());
         let grouped: Vec<_> = inputs
             .into_iter()
-            .map(|(domain, evals)| {
-                let log_native_height = log2_strict_usize(domain.size());
-                // Effective per-matrix blowup: `log_blowup` for the tallest matrix, and one
-                // extra bit per octave of height below it. See the module-level cost note.
-                let extra_bits = log_shared_lde_height - log_native_height;
+            .zip(&log_native_heights)
+            .zip(&plan.group_of_matrix)
+            .map(|(((domain, evals), &log_native_height), &group_idx)| {
+                // Effective per-matrix blowup: `log_blowup` for the tallest matrix in the
+                // group, and one extra bit per octave of height below it — which is what the
+                // spread cap bounds. See the module-level cost note.
+                let extra_bits = plan.log_lde_heights[group_idx] - log_native_height;
                 let shift = Val::GENERATOR / domain.shift();
                 let lde = self
                     .dft
@@ -397,11 +626,10 @@ where
                     .bit_reverse_rows()
                     .to_row_major_matrix();
                 widths.push(lde.width());
-                log_native_heights.push(log_native_height);
                 group_fiber_rows(lde, self.stir.log_starting_folding_factor)
             })
             .collect();
-        self.commit_shared_domain(grouped, log_native_heights, widths, log_shared_lde_height)
+        self.commit_groups(&plan, grouped, &log_native_heights, &widths)
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -410,8 +638,10 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let grouped = self.input_mmcs.get_matrices(&prover_data.data)[idx];
-        let lde = RowMajorMatrixView::new(grouped.values.as_slice(), prover_data.widths[idx]);
+        let (group_idx, idx_in_group) = prover_data.placement[idx];
+        let group = &prover_data.groups[group_idx];
+        let grouped = self.input_mmcs.get_matrices(&group.data)[idx_in_group];
+        let lde = RowMajorMatrixView::new(grouped.values.as_slice(), group.widths[idx_in_group]);
         if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
             let width = lde.width();
             let values: &'a [Val] = lde.values;
@@ -419,7 +649,7 @@ where
                 .as_cow()
                 .bit_reverse_rows();
         }
-        let poly_height = 1usize << prover_data.log_native_heights[idx];
+        let poly_height = 1usize << group.log_native_heights[idx_in_group];
         let lde_mat = lde.bit_reverse_rows().to_row_major_matrix();
         let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
         let width = coeffs.width();
@@ -486,20 +716,17 @@ where
             .iter()
             .map(|lde| log2_strict_usize(lde.height()) - self.stir.log_blowup)
             .collect();
-        let log_max_native_height = log_native_heights
-            .iter()
-            .copied()
-            .max()
-            .expect("checked non-empty above");
-        let log_shared_lde_height = log_max_native_height + self.stir.log_blowup;
+        let plan = self.plan_groups(&log_native_heights);
 
         let mut widths = Vec::with_capacity(ldes.len());
         let grouped: Vec<_> = ldes
             .into_iter()
             .zip(&log_native_heights)
-            .map(|(lde, &log_native_height)| {
+            .zip(&plan.group_of_matrix)
+            .map(|((lde, &log_native_height), &group_idx)| {
                 widths.push(lde.width());
-                let extended = if lde.height() == 1usize << log_shared_lde_height {
+                let log_lde_height = plan.log_lde_heights[group_idx];
+                let extended = if lde.height() == 1usize << log_lde_height {
                     lde
                 } else {
                     let natural_lde = lde.bit_reverse_rows().to_row_major_matrix();
@@ -509,18 +736,14 @@ where
                         .values
                         .truncate((1usize << log_native_height) * width);
                     self.dft
-                        .coset_lde_batch(
-                            coeffs,
-                            log_shared_lde_height - log_native_height,
-                            Val::GENERATOR,
-                        )
+                        .coset_lde_batch(coeffs, log_lde_height - log_native_height, Val::GENERATOR)
                         .bit_reverse_rows()
                         .to_row_major_matrix()
                 };
                 group_fiber_rows(extended, self.stir.log_starting_folding_factor)
             })
             .collect();
-        self.commit_shared_domain(grouped, log_native_heights, widths, log_shared_lde_height)
+        self.commit_groups(&plan, grouped, &log_native_heights, &widths)
     }
 
     #[instrument(name = "STIR PCS open", skip_all)]
@@ -533,6 +756,13 @@ where
         let mats_and_points: Vec<_> = commitment_data_with_opening_points
             .iter()
             .map(|(data, points)| (lde_views(&self.input_mmcs, data), points))
+            .collect();
+
+        // `(native height, group LDE height)` per matrix, in caller order: the first selects
+        // the `Combine` class, the second selects which STIR instance that class feeds.
+        let matrix_layouts: Vec<Vec<(usize, usize)>> = commitment_data_with_opening_points
+            .iter()
+            .map(|(data, _)| data.matrix_layout())
             .collect();
 
         let (global_max_height, global_max_width) = mats_and_points
@@ -562,10 +792,10 @@ where
 
         let all_opened_values: OpenedValues<Challenge> = mats_and_points
             .iter()
-            .zip(&commitment_data_with_opening_points)
-            .map(|((mats, points), (data, _))| {
-                izip!(mats.iter(), points.iter(), data.log_native_heights.iter())
-                    .map(|(mat, points_for_mat, &log_native_h)| {
+            .zip(&matrix_layouts)
+            .map(|((mats, points), layout)| {
+                izip!(mats.iter(), points.iter(), layout.iter())
+                    .map(|(mat, points_for_mat, &(log_native_h, _))| {
                         let h = 1usize << log_native_h;
                         let (low_coset, _) = mat.split_rows(h);
 
@@ -608,15 +838,15 @@ where
         let mut num_reduced: alloc::collections::BTreeMap<(usize, usize), usize> =
             alloc::collections::BTreeMap::new();
 
-        for (((mats, points), opened_vals), (data, _)) in mats_and_points
+        for (((mats, points), opened_vals), layout) in mats_and_points
             .iter()
             .zip(&all_opened_values)
-            .zip(&commitment_data_with_opening_points)
+            .zip(&matrix_layouts)
         {
-            for (((mat, points_for_mat), opened_for_mat), &log_native_h) in
+            for (((mat, points_for_mat), opened_for_mat), &(log_native_h, log_lde_h)) in
                 izip!(mats.iter(), points.iter())
                     .zip(opened_vals.iter())
-                    .zip(data.log_native_heights.iter())
+                    .zip(layout.iter())
             {
                 // A matrix opened at no points would contribute nothing to the reduced
                 // opening, but the verifier still counts it as a native-height class (it reads
@@ -629,7 +859,7 @@ where
                      points; every committed matrix must be opened at least once"
                 );
 
-                let key = (data.log_shared_lde_height, log_native_h);
+                let key = (log_lde_h, log_native_h);
                 let ro = reduced_openings
                     .entry(key)
                     .or_insert_with(|| vec![Challenge::ZERO; mat.height()]);
@@ -698,7 +928,7 @@ where
                 .iter()
                 .zip(&bucket_native_heights)
                 .map(|(&log_h, native_heights)| {
-                    let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
+                    let log_stir_degree = self.log_stir_degree(log_h);
                     self.get_or_compute_stir_config(
                         log_stir_degree,
                         Self::combine_key(native_heights),
@@ -738,12 +968,10 @@ where
                         commitment_data_with_opening_points
                             .iter()
                             .map(|(data, _)| {
-                                // A commitment's whole shared domain either feeds this
-                                // bucket or none of it does -- there is no partial case
-                                // now that every matrix in a commitment shares one domain.
-                                if data.log_shared_lde_height != log_h {
-                                    return None;
-                                }
+                                // Each group has its own tree on its own domain, so a bucket
+                                // reads exactly the group committed at its LDE height —
+                                // never a partial slice of one, and nothing from the others.
+                                let group = data.group_at(log_h)?;
 
                                 let q_globals: Vec<usize> = first_round_query_indices
                                     .iter()
@@ -751,7 +979,7 @@ where
                                     .collect();
 
                                 let (opened_values, opening_proof) =
-                                    self.input_mmcs.open_multi_batch(&q_globals, &data.data);
+                                    self.input_mmcs.open_multi_batch(&q_globals, &group.data);
                                 Some(InputOpenings {
                                     opened_values,
                                     opening_proof,
@@ -807,25 +1035,47 @@ where
 
         let alpha: Challenge = challenger.sample_algebra_element();
 
-        // Every matrix in one commitment shares its shared LDE domain: the tallest matrix's
-        // native height plus log_blowup. This is public (derived from the claimed domains),
-        // matching how the prover derived it at commit time.
-        let commitment_shared_heights: Vec<usize> = commitments_with_opening_points
+        // Reproduce each commitment's shared-domain layout from the claimed domain sizes,
+        // exactly as `commit` derived it from the committed ones. Nothing about the layout
+        // travels in the proof: it is a function of the claimed heights and this PCS's
+        // parameters, and a prover that used a different one fixed different MMCS dimensions
+        // and fails the input opening check below.
+        let plans: Vec<GroupPlan> = commitments_with_opening_points
             .iter()
             .map(|(_, domain_claims)| {
-                let log_max_native = domain_claims
+                let log_native_heights: Vec<usize> = domain_claims
                     .iter()
                     .map(|(domain, _)| log2_strict_usize(domain.size()))
-                    .max()
-                    .unwrap_or(0);
-                log_max_native + self.stir.log_blowup
+                    .collect();
+                self.plan_groups(&log_native_heights)
+            })
+            .collect();
+
+        // SHAPE CHECK: one Merkle root per group of the layout the claims imply.
+        for ((commitment, _), plan) in commitments_with_opening_points.iter().zip(&plans) {
+            if commitment.len() != plan.log_lde_heights.len() {
+                return Err(StirError::InvalidProofShape);
+            }
+        }
+
+        // Log2 LDE height of the domain each matrix sits on, in claimed order.
+        let matrix_lde_heights: Vec<Vec<usize>> = plans
+            .iter()
+            .map(|plan| {
+                plan.group_of_matrix
+                    .iter()
+                    .map(|&group_idx| plan.log_lde_heights[group_idx])
+                    .collect()
             })
             .collect();
 
         // Distinct outer buckets (shared LDE heights), descending. Must match the prover's
         // bucket iteration order.
         let bucket_log_heights: Vec<usize> = {
-            let mut heights: Vec<usize> = commitment_shared_heights.clone();
+            let mut heights: Vec<usize> = plans
+                .iter()
+                .flat_map(|plan| plan.log_lde_heights.iter().copied())
+                .collect();
             heights.sort_unstable();
             heights.dedup();
             heights.reverse();
@@ -835,6 +1085,19 @@ where
         if proof.len() != bucket_log_heights.len() {
             return Err(StirError::InvalidProofShape);
         }
+
+        // Which of a commitment's groups (hence which of its Merkle roots) feeds each
+        // bucket, if any. Group LDE heights within a commitment are distinct, so this is
+        // at most one group per bucket.
+        let bucket_group_indices: Vec<Vec<Option<usize>>> = bucket_log_heights
+            .iter()
+            .map(|&log_h| {
+                plans
+                    .iter()
+                    .map(|plan| plan.log_lde_heights.iter().position(|&h| h == log_h))
+                    .collect()
+            })
+            .collect();
 
         let global_max_width = commitments_with_opening_points
             .iter()
@@ -865,12 +1128,13 @@ where
             alloc::collections::BTreeMap::new();
         let point_data: Vec<Vec<Vec<(Challenge, Challenge)>>> = commitments_with_opening_points
             .iter()
-            .zip(&commitment_shared_heights)
-            .map(|((_, domain_claims), &log_shared_h)| {
+            .zip(&matrix_lde_heights)
+            .map(|((_, domain_claims), lde_heights)| {
                 domain_claims
                     .iter()
-                    .map(|(domain, point_claims)| {
-                        let key = (log_shared_h, log2_strict_usize(domain.size()));
+                    .zip(lde_heights)
+                    .map(|((domain, point_claims), &log_lde_h)| {
+                        let key = (log_lde_h, log2_strict_usize(domain.size()));
                         point_claims
                             .iter()
                             .map(|(_, vals)| {
@@ -913,12 +1177,13 @@ where
             .map(|&log_shared_h| {
                 let mut native_heights: Vec<usize> = commitments_with_opening_points
                     .iter()
-                    .zip(&commitment_shared_heights)
-                    .filter(|&(_, h)| *h == log_shared_h)
-                    .flat_map(|((_, domain_claims), _)| {
+                    .zip(&matrix_lde_heights)
+                    .flat_map(|((_, domain_claims), lde_heights)| {
                         domain_claims
                             .iter()
-                            .map(|(domain, _)| log2_strict_usize(domain.size()))
+                            .zip(lde_heights)
+                            .filter(move |&(_, &log_lde_h)| log_lde_h == log_shared_h)
+                            .map(|((domain, _), _)| log2_strict_usize(domain.size()))
                     })
                     .collect();
                 native_heights.sort_unstable();
@@ -933,7 +1198,7 @@ where
                 .iter()
                 .zip(&bucket_native_heights)
                 .map(|(&log_h, native_heights)| {
-                    let log_stir_degree = log_h.saturating_sub(self.stir.log_blowup).max(1);
+                    let log_stir_degree = self.log_stir_degree(log_h);
                     self.get_or_try_compute_stir_config(
                         log_stir_degree,
                         Self::combine_key(native_heights),
@@ -970,7 +1235,7 @@ where
         // Captured by every bucket's closure below; taking references up front lets `move`
         // give each closure its own copy of the reference rather than the whole value.
         let commitments_with_opening_points = &commitments_with_opening_points;
-        let commitment_shared_heights = &commitment_shared_heights;
+        let matrix_lde_heights = &matrix_lde_heights;
         let point_data = &point_data;
         let alpha_powers = &alpha_powers;
         let bucket_combine = &bucket_combine;
@@ -986,8 +1251,12 @@ where
             .zip(proof.iter().map(|(_, input_openings)| input_openings))
             .zip(bucket_combine)
             .zip(&bucket_native_heights)
+            .zip(&bucket_group_indices)
             .map(
-                |((((&log_h, stir_config), input_openings), combine_info), native_heights)| {
+                |(
+                    ((((&log_h, stir_config), input_openings), combine_info), native_heights),
+                    group_indices,
+                )| {
                 let bucket_height = 1usize << log_h;
                 let log_arity0 = stir_config.log_starting_folding_factor;
                 let arity0 = 1usize << log_arity0;
@@ -1014,9 +1283,14 @@ where
                     // is usually far shorter than the matrix count.
                     let bucket_points: Vec<Challenge> = commitments_with_opening_points
                         .iter()
-                        .zip(commitment_shared_heights.iter())
-                        .filter(|&(_, h)| *h == log_h)
-                        .flat_map(|((_, domain_claims), _)| domain_claims.iter())
+                        .zip(matrix_lde_heights.iter())
+                        .flat_map(|((_, domain_claims), lde_heights)| {
+                            domain_claims
+                                .iter()
+                                .zip(lde_heights)
+                                .filter(move |&(_, &h)| h == log_h)
+                                .map(|(claim, _)| claim)
+                        })
                         .flat_map(|(_, point_claims)| point_claims.iter().map(|(point, _)| *point))
                         .fold(Vec::new(), |mut points, point| {
                             if !points.contains(&point) {
@@ -1041,34 +1315,43 @@ where
                     }
                     let inv_denoms = batch_multiplicative_inverse(&denom_diffs);
 
-                    // A commitment's whole shared domain either feeds this bucket (all its
-                    // matrices) or none of it does — there is no partial case now that every
-                    // matrix in a commitment shares one domain.
+                    // A commitment feeds this bucket through at most one of its groups: the
+                    // one committed on this domain. Its other groups live in other trees at
+                    // other heights and belong to other buckets.
                     for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
                         commitments_with_opening_points
                             .iter()
                             .zip(input_openings.iter())
                             .enumerate()
                     {
-                        let has_at_bucket = commitment_shared_heights[commit_idx] == log_h;
+                        let group_idx = group_indices[commit_idx];
 
                         let Some(opening) = per_commit_opening else {
-                            if has_at_bucket {
+                            if group_idx.is_some() {
                                 return Err(StirError::InvalidProofShape);
                             }
                             continue;
                         };
-                        if !has_at_bucket {
+                        let Some(group_idx) = group_idx else {
                             return Err(StirError::InvalidProofShape);
-                        }
+                        };
+
+                        // The commitment's matrices on this domain, in the order they were
+                        // committed to its tree: caller order, filtered to this group.
+                        let group_mats: Vec<usize> = matrix_lde_heights[commit_idx]
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(idx, &h)| (h == log_h).then_some(idx))
+                            .collect();
 
                         // Pin each matrix's width to its claimed evaluation count, never to
                         // the proof. Every matrix has at least one claim — the up-front check
                         // in `verify` rejects otherwise before the transcript is touched.
-                        let mat_widths: Vec<usize> = domain_claims
+                        let mat_widths: Vec<usize> = group_mats
                             .iter()
-                            .map(|(_, point_claims)| {
-                                point_claims
+                            .map(|&idx| {
+                                domain_claims[idx]
+                                    .1
                                     .first()
                                     .map(|(_, v)| v.len())
                                     .expect("rejected up front in verify")
@@ -1080,20 +1363,21 @@ where
                         // are resolved once here rather than once per
                         // `(query, lane, matrix, point)`, which is where the innermost loop
                         // below would otherwise re-scan `bucket_points` linearly.
-                        let mat_class_indices: Vec<usize> = domain_claims
+                        let mat_class_indices: Vec<usize> = group_mats
                             .iter()
-                            .map(|(domain, _)| {
-                                let log_native_h = log2_strict_usize(domain.size());
+                            .map(|&idx| {
+                                let log_native_h = log2_strict_usize(domain_claims[idx].0.size());
                                 native_heights
                                     .iter()
                                     .position(|&h| h == log_native_h)
                                     .expect("bucket_native_heights is built from these claims")
                             })
                             .collect();
-                        let mat_point_slots: Vec<Vec<usize>> = domain_claims
+                        let mat_point_slots: Vec<Vec<usize>> = group_mats
                             .iter()
-                            .map(|(_, point_claims)| {
-                                point_claims
+                            .map(|&idx| {
+                                domain_claims[idx]
+                                    .1
                                     .iter()
                                     .map(|(point, _)| {
                                         bucket_points
@@ -1105,9 +1389,8 @@ where
                             })
                             .collect();
 
-                        // Every matrix in the commitment shares this bucket's domain, so all
-                        // of them are opened. Matrices are committed fiber-grouped:
-                        // `2^log_arity0` LDE rows per committed row.
+                        // Matrices are committed fiber-grouped: `2^log_arity0` LDE rows per
+                        // committed row.
                         let dimensions: Vec<p3_matrix::Dimensions> = mat_widths
                             .iter()
                             .map(|&width| p3_matrix::Dimensions {
@@ -1128,7 +1411,7 @@ where
 
                         self.input_mmcs
                             .verify_multi_batch(
-                                commitment,
+                                &commitment[group_idx],
                                 &dimensions,
                                 &q_globals,
                                 &opening.opened_values,
@@ -1148,6 +1431,10 @@ where
                                 for (mat_idx, point_slots) in
                                     mat_point_slots.iter().enumerate()
                                 {
+                                    // `mat_idx` indexes this group's tree, and therefore the
+                                    // opened rows; `point_data` is keyed by the commitment's
+                                    // full claim order, which `group_mats` maps back to.
+                                    let claim_idx = group_mats[mat_idx];
                                     let width = mat_widths[mat_idx];
                                     let row_vals =
                                         &row_vals_by_mat[mat_idx][slot * width..][..width];
@@ -1162,7 +1449,7 @@ where
 
                                     for (point_idx, &bp_idx) in point_slots.iter().enumerate() {
                                         let (alpha_pow_offset, y_combined) =
-                                            point_data[commit_idx][mat_idx][point_idx];
+                                            point_data[commit_idx][claim_idx][point_idx];
                                         let inv_denom =
                                             inv_denoms[(q_idx * arity0 + l) * n_bp + bp_idx];
 
@@ -1491,6 +1778,113 @@ mod tests {
             config.final_folding_pow_bits,
             config.round_configs,
         )
+    }
+
+    /// A PCS over `TestVal`/`EF` at the given layout and soundness knobs.
+    fn test_pcs_with(
+        max_log_height_spread: usize,
+        soundness_type: SecurityAssumption,
+        security_level: usize,
+    ) -> TestPcs {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(11);
+        let perm = TestPerm::new_from_rng_128(&mut rng);
+        let val_mmcs = TestValMmcs::new(TestHash::new(perm.clone()), TestCompress::new(perm), 0);
+        let stir = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 2,
+            log_starting_folding_factor: 2,
+            soundness_type,
+            security_level,
+            max_pow_bits: 0,
+            mmcs: TestStirMmcs::new(val_mmcs.clone()),
+        };
+        TwoAdicStirPcs::new(Radix2DitParallel::default(), val_mmcs, stir)
+            .with_max_log_height_spread(max_log_height_spread)
+    }
+
+    /// Group sizes of the plan for `log_native_heights`, in descending LDE height.
+    fn group_sizes(plan: &GroupPlan) -> Vec<usize> {
+        (0..plan.log_lde_heights.len())
+            .map(|g| plan.group_of_matrix.iter().filter(|&&x| x == g).count())
+            .collect()
+    }
+
+    #[test]
+    fn groups_split_at_the_configured_spread() {
+        let heights = [8usize, 6, 4];
+        let cb = SecurityAssumption::CapacityBound;
+
+        // Spread 2 admits 8 with 6 but not 8 with 4, so the run breaks after the second.
+        let plan = test_pcs_with(2, cb, 32).plan_groups(&heights);
+        assert_eq!(plan.log_lde_heights, vec![9, 5]);
+        assert_eq!(plan.group_of_matrix, vec![0, 0, 1]);
+
+        // Spread 1 admits none of these pairs.
+        let plan = test_pcs_with(1, cb, 32).plan_groups(&heights);
+        assert_eq!(plan.log_lde_heights, vec![9, 7, 5]);
+        assert_eq!(plan.group_of_matrix, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn zero_spread_is_the_per_height_class_layout() {
+        // Every distinct native height on its own domain: no `Combine`, one STIR instance
+        // each, and every matrix extended only by `log_blowup`.
+        let heights = [8usize, 7, 6, 6];
+        let plan = test_pcs_with(0, SecurityAssumption::CapacityBound, 32).plan_groups(&heights);
+
+        assert_eq!(plan.log_lde_heights, vec![9, 8, 7]);
+        assert_eq!(plan.group_of_matrix, vec![0, 1, 2, 2]);
+        assert_eq!(group_sizes(&plan), vec![1, 1, 2]);
+    }
+
+    #[test]
+    fn spread_above_the_committed_range_is_a_single_shared_domain() {
+        let heights = [8usize, 6, 4];
+        let plan = test_pcs_with(64, SecurityAssumption::CapacityBound, 32).plan_groups(&heights);
+
+        assert_eq!(plan.log_lde_heights, vec![9]);
+        assert_eq!(plan.group_of_matrix, vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn repeated_heights_share_one_class_and_one_group() {
+        // Grouping is over *distinct* heights, so duplicates never open a new group and the
+        // plan does not depend on how many matrices carry a given height.
+        let cb = SecurityAssumption::CapacityBound;
+        let pcs = test_pcs_with(2, cb, 32);
+
+        let plan = pcs.plan_groups(&[8, 8, 6, 8]);
+        assert_eq!(plan.log_lde_heights, vec![9]);
+        assert_eq!(plan.group_of_matrix, vec![0, 0, 0, 0]);
+
+        // Caller order does not matter either: a matrix follows its height.
+        let plan = pcs.plan_groups(&[4, 8, 4, 6]);
+        assert_eq!(plan.log_lde_heights, vec![9, 5]);
+        assert_eq!(plan.group_of_matrix, vec![1, 0, 1, 0]);
+    }
+
+    #[test]
+    fn groups_shrink_when_combine_does_not_fit() {
+        // JohnsonBound at 80 bits over a 124-bit challenge field: each height configures on
+        // its own, but merging the two does not. The spread cap would allow one group, so
+        // this is feasibility alone deciding — an infeasible parameter set degrades into more
+        // STIR instances instead of failing.
+        let jb = SecurityAssumption::JohnsonBound;
+        let heights = [12usize, 11];
+
+        let pcs = test_pcs_with(8, jb, 80);
+        let ell = 2 * ((1u64 << 12) + 1) - ((1u64 << 12) + (1u64 << 11));
+        assert!(TestConfig::try_new(12, pcs.stir.clone()).is_ok());
+        assert!(TestConfig::try_new_with_combine(12, pcs.stir.clone(), 2, ell).is_err());
+
+        let plan = pcs.plan_groups(&heights);
+        assert_eq!(plan.log_lde_heights, vec![13, 12]);
+        assert_eq!(plan.group_of_matrix, vec![0, 1]);
+
+        // The same shape at a target the merge does fit stays in one group, so the split
+        // above is not just the spread cap in disguise.
+        let plan = test_pcs_with(8, jb, 32).plan_groups(&heights);
+        assert_eq!(plan.log_lde_heights, vec![13]);
     }
 
     fn test_pcs_and_params() -> (TestPcs, StirParameters<TestStirMmcs>) {

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -53,21 +53,25 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;
+use core::ops::Deref;
 
 use itertools::{Itertools, izip};
-use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_challenger::{
+    CanObserve, CanSampleUniformBits, DuplexChallenger, FieldChallenger, GrindingChallenger,
+};
 use p3_commit::{Mmcs, OpenedValues, Pcs};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
-    BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, TwoAdicField,
-    batch_multiplicative_inverse,
+    BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PrimeCharacteristicRing,
+    TwoAdicField, batch_multiplicative_inverse,
 };
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::{BitReversedMatrixView, BitReversibleMatrix};
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixCow, RowMajorMatrixView};
 use p3_matrix::interpolation::{Interpolate, compute_adjusted_weights};
 use p3_maybe_rayon::prelude::*;
+use p3_symmetric::CryptographicPermutation;
 use p3_util::linear_map::LinearMap;
 use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits};
 use serde::{Deserialize, Serialize};
@@ -155,6 +159,47 @@ impl<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> StirProverData<Val, InputMm
     }
 }
 
+/// One Merkle root per shared-domain group of a commitment, in descending LDE height.
+///
+/// The matrices of one `commit()` call are partitioned into groups of bounded height spread,
+/// each extended onto its own shared domain (§7's same-domain requirement applies within a
+/// group, not across the whole commitment) and committed in its own tree. A commitment whose
+/// heights all fit one group therefore holds a single root.
+///
+/// The roots are wrapped rather than handed out as a bare `Vec` so a challenger can observe
+/// the whole commitment in one call — which is what
+/// `p3_uni_stark::StarkGenericConfig`'s `Challenger: CanObserve<Pcs::Commitment>` bound asks
+/// for. Observing runs the root count first, so two commitments that split a given total of
+/// roots differently cannot reach the same transcript state.
+///
+/// Dereferences to its roots, so reading them needs no unwrapping.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct StirCommitment<C>(Vec<C>);
+
+impl<C> Deref for StirCommitment<C> {
+    type Target = [C];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<F, P, C, const WIDTH: usize, const RATE: usize> CanObserve<StirCommitment<C>>
+    for DuplexChallenger<F, P, WIDTH, RATE>
+where
+    F: Copy + PrimeCharacteristicRing,
+    P: CryptographicPermutation<[F; WIDTH]>,
+    Self: CanObserve<C>,
+{
+    fn observe(&mut self, commitment: StirCommitment<C>) {
+        <Self as CanObserve<F>>::observe(self, F::from_usize(commitment.0.len()));
+        for root in commitment.0 {
+            self.observe(root);
+        }
+    }
+}
+
 /// How one commitment's matrices are partitioned across shared LDE domains.
 ///
 /// Derived identically by the prover (from the committed heights) and the verifier (from the
@@ -236,9 +281,11 @@ const CONFIG_CACHE_CAPACITY: usize = 256;
 ///
 /// Merging native-height classes onto one domain trades commit work for proof size: a matrix
 /// `s` octaves below its group's tallest pays a `2^s` larger blowup, while §7's `Combine`
-/// removes a whole STIR instance and its query-count floor. Three octaves is the spread of
-/// the shape that trade was measured on; past it the extra DFT and Merkle work grows without
-/// bound while `Combine`'s return does not, so wider spreads get their own domain.
+/// removes a whole STIR instance and its query-count floor. Three octaves is what that trade
+/// was measured to be worth buying: the shortest member of a group spanning it pays an `8x`
+/// blowup, in its DFT and in its full width in every one of the group's tree leaves, to save
+/// one instance. Past it the commit side keeps doubling per octave while `Combine`'s return
+/// does not, so wider spreads get their own domain.
 pub const DEFAULT_MAX_LOG_HEIGHT_SPREAD: usize = 3;
 
 /// A polynomial commitment scheme using STIR to generate opening proofs.
@@ -286,6 +333,14 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
         self
     }
 
+    /// How wide a native-height spread this instance lets share one LDE domain.
+    ///
+    /// The two sides of a proof must agree on it, so both can check that they do rather than
+    /// relying on having been constructed the same way.
+    pub const fn max_log_height_spread(&self) -> usize {
+        self.max_log_height_spread
+    }
+
     /// Commit one tree per shared-domain group.
     ///
     /// `plan` assigns matrices to groups; `grouped[i]` is matrix `i`'s fiber-grouped LDE,
@@ -296,11 +351,16 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
         grouped: Vec<RowMajorMatrix<Val>>,
         log_native_heights: &[usize],
         widths: &[usize],
-    ) -> (Vec<InputMmcs::Commitment>, StirProverData<Val, InputMmcs>)
+    ) -> (
+        StirCommitment<InputMmcs::Commitment>,
+        StirProverData<Val, InputMmcs>,
+    )
     where
         Val: Send + Sync + Clone,
-        InputMmcs: Mmcs<Val>,
+        InputMmcs: Mmcs<Val, Commitment: Send> + Sync,
+        InputMmcs::ProverData<RowMajorMatrix<Val>>: Send,
     {
+        let input_mmcs = &self.input_mmcs;
         let num_groups = plan.log_lde_heights.len();
         let mut per_group: Vec<Vec<RowMajorMatrix<Val>>> = vec![Vec::new(); num_groups];
         let mut per_group_heights: Vec<Vec<usize>> = vec![Vec::new(); num_groups];
@@ -315,14 +375,19 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
             per_group_widths[group_idx].push(widths[matrix_idx]);
         }
 
-        let (commitments, groups) = izip!(
+        // Groups share nothing — separate matrices, separate trees, separate prover data — so
+        // they are built in parallel. Only the tallest group has enough rows to saturate the
+        // pool on its own; the inner per-tree parallelism work-steals alongside this one.
+        let (commitments, groups): (Vec<_>, Vec<_>) = izip!(
             per_group,
             per_group_widths,
             per_group_heights,
             &plan.log_lde_heights
         )
+        .collect::<Vec<_>>()
+        .into_par_iter()
         .map(|(matrices, widths, log_native_heights, &log_lde_height)| {
-            let (commitment, data) = self.input_mmcs.commit(matrices);
+            let (commitment, data) = input_mmcs.commit(matrices);
             (
                 commitment,
                 DomainGroup {
@@ -335,7 +400,10 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
         })
         .unzip();
 
-        (commitments, StirProverData { groups, placement })
+        (
+            StirCommitment(commitments),
+            StirProverData { groups, placement },
+        )
     }
 }
 
@@ -405,10 +473,15 @@ where
     /// Widest band of native heights below `tallest`, in octaves, that may share `tallest`'s
     /// LDE domain.
     ///
-    /// Growth stops at the first of two limits: the configured spread cap, which bounds the
-    /// extra blowup a short matrix pays for sitting on a taller group's domain; and `Combine`
-    /// feasibility, which is what makes an infeasible parameter set degrade into more STIR
-    /// instances rather than failing.
+    /// Growth stops at the first of three limits: the configured spread cap, which bounds the
+    /// extra blowup a short matrix pays for sitting on a taller group's domain; `lowest`, the
+    /// lowest height that could still join the band; and `Combine` feasibility, which is what
+    /// makes an infeasible parameter set degrade into more STIR instances rather than failing.
+    ///
+    /// The `lowest` cap never moves an admissibility decision. A span of `s` octaves is
+    /// admitted exactly when `s` is within every limit, and `s <= tallest - lowest` holds for
+    /// any span that exists at all; capping only skips deriving — and caching — configs for
+    /// bands no group could fill.
     ///
     /// Feasibility is probed against the *whole* band `[tallest - w, tallest]` rather than the
     /// heights a particular commitment happens to hold. That matters because a bucket pools
@@ -424,9 +497,12 @@ where
     ///
     /// The configs derived while probing are served from the same cache the bucket
     /// construction later reads, so a repeated shape pays for them once.
-    fn combine_band_width(&self, tallest: usize) -> usize {
+    fn combine_band_width(&self, tallest: usize, lowest: usize) -> usize {
         let log_stir_degree = self.log_stir_degree(tallest + self.stir.log_blowup);
-        let max_width = self.max_log_height_spread.min(tallest);
+        let max_width = self
+            .max_log_height_spread
+            .min(tallest)
+            .min(tallest - lowest);
 
         let mut width = 0;
         while width < max_width {
@@ -445,23 +521,61 @@ where
     /// Partition distinct native heights, descending, into shared-domain groups.
     ///
     /// Returns each group's size, so group `g` covers the slice starting after the previous
-    /// groups. Each group takes every remaining height inside the band
-    /// [`Self::combine_band_width`] admits below its tallest.
+    /// groups. A group is admissible only when its whole span fits inside the band
+    /// [`Self::combine_band_width`] admits below its own tallest, which is what keeps that
+    /// probe conservative for whatever union of classes a bucket later pools.
+    ///
+    /// Among admissible partitions this takes the fewest groups — one STIR instance each, so
+    /// the group count fixes the proof's shape and its query structure — and, among those, the
+    /// one minimizing `Σ_g 2^(tallest of g)·|g|`: every member of a group is extended onto that
+    /// group's shared domain, so a group costs its own height once per member, in both DFT
+    /// work and Merkle leaf material. Filling each group greedily instead reaches the same
+    /// group count but pulls short heights onto the tallest domain that will take them, which
+    /// is the most expensive placement available to them. Both objectives read only the
+    /// distinct heights, so the prover and the verifier derive the same partition.
     fn partition_native_heights(&self, descending: &[usize]) -> Vec<usize> {
-        let mut sizes = Vec::new();
-        let mut start = 0;
+        let Some(&lowest) = descending.last() else {
+            return Vec::new();
+        };
+        let n = descending.len();
 
-        while start < descending.len() {
-            let tallest = descending[start];
-            let floor = tallest - self.combine_band_width(tallest);
-            let size = descending[start..]
-                .iter()
-                .take_while(|&&h| h >= floor)
-                .count();
-            sizes.push(size);
-            start += size;
+        let band_widths: Vec<usize> = descending
+            .iter()
+            .map(|&tallest| self.combine_band_width(tallest, lowest))
+            .collect();
+
+        // `best[j]` is the lexicographically smallest `(group count, cost)` covering
+        // `descending[..j]`, and `start_of_last[j]` where the final group achieving it begins.
+        // Singleton groups are always admissible, so every prefix is reachable.
+        let mut best = vec![(usize::MAX, u128::MAX); n + 1];
+        let mut start_of_last = vec![0usize; n + 1];
+        best[0] = (0, 0);
+
+        for j in 1..=n {
+            for i in 0..j {
+                if descending[i] - descending[j - 1] > band_widths[i] {
+                    continue;
+                }
+                let (groups, cost) = best[i];
+                let candidate = (
+                    groups + 1,
+                    cost + ((j - i) as u128) * (1u128 << descending[i]),
+                );
+                if candidate < best[j] {
+                    best[j] = candidate;
+                    start_of_last[j] = i;
+                }
+            }
         }
 
+        let mut sizes = Vec::new();
+        let mut end = n;
+        while end > 0 {
+            let start = start_of_last[end];
+            sizes.push(end - start);
+            end = start;
+        }
+        sizes.reverse();
         sizes
     }
 
@@ -530,7 +644,8 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> Pcs<Challenge, Challe
 where
     Val: TwoAdicField,
     Dft: TwoAdicSubgroupDft<Val>,
-    InputMmcs: Mmcs<Val, Error: Sync + Debug>,
+    InputMmcs: Mmcs<Val, Error: Sync + Debug, Commitment: Send> + Sync,
+    InputMmcs::ProverData<RowMajorMatrix<Val>>: Send,
     StirMmcs: Mmcs<Challenge>,
     Challenge: ExtensionField<Val> + TwoAdicField + BasedVectorSpace<Val>,
     Challenger: FieldChallenger<Val>
@@ -541,14 +656,7 @@ where
         + Clone,
 {
     type Domain = TwoAdicMultiplicativeCoset<Val>;
-    /// One Merkle root per shared-domain group, in descending LDE height.
-    ///
-    /// The matrices of one `commit()` call are partitioned into groups of bounded height
-    /// spread, each extended onto its own shared domain (§7's same-domain requirement applies
-    /// within a group, not across the whole commitment) and committed in its own tree. A
-    /// commitment whose heights all fit one group therefore has a single root, and callers
-    /// observe the roots in order.
-    type Commitment = Vec<InputMmcs::Commitment>;
+    type Commitment = StirCommitment<InputMmcs::Commitment>;
     type ProverData = StirProverData<Val, InputMmcs>;
     type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
     /// Proof structure: one entry per distinct shared LDE height across every commitment's
@@ -658,6 +766,7 @@ where
         let result = self
             .dft
             .coset_dft_batch(coeffs, domain.shift())
+            .bit_reverse_rows()
             .to_row_major_matrix();
         let result_width = result.width();
         RowMajorMatrixCow::new(Cow::Owned(result.values), result_width).bit_reverse_rows()
@@ -729,14 +838,21 @@ where
                 let extended = if lde.height() == 1usize << log_lde_height {
                     lde
                 } else {
+                    // Recovering the polynomial and evaluating it on the wider coset is a
+                    // forward transform of its coefficients, zero-padded to the target size.
+                    // A second `lde` would instead read those coefficients back as evaluations
+                    // on a subgroup, and extend a different polynomial.
                     let natural_lde = lde.bit_reverse_rows().to_row_major_matrix();
                     let mut coeffs = self.dft.coset_idft_batch(natural_lde, Val::GENERATOR);
                     let width = coeffs.width();
                     coeffs
                         .values
                         .truncate((1usize << log_native_height) * width);
+                    coeffs
+                        .values
+                        .resize((1usize << log_lde_height) * width, Val::ZERO);
                     self.dft
-                        .coset_lde_batch(coeffs, log_lde_height - log_native_height, Val::GENERATOR)
+                        .coset_dft_batch(coeffs, Val::GENERATOR)
                         .bit_reverse_rows()
                         .to_row_major_matrix()
                 };
@@ -1473,10 +1589,10 @@ where
                             Ok(expected_ro_by_class.into_iter().next().unwrap())
                         }
                         Some((r_comb, coeffs_by_height)) => {
-                            // SHAPE CHECK: every expected class must be present.
-                            if expected_ro_by_class.len() != coeffs_by_height.len() {
-                                return Err(StirError::InvalidProofShape);
-                            }
+                            // Both sides are sized by the same deduplicated class list, so
+                            // this is an invariant rather than a check on anything the proof
+                            // controls.
+                            debug_assert_eq!(expected_ro_by_class.len(), coeffs_by_height.len());
 
                             // Pointwise mirror of the prover's `combine_on_coset`, evaluated
                             // only at the queried lanes. The `1 − r_comb·x` denominators do
@@ -1700,6 +1816,7 @@ mod tests {
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_security::whir::SecurityAssumption;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use proptest::prelude::*;
     use rand::SeedableRng;
 
     use super::*;
@@ -1814,15 +1931,44 @@ mod tests {
         let heights = [8usize, 6, 4];
         let cb = SecurityAssumption::CapacityBound;
 
-        // Spread 2 admits 8 with 6 but not 8 with 4, so the run breaks after the second.
+        // Spread 2 rules out one group over all three, so two is the fewest available. Of the
+        // two-group splits it does admit, `{8} | {6, 4}` keeps the 2^6 matrix off the 2^9
+        // domain and is the cheaper one to extend.
         let plan = test_pcs_with(2, cb, 32).plan_groups(&heights);
-        assert_eq!(plan.log_lde_heights, vec![9, 5]);
-        assert_eq!(plan.group_of_matrix, vec![0, 0, 1]);
+        assert_eq!(plan.log_lde_heights, vec![9, 7]);
+        assert_eq!(plan.group_of_matrix, vec![0, 1, 1]);
 
         // Spread 1 admits none of these pairs.
         let plan = test_pcs_with(1, cb, 32).plan_groups(&heights);
         assert_eq!(plan.log_lde_heights, vec![9, 7, 5]);
         assert_eq!(plan.group_of_matrix, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn a_group_spans_the_cheapest_admissible_run_not_the_widest() {
+        // `[20, 17, 16, 15]` needs two groups either way — the full span is five octaves, past
+        // the cap — but which two matters. Filling the tall group first puts the 2^17 matrix
+        // on the 2^21 domain: a 16x blowup, and a `Combine` over two classes in the tall
+        // bucket. Leaving it with the short heights costs it 2x instead, at the same group
+        // count and with no `Combine` in the tall bucket at all.
+        let pcs = test_pcs_with(
+            DEFAULT_MAX_LOG_HEIGHT_SPREAD,
+            SecurityAssumption::CapacityBound,
+            16,
+        );
+
+        let plan = pcs.plan_groups(&[20, 17, 16, 15]);
+        assert_eq!(plan.log_lde_heights, vec![21, 18]);
+        assert_eq!(plan.group_of_matrix, vec![0, 1, 1, 1]);
+
+        // Shapes lying wholly inside one band, or wholly outside it, have nothing to
+        // redistribute: the widest run is also the cheapest once the group count is fixed.
+        assert_eq!(pcs.plan_groups(&[20, 18, 17]).log_lde_heights, vec![21]);
+        assert_eq!(
+            pcs.plan_groups(&[20, 12, 12, 12, 12]).log_lde_heights,
+            vec![21, 13]
+        );
+        assert_eq!(pcs.plan_groups(&[20, 10]).log_lde_heights, vec![21, 11]);
     }
 
     #[test]
@@ -1859,8 +2005,8 @@ mod tests {
 
         // Caller order does not matter either: a matrix follows its height.
         let plan = pcs.plan_groups(&[4, 8, 4, 6]);
-        assert_eq!(plan.log_lde_heights, vec![9, 5]);
-        assert_eq!(plan.group_of_matrix, vec![1, 0, 1, 0]);
+        assert_eq!(plan.log_lde_heights, vec![9, 7]);
+        assert_eq!(plan.group_of_matrix, vec![1, 0, 1, 1]);
     }
 
     #[test]
@@ -1885,6 +2031,166 @@ mod tests {
         // above is not just the spread cap in disguise.
         let plan = test_pcs_with(8, jb, 32).plan_groups(&heights);
         assert_eq!(plan.log_lde_heights, vec![13]);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// The layout has to be a pure function of the multiset of native heights and this
+        /// PCS's parameters: that is the assumption the verifier reconstructs it under, so a
+        /// failure here is a verifier disagreeing with the prover for a reason no shape check
+        /// in the proof could explain. The interesting inputs are multisets — duplicates,
+        /// caller order, and heights sitting on a band edge — so this is sampled rather than
+        /// enumerated.
+        #[test]
+        fn plan_groups_partitions_the_height_multiset(
+            heights in prop::collection::vec(2usize..=12, 1..8),
+            max_log_height_spread in 0usize..=8,
+        ) {
+            let pcs = test_pcs_with(
+                max_log_height_spread,
+                SecurityAssumption::CapacityBound,
+                32,
+            );
+            let plan = pcs.plan_groups(&heights);
+
+            prop_assert_eq!(plan.group_of_matrix.len(), heights.len());
+            for pair in plan.log_lde_heights.windows(2) {
+                prop_assert!(pair[0] > pair[1]);
+            }
+
+            // Distinct heights of each group, read back off the assignment.
+            let mut members: Vec<Vec<usize>> = vec![Vec::new(); plan.log_lde_heights.len()];
+            for (&h, &g) in heights.iter().zip(&plan.group_of_matrix) {
+                if !members[g].contains(&h) {
+                    members[g].push(h);
+                }
+            }
+            let mut distinct = heights.clone();
+            distinct.sort_unstable();
+            distinct.dedup();
+            prop_assert_eq!(members.iter().map(Vec::len).sum::<usize>(), distinct.len());
+
+            for (group, &log_lde_h) in members.iter_mut().zip(&plan.log_lde_heights) {
+                prop_assert!(!group.is_empty());
+                group.sort_unstable_by(|a, b| b.cmp(a));
+                let (tallest, lowest) = (group[0], group[group.len() - 1]);
+                // Each group sits on its own tallest member's domain, ...
+                prop_assert_eq!(log_lde_h, tallest + pcs.stir.log_blowup);
+                // ... and stays inside the band that member admits, which is what keeps the
+                // band probe conservative for whatever union of classes a bucket pools.
+                prop_assert!(tallest - lowest <= pcs.combine_band_width(tallest, lowest));
+            }
+
+            // Only the multiset decides: permuting the input moves matrices between slots but
+            // not between heights, and repeating a height adds no class.
+            let permuted: Vec<usize> = heights.iter().rev().copied().collect();
+            let permuted_plan = pcs.plan_groups(&permuted);
+            let permuted_back: Vec<usize> =
+                permuted_plan.group_of_matrix.iter().rev().copied().collect();
+            prop_assert_eq!(&permuted_plan.log_lde_heights, &plan.log_lde_heights);
+            prop_assert_eq!(&permuted_back, &plan.group_of_matrix);
+
+            let duplicated: Vec<usize> = heights.iter().chain(heights.iter()).copied().collect();
+            let duplicated_plan = pcs.plan_groups(&duplicated);
+            prop_assert_eq!(&duplicated_plan.log_lde_heights, &plan.log_lde_heights);
+            prop_assert_eq!(
+                &duplicated_plan.group_of_matrix[..heights.len()],
+                &plan.group_of_matrix[..]
+            );
+        }
+    }
+
+    /// STIR parameters over the test types, at the given soundness knobs.
+    fn test_params(
+        soundness_type: SecurityAssumption,
+        security_level: usize,
+        log_blowup: usize,
+        max_pow_bits: usize,
+    ) -> StirParameters<TestStirMmcs> {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(11);
+        let perm = TestPerm::new_from_rng_128(&mut rng);
+        let val_mmcs = TestValMmcs::new(TestHash::new(perm.clone()), TestCompress::new(perm), 0);
+        StirParameters {
+            log_blowup,
+            log_folding_factor: 2,
+            log_starting_folding_factor: 2,
+            soundness_type,
+            security_level,
+            max_pow_bits,
+            mmcs: TestStirMmcs::new(val_mmcs),
+        }
+    }
+
+    #[test]
+    fn band_feasibility_implies_subset_feasibility() {
+        // `combine_band_width` probes the *whole* band `[tallest - w, tallest]` and then lets
+        // any subset of it containing `tallest` form a group, on the argument that the full
+        // band maximizes Lemma 4.13's `ell` over every subset that could form. That argument
+        // is what keeps the probe conservative, and it is load bearing: if it stopped holding,
+        // the probe would call a width feasible, the bucket's actual class set would be a
+        // strict subset whose config comes back `Err`, and `open` would panic on the prover at
+        // exactly a parameter set the fallback exists to rescue. The quantifier is "every
+        // subset", so this checks every subset rather than sampling them.
+        for soundness_type in [
+            SecurityAssumption::CapacityBound,
+            SecurityAssumption::JohnsonBound,
+        ] {
+            for security_level in [32usize, 64, 80] {
+                for log_blowup in [1usize, 2] {
+                    for max_pow_bits in [0usize, 16] {
+                        let params =
+                            test_params(soundness_type, security_level, log_blowup, max_pow_bits);
+                        for log_d_star in [6usize, 10, 14] {
+                            for w in 1..=6.min(log_d_star) {
+                                let band: Vec<usize> =
+                                    (0..=w).map(|i| log_d_star - i).collect::<Vec<_>>();
+                                let (n, ell) = TestPcs::combine_key(&band)
+                                    .expect("a band of width >= 1 holds two classes");
+                                if TestConfig::try_new_with_combine(
+                                    log_d_star,
+                                    params.clone(),
+                                    n,
+                                    ell,
+                                )
+                                .is_err()
+                                {
+                                    // The band itself is infeasible, so it implies nothing.
+                                    continue;
+                                }
+
+                                for mask in 0u32..(1 << w) {
+                                    let mut subset = vec![log_d_star];
+                                    subset.extend(
+                                        (0..w)
+                                            .filter(|i| mask & (1 << i) != 0)
+                                            .map(|i| log_d_star - 1 - i),
+                                    );
+                                    let Some((sub_n, sub_ell)) = TestPcs::combine_key(&subset)
+                                    else {
+                                        continue;
+                                    };
+                                    assert!(
+                                        TestConfig::try_new_with_combine(
+                                            log_d_star,
+                                            params.clone(),
+                                            sub_n,
+                                            sub_ell,
+                                        )
+                                        .is_ok(),
+                                        "band [{}..{log_d_star}] configures but subset \
+                                         {subset:?} does not, at {soundness_type:?} \
+                                         security_level={security_level} \
+                                         log_blowup={log_blowup} max_pow_bits={max_pow_bits}",
+                                        log_d_star - w,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn test_pcs_and_params() -> (TestPcs, StirParameters<TestStirMmcs>) {

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -925,17 +925,13 @@ mod babybear_pcs {
         (val_mmcs, challenge_mmcs)
     }
 
-    /// Observe a commitment's Merkle roots in order.
-    ///
-    /// One root per shared-domain group, so a commitment whose heights all fit a single group
-    /// contributes exactly one — matching what a single-tree PCS would observe.
+    /// Observe a commitment through the single `CanObserve` call `StarkGenericConfig` asks
+    /// for: the root count, then one root per shared-domain group.
     fn observe_commitment(
         challenger: &mut Challenger,
         commit: &<MyPcs as Pcs<Challenge, Challenger>>::Commitment,
     ) {
-        for root in commit {
-            challenger.observe(root.clone());
-        }
+        challenger.observe(commit.clone());
     }
 
     fn get_pcs() -> (MyPcs, Challenger) {
@@ -963,13 +959,60 @@ mod babybear_pcs {
         (pcs, Challenger::new(perm))
     }
 
-    /// Commit `log_degrees` under `pcs`, open every matrix at one shared point, and verify.
+    /// `get_evaluations_on_domain` on a domain taller than the committed LDE — the shape
+    /// `uni-stark`'s prover asks for whenever the quotient domain exceeds `log_blowup`, and the
+    /// one case the fast slice-of-the-committed-rows path cannot serve, so it forces the general
+    /// interpolate-and-reevaluate path.
+    #[test]
+    fn get_evaluations_on_domain_extrapolates_beyond_the_committed_lde() {
+        use p3_field::coset::TwoAdicMultiplicativeCoset;
+        use p3_matrix::Matrix;
+
+        let (pcs, _) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let log_d = 4;
+        let d = 1usize << log_d;
+        let width = 3;
+        let trace = RowMajorMatrix::<Val>::rand(&mut rng, d, width);
+
+        let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d);
+        let (_, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(domain, trace.clone())]);
+
+        // Strictly taller than the committed LDE (`d` folded by `log_blowup = 1`), so the fast
+        // path's `lde.height() >= domain.size()` guard cannot fire.
+        let tall_domain = TwoAdicMultiplicativeCoset::new(Val::GENERATOR, log_d + 2).unwrap();
+        let evals = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+            &pcs,
+            &data,
+            0,
+            tall_domain,
+        );
+        let evals = evals.to_row_major_matrix();
+
+        let dft = Dft::default();
+        let mut coeffs = dft.idft_batch(trace);
+        let coeffs_width = coeffs.width();
+        coeffs
+            .values
+            .resize(tall_domain.size() * coeffs_width, Val::ZERO);
+        let expected = dft
+            .coset_dft_batch(coeffs, tall_domain.shift())
+            .to_row_major_matrix();
+
+        assert_eq!(evals, expected);
+    }
+
+    /// Commit `log_degrees`, with `widths[i]` columns in matrix `i`, open every matrix at one
+    /// shared point, and verify.
     ///
     /// Returns the commitment so callers can inspect how many groups the layout produced.
     fn round_trip_under(
         pcs: &MyPcs,
         challenger_template: &Challenger,
         log_degrees: &[usize],
+        widths: &[usize],
     ) -> <MyPcs as Pcs<Challenge, Challenger>>::Commitment {
         #[allow(unused_imports)]
         use p3_commit::Pcs as _;
@@ -977,11 +1020,12 @@ mod babybear_pcs {
         let mut rng = seeded_rng();
         let domains_and_polys: Vec<_> = log_degrees
             .iter()
-            .map(|&log_d| {
+            .zip(widths)
+            .map(|(&log_d, &width)| {
                 let d = 1 << log_d;
                 (
                     <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(pcs, d),
-                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, width),
                 )
             })
             .collect();
@@ -1026,13 +1070,35 @@ mod babybear_pcs {
         let log_degrees = [8usize, 6, 4];
         for (max_log_height_spread, expected_roots) in [(0, 3), (1, 3), (2, 2), (8, 1)] {
             let (pcs, challenger_template) = get_pcs_with_spread(max_log_height_spread);
-            let commit = round_trip_under(&pcs, &challenger_template, &log_degrees);
+            let commit = round_trip_under(&pcs, &challenger_template, &log_degrees, &[3, 3, 3]);
             assert_eq!(
                 commit.len(),
                 expected_roots,
                 "spread {max_log_height_spread} should give {expected_roots} groups"
             );
         }
+    }
+
+    #[test]
+    fn test_pcs_round_trips_with_interleaved_heights_and_widths() {
+        // Every other round trip commits descending heights at one uniform width, which makes
+        // `group_of_matrix` monotone: a group's claim indices are then a contiguous prefix, so
+        // the remap from a group's tree order back to the commitment's claim order is the
+        // identity and a mixup would read the right slot by accident. The same goes for
+        // per-matrix widths. Ascending, interleaved and repeated heights, each at its own
+        // width, make both index sets non-contiguous and the widths distinguishable.
+        for spread in [0usize, 1, 2, 3, 8] {
+            let (pcs, challenger_template) = get_pcs_with_spread(spread);
+            round_trip_under(
+                &pcs,
+                &challenger_template,
+                &[4, 8, 4, 8, 6],
+                &[2, 5, 3, 7, 4],
+            );
+        }
+
+        let (pcs, challenger_template) = get_pcs_with_spread(2);
+        round_trip_under(&pcs, &challenger_template, &[6, 8, 2, 4], &[1, 9, 4, 2]);
     }
 
     #[test]
@@ -1073,9 +1139,14 @@ mod babybear_pcs {
                 &pcs,
                 domains_and_polys.iter().cloned(),
             );
+            // Equal roots is the whole claim, not just an equal group count: two layouts can
+            // agree on how many trees they build and still put different heights on different
+            // domains. `[8, 7, 4]` gives `{8,7} | {4}` at spread 1 and `{8} | {7,4}` at spread
+            // 3 — two trees each, different LDE heights, different class sets — so a length
+            // comparison cannot see the failure this is about. Matching roots pin the
+            // dimensions and the extended values together.
             assert_eq!(
-                commit.len(),
-                direct_commit.len(),
+                commit, direct_commit,
                 "commit_ldes and commit disagree on the layout at spread \
                  {max_log_height_spread}"
             );
@@ -1199,16 +1270,112 @@ mod babybear_pcs {
     }
 
     #[test]
-    fn test_pcs_verify_rejects_a_proof_built_at_a_different_spread() {
+    fn test_pcs_bucket_skips_a_commitment_that_has_no_group_on_its_domain() {
         #[allow(unused_imports)]
         use p3_commit::Pcs as _;
 
-        // The layout is not carried in the proof: both sides derive it from the claimed
-        // heights and their own parameters. A verifier configured for a different spread
-        // therefore expects a different number of trees, and must not accept.
-        let log_degrees = [8usize, 6, 4];
-        let (prover_pcs, challenger_template) = get_pcs_with_spread(8);
-        let (verifier_pcs, _) = get_pcs_with_spread(0);
+        // Three commitments at spread 1, so that every bucket sees both states a commitment
+        // can be in. A and C hold {2^8, 2^4} (C in the opposite caller order) and split into
+        // two groups each, on the 2^9 and 2^5 domains; B holds only {2^6}, one group on the
+        // 2^7 domain. The three buckets are then 9, 7 and 5, and each one has a commitment
+        // that contributes nothing to it — the `None` input-opening slot, which a proof over a
+        // single bucket never reaches.
+        let (pcs, challenger_template) = get_pcs_with_spread(1);
+        let mut rng = seeded_rng();
+
+        let commit_shapes: [&[usize]; 3] = [&[8, 4], &[6], &[4, 8]];
+        let mats: Vec<Vec<_>> = commit_shapes
+            .iter()
+            .map(|log_ds| {
+                log_ds
+                    .iter()
+                    .map(|&log_d| {
+                        let domain =
+                            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+                                &pcs,
+                                1 << log_d,
+                            );
+                        (domain, RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3))
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let mut commits = Vec::new();
+        let mut datas = Vec::new();
+        for per_commit in &mats {
+            let (commit, data) =
+                <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, per_commit.iter().cloned());
+            observe_commitment(&mut p_ch, &commit);
+            commits.push(commit);
+            datas.push(data);
+        }
+        assert_eq!(
+            commits.iter().map(|c| c.len()).collect::<Vec<_>>(),
+            vec![2, 1, 2]
+        );
+
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let data_and_points: Vec<_> = datas
+            .iter()
+            .zip(&mats)
+            .map(|(data, per_commit)| (data, per_commit.iter().map(|_| vec![zeta]).collect()))
+            .collect();
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+
+        // Buckets 2^9, 2^7 and 2^5, and B reaches only the middle one.
+        assert_eq!(proof.len(), 3);
+
+        let mut v_ch = challenger_template;
+        for commit in &commits {
+            observe_commitment(&mut v_ch, commit);
+        }
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let commitments_with_claims: Vec<_> = commits
+            .into_iter()
+            .zip(&mats)
+            .enumerate()
+            .map(|(commit_idx, (commit, per_commit))| {
+                let claims = per_commit
+                    .iter()
+                    .enumerate()
+                    .map(|(mat_idx, (domain, _))| {
+                        (
+                            *domain,
+                            vec![(zeta, opening_values[commit_idx][mat_idx][0].clone())],
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                (commit, claims)
+            })
+            .collect();
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            commitments_with_claims,
+            &proof,
+            &mut v_ch,
+        )
+        .unwrap_or_else(|e| panic!("partially-present commitment verification failed: {e:?}"));
+    }
+
+    /// Prove `log_degrees` at `prover_spread`, verify at `verifier_spread`, and return the
+    /// error the mismatch produces.
+    fn verify_at_a_different_spread(
+        log_degrees: &[usize],
+        prover_spread: usize,
+        verifier_spread: usize,
+    ) -> p3_stir::StirError<<ChallengeMmcs as Mmcs<Challenge>>::Error, <ValMmcs as Mmcs<Val>>::Error>
+    {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let (prover_pcs, challenger_template) = get_pcs_with_spread(prover_spread);
+        let (verifier_pcs, _) = get_pcs_with_spread(verifier_spread);
 
         let mut rng = seeded_rng();
         let domains_and_polys: Vec<_> = log_degrees
@@ -1250,13 +1417,39 @@ mod babybear_pcs {
             .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
             .collect();
 
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &verifier_pcs,
             vec![(commit, claims)],
             &proof,
             &mut v_ch,
         )
-        .expect_err("a proof laid out at a different spread must be rejected");
+        .expect_err("a proof laid out at a different spread must be rejected")
+    }
+
+    #[test]
+    fn test_pcs_verify_rejects_a_proof_built_at_a_different_spread() {
+        // The layout is not carried in the proof: both sides derive it from the claimed
+        // heights and their own parameters. A verifier configured for a different spread
+        // therefore expects a different number of trees, and must not accept.
+        //
+        // `[8, 6, 4]` is one tree at spread 8 and three at spread 0, so the root-count check
+        // that runs before anything else rejects it.
+        let err = verify_at_a_different_spread(&[8, 6, 4], 8, 0);
+        assert!(
+            matches!(err, p3_stir::StirError::InvalidProofShape),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_pcs_verify_rejects_a_relaid_out_proof_with_the_same_root_count() {
+        // The case the root-count check cannot see, and the one the layout-agreement claim
+        // actually rests on. `[8, 7, 4]` is `{8,7} | {4}` at spread 1 and `{8} | {7,4}` at
+        // spread 3: two trees either way, so the root-count check and the bucket-count check
+        // both pass, and the disagreement only surfaces further in, on the dimensions the
+        // input MMCS opening is checked against. Keep both cases — collapsing this one back
+        // into a root-count mismatch stops exercising that path.
+        let err = verify_at_a_different_spread(&[8, 7, 4], 1, 3);
         assert!(
             matches!(err, p3_stir::StirError::InvalidProofShape),
             "{err:?}"
@@ -2518,5 +2711,95 @@ mod babybear_stir_multi {
         let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
             .expect_err("disagreeing replicated witnesses across buckets must be rejected");
         assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `TwoAdicStirPcs` as a `StarkGenericConfig`'s PCS
+// ---------------------------------------------------------------------------
+
+mod uni_stark_with_stir_pcs {
+    use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_stir::TwoAdicStirPcs;
+    use p3_uni_stark::{StarkConfig, prove, verify};
+
+    use super::*;
+
+    type Val = BabyBear;
+    type Challenge = BinomialExtensionField<Val, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type ValMmcs =
+        MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
+    type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+    type Dft = Radix2DitParallel<Val>;
+    type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+    type MyPcs = TwoAdicStirPcs<Val, Dft, ValMmcs, ChallengeMmcs, Challenge, Challenger>;
+    type MyConfig = StarkConfig<MyPcs, Challenge, Challenger>;
+
+    /// Two columns holding `(i, i + 1)`: `b = a + 1` on every row, and `a` advances to the
+    /// previous row's `b` on every transition.
+    struct StepAir;
+
+    impl<F> BaseAir<F> for StepAir {
+        fn width(&self) -> usize {
+            2
+        }
+
+        fn max_constraint_degree(&self) -> Option<usize> {
+            Some(2)
+        }
+    }
+
+    impl<AB: AirBuilder> Air<AB> for StepAir {
+        fn eval(&self, builder: &mut AB) {
+            let main = builder.main();
+            let (a, b, next_a) = {
+                let local = main.current_slice();
+                let next = main.next_slice();
+                (local[0], local[1], next[0])
+            };
+            builder.assert_eq(b, a + AB::Expr::ONE);
+            builder.when_transition().assert_eq(next_a, b);
+        }
+    }
+
+    fn step_trace(log_n: usize) -> RowMajorMatrix<Val> {
+        RowMajorMatrix::new(
+            (0..(1u64 << log_n))
+                .flat_map(|i| [Val::from_u64(i), Val::from_u64(i + 1)])
+                .collect(),
+            2,
+        )
+    }
+
+    #[test]
+    fn test_stir_pcs_drives_a_uni_stark_proof() {
+        // `StarkGenericConfig` requires `Challenger: CanObserve<Pcs::Commitment>`, so a
+        // commitment carrying one root per shared-domain group has to be observable as a
+        // single value. Proving through `p3-uni-stark` is what checks that end to end: it
+        // commits a trace and a quotient (through `commit_ldes`, at heights the layout may
+        // well split differently), observes both commitments, and opens them together.
+        // `p3-batch-stark` re-exports this same trait, so it is covered by the same bound.
+        let perm = Perm::new_from_rng_128(&mut seeded_rng());
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+        let val_mmcs = ValMmcs::new(hash, compress, 0);
+        let stir_params = StirParameters {
+            log_blowup: 1,
+            log_folding_factor: 2,
+            log_starting_folding_factor: 2,
+            soundness_type: SecurityAssumption::CapacityBound,
+            security_level: 16,
+            max_pow_bits: 0,
+            mmcs: ChallengeMmcs::new(val_mmcs.clone()),
+        };
+        let pcs = MyPcs::new(Dft::default(), val_mmcs, stir_params);
+        let config = MyConfig::new(pcs, Challenger::new(perm));
+
+        let proof = prove(&config, &StepAir, step_trace(5), &[]);
+        verify(&config, &StepAir, &proof, &[]).expect("verification failed");
     }
 }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -925,7 +925,26 @@ mod babybear_pcs {
         (val_mmcs, challenge_mmcs)
     }
 
+    /// Observe a commitment's Merkle roots in order.
+    ///
+    /// One root per shared-domain group, so a commitment whose heights all fit a single group
+    /// contributes exactly one — matching what a single-tree PCS would observe.
+    fn observe_commitment(
+        challenger: &mut Challenger,
+        commit: &<MyPcs as Pcs<Challenge, Challenger>>::Commitment,
+    ) {
+        for root in commit {
+            challenger.observe(root.clone());
+        }
+    }
+
     fn get_pcs() -> (MyPcs, Challenger) {
+        get_pcs_with_spread(p3_stir::DEFAULT_MAX_LOG_HEIGHT_SPREAD)
+    }
+
+    /// [`get_pcs`] with an explicit cap on how wide a native-height spread may share one LDE
+    /// domain.
+    fn get_pcs_with_spread(max_log_height_spread: usize) -> (MyPcs, Challenger) {
         let perm = Perm::new_from_rng_128(&mut seeded_rng());
         let (val_mmcs, challenge_mmcs) = make_mmcs(&perm);
 
@@ -939,8 +958,309 @@ mod babybear_pcs {
             mmcs: challenge_mmcs,
         };
 
-        let pcs = MyPcs::new(Dft::default(), val_mmcs, stir_params);
+        let pcs = MyPcs::new(Dft::default(), val_mmcs, stir_params)
+            .with_max_log_height_spread(max_log_height_spread);
         (pcs, Challenger::new(perm))
+    }
+
+    /// Commit `log_degrees` under `pcs`, open every matrix at one shared point, and verify.
+    ///
+    /// Returns the commitment so callers can inspect how many groups the layout produced.
+    fn round_trip_under(
+        pcs: &MyPcs,
+        challenger_template: &Challenger,
+        log_degrees: &[usize],
+    ) -> <MyPcs as Pcs<Challenge, Challenger>>::Commitment {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        let mut rng = seeded_rng();
+        let domains_and_polys: Vec<_> = log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(pcs, d),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(pcs, domains_and_polys.iter().cloned());
+        observe_commitment(&mut p_ch, &commit);
+        let zeta: Challenge = p_ch.sample_algebra_element();
+
+        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(pcs, vec![(&data, points)], &mut p_ch);
+
+        let mut v_ch = challenger_template.clone();
+        observe_commitment(&mut v_ch, &commit);
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect();
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            pcs,
+            vec![(commit.clone(), claims)],
+            &proof,
+            &mut v_ch,
+        )
+        .unwrap_or_else(|e| panic!("verification failed: {e:?}"));
+
+        commit
+    }
+
+    #[test]
+    fn test_pcs_round_trips_at_every_spread() {
+        // The same claim must verify whichever layout the spread cap produces: one STIR
+        // instance per distinct height at 0, everything merged onto one domain at 8, and the
+        // mixed cases in between.
+        let log_degrees = [8usize, 6, 4];
+        for (max_log_height_spread, expected_roots) in [(0, 3), (1, 3), (2, 2), (8, 1)] {
+            let (pcs, challenger_template) = get_pcs_with_spread(max_log_height_spread);
+            let commit = round_trip_under(&pcs, &challenger_template, &log_degrees);
+            assert_eq!(
+                commit.len(),
+                expected_roots,
+                "spread {max_log_height_spread} should give {expected_roots} groups"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pcs_commit_ldes_groups_like_commit_and_round_trips() {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        // `commit_ldes` takes matrices already extended to their own native blowup and
+        // re-extends the short ones onto their group's domain, so it has to reach the same
+        // layout `commit` does from the same heights — otherwise batch-stark's quotient
+        // commitment would be laid out differently from its trace commitments.
+        let log_degrees = [8usize, 6, 4];
+        for max_log_height_spread in [0usize, 2, 64] {
+            let (pcs, challenger_template) = get_pcs_with_spread(max_log_height_spread);
+            let mut rng = seeded_rng();
+
+            let domains_and_polys: Vec<_> = log_degrees
+                .iter()
+                .map(|&log_d| {
+                    let d = 1 << log_d;
+                    (
+                        <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
+                        RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                    )
+                })
+                .collect();
+
+            let ldes = <MyPcs as Pcs<Challenge, Challenger>>::get_quotient_ldes(
+                &pcs,
+                domains_and_polys.iter().cloned(),
+                1,
+            );
+
+            let mut p_ch = challenger_template.clone();
+            let (commit, data) = <MyPcs as Pcs<Challenge, Challenger>>::commit_ldes(&pcs, ldes);
+
+            let (direct_commit, _) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
+                &pcs,
+                domains_and_polys.iter().cloned(),
+            );
+            assert_eq!(
+                commit.len(),
+                direct_commit.len(),
+                "commit_ldes and commit disagree on the layout at spread \
+                 {max_log_height_spread}"
+            );
+
+            observe_commitment(&mut p_ch, &commit);
+            let zeta: Challenge = p_ch.sample_algebra_element();
+            let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+            let (opening_values, proof) =
+                <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+
+            let mut v_ch = challenger_template;
+            observe_commitment(&mut v_ch, &commit);
+            let v_zeta: Challenge = v_ch.sample_algebra_element();
+            assert_eq!(v_zeta, zeta);
+
+            let claims: Vec<_> = domains_and_polys
+                .iter()
+                .zip(opening_values.first().unwrap().iter())
+                .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+                .collect();
+
+            <MyPcs as Pcs<Challenge, Challenger>>::verify(
+                &pcs,
+                vec![(commit, claims)],
+                &proof,
+                &mut v_ch,
+            )
+            .unwrap_or_else(|e| {
+                panic!("commit_ldes round trip failed at spread {max_log_height_spread}: {e:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn test_pcs_merges_classes_pooled_from_several_commitments() {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        // A bucket pools every group topped at the same native height, across commitments, and
+        // merges their classes into one `Combine`. Here commitment A holds {2^8, 2^6} and B
+        // holds {2^8, 2^7}: both groups sit on the 2^9 domain, so the bucket runs `Combine`
+        // over the union {2^8, 2^7, 2^6} — a class set neither commitment holds on its own.
+        // This is what the band-width probe is sized against.
+        let (pcs, challenger_template) = get_pcs_with_spread(2);
+        let mut rng = seeded_rng();
+
+        let domains = |log_ds: &[usize]| -> Vec<_> {
+            log_ds
+                .iter()
+                .map(|&log_d| {
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+                        &pcs,
+                        1 << log_d,
+                    )
+                })
+                .collect()
+        };
+
+        let domains_a: Vec<_> = domains(&[8, 6]);
+        let domains_b: Vec<_> = domains(&[8, 7]);
+        let mats_a: Vec<_> = domains_a
+            .iter()
+            .map(|d| (*d, RowMajorMatrix::<Val>::rand(&mut rng, d.size(), 3)))
+            .collect();
+        let mats_b: Vec<_> = domains_b
+            .iter()
+            .map(|d| (*d, RowMajorMatrix::<Val>::rand(&mut rng, d.size(), 3)))
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit_a, data_a) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, mats_a.iter().cloned());
+        observe_commitment(&mut p_ch, &commit_a);
+        let (commit_b, data_b) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, mats_b.iter().cloned());
+        observe_commitment(&mut p_ch, &commit_b);
+
+        // Both commitments span two octaves, which the cap admits, so each is a single group.
+        assert_eq!(commit_a.len(), 1);
+        assert_eq!(commit_b.len(), 1);
+
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let data_and_points = vec![
+            (&data_a, vec![vec![zeta], vec![zeta]]),
+            (&data_b, vec![vec![zeta], vec![zeta]]),
+        ];
+        let (opening_values, proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+
+        // One shared 2^9 domain, so one STIR instance for both commitments.
+        assert_eq!(proof.len(), 1);
+
+        let mut v_ch = challenger_template;
+        observe_commitment(&mut v_ch, &commit_a);
+        observe_commitment(&mut v_ch, &commit_b);
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims = |commit_idx: usize, doms: &[<MyPcs as Pcs<Challenge, Challenger>>::Domain]| {
+            doms.iter()
+                .enumerate()
+                .map(|(mat_idx, domain)| {
+                    (
+                        *domain,
+                        vec![(zeta, opening_values[commit_idx][mat_idx][0].clone())],
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            vec![
+                (commit_a, claims(0, &domains_a)),
+                (commit_b, claims(1, &domains_b)),
+            ],
+            &proof,
+            &mut v_ch,
+        )
+        .unwrap_or_else(|e| panic!("pooled-class verification failed: {e:?}"));
+    }
+
+    #[test]
+    fn test_pcs_verify_rejects_a_proof_built_at_a_different_spread() {
+        #[allow(unused_imports)]
+        use p3_commit::Pcs as _;
+
+        // The layout is not carried in the proof: both sides derive it from the claimed
+        // heights and their own parameters. A verifier configured for a different spread
+        // therefore expects a different number of trees, and must not accept.
+        let log_degrees = [8usize, 6, 4];
+        let (prover_pcs, challenger_template) = get_pcs_with_spread(8);
+        let (verifier_pcs, _) = get_pcs_with_spread(0);
+
+        let mut rng = seeded_rng();
+        let domains_and_polys: Vec<_> = log_degrees
+            .iter()
+            .map(|&log_d| {
+                let d = 1 << log_d;
+                (
+                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+                        &prover_pcs,
+                        d,
+                    ),
+                    RowMajorMatrix::<Val>::rand(&mut rng, d, 3),
+                )
+            })
+            .collect();
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
+            &prover_pcs,
+            domains_and_polys.iter().cloned(),
+        );
+        observe_commitment(&mut p_ch, &commit);
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &prover_pcs,
+            vec![(&data, points)],
+            &mut p_ch,
+        );
+
+        let mut v_ch = challenger_template;
+        observe_commitment(&mut v_ch, &commit);
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        assert_eq!(v_zeta, zeta);
+
+        let claims: Vec<_> = domains_and_polys
+            .iter()
+            .zip(opening_values.first().unwrap().iter())
+            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
+            .collect();
+
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &verifier_pcs,
+            vec![(commit, claims)],
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a proof laid out at a different spread must be rejected");
+        assert!(
+            matches!(err, p3_stir::StirError::InvalidProofShape),
+            "{err:?}"
+        );
     }
 
     #[test]
@@ -976,7 +1296,7 @@ mod babybear_pcs {
 
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_challenger.observe(commit.clone());
+        observe_commitment(&mut p_challenger, &commit);
 
         let zeta: Challenge = p_challenger.sample_algebra_element();
 
@@ -987,7 +1307,7 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_challenger = challenger_template;
-        v_challenger.observe(commit.clone());
+        observe_commitment(&mut v_challenger, &commit);
         let v_zeta: Challenge = v_challenger.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1074,7 +1394,7 @@ mod babybear_pcs {
 
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_challenger.observe(commit.clone());
+        observe_commitment(&mut p_challenger, &commit);
 
         let zeta: Challenge = p_challenger.sample_algebra_element();
 
@@ -1084,7 +1404,7 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_challenger);
 
         let mut v_challenger = challenger_template;
-        v_challenger.observe(commit.clone());
+        observe_commitment(&mut v_challenger, &commit);
         let v_zeta: Challenge = v_challenger.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1178,7 +1498,7 @@ mod babybear_pcs {
         let mut stir_p_ch = Challenger::new(perm.clone());
         let (stir_commit, stir_data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&stir_pcs, [(stir_domain, mat)]);
-        stir_p_ch.observe(stir_commit.clone());
+        observe_commitment(&mut stir_p_ch, &stir_commit);
         // STIR's input commitment hashes fiber-grouped leaves, so its root — and hence the
         // point derived from it — differs from FRI's over the same matrix. Proof size does
         // not depend on which point is opened, so the comparison stays like-for-like.
@@ -1190,7 +1510,7 @@ mod babybear_pcs {
         );
 
         let mut stir_v_ch = Challenger::new(perm);
-        stir_v_ch.observe(stir_commit.clone());
+        observe_commitment(&mut stir_v_ch, &stir_commit);
         let stir_v_zeta: Challenge = stir_v_ch.sample_algebra_element();
         assert_eq!(stir_v_zeta, stir_zeta);
         let stir_claims = vec![(
@@ -1280,10 +1600,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_a, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        observe_commitment(&mut p_ch, &commit_a);
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_b, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        observe_commitment(&mut p_ch, &commit_b);
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1294,8 +1614,8 @@ mod babybear_pcs {
 
         // Verify.
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        observe_commitment(&mut v_ch, &commit_a);
+        observe_commitment(&mut v_ch, &commit_b);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1335,10 +1655,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        observe_commitment(&mut p_ch, &commit_a);
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        observe_commitment(&mut p_ch, &commit_b);
 
         let zeta: Challenge = p_ch.sample_algebra_element();
 
@@ -1347,8 +1667,8 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        observe_commitment(&mut v_ch, &commit_a);
+        observe_commitment(&mut v_ch, &commit_b);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1384,7 +1704,7 @@ mod babybear_pcs {
             &pcs,
             vec![(domain, mat_a), (domain, mat_b)],
         );
-        p_ch.observe(commit);
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         // `mat_a` is opened at `zeta`; `mat_b` is opened at no points at all.
@@ -1408,7 +1728,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template;
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit);
+        observe_commitment(&mut p_ch, &commit);
 
         let data_and_points = vec![(&data, vec![vec![]])];
         let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
@@ -1445,7 +1765,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
@@ -1453,7 +1773,7 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
         let untouched = v_ch.clone();
@@ -1544,10 +1864,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        observe_commitment(&mut p_ch, &commit_a);
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        observe_commitment(&mut p_ch, &commit_b);
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1563,8 +1883,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        observe_commitment(&mut v_ch, &commit_a);
+        observe_commitment(&mut v_ch, &commit_b);
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1599,10 +1919,10 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit_a, data_a) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_a)]);
-        p_ch.observe(commit_a.clone());
+        observe_commitment(&mut p_ch, &commit_a);
         let (commit_b, data_b) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat_b)]);
-        p_ch.observe(commit_b.clone());
+        observe_commitment(&mut p_ch, &commit_b);
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
@@ -1618,8 +1938,8 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit_a.clone());
-        v_ch.observe(commit_b.clone());
+        observe_commitment(&mut v_ch, &commit_a);
+        observe_commitment(&mut v_ch, &commit_b);
         let _v_zeta: Challenge = v_ch.sample_algebra_element();
 
         let opening_a = opening_values[0][0][0].clone();
@@ -1652,7 +1972,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1669,7 +1989,7 @@ mod babybear_pcs {
         }
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1712,7 +2032,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
@@ -1720,7 +2040,7 @@ mod babybear_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1806,14 +2126,14 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
         let (opening_values, proof) =
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1884,14 +2204,14 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
         let (opening_values, proof) =
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1924,7 +2244,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1933,7 +2253,7 @@ mod babybear_pcs {
         );
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         assert_eq!(v_zeta, zeta);
 
@@ -1964,7 +2284,7 @@ mod babybear_pcs {
         let mut p_ch = challenger_template.clone();
         let (commit, data) =
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
-        p_ch.observe(commit.clone());
+        observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
@@ -1978,7 +2298,7 @@ mod babybear_pcs {
         proof[0].0.initial_commitment = Some(proof[0].0.round_proofs[0].commitment.clone());
 
         let mut v_ch = challenger_template;
-        v_ch.observe(commit.clone());
+        observe_commitment(&mut v_ch, &commit);
         let v_zeta: Challenge = v_ch.sample_algebra_element();
         let claims = vec![(
             commit,


### PR DESCRIPTION
Follow-up to #1990, addressing the third item of @tcoratger's review comment on
`config.rs:445` — *"Decide what happens outside it. Falling back to the base branch's
per-height-class instances when `ell` does not fit the budget would keep the win where it is
affordable instead of panicking."* — using the mechanism named in the same review's
`pcs.rs:274` comment: *"the same knob fixes the blocker: bucketing matrices into several
shared domains by bounded height spread caps both this and `ell`."*

Items 1 (`verify` must not panic) and 2 (name the envelope) landed in #1998 and #1990
respectively; this is the remaining one.

## Summary

#1990 put every matrix of a `commit()` call onto one shared LDE domain sized to the tallest.
Two costs follow from that single choice: a short matrix pays the tallest one's blowup, and
`Combine`'s soundness cost grows with the whole committed spread (`log2(ell - 1) + log_d*`,
about `2·log_d*`, which is what makes the feasibility envelope so tight).

Both are bounded by the same knob. The matrices are now partitioned into **shared-domain
groups of bounded native-height spread**, each extended onto its own domain and committed in
its own tree, so a commitment carries one root per group.

The two existing layouts are the endpoints of that knob:

| `max_log_height_spread` | layout |
|---|---|
| `0` | every distinct native height on its own domain — no `Combine`, one STIR instance per height (the pre-#1990 layout) |
| ≥ committed spread | everything on one domain, all classes merged (#1990's layout) |
| `3` (`DEFAULT_MAX_LOG_HEIGHT_SPREAD`) | the spread of the shape #1990's trade was measured on |

Groups also shrink on their own when `Combine` does not fit the challenge field, so a
parameter set outside the envelope now degrades into more STIR instances rather than failing
— which is the fallback the review asked for.

## Benchmark

KoalaBear / 155-bit quintic, width 32, security 100, `log_blowup = 1`, `k = k0 = 16`.
Proof size is deterministic; commit/open are seconds-scale single runs, so the ratios are
well outside the noise. Verify is a single un-warmed call at ~10–17 ms and is indicative only.

| heights | spread cap | roots | commit | open | proof |
|---|---|---|---|---|---|
| `[20,18,17]` | 0 | 3 | 2099 ms | 1211 ms | 697 203 B |
| `[20,18,17]` | **3 (default)** | 1 | 4269 ms | 1122 ms | **601 472 B** |
| `[20,18,17]` | uncapped (#1990) | 1 | 4266 ms | 1156 ms | 601 472 B |
| `[20,12,12,12,12]` | **3 (default)** | 2 | **1547 ms** | 963 ms | **889 603 B** |
| `[20,12,12,12,12]` | uncapped (#1990) | 1 | 8457 ms | 1356 ms | 947 625 B |
| `[20,10]` | **3 (default)** | 2 | **1503 ms** | 768 ms | **391 891 B** |
| `[20,10]` | uncapped (#1990) | 1 | 2766 ms | 941 ms | 418 693 B |

At the shape #1990 was tuned on the default reproduces #1990 exactly — same layout, same
proof, same timings. At the wide shapes it is strictly better on **both** axes: 5.5x and 1.8x
less commit work *and* a smaller proof, because merging a `2^12` class into a `2^20` domain
costs more in degree correction than it saves in query counts. That is the commit-cost
regression the review measured (`[20,12,12,12,12]` at 2.82x prover), gone.

## Why the feasibility probe is conservative

A bucket pools every group topped at the same height **across all commitments opened
together**, so probing feasibility against one commitment's own heights is not enough:
commitment A holding `{2^8, 2^6}` and B holding `{2^8, 2^7}` both land on the `2^9` domain and
`Combine` over the union `{2^8, 2^7, 2^6}` — a class set neither holds. Each probe passes; the
union can still exceed the envelope.

`combine_band_width` therefore probes the whole band `[tallest - w, tallest]` rather than the
heights actually present. Adding a class raises Lemma 4.13's `ell` by `2^tallest + 1 - 2^h > 0`,
so the full band maximises `ell` over every subset that could form, and a width feasible for it
is feasible for whatever union shows up. The width depends only on the tallest height and the
parameters, so every commitment agrees on it without seeing the others.

The layout itself is never carried in the proof — both sides derive it from the claimed domain
sizes — so a verifier configured for a different spread expects a different number of trees and
rejects.

## API change

`Pcs::Commitment` goes back to `Vec<InputMmcs::Commitment>` (the pre-#1990 shape), one root per
group, so callers observe the roots in order rather than with a single `observe`. A commitment
whose heights all fit one group still has exactly one root. In-repo call sites (tests, bench,
`pcs_comparison`) are updated.

## Test plan

- [x] Round trips at spreads `{0, 1, 2, 8}` over heights `[8, 6, 4]`, each asserting the
      expected root count
- [x] Both endpoints pinned: `0` gives the per-height-class layout, a wide cap gives a single
      shared domain
- [x] Repeated and out-of-order heights map to the right groups (grouping is over *distinct*
      heights, so it does not depend on caller order or multiplicity)
- [x] Feasibility-driven shrinking where the spread cap alone would not split
      (`JohnsonBound`, security 80, heights `[2^12, 2^11]` on the 124-bit quartic: each height
      configures alone, the merge does not)
- [x] A bucket pooling classes from two commitments that neither holds on its own
- [x] `commit_ldes` reaches the same layout as `commit` (batch-stark commits quotient chunks
      through it)
- [x] A proof laid out at one spread is rejected by a verifier configured for another
- [x] `p3-stir` 143 tests green; `p3-security`, `p3-whir`, `p3-fri`, `p3-uni-stark`,
      `p3-batch-stark` unaffected
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all --check` clean, rustdoc warning-free
