### PR TITLE
docs(sumcheck, multilinear-util): correct weight ordering, add promised assert

### DIFF
--- a/multilinear-util/src/eq_batch.rs
+++ b/multilinear-util/src/eq_batch.rs
@@ -153,6 +153,10 @@ where
     F: Field,
     A: Algebra<F> + Send + Sync,
 {
+    // One column per evaluation point on both sides. Without this the `take`
+    // below would silently drop the trailing points instead of failing.
+    debug_assert_eq!(evals.width(), buffer.width());
+
     // Process variables in reverse order to maintain correct bit ordering in output buffer.
     //
     // We apply it simultaneously across all columns (evaluation points).

--- a/sumcheck/src/lagrange.rs
+++ b/sumcheck/src/lagrange.rs
@@ -70,8 +70,12 @@ pub(crate) fn lagrange_weights_01inf<F: Field>(r: F) -> [F; 3] {
 ///
 /// # Output Ordering
 ///
-/// Lexicographic by multi-index `(i_0, i_1, ..., i_{k-1})` where each `i_j`
-/// ranges over the three basis functions (0, 1, inf).
+/// Index `sum_j i_j * 3^j` holds `prod_j L_{i_j}(r_j)`, where each `i_j` ranges
+/// over the three basis functions (0, 1, inf). So `i_0` is the **least**
+/// significant digit and the weights for `r_0` vary fastest.
+///
+/// For `k = 2` that is `weights[3 * i_1 + i_0] = L_{i_0}(r_0) * L_{i_1}(r_1)`,
+/// which is what `test_lagrange_weights_multi_k2` pins.
 pub fn lagrange_weights_01inf_multi<F: Field>(rs: &[F]) -> Vec<F> {
     let total = 3usize.pow(rs.len() as u32);
     let mut current = Vec::with_capacity(total);


### PR DESCRIPTION
Two places where a doc comment and its code disagree. Split out from #2008 so that fix stays single-purpose.

## 1. `lagrange_weights_01inf_multi` documents the wrong ordering

The doc says:

> Lexicographic by multi-index `(i_0, i_1, ..., i_{k-1})`

but the loop prepends each new coordinate's basis index as the **most** significant digit, so the result is indexed by `sum_j i_j * 3^j` — `i_0` is the *least* significant digit and the weights for `r_0` vary fastest.

The function's own `test_lagrange_weights_multi_k2` already pins the real convention:

```rust
// weights[3*j + i] = L_i(r0) * L_j(r1)
assert_eq!(weights[3 * j + i], w0[i] * w1[j]);
```

So the code and the test agree with each other; only the comment is wrong. Confirmed at `k = 3` before writing the replacement — `weights[i0 + 3*i1 + 9*i2]` matches for all 27 entries, `weights[9*i0 + 3*i1 + i2]` matches for none.

This one is worth getting right because the function is `pub`: a caller who indexes it the way the doc describes gets silently wrong weights for `k >= 2`, with no shape or length error to catch it.

## 2. `fill_buffer_batch` promises a `debug_assert` that isn't there

The doc says:

> # Panics
> Panics in debug builds if `evals.width() != buffer.width()`.

There is no such assertion. The `take(width)` in the column loop silently drops the trailing evaluation points instead. This adds the assertion the docs already promise.

The one caller, `eval_eq_batch_common`, sizes `parallel_buffer` from `evals.width()`, so it cannot fire today — it guards the invariant for the next caller rather than fixing a live bug.

## Testing

No behaviour change in release builds; the assertion is debug-only and the other hunk is a comment.

Ran in debug (so the new assertion is live) across the crate and every consumer of `eval_eq_batch` / `eval_eq_base_batch` / `new_from_point`:

- `p3-multilinear-util` — 148 passed
- `p3-sumcheck` — 244 passed
- `p3-whir` — 125 passed
- `p3-multi-stark` — 59 passed

`cargo clippy --all-targets` and `cargo +nightly fmt --check` clean.