### PR TITLE
feat: expose pruned-multiproof restoration and FRI/STARK opening internals

### DIFF
--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -195,6 +195,10 @@ where
             airs,
             trace_ext_degree_bits,
             &vec![0; airs.len()],
+            // Every override is zero, so packing cannot move the quotient bucket (the
+            // `debug_assert_eq!` below still pins that) and the blowup ceiling is
+            // unreachable from here.
+            usize::MAX,
         )
     }
 
@@ -203,13 +207,28 @@ where
     /// instead of only the free (quotient-chunk-preserving) budget. A `0` override reproduces
     /// [`Self::from_airs_and_degrees`] exactly. A caller raising an override past the free
     /// ceiling deliberately spends more quotient chunks on that instance to commit fewer aux
-    /// columns — the resulting chunk count must still fit the PCS's blowup
-    /// (`num_quotient_chunks <= 1 << log_blowup`), which this function does not itself enforce.
+    /// columns.
+    ///
+    /// # Arguments
+    ///
+    /// * `lookup_budget_overrides` - Per-AIR fraction-pin degree floors; one entry per AIR.
+    /// * `log_blowup` - The PCS's `log_blowup`. A rate-`2^-log_blowup` low-degree test only
+    ///   certifies degree `< |domain| * 2^-log_blowup`, so a quotient split into more than
+    ///   `2^log_blowup` chunks asks FRI to certify a degree it has no rate budget for. Any
+    ///   instance whose override raises the chunk count past that ceiling panics here.
+    ///
+    /// # Panics
+    ///
+    /// If an override raises an instance's quotient chunk count past `1 << log_blowup`. This
+    /// is a hard [`assert!`] rather than a `debug_assert!`: overrides are a rare, explicit,
+    /// caller-side choice, so the recomputation costs nothing on the default path, and a
+    /// release build must not silently emit a rate-violating proof.
     pub fn from_airs_and_degrees_with_lookup_budgets<A>(
         config: &SC,
         airs: &[A],
         trace_ext_degree_bits: &[usize],
         lookup_budget_overrides: &[usize],
+        log_blowup: usize,
     ) -> Self
     where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
@@ -297,7 +316,8 @@ where
             .iter()
             .zip(trace_ext_degree_bits.iter())
             .zip(lookup_budget_overrides.iter())
-            .map(|((air, &ext_db), &override_budget)| {
+            .enumerate()
+            .map(|(i, ((air, &ext_db), &override_budget))| {
                 // Base trace length `N` (before any ZK extension), matching what the
                 // prover and verifier feed the degree model for this instance.
                 let trace_len = 1usize << (ext_db - is_zk);
@@ -337,10 +357,31 @@ where
                         log_chunks,
                         "same-bus packing must preserve the quotient chunk count when no override is set"
                     );
+                } else {
+                    // A deliberate override is allowed to raise the bucket, but only within the
+                    // PCS's rate budget: the low-degree test certifies degree
+                    // `< |domain| * 2^-log_blowup`, so a quotient split into more than
+                    // `2^log_blowup` chunks has no soundness margin left. This is the bound
+                    // `StarkSecurityParams::new` states as a buildability condition; without
+                    // this check nothing else on the prove or verify path detects a violation.
+                    let packed_log_chunks =
+                        get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                            air,
+                            AirLayout::from_air(air),
+                            trace_len,
+                            &packed,
+                            is_zk,
+                            &lookup_gadget,
+                        );
+                    // The committed chunk count is `2^(log_chunks + is_zk)`.
+                    let log_num_chunks = packed_log_chunks + is_zk;
+                    assert!(
+                        log_num_chunks <= log_blowup,
+                        "instance {i}: lookup-budget override raised the quotient bucket to \
+                         2^{log_num_chunks} chunks, past the PCS blowup 2^{log_blowup}; \
+                         the prover cannot commit a quotient"
+                    );
                 }
-                // A deliberate override is allowed to raise the bucket; the caller is
-                // responsible for keeping the resulting chunk count within the PCS's blowup
-                // and for re-deriving the AIR layout from `packed`, not `unpacked`.
 
                 packed
             })

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -190,10 +190,40 @@ where
         SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
         A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>,
     {
+        Self::from_airs_and_degrees_with_lookup_budgets(
+            config,
+            airs,
+            trace_ext_degree_bits,
+            &vec![0; airs.len()],
+        )
+    }
+
+    /// As [`Self::from_airs_and_degrees`], but each AIR may specify a lookup-packing budget
+    /// floor: `pack_same_bus` is called with `max(free_budget, lookup_budget_overrides[i])`
+    /// instead of only the free (quotient-chunk-preserving) budget. A `0` override reproduces
+    /// [`Self::from_airs_and_degrees`] exactly. A caller raising an override past the free
+    /// ceiling deliberately spends more quotient chunks on that instance to commit fewer aux
+    /// columns — the resulting chunk count must still fit the PCS's blowup
+    /// (`num_quotient_chunks <= 1 << log_blowup`), which this function does not itself enforce.
+    pub fn from_airs_and_degrees_with_lookup_budgets<A>(
+        config: &SC,
+        airs: &[A],
+        trace_ext_degree_bits: &[usize],
+        lookup_budget_overrides: &[usize],
+    ) -> Self
+    where
+        SymbolicExpressionExt<Val<SC>, SC::Challenge>: Algebra<SC::Challenge>,
+        A: Air<InteractionSymbolicBuilder<Val<SC>, SC::Challenge>>,
+    {
         assert_eq!(
             airs.len(),
             trace_ext_degree_bits.len(),
             "airs and trace_ext_degree_bits must have the same length"
+        );
+        assert_eq!(
+            airs.len(),
+            lookup_budget_overrides.len(),
+            "airs and lookup_budget_overrides must have the same length"
         );
 
         let pcs = config.pcs();
@@ -266,7 +296,8 @@ where
         let lookups: Vec<Lookups<Val<SC>>> = airs
             .iter()
             .zip(trace_ext_degree_bits.iter())
-            .map(|(air, &ext_db)| {
+            .zip(lookup_budget_overrides.iter())
+            .map(|((air, &ext_db), &override_budget)| {
                 // Base trace length `N` (before any ZK extension), matching what the
                 // prover and verifier feed the degree model for this instance.
                 let trace_len = 1usize << (ext_db - is_zk);
@@ -287,22 +318,29 @@ where
                 //
                 //     log2_ceil((d + is_zk).max(2) - 1) <= log_chunks
                 //  => d <= 2^log_chunks + 1 - is_zk
-                let budget = (1usize << log_chunks) + 1 - is_zk;
+                let free_budget = (1usize << log_chunks) + 1 - is_zk;
+                let budget = free_budget.max(override_budget);
                 let packed = unpacked.pack_same_bus(&lookup_gadget, budget);
 
-                // The fold must not have moved the quotient bucket.
-                debug_assert_eq!(
-                    get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
-                        air,
-                        AirLayout::from_air(air),
-                        trace_len,
-                        &packed,
-                        is_zk,
-                        &lookup_gadget,
-                    ),
-                    log_chunks,
-                    "same-bus packing must preserve the quotient chunk count"
-                );
+                if override_budget <= free_budget {
+                    // No deliberate override: the fold must not have moved the quotient bucket,
+                    // exactly as before.
+                    debug_assert_eq!(
+                        get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                            air,
+                            AirLayout::from_air(air),
+                            trace_len,
+                            &packed,
+                            is_zk,
+                            &lookup_gadget,
+                        ),
+                        log_chunks,
+                        "same-bus packing must preserve the quotient chunk count when no override is set"
+                    );
+                }
+                // A deliberate override is allowed to raise the bucket; the caller is
+                // responsible for keeping the resulting chunk count within the PCS's blowup
+                // and for re-deriving the AIR layout from `packed`, not `unpacked`.
 
                 packed
             })

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 pub use data::VerifierData;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_air::{Air, BaseAir};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{CommitmentWithOpeningPoints, Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, ExtensionField, PrimeCharacteristicRing, PrimeField};
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
@@ -28,6 +28,15 @@ use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof};
 use crate::symbolic::get_log_num_quotient_chunks;
 use crate::transcript::BatchTranscript;
 
+/// What [`commitments_with_opening_points`] builds: the PCS opening argument itself — one
+/// [`CommitmentWithOpeningPoints`] per commitment round — paired with each instance's
+/// quotient-chunk domains, a byproduct of the same construction that the caller needs for its
+/// own post-opening constraint check.
+pub type OpeningArgumentWithQuotientDomains<SC> = (
+    Vec<CommitmentWithOpeningPoints<Challenge<SC>, Commitment<SC>, Domain<SC>>>,
+    Vec<Vec<Domain<SC>>>,
+);
+
 /// Builds the `commitments_with_opening_points` a batch-STARK proof's PCS opening argument is
 /// checked against: one round per commitment (an optional ZK-randomization round, the trace
 /// round, the quotient-chunks round, an optional preprocessed round, an optional permutation
@@ -45,14 +54,40 @@ use crate::transcript::BatchTranscript;
 /// # Arguments
 ///
 /// - `zeta` — the out-of-domain point, already sampled from the transcript.
-/// - `ext_domain_sizes`, `preprocessed_widths`, `log_num_quotient_chunks`,
-///   `num_quotient_chunks` — per-instance, derived exactly as `verify_batch`'s own precompute
-///   loop computes them.
+/// - `degree_bits` — per-instance extended trace degree bits, straight from the proof. Both
+///   the trace and quotient domain sizes are derived from these through the same
+///   [`validate_degree_bits`] gate `verify_batch` applies.
+/// - `preprocessed_widths`, `log_num_quotient_chunks` — per-instance, derived exactly as
+///   `verify_batch`'s own precompute loop computes them. The committed chunk count follows
+///   from `log_num_quotient_chunks` and the ZK setting, so it is derived here rather than
+///   passed in.
 ///
-/// Performs no transcript interaction and no shape validation beyond what the construction
-/// itself requires (e.g. matching quotient-chunk counts): a caller needing `verify_batch`'s
-/// full set of proof-shape checks should either call `verify_batch` directly or replicate the
-/// checks it needs itself.
+/// Performs no transcript interaction.
+///
+/// # Omitted checks
+///
+/// Only the shape checks this construction itself needs are performed (degree-bit bounds,
+/// quotient-domain sizes, matching quotient-chunk counts, preprocessed metadata agreement).
+/// A caller assembling the opening argument itself inherits the rest of `verify_batch`'s
+/// proof-shape validation, none of which happens here:
+///
+/// - per-instance counts agreeing across `airs`, opened values, public values, degree bits,
+///   lookup terminals and lookups ([`InvalidProofShapeError::InstanceCountMismatch`]);
+/// - presence of the ZK randomization commitment and its per-instance opened values matching
+///   [`Pcs::ZK`], and each random opening's dimension;
+/// - public-value counts, trace-width agreement (local and next) and the
+///   `main_next_row_columns` presence rule;
+/// - quotient-chunk counts and per-chunk dimensions;
+/// - preprocessed presence/width agreement against `CommonData` and the
+///   `preprocessed_next_row_columns` presence rule;
+/// - one lookup terminal per AIR with lookups and none otherwise, plus the lookup-commitment
+///   consistency check (`commitments.permutation.is_some()` iff some AIR has lookups);
+/// - [`check_multiplicity_height_bound`], the LogUp bound that stops multiplicities wrapping
+///   modulo `p`;
+/// - [`check_periodic_column_lengths`].
+///
+/// A caller needing all of them should either call `verify_batch` directly or replicate the
+/// ones it needs.
 ///
 /// # Returns
 ///
@@ -60,7 +95,6 @@ use crate::transcript::BatchTranscript;
 /// instance's quotient-chunk domains, a byproduct of this construction that `verify_batch`
 /// also needs for its own post-opening constraint check.
 #[expect(clippy::too_many_arguments)]
