### PR TITLE
fix(security): account for out-of-domain point count in budget's OOD round

### DIFF
--- a/security/Cargo.toml
+++ b/security/Cargo.toml
@@ -16,5 +16,8 @@ p3-field.workspace = true
 p3-util.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
 
+[dev-dependencies]
+proptest.workspace = true
+
 [lints]
 workspace = true

--- a/security/src/budget/mod.rs
+++ b/security/src/budget/mod.rs
@@ -101,16 +101,12 @@ pub const fn security_report(
 
     // The out-of-domain point is rejection-sampled outside the trace and LDE domains but is not
     // ground. A violated constraint leaves the DEEP-ALI identity a nonzero polynomial in that
-    // point of degree at most `(max_constraint_degree + 1) · height`. Lifting evaluates the
-    // shorter AIRs at powers of the same point, so all of them pay the maximum height.
-    let out_of_domain = round(
-        OUT_OF_DOMAIN_LABEL,
-        instance,
-        air.max_constraint_degree as u64 + 1,
-        instance.log_max_height,
-        0,
-        cap,
-    );
+    // point of degree at most `(max_constraint_degree + 1) · height + (max_combo − 1) ·
+    // (max_constraint_degree − 1)`: one factor of the identity's degree per out-of-domain point
+    // referenced, plus a flat term per extra point from the shared numerator. Lifting evaluates
+    // the shorter AIRs at powers of the same point, so all of them pay the maximum height.
+    let out_of_domain =
+        out_of_domain_round(instance, air.max_constraint_degree, air.max_combo, cap);
 
     // The DEEP quotient batches every committed column and out-of-domain point by powers of two
     // further challenges, giving a univariate whose degree is the number of batched terms.
@@ -182,6 +178,28 @@ const fn round(
     SecurityTerm::new(label, min(bits, cap))
 }
 
+/// Bounds the out-of-domain round: error `((d + 1) · H + (combo − 1) · (d − 1)) / |E|`, with `H`
+/// the trace height and `combo` the number of out-of-domain points referenced per column. Unlike
+/// [`round`], the extra `(combo − 1) · (d − 1)` term is additive rather than a multiple of `H`, so
+/// it is folded into the size directly instead of decomposed into a coefficient and a log-size.
+/// This round is always charged — there is no "no such round" case to special-case at zero.
+const fn out_of_domain_round(
+    instance: &InstanceShape,
+    max_constraint_degree: u32,
+    max_combo: u32,
+    cap: u64,
+) -> SecurityTerm {
+    let d = max_constraint_degree as u64;
+    let height = 1u64 << instance.log_max_height;
+    let extra_points = (max_combo as u64).saturating_sub(1);
+    let size = (d + 1) * height + extra_points * d.saturating_sub(1);
+
+    let error = fixed::ceil_log2(size);
+    let bits = instance.field_bits.saturating_sub(error);
+
+    SecurityTerm::new(OUT_OF_DOMAIN_LABEL, min(bits, cap))
+}
+
 const fn min(a: u64, b: u64) -> u64 {
     if a < b { a } else { b }
 }
@@ -217,6 +235,7 @@ mod tests {
         AirShape {
             num_composed_constraints: 531,
             max_constraint_degree: 9,
+            max_combo: 2,
             num_deep_terms: Some(130),
             lookup: LookupShape {
                 fractions_per_row: 27,
@@ -299,6 +318,7 @@ mod tests {
         let large = AirShape {
             num_composed_constraints: 4096,
             max_constraint_degree: 9,
+            max_combo: 2,
             num_deep_terms: Some(1024),
             lookup: LookupShape {
                 fractions_per_row: 64,

--- a/security/src/budget/mod.rs
+++ b/security/src/budget/mod.rs
@@ -14,7 +14,11 @@
 //!
 //! Every bound is stated as `error ≤ coefficient · size / |E|`, which in bits is
 //! `log2|E| − log2(coefficient) − log2(size)`. Coefficients round up and the field size rounds
-//! down, so each round is understated rather than overstated.
+//! down, so each round is understated rather than overstated. The out-of-domain round is the one
+//! exception to that framing: part of its size is additive rather than a multiple of the trace
+//! height, so it takes the logarithm of the whole product at once. It states the same bound as
+//! [`crate::deep::deep_ali_error`], the `f64` mirror of the same equation, and the two are meant
+//! to be read together.
 //!
 //! # Folding accounting
 //!
@@ -101,10 +105,13 @@ pub const fn security_report(
 
     // The out-of-domain point is rejection-sampled outside the trace and LDE domains but is not
     // ground. A violated constraint leaves the DEEP-ALI identity a nonzero polynomial in that
-    // point of degree at most `(max_constraint_degree + 1) · height + (max_combo − 1) ·
-    // (max_constraint_degree − 1)`: one factor of the identity's degree per out-of-domain point
-    // referenced, plus a flat term per extra point from the shared numerator. Lifting evaluates
-    // the shorter AIRs at powers of the same point, so all of them pay the maximum height.
+    // point of degree at most the larger of `max_constraint_degree · (height + max_combo − 1) +
+    // (height − 1)` (clearing the shared denominator lifts each of a constraint's degree-many
+    // trace factors by one per out-of-domain point referenced, and the quotient side contributes
+    // the rest) and `(c + 1) · height + max_combo − 1` (the degree Plonky3's own power-of-two
+    // quotient chunking induces, binding whenever `c` exceeds `max_constraint_degree`). Lifting
+    // evaluates the shorter AIRs at powers of the same point, so all of them pay the maximum
+    // height.
     let out_of_domain =
         out_of_domain_round(instance, air.max_constraint_degree, air.max_combo, cap);
 
@@ -178,23 +185,74 @@ const fn round(
     SecurityTerm::new(label, min(bits, cap))
 }
 
-/// Bounds the out-of-domain round: error `((d + 1) · H + (combo − 1) · (d − 1)) / |E|`, with `H`
-/// the trace height and `combo` the number of out-of-domain points referenced per column. Unlike
-/// [`round`], the extra `(combo − 1) · (d − 1)` term is additive rather than a multiple of `H`, so
-/// it is folded into the size directly instead of decomposed into a coefficient and a log-size.
-/// This round is always charged — there is no "no such round" case to special-case at zero.
+/// Bounds the out-of-domain round: error `max(d · (H + combo − 1) + (H − 1), (c + 1) · H + combo
+/// − 1) / |E|`, with `H` the trace height, `d` the maximum constraint degree, `combo` the number
+/// of out-of-domain points referenced per column, and `c = 2^⌈log2(max(d, 2) − 1)⌉` the number of
+/// power-of-two quotient chunks Plonky3 commits (`uni_stark::symbolic::get_log_num_quotient_chunks`).
+///
+/// Checking the DEEP-ALI identity at the sampled point clears the common denominator
+/// `Π_i (x − z_i)`, which lifts each of a constraint's `d` trace factors from degree `≤ H − 1` to
+/// degree `≤ H + combo − 1`, and the quotient side adds a further `H − 1`:
+///
+/// ```text
+/// d · (H + combo − 1)     from the d lifted factors
+///           + (H − 1)     from the quotient side
+/// ```
+///
+/// That is ethSTARK's `X^i · h_i(X^d)` split. Plonky3 instead commits the quotient as `c`
+/// power-of-two chunks reconstructed with degree-`(c − 1) · H` coset selectors, giving identity
+/// degree `(c + 1) · H + combo − 1`; this exceeds the first term whenever `c > d`, which is why
+/// the two are combined by a maximum rather than the first alone. `c` assumes a non-`zk` quotient
+/// split.
+///
+/// [`crate::deep::deep_ali_error`] states the same bound in `f64`. Unlike [`round`], both terms
+/// are additive rather than a multiple of `H`, so the whole product is folded into the size
+/// directly instead of decomposed into a coefficient and a log-size. This round is always charged
+/// — there is no "no such round" case to special-case at zero.
+///
+/// A degenerate degree or point count clamps to one, which keeps `size ≥ 1` and so keeps
+/// [`fixed::ceil_log2`]'s zero-assert unreachable. A size too large to take the logarithm of is
+/// reported at zero bits rather than wrapped, since truncating it would understate the error.
 const fn out_of_domain_round(
     instance: &InstanceShape,
     max_constraint_degree: u32,
     max_combo: u32,
     cap: u64,
 ) -> SecurityTerm {
-    let d = max_constraint_degree as u64;
-    let height = 1u64 << instance.log_max_height;
-    let extra_points = (max_combo as u64).saturating_sub(1);
-    let size = (d + 1) * height + extra_points * d.saturating_sub(1);
+    if instance.log_max_height >= u64::BITS {
+        return SecurityTerm::new(OUT_OF_DOMAIN_LABEL, 0);
+    }
 
-    let error = fixed::ceil_log2(size);
+    let d = if max_constraint_degree == 0 {
+        1
+    } else {
+        max_constraint_degree as u128
+    };
+    let combo = if max_combo == 0 { 1 } else { max_combo as u128 };
+    let height = 1u128 << instance.log_max_height;
+    let ethstark = d * (height + combo - 1) + (height - 1);
+
+    // `c = 2^⌈log2(chunk_arg)⌉`, mirroring `p3_util::log2_ceil_usize` in `u128`: the smallest
+    // power of two at least `chunk_arg`, found by counting the leading zeros of `chunk_arg − 1`.
+    let chunk_arg = (if max_constraint_degree < 2 {
+        2
+    } else {
+        max_constraint_degree as u128
+    }) - 1;
+    let log_chunks = u128::BITS - chunk_arg.saturating_sub(1).leading_zeros();
+    let chunks = 1u128 << log_chunks;
+    let chunked = (chunks + 1) * height + combo - 1;
+
+    let size = if ethstark > chunked {
+        ethstark
+    } else {
+        chunked
+    };
+    if size > u64::MAX as u128 {
+        return SecurityTerm::new(OUT_OF_DOMAIN_LABEL, 0);
+    }
+
+    let error = fixed::ceil_log2(size as u64);
     let bits = instance.field_bits.saturating_sub(error);
 
     SecurityTerm::new(OUT_OF_DOMAIN_LABEL, min(bits, cap))
@@ -308,6 +366,42 @@ mod tests {
             let level = security_report(&params(), &instance(log_height), &air()).security_level();
             assert!(level <= previous, "level rose at log height {log_height}");
             previous = level;
+        }
+    }
+
+    /// Stronger than the level above, which is a minimum over rounds and therefore hides a round
+    /// that gains bits with height behind whichever round binds. Each round on its own must be
+    /// non-increasing, across the whole range the shape's `u32` height admits.
+    #[test]
+    fn every_round_is_monotone_in_trace_height() {
+        let mut previous = [u64::MAX; report::NUM_TERMS];
+        for log_height in 0..=64u32 {
+            let report = security_report(&params(), &instance(log_height), &air());
+            for (term, prev) in report.terms().iter().zip(previous.iter_mut()) {
+                assert!(
+                    term.bits <= *prev,
+                    "{} rose at log height {log_height}",
+                    term.label
+                );
+                *prev = term.bits;
+            }
+        }
+    }
+
+    /// Opening more out-of-domain points raises the degree the DEEP-ALI identity is tested at, so
+    /// it can only cost the out-of-domain round bits.
+    #[test]
+    fn security_is_monotone_in_max_combo() {
+        let mut previous = u64::MAX;
+        for max_combo in 1..=16u32 {
+            let air = AirShape { max_combo, ..air() };
+            let term = security_report(&params(), &instance(6), &air).terms()[2];
+            assert_eq!(term.label, OUT_OF_DOMAIN_LABEL);
+            assert!(
+                term.bits <= previous,
+                "out-of-domain rose at max_combo {max_combo}"
+            );
+            previous = term.bits;
         }
     }
 

--- a/security/src/budget/shape.rs
+++ b/security/src/budget/shape.rs
@@ -82,6 +82,11 @@ pub struct AirShape {
     pub num_composed_constraints: u32,
     /// Maximum constraint degree over all AIRs.
     pub max_constraint_degree: u32,
+    /// Maximum number of out-of-domain points referenced per committed column: `2` for an AIR
+    /// that opens `local` and `next` rotations, `1` if it has no transition constraint.
+    ///
+    /// Read by the out-of-domain round, independent of [`Self::num_deep_terms`].
+    pub max_combo: u32,
     /// Total committed columns opened by a DEEP-quotient batching argument, plus one slot per
     /// out-of-domain point, or `None` when the protocol performs no α/β column-batching reduction
     /// over its committed openings. The budget's out-of-domain round is charged regardless of this

--- a/security/src/budget/shape.rs
+++ b/security/src/budget/shape.rs
@@ -82,8 +82,9 @@ pub struct AirShape {
     pub num_composed_constraints: u32,
     /// Maximum constraint degree over all AIRs.
     pub max_constraint_degree: u32,
-    /// Maximum number of out-of-domain points referenced per committed column: `2` for an AIR
-    /// that opens `local` and `next` rotations, `1` if it has no transition constraint.
+    /// Maximum number of out-of-domain points referenced per committed column — one per distinct
+    /// point the AIR's rotations induce: `2` for an AIR that opens `local` and `next`, `1` for an
+    /// AIR whose constraints all read a single row, and higher for a wider rotation set.
     ///
     /// Read by the out-of-domain round, independent of [`Self::num_deep_terms`].
     pub max_combo: u32,

--- a/security/src/deep.rs
+++ b/security/src/deep.rs
@@ -1,8 +1,18 @@
 //! DEEP-ALI out-of-domain sampling error.
 //!
-//! ε_DEEP = L⁺ · (max_deg · (k + max_combo − 1) + (k − 1)) / |F|,
-//! with k = trace domain size. Matches `soundcalc/circuits/deep_ali.py`.
-//! `soundcalc` divides by `|F| − k − D`; the difference is negligible.
+//! ε_DEEP = L⁺ · factor / |F|, with k = trace domain size and
+//!
+//! factor = max(max_deg · (k + max_combo − 1) + (k − 1), (c + 1) · k + max_combo − 1).
+//!
+//! The first term is ethSTARK's `X^i · h_i(X^d)` quotient split, matching
+//! `soundcalc/circuits/deep_ali.py`. The second is Plonky3's own quotient split into
+//! `c = 2^⌈log2(max(max_deg, 2) − 1)⌉` power-of-two chunks
+//! (`uni_stark::symbolic::get_log_num_quotient_chunks`), which the first term only
+//! dominates when `c ≤ max_deg`. `soundcalc` divides by `|F| − k − D`; the difference is
+//! negligible.
+//!
+//! `c` assumes a non-`zk` quotient split; a `zk` instance further randomizes each chunk's
+//! domain and is not modeled here.
 //!
 //! The list size `L⁺` enters linearly here, following `soundcalc`.
 //! [2024/1553] Theorem 2 (`eps_2`) instead uses `L² ≈ (m/ρ)²`, which is
@@ -23,7 +33,10 @@ pub fn deep_ali_error(air: &StarkAirParams, shape: &InstanceShape, list_size: f6
     let k = (1u64 << shape.log_trace_length) as f64;
     let max_deg = air.max_constraint_degree.max(1) as f64;
     let combo = air.max_combo as f64;
-    let factor = (max_deg * (k + combo - 1.0) + (k - 1.0)).max(1.0);
+    let ethstark = max_deg * (k + combo - 1.0) + (k - 1.0);
+    let chunks = (air.max_constraint_degree.max(2) - 1).next_power_of_two() as f64;
+    let chunked = (chunks + 1.0) * k + combo - 1.0;
+    let factor = ethstark.max(chunked).max(1.0);
     let bits = shape.modulus_bits as f64 - log2(list_size) - log2(factor);
     ErrorBits::from_log2(bits.max(0.0))
 }

--- a/security/tests/budget_parity.rs
+++ b/security/tests/budget_parity.rs
@@ -17,6 +17,7 @@ use p3_security::grinding::{GrindingSites, boost};
 use p3_security::logup::{LogUpAir, security_term as logup_security_term};
 use p3_security::shape::{InstanceShape as F64InstanceShape, StarkAirParams};
 use p3_security::{air, deep, fixed};
+use proptest::prelude::*;
 
 const TIGHT_TOL: f64 = 1e-4;
 const LOG_BLOWUP: u32 = 3;
@@ -52,6 +53,13 @@ const PARAM_ROWS: &[(u32, u32, u32, u32)] = &[(27, 17, 12, 4), (100, 0, 0, 0), (
 
 /// Out-of-domain points referenced per column: `local` and `next` rotations.
 const OOD_MAX_COMBO: u32 = 2;
+
+/// Widest rotation set the grid drives `max_combo` to.
+const OOD_MAX_COMBO_SWEEP: u32 = 8;
+
+/// Tolerance for the property below, which asserts exact agreement rather than a bounded gap and
+/// so only needs to absorb `f64` evaluation noise.
+const PROP_TOL: f64 = 1e-9;
 
 fn to_f64(fixed_bits: u64) -> f64 {
     fixed_bits as f64 / fixed::ONE as f64
@@ -100,31 +108,37 @@ fn every_round_direction_and_tightness() {
                 folding_pow_bits,
                 lookup_pow_bits: 0,
             };
-            let air_shape = AirShape {
-                num_composed_constraints: air_vector.num_composed_constraints,
-                max_constraint_degree: air_vector.max_constraint_degree,
-                max_combo: OOD_MAX_COMBO,
-                num_deep_terms: Some(air_vector.num_deep_terms),
-                lookup: LookupShape {
-                    fractions_per_row: air_vector.fractions_per_row,
-                    max_message_width: air_vector.max_message_width,
-                },
-            };
-
-            for log_max_height in 6..=29u32 {
-                let instance = InstanceShape {
-                    log_max_height,
-                    field_bits: FIELD_BITS,
-                    collision_resistance: CAP_BITS as u32,
+            // `max_combo` enters the out-of-domain bound additively rather than as a multiple of
+            // the trace height, so the two sides only separate by more than `TIGHT_TOL` at the
+            // bottom of the height sweep below, and most sharply on the lower-degree `SMALL`
+            // vector — both of which the grid keeps reaching for this sweep to say anything.
+            for max_combo in 1..=OOD_MAX_COMBO_SWEEP {
+                let air_shape = AirShape {
+                    num_composed_constraints: air_vector.num_composed_constraints,
+                    max_constraint_degree: air_vector.max_constraint_degree,
+                    max_combo,
+                    num_deep_terms: Some(air_vector.num_deep_terms),
+                    lookup: LookupShape {
+                        fractions_per_row: air_vector.fractions_per_row,
+                        max_message_width: air_vector.max_message_width,
+                    },
                 };
-                let report = security_report(&params, &instance, &air_shape);
 
-                check_query(&report, num_queries, query_pow_bits);
-                check_lookup(&report, air_vector, log_max_height);
-                check_composition(&report, air_vector);
-                check_ood(&report, air_vector, log_max_height);
-                check_folding(&report, log_max_height, folding_pow_bits);
-                check_deep_composition(&report, air_vector, deep_pow_bits);
+                for log_max_height in 6..=29u32 {
+                    let instance = InstanceShape {
+                        log_max_height,
+                        field_bits: FIELD_BITS,
+                        collision_resistance: CAP_BITS as u32,
+                    };
+                    let report = security_report(&params, &instance, &air_shape);
+
+                    check_query(&report, num_queries, query_pow_bits);
+                    check_lookup(&report, air_vector, log_max_height);
+                    check_composition(&report, air_vector);
+                    check_ood(&report, air_vector, max_combo, log_max_height);
+                    check_folding(&report, log_max_height, folding_pow_bits);
+                    check_deep_composition(&report, air_vector, deep_pow_bits);
+                }
             }
         }
     }
@@ -202,22 +216,23 @@ fn check_composition(report: &SecurityReport, air_vector: &AirVector) {
     );
 }
 
-fn check_ood(report: &SecurityReport, air_vector: &AirVector, log_max_height: u32) {
+fn check_ood(report: &SecurityReport, air_vector: &AirVector, max_combo: u32, log_max_height: u32) {
     let fixed_bits = term_bits(report, OUT_OF_DOMAIN_LABEL);
     let stark_air = StarkAirParams {
         num_constraints: air_vector.num_composed_constraints as usize,
         max_constraint_degree: air_vector.max_constraint_degree as usize,
-        max_combo: OOD_MAX_COMBO as usize,
+        max_combo: max_combo as usize,
     };
     let p3_bits = cap(deep::deep_ali_error(&stark_air, &f64_instance(log_max_height), 1.0).bits());
 
     assert!(
         fixed_bits <= p3_bits + TIGHT_TOL,
-        "ood: {fixed_bits} > {p3_bits} at h={log_max_height}"
+        "ood: {fixed_bits} > {p3_bits} at h={log_max_height} combo={max_combo}"
     );
     assert!(
         p3_bits - fixed_bits < TIGHT_TOL,
-        "ood: gap {} >= tolerance at h={log_max_height}, fixed drifted conservative",
+        "ood: gap {} >= tolerance at h={log_max_height} combo={max_combo}, \
+         fixed drifted conservative",
         p3_bits - fixed_bits
     );
 }
@@ -298,4 +313,62 @@ fn collision_term_is_the_cap() {
     };
     let report = security_report(&params, &instance, &air_shape);
     assert_eq!(term_bits(&report, COLLISION_LABEL), 96.0);
+}
+
+proptest! {
+    /// The grid above pins the parameter shape to a handful of vectors; this covers the whole
+    /// three-dimensional space the out-of-domain round is a function of.
+    ///
+    /// A counterexample is by construction a shape whose fixed-point budget reports more bits than
+    /// the scalar reference — a recursive verifier accepting a configuration the `f64` path
+    /// rejects.
+    #[test]
+    fn out_of_domain_never_exceeds_the_f64_reference(
+        max_constraint_degree in 1..=32u32,
+        log_max_height in 0..=48u32,
+        max_combo in 1..=16u32,
+    ) {
+        let params = ProtocolParams {
+            log_blowup: LOG_BLOWUP,
+            log_folding_arity: LOG_FOLDING_ARITY,
+            num_queries: 27,
+            query_pow_bits: 17,
+            deep_pow_bits: 12,
+            folding_pow_bits: 4,
+            lookup_pow_bits: 0,
+        };
+        let instance = InstanceShape {
+            log_max_height,
+            field_bits: FIELD_BITS,
+            collision_resistance: CAP_BITS as u32,
+        };
+        let air_shape = AirShape {
+            num_composed_constraints: SMALL.num_composed_constraints,
+            max_constraint_degree,
+            max_combo,
+            num_deep_terms: Some(SMALL.num_deep_terms),
+            lookup: LookupShape {
+                fractions_per_row: SMALL.fractions_per_row,
+                max_message_width: SMALL.max_message_width,
+            },
+        };
+        let fixed_bits = term_bits(
+            &security_report(&params, &instance, &air_shape),
+            OUT_OF_DOMAIN_LABEL,
+        );
+
+        let stark_air = StarkAirParams {
+            num_constraints: SMALL.num_composed_constraints as usize,
+            max_constraint_degree: max_constraint_degree as usize,
+            max_combo: max_combo as usize,
+        };
+        let reference = deep::deep_ali_error(&stark_air, &f64_instance(log_max_height), 1.0);
+        let p3_bits = cap(reference.bits());
+
+        prop_assert!(
+            fixed_bits <= p3_bits + PROP_TOL,
+            "ood: {fixed_bits} > {p3_bits} at d={max_constraint_degree} \
+             h={log_max_height} combo={max_combo}"
+        );
+    }
 }

--- a/security/tests/budget_parity.rs
+++ b/security/tests/budget_parity.rs
@@ -3,12 +3,7 @@
 //! the same conjectured-security math can never drift apart silently.
 //!
 //! See `budget`'s module doc for the folding-accounting and DEEP-quotient-batching design notes
-//! this test exercises. The out-of-domain round is the one place the two formulas genuinely
-//! differ (not just fixed-point vs. `f64`): `budget`'s out-of-domain round assumes a single
-//! out-of-domain point per column (`factor = (d + 1)·height`), while `deep::deep_ali_error`
-//! accounts for `max_combo` points (`factor = d·(height + combo − 1) + (height − 1)`). At
-//! `combo = 2` these differ by exactly `d − 1`, so [`ood_tolerance`] bounds that gap analytically
-//! rather than folding it into a flat epsilon.
+//! this test exercises.
 
 use p3_security::budget::report::{
     COLLISION_LABEL, COMPOSITION_LABEL, DEEP_COMPOSITION_LABEL, FOLDING_LABEL, LOOKUP_LABEL,
@@ -55,6 +50,9 @@ const LARGE: AirVector = AirVector {
 
 const PARAM_ROWS: &[(u32, u32, u32, u32)] = &[(27, 17, 12, 4), (100, 0, 0, 0), (150, 31, 31, 31)];
 
+/// Out-of-domain points referenced per column: `local` and `next` rotations.
+const OOD_MAX_COMBO: u32 = 2;
+
 fn to_f64(fixed_bits: u64) -> f64 {
     fixed_bits as f64 / fixed::ONE as f64
 }
@@ -89,12 +87,6 @@ const fn cap(bits: f64) -> f64 {
     }
 }
 
-fn ood_tolerance(max_constraint_degree: u32, log_max_height: u32) -> f64 {
-    let d = max_constraint_degree as f64;
-    let height = 2f64.powi(log_max_height as i32);
-    (1.0 + (d - 1.0) / ((d + 1.0) * height)).log2() + TIGHT_TOL
-}
-
 #[test]
 fn every_round_direction_and_tightness() {
     for air_vector in [&SMALL, &LARGE] {
@@ -111,6 +103,7 @@ fn every_round_direction_and_tightness() {
             let air_shape = AirShape {
                 num_composed_constraints: air_vector.num_composed_constraints,
                 max_constraint_degree: air_vector.max_constraint_degree,
+                max_combo: OOD_MAX_COMBO,
                 num_deep_terms: Some(air_vector.num_deep_terms),
                 lookup: LookupShape {
                     fractions_per_row: air_vector.fractions_per_row,
@@ -214,23 +207,18 @@ fn check_ood(report: &SecurityReport, air_vector: &AirVector, log_max_height: u3
     let stark_air = StarkAirParams {
         num_constraints: air_vector.num_composed_constraints as usize,
         max_constraint_degree: air_vector.max_constraint_degree as usize,
-        max_combo: 2,
+        max_combo: OOD_MAX_COMBO as usize,
     };
     let p3_bits = cap(deep::deep_ali_error(&stark_air, &f64_instance(log_max_height), 1.0).bits());
 
-    // `tolerance` is the analytic gap between the two formulas (see this file's module doc) plus
-    // `TIGHT_TOL` of rounding slop; the direction check below bounds one side of that gap, and the
-    // tightness check bounds the other against the analytic gap alone.
-    let tolerance = ood_tolerance(air_vector.max_constraint_degree, log_max_height);
-    let exact_gap = tolerance - TIGHT_TOL;
     assert!(
-        fixed_bits <= p3_bits + tolerance,
-        "ood: {fixed_bits} > {p3_bits} + {tolerance} at h={log_max_height}"
+        fixed_bits <= p3_bits + TIGHT_TOL,
+        "ood: {fixed_bits} > {p3_bits} at h={log_max_height}"
     );
     assert!(
-        p3_bits + exact_gap - fixed_bits < TIGHT_TOL,
+        p3_bits - fixed_bits < TIGHT_TOL,
         "ood: gap {} >= tolerance at h={log_max_height}, fixed drifted conservative",
-        p3_bits + exact_gap - fixed_bits
+        p3_bits - fixed_bits
     );
 }
 
@@ -301,6 +289,7 @@ fn collision_term_is_the_cap() {
     let air_shape = AirShape {
         num_composed_constraints: LARGE.num_composed_constraints,
         max_constraint_degree: LARGE.max_constraint_degree,
+        max_combo: OOD_MAX_COMBO,
         num_deep_terms: Some(LARGE.num_deep_terms),
         lookup: LookupShape {
             fractions_per_row: LARGE.fractions_per_row,


### PR DESCRIPTION
## Summary
- `p3_security::budget::security_report`'s out-of-domain round bounded the DEEP-ALI degree as `(d + 1) · height`, implicitly assuming a single out-of-domain point per column.
- An AIR that also opens `next`-row rotations references a second out-of-domain point, which needs an extra `(combo − 1) · (d − 1)` term — omitting it understated the round's error (i.e. overstated security) by a fraction of a bit, shrinking as trace height grows.
- `AirShape` gains a `max_combo` field (mirroring the crate's existing `f64`-based `StarkAirParams::max_combo`), and the out-of-domain round now computes the full formula directly.
- `security/tests/budget_parity.rs` previously bounded this exact gap with an analytic tolerance function; with the fix the fixed-point and `f64` reference paths agree exactly, so that tolerance is replaced with the same tight equality check used by every other round.

## Test plan
- [x] `cargo test -p p3-security` (67 unit tests + `budget_parity` integration tests)
- [x] `cargo clippy -p p3-security --all-targets -- -D warnings`
- [x] `cargo fmt -p p3-security -- --check`