-#[expect(clippy::type_complexity)]
 pub fn commitments_with_opening_points<SC, A>(
     config: &SC,
     airs: &[A],
@@ -69,37 +103,36 @@ pub fn commitments_with_opening_points<SC, A>(
     opened_values: &BatchOpenedValues<Challenge<SC>>,
     common: &CommonData<SC>,
     degree_bits: &[usize],
-    ext_domain_sizes: &[usize],
     preprocessed_widths: &[usize],
     log_num_quotient_chunks: &[usize],
-    num_quotient_chunks: &[usize],
-) -> Result<
-    (
-        Vec<(
-            Commitment<SC>,
-            Vec<(Domain<SC>, Vec<(Challenge<SC>, Vec<Challenge<SC>>)>)>,
-        )>,
-        Vec<Vec<Domain<SC>>>,
-    ),
-    BatchVerificationError<PcsError<SC>>,
->
+) -> Result<OpeningArgumentWithQuotientDomains<SC>, BatchVerificationError<PcsError<SC>>>
 where
     SC: SGC,
     A: BaseAir<Val<SC>>,
 {
     let pcs = config.pcs();
+    let is_zk = config.is_zk();
     let mut coms_to_verify = vec![];
 
-    // Trace round: per instance, open at zeta and zeta_next
-    let (trace_domains, ext_trace_domains): (Vec<Domain<SC>>, Vec<Domain<SC>>) = ext_domain_sizes
+    // Trace round: per instance, open at zeta and zeta_next.
+    //
+    // The extended domain size is `1 << degree_bits[i]`, gated by `validate_degree_bits` so
+    // that an out-of-range degree is an error rather than an overflow, and so that a caller
+    // cannot pass a domain size disagreeing with the degree bits it also passed.
+    let trace_domain_pairs = degree_bits
         .iter()
-        .map(|&ext_size| {
-            (
-                pcs.natural_domain_for_degree(ext_size >> config.is_zk()),
-                pcs.natural_domain_for_degree(ext_size),
-            )
+        .enumerate()
+        .map(|(i, &ext_db)| {
+            let (_, ext_domain_size) =
+                validate_degree_bits(Some(i), ext_db, is_zk, pcs.log_max_lde_height())?;
+            Ok((
+                pcs.natural_domain_for_degree(ext_domain_size >> is_zk),
+                pcs.natural_domain_for_degree(ext_domain_size),
+            ))
         })
-        .unzip();
+        .collect::<Result<Vec<_>, InvalidProofShapeError>>()?;
+    let (trace_domains, ext_trace_domains): (Vec<Domain<SC>>, Vec<Domain<SC>>) =
+        trace_domain_pairs.into_iter().unzip();
 
     if let Some(random_commit) = &commitments.random {
         coms_to_verify.push((
@@ -149,7 +182,14 @@ where
         .map(|i| {
             let ext_db = degree_bits[i];
             let log_num_chunks = log_num_quotient_chunks[i];
-            let n_chunks = num_quotient_chunks[i];
+            // The committed chunk count, ZK randomization included.
+            let (_, n_chunks) = checked_log_size_sum(log_num_chunks, is_zk).ok_or_else(|| {
+                InvalidProofShapeError::QuotientDomainTooLarge {
+                    air: Some(i),
+                    maximum: usize::BITS as usize - 1,
+                    got: log_num_chunks.saturating_add(is_zk),
+                }
+            })?;
             let ext_dom = ext_trace_domains[i];
             let (quotient_domain_log_size, quotient_domain_size) =
                 checked_log_size_sum(ext_db, log_num_chunks).ok_or_else(|| {
@@ -175,7 +215,7 @@ where
         .iter()
         .map(|doms| {
             doms.iter()
-                .map(|dom| pcs.natural_domain_for_degree(dom.size() << (config.is_zk())))
+                .map(|dom| pcs.natural_domain_for_degree(dom.size() << is_zk))
                 .collect::<Vec<_>>()
         })
         .collect::<Vec<_>>();
@@ -558,10 +598,8 @@ where
         opened_values,
         common,
         degree_bits,
-        &ext_domain_sizes,
         &preprocessed_widths,
         &log_num_quotient_chunks,
-        &num_quotient_chunks,
     )?;
 
     // Verify all openings via PCS.

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -4,8 +4,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 pub use data::VerifierData;
-use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
+use p3_air::{Air, BaseAir};
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, ExtensionField, PrimeCharacteristicRing, PrimeField};
 use p3_lookup::folder::VerifierConstraintFolderWithLookups;
@@ -22,11 +22,277 @@ use p3_util::zip_eq::zip_eq;
 use tracing::{info_span, instrument};
 
 use crate::common::CommonData;
-use crate::config::{Challenge, Domain, PcsError, StarkGenericConfig as SGC, Val};
+use crate::config::{Challenge, Commitment, Domain, PcsError, StarkGenericConfig as SGC, Val};
 use crate::error::BatchVerificationError;
-use crate::proof::BatchProof;
+use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof};
 use crate::symbolic::get_log_num_quotient_chunks;
 use crate::transcript::BatchTranscript;
+
+/// Builds the `commitments_with_opening_points` a batch-STARK proof's PCS opening argument is
+/// checked against: one round per commitment (an optional ZK-randomization round, the trace
+/// round, the quotient-chunks round, an optional preprocessed round, an optional permutation
+/// round), each pairing a commitment with the domains/points/claimed-evaluations
+/// [`Pcs::verify`] checks it at.
+///
+/// This is exactly what [`verify_batch`] builds internally before calling `pcs.verify` — pulled
+/// out so a caller that has already sampled `zeta` from its own transcript replay (and already
+/// has the per-instance shape data `verify_batch`'s own precompute loop derives) can build the
+/// same structure without needing a live `A: Air<...>` reference for anything beyond
+/// [`BaseAir::main_next_row_columns`]/[`BaseAir::preprocessed_next_row_columns`] — e.g. a
+/// recursive verifier that reads trace width and quotient degree from the proof's own
+/// opened-value shape instead of a live AIR.
+///
+/// # Arguments
+///
+/// - `zeta` — the out-of-domain point, already sampled from the transcript.
+/// - `ext_domain_sizes`, `preprocessed_widths`, `log_num_quotient_chunks`,
+///   `num_quotient_chunks` — per-instance, derived exactly as `verify_batch`'s own precompute
+///   loop computes them.
+///
+/// Performs no transcript interaction and no shape validation beyond what the construction
+/// itself requires (e.g. matching quotient-chunk counts): a caller needing `verify_batch`'s
+/// full set of proof-shape checks should either call `verify_batch` directly or replicate the
+/// checks it needs itself.
+///
+/// # Returns
+///
+/// `(commitments_with_opening_points, quotient_domains)` — the second element is each
+/// instance's quotient-chunk domains, a byproduct of this construction that `verify_batch`
+/// also needs for its own post-opening constraint check.
+#[expect(clippy::too_many_arguments)]
+#[expect(clippy::type_complexity)]
+pub fn commitments_with_opening_points<SC, A>(
+    config: &SC,
+    airs: &[A],
+    zeta: Challenge<SC>,
+    commitments: &BatchCommitments<Commitment<SC>>,
+    opened_values: &BatchOpenedValues<Challenge<SC>>,
+    common: &CommonData<SC>,
+    degree_bits: &[usize],
+    ext_domain_sizes: &[usize],
+    preprocessed_widths: &[usize],
+    log_num_quotient_chunks: &[usize],
+    num_quotient_chunks: &[usize],
+) -> Result<
+    (
+        Vec<(
+            Commitment<SC>,
+            Vec<(Domain<SC>, Vec<(Challenge<SC>, Vec<Challenge<SC>>)>)>,
+        )>,
+        Vec<Vec<Domain<SC>>>,
+    ),
+    BatchVerificationError<PcsError<SC>>,
+>
+where
+    SC: SGC,
+    A: BaseAir<Val<SC>>,
+{
+    let pcs = config.pcs();
+    let mut coms_to_verify = vec![];
+
+    // Trace round: per instance, open at zeta and zeta_next
+    let (trace_domains, ext_trace_domains): (Vec<Domain<SC>>, Vec<Domain<SC>>) = ext_domain_sizes
+        .iter()
+        .map(|&ext_size| {
+            (
+                pcs.natural_domain_for_degree(ext_size >> config.is_zk()),
+                pcs.natural_domain_for_degree(ext_size),
+            )
+        })
+        .unzip();
+
+    if let Some(random_commit) = &commitments.random {
+        coms_to_verify.push((
+            random_commit.clone(),
+            ext_trace_domains
+                .iter()
+                .zip(opened_values.instances.iter())
+                .map(|(domain, inst_opened_vals)| {
+                    // We already checked that random is present for each instance when ZK is enabled.
+                    let random_vals = inst_opened_vals.base_opened_values.random.as_ref().unwrap();
+                    (*domain, vec![(zeta, random_vals.clone())])
+                })
+                .collect::<Vec<_>>(),
+        ));
+    }
+
+    let trace_round: Vec<_> = ext_trace_domains
+        .iter()
+        .zip(opened_values.instances.iter())
+        .enumerate()
+        .map(|(i, (ext_dom, inst_opened_vals))| {
+            let mut points = vec![(
+                zeta,
+                inst_opened_vals.base_opened_values.trace_local.clone(),
+            )];
+            if !airs[i].main_next_row_columns().is_empty() {
+                let zeta_next = trace_domains[i]
+                    .next_point(zeta)
+                    .ok_or(VerificationError::NextPointUnavailable)?;
+                points.push((
+                    zeta_next,
+                    inst_opened_vals
+                        .base_opened_values
+                        .trace_next
+                        .clone()
+                        .expect("checked in shape validation"),
+                ));
+            }
+            Ok((*ext_dom, points))
+        })
+        .collect::<Result<Vec<_>, VerificationError<PcsError<SC>>>>()?;
+    coms_to_verify.push((commitments.main.clone(), trace_round));
+
+    // Quotient chunks round: flatten per-instance chunks to match commit order.
+    // Use extended domains for the outer commit domain, with size = base_degree * num_quotient_chunks.
+    let quotient_domains: Vec<Vec<Domain<SC>>> = (0..degree_bits.len())
+        .map(|i| {
+            let ext_db = degree_bits[i];
+            let log_num_chunks = log_num_quotient_chunks[i];
+            let n_chunks = num_quotient_chunks[i];
+            let ext_dom = ext_trace_domains[i];
+            let (quotient_domain_log_size, quotient_domain_size) =
+                checked_log_size_sum(ext_db, log_num_chunks).ok_or_else(|| {
+                    InvalidProofShapeError::QuotientDomainTooLarge {
+                        air: Some(i),
+                        maximum: usize::BITS as usize - 1,
+                        got: ext_db.saturating_add(log_num_chunks),
+                    }
+                })?;
+            let qdom = ext_dom
+                .try_create_disjoint_domain(quotient_domain_size)
+                .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
+                    air: Some(i),
+                    maximum: pcs.log_max_lde_height(),
+                    got: quotient_domain_log_size,
+                })?;
+            Ok(qdom.split_domains(n_chunks))
+        })
+        .collect::<Result<Vec<_>, InvalidProofShapeError>>()?;
+
+    // When ZK is enabled, the size of the quotient chunks' domains doubles.
+    let randomized_quotient_chunks_domains = quotient_domains
+        .iter()
+        .map(|doms| {
+            doms.iter()
+                .map(|dom| pcs.natural_domain_for_degree(dom.size() << (config.is_zk())))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // Build the per-matrix openings for the aggregated quotient commitment.
+    let mut qc_round = Vec::new();
+    for (i, domains) in randomized_quotient_chunks_domains.iter().enumerate() {
+        let inst_qcs = &opened_values.instances[i]
+            .base_opened_values
+            .quotient_chunks;
+        for (d, vals) in zip_eq(
+            domains.iter(),
+            inst_qcs,
+            VerificationError::from(InvalidProofShapeError::QuotientDomainsCountMismatch {
+                air: i,
+            }),
+        )? {
+            qc_round.push((*d, vec![(zeta, vals.clone())]));
+        }
+    }
+    coms_to_verify.push((commitments.quotient_chunks.clone(), qc_round));
+
+    // Preprocessed rounds: a single global commitment with one matrix per
+    // instance that has preprocessed columns.
+    if let Some(global) = &common.preprocessed {
+        let mut pre_round = Vec::new();
+
+        for (matrix_index, &inst_idx) in global.matrix_to_instance.iter().enumerate() {
+            let pre_w = preprocessed_widths[inst_idx];
+            if pre_w == 0 {
+                return Err(
+                    InvalidProofShapeError::PreprocessedMetadataMismatch { air: inst_idx }.into(),
+                );
+            }
+
+            let inst = &opened_values.instances[inst_idx];
+            let local = inst
+                .base_opened_values
+                .preprocessed_local
+                .as_ref()
+                .ok_or_else(|| {
+                    VerificationError::from(InvalidProofShapeError::MissingPreprocessedValues {
+                        air: inst_idx,
+                    })
+                })?;
+
+            // Validate that the preprocessed data's extended degree matches what we expect.
+            let ext_db = degree_bits[inst_idx];
+
+            let meta = global.instances[inst_idx].as_ref().ok_or_else(|| {
+                VerificationError::from(InvalidProofShapeError::PreprocessedMetadataMismatch {
+                    air: inst_idx,
+                })
+            })?;
+            if meta.matrix_index != matrix_index || meta.degree_bits != ext_db {
+                return Err(
+                    InvalidProofShapeError::PreprocessedMetadataMismatch { air: inst_idx }.into(),
+                );
+            }
+
+            let meta_db = meta.degree_bits;
+            let pre_domain = pcs.natural_domain_for_degree(1 << meta_db);
+            if !airs[inst_idx].preprocessed_next_row_columns().is_empty() {
+                let next = inst
+                    .base_opened_values
+                    .preprocessed_next
+                    .as_ref()
+                    .ok_or_else(|| {
+                        VerificationError::from(InvalidProofShapeError::MissingPreprocessedValues {
+                            air: inst_idx,
+                        })
+                    })?;
+                let zeta_next_i = trace_domains[inst_idx]
+                    .next_point(zeta)
+                    .ok_or(VerificationError::NextPointUnavailable)?;
+
+                pre_round.push((
+                    pre_domain,
+                    vec![(zeta, local.clone()), (zeta_next_i, next.clone())],
+                ));
+            } else {
+                pre_round.push((pre_domain, vec![(zeta, local.clone())]));
+            }
+        }
+
+        coms_to_verify.push((global.commitment.clone(), pre_round));
+    }
+
+    if commitments.permutation.is_some() {
+        let permutation_commit = commitments.permutation.clone().unwrap();
+        let mut permutation_round = Vec::new();
+        for (i, (ext_dom, inst_opened_vals)) in ext_trace_domains
+            .iter()
+            .zip(opened_values.instances.iter())
+            .enumerate()
+        {
+            if inst_opened_vals.permutation_local.len() != inst_opened_vals.permutation_next.len() {
+                return Err(LookupError::PermutationLengthMismatch { air: i }.into());
+            }
+            if !inst_opened_vals.permutation_local.is_empty() {
+                let zeta_next = trace_domains[i]
+                    .next_point(zeta)
+                    .ok_or(VerificationError::NextPointUnavailable)?;
+                permutation_round.push((
+                    *ext_dom,
+                    vec![
+                        (zeta, inst_opened_vals.permutation_local.clone()),
+                        (zeta_next, inst_opened_vals.permutation_next.clone()),
+                    ],
+                ));
+            }
+        }
+        coms_to_verify.push((permutation_commit, permutation_round));
+    }
+
+    Ok((coms_to_verify, quotient_domains))
+}
 
 #[instrument(skip_all)]
 pub fn verify_batch<SC, A>(
@@ -284,213 +550,31 @@ where
     // Sample OOD point.
     let zeta = transcript.sample_zeta();
 
-    // Build commitments_with_opening_points to verify openings.
-    let mut coms_to_verify = vec![];
-
-    // Trace round: per instance, open at zeta and zeta_next
-    let (trace_domains, ext_trace_domains): (Vec<Domain<SC>>, Vec<Domain<SC>>) = ext_domain_sizes
-        .iter()
-        .map(|&ext_size| {
-            (
-                pcs.natural_domain_for_degree(ext_size >> config.is_zk()),
-                pcs.natural_domain_for_degree(ext_size),
-            )
-        })
-        .unzip();
-
-    if let Some(random_commit) = &commitments.random {
-        coms_to_verify.push((
-            random_commit.clone(),
-            ext_trace_domains
-                .iter()
-                .zip(opened_values.instances.iter())
-                .map(|(domain, inst_opened_vals)| {
-                    // We already checked that random is present for each instance when ZK is enabled.
-                    let random_vals = inst_opened_vals.base_opened_values.random.as_ref().unwrap();
-                    (*domain, vec![(zeta, random_vals.clone())])
-                })
-                .collect::<Vec<_>>(),
-        ));
-    }
-
-    let trace_round: Vec<_> = ext_trace_domains
-        .iter()
-        .zip(opened_values.instances.iter())
-        .enumerate()
-        .map(|(i, (ext_dom, inst_opened_vals))| {
-            let mut points = vec![(
-                zeta,
-                inst_opened_vals.base_opened_values.trace_local.clone(),
-            )];
-            if !airs[i].main_next_row_columns().is_empty() {
-                let zeta_next = trace_domains[i]
-                    .next_point(zeta)
-                    .ok_or(VerificationError::NextPointUnavailable)?;
-                points.push((
-                    zeta_next,
-                    inst_opened_vals
-                        .base_opened_values
-                        .trace_next
-                        .clone()
-                        .expect("checked in shape validation"),
-                ));
-            }
-            Ok((*ext_dom, points))
-        })
-        .collect::<Result<Vec<_>, VerificationError<PcsError<SC>>>>()?;
-    coms_to_verify.push((commitments.main.clone(), trace_round));
-
-    // Quotient chunks round: flatten per-instance chunks to match commit order.
-    // Use extended domains for the outer commit domain, with size = base_degree * num_quotient_chunks.
-    let quotient_domains: Vec<Vec<Domain<SC>>> = (0..degree_bits.len())
-        .map(|i| {
-            let ext_db = degree_bits[i];
-            let log_num_chunks = log_num_quotient_chunks[i];
-            let n_chunks = num_quotient_chunks[i];
-            let ext_dom = ext_trace_domains[i];
-            let (quotient_domain_log_size, quotient_domain_size) =
-                checked_log_size_sum(ext_db, log_num_chunks).ok_or_else(|| {
-                    InvalidProofShapeError::QuotientDomainTooLarge {
-                        air: Some(i),
-                        maximum: usize::BITS as usize - 1,
-                        got: ext_db.saturating_add(log_num_chunks),
-                    }
-                })?;
-            let qdom = ext_dom
-                .try_create_disjoint_domain(quotient_domain_size)
-                .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
-                    air: Some(i),
-                    maximum: pcs.log_max_lde_height(),
-                    got: quotient_domain_log_size,
-                })?;
-            Ok(qdom.split_domains(n_chunks))
-        })
-        .collect::<Result<Vec<_>, InvalidProofShapeError>>()?;
-
-    // When ZK is enabled, the size of the quotient chunks' domains doubles.
-    let randomized_quotient_chunks_domains = quotient_domains
-        .iter()
-        .map(|doms| {
-            doms.iter()
-                .map(|dom| pcs.natural_domain_for_degree(dom.size() << (config.is_zk())))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    // Build the per-matrix openings for the aggregated quotient commitment.
-    let mut qc_round = Vec::new();
-    for (i, domains) in randomized_quotient_chunks_domains.iter().enumerate() {
-        let inst_qcs = &opened_values.instances[i]
-            .base_opened_values
-            .quotient_chunks;
-        for (d, vals) in zip_eq(
-            domains.iter(),
-            inst_qcs,
-            VerificationError::from(InvalidProofShapeError::QuotientDomainsCountMismatch {
-                air: i,
-            }),
-        )? {
-            qc_round.push((*d, vec![(zeta, vals.clone())]));
-        }
-    }
-    coms_to_verify.push((commitments.quotient_chunks.clone(), qc_round));
-
-    // Preprocessed rounds: a single global commitment with one matrix per
-    // instance that has preprocessed columns.
-    if let Some(global) = &common.preprocessed {
-        let mut pre_round = Vec::new();
-
-        for (matrix_index, &inst_idx) in global.matrix_to_instance.iter().enumerate() {
-            let pre_w = preprocessed_widths[inst_idx];
-            if pre_w == 0 {
-                return Err(
-                    InvalidProofShapeError::PreprocessedMetadataMismatch { air: inst_idx }.into(),
-                );
-            }
-
-            let inst = &opened_values.instances[inst_idx];
-            let local = inst
-                .base_opened_values
-                .preprocessed_local
-                .as_ref()
-                .ok_or_else(|| {
-                    VerificationError::from(InvalidProofShapeError::MissingPreprocessedValues {
-                        air: inst_idx,
-                    })
-                })?;
-
-            // Validate that the preprocessed data's extended degree matches what we expect.
-            let ext_db = degree_bits[inst_idx];
-
-            let meta = global.instances[inst_idx].as_ref().ok_or_else(|| {
-                VerificationError::from(InvalidProofShapeError::PreprocessedMetadataMismatch {
-                    air: inst_idx,
-                })
-            })?;
-            if meta.matrix_index != matrix_index || meta.degree_bits != ext_db {
-                return Err(
-                    InvalidProofShapeError::PreprocessedMetadataMismatch { air: inst_idx }.into(),
-                );
-            }
-
-            let meta_db = meta.degree_bits;
-            let pre_domain = pcs.natural_domain_for_degree(1 << meta_db);
-            if !airs[inst_idx].preprocessed_next_row_columns().is_empty() {
-                let next = inst
-                    .base_opened_values
-                    .preprocessed_next
-                    .as_ref()
-                    .ok_or_else(|| {
-                        VerificationError::from(InvalidProofShapeError::MissingPreprocessedValues {
-                            air: inst_idx,
-                        })
-                    })?;
-                let zeta_next_i = trace_domains[inst_idx]
-                    .next_point(zeta)
-                    .ok_or(VerificationError::NextPointUnavailable)?;
-
-                pre_round.push((
-                    pre_domain,
-                    vec![(zeta, local.clone()), (zeta_next_i, next.clone())],
-                ));
-            } else {
-                pre_round.push((pre_domain, vec![(zeta, local.clone())]));
-            }
-        }
-
-        coms_to_verify.push((global.commitment.clone(), pre_round));
-    }
-
-    if is_lookup {
-        let permutation_commit = commitments.permutation.clone().unwrap();
-        let mut permutation_round = Vec::new();
-        for (i, (ext_dom, inst_opened_vals)) in ext_trace_domains
-            .iter()
-            .zip(opened_values.instances.iter())
-            .enumerate()
-        {
-            if inst_opened_vals.permutation_local.len() != inst_opened_vals.permutation_next.len() {
-                return Err(LookupError::PermutationLengthMismatch { air: i }.into());
-            }
-            if !inst_opened_vals.permutation_local.is_empty() {
-                let zeta_next = trace_domains[i]
-                    .next_point(zeta)
-                    .ok_or(VerificationError::NextPointUnavailable)?;
-                permutation_round.push((
-                    *ext_dom,
-                    vec![
-                        (zeta, inst_opened_vals.permutation_local.clone()),
-                        (zeta_next, inst_opened_vals.permutation_next.clone()),
-                    ],
-                ));
-            }
-        }
-        coms_to_verify.push((permutation_commit, permutation_round));
-    }
+    let (coms_to_verify, quotient_domains) = commitments_with_opening_points(
+        config,
+        airs,
+        zeta,
+        commitments,
+        opened_values,
+        common,
+        degree_bits,
+        &ext_domain_sizes,
+        &preprocessed_widths,
+        &log_num_quotient_chunks,
+        &num_quotient_chunks,
+    )?;
 
     // Verify all openings via PCS.
     pcs.verify(coms_to_verify, opening_proof, &mut transcript.challenger)
         .map_err(VerificationError::InvalidOpeningArgument)?;
+
+    // Un-extended trace domains, one per instance — needed below for periodic-column
+    // evaluation. `commitments_with_opening_points` derives the same domains internally but
+    // doesn't expose them, since only the caller's own post-opening constraint check needs them.
+    let trace_domains: Vec<Domain<SC>> = ext_domain_sizes
+        .iter()
+        .map(|&ext_size| pcs.natural_domain_for_degree(ext_size >> config.is_zk()))
+        .collect();
 
     // Now check constraint equality per instance.
     // For each instance, recombine quotient from chunks at zeta and compare to folded constraints.

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -2799,3 +2799,63 @@ fn test_invalid_permutation_opening_len_rejected() {
         "Verifier should reject permutation opening with wrong length"
     );
 }
+
+// --- Lookup-packing budget override ---
+
+/// Build a single `MulAirLookups` instance whose global lookups all target the same bus,
+/// so `pack_same_bus` has multiple same-bus interactions available to fold.
+fn mul_air_with_n_same_bus_lookups(reps: usize) -> (DemoAirWithLookups, usize) {
+    let mul_air = MulAir { reps };
+    let mul_air_lookups = MulAirLookups::new(mul_air, false, true, vec!["Bus".to_string(); reps]);
+    let log_height = 4; // 16 rows
+    (DemoAirWithLookups::MulLookups(mul_air_lookups), log_height)
+}
+
+#[test]
+fn from_airs_and_degrees_with_lookup_budgets_at_zero_matches_the_free_budget() {
+    let config = make_config(2028);
+    let (air, log_height) = mul_air_with_n_same_bus_lookups(4);
+    let airs = [air];
+
+    let default = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
+    let overridden = ProverData::<MyConfig>::from_airs_and_degrees_with_lookup_budgets(
+        &config,
+        &airs,
+        &[log_height],
+        &[0],
+    );
+
+    assert_eq!(
+        format!("{:?}", default.common.lookups),
+        format!("{:?}", overridden.common.lookups),
+        "a zero override must reproduce the free-budget packing exactly"
+    );
+}
+
+#[test]
+fn from_airs_and_degrees_with_lookup_budgets_packs_past_the_free_budget() {
+    let config = make_config(2029);
+    let (air, log_height) = mul_air_with_n_same_bus_lookups(4);
+    let airs = [air];
+
+    let free = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
+    let free_num_lookups = free.common.lookups[0].len();
+
+    // A large override forces every same-bus interaction into one column.
+    let forced = ProverData::<MyConfig>::from_airs_and_degrees_with_lookup_budgets(
+        &config,
+        &airs,
+        &[log_height],
+        &[usize::MAX],
+    );
+    let forced_num_lookups = forced.common.lookups[0].len();
+
+    assert!(
+        forced_num_lookups < free_num_lookups,
+        "override must pack past the free ceiling: free={free_num_lookups}, forced={forced_num_lookups}"
+    );
+    assert_eq!(
+        forced_num_lookups, 1,
+        "usize::MAX budget packs all 4 same-bus interactions into 1 column"
+    );
+}

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -2802,6 +2802,10 @@ fn test_invalid_permutation_opening_len_rejected() {
 
 // --- Lookup-packing budget override ---
 
+/// The `log_blowup` every `FriParameters::new_testing` config in this file uses, and so the
+/// quotient-chunk ceiling `from_airs_and_degrees_with_lookup_budgets` holds overrides to.
+const TESTING_LOG_BLOWUP: usize = 2;
+
 /// Build a single `MulAirLookups` instance whose global lookups all target the same bus,
 /// so `pack_same_bus` has multiple same-bus interactions available to fold.
 fn mul_air_with_n_same_bus_lookups(reps: usize) -> (DemoAirWithLookups, usize) {
@@ -2823,6 +2827,7 @@ fn from_airs_and_degrees_with_lookup_budgets_at_zero_matches_the_free_budget() {
         &airs,
         &[log_height],
         &[0],
+        TESTING_LOG_BLOWUP,
     );
 
     assert_eq!(
@@ -2841,12 +2846,15 @@ fn from_airs_and_degrees_with_lookup_budgets_packs_past_the_free_budget() {
     let free = ProverData::<MyConfig>::from_airs_and_degrees(&config, &airs, &[log_height]);
     let free_num_lookups = free.common.lookups[0].len();
 
-    // A large override forces every same-bus interaction into one column.
+    // An override past the free ceiling forces same-bus interactions into fewer columns,
+    // spending quotient chunks to do it. `4` keeps the resulting bucket inside the testing
+    // config's blowup; see the panic test below for what happens when it doesn't.
     let forced = ProverData::<MyConfig>::from_airs_and_degrees_with_lookup_budgets(
         &config,
         &airs,
         &[log_height],
-        &[usize::MAX],
+        &[4],
+        TESTING_LOG_BLOWUP,
     );
     let forced_num_lookups = forced.common.lookups[0].len();
 
@@ -2854,8 +2862,23 @@ fn from_airs_and_degrees_with_lookup_budgets_packs_past_the_free_budget() {
         forced_num_lookups < free_num_lookups,
         "override must pack past the free ceiling: free={free_num_lookups}, forced={forced_num_lookups}"
     );
-    assert_eq!(
-        forced_num_lookups, 1,
-        "usize::MAX budget packs all 4 same-bus interactions into 1 column"
+}
+
+#[test]
+#[should_panic(expected = "past the PCS blowup")]
+fn from_airs_and_degrees_with_lookup_budgets_rejects_overshooting_the_blowup() {
+    let config = make_config(2030);
+    let (air, log_height) = mul_air_with_n_same_bus_lookups(6);
+    let airs = [air];
+
+    // Folding six same-bus interactions into one column pushes the quotient bucket well past
+    // the rate budget of a `log_blowup = 1` low-degree test. Nothing downstream detects that,
+    // so it has to fail here, at setup.
+    let _ = ProverData::<MyConfig>::from_airs_and_degrees_with_lookup_budgets(
+        &config,
+        &airs,
+        &[log_height],
+        &[usize::MAX],
+        1,
     );
 }

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -350,6 +350,23 @@ where
     }
 }
 
+/// A joint commitment to a collection of matrices and their opening at
+/// a collection of points.
+///
+/// This is the shape [`Pcs::verify`] checks an opening argument against, so it is also what
+/// any code building that argument produces.
+pub type CommitmentWithOpeningPoints<Challenge, Commitment, Domain> = (
+    Commitment,
+    // For each matrix in the commitment:
+    Vec<(
+        // The domain of the matrix
+        Domain,
+        // A vector of (point, claimed_evaluation) pairs.
+        // The claimed evaluation count per point is also the matrix width used by verification.
+        Vec<(Challenge, Vec<Challenge>)>,
+    )>,
+);
+
 pub type OpenedValues<F> = Vec<OpenedValuesForRound<F>>;
 pub type OpenedValuesForRound<F> = Vec<OpenedValuesForMatrix<F>>;
 pub type OpenedValuesForMatrix<F> = Vec<OpenedValuesForPoint<F>>;

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -47,8 +47,14 @@ impl<F: Field, M: Mmcs<F>> CommitPhaseMultiStep<F, M> {
     /// Convert `log_arity` to `usize` and enforce the protocol bounds.
     ///
     /// Returns `None` when `log_arity` is zero or exceeds `max_log_arity`.
+    ///
+    /// Every field of this struct deserializes straight from an untrusted proof, so this is
+    /// the guard that turns a proof-controlled `log_arity` into a schedule entry usable by
+    /// [`crate::verifier::fold_query`]. It is public for that reason: a caller replaying the
+    /// fold chain outside [`crate::verifier::verify_fri`] must derive its `log_arities`
+    /// through this method.
     #[inline]
-    pub(crate) fn checked_log_arity(&self, max_log_arity: usize) -> Option<usize> {
+    pub fn checked_log_arity(&self, max_log_arity: usize) -> Option<usize> {
         let log_arity = self.log_arity as usize;
         (1..=max_log_arity)
             .contains(&log_arity)

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -76,19 +76,10 @@ pub type ProverDataWithOpeningPoints<'a, EF, ProverData> = (
     >,
 );
 
-/// A joint commitment to a collection of matrices and their opening at
-/// a collection of points.
-pub type CommitmentWithOpeningPoints<Challenge, Commitment, Domain> = (
-    Commitment,
-    // For each matrix in the commitment:
-    Vec<(
-        // The domain of the matrix
-        Domain,
-        // A vector of (point, claimed_evaluation) pairs.
-        // The claimed evaluation count per point is also the matrix width used by verification.
-        Vec<(Challenge, Vec<Challenge>)>,
-    )>,
-);
+// Re-exported so `p3_fri::CommitmentWithOpeningPoints` keeps naming the shape this PCS
+// verifies against; it is defined in `p3-commit` alongside `Pcs` so crates that build an
+// opening argument without depending on FRI can name it too.
+pub use p3_commit::CommitmentWithOpeningPoints;
 
 pub struct TwoAdicFriFolding<InputProof, InputError>(pub PhantomData<(InputProof, InputError)>);
 

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -74,6 +74,18 @@ where
     },
     #[error("final folded height mismatch: expected {expected}, got {got}")]
     FinalFoldHeightMismatch { expected: usize, got: usize },
+    /// The arity schedule folds past the final domain size.
+    ///
+    /// Reducing `log_global_max_height` by `total_log_reduction` bits would drop below
+    /// `log_final_height`, so the schedule cannot describe a valid fold chain.
+    #[error(
+        "fold schedule reduces 2^{log_global_max_height} by {total_log_reduction} bits, past the final height 2^{log_final_height}"
+    )]
+    FoldScheduleTooLong {
+        total_log_reduction: usize,
+        log_global_max_height: usize,
+        log_final_height: usize,
+    },
     #[error(
         "unconsumed reduced openings remain after folding: next log height {next_log_height}, remaining {remaining}"
     )]
@@ -219,27 +231,16 @@ where
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Every round must open every query, and each opening must carry
-    // exactly arity - 1 sibling values.
-    for (round, (opening, &log_arity)) in
-        izip!(&proof.commit_phase_openings, &log_arities).enumerate()
-    {
+    // Every round must open exactly the sampled queries: no fewer, and no unopened extras
+    // riding along in the transcript. The per-query sibling counts are checked by
+    // `fold_query` itself, which is the code that indexes them.
+    for (round, opening) in proof.commit_phase_openings.iter().enumerate() {
         if opening.sibling_values.len() != params.num_queries {
             return Err(FriError::CommitPhaseQueryCountMismatch {
                 round,
                 expected: params.num_queries,
                 got: opening.sibling_values.len(),
             });
-        }
-        let arity = 1 << log_arity;
-        for siblings in &opening.sibling_values {
-            if siblings.len() != arity - 1 {
-                return Err(FriError::SiblingValuesLengthMismatch {
-                    round,
-                    expected: arity - 1,
-                    got: siblings.len(),
-                });
-            }
         }
     }
 
@@ -452,6 +453,26 @@ where
 /// With variable arity, each round may fold by a different factor determined by the
 /// `log_arity` field in the opening.
 ///
+/// # Security
+///
+/// The returned value is **not authenticated**. It is the folded evaluation implied by
+/// the rows this pass reconstructed from proof data, and it only becomes meaningful once
+/// the caller authenticates those rows against `commit_phase_commits` — the
+/// [`Mmcs::verify_multi_batch`] loop at the end of [`verify_fri`]. On its own it carries no
+/// guarantee that the prover ever committed to the codeword it was folded from.
+///
+/// All shape obligations on proof-controlled input are checked here, so the function is
+/// total on well-typed input: every round must open this `query` with exactly `arity - 1`
+/// siblings, and the arity schedule must not fold past `log_final_height`. Two obligations
+/// remain the caller's:
+///
+/// - `log_arities` must be derived through [`CommitPhaseMultiStep::checked_log_arity`], which
+///   is what bounds each proof-supplied arity to `1..=max_log_arity`. Nothing here can
+///   recover `max_log_arity`, so an unbounded schedule is accepted as long as its lengths
+///   line up.
+/// - `group_indices_by_round` and `rows_by_round` must each be pre-sized to
+///   `commit_phase_commits.len()` entries; this pass indexes them by round.
+///
 /// Arguments:
 /// - `folding`: The FRI folding scheme used by the prover.
 /// - `query`: The position of this query within the sampled batch.
@@ -487,6 +508,43 @@ where
     M: Mmcs<EF>,
     Folding: FriFoldingStrategy<F, EF>,
 {
+    // Shape checks on the proof-controlled openings, before any indexing into them.
+    // `verify_fri` establishes these for every query up front; a caller replaying a single
+    // query cannot be assumed to have, and the row reconstruction below indexes
+    // `sibling_values[query]` and `siblings[..arity - 1]` directly.
+    //
+    // The cost is `O(rounds)` integer comparisons guarding `O(rounds * arity)` field
+    // operations, so it is noise on the verify path too.
+    for (round, (opening, &log_arity)) in izip!(commit_phase_openings, log_arities).enumerate() {
+        let Some(siblings) = opening.sibling_values.get(query) else {
+            return Err(FriError::CommitPhaseQueryCountMismatch {
+                round,
+                expected: query + 1,
+                got: opening.sibling_values.len(),
+            });
+        };
+        let arity = 1 << log_arity;
+        if siblings.len() != arity - 1 {
+            return Err(FriError::SiblingValuesLengthMismatch {
+                round,
+                expected: arity - 1,
+                got: siblings.len(),
+            });
+        }
+    }
+
+    // The arity schedule is proof-controlled, so it may fold past the final height, which
+    // would underflow `log_current_height - log_arity` below. Under-folding is caught by the
+    // terminal height check instead, which reports the height actually reached.
+    let total_log_reduction: usize = log_arities.iter().sum();
+    if total_log_reduction > log_global_max_height.saturating_sub(log_final_height) {
+        return Err(FriError::FoldScheduleTooLong {
+            total_log_reduction,
+            log_global_max_height,
+            log_final_height,
+        });
+    }
+
     let mut ro_iter = reduced_openings.into_iter().peekable();
 
     // These checks are not essential to security,

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -144,7 +144,7 @@ where
 /// A chain of FRI input openings allowing a verifier to check a sequence of
 /// FRI folds and rolls. The first element of each pair indicates the round of
 /// fri in which the input should be rolled in. The second element is the opening.
-type FriOpenings<F> = Vec<(usize, F)>;
+pub type FriOpenings<F> = Vec<(usize, F)>;
 
 /// Verifies a FRI proof.
 ///
@@ -468,7 +468,7 @@ where
 /// - `rows_by_round`: Collector for this query's reconstructed evaluation row at each round.
 #[expect(clippy::too_many_arguments)]
 #[inline]
-fn fold_query<Folding, F, EF, M>(
+pub fn fold_query<Folding, F, EF, M>(
     folding: &Folding,
     query: usize,
     start_index: &mut usize,
@@ -614,7 +614,7 @@ where
 ///   and openings of those matrices at a collection of points.
 #[expect(clippy::type_complexity)]
 #[inline]
-fn open_inputs<Val, Challenge, InputMmcs, FriMmcs>(
+pub fn open_inputs<Val, Challenge, InputMmcs, FriMmcs>(
     params: &FriParameters<FriMmcs>,
     log_global_max_height: usize,
     indices: &[usize],

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -12,4 +12,4 @@ pub use hiding_mmcs::*;
 pub use merkle_tree::MerkleTree;
 pub use mmcs::{MerkleTreeError, MerkleTreeMmcs, PrunedBatchOpening, PrunedProofError};
 pub use p3_symmetric::MerkleCap;
-pub use pruning::PrunedMerklePaths;
+pub use pruning::{MerkleAuthPath, PrunedMerklePaths};

--- a/merkle-tree/src/mmcs/batch.rs
+++ b/merkle-tree/src/mmcs/batch.rs
@@ -298,6 +298,7 @@ where
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use alloc::vec::Vec;
 
     use itertools::Itertools;
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -308,12 +309,14 @@ mod tests {
     use p3_symmetric::{
         CryptographicHasher, PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation,
     };
+    use proptest::prelude::*;
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
     use crate::{MerkleTreeError, MerkleTreeMmcs};
 
     type F = BabyBear;
+    type Packing = <F as Field>::Packing;
 
     type Perm = Poseidon2BabyBear<16>;
     type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
@@ -1085,5 +1088,218 @@ mod tests {
 
         // The two occurrences of query 0 must restore identically.
         assert_eq!(restored[0], restored[2]);
+    }
+
+    /// The 4-ary counterpart of the test above.
+    ///
+    /// At arity 2 every level's chunk holds a single sibling, so `num_siblings_per_path == 1`
+    /// and the restoration offset `if pos < own_pos { pos } else { pos - 1 }` is identically
+    /// `0` — every way that arithmetic could be wrong (a mis-ordered chunk, an off-by-one
+    /// against `pruning::sibling_offset`, a wrong per-level chunk stride) is invisible. At
+    /// arity 4 the offsets range over `0..3` and the strides are 3 wide, so the same
+    /// `verify_batch` cross-check now actually constrains them.
+    #[test]
+    fn restore_and_recompute_paths_matches_single_query_verification_4ary() {
+        let mut rng = SmallRng::seed_from_u64(8);
+        let perm16 = Perm::new_from_rng_128(&mut rng);
+        let perm32 = PermWide::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm16);
+        let compress = MyCompress4::new(perm32);
+        let mmcs = MyMmcs4::new(hash, compress, 0);
+
+        // Height 20 (padded to 32) injects the height-5 matrix after the first 4-ary level.
+        let mat_1 = RowMajorMatrix::<F>::rand(&mut rng, 20, 2);
+        let mat_2 = RowMajorMatrix::<F>::rand(&mut rng, 5, 3);
+        let dims = vec![
+            Dimensions {
+                width: 2,
+                height: 20,
+            },
+            Dimensions {
+                width: 3,
+                height: 5,
+            },
+        ];
+
+        let (commit, prover_data) = mmcs.commit(vec![mat_1, mat_2]);
+
+        // 1 and 2 share a leaf group; 6 joins them only at the level above the injection
+        // point; 19 stays separate to the top; 1 repeats to exercise order expansion.
+        let query_indices = vec![1usize, 2, 6, 19, 1];
+        let (opened_values, pruned_proof) = mmcs.open_multi_batch(&query_indices, &prover_data);
+
+        let restored = mmcs
+            .restore_and_recompute_paths(&dims, &query_indices, &opened_values, &pruned_proof)
+            .expect("restoration succeeds for a 4-ary mixed-height batch");
+        assert_eq!(restored.len(), query_indices.len());
+
+        for (q, &index) in query_indices.iter().enumerate() {
+            assert_eq!(restored[q].leaf_index, index);
+            mmcs.verify_batch(
+                &commit,
+                &dims,
+                index,
+                BatchOpeningRef::new(&opened_values[q], &restored[q].siblings),
+            )
+            .expect("a restored 4-ary path must independently authenticate its query");
+        }
+
+        assert_eq!(restored[0], restored[4]);
+    }
+
+    /// Randomized cross-check behind both proptests below.
+    ///
+    /// `restore_and_recompute_paths` and `verify_batch_pruned` are two entry points onto one
+    /// shared frontier walk, so this pins both ends of it:
+    ///
+    /// - every restored path must authenticate its own query through the trusted single-query
+    ///   `verify_batch` — a failure means the restored siblings are self-consistent but
+    ///   *wrong*, i.e. the scatter wrote the wrong offset, stride, or group range;
+    /// - the two entry points must accept and reject the same proofs, which is the regression
+    ///   guard for the walk they share: it is checked on the honest proof and again on a
+    ///   tampered one.
+    ///
+    /// `heights` must stay on the `ceil(max_height / 2^k)` ladder or `commit` panics, so the
+    /// caller passes exponents rather than heights.
+    fn cross_check_restored_paths<C, const N: usize>(
+        mmcs: &MerkleTreeMmcs<Packing, Packing, MyHash, C, N, 8>,
+        max_height: usize,
+        extra_exponents: &[usize],
+        widths: &[usize],
+        raw_queries: &[usize],
+        seed: u64,
+    ) where
+        C: PseudoCompressionFunction<[F; 8], N> + PseudoCompressionFunction<[Packing; 8], N> + Sync,
+    {
+        let mut rng = SmallRng::seed_from_u64(seed);
+
+        // Commit-reachable heights: the tallest, then `ceil(max_height / 2^k)` for the
+        // requested exponents, deduplicated and kept tallest-first.
+        let mut heights = vec![max_height];
+        for &k in extra_exponents {
+            heights.push(max_height.div_ceil(1 << k));
+        }
+        heights.sort_unstable_by_key(|&h| core::cmp::Reverse(h));
+        heights.dedup();
+
+        let mats: Vec<RowMajorMatrix<F>> = heights
+            .iter()
+            .zip(widths.iter().cycle())
+            .map(|(&height, &width)| RowMajorMatrix::<F>::rand(&mut rng, height, width))
+            .collect();
+        let dims: Vec<Dimensions> = mats.iter().map(|m| m.dimensions()).collect();
+
+        let (commit, prover_data) = mmcs.commit(mats);
+
+        let queries: Vec<usize> = raw_queries.iter().map(|&q| q % max_height).collect();
+        let (opened_values, pruned_proof) = mmcs.open_multi_batch(&queries, &prover_data);
+
+        let restored = mmcs
+            .restore_and_recompute_paths(&dims, &queries, &opened_values, &pruned_proof)
+            .expect("restoration succeeds for an honestly generated multiproof");
+        assert_eq!(restored.len(), queries.len());
+
+        for (q, &index) in queries.iter().enumerate() {
+            assert_eq!(restored[q].leaf_index, index);
+            mmcs.verify_batch(
+                &commit,
+                &dims,
+                index,
+                BatchOpeningRef::new(&opened_values[q], &restored[q].siblings),
+            )
+            .unwrap_or_else(|err| {
+                panic!(
+                    "restored path for query {index} failed single-query verification: {err} \
+                     (heights {heights:?}, queries {queries:?})"
+                )
+            });
+        }
+
+        // Both entry points accept the honest proof.
+        mmcs.verify_batch_pruned(&commit, &dims, &queries, &opened_values, &pruned_proof)
+            .expect("the pruned multiproof verifies");
+
+        // ...and both reject a tampered one. An all-leaves query set prunes every boundary
+        // digest away, leaving nothing to tamper with.
+        if let Some(first) = pruned_proof.sibling_hashes.first().copied() {
+            let mut tampered = pruned_proof.clone();
+            tampered.sibling_hashes[0] = [first[0] + F::ONE; 8];
+
+            assert!(
+                mmcs.verify_batch_pruned(&commit, &dims, &queries, &opened_values, &tampered)
+                    .is_err(),
+                "verification must reject a tampered multiproof"
+            );
+
+            // Restoration itself has no commitment to check against, so "reject" here means
+            // the tamper still surfaces: at least one restored path fails to authenticate.
+            // (Not every one does — a boundary digest sits on some paths and not others,
+            // which is exactly why `verify_batch_pruned` rejects the batch as a whole.)
+            let restored_from_tampered =
+                mmcs.restore_and_recompute_paths(&dims, &queries, &opened_values, &tampered);
+            let all_paths_verify = restored_from_tampered.is_ok_and(|paths| {
+                paths
+                    .iter()
+                    .zip(&queries)
+                    .enumerate()
+                    .all(|(q, (path, &index))| {
+                        mmcs.verify_batch(
+                            &commit,
+                            &dims,
+                            index,
+                            BatchOpeningRef::new(&opened_values[q], &path.siblings),
+                        )
+                        .is_ok()
+                    })
+            });
+            assert!(
+                !all_paths_verify,
+                "a tampered multiproof must break at least one restored path, \
+                 matching the rejection above (heights {heights:?}, queries {queries:?})"
+            );
+        }
+    }
+
+    proptest! {
+        /// Binary trees, including non-zero caps.
+        #[test]
+        fn proptest_restored_paths_verify_individually_binary(
+            max_height in 1usize..=70,
+            extra_exponents in prop::collection::vec(1usize..=3, 0..3),
+            widths in prop::collection::vec(1usize..=4, 1..4),
+            cap_height in 0usize..=2,
+            raw_queries in prop::collection::vec(0usize..70, 1..=6),
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let perm = Perm::new_from_rng_128(&mut rng);
+            let mmcs = MyMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), cap_height);
+            cross_check_restored_paths(
+                &mmcs, max_height, &extra_exponents, &widths, &raw_queries, seed,
+            );
+        }
+
+        /// 4-ary trees, where the per-level chunks are 3 wide and the restoration offsets are
+        /// no longer identically zero.
+        ///
+        /// `cap_height` is pinned to 0: a 4-ary commit with a non-zero cap and non-power-of-two
+        /// heights trips a pre-existing `assert!(cap.len().is_power_of_two())` in `p3_symmetric`,
+        /// which has nothing to do with restoration.
+        #[test]
+        fn proptest_restored_paths_verify_individually_4ary(
+            max_height in 1usize..=70,
+            extra_exponents in prop::collection::vec(1usize..=3, 0..3),
+            widths in prop::collection::vec(1usize..=4, 1..4),
+            raw_queries in prop::collection::vec(0usize..70, 1..=6),
+            seed in any::<u64>(),
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let perm16 = Perm::new_from_rng_128(&mut rng);
+            let perm32 = PermWide::new_from_rng_128(&mut rng);
+            let mmcs = MyMmcs4::new(MyHash::new(perm16), MyCompress4::new(perm32), 0);
+            cross_check_restored_paths(
+                &mmcs, max_height, &extra_exponents, &widths, &raw_queries, seed,
+            );
+        }
     }
 }

--- a/merkle-tree/src/mmcs/batch.rs
+++ b/merkle-tree/src/mmcs/batch.rs
@@ -1027,4 +1027,63 @@ mod tests {
             .verify_batch(&cap2, &dims, 0, BatchOpeningRef::new(&opening2, &proof2))
             .unwrap();
     }
+
+    /// Cross-checks `restore_and_recompute_paths` against the trusted single-query
+    /// `verify_batch`: every path it hands back must, on its own, authenticate its query
+    /// against the real commitment — proving the restored siblings are correct, not just
+    /// self-consistent. Exercises the two cases that matter most:
+    /// - a mixed-height batch, so restoration must fold the injected matrix's digest
+    ///   correctly (injection never appears in the pruned proof itself, see `mmcs/mod.rs`'s
+    ///   module docs);
+    /// - two queries (0 and 2) that only merge one level *above* the injection point, so their
+    ///   later-level sibling is nowhere in `verify_batch_pruned`'s own bookkeeping — only this
+    ///   function computes it;
+    /// - a duplicate query index, exercising the original-order expansion.
+    #[test]
+    fn restore_and_recompute_paths_matches_single_query_verification() {
+        let mut rng = SmallRng::seed_from_u64(7);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm);
+        let mmcs = MyMmcs::new(hash, compress, 0);
+
+        // Same shapes as `commit_mixed`: mat_1 height 5 (padded to 8) injects mat_2 (height 3)
+        // right after the first level of binary compression.
+        let mat_1 = RowMajorMatrix::<F>::rand(&mut rng, 5, 2);
+        let mat_2 = RowMajorMatrix::<F>::rand(&mut rng, 3, 3);
+        let dims = vec![
+            Dimensions {
+                width: 2,
+                height: 5,
+            },
+            Dimensions {
+                width: 3,
+                height: 3,
+            },
+        ];
+
+        let (commit, prover_data) = mmcs.commit(vec![mat_1, mat_2]);
+
+        let query_indices = vec![0usize, 2, 0];
+        let (opened_values, pruned_proof) = mmcs.open_multi_batch(&query_indices, &prover_data);
+
+        let restored = mmcs
+            .restore_and_recompute_paths(&dims, &query_indices, &opened_values, &pruned_proof)
+            .expect("restoration succeeds for a mixed-height batch with a post-injection merge");
+        assert_eq!(restored.len(), query_indices.len());
+
+        for (q, &index) in query_indices.iter().enumerate() {
+            assert_eq!(restored[q].leaf_index, index);
+            mmcs.verify_batch(
+                &commit,
+                &dims,
+                index,
+                BatchOpeningRef::new(&opened_values[q], &restored[q].siblings),
+            )
+            .expect("a restored path must independently authenticate its query");
+        }
+
+        // The two occurrences of query 0 must restore identically.
+        assert_eq!(restored[0], restored[2]);
+    }
 }

--- a/merkle-tree/src/mmcs/mod.rs
+++ b/merkle-tree/src/mmcs/mod.rs
@@ -83,6 +83,39 @@ pub struct MerkleTreeMmcs<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize
     _phantom: PhantomData<(P, PW)>,
 }
 
+/// The outcome of one amortized pruned-frontier walk.
+///
+/// Produced by [`MerkleTreeMmcs::walk_pruned_frontier`] and consumed by both of its callers:
+/// [`MerkleTreeMmcs::verify_batch_pruned`] checks `digests` against the commitment, while
+/// [`MerkleTreeMmcs::restore_and_recompute_paths`] hands `restored` back to the caller.
+struct PrunedFrontier<W, const DIGEST_ELEMS: usize> {
+    /// Final digest of every group still standing at the cap layer.
+    digests: Vec<[W; DIGEST_ELEMS]>,
+
+    /// Layer-local (cap) index of each surviving group, parallel to `digests`.
+    node_indices: Vec<usize>,
+
+    /// Ascending distinct queried leaves: the slot order `restored` is indexed by.
+    sorted_unique: Vec<usize>,
+
+    /// One authentication path per sorted-unique slot. Complete only when the walk ran with
+    /// recording enabled; otherwise these still hold just the boundary digests
+    /// [`restore_paths`] scattered, with every recomputed inner node left at its default.
+    restored: Vec<MerkleAuthPath<W, DIGEST_ELEMS>>,
+}
+
+impl<W, const DIGEST_ELEMS: usize> Default for PrunedFrontier<W, DIGEST_ELEMS> {
+    /// The walk of an empty query set: nothing to authenticate, nothing to restore.
+    fn default() -> Self {
+        Self {
+            digests: vec![],
+            node_indices: vec![],
+            sorted_unique: vec![],
+            restored: vec![],
+        }
+    }
+}
+
 impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
     MerkleTreeMmcs<P, PW, H, C, N, DIGEST_ELEMS>
 {
@@ -427,34 +460,39 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         }
     }
 
-    /// Verifies a pruned batch opening against the commitment.
+    /// Walks the pruned frontier once for all queries together, the shared engine behind
+    /// [`verify_batch_pruned`](Self::verify_batch_pruned) and
+    /// [`restore_and_recompute_paths`](Self::restore_and_recompute_paths).
     ///
-    /// Walks the tree once for all queries together: paths that share a parent
-    /// at some level reuse a single compression instead of recomputing it once
-    /// per query. Mirrors the per-path [`Mmcs::verify_batch`](p3_commit::Mmcs::verify_batch) algorithm but
-    /// fans out into level-by-level groups.
+    /// Paths that share a parent at some level reuse a single compression instead of
+    /// recomputing it once per query. Mirrors the per-path
+    /// [`Mmcs::verify_batch`](p3_commit::Mmcs::verify_batch) algorithm but fans out into
+    /// level-by-level groups.
+    ///
+    /// Every shape and consistency check the pruned-proof soundness argument relies on lives
+    /// here — the geometry gate, the sorted-unique derivation from verifier-side indices,
+    /// duplicate-opening agreement, width checks, and the group-opening agreement at each
+    /// injection point — so both entry points inherit exactly the same ones. What they do
+    /// with the result differs: one checks the surviving digests against the commitment, the
+    /// other hands back the recorded paths.
+    ///
+    /// With `RECORD`, each level additionally scatters its "other children" into *every*
+    /// query's own path rather than only the group lead's. `RECORD = false` compiles that
+    /// block out entirely, leaving the verification walk exactly as it would be written by
+    /// hand.
     ///
     /// # Index binding
     ///
     /// `indices` must come from verifier-side data (e.g. the transcript).
-    /// Each opening is checked to authenticate exactly its supplied index,
-    /// so a proof cannot silently substitute a different leaf.
-    ///
-    /// # Arguments
-    ///
-    /// - `commit`         — the Merkle cap the openings must land in.
-    /// - `dimensions`     — verifier-known dimensions of the committed matrices.
-    /// - `indices`        — leaf index for each query, in query order.
-    /// - `opened_values`  — `opened_values[q][m]` is the claimed row of matrix `m` at `indices[q]`.
-    /// - `proof`          — the pruned authentication paths.
-    pub fn verify_batch_pruned<R>(
+    /// The walk is pinned entirely to those indices, so a proof cannot silently
+    /// substitute a different leaf.
+    fn walk_pruned_frontier<R, const RECORD: bool>(
         &self,
-        commit: &<Self as Mmcs<P::Value>>::Commitment,
         dimensions: &[Dimensions],
         indices: &[usize],
         opened_values: &[Vec<R>],
         proof: &PrunedMerklePaths<PW::Value, DIGEST_ELEMS>,
-    ) -> Result<(), MerkleTreeError>
+    ) -> Result<PrunedFrontier<PW::Value, DIGEST_ELEMS>, MerkleTreeError>
     where
         R: AsRef<[P::Value]> + PartialEq,
         P: PackedValue,
@@ -492,7 +530,7 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // A proof carrying any sibling for it is malformed.
         if n_originals == 0 {
             return if proof.sibling_hashes.is_empty() {
-                Ok(())
+                Ok(PrunedFrontier::default())
             } else {
                 Err(PrunedProofError::SiblingCountMismatch {
                     expected: 0,
@@ -550,7 +588,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // - Scatters the flat boundary digests into each lead path's buffer.
         // - Rejects a proof whose digest count differs from the frontier.
         // - No hashing here: the amortized walk recomputes every inner node.
-        let restored = restore_paths(proof, &sorted_unique, &arity_schedule, full_sibling_count)?;
+        let mut restored =
+            restore_paths(proof, &sorted_unique, &arity_schedule, full_sibling_count)?;
 
         // Every representative opening must expose one row per committed matrix.
         // Ascending, distinct leaf order already holds by construction.
@@ -603,10 +642,8 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         // - `node_indices[g]` : layer-local node index for group g
         // - `lead[g]`         : sorted path whose siblings buffer we read from
         //                       (any path in the group works; we keep the first)
-        // - `sibling_cursor`  : how many sibling slots of `lead[g]` we've used
         let mut node_indices: Vec<usize> = sorted_unique.clone();
         let mut lead: Vec<usize> = (0..n_unique).collect();
-        let mut sibling_cursor: Vec<usize> = vec![0usize; n_unique];
 
         // Sorted-path-slot range `[group_lo[g], group_hi[g])` merged into
         // group `g` so far. Sorted paths only ever merge with contiguous
@@ -621,20 +658,31 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         let mut new_digests: Vec<[PW::Value; DIGEST_ELEMS]> = Vec::with_capacity(n_unique);
         let mut new_indices: Vec<usize> = Vec::with_capacity(n_unique);
         let mut new_lead: Vec<usize> = Vec::with_capacity(n_unique);
-        let mut new_cursor: Vec<usize> = Vec::with_capacity(n_unique);
         let mut new_group_lo: Vec<usize> = Vec::with_capacity(n_unique);
         let mut new_group_hi: Vec<usize> = Vec::with_capacity(n_unique);
+
+        // Prefix sums of per-level chunk sizes, matching `pruning::total_siblings_for_levels`:
+        // the level-`l` chunk of a full path starts at `chunk_base[l]`.
+        //
+        // Every frontier entry advances exactly one level per iteration, so this doubles as
+        // the sibling cursor: at level `l` every group reads its lead's chunk starting at
+        // `chunk_base[l]`, whatever merges have happened below.
+        let mut chunk_base: Vec<usize> = Vec::with_capacity(arity_schedule.len() + 1);
+        chunk_base.push(0);
+        for &step in &arity_schedule {
+            chunk_base.push(chunk_base.last().unwrap() + (step - 1));
+        }
 
         // Phase 8: Walk up the tree. At each layer we collapse contiguous
         // groups of unique paths that share a parent, replacing each group
         // with a single combined digest.
-        for &step in &arity_schedule {
+        for (level, &step) in arity_schedule.iter().enumerate() {
             let num_siblings_per_path = step - 1;
+            let chunk_start = chunk_base[level];
 
             new_digests.clear();
             new_indices.clear();
             new_lead.clear();
-            new_cursor.clear();
             new_group_lo.clear();
             new_group_hi.clear();
 
@@ -652,10 +700,16 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
 
                 let lead_path = lead[i];
                 let lead_pos = node_indices[i] - group_start;
-                // Restored paths are indexed by sorted-unique slot.
-                // The lead of the group is exactly one such slot, and owns its siblings.
-                let lead_siblings = &restored[lead_path].siblings;
-                let cursor_start = sibling_cursor[i];
+
+                // Restored paths are indexed by sorted-unique slot. The lead of the group is
+                // exactly one such slot, and owns this level's siblings. Copy its chunk out
+                // up front: under `RECORD` the scatter below writes into
+                // `restored[lead_path]` too whenever the lead is one of this group's own
+                // slots, which would conflict with holding a borrow of it.
+                let mut lead_siblings = [default_digest; N];
+                lead_siblings[..num_siblings_per_path].copy_from_slice(
+                    &restored[lead_path].siblings[chunk_start..chunk_start + num_siblings_per_path],
+                );
 
                 // Build the N-ary input array:
                 // - positions hit by group members → their current digest
@@ -679,15 +733,32 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
                         continue;
                     }
                     if !filled[k] {
-                        inputs[k] = lead_siblings[cursor_start + sib_idx];
+                        inputs[k] = lead_siblings[sib_idx];
                     }
                     sib_idx += 1;
+                }
+
+                if RECORD {
+                    // Every pre-merge entry in this group gives its own "other children" view —
+                    // at this level's own position, not the group lead's — to every original
+                    // query slot it represents (a range of one, unless it merged earlier).
+                    for k in i..j {
+                        let own_pos = node_indices[k] - group_start;
+                        for (pos, &child) in inputs.iter().enumerate().take(step) {
+                            if pos == own_pos {
+                                continue;
+                            }
+                            let offset = if pos < own_pos { pos } else { pos - 1 };
+                            for item in restored.iter_mut().take(group_hi[k]).skip(group_lo[k]) {
+                                item.siblings[chunk_start + offset] = child;
+                            }
+                        }
+                    }
                 }
 
                 new_digests.push(self.compress.compress(inputs));
                 new_indices.push(parent_idx);
                 new_lead.push(lead_path);
-                new_cursor.push(cursor_start + num_siblings_per_path);
                 new_group_lo.push(group_lo[i]);
                 new_group_hi.push(group_hi[j - 1]);
 
@@ -697,7 +768,6 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
             core::mem::swap(&mut digests, &mut new_digests);
             core::mem::swap(&mut node_indices, &mut new_indices);
             core::mem::swap(&mut lead, &mut new_lead);
-            core::mem::swap(&mut sibling_cursor, &mut new_cursor);
             core::mem::swap(&mut group_lo, &mut new_group_lo);
             core::mem::swap(&mut group_hi, &mut new_group_hi);
 
@@ -764,11 +834,63 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
             }
         }
 
-        // Phase 8: Each surviving digest must land inside the cap at its
-        // layer-local index. A single mismatch rejects the whole batch.
-        for g in 0..digests.len() {
-            let cap_idx = node_indices[g];
-            if cap_idx >= commit.num_roots() || commit[cap_idx] != digests[g] {
+        Ok(PrunedFrontier {
+            digests,
+            node_indices,
+            sorted_unique,
+            restored,
+        })
+    }
+
+    /// Verifies a pruned batch opening against the commitment.
+    ///
+    /// Walks the tree once for all queries together via
+    /// [`walk_pruned_frontier`](Self::walk_pruned_frontier): paths that share a parent at
+    /// some level reuse a single compression instead of recomputing it once per query.
+    ///
+    /// # Index binding
+    ///
+    /// `indices` must come from verifier-side data (e.g. the transcript).
+    /// Each opening is checked to authenticate exactly its supplied index,
+    /// so a proof cannot silently substitute a different leaf.
+    ///
+    /// # Arguments
+    ///
+    /// - `commit`         — the Merkle cap the openings must land in.
+    /// - `dimensions`     — verifier-known dimensions of the committed matrices.
+    /// - `indices`        — leaf index for each query, in query order.
+    /// - `opened_values`  — `opened_values[q][m]` is the claimed row of matrix `m` at `indices[q]`.
+    /// - `proof`          — the pruned authentication paths.
+    pub fn verify_batch_pruned<R>(
+        &self,
+        commit: &<Self as Mmcs<P::Value>>::Commitment,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+        opened_values: &[Vec<R>],
+        proof: &PrunedMerklePaths<PW::Value, DIGEST_ELEMS>,
+    ) -> Result<(), MerkleTreeError>
+    where
+        R: AsRef<[P::Value]> + PartialEq,
+        P: PackedValue,
+        PW: PackedValue,
+        H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
+            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
+            + Sync,
+        C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
+            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
+            + Sync,
+        PW::Value: Eq + Clone,
+        [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
+    {
+        // `RECORD = false`: nothing here reads the per-query paths, so the recording branch
+        // compiles out and this walk is exactly the amortized verification walk.
+        let frontier =
+            self.walk_pruned_frontier::<R, false>(dimensions, indices, opened_values, proof)?;
+
+        // Each surviving digest must land inside the cap at its layer-local
+        // index. A single mismatch rejects the whole batch.
+        for (&cap_idx, digest) in frontier.node_indices.iter().zip(&frontier.digests) {
+            if cap_idx >= commit.num_roots() || commit[cap_idx] != *digest {
                 return Err(CapMismatch);
             }
         }
@@ -782,11 +904,12 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
     /// [`verify_batch_pruned`](Self::verify_batch_pruned) only checks the final digest of
     /// each amortized group against the commitment; it never needs a usable per-query path,
     /// so it never records one. Some callers do need that — e.g. an in-circuit verifier built
-    /// around a single-path-per-query gadget, with no notion of a shared/amortized proof. This
-    /// walks the exact same amortized frontier (so it costs no more hashing than verification
-    /// does) but additionally scatters each level's "other children" into *every* query's own
-    /// path, not just the group lead's — including query pairs that only merge partway up the
-    /// tree, whose later-level siblings are otherwise nowhere in the pruned proof at all.
+    /// around a single-path-per-query gadget, with no notion of a shared/amortized proof.
+    /// This runs [`walk_pruned_frontier`](Self::walk_pruned_frontier) — literally the same
+    /// walk verification uses, so it costs no more hashing — with recording enabled, which
+    /// additionally scatters each level's "other children" into *every* query's own path,
+    /// not just the group lead's, including query pairs that only merge partway up the tree,
+    /// whose later-level siblings are otherwise nowhere in the pruned proof at all.
     ///
     /// Arguments match [`verify_batch_pruned`](Self::verify_batch_pruned) minus `commit`: this
     /// function does not check anything against a commitment. A caller that also wants that
@@ -818,262 +941,18 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         PW::Value: Eq + Clone,
         [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     {
-        let max_height =
-            validate_commit_reachable_heights(dimensions.iter().map(|dims| dims.height))?;
-        let arity_schedule = self.proof_arity_schedule(dimensions)?;
-        let full_sibling_count: usize = arity_schedule.iter().map(|step| step - 1).sum();
-
-        let n_originals = indices.len();
-        if opened_values.len() != n_originals {
-            return Err(WrongBatchSize);
-        }
-
-        if n_originals == 0 {
-            return if proof.sibling_hashes.is_empty() {
-                Ok(vec![])
-            } else {
-                Err(PrunedProofError::SiblingCountMismatch {
-                    expected: 0,
-                    got: proof.sibling_hashes.len(),
-                }
-                .into())
-            };
-        }
-
-        let mut sorted_unique: Vec<usize> = indices.to_vec();
-        sorted_unique.sort_unstable();
-        sorted_unique.dedup();
-        let n_unique = sorted_unique.len();
-
-        let &highest = sorted_unique.last().expect("nonempty query set");
-        if highest >= max_height {
-            return Err(IndexOutOfBounds {
-                max_height,
-                index: highest,
-            });
-        }
-
-        let mut reps: Vec<Option<usize>> = vec![None; n_unique];
-        for (orig_idx, &leaf) in indices.iter().enumerate() {
-            let slot = sorted_unique
-                .binary_search(&leaf)
-                .expect("leaf came from the query set");
-            match reps[slot] {
-                None => reps[slot] = Some(orig_idx),
-                Some(rep_idx) => {
-                    if opened_values[rep_idx] != opened_values[orig_idx] {
-                        return Err(PrunedProofError::InconsistentDuplicateOpenings { slot }.into());
-                    }
-                }
-            }
-        }
-        let reps: Vec<usize> = reps
-            .into_iter()
-            .map(|r| r.expect("every unique slot is one of the queries"))
-            .collect();
-
-        let mut restored =
-            restore_paths(proof, &sorted_unique, &arity_schedule, full_sibling_count)?;
-
-        for &rep in &reps {
-            if opened_values[rep].len() != dimensions.len() {
-                return Err(WrongBatchSize);
-            }
-            check_widths(dimensions, &opened_values[rep])?;
-        }
-
-        let mut heights_tallest_first = dimensions
-            .iter()
-            .enumerate()
-            .sorted_by_key(|(_, dims)| Reverse(dims.height))
-            .peekable();
-
-        let mut curr_height_padded = padded_len(max_height, N);
-        let leaf_height_npt = max_height.next_power_of_two();
-
-        let leaf_matrix_indices: Vec<usize> = heights_tallest_first
-            .peeking_take_while(|(_, dims)| dims.height.next_power_of_two() == leaf_height_npt)
-            .map(|(i, _)| i)
-            .collect();
-
-        let mut digests: Vec<[PW::Value; DIGEST_ELEMS]> = reps
-            .iter()
-            .map(|&rep| {
-                self.hash.hash_iter_slices(
-                    leaf_matrix_indices
-                        .iter()
-                        .map(|&mi| opened_values[rep][mi].as_ref()),
-                )
-            })
-            .collect();
-
-        let mut node_indices: Vec<usize> = sorted_unique.clone();
-        let mut lead: Vec<usize> = (0..n_unique).collect();
-        let mut sibling_cursor: Vec<usize> = vec![0usize; n_unique];
-        let mut group_lo: Vec<usize> = (0..n_unique).collect();
-        let mut group_hi: Vec<usize> = (1..=n_unique).collect();
-
-        let default_digest = [PW::Value::default(); DIGEST_ELEMS];
-
-        let mut new_digests: Vec<[PW::Value; DIGEST_ELEMS]> = Vec::with_capacity(n_unique);
-        let mut new_indices: Vec<usize> = Vec::with_capacity(n_unique);
-        let mut new_lead: Vec<usize> = Vec::with_capacity(n_unique);
-        let mut new_cursor: Vec<usize> = Vec::with_capacity(n_unique);
-        let mut new_group_lo: Vec<usize> = Vec::with_capacity(n_unique);
-        let mut new_group_hi: Vec<usize> = Vec::with_capacity(n_unique);
-
-        // Prefix sums of per-level chunk sizes, matching `pruning::total_siblings_for_levels`:
-        // the level-`l` chunk of a full path starts at `chunk_base[l]`.
-        let mut chunk_base: Vec<usize> = Vec::with_capacity(arity_schedule.len() + 1);
-        chunk_base.push(0);
-        for &step in &arity_schedule {
-            chunk_base.push(chunk_base.last().unwrap() + (step - 1));
-        }
-
-        for (level, &step) in arity_schedule.iter().enumerate() {
-            let num_siblings_per_path = step - 1;
-
-            new_digests.clear();
-            new_indices.clear();
-            new_lead.clear();
-            new_cursor.clear();
-            new_group_lo.clear();
-            new_group_hi.clear();
-
-            let mut i = 0;
-            while i < digests.len() {
-                let parent_idx = node_indices[i] / step;
-                let group_start = parent_idx * step;
-
-                let mut j = i + 1;
-                while j < digests.len() && node_indices[j] / step == parent_idx {
-                    j += 1;
-                }
-
-                let lead_path = lead[i];
-                let lead_pos = node_indices[i] - group_start;
-                let cursor_start = sibling_cursor[i];
-                // Clone out of `restored` up front: this level's own writes below touch
-                // `restored[lead_path]` too whenever `lead_path` is one of this group's
-                // original slots, which would otherwise conflict with this borrow.
-                let lead_siblings: Vec<[PW::Value; DIGEST_ELEMS]> = restored[lead_path].siblings
-                    [cursor_start..cursor_start + num_siblings_per_path]
-                    .to_vec();
-
-                let mut inputs = [default_digest; N];
-                let mut filled = [false; N];
-                for k in i..j {
-                    let pos = node_indices[k] - group_start;
-                    inputs[pos] = digests[k];
-                    filled[pos] = true;
-                }
-
-                let mut sib_idx = 0;
-                for k in 0..step {
-                    if k == lead_pos {
-                        continue;
-                    }
-                    if !filled[k] {
-                        inputs[k] = lead_siblings[sib_idx];
-                    }
-                    sib_idx += 1;
-                }
-
-                // Every pre-merge entry in this group gives its own "other children" view —
-                // at this level's own position, not the group lead's — to every original
-                // query slot it represents (a range of one, unless it merged earlier).
-                for k in i..j {
-                    let own_pos = node_indices[k] - group_start;
-                    for (pos, &child) in inputs.iter().enumerate().take(step) {
-                        if pos == own_pos {
-                            continue;
-                        }
-                        let offset = if pos < own_pos { pos } else { pos - 1 };
-                        for item in restored.iter_mut().take(group_hi[k]).skip(group_lo[k]) {
-                            item.siblings[chunk_base[level] + offset] = child;
-                        }
-                    }
-                }
-
-                new_digests.push(self.compress.compress(inputs));
-                new_indices.push(parent_idx);
-                new_lead.push(lead_path);
-                new_cursor.push(cursor_start + num_siblings_per_path);
-                new_group_lo.push(group_lo[i]);
-                new_group_hi.push(group_hi[j - 1]);
-
-                i = j;
-            }
-
-            core::mem::swap(&mut digests, &mut new_digests);
-            core::mem::swap(&mut node_indices, &mut new_indices);
-            core::mem::swap(&mut lead, &mut new_lead);
-            core::mem::swap(&mut sibling_cursor, &mut new_cursor);
-            core::mem::swap(&mut group_lo, &mut new_group_lo);
-            core::mem::swap(&mut group_hi, &mut new_group_hi);
-
-            let logical_next = curr_height_padded / step;
-            curr_height_padded = padded_len(logical_next, N);
-
-            let logical_next_npt = logical_next.next_power_of_two();
-            let next_height = heights_tallest_first
-                .peek()
-                .map(|(_, dims)| dims.height)
-                .filter(|h| h.next_power_of_two() == logical_next_npt);
-            if let Some(next_height) = next_height {
-                let inject_matrix_indices: Vec<usize> = heights_tallest_first
-                    .peeking_take_while(|(_, dims)| dims.height == next_height)
-                    .map(|(i, _)| i)
-                    .collect();
-
-                for g in 0..digests.len() {
-                    let rep_orig = reps[lead[g]];
-
-                    for (slot, &member_orig) in
-                        reps.iter().enumerate().take(group_hi[g]).skip(group_lo[g])
-                    {
-                        if slot == lead[g] {
-                            continue;
-                        }
-                        for &mi in &inject_matrix_indices {
-                            if opened_values[member_orig][mi] != opened_values[rep_orig][mi] {
-                                return Err(PrunedProofError::InconsistentGroupOpening {
-                                    slot,
-                                    matrix: mi,
-                                }
-                                .into());
-                            }
-                        }
-                    }
-
-                    let next_height_digest = self.hash.hash_iter_slices(
-                        inject_matrix_indices
-                            .iter()
-                            .map(|&mi| opened_values[rep_orig][mi].as_ref()),
-                    );
-
-                    let inject_inputs: [_; N] = core::array::from_fn(|k| {
-                        if k == 0 {
-                            digests[g]
-                        } else if k == 1 {
-                            next_height_digest
-                        } else {
-                            default_digest
-                        }
-                    });
-                    digests[g] = self.compress.compress(inject_inputs);
-                }
-            }
-        }
+        let frontier =
+            self.walk_pruned_frontier::<R, true>(dimensions, indices, opened_values, proof)?;
 
         // Expand back to the caller's original (possibly duplicated) query order.
         indices
             .iter()
             .map(|&leaf| {
-                let slot = sorted_unique
+                let slot = frontier
+                    .sorted_unique
                     .binary_search(&leaf)
                     .expect("leaf came from the query set");
-                Ok(restored[slot].clone())
+                Ok(frontier.restored[slot].clone())
             })
             .collect()
     }

--- a/merkle-tree/src/mmcs/mod.rs
+++ b/merkle-tree/src/mmcs/mod.rs
@@ -775,4 +775,306 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
 
         Ok(())
     }
+
+    /// Reconstructs one full, self-sufficient Merkle authentication path per query from a
+    /// pruned multiproof.
+    ///
+    /// [`verify_batch_pruned`](Self::verify_batch_pruned) only checks the final digest of
+    /// each amortized group against the commitment; it never needs a usable per-query path,
+    /// so it never records one. Some callers do need that — e.g. an in-circuit verifier built
+    /// around a single-path-per-query gadget, with no notion of a shared/amortized proof. This
+    /// walks the exact same amortized frontier (so it costs no more hashing than verification
+    /// does) but additionally scatters each level's "other children" into *every* query's own
+    /// path, not just the group lead's — including query pairs that only merge partway up the
+    /// tree, whose later-level siblings are otherwise nowhere in the pruned proof at all.
+    ///
+    /// Arguments match [`verify_batch_pruned`](Self::verify_batch_pruned) minus `commit`: this
+    /// function does not check anything against a commitment. A caller that also wants that
+    /// check should call `verify_batch_pruned` (or verify each returned path against the
+    /// commitment itself); the two do the same walk and either can be skipped once the other
+    /// has run.
+    ///
+    /// # Returns
+    ///
+    /// One [`MerkleAuthPath`] per entry of `indices`, in the same order (duplicates included) —
+    /// the same shape a pre-pruning, per-query proof would have supplied directly.
+    pub fn restore_and_recompute_paths<R>(
+        &self,
+        dimensions: &[Dimensions],
+        indices: &[usize],
+        opened_values: &[Vec<R>],
+        proof: &PrunedMerklePaths<PW::Value, DIGEST_ELEMS>,
+    ) -> Result<Vec<MerkleAuthPath<PW::Value, DIGEST_ELEMS>>, MerkleTreeError>
+    where
+        R: AsRef<[P::Value]> + PartialEq,
+        P: PackedValue,
+        PW: PackedValue,
+        H: CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>
+            + CryptographicHasher<P, [PW; DIGEST_ELEMS]>
+            + Sync,
+        C: PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>
+            + PseudoCompressionFunction<[PW; DIGEST_ELEMS], N>
+            + Sync,
+        PW::Value: Eq + Clone,
+        [PW::Value; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
+    {
+        let max_height =
+            validate_commit_reachable_heights(dimensions.iter().map(|dims| dims.height))?;
+        let arity_schedule = self.proof_arity_schedule(dimensions)?;
+        let full_sibling_count: usize = arity_schedule.iter().map(|step| step - 1).sum();
+
+        let n_originals = indices.len();
+        if opened_values.len() != n_originals {
+            return Err(WrongBatchSize);
+        }
+
+        if n_originals == 0 {
+            return if proof.sibling_hashes.is_empty() {
+                Ok(vec![])
+            } else {
+                Err(PrunedProofError::SiblingCountMismatch {
+                    expected: 0,
+                    got: proof.sibling_hashes.len(),
+                }
+                .into())
+            };
+        }
+
+        let mut sorted_unique: Vec<usize> = indices.to_vec();
+        sorted_unique.sort_unstable();
+        sorted_unique.dedup();
+        let n_unique = sorted_unique.len();
+
+        let &highest = sorted_unique.last().expect("nonempty query set");
+        if highest >= max_height {
+            return Err(IndexOutOfBounds {
+                max_height,
+                index: highest,
+            });
+        }
+
+        let mut reps: Vec<Option<usize>> = vec![None; n_unique];
+        for (orig_idx, &leaf) in indices.iter().enumerate() {
+            let slot = sorted_unique
+                .binary_search(&leaf)
+                .expect("leaf came from the query set");
+            match reps[slot] {
+                None => reps[slot] = Some(orig_idx),
+                Some(rep_idx) => {
+                    if opened_values[rep_idx] != opened_values[orig_idx] {
+                        return Err(PrunedProofError::InconsistentDuplicateOpenings { slot }.into());
+                    }
+                }
+            }
+        }
+        let reps: Vec<usize> = reps
+            .into_iter()
+            .map(|r| r.expect("every unique slot is one of the queries"))
+            .collect();
+
+        let mut restored =
+            restore_paths(proof, &sorted_unique, &arity_schedule, full_sibling_count)?;
+
+        for &rep in &reps {
+            if opened_values[rep].len() != dimensions.len() {
+                return Err(WrongBatchSize);
+            }
+            check_widths(dimensions, &opened_values[rep])?;
+        }
+
+        let mut heights_tallest_first = dimensions
+            .iter()
+            .enumerate()
+            .sorted_by_key(|(_, dims)| Reverse(dims.height))
+            .peekable();
+
+        let mut curr_height_padded = padded_len(max_height, N);
+        let leaf_height_npt = max_height.next_power_of_two();
+
+        let leaf_matrix_indices: Vec<usize> = heights_tallest_first
+            .peeking_take_while(|(_, dims)| dims.height.next_power_of_two() == leaf_height_npt)
+            .map(|(i, _)| i)
+            .collect();
+
+        let mut digests: Vec<[PW::Value; DIGEST_ELEMS]> = reps
+            .iter()
+            .map(|&rep| {
+                self.hash.hash_iter_slices(
+                    leaf_matrix_indices
+                        .iter()
+                        .map(|&mi| opened_values[rep][mi].as_ref()),
+                )
+            })
+            .collect();
+
+        let mut node_indices: Vec<usize> = sorted_unique.clone();
+        let mut lead: Vec<usize> = (0..n_unique).collect();
+        let mut sibling_cursor: Vec<usize> = vec![0usize; n_unique];
+        let mut group_lo: Vec<usize> = (0..n_unique).collect();
+        let mut group_hi: Vec<usize> = (1..=n_unique).collect();
+
+        let default_digest = [PW::Value::default(); DIGEST_ELEMS];
+
+        let mut new_digests: Vec<[PW::Value; DIGEST_ELEMS]> = Vec::with_capacity(n_unique);
+        let mut new_indices: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_lead: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_cursor: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_group_lo: Vec<usize> = Vec::with_capacity(n_unique);
+        let mut new_group_hi: Vec<usize> = Vec::with_capacity(n_unique);
+
+        // Prefix sums of per-level chunk sizes, matching `pruning::total_siblings_for_levels`:
+        // the level-`l` chunk of a full path starts at `chunk_base[l]`.
+        let mut chunk_base: Vec<usize> = Vec::with_capacity(arity_schedule.len() + 1);
+        chunk_base.push(0);
+        for &step in &arity_schedule {
+            chunk_base.push(chunk_base.last().unwrap() + (step - 1));
+        }
+
+        for (level, &step) in arity_schedule.iter().enumerate() {
+            let num_siblings_per_path = step - 1;
+
+            new_digests.clear();
+            new_indices.clear();
+            new_lead.clear();
+            new_cursor.clear();
+            new_group_lo.clear();
+            new_group_hi.clear();
+
+            let mut i = 0;
+            while i < digests.len() {
+                let parent_idx = node_indices[i] / step;
+                let group_start = parent_idx * step;
+
+                let mut j = i + 1;
+                while j < digests.len() && node_indices[j] / step == parent_idx {
+                    j += 1;
+                }
+
+                let lead_path = lead[i];
+                let lead_pos = node_indices[i] - group_start;
+                let cursor_start = sibling_cursor[i];
+                // Clone out of `restored` up front: this level's own writes below touch
+                // `restored[lead_path]` too whenever `lead_path` is one of this group's
+                // original slots, which would otherwise conflict with this borrow.
+                let lead_siblings: Vec<[PW::Value; DIGEST_ELEMS]> = restored[lead_path].siblings
+                    [cursor_start..cursor_start + num_siblings_per_path]
+                    .to_vec();
+
+                let mut inputs = [default_digest; N];
+                let mut filled = [false; N];
+                for k in i..j {
+                    let pos = node_indices[k] - group_start;
+                    inputs[pos] = digests[k];
+                    filled[pos] = true;
+                }
+
+                let mut sib_idx = 0;
+                for k in 0..step {
+                    if k == lead_pos {
+                        continue;
+                    }
+                    if !filled[k] {
+                        inputs[k] = lead_siblings[sib_idx];
+                    }
+                    sib_idx += 1;
+                }
+
+                // Every pre-merge entry in this group gives its own "other children" view —
+                // at this level's own position, not the group lead's — to every original
+                // query slot it represents (a range of one, unless it merged earlier).
+                for k in i..j {
+                    let own_pos = node_indices[k] - group_start;
+                    for (pos, &child) in inputs.iter().enumerate().take(step) {
+                        if pos == own_pos {
+                            continue;
+                        }
+                        let offset = if pos < own_pos { pos } else { pos - 1 };
+                        for item in restored.iter_mut().take(group_hi[k]).skip(group_lo[k]) {
+                            item.siblings[chunk_base[level] + offset] = child;
+                        }
+                    }
+                }
+
+                new_digests.push(self.compress.compress(inputs));
+                new_indices.push(parent_idx);
+                new_lead.push(lead_path);
+                new_cursor.push(cursor_start + num_siblings_per_path);
+                new_group_lo.push(group_lo[i]);
+                new_group_hi.push(group_hi[j - 1]);
+
+                i = j;
+            }
+
+            core::mem::swap(&mut digests, &mut new_digests);
+            core::mem::swap(&mut node_indices, &mut new_indices);
+            core::mem::swap(&mut lead, &mut new_lead);
+            core::mem::swap(&mut sibling_cursor, &mut new_cursor);
+            core::mem::swap(&mut group_lo, &mut new_group_lo);
+            core::mem::swap(&mut group_hi, &mut new_group_hi);
+
+            let logical_next = curr_height_padded / step;
+            curr_height_padded = padded_len(logical_next, N);
+
+            let logical_next_npt = logical_next.next_power_of_two();
+            let next_height = heights_tallest_first
+                .peek()
+                .map(|(_, dims)| dims.height)
+                .filter(|h| h.next_power_of_two() == logical_next_npt);
+            if let Some(next_height) = next_height {
+                let inject_matrix_indices: Vec<usize> = heights_tallest_first
+                    .peeking_take_while(|(_, dims)| dims.height == next_height)
+                    .map(|(i, _)| i)
+                    .collect();
+
+                for g in 0..digests.len() {
+                    let rep_orig = reps[lead[g]];
+
+                    for (slot, &member_orig) in
+                        reps.iter().enumerate().take(group_hi[g]).skip(group_lo[g])
+                    {
+                        if slot == lead[g] {
+                            continue;
+                        }
+                        for &mi in &inject_matrix_indices {
+                            if opened_values[member_orig][mi] != opened_values[rep_orig][mi] {
+                                return Err(PrunedProofError::InconsistentGroupOpening {
+                                    slot,
+                                    matrix: mi,
+                                }
+                                .into());
+                            }
+                        }
+                    }
+
+                    let next_height_digest = self.hash.hash_iter_slices(
+                        inject_matrix_indices
+                            .iter()
+                            .map(|&mi| opened_values[rep_orig][mi].as_ref()),
+                    );
+
+                    let inject_inputs: [_; N] = core::array::from_fn(|k| {
+                        if k == 0 {
+                            digests[g]
+                        } else if k == 1 {
+                            next_height_digest
+                        } else {
+                            default_digest
+                        }
+                    });
+                    digests[g] = self.compress.compress(inject_inputs);
+                }
+            }
+        }
+
+        // Expand back to the caller's original (possibly duplicated) query order.
+        indices
+            .iter()
+            .map(|&leaf| {
+                let slot = sorted_unique
+                    .binary_search(&leaf)
+                    .expect("leaf came from the query set");
+                Ok(restored[slot].clone())
+            })
+            .collect()
+    }
 }

--- a/merkle-tree/src/pruning.rs
+++ b/merkle-tree/src/pruning.rs
@@ -57,7 +57,7 @@ use crate::PrunedProofError;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(serialize = "[D; DIGEST_ELEMS]: Serialize"))]
 #[serde(bound(deserialize = "[D; DIGEST_ELEMS]: serde::de::DeserializeOwned"))]
-pub(crate) struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
+pub struct MerkleAuthPath<D, const DIGEST_ELEMS: usize> {
     /// Index of this leaf in the tree (0-based).
     pub leaf_index: usize,
 


### PR DESCRIPTION
## Description

Recursive verifiers built around a single-path-per-query in-circuit MMCS gadget can't consume 0.7's pruned multiproofs directly: a proof omits any sibling digest another query's own leaf already covers, on the assumption the verifier recomputes it by hashing rather than reading it. That's cheaper to verify but leaves nothing a per-query gadget can authenticate independently. Three additions close that gap without touching any existing public API or its tested behavior:

- p3-merkle-tree: `MerkleTreeMmcs::restore_and_recompute_paths` walks the same amortized frontier `verify_batch_pruned` does, but records each level's "other children" into every query's own path (not just the group lead's), including mixed-height batches where a shorter matrix's digest is injected mid-tree. Cross-checked against the trusted single-query `verify_batch` as an independent oracle, including queries that only merge one level above an injection point.

- p3-fri: `fold_query`, `open_inputs`, and the `FriOpenings` type are now public. A recursive verifier's witness generation needs each query's own per-round folded evaluation to hash a commit-phase leaf correctly; that value only exists by replaying FRI's fold chain, and this was the only implementation of it.

- p3-batch-stark: pulled the `commitments_with_opening_points` construction out of `verify_batch` into its own function, taking the already-sampled `zeta` and the already-derived per-instance shape data as plain arguments instead of requiring a live `A: Air<...>` reference for anything beyond `BaseAir::main_next_row_columns`/ `preprocessed_next_row_columns`. This is what a caller needs to make `open_inputs` callable at all. `verify_batch` itself is now a thin caller of it — behavior confirmed unchanged via the full prove/verify integration suite (ZK, lookups, preprocessed/periodic columns, tamper-rejection) and a whole-workspace compile check